### PR TITLE
SQLite: Separate Comdb2 syntax from SQLite core syntax.

### DIFF
--- a/sqlite/parse.y
+++ b/sqlite/parse.y
@@ -1942,9 +1942,6 @@ rle_compress_type(A) ::= CRLE. {A = REC_CRLE;}
 rle_compress_type(A) ::= ZLIB. {A = REC_ZLIB;}
 rle_compress_type(A) ::= LZ4. {A = REC_LZ4;}
 
-/////////////////// COMDB2 DRYRUN COMMAND  //////////////////////////////
-
-
 //////////////////// COMDB2 STORED PROCEDURES /////////////////////////////////
 
 cmd ::= createkw PROCEDURE nm(N) NOSQL(X). {

--- a/sqlite/vdbe.c
+++ b/sqlite/vdbe.c
@@ -5892,13 +5892,9 @@ case OP_IdxGE:  {       /* jump */
 #endif
   res = 0;  /* Not needed.  Only used to silence a warning. */
   rc = sqlite3VdbeIdxKeyCompare(db, pC, &r, &res);
-  /*
-    TODO: NC - Find why did the opcodes change by the addition
-    of a new token.
-  */
-  //assert( (OP_IdxLE&1)==(OP_IdxLT&1) && (OP_IdxGE&1)==(OP_IdxGT&1) );
-  if((pOp->opcode == OP_IdxLT) || (pOp->opcode == OP_IdxLE)){
-    //assert( pOp->opcode==OP_IdxLE || pOp->opcode==OP_IdxLT );
+  assert( (OP_IdxLE&1)==(OP_IdxLT&1) && (OP_IdxGE&1)==(OP_IdxGT&1) );
+  if( (pOp->opcode&1)==(OP_IdxLT&1) ){
+    assert( pOp->opcode==OP_IdxLE || pOp->opcode==OP_IdxLT );
     res = -res;
   }else{
     assert( pOp->opcode==OP_IdxGE || pOp->opcode==OP_IdxGT );

--- a/tests/comdb2sys.test/comdb2sys.out
+++ b/tests/comdb2sys.test/comdb2sys.out
@@ -81,11 +81,11 @@
 (tablename='t3', bytes=73728)
 (tablename='t4', bytes=73728)
 [select * from comdb2_tablesizes order by tablename] rc 0
-(KEYWORDS_COUNT=182)
+(KEYWORDS_COUNT=183)
 [SELECT COUNT(*) AS KEYWORDS_COUNT FROM comdb2_keywords] rc 0
 (RESERVED_KW=107)
 [SELECT COUNT(*) AS RESERVED_KW FROM comdb2_keywords WHERE reserved = 'Y'] rc 0
-(NONRESERVED_KW=75)
+(NONRESERVED_KW=76)
 [SELECT COUNT(*) AS NONRESERVED_KW FROM comdb2_keywords WHERE reserved = 'N'] rc 0
 (name='ABORT', reserved='Y')
 (name='ALL', reserved='Y')
@@ -264,6 +264,7 @@
 (name='TIME', reserved='N')
 (name='TRIGGER', reserved='N')
 (name='TRUNCATE', reserved='N')
+(name='TUNABLE', reserved='N')
 (name='USERSCHEMA', reserved='N')
 (name='VERSION', reserved='N')
 (name='VIEW', reserved='N')

--- a/tests/limitsortingtbl.test/sel1.expected
+++ b/tests/limitsortingtbl.test/sel1.expected
@@ -307,7 +307,7 @@
 (Plan='  1 [  SorterOpen]: Open sorter new table with 5 field(s) and cursor [1] to operate on it sort order (asc)')
 (Plan='  2 [    OpenRead]: Open read cursor [0] on table "t1"  (cmnt:t1)')
 (Plan='  3 [ ColumnsUsed]: Cursor [0] using column mask 1110000000000000000000000000000000000000000000000000000000000000')
-(Plan='  4 [     Explain]: No-op (169)')
+(Plan='  4 [     Explain]: No-op (168)')
 (Plan='  5 [      Rewind]: Move cursor [0] to first entry. If no entries exist, go to 13')
 (Plan='  6 [      Column]:     R2 = "i" from cursor [0] on table "t1"  (cmnt:t1.i)')
 (Plan='  7 [      Column]:     R3 = "j" from cursor [0] on table "t1"  (cmnt:t1.j)')


### PR DESCRIPTION
Some of SQLite's optimizations assume certain VDBE opcodes are consecutive, for example, OP_IdxXX and OP_SeekXX. However we may well break the assumption: Comdb2 rules are defined in the middle of SQLite core syntax, thus the 2 groups of tokens are mixed up.

It can be easily fixed by moving our syntax to the end of the lemon grammar file.

