### PR TITLE
tests should not load global lrl files

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -340,7 +340,6 @@ int gbl_create_mode = 0; /* turn on create-if-not-exists mode*/
 const char *gbl_repoplrl_fname = NULL; /* if != NULL this is the fname of the
                                         * external lrl file to create with
                                         * this db's settings and table defs */
-int gbl_nogbllrl = 0;                /* don't load /bb/bin/comdb2*.lrl */
 int gbl_local_mode = 0;                /* local mode, no siblings */
 int gbl_fullrecovery = 0;              /* backend full-recovery mode*/
 int gbl_maxretries = 500;              /* thats a lotta retries */
@@ -3148,14 +3147,6 @@ static int init(int argc, char **argv)
     if (gbl_fullrecovery) {       /*  11  */
         logmsg(LOGMSG_FATAL, "force full recovery.\n");
         gbl_exit = 1;
-    }
-    if (gbl_nogbllrl) {         /*  14  */
-        /* disable loading comdb2.lrl and comdb2_local.lrl with an absolute
-         * path in /bb/bin. comdb2.lrl and comdb2_local.lrl in the pwd are
-         * still loaded */
-        logmsg(LOGMSG_INFO, "not loading %s/bin/comdb2.lrl and "
-               "%s/bin/comdb2_local.lrl.\n",
-               gbl_config_root, gbl_config_root);
     }
 
     /* every option that sets exit implies local mode */

--- a/db/config.c
+++ b/db/config.c
@@ -35,7 +35,6 @@
 
 extern int gbl_create_mode;
 extern int gbl_fullrecovery;
-extern int gbl_nogbllrl;
 extern int gbl_exit;
 extern int gbl_recovery_timestamp;
 extern int gbl_recovery_lsn_file;
@@ -53,6 +52,7 @@ extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern char **qdbs;
 extern char **sfuncs;
 extern char **afuncs;
+static int gbl_nogbllrl;    /* don't load /bb/bin/comdb2*.lrl */
 
 static struct option long_options[] = {
     {"lrl", required_argument, NULL, 0},
@@ -412,7 +412,7 @@ struct dbenv *read_lrl_file_int(struct dbenv *dbenv, const char *lrlname,
         return dbenv;
     }
 
-    logmsg(LOGMSG_DEBUG, "processing %s...\n", lrlname);
+    logmsg(LOGMSG_INFO, "processing %s...\n", lrlname);
     while (fgets(line, sizeof(line), ff)) {
         char *s = strchr(line, '\n');
         if (s) *s = 0;
@@ -453,7 +453,6 @@ struct dbenv *read_lrl_file_int(struct dbenv *dbenv, const char *lrlname,
 static struct dbenv *read_lrl_file(struct dbenv *dbenv, const char *lrlname,
                                    int required)
 {
-
     struct lrlfile *lrlfile;
     struct dbenv *out;
     out = read_lrl_file_int(dbenv, (char *)lrlname, required);
@@ -1379,6 +1378,13 @@ int read_lrl_files(struct dbenv *dbenv, const char *lrlname)
                 return 0;
             }
         }
+    } else {
+        /* disable loading comdb2.lrl and comdb2_local.lrl with an absolute
+         * path in /bb/bin. comdb2.lrl and comdb2_local.lrl in the pwd are
+         * still loaded */
+        logmsg(LOGMSG_INFO, "Not loading %s/bin/comdb2.lrl and "
+               "%s/bin/comdb2_local.lrl.\n",
+               gbl_config_root, gbl_config_root);
     }
 
     /* look for overriding lrl's in the local directory */

--- a/db/config.c
+++ b/db/config.c
@@ -52,7 +52,7 @@ extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern char **qdbs;
 extern char **sfuncs;
 extern char **afuncs;
-static int gbl_nogbllrl;    /* don't load /bb/bin/comdb2*.lrl */
+static int gbl_nogbllrl; /* don't load /bb/bin/comdb2*.lrl */
 
 static struct option long_options[] = {
     {"lrl", required_argument, NULL, 0},
@@ -1383,7 +1383,7 @@ int read_lrl_files(struct dbenv *dbenv, const char *lrlname)
          * path in /bb/bin. comdb2.lrl and comdb2_local.lrl in the pwd are
          * still loaded */
         logmsg(LOGMSG_INFO, "Not loading %s/bin/comdb2.lrl and "
-               "%s/bin/comdb2_local.lrl.\n",
+                            "%s/bin/comdb2_local.lrl.\n",
                gbl_config_root, gbl_config_root);
     }
 

--- a/tests/setup
+++ b/tests/setup
@@ -197,7 +197,8 @@ done >> $DBDIR/${DBNAME}.lrl
 
 mkdir -p $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2
 
-$comdb2task --create --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/$DBNAME.pid $DBNAME  >$TESTDIR/logs/${DBNAME}.init 2>&1
+PARAMS="--no-global-lrl $DBNAME"
+$comdb2task --create --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/$DBNAME.pid $PARAMS  >$TESTDIR/logs/${DBNAME}.init 2>&1
 rc=$?
 rm -f ${DBNAME}.trap
 if [[ $rc -ne 0 ]]; then
@@ -217,9 +218,9 @@ cd $DBDIR >/dev/null
 if [[ -z "$CLUSTER" ]]; then
     echo "!$TESTCASE: starting single node"
     if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
-        echo -e "!$TESTCASE: Execute the following command in a separate terminal: ${TEXTCOLOR}cd $DBDIR && ${DEBUG_PREFIX} $comdb2task $DBNAME -pidfile ${TMPDIR}/$DBNAME.pid${NOCOLOR}"
+        echo -e "!$TESTCASE: Execute the following command in a separate terminal: ${TEXTCOLOR}cd $DBDIR && ${DEBUG_PREFIX} $comdb2task $PARAMS -pidfile ${TMPDIR}/$DBNAME.pid${NOCOLOR}"
     else
-        ${DEBUG_PREFIX} $comdb2task $DBNAME -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.db &
+        ${DEBUG_PREFIX} $comdb2task $PARAMS -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.db &
     fi
 
     set +e
@@ -245,14 +246,14 @@ else
     done
 
     echo "export COMDB2_ROOT=$COMDB2_ROOT" >> ${TESTDIR}/replicant_vars
-    CMD="source ${TESTDIR}/replicant_vars ; $comdb2task ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl"
+    CMD="source ${TESTDIR}/replicant_vars ; $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl"
     echo "!$TESTCASE: starting"
     for node in $CLUSTER; do
         if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
-                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $comdb2task ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
+                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
             else
-                ${DEBUG_PREFIX} $comdb2task ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 &
+                ${DEBUG_PREFIX} $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 &
             fi
             continue
         fi

--- a/tests/setup
+++ b/tests/setup
@@ -139,7 +139,6 @@ if [ -n "$PMUXPORT" ] ; then
 fi
 stop_pmux="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port} && echo exit >&3 )"
 
-
 COPIEDTOCLUSTER=${TMPDIR}/copiedtocluster.log
 export COMDB2AR_EXOPTS="-x $comdb2task"
 
@@ -162,7 +161,9 @@ copy_files_to_cluster()
         fi
         scp -o StrictHostKeyChecking=no $pmux $node:${pmux}
         echo start pmux on $node if not running 
+        set +e
         ssh -o StrictHostKeyChecking=no $node "COMDB2_PMUX_FILE='$TESTSROOTDIR/pmux.sqlite' ${SRCHOME}/$pmux_cmd"
+        set -e
     done
 }
 
@@ -178,6 +179,8 @@ if [ $? -eq 0 ] ; then
     COMDB2_PMUX_FILE="$TESTSROOTDIR/pmux.sqlite" ${SRCHOME}/$pmux_cmd
 fi
 
+set -e  # from here, a bad rc will mean failure and exit
+
 # if CLUSTER is length is nonzero, and file does not exist, copy to cluster
 if [ -n "$CLUSTER" ] ; then 
     { > $COPIEDTOCLUSTER ; } &> /dev/null 
@@ -188,7 +191,6 @@ fi
 set +o noclobber 
 
 
-set -e  # from here, a bad rc will mean failure and exit
 
 for csc2 in $(ls *.csc2 2>/dev/null); do
     table=${csc2%%.csc2}
@@ -197,7 +199,7 @@ done >> $DBDIR/${DBNAME}.lrl
 
 mkdir -p $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2
 
-PARAMS="--no-global-lrl $DBNAME"
+PARAMS="$DBNAME --no-global-lrl"
 $comdb2task --create --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/$DBNAME.pid $PARAMS  >$TESTDIR/logs/${DBNAME}.init 2>&1
 rc=$?
 rm -f ${DBNAME}.trap
@@ -246,14 +248,14 @@ else
     done
 
     echo "export COMDB2_ROOT=$COMDB2_ROOT" >> ${TESTDIR}/replicant_vars
-    CMD="source ${TESTDIR}/replicant_vars ; $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl"
+    CMD="source ${TESTDIR}/replicant_vars ; $comdb2task ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl"
     echo "!$TESTCASE: starting"
     for node in $CLUSTER; do
         if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
-                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
+                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $comdb2task ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
             else
-                ${DEBUG_PREFIX} $comdb2task ${PARAMS} -lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 &
+                ${DEBUG_PREFIX} $comdb2task ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 &
             fi
             continue
         fi
@@ -269,17 +271,18 @@ else
         fi
     done
 
-    set +e
     echo "!$TESTCASE: waiting until ready"
     sleep 1
     for node in $CLUSTER; do
+        set +e
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
         while  [[ "$out" != "1" ]]; do
             sleep 2
             out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
         done
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'comdb2_host()' 2>&1)
-        if [ $out != $node ] ; then
+        set -e
+        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)
+        if [ "$out" != "$node" ] ; then
             echo "comdb2_host() '$out' != expected '$node'"
             sleep 1
             exit 1

--- a/tests/tunables.test/runit
+++ b/tests/tunables.test/runit
@@ -9,6 +9,7 @@ fi
 
 for testreq in `ls t*.sql` ; do
     testname=`echo $testreq | cut -d "." -f 1`
+    #cmd="cdb2sql --tabs -s -f $testreq ${CDB2_OPTIONS} $dbname default "
     cmd="cdb2sql -s -f $testreq ${CDB2_OPTIONS} $dbname default "
     echo $cmd "> $testname.output"
     $cmd 2>&1 | perl -pe "s/.n_writeops_done=([0-9]+)/rows inserted='\1'/; s/BLOCK2_SEQV2\(824\)/BLOCK_SEQ(800)/; s/OP #2 BLOCK_SEQ/OP #3 BLOCK_SEQ/;" > $testname.output


### PR DESCRIPTION
This is needed so tests are isolated from machine setup, but also enables us to test the --no-global-lrl parameter.