### PR TITLE
Use CLOCK_REALTIME to schedule cron events.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -773,7 +773,7 @@ int gbl_cmptxn_inherit_locks = 1;
 int gbl_rep_printlock = 0;
 
 int gbl_keycompr = 0;
-int gbl_memstat_freq = 60 * 3;
+int gbl_memstat_freq = 60 * 5;
 int gbl_accept_on_child_nets = 0;
 int gbl_disable_etc_services_lookup = 0;
 int gbl_fingerprint_queries = 0;

--- a/db/views_cron.c
+++ b/db/views_cron.c
@@ -201,8 +201,7 @@ static void *_cron_runner(void *arg)
     cron_sched_t *sched = (cron_sched_t *)arg;
     cron_event_t *event;
     int secs_until_next_event;
-    int now;
-    struct timespec ts;
+    struct timespec ts, now;
     int rc;
     struct errstat xerr;
     int locked;
@@ -219,12 +218,12 @@ static void *_cron_runner(void *arg)
         pthread_mutex_lock(&sched->mtx);
         locked = 1;
 
-        now = time_epoch();
+        clock_gettime(CLOCK_REALTIME, &now);
         while (event = sched->events.top) {
             /* refresh now, since callback can take a long time!*/
-            now = time_epoch();
+            clock_gettime(CLOCK_REALTIME, &now);
 
-            if (event->epoch <= now) {
+            if (event->epoch <= now.tv_sec) {
                 bzero(&xerr, sizeof(xerr));
 
                 /* lets do it */
@@ -267,7 +266,7 @@ static void *_cron_runner(void *arg)
         if (event) {
             ts.tv_sec = event->epoch;
         } else {
-            ts.tv_sec = now + DEFAULT_SLEEP_IDLE_SCHEDULE;
+            ts.tv_sec = now.tv_sec + DEFAULT_SLEEP_IDLE_SCHEDULE;
         }
         ts.tv_nsec = 0;
 


### PR DESCRIPTION
The function time() is imprecise. Using time() to schedule cron events causes
unnecessary spins on the wait condition when time() is behind the realtime clock.