### PR TITLE
cdb2jdbc: Allow connection forwarding via portmux.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -187,7 +187,7 @@ public class BBSysUtils {
         try {
             String name = String.format("get %s/%s/%s\n", app, service, instance);
 
-            io = new SockIO(host, port);
+            io = new SockIO(host, port, null);
 
             io.write(name.getBytes());
             io.flush();
@@ -240,7 +240,7 @@ public class BBSysUtils {
 
         try {
             if (dbInfoResp == null) {
-                io = new SockIO(host, port);
+                io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null);
 
                 /*********************************
                  * Sending data...
@@ -360,7 +360,7 @@ public class BBSysUtils {
         SockIO io = null;
 
         try {
-            io = new SockIO(host, port);
+            io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null);
 
             /*********************************
              * Sending data...
@@ -654,6 +654,16 @@ public class BBSysUtils {
          * Ask them one-by-one to get the host(s) and port(s) of the database we
          * want to hndlect to.
          **********************************************/
+
+        /* If pmux route is enabled, use pmux port. */
+        if (hndl.pmuxrte) {
+            hndl.myDbPorts.clear();
+            for (int i = 0; i != hndl.myDbHosts.size(); ++i)
+                hndl.myDbPorts.add(hndl.portMuxPort);
+            return;
+        }
+
+
         found = false;
 
         int port = -1;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -236,6 +236,16 @@ public class Comdb2Connection implements Connection {
         hndl.setSSLCAType(catype);
     }
 
+    public void setAllowPmuxRoute(String val) {
+        if ("true".equalsIgnoreCase(val)
+                || "1".equalsIgnoreCase(val)
+                || "T".equalsIgnoreCase(val)
+                || "on".equalsIgnoreCase(val))
+            hndl.setAllowPmuxRoute(true);
+        else
+            hndl.setAllowPmuxRoute(false);
+    }
+
     public ArrayList<String> getDbHosts() throws NoDbHostFoundException{
         return hndl.getDbHosts();
     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -67,6 +67,7 @@ public class Comdb2Handle extends AbstractConnection {
     boolean hasUserTcpSz;
     int tcpbufsz;
     int age = 180; /* default max age 180 seconds */
+    boolean pmuxrte = false;
 
     private boolean in_retry = false;
     private boolean temp_trans = false;
@@ -147,6 +148,16 @@ public class Comdb2Handle extends AbstractConnection {
         ret.dnssuffix = dnssuffix;
         ret.hasUserTcpSz = hasUserTcpSz;
         ret.tcpbufsz = tcpbufsz;
+        ret.age = age;
+        ret.pmuxrte = pmuxrte;
+        ret.sslmode = sslmode;
+        ret.sslcert = sslcert;
+        ret.sslcertpass = sslcertpass;
+        ret.sslcerttype = sslcerttype;
+        ret.sslca = sslca;
+        ret.sslcapass = sslcapass;
+        ret.sslcatype = sslcatype;
+        ret.peersslmode = peersslmode;
         return ret;
     }
 
@@ -204,6 +215,12 @@ public class Comdb2Handle extends AbstractConnection {
 
     public void setOverriddenPort(int port) {
         overriddenPort = port;
+    }
+
+    public void setAllowPmuxRoute(boolean val) {
+        pmuxrte = val;
+        if (val)
+            overriddenPort = portMuxPort;
     }
 
     void addHosts(List<String> hosts) {
@@ -1639,7 +1656,7 @@ readloop:
            we're not on it, connect to it. */
         if (prefIdx != -1 && dbHostIdx != prefIdx) {
             io = new SockIO(myDbHosts.get(prefIdx),
-                    myDbPorts.get(prefIdx), tcpbufsz);
+                    myDbPorts.get(prefIdx), tcpbufsz, pmuxrte ? myDbName : null);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1676,7 +1693,7 @@ readloop:
                         || try_node == dbHostConnected)
                     continue;
 
-                io = new SockIO(myDbHosts.get(try_node), myDbPorts.get(try_node), tcpbufsz);
+                io = new SockIO(myDbHosts.get(try_node), myDbPorts.get(try_node), tcpbufsz, pmuxrte ? myDbName : null);
                 if (io.open()) {
                     try {
                         io.write("newsql\n");
@@ -1713,7 +1730,7 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz);
+            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz, pmuxrte ? myDbName : null);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1742,7 +1759,7 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz);
+            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz, pmuxrte ? myDbName : null);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1769,7 +1786,7 @@ readloop:
          */
         if (masterIndexInMyDbHosts >= 0) {
             io = new SockIO(myDbHosts.get(masterIndexInMyDbHosts),
-                    myDbPorts.get(masterIndexInMyDbHosts), tcpbufsz);
+                    myDbPorts.get(masterIndexInMyDbHosts), tcpbufsz, pmuxrte ? myDbName : null);
             if (io.open()) {
                 try {
                     io.write("newsql\n");

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -46,6 +46,7 @@ public class Driver implements java.sql.Driver {
     public static final String PROPERTY_SSL_CA = "trust_store";
     public static final String PROPERTY_SSL_CAPASS = "trust_store_password";
     public static final String PROPERTY_SSL_CATYPE = "trust_store_type";
+    public static final String PROPERTY_PMUX_RTE = "allow_pmux_route";
 
     /**
      * Register our driver statically.
@@ -96,6 +97,7 @@ public class Driver implements java.sql.Driver {
         String sslca = null;
         String sslcapass = null;
         String sslcatype = null;
+        String pmuxrte = null;
         String attributes = null;
 
         String policy = null;
@@ -198,6 +200,8 @@ public class Driver implements java.sql.Driver {
                         sslcapass = keyval[1];
                     else if (PROPERTY_SSL_CATYPE.equalsIgnoreCase(keyval[0]))
                         sslcatype = keyval[1];
+                    else if (PROPERTY_PMUX_RTE.equalsIgnoreCase(keyval[0]))
+                        pmuxrte = keyval[1];
                 }
             }
         }
@@ -252,6 +256,8 @@ public class Driver implements java.sql.Driver {
             sslcapass = info.getProperty(PROPERTY_SSL_CAPASS);
         if (sslcatype == null)
             sslcatype = info.getProperty(PROPERTY_SSL_CATYPE);
+        if (pmuxrte == null)
+            pmuxrte = info.getProperty(PROPERTY_PMUX_RTE);
 
         try {
             if (port != null) {
@@ -372,6 +378,11 @@ public class Driver implements java.sql.Driver {
             if (sslcatype != null) {
                 logger.log(Level.FINE, String.format("Setting ssl tstype to %s\n", sslcatype));
                 ret.setSSLCAType(sslcatype);
+            }
+
+            if (pmuxrte != null) {
+                logger.log(Level.FINE, String.format("Setting pmux passthrouth to %s\n", pmuxrte));
+                ret.setAllowPmuxRoute(pmuxrte);
             }
         } catch (NumberFormatException e1) {
             logger.log(Level.WARNING, "Incorrect configuration in: " + url, e1);

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
@@ -29,6 +29,7 @@ public class SockIO implements IO {
     protected String host;
     protected int port;
     protected int tcpbufsz;
+    protected String pmuxrtedb = null;
 
     protected boolean opened = false;
 
@@ -49,14 +50,19 @@ public class SockIO implements IO {
         opened = false;
     }
 
-    public SockIO(String host, int port, int tcpbufsz) {
+    public SockIO(String host, int port, int tcpbufsz, String pmuxrtedb) {
         this.host = host;
         this.port = port;
         this.tcpbufsz = tcpbufsz;
+        this.pmuxrtedb = pmuxrtedb;
     }
 
     public SockIO(String host, int port) {
-        this(host, port, 0);
+        this(host, port, 0, null);
+    }
+
+    public SockIO(String host, int port, String pmuxrtedb) {
+        this(host, port, 0, pmuxrtedb);
     }
 
     public SockIO() {
@@ -131,6 +137,14 @@ public class SockIO implements IO {
             out = new BufferedOutputStream(sock.getOutputStream());
             in = new BufferedInputStream(sock.getInputStream());
             opened = true;
+
+            if (pmuxrtedb != null) {
+                String rtepacket = String.format("rte %s/%s/%s\n", "comdb2", "replication", pmuxrtedb);
+                /* Errors are handled by the catch block below. */
+                out.write(rtepacket.getBytes());
+                out.flush();
+                readLine(32);
+            }
         } catch (IOException e) {
             opened = false;
             logger.log(Level.FINE, "Unable to open socket connection to " + host + ":" + port, e);

--- a/docs/pages/programming/jdbc_api.md
+++ b/docs/pages/programming/jdbc_api.md
@@ -201,6 +201,10 @@ The parameters are as follows:
     * _trust_store_type_=String
 
       Type of the trusted CA keystore. The default is `"JKS"`.
+
+    *_allow_pmux_route_=Boolean
+
+      Allow connection forwarding via `pmux`. The default is `false`.
         
     \* _To define multiple options, separate them by ampersands._
 


### PR DESCRIPTION
To enable it, use `jdbc:comdb2//<host>//<database>?allow_pmux_route=on`.