### PR TITLE
fix missing string.h include

### DIFF
--- a/bb/ssl_support.c
+++ b/bb/ssl_support.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <pthread.h>

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -27,6 +27,7 @@
 /* sys */
 #include <errno.h>
 #include <openssl/crypto.h>
+#include <string.h>
 
 /* bb */
 #include <util.h>


### PR DESCRIPTION
gcc (6.3) complains about implicit declaration of the strlen and
strerror functions in ssl_support.c and ssl_bend.c.  Add the missing
string.h include to fix this.