### PR TITLE
Remove tautological comparison

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -9576,7 +9576,7 @@ int dec64_exponent_is_outrageous(server_decimal64_t *pdec64, char *decimals)
         }
         /* check range for positive exponents; first nibble is 8 for new format!
          */
-        if ((highnibble & 0x080) && (highnibble != 0x080)) {
+        if (highnibble & 0x080) {
             return 0;
         }
         return 1;

--- a/db/types.c
+++ b/db/types.c
@@ -9567,7 +9567,7 @@ int dec64_exponent_is_outrageous(server_decimal64_t *pdec64, char *decimals)
         ;
 
     if (i >= sizeof(pdec64->coef) - 1) {
-        char highnibble = (*(char *)(&pdec64->exp)) & 0x0F0;
+        unsigned char highnibble = (*(char *)(&pdec64->exp)) & 0x0F0;
 
         /* check range for negative exponents; first nibble is 7 for new format!
          */
@@ -9576,7 +9576,7 @@ int dec64_exponent_is_outrageous(server_decimal64_t *pdec64, char *decimals)
         }
         /* check range for positive exponents; first nibble is 8 for new format!
          */
-        if (highnibble & 0x080) {
+        if (highnibble & 0x080) && (highnibble != 0x080)) {
             return 0;
         }
         return 1;


### PR DESCRIPTION
```
./db/types.c:9579:49: error: comparison of constant 128 with expression of type 'char' is always true [-Werror,-Wtautological-constant-out-of-range-compare]
        if ((highnibble & 0x080) && (highnibble != 0x080)) {
                                     ~~~~~~~~~~ ^  ~~~~~
```