### PR TITLE
cdb2jdbc: Support typed statements.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2MetaData.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2MetaData.java
@@ -118,10 +118,8 @@ public class Comdb2MetaData implements ResultSetMetaData {
         return "";
     }
 
-    @Override
-    public int getColumnType(int column) throws SQLException {
-        --column; /* zero-based */
-        switch (hndl.columnType(column)) {
+    public static int comdb2ToSql(int type) {
+        switch (type) {
             case Types.CDB2_INTEGER:
                 return java.sql.Types.BIGINT;
             case Types.CDB2_REAL:
@@ -133,9 +131,69 @@ public class Comdb2MetaData implements ResultSetMetaData {
                 return java.sql.Types.TIMESTAMP;
             case Types.CDB2_BLOB:
                 return java.sql.Types.BLOB;
-            default:
-                return java.sql.Types.OTHER;
         }
+        return java.sql.Types.OTHER;
+    }
+
+    public static int sqlToComdb2(int type) {
+        switch (type) {
+            case java.sql.Types.BIGINT:
+            case java.sql.Types.BOOLEAN:
+            case java.sql.Types.INTEGER:
+            case java.sql.Types.SMALLINT:
+            case java.sql.Types.TINYINT:
+                return Types.CDB2_INTEGER;
+
+            case java.sql.Types.DOUBLE:
+            case java.sql.Types.FLOAT:
+            case java.sql.Types.REAL:
+                return Types.CDB2_REAL;
+
+            case java.sql.Types.ARRAY:
+            case java.sql.Types.BINARY:
+            case java.sql.Types.BIT:
+            case java.sql.Types.BLOB:
+            case java.sql.Types.CLOB:
+            case java.sql.Types.DATALINK:
+            case java.sql.Types.JAVA_OBJECT:
+            case java.sql.Types.LONGVARBINARY:
+            case java.sql.Types.NCLOB:
+            case java.sql.Types.VARBINARY:
+                return Types.CDB2_BLOB;
+
+            case java.sql.Types.DATE:
+            case java.sql.Types.TIME:
+                /* Date and Time are millisecond precision. */
+                return Types.CDB2_DATETIME;
+            case java.sql.Types.TIMESTAMP:
+                /* Date and Time are nanosecond precision. */
+                return Types.CDB2_DATETIMEUS;
+
+            case java.sql.Types.CHAR:
+            case java.sql.Types.DECIMAL:
+            case java.sql.Types.DISTINCT:
+            case java.sql.Types.LONGNVARCHAR:
+            case java.sql.Types.LONGVARCHAR:
+            case java.sql.Types.NCHAR:
+            case java.sql.Types.NULL:
+            case java.sql.Types.NUMERIC:
+            case java.sql.Types.NVARCHAR:
+            case java.sql.Types.OTHER:
+            case java.sql.Types.REF:
+            case java.sql.Types.ROWID:
+            case java.sql.Types.SQLXML:
+            case java.sql.Types.STRUCT:
+            case java.sql.Types.VARCHAR:
+                return Types.CDB2_CSTRING;
+        }
+        return Types.CDB2_CSTRING;
+    }
+
+
+    @Override
+    public int getColumnType(int column) throws SQLException {
+        --column; /* zero-based */
+        return comdb2ToSql(hndl.columnType(column));
     }
 
     @Override

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -21,6 +21,7 @@ import java.sql.Statement;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.*;
 
 /**
  * @author Rivers Zhang
@@ -66,6 +67,10 @@ public class Comdb2Statement implements Statement {
 
     @Override
     public ResultSet executeQuery(String sql) throws SQLException {
+        return executeQuery(sql, null);
+    }
+
+    public ResultSet executeQuery(String sql, List<Integer> types) throws SQLException {
         int rc;
         String locase = sql.toLowerCase().trim();
 
@@ -118,7 +123,14 @@ public class Comdb2Statement implements Statement {
             }
         }
 
-        if ( (rc = hndl.runStatement(sql)) != 0 )
+        List<Integer> cdb2types = null;
+        if (types != null) {
+            cdb2types = new ArrayList<Integer>();
+            for (Integer elem : types)
+                cdb2types.add(Comdb2MetaData.sqlToComdb2(elem));
+        }
+
+        if ( (rc = hndl.runStatement(sql, cdb2types)) != 0 )
             throw Comdb2Connection.createSQLException(
                     hndl.errorString(), rc, sql, hndl.getLastThrowable());
 

--- a/docs/pages/programming/jdbc_api.md
+++ b/docs/pages/programming/jdbc_api.md
@@ -288,6 +288,48 @@ jdbc:comdb2//<hostname>/<database>?trust_store=<path/to/jks>&trust_store_passwor
 ```
 
 
+## Comdb2 Extensions to the JDBC API
+
+### Executing Typed Queries
+
+A typed query gives applications more control over return types.
+The database will coerce the types of the resulting columns to the types specified by the application.
+If the types aren’t compatible, an exception will be thrown.
+
+To access the extension, you would need to cast the `java.sql.Statement` object to `com.bloomberg.comdb2.jdbc.Comdb2Statement`.
+For example:
+
+```java
+conn = DriverManager.getConnection("jdbc:comdb2:/localhost/testdb");
+stmt = conn.createStatement();
+comdb2stmt = (Comdb2Statement)stmt;
+String sql = "select now()";
+rset = comdb2stmt.executeQuery(sql, Arrays.asList(java.sql.Types.VARCHAR));
+```
+
+In the example above, the row will come back as a `java.lang.String` instead of a `java.sql.TIMESTAMP`.
+
+
+### Using Intervals
+
+JDBC standard does not define data types for intervals. You could work it around using Comdb2 interval types.
+For example, to bind an INTERVALDS (interval day to second) value, you would use:
+
+```
+// Load driver, get connection and create a parepared statement...
+// bind an interval year-month (+3 mon)
+stmt.setObject(1, new Cdb2Types.IntervalYearMonth(1, 0, 3));
+```
+
+### Using Named Parameters for PreparedStatement
+
+Comdb2 has built-in support for named parameters. You would simply use `@param_name` instead of `?` in your queries:
+
+```
+PreparedStatement stmt = conn.prepareStatement("insert into employee values (@id, @firstname, @lastname)");
+```
+
+
 ## Java and Comdb2 Types
 
 The table below shows the conversions between Java and Comdb2 types.


### PR DESCRIPTION
JDBC standard does not define such a function. Therefore we add it as an extension.