### PR TITLE
Have ssl mode OPTIONAL to optionally allow for ssl

### DIFF
--- a/bbinc/ssl_support.h
+++ b/bbinc/ssl_support.h
@@ -51,6 +51,7 @@
 #define SSL_MODE_REQUIRE        "REQUIRE"
 #define SSL_MODE_VERIFY_CA      "VERIFY_CA"
 #define SSL_MODE_VERIFY_HOST    "VERIFY_HOSTNAME"
+#define SSL_MODE_OPTIONAL       "OPTIONAL"
 
 /* Default file names */
 #if SBUF2_SERVER

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -86,6 +86,8 @@ int ssl_process_lrl(char *line, size_t len)
             gbl_client_ssl_mode = SSL_VERIFY_CA;
         else if (tokcmp(tok, ltok, SSL_MODE_VERIFY_HOST) == 0)
             gbl_client_ssl_mode = SSL_VERIFY_HOSTNAME;
+        else if (tokcmp(tok, ltok, SSL_MODE_OPTIONAL) == 0)
+            gbl_client_ssl_mode = SSL_UNKNOWN;
         else {
             my_ssl_eprintln("Unrecognized SSL mode `%s`.", tok);
             return EINVAL;

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -152,14 +152,13 @@ are refused to join the cluster.
 
 | LRL Directive | Description | Default Value |
 |---------------|-------------|---------------|
-| `ssl_client_mode mode` | Can be one of `ALLOW`<sup>[1](#ssloptfootnote)</sup>, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
+| `ssl_client_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
 | `ssl_replicant_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
 | `ssl_cert_path path` | Directory containing the server certificate files. Comdb2 searches `server.crt`, `server.key` and `root.crt` for the server certificate, key and trusted CAs respectively | The data directory |
 | `ssl_cert file`| Path to the certificate | `<ssl_cert_path>/server.crt` |
 | `ssl_key file` | Path to the key | `<ssl_cert_path>/server.key` |
 | `ssl_ca file` | Path to the trusted CA certificates | `<ssl_cert_path>/root.crt` |
 
-<a name="ssloptfootnote">[1]</a>: If mode is `ALLOW`, the server will try to open the certificate file in the designated location and will fail to start if it can not be found. For the server configuration, an equivalent mode to `ALLOW` is `OPTIONAL` which behaves in exactly the same way except it will not fail to start the server if certificate file is not found at start time.
 
 ## Client SSL Configuration Summary
 
@@ -177,9 +176,9 @@ are refused to join the cluster.
 
 |  Mode  | Encryption  | MITM | Overhead  |
 |---|---|---|---|
-|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
-|  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead |
-| `VERIFY-CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
-| `VERIFY-HOSTNAME` | Yes | No | SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
+|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
+|  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead |
+| `VERIFY-CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
+| `VERIFY-HOSTNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
 
-<a name="sslfootnote">[2]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.
+<a name="sslfootnote">[1]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -152,13 +152,14 @@ are refused to join the cluster.
 
 | LRL Directive | Description | Default Value |
 |---------------|-------------|---------------|
-| `ssl_client_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
+| `ssl_client_mode mode` | Can be one of `ALLOW`<sup>[1](#ssloptfootnote)</sup>, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
 | `ssl_replicant_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA` and `VERIFY_HOSTNAME` | `ALLOW` |
 | `ssl_cert_path path` | Directory containing the server certificate files. Comdb2 searches `server.crt`, `server.key` and `root.crt` for the server certificate, key and trusted CAs respectively | The data directory |
 | `ssl_cert file`| Path to the certificate | `<ssl_cert_path>/server.crt` |
 | `ssl_key file` | Path to the key | `<ssl_cert_path>/server.key` |
 | `ssl_ca file` | Path to the trusted CA certificates | `<ssl_cert_path>/root.crt` |
 
+<a name="ssloptfootnote">[1]</a>: If mode is `ALLOW`, the server will try to open the certificate file in the designated location and will fail to start if it can not be found. For te server configuration, an equivalent mode to `ALLOW` is `OPTIONAL` which behaves in exactly the same way exept it will not fail to start the server if certificate file is not found at start time.
 
 ## Client SSL Configuration Summary
 
@@ -176,9 +177,9 @@ are refused to join the cluster.
 
 |  Mode  | Encryption  | MITM | Overhead  |
 |---|---|---|---|
-|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
-|  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead |
-| `VERIFY-CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
-| `VERIFY-HOSTNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
+|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
+|  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead |
+| `VERIFY-CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
+| `VERIFY-HOSTNAME` | Yes | No | SSL negotiation<sup>[2](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
 
-<a name="sslfootnote">[1]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.
+<a name="sslfootnote">[2]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -159,7 +159,7 @@ are refused to join the cluster.
 | `ssl_key file` | Path to the key | `<ssl_cert_path>/server.key` |
 | `ssl_ca file` | Path to the trusted CA certificates | `<ssl_cert_path>/root.crt` |
 
-<a name="ssloptfootnote">[1]</a>: If mode is `ALLOW`, the server will try to open the certificate file in the designated location and will fail to start if it can not be found. For te server configuration, an equivalent mode to `ALLOW` is `OPTIONAL` which behaves in exactly the same way exept it will not fail to start the server if certificate file is not found at start time.
+<a name="ssloptfootnote">[1]</a>: If mode is `ALLOW`, the server will try to open the certificate file in the designated location and will fail to start if it can not be found. For the server configuration, an equivalent mode to `ALLOW` is `OPTIONAL` which behaves in exactly the same way except it will not fail to start the server if certificate file is not found at start time.
 
 ## Client SSL Configuration Summary
 

--- a/tests/autoanalyze.test/lrl.options
+++ b/tests/autoanalyze.test/lrl.options
@@ -10,4 +10,4 @@ setattr min_aa_time  20
 setattr aa_llmeta_save_freq  2
 
 noudp
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_blob_update.test/lrl.options
+++ b/tests/sc_blob_update.test/lrl.options
@@ -8,4 +8,4 @@ setattr REPTIMEOUT_MINMS 30000
 setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_constraints.test/lrl.options
+++ b/tests/sc_constraints.test/lrl.options
@@ -3,4 +3,4 @@ setattr REPTIMEOUT_MINMS 30000
 setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_inserts.test/lrl.options
+++ b/tests/sc_inserts.test/lrl.options
@@ -6,4 +6,4 @@ round_robin_stripes
 setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_inserts_deletes.test/lrl.options
+++ b/tests/sc_inserts_deletes.test/lrl.options
@@ -3,4 +3,4 @@ round_robin_stripes
 setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_rebuilds.test/lrl.options
+++ b/tests/sc_rebuilds.test/lrl.options
@@ -1,1 +1,1 @@
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_repeated_updates.test/lrl.options
+++ b/tests/sc_repeated_updates.test/lrl.options
@@ -1,3 +1,3 @@
 table t2 t2.csc2
 round_robin_stripes
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sc_tableversion.test/lrl.options
+++ b/tests/sc_tableversion.test/lrl.options
@@ -3,4 +3,4 @@ init_with_instant_schema_change
 init_with_ondisk_header
 init_with_inplace_updates 
 round_robin_stripes
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/selectv.test/lrl.options
+++ b/tests/selectv.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 dtastripe 4
 blobstripe
 round_robin_stripes
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/selectv_range.test/lrl.options
+++ b/tests/selectv_range.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 enable_selectv_range_check
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/serial_randtest2.test/lrl.options
+++ b/tests/serial_randtest2.test/lrl.options
@@ -2,4 +2,4 @@ enable_true_serializable
 enable_snapshot_isolation
 
 table t1 t1.csc2
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/siasof.test/lrl.options
+++ b/tests/siasof.test/lrl.options
@@ -4,4 +4,4 @@ round_robin_stripes
 enable_snapshot_isolation
 enable_new_snapshot_asof
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sicomplex.test/lrl.options
+++ b/tests/sicomplex.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sicomplex2.test/lrl.options
+++ b/tests/sicomplex2.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sicomplex3.test/lrl.options
+++ b/tests/sicomplex3.test/lrl.options
@@ -4,4 +4,4 @@ round_robin_stripes
 enable_snapshot_isolation
 nowatch
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sicountbug2.test/lrl.options
+++ b/tests/sicountbug2.test/lrl.options
@@ -2,4 +2,4 @@ table t1 t1.csc2
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sidupidx3.test/lrl.options
+++ b/tests/sidupidx3.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sirandtest.test/lrl.options
+++ b/tests/sirandtest.test/lrl.options
@@ -3,4 +3,4 @@ table t2 t2.csc2
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/sirandtest2.test/lrl.options
+++ b/tests/sirandtest2.test/lrl.options
@@ -5,4 +5,4 @@ blobstripe
 round_robin_stripes
 enable_snapshot_isolation
 setattr MAX_SHADOW_ROWS 10000000
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL

--- a/tests/yast_r7.test/lrl.options
+++ b/tests/yast_r7.test/lrl.options
@@ -1,3 +1,3 @@
 update_delete_limit
 dtastripe 1
-ssl_client_mode ALLOW
+ssl_client_mode OPTIONAL


### PR DESCRIPTION
Current mode ALLOW will try to load ssl cert file at start and exit with failure if can't find that file.
This mode, OPTIONAL, tries to load cert file, and if it does not find it it continues starting up the db.
This mode is useful for tests when run with SKIPSSL=1 option. 
We will not document this because it does not seem useful in any other circumstance to use this mode. 