### PR TITLE
Don't set OPTBBINCLUDE

### DIFF
--- a/main.mk
+++ b/main.mk
@@ -8,7 +8,6 @@ export $(arch)
 TAGS?=ctags
 CFLAGS_INC=-I$(SRCHOME)/bbinc -Ibb -I$(SRCHOME) -DCOMDB2_ROOT=$(COMDB2_ROOT)
 CFLAGS_64=-DBB64BIT
-OPTBBINCLUDE?=-I/opt/bb/include
 
 ifeq ($(arch),Linux)
   #CFLAGS_STRICT=-Wall -Wno-unused-variable -Wno-unused-but-set-variable -Wno-unused-function -Wno-unused-label


### PR DESCRIPTION
No longer needed, and can break builds if /opt/bb/include files conflict with ours.