### PR TITLE
db: Providing an LRL option to control VDBE sorter virtual memory usage

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2648,6 +2648,15 @@ static int read_lrl_option(struct dbenv *dbenv, char *line, void *p, int len)
         gbl_sqlite_sorter_mem = ii;
     }
 
+    else if (tokcmp(tok, ltok, "sqlsortermaxmmapsize") == 0) {
+        tok = segtok(line, len, &st, &ltok);
+        long long maxmmapsz = toknumll(tok, ltok);
+        logmsg(LOGMSG_INFO, "setting sqlsortermaxmmapsize to %ld bytes\n",
+               maxmmapsz);
+        sqlite3_config(SQLITE_CONFIG_MMAP_SIZE, SQLITE_DEFAULT_MMAP_SIZE,
+                       maxmmapsz);
+    }
+
     else if (tokcmp(tok, ltok, "sqlsortermult") == 0) {
         tok = segtok(line, len, &st, &ltok);
         ii = toknum(tok, ltok);

--- a/docs/aspell.en.pws
+++ b/docs/aspell.en.pws
@@ -404,6 +404,7 @@ FKEY
 HH
 FS
 sqlsortermem
+sqlsortermaxmmapsize
 ie
 ioqueue
 foreigntablename

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -737,6 +737,7 @@ These options are toggle-able at runtime.
 |enable_prefault_udp | not set |  Send lossy prefault requests to replicants 
 |disable_prefault_udp | | Disable `enable_prefault_udp`
 |sqlsortermem | 314572800 | maximum amount of memory to give the sqlite sorter
+|sqlsortermaxmmapsize | 2147418112 | maximum amount of file-backed mmap size in bytes to give the sqlite sorter
 |cache | 64 mb | Database cache size, see [cache size](#cache-size)
 |cachekb | | see [cache size](#cache-size)
 |cachekbmin | | see [cache size](#cache-size)


### PR DESCRIPTION
By default, sqlite VDBE sorter maps up to 2GB of the process's virtual memory to temporary files.
Comdb2 is multi-threaded. Each SQL thread has its own VDBE. Hence it could cause total database size to exceed allowable `ulimit -v'.
We should at least have a tunable to control VDBE virtual memory usage.