### PR TITLE
disable skip scan for remote sql

### DIFF
--- a/sqlite/analyze.c
+++ b/sqlite/analyze.c
@@ -1635,7 +1635,8 @@ static void decodeIntArray(
 #endif
   {
     pIndex->bUnordered = 0;
-    pIndex->noSkipScan = 0;
+    /* COMDB2 MODIFICATION */
+    /* pIndex->noSkipScan = 0; */
     if( strcmp(z, "unordered")==0 ){
       pIndex->bUnordered = 1;
     }else if( sqlite3_strglob("sz=[0-9]*", z)==0 ){
@@ -1698,12 +1699,16 @@ static int analysisLoader(void *pData, int argc, char **argv, char **NotUsed){
     pIndex->bUnordered = 0;
     decodeIntArray((char*)z, nCol, aiRowEst, pIndex->aiRowLogEst, pIndex);
     if( pIndex->pPartIdxWhere==0 ) pTable->nRowLogEst = pIndex->aiRowLogEst[0];
-    /* COMDB2 MODIFICATION: assign noskipscan parameter */ 
-    pIndex->noSkipScan = is_comdb2_index_disableskipscan(pTable->zName, pIndex->zName);
+    /* COMDB2 MODIFICATION: assign noskipscan parameter, only if not disabled 
+    ** already.  */ 
+    if( !pIndex->noSkipScan ){
+      pIndex->noSkipScan = is_comdb2_index_disableskipscan(pTable->zName, 
+                                                           pIndex->zName);
 #ifdef DEBUG
-    if(pIndex->noSkipScan)
+      if(pIndex->noSkipScan)
         printf("SET INDEX %s.%s noskipscan\n", pTable->zName, pIndex->zName);
 #endif
+    }
 
 #ifndef SQLITE_BUILDING_FOR_COMDB2
   /* COMDB2 MODIFICATION

--- a/sqlite/build.c
+++ b/sqlite/build.c
@@ -3676,8 +3676,8 @@ void sqlite3CreateIndex(
     if( db->init.iDb > 1 ){
       extern int gbl_fdb_track;
       if (gbl_fdb_track)
-        fprintf(stderr, "XXX: no skip-scan for remote index %s:%s\n", 
-                pIndex->pTable->zName, pIndex->zName);
+        logmsg(LOGMSG_DEBUG, "XXX: no skip-scan for remote index %s:%s\n", 
+               pIndex->pTable->zName, pIndex->zName);
       pIndex->noSkipScan  = 1;
     } else {
       pIndex->noSkipScan = 0;

--- a/sqlite/build.c
+++ b/sqlite/build.c
@@ -3670,6 +3670,19 @@ void sqlite3CreateIndex(
     Index *p;
     assert( !IN_DECLARE_VTAB );
     assert( sqlite3SchemaMutexHeld(db, 0, pIndex->pSchema) );
+    
+    /* COMDB2 MODIFICATION */
+    /* remote indexes don't use skip-scan indexes */
+    if( db->init.iDb > 1 ){
+      extern int gbl_fdb_track;
+      if (gbl_fdb_track)
+        fprintf(stderr, "XXX: no skip-scan for remote index %s:%s\n", 
+                pIndex->pTable->zName, pIndex->zName);
+      pIndex->noSkipScan  = 1;
+    } else {
+      pIndex->noSkipScan = 0;
+    }
+
     p = sqlite3HashInsert(&pIndex->pSchema->idxHash, 
                           pIndex->zName, pIndex);
     if( p ){


### PR DESCRIPTION
The skip scan is almost always more expensive for remote sql, as shown in a few production runs.  This change will disable it.