### PR TITLE
Fix buffer overrun in emit_sql_row

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -9378,11 +9378,9 @@ int emit_sql_row(struct sqlthdstate *thd, struct column_info *cols,
         cols = malloc(ncols * sizeof(struct column_info));
         for (col = 0; col < ncols; col++) {
             const char *ctype = sqlite3_column_decltype(stmt, col);
-            size_t size = sizeof(cols[col].column_name);
+            const size_t size = sizeof(cols[col].column_name);
             cols[col].type = typestr_to_type(ctype);
-            snprintf(cols[col].column_name, 
-                     size, 
-                     "%s",
+            snprintf(cols[col].column_name, size, "%s",
                      sqlite3_column_name(stmt, col));
             cols[col].column_name[size - 1] = 0;
         }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -9382,7 +9382,6 @@ int emit_sql_row(struct sqlthdstate *thd, struct column_info *cols,
             cols[col].type = typestr_to_type(ctype);
             snprintf(cols[col].column_name, size, "%s",
                      sqlite3_column_name(stmt, col));
-            cols[col].column_name[size - 1] = 0;
         }
         created_cols = 1;
     }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -9378,10 +9378,13 @@ int emit_sql_row(struct sqlthdstate *thd, struct column_info *cols,
         cols = malloc(ncols * sizeof(struct column_info));
         for (col = 0; col < ncols; col++) {
             const char *ctype = sqlite3_column_decltype(stmt, col);
+            size_t size = sizeof(cols[col].column_name);
             cols[col].type = typestr_to_type(ctype);
-            snprintf(cols[col].column_name, sizeof(cols[col]), "%s",
+            snprintf(cols[col].column_name, 
+                     size, 
+                     "%s",
                      sqlite3_column_name(stmt, col));
-            cols[col].column_name[sizeof(cols[col]) - 1] = 0;
+            cols[col].column_name[size - 1] = 0;
         }
         created_cols = 1;
     }


### PR DESCRIPTION
```
db/sqlinterfaces.c:9386:13: error: '__builtin___snprintf_chk' will always overflow destination buffer [-Werror,-Wbuiltin-memcpy-chk-size]
            snprintf(cols[col].column_name, sizeof(cols[col]), "%s",
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/secure/_stdio.h:57:3: note: expanded from macro 'snprintf'
  __builtin___snprintf_chk (str, len, 0, __darwin_obsz(str), __VA_ARGS__)
  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
db/sqlinterfaces.c:9388:13: error: array index 35 is past the end of the array (which contains 32 elements) [-Werror,-Warray-bounds]
            cols[col].column_name[sizeof(cols[col]) - 1] = 0;
            ^                     ~~~~~~~~~~~~~~~~~~~~~
./db/sqlinterfaces.h:59:5: note: array 'column_name' declared here
    char column_name[32]; /* fixed column sizes */
    ^
```