### PR TITLE
Add which to CentOS install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ On every machine in the cluster:
    sudo yum install -y gcc gcc-c++ protobuf-c libunwind libunwind-devel   \
    protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
    readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
-   zlib lz4-devel gawk tcl epel-release lz4 rpm-build
+   zlib lz4-devel gawk tcl epel-release lz4 rpm-build which
    ```
 
 3. Build Comdb2:


### PR DESCRIPTION
While its normally installed in the base CentOS image, its a requirement of several scripts. Else you end up with errors like:

```
berkdb/dist/geninc.sh: line 13: which: command not found
berkdb/dist/geninc.sh: line 101: -f: command not found
```