### PR TITLE
fix remsql

### DIFF
--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -195,7 +195,7 @@ int fdb_svc_alter_schema(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
     ixschema = db->ixschema[ixnum];
 
     /* already datacopy indexes are ok */
-    if ((ixschema->flags & SCHEMA_DATACOPY) == 0) {
+    if (ixschema->flags & SCHEMA_DATACOPY) {
         return 0;
     }
 


### PR DESCRIPTION
I guess this is a day0 bug as originally we had `if (ixschema->flags & SCHEMA_DATACOPY == 0)` And it happened to work because `SCHEMA_DATACOPY == 0` is always 0. I guess #211 was trying to fix this but it actually broke it.