### PR TITLE
Specify versions for Docker and Compose

### DIFF
--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -8,10 +8,10 @@
 This utility was built and tested using the following versions of Docker Engine and Compose:
 
 Docker Engine
-* version 17.06.0-ce, build 02c1d87
+* version 17.06.0-ce
 
 Docker Compose
-* version 1.14.0, build c7bdf9e
+* version 1.14.0
 
 ## Dockerfiles
 

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -5,6 +5,14 @@
 2) *For using `make docker-cluster`* Install [Docker Compose](https://docs.docker.com/compose/install/)
 3) Read these docs to see what everything is used for
 
+This utility was built and tested using the following versions of Docker Engine and Compose:
+
+Docker Engine
+* version 17.06.0-ce, build 02c1d87
+
+Docker Compose
+* version 1.14.0, build c7bdf9e
+
 ## Dockerfiles
 
 This folder contains several Dockerfiles which serve different functions in running Comdb2 on Docker.

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -1,5 +1,5 @@
-# Compose file for comsb2 development standalone
-version: "3"
+# Compose file for comdb2 development standalone
+version: "2"
 
 services:
   comdb2-node1:


### PR DESCRIPTION
Add docker and compose versions that are confirmed to be working to the docs. An older version was found to be incompatible. #skipbuild