### PR TITLE
Add a Knossos linearizability tester.

### DIFF
--- a/linearizable/filetest/.gitignore
+++ b/linearizable/filetest/.gitignore
@@ -1,0 +1,11 @@
+/target
+/classes
+/checkouts
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+.hgignore
+.hg/

--- a/linearizable/filetest/CHANGELOG.md
+++ b/linearizable/filetest/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
+
+## [Unreleased]
+### Added
+- Simple tester that reads history from a file

--- a/linearizable/filetest/LICENSE
+++ b/linearizable/filetest/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2017, Bloomberg Finance L.P.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/linearizable/filetest/README.md
+++ b/linearizable/filetest/README.md
@@ -1,0 +1,13 @@
+# jepsen.filetest
+
+Simple cas/linearizability tester - read history from a file, return whether it's linearizable
+
+## Usage
+
+lein run history.txt
+
+## License
+
+Copyright © 2017 Bloomberg Finance L.P.
+
+Licensed under the Apache License, Version 2.0 

--- a/linearizable/filetest/doc/intro.md
+++ b/linearizable/filetest/doc/intro.md
@@ -1,0 +1,7 @@
+# Introduction to jepsen.filetest
+
+Jepsen/Knossos provide a lovely framework for testing database correctness.  The only
+problem is that we, as database developers, aren't also particularly strong in 
+clojure.  This is a very small simple wrapper around Knossos to allow writing the 
+test itself in any language, and running the resulting history through the Knossos
+checker.

--- a/linearizable/filetest/history.txt
+++ b/linearizable/filetest/history.txt
@@ -1,0 +1,6 @@
+[
+{:type :invoke :f :write :value 1 :process 0 :time 1}
+{:type :ok :f :write :process 0 :value 1 :time 2}
+{:type :invoke :f :read :process 0 :time 3}
+{:type :ok :process 0 :f :read :value 1 :time 4}
+]

--- a/linearizable/filetest/project.clj
+++ b/linearizable/filetest/project.clj
@@ -1,0 +1,9 @@
+(defproject jepsen.filetest "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :main jepsen.filetest
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [jepsen "0.1.4"]
+                 [knossos "0.2.9-SNAPSHOT" :exclusions [org.slf4j/slf4j-log4j12]]])

--- a/linearizable/filetest/src/jepsen/filetest.clj
+++ b/linearizable/filetest/src/jepsen/filetest.clj
@@ -1,0 +1,21 @@
+(ns jepsen.filetest
+ (:gen-class)
+ (:require
+ [knossos 
+         [model :as model]
+         [linear :as linear]]))
+
+(defn -main
+ "Usage: historyfile"
+ [& args]
+
+ (if (not= (count args) 1)
+  (System/exit 1))
+
+ (let [history (read-string (slurp (first args)))]
+  (let [analysis (linear/analysis (model/cas-register) history)]
+   (clojure.pprint/pprint analysis)
+   (System/exit 
+    (if (:valid? analysis) 
+     0
+     1)))))


### PR DESCRIPTION
Turns out we're better at C than Clojure.  This gives us a way to write a test in C, and run it through Knossos.  Should be easily adaptable to other Jepsen/Knossos tests.