### PR TITLE
change Mem back to original type after sqliteVdbeMemDecimalBasicArith…

### DIFF
--- a/sqlite/vdbemem.c
+++ b/sqlite/vdbemem.c
@@ -2931,6 +2931,8 @@ int sqliteVdbeMemDecimalBasicArithmetics(
   decContext  ctx;
   void        *ret = NULL;
   int         rc = 0;
+  int         decimalfied = 0;
+  Mem         sav;
 
   bzero(res, sizeof(Mem));
   res->flags |= MEM_Interval;
@@ -2938,9 +2940,12 @@ int sqliteVdbeMemDecimalBasicArithmetics(
   switch( b->flags & MEM_TypeMask ){
     case MEM_Int:
     case MEM_Str: {
+      decimalfied = 1;
+      memcpy(&sav, b, sizeof(Mem));
       
-      rc = sqlite3VdbeMemDecimalfy( b);
+      rc = sqlite3VdbeMemDecimalfy(b);
       if( rc ){
+        decimalfied = 0;
         goto done;
       }
 
@@ -3021,6 +3026,8 @@ int sqliteVdbeMemDecimalBasicArithmetics(
   }
 
 done:
+   if( decimalfied )
+     memcpy(b, &sav, sizeof(Mem));
    return rc;
 }
 

--- a/tests/decimal.test/t4_01.req
+++ b/tests/decimal.test/t4_01.req
@@ -1,0 +1,17 @@
+drop table if exists t4
+create table t4 {
+    tag ondisk {
+        int id
+        decimal32 dec
+        double num
+    }
+    keys {
+        "ID" = id
+    }
+}$$
+insert into t4 values(1, 5, 10)
+select * from t4
+update t4 set dec = dec * '2', num = num * '2' where id = 1
+select * from t4
+update t4 set dec = dec * 2, num = num * 2 where id = 1
+select * from t4

--- a/tests/decimal.test/t4_01.req.out
+++ b/tests/decimal.test/t4_01.req.out
@@ -1,0 +1,23 @@
+[drop table if exists t4] rc 0
+[create table t4 {
+    tag ondisk {
+        int id
+        decimal32 dec
+        double num
+    }
+    keys {
+        "ID" = id
+    }
+}] rc 0
+(rows inserted=1)
+[insert into t4 values(1, 5, 10)] rc 0
+(id=1, dec='5', num=10.000000)
+[select * from t4] rc 0
+(rows updated=1)
+[update t4 set dec = dec * '2', num = num * '2' where id = 1] rc 0
+(id=1, dec='10', num=20.000000)
+[select * from t4] rc 0
+(rows updated=1)
+[update t4 set dec = dec * 2, num = num * 2 where id = 1] rc 0
+(id=1, dec='20', num=40.000000)
+[select * from t4] rc 0


### PR DESCRIPTION
…metics

fixed:
```
[drop table if exists t1] rc 0                                        
[create table t1 {                                                    
    tag ondisk {                                                      
        int id                                                        
        decimal32 dec                                                 
        double num                                                    
    }                                                                 
    keys {                                                            
        "ID" = id                                                     
    }                                                                 
}] rc 0                                                               
(rows inserted=1)                                                     
[insert into t1 values(1, 5, 10)] rc 0                                
(id=1, dec='5', num=10.000000)                                        
[select * from t1] rc 0                                               
[update t1 set dec = dec * '2', num = num * '2' where id = 1] failed with rc 113 incompatible values from SQL interval (day-second, year-month or decimal) to bdouble field 'num' for table 't1'
(id=1, dec='5', num=10.000000)                                        
[select * from t1] rc 0                                               
[update t1 set dec = dec * 2, num = num * 2 where id = 1] failed with rc 113 incompatible values from SQL interval (day-second, year-month or decimal) to bdouble field 'num' for table 't1'
(id=1, dec='5', num=10.000000)                                        
[select * from t1] rc 0                
```

Both  `update t1 set dec = dec * '2', num = num * '2' where id = 1` and `update t1 set dec = dec * 2, num = num * 2 where id = 1` should not fail.

The problem is when we do `dec = dec * 2`, we convert integer 2 to interval (with decimal type) and we dont change it back. Therefore, `num * 2` fails.