### PR TITLE
Sctests timeout

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -383,6 +383,8 @@ static int check_table_version(struct ireq *iq)
         errstat_set_strf(&iq->errstat,
                          "failed to get version for table:%s rc:%d\n",
                          iq->sc->table, rc);
+        sc_errf(iq->sc, "failed to get version for table:%s rc:%d\n",
+                iq->sc->table, rc);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
@@ -390,6 +392,8 @@ static int check_table_version(struct ireq *iq)
         errstat_set_strf(&iq->errstat,
                          "stale version for table:%s master:%d replicant:%d\n",
                          iq->sc->table, version, iq->usedbtablevers);
+        sc_errf(iq->sc, "stale version for table:%s master:%d replicant:%d\n",
+                iq->sc->table, version, iq->usedbtablevers);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
@@ -542,6 +546,7 @@ int do_schema_change(struct schema_change_type *s)
         s->db = get_dbtable_by_name(s->table);
     }
     iq.usedb = s->db;
+    iq.usedbtablevers = s->db ? s->db->tableversion : 0;
     sc_arg_t *arg = malloc(sizeof(sc_arg_t));
     arg->iq = &iq;
     arg->trans = NULL;

--- a/tests/sc_fieldlarger.test/Makefile
+++ b/tests/sc_fieldlarger.test/Makefile
@@ -1,1 +1,2 @@
 include $(TESTSROOTDIR)/testcase.mk
+export TEST_TIMEOUT=10m

--- a/tests/sc_fieldlarger.test/runit
+++ b/tests/sc_fieldlarger.test/runit
@@ -182,6 +182,7 @@ while [ ! -f alter1.done ] ; do
         failexit " error inserting out=$out"
     fi
     j=$((j+1))
+    sleep 0.001
 done
 
 flushall

--- a/tests/sc_swapfields.test/Makefile
+++ b/tests/sc_swapfields.test/Makefile
@@ -1,1 +1,2 @@
 include $(TESTSROOTDIR)/testcase.mk
+export TEST_TIMEOUT=10m

--- a/tests/sc_swapfields.test/runit
+++ b/tests/sc_swapfields.test/runit
@@ -201,6 +201,7 @@ while [ ! -f alter1.done ] ; do
         failexit " error inserting out=$out"
     fi
     j=$((j+1))
+    sleep 0.001
 done
 
 


### PR DESCRIPTION
This should fix three failing tests: sc_fieldlarger, sc_swapfields and sc_timepart
sc_fieldlarger and sc_swapfields were failing because concurrent inserts in the tests were running too fast and the schema change wasnt able to catch up.
sc_timepart's failure was due to newly added check_table_version in ddl. Fixed in the second commit of this PR.