### PR TITLE
jdbc docker build now results in artifacts owned by the building user

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,4 @@ tests/pmux.sqlite
 docs/site/images/*.gif
 docs/sqlitegen/all.html
 docs/sqlitegen/syntax_linkage.tcl
+docker/home/

--- a/.gitignore
+++ b/.gitignore
@@ -267,4 +267,4 @@ tests/pmux.sqlite
 docs/site/images/*.gif
 docs/sqlitegen/all.html
 docs/sqlitegen/syntax_linkage.tcl
-docker/home/
+docker/maven.m2/

--- a/Makefile
+++ b/Makefile
@@ -128,10 +128,12 @@ jdbc-docker-build-container:
 	docker build -t jdbc-docker-builder:$(VERSION) -f docker/Dockerfile.jdbc.build docker
 
 jdbc-docker-build: jdbc-docker-build-container
+	mkdir -p docker/home
 	docker run \
-		--env HOME=/tmp \
+		--user $(shell id -u):$(shell id -g) \
+		--env HOME=/jdbc.build/docker/home \
 		-v $(BASEDIR):/jdbc.build \
-		-w /jdbc.build \
+		-w /jdbc.build/docker/home \
 		jdbc-docker-builder:$(VERSION) \
 		/bin/maven/bin/mvn -f /jdbc.build/cdb2jdbc/pom.xml clean install
 

--- a/Makefile
+++ b/Makefile
@@ -128,12 +128,12 @@ jdbc-docker-build-container:
 	docker build -t jdbc-docker-builder:$(VERSION) -f docker/Dockerfile.jdbc.build docker
 
 jdbc-docker-build: jdbc-docker-build-container
-	mkdir -p docker/home
 	docker run \
 		--user $(shell id -u):$(shell id -g) \
-		--env HOME=/jdbc.build/docker/home \
+		--env HOME=/tmp \
 		-v $(BASEDIR):/jdbc.build \
-		-w /jdbc.build/docker/home \
+		-v ${BASEDIR}/docker/maven.m2:/maven.m2 \
+		-w /jdbc.build/docker \
 		jdbc-docker-builder:$(VERSION) \
 		/bin/maven/bin/mvn -f /jdbc.build/cdb2jdbc/pom.xml clean install
 

--- a/docker/Dockerfile.jdbc.build
+++ b/docker/Dockerfile.jdbc.build
@@ -6,8 +6,9 @@ RUN \
   tar -xvf apache-maven-3.5.0-bin.tar.gz -C /bin && \
   mv /bin/apache-maven-3.5.0 bin/maven
 
-# Install protobuf 3.2
+# Install protobuf 3.2 and give all users exec access
 RUN \
   wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
   unzip protoc-3.2.0-linux-x86_64.zip -d protoc && \
-  mv protoc/bin/protoc /bin
+  mv protoc/bin/protoc /bin && \
+  chmod 755 /bin/protoc

--- a/docker/Dockerfile.jdbc.build
+++ b/docker/Dockerfile.jdbc.build
@@ -6,6 +6,10 @@ RUN \
   tar -xvf apache-maven-3.5.0-bin.tar.gz -C /bin && \
   mv /bin/apache-maven-3.5.0 bin/maven
 
+# Sets maven to use a useful settings.xml file
+COPY \
+  maven-settings.xml /bin/maven/conf/settings.xml
+
 # Install protobuf 3.2 and give all users exec access
 RUN \
   wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \

--- a/docker/maven-settings.xml
+++ b/docker/maven-settings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <!-- Sets repo to a known location we can map when running the container -->
+  <localRepository>/maven.m2/repository</localRepository>
+
+  <pluginGroups>
+  </pluginGroups>
+
+  <proxies>
+  </proxies>
+
+  <servers>
+  </servers>
+
+  <mirrors>
+  </mirrors>
+
+  <profiles>
+  </profiles>
+</settings>


### PR DESCRIPTION
Also, creates a proper home directory where maven can find its .m2 directory. This ensures that subsequent builds do not need to redownload all the same dependencies.