### PR TITLE
Fix a typo in datetime ms/us coercion.

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -13310,7 +13310,7 @@ void _setIntervalDSUS(intv_ds_t *ds, long long sec, int usec)
     /* brr, ugly */                                                            \
     tmpin[0] = 8; /* data_bit */                                               \
     sec = flibc_htonll(in->dttz_sec);                                          \
-    if (in->dttz_frac == prec)                                                 \
+    if (in->dttz_prec == prec)                                                 \
         frac = in->dttz_frac;                                                  \
     else                                                                       \
         frac = in->dttz_frac * POW10(prec) /                                   \

--- a/tests/datetimeusec.test/runit
+++ b/tests/datetimeusec.test/runit
@@ -100,10 +100,24 @@ echo "client typed (server milli -> client micro) query failed."
 exit 1
 fi
 
+cnt=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'select cast("2017-07-14T183510.006" as datetime)' 9 | grep -c '2017-07-14T183510.006000'`
+if [[ $cnt -ne 1 ]]
+then
+echo "client typed (server milli -> client micro) query failed."
+exit 1
+fi
+
 cnt=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'select now(6)' 6 | cut -d' ' -f1 | cut -d'.' -f2 | wc -c`
 if [[ $cnt -ne 4 ]]
 then
 echo "client typed (server micro -> client milli) query failed."
+exit 1
+fi
+
+cnt=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'select cast("2017-07-14T183510.000003" as datetime)' 6 | grep -c '2017-07-14T183510.000'`
+if [[ $cnt -ne 1 ]]
+then
+echo "client typed (server milli -> client micro) query failed."
 exit 1
 fi
 


### PR DESCRIPTION
The bug causes the database to generate incorrect results when a client
selects back a datetime value with a fraction of 6 milliseconds using
client type CDB2_DATETIMEUS, or selects back a datetimeus value
with a fraction of 3 microseconds using client type CDB2_DATETIME.

The bug has been in the codebase since datetimeus was first introduced.