### PR TITLE
On startup, wait for coherent before "I AM READY"

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -8574,7 +8574,7 @@ void create_marker_file()
     if (tmpfd != -1) close(tmpfd);
 }
 
-void set_timepart_and_handle_resume_sc() 
+static void set_timepart_and_handle_resume_sc() 
 {
     /* We need to do this before resuming schema chabge , if any */
     logmsg(LOGMSG_INFO, "Reloading time partitions\n");
@@ -8622,17 +8622,16 @@ struct tool tool_callbacks[] = {
    NULL
 };
 
-
-void wait_for_coherent()
+static void wait_for_coherent()
 {
-    const unsigned int cslp = 10000;         // 10000us == 10ms
-    const unsigned int wrn_cnt = 5 * 1000000 / cslp; // 5s
+    const unsigned int cslp = 10000;                 /* 10000us == 10ms */
+    const unsigned int wrn_cnt = 5 * 1000000 / cslp; /* 5s */
     unsigned int counter = 1;
     while (!bdb_am_i_coherent(thedb->bdb_env)) {
-       if ((++counter % wrn_cnt) == 0) {
-          logmsg(LOGMSG_ERROR, "I am still incoherent\n");
-       }
-       usleep(cslp);
+        if ((++counter % wrn_cnt) == 0) {
+            logmsg(LOGMSG_ERROR, "I am still incoherent\n");
+        }
+        usleep(cslp);
     }
 }
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -8574,7 +8574,7 @@ void create_marker_file()
     if (tmpfd != -1) close(tmpfd);
 }
 
-static void set_timepart_and_handle_resume_sc() 
+static void set_timepart_and_handle_resume_sc()
 {
     /* We need to do this before resuming schema chabge , if any */
     logmsg(LOGMSG_INFO, "Reloading time partitions\n");

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -8622,6 +8622,20 @@ struct tool tool_callbacks[] = {
    NULL
 };
 
+
+void wait_for_coherent()
+{
+    const unsigned int cslp = 10000;         // 10000us == 10ms
+    const unsigned int wrn_cnt = 5 * 1000000 / cslp; // 5s
+    unsigned int counter = 1;
+    while (!bdb_am_i_coherent(thedb->bdb_env)) {
+       if ((++counter % wrn_cnt) == 0) {
+          logmsg(LOGMSG_ERROR, "I am still incoherent\n");
+       }
+       usleep(cslp);
+    }
+}
+
 int main(int argc, char **argv)
 {
     char *marker_file;
@@ -8771,6 +8785,7 @@ int main(int argc, char **argv)
     // db started - disable recsize kludge so
     // new schemachanges won't allow broken size.
     gbl_broken_max_rec_sz = 0;
+    wait_for_coherent();
 
     gbl_ready = 1;
     logmsg(LOGMSG_WARN, "I AM READY.\n");


### PR DESCRIPTION
Currently when a node is coming up, it prints 'I AM READY' before it can serve clients because it may not be coherent yet. This patch will have a node wait until it becomes coherent before it proceeds to print it is ready. 