### PR TITLE
tranddl: fix blockprocessor deadlock retry case

### DIFF
--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -723,6 +723,12 @@ static void osql_scdone_commit_callback(struct ireq *iq)
             free_schema_change_type(iq->sc);
             iq->sc = sc_next;
         }
+        iq->sc_pending = NULL;
+        iq->sc_seed = 0;
+    }
+    if (iq->sc_locked) {
+        unlock_schema_lk();
+        iq->sc_locked = 0;
     }
 }
 
@@ -738,6 +744,12 @@ static void osql_scdone_abort_callback(struct ireq *iq)
             free_schema_change_type(iq->sc);
             iq->sc = sc_next;
         }
+        iq->sc_pending = NULL;
+        iq->sc_seed = 0;
+    }
+    if (iq->sc_locked) {
+        unlock_schema_lk();
+        iq->sc_locked = 0;
     }
 }
 

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5458,7 +5458,8 @@ add_blkseq:
                 uuid_t u;
                 memcpy(&u, iq->seq, iq->seqlen);
                 comdb2uuidstr(u, us);
-            }             /* force a parent-deadlock for cdb2tcm */
+            }
+            /* force a parent-deadlock for cdb2tcm */
             if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
                 logmsg(LOGMSG_USER, "tcm forcing parent retry\n");
                 rc = RC_INTERNAL_RETRY;
@@ -5551,6 +5552,25 @@ add_blkseq:
             }
         } else /* rowlocks */
         {
+            /* force a parent-deadlock for cdb2tcm */
+            if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
+                logmsg(LOGMSG_USER, "tcm forcing parent retry in rowlocks\n");
+                if (hascommitlock) {
+                    irc = pthread_rwlock_unlock(&commit_lock);
+                    if (irc != 0) {
+                        logmsg(LOGMSG_USER,
+                               "pthread_rwlock_unlock(&commit_lock) %d\n", irc);
+                        exit(1);
+                    }
+                    hascommitlock = 0;
+                }
+                trans_abort_logical(iq, trans, NULL, 0, NULL, 0);
+                rc = RC_INTERNAL_RETRY;
+                if (block_state_restore(iq, p_blkstate)) return ERR_INTERNAL;
+                outrc = RC_INTERNAL_RETRY;
+                fromline = __LINE__;
+                goto cleanup;
+            }
             /* commit or abort the trasaction as appropriate,
                and write the blkseq */
             if (!backed_out) {
@@ -5591,12 +5611,6 @@ add_blkseq:
 
                 if (rc == BDBERR_NOT_DURABLE)
                     rc = ERR_NOT_DURABLE;
-            }
-
-            /* force a parent-deadlock for cdb2tcm */
-            if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
-                logmsg(LOGMSG_USER, "tcm forcing parent retry in rowlocks\n");
-                rc = RC_INTERNAL_RETRY;
             }
         }
 
@@ -5735,15 +5749,8 @@ add_blkseq:
             sbuf2close(iq->dbglog_file);
             iq->dbglog_file = NULL;
         }
-        osql_postcommit_handle(iq);
     } else {
         iq->dbenv->txns_aborted++;
-        osql_postabort_handle(iq);
-    }
-
-    if (iq->sc_locked) {
-        unlock_schema_lk();
-        iq->sc_locked = 0;
     }
 
     /* update stats (locklessly so we may get gibberish - I know this
@@ -5864,12 +5871,11 @@ static int toblock_main(struct javasp_trans_state *javasp_trans_handle,
     rc = toblock_main_int(javasp_trans_handle, iq, p_blkstate);
     end = gettimeofday_ms();
 
-    if(rc == 0) 
-    {
+    if (rc == 0) {
+        osql_postcommit_handle(iq);
         handle_postcommit_bpfunc(iq);
-    }
-    else
-    {
+    } else {
+        osql_postabort_handle(iq);
         handle_postabort_bpfunc(iq);
     }
 

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5461,7 +5461,7 @@ add_blkseq:
             }
             /* force a parent-deadlock for cdb2tcm */
             if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
-                logmsg(LOGMSG_USER, "tcm forcing parent retry\n");
+                logmsg(LOGMSG_DEBUG, "tcm forcing parent retry\n");
                 rc = RC_INTERNAL_RETRY;
             }
 
@@ -5554,11 +5554,11 @@ add_blkseq:
         {
             /* force a parent-deadlock for cdb2tcm */
             if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
-                logmsg(LOGMSG_USER, "tcm forcing parent retry in rowlocks\n");
+                logmsg(LOGMSG_DEBUG, "tcm forcing parent retry in rowlocks\n");
                 if (hascommitlock) {
                     irc = pthread_rwlock_unlock(&commit_lock);
                     if (irc != 0) {
-                        logmsg(LOGMSG_USER,
+                        logmsg(LOGMSG_FATAL,
                                "pthread_rwlock_unlock(&commit_lock) %d\n", irc);
                         exit(1);
                     }


### PR DESCRIPTION
- move osql_postcommit_handle and osql_postabort_handle to toblock_main
- correctly test deadlock retry logic in rowlocks mode by forcing a retry rcode
- dont add blkseq when forcing a retry
- this should fix intermittent ptranfail_socksql.test failures