### PR TITLE
cdb2jdbc: Use % specifiers instead of string concatenation for log messages.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -89,7 +89,7 @@ public class Comdb2Handle extends AbstractConnection {
     private boolean isRead;
     private String lastSql;
     private long rowsRead;
-    private byte[] uuid;
+    private String uuid;
     private String stringCnonce;
     private byte[] cnonce;
     private int maxretries = 20;
@@ -153,9 +153,8 @@ public class Comdb2Handle extends AbstractConnection {
     public Comdb2Handle(String dbname, String cluster) {
         super(new ProtobufProtocol(), null);
         sets = new ArrayList<String>();
-        String stringUuid = UUID.randomUUID().toString();
-        uuid = stringUuid.getBytes();
-        tdlog(Level.FINEST, "Created handle with uuid " + uuid);
+        uuid = UUID.randomUUID().toString();
+        tdlog(Level.FINEST, "Created handle with uuid %s", uuid);
         bindVars = new HashMap<String, Cdb2BindValue>();
         queryList = new ArrayList<QueryItem>();
         myDbName = dbname;
@@ -245,7 +244,7 @@ public class Comdb2Handle extends AbstractConnection {
         if (this.myDbHosts.size() == 0) {
             this.lookup();
         }
-        tdlog(Level.FINEST, "comdb2Handle:this.myDbHosts is " + this.myDbHosts);
+        tdlog(Level.FINEST, "comdb2Handle:this.myDbHosts is %s", this.myDbHosts);
         ArrayList<String> hosts = new ArrayList(this.myDbHosts.size());
         for (String item : this.myDbHosts) hosts.add(new String(item));
         return hosts;
@@ -273,16 +272,12 @@ public class Comdb2Handle extends AbstractConnection {
         return maxretries;
     }
 
-    private void tdlog(Level level, String str, Object[] params) {
-        tdlog(level, str);
-    }
-
-    private void tdlog(Level level, String str, Object param) {
-        tdlog(level, str);
-    }
-
     // Add td info to the beginning of the string
-    private void tdlog(Level level, String str) {
+    private void tdlog(Level level, String str, Object... params) {
+        /* Fast return if the level is not loggable. */
+        if (!logger.isLoggable(level))
+            return;
+
         String mach = "(not-connected)";
         if (dbHostConnected >= 0) {
             mach = myDbHosts.get(dbHostConnected);
@@ -306,11 +301,19 @@ public class Comdb2Handle extends AbstractConnection {
                     " cnonce=" + stringCnonce + ": " + str);
 
 
-        }
-        else {
-            logger.log(level, "td=" + Thread.currentThread().getId() + 
-                    " mach=" + mach + " snapshotFile=" + snapshotFile + " snapshotOffset=" + 
-                    snapshotOffset + " cnonce=" + stringCnonce + ": " + str);
+        } else {
+            String message = String.format(str, params);
+            Object[] messageParams = new Object[] {
+                Thread.currentThread().getId(),
+                mach,
+                snapshotFile,
+                snapshotOffset,
+                stringCnonce,
+                message
+            };
+            logger.log(level,
+                       "td={0} mach={1} snapshotFile={2} snapshotOffset={3} cnonce={4}: {5}",
+                       messageParams);
         }
     }
 
@@ -319,7 +322,7 @@ public class Comdb2Handle extends AbstractConnection {
         String methodName = Thread.currentThread().getStackTrace()[frame-1].getMethodName();
         String callerMethodName = Thread.currentThread().getStackTrace()[3].getMethodName();
         int callerLine = Thread.currentThread().getStackTrace()[3].getLineNumber();
-        tdlog(Level.FINEST, callerMethodName + "->" + methodName + "[" + callerLine + "]");
+        tdlog(Level.FINEST, "%s->%s->[%d]", callerMethodName, methodName, callerLine);
     }
 
     public void setPolicy(String policy) {
@@ -364,8 +367,9 @@ public class Comdb2Handle extends AbstractConnection {
             return Errors.CDB2ERR_TRAN_IO_ERROR;
         }
         
-        tdlog(Level.FINEST, "retryQueries: nretry=" + nretry + " runlast=" + runlast + 
-                " queryList.size()=" + queryList.size());
+        tdlog(Level.FINEST,
+              "retryQueries: nretry=%d runlast=%b queryList.size()=%d",
+              nretry, runlast, queryList.size());
 
         clearResp();
         isRetry = nretry;
@@ -442,7 +446,7 @@ public class Comdb2Handle extends AbstractConnection {
             nsh = new NewSqlHeader(RequestType.CDB2_REQUEST_CDB2QUERY,
                                                 0, 0, buffer.length);
 
-            tdlog(Level.FINEST, "retryQueries resending '" + item.sql + "'");
+            tdlog(Level.FINEST, "retryQueries resending '%s'", item.sql);
 
             try {
                 io.write(nsh.toBytes());
@@ -451,7 +455,7 @@ public class Comdb2Handle extends AbstractConnection {
             } catch (IOException e) {
                 last_non_logical_err = e;
                 driverErrStr = "Can't read response from db";
-                tdlog(Level.FINEST, "Error resending '" + item.sql + "'");
+                tdlog(Level.FINEST, "Error resending '%s'", item.sql);
                 closeNoException();
                 return 1;
             }
@@ -459,8 +463,9 @@ public class Comdb2Handle extends AbstractConnection {
             clearResp();
 
             if (skipFeature && !item.isRead) {
-                tdlog(Level.FINEST, "retryQueries continuing because skipFeature is " 
-                        + skipFeature + " and item.isRead is " + item.isRead);
+                tdlog(Level.FINEST,
+                      "retryQueries continuing because skipFeature is %b and item.isRead is %b",
+                      skipFeature, item.isRead);
                 continue;
             }
 
@@ -485,8 +490,9 @@ public class Comdb2Handle extends AbstractConnection {
 
     private boolean retryQueriesAndSkip(int nretry, long skipNRows) {
         if (snapshotFile <= 0) {
-            tdlog(Level.FINEST, "retryQueriesAndSkip returning false immediately " +
-                    "because snapshotFile is " + snapshotFile);
+            tdlog(Level.FINEST,
+                  "retryQueriesAndSkip returning false immediately because snapshotFile is %d",
+                  snapshotFile);
             return false;
         }
 
@@ -504,7 +510,9 @@ public class Comdb2Handle extends AbstractConnection {
 
         firstResp = readRecord();
         boolean rcode = (firstResp == null) ? false : true;
-        tdlog(Level.FINEST, "retryQueriesAndSkip: firstResp is " + firstResp + " returning " + rcode);
+        tdlog(Level.FINEST,
+              "retryQueriesAndSkip: firstResp is %s returning %d",
+              firstResp, rcode);
         return rcode;
     }
 
@@ -530,9 +538,9 @@ public class Comdb2Handle extends AbstractConnection {
             sqlQuery.retry = isRetry;
         }
 
-        tdlog(Level.FINEST, "sendQuery sql='" + sql + "' isBegin=" + isBegin +
-                " skipNRows=" + skipNRows + " nretry=" + nretry + " doAppend="
-                + doAppend);
+        tdlog(Level.FINEST,
+              "sendQuery sql='%s' isBegin=%b skipNRows=%d nretry=%d doAppend=%b",
+              sql, isBegin, skipNRows, nretry, doAppend);
 
         /* SKIP_ROWS optimization is disabled temporarily
            in cdb2jdbc to make executeUpdate() work. */
@@ -552,7 +560,7 @@ public class Comdb2Handle extends AbstractConnection {
         sqlQuery.cnonce = cnonce;
 
         if (snapshotFile > 0) { 
-            tdlog(Level.FINEST, "Setting hasSnapshotInfo to true because snapshotFile is " + snapshotFile);
+            tdlog(Level.FINEST, "Setting hasSnapshotInfo to true because snapshotFile is %d", snapshotFile);
             sqlQuery.hasSnapshotInfo = true;
             sqlQuery.file = snapshotFile;
             sqlQuery.offset = snapshotOffset;
@@ -582,7 +590,7 @@ public class Comdb2Handle extends AbstractConnection {
             return true;
         } catch (IOException e) {
             last_non_logical_err = e;
-            tdlog(Level.FINE, "sendQuery unable to write to " + myDbName + "/" + myDbCluster, e);
+            tdlog(Level.FINE, "sendQuery unable to write to %s/%s", myDbName, myDbCluster);
             driverErrStr = "Failed sending query.";
             return false;
         }
@@ -651,7 +659,7 @@ public class Comdb2Handle extends AbstractConnection {
                 Cdb2SqlResponse rsp = null;
                 try {
                     rsp = protocol.unpackSqlResp(raw);
-                    tdlog(Level.FINEST, "readRecord respType is " + rsp.respType);
+                    tdlog(Level.FINEST, "readRecord respType is %d", rsp.respType);
                 } catch (IOException ioe) {
                     last_non_logical_err = ioe;
                     tdlog(Level.FINEST, "unpackSqlResp returns null");
@@ -744,7 +752,7 @@ public class Comdb2Handle extends AbstractConnection {
         sql = sql.trim();
         String lowerSql = sql.toLowerCase();
 
-        tdlog(Level.FINE, "[running sql] " + sql);
+        tdlog(Level.FINE, "[running sql] %s", sql);
 
         if (lowerSql.startsWith("set")) {
             Iterator<String> iter = sets.iterator();
@@ -755,10 +763,11 @@ public class Comdb2Handle extends AbstractConnection {
             }
 
             if (isClientOnlySetCommand(lowerSql)) {
-                tdlog(Level.FINEST, "Added client-only set command " + sql);
+                tdlog(Level.FINEST, "Added client-only set command %s", sql);
             } else {
                 sets.add(sql);
-                tdlog(Level.FINEST, "Added '" + sql + "' to sets size is " + sets.size() + " uuid is " + uuid);
+                tdlog(Level.FINEST, "Added '%s' to sets size is %d uuid is %s",
+                      sql, sets.size(), uuid);
 
                 // HASql sessions need the file & offset from begin
                 String hasql[] = lowerSql.split("hasql");
@@ -802,8 +811,9 @@ public class Comdb2Handle extends AbstractConnection {
 
         if ((is_begin && inTxn) || (is_commit && !inTxn)) {
             last_non_logical_err = null;
-            tdlog(Level.FINEST, "returning wrong-handle-state, is_begin=" + 
-                    is_begin + " is_commit=" + is_commit + " inTxn=" + inTxn);
+            tdlog(Level.FINEST,
+                  "returning wrong-handle-state, is_begin=%b is_commit=%b inTxn=%b",
+                  is_begin, is_commit, inTxn);
             driverErrStr = "Wrong sql handle state";
             last_non_logical_err = null;
             return Errors.CDB2ERR_BADSTATE;
@@ -825,7 +835,7 @@ public class Comdb2Handle extends AbstractConnection {
         int retry = 0;
         boolean sent = false;
         for ( ; retry < maxretries && !sslerr; ++retry) {
-            tdlog(Level.FINEST, "executing retry loop with retry " + retry);
+            tdlog(Level.FINEST, "executing retry loop with retry %d", retry);
             firstRecordRead = false;
 
             /* Add wait if we have tried on all the nodes. */
@@ -834,7 +844,7 @@ public class Comdb2Handle extends AbstractConnection {
                     int sleepms = (100 * (retry - myDbHosts.size() + 1));
                     if (sleepms > 1000) {
                         sleepms = 1000;
-                        tdlog(Level.FINE, "Sleeping on retry " + retry);
+                        tdlog(Level.FINE, "Sleeping on retry %d", retry);
                     }
                     Thread.sleep(sleepms);
                 } catch (InterruptedException e) {
@@ -860,19 +870,19 @@ public class Comdb2Handle extends AbstractConnection {
                     driverErrStr = "Can't connect to db.";
                     return Errors.CDB2ERR_CONNECT_ERROR;
                 }
-                tdlog(Level.FINEST, "Connected to " + dbHostConnected);
+                tdlog(Level.FINEST, "Connected to %s", dbHostConnected);
 
                 if (!is_begin) {
                     retryAll = true;
                     int retryrc = retryQueries(retry, runLast);
 
                     if (retryrc < 0) {
-                        tdlog(Level.FINE, "Can't retry query, retryrc = " + retryrc);
+                        tdlog(Level.FINE, "Can't retry query, retryrc = %d", retryrc);
                         driverErrStr = "Can't retry query to db.";
                         return retryrc;
                     } 
                     else if (retryrc > 0) {
-                        tdlog(Level.FINEST, "retryQueries returns " + retryrc);
+                        tdlog(Level.FINEST, "retryQueries returns %d", retryrc);
                         closeNoException();
                         retryAll = true;
                         continue;
@@ -925,38 +935,32 @@ public class Comdb2Handle extends AbstractConnection {
                     if (_skipFeature) {
                         if (errVal != 0) {
                             if (is_rollback) {
-                                tdlog(Level.FINER, "Rollback returning 0 on " +
-                                        "errVal " + errVal);
+                                tdlog(Level.FINER, "Rollback returning 0 on errVal %d", errVal);
                                 return 0;
                             } else {
-                                tdlog(Level.FINER, "Returning errVal " + errVal + 
-                                        " on commit");
+                                tdlog(Level.FINER, "Returning errVal %d on commit", errVal);
                                 return errVal;
                             }
                         }
                     } else if (errVal != 0) {
-                        tdlog(Level.FINEST, "Commit errVal is " + errVal + 
-                                " is_rollback=" + is_rollback + " skipFeature=" +
-                                _skipFeature);
+                        tdlog(Level.FINEST, "Commit errVal is %d is_rollback=%b skipFeature=%b",
+                              errVal, is_rollback, _skipFeature);
                         /* With skip_feature off, we need to read the 1st response
                            of commit/rollback even if there is an in-trans error. */
                         break;
                     } else {
-                        tdlog(Level.FINEST, "Commit errVal (2) is " + errVal + 
-                                " is_rollback=" + is_rollback + " skipFeature=" +
-                                _skipFeature);
+                        tdlog(Level.FINEST, "Commit errVal (2) is %d is_rollback=%b skipFeature=%b",
+                              errVal, is_rollback, _skipFeature);
                     }
                 }
 
                 if (errVal != 0) {
-                    tdlog(Level.FINER, "Returning errVal " + errVal + 
-                            " is_rollback " + is_rollback);
+                    tdlog(Level.FINER, "Returning errVal %d is_rollback=%b", errVal, is_rollback);
                     return is_rollback? 0 : errVal;
                 }
 
                 if (skipFeature && !isRead && (inTxn || !isHASql)) {
-                    tdlog(Level.FINER, "skipFeature is enabled and !isRead: " +
-                            "returning 0");
+                    tdlog(Level.FINER, "skipFeature is enabled and !isRead: %b returning 0", !isRead);
                     return 0;
                 }
             } while (false);
@@ -967,25 +971,22 @@ public class Comdb2Handle extends AbstractConnection {
             tdlog(Level.FINEST, "reading results");
             // Read results
             if ((nsh = readNsh()) == null || (raw = readRaw(nsh.length)) == null) {
-                tdlog(Level.FINEST, "Failure to read: nsh=" + nsh + " raw=" + raw);
+                tdlog(Level.FINEST, "Failure to read: nsh=%s raw=%s", nsh, raw);
                 // Read error
                 if (errVal != 0) {
                     if (is_rollback) {
-                        tdlog(Level.FINER, "returning 0 for null readNsh / readRaw on rollback errVal=" + 
-                                errVal);
+                        tdlog(Level.FINER, "returning 0 for null readNsh / readRaw on rollback errVal=%d", errVal);
                         return 0;
                     }
                     else if (is_retryable(errVal)) {
-                        tdlog(Level.FINER, "continuing on retryable error " + errVal + 
-                                " for null readNsh");
+                        tdlog(Level.FINER, "continuing on retryable error %d for null readNsh", errVal);
                         errorInTxn = 0;
                         closeNoException();
                         retryAll = true;
                         continue;
                     }
                     else {
-                        tdlog(Level.FINER, "Returning on-retryable error " + errVal + 
-                                " for null readNsh");
+                        tdlog(Level.FINER, "continuing on retryable error %d for null readNsh", errVal);
                         if (is_commit) {
                             cleanup_query_list();
                         } 
@@ -1004,9 +1005,9 @@ public class Comdb2Handle extends AbstractConnection {
 
                 if (isHASql || commitSnapshotFile > 0) {
                     if (commitSnapshotFile > 0) {
-                        tdlog(Level.FINER, "Resetting txn state info on commit, isHASql=" +
-                                isHASql + " lsn=[" + commitSnapshotFile + "][" +
-                                commitSnapshotOffset + "]");
+                        tdlog(Level.FINER,
+                              "Resetting txn state info on commit, isHASql=%b lsn=[%d][%d]",
+                              isHASql, commitSnapshotFile, commitSnapshotOffset);
                         inTxn = true;
                         snapshotFile = commitSnapshotFile;
                         snapshotOffset = commitSnapshotOffset;
@@ -1024,9 +1025,9 @@ public class Comdb2Handle extends AbstractConnection {
                     cleanup_query_list();
                 }
                 driverErrStr = "Can't read response from the db.";
-                tdlog(Level.FINER, "Returning connect-error, is_commit=" +
-                        is_commit + " snapshotFile=" + snapshotFile + " is_rollback=" +
-                        is_rollback);
+                tdlog(Level.FINER,
+                      "Returning connect-error, is_commit=%b snapshotFile=%d is_rollback=%b",
+                      is_commit, snapshotFile, is_rollback);
                 return Errors.CDB2ERR_CONNECT_ERROR;
             }
 
@@ -1069,8 +1070,7 @@ public class Comdb2Handle extends AbstractConnection {
                 dbHostIdx = -1;
                 closeNoException();
 
-                tdlog(Level.FINER, "continuing with retryAll=true on " +
-                        "nsh.type=DBINFO_RESPONSE_VALUE");
+                tdlog(Level.FINER, "continuing with retryAll=true on nsh.type=DBINFO_RESPONSE_VALUE");
                 continue;
             }
 
@@ -1080,14 +1080,14 @@ public class Comdb2Handle extends AbstractConnection {
                 if (errVal != 0) {
 
                     if (is_rollback) {
-                        tdlog(Level.FINER, "returning 0 for rollback after unpack for errVal=" + errVal);
+                        tdlog(Level.FINER, "returning 0 for rollback after unpack for errVal=%d", errVal);
                         return 0;
                     }
                     else {
                         if (isHASqlCommit) {
                             cleanup_query_list();
                         }
-                        tdlog(Level.FINER, "returning errval for after unpack for errVal=" + errVal);
+                        tdlog(Level.FINER, "returning errval for after unpack for errVal=%d", errVal);
                         return errVal;
                     }
                 } else {
@@ -1100,24 +1100,22 @@ public class Comdb2Handle extends AbstractConnection {
                 last_non_logical_err = ioe;
                 if (errVal != 0) {
 
-                    if (is_rollback) { tdlog(Level.FINER, "Returning 0 on rollback for "+
-                                "errval" + errVal + " for null firstResp");
+                    if (is_rollback) {
+                        tdlog(Level.FINER, "Returning 0 on rollback for errval %d for null firstResp", errVal);
                         return 0;
                     }
                     else if (is_retryable(errVal)) {
                         errorInTxn = 0;
                         closeNoException();
                         retryAll = true;
-                        tdlog(Level.FINER, "Retrying for failed protocol unpack errval=" +
-                                errVal);
+                        tdlog(Level.FINER, "Retrying for failed protocol unpack errval=%d", errVal);
                         continue;
                     }
                     else {
                         if (isHASqlCommit) {
                             cleanup_query_list();
                         }
-                        tdlog(Level.FINEST, "Returning non-retryable error " + errVal+ 
-                                " for null firstrep");
+                        tdlog(Level.FINEST, "Returning non-retryable error %d for null firstresp", errVal);
                         return errVal;
                     }
                 }
@@ -1125,16 +1123,16 @@ public class Comdb2Handle extends AbstractConnection {
                 if (!is_commit || snapshotFile > 0) {
                     closeNoException();
                     retryAll = true;
-                    tdlog(Level.FINER, "Continue with true retryAll for "+
-                            "non-commit, null firstResp and 0 errVal");
+                    tdlog(Level.FINER,
+                          "Continue with true retryAll for non-commit, null firstResp and 0 errVal");
                     continue;
                 } 
                
                 driverErrStr = "Timeout while reading response from server.";
 
-                tdlog(Level.FINER, "Returning IO_ERROR for firstResp=null "
-                        + "errVal=0 is_commit=" + is_commit + " snapshotFile=" +
-                        snapshotFile + " is_rollback=" + is_rollback);
+                tdlog(Level.FINER,
+                      "Returning IO_ERROR for firstResp=null errVal=0 is_commit=%b snapshotFile=%d is_rollback=%b",
+                      is_commit, snapshotFile, is_rollback);
 
                 if (isHASqlCommit) {
                     cleanup_query_list();
@@ -1159,8 +1157,8 @@ public class Comdb2Handle extends AbstractConnection {
                     commitQueryList = null;
                     commitSnapshotFile = 0;
                 }
-                tdlog(Level.FINER, "Continue with true retryAll for " +
-                        "firstResp.errCode=MASTER_TIMEOUT_VALUE");
+                tdlog(Level.FINER,
+                      "Continue with true retryAll for firstResp.errCode=MASTER_TIMEOUT_VALUE");
                 continue;
             }
 
@@ -1195,7 +1193,7 @@ public class Comdb2Handle extends AbstractConnection {
                         commitQueryList = null;
                         commitSnapshotFile = 0;
                     }
-                    tdlog(Level.FINER, "firstResp.columnNames errCode=" + firstResp.errCode);
+                    tdlog(Level.FINER, "firstResp.columnNames errCode=%d", firstResp.errCode);
                     continue;
                 }
 
@@ -1207,8 +1205,9 @@ public class Comdb2Handle extends AbstractConnection {
                     if (isHASqlCommit) {
                         cleanup_query_list();
                     }
-                    tdlog(Level.FINER, "Returning rc=" + rc + " on firstResp.errCode=" +
-                            firstResp.errCode);
+                    tdlog(Level.FINER,
+                          "Returning rc=%d on firstResp.errCode=%d",
+                          rc, firstResp.errCode);
                     return rc;
                 }
 
@@ -1240,7 +1239,7 @@ public class Comdb2Handle extends AbstractConnection {
                     if (is_begin)
                         cleanup_query_list();
 
-                    tdlog(Level.FINER, "Retrying on nxtrc=" + nxtrc + " is_begin=" + is_begin);
+                    tdlog(Level.FINER, "Retrying on nxtrc=%d is_begin=%b", nxtrc, is_begin);
                     retryAll = true;
                     continue;
                 }
@@ -1248,13 +1247,13 @@ public class Comdb2Handle extends AbstractConnection {
                 if (isHASqlCommit) {
                     cleanup_query_list();
                 }
-                tdlog(Level.FINER, "Returning nxtrc="+nxtrc+" is_begin=" + is_begin + 
-                        " isHASql=" + isHASql);
+                tdlog(Level.FINER, "Returning nxtrc=%d is_begin=%b isHASql=%b",
+                      nxtrc, is_begin, isHASql);
                 return convert_rc(nxtrc);
             } else {
                 // XXX I could paper over this with the api, but i want to see what is 
                 // happening first
-                tdlog(Level.FINEST, "XXX FAIL .. firstResp.respType=" + firstResp.respType);
+                tdlog(Level.FINEST, "XXX FAIL .. firstResp.respType=%d", firstResp.respType);
             }
 
         } /* end of the big for loop */
@@ -1265,7 +1264,7 @@ public class Comdb2Handle extends AbstractConnection {
             cleanup_query_list();
         }
 
-        tdlog(Level.FINER, "Maximum retries done: returning IO_ERROR, is_rollback=" + is_rollback);
+        tdlog(Level.FINER, "Maximum retries done: returning IO_ERROR, is_rollback=%b", is_rollback);
         return is_rollback ? 0 : Errors.CDB2ERR_TRAN_IO_ERROR;
     }
 
@@ -1393,7 +1392,7 @@ public class Comdb2Handle extends AbstractConnection {
 readloop:
         do {
             continue_retry = false;
-            tdlog(Level.FINEST, "Enter readloop with skip_to_open=" + skip_to_open);
+            tdlog(Level.FINEST, "Enter readloop with skip_to_open=%b", skip_to_open);
             if (!skip_to_open) {
                 if (firstResp == null) {
                     tdlog(Level.FINEST, "next_int: returning OK_DONE for null firstResp");
@@ -1402,7 +1401,7 @@ readloop:
 
                 if (firstResp.errCode != 0) {
                     last_non_logical_err = null;
-                    tdlog(Level.FINEST, "next_int: returning firstResp.errCode " + firstResp.errCode);
+                    tdlog(Level.FINEST, "next_int: returning firstResp.errCode %d", firstResp.errCode);
                     return firstResp.errCode;
                 }
                 if (lastResp != null) {
@@ -1415,13 +1414,13 @@ readloop:
                         int rc = convert_rc(lastResp.errCode);
                         if (inTxn)
                             errorInTxn = rc;
-                        tdlog(Level.FINEST, "next_int: returning " + rc + " for lastResp.respType=2(1) inTxn=" + inTxn);
+                        tdlog(Level.FINEST, "next_int: returning %d for lastResp.respType=2(1) inTxn=%b", rc, inTxn);
                         return rc;
                     }
                 }
             }
             else {
-                tdlog(Level.FINEST, "skipped first part of readloop because skip_to_open is " + skip_to_open);
+                tdlog(Level.FINEST, "skipped first part of readloop because skip_to_open is %b", skip_to_open);
             }
 
             if (skip_to_open || (lastResp = readRecord()) == null) {
@@ -1442,14 +1441,14 @@ readloop:
                         tmsec = (nretry - myDbHosts.size()) * 100;
                         if (tmsec > 1000)
                             tmsec = 1000;
-                        tdlog(Level.FINEST, "Sleeping on read retry " + nretry);
+                        tdlog(Level.FINEST, "Sleeping on read retry %d", nretry);
                         try {
                             Thread.sleep(tmsec);
                         }
                         catch (InterruptedException e) { }
                     }
                     if (!open()) {
-                        tdlog(Level.FINEST, "next_int: retrying with snapshotFile=" + snapshotFile);
+                        tdlog(Level.FINEST, "next_int: retrying with snapshotFile=%d", snapshotFile);
                         continue;
                     }
                     if (!retryQueriesAndSkip(nretry, rowsRead)) {
@@ -1464,8 +1463,9 @@ readloop:
 
                 if (snapshotFile <= 0 || nretry >= maxretries) {
                     /* if no HA txn or max number of HA replays done */
-                    tdlog(Level.FINEST, "next_int: returning CONNECT_ERROR(2) with snapshotFile=" 
-                            + snapshotFile + " and maxretries=" + maxretries);
+                    tdlog(Level.FINEST,
+                          "next_int: returning CONNECT_ERROR(2) with snapshotFile=%d and maxretries=%d",
+                          snapshotFile, maxretries);
                     return Errors.CDB2ERR_CONNECT_ERROR;
                 }
             }
@@ -1474,8 +1474,9 @@ readloop:
             if (lastResp.hasSnapshotInfo) {
                 snapshotFile = lastResp.file;
                 snapshotOffset = lastResp.offset;
-                tdlog(Level.FINEST, "next_int: set snapshot lsn to [" + snapshotFile +
-                        "][" + snapshotOffset + "]");
+                tdlog(Level.FINEST,
+                      "next_int: set snapshot lsn to [%d][%d]",
+                      snapshotFile, snapshotOffset);
             }
 
             /*
@@ -1497,9 +1498,9 @@ readloop:
 
             if (lastResp.respType == 2) { // COLUMN_VALUES
                 if (is_retryable(lastResp.errCode) && snapshotFile > 0) {
-                    tdlog(Level.FINEST, "next_int: continuing retryable rcode " + 
-                            lastResp.errCode + " at [" + snapshotFile +
-                            "][" + snapshotOffset + "]");
+                    tdlog(Level.FINEST,
+                          "next_int: continuing retryable rcode %d at [%d][%d]",
+                          lastResp.errCode, snapshotFile, snapshotOffset);
                     closeNoException();
                     skip_to_open = true;
                     continue readloop;
@@ -1511,7 +1512,9 @@ readloop:
                 if (inTxn) {
                     errorInTxn = rc;
                 }
-                tdlog(Level.FINEST, "next_int: returning " + rc + " for lastResp.respType=2(2) inTxn=" + inTxn);
+                tdlog(Level.FINEST,
+                      "next_int: returning %d for lastResp.respType=2(2) inTxn=%b",
+                      rc, inTxn);
                 return rc;
             }
         } while(skip_to_open || continue_retry);
@@ -1533,8 +1536,9 @@ readloop:
                     break;
                 }
             }
-            tdlog(Level.FINEST, "next_int: lastResp.respType is 3, nSetsSent=" + nSetsSent + 
-                    " lastResp.errCode=" + lastResp.errCode);
+            tdlog(Level.FINEST,
+                  "next_int: lastResp.respType is 3, nSetsSent=%d lastResp.errCode=%d",
+                  nSetsSent, lastResp.errCode);
 
             return Errors.CDB2_OK_DONE;
         }
@@ -1565,7 +1569,7 @@ readloop:
             return true;
         } else {
             rc = reopen(true);
-            tdlog(Level.FINEST, "Connection reopened returned " + rc);
+            tdlog(Level.FINEST, "Connection reopened returned %b", rc);
             return rc;
         }
     }
@@ -1808,8 +1812,7 @@ readloop:
         try {
             close();
         } catch (IOException e) {
-            tdlog(Level.WARNING, "Unable to close connection to "
-                    + myDbName + "/" + myDbCluster, e);
+            tdlog(Level.WARNING, "Unable to close connection to %s/%s", myDbName, myDbCluster);
         }
     }
 


### PR DESCRIPTION
String concatenation is expensive and right now we do it without knowing if it is actually needed or not.
It can be avoided using string formatter: The string processing is done only when the given log level
needs to be logged.