### PR TITLE
do not try to send information if recovery mode

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -91,6 +91,7 @@
 
 extern int gbl_keycompr;
 extern int gbl_early;
+extern int gbl_exit;
 extern int gbl_fullrecovery;
 extern char *gbl_mynode;
 
@@ -2123,6 +2124,10 @@ void create_udpbackup_analyze_thread(bdb_state_type *bdb_state)
 {
     pthread_t thread_id;
     pthread_attr_t thd_attr;
+
+    if(gbl_exit)
+        return;
+
     logmsg(LOGMSG_INFO, "starting udpbackup_and_autoanalyze_thd thread\n");
 
     pthread_attr_init(&thd_attr);
@@ -5588,7 +5593,7 @@ bdb_open_int(int envonly, const char name[], const char dir[], int lrl,
         bdb_state->master_handle = 1;
 
         /* dont create all these aux helper threads for a run of initcomdb2 */
-        if (!create) {
+        if (!create && !gbl_exit) {
             /*
               create checkpoint thread.
               this thread periodically applied changes reflected in the

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2125,8 +2125,7 @@ void create_udpbackup_analyze_thread(bdb_state_type *bdb_state)
     pthread_t thread_id;
     pthread_attr_t thd_attr;
 
-    if(gbl_exit)
-        return;
+    if (gbl_exit) return;
 
     logmsg(LOGMSG_INFO, "starting udpbackup_and_autoanalyze_thd thread\n");
 


### PR DESCRIPTION
Database should not create communication threads if it will come down immediately.  Otherwise it is spewing like this:
[ERROR] net_udp_send:sendto: Socket operation on non-socket
dest=fakehost, addr=0.0.0.0
