### PR TITLE
analyze empty tables

### DIFF
--- a/sqlite/sqlite_tunables.h
+++ b/sqlite/sqlite_tunables.h
@@ -9,3 +9,5 @@ DEF_ATTR(SCALE_IN_CLAUSE, scale_in_clause, BOOLEAN, 1)
 DEF_ATTR(STAT4_SAMPLES_MULTIPLIER, stat4_samples_multiplier, QUANTITY, 0) 
 /* stat4 number of samples more than the default 24 */
 DEF_ATTR(STAT4_EXTRA_SAMPLES, stat4_extra_samples, QUANTITY, 0) 
+/* build sqlite_stat1 table entries for empty tables */
+DEF_ATTR(ANALYZE_EMPTY_TABLES, analyze_empty_tables, BOOLEAN, 0)

--- a/tests/analyze.test/t9_01.req
+++ b/tests/analyze.test/t9_01.req
@@ -1,0 +1,8 @@
+drop table if exists t9
+create table t9 {schema { int a } keys { "a"=a }}$$
+exec procedure sys.cmd.send("setsqlattr analyze_empty_tables off")
+exec procedure sys.cmd.analyze("t9")
+select * from sqlite_stat1 where tbl="t9"
+exec procedure sys.cmd.send("setsqlattr analyze_empty_tables on")
+exec procedure sys.cmd.analyze("t9")
+select * from sqlite_stat1 where tbl="t9"

--- a/tests/analyze.test/t9_01.req.out
+++ b/tests/analyze.test/t9_01.req.out
@@ -1,0 +1,13 @@
+[drop table if exists t9] rc 0
+[create table t9 {schema { int a } keys { "a"=a }}] rc 0
+[exec procedure sys.cmd.send("setsqlattr analyze_empty_tables off")] rc 0
+(out='Analyze completed table t9')
+(out='Analyze table 't9' is complete')
+[exec procedure sys.cmd.analyze("t9")] rc 0
+[select * from sqlite_stat1 where tbl="t9"] rc 0
+[exec procedure sys.cmd.send("setsqlattr analyze_empty_tables on")] rc 0
+(out='Analyze completed table t9')
+(out='Analyze table 't9' is complete')
+[exec procedure sys.cmd.analyze("t9")] rc 0
+(tbl='t9', idx='$A_9888C5EA', stat='1 0')
+[select * from sqlite_stat1 where tbl="t9"] rc 0


### PR DESCRIPTION
- sqlite patch: https://www.sqlite.org/src/fdiff?sbs=1&v1=0d0ccf7520a201d8&v2=62a35801482e72fa
- I set the tunable to OFF so that it wont break existing tests which assume no entry for empty tables.
- added a simple test case to analyze.test