### PR TITLE
cdb2jdbc: Honor custom comdb2dbname.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -167,7 +167,7 @@ public class BBSysUtils {
                 rc = true;
             }
         } catch (UnknownHostException e) {
-            logger.log(Level.SEVERE, "ERROR in getting address" + comdb2db_bdns, e);
+            logger.log(Level.SEVERE, "ERROR in getting address " + comdb2db_bdns, e);
         }
         return rc;
     }
@@ -472,15 +472,16 @@ public class BBSysUtils {
      * @param hndl
      * @throws NoDbHostFoundException
      */
-    static void getDbHosts(Comdb2Handle hndl) throws NoDbHostFoundException {
+    static void getDbHosts(Comdb2Handle hndl, boolean refresh) throws NoDbHostFoundException {
         if (debug) { 
             System.out.println("Starting getDbHosts"); 
         }
-        /* Clear node info of both the database and comdb2db */
-        hndl.comdb2dbName = null;
-        hndl.comdb2dbHosts.clear();
-        hndl.myDbHosts.clear();
-        hndl.myDbPorts.clear();
+        if (refresh) {
+            /* Clear node info of both the database and comdb2db */
+            hndl.comdb2dbHosts.clear();
+            hndl.myDbHosts.clear();
+            hndl.myDbPorts.clear();
+        }
 
         if (hndl.myDbCluster.equalsIgnoreCase("local")) {
 			/* type is local */

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2DatabaseMetaDataResultSet.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2DatabaseMetaDataResultSet.java
@@ -126,7 +126,7 @@ public class Comdb2DatabaseMetaDataResultSet implements ResultSet {
             return java.sql.Types.BLOB;
         if (type.equalsIgnoreCase("varchar"))
             return java.sql.Types.VARCHAR;
-        if (type.equalsIgnoreCase("datetime"))
+        if (type.startsWith("datetime"))
             return java.sql.Types.TIMESTAMP;
         if (type.equalsIgnoreCase("decimal"))
             return java.sql.Types.DECIMAL;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -177,7 +177,7 @@ public class Comdb2Handle extends AbstractConnection {
     }
 
     public void lookup() throws NoDbHostFoundException {
-        BBSysUtils.getDbHosts(this);
+        BBSysUtils.getDbHosts(this, false);
     }
 
     /* attribute setters - bb precious */
@@ -1812,7 +1812,7 @@ readloop:
            Re-check information about db. */
         if (!isDirectCpu && refresh_dbinfo_if_failed) {
             try {
-                lookup();
+                BBSysUtils.getDbHosts(this, true);
                 reopen(false);
             } catch (NoDbHostFoundException e) {
                 logger.log(Level.SEVERE, "Failed to refresh dbinfo", e);


### PR DESCRIPTION
#skipbuild as it is a JDBC driver patch and has been tested internally.

The bug does not affect users outside bloomberg.