### PR TITLE
Smoketest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ install: all
 	install -D cdb2_dump $(DESTDIR)$(PREFIX)/bin/cdb2_dump
 	install -D cdb2_stat $(DESTDIR)$(PREFIX)/bin/cdb2_stat
 	install -D cdb2sql $(DESTDIR)$(PREFIX)/bin/cdb2sql
-	install -D cdb2_sqlreplay $(DESTDIR)$(PREFIX)/bin/sqlreplay
+	install -D cdb2_sqlreplay $(DESTDIR)$(PREFIX)/bin/cdb2_sqlreplay
 	install -D pmux $(DESTDIR)$(PREFIX)/bin/pmux
 	install -D cdb2sockpool $(DESTDIR)$(PREFIX)/bin/cdb2sockpool
 	install -D tools/pmux/pmux.service $(DESTDIR)/lib/systemd/system/pmux.service

--- a/deb/control
+++ b/deb/control
@@ -6,7 +6,8 @@ Build-Depends:  build-essential, make, libprotobuf-c0-dev, protobuf-c-compiler, 
 Standards-Version: 3.9.4
 
 Package: comdb2
-Depends: libz1, libuuid1, tzdata, liblz4-tool, libreadline6, libsqlite3-0, libprotobuf-c1, libssl1.0.0, supervisor
+Depends: libz1, libuuid1, tzdata, liblz4-tool, libreadline6, libsqlite3-0, libprotobuf-c1, libssl1.0.0
+Recommends: supervisor
 Architecture: any 
 Description: Comdb2 RDBMS
  Comdb2 RDBMS

--- a/deb/postinst
+++ b/deb/postinst
@@ -36,13 +36,21 @@ case "$1" in
         echo 'PATH=$PATH:/opt/bb/bin' >> /home/comdb2/.profile
         chmod +x /home/comdb2/.profile
         chown comdb2:comdb2 /home/comdb2/.profile
-        systemctl daemon-reload
-        systemctl stop pmux
-        systemctl start pmux
-        systemctl stop cdb2sockpool
-        systemctl start cdb2sockpool
-        systemctl enable supervisor_cdb2
-        systemctl start supervisor_cdb2
+        if [ ! -e /.dockerenv ]; then
+            systemctl daemon-reload
+            systemctl stop pmux
+            systemctl start pmux
+            systemctl stop cdb2sockpool
+            systemctl start cdb2sockpool
+            set +e
+            dpkg -l | grep -q "ii supervisor"
+            rc=$?
+            set -e
+            if [ $rc -eq 0 ]; then
+                systemctl enable supervisor_cdb2
+                systemctl start supervisor_cdb2
+            fi
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/deb/postinst
+++ b/deb/postinst
@@ -43,7 +43,7 @@ case "$1" in
             systemctl stop cdb2sockpool
             systemctl start cdb2sockpool
             set +e
-            dpkg -l | grep -q "ii supervisor"
+            dpkg -l "supervisor" >/dev/null
             rc=$?
             set -e
             if [ $rc -eq 0 ]; then

--- a/rpmbuild/comdb2.spec
+++ b/rpmbuild/comdb2.spec
@@ -8,7 +8,7 @@ URL:            http://github.com/bloomberg/comdb2
 Source0:        comdb2-VVEERRSSIIOONN.tar.gz
 
 BuildRequires:  gcc gcc-c++ protobuf-c libunwind libunwind-devel protobuf-c-devel byacc flex openssl openssl-devel openssl-libs readline readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel zlib lz4-devel gawk tcl
-Requires:       protobuf-c libunwind openssl openssl-libs readline sqlite libuuid zlib lz4 supervisor
+Requires:       protobuf-c libunwind openssl openssl-libs readline sqlite libuuid zlib lz4
 
 %description
 Comdb2 is a distributed relational database.
@@ -31,6 +31,7 @@ rm -rf $RPM_BUILD_ROOT
 /opt/bb/bin/cdb2_printlog
 /opt/bb/bin/cdb2_stat
 /opt/bb/bin/cdb2_verify
+/opt/bb/bin/cdb2_sqlreplay
 /opt/bb/bin/cdb2sql
 /opt/bb/bin/comdb2
 /opt/bb/bin/comdb2ar
@@ -72,11 +73,19 @@ chown comdb2:comdb2 /home/comdb2/.bashrc
 # This is ubuntu specific: maybe switch here for other systems?
 cp /opt/bb/lib/systemd/system/pmux.service /etc/systemd/system
 systemctl daemon-reload
-systemctl stop pmux
-systemctl start pmux
-systemctl enable supervisor_cdb2
-systemctl start supervisor_cdb2
-systemctl enable cdb2sockpool
-systemctl start cdb2sockpool
+if [ ! -e /.dockerenv ]; then
+    systemctl stop pmux
+    systemctl start pmux
+    systemctl enable supervisor_cdb2
+    systemctl start supervisor_cdb2
+    set +e
+    rpm -qa | grep -q "^supervisor"
+    rc=$?
+    set -e
+    if [ $rc -eq 0 ]; then
+        systemctl enable cdb2sockpool
+        systemctl start cdb2sockpool
+    fi
+fi
 
 %changelog

--- a/tests/smoketest/Dockerfile.deb.build
+++ b/tests/smoketest/Dockerfile.deb.build
@@ -1,0 +1,38 @@
+FROM ubuntu:latest
+
+RUN apt-get update && \
+  apt-get install -y \
+    bc \
+    bison \
+    build-essential \
+    flex \
+    gawk \
+    liblz4-dev \
+    libprotobuf-c-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libunwind-dev \
+    libz-dev \
+    make \
+    ncurses-dev \
+    protobuf-c-compiler \
+    tcl \
+    uuid-dev \
+    libz1 \
+    liblz4-tool \
+    libprotobuf-c1 \
+    libreadline6 \
+    libsqlite3-0 \
+    libuuid1 \
+    libz1 \
+    tzdata && \
+  rm -rf /var/lib/apt/lists/*
+
+COPY . /build/
+
+WORKDIR /build
+
+RUN make deb-current && dpkg -i ../comdb2*.deb 
+
+ENV PATH="/opt/bb/bin:${PATH}"

--- a/tests/smoketest/Dockerfile.inst.build
+++ b/tests/smoketest/Dockerfile.inst.build
@@ -1,0 +1,16 @@
+FROM centos:latest
+
+RUN \
+   yum install -y epel-release && \
+   yum install -y gcc gcc-c++ protobuf-c libunwind libunwind-devel   \
+   protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
+   readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
+   zlib lz4-devel gawk tcl lz4 rpm-build which
+
+COPY . /build/
+
+WORKDIR /build/
+
+RUN make clean && make -j4 && make install
+
+ENV PATH="/opt/bb/bin:${PATH}"

--- a/tests/smoketest/Dockerfile.rpm.build
+++ b/tests/smoketest/Dockerfile.rpm.build
@@ -1,0 +1,16 @@
+FROM centos:latest
+
+RUN \
+   yum install -y epel-release && \
+   yum install -y gcc gcc-c++ protobuf-c libunwind libunwind-devel   \
+   protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
+   readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
+   zlib lz4-devel gawk tcl lz4 rpm-build which
+
+COPY . /build/
+
+WORKDIR /build
+
+RUN make rpm-current && rpm -i ${HOME}/rpmbuild/RPMS/*/comdb2*.rpm
+
+ENV PATH="/opt/bb/bin:${PATH}"

--- a/tests/smoketest/Makefile
+++ b/tests/smoketest/Makefile
@@ -1,26 +1,25 @@
 all: build-deb build-rpm build-inst
 
 build-deb:
-	-docker rm debtest
+	-docker rm -f debtest
 	docker build -t smoketest-deb -f Dockerfile.deb.build ../../
-	docker run -d --name debtest -t smoketest-deb /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	docker run -d --name debtest --net host -t smoketest-deb /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
 	./testdbs debtest
 	-docker kill debtest
 	-docker rm debtest
 
 build-rpm:
-	-docker rm rpmtest
+	-docker rm -f rpmtest
 	docker build -t smoketest-rpm -f Dockerfile.rpm.build ../../
-	docker run -d --name rpmtest -t smoketest-rpm /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	docker run -d --name rpmtest --net host -t smoketest-rpm /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
 	./testdbs rpmtest
 	-docker kill rpmtest
 	-docker rm rpmtest
 
 build-inst:
-	-docker rm insttest
+	-docker rm -f insttest
 	docker build -t smoketest-inst -f Dockerfile.inst.build ../../
-	docker run -d --name insttest -t smoketest-inst /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	docker run -d --name insttest --net host -t smoketest-inst /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
 	./testdbs insttest
 	-docker kill insttest
 	-docker rm insttest
-

--- a/tests/smoketest/Makefile
+++ b/tests/smoketest/Makefile
@@ -1,0 +1,26 @@
+all: build-deb build-rpm build-inst
+
+build-deb:
+	-docker rm debtest
+	docker build -t smoketest-deb -f Dockerfile.deb.build ../../
+	docker run -d --name debtest -t smoketest-deb /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	./testdbs debtest
+	-docker kill debtest
+	-docker rm debtest
+
+build-rpm:
+	-docker rm rpmtest
+	docker build -t smoketest-rpm -f Dockerfile.rpm.build ../../
+	docker run -d --name rpmtest -t smoketest-rpm /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	./testdbs rpmtest
+	-docker kill rpmtest
+	-docker rm rpmtest
+
+build-inst:
+	-docker rm insttest
+	docker build -t smoketest-inst -f Dockerfile.inst.build ../../
+	docker run -d --name insttest -t smoketest-inst /build/tests/smoketest/docker-dev-entrypoint.sh db1 db2 db3 db4 db5
+	./testdbs insttest
+	-docker kill insttest
+	-docker rm insttest
+

--- a/tests/smoketest/db.conf
+++ b/tests/smoketest/db.conf
@@ -1,0 +1,7 @@
+comdb2_config:allow_pmux_route:true
+db1:172.17.0.2
+db2:172.17.0.2
+db3:172.17.0.2
+db4:172.17.0.2
+db5:172.17.0.2
+comdb2_config:default_type:docker

--- a/tests/smoketest/db.conf
+++ b/tests/smoketest/db.conf
@@ -1,7 +1,0 @@
-comdb2_config:allow_pmux_route:true
-db1:172.17.0.2
-db2:172.17.0.2
-db3:172.17.0.2
-db4:172.17.0.2
-db5:172.17.0.2
-comdb2_config:default_type:docker

--- a/tests/smoketest/docker-dev-entrypoint.sh
+++ b/tests/smoketest/docker-dev-entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+export PATH=$PATH:/opt/bb/bin/
+
+while [[ $1 = -* ]]; do
+    # TODO: handle options, if any, here
+    shift
+done
+
+pmux -l
+
+host=$(hostname -i)
+
+if [[ -f /opt/bb/etc/cdb2/config/comdb2.d/hostname.lrl ]]; then
+    for dbname in /opt/bb/var/cdb2/*; do 
+        dbname=${dbname##*/}
+        comdb2 $dbname > /opt/bb/var/log/$dbname.out 2>&1 &
+    done
+else 
+    echo "hostname $host" > /opt/bb/etc/cdb2/config/comdb2.d/hostname.lrl
+
+    for dbname in $*; do
+        comdb2 --create $dbname >/dev/null 2>&1 &
+    done
+    wait
+
+    for dbname in $*; do
+        comdb2 $dbname > /opt/bb/var/log/$dbname.out 2>&1 &
+    done
+fi
+
+(
+echo "#!/bin/bash"
+echo
+echo echo comdb2_config:allow_pmux_route:true
+for db in $*; do
+    echo "echo $db:$host"
+done 
+echo echo comdb2_config:default_type:docker
+) > /bin/cdb2config
+
+chmod +x /bin/cdb2config
+
+wait

--- a/tests/smoketest/testdbs
+++ b/tests/smoketest/testdbs
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+container=$1
+
+try=1
+while [[ $try -lt 30 ]] ; do 
+    echo "Getting config"
+    docker exec -ti $container /bin/cdb2config > db.conf
+    if [[ $? -eq 0 ]]; then
+        grep -q comdb2_config:default_type db.conf
+        if [[ $? -eq 0 ]]; then
+            export CDB2_CONFIG_FILE=db.conf
+            for db in $(seq 1 5); do
+                echo "Trying db${db}"
+                dbn=$(cdb2sql -tabs db${db} default 'select comdb2_dbname()' 2>/dev/null)
+                while [[ "$dbn" != "db$db" ]]; do
+                    if [[ $try -eq 30 ]]; then
+                        echo "Timed out!"
+                        exit 1
+                    fi
+                    sleep 1
+                    try=$(($try+1))
+                done
+                echo "Ok."
+            done
+            exit 0
+        fi
+    fi
+
+    sleep 1
+    try=$(($try+1))
+done
+exit 1


### PR DESCRIPTION
This tests that building and installing .deb and .rpm packages still works.  Also tests that after installing the packages or running make install a database can be brought up and a simple query works.  Would be good if roborivers can run this before running other tests - not much point testing if can't have an installable image.  Requires Docker, which is a pretty heavy requirement, but good for roborivers.