### PR TITLE
cdb2api Fix per-database config path.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -40,7 +40,8 @@
 #define COMDB2DB_NUM 32432
 
 static char CDB2DBCONFIG_NOBBENV[512] = "/opt/bb/etc/cdb2/config/comdb2db.cfg";
-static char CDB2DBCONFIG_NOBBENV_PATH[64] = "/opt/bb/etc/cdb2/config.d/";
+/* The real path is COMDB2_ROOT + CDB2DBCONFIG_NOBBENV_PATH  */
+static char CDB2DBCONFIG_NOBBENV_PATH[] = "/etc/cdb2/config.d/";
 
 static char CDB2DBCONFIG_TEMP_BB_BIN[512] = "/bb/bin/comdb2db.cfg";
 


### PR DESCRIPTION
This is a bad merge I made from Akshat's SSL branch.
CDB2DBCONFIG_NOBBENV_PATH is a suffix.
get_config_file() concatenates COMDB2_ROOT and CDB2DBCONFIG_NOBBENV_PATH to make the real path.