### PR TITLE
fix build issue

### DIFF
--- a/tools/module.mk
+++ b/tools/module.mk
@@ -30,12 +30,12 @@ cdb2sql: tools_LDLIBS+=$(LIBREADLINE)
 cdb2sql: $(cdb2sql_OBJS)
 	$(CC) $(tools_LDFLAGS) $^ $(tools_LDLIBS) -o $@
 
-cdb2replay_OBJS:=tools/cdb2_sqlreplay/cdb2_sqlreplay.o
+cdb2replay_OBJS:=cdb2_sqlreplay.o
 cdb2replay_CFLAGS=-Icson
 cdb2replay_LDLIBS=-Lcson -lcson -Lcdb2api -l:libcdb2api.a -Lprotobuf   \
                   -lssl -lcrypto -lz -lpthread
 
-$(cdb2replay_OBJS): %.o: %.cpp $(LIBS_BIN)
+$(cdb2replay_OBJS): tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp $(LIBS_BIN)
 	$(CXX11) $(CPPFLAGS) $(tools_CPPFLAGS) $(cdb2replay_CFLAGS) $(CXX11FLAGS) -c $< -o $@
 
 cdb2_sqlreplay: $(cdb2replay_OBJS)


### PR DESCRIPTION
to fix build error:

make: *** No rule to make target 'tools/cdb2_sqlreplay/cdb2_sqlreplay.c', needed by 'tools/cdb2_sqlreplay/cdb2_sqlreplay.o'.  Stop.