### PR TITLE
Cdb2sql: better behavior when entering ctrl-c

### DIFF
--- a/tools/cdb2sql/cdb2sql.c
+++ b/tools/cdb2sql/cdb2sql.c
@@ -50,7 +50,8 @@ static char *dbname = NULL;
 static char *dbtype = NULL;
 static char *dbhostname = NULL;
 static char main_prompt[MAX_DBNAME_LENGTH + 2];
-static char gbl_in_stmt = 0;
+static unsigned char gbl_in_stmt = 0;
+static unsigned char gbl_sent_cancel_cnonce = 0;
 
 /* display mode */
 enum {
@@ -698,6 +699,7 @@ static void process_line(char *sql, int ntypes, int *types)
     gbl_in_stmt = 1;
     rc = run_statement(sqlstr, ntypes, types, &start_time_ms, &run_time_ms);
     gbl_in_stmt = 0;
+    gbl_sent_cancel_cnonce = 0;
 
     if (rc != 0) {
         error++;
@@ -890,6 +892,7 @@ static void replace_args(int argc, char *argv[])
     }
 }
 
+
 void send_cancel_cnonce(const char *cnonce)
 {
     if (!gbl_in_stmt) return;
@@ -915,10 +918,11 @@ void send_cancel_cnonce(const char *cnonce)
              expanded);
     if (debug_trace) printf("Cancel sql string '%s'\n", sql);
     rc = cdb2_run_statement(cdb2h_2, sql);
-    if (rc && debug_trace)
+    if (!rc) 
+	gbl_sent_cancel_cnonce = 1;
+    else if (debug_trace)
         fprintf(stderr, "failed to cancel rc %d with '%s'\n", rc, sql);
     cdb2_close(cdb2h_2);
-    gbl_in_stmt = 0;
 }
 
 /* If ctrl_c was pressed to clear existing line and go to new line
@@ -929,9 +933,14 @@ void send_cancel_cnonce(const char *cnonce)
 static void int_handler(int signum)
 {
     printf("\n");
-    rl_on_new_line();
-    rl_replace_line("", 0);
-    rl_redisplay();
+    if (gbl_in_stmt && !gbl_sent_cancel_cnonce)
+        printf("Requesting to cancel query (press Ctrl-C to exit program). Please wait...\n");
+    if (gbl_sent_cancel_cnonce) exit(1);
+    if(!gbl_in_stmt) {
+	    rl_on_new_line();
+	    rl_replace_line("", 0);
+	    rl_redisplay();
+    }
     send_cancel_cnonce(cdb2_cnonce(cdb2h));
 }
 


### PR DESCRIPTION
Improve behavior when entering ctrl-c: if request is taking
too long, entering Ctrl-C will send cancel to server and wait for
server to return control. This way prompt ">" is really displayed
when cdb2sql really has control again. If query is taking longer
to return control (because server is corrupted for instance),
the only recourse user now has is to exit the program and that
can now be achieved by entering Ctrl-C again:
```
ubuntu@ip12345:~/comdb2$ ./cdb2sql biginplace26064 @localhost:port=19047 -
biginplace26064> ^C
biginplace26064> ^C
biginplace26064> ^C
biginplace26064> ^C
biginplace26064> select sleep(10)
^C
Requesting to cancel query (press Ctrl-C to exit program). Please wait...
^C
ubuntu@ip12345:~/comdb2$
```