### PR TITLE
IO-less checkpoints.

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1500,7 +1500,7 @@ static int bdb_flush_int(bdb_state_type *bdb_state, int *bdberr, int force)
     start = time_epochms();
     rc = ll_checkpoint(bdb_state, force);
     if (rc != 0) {
-logmsg(LOGMSG_ERROR, "txn_checkpoint err %d\n", rc);
+        logmsg(LOGMSG_ERROR, "txn_checkpoint err %d\n", rc);
         *bdberr = BDBERR_MISC;
         return -1;
     }
@@ -8281,7 +8281,7 @@ void populate_deleted_files(bdb_state_type *bdb_state)
     DB_LSN lsn;
     DB_LSN prev_lsn;
     file_set_t *fs;
-    file_set_t *prev_fs;
+    file_set_t *prev_fs = NULL;
     int rc;
 
     logmsg(LOGMSG_INFO, "Checking for removed files\n");

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2065,7 +2065,6 @@ struct __db_env {
 	int				/* Sleep after writing max buffers. */
 			 mp_maxwrite_sleep;
 	double		 mp_multiple;	/* Multiplier for hash buckets. */
-	int		 mp_perfect_ckp;	/* 1: Use perfect ckp. 0: Don't */
 
 	/* Number of recovery pages for each backing DB_MPOOLFILE. */
 	int		 mp_recovery_pages;
@@ -2088,6 +2087,7 @@ struct __db_env {
 	u_int32_t	 tx_max;	/* Maximum number of transactions. */
 	time_t		 tx_timestamp;	/* Recover to specific timestamp. */
 	db_timeout_t	 tx_timeout;	/* Timeout for transactions. */
+	int		 tx_perfect_ckp;	/* 1: Use perfect ckp. 0: Don't */
 
 	/*******************************************************
 	 * Private: owned by DB.

--- a/berkdb/build/db_int.h
+++ b/berkdb/build/db_int.h
@@ -529,4 +529,16 @@ int __checkpoint_verify(DB_ENV *);
 #include <mem_override.h>
 #endif
 
+/* Perfect checkpoints */
+/* Global knob */
+extern int gbl_use_perfect_ckp;
+/*
+ * Thread-specific key to store DB_TXN when we do a txn_begin().
+ * It is cleared in txn_commit() and txn_abort().
+ * Alternatively I could make memp* functions take an extra
+ * (DB_TXN *) argument and consequently change 1000+ occurrences
+ * of these functions. Easy peasy.
+ */
+extern pthread_key_t txn_key;
+
 #endif /* !_DB_INTERNAL_H_ */

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -338,7 +338,9 @@ struct __bh {
 	db_pgno_t pgno;			/* Underlying MPOOLFILE page number. */
 	roff_t	  mf_offset;		/* Associated MPOOLFILE offset. */
 
-	DB_LSN first_dirty_lsn;		/* LSN when the page was marked dirty first time. */
+	/* The begin LSN of the transaction that
+	   marked the page from clean to dirty. */
+	DB_LSN first_dirty_tx_begin_lsn;
 
 	/*
 	 * !!!

--- a/berkdb/dbinc_auto/txn_ext.h
+++ b/berkdb/dbinc_auto/txn_ext.h
@@ -65,6 +65,7 @@ int __txn_init_print __P((DB_ENV *, int (***)(DB_ENV *, DBT *, DB_LSN *, db_reco
 int __txn_init_getpgnos __P((DB_ENV *, int (***)(DB_ENV *, DBT *, DB_LSN *, db_recops, void *), size_t *));
 int __txn_init_getallpgnos __P((DB_ENV *, int (***)(DB_ENV *, DBT *, DB_LSN *, db_recops, void *), size_t *));
 int __txn_init_recover __P((DB_ENV *, int (***)(DB_ENV *, DBT *, DB_LSN *, db_recops, void *), size_t *));
+DB_LSN __txn_get_first_dirty_begin_lsn __P((DB_LSN));
 void __txn_dbenv_create __P((DB_ENV *));
 int __txn_set_tx_max __P((DB_ENV *, u_int32_t));
 int __txn_regop_recover __P((DB_ENV *, DBT *, DB_LSN *, db_recops, void *));

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -943,7 +943,7 @@ __dbenv_refresh(dbenv, orig_flags, rep_check)
 		 */
 		{
 			if (F_ISSET(dbenv, DB_ENV_PRIVATE) &&
-			    (t_ret = __memp_sync(dbenv, NULL, NULL)) != 0 && ret == 0)
+			    (t_ret = __memp_sync(dbenv, NULL)) != 0 && ret == 0)
 				ret = t_ret;
 
 			if ((t_ret = __memp_dbenv_refresh(dbenv)) != 0 &&

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -1127,7 +1127,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		logc = NULL;
 
 		/* Flush everything to disk, we are losing the log. */
-		if ((ret = __memp_sync(dbenv, NULL, NULL)) != 0)
+		if ((ret = __memp_sync(dbenv, NULL)) != 0)
 			 goto err;
 
 		region->last_ckp = ((DB_TXNHEAD *)txninfo)->ckplsn;

--- a/berkdb/mp/mp_alloc.c
+++ b/berkdb/mp/mp_alloc.c
@@ -417,7 +417,7 @@ found:		if (offsetp != NULL)
 			case 5:
 			case 6:
 				(void)__memp_sync_int(dbenv, NULL, 0,
-				    DB_SYNC_ALLOC, NULL, 0, NULL);
+				    DB_SYNC_ALLOC, NULL, 0, NULL, 0);
 
 				sleeptime++;
 				if (__gbl_max_mpalloc_sleeptime &&

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -316,6 +316,7 @@ __memp_recover_page(dbmfp, hp, bhp, pgno)
 	int ret, i, pgidx, free_buf, ftype;
 	u_int32_t n_cache;
 	db_pgno_t inpg;
+	DB_TXN *thrtxn;
 
 	dbenv = dbmfp->dbenv;
 	mfp = dbmfp->mfp;
@@ -415,6 +416,10 @@ __memp_recover_page(dbmfp, hp, bhp, pgno)
 	atomic_inc(env, &c_mp->stat.st_page_dirty);
 	F_SET(bhp, BH_DIRTY);
 	F_CLR(bhp, BH_TRASH);
+
+	/* The page was clean before getting in here, so update the LSN. */
+    if (dbenv->tx_perfect_ckp)
+		bhp->first_dirty_tx_begin_lsn = __txn_get_first_dirty_begin_lsn(largest_lsn);
 
 	logmsg(LOGMSG_INFO, "Found recovery page %d lsn %d:%d at idx %d\n",
 	    pgno, largest_lsn.file, largest_lsn.offset, pgidx);
@@ -1096,12 +1101,9 @@ file_dead:
 			atomic_dec(env, &hp->hash_page_dirty);
 			atomic_dec(env, &c_mp->stat.st_page_dirty);
 
-			if (dbenv->mp_perfect_ckp) {
+			if (dbenv->tx_perfect_ckp) {
 				/* Clear first_dirty_lsn. */
-				bhp->first_dirty_lsn = (DB_LSN){
-					.file = UINT32_T_MAX,
-					.offset = UINT32_T_MAX
-				};
+				MAX_LSN(bhp->first_dirty_tx_begin_lsn);
 			}
 
 			F_CLR(bhp, BH_DIRTY | BH_DIRTY_CREATE);

--- a/berkdb/mp/mp_method.c
+++ b/berkdb/mp/mp_method.c
@@ -37,9 +37,6 @@ static int __memp_set_mp_recovery_pages __P((DB_ENV *, int));
 static pthread_once_t init_pgcompact_once = PTHREAD_ONCE_INIT;
 void __memp_init_pgcompact_routines(void);
 
-/* Global switch for perfect checkpoint. */
-int gbl_use_perfect_ckp = 1;
-
 /*
  * __memp_dbenv_create --
  *	Mpool specific creation of the DB_ENV structure.
@@ -67,8 +64,6 @@ __memp_dbenv_create(dbenv)
 	    32 * ((8 * 1024) + sizeof(BH)) + 37 * sizeof(DB_MPOOL_HASH);
 	dbenv->mp_ncache = 1;
 	dbenv->mp_multiple = 1.0;
-	/* Make a copy in the structure to improve locality. */
-	dbenv->mp_perfect_ckp = gbl_use_perfect_ckp;
 
 #ifdef HAVE_RPC
 	if (F_ISSET(dbenv, DB_ENV_RPCCLIENT)) {

--- a/berkdb/mp/mp_trickle.c
+++ b/berkdb/mp/mp_trickle.c
@@ -111,8 +111,10 @@ __memp_trickle(dbenv, pct, nwrotep, lru)
 		nwrotep = &wrote;
 	if (dbenv->iomap && dbenv->attr.iomap_enabled)
 		dbenv->iomap->memptrickle_active = time(NULL);
+	/* With perfect checkpoints it is unlikely to ensure the percentage
+	   of clean pages. So here we write all modified pages to disk. */
 	ret = __memp_sync_int(dbenv, NULL, n,
-	    lru ? DB_SYNC_LRU : DB_SYNC_TRICKLE, nwrotep, 1, NULL);
+	    lru ? DB_SYNC_LRU : DB_SYNC_TRICKLE, nwrotep, 1, NULL, 0);
 	if (dbenv->iomap && dbenv->attr.iomap_enabled)
 		dbenv->iomap->memptrickle_active = 0;
 

--- a/berkdb/qam/qam_files.c
+++ b/berkdb/qam/qam_files.c
@@ -445,7 +445,7 @@ __qam_fremove(dbp, pgnoaddr)
 	 * we scrub the buffers before we __memp_fclose-ing the MPF
 	 */
 	if ((ret = __memp_sync_int(dbenv, mpf, 0, DB_SYNC_REMOVABLE_QEXTENT,
-	    &wrote, 0, NULL)) != 0) {
+	    &wrote, 0, NULL, 0)) != 0) {
 		fprintf(stderr, "failure to sync removable extent! ret = %d\n",
 		    ret);
 		/* plunge ahead, hopefully there will be no race */
@@ -520,7 +520,7 @@ __qam_sync(dbp)
 	if (((QUEUE *)dbp->q_internal)->page_ext == 0)
 		return (__memp_fsync(mpf));
 	else
-		return (__memp_sync(dbenv, NULL, NULL));
+		return (__memp_sync(dbenv, NULL));
 }
 
 /*

--- a/berkdb/txn/txn_method.c
+++ b/berkdb/txn/txn_method.c
@@ -12,7 +12,9 @@ static const char revid[] = "$Id: txn_method.c,v 11.66 2003/06/30 17:20:30 bosti
 #endif /* not lint */
 
 #ifndef NO_SYSTEM_INCLUDES
+#include <stdlib.h>
 #include <sys/types.h>
+#include <pthread.h>
 
 #ifdef HAVE_RPC
 #include <rpc/rpc.h>
@@ -40,6 +42,60 @@ static int __txn_set_logical_start __P((DB_ENV *,
 static int __txn_set_logical_commit __P((DB_ENV *,
 	int (*)(DB_ENV *, void *, u_int64_t, DB_LSN *)));
 
+int gbl_use_perfect_ckp = 1;
+pthread_key_t txn_key;
+static pthread_once_t init_txn_key_once = PTHREAD_ONCE_INIT;
+
+/*
+ * __txn_init_key --
+ * Initialize txn_key which is used by pefect checkpoints.
+ */
+static void
+__txn_init_key(void)
+{
+	if (pthread_key_create(&txn_key, NULL) != 0) {
+		logmsgperror("pthread_key_create");
+		abort();
+	}
+}
+
+/*
+ * __txn_get_first_dirty_begin_lsn --
+ *  Return the begin LSN of the thread local DB_TXN object.
+ *  If there is no thread local DB_TXN object (out of the context
+ *  of any transactions or the work is transfered to another
+ *  thread of control), return the default LSN value.
+ *
+ *  I don't think passing or returning a DB_LSN pointer
+ *  is faster than simply using DB_LSN on 64-bit machines:
+ *  DB_LSN is only 8 bytes long - same size as a pointer.
+ *  Plus the caller does not need to take address of the argument
+ *  or dereference the return value.
+ *
+ * PUBLIC: DB_LSN __txn_get_first_dirty_begin_lsn __P((DB_LSN));
+ */
+DB_LSN
+__txn_get_first_dirty_begin_lsn(dfl)
+	DB_LSN dfl;
+{
+	DB_TXN *thrlcltxn = pthread_getspecific(txn_key);
+
+	if (thrlcltxn == NULL)
+		return (dfl);
+
+	if (thrlcltxn->parent != NULL) {
+		do {
+			thrlcltxn = thrlcltxn->parent;
+		} while (thrlcltxn->parent != NULL);
+
+		if (pthread_setspecific(txn_key, thrlcltxn) != 0) {
+			logmsgperror("pthread_setspecific");
+			abort();
+		}
+	}
+
+	return (thrlcltxn->we_start_at_this_lsn);
+}
 
 /*
  * __txn_dbenv_create --
@@ -57,7 +113,6 @@ __txn_dbenv_create(dbenv)
 	 * state or turn off mutex locking, and so we can neither check
 	 * the panic state or acquire a mutex in the DB_ENV create path.
 	 */
-
 	dbenv->tx_max = DEF_MAX_TXNS;
 
 #ifdef HAVE_RPC
@@ -91,6 +146,16 @@ __txn_dbenv_create(dbenv)
 		dbenv->set_logical_commit = __txn_set_logical_commit;
 		dbenv->txn_begin_set_retries = __txn_begin_set_retries_pp;
 	}
+
+	/* If we lazily initialize the key in __txn_begin(), Operations outside
+	   the context of any transaction before the 1st call to __txn_begin()
+	   may end up accessing an unintialized pthread key.
+	   There will be multiple __txn_dbenv_create() calls (e.g., temptables)
+	   thus it needs to be pthread_once. */
+	if (gbl_use_perfect_ckp)
+		pthread_once(&init_txn_key_once, __txn_init_key);
+	/* Make a copy in the structure to improve locality. */
+	dbenv->tx_perfect_ckp = gbl_use_perfect_ckp;
 }
 
 static int

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5573,5 +5573,3 @@ static void create_service_file(const char *lrlname)
 }
 
 #undef QUOTE
-
-/* vim: set sw=4 ts=4 et: */

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2294,6 +2294,7 @@ int process_command(struct dbenv *dbenv, char *line, int lline, int st)
     } else if (tokcmp(tok, ltok, "ckp_sleep_before_sync") == 0) {
         /* Don't document the msgtrap -
            it is for debugging/testing only. */
+        extern int gbl_ckp_sleep_before_sync;
         tok = segtok(line, lline, &st, &ltok);
         gbl_ckp_sleep_before_sync = (ltok != 0) ? toknum(tok, ltok) : 5;
         logmsg(LOGMSG_USER, "gbl_ckp_sleep_before_sync is now %d milliseconds\n",

--- a/tests/perfect_ckp.test/lrl.options
+++ b/tests/perfect_ckp.test/lrl.options
@@ -1,2 +1,12 @@
 setattr MASTER_REJECT_REQUESTS 0
-perfect_ckp
+perfect_ckp 1
+## Don't auto checkpoint
+setattr CHECKPOINTTIME 600
+
+## The following LRL options make the effect of perfect checkpoints more obvious.
+## They are *not* required under perfect checkpoints. 
+
+## disable trickle
+setattr MEMPTRICKLEPERCENT 0
+## have a large enough buffer pool
+cache 16 mb

--- a/tests/perfect_ckp.test/runit
+++ b/tests/perfect_ckp.test/runit
@@ -19,6 +19,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
+####### Step 1: Prepare table ######
 dbnm=$1
 tier=$2
 pgrep -a comdb2
@@ -33,6 +34,7 @@ echo Creating table
 cdb2sql ${CDB2_OPTIONS} $dbnm $tier "drop table t" >/dev/null
 cdb2sql ${CDB2_OPTIONS} $dbnm $tier "create table t { tag ondisk {int i} }" >/dev/null
 
+###### Step 2: Start background writers ######
 echo Inserting 10k records
 i=0
 while [ $i -lt 10000 ] ; do
@@ -49,7 +51,7 @@ while [ $loop -lt 4 ]; do
     loop=$((loop + 1))
 done
 
-
+###### Step 3: main loop for checkpoints ######
 echo Testing perfect checkpoint on master node
 
 master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm $tier 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
@@ -61,23 +63,21 @@ fi
 echo "MASTER is $master"
 
 loop=0
-success=0
+# Flush buffer pool and force a checkpoint before entering the main loop.
+cdb2sql ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("flush")'
 gbl_before=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
 gbl_sync_before=`echo "$gbl_before" | head -1`
 gbl_skip_before=`echo "$gbl_before" | tail -1`
+
 while [ $loop -lt 20 ]; do
     before=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("flush")'
-    after=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm $tier 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb checkpoint")'
+    after=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
 
     sync_before=`echo "$before" | head -1`
     skip_before=`echo "$before" | tail -1`
     sync_after=`echo "$after" | head -1`
     skip_after=`echo "$after" | tail -1`
-
-    if [ $skip_after -gt $skip_before ]; then
-        success=$((success + 1))
-    fi
 
     loop=$((loop + 1))
     sync_delta=$((sync_after - sync_before))
@@ -90,10 +90,10 @@ while [ $loop -lt 20 ]; do
     fi
 
     echo "$loop: I/O optimized by $skip_ratio percent"
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm $tier 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages
     sleep 1
 done
-gbl_after=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm $tier 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
+gbl_after=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages | cut -d' ' -f2`
 gbl_sync_after=`echo "$gbl_after" | head -1`
 gbl_skip_after=`echo "$gbl_after" | tail -1`
 
@@ -102,6 +102,7 @@ gbl_skip_delta=$((gbl_skip_after - gbl_skip_before))
 gbl_tot_delta=$((gbl_sync_delta + gbl_skip_delta))
 gbl_skip_ratio=0
 
+###### Step 4: Collect stats ######
 if [ $gbl_tot_delta -ne 0 ]; then
     gbl_skip_ratio=`echo "$gbl_skip_delta/$gbl_tot_delta*100" | bc -l`
 fi
@@ -112,19 +113,23 @@ echo Killing all background threads
 echo "kill $bgids"
 kill -9 $bgids
 
-if [ $success -eq 0 ]; then
-    echo 'st_ckp_pages_skip did not increase.' >&2
+# use bc -l to do floating point math.
+success=`echo "$gbl_skip_ratio - 100" | bc -l`
+if [ "$success" != "0" ]; then
+    echo 'Imperfect checkpoints???' >&2
     echo 'FAILED.' >&2
     exit 1
 fi
 
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm $tier 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb cachestat")' | grep st_ckp_pages
 
+# TODO XXX FIXME cluster test
 if [ ! -z "$CLUSTER" ]; then
     echo 'Passed'
     exit 0
 fi
 
+###### Step 5: bounce db to verify recovery ######
 echo Killing database
 kill -9 $pid
 
@@ -152,14 +157,28 @@ while [ $outloop -lt 20 ]; do
             if [ $n -ne 2500 ]; then
                 echo 'Data mismatch. FAILED.' >&2
                 kill -9 $pid
+                rm -f /tmp/_perfect_ckp.$$
                 exit 1
             fi
             loop=$((loop + 1))
         done
 
+
+        good=`cdb2sql ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.verify('t')" | grep -i 'succeed'`
+        echo $good
         kill -9 $pid
+        rm -f /tmp/_perfect_ckp.$$
+        if [ "$good" = "" ]; then
+            echo 'Failed to verify table t.'
+            exit 1
+        fi
+
         echo 'Passed.'
         exit 0
     fi
     sleep 10
 done
+echo "Failed to bring up the db. log at /tmp/_perfect_ckp.$$"
+kill -9 $pid
+rm -f /tmp/_perfect_ckp.$$
+exit 1


### PR DESCRIPTION
With perfect checkpoints, we only sync pages with first-dirty-LSN less than
a checkpoint LSN. Mark came up with this absolutely IO-less checkpoints idea
on top of perfeck checkpoints: instead of using the begin LSN of the oldest
active transaction as the checkpoint LSN, we find the oldest transaction
(not necessarily active) which first marked a page dirty among all modified
pages in the buffer pool, and use the begin LSN of that transaction as the
checkpoint LSN. Therefore we don't need to flush anything because all dirty
pages' LSN-s will be greater than the checkpoint LSN.

The only downside is that recovery takes more time under IO-less checkpoints.