### PR TITLE
have debg reqlog be printed with LOG_USER level

### DIFF
--- a/bb/logmsg.c
+++ b/bb/logmsg.c
@@ -48,6 +48,8 @@ static int level_to_syslog(loglvl lvl) {
             return LOG_DEBUG;
         case LOGMSG_INFO:
             return LOG_INFO;
+        case LOGMSG_USER:
+            return LOG_USER;
         case LOGMSG_WARN:
             return LOG_WARNING;
         case LOGMSG_ERROR:
@@ -71,7 +73,10 @@ static char *logmsg_level_str(int lvl)
     }
 }
 
-static int logmsgv_lk(loglvl lvl, const char *fmt, va_list args) {
+static int logmsgv_lk(loglvl lvl, const char *fmt, va_list args) 
+{
+    if(!fmt) return 0;
+
     char *msg;
     char timestamp[200];
     va_list argscpy;

--- a/bb/logmsg.c
+++ b/bb/logmsg.c
@@ -48,8 +48,6 @@ static int level_to_syslog(loglvl lvl) {
             return LOG_DEBUG;
         case LOGMSG_INFO:
             return LOG_INFO;
-        case LOGMSG_USER:
-            return LOG_USER;
         case LOGMSG_WARN:
             return LOG_WARNING;
         case LOGMSG_ERROR:

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -222,7 +222,7 @@ static void flushdump(struct reqlogger *logger, struct output *out)
         niov++;
         if (out == default_out) {
             for (int i = 0; i < niov; i++)
-                logmsg(LOGMSG_INFO, iov[i].iov_base);
+                logmsg(LOGMSG_USER, iov[i].iov_base);
         } else {
             int dum = writev(out->fd, iov, niov);
         }


### PR DESCRIPTION
It currently is set to LOG_INFO and does not show up
with default logging level.