### PR TITLE
WIP: need to perform validation on database name

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1157,7 +1157,7 @@ enum {
 extern pthread_key_t bdb_key;
 
 char *bdb_strerror(int error);
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 
 void *mymalloc(size_t size);
 void myfree(void *ptr);

--- a/bdb/berktest.c
+++ b/bdb/berktest.c
@@ -16,7 +16,7 @@
 static DB_ENV *dbenv = NULL;
 static u_int32_t commit_delay_ms = 2;
 
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 
 /* Common among tables */
 typedef struct globalopts {
@@ -90,7 +90,7 @@ static int create_and_open(berktable_t *table)
 static void close_tables(berktable_t *tables, int tablecount)
 {
     int i, rc;
-    char new[100];
+    char new[PATH_MAX];
     berktable_t *table;
 
     for (i = 0; i < tablecount; i++) {
@@ -100,7 +100,7 @@ static void close_tables(berktable_t *tables, int tablecount)
                 logmsg(LOGMSG_ERROR, "%s close error: %d\n", __func__, rc);
                 continue;
             }
-            unlink(bdb_trans(table->name, new));
+            unlink(bdb_trans(table->name, new, sizeof(new)));
         }
     }
     free(tables);
@@ -110,14 +110,14 @@ static berktable_t *create_tables(int *tablecount)
 {
     berktable_t *tables = calloc(sizeof(berktable_t), 2), *table;
     u_int32_t uniq = getpid() * random();
-    char new[100];
+    char new[PATH_MAX];
     int count, rc;
 
     /* Index */
     count = 0;
     table = &tables[count];
     snprintf(table->name, sizeof(table->name), "XXX._berktest%d.index", uniq);
-    unlink(bdb_trans(table->name, new));
+    unlink(bdb_trans(table->name, new, sizeof(new)));
     table->pagesize = 4096;
     table->keysize = 13;
     table->datasize = 8;
@@ -131,7 +131,7 @@ static berktable_t *create_tables(int *tablecount)
     count++;
     table = &tables[count];
     snprintf(table->name, sizeof(table->name), "XXX._berktest%d.data", uniq);
-    unlink(bdb_trans(table->name, new));
+    unlink(bdb_trans(table->name, new, sizeof(new)));
     table->pagesize = 4096;
     table->keysize = 8;
     table->datasize = 12;

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -1112,8 +1112,8 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
 {
     int stripe, blobno, ix;
     int fd = -1;
-    char fname[512];
-    char tmpname[512];
+    char fname[PATH_MAX];
+    char tmpname[PATH_MAX];
     int numstripes, numblobs;
     int bdberr;
     unsigned int npages;
@@ -1126,7 +1126,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
             if (bdb_state->dbp_data[blobno][stripe]) {
                 if (bdb_get_data_filename(bdb_state, stripe, blobno, tmpname,
                                           sizeof(tmpname), &bdberr) == 0) {
-                    bdb_trans(tmpname, fname);
+                    bdb_trans(tmpname, fname, sizeof(fname));
                     fd = open(fname, O_RDONLY);
                     if (fd == -1) {
                         logmsg(LOGMSG_ERROR, "open(\"%s\") => %d %s\n", fname, errno,
@@ -1152,7 +1152,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
     for (ix = 0; ix < bdb_state->numix; ix++) {
         if (bdb_get_index_filename(bdb_state, ix, tmpname, sizeof(tmpname),
                                    &bdberr) == 0) {
-            bdb_trans(tmpname, fname);
+            bdb_trans(tmpname, fname, sizeof(fname));
             fd = open(fname, O_RDONLY);
             if (fd == -1) {
                 logmsg(LOGMSG_ERROR, "open(\"%s\") => %d %s\n", fname, errno,
@@ -1941,12 +1941,12 @@ static void bdb_queue_extent_info(FILE *out, bdb_state_type *bdb_state,
     char **names;
     int rc;
     int i;
-    char qname[4096];
+    char qname[PATH_MAX];
     char tran_name[128];
 
     snprintf(tran_name, sizeof(tran_name), "XXX.%s.queue", name);
 
-    bdb_trans(tran_name, qname);
+    bdb_trans(tran_name, qname, sizeof(qname));
 
     rc = __qam_extent_names(bdb_state->dbenv, qname, &names);
     if (rc) {

--- a/bdb/os_namemangle.c
+++ b/bdb/os_namemangle.c
@@ -48,7 +48,7 @@ int gbl_namemangle_loglevel = 0;
 
 #include <ctrace.h>
 
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 
 /*
 ** error: conflicting types for built-in function 'clogf'
@@ -80,8 +80,8 @@ int ___os_abspath(const char *path);
 int __os_abspath(const char *path)
 {
     int rc;
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     rc = ___os_abspath(pbuf);
     if (gbl_namemangle_loglevel > 1)
         clogf("__os_abspath(%s:%s) = %d\n", path, pbuf, rc);
@@ -91,8 +91,8 @@ int __os_abspath(const char *path)
 int ___os_dirlist(DB_ENV *dbenv, const char *dir, char ***namesp, int *cntp);
 int __os_dirlist(DB_ENV *dbenv, const char *dir, char ***namesp, int *cntp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(dir, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(dir, buf, sizeof(buf));
     int rc = ___os_dirlist(dbenv, pbuf, namesp, cntp);
     clogf("___os_dirlist(%s:%s) = %d\n", dir, pbuf, rc);
     return rc;
@@ -102,8 +102,8 @@ int __os_dirlist(DB_ENV *dbenv, const char *dir, char ***namesp, int *cntp)
 int ___os_exists(const char *path, int *isdirp);
 int __os_exists(const char *path, int *isdirp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_exists(pbuf, isdirp);
     if (gbl_namemangle_loglevel > 1)
         clogf("___os_exists(%s:%s) = %d\n", path, pbuf, rc);
@@ -115,8 +115,8 @@ int __os_exists(const char *path, int *isdirp)
 int ___os_exists(DB_ENV *dbenv, const char *path, int *isdirp);
 int __os_exists(DB_ENV *dbenv, const char *path, int *isdirp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_exists(dbenv, pbuf, isdirp);
     if (gbl_namemangle_loglevel > 1)
         clogf("___os_exists(%s:%s) = %d\n", path, pbuf, rc);
@@ -129,8 +129,8 @@ int ___os_open(DB_ENV *dbenv, const char *name, u_int32_t flags, int mode,
 int __os_open(DB_ENV *dbenv, const char *name, u_int32_t flags, int mode,
               DB_FH **fhpp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(name, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(name, buf, sizeof(buf));
     int rc = ___os_open(dbenv, pbuf, flags, 0664, fhpp);
     clogf("___os_open(%s:%s) = %d\n", name, pbuf, rc);
     return rc;
@@ -144,8 +144,8 @@ int __os_open_extend(DB_ENV *dbenv, const char *name, u_int32_t log_size,
                      u_int32_t page_size, u_int32_t flags, int mode,
                      DB_FH **fhpp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(name, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(name, buf, sizeof(buf));
     int rc =
         ___os_open_extend(dbenv, pbuf, log_size, page_size, flags, 0664, fhpp);
     clogf("___os_open_extend(%s:%s) = %d\n", name, pbuf, rc);
@@ -159,8 +159,8 @@ int ___os_open_extend(DB_ENV *dbenv, const char *name, u_int32_t page_size,
 int __os_open_extend(DB_ENV *dbenv, const char *name, u_int32_t page_size,
                      u_int32_t flags, int mode, DB_FH **fhpp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(name, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(name, buf, sizeof(buf));
     int rc = ___os_open_extend(dbenv, pbuf, page_size, flags, 0664, fhpp);
     clogf("___os_open_extend(%s:%s) = %d\n", name, pbuf, rc);
     return rc;
@@ -172,8 +172,8 @@ int ___os_openhandle(DB_ENV *dbenv, const char *name, int flags, int mode,
 int __os_openhandle(DB_ENV *dbenv, const char *name, int flags, int mode,
                     DB_FH **fhpp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(name, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(name, buf, sizeof(buf));
     int rc = ___os_openhandle(dbenv, pbuf, flags, mode, fhpp);
     clogf("___os_openhandle(%s:%s) = %d\n", name, pbuf, rc);
     return rc;
@@ -184,8 +184,8 @@ int ___os_fileid(DB_ENV *dbenv, const char *fname, int unique_okay,
 int __os_fileid(DB_ENV *dbenv, const char *fname, int unique_okay,
                 u_int8_t *fidp)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(fname, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(fname, buf, sizeof(buf));
     int rc = ___os_fileid(dbenv, pbuf, unique_okay, fidp);
     clogf("___os_fileid(%s:%s) = %d (*fidp = %u)\n", fname, pbuf, rc,
           (unsigned)*fidp);
@@ -197,10 +197,10 @@ int ___os_rename(DB_ENV *dbenv, const char *old, const char *new,
 int __os_rename(DB_ENV *dbenv, const char *old, const char *new,
                 u_int32_t flags)
 {
-    char old_path[256];
-    char new_path[256];
-    const char *pold = bdb_trans(old, old_path);
-    const char *pnew = bdb_trans(new, new_path);
+    char old_path[PATH_MAX];
+    char new_path[PATH_MAX];
+    const char *pold = bdb_trans(old, old_path, sizeof(old_path));
+    const char *pnew = bdb_trans(new, new_path, sizeof(new_path));
     int rc = ___os_rename(dbenv, pold, pnew, flags);
     clogf("___os_rename(%s:%s => %s:%s) = %d\n", old, pold, new, pnew, rc);
     return rc;
@@ -211,8 +211,8 @@ int ___os_ioinfo(DB_ENV *dbenv, const char *path, DB_FH *fhp,
 int __os_ioinfo(DB_ENV *dbenv, const char *path, DB_FH *fhp, u_int32_t *mbytesp,
                 u_int32_t *bytesp, u_int32_t *iosizep)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_ioinfo(dbenv, pbuf, fhp, mbytesp, bytesp, iosizep);
     clogf("___os_ioinfo(%s:%s) = %d\n", path, pbuf, rc);
     return rc;
@@ -221,8 +221,8 @@ int __os_ioinfo(DB_ENV *dbenv, const char *path, DB_FH *fhp, u_int32_t *mbytesp,
 int ___os_region_unlink(DB_ENV *dbenv, const char *path);
 int __os_region_unlink(DB_ENV *dbenv, const char *path)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_region_unlink(dbenv, pbuf);
     clogf("___os_region_unlink(%s:%s) = %d\n", path, pbuf, rc);
     return rc;
@@ -231,8 +231,8 @@ int __os_region_unlink(DB_ENV *dbenv, const char *path)
 int ___os_unlink(DB_ENV *dbenv, const char *path);
 int __os_unlink(DB_ENV *dbenv, const char *path)
 {
-    char buf[256];
-    const char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    const char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_unlink(dbenv, pbuf);
     clogf("__os_unlink(%s:%s) = %d\n", path, pbuf, rc);
     return rc;
@@ -243,8 +243,8 @@ int ___os_mapfile(DB_ENV *dbenv, char *path, DB_FH *fhp, size_t len,
 int __os_mapfile(DB_ENV *dbenv, char *path, DB_FH *fhp, size_t len,
                  int is_rdonly, void **addrp)
 {
-    char buf[256];
-    char *pbuf = bdb_trans(path, buf);
+    char buf[PATH_MAX];
+    char *pbuf = bdb_trans(path, buf, sizeof(buf));
     int rc = ___os_mapfile(dbenv, pbuf, fhp, len, is_rdonly, addrp);
     clogf("__os_mapfile(%s:%s) = %d\n", path, pbuf, rc);
     return rc;

--- a/bdb/os_namemangle_45.c
+++ b/bdb/os_namemangle_45.c
@@ -42,7 +42,7 @@
 
 #include <ctrace.h>
 
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 
 int ___os_abspath(const char *path);
 int __os_abspath(const char *path)

--- a/bdb/os_namemangle_46.c
+++ b/bdb/os_namemangle_46.c
@@ -52,7 +52,7 @@ static const char revid[] =
 
 #include <ctrace.h>
 
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 
 /* This is very, very verbose even at level 1.  Default to level 0. */
 int gbl_namemangle_loglevel = 0;

--- a/bdb/summarize.c
+++ b/bdb/summarize.c
@@ -125,8 +125,8 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
     DB_ENV *dbenv = bdb_state->dbenv;
     int is_hmac = CRYPTO_ON(dbenv);
     uint8_t pfxbuf[KEYBUF];
-    char tmpname[255];
-    char tran_tmpname[255];
+    char tmpname[PATH_MAX];
+    char tran_tmpname[PATH_MAX];
     int rc = 0;
     DB dbp_ = {0}, *dbp;
     PAGE *page = NULL;
@@ -182,7 +182,7 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
             rc = BDBERR_DEADLOCK;
         goto done;
     }
-    bdb_trans(tmpname, tran_tmpname);
+    bdb_trans(tmpname, tran_tmpname, sizeof(tran_tmpname));
     logmsg(LOGMSG_DEBUG, "open %s\n", tran_tmpname);
 
     fd = open(tran_tmpname, O_RDONLY);

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -22,6 +22,7 @@ static const char revid[] = "$Id: env_open.c,v 11.144 2003/09/13 18:39:34 bostic
 #include <stdarg.h>
 #endif
 #include <unistd.h>
+#include <limits.h>
 
 #include <plhash.h>
 #include "db_int.h"
@@ -1276,7 +1277,7 @@ __db_tmp_open(dbenv, tmp_oflags, path, fhpp)
 #include "dbinc/hmac.h"
 #include "dbinc_auto/hmac_ext.h"
 
-extern char *bdb_trans(const char infile[], char outfile[]);
+extern char *bdb_trans(const char infile[], char outfile[], size_t len);
 extern int ___os_openhandle(DB_ENV *dbenv, const char *name, int flags,
     int mode, DB_FH ** fhpp);
 extern int __os_closehandle(DB_ENV *dbenv, DB_FH * fhp);
@@ -1285,8 +1286,8 @@ int
 __checkpoint_open(DB_ENV *dbenv, const char *db_home)
 {
 	int ret = 0;
-	char buf[256];
-	char fname[256];
+	char buf[PATH_MAX];
+	char fname[PATH_MAX];
 	const char *pbuf;
 	struct __db_checkpoint ckpt = { 0 };
 	int niop = 0;
@@ -1294,7 +1295,7 @@ __checkpoint_open(DB_ENV *dbenv, const char *db_home)
 	size_t sz;
 
 	snprintf(fname, sizeof(fname), "%s/checkpoint", db_home);
-	pbuf = bdb_trans(fname, buf);
+	pbuf = bdb_trans(fname, buf, sizeof(buf));
 
 	ret =
 	    ___os_openhandle(dbenv, pbuf, O_SYNC | O_RDWR, 0666,

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -35,7 +35,7 @@ static const char revid[] = "$Id: mp_bh.c,v 11.86 2003/07/02 20:02:37 mjc Exp $"
 
 #include <logmsg.h>
 
-char *bdb_trans(const char infile[], char outfile[]);
+char *bdb_trans(const char infile[], char outfile[], size_t len);
 extern int gbl_test_badwrite_intvl;
 
 static int __memp_pgwrite
@@ -570,9 +570,9 @@ berkdb_verify_page_lsn_written_to_disk(DB_ENV *dbenv, DB_LSN *lsn)
 	DIR *d;
 	int filenum = 0;
 	struct dirent *ent;
-	char dir[512];
+	char dir[PATH_MAX];
 
-	bdb_trans(dbenv->db_home, dir);
+	bdb_trans(dbenv->db_home, dir, sizeof(dir));
 
 	pthread_mutex_lock(&verifylk);
 	d = opendir(dir);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -8852,6 +8852,38 @@ int check_current_schemas(void)
     return 0;
 }
 
+/**
+ * -- is_valid_dbname
+ * decides whether a given `dbname` is valid database name.
+ */
+int is_valid_dbname(const char *dbname) {
+	// cannot be null.
+	if(dbname == NULL) {
+		logmsg(LOGMSG_ERROR, "DATABASE NAME CANNOT BE EMPTY\n");
+		return -1;
+
+	}
+
+	// cannot be larger than `MAX_DBNAME_LENGTH`
+	size_t len;
+	len = strlen(dbname);
+	if (len >= MAX_DBNAME_LENGTH) {
+		logmsg(LOGMSG_ERROR, "INVALID DATABASE NAME, MUST BE < %d CHARACTERS\n", MAX_DBNAME_LENGTH);
+		return -1;
+	}
+	
+	// alphanumeric and _ are allowed.
+	const char *p = dbname;
+	while (*p++) {
+		if(!isalnum(*p) && *p != '_') {
+			logmsg(LOGMSG_ERROR, "DATABASE NAME CAN ONLY CONTAIN ALPHA NUMERIC CHARACTERS\n");
+			return -1;
+		}
+	}
+
+	return 0;
+}
+
 void log_delete_add_state(struct dbenv *dbenv, struct log_delete_state *state)
 {
     pthread_mutex_lock(&dbenv->log_delete_counter_mutex);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3344,6 +3344,7 @@ char *get_full_filename(char *path, int pathlen, enum dirtype type, char *name,
 int query_limit_cmd(char *line, int llen, int toff);
 
 int is_valid_tablename(char *tbl);
+int is_valid_dbname(const char *dbname);
 
 /* defined in toproxy.c */
 void reload_proxy_lrl_lines(char *lrlfile);


### PR DESCRIPTION
While attempting to create a database with 63 characters, I noticed that even though it is a valid length, it was flaking in an interesting way: the output claimed the database was created, but in reality, it wasn't.

I ran comdb2 with `strace ./comdb2 --create `perl -e "print 'h'x63"`` and noticed an odd `unlink` system call to `unlink("atas7")` and `unlink("atas6")`. I compared this against a normal execution, and noticed this was failing at the creation of `sqlite_stat_*.datas*` files.

This is a `WIP`, but I'm looking to improve on a few things:

- stronger validation for what constitutes a valid database name
- continue the usage of `PATH_MAX` found in newer code, since we have to worry not only about the length of the database name, but also the path it will reside
- we should probably get away from `unlink` and instead ask the client to remove the database if it exists? or introduce a `--force` flag? as it is, an attacker can traverse paths by providing a name that contains '..' for example.
- trying to see how we can finalize `is_valid_dbname`, and find the most suitable point to call it.


