### PR TITLE
Fix DDL locking bugs

### DIFF
--- a/bbinc/list.h
+++ b/bbinc/list.h
@@ -106,6 +106,8 @@ extern int listc_size(void *list);
 
 #define LISTC_TOP(listp) ((listp)->top)
 
+#define LISTC_NEXT(currentp, linkv) ((currentp)->linkv.next)
+
 /* Iteration in which it is safe to remove the current element.
  * tmpp is an additional pointer of the same type as currentp,
  * to cache the next element */

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1873,7 +1873,7 @@ int bdb_table_version_delete(bdb_state_type *bdb_state, tran_type *tran,
  *  If an entry doesn't exist, version 0 is returned
  *
  */
-int bdb_table_version_select(bdb_state_type *bdb_state, tran_type *tran,
+int bdb_table_version_select(const char *name, tran_type *tran,
                              unsigned long long *version, int *bdberr);
 
 void bdb_send_analysed_table_to_master(bdb_state_type *bdb_state, char *table);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -6996,7 +6996,7 @@ int bdb_table_version_upsert(bdb_state_type *bdb_state, tran_type *tran,
     }
 
     /* find the existing record, if any */
-    rc = bdb_table_version_select(bdb_state, tran, &version, bdberr);
+    rc = bdb_table_version_select(bdb_state->name, tran, &version, bdberr);
     if (rc) {
         *bdberr = BDBERR_MISC;
         return -1;
@@ -7086,7 +7086,7 @@ int bdb_table_version_delete(bdb_state_type *bdb_state, tran_type *tran,
     }
 
     /* find the existing record, if any */
-    rc = bdb_table_version_select(bdb_state, tran, &version, bdberr);
+    rc = bdb_table_version_select(bdb_state->name, tran, &version, bdberr);
     if (rc) {
         *bdberr = BDBERR_MISC;
         return -1;
@@ -7125,14 +7125,13 @@ int bdb_table_version_delete(bdb_state_type *bdb_state, tran_type *tran,
  *  If an entry doesn't exist, version 0 is returned
  *
  */
-int bdb_table_version_select(bdb_state_type *bdb_state, tran_type *tran,
+int bdb_table_version_select(const char *tblname, tran_type *tran,
                              unsigned long long *version, int *bdberr)
 {
     struct llmeta_sane_table_version schema_version;
     char key[LLMETA_IXLEN] = {0};
     char fnddata[sizeof(*version)];
     int fnddatalen;
-    const char *tblname = bdb_state->name;
     int tblnamelen;
     uint8_t *p_buf, *p_buf_end;
     int retries;

--- a/db/dbglog_support.c
+++ b/db/dbglog_support.c
@@ -44,6 +44,7 @@
 #include <cdb2_constants.h>
 #include <cdb2api.h>
 #include <logmsg.h>
+#include <str0.h>
 
 /* dbglog + //DBSTATS support.  We have lots of interaces to
  sql, so here's
@@ -170,24 +171,18 @@ int record_query_cost(struct sql_thread *thd, struct sqlclntstate *clnt)
             query_info->n_components--;
             continue;
         }
-
         stats[i].nfind = c->nfind;
         stats[i].nnext = c->nnext;
         stats[i].nwrite = c->nwrite;
         stats[i].ix = c->ix;
         stats[i].table[0] = 0;
-        if (c->u.db) {
-            if (c->remote) {
-                snprintf(stats[i].table, sizeof(stats[i].table), "%s.%s",
-                         fdb_table_entry_dbname(c->u.fdb),
-                         fdb_table_entry_tblname(c->u.fdb));
-            } else {
-                strncpy(stats[i].table, c->u.db->dbname,
-                        sizeof(stats[i].table));
-            }
-            stats[i].table[sizeof(stats[i].table) - 1] = 0;
+        if (c->fdb) {
+            snprintf0(stats[i].table, sizeof(stats[i].table), "%s.%s",
+                      fdb_table_entry_dbname(c->fdb),
+                      fdb_table_entry_tblname(c->fdb));
+        } else if (c->lcl_tbl_name[0]) {
+            strncpy0(stats[i].table, c->lcl_tbl_name, sizeof(stats[i].table));
         }
-
         i++;
     }
     return 0;

--- a/db/glue.c
+++ b/db/glue.c
@@ -6139,7 +6139,7 @@ int table_version_upsert(struct dbtable *db, void *trans, int *bdberr)
     //select needs to be done with the same transaction to avoid 
     //undetectable deadlock for writing and reading from same thread
     unsigned long long version;
-    rc = bdb_table_version_select(db->handle, trans, &version, bdberr);
+    rc = bdb_table_version_select(db->dbname, trans, &version, bdberr);
     if (rc || *bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, *bdberr);
@@ -6160,7 +6160,7 @@ unsigned long long table_version_select(struct dbtable *db, tran_type *tran)
     unsigned long long version;
     int rc;
 
-    rc = bdb_table_version_select(db->handle, tran, &version, &bdberr);
+    rc = bdb_table_version_select(db->dbname, tran, &version, &bdberr);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, bdberr);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1231,6 +1231,7 @@ int osql_bplog_reqlog_queries(struct ireq *iq)
     return 0;
 }
 
+static pthread_mutex_t ddl_lk = PTHREAD_MUTEX_INITIALIZER;
 static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
                          int *nops, struct block_err *err, SBUF2 *logsb)
 {
@@ -1279,17 +1280,14 @@ static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
     listc_init(&iq->bpfunc_lst, offsetof(bpfunc_lstnode_t, linkct));
 
     /* go through the complete list and apply all the changes */
+    if (iq->tranddl) pthread_mutex_lock(&ddl_lk);
     LISTC_FOR_EACH(&tran->complete, info, c_reqs)
     {
-
-        /* TODO: add an extended error structure to be passed back to the client
-         */
         out_rc = process_this_session(iq, iq_tran, info->sess, &bdberr, nops,
                                       err, logsb, dbc, osql_process_packet);
-
-        if (out_rc)
-            break;
+        if (out_rc) break;
     }
+    if (iq->tranddl) pthread_mutex_unlock(&ddl_lk);
 #if 0
     /* we will apply these outside a transaction */
     if (out_rc) {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1632,7 +1632,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 *
 */
 int osql_schemachange_logic(struct schema_change_type *sc,
-                            struct sql_thread *thd)
+                            struct sql_thread *thd, int usedb)
 {
     struct sqlclntstate *clnt = thd->sqlclntstate;
     osqlstate_t *osql = &clnt->osql;
@@ -1660,6 +1660,13 @@ int osql_schemachange_logic(struct schema_change_type *sc,
                "%s:%d %s - failed to cache socksql schemachange rc=%d\n",
                __FILE__, __LINE__, __func__, rc);
     }
-    return osql_send_schemachange(host, rqid, thd->sqlclntstate->osql.uuid, sc,
-                                  NET_OSQL_BLOCK_RPL_UUID, osql->logsb);
+    if (usedb) {
+        rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, tblname,
+                             NET_OSQL_BLOCK_RPL_UUID, osql->logsb);
+    }
+    if (rc == SQLITE_OK) {
+        rc = osql_send_schemachange(host, rqid, thd->sqlclntstate->osql.uuid,
+                                    sc, NET_OSQL_BLOCK_RPL_UUID, osql->logsb);
+    }
+    return rc;
 }

--- a/db/osqlsqlthr.h
+++ b/db/osqlsqlthr.h
@@ -183,8 +183,8 @@ int osql_sock_restart(struct sqlclntstate *clnt, int maxretries,
 * Returns SQLITE_OK if successful.
 *
 */
-int osql_schemachange_logic(struct schema_change_type *,
-                            struct sql_thread *thd);
+int osql_schemachange_logic(struct schema_change_type *, struct sql_thread *,
+                            int usedb);
 
 int osql_dbq_consume_logic(struct sqlclntstate *, const char *spname, genid_t);
 int osql_dbq_consume(struct sqlclntstate *, const char *spname, genid_t);

--- a/db/sql.h
+++ b/db/sql.h
@@ -518,16 +518,13 @@ struct sqlclntstate {
 
 /* Query stats. */
 struct query_path_component {
-    union {
-        struct dbtable *db;           /* local db, or tmp if NULL */
-        struct fdb_tbl_ent *fdb; /* remote db */
-    } u;
+    struct fdb_tbl_ent *fdb; /* null: local_tbl_name */
+    char lcl_tbl_name[MAXTABLELEN];
     int ix;
     int nfind;
     int nnext;
     int nwrite;
     int nblobs;
-    int remote; /* mark this as remote, see *u */
     LINKC_T(struct query_path_component) lnk;
 };
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -6278,14 +6278,12 @@ void addVbdeSorterCost(const VdbeSorter *pSorter)
         return;
 
     struct query_path_component fnd, *qc;
-
-    fnd.u.db = 0;
+    fnd.fdb = 0;
+    fnd.lcl_tbl_name[0] = 0;
     fnd.ix = 0;
 
     if (NULL == (qc = hash_find(thd->query_hash, &fnd))) {
         qc = calloc(sizeof(struct query_path_component), 1);
-        qc->u.db = 0;
-        qc->ix = 0;
         hash_add(thd->query_hash, qc);
         listc_abl(&thd->query_stats, qc);
     }
@@ -6368,9 +6366,9 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
         if (pCur->bt && pCur->bt->is_remote) {
             if (!pCur->fdbc)
                 goto skip; /* failed during cursor creation */
-            fnd.u.fdb = pCur->fdbc->table_entry(pCur);
+            fnd.fdb = pCur->fdbc->table_entry(pCur);
         } else {
-            fnd.u.db = pCur->db;
+            strcpy(fnd.lcl_tbl_name, pCur->db->dbname);
         }
         fnd.ix = pCur->ixnum;
 
@@ -6378,10 +6376,9 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
             NULL == (qc = hash_find(thd->query_hash, &fnd))) {
             qc = calloc(sizeof(struct query_path_component), 1);
             if (pCur->bt && pCur->bt->is_remote) {
-                qc->remote = 1;
-                qc->u.fdb = fnd.u.fdb;
+                qc->fdb = fnd.fdb;
             } else {
-                qc->u.db = pCur->db;
+                strcpy(qc->lcl_tbl_name, pCur->db->dbname);
             }
             qc->ix = pCur->ixnum;
             hash_add(thd->query_hash, qc);

--- a/db/tag.c
+++ b/db/tag.c
@@ -6748,7 +6748,7 @@ void update_dbstore(struct dbtable *db)
                        "PANIC!!\n",
                        db->dbname, __func__, from->name, tag);
                 /* FIXME */
-                exit(1);
+                abort();
             }
 
             if (db->versmap[v][i] != i || from->type != to->type ||
@@ -6766,7 +6766,7 @@ void update_dbstore(struct dbtable *db)
                         logmsg(LOGMSG_FATAL, "%s: %s() @ %d calloc failed!! PANIC!!\n",
                                db->dbname, __func__, __LINE__);
                         /* FIXME */
-                        exit(1);
+                        abort();
                     }
                     rc = SERVER_to_SERVER(
                         from->in_default, from->in_default_len,
@@ -6779,7 +6779,7 @@ void update_dbstore(struct dbtable *db)
                                "PANIC!!\n",
                                db->dbname, __func__, __LINE__);
                         /* FIXME */
-                        exit(1);
+                        abort();
                     }
                 }
             }

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -283,7 +283,7 @@ int finalize_add_table(struct ireq *iq, tran_type *tran)
         return rc;
     }
 
-    if ((rc = bdb_table_version_select(db->handle, tran, &db->tableversion,
+    if ((rc = bdb_table_version_select(db->dbname, tran, &db->tableversion,
                                        &bdberr)) != 0) {
         sc_errf(s, "Failed fetching table version bdberr %d\n", bdberr);
         return rc;

--- a/sqlite/comdb2build.h
+++ b/sqlite/comdb2build.h
@@ -77,15 +77,11 @@ void comdb2setSkipscan(Parse* pParse, Token* nm, Token* lnm, int enable);
 void comdb2setAlias(Parse*, Token*, Token*);
 void comdb2getAlias(Parse*, Token*);
 
-void comdb2rebuildFull(Parse*,Token*,Token*);
-
-void comdb2rebuildIndex(Parse*, Token*, Token*, Token*);
-
-void comdb2rebuildData(Parse*, Token*, Token*);
-
-void comdb2rebuildDataBlob(Parse*,Token*, Token*);
-
-void comdb2truncate(Parse*, Token*, Token*);
+void comdb2RebuildFull(Parse*,Token*,Token*);
+void comdb2RebuildIndex(Parse*, Token*, Token*, Token*);
+void comdb2RebuildData(Parse*, Token*, Token*);
+void comdb2RebuildDataBlob(Parse*,Token*, Token*);
+void comdb2Truncate(Parse*, Token*, Token*);
 
 void comdb2bulkimport(Parse*, Token*, Token*, Token*, Token*);
 

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -23,8 +23,6 @@
 #include <dbqueue.h>
 #include <translistener.h>
 
-#define LISTC_NEXT(currentp, linkv) ((currentp)->linkv.next)
-
 typedef struct trigger trigger;
 struct trigger {
   LINKC_T(trigger) lnk;

--- a/sqlite/parse.y
+++ b/sqlite/parse.y
@@ -1771,19 +1771,19 @@ cmd ::= rebuild.
 
 rebuild ::= REBUILD nm(T) dbnm(X). { /* REBUILD FULL CANNOT BE USED
                                         BECAUSE OF SQLITE SYNTAX */
-    comdb2rebuildFull(pParse,&T,&X);
+    comdb2RebuildFull(pParse,&T,&X);
 }
 
 rebuild ::= REBUILD INDEX nm(T) dbnm(Y) nm(X). {
-    comdb2rebuildIndex(pParse, &T,&Y, &X);
+    comdb2RebuildIndex(pParse, &T,&Y, &X);
 }
 
 rebuild ::= REBUILD DATA nm(T) dbnm(X). {
-    comdb2rebuildData(pParse, &T, &X);
+    comdb2RebuildData(pParse, &T, &X);
 }
 
 rebuild ::= REBUILD DATABLOB nm(N) dbnm(X). {
-    comdb2rebuildDataBlob(pParse,&N, &X);
+    comdb2RebuildDataBlob(pParse,&N, &X);
 }
 /////////////////////COMDB2 GRANT STATEMENT //////////////////////////////////
 
@@ -1833,7 +1833,7 @@ cmd ::= REVOKE userschema(P) nm(U1) TO nm(U2). {
 cmd ::= truncate.
 truncate ::= TRUNCATE table_opt nm(T) dbnm(Y).
 {
-    comdb2truncate(pParse, &T, &Y);
+    comdb2Truncate(pParse, &T, &Y);
 }
 
 table_opt ::= .

--- a/tests/schemalk.test/Makefile
+++ b/tests/schemalk.test/Makefile
@@ -1,0 +1,2 @@
+include $(TESTSROOTDIR)/testcase.mk
+export ARG=-s --cdb2cfg $(CDB2_CONFIG) $(DBNAME) default

--- a/tests/schemalk.test/lrl.options
+++ b/tests/schemalk.test/lrl.options
@@ -1,0 +1,1 @@
+dtastripe 1

--- a/tests/schemalk.test/runit
+++ b/tests/schemalk.test/runit
@@ -1,0 +1,62 @@
+#!/bin/bash
+scnum=500
+sec=0.1
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'create table t (i int)$$'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'create index i on t(i)'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'alter table t add j int$$'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'alter table t add k int$$'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'alter table t drop j$$'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'alter table t drop k$$'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'truncate table t'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+for ((i=0;i<${scnum};++i)); do
+echo 'drop table t'
+sleep $sec
+done | cdb2sql $ARG - &
+
+
+wait
+
+
+cdb2sql $ARG 'drop table if exists t' || exit 1
+cdb2sql $ARG 'create table t (a int, b int, c int)' || exit 1
+cdb2sql $ARG 'insert into t values(0, 1, 2),(1,2,3),(2,3,4)' || exit 1
+cdb2sql $ARG 'select * from t' || exit 1
+
+exit 0


### PR DESCRIPTION
* Add table-name locking for DDL stmts on replicants (like DML)
* Send usedb for alter/truncate/drop/rebuild (detect stale schema on master)
* Run one schemachange transaction at a time on master