### PR TITLE
Provide way to run unit tests without running a db

### DIFF
--- a/tests/crle.test/Makefile
+++ b/tests/crle.test/Makefile
@@ -1,4 +1,6 @@
+COMDB2_UNITTEST=1
 include $(TESTSROOTDIR)/testcase.mk
 
 tool:
 	make -skC $(TESTSROOTDIR)/tools crle
+

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -11,13 +11,13 @@ echo Starting $TESTCASE with id $TESTID at $DATETIME >> $TESTDIR/test.log
 mkdir -p ${TESTDIR}/logs/
 
 function call_unsetup {
-    [[ $TESTCASE == "crle" ]] && return
+    [[ $COMDB2_UNITTEST == 1 ]] && return
     ${TESTSROOTDIR}/unsetup $successful &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
 }
 
 
 function call_setup {
-    [[ "$TESTCASE" == "crle" ]] && return
+    [[ $COMDB2_UNITTEST == 1 ]] && return
     timeout ${SETUP_TIMEOUT} ${TESTSROOTDIR}/setup &> >(gawk '{ t='${DBNAME}'; print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.setup | cut -c11- | grep "^!" )
     rc=$?
     glist=`pgrep gawk -a | grep ${DBNAME} | cut -f1 -d' ' | xargs echo`

--- a/tests/setup
+++ b/tests/setup
@@ -5,6 +5,8 @@ set -x
 
 debug=0
 
+[[ $COMDB2_UNITTEST == 1 ]] && exit 0
+
 while [[ $# -gt 0 && $1 = -* ]]; do
     [[ $1 = '-debug' ]] && debug=1
     shift

--- a/tests/testcase.mk
+++ b/tests/testcase.mk
@@ -12,6 +12,7 @@ export CDB2_OPTIONS=--cdb2cfg $(CDB2_CONFIG)
 export COMDB2_ROOT=$(TESTDIR)
 export comdb2ar=$(SRCHOME)/comdb2ar
 export comdb2task=$(SRCHOME)/comdb2
+export COMDB2_UNITTEST?=0
 
 test:: tool
 	echo "Working from dir `pwd`" >> $(TESTDIR)/test.log

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -2,6 +2,8 @@
 
 set -x
 
+[[ $COMDB2_UNITTEST == 1 ]] && exit 0
+
 echo "!$TESTCASE: stopping"
 [ -z "$TESTDIR" ] && TESTDIR=${PWD}/test_${TESTID}
 [ -z "$TMPDIR" ] && TMPDIR=${TESTDIR}/tmp


### PR DESCRIPTION
By setting global variable COMDB2_UNITTEST in the makefile, we can run
a designated unit test [or tests] without running a backing db.
Convert crle test to use such feature.