### PR TITLE
Req durable lsn fix

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4008,7 +4008,8 @@ void receive_start_lsn_request(void *ack_handle, void *usr_ptr, char *from_host,
 
     if (start_lsn.gen != current_gen) {
         logmsg(LOGMSG_ERROR, "%s line %d generation-mismatch: current_gen=%d, "
-                "durable_gen=%d\n", __func__, __LINE__, current_gen, start_lsn.gen);
+                             "durable_gen=%d\n",
+               __func__, __LINE__, current_gen, start_lsn.gen);
         net_ack_message(ack_handle, 3);
         return;
     }
@@ -5495,8 +5496,9 @@ int request_durable_lsn_from_master(bdb_state_type *bdb_state,
         bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &current_gen);
 
         if (current_gen != *durable_gen) {
-            logmsg(LOGMSG_ERROR, "%s line %d master generation-mismatch: current_gen=%d, durable_gen=%d\n",
-                    __func__, __LINE__, current_gen, *durable_gen);
+            logmsg(LOGMSG_ERROR, "%s line %d master generation-mismatch: "
+                                 "current_gen=%d, durable_gen=%d\n",
+                   __func__, __LINE__, current_gen, *durable_gen);
             badcount++;
             return -3;
         }

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3979,6 +3979,7 @@ void receive_start_lsn_request(void *ack_handle, void *usr_ptr, char *from_host,
     start_lsn_response_t start_lsn = {0};
     uint8_t buf[START_LSN_RESPONSE_TYPE_LEN];
     uint8_t *p_buf, *p_buf_end;
+    uint32_t current_gen;
     bdb_state_type *bdb_state = usr_ptr;
     repinfo_type *repinfo = bdb_state->repinfo;
 
@@ -4002,6 +4003,15 @@ void receive_start_lsn_request(void *ack_handle, void *usr_ptr, char *from_host,
 
     bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &start_lsn.lsn, 
             &start_lsn.gen);
+
+    bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &current_gen);
+
+    if (start_lsn.gen != current_gen) {
+        logmsg(LOGMSG_ERROR, "%s line %d generation-mismatch: current_gen=%d, "
+                "durable_gen=%d\n", __func__, __LINE__, current_gen, start_lsn.gen);
+        net_ack_message(ack_handle, 3);
+        return;
+    }
 
     if (start_lsn.lsn.file == 2147483647) {
         logmsg(LOGMSG_FATAL, "Huh? Durable lsn is 2147483647???\n");
@@ -5459,6 +5469,7 @@ int request_durable_lsn_from_master(bdb_state_type *bdb_state,
     const uint8_t *p_buf, *p_buf_end;
     DB_LSN durable_lsn;
     uint8_t *buf = NULL;
+    uint32_t current_gen;
     int data = 0, buflen = 0, waitms = bdb_state->attr->durable_lsn_request_waitms, rc;
     int request_durable_lsn_trace = bdb_state->attr->request_durable_lsn_trace;
     start_lsn_response_t start_lsn;
@@ -5481,6 +5492,15 @@ int request_durable_lsn_from_master(bdb_state_type *bdb_state,
         }
 
         bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &durable_lsn, durable_gen);
+        bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &current_gen);
+
+        if (current_gen != *durable_gen) {
+            logmsg(LOGMSG_ERROR, "%s line %d master generation-mismatch: current_gen=%d, durable_gen=%d\n",
+                    __func__, __LINE__, current_gen, *durable_gen);
+            badcount++;
+            return -3;
+        }
+
         *durable_file = durable_lsn.file;
         *durable_offset = durable_lsn.offset;
 

--- a/bdb/threads.c
+++ b/bdb/threads.c
@@ -292,7 +292,8 @@ void *coherency_lease_thread(void *arg)
 
             /* See if master has written a durable LSN */
             bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &current_gen);
-            bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &durable_lsn, &durable_gen);
+            bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &durable_lsn,
+                                              &durable_gen);
 
             /* Insert a record if it hasn't */
             if (durable_gen != current_gen) {

--- a/bdb/threads.c
+++ b/bdb/threads.c
@@ -284,9 +284,21 @@ void *coherency_lease_thread(void *arg)
 
     while (lease_time = bdb_state->attr->coherency_lease) {
         inc_wait = 0;
+        uint32_t current_gen, durable_gen;
+        DB_LSN durable_lsn;
 
-        if (repinfo->master_host == repinfo->myhost)
+        if (repinfo->master_host == repinfo->myhost) {
             send_coherency_leases(bdb_state, lease_time, &inc_wait);
+
+            /* See if master has written a durable LSN */
+            bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &current_gen);
+            bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &durable_lsn, &durable_gen);
+
+            /* Insert a record if it hasn't */
+            if (durable_gen != current_gen) {
+                inc_wait = 1;
+            }
+        }
 
         now = time(NULL);
         if (inc_wait && (add_interval = bdb_state->attr->add_record_interval)) {

--- a/linearizable/jepsen/jepsenloop.sh
+++ b/linearizable/jepsen/jepsenloop.sh
@@ -38,6 +38,8 @@ scripts=$pathbase/linearizable/scripts
 . $scripts/setvars
 outbase=${COMDB2_OUTBASE:-/db/testout}
 
+$scripts/heallall
+
 # add to comdb2db
 $scripts/addmach_comdb2db $db
 

--- a/linearizable/jepsen/src/comdb2/core.clj
+++ b/linearizable/jepsen/src/comdb2/core.clj
@@ -600,12 +600,12 @@
                       (->> (gen/mix [w cas cas r])
                            (gen/clients)
                            (gen/stagger 1/10)
-                           (gen/time-limit 10)
+                           (gen/time-limit 300)
                            with-nemesis)
                       (gen/log "waiting for quiescence")
                       (gen/sleep 10))
        :model       (model/cas-register-comdb2 [1 1])
-       :time-limit   100
+       :time-limit   300
        :recovery-time  30
        :checker     (checker/compose
                       {:perf  (checker/perf)


### PR DESCRIPTION
Don't allow the master to service durable-lsn requests unless it has written a durable-lsn.  Trigger an insert on the master if the lease-thread detects that it hasn't yet written something durably.