### PR TITLE
SSL: Reuse existing connections when server requires SSL.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -545,6 +545,16 @@ public class BBSysUtils {
             hndl.myDbPorts.add(hndl.overriddenPort);
         }
 
+        if (hndl.isDirectCpu) {
+            for (int i = 0; i != hndl.myDbPorts.size(); ++i) {
+                if (hndl.myDbPorts.get(i) == -1) {
+                    hndl.myDbPorts.set(i, getPortMux(hndl.myDbHosts.get(i),
+                                hndl.portMuxPort, "comdb2", "replication", hndl.myDbName));
+                }
+            }
+            return;
+        }
+
         /******************************************
          * If no hosts defined, we have to query comdb2db to get necessary
          * information.

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -7273,9 +7273,12 @@ retry_read:
             }
         }
 
-        if (client_supports_ssl)
-            send_dbinforesponse(sb);
-        else {
+        if (client_supports_ssl) {
+            newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE_SSL,
+                                  NULL, 1 , malloc, __func__, __LINE__);
+            /* Client is going to reuse the connection. Don't drop it. */
+            goto retry_read;
+        } else {
             char *err = "The database requires SSL connections.";
             struct fsqlresp resp;
             bzero(&resp, sizeof(resp));

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -77,6 +77,7 @@ enum ResponseHeader {
    SQL_RESPONSE_PING = 1007; // SQL_RESPONSE + requesting ack
    SQL_RESPONSE_PONG = 1008;
    SQL_RESPONSE_TRACE = 1009;
+   SQL_RESPONSE_SSL = 1010; // SSL header + empty payload to trigger client SSL
 }
 
 enum ResponseType {

--- a/tests/simple_ssl.test/runit
+++ b/tests/simple_ssl.test/runit
@@ -61,4 +61,14 @@ if [ $cnt = 0 ]; then
   exit 1
 fi
 
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()"`
+if [ "$host" != "" ]; then
+    numconnect=`CDB2_DEBUG=1 cdb2sql ${CDB2_OPTIONS} $dbnm --host $host 'select 1' 2>&1 | grep -c 'fd -1'`
+    if [ "$numconnect" != "1" ]; then
+        echo "Should only connect once but attempted to connect $numconnect times."
+        exit 1
+    fi
+fi
+
+
 echo "Passed."


### PR DESCRIPTION
Currently client APIs drop the plaintext connection and start a new SSL connection to server, if server requires SSL.
The SSL negotiation, however, can be more efficient by reusing the same connection.