### PR TITLE
db Fix bad LRL directives.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4999,11 +4999,11 @@ static int read_lrl_option(struct dbenv *dbenv, char *line, void *p, int len)
         if (rc != 0)
             return -1;
     } else if (tokcmp(line, ltok, "perfect_ckp") == 0) {
-        tok = segtok(line, sizeof(line), &st, &ltok);
+        tok = segtok(line, len, &st, &ltok);
         gbl_use_perfect_ckp = (ltok <= 0) ? 1 : toknum(tok, ltok);
     } else if (tokcmp(line, ltok, "memnice") == 0) {
         int nicerc;
-        tok = segtok(line, sizeof(line), &st, &ltok);
+        tok = segtok(line, len, &st, &ltok);
         nicerc = comdb2ma_nice((ltok <= 0) ? 1 : toknum(tok, ltok));
         if (nicerc != 0) {
             logmsg(LOGMSG_ERROR, "Failed to change mem niceness: rc = %d.\n",
@@ -5011,7 +5011,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line, void *p, int len)
             return -1;
         }
     } else if (tokcmp(line, ltok, "upd_null_cstr_return_conv_err") == 0) {
-        tok = segtok(line, sizeof(line), &st, &ltok);
+        tok = segtok(line, len, &st, &ltok);
         gbl_upd_null_cstr_return_conv_err = (tok <= 0) ? 1 : toknum(tok, ltok);
     } 
     else {

--- a/linearizable/linearizable.lrl
+++ b/linearizable/linearizable.lrl
@@ -45,7 +45,7 @@ setattr REP_WORKERS 0
 setattr STARTUP_SYNC_ATTEMPTS -1
 
 # Perfect checkpoints is also causing crashes.  Disable for now.
-no_perfect_ckp
+perfect_ckp 0
 
 # Don't run the watchdog thread
 nowatch


### PR DESCRIPTION
Also update linearizable.lrl as `no_perfeck_ckp' is replace by `perfeck_ckp 0'.