### PR TITLE
Avoid possibly overflowing hosts.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4764,9 +4764,11 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         p = strchr(type, ':');
         if (p) {
             strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
-            p = strchr(hndl->hosts[0], ':');
-            *p = 0;
-            hndl->ports[0] = atoi(p + 1);
+	    p = strchr(hndl->hosts[0], ':');
+	    if (p) {
+		*p = 0;
+		hndl->ports[0] = atoi(p + 1);
+	    }
         } else {
             strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
             if (!allow_pmux_route) {

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4763,7 +4763,7 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         char *p;
         p = strchr(type, ':');
         if (p) {
-            strcpy(hndl->hosts[0], type);
+            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0]));
             p = strchr(hndl->hosts[0], ':');
             *p = 0;
             hndl->ports[0] = atoi(p + 1);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4763,14 +4763,14 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         char *p;
         p = strchr(type, ':');
         if (p) {
-            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
+            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0]) - 1);
 	    p = strchr(hndl->hosts[0], ':');
 	    if (p) {
 		*p = 0;
 		hndl->ports[0] = atoi(p + 1);
 	    }
         } else {
-            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
+            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0]) - 1);
             if (!allow_pmux_route) {
                 hndl->ports[0] =
                     cdb2portmux_get(type, "comdb2", "replication", dbname);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4768,7 +4768,7 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
             *p = 0;
             hndl->ports[0] = atoi(p + 1);
         } else {
-            strcpy(hndl->hosts[0], type);
+            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
             if (!allow_pmux_route) {
                 hndl->ports[0] =
                     cdb2portmux_get(type, "comdb2", "replication", dbname);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4763,7 +4763,7 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         char *p;
         p = strchr(type, ':');
         if (p) {
-            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0]));
+            strncpy(hndl->hosts[0], type, sizeof(hndl->hosts[0])-1);
             p = strchr(hndl->hosts[0], ':');
             *p = 0;
             hndl->ports[0] = atoi(p + 1);


### PR DESCRIPTION
A few more details were sent to `opencomdb2@bloomberg.net`.