### PR TITLE
Add comdb2_gitversion() function

### DIFF
--- a/sqlite/func.c
+++ b/sqlite/func.c
@@ -675,7 +675,7 @@ static void guidFromByteFunc(
 
 
 /*
-** Implementation of the comdb2_version() SQL function.  The return
+** Implementation of comdb2_version() SQL function.  The return
 ** value is the same as the stat value for version
 */
 static void comdb2VersionFunc(
@@ -687,6 +687,21 @@ static void comdb2VersionFunc(
   char zBuf[50];
   const char * version = getenv("COMDB2_VERSION");
   sqlite3_snprintf(sizeof(zBuf), zBuf, "%s (%s)", gbl_db_release_name, version);
+  sqlite3_result_text(context, zBuf, -1, SQLITE_TRANSIENT);
+}
+
+/*
+** Implementation of comdb2_gitversion() SQL function. 
+** Uses git describe to get git repository version in makefile
+*/
+static void comdb2GitversionFunc(
+  sqlite3_context *context,
+  int NotUsed,
+  sqlite3_value **NotUsed2
+){
+  UNUSED_PARAMETER2(NotUsed, NotUsed2);
+  char zBuf[50];
+  sqlite3_snprintf(sizeof(zBuf), zBuf, "%s", COMDB2_GITVERSION);
   sqlite3_result_text(context, zBuf, -1, SQLITE_TRANSIENT);
 }
 
@@ -2198,6 +2213,7 @@ void sqlite3RegisterBuiltinFunctions(void){
   #endif
 #ifdef SQLITE_BUILDING_FOR_COMDB2
     FUNCTION(comdb2_version,    0, 0, 0, comdb2VersionFunc),
+    FUNCTION(comdb2_gitversion, 0, 0, 0, comdb2GitversionFunc),
     FUNCTION(table_version,     1, 0, 0, tableVersionFunc),
     FUNCTION(partition_info,    2, 0, 0, partitionInfoFunc),
     FUNCTION(comdb2_host,       0, 0, 0, comdb2HostFunc),

--- a/sqlite/module.mk
+++ b/sqlite/module.mk
@@ -43,6 +43,9 @@ sqlite/ext/misc/json1.o
 
 sqlite/md5.o: CFLAGS+=-O2
 
+COMDB2_GITVERSION:=$(shell git describe --always)
+sqlite/func.o: CFLAGS+=-DCOMDB2_GITVERSION=\"$(COMDB2_GITVERSION)\"
+
 SQLITE_GENC:=sqlite/parse.c sqlite/opcodes.c sqlite/inline/serialget.c	\
 sqlite/inline/memcompare.c sqlite/inline/vdbecompare.c
 SQLITE_GENH:=sqlite/parse.h sqlite/opcodes.h sqlite/keywordhash.h

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,13 +12,13 @@ export SRCHOME
 export TESTID:=$(shell tools/get_random.sh)
 CURRDIR:=$(shell pwd)
 export TESTDIR:=$(CURRDIR)/test_$(TESTID)
-export GITVERSION:=$(shell git rev-parse --short HEAD)
+export GITVERSION:=$(shell git describe --always)
 
 
 basicops_nokey:
 	$(shell mkdir -p ${TESTDIR})
 	$(shell which git > /dev/null 2>&1 && git rev-parse --abbrev-ref HEAD | xargs echo "Branch" >> ${TESTDIR}/test.log)
-	$(shell which git > /dev/null 2>&1 && git rev-parse --short HEAD | xargs echo "SHA " >> ${TESTDIR}/test.log)
+	$(shell which git > /dev/null 2>&1 && git describe --always | xargs echo "SHA " >> ${TESTDIR}/test.log)
 	$(shell echo "TESTID=${TESTID} " >> ${TESTDIR}/test.log)
 	$(shell echo "CLUSTER=${CLUSTER} " >> ${TESTDIR}/test.log)
 	$(shell echo "SRCHOME=${SRCHOME} " >> ${TESTDIR}/test.log)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,7 @@ export SRCHOME
 export TESTID:=$(shell tools/get_random.sh)
 CURRDIR:=$(shell pwd)
 export TESTDIR:=$(CURRDIR)/test_$(TESTID)
+export GITVERSION:=$(shell git rev-parse --short HEAD)
 
 
 basicops_nokey:

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -226,6 +226,7 @@ for node in $cluster ; do
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_host()"`
     assertres $res $node
 
+
     port=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_port()"`
     echo "connect to db with direct port info"
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @$node:port=$port "select comdb2_dbname()"`
@@ -234,17 +235,18 @@ for node in $cluster ; do
     echo "connect with wrong db name"
     set +e
     cdb2sql --tabs ${CDB2_OPTIONS} badname @$node:port=$port "select comdb2_dbname()" &> out.txt
-    echo "[select comdb2_dbname()] failed with rc -1 DB name mismatch" > out.exp
+    echo "[select comdb2_dbname()] failed with rc -1 DB name mismatch query:badname actual:$DBNAME" > out.exp
     rc=$?
     set -e
 #    TODO: this returns rc=0 even though error and can't run query!!
 #    if [ $rc -eq 0 ]; then
 #        failexit "Expected bad rc when connecting with the wrong db name"
 #    fi
-    if [ diff out.txt out.exp ]; then
-        failexit "Expected failure when connecting with the wrong db name"
+    if ! diff out.txt out.exp ; then
+        failexit "Expected failure when connecting with the wrong db name, diff out.txt out.exp"
     fi
 
+    echo "check git hash of comdb2 task with current directory git hash, it will be different if you git commit after liking comdb2 server."
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_gitversion()"`
     assertres $res $GITVERSION
 done

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -226,7 +226,6 @@ for node in $cluster ; do
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_host()"`
     assertres $res $node
 
-
     port=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_port()"`
     echo "connect to db with direct port info"
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @$node:port=$port "select comdb2_dbname()"`
@@ -245,6 +244,9 @@ for node in $cluster ; do
     if [ diff out.txt out.exp ]; then
         failexit "Expected failure when connecting with the wrong db name"
     fi
+
+    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_gitversion()"`
+    assertres $res $GITVERSION
 done
 
 

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -56,6 +56,6 @@ call_unsetup
 
 DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
 echo Done $TESTCASE with id $TESTID at $DATETIME >> $TESTDIR/test.log
-echo "Duration $SECONDS seconds" >> ${TESTDIR}/logs/${DBNAME}.testcase
+echo "Duration $SECONDS seconds" | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >> ${TESTDIR}/logs/${DBNAME}.testcase
 
 exit $rc

--- a/tests/setup
+++ b/tests/setup
@@ -230,6 +230,13 @@ if [[ -z "$CLUSTER" ]]; then
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs $DBNAME default 'select 1' 2>/dev/null)
         sleep 1
     done
+
+    out=$(cdb2sql ${CDB2_OPTIONS} --tabs $DBNAME default 'select comdb2_gitversion()' 2>&1)
+    if [ "$out" != "$GITVERSION" ] ; then
+        echo "comdb2_gitversion() '$out' != expected '$GITVERSION'"
+        exit 1
+    fi
+
 else
     echo "!$TESTCASE: copying to cluster"
     for node in $CLUSTER; do
@@ -280,13 +287,11 @@ else
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'comdb2_host()' 2>&1)
         if [ $out != $node ] ; then
             echo "comdb2_host() '$out' != expected '$node'"
-            sleep 1
             exit 1
         fi
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_gitversion()' 2>&1)
         if [ "$out" != "$GITVERSION" ] ; then
             echo "comdb2_gitversion() '$out' != expected '$GITVERSION'"
-            sleep 1
             exit 1
         fi
     done

--- a/tests/setup
+++ b/tests/setup
@@ -231,12 +231,6 @@ if [[ -z "$CLUSTER" ]]; then
         sleep 1
     done
 
-    out=$(cdb2sql ${CDB2_OPTIONS} --tabs $DBNAME default 'select comdb2_gitversion()' 2>&1)
-    if [ "$out" != "$GITVERSION" ] ; then
-        echo "comdb2_gitversion() '$out' != expected '$GITVERSION'"
-        exit 1
-    fi
-
 else
     echo "!$TESTCASE: copying to cluster"
     for node in $CLUSTER; do
@@ -287,11 +281,6 @@ else
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'comdb2_host()' 2>&1)
         if [ $out != $node ] ; then
             echo "comdb2_host() '$out' != expected '$node'"
-            exit 1
-        fi
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_gitversion()' 2>&1)
-        if [ "$out" != "$GITVERSION" ] ; then
-            echo "comdb2_gitversion() '$out' != expected '$GITVERSION'"
             exit 1
         fi
     done

--- a/tests/setup
+++ b/tests/setup
@@ -269,6 +269,7 @@ else
     done
 
     set +e
+    gitversion=$(git describe --always)
     echo "!$TESTCASE: waiting until ready"
     sleep 1
     for node in $CLUSTER; do
@@ -280,6 +281,12 @@ else
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'comdb2_host()' 2>&1)
         if [ $out != $node ] ; then
             echo "comdb2_host() '$out' != expected '$node'"
+            sleep 1
+            exit 1
+        fi
+        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_gitversion()' 2>&1)
+        if [ "$out" != "$gitversion" ] ; then
+            echo "comdb2_gitversion() '$out' != expected '$gitversion'"
             sleep 1
             exit 1
         fi

--- a/tests/setup
+++ b/tests/setup
@@ -269,7 +269,6 @@ else
     done
 
     set +e
-    gitversion=$(git describe --always)
     echo "!$TESTCASE: waiting until ready"
     sleep 1
     for node in $CLUSTER; do
@@ -285,8 +284,8 @@ else
             exit 1
         fi
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_gitversion()' 2>&1)
-        if [ "$out" != "$gitversion" ] ; then
-            echo "comdb2_gitversion() '$out' != expected '$gitversion'"
+        if [ "$out" != "$GITVERSION" ] ; then
+            echo "comdb2_gitversion() '$out' != expected '$GITVERSION'"
             sleep 1
             exit 1
         fi

--- a/tests/setup
+++ b/tests/setup
@@ -230,7 +230,6 @@ if [[ -z "$CLUSTER" ]]; then
         out=$(cdb2sql ${CDB2_OPTIONS} --tabs $DBNAME default 'select 1' 2>/dev/null)
         sleep 1
     done
-
 else
     echo "!$TESTCASE: copying to cluster"
     for node in $CLUSTER; do


### PR DESCRIPTION
Add git version to the executable, this is useful to determine build.
The original intention was to make sure that we are running the same 
server executable in all the nodes of a cluster. 

Turns out that this is not useful to check from setup: if you commit a change
the git version will change, however the executable was built earlier with
a previous git hash--setup can't rely on hash because of mismatch
between git version in the executable, and the version in current dir.
Thus, i am moving this to a check in the basic.test so we can
detect the mismatch but only in that one test.

To try and catch wrong executable, we would need to take md5sum of
executable at the beginning of the tests, and check with every
running setup that the md5sum matches.