### PR TITLE
fix tranddl in read committed or higher

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -454,8 +454,8 @@ enum dbt_api_return_codes {
     DB_ERR_DYNTAG_LOAD_FAIL = 118,
     /* GENERAL BLOCK TRN RCODES */
     DB_RC_TRN_OK = 0,
-    DB_ERR_TRN_DUP = 1,             /* dup add 2 , returned with 220 before */
-    DB_ERR_TRN_VERIFY = 2,          /* verify 4, returned with 220 before */
+    DB_ERR_TRN_DUP = 1,    /* dup add 2 , returned with 220 before */
+    DB_ERR_TRN_VERIFY = 2, /* verify 4, returned with 220 before */
     DB_ERR_TRN_FKEY = 3,
     DB_ERR_TRN_NULL_CONSTRAINT = 4, /* 318 */
     DB_ERR_TRN_BUF_INVALID = 200,   /* 105 */
@@ -466,6 +466,7 @@ enum dbt_api_return_codes {
     DB_ERR_TRN_DB_CONN = 205,
     DB_ERR_TRN_DB_IO = 206,
     DB_ERR_TRN_NOT_SERIAL = 230,
+    DB_ERR_TRN_SC = 240,
 
     /* INTERNAL DB ERRORS */
     DB_ERR_INTR_NO_MASTER = 300,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6424,7 +6424,9 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         char *tablename;
 
         tablename = (char *)osqlcomm_usedb_type_get(&dt, p_buf, p_buf_end);
-        bdb_lock_tablename_read(thedb->bdb_env, tablename, trans);
+        bdb_lock_tablename_read(thedb->bdb_env, tablename,
+                                iq->tranddl ? bdb_get_physical_tran(trans)
+                                            : trans);
 
         if (logsb) {
             sbuf2printf(logsb, "[%llu %s] OSQL_USEDB %*.s\n", rqid,

--- a/db/osqlshadtbl.h
+++ b/db/osqlshadtbl.h
@@ -151,7 +151,7 @@ int is_genid_recorded(struct sql_thread *thd, int tblnum,
  *
  */
 int osql_save_schemachange(struct sql_thread *thd,
-                           struct schema_change_type *sc);
+                           struct schema_change_type *sc, int usedb);
 
 /**
  * Process shadow tables

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -417,6 +417,8 @@ int handle_ireq(struct ireq *iq)
                         }
                     }
 
+                    iq->usedb = iq->origdb;
+
                     n_retries++;
                     poll(0, 0, (rand() % 25 + 1));
                     goto retry;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -8744,6 +8744,8 @@ int blockproc2sql_error(int rc, const char *func, int line)
         return DB_ERR_TRN_DB_FAIL;
     case 230:
         return DB_ERR_TRN_NOT_SERIAL;
+    case 240:
+        return DB_ERR_TRN_SC;
     case 301:
         return DB_ERR_CONV_FAIL;
     case 998:

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -83,8 +83,14 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
         /* these checks should be present in dryrun_int as well */
         if (changed == SC_BAD_NEW_FIELD) {
             sc_errf(s, "cannot add new field without dbstore or null\n");
+            if (s->iq)
+                reqerrstr(s->iq, ERR_SC,
+                          "cannot add new field without dbstore or null");
         } else if (changed == SC_BAD_INDEX_CHANGE) {
             sc_errf(s, "cannot change index referenced by other tables\n");
+            if (s->iq)
+                reqerrstr(s->iq, ERR_SC,
+                          "cannot change index referenced by other tables");
         }
         sc_errf(s, "Failed to process schema!\n");
         return -1;

--- a/sqlite/comdb2build.c
+++ b/sqlite/comdb2build.c
@@ -510,7 +510,10 @@ static void comdb2Rebuild(Parse *p, Token* nm, Token* lnm, uint8_t opt);
 
 int authenticateSC(const char * table,  Parse *pParse) 
 {
-    if(gbl_schema_change_in_progress) return -1;
+    if (gbl_schema_change_in_progress) {
+        setError(pParse, SQLITE_ERROR, "Schema change already in progress");
+        return -1;
+    }
 
     Vdbe *v  = sqlite3GetVdbe(pParse);
     char *username = strstr(table, "@");

--- a/tests/ddl_no_csc2.test/t00_create_table.expected
+++ b/tests/ddl_no_csc2.test/t00_create_table.expected
@@ -173,7 +173,7 @@ keys
 [DROP TABLE t4] failed with rc -3 no such table: t4
 [DROP TABLE t7] failed with rc -3 no such table: t7
 [DROP TABLE t8] failed with rc -3 no such table: t8
-[CREATE TABLE t1(i INT, j INT, UNIQUE(i, j), UNIQUE(i, j))] failed with rc 304 Error at line   9: CANT HAVE SAME TAG '$KEY_F9E83FD8' FOR INDICES 1 AND 0!
+[CREATE TABLE t1(i INT, j INT, UNIQUE(i, j), UNIQUE(i, j))] failed with rc 240 Error at line   9: CANT HAVE SAME TAG '$KEY_F9E83FD8' FOR INDICES 1 AND 0!
 (tablename='t2')
 (tablename='t3')
 (tablename='t4')

--- a/tests/ddl_no_csc2.test/t01_alter_table.expected
+++ b/tests/ddl_no_csc2.test/t01_alter_table.expected
@@ -1,4 +1,4 @@
-[ALTER TABLE t1 ADD COLUMN k INT NOT NULL] failed with rc 304 
+[ALTER TABLE t1 ADD COLUMN k INT NOT NULL] failed with rc 240 cannot add new field without dbstore or null
 [ALTER TABLE t2 DROP COLUMN doesnotexist] failed with rc -3 Column 'doesnotexist' not found.
 [ALTER TABLE t2 DROP COLUMN `j`] failed with rc -3 Table must have at least one column.
 (tablename='t1')

--- a/tests/rawindex.test/t12.req.out
+++ b/tests/rawindex.test/t12.req.out
@@ -11,4 +11,4 @@
 (csc2='schema{int i cstring j[16]} keys{"I" = (int)"i" {where j > "''" and j < ''''''}}')
 (csc2='schema{int i cstring j[16]} keys{"I" = (int)"i" {where j < '''}'}}')
 (csc2='schema{int i cstring j[16]} keys{"I" = (int)"i" {where j < "'}"}}')
-[create table t12 {schema{int i cstring j[16]} keys{"I" = (int)"i" {where j < ''}'}}}] failed with rc 304 ERROR at line   0: syntax error: '
+[create table t12 {schema{int i cstring j[16]} keys{"I" = (int)"i" {where j < ''}'}}}] failed with rc 240 ERROR at line   0: syntax error: '

--- a/tests/sc_vutf8_blob2.test/t02.expected
+++ b/tests/sc_vutf8_blob2.test/t02.expected
@@ -28,7 +28,7 @@
 (i=4, str='01234567891234567890123456789')
 (i=5, str='01234567891234567890123456789')
 (i=6, str='01234567891234567890123456789')
-[alter table t2 { schema { int i cstring str[10]}}] failed with rc 304 cannot convert data incompatible values to bcstring field 'str' for table 't2'
+[alter table t2 { schema { int i cstring str[10]}}] failed with rc 240 cannot convert data incompatible values to bcstring field 'str' for table 't2'
 (i=1, str='01234567891234567890123456789')
 (i=2, str='01234567891234567890123456789')
 (i=3, str='01234567891234567890123456789')

--- a/tests/snapisol.test/t7_01.req
+++ b/tests/snapisol.test/t7_01.req
@@ -1,0 +1,29 @@
+1 drop table if exists t7
+1 drop table if exists t70
+1 create table t7 {schema {int a}}
+1 create table t70 {schema {int a}}
+1 insert into t7 values (1)
+1 set transaction snapshot isolation
+2 set transaction snapshot isolation
+1 begin
+2 begin
+1 update t7 set a=a+1
+1 select * from t7
+2 select * from t7
+1 alter table t70 {schema {int a int b}}
+1 commit
+2 commit
+1 select * from t7
+2 select * from t7
+1 begin
+2 begin
+1 update t7 set a=10
+1 select * from t7
+2 update t7 set a=20
+2 select * from t7
+1 alter table t70 {schema {int a int b null=yes}}
+2 alter table t70 {schema {int a int c null=yes}}
+1 commit
+2 commit
+1 select * from t7
+1 select csc2 from sqlite_master where name = 't70'

--- a/tests/snapisol.test/t7_01.req.out
+++ b/tests/snapisol.test/t7_01.req.out
@@ -1,0 +1,40 @@
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+done
+done
+done
+done
+(a=2)
+done
+(a=1)
+done
+done
+[commit] failed with rc 240 cannot add new field without dbstore or null
+done
+done
+(a=1)
+done
+(a=1)
+done
+done
+done
+done
+(a=10)
+done
+done
+(a=20)
+done
+done
+done
+done
+[commit] failed with rc 240 stale table version for schema change
+done
+(a=10)
+done
+(csc2='schema {int a int b null=yes}')
+done

--- a/tests/sp.test/t01.req.out
+++ b/tests/sp.test/t01.req.out
@@ -263,8 +263,8 @@ SP: exec procedure bound(@i, @u, @ll, @ull, @s, @us, @f, @d, @dt, @cstr, @ba, @b
 (id='8eb31cbc-f341-433b-9110-53713e0dd257')
 (id=1)
 (testcase='SET INVALID DEFAULTS - VERSIONED SPs HAVE CHECKS')
-[put default procedure sp2000 '2000'] failed with rc 304 no such procedure sp2000:2000
-[put default procedure sp1 '2000'] failed with rc 304 no such procedure sp1:2000
+[put default procedure sp2000 '2000'] failed with rc 240 no such procedure sp2000:2000
+[put default procedure sp1 '2000'] failed with rc 240 no such procedure sp1:2000
 (testcase='SHOULD GET SAME RESULTS AS comdb2sc.tsk')
 (version='1')
 (i=0)


### PR DESCRIPTION
- save db version and sc object in temp table
- check db version on replicants before sending sc osql ops to master
- fail on replicants if there is another schema change on the same table in between the transaction's begin and commit time
- fix sc error code 304 -> 240