### PR TITLE
don't use deprecated RAND_pseudo_bytes

### DIFF
--- a/bb/ssl_support.c
+++ b/bb/ssl_support.c
@@ -333,8 +333,13 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx,
     SSL_CTX_sess_set_cache_size(myctx, sess_sz);
 
 #if SBUF2_SERVER
-    /* Set up session id context. Pseudo-random bytes are good enough. */
-    RAND_pseudo_bytes(sid_ctx, sizeof(sid_ctx));
+    /* Set up session id context. */
+    if (RAND_bytes(sid_ctx, sizeof(sid_ctx)) != 1) {
+        ssl_sfliberrprint(err, n, my_ssl_eprintln,
+			  "Failed to get random bytes");
+	rc = ERR_get_error();
+	goto error;
+    }
     SSL_CTX_set_session_id_context(myctx, sid_ctx, sizeof(sid_ctx));
 #endif
 


### PR DESCRIPTION
RAND_pseudo_bytes() is deprecated in OpenSSL 1.1.0.  This makes
compilation with -Werror fail on my Arch Linux box.  The alternative to
RAND_pseudo_bytes() is RAND_bytes().

The default random implementation is using the same codepath in
OpenSSL (I only checked the source for 1.0.2k), except RAND_bytes()
doesn't set the error code.  Instead of returning an error when
RAND_bytes() returns 0, we could also just ignore the error.  This would
however make us rely on undocumented behaviour that might be broken in
the future.

Instead use RAND_bytes() and check the error code properly, to ensure
compatibility with newer OpenSSL versions.  That does mean that we
introduce an additional point of failure in the function if there is not
enough entropy available, but RAND_bytes() is used in other places, and
in the normal case there should be enough entropy available to get 8
random bytes.  The alternative would be to use RAND_bytes() and ignore
the error code, but that might break with future OpenSSL versions.