### PR TITLE
tools: Install tools into the top level dir.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,7 +133,7 @@ cdb2_printlog
 cdb2_verify
 cdb2_dump
 cdb2_stat
-cdb2_sqlreqplay
+cdb2_sqlreplay
 
 # fluff produced by various tools that tends to accumulate
 *.sw[op]

--- a/libs.mk
+++ b/libs.mk
@@ -62,6 +62,6 @@ LIBS_BIN=$(BDB_BIN) $(BERKDB_BIN) $(SQLITE_BIN) $(CMACC2_BIN)	\
 
 LIB_DEPS=dlmalloc net sqlite datetime lua comdb2rle crc32c lz4 dfpal csc2 bb bdb berkdb bblib cdb2api cson protobuf schemachange sockpool
 
-LCLLIBS=$(SCHEMA) $(BDB) $(BERKDB) $(SQLITE) $(CMACC2) $(DATETIME) $(LUA)	\
-     $(NET) $(CRC32C) $(COMDB2RLE) $(DFPAL) $(BBLIB) $(CDB2API)	\
-     $(DLMALLOC) $(PROTOBUF) $(CSON) $(SOCKPOOL)
+LCLLIBS=$(SCHEMA) $(BDB) $(BERKDB) $(SQLITE) $(CMACC2) $(DATETIME)	\
+     $(LUA) $(NET) $(CRC32C) $(COMDB2RLE) $(DFPAL) $(BBLIB)		\
+     $(CDB2API) $(DLMALLOC) $(PROTOBUF) $(CSON) $(SOCKPOOL)

--- a/tools/module.mk
+++ b/tools/module.mk
@@ -29,6 +29,7 @@ cdb2sql: tools_LDLIBS+=$(LIBREADLINE)
 cdb2sql: tools/cdb2sql/cdb2sql.o
 comdb2sc: tools/comdb2sc/comdb2sc.o
 cdb2_sqlreplay: tools/cdb2_sqlreplay/cdb2_sqlreplay.o
+cdb2sql comdb2sc cdb2_sqlreplay:
 	$(CC) $(tools_LDFLAGS) $^ $(tools_LDLIBS) -o $@
 
 # Cdb2sockpool - Use base rules, multiple object files
@@ -105,6 +106,7 @@ $(cdb2_OBJS): tools_CPPFLAGS+=$(cdb2_CPPFLAGS)
 cdb2_dump: tools/cdb2_dump/cdb2_dump.o
 cdb2_stat: tools/cdb2_stat/cdb2_stat.o
 cdb2_verify: tools/cdb2_verify/cdb2_verify.o
+cdb2_dump cdb2_stat cdb2_verify:
 	$(CC) $(tools_LDFLAGS) $< $(BERKDB) $(SCHEMA) $(tools_LDLIBS) -o $@
 
 # Cdb2_printlog

--- a/tools/module.mk
+++ b/tools/module.mk
@@ -1,11 +1,6 @@
 # Local defs
-tools_TASKS:=cdb2sql comdb2sc cdb2sockpool comdb2ar pmux cdb2_dump	\
-cdb2_stat cdb2_verify cdb2_printlog cdb2_sqlreplay
-lcl_TASKS:=$(foreach task,$(tools_TASKS),tools/$(task)/$(task))
-
-$(tools_TASKS): $(lcl_TASKS) 
-	@rm -f $@
-	cp tools/$(@F)/$(@F) $@
+tools_TASKS:=cdb2sql comdb2sc cdb2_sqlreplay cdb2sockpool comdb2ar	\
+pmux cdb2_dump cdb2_stat cdb2_verify cdb2_printlog
 
 tools_INCLUDE:=-I$(SRCHOME)/crc32c -I$(SRCHOME)/bbinc			\
 -I$(SRCHOME)/cdb2api -I$(SRCHOME)/berkdb -I$(SRCHOME)/berkdb/build	\
@@ -20,17 +15,20 @@ tools_LDLIBS:=$(LDLIBS) -ldl $(LCLLIBS) $(tools_SYSLIBS)
 
 # Base rules for all objects
 tools/%.o: tools/%.c tools/%.d $(LIBS_BIN)
-	$(CC) $(DEPFLAGS) -g $(tools_CPPFLAGS) $(CFLAGS) -c -o $@ $<
+	$(CC) $(DEPFLAGS) $(tools_CPPFLAGS) $(CFLAGS) -c -o $@ $<
 	$(POSTCOMPILE)
 
 tools/%.o: tools/%.cpp tools/%.d $(LIBS_BIN)
-	$(CXX11) $(DEPFLAGS_CXX11) -g $(tools_CPPFLAGS) $(CXX11FLAGS) -c -o $@ $<
+	$(CXX11) $(DEPFLAGS_CXX11) $(tools_CPPFLAGS) $(CXX11FLAGS) -c -o $@ $<
 	$(POSTCOMPILE)
 
 # Cdb2sql and Comdb2sc - These only have .c file each, though they do
 # depend on some of the auto-generated .h from other moodules
 # Cdb2sql and comdb2sc
-tools/%: tools/%.o
+cdb2sql: tools_LDLIBS+=$(LIBREADLINE)
+cdb2sql: tools/cdb2sql/cdb2sql.o
+comdb2sc: tools/comdb2sc/comdb2sc.o
+cdb2_sqlreplay: tools/cdb2_sqlreplay/cdb2_sqlreplay.o
 	$(CC) $(tools_LDFLAGS) $^ $(tools_LDLIBS) -o $@
 
 # Cdb2sockpool - Use base rules, multiple object files
@@ -38,7 +36,7 @@ cdb2sockpool_SOURCES:=utils.c settings.c cdb2sockpool.c
 cdb2sockpool_OBJS:=$(patsubst %.c,tools/cdb2sockpool/%.o,$(cdb2sockpool_SOURCES))
 cdb2sockpool_LDLIBS=-lbb -lsockpool
 
-tools/cdb2sockpool/cdb2sockpool: $(cdb2sockpool_OBJS)
+cdb2sockpool: $(cdb2sockpool_OBJS)
 
 # Comdb2ar - Use base rules
 comdb2ar_SOURCES:=appsock.cpp comdb2ar.cpp db_wrap.cpp		\
@@ -57,7 +55,7 @@ comdb2ar_OBJS:=$(patsubst %.cpp,tools/comdb2ar/%.o,		\
 comdb2ar_LDLIBS+= $(BBSTATIC) $(BBLIB) $(DLMALLOC)		\
 		  $(BBDYN) -lpthread -lm -lssl -lcrypto -ldl -lrt -lz $(ARCHLIBS)
 
-tools/comdb2ar/comdb2ar: $(comdb2ar_OBJS)
+comdb2ar: $(comdb2ar_OBJS)
 	$(CXX11) $(tools_LDFLAGS) $^ $(comdb2ar_LDLIBS) -o $@
 
 # Files that include db.h require COMDB2AR to be defined
@@ -66,11 +64,6 @@ db_wrap_FLAGS=$(CFLAGS_ARCHFLAGS) -DCOMDB2AR -I$(SRCHOME)/mem	\
 
 tools/comdb2ar/db_wrap.o: tools_CPPFLAGS+=$(db_wrap_FLAGS)
 tools/comdb2ar/serialise.o: tools_CPPFLAGS+=$(db_wrap_FLAGS)
-
-cdb2sql_LDLIBS=$(tools_LDLIBS) $(LIBREADLINE)
-cdb2sql_OBJS:=tools/cdb2sql/cdb2sql.o
-tools/cdb2sql/cdb2sql: $(cdb2sql_OBJS)
-	$(CC) $(tools_LDFLAGS) $^ $(cdb2sql_LDLIBS) -o $@
 
 # Pmux - Use flag for C++11 standard
 pmux_LDFLAGS=$(CXX11LDFLAGS) -L$(SRCHOME)/cdb2api	\
@@ -88,7 +81,7 @@ endif
 pmux_SOURCES:=tools/pmux/pmux.cpp
 pmux_OBJS:=$(patsubst %.cpp,%.o,$(pmux_SOURCES))
 
-tools/pmux/pmux: $(pmux_OBJS)
+pmux: $(pmux_OBJS)
 	$(CXX11) $(pmux_LDFLAGS) $< $(pmux_LDLIBS) -o $@
 
 $(pmux_OBJS): %.o: %.cpp $(LIBS_BIN)
@@ -98,8 +91,8 @@ $(pmux_OBJS): %.o: %.cpp $(LIBS_BIN)
 # Cdb2_dump et al. - Needs more dependencies for the cdb2_ tools
 # Cdb2_dump and others. Omit cdb2_printlog for now because it needs
 # multiple $OBJS
-cdb2_TASKS:=$(filter tools/cdb2_%,$(filter-out tools/cdb2_printlog%,$(lcl_TASKS)))
-cdb2_OBJS:=$(patsubst %,%.o,$(cdb2_TASKS))
+cdb2_SRC:=cdb2_dump/cdb2_dump.c cdb2_stat/cdb2_stat.c cdb2_verify/cdb2_verify.c
+cdb2_OBJS:=$(patsubst %.c,tools/%.o,$(cdb2_SRC))
 
 # Dependencies for the cdb2_ tools
 cdb2_CPPFLAGS:=-I$(SRCHOME)/bdb -I$(SRCHOME)/net -I$(SRCHOME)/crc32c
@@ -109,7 +102,9 @@ $(cdb2_OBJS): tools_CPPFLAGS+=$(cdb2_CPPFLAGS)
 
 # Since there are circular dependencies -ldb and -lschemachange must
 # go first.
-$(cdb2_TASKS): %: %.o
+cdb2_dump: tools/cdb2_dump/cdb2_dump.o
+cdb2_stat: tools/cdb2_stat/cdb2_stat.o
+cdb2_verify: tools/cdb2_verify/cdb2_verify.o
 	$(CC) $(tools_LDFLAGS) $< $(BERKDB) $(SCHEMA) $(tools_LDLIBS) -o $@
 
 # Cdb2_printlog
@@ -120,8 +115,8 @@ $(cdb2_printlog_OBJS): tools_CPPFLAGS+=$(cdb2_CPPFLAGS)
 
 # Since there are circular dependencies -ldb and -lschemachange must
 # go first.
-tools/cdb2_printlog/cdb2_printlog: $(cdb2_printlog_OBJS)
-	$(CC) $(tools_LDFLAGS) $(cdb2_printlog_OBJS) $(BERKDB) $(SCHEMA) $(tools_LDLIBS) -o $@
+cdb2_printlog: $(cdb2_printlog_OBJS)
+	$(CC) $(tools_LDFLAGS) $^ $(BERKDB) $(SCHEMA) $(tools_LDLIBS) -o $@
 
 # Defined in the top level makefile
 TASKS+=$(lcl_TASKS) $(tools_TASKS)


### PR DESCRIPTION
Before, we were installing tools each into their own directory and
then copying them to the top level build directory. This was viewed
as a waste of space by some.