### PR TITLE
Have ability to enable skipscan

### DIFF
--- a/sqlite/analyze.c
+++ b/sqlite/analyze.c
@@ -1706,9 +1706,8 @@ static int analysisLoader(void *pData, int argc, char **argv, char **NotUsed){
     pIndex->bUnordered = 0;
     decodeIntArray((char*)z, nCol, aiRowEst, pIndex->aiRowLogEst, pIndex);
     if( pIndex->pPartIdxWhere==0 ) pTable->nRowLogEst = pIndex->aiRowLogEst[0];
-    /* COMDB2 MODIFICATION: assign noskipscan parameter, only if not disabled 
-    ** already.  */ 
-    if( !pIndex->noSkipScan ){
+    /* COMDB2 MODIFICATION: assign noskipscan, only if not foreign table */ 
+    if( pIndex->pTable->iDb < 2 ){
       pIndex->noSkipScan = is_comdb2_index_disableskipscan(pTable->zName, 
                                                            pIndex->zName);
 #ifdef DEBUG

--- a/tests/skipscan.test/runit
+++ b/tests/skipscan.test/runit
@@ -46,6 +46,7 @@ if ! grep "begin skip-scan" out1.txt > /dev/null ; then
     failexit "not using skipscan in out1"
 fi
 
+echo "disable skipscan, check plan"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "put skipscan disable $table"
 sleep 1
 
@@ -60,15 +61,14 @@ if grep "begin skip-scan" out2.txt > /dev/null ; then
     failexit "out2 should have no skipscan"
 fi
 
-# recent code in analyze.c does not allow skipscan to be turned off
-# in a #running server--if ever finds a solution can enable the below:
-#cdb2sql ${CDB2_OPTIONS} $dbnm default "put skipscan enable $table"
-#sleep 1
+echo "enable skipscan, check plan"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "put skipscan enable $table"
+sleep 1
 
-#echo "set explain on
-#select a from $table where b < 34" | cdb2sql ${CDB2_OPTIONS} $dbnm default - > out3.txt
+echo "set explain on
+select a from $table where b < 34" | cdb2sql ${CDB2_OPTIONS} $dbnm default - > out3.txt
 
-#if ! diff out1.txt out3.txt > /dev/null ; then
-#    failexit "out3 should be same as out1"
-#fi
+if ! diff out1.txt out3.txt > /dev/null ; then
+    failexit "out3 should be same as out1"
+fi
 


### PR DESCRIPTION
Earlier change in https://github.com/bloomberg/comdb2/pull/97 made it possible to turn off skipscan but not
possible to turn it back on. This checkin allows skipscan
to be turned back on via put command -- amending test
accordingly to check this ability.