### PR TITLE
Don't grab the bdb lock in trigger_unregister_node

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2813,7 +2813,7 @@ again:
         if (i == count) {
             /* no longer connected to this node */
             Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
-            trigger_unregister_node_lk(host);
+            trigger_unregister_node(host);
             if (bdb_state->attr->wait_for_seqnum_trace) {
                 logmsg(LOGMSG_USER, " err waiting for seqnum: host %s no "
                         "longer connected\n",

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -214,20 +214,11 @@ static int trigger_unregister_node_int(const char *host)
     return 0;
 }
 
-int trigger_unregister_node_lk(const char *host)
+int trigger_unregister_node(const char *host)
 {
     pthread_mutex_lock(&trighash_lk);
     int rc = trigger_unregister_node_int(host);
     pthread_mutex_unlock(&trighash_lk);
-    return rc;
-}
-
-int trigger_unregister_node(const char *host)
-{
-    GET_BDB_STATE(bdb_state);
-    BDB_READLOCK("unregister trigger node");
-    int rc = trigger_unregister_node_lk(host);
-    BDB_RELLOCK();
     return rc;
 }
 

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -33,7 +33,6 @@ void trigger_start(const char *);
 int trigger_register_req(trigger_reg_t *);
 int trigger_unregister_req(trigger_reg_t *);
 int trigger_unregister_node(const char *node);    // will get bdblock
-int trigger_unregister_node_lk(const char *node); // get bdblock, then call
 int trigger_registered(const char *);
 void trigger_clear_hash(void);
 void trigger_stat(void);

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -32,7 +32,7 @@ int trigger_unregister(trigger_reg_t *);
 void trigger_start(const char *);
 int trigger_register_req(trigger_reg_t *);
 int trigger_unregister_req(trigger_reg_t *);
-int trigger_unregister_node(const char *node);    // will get bdblock
+int trigger_unregister_node(const char *node);
 int trigger_registered(const char *);
 void trigger_clear_hash(void);
 void trigger_stat(void);


### PR DESCRIPTION
Getting the bdb-lock here can cause an abort if the pthread_key holding the lock isn't set yet.  My testing showed that this occurs in connection-refresh code.  Holding the bdb-lock in trigger_register_node prevents the master from swinging, but holding it here is unnecessary.