### PR TITLE
fix readonly select error when temptables are created

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1595,7 +1595,7 @@ int sql_cancelled_transaction(struct ireq *iq)
 {
     int rc;
 
-    logmsg(LOGMSG_WARN, "%s: cancelled transaction\n", __func__);
+    logmsg(LOGMSG_DEBUG, "%s: cancelled transaction\n", __func__);
     rc = osql_bplog_free(iq, 1, __func__, NULL, 0);
 
     if (iq->p_buf_orig) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3902,7 +3902,9 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
         pCur->nwrite++;
     }
 
-    if (clnt->is_readonly) {
+    if (clnt->is_readonly &&
+        /* exclude writes in a temp table for a select */
+        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || clnt->iswrite)){
         errstat_set_strf(&clnt->osql.xerr, "SET READONLY ON for the client");
         rc = SQLITE_ACCESS;
         goto done;
@@ -8484,7 +8486,9 @@ int sqlite3BtreeInsert(
 
     assert(0 == pCur->is_sampled_idx);
 
-    if (clnt->is_readonly) {
+    if (clnt->is_readonly &&
+        /* exclude writes in a temp table for a select */
+        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || clnt->iswrite)){
         errstat_set_strf(&clnt->osql.xerr, "SET READONLY ON for the client");
         rc = SQLITE_ACCESS;
         goto done;

--- a/tests/readonly/Makefile
+++ b/tests/readonly/Makefile
@@ -1,0 +1,2 @@
+include $(TESTSROOTDIR)/testcase.mk
+export TEST_TIMEOUT=3m

--- a/tests/readonly/lrl.options
+++ b/tests/readonly/lrl.options
@@ -1,0 +1,3 @@
+table t t.csc2
+
+dtastripe 4

--- a/tests/readonly/output.txt
+++ b/tests/readonly/output.txt
@@ -1,0 +1,30 @@
+cdb2sql> insert into t values (40)
+(rows inserted=1)
+[insert into t values (40)] rc 0
+cdb2sql> insert into t values (20)
+(rows inserted=1)
+[insert into t values (20)] rc 0
+cdb2sql> insert into t values (30)
+(rows inserted=1)
+[insert into t values (30)] rc 0
+cdb2sql> insert into t values (10)
+(rows inserted=1)
+[insert into t values (10)] rc 0
+cdb2sql> insert into t values (50)
+(rows inserted=1)
+[insert into t values (50)] rc 0
+cdb2sql> select * from t order by id limit 4
+(id=10)
+(id=20)
+(id=30)
+(id=40)
+[select * from t order by id limit 4] rc 0
+cdb2sql> set readonly on
+[set readonly on] rc 0
+cdb2sql> select * from t order by id limit 4
+(id=10)
+(id=20)
+(id=30)
+(id=40)
+[select * from t order by id limit 4] rc 0
+cdb2sql> 

--- a/tests/readonly/output2.txt
+++ b/tests/readonly/output2.txt
@@ -1,0 +1,7 @@
+[insert into t values (1)] failed with rc -106 SET READONLY ON for the client
+[update t set id=id+1 limit 1] failed with rc -106 SET READONLY ON for the client
+cdb2sql> set readonly on
+[set readonly on] rc 0
+cdb2sql> insert into t values (1)
+cdb2sql> update t set id=id+1 limit 1
+cdb2sql> 

--- a/tests/readonly/reqoutput.txt
+++ b/tests/readonly/reqoutput.txt
@@ -1,0 +1,30 @@
+cdb2sql> insert into t values (40)
+(rows inserted=1)
+[insert into t values (40)] rc 0
+cdb2sql> insert into t values (20)
+(rows inserted=1)
+[insert into t values (20)] rc 0
+cdb2sql> insert into t values (30)
+(rows inserted=1)
+[insert into t values (30)] rc 0
+cdb2sql> insert into t values (10)
+(rows inserted=1)
+[insert into t values (10)] rc 0
+cdb2sql> insert into t values (50)
+(rows inserted=1)
+[insert into t values (50)] rc 0
+cdb2sql> select * from t order by id limit 4
+(id=10)
+(id=20)
+(id=30)
+(id=40)
+[select * from t order by id limit 4] rc 0
+cdb2sql> set readonly on
+[set readonly on] rc 0
+cdb2sql> select * from t order by id limit 4
+(id=10)
+(id=20)
+(id=30)
+(id=40)
+[select * from t order by id limit 4] rc 0
+cdb2sql> 

--- a/tests/readonly/reqoutput2.txt
+++ b/tests/readonly/reqoutput2.txt
@@ -1,0 +1,7 @@
+[insert into t values (1)] failed with rc -106 SET READONLY ON for the client
+[update t set id=id+1 limit 1] failed with rc -106 SET READONLY ON for the client
+cdb2sql> set readonly on
+[set readonly on] rc 0
+cdb2sql> insert into t values (1)
+cdb2sql> update t set id=id+1 limit 1
+cdb2sql> 

--- a/tests/readonly/runit
+++ b/tests/readonly/runit
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+dbnm=$1
+#cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - > output.txt 2>&1
+cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm local - > output.txt 2>&1
+insert into t values (40)
+insert into t values (20)
+insert into t values (30)
+insert into t values (10)
+insert into t values (50)
+select * from t order by id limit 4
+set readonly on
+select * from t order by id limit 4
+EOF
+
+df=`diff output.txt reqoutput.txt`
+if [ $? -ne 0 ] ; then
+    echo "Failed"
+    exit 1
+fi 
+
+cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm local - > output2.txt 2>&1 
+set readonly on
+insert into t values (1)
+update t set id=id+1 limit 1
+EOF
+
+df=`diff output2.txt reqoutput2.txt`
+if [ $? -ne 0 ] ; then
+    echo "Failed"
+    exit 1
+fi 
+
+echo "Success"

--- a/tests/readonly/t.csc2
+++ b/tests/readonly/t.csc2
@@ -1,0 +1,4 @@
+schema
+{
+   int  id
+}


### PR DESCRIPTION
Queries that need to write to a temptable should be allowed.
Example:
"select * from T order by C limit N"
