### PR TITLE
Docker configuration modifications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ docker-dev: docker-standalone
 docker-standalone: docker-build
 	docker build -t comdb2-standalone:$(VERSION) -f contrib/docker/Dockerfile.standalone contrib/docker
 
-docker-cluster: docker-standalone
+docker-cluster: docker-dev
 	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node1
 	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node2
 	mkdir -p $(realpath $(SRCHOME))/contrib/docker/volumes/node3
@@ -160,6 +160,7 @@ docker-build: build-build-container
 		-v $(realpath $(SRCHOME))/contrib/docker/build:/comdb2 \
 		-v $(realpath $(SRCHOME)):/comdb2.build \
 		-w /comdb2.build \
+		--rm \
 		comdb2-build:$(VERSION) \
         make DESTDIR=/comdb2 -j3 install
  

--- a/Makefile
+++ b/Makefile
@@ -155,12 +155,10 @@ docker-cluster: docker-dev
 # Build the database in the build container
 docker-build: build-build-container
 	mkdir -p $(realpath $(SRCHOME))/contrib/docker/build
-	docker run --user $(shell id -u):$(shell id -g) \
-		--env HOME=/tmp \
+	docker run --env HOME=/tmp \
 		-v $(realpath $(SRCHOME))/contrib/docker/build:/comdb2 \
-		-v $(realpath $(SRCHOME)):/comdb2.build \
 		-w /comdb2.build \
 		--rm \
 		comdb2-build:$(VERSION) \
-        make DESTDIR=/comdb2 -j3 install
+		make DESTDIR=/comdb2 -j3 install
  

--- a/contrib/docker/Dockerfile.build
+++ b/contrib/docker/Dockerfile.build
@@ -29,4 +29,7 @@ RUN apt-get update && \
     tzdata && \
   rm -rf /var/lib/apt/lists/*
 
+COPY . /comdb2.build
+RUN cd /comdb2.build && make clean
+
 VOLUME /comdb2

--- a/contrib/docker/Dockerfile.dev
+++ b/contrib/docker/Dockerfile.dev
@@ -2,6 +2,8 @@ FROM comdb2-standalone:7.0.0pre
 
 ENV PATH      $PATH:/opt/bb/bin
 
+RUN apt-get update && apt-get install -y vim gdb iputils-ping strace
+
 EXPOSE 5105
 
 COPY contrib/docker/docker-dev-entrypoint.sh /

--- a/contrib/docker/docker-compose.yml
+++ b/contrib/docker/docker-compose.yml
@@ -5,54 +5,66 @@ services:
   comdb2-node1:
     container_name: node1
     hostname: node1
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: ./cluster-entrypoint.sh
     volumes:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node1:/db
     expose: [5105]
+    cap_add:
+      - ALL
   comdb2-node2:
     container_name: node2
     hostname: node2
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: ./cluster-entrypoint.sh
     volumes:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node2:/db
     expose: [5105]
+    cap_add:
+      - ALL
   comdb2-node3:
     container_name: node3
     hostname: node3
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: ./cluster-entrypoint.sh
     volumes:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node3:/db
     expose: [5105]
+    cap_add:
+      - ALL
   comdb2-node4:
     container_name: node4
     hostname: node4
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: ./cluster-entrypoint.sh
     volumes:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node4:/db
     expose: [5105]
+    cap_add:
+      - ALL
   comdb2-node5:
     container_name: node5
     hostname: node5
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: ./cluster-entrypoint.sh
     volumes:
       - ./cluster-entrypoint.sh:/cluster-entrypoint.sh
       - ./volumes/node5:/db
     expose: [5105]
+    cap_add:
+      - ALL
   comdb2-dev:
     container_name: dev
     hostname: dev
-    image: comdb2-standalone:7.0.0pre
+    image: comdb2-dev:7.0.0pre
     entrypoint: 
       - ./runforever
     volumes:
       - ./testdb.cfg:/opt/bb/etc/cdb2/config.d/testdb.cfg
       - ./runforever:/runforever
+    cap_add:
+      - ALL


### PR DESCRIPTION
Changes to Docker configuration to make it easier to develop/debug on.
* Add Debug utils to `comdb2-dev` (`gdb, vim, iputils, strace`)
* docker-cluster image change to `comdb2-dev` for debug utils
* Remove build containers after they finish building source
* Add [all privileges](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities) to `docker-cluster` containers
* Isolate build container source from host - allows for the host and docker to run `make` without interfering with each other