### PR TITLE
Fix durable lsn crash

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -5094,9 +5094,8 @@ void *watcher_thread(void *arg)
             send_myseqnum_to_all(bdb_state, 0);
         }
 
-        bdb_state->dbenv->getattr(bdb_state->dbenv,
-                                  "elect_highest_committed_gen",
-                                  NULL, &is_durable);
+        bdb_state->dbenv->getattr(
+            bdb_state->dbenv, "elect_highest_committed_gen", NULL, &is_durable);
         if (is_durable) {
             update_durable_lsn(bdb_state);
         }

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -5094,6 +5094,13 @@ void *watcher_thread(void *arg)
             send_myseqnum_to_all(bdb_state, 0);
         }
 
+        bdb_state->dbenv->getattr(bdb_state->dbenv,
+                                  "elect_highest_committed_gen",
+                                  NULL, &is_durable);
+        if (is_durable) {
+            update_durable_lsn(bdb_state);
+        }
+
         BDB_RELLOCK();
 
         /*
@@ -5341,12 +5348,6 @@ void *watcher_thread(void *arg)
 
         send_context_to_all(bdb_state);
 
-        bdb_state->dbenv->getattr(bdb_state->dbenv, 
-                                  "elect_highest_committed_gen", 
-                                  NULL, &is_durable);
-        if (is_durable) {
-            update_durable_lsn(bdb_state);
-        }
     }
 }
 


### PR DESCRIPTION
Set it in the lock where we check if db is exiting too.