### PR TITLE
QnD hack to allow access to all of sidebar

### DIFF
--- a/docs/gh-resource/js/customscripts.js
+++ b/docs/gh-resource/js/customscripts.js
@@ -8,9 +8,12 @@ $( document ).ready(function() {
     // position as your scroll. if you have a lot of nav items, this height may not work for you.
     var h = $(window).height();
     //console.log (h);
+    // PMM modification - for "adequately large screens", this makes the sidebar non-scrolling - we have a longer sidebar than most
+    /*
     if (h > 800) {
         $( "#mysidebar" ).attr("class", "nav affix");
     }
+   */
     // activate tooltips. although this is a bootstrap js function, it must be activated this way in your theme.
     $('[data-toggle="tooltip"]').tooltip({
         placement : 'top'


### PR DESCRIPTION
* I find unless I'm monopolising all the space on one of the giant monitors that the side bar is too long.
* There is an auto openey/closey style for side bar items _which I hate_ as now I need to remember all *hidden items in a giant list*
* the first annoying behaviour is by design in the code, and somewhat arbitrary
* this turns it off, and is always usable, and works well enough for items where the focus would remain on the page
* ideally, the navigation would scroll the chosen item back into view for low items
