### PR TITLE
Using thread_safe readdir_r() on all platforms.

### DIFF
--- a/bb/bb_oscompat.c
+++ b/bb/bb_oscompat.c
@@ -2397,18 +2397,9 @@ int bb_getpeercred(int fd, pid_t *pid, uid_t *euid, gid_t *egid)
     return bb_getpeercred_silent(fd, pid, euid, egid, /* silent */ 0);
 }
 
-int bb_readdir(DIR *d, void *buf, struct dirent **dent) {
-#ifdef _LINUX_SOURCE
-    int rc;
-    *dent = readdir(d);
-    if (*dent == NULL)
-        return errno;
-    memcpy(buf, *dent, sizeof(struct dirent));
-    return 0;
-#else
-    int rc;
+int bb_readdir(DIR *d, void *buf, struct dirent **dent)
+{
     return readdir_r(d, buf, dent);
-#endif
 }
 
 #ifdef BB_OSCOMPAT_TESTPROGRAM


### PR DESCRIPTION
We memcpy the directory entry returned from `readdir()` to our own buffer. However it is not strictly thread-safe, for instance: http://comdb2.s3-website-us-east-1.amazonaws.com/tests/3610e435345d711ad2a59daf931401634b424915/detail.txt