### PR TITLE
sqlite: Assertion fault in STAT4 on a double-negation.

### DIFF
--- a/sqlite/vdbemem.c
+++ b/sqlite/vdbemem.c
@@ -1611,7 +1611,7 @@ static int valueFromExpr(
     }
   }else if( op==TK_UMINUS  ){
     /* This branch happens for multiple negative signs.  Ex: -(-5) */
-    if( SQLITE_OK==sqlite3ValueFromExpr(db,pExpr->pLeft,enc,affinity,&pVal) 
+    if( SQLITE_OK==valueFromExpr(db,pExpr->pLeft,enc,affinity,&pVal,pCtx) 
      && pVal!=0
     ){
       sqlite3VdbeMemNumerify(pVal);

--- a/tests/yast_r7.test/analyze1.test
+++ b/tests/yast_r7.test/analyze1.test
@@ -346,6 +346,19 @@ do_test analyze-5.5 {
     "
 } {{$T4I1_EFB47759} {$T4I2_98B347CF} t4}
 
+# Ticket [cfa2c908f218254d7be64aa4b8fa55ba4df20853] 2017-06-13
+# Assertion fault in STAT4 on a double-negation.
+#
+do_test analyze-6.0 {
+    execsql {
+      CREATE TABLE t5(x);
+      CREATE INDEX t5x ON t5(x);
+      INSERT INTO t5 VALUES(1),(2),(3);
+      ANALYZE;
+      SELECT x FROM t5 WHERE x = -(-1);
+    }
+} {1}
+
 # This test corrupts the database file so it must be the last test
 # in the series.
 #


### PR DESCRIPTION
The bug is reported upstream (See https://www.sqlite.org/src/info/cfa2c908f2182).