### PR TITLE
comment out secondary indices

### DIFF
--- a/berkdb/db/db_cam.c
+++ b/berkdb/db/db_cam.c
@@ -1280,6 +1280,7 @@ __db_c_put(dbc_arg, key, data, flags)
 	memset(&olddata, 0, sizeof(DBT));
 	F_SET(&olddata, DB_DBT_MALLOC);
 
+#ifndef COMDB2_VERSION
 	/*
 	 * Putting to secondary indices is forbidden;  when we need
 	 * to internally update one, we'll call this with a private
@@ -1288,9 +1289,11 @@ __db_c_put(dbc_arg, key, data, flags)
 	 */
 	if (flags == DB_UPDATE_SECONDARY)
 		flags = DB_KEYLAST;
+#endif
 
 	CDB_LOCKING_INIT(dbp, dbc_arg);
 
+#ifndef COMDB2_VERSION
 	/*
 	 * Check to see if we are a primary and have secondary indices.
 	 * If we are not, we save ourselves a good bit of trouble and
@@ -1727,6 +1730,7 @@ skipput:	FREE_IF_NEEDED(sdbp, &skey)
 	/* Secondary index updates are now done.  On to the "real" stuff. */
 
 skip_s_update:
+#endif
 	/*
 	 * If we have an off-page duplicates cursor, and the operation applies
 	 * to it, perform the operation.  Duplicate the cursor and call the

--- a/tests/setup
+++ b/tests/setup
@@ -37,8 +37,14 @@ if [[ -n ${DEBUGGER} ]]; then
             INTERACTIVE_DEBUG=0
         fi
         ;;
+    callgrind)
+        DEBUG_PREFIX="valgrind --tool=callgrind --instr-atstart=yes --dump-instr=yes --collect-jumps=yes --callgrind-out-file=$TESTDIR/$TESTCASE.callgrind"
+        if [[ -z ${INTERACTIVE_DEBUG} ]]; then
+            INTERACTIVE_DEBUG=0
+        fi
+        ;;
     perf)
-        DEBUG_PREFIX="perf record -o $TESTCASE.perfdata -g "
+        DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g "
         INTERACTIVE_DEBUG=0
         ;;    
     *)

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -12,11 +12,11 @@ function kill_by_pidfile() {
     pidfile=$1
     if [[ -f $pidfile ]]; then
         local pid=$(cat $pidfile)
-        local pstr=$(ps -p $pid -o args)
+        local pstr=$(ps -p $pid -o args | grep comdb2)
         echo $pstr | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then 
+        if [[ $? -eq 0 ]]; then
             echo "${TESTCASE}: killing $pid"
-            if [ "`echo $pstr | awk '{ print $1 }'`" -eq "comdb2" ] ; then
+            if [ "`echo $pstr | awk '{ print $1 }' | xargs basename`" = "comdb2" ] ; then
                 kill -9 $pid
             else
                 kill $pid

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -12,10 +12,15 @@ function kill_by_pidfile() {
     pidfile=$1
     if [[ -f $pidfile ]]; then
         local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
+        local pstr=$(ps -p $pid -o args)
+        echo $pstr | grep -q "comdb2 ${DBNAME}"
         if [[ $? -eq 0 ]]; then 
             echo "${TESTCASE}: killing $pid"
-            kill -9 $pid
+            if [ "`echo $pstr | awk '{ print $1 }'`" -eq "comdb2" ] ; then
+                kill -9 $pid
+            else
+                kill $pid
+            fi
         fi
         rm -f $pidfile
     else


### PR DESCRIPTION
- comment out secondary indices code in c_put()
- add callgrind as one of debug tool parameters
- dont kill comdb2 command from test with -9 if task name is not comdb2
  (it can be debugger which we don't want to kill with -9)