### PR TITLE
Add a cluster example in Docker and documentation for Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -280,6 +280,7 @@ docs/sqlitegen/all.html
 docs/sqlitegen/syntax_linkage.tcl
 docker/maven.m2/
 contrib/docker/build
+contrib/docker/volumes
 
 # editor files
 .vscode

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ build-build-container:
 
 docker-clean:
 	rm -fr contrib/docker/build/*
+	docker-compose -f $(realpath $(SRCHOME))/contrib/docker/docker-compose.yml down
 
 docker-dev: docker-standalone
 	docker build -t comdb2-dev:$(VERSION) -f contrib/docker/Dockerfile.dev .
@@ -141,6 +142,15 @@ docker-dev: docker-standalone
 
 docker-standalone: docker-build
 	docker build -t comdb2-standalone:$(VERSION) -f contrib/docker/Dockerfile.standalone contrib/docker
+
+docker-cluster: docker-standalone
+	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node1
+	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node2
+	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node3
+	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node4
+	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node5
+	docker-compose -f $(realpath $(SRCHOME))/contrib/docker/docker-compose.yml down
+	docker-compose -f $(realpath $(SRCHOME))/contrib/docker/docker-compose.yml up -d
 
 # Build the database in the build container
 docker-build: build-build-container
@@ -152,3 +162,4 @@ docker-build: build-build-container
 		-w /comdb2.build \
 		comdb2-build:$(VERSION) \
         make DESTDIR=/comdb2 -j3 install
+ 

--- a/contrib/docker/Dockerfile.standalone
+++ b/contrib/docker/Dockerfile.standalone
@@ -19,5 +19,3 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 COPY build /
-
-ENTRYPOINT ["/opt/bb/bin/pmux", "-l"]

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -1,0 +1,69 @@
+# Comdb2 on Docker
+
+## Prerequsites
+1) Install [Docker Engine](https://docs.docker.com/engine/installation/)
+2) *For using `make docker-cluster`* Install [Docker Compose](https://docs.docker.com/compose/install/)
+3) Read these docs to see what everything is used for
+
+## Dockerfiles
+
+This folder contains several Dockerfiles which serve different functions in running Comdb2 on Docker.
+
+File | Description
+--- | ---
+`Dockerfile.standalone` | Contains dependencies needed to run the database and the built source installed
+`Dockerfile.dev` | Replaces the entrypoint in `Dockerfile.standalone` with one that spins up a database
+`Dockerfile.build` | Contains all build dependencies to build source and output into `./build` folder for use by dependent images 
+`Dockerfile.jdbc.build` | JDBC Driver builder
+
+### Dependency Between Images
+
+<table>
+<tr>
+    <td>Dockerfile.build</td>
+    <td>=> Dockerfile.standalone</td>
+    <td>=> Dockerfile.dev</td>
+</tr>
+<tr>
+    <td></td>
+    <td></td>
+    <td>=> Dockerfile.cluster</td>
+</tr>
+</table>
+
+## Using `make`
+Docker image builds and spining up a Comdb2 cluster through Docker Compose can be done through `make`. At the root directory of the Comdb2 project, the following commands can be ran.
+
+Command | Usage
+--- | ---
+`make docker-standalone` | Builds the `comdb2-standalone:<version>` Docker image
+`make docker-dev` | Builds the `comdb2-dev:<version>` Docker image
+`make docker-cluster` | Creates and runs a Comdb2 cluster using `docker-compose` after initial configuration. *See docker-cluster instructions*
+`make docker-build` | Creates a build container and builds the source into the `contrib/docker/build/` folder
+`make docker-clean` | Removes the `contrib/docker/build/` folder created in the `docker-build` process and runs `docker-compose down` to shut down and remove any running compose clusters
+
+### Using `make docker-cluster`
+The `make docker-cluster` command is a way to run an example Comdb2 cluster. As configured in `docker-compose.yml`, this command will create a 5 node Comdb2 cluster. There are a few setup steps to configure the host environment.
+
+1) Run `make docker-cluster`. This will create the volume-linked folders on your host machine in `contrib/docker/volumes`. It is expected that this will fail to start because no databases have been created yet.
+
+2) Create a Comdb2 Database called `testdb` in the `node1` folder created in `contrib/docker/volumes/`. Steps to create a database can be found [here](https://bloomberg.github.io/comdb2/example_db.html#the-slightly-longer-version). If you would like to modify the name of the database, also change the name in the `cluster-entrypoint.sh` file.
+
+3) Open the LRL file (ex. `testdb.lrl`) in the folder. Change the `dir /some/path` to `dir /db`. Also add the following line to the end of the file `cluster nodes node1 node2 node3 node4 node5`.
+
+4) Copy all the database files that have just been created in the `node1` folder into all the other `nodeX` folders.
+
+5) Run `make docker-cluster` and the cluster should start running
+
+To open a shell in one of the nodes in the cluster, run `docker exec -it nodeX /bin/bash` to open a `bash` shell on that node.
+
+
+## Misc. Files
+
+There are several additional files that are used to support Docker operations.
+
+File | Description
+--- | ---
+`docker-compose.yml` | This is an example Docker Compose file for running a Comdb2 cluster
+`cluster-entrypoint.sh` | Entrypoint script for the example cluster
+`docker-dev-entrypoint.sh` | Entrypoint script for `comdb2-dev:<version>` image

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -43,11 +43,11 @@ Command | Usage
 `make docker-clean` | Removes the `contrib/docker/build/` folder created in the `docker-build` process and runs `docker-compose down` to shut down and remove any running compose clusters
 
 ### Using `make docker-cluster`
-The `make docker-cluster` command is a way to run an example Comdb2 cluster. As configured in `docker-compose.yml`, this command will create a 5 node Comdb2 cluster. There are a few setup steps to configure the host environment.
+The `make docker-cluster` command is a way to run an example Comdb2 cluster. As configured in `docker-compose.yml`, this command will create a 5 node Comdb2 cluster and an "application" container called `dev`. There are a few setup steps to configure the host environment.
 
 1) Run `make docker-cluster`. This will create the volume-linked folders on your host machine in `contrib/docker/volumes`. It is expected that this will fail to start because no databases have been created yet.
 
-2) Create a Comdb2 Database called `testdb` in the `node1` folder created in `contrib/docker/volumes/`. Steps to create a database can be found [here](https://bloomberg.github.io/comdb2/example_db.html#the-slightly-longer-version). If you would like to modify the name of the database, also change the name in the `cluster-entrypoint.sh` file.
+2) Create a Comdb2 Database called `testdb` in the `node1` folder created in `contrib/docker/volumes/`. Steps to create a database can be found [here](https://bloomberg.github.io/comdb2/example_db.html#the-slightly-longer-version). If you would like to modify the name of the database, also change the name in the `cluster-entrypoint.sh` file and rename the `testdb.cfg` to `<dbname>.cfg`.
 
 3) Open the LRL file (ex. `testdb.lrl`) in the folder. Change the `dir /some/path` to `dir /db`. Also add the following line to the end of the file `cluster nodes node1 node2 node3 node4 node5`.
 
@@ -55,10 +55,11 @@ The `make docker-cluster` command is a way to run an example Comdb2 cluster. As 
 
 5) Run `make docker-cluster` and the cluster should start running. Running `docker ps` should show nodes 1 through 5 up and running.
 
+To open a shell on the dev container (would be replaced by your application in actual use), run `docker exec -it dev /bin/bash` to open a `bash` shell. Once connected, run `cdb2sql testdb dev` to run the cdb2sql client.
+
 To open a shell in one of the nodes in the cluster, run `docker exec -it nodeX /bin/bash` to open a `bash` shell on that node.
 
 If your cluster is not working, try navigating to `contrib/docker/` and run `docker-compose up` which will try to spin up the nodes in the foreground and will show any errors the cluster nodes may be experiencing.
-
 
 
 ## Misc. Files
@@ -70,3 +71,5 @@ File | Description
 `docker-compose.yml` | This is an example Docker Compose file for running a Comdb2 cluster
 `cluster-entrypoint.sh` | Entrypoint script for the example cluster
 `docker-dev-entrypoint.sh` | Entrypoint script for `comdb2-dev:<version>` image
+`runforever` | Shell script that runs forever. Used to keep containiers alive after startup
+`testdb.cfg` | Config file for `cdb2sql` when running in the example cluster

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -32,7 +32,7 @@ File | Description
 </table>
 
 ## Using `make`
-Docker image builds and spining up a Comdb2 cluster through Docker Compose can be done through `make`. At the root directory of the Comdb2 project, the following commands can be ran.
+Docker image builds and spining up a Comdb2 cluster through Docker Compose can be done through `make`. The following commands can be executed from the root directory of the Comdb2 project.
 
 Command | Usage
 --- | ---
@@ -53,9 +53,12 @@ The `make docker-cluster` command is a way to run an example Comdb2 cluster. As 
 
 4) Copy all the database files that have just been created in the `node1` folder into all the other `nodeX` folders.
 
-5) Run `make docker-cluster` and the cluster should start running
+5) Run `make docker-cluster` and the cluster should start running. Running `docker ps` should show nodes 1 through 5 up and running.
 
 To open a shell in one of the nodes in the cluster, run `docker exec -it nodeX /bin/bash` to open a `bash` shell on that node.
+
+If your cluster is not working, try navigating to `contrib/docker/` and run `docker-compose up` which will try to spin up the nodes in the foreground and will show any errors the cluster nodes may be experiencing.
+
 
 
 ## Misc. Files

--- a/contrib/docker/cluster-entrypoint.sh
+++ b/contrib/docker/cluster-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Start pmux
+pmux -l
+
+# Start DB
+comdb2 --lrl /db/testdb.lrl testdb

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,0 +1,49 @@
+# Compose file for comsb2 development standalone
+version: "3"
+
+services:
+  comdb2-node1:
+    container_name: node1
+    hostname: node1
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: ./cluster-entrypoint.sh
+    volumes:
+      - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
+      - ./volumes/node1:/db
+    expose: [5105]
+  comdb2-node2:
+    container_name: node2
+    hostname: node2
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: ./cluster-entrypoint.sh
+    volumes:
+      - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
+      - ./volumes/node2:/db
+    expose: [5105]
+  comdb2-node3:
+    container_name: node3
+    hostname: node3
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: ./cluster-entrypoint.sh
+    volumes:
+      - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
+      - ./volumes/node3:/db
+    expose: [5105]
+  comdb2-node4:
+    container_name: node4
+    hostname: node4
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: ./cluster-entrypoint.sh
+    volumes:
+      - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
+      - ./volumes/node4:/db
+    expose: [5105]
+  comdb2-node5:
+    container_name: node5
+    hostname: node5
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: ./cluster-entrypoint.sh
+    volumes:
+      - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
+      - ./volumes/node5:/db
+    expose: [5105]

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -47,3 +47,12 @@ services:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node5:/db
     expose: [5105]
+  comdb2-dev:
+    container_name: dev
+    hostname: dev
+    image: comdb2-standalone:7.0.0pre
+    entrypoint: 
+      - ./runforever
+    volumes:
+      - ./testdb.cfg:/opt/bb/etc/cdb2/config.d/testdb.cfg
+      - ./runforever:/runforever

--- a/contrib/docker/runforever
+++ b/contrib/docker/runforever
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This exists to let the 'dev' container stay up, and allow users to 
+# attach to it to run cdb2sql against the cluster.
+
+while :; do
+    sleep 1
+done

--- a/contrib/docker/testdb.cfg
+++ b/contrib/docker/testdb.cfg
@@ -1,0 +1,2 @@
+testdb node1 node2 node3 node4 node5
+comdb2_config: allow_pmux_route 1


### PR DESCRIPTION
Add a 5 node comdb2 cluster example using `docker-compose` and documentation for Comdb2 on Docker