### PR TITLE
Clear thread-specific bdb tran on abort to prevent berkdb_send_rtn from using it.

### DIFF
--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2333,18 +2333,16 @@ cleanup:
     case TRANCLASS_LOGICAL:
     case TRANCLASS_PHYSICAL:
     case TRANCLASS_BERK:
-        /* if we are the master and we free tran we need to
-           get rid of the stored reference so functions
-           like berkdb_send_rtn don't try to use it */
-        if (tran->master) {
-            rc = pthread_setspecific(bdb_state->seqnum_info->key, NULL);
-            if (rc != 0)
-                logmsg(LOGMSG_ERROR, "pthread_setspecific failed\n");
-        }
-
         bdb_tran_free_shadows(bdb_state, tran);
-
         break;
+    }
+
+    /* if we are the master and we free tran we need to get rid of the stored
+     * reference so functions like berkdb_send_rtn don't try to use it */
+    if (tran->master) {
+        rc = pthread_setspecific(bdb_state->seqnum_info->key, NULL);
+        if (rc != 0)
+            logmsg(LOGMSG_ERROR, "pthread_setspecific failed\n");
     }
 
     if (tran->trak)


### PR DESCRIPTION
It is revealed by valgrind:

```
==25786== Invalid read of size 1
==25786==    at 0x58ADD4: berkdb_send_rtn (rep.c:881)
==25786==    by 0x725788: __rep_send_message (rep_util.c:205)
==25786==    by 0x6EF846: __log_put_int_int (log_put.c:307)
==25786==    by 0x6EFC10: __log_put_int (log_put.c:420)
==25786==    by 0x6EFC7E: __log_put (log_put.c:442)
==25786==    by 0x745458: __db_debug_log (db_auto.c:2007)
==25786==    by 0x72CACA: __txn_checkpoint (txn.c:2275)
==25786==    by 0x72C4FE: __txn_checkpoint_pp (txn.c:2093)
==25786==    by 0x5BF69F: ll_checkpoint (ll.c:1548)
==25786==    by 0x5DF385: bdb_flush_int (file.c:1501)
==25786==    by 0x5DF421: bdb_flush (file.c:1519)
==25786==    by 0x4520B6: flush_db (glue.c:5062)
==25786==  Address 0x17e9084a is 330 bytes inside a block of size 464 free'd
==25786==    at 0x6620E90: free (vg_replace_malloc.c:473)
==25786==    by 0x5CC83A: bdb_tran_abort_int_int (tran.c:2367)
==25786==    by 0x5CC88C: bdb_tran_abort_int (tran.c:2375)
==25786==    by 0x5CC973: bdb_tran_abort_wrap (tran.c:2404)
==25786==    by 0x5CC9FA: bdb_tran_abort (tran.c:2421)
==25786==    by 0x446BC9: trans_abort_shadow (glue.c:521)
==25786==    by 0x51C37A: osql_sock_commit (osqlsqlthr.c:858)
==25786==    by 0x4B0FF1: sqlite3BtreeCommit (sqlglue.c:5087)
==25786==    by 0x4BEEE9: sqlite3BtreeCommitPhaseTwo (sqlglue.c:10840)
==25786==    by 0x7DCCAC: vdbeCommit (vdbeaux.c:2366)
==25786==    by 0x7DD4B3: sqlite3VdbeHalt (vdbeaux.c:2757)
==25786==    by 0x7CCC3F: sqlite3VdbeExec (vdbe.c:1276)
```

bdb_tran_commit() already does this.