### PR TITLE
index on expression fixes

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -915,15 +915,16 @@ static int bdb_verify_ll(
                 }
 
             } else if (bdb_state->ixcollattr[ix]) {
-                if (dbt_data.size !=
-                    (sizeof(unsigned long long) + bdb_state->ixcollattr[ix])) {
+                if (dbt_data.size != (sizeof(unsigned long long) +
+                                      4 * bdb_state->ixcollattr[ix])) {
                     ret = 1;
-                    locprint(sb, lua_callback, lua_params, "!%016llx ix %d decimal payload wrong size "
-                                    "expected %d got %d\n",
-                                genid_flipped, ix,
-                                sizeof(unsigned long long) +
-                                    bdb_state->ixcollattr[ix],
-                                dbt_data.size);
+                    locprint(sb, lua_callback, lua_params,
+                             "!%016llx ix %d decimal payload wrong size "
+                             "expected %d got %d\n",
+                             genid_flipped, ix,
+                             sizeof(unsigned long long) +
+                                 4 * bdb_state->ixcollattr[ix],
+                             dbt_data.size);
                     goto next_key;
                 }
                 memcpy(&genid_right, (uint8_t *)dbt_data.data, sizeof(genid));

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5047,6 +5047,9 @@ static void register_all_int_switches()
     register_int_switch("early_verify",
                         "Give early verify errors for updates in SQLite layer",
                         &gbl_early_verify);
+    register_int_switch("new_indexes",
+                        "Let replicants send indexes values to master",
+                        &gbl_new_indexes);
 }
 
 static void getmyid(void)

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3320,7 +3320,7 @@ struct field *convert_client_field(CDB2SQLQUERY__Bindvalue *bindvalue,
 int bind_parameters(sqlite3_stmt *stmt, struct schema *params,
                     struct sqlclntstate *clnt, char **err);
 void bind_verify_indexes_query(sqlite3_stmt *stmt, void *sm);
-void verify_indexes_column_value(sqlite3_stmt *stmt, void *sm);
+int verify_indexes_column_value(sqlite3_stmt *stmt, void *sm);
 
 void verify_schema_change_constraint(struct ireq *iq, struct dbtable *, void *trans,
                                      void *od_dta, unsigned long long ins_keys);

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -54,7 +54,6 @@ extern int gbl_fdb_allow_cross_classes;
 
 extern int gbl_partial_indexes;
 extern int gbl_expressions_indexes;
-extern int gbl_new_indexes;
 
 int gbl_fdb_track = 0;
 int gbl_fdb_track_times = 0;
@@ -1669,11 +1668,6 @@ static int insert_table_entry_from_packedsqlite(fdb_t *fdb, fdb_tbl_t *tbl,
     }
     if (where)
         where[1] = ' ';
-
-    if (gbl_new_indexes) {
-        tbl->ix_partial = 1;
-        tbl->ix_expr = 1;
-    }
 
     /*
     printf("Saved pointer %p\n", row);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12260,6 +12260,14 @@ void bind_verify_indexes_query(sqlite3_stmt *stmt, void *sm)
     bind_stmt_mem(psm->sc, stmt, psm->min);
 }
 
+/* verify_indexes_column_value
+** Make a hard copy of the result column from an internal sql query
+** so that we have access to the result even after the sql thread exits.
+**
+** pFrom is the result from a sql thread, pTo is a hard copy of pFrom.
+** The hard copy will be converted to ondisk format in mem_to_ondisk in
+** function indexes_expressions_data.
+*/
 int verify_indexes_column_value(sqlite3_stmt *stmt, void *sm)
 {
     struct schema_mem *psm = (struct schema_mem *)sm;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12270,22 +12270,24 @@ int verify_indexes_column_value(sqlite3_stmt *stmt, void *sm)
         pTo->db = NULL;
         pTo->szMalloc = 0;
         pTo->zMalloc = NULL;
-        if (pFrom->zMalloc && pFrom->szMalloc) {
-            pTo->szMalloc = pFrom->szMalloc;
-            pTo->zMalloc = malloc(pTo->szMalloc);
-            if (pTo->zMalloc == NULL)
-                return SQLITE_NOMEM;
-            memcpy(pTo->zMalloc, pFrom->zMalloc, pTo->szMalloc);
-            pTo->z = pTo->zMalloc;
-        } else if (pFrom->z && pFrom->n) {
-            pTo->n = pFrom->n;
-            pTo->szMalloc = pFrom->n + 1;
-            pTo->zMalloc = malloc(pTo->szMalloc);
-            if (pTo->zMalloc == NULL)
-                return SQLITE_NOMEM;
-            memcpy(pTo->zMalloc, pFrom->z, pFrom->n);
-            pTo->zMalloc[pFrom->n] = 0;
-            pTo->z = pTo->zMalloc;
+        pTo->flags &= ~MEM_Dyn;
+        assert(pTo->flags & MEM_Blob == 0);
+        if (pTo->flags & MEM_Str) {
+            if (pFrom->zMalloc && pFrom->szMalloc) {
+                pTo->szMalloc = pFrom->szMalloc;
+                pTo->zMalloc = malloc(pTo->szMalloc);
+                if (pTo->zMalloc == NULL) return SQLITE_NOMEM;
+                memcpy(pTo->zMalloc, pFrom->zMalloc, pTo->szMalloc);
+                pTo->z = pTo->zMalloc;
+            } else if (pFrom->z && pFrom->n) {
+                pTo->n = pFrom->n;
+                pTo->szMalloc = pFrom->n + 1;
+                pTo->zMalloc = malloc(pTo->szMalloc);
+                if (pTo->zMalloc == NULL) return SQLITE_NOMEM;
+                memcpy(pTo->zMalloc, pFrom->z, pFrom->n);
+                pTo->zMalloc[pFrom->n] = 0;
+                pTo->z = pTo->zMalloc;
+            }
         }
     }
     return 0;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -89,6 +89,7 @@
 
 #include <genid.h>
 #include <strbuf.h>
+#include <thread_malloc.h>
 #include "fdb_fend.h"
 #include "fdb_access.h"
 #include "bdb_osqlcur.h"
@@ -2280,6 +2281,7 @@ void create_master_tables(void)
 #endif
 }
 
+static int indexes_thread_memory = 1048576;
 /* force an update on sqlite_master to test partial indexes syntax*/
 int new_indexes_syntax_check(struct ireq *iq)
 {
@@ -2294,6 +2296,7 @@ int new_indexes_syntax_check(struct ireq *iq)
         return -1;
 
     sql_mem_init(NULL);
+    thread_memcreate(indexes_thread_memory);
 
     reset_clnt(&client, NULL, 1);
     client.sb = NULL;
@@ -12257,12 +12260,35 @@ void bind_verify_indexes_query(sqlite3_stmt *stmt, void *sm)
     bind_stmt_mem(psm->sc, stmt, psm->min);
 }
 
-void verify_indexes_column_value(sqlite3_stmt *stmt, void *sm)
+int verify_indexes_column_value(sqlite3_stmt *stmt, void *sm)
 {
     struct schema_mem *psm = (struct schema_mem *)sm;
-    if (psm->mout)
-        sqlite3VdbeMemCopy(psm->mout,
-                           (const Mem *)sqlite3_column_value(stmt, 0));
+    Mem *pTo = psm->mout;
+    Mem *pFrom = sqlite3_column_value(stmt, 0);
+    if (pTo) {
+        memcpy(pTo, pFrom, MEMCELLSIZE);
+        pTo->db = NULL;
+        pTo->szMalloc = 0;
+        pTo->zMalloc = NULL;
+        if (pFrom->zMalloc && pFrom->szMalloc) {
+            pTo->szMalloc = pFrom->szMalloc;
+            pTo->zMalloc = malloc(pTo->szMalloc);
+            if (pTo->zMalloc == NULL)
+                return SQLITE_NOMEM;
+            memcpy(pTo->zMalloc, pFrom->zMalloc, pTo->szMalloc);
+            pTo->z = pTo->zMalloc;
+        } else if (pFrom->z && pFrom->n) {
+            pTo->n = pFrom->n;
+            pTo->szMalloc = pFrom->n + 1;
+            pTo->zMalloc = malloc(pTo->szMalloc);
+            if (pTo->zMalloc == NULL)
+                return SQLITE_NOMEM;
+            memcpy(pTo->zMalloc, pFrom->z, pFrom->n);
+            pTo->zMalloc[pFrom->n] = 0;
+            pTo->z = pTo->zMalloc;
+        }
+    }
+    return 0;
 }
 
 static int run_verify_indexes_query(char *sql, struct schema *sc, Mem *min,
@@ -12480,7 +12506,7 @@ int indexes_expressions_data(struct schema *sc, const char *inbuf, char *outbuf,
                              const char *tzname)
 {
     Mem *m = NULL;
-    Mem mout;
+    Mem *mout = NULL;
     int nblobs = 0;
     struct field_conv_opts_tz convopts = {.flags = 0};
     struct mem_info info;
@@ -12497,7 +12523,8 @@ int indexes_expressions_data(struct schema *sc, const char *inbuf, char *outbuf,
         tzname = "America/New_York";
 
     sql = strbuf_new();
-    memset(&mout, 0, sizeof(Mem));
+    mout = (Mem *)malloc(sizeof(Mem));
+    memset(mout, 0, sizeof(Mem));
 
     m = (Mem *)malloc(sizeof(Mem) * MAXCOLUMNS);
     if (m == NULL) {
@@ -12518,7 +12545,7 @@ int indexes_expressions_data(struct schema *sc, const char *inbuf, char *outbuf,
 
     build_indexes_expressions_query(sql, sc, "expridx_temp", f->name);
 
-    rc = run_verify_indexes_query((char *)strbuf_buf(sql), sc, m, &mout, &exist);
+    rc = run_verify_indexes_query((char *)strbuf_buf(sql), sc, m, mout, &exist);
     if (rc || !exist) {
         logmsg(LOGMSG_ERROR, "%s: failed to run internal query, rc %d\n", __func__,
                 rc);
@@ -12530,7 +12557,7 @@ int indexes_expressions_data(struct schema *sc, const char *inbuf, char *outbuf,
     info.null = 0;
     info.fail_reason = fail_reason;
     info.tzname = tzname;
-    info.m = &mout;
+    info.m = mout;
     info.nblobs = &nblobs;
     info.convopts = &convopts;
     info.outblob = NULL;
@@ -12539,15 +12566,17 @@ int indexes_expressions_data(struct schema *sc, const char *inbuf, char *outbuf,
 
     rc = mem_to_ondisk(outbuf, f, &info, NULL);
     if (rc) {
-        logmsg(LOGMSG_ERROR, "%s: rc %d failed to form index \"%s\", result flag "
-                        "%x, index type %d\n",
-                __func__, rc, f->name, mout.flags, f->type);
+        logmsg(LOGMSG_ERROR,
+               "%s: rc %d failed to form index \"%s\", result flag "
+               "%x, index type %d\n",
+               __func__, rc, f->name, mout->flags, f->type);
         goto done;
     }
-    sqlite3VdbeMemRelease(&mout);
+    if (mout->zMalloc) free(mout->zMalloc);
 done:
     if (m)
         free(m);
+    if (mout) free(mout);
     strbuf_free(sql);
     if (rc)
         return -1;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5202,8 +5202,7 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
 
     if (clnt->verify_indexes && steprc == SQLITE_ROW) {
         clnt->has_sqliterow = 1;
-        verify_indexes_column_value(stmt, clnt->schema_mems);
-        return 0;
+        return verify_indexes_column_value(stmt, clnt->schema_mems);
     } else if (clnt->verify_indexes && steprc == SQLITE_DONE) {
         clnt->has_sqliterow = 0;
         return 0;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5353,6 +5353,12 @@ static void sqlite_done(struct sqlthdstate *thd, struct sqlclntstate *clnt,
 {
     sqlite3_stmt *stmt = rec->stmt;
 
+    /* skip stat and logging for index on expression internal queries */
+    if (clnt->verify_indexes) {
+        put_prepared_stmt(thd, clnt, rec, outrc, 0);
+        return;
+    }
+
     sql_statement_done(thd->sqlthd, thd->logger, clnt->osql.rqid, outrc);
 
     if (clnt->rawnodestats && thd->sqlthd) {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -387,37 +387,6 @@ int do_alter_table_int(struct ireq *iq, tran_type *tran)
                 goto pi_done;
             }
 
-            if (temp_newdb->dbenv->master == gbl_mynode) {
-                /* I am master: create new db */
-                logmsg(LOGMSG_DEBUG, "create new db\n");
-                temp_newdb->handle = bdb_create_tran(
-                    temp_newdb->dbname, thedb->basedir, temp_newdb->lrl,
-                    temp_newdb->nix, temp_newdb->ix_keylen,
-                    temp_newdb->ix_dupes, temp_newdb->ix_recnums,
-                    temp_newdb->ix_datacopy, temp_newdb->ix_collattr,
-                    temp_newdb->ix_nullsallowed, temp_newdb->numblobs + 1,
-                    thedb->bdb_env, 0, &bdberr, tran);
-                open_auxdbs(temp_newdb, 1);
-            } else {
-                /* I am NOT master: open replicated db */
-                logmsg(LOGMSG_DEBUG, "open replicated db\n");
-                temp_newdb->handle = bdb_open_more(
-                    temp_newdb->dbname, thedb->basedir, temp_newdb->lrl,
-                    temp_newdb->nix, temp_newdb->ix_keylen,
-                    temp_newdb->ix_dupes, temp_newdb->ix_recnums,
-                    temp_newdb->ix_datacopy, temp_newdb->ix_collattr,
-                    temp_newdb->ix_nullsallowed, temp_newdb->numblobs + 1,
-                    thedb->bdb_env, &bdberr);
-                open_auxdbs(temp_newdb, 0);
-            }
-            if (temp_newdb->handle == NULL) {
-                logmsg(LOGMSG_ERROR,
-                       "%s: failed to open table %s/%s, rcode %d\n", __func__,
-                       thedb->basedir, temp_newdb->dbname, bdberr);
-                rc = SC_BDB_ERROR;
-                goto pi_done;
-            }
-
             thedb->dbs =
                 realloc(thedb->dbs, (thedb->num_dbs + 1) * sizeof(struct dbtable *));
             thedb->dbs[thedb->num_dbs++] = temp_newdb;
@@ -426,11 +395,6 @@ int do_alter_table_int(struct ireq *iq, tran_type *tran)
             create_sqlmaster_records(tran);
             create_master_tables(); /* create sql statements */
             ret = new_indexes_syntax_check(iq);
-            if (bdb_close_only(temp_newdb->handle, &bdberr) != 0) {
-                logmsg(LOGMSG_ERROR,
-                       "%s: failed to close table %s/%s, rcode %d\n", __func__,
-                       thedb->basedir, temp_newdb->dbname, bdberr);
-            }
             newdb->ix_blob = temp_newdb->ix_blob;
             newdb->schema->ix_blob = newdb->ix_blob;
             delete_schema(temp_newdb_name);

--- a/sqlite/build.c
+++ b/sqlite/build.c
@@ -1035,7 +1035,6 @@ i16 sqlite3ColumnOfIndex(Index *pIdx, i16 iCol){
   return -1;
 }
 
-extern int gbl_new_indexes;
 /*
 ** Begin constructing a new table representation in memory.  This is
 ** the first of several action routines that get called in response
@@ -1160,14 +1159,8 @@ void sqlite3StartTable(
   pTable->nRef = 1;
   pTable->nRowLogEst = 200; assert( 200==sqlite3LogEst(1048576) );
   /* COMDB2 MODIFICATION */
-  if (gbl_new_indexes) {
-      pTable->hasPartIdx = 1;
-      pTable->hasExprIdx = 1;
-  }
-  else {
-      pTable->hasPartIdx = 0;
-      pTable->hasExprIdx = 0;
-  }
+  pTable->hasPartIdx = 0;
+  pTable->hasExprIdx = 0;
   assert( pParse->pNewTable==0 );
   pParse->pNewTable = pTable;
 

--- a/tests/idxexpr_alltypes.test/Makefile
+++ b/tests/idxexpr_alltypes.test/Makefile
@@ -1,0 +1,2 @@
+include $(TESTSROOTDIR)/testcase.mk
+export TEST_TIMEOUT=20m

--- a/tests/idxexpr_alltypes.test/README
+++ b/tests/idxexpr_alltypes.test/README
@@ -1,0 +1,1 @@
+Test indexes on expressions on all datatype

--- a/tests/idxexpr_alltypes.test/lrl.options
+++ b/tests/idxexpr_alltypes.test/lrl.options
@@ -1,0 +1,1 @@
+logmsg level info

--- a/tests/idxexpr_alltypes.test/runit
+++ b/tests/idxexpr_alltypes.test/runit
@@ -1,0 +1,159 @@
+#!/bin/bash
+
+dbname=$1
+NRECS=10000
+NRUNS=1000
+
+cdb2sql ${CDB2_OPTIONS} $dbname default - <<"EOF"
+drop table if exists alltypes
+create table alltypes {
+schema
+{
+    short           alltypes_short           null=yes
+    u_short         alltypes_ushort          null=yes
+    int             alltypes_int             null=yes
+    u_int           alltypes_uint            null=yes
+    longlong        alltypes_longlong        null=yes
+    float           alltypes_float           null=yes
+    double          alltypes_double          null=yes
+    byte            alltypes_byte[16]        null=yes
+    cstring         alltypes_cstring[16]     null=yes
+    datetime        alltypes_datetime        null=yes
+    datetimeus      alltypes_datetimeus      null=yes
+    intervalym      alltypes_intervalym      null=yes
+    intervalds      alltypes_intervalds      null=yes
+    intervaldsus    alltypes_intervaldsus    null=yes
+    decimal32       alltypes_decimal32       null=yes
+    decimal64       alltypes_decimal64       null=yes
+    decimal128      alltypes_decimal128      null=yes
+}
+}
+EOF
+
+# Create a random blob 
+function randbl
+{
+    typeset sz=$1
+
+    for i in $(seq 1 $sz); do
+
+        echo -n $(echo "obase=16; $(($RANDOM % 16))" | bc);
+
+    done;
+
+    echo
+
+    return 0
+}
+
+function failexit
+{
+    echo "Failed $1"
+    exit -1
+}
+
+function assertcnt 
+{
+    tbl=$1
+    target=$2
+    cnt=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbname default "select count(*) from $tbl")
+    if [ $? -ne 0 ] ; then
+        echo "assertcnt: select error"
+    fi
+
+    #echo "count is now $cnt"
+    if [[ $cnt != $target ]] ; then
+        failexit "count of $tbl is now $cnt but should be $target"
+    fi
+}
+
+function do_verify
+{
+    tbl=$1
+    typeset cnt=0
+
+    cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.verify('$tbl')" &> verify.out
+
+    if ! grep succeeded verify.out > /dev/null ; then
+        failexit "verify $tbl failed"
+    fi
+}
+
+for i in $(seq 1 $NRECS); do
+    bl=$(randbl 32)
+    echo "insert into alltypes values ($i, $i, $i, $i, $i, '$i.$i', cast(now(6) as real), x'$bl', 'abcdefghij$i', now(), now(6), cast($i as years), cast($i as days), cast($i as days), '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 92))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 381))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 6141))')"
+done | cdb2sql ${CDB2_OPTIONS} $dbname default - >/dev/null
+
+assertcnt alltypes $NRECS
+do_verify alltypes
+
+cdb2sql ${CDB2_OPTIONS} $dbname default - <<"EOF"
+alter table alltypes {
+schema
+{
+    short           alltypes_short           null=yes
+    u_short         alltypes_ushort          null=yes
+    int             alltypes_int             null=yes
+    u_int           alltypes_uint            null=yes
+    longlong        alltypes_longlong        null=yes
+    float           alltypes_float           null=yes
+    double          alltypes_double          null=yes
+    byte            alltypes_byte[16]        null=yes
+    cstring         alltypes_cstring[16]     null=yes
+    datetime        alltypes_datetime        null=yes
+    datetimeus      alltypes_datetimeus      null=yes
+    intervalym      alltypes_intervalym      null=yes
+    intervalds      alltypes_intervalds      null=yes
+    intervaldsus    alltypes_intervaldsus    null=yes
+    decimal32       alltypes_decimal32       null=yes
+    decimal64       alltypes_decimal64       null=yes
+    decimal128      alltypes_decimal128      null=yes
+}
+keys
+{
+    dup "SHORT" = (short)"alltypes_short * 1"
+    dup "USHORT" = (u_short)"alltypes_ushort * 1"
+    dup "INT" = (int)"alltypes_int * 1"
+    dup "UINT" = (u_int)"alltypes_uint * 1"
+    dup "LONGLONG" = (longlong)"alltypes_longlong * 1"
+    dup "FLOAT" = (float)"alltypes_float * 1"
+    dup "DOUBLE" = (double)"alltypes_double * 1"
+    dup "BYTE[16]" = (byte[16])"alltypes_byte"
+    dup "CSTRING[16]" = (cstring[16])"upper(alltypes_cstring)"
+    dup "DATETIME" = (datetime)"alltypes_datetime * 1"
+    dup "DATETIMEUS" = (datetimeus)"alltypes_datetimeus * 1"
+    dup "INTERVALYM" = (intervalym)"alltypes_intervalym * 1"
+    dup "INTERVALDS" = (intervalds)"alltypes_intervalds * 1"
+    dup "INTERVALDSUS" = (intervalds)"alltypes_intervaldsus * 1"
+    dup "DECIMAL32" = (decimal32)"alltypes_decimal32 * 1"
+    dup "DECIMAL64" = (decimal64)"alltypes_decimal64 * 1"
+    dup "DECIMAL128" = (decimal128)"alltypes_decimal128 * 1"
+}
+}
+EOF
+if [[ $? != 0 ]]; then
+    failexit "alter table failed"
+fi
+
+assertcnt alltypes $NRECS
+do_verify alltypes
+
+for i in $(seq 1 $NRUNS); do
+    what=$(($RANDOM % 3))
+    id=$(($RANDOM % 100))
+    rd=$(($RANDOM % 100))
+    bl=$(randbl 32)
+    case $what in
+        0) echo "insert into alltypes values ($id, $id, $id, $id, $id, '$id.$id', cast(now(6) as real), x'$bl', 'abcdefghij$id', now(), now(6), cast($id as years), cast($id as days), cast($id as days), '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 92))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 381))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 6141))')"
+        ;;
+        1)  echo "delete from alltypes where alltypes_int = $id limit 1"
+        ;;
+        2)  echo "update alltypes set alltypes_short=$rd, alltypes_ushort=$rd, alltypes_int=$rd, alltypes_uint=$rd, alltypes_longlong=$rd, alltypes_float='$rd.$rd', alltypes_double=cast(now(6) as real), alltypes_byte=x'$bl', alltypes_cstring='abcdefghij$rd', alltypes_datetime=now(), alltypes_datetimeus=now(6), alltypes_intervalym=cast($rd as years), alltypes_intervalds=cast($rd as days), alltypes_intervaldsus=cast($rd as days), alltypes_decimal32='$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 92))', alltypes_decimal64='$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 381))', alltypes_decimal128='$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 6141))' where alltypes_int = $id"
+        ;;
+    esac
+done | cdb2sql ${CDB2_OPTIONS} $dbname default - >/dev/null
+
+do_verify alltypes
+
+echo "Success"
+exit 0

--- a/tests/idxexpr_alltypes.test/runit
+++ b/tests/idxexpr_alltypes.test/runit
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 dbname=$1
-NRECS=10000
-NRUNS=1000
+NRUNS=100
 
 cdb2sql ${CDB2_OPTIONS} $dbname default - <<"EOF"
 drop table if exists alltypes
@@ -79,11 +78,25 @@ function do_verify
     fi
 }
 
-for i in $(seq 1 $NRECS); do
-    bl=$(randbl 32)
-    echo "insert into alltypes values ($i, $i, $i, $i, $i, '$i.$i', cast(now(6) as real), x'$bl', 'abcdefghij$i', now(), now(6), cast($i as years), cast($i as days), cast($i as days), '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 92))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 381))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 6141))')"
-done | cdb2sql ${CDB2_OPTIONS} $dbname default - >/dev/null
+function insert
+{
+    s=$1
+    e=$2
+    typeset i
+    for i in $(seq $s $e); do
+        bl=$(randbl 32)
+        echo "insert into alltypes values ($i, $i, $i, $i, $i, '$i.$i', cast(now(6) as real), x'$bl', 'abcdefghij$i', now(), now(6), cast($i as years), cast($i as days), cast($i as days), '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 92))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 381))', '$(($RANDOM % 1000)).$(($RANDOM % 1000))e$(($RANDOM % 6141))')"
+    done | cdb2sql ${CDB2_OPTIONS} $dbname default - >/dev/null
+}
 
+insert 1 2000 &
+insert 2001 4000 &
+insert 4001 6000 &
+insert 6001 8000 &
+insert 8001 10000 &
+wait
+
+NRECS=10000
 assertcnt alltypes $NRECS
 do_verify alltypes
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=903)
+(TUNABLES_COUNT=904)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -485,6 +485,7 @@
 (name='net_verbose', description='net_verbose', type='BOOLEAN', value='OFF', read_only='N')
 (name='netbufsz', description='Size of the network buffer (per node) for the replication network. (Default: 1MB)', type='INTEGER', value='1048576', read_only='Y')
 (name='netbufsz_signal', description='Size of the network buffer (per node) for the signal network. (Default: 65536)', type='INTEGER', value='65536', read_only='Y')
+(name='new_indexes', description='Let replicants send indexes values to master', type='BOOLEAN', value='OFF', read_only='N')
 (name='new_master_dummy_add_delay', description='Force a transaction after this delay, after becoming master.', type='INTEGER', value='5', read_only='N')
 (name='newqdelmode', description='Enables new queue deletion mode.', type='BOOLEAN', value='ON', read_only='N')
 (name='nice', description='If set, nice() will be called with this value to set the database nice level.', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
- fix index on expressions on string segfault in schemachange.
- added experimental "enable_new_indexes" lrl option to let replicants ship key values to master for all tables. (w/o the option, replicants only send key values to master for tables that contain indexes on expressions.)
- added a test (idxexpr_alltypes.test) to test indexes on expressions on all supported data types.