### PR TITLE
We should not abort on error after commit in llmeta

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -1358,17 +1358,13 @@ int bdb_llmeta_set_tables(
                         "this should not happen",
                 __func__);
         *bdberr = BDBERR_MISC;
-        free(p_buf_start);
-        p_buf = NULL;
-        return -1;
+        goto cleanup;
     }
 
 retry:
     if (++retries >= 500 /*gbl_maxretries*/) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
-        free(p_buf_start);
-        p_buf = NULL;
-        return -1;
+        goto cleanup;
     }
 
     /*if the user didn't give us a transaction, create our own*/
@@ -1381,9 +1377,7 @@ retry:
             logmsg(LOGMSG_ERROR, "%s: failed to get "
                             "transaction\n",
                     __func__);
-            free(p_buf_start);
-            p_buf = NULL;
-            return -1;
+            goto cleanup;
         }
     } else
         trans = input_trans;
@@ -1403,7 +1397,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            goto cleanup;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -1433,6 +1427,7 @@ backout:
 
         logmsg(LOGMSG_ERROR, "%s: failed with bdberr %d\n", __func__, *bdberr);
     }
+cleanup:
     free(p_buf_start);
     p_buf = NULL;
     return -1;
@@ -1690,7 +1685,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -1903,7 +1898,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -2078,7 +2073,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -2260,7 +2255,7 @@ retry:
     if (!input_tran) {
         if (bdb_tran_commit(llmeta_bdb_state, tran, bdberr) &&
             *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -2682,7 +2677,7 @@ retry:
         logmsg(LOGMSG_ERROR, "%s bdb_tran_commit rc: %d bdberr: %d\n", __func__, rc,
                 bdberr);
         tran = NULL;
-        goto fail;
+        return -1;
     }
     return 0;
 
@@ -2847,7 +2842,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -3420,7 +3415,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -3659,7 +3654,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -4632,7 +4627,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -4754,7 +4749,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -4880,7 +4875,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     /* invalidate any caches */
@@ -4978,7 +4973,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -5248,7 +5243,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     /* invalidate any caches */
@@ -5991,7 +5986,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;
@@ -6274,7 +6269,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc & *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
         llmeta_bdb_state->dbenv->log_flush(llmeta_bdb_state->dbenv, NULL);
     }
 
@@ -6399,7 +6394,7 @@ retry:
     if (!input_trans) {
         rc = bdb_tran_commit(llmeta_bdb_state, trans, bdberr);
         if (rc && *bdberr != BDBERR_NOERROR)
-            goto backout;
+            return -1;
     }
 
     *bdberr = BDBERR_NOERROR;

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -2677,7 +2677,7 @@ retry:
         logmsg(LOGMSG_ERROR, "%s bdb_tran_commit rc: %d bdberr: %d\n", __func__, rc,
                 bdberr);
         tran = NULL;
-        return -1;
+        goto fail;
     }
     return 0;
 

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1593,6 +1593,9 @@ static int bdb_tran_commit_with_seqnum_int_int(
         if (bdb_osql_trn_repo_unlock())
             abort();
         if (rc != 0) {
+            logmsg(LOGMSG_ERROR, 
+                   "%s:%d failed commit_getlsn, rc %d\n", __func__,
+                   __LINE__, iirc);
             *bdberr = BDBERR_MISC;
             outrc = -1;
             goto cleanup;

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1595,7 +1595,7 @@ static int bdb_tran_commit_with_seqnum_int_int(
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, 
                    "%s:%d failed commit_getlsn, rc %d\n", __func__,
-                   __LINE__, iirc);
+                   __LINE__, rc);
             *bdberr = BDBERR_MISC;
             outrc = -1;
             goto cleanup;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3940,9 +3940,8 @@ void osql_decom_node(char *decom_node)
  */
 void osql_net_exiting(void)
 {
-    netinfo_type *netinfo_ptr;
-
-    netinfo_ptr = (netinfo_type *)comm->handle_sibling;
+    if(!comm) return;
+    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
 
     net_exiting(netinfo_ptr);
 }

--- a/tools/cdb2_stat/cdb2_stat.c
+++ b/tools/cdb2_stat/cdb2_stat.c
@@ -225,7 +225,7 @@ argcombo:			fprintf(stderr,
 
 
     if (io_override_init())
-        goto err;
+        goto shutdown;
     io_override_set_std(stdout);
 
 

--- a/tools/cdb2_stat/cdb2_stat.c
+++ b/tools/cdb2_stat/cdb2_stat.c
@@ -66,6 +66,8 @@ int	 txn_stats __P((DB_ENV *, u_int32_t));
 void	 txn_xid_stats __P((DB_TXN_ACTIVE *));
 int	 usage __P((void));
 int	 version_check __P((const char *));
+extern int io_override_init(void);
+extern int io_override_set_std(FILE *f);
 extern int comdb2ma_init(size_t init_sz, size_t max_cap);
 
 int
@@ -220,6 +222,12 @@ argcombo:			fprintf(stderr,
 
 	/* Handle possible interruptions. */
 	__db_util_siginit();
+
+
+    if (io_override_init())
+        goto err;
+    io_override_set_std(stdout);
+
 
 	/*
 	 * Create an environment object and initialize it for error


### PR DESCRIPTION
When we fail commit we should not abort -- commit itself
cleans up on failure.