### PR TITLE
show errors from run_internal_sql, gbl_ready changes

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -234,7 +234,6 @@ int gbl_blocksql_grace =
     10; /* how many seconds we wait for a blocksql during downgrade */
 int gbl_upd_key;
 unsigned long long gbl_sqltick;
-int gbl_db_started;
 int gbl_watchdog_watch_threshold = 60;
 int gbl_watchdog_disable_at_start = 0; /* don't enable watchdog on start */
 int gbl_nonames = 1;
@@ -8704,8 +8703,6 @@ int main(int argc, char **argv)
         }
     }
 
-    gbl_db_started = 1;
-
     /* if not using the nowatch lrl option */
     if (!gbl_watchdog_disable_at_start)
         watchdog_enable();
@@ -8720,7 +8717,6 @@ int main(int argc, char **argv)
     if (comdb2ma_stats_cron() != 0)
         abort();
 
-    gbl_db_started = 1;
     if (strcmp(thedb->envname, "leddydb") == 0)
        logmsg(LOGMSG_WARN, "I AM LEDDY.\n");
     else

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1545,7 +1545,6 @@ extern int gbl_nonames;
 extern int gbl_abort_on_missing_session;
 extern int gbl_reject_osql_mismatch;
 extern int gbl_abort_on_clear_inuse_rqid;
-extern int gbl_db_started;
 
 extern int gbl_exit_on_pthread_create_fail;
 extern int gbl_exit_on_internal_error;

--- a/db/glue.c
+++ b/db/glue.c
@@ -2893,7 +2893,7 @@ static int new_master_callback(void *bdb_handle, char *host)
             gbl_master_changes++;
 
             /* if there is an active schema changes, resume it */
-            if (resume_schema_change()) {
+            if (gbl_ready && resume_schema_change()) {
                 logmsg(LOGMSG_ERROR, "failed trying to resume schema change, if "
                         "one was in progress it will have to be restarted\n");
             }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -9603,7 +9603,12 @@ void run_internal_sql(char *sql)
     clnt.sql = sql;
 
     dispatch_sql_query(&clnt);
-
+    if (clnt.query_rc || clnt.saved_errstr) {
+        logmsg(LOGMSG_ERROR, "%s: Error from query: '%s' (rc = %d) \n", __func__, sql,
+               clnt.query_rc);
+        if (clnt.saved_errstr)
+            logmsg(LOGMSG_ERROR, "%s: Error: '%s' \n", __func__, clnt.saved_errstr);
+    }
     clnt_reset_cursor_hints(&clnt);
     osql_clean_sqlclntstate(&clnt);
 

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -144,10 +144,6 @@ static void *trigger_start_int(void *name_)
     char name[strlen(name_) + 1];
     strcpy(name, name_);
     free(name_);
-    if (!gbl_db_started) {
-        printf("%s too soon - not running trigger:%s\n", __func__, name);
-        return NULL;
-    }
     trigger_reg_t *reg;
     trigger_reg_init(reg, name);
     printf("%s waiting for %s elect_cookie:%d trigger_cookie:0x%llx\n",
@@ -192,8 +188,7 @@ void trigger_start(const char *name)
     if (!gbl_ready) return;
     printf("%s master selected me to run: %s\n", __func__, name);
     pthread_t t;
-    pthread_create(&t, &gbl_pthread_attr_detached, trigger_start_int,
-                   strdup(name));
+    pthread_create(&t, &gbl_pthread_attr_detached, trigger_start_int, strdup(name));
 }
 
 // FIXME TODO XXX: KEEP TWO HASHES (1) by qname (2) by node num

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -170,7 +170,7 @@ static void *watchdog_thread(void *arg)
     pthread_attr_setdetachstate(&gbl_pthread_joinable_attr,
                                 PTHREAD_CREATE_JOINABLE);
 
-    while (!gbl_db_started) {
+    while (!gbl_ready) {
         sleep(10);
     }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -88,7 +88,7 @@ int start_schema_change(struct dbenv *dbenvin, struct schema_change_type *s,
     }
 
     if (thedb->master == gbl_mynode && !s->resume) {
-        logmsg(LOGMSG_DEBUG, "calling bdb_set_disable_plan_genid 0x%llx\n", sc_seed);
+        logmsg(LOGMSG_WARN, "Calling bdb_set_disable_plan_genid 0x%llx\n", sc_seed);
         int bdberr;
         int rc = bdb_set_disable_plan_genid(thedb->bdb_env, NULL, sc_seed, &bdberr); 
         if (rc) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -46,8 +46,7 @@ int start_schema_change(struct dbenv *dbenvin, struct schema_change_type *s,
             free_schema_change_type(s);
             return rc;
         }
-        printf("fetched schema change seed %llx\n", seed);
-        logmsg(LOGMSG_WARN, "Resuming schema change: fetched seed %llx\n", seed);
+        logmsg(LOGMSG_INFO, "Resuming schema change: fetched seed 0x%llx\n", seed);
     }
     else {
         seed = get_genid(thedb->bdb_env, 0);
@@ -88,7 +87,7 @@ int start_schema_change(struct dbenv *dbenvin, struct schema_change_type *s,
     }
 
     if (thedb->master == gbl_mynode && !s->resume) {
-        logmsg(LOGMSG_WARN, "Calling bdb_set_disable_plan_genid 0x%llx\n", sc_seed);
+        logmsg(LOGMSG_INFO, "Calling bdb_set_disable_plan_genid 0x%llx\n", sc_seed);
         int bdberr;
         int rc = bdb_set_disable_plan_genid(thedb->bdb_env, NULL, sc_seed, &bdberr); 
         if (rc) {

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -227,7 +227,7 @@ function kill_restart_node
 
     if [ -n "$CLUSTER" ] ; then
         kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv -b $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
+        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
         sleep 1
         if [ $node != `hostname` ] ; then
             ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $comdb2task ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
@@ -237,7 +237,7 @@ function kill_restart_node
         fi
     else
         kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv -b $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
+        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
         sleep 1
         echo "$DBNAME: starting single node"
         echo "$comdb2task $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
@@ -246,12 +246,12 @@ function kill_restart_node
 
     popd
 
-    out=
+    out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
     # wait until we can query it
     echo "$DBNAME: waiting until ready"
     while [[ "$out" != "1" ]]; do
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
         sleep 2
+        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
     done
 }
 

--- a/tests/setup
+++ b/tests/setup
@@ -261,10 +261,10 @@ else
     echo "!$TESTCASE: waiting until ready"
     sleep 1
     for node in $CLUSTER; do
-        out=""
+        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
         while  [[ "$out" != "1" ]]; do
-            out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
             sleep 2
+            out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
         done
     done
     for node in $CLUSTER; do


### PR DESCRIPTION
- display error when run_internal_sql has errors running sql
- only resume SC if gbl_ready in new_master_callback()
- substitude usage of gbl_db_started with gbl_ready
- use numbered backup for sc_resume test