### PR TITLE
Constant Time Comparison

### DIFF
--- a/berkdb/crypto/crypto.c
+++ b/berkdb/crypto/crypto.c
@@ -34,8 +34,8 @@ __crypto_compare(src, dst, len)
 	const void *dst;
 	size_t len;
 {
-	const unsigned char *a = (const unsigned char *)src;
-	const unsigned char *b = (const unsigned char *)dst;
+	const unsigned char *a = src;
+	const unsigned char *b = dst;
 	unsigned char result = 0;
 	size_t it;
 

--- a/berkdb/crypto/crypto.c
+++ b/berkdb/crypto/crypto.c
@@ -40,7 +40,7 @@ __crypto_compare(src, dst, len)
 	size_t it;
 
 	for(it = 0; it < len; ++it) {
-		result |= src[it] ^ dst[it];
+		result |= a[it] ^ b[it];
 	}
 
 	return result;

--- a/berkdb/dbinc/crypto.h
+++ b/berkdb/dbinc/crypto.h
@@ -53,6 +53,7 @@ struct __db_cipher {
 #ifdef HAVE_CRYPTO
 
 #include <openssl/aes.h>
+#include <openssl/crypto.h>
 
 /*
  * Shared ciphering structure


### PR DESCRIPTION
I noticed `comdb2` makes uses of `OpenSSL` for various parts of the system. 

We could leverage `CRYPTO_memcmp` to perform constant-time comparison of secrets when `OpenSSL` is available. In case it is not available, we can fallback to a less optimized implementation. 

https://cryptocoding.net/index.php/Coding_rules#Compare_secret_strings_in_constant_time
