### PR TITLE
Logging: Convert all times in log to microseconds.

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -728,35 +728,37 @@ void bdb_print_stats(const struct bdb_thread_stats *st, const char *prefix,
     char s[128];
     if (st->n_lock_waits > 0) {
         snprintf(s, sizeof(s), "%s%u lock waits took %u ms (%u ms/wait)\n",
-                 prefix, st->n_lock_waits, st->lock_wait_time_ms,
-                 st->lock_wait_time_ms / st->n_lock_waits);
+                 prefix, st->n_lock_waits, MSEC(st->lock_wait_time_us),
+                 MSEC(st->lock_wait_time_us / st->n_lock_waits));
         printfn(s, context);
     }
     if (st->n_preads > 0) {
         snprintf(s, sizeof(s), "%s%u preads took %u ms total of %u bytes\n",
-                 prefix, st->n_preads, st->pread_time_ms, st->pread_bytes);
+                 prefix, st->n_preads, MSEC(st->pread_time_us),
+                 st->pread_bytes);
         printfn(s, context);
     }
     if (st->n_pwrites > 0) {
         snprintf(s, sizeof(s), "%s%u pwrites took %u ms total of %u bytes\n",
-                 prefix, st->n_pwrites, st->pwrite_time_ms, st->pwrite_bytes);
+                 prefix, st->n_pwrites, MSEC(st->pwrite_time_us),
+                 st->pwrite_bytes);
         printfn(s, context);
     }
     if (st->n_memp_fgets > 0) {
         snprintf(s, sizeof(s), "%s%u __memp_fget calls took %u ms\n", prefix,
-                 st->n_memp_fgets, st->memp_fget_time_ms);
+                 st->n_memp_fgets, MSEC(st->memp_fget_time_us));
         printfn(s, context);
     }
     if (st->n_memp_pgs > 0) {
         snprintf(s, sizeof(s), "%s%u __memp_pg calls took %u ms\n", prefix,
-                 st->n_memp_pgs, st->memp_pg_time_ms);
+                 st->n_memp_pgs, MSEC(st->memp_pg_time_us));
         printfn(s, context);
     }
     if (st->n_shallocs > 0 || st->n_shalloc_frees > 0) {
         snprintf(s, sizeof(s),
                  "%s%u shallocs took %u ms, %u shalloc_frees took %u ms\n",
-                 prefix, st->n_shallocs, st->shalloc_time_ms,
-                 st->n_shalloc_frees, st->shalloc_free_time_ms);
+                 prefix, st->n_shallocs, MSEC(st->shalloc_time_us),
+                 st->n_shalloc_frees, MSEC(st->shalloc_free_time_us));
         printfn(s, context);
     }
 }

--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -728,37 +728,36 @@ void bdb_print_stats(const struct bdb_thread_stats *st, const char *prefix,
     char s[128];
     if (st->n_lock_waits > 0) {
         snprintf(s, sizeof(s), "%s%u lock waits took %u ms (%u ms/wait)\n",
-                 prefix, st->n_lock_waits, MSEC(st->lock_wait_time_us),
-                 MSEC(st->lock_wait_time_us / st->n_lock_waits));
+                 prefix, st->n_lock_waits, U2M(st->lock_wait_time_us),
+                 U2M(st->lock_wait_time_us / st->n_lock_waits));
         printfn(s, context);
     }
     if (st->n_preads > 0) {
         snprintf(s, sizeof(s), "%s%u preads took %u ms total of %u bytes\n",
-                 prefix, st->n_preads, MSEC(st->pread_time_us),
-                 st->pread_bytes);
+                 prefix, st->n_preads, U2M(st->pread_time_us), st->pread_bytes);
         printfn(s, context);
     }
     if (st->n_pwrites > 0) {
         snprintf(s, sizeof(s), "%s%u pwrites took %u ms total of %u bytes\n",
-                 prefix, st->n_pwrites, MSEC(st->pwrite_time_us),
+                 prefix, st->n_pwrites, U2M(st->pwrite_time_us),
                  st->pwrite_bytes);
         printfn(s, context);
     }
     if (st->n_memp_fgets > 0) {
         snprintf(s, sizeof(s), "%s%u __memp_fget calls took %u ms\n", prefix,
-                 st->n_memp_fgets, MSEC(st->memp_fget_time_us));
+                 st->n_memp_fgets, U2M(st->memp_fget_time_us));
         printfn(s, context);
     }
     if (st->n_memp_pgs > 0) {
         snprintf(s, sizeof(s), "%s%u __memp_pg calls took %u ms\n", prefix,
-                 st->n_memp_pgs, MSEC(st->memp_pg_time_us));
+                 st->n_memp_pgs, U2M(st->memp_pg_time_us));
         printfn(s, context);
     }
     if (st->n_shallocs > 0 || st->n_shalloc_frees > 0) {
         snprintf(s, sizeof(s),
                  "%s%u shallocs took %u ms, %u shalloc_frees took %u ms\n",
-                 prefix, st->n_shallocs, MSEC(st->shalloc_time_us),
-                 st->n_shalloc_frees, MSEC(st->shalloc_free_time_us));
+                 prefix, st->n_shallocs, U2M(st->shalloc_time_us),
+                 st->n_shalloc_frees, U2M(st->shalloc_free_time_us));
         printfn(s, context);
     }
 }

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -138,12 +138,12 @@ struct bdb_queue_stats {
 
 /* Multiplication usually takes fewer CPU cycles than division. Therefore
    when comparing a usec and a msec, it is preferable to use:
-   usec <comparison operator> USEC(msec)  */
-#ifndef MSEC
-#define MSEC(usec) ((usec) / 1000)
+   usec <comparison operator> MSEC_TO_M2U(msec)  */
+#ifndef U2M
+#define U2M(usec) ((usec) / 1000)
 #endif
-#ifndef USEC
-#define USEC(msec) ((msec)*1000ULL)
+#ifndef M2U
+#define M2U(msec) ((msec)*1000ULL)
 #endif
 struct bdb_thread_stats {
     unsigned n_lock_waits;

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -135,29 +135,39 @@ struct bdb_queue_stats {
 };
 
 /* This is identical to bb_berkdb_thread_stats in db.h */
+
+/* Multiplication usually takes fewer CPU cycles than division. Therefore
+   when comparing a usec and a msec, it is preferable to use:
+   usec <comparison operator> USEC(msec)  */
+#ifndef MSEC
+#define MSEC(usec) ((usec) / 1000)
+#endif
+#ifndef USEC
+#define USEC(msec) ((msec)*1000ULL)
+#endif
 struct bdb_thread_stats {
     unsigned n_lock_waits;
-    unsigned lock_wait_time_ms;
+    uint64_t lock_wait_time_us;
 
     unsigned n_preads;
     unsigned pread_bytes;
-    unsigned pread_time_ms;
+    uint64_t pread_time_us;
 
     unsigned n_pwrites;
     unsigned pwrite_bytes;
-    unsigned pwrite_time_ms;
+    uint64_t pwrite_time_us;
 
     unsigned n_memp_fgets;
-    unsigned memp_fget_time_ms;
+    uint64_t memp_fget_time_us;
 
     unsigned n_memp_pgs;
-    unsigned memp_pg_time_ms;
+    uint64_t memp_pg_time_us;
 
     unsigned n_shallocs;
-    unsigned shalloc_time_ms;
+    uint64_t shalloc_time_us;
 
     unsigned n_shalloc_frees;
-    unsigned shalloc_free_time_ms;
+    uint64_t shalloc_free_time_us;
 };
 
 /* these are the values that "bdberr" can be */

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -136,11 +136,13 @@ struct bdb_queue_stats {
 
 /* This is identical to bb_berkdb_thread_stats in db.h */
 
-/* Multiplication usually takes fewer CPU cycles than division. Therefore
-   when comparing a usec and a msec, it is preferable to use:
-   usec <comparison operator> MSEC_TO_M2U(msec)  */
+/*
+ * Multiplication usually takes fewer CPU cycles than division. Therefore
+ * when comparing a usec and a msec, it is preferable to use:
+ * usec <comparison operator> M2U(msec)
+ */
 #ifndef U2M
-#define U2M(usec) ((usec) / 1000)
+#define U2M(usec) (int)((usec) / 1000)
 #endif
 #ifndef M2U
 #define M2U(msec) ((msec)*1000ULL)

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -1722,18 +1722,18 @@ void bdb_process_user_command(bdb_state_type *bdb_state, char *line, int lline,
         unsigned n_preads = p->n_preads ? p->n_preads : 1;
         unsigned n_pwrites = p->n_pwrites ? p->n_pwrites : 1;
         logmsgf(LOGMSG_USER, out, "  %u lock waits took %u ms (%u ms/wait)\n",
-                p->n_lock_waits, p->lock_wait_time_ms,
-                p->lock_wait_time_ms / n_lock_waits);
-        logmsgf(LOGMSG_USER, out, "  %u preads took %u ms total of %u bytes\n", p->n_preads,
-                p->pread_time_ms, p->pread_bytes);
+                p->n_lock_waits, MSEC(p->lock_wait_time_us),
+                MSEC(p->lock_wait_time_us / n_lock_waits));
+        logmsgf(LOGMSG_USER, out, "  %u preads took %u ms total of %u bytes\n",
+                p->n_preads, MSEC(p->pread_time_us), p->pread_bytes);
         if (p->n_preads > 0)
             logmsgf(LOGMSG_USER, out, "  average pread time %u ms\n",
-                    p->pread_time_ms / n_preads);
+                    MSEC(p->pread_time_us) / n_preads);
         logmsgf(LOGMSG_USER, out, "  %u pwrites took %u ms total of %u bytes\n",
-                p->n_pwrites, p->pwrite_time_ms, p->pwrite_bytes);
+                p->n_pwrites, MSEC(p->pwrite_time_us), p->pwrite_bytes);
         if (p->n_pwrites > 0)
             logmsgf(LOGMSG_USER, out, "  average pwrite time %u ms\n",
-                    p->pwrite_time_ms / n_pwrites);
+                    MSEC(p->pwrite_time_us / n_pwrites));
     }
 
     else if (tokcmp(tok, ltok, "memdump") == 0) {

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -1722,18 +1722,18 @@ void bdb_process_user_command(bdb_state_type *bdb_state, char *line, int lline,
         unsigned n_preads = p->n_preads ? p->n_preads : 1;
         unsigned n_pwrites = p->n_pwrites ? p->n_pwrites : 1;
         logmsgf(LOGMSG_USER, out, "  %u lock waits took %u ms (%u ms/wait)\n",
-                p->n_lock_waits, MSEC(p->lock_wait_time_us),
-                MSEC(p->lock_wait_time_us / n_lock_waits));
+                p->n_lock_waits, U2M(p->lock_wait_time_us),
+                U2M(p->lock_wait_time_us / n_lock_waits));
         logmsgf(LOGMSG_USER, out, "  %u preads took %u ms total of %u bytes\n",
-                p->n_preads, MSEC(p->pread_time_us), p->pread_bytes);
+                p->n_preads, U2M(p->pread_time_us), p->pread_bytes);
         if (p->n_preads > 0)
             logmsgf(LOGMSG_USER, out, "  average pread time %u ms\n",
-                    MSEC(p->pread_time_us) / n_preads);
+                    U2M(p->pread_time_us) / n_preads);
         logmsgf(LOGMSG_USER, out, "  %u pwrites took %u ms total of %u bytes\n",
-                p->n_pwrites, MSEC(p->pwrite_time_us), p->pwrite_bytes);
+                p->n_pwrites, U2M(p->pwrite_time_us), p->pwrite_bytes);
         if (p->n_pwrites > 0)
             logmsgf(LOGMSG_USER, out, "  average pwrite time %u ms\n",
-                    MSEC(p->pwrite_time_us / n_pwrites));
+                    U2M(p->pwrite_time_us / n_pwrites));
     }
 
     else if (tokcmp(tok, ltok, "memdump") == 0) {

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2662,6 +2662,18 @@ struct bb_berkdb_thread_stats {
 	uint64_t shalloc_free_time_us;
 };
 
+/*
+ * Helper macros for microsecond-granularity event logging.
+ * Multiplication usually takes fewer CPU cycles than division. Therefore
+ * when comparing a usec and a msec, it is preferable to use:
+ * usec <comparison operator> M2U(msec)
+ */
+#ifndef U2M
+#define U2M(usec) (int)((usec) / 1000)
+#endif
+#ifndef M2U
+#define M2U(msec) ((msec) * 1000ULL)
+#endif
 uint64_t bb_berkdb_fasttime(void);
 struct bb_berkdb_thread_stats *bb_berkdb_get_thread_stats(void);
 struct bb_berkdb_thread_stats *bb_berkdb_get_process_stats(void);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2639,30 +2639,30 @@ void __db_hdestroy __P((void));
  * build_sundev1/db.h */
 struct bb_berkdb_thread_stats {
 	unsigned n_lock_waits;
-	unsigned lock_wait_time_ms;
+	uint64_t lock_wait_time_us;
 
 	unsigned n_preads;
 	unsigned pread_bytes;
-	unsigned pread_time_ms;
+	uint64_t pread_time_us;
 
 	unsigned n_pwrites;
 	unsigned pwrite_bytes;
-	unsigned pwrite_time_ms;
+	uint64_t pwrite_time_us;
 
 	unsigned n_memp_fgets;
-	unsigned memp_fget_time_ms;
+	uint64_t memp_fget_time_us;
 
 	unsigned n_memp_pgs;
-	unsigned memp_pg_time_ms;
+	uint64_t memp_pg_time_us;
 
 	unsigned n_shallocs;
-	unsigned shalloc_time_ms;
+	uint64_t shalloc_time_us;
 
 	unsigned n_shalloc_frees;
-	unsigned shalloc_free_time_ms;
+	uint64_t shalloc_free_time_us;
 };
 
-int bb_berkdb_fasttime(void);
+uint64_t bb_berkdb_fasttime(void);
 struct bb_berkdb_thread_stats *bb_berkdb_get_thread_stats(void);
 struct bb_berkdb_thread_stats *bb_berkdb_get_process_stats(void);
 void bb_berkdb_thread_stats_init(void);

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2044,7 +2044,7 @@ __lock_get_internal_int(lt, locker, in_locker, flags, obj, lock_mode, timeout,
 		return DB_LOCK_DEADLOCK;
 	}
 	u_int32_t partition = gbl_lk_parts, lpartition = gbl_lkr_parts;
-	int x1, x2;
+	uint64_t x1, x2;
 	struct __db_lock *newl, *lp, *firstlp, *wwrite;
 	DB_ENV *dbenv;
 	DB_LOCKER *sh_locker;
@@ -2755,9 +2755,9 @@ upgrade:
 			}
 			t = bb_berkdb_get_thread_stats();
 			p = bb_berkdb_get_process_stats();
-			p->lock_wait_time_ms += (x2 - x1);
+			p->lock_wait_time_us += (x2 - x1);
 			p->n_lock_waits++;
-			t->lock_wait_time_ms += (x2 - x1);
+			t->lock_wait_time_us += (x2 - x1);
 			t->n_lock_waits++;
 
 			if (gbl_bb_log_lock_waits_fn) {

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2766,7 +2766,7 @@ upgrade:
 				 * the lock. */
 				u_int8_t *ptr;
 				gbl_bb_log_lock_waits_fn(sh_obj->lockobj.data,
-				    sh_obj->lockobj.size, (x2 - x1));
+				    sh_obj->lockobj.size, U2M(x2 - x1));
 			}
 		}
 

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -1129,18 +1129,18 @@ file_dead:
  * Bloomberg hack - record a hit to memp_fget, with the time taken
  */
 static void
-bb_memp_pg_hit(int start_time_ms)
+bb_memp_pg_hit(uint64_t start_time_us)
 {
-	int time_diff = bb_berkdb_fasttime() - start_time_ms;
+	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
 	struct bb_berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_memp_pgs++;
-	stats->memp_pg_time_ms += time_diff;
+	stats->memp_pg_time_us += time_diff;
 
 	stats = bb_berkdb_get_process_stats();
 	stats->n_memp_pgs++;
-	stats->memp_pg_time_ms += time_diff;
+	stats->memp_pg_time_us += time_diff;
 }
 
 
@@ -1164,14 +1164,14 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
 	MPOOLFILE *mfp;
 	int ftype, ret;
 
-	int start_time_ms;
+	uint64_t start_time_us;
 
 	dbenv = dbmfp->dbenv;
 	dbmp = dbenv->mp_handle;
 	mfp = dbmfp->mfp;
 
 	if (gbl_bb_berkdb_enable_memp_pg_timing)
-		start_time_ms = bb_berkdb_fasttime();
+		start_time_us = bb_berkdb_fasttime();
 
 	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
 
@@ -1204,14 +1204,14 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
 		MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
 	if (gbl_bb_berkdb_enable_memp_pg_timing)
-		bb_memp_pg_hit(start_time_ms);
+		bb_memp_pg_hit(start_time_us);
 	return (0);
 
 err:	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 	__db_err(dbenv, "%s: %s failed for page %lu",
 	    __memp_fn(dbmfp), is_pgin ? "pgin" : "pgout", (u_long) pgno);
 	if (gbl_bb_berkdb_enable_memp_pg_timing)
-		bb_memp_pg_hit(start_time_ms);
+		bb_memp_pg_hit(start_time_us);
 	return (ret);
 }
 

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -120,18 +120,18 @@ __berkdb_register_memp_callback(void (*callback) (void))
  * Bloomberg hack - record a hit to memp_fget, with the time taken
  */
 static void
-bb_memp_hit(int start_time_ms)
+bb_memp_hit(uint64_t start_time_us)
 {
-	int time_diff = bb_berkdb_fasttime() - start_time_ms;
+	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
 	struct bb_berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_memp_fgets++;
-	stats->memp_fget_time_ms += time_diff;
+	stats->memp_fget_time_us += time_diff;
 
 	stats = bb_berkdb_get_process_stats();
 	stats->n_memp_fgets++;
-	stats->memp_fget_time_ms += time_diff;
+	stats->memp_fget_time_us += time_diff;
 }
 
 
@@ -223,13 +223,13 @@ __memp_fget_internal(dbmfp, pgnoaddr, flags, addrp, did_io)
 	int b_incr, extending, first, ret, is_recovery_page;
 	db_pgno_t falloc_off, falloc_len;
 
-	int start_time_ms;
+	uint64_t start_time_us;
 
 	if (memp_fget_callback)
 		memp_fget_callback();
 
 	if (gbl_bb_berkdb_enable_memp_timing) {
-		start_time_ms = bb_berkdb_fasttime();
+		start_time_us = bb_berkdb_fasttime();
 	}
 
 	*(void **)addrp = NULL;
@@ -297,7 +297,7 @@ __memp_fget_internal(dbmfp, pgnoaddr, flags, addrp, did_io)
 		    R_ADDR(dbmfp, *pgnoaddr * mfp->stat.st_pagesize);
 		++mfp->stat.st_map;
 		if (gbl_bb_berkdb_enable_memp_timing)
-			bb_memp_hit(start_time_ms);
+			bb_memp_hit(start_time_us);
 		return (0);
 	}
 
@@ -823,7 +823,7 @@ alloc:		/*
 	*(void **)addrp = bhp->buf;
 
 	if (gbl_bb_berkdb_enable_memp_timing)
-		bb_memp_hit(start_time_ms);
+		bb_memp_hit(start_time_us);
 	return (0);
 
 err:	/*
@@ -849,7 +849,7 @@ err:	/*
 	}
 
 	if (gbl_bb_berkdb_enable_memp_timing)
-		bb_memp_hit(start_time_ms);
+		bb_memp_hit(start_time_us);
 	return (ret);
 }
 

--- a/berkdb/os/os_fsync.c
+++ b/berkdb/os/os_fsync.c
@@ -67,7 +67,7 @@ static long long *__berkdb_num_fsyncs = 0;
 static void (*fsync_callback)(int fd) = 0;
 
 /* defined in os_rw.c */
-int bb_berkdb_fasttime(void);
+uint64_t bb_berkdb_fasttime(void);
 
 void
 __berkdb_set_num_fsyncs(long long *n)
@@ -100,7 +100,7 @@ __os_fsync(dbenv, fhp)
 	DB_FH *fhp;
 {
 	int ret, retries, ckalmn;
-	int x1 = 0, x2 = 0;
+	uint64_t x1 = 0, x2 = 0;
 	struct bb_berkdb_thread_stats *p, *t;
 
 	ckalmn = __berkdb_fsync_alarm_ms;

--- a/berkdb/os/os_fsync.c
+++ b/berkdb/os/os_fsync.c
@@ -170,11 +170,11 @@ __os_fsync(dbenv, fhp)
 		x2 = bb_berkdb_fasttime();
 
 
-	if ((x2 - x1) > ckalmn && __berkdb_trace_func) {
+	if ((x2 - x1) > M2U(ckalmn) && __berkdb_trace_func) {
 		char s[80];
 
 		snprintf(s, sizeof(s), "LONG FSYNC FD=%d %d ms\n",
-		    fhp->fd, x2 - x1);
+		    fhp->fd, U2M(x2 - x1));
 		__berkdb_trace_func(s);
 	}
 

--- a/berkdb/os/os_rw.c
+++ b/berkdb/os/os_rw.c
@@ -55,12 +55,6 @@ static const char revid[] = "$Id: os_rw.c,v 11.30 2003/05/23 21:19:05 bostic Exp
 #include <poll.h>
 #include "logmsg.h"
 
-#ifndef U2M
-#  define U2M(usec) ((usec) / 1000)
-#endif
-#ifndef M2U
-#  define M2U(msec) ((msec) * 1000ULL)
-#endif
 uint64_t bb_berkdb_fasttime(void);
 
 #ifdef HAVE_FILESYSTEM_NOTZERO
@@ -532,7 +526,7 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 				t->pread_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_read_alarm_ms &&
+			if ((x2 - x1) > M2U(__berkdb_read_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
@@ -748,7 +742,7 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 				t->pread_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_read_alarm_ms &&
+			if ((x2 - x1) > M2U(__berkdb_read_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
@@ -1172,7 +1166,7 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 				t->pread_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_read_alarm_ms &&
+			if ((x2 - x1) > M2U(__berkdb_read_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 

--- a/berkdb/os/os_rw.c
+++ b/berkdb/os/os_rw.c
@@ -55,11 +55,11 @@ static const char revid[] = "$Id: os_rw.c,v 11.30 2003/05/23 21:19:05 bostic Exp
 #include <poll.h>
 #include "logmsg.h"
 
-#ifndef MSEC
-#  define MSEC(usec) ((usec) / 1000)
+#ifndef U2M
+#  define U2M(usec) ((usec) / 1000)
 #endif
-#ifndef USEC
-#  define USEC(msec) ((msec) * 1000ULL)
+#ifndef M2U
+#  define M2U(msec) ((msec) * 1000ULL)
 #endif
 uint64_t bb_berkdb_fasttime(void);
 
@@ -538,7 +538,7 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREAD (%d) %d ms fd %d\n",
-				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
+				    (int)pagesize, U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else if (F_ISSET(fhp, DB_FH_DIRECT))
@@ -592,13 +592,13 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms) &&
+			if ((x2 - x1) > M2U(__berkdb_write_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITE (%d) %d ms fd %d\n",
-				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
+				    (int)pagesize, U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else {
@@ -754,7 +754,7 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREAD (%d) %d ms fd %d\n",
-				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
+				    (int)pagesize, U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else if (F_ISSET(fhp, DB_FH_DIRECT))
@@ -808,13 +808,13 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms) &&
+			if ((x2 - x1) > M2U(__berkdb_write_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITE (%d) %d ms fd %d\n",
-				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
+				    (int)pagesize, U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else {
@@ -1178,7 +1178,7 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREADV (%d) %d ms "
-				    "fd %d\n", (int)(*niop), MSEC(x2 - x1), fhp->fd);
+				    "fd %d\n", (int)(*niop), U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		}
@@ -1229,14 +1229,14 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms)
+			if ((x2 - x1) > M2U(__berkdb_write_alarm_ms)
 			    && __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITEV (%d) %d ms "
 				    " fd %d\n",
-				    (int)(nobufs * pagesize), MSEC(x2 - x1), fhp->fd);
+				    (int)(nobufs * pagesize), U2M(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		}

--- a/berkdb/os/os_rw.c
+++ b/berkdb/os/os_rw.c
@@ -17,8 +17,6 @@ int __slow_write_ns = 0;
 
 void (*__berkdb_trace_func) (const char *) = 0;
 
-int bb_berkdb_fasttime(void);
-
 void
 __berkdb_set_num_read_ios(long long *n)
 {
@@ -56,6 +54,14 @@ static const char revid[] = "$Id: os_rw.c,v 11.30 2003/05/23 21:19:05 bostic Exp
 
 #include <poll.h>
 #include "logmsg.h"
+
+#ifndef MSEC
+#  define MSEC(usec) ((usec) / 1000)
+#endif
+#ifndef USEC
+#  define USEC(msec) ((msec) * 1000ULL)
+#endif
+uint64_t bb_berkdb_fasttime(void);
 
 #ifdef HAVE_FILESYSTEM_NOTZERO
 static int __os_zerofill __P((DB_ENV *, DB_FH *));
@@ -499,7 +505,7 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 
 
 		if (__berkdb_read_alarm_ms) {
-			int x1, x2;
+			uint64_t x1, x2;
 
 			x1 = bb_berkdb_fasttime();
 
@@ -520,10 +526,10 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_preads++;
 				p->pread_bytes += pagesize;
-				p->pread_time_ms += (x2 - x1);
+				p->pread_time_us += (x2 - x1);
 				t->n_preads++;
 				t->pread_bytes += pagesize;
-				t->pread_time_ms += (x2 - x1);
+				t->pread_time_us += (x2 - x1);
 			}
 
 			if ((x2 - x1) > __berkdb_read_alarm_ms &&
@@ -532,7 +538,7 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREAD (%d) %d ms fd %d\n",
-				    (int)pagesize, x2 - x1, fhp->fd);
+				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else if (F_ISSET(fhp, DB_FH_DIRECT))
@@ -559,7 +565,7 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 #endif
 
 		if (__berkdb_write_alarm_ms) {
-			int x1, x2;
+			uint64_t x1, x2;
 
 			x1 = bb_berkdb_fasttime();
 
@@ -580,19 +586,19 @@ __os_io_partial(dbenv, op, fhp, pgno, pagesize, parlen, buf, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_pwrites++;
 				p->pwrite_bytes += pagesize;
-				p->pwrite_time_ms += (x2 - x1);
+				p->pwrite_time_us += (x2 - x1);
 				t->n_pwrites++;
 				t->pwrite_bytes += pagesize;
-				t->pwrite_time_ms += (x2 - x1);
+				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_write_alarm_ms &&
+			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITE (%d) %d ms fd %d\n",
-				    (int)pagesize, x2 - x1, fhp->fd);
+				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else {
@@ -715,7 +721,7 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 
 
 		if (__berkdb_read_alarm_ms) {
-			int x1, x2;
+			uint64_t x1, x2;
 
 			x1 = bb_berkdb_fasttime();
 
@@ -736,10 +742,10 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_preads++;
 				p->pread_bytes += pagesize;
-				p->pread_time_ms += (x2 - x1);
+				p->pread_time_us += (x2 - x1);
 				t->n_preads++;
 				t->pread_bytes += pagesize;
-				t->pread_time_ms += (x2 - x1);
+				t->pread_time_us += (x2 - x1);
 			}
 
 			if ((x2 - x1) > __berkdb_read_alarm_ms &&
@@ -748,7 +754,7 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREAD (%d) %d ms fd %d\n",
-				    (int)pagesize, x2 - x1, fhp->fd);
+				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else if (F_ISSET(fhp, DB_FH_DIRECT))
@@ -775,7 +781,7 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 #endif
 
 		if (__berkdb_write_alarm_ms) {
-			int x1, x2;
+			uint64_t x1, x2;
 
 			x1 = bb_berkdb_fasttime();
 
@@ -796,19 +802,19 @@ __os_io(dbenv, op, fhp, pgno, pagesize, buf, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_pwrites++;
 				p->pwrite_bytes += pagesize;
-				p->pwrite_time_ms += (x2 - x1);
+				p->pwrite_time_us += (x2 - x1);
 				t->n_pwrites++;
 				t->pwrite_bytes += pagesize;
-				t->pwrite_time_ms += (x2 - x1);
+				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_write_alarm_ms &&
+			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms) &&
 			    __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITE (%d) %d ms fd %d\n",
-				    (int)pagesize, x2 - x1, fhp->fd);
+				    (int)pagesize, MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		} else {
@@ -1122,7 +1128,7 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 	DB_ASSERT(F_ISSET(fhp, DB_FH_OPENED) &&
 	    fhp->fd != -1 && DB_GLOBAL(j_read) != NULL);
 
-	int x1, x2;
+	uint64_t x1, x2;
 
 	max_bufs = nobufs;
 	*niop = 0;
@@ -1160,10 +1166,10 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_preads++;
 				p->pread_bytes += *niop;
-				p->pread_time_ms += (x2 - x1);
+				p->pread_time_us += (x2 - x1);
 				t->n_preads++;
 				t->pread_bytes += *niop;
-				t->pread_time_ms += (x2 - x1);
+				t->pread_time_us += (x2 - x1);
 			}
 
 			if ((x2 - x1) > __berkdb_read_alarm_ms &&
@@ -1172,7 +1178,7 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 
 				snprintf(s, sizeof(s),
 				    "LONG PREADV (%d) %d ms "
-				    "fd %d\n", (int)(*niop), x2 - x1, fhp->fd);
+				    "fd %d\n", (int)(*niop), MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		}
@@ -1217,20 +1223,20 @@ __os_iov(dbenv, op, fhp, pgno, pagesize, bufs, nobufs, niop)
 				p = bb_berkdb_get_process_stats();
 				p->n_pwrites++;
 				p->pwrite_bytes += nobufs * pagesize;
-				p->pwrite_time_ms += (x2 - x1);
+				p->pwrite_time_us += (x2 - x1);
 				t->n_pwrites++;
 				t->pwrite_bytes += nobufs * pagesize;
-				t->pwrite_time_ms += (x2 - x1);
+				t->pwrite_time_us += (x2 - x1);
 			}
 
-			if ((x2 - x1) > __berkdb_write_alarm_ms
+			if ((x2 - x1) > USEC(__berkdb_write_alarm_ms)
 			    && __berkdb_trace_func) {
 				char s[80];
 
 				snprintf(s, sizeof(s),
 				    "LONG PWRITEV (%d) %d ms "
 				    " fd %d\n",
-				    (int)(nobufs * pagesize), x2 - x1, fhp->fd);
+				    (int)(nobufs * pagesize), MSEC(x2 - x1), fhp->fd);
 				__berkdb_trace_func(s);
 			}
 		}
@@ -1365,37 +1371,31 @@ err:	if (need_free)
 #endif
 
 
-int
+uint64_t
 bb_berkdb_fasttime(void)
 {
-	int return_time = 0;
-
 #if defined(_AIX)
 
 	timebasestruct_t hr_time;
-	long long absolute_time = 0, hr_mstime = 0;
+	long long absolute_time = 0, hr_ustime = 0;
 
 	read_real_time(&hr_time, TIMEBASE_SZ);
 	time_base_to_time(&hr_time, TIMEBASE_SZ);
 	absolute_time = (long long)hr_time.tb_high * 1000000000LL
 	    + (long long)hr_time.tb_low;
-	hr_mstime = absolute_time / 1000000LL;
+	hr_ustime = absolute_time / 1000LL;
 
-	return_time = (int)(hr_mstime);
-
-	return return_time;
+	return hr_ustime;
 
 #elif defined(__sun)
 
 	hrtime_t hr_time = 0;
-	hrtime_t hr_mstime = 0;
+	hrtime_t hr_ustime = 0;
 
 	hr_time = gethrtime();
-	hr_mstime = hr_time / 1000000LL;
+	hr_ustime = hr_time / 1000LL;
 
-	return_time = (int)(hr_mstime);
-
-	return return_time;
+	return hr_ustime;
 
 #elif defined(__linux)
 	struct timeval tp;
@@ -1403,22 +1403,18 @@ bb_berkdb_fasttime(void)
 	gettimeofday(&tp, NULL);
 
 	absolute_time = (tp.tv_sec * 1000000LL) + tp.tv_usec;
-	return_time = (int)(absolute_time / 1000LL);
 
-	return return_time;
+	return absolute_time;
 
 #elif defined(__hpux)
 
 	hrtime_t hr_time = 0;
-	hrtime_t hr_mstime = 0;
+	hrtime_t hr_ustime = 0;
 
 	hr_time = gethrtime();
-	hr_mstime = hr_time / 1000000LL;
+	hr_ustime = hr_time / 1000LL;
 
-	return_time = (int)(hr_mstime);
-
-	return return_time;
-
+	return hr_ustime;
 
 #else
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -7985,8 +7985,8 @@ void *statthd(void *p)
                                       last_bdb_stats.n_lock_waits;
                     reqlog_logf(statlogger, REQL_INFO,
                                 "%u locks, avg time %ums\n", nreads,
-                                (cur_bdb_stats.lock_wait_time_ms -
-                                 last_bdb_stats.lock_wait_time_ms) /
+                                MSEC(cur_bdb_stats.lock_wait_time_us -
+                                     last_bdb_stats.lock_wait_time_us) /
                                     nreads);
                 }
                 if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
@@ -7996,8 +7996,8 @@ void *statthd(void *p)
                                 "%u preads, %u bytes, avg time %ums\n", npreads,
                                 cur_bdb_stats.pread_bytes -
                                     last_bdb_stats.pread_bytes,
-                                (cur_bdb_stats.pread_time_ms -
-                                 last_bdb_stats.pread_time_ms) /
+                                MSEC(cur_bdb_stats.pread_time_us -
+                                     last_bdb_stats.pread_time_us) /
                                     npreads);
                 }
                 if (cur_bdb_stats.n_pwrites > last_bdb_stats.n_pwrites) {
@@ -8007,8 +8007,8 @@ void *statthd(void *p)
                                 "%u pwrites, %u bytes, avg time %ums\n",
                                 npwrites, cur_bdb_stats.pwrite_bytes -
                                               last_bdb_stats.pwrite_bytes,
-                                (cur_bdb_stats.pwrite_time_ms -
-                                 last_bdb_stats.pwrite_time_ms) /
+                                MSEC(cur_bdb_stats.pwrite_time_us -
+                                     last_bdb_stats.pwrite_time_us) /
                                     npwrites);
                 }
                 last_bdb_stats = cur_bdb_stats;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -7985,8 +7985,8 @@ void *statthd(void *p)
                                       last_bdb_stats.n_lock_waits;
                     reqlog_logf(statlogger, REQL_INFO,
                                 "%u locks, avg time %ums\n", nreads,
-                                MSEC(cur_bdb_stats.lock_wait_time_us -
-                                     last_bdb_stats.lock_wait_time_us) /
+                                U2M(cur_bdb_stats.lock_wait_time_us -
+                                    last_bdb_stats.lock_wait_time_us) /
                                     nreads);
                 }
                 if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
@@ -7996,8 +7996,8 @@ void *statthd(void *p)
                                 "%u preads, %u bytes, avg time %ums\n", npreads,
                                 cur_bdb_stats.pread_bytes -
                                     last_bdb_stats.pread_bytes,
-                                MSEC(cur_bdb_stats.pread_time_us -
-                                     last_bdb_stats.pread_time_us) /
+                                U2M(cur_bdb_stats.pread_time_us -
+                                    last_bdb_stats.pread_time_us) /
                                     npreads);
                 }
                 if (cur_bdb_stats.n_pwrites > last_bdb_stats.n_pwrites) {
@@ -8007,8 +8007,8 @@ void *statthd(void *p)
                                 "%u pwrites, %u bytes, avg time %ums\n",
                                 npwrites, cur_bdb_stats.pwrite_bytes -
                                               last_bdb_stats.pwrite_bytes,
-                                MSEC(cur_bdb_stats.pwrite_time_us -
-                                     last_bdb_stats.pwrite_time_us) /
+                                U2M(cur_bdb_stats.pwrite_time_us -
+                                    last_bdb_stats.pwrite_time_us) /
                                     npwrites);
                 }
                 last_bdb_stats = cur_bdb_stats;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1254,8 +1254,8 @@ struct ireq {
     const char *where;
     char *gluewhere; /*backend code where*/
     int debug;
-    int debug_now;
-    int nowms; /*received.*/
+    uint64_t debug_now;
+    uint64_t nowus; /*received.*/
     struct query_limits __limits;
     int opcode;
     struct dbenv *dbenv;
@@ -1293,7 +1293,7 @@ struct ireq {
     /************/
     uint8_t region3; /* used for offsetof */
 
-    int startms; /*thread handling*/
+    uint64_t startus; /*thread handling*/
     int is_fake;
     int is_dumpresponse;
     int is_fromsocket;
@@ -2892,7 +2892,7 @@ void reqlog_new_sql_request(struct reqlogger *logger, char *sqlstmt,
                             char *tags, void *tagbuf, int tagbufsz,
                             void *nullbits, int numbits);
 void reqlog_set_sql(struct reqlogger *logger, char *sqlstmt);
-int reqlog_current_ms(struct reqlogger *logger);
+uint64_t reqlog_current_us(struct reqlogger *logger);
 void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc, int line);
 void reqlog_diffstat_init(struct reqlogger *logger);
 /* this is meant to be called by only 1 thread, will need locking if
@@ -2903,7 +2903,7 @@ void reqlog_set_diffstat_thresh(int val);
 int reqlog_truncate();
 void reqlog_set_truncate(int val);
 void reqlog_set_vreplays(struct reqlogger *logger, int replays);
-void reqlog_set_queue_time(struct reqlogger *logger, int timems);
+void reqlog_set_queue_time(struct reqlogger *logger, uint64_t timeus);
 void reqlog_set_fingerprint(struct reqlogger *logger, char fingerprint[16]);
 void reqlog_set_rqid(struct reqlogger *logger, void *id, int idlen);
 void reqlog_set_request(struct reqlogger *logger, CDB2SQLQUERY *q);
@@ -3299,7 +3299,7 @@ extern int gbl_stop_thds_time_threshold;
 extern pthread_mutex_t stop_thds_time_lk;
 
 int trans_commit_logical_tran(void *trans, int *bdberr);
-int bb_berkdb_fasttime(void);
+uint64_t bb_berkdb_fasttime(void);
 extern int gbl_berk_track_cursors;
 
 void osql_checkboard_foreach_serial_dummy(bdb_osql_trn_t *tran);

--- a/db/dbqueue.c
+++ b/db/dbqueue.c
@@ -1525,29 +1525,29 @@ static void *dbqueue_consume_thread(void *arg)
                    diffms, consumer->db->dbname, consumer->consumern);
             if (t->n_lock_waits > 0) {
                 logmsg(LOGMSG_WARN, "  %u lock waits took %u ms (%u ms/wait)\n",
-                       t->n_lock_waits, MSEC(t->lock_wait_time_us),
-                       MSEC(t->lock_wait_time_us / t->n_lock_waits));
+                       t->n_lock_waits, U2M(t->lock_wait_time_us),
+                       U2M(t->lock_wait_time_us / t->n_lock_waits));
             }
             if (t->n_preads > 0) {
                 logmsg(LOGMSG_WARN,
                        "  %u preads took %u ms total of %u bytes\n",
-                       t->n_preads, MSEC(t->pread_time_us), t->pread_bytes);
+                       t->n_preads, U2M(t->pread_time_us), t->pread_bytes);
             }
             if (t->n_pwrites > 0) {
                 logmsg(LOGMSG_WARN,
                        "  %u pwrites took %u ms total of %u bytes\n",
-                       t->n_pwrites, MSEC(t->pwrite_time_us), t->pwrite_bytes);
+                       t->n_pwrites, U2M(t->pwrite_time_us), t->pwrite_bytes);
             }
             if (t->n_memp_fgets > 0) {
                 logmsg(LOGMSG_WARN, "  %u __memp_fget calls took %u ms\n",
-                       t->n_memp_fgets, MSEC(t->memp_fget_time_us));
+                       t->n_memp_fgets, U2M(t->memp_fget_time_us));
             }
             if (t->n_shallocs > 0 || t->n_shalloc_frees > 0) {
                 logmsg(LOGMSG_WARN,
                        "  %u shallocs took %u ms, %u shalloc_frees "
                        "took %u ms\n",
-                       t->n_shallocs, MSEC(t->shalloc_time_us),
-                       t->n_shalloc_frees, MSEC(t->shalloc_free_time_us));
+                       t->n_shallocs, U2M(t->shalloc_time_us),
+                       t->n_shalloc_frees, U2M(t->shalloc_free_time_us));
             }
         }
         if (rc == 0) {

--- a/db/dbqueue.c
+++ b/db/dbqueue.c
@@ -1519,30 +1519,35 @@ static void *dbqueue_consume_thread(void *arg)
 
         if (diffms > LONG_REQMS) {
             const struct bdb_thread_stats *t = bdb_get_thread_stats();
-            logmsg(LOGMSG_WARN, "LONG REQUEST %-8d msec  consumer thread queue '%s' "
+            logmsg(LOGMSG_WARN,
+                   "LONG REQUEST %-8d msec  consumer thread queue '%s' "
                    "consumer %d dbq_get\n",
                    diffms, consumer->db->dbname, consumer->consumern);
             if (t->n_lock_waits > 0) {
                 logmsg(LOGMSG_WARN, "  %u lock waits took %u ms (%u ms/wait)\n",
-                        t->n_lock_waits, t->lock_wait_time_ms,
-                        t->lock_wait_time_ms / t->n_lock_waits);
+                       t->n_lock_waits, MSEC(t->lock_wait_time_us),
+                       MSEC(t->lock_wait_time_us / t->n_lock_waits));
             }
             if (t->n_preads > 0) {
-                logmsg(LOGMSG_WARN, "  %u preads took %u ms total of %u bytes\n",
-                        t->n_preads, t->pread_time_ms, t->pread_bytes);
+                logmsg(LOGMSG_WARN,
+                       "  %u preads took %u ms total of %u bytes\n",
+                       t->n_preads, MSEC(t->pread_time_us), t->pread_bytes);
             }
             if (t->n_pwrites > 0) {
-                logmsg(LOGMSG_WARN, "  %u pwrites took %u ms total of %u bytes\n",
-                        t->n_pwrites, t->pwrite_time_ms, t->pwrite_bytes);
+                logmsg(LOGMSG_WARN,
+                       "  %u pwrites took %u ms total of %u bytes\n",
+                       t->n_pwrites, MSEC(t->pwrite_time_us), t->pwrite_bytes);
             }
             if (t->n_memp_fgets > 0) {
                 logmsg(LOGMSG_WARN, "  %u __memp_fget calls took %u ms\n",
-                        t->n_memp_fgets, t->memp_fget_time_ms);
+                       t->n_memp_fgets, MSEC(t->memp_fget_time_us));
             }
             if (t->n_shallocs > 0 || t->n_shalloc_frees > 0) {
-                logmsg(LOGMSG_WARN, "  %u shallocs took %u ms, %u shalloc_frees took %u ms\n",
-                    t->n_shallocs, t->shalloc_time_ms, t->n_shalloc_frees,
-                    t->shalloc_free_time_ms);
+                logmsg(LOGMSG_WARN,
+                       "  %u shallocs took %u ms, %u shalloc_frees "
+                       "took %u ms\n",
+                       t->n_shallocs, MSEC(t->shalloc_time_us),
+                       t->n_shalloc_frees, MSEC(t->shalloc_free_time_us));
             }
         }
         if (rc == 0) {

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -188,25 +188,25 @@ void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
     cson_object_set(perfobj, "runtime", cson_new_int(end - start));
 
     if (thread_stats->n_lock_waits || thread_stats->n_preads ||
-        thread_stats->n_pwrites || thread_stats->pread_time_ms ||
-        thread_stats->pwrite_time_ms || thread_stats->lock_wait_time_ms) {
+        thread_stats->n_pwrites || thread_stats->pread_time_us ||
+        thread_stats->pwrite_time_us || thread_stats->lock_wait_time_us) {
         if (thread_stats->n_lock_waits) {
             cson_object_set(perfobj, "lockwaits",
                             cson_new_int(thread_stats->n_lock_waits));
             cson_object_set(perfobj, "lockwaittime",
-                            cson_new_int(thread_stats->lock_wait_time_ms));
+                            cson_new_int(thread_stats->lock_wait_time_us));
         }
         if (thread_stats->n_preads) {
             cson_object_set(perfobj, "reads",
                             cson_new_int(thread_stats->n_preads));
             cson_object_set(perfobj, "readtimetime",
-                            cson_new_int(thread_stats->pread_time_ms));
+                            cson_new_int(thread_stats->pread_time_us));
         }
         if (thread_stats->n_pwrites) {
             cson_object_set(perfobj, "writes",
                             cson_new_int(thread_stats->n_pwrites));
             cson_object_set(perfobj, "writetime",
-                            cson_new_int(thread_stats->pwrite_time_ms));
+                            cson_new_int(thread_stats->pwrite_time_us));
         }
     }
     cson_object_set(obj, "perf", perfval);
@@ -353,8 +353,8 @@ static void eventlog_add_int(cson_object *obj, const struct reqlogger *logger)
         // fingerprint);
     }
 
-    if (logger->queuetimems)
-        cson_object_set(obj, "qtime", cson_new_int(logger->queuetimems));
+    if (logger->queuetimeus)
+        cson_object_set(obj, "qtime", cson_new_int(logger->queuetimeus));
 
     eventlog_context(obj, logger);
     eventlog_params(obj, logger, detailed);
@@ -422,7 +422,7 @@ void eventlog_stop(void)
     eventlog_disable();
 }
 
-void eventlog_process_message_locked(char *line, int lline, int *toff)
+static void eventlog_process_message_locked(char *line, int lline, int *toff)
 {
     char *tok;
     int ltok;

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -301,17 +301,18 @@ static void thd_coalesce_check_ll(void)
 static void thd_dump_nolock(void)
 {
     struct thd *thd;
-    int nowms, opc, cnt = 0;
-    nowms = time_epochms();
+    uint64_t nowus;
+    int opc, cnt = 0;
+    nowus = time_epochus();
 
     {
         for (thd = busy.top; thd; thd = thd->lnk.next) {
             cnt++;
             opc = thd->iq->opcode;
-            logmsg(LOGMSG_USER, 
-                "busy  tid %-5d  time %5d ms  %-6s (%-3d) %-20s where %s %s\n",
-                thd->tid, nowms - thd->iq->nowms, req2a(opc), opc,
-                getorigin(thd->iq), thd->iq->where, thd->iq->gluewhere);
+            logmsg(LOGMSG_USER, "busy  tid %-5d  time %5d ms  %-6s (%-3d) "
+                                "%-20s where %s %s\n",
+                   thd->tid, MSEC(nowus - thd->iq->nowus), req2a(opc), opc,
+                   getorigin(thd->iq), thd->iq->where, thd->iq->gluewhere);
         }
 
         for (thd = idle.top; thd; thd = thd->lnk.next) {
@@ -369,17 +370,19 @@ void thd_coalesce(struct dbenv *dbenv)
 void thd_dump(void)
 {
     struct thd *thd;
-    int nowms, cnt = 0;
-    nowms = time_epochms();
+    uint64_t nowus;
+    int cnt = 0;
+    nowus = time_epochus();
     LOCK(&lock)
     {
         for (thd = busy.top; thd; thd = thd->lnk.next) {
             cnt++;
-            logmsg(LOGMSG_USER, "busy  tid %-5d  time %5d ms  %-6s (%-3d) %-20s where %s "
+            logmsg(LOGMSG_USER,
+                   "busy  tid %-5d  time %5d ms  %-6s (%-3d) %-20s where %s "
                    "%s\n",
-                   thd->tid, nowms - thd->iq->nowms, req2a(thd->iq->opcode),
-                   thd->iq->opcode, getorigin(thd->iq), thd->iq->where,
-                   thd->iq->gluewhere);
+                   thd->tid, MSEC(nowus - thd->iq->nowus),
+                   req2a(thd->iq->opcode), thd->iq->opcode, getorigin(thd->iq),
+                   thd->iq->where, thd->iq->gluewhere);
         }
 
         for (thd = idle.top; thd; thd = thd->lnk.next) {
@@ -501,7 +504,7 @@ static void *thd_req(void *vthd)
                     thd->tid, pthread_self());
             abort();
         }
-        thd->iq->startms = time_epochms();
+        thd->iq->startus = time_epochus();
         thd->iq->where = "executing";
         /*PROCESS REQUEST*/
         thd->iq->reqlogger = logger;
@@ -1103,11 +1106,12 @@ int init_ireq(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb, uint8_t *p_buf,
               int luxref, unsigned long long rqid)
 {
     struct req_hdr hdr;
-    int rc, nowms, num, ndispatch, iamwriter = 0;
+    uint64_t nowus;
+    int rc, num, ndispatch, iamwriter = 0;
     struct thd *thd;
     int numwriterthreads;
 
-    nowms = time_epochms();
+    nowus = time_epochus();
 
     if (iq == 0) {
         if (!do_inline)
@@ -1130,7 +1134,7 @@ int init_ireq(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb, uint8_t *p_buf,
     iq->frompid = frompid;
     iq->gluewhere = "-";
     iq->debug = debug_this_request(gbl_debug_until) || (debug && gbl_debug);
-    iq->debug_now = iq->nowms = nowms;
+    iq->debug_now = iq->nowus = nowus;
     iq->dbenv = dbenv;
     iq->rqid = rqid;
 

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -311,7 +311,7 @@ static void thd_dump_nolock(void)
             opc = thd->iq->opcode;
             logmsg(LOGMSG_USER, "busy  tid %-5d  time %5d ms  %-6s (%-3d) "
                                 "%-20s where %s %s\n",
-                   thd->tid, MSEC(nowus - thd->iq->nowus), req2a(opc), opc,
+                   thd->tid, U2M(nowus - thd->iq->nowus), req2a(opc), opc,
                    getorigin(thd->iq), thd->iq->where, thd->iq->gluewhere);
         }
 
@@ -380,7 +380,7 @@ void thd_dump(void)
             logmsg(LOGMSG_USER,
                    "busy  tid %-5d  time %5d ms  %-6s (%-3d) %-20s where %s "
                    "%s\n",
-                   thd->tid, MSEC(nowus - thd->iq->nowus),
+                   thd->tid, U2M(nowus - thd->iq->nowus),
                    req2a(thd->iq->opcode), thd->iq->opcode, getorigin(thd->iq),
                    thd->iq->where, thd->iq->gluewhere);
         }

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -212,9 +212,8 @@ static void flushdump(struct reqlogger *logger, struct output *out)
         niov++;
         if (append_duration) {
             iov[niov].iov_base = durstr;
-            iov[niov].iov_len =
-                snprintf(durstr, sizeof(durstr), " TIME +%d",
-                         MSEC(time_epochus() - logger->startus));
+            iov[niov].iov_len = snprintf(durstr, sizeof(durstr), " TIME +%d",
+                                         U2M(time_epochus() - logger->startus));
             niov++;
         }
         iov[niov].iov_base = "\n";
@@ -1612,10 +1611,10 @@ static void log_header_ll(struct reqlogger *logger, struct output *out)
     struct reqlog_print_callback_args args;
 
     if (out == long_request_out) {
-        dumpf(logger, out, "LONG REQUEST %d msec ", MSEC(logger->durationus));
+        dumpf(logger, out, "LONG REQUEST %d msec ", U2M(logger->durationus));
     } else {
         dumpf(logger, out, "%s %d msec ", logger->request_type,
-              MSEC(logger->durationus));
+              U2M(logger->durationus));
     }
     dumpf(logger, out, "from %s rc %d\n", reqorigin(logger), logger->rc);
 
@@ -1845,7 +1844,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                 }
             }
 
-            if (!inrange(&rule->duration, MSEC(logger->durationus))) {
+            if (!inrange(&rule->duration, U2M(logger->durationus))) {
                 continue;
             }
 
@@ -1952,17 +1951,17 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
         long_request_thresh = long_request_ms;
     }
 
-    if (logger->durationus >= USEC(long_request_thresh)) {
+    if (logger->durationus >= M2U(long_request_thresh)) {
 
         log_header(logger, long_request_out, 1);
         long_reqs++;
 
-        if (logger->durationus > USEC(longest_long_request_ms)) {
-            longest_long_request_ms = MSEC(logger->durationus);
+        if (logger->durationus > M2U(longest_long_request_ms)) {
+            longest_long_request_ms = U2M(logger->durationus);
         }
         if (shortest_long_request_ms == -1 ||
-            logger->durationus < USEC(shortest_long_request_ms)) {
-            shortest_long_request_ms = MSEC(logger->durationus);
+            logger->durationus < M2U(shortest_long_request_ms)) {
+            shortest_long_request_ms = U2M(logger->durationus);
         }
         long_request_count++;
         if (last_long_request_epoch != time_epoch()) {
@@ -1980,7 +1979,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                     if (long_request_count == 1) {
                         logmsg(LOGMSG_USER,
                                "LONG REQUEST %d MS logged in %s [%s]\n",
-                               MSEC(logger->durationus),
+                               U2M(logger->durationus),
                                long_request_out->filename, sqlinfo);
                     } else {
                         logmsg(LOGMSG_USER,
@@ -1994,7 +1993,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                 } else {
                     if (long_request_count == 1) {
                         logmsg(LOGMSG_USER, "LONG REQUEST %d MS logged in %s\n",
-                               MSEC(logger->durationus),
+                               U2M(logger->durationus),
                                long_request_out->filename);
                     } else {
                         logmsg(LOGMSG_USER,

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -212,8 +212,9 @@ static void flushdump(struct reqlogger *logger, struct output *out)
         niov++;
         if (append_duration) {
             iov[niov].iov_base = durstr;
-            iov[niov].iov_len = snprintf(durstr, sizeof(durstr), " TIME +%d",
-                                         time_epochms() - logger->startms);
+            iov[niov].iov_len =
+                snprintf(durstr, sizeof(durstr), " TIME +%d",
+                         MSEC(time_epochus() - logger->startus));
             niov++;
         }
         iov[niov].iov_base = "\n";
@@ -632,7 +633,6 @@ static const char *help_text[] = {
     "Request logging framework commands",
     "reql longrequest #           - set long request threshold in msec",
     "reql longsqlrequest #        - set long SQL request threshold in msec",
-    "reql logallsql [on|off]      - log every sql request",
     "reql longreqfile <filename>  - set file to log long requests in",
     "reql diffstat #              - set diff stat threshold in sec",
     "reql truncate #              - set request truncation",
@@ -1412,8 +1412,7 @@ void reqlog_new_request(struct ireq *iq)
     }
 
     reqlog_reset_logger(logger);
-    logger->startms = iq->nowms;
-    logger->startus = time_epochus();
+    logger->startus = iq->nowus;
     logger->iq = iq;
     logger->opcode = iq->opcode;
     if (iq->is_fromsocket) {
@@ -1544,7 +1543,6 @@ void reqlog_new_sql_request(struct reqlogger *logger, char *sqlstmt, char *tags,
     reqlog_reset_logger(logger);
     logger->request_type = "sql_request";
     logger->opcode = OP_SQL;
-    logger->startms = time_epochms();
     logger->startus = time_epochus();
     reqlog_start_request(logger);
 
@@ -1614,10 +1612,10 @@ static void log_header_ll(struct reqlogger *logger, struct output *out)
     struct reqlog_print_callback_args args;
 
     if (out == long_request_out) {
-        dumpf(logger, out, "LONG REQUEST %d msec ", logger->durationms);
+        dumpf(logger, out, "LONG REQUEST %d msec ", MSEC(logger->durationus));
     } else {
         dumpf(logger, out, "%s %d msec ", logger->request_type,
-              logger->durationms);
+              MSEC(logger->durationus));
     }
     dumpf(logger, out, "from %s rc %d\n", reqorigin(logger), logger->rc);
 
@@ -1771,9 +1769,9 @@ void reqlog_set_rows(struct reqlogger *logger, int rows)
     if (logger) logger->sqlrows = rows;
 }
 
-int reqlog_current_ms(struct reqlogger *logger)
+uint64_t reqlog_current_us(struct reqlogger *logger)
 {
-    return (time_epochms() - logger->startms);
+    return (time_epochus() - logger->startus);
 }
 
 void reqlog_set_rqid(struct reqlogger *logger, void *id, int idlen)
@@ -1826,8 +1824,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
 
     logger->rc = rc;
 
-    logger->durationms =
-        (time_epochms() - logger->startms) + logger->queuetimems;
+    logger->durationus =
+        (time_epochus() - logger->startus) + logger->queuetimeus;
 
     eventlog_add(logger);
 
@@ -1847,7 +1845,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                 }
             }
 
-            if (!inrange(&rule->duration, logger->durationms)) {
+            if (!inrange(&rule->duration, MSEC(logger->durationus))) {
                 continue;
             }
 
@@ -1954,17 +1952,17 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
         long_request_thresh = long_request_ms;
     }
 
-    if (logger->durationms >= long_request_thresh) {
+    if (logger->durationus >= USEC(long_request_thresh)) {
 
         log_header(logger, long_request_out, 1);
         long_reqs++;
 
-        if (logger->durationms > longest_long_request_ms) {
-            longest_long_request_ms = logger->durationms;
+        if (logger->durationus > USEC(longest_long_request_ms)) {
+            longest_long_request_ms = MSEC(logger->durationus);
         }
         if (shortest_long_request_ms == -1 ||
-            logger->durationms < shortest_long_request_ms) {
-            shortest_long_request_ms = logger->durationms;
+            logger->durationus < USEC(shortest_long_request_ms)) {
+            shortest_long_request_ms = MSEC(logger->durationus);
         }
         long_request_count++;
         if (last_long_request_epoch != time_epoch()) {
@@ -1982,8 +1980,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                     if (long_request_count == 1) {
                         logmsg(LOGMSG_USER,
                                "LONG REQUEST %d MS logged in %s [%s]\n",
-                               logger->durationms, long_request_out->filename,
-                               sqlinfo);
+                               MSEC(logger->durationus),
+                               long_request_out->filename, sqlinfo);
                     } else {
                         logmsg(LOGMSG_USER,
                                "%d LONG REQUESTS %d MS - %d MS logged "
@@ -1996,7 +1994,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
                 } else {
                     if (long_request_count == 1) {
                         logmsg(LOGMSG_USER, "LONG REQUEST %d MS logged in %s\n",
-                               logger->durationms, long_request_out->filename);
+                               MSEC(logger->durationus),
+                               long_request_out->filename);
                     } else {
                         logmsg(LOGMSG_USER,
                                "%d LONG REQUESTS %d MS - %d MS logged in %s\n",
@@ -2382,9 +2381,9 @@ void reqlog_set_vreplays(struct reqlogger *logger, int replays)
     if (logger) logger->vreplays = replays;
 }
 
-void reqlog_set_queue_time(struct reqlogger *logger, int timems)
+void reqlog_set_queue_time(struct reqlogger *logger, uint64_t timeus)
 {
-    if (logger) logger->queuetimems = timems;
+    if (logger) logger->queuetimeus = timeus;
 }
 
 void reqlog_set_fingerprint(struct reqlogger *logger, char fingerprint[16])

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -74,8 +74,7 @@ struct reqlogger {
     unsigned dump_mask;
     unsigned mask; /* bitwise or of the above two masks */
 
-    int startms;
-    int64_t startus;
+    uint64_t startus;
 
     struct prefix_type prefix;
     char dumpline[1024];
@@ -105,9 +104,9 @@ struct reqlogger {
     double sqlcost;
 
     int rc;
-    int durationms;
+    uint64_t durationus;
     int vreplays;
-    int queuetimems;
+    uint64_t queuetimeus;
     char fingerprint[16];
     int have_fingerprint;
     char id[41];

--- a/db/sql.h
+++ b/db/sql.h
@@ -467,8 +467,8 @@ struct sqlclntstate {
     unsigned int file;
     unsigned int offset;
 
-    int enque_time;
-    int deque_time;
+    uint64_t enque_timeus;
+    uint64_t deque_timeus;
 
     /* due to some sqlite vagaries, cursor is closed
        and I lose the side row; cache it here! */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1857,7 +1857,7 @@ static void log_queue_time(struct reqlogger *logger, struct sqlclntstate *clnt)
         return;
     if (clnt->deque_timeus - clnt->enque_timeus > 0)
         reqlog_logf(logger, REQL_INFO, "queuetime took %dms",
-                    MSEC(clnt->deque_timeus - clnt->enque_timeus));
+                    U2M(clnt->deque_timeus - clnt->enque_timeus));
     reqlog_set_queue_time(logger, clnt->deque_timeus - clnt->enque_timeus);
 }
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1855,10 +1855,10 @@ static void log_queue_time(struct reqlogger *logger, struct sqlclntstate *clnt)
 {
     if (!gbl_track_queue_time)
         return;
-    if (clnt->deque_time - clnt->enque_time > 0)
+    if (clnt->deque_timeus - clnt->enque_timeus > 0)
         reqlog_logf(logger, REQL_INFO, "queuetime took %dms",
-                    clnt->deque_time - clnt->enque_time);
-    reqlog_set_queue_time(logger, clnt->deque_time - clnt->enque_time);
+                    MSEC(clnt->deque_timeus - clnt->enque_timeus));
+    reqlog_set_queue_time(logger, clnt->deque_timeus - clnt->enque_timeus);
 }
 
 static void log_cost(struct reqlogger *logger, int64_t cost, int64_t rows) {
@@ -5649,7 +5649,7 @@ static void sqlengine_work_lua_thread(struct thdpool *pool, void *work,
     thr_set_user(clnt->appsock_id);
 
     clnt->osql.timings.query_dispatched = osql_log_time();
-    clnt->deque_time = time_epochms();
+    clnt->deque_timeus = time_epochus();
 
     rdlock_schema_lk();
     sqlengine_prepare_engine(thd, clnt);
@@ -5685,7 +5685,7 @@ static void sqlengine_work_appsock(struct thdpool *pool, void *work,
     thr_set_user(clnt->appsock_id);
 
     clnt->osql.timings.query_dispatched = osql_log_time();
-    clnt->deque_time = time_epochms();
+    clnt->deque_timeus = time_epochus();
 
     /* make sure we have an sqlite engine sqldb */
     if (clnt->verify_indexes) {
@@ -5979,7 +5979,7 @@ int dispatch_sql_query(struct sqlclntstate *clnt)
     pthread_mutex_unlock(&clnt->wait_mutex);
 
     snprintf(msg, sizeof(msg), "%s \"%s\"", clnt->origin, clnt->sql);
-    clnt->enque_time = time_epochms();
+    clnt->enque_timeus = time_epochus();
 
     char *sqlcpy;
     if ((rc = thdpool_enqueue(gbl_sqlengine_thdpool, sqlengine_work_appsock_pp,
@@ -6284,7 +6284,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->selectv_arr = NULL;
     clnt->file = 0;
     clnt->offset = 0;
-    clnt->enque_time = clnt->deque_time = 0;
+    clnt->enque_timeus = clnt->deque_timeus = 0;
     clnt->writeTransaction = 0;
 
     clnt->ins_keys = 0ULL;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5746,15 +5746,7 @@ add_blkseq:
     }
 
     struct timespec end_time;
-    int diff_time_micros = 0;
-#if 0
-    clock_gettime(CLOCK_REALTIME, &end_time); 
-
-    int diff_time_us = (end_time.tv_sec - start_time.tv_sec)*1000*1000 + (end_time.tv_nsec - start_time.tv_nsec)/1000;
-
-    printf("\n Time taken for commit = %d micro seconds", diff_time_us);
-#endif
-    diff_time_micros = (reqlog_current_ms(iq->reqlogger)) * 1000;
+    int diff_time_micros = (int)reqlog_current_us(iq->reqlogger);
 
     pthread_mutex_lock(&commit_stat_lk);
     n_commit_time += diff_time_micros;


### PR DESCRIPTION
Continue reporting LONG EVENTS, etc. as we do now, but report microseconds for event logging.