### PR TITLE
dont exit cdb2sql on ctrl_c

### DIFF
--- a/tools/cdb2sql/cdb2sql.c
+++ b/tools/cdb2sql/cdb2sql.c
@@ -83,9 +83,6 @@ static int istty = 0;
 static char *gensql_tbl = NULL;
 static char *prompt = main_prompt;
 
-int sigaction(int signum, const struct sigaction *act,
-              struct sigaction *oldact);
-
 static void hexdump(FILE *f, void *datap, int len)
 {
     u_char *data = (u_char *)datap;
@@ -890,8 +887,6 @@ static void replace_args(int argc, char *argv[])
     }
 }
 
-static int int_handler_cnt = 0;
-
 /* If ctrl_c was pressed to clear existing line and go to new line
  * If we see two ctrl_c in a row we exit.
  * However, after a ctrl_c if user typed something
@@ -899,8 +894,6 @@ static int int_handler_cnt = 0;
  */
 static void int_handler(int signum)
 {
-    if (strlen(rl_line_buffer) > 0) int_handler_cnt = 0;
-    if (++int_handler_cnt > 1) exit(1);
     printf("\n");
     rl_on_new_line();
     rl_replace_line("", 0);

--- a/tools/cdb2sql/cdb2sql.c
+++ b/tools/cdb2sql/cdb2sql.c
@@ -83,9 +83,8 @@ static int istty = 0;
 static char *gensql_tbl = NULL;
 static char *prompt = main_prompt;
 
-
 int sigaction(int signum, const struct sigaction *act,
-                     struct sigaction *oldact);
+              struct sigaction *oldact);
 
 static void hexdump(FILE *f, void *datap, int len)
 {
@@ -891,20 +890,17 @@ static void replace_args(int argc, char *argv[])
     }
 }
 
-
 static int int_handler_cnt = 0;
 
 /* If ctrl_c was pressed to clear existing line and go to new line
  * If we see two ctrl_c in a row we exit.
- * However, after a ctrl_c if user typed something 
+ * However, after a ctrl_c if user typed something
  * (rl_line_buffer is not empty) and then issue a ctrl_c then dont exit.
  */
 static void int_handler(int signum)
 {
-    if(strlen(rl_line_buffer) > 0) 
-	int_handler_cnt = 0;
-    if (++int_handler_cnt > 1) 
-        exit(1);
+    if (strlen(rl_line_buffer) > 0) int_handler_cnt = 0;
+    if (++int_handler_cnt > 1) exit(1);
     printf("\n");
     rl_on_new_line();
     rl_replace_line("", 0);
@@ -1062,9 +1058,9 @@ int main(int argc, char *argv[])
         istty = 0;
     if (istty) {
         load_readline_history();
-	struct sigaction sact;
-	sact.sa_handler = int_handler;
-	sigaction(SIGINT, &sact, NULL);
+        struct sigaction sact;
+        sact.sa_handler = int_handler;
+        sigaction(SIGINT, &sact, NULL);
     }
     char *line;
     int multi;


### PR DESCRIPTION
Ctrl_C will clean out the current input line.
Ctrl_d will exit if input line is blank.
Does not cancel currently running sql yet.