### PR TITLE
Adds ability to build the jdbc driver using a docker container

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -26,7 +26,7 @@ limitations under the License. -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>2.6.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
         <groupId>log4j</groupId>

--- a/docker/Dockerfile.jdbc.build
+++ b/docker/Dockerfile.jdbc.build
@@ -1,0 +1,13 @@
+FROM openjdk:8
+
+# Download maven
+RUN \
+  wget http://apache.mirrors.tds.net/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz && \
+  tar -xvf apache-maven-3.5.0-bin.tar.gz -C /bin && \
+  mv /bin/apache-maven-3.5.0 bin/maven
+
+# Install protobuf 3.2
+RUN \
+  wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
+  unzip protoc-3.2.0-linux-x86_64.zip -d protoc && \
+  mv protoc/bin/protoc /bin


### PR DESCRIPTION
This allows one to build the jdbc driver without any necessary dependencies on the host machine other than docker (ie, a particular version protoc is not required). The resulting .jar file will be placed in the standard location `<root>/cdb2jdbc/target`

To build the jdbc driver using docker run the following command in the root directory
```
$> make jdbc-docker-build
```

This also changes the version of protoc to 3.2.0