### PR TITLE
Hasql fix

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -5120,23 +5120,6 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
                     break;
                 }
 
-                if (txn_rl_args->prev_lsn.file < file ||
-                    (txn_rl_args->prev_lsn.file == file &&
-                     txn_rl_args->prev_lsn.offset <= offset)) {
-                    if (gbl_extended_sql_debug_trace) {
-                        logmsg(LOGMSG_USER, "td %u %s line %d lsn %d:%d "
-                                            "break-loop because prev-lsn "
-                                            "(%d:%d) <= target-lsn "
-                                            "(%d:%d)\n",
-                               (uint32_t)pthread_self(), __func__, __LINE__,
-                               lsn.file, lsn.offset, txn_rl_args->prev_lsn.file,
-                               txn_rl_args->prev_lsn.offset, file, offset);
-                    }
-                    __os_free(dbenv, txn_rl_args);
-                    done = 1;
-                    break;
-                }
-
                 if (txn_rl_args->opcode == TXN_COMMIT &&
                     txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT) {
                     if (*n_lsns + 1 >= curlim) {

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -5089,8 +5089,8 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 		goto err;
 	}
 
-        while (!done && (!file || (lsn.file > file || (lsn.file == file &&
-                                                       lsn.offset > offset)))) {
+        while (!done &&
+               (lsn.file > file || (lsn.file == file && lsn.offset > offset))) {
             LOGCOPY_32(&rectype, mylog.data);
             switch (rectype) {
             case DB___txn_regop_rowlocks: {
@@ -5338,8 +5338,7 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
                     done = 1;
         }
 
-        if (ret == DB_NOTFOUND)
-		ret = 0;
+        if (ret == DB_NOTFOUND) ret = 0;
 
 err:
     if ((t_ret = __log_c_close(logc)) != 0 && ret == 0) {

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -50,6 +50,7 @@ static const char revid[] =
 #include <epochlib.h>
 #include "schema_lk.h"
 #include "logmsg.h"
+#include <errno.h>
 
 
 #ifndef TESTSUITE
@@ -5130,9 +5131,7 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
                                                  "snapshot (realloc "
                                                  "failure at trns %d)\n",
                                    __FILE__, __LINE__, *n_lsns);
-                            ret = 22
-                                /*BDBERR_TRANTOOCOMPLEX */
-                                ;
+                            ret = ENOMEM;
                             if (lsns) free(lsns);
                             lsns = NULL;
                             __os_free(dbenv, txn_rl_args);
@@ -5209,10 +5208,7 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
                                 "%s:%d Too complex snapshot (realloc failure at trns %d)\n",
 							    __FILE__, __LINE__,
 							    *n_lsns);
-                                                        ret = 22
-                                                            /*BDBERR_TRANTOOCOMPLEX
-                                                               */
-                                                            ;
+                                                        ret = ENOMEM;
                                                         if (lsns) free(lsns);
                                                         lsns = NULL;
                                                         __os_free(dbenv,
@@ -5297,10 +5293,7 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
                                                            "%d)\n",
                                                            __FILE__, __LINE__,
                                                            *n_lsns);
-                                                    ret = 22
-                                                        /*BDBERR_TRANTOOCOMPLEX
-                                                           */
-                                                        ;
+                                                    ret = ENOMEM;
                                                     if (lsns) free(lsns);
                                                     lsns = NULL;
                                                     __os_free(dbenv, txn_args);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4692,9 +4692,9 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
         goto done;
 
     case TRANLEVEL_SNAPISOL:
-        clnt->dbtran.shadow_tran = trans_start_snapisol(
-            &iq, clnt->bdb_osql_trak, clnt->snapshot, snapshot_file,
-            snapshot_offset, &error);
+        clnt->dbtran.shadow_tran =
+            trans_start_snapisol(&iq, clnt->bdb_osql_trak, clnt->snapshot,
+                                 snapshot_file, snapshot_offset, &error);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_snapisol error %d\n", __func__,
@@ -4723,9 +4723,9 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
          * the same data (inserts are easily skipped, but deletes
          * and updates will have visible effects otherwise
          */
-        clnt->dbtran.shadow_tran = trans_start_serializable(
-            &iq, clnt->bdb_osql_trak, clnt->snapshot, snapshot_file,
-            snapshot_offset, &error);
+        clnt->dbtran.shadow_tran =
+            trans_start_serializable(&iq, clnt->bdb_osql_trak, clnt->snapshot,
+                                     snapshot_file, snapshot_offset, &error);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_serializable error\n", __func__);


### PR DESCRIPTION
Use client-side supplied snapshot information at transaction start.  Use the LSN of the commit record rather than the prev-record to decide whether it should be part of backfill.