### PR TITLE
Install comdb2ar and cdb2_sqlreplay from debian package

### DIFF
--- a/deb/postrm
+++ b/deb/postrm
@@ -4,4 +4,4 @@
 set -e 
 
 # remove linked binaries
-rm -f /opt/bb/bin/cdb2_dump /opt/bb/bin/cdb2_printlog /opt/bb/bin/cdb2_sqlreplay /opt/bb/bin/cdb2_stat /opt/bb/bin/cdb2_verify /opt/bb/bin/comdb2ar
+rm -f /opt/bb/bin/cdb2_dump /opt/bb/bin/cdb2_printlog /opt/bb/bin/cdb2_stat /opt/bb/bin/cdb2_verify


### PR DESCRIPTION
They were being removed by the postrm package script