### PR TITLE
Enable auto-registration of JDBC Driver.

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -41,6 +41,13 @@ limitations under the License. -->
     </dependency>
   </dependencies>
   <build>
+    <!-- explicitly copy services file to JAR for auto-regiration -->
+    <resources>
+      <resource>
+        <directory>src/main/resources/META-INF/services</directory>
+        <targetPath>META-INF/services</targetPath>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>

--- a/cdb2jdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/cdb2jdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -1,0 +1,1 @@
+com.bloomberg.comdb2.jdbc.Driver


### PR DESCRIPTION
This PR adds an explicit step in the POM file to copy the META-INF/services directory to the target JAR file. The PR includes a new services file with one line that contains the full class name of the Driver to auto-register. This avoids the need to explicitly load the class before using it (and therefore makes the JDBC driver work with the Kafka JDBC Connector).