### PR TITLE
check md5sum of comdb2 executable for each test

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,6 +12,7 @@ export SRCHOME
 export TESTID:=$(shell tools/get_random.sh)
 CURRDIR:=$(shell pwd)
 export TESTDIR:=$(CURRDIR)/test_$(TESTID)
+# get md5sum of executable use check when running every test in a series
 export COMDB2MD5SUM:=$(shell md5sum ${SRCHOME}/comdb2 | cut -d ' ' -f1)
 
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -13,6 +13,7 @@ export TESTID:=$(shell tools/get_random.sh)
 CURRDIR:=$(shell pwd)
 export TESTDIR:=$(CURRDIR)/test_$(TESTID)
 export GITVERSION:=$(shell git describe --always)
+export COMDB2MD5SUM:=$(shell md5sum ${SRCHOME}/comdb2 | cut -d ' ' -f1)
 
 
 basicops_nokey:

--- a/tests/setup
+++ b/tests/setup
@@ -216,9 +216,8 @@ fi
 
 compare_md5_sum()
 {
-    loc_comdb2md5sum=$1
-    if [ "$loc_comdb2md5sum" != "$COMDB2MD5SUM" ]; then
-        echo "MD5SUM $COMDB2MD5SUM does not match current $loc_comdb2md5sum"
+    if [ "$1" != "$COMDB2MD5SUM" ]; then
+        echo "Comdb2 md5 checksum mismatch, expected: $COMDB2MD5SUM got: $1"
         exit 1
     fi
 }

--- a/tests/setup
+++ b/tests/setup
@@ -214,10 +214,22 @@ fi
 #    exit 1
 #fi
 
+compare_md5_sum()
+{
+    loc_comdb2md5sum=$1
+    if [ "$loc_comdb2md5sum" != "$COMDB2MD5SUM" ]; then
+        echo "MD5SUM $COMDB2MD5SUM does not match current $loc_comdb2md5sum"
+        exit 1
+    fi
+}
+
 
 # start it
 cd $DBDIR >/dev/null
 if [[ -z "$CLUSTER" ]]; then
+    loc_comdb2md5sum=`md5sum $comdb2task`
+    compare_md5_sum $loc_comdb2md5sum
+
     echo "!$TESTCASE: starting single node"
     if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
         echo -e "!$TESTCASE: Execute the following command in a separate terminal: ${TEXTCOLOR}cd $DBDIR && ${DEBUG_PREFIX} $comdb2task $PARAMS -pidfile ${TMPDIR}/$DBNAME.pid${NOCOLOR}"
@@ -236,8 +248,13 @@ if [[ -z "$CLUSTER" ]]; then
 else
     echo "!$TESTCASE: copying to cluster"
     for node in $CLUSTER; do
-        if [ $node == $myhostname ] ; then # skip copying to ourself
-            continue
+        if [ $node == $myhostname ] ; then
+            loc_comdb2md5sum=`md5sum $comdb2task | cut -d ' ' -f1`
+            compare_md5_sum $loc_comdb2md5sum
+            continue        # no copying to self
+        else 
+            loc_comdb2md5sum=`ssh -o StrictHostKeyChecking=no $node "md5sum $comdb2task" | cut -d ' ' -f1`
+            compare_md5_sum $loc_comdb2md5sum
         fi
         ${SRCHOME}/db/copycomdb2 $DBDIR/${DBNAME}.lrl ${node}: &> $TESTDIR/logs/${DBNAME}.${node}.copy
         if [[ $? -ne 0 ]]; then


### PR DESCRIPTION
Make sure that we run the same executable for all the tests. Changing the comdb2 executable in the src directory will cause the next testcase of the already-running-test to fail.  