### PR TITLE
Create per-SQL-thread Sqlite and Lua allocators regardless of the value of MALLOC_ARENA_MAX

### DIFF
--- a/bb/mem_subsystems.txt
+++ b/bb/mem_subsystems.txt
@@ -5,7 +5,7 @@ db            uncategorized        0                            0
 bdb           bdb                  0                            0
 berkdb        berkdb               0                            0
 net           net                  0                            0
-sqlite        sqlite               1024                         0
+sqlite        sqlite               0                            0
 bb            bb                   0                            0
 csc2          csc2                 0                            0
 datetime      datetime             0                            0
@@ -13,4 +13,4 @@ dfp/decNumber dfp_decNumber        0                            0
 protobuf      protobuf             0                            0
 comdb2rle     comdb2rle            0                            0
 schemachange  schemachange         0                            0
-lua           lua                  1024                         0
+lua           lua                  0                            0

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -224,7 +224,6 @@ int gbl_penaltyincpercent = 20;
 int gbl_maxwthreadpenalty;
 int gbl_spstrictassignments = 0;
 int gbl_delayed_ondisk_tempdbs = 0;
-int gbl_default_sql_mspace_kbsz = 1024;
 int gbl_lock_conflict_trace = 0;
 int gbl_move_deadlk_max_attempt = 500;
 
@@ -2276,10 +2275,6 @@ static int read_lrl_option(struct dbenv *dbenv, char *line, void *p, int len)
         gbl_init_single_meta = 1;
     } else if (tokcmp(tok, ltok, "delayed_ondisk_tempdbs") == 0) {
         gbl_delayed_ondisk_tempdbs = 1;
-    } else if (tokcmp(tok, ltok, "default_sql_mspace_kbsz") == 0) {
-        tok = segtok(line, len, &st, &ltok);
-        ii = toknum(tok, ltok);
-        gbl_default_sql_mspace_kbsz = ii;
     } else if (tokcmp(tok, ltok, "init_with_genid48") == 0) {
         logmsg(LOGMSG_INFO, "Genid48 will be enabled for this database\n");
         gbl_init_with_genid48 = 1;

--- a/db/sql.h
+++ b/db/sql.h
@@ -757,15 +757,9 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
 
 void sql_get_query_id(struct sql_thread *thd);
 
-#ifdef PER_THREAD_MALLOC
-#define sql_dlmalloc_init()
-#define sql_mem_init(x)
-#define sql_mem_shutdown(x)
-#else
 void sql_dlmalloc_init(void);
 int sql_mem_init(void *dummy);
 void sql_mem_shutdown(void *dummy);
-#endif
 
 int sqlite3_open_serial(const char *filename, sqlite3 **, struct sqlthdstate *);
 

--- a/lua/sp_int.h
+++ b/lua/sp_int.h
@@ -35,9 +35,7 @@ typedef struct tmptbl_info_t tmptbl_info_t;
 struct stored_proc {
     Lua lua;
     int lua_version;
-    #ifndef PER_THREAD_MALLOC
     comdb2ma mspace;
-    #endif
     char spname[MAX_SPNAME];
     struct spversion_t spversion;
     char *src;

--- a/tests/mem_be_nice.test/lrl.options
+++ b/tests/mem_be_nice.test/lrl.options
@@ -1,0 +1,2 @@
+# make sure we have the ability to handle more than 8 queries simultaneously
+sqlenginepool maxt 16

--- a/tests/mem_be_nice.test/runit
+++ b/tests/mem_be_nice.test/runit
@@ -3,27 +3,50 @@ bash -n "$0" | exit 1
 
 dbnm=$1
 
+set -e
+
+# Make sure that all queries go to the same node.
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+echo "target machine is $mach"
+
 for i in `seq 1 8`; do
-  cdb2sql ${CDB2_OPTIONS} -f stmts.sql $dbnm default >/dev/null &
+  cdb2sql --host $mach ${CDB2_OPTIONS} -f stmts.sql $dbnm default >/dev/null &
 done
 
-cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat sqlite hr")'
+appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c sqlite`
+echo "# sqlite allocators: $appsockcnt"
+if [[ $appsockcnt -gt 5 ]]; then
+  echo "Expecting <= 5 (4 for per-thread and 1 for main thread) sqlite allocators."
+  echo "Failed."
+  exit 1
+fi
 
-cnt=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat sqlite hr")' | grep sqlite | grep -v main | grep -cv 'cmd:'`
-echo "# sqlite allocators: $cnt"
+appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c lua`
+echo "# lua allocators: $appsockcnt"
+if [[ $appsockcnt -gt 5 ]]; then
+  echo "Expecting <= 5 (4 for per-thread and 1 for main thread) lua allocators."
+  echo "Failed."
+  exit 1
+fi
 
-if [[ $cnt -gt 4 ]]; then
+# Give the database a bit time to dispatch all queries.
+sleep 2
+
+sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c SQLITE`
+echo "# SQLITE allocators: $sqlengcnt"
+if [[ $sqlengcnt -lt 9 ]]; then
+  echo "Expecting >= 9 (8 open connections and myself) SQLITE allocators."
+  echo "Failed."
+  exit 1
+fi
+
+sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c LUA`
+echo "# LUA allocators: $sqlengcnt"
+if [[ $sqlengcnt -lt 9 ]]; then
+  echo "Expecting >= 9 (8 open connections and myself) LUA allocators."
   echo "Failed."
   exit 1
 fi
 
 wait
-
-cnt=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat sqlite hr")' | grep sqlite | grep -v main | grep -cv 'cmd:'`
-echo "# sqlite allocators: $cnt"
-
-if [[ $cnt -gt 4 ]]; then
-  echo "Failed."
-  exit 1
-fi
 echo "Passed."

--- a/tests/mem_be_nice.test/stmts.sql
+++ b/tests/mem_be_nice.test/stmts.sql
@@ -1,3 +1,2 @@
-select 1
+exec procedure sys.cmd.send("stat")
 select sleep(5)
-select 1


### PR DESCRIPTION
Currently a database creates at most MALLOC_ARENA_MAX allocators per subsystem. It could lead
to extremely high lock contention especially on sqlite/lua allocators when there is a burst
on the application side.

The fix is to always create thread-specific Sqlite/Lua allocators for SQL threads.
The code was originally from R5 and has been running reliably on production since 2015.

In addition it gives us a nice Garbage Collection feature:
These thread-specific allocators will be completely destroyed with their parent threads.
Hence all memory will be released back to the heap and can be furthermore returned to
the Operation System.