### PR TITLE
sc_live races

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3580,8 +3580,11 @@ int broadcast_sc_start(uint64_t seed, uint32_t host, time_t t)
     struct start_sc *sc;
     int len;
     const char *from = get_hostname_with_crc32(thedb->bdb_env, host);
+    if (from == NULL) {
+        from = "unknown";
+    }
 
-    len = offsetof(struct start_sc, host) + strlen(gbl_mynode) + 1;
+    len = offsetof(struct start_sc, host) + strlen(from) + 1;
 
     sc = alloca(len);
     sc->seed = flibc_htonll(seed);

--- a/db/glue.c
+++ b/db/glue.c
@@ -346,6 +346,7 @@ int trans_start_int(struct ireq *iq, void *parent_trans, tran_type **out_trans,
 
 int trans_start_logical_sc(struct ireq *iq, tran_type **out_trans)
 {
+    iq->use_handle = thedb->bdb_env;
     return trans_start_int_int(iq, NULL, out_trans, 1, 1, 0);
 }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6370,6 +6370,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             }
             if (iq->sc->db) iq->usedb = iq->sc->db;
             rc = finalize_schema_change(iq, ptran);
+            iq->usedb = NULL;
             if (rc != SC_OK) {
                 return rc; // Change to failed schema change error;
             }
@@ -7053,6 +7054,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             iq->sc_pending = iq->sc;
             bset(&iq->osql_flags, OSQL_FLAGS_SCDONE);
         }
+        iq->usedb = NULL;
 
         if (!rc || rc == SC_COMMIT_PENDING)
             return 0;

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -312,9 +312,8 @@ int live_sc_post_add_record(struct ireq *iq, void *trans,
                                       ins_keys, blobs, maxblobs, ".NEW..ONDISK",
                                       rebuild, 0);
         if (rc) {
-            logmsg(LOGMSG_ERROR,
-                   "%s: verify_record_constraint "
-                   "rcode %d, genid 0x%llx\n",
+            logmsg(LOGMSG_ERROR, "%s: verify_record_constraint "
+                                 "rcode %d, genid 0x%llx\n",
                    __func__, rc, genid);
             logmsg(LOGMSG_ERROR, "Aborting schema change due to constraint "
                                  "violation in new schema\n");
@@ -380,9 +379,8 @@ int live_sc_post_upd_record(struct ireq *iq, void *trans,
     struct dbtable *usedb = iq->usedb;
 
 #ifdef DEBUG_SC
-    fprintf(stderr,
-            "%s: oldgenid 0x%llx, newgenid "
-            "0x%llx, deferredAdd %d\n",
+    fprintf(stderr, "%s: oldgenid 0x%llx, newgenid "
+                    "0x%llx, deferredAdd %d\n",
             __func__, oldgenid, newgenid, deferredAdd);
 #endif
 

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -72,7 +72,7 @@ int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
 
 /* delete from new btree when genid is older than schemachange position
  */
-int live_sc_post_delete_int(struct ireq *iq, void *trans,
+int live_sc_post_del_record(struct ireq *iq, void *trans,
                             unsigned long long genid, const void *old_dta,
                             unsigned long long del_keys,
                             blob_buffer_t *oldblobs)
@@ -81,7 +81,7 @@ int live_sc_post_delete_int(struct ireq *iq, void *trans,
 
     iq->usedb = usedb->sc_to;
     if (iq->debug) {
-        reqpushprefixf(iq, "live_sc_post_delete_int: ");
+        reqpushprefixf(iq, "%s: ", __func__);
         reqprintf(iq, "deleting genid 0x%llx from new table", genid);
     }
 
@@ -263,14 +263,14 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
     return rc;
 }
 
-int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
-                         const uint8_t *od_dta, unsigned long long ins_keys,
-                         blob_buffer_t *blobs, size_t maxblobs, int origflags,
-                         int *rrn)
+int live_sc_post_add_record(struct ireq *iq, void *trans,
+                            unsigned long long genid, const uint8_t *od_dta,
+                            unsigned long long ins_keys, blob_buffer_t *blobs,
+                            size_t maxblobs, int origflags, int *rrn)
 
 {
 #ifdef DEBUG_SC
-    printf("live_sc_post_add_int: looking at genid %llx\n", genid);
+    printf("%s: looking at genid %llx\n", __func__, genid);
 #endif
     // this is an INSERT of new row so add_record to sc_to
     char *tagname = ".NEW..ONDISK";
@@ -305,18 +305,17 @@ int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
     if ((origflags & RECFLAGS_NO_CONSTRAINTS) && usedb->sc_to->n_constraints) {
         int rebuild = usedb->sc_to->plan && usedb->sc_to->plan->dta_plan;
 #ifdef DEBUG_SC
-        fprintf(stderr, "live_sc_post_add_int: need to "
-                        "verify_record_constraint genid 0x%llx\n",
-                genid);
+        fprintf(stderr, "%s: need to verify_record_constraint genid 0x%llx\n",
+                __func__, genid);
 #endif
         rc = verify_record_constraint(iq, usedb->sc_to, trans, new_dta,
                                       ins_keys, blobs, maxblobs, ".NEW..ONDISK",
                                       rebuild, 0);
         if (rc) {
             logmsg(LOGMSG_ERROR,
-                   "live_sc_post_add_int: verify_record_constraint "
+                   "%s: verify_record_constraint "
                    "rcode %d, genid 0x%llx\n",
-                   rc, genid);
+                   __func__, rc, genid);
             logmsg(LOGMSG_ERROR, "Aborting schema change due to constraint "
                                  "violation in new schema\n");
 
@@ -328,7 +327,7 @@ int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "live_sc_post_add_int: ");
+        reqpushprefixf(iq, "%s: ", __func__);
         reqprintf(iq, "adding genid 0x%llx to new table", genid);
     }
 
@@ -351,8 +350,8 @@ int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
     iq->usedb = usedb;
 
     if (rc != 0 && rc != RC_INTERNAL_RETRY) {
-        logmsg(LOGMSG_ERROR, "live_sc_post_add_int rcode %d, genid 0x%llx\n",
-               rc, genid);
+        logmsg(LOGMSG_ERROR, "%s: rcode %d, genid 0x%llx\n", __func__, rc,
+               genid);
         logmsg(LOGMSG_ERROR,
                "Aborting schema change due to unexpected error\n");
         gbl_sc_abort = 1;
@@ -370,7 +369,7 @@ int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
 
 /* both new and old are to the left of SC ptr, need to update
  */
-int live_sc_post_update_int(struct ireq *iq, void *trans,
+int live_sc_post_upd_record(struct ireq *iq, void *trans,
                             unsigned long long oldgenid, const void *old_dta,
                             unsigned long long newgenid, const void *new_dta,
                             unsigned long long ins_keys,
@@ -381,9 +380,10 @@ int live_sc_post_update_int(struct ireq *iq, void *trans,
     struct dbtable *usedb = iq->usedb;
 
 #ifdef DEBUG_SC
-    fprintf(stderr, "live_sc_post_update_int: oldgenid 0x%llx, newgenid "
-                    "0x%llx, deferredAdd %d\n",
-            oldgenid, newgenid, deferredAdd);
+    fprintf(stderr,
+            "%s: oldgenid 0x%llx, newgenid "
+            "0x%llx, deferredAdd %d\n",
+            __func__, oldgenid, newgenid, deferredAdd);
 #endif
 
     int rc;
@@ -391,7 +391,7 @@ int live_sc_post_update_int(struct ireq *iq, void *trans,
     iq->usedb = usedb->sc_to;
 
     if (iq->debug) {
-        reqpushprefixf(iq, "live_sc_post_update_int: ");
+        reqpushprefixf(iq, "%s: ", __func__);
         reqprintf(iq,
                   "updating genid 0x%llx to 0x%llx in new table (defered=%d)",
                   oldgenid, newgenid, deferredAdd);
@@ -402,10 +402,8 @@ int live_sc_post_update_int(struct ireq *iq, void *trans,
                         oldblobs, newblobs);
     iq->usedb = usedb;
     if (rc != 0 && rc != RC_INTERNAL_RETRY) {
-        logmsg(LOGMSG_ERROR,
-               "live_sc_post_update_int: rcode %d for update genid "
-               "0x%llx to 0x%llx\n",
-               rc, oldgenid, newgenid);
+        logmsg(LOGMSG_ERROR, "%s: rcode %d for update genid 0x%llx to 0x%llx\n",
+               __func__, rc, oldgenid, newgenid);
         logmsg(LOGMSG_ERROR,
                "Aborting schema change due to unexpected error\n");
         gbl_sc_abort = 1;

--- a/schemachange/sc_callbacks.h
+++ b/schemachange/sc_callbacks.h
@@ -23,17 +23,17 @@ int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
                                      unsigned long long genid,
                                      unsigned long long stripe_ptr);
 
-int live_sc_post_delete_int(struct ireq *iq, void *trans,
+int live_sc_post_del_record(struct ireq *iq, void *trans,
                             unsigned long long genid, const void *old_dta,
                             unsigned long long del_keys,
                             blob_buffer_t *oldblobs);
 
-int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
-                         const uint8_t *od_dta, unsigned long long ins_keys,
-                         blob_buffer_t *blobs, size_t maxblobs, int origflags,
-                         int *rrn);
+int live_sc_post_add_record(struct ireq *iq, void *trans,
+                            unsigned long long genid, const uint8_t *od_dta,
+                            unsigned long long ins_keys, blob_buffer_t *blobs,
+                            size_t maxblobs, int origflags, int *rrn);
 
-int live_sc_post_update_int(struct ireq *iq, void *trans,
+int live_sc_post_upd_record(struct ireq *iq, void *trans,
                             unsigned long long oldgenid, const void *old_dta,
                             unsigned long long newgenid, const void *new_dta,
                             unsigned long long ins_keys,

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -82,7 +82,7 @@ int gbl_sc_thd_failed = 0;
 /* All writer threads have to grab the lock in read/write mode.  If a live
  * schema change is in progress then they have to do extra stuff. */
 int sc_live = 0;
-/*static pthread_rwlock_t sc_rwlock = PTHREAD_RWLOCK_INITIALIZER;*/
+pthread_rwlock_t sc_live_rwlock = PTHREAD_RWLOCK_INITIALIZER;
 
 int schema_change = SC_NO_CHANGE; /*static int schema_change_doomed = 0;*/
 
@@ -233,9 +233,11 @@ void reset_sc_stat()
  * change (removing temp tables etc). */
 void live_sc_off(struct dbtable *db)
 {
+    pthread_rwlock_wrlock(&sc_live_rwlock);
     db->sc_to = NULL;
     db->sc_from = NULL;
     sc_live = 0;
+    pthread_rwlock_unlock(&sc_live_rwlock);
 }
 
 int reload_lua()

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -174,7 +174,7 @@ int sc_set_running(int running, uint64_t seed, const char *host, time_t time)
     gbl_schema_change_in_progress = running;
     if (running) {
         sc_seed = seed;
-        sc_host = crc32c(host, strlen(host));
+        sc_host = host ? crc32c(host, strlen(host)) : 0;
         sc_time = time;
     } else {
         sc_seed = 0;

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -70,7 +70,7 @@ extern int gbl_sc_thd_failed;
 /* All writer threads have to grab the lock in read/write mode.  If a live
  * schema change is in progress then they have to do extra stuff. */
 extern int sc_live;
-/* pthread_rwlock_t sc_rwlock = PTHREAD_RWLOCK_INITIALIZER;*/
+extern pthread_rwlock_t sc_live_rwlock;
 
 extern int schema_change; /*static int schema_change_doomed = 0;*/
 extern int stopsc;        /* stop schemachange, so it can resume */

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -182,7 +182,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         logmsg(
             LOGMSG_INFO,
             "Resuming schema change: fetched seed 0x%llx, original node %s\n",
-            seed, node);
+            seed, node ? node : "(unknown)");
         if (stopsc) {
             errstat_set_strf(&iq->errstat, "Master node downgrading - new "
                                            "master will resume schemachange");

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -530,44 +530,84 @@ done:
     return rc;
 }
 
-int live_sc_post_delete(struct ireq *iq, void *trans, unsigned long long genid,
-                        const void *old_dta, unsigned long long del_keys,
-                        blob_buffer_t *oldblobs)
+int live_sc_post_delete_int(struct ireq *iq, void *trans,
+                            unsigned long long genid, const void *old_dta,
+                            unsigned long long del_keys,
+                            blob_buffer_t *oldblobs)
 {
-    int rc = 0;
-    pthread_rwlock_rdlock(&sc_live_rwlock);
     if (!(sc_live && iq->usedb->sc_from == iq->usedb)) {
-        goto out;
+        return 0;
     }
 
     int stripe = get_dtafile_from_genid(genid);
     if (stripe < 0 || stripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR,
-               "live_sc_post_delete: genid 0x%llx stripe %d out of range!\n",
-               genid, stripe);
-        goto out;
+        logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
+               __func__, genid, stripe);
+        return 0;
     }
     unsigned long long *sc_genids = iq->usedb->sc_to->sc_genids;
     if (!sc_genids[stripe]) {
         /* A genid of zero is invalid.  So, if the schema change cursor is at
          * genid zero it means pretty conclusively that it hasn't done anything
          * yet so we cannot possibly be behind the cursor. */
-        goto out;
+        return 0;
     }
 
     int is_gen_gt_scptr = is_genid_right_of_stripe_pointer(
         iq->usedb->handle, genid, sc_genids[stripe]);
     if (is_gen_gt_scptr) {
-        goto out;
+        return 0;
     }
 
     /* genid is older than schema change position - a delete from new
      * table will be required. */
 
+    return live_sc_post_del_record(iq, trans, genid, old_dta, del_keys,
+                                   oldblobs);
+}
+
+int live_sc_post_delete(struct ireq *iq, void *trans, unsigned long long genid,
+                        const void *old_dta, unsigned long long del_keys,
+                        blob_buffer_t *oldblobs)
+{
+    int rc = 0;
+    pthread_rwlock_rdlock(&sc_live_rwlock);
+
     rc = live_sc_post_delete_int(iq, trans, genid, old_dta, del_keys, oldblobs);
-out:
+
     pthread_rwlock_unlock(&sc_live_rwlock);
     return rc;
+}
+
+int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
+                         uint8_t *od_dta, unsigned long long ins_keys,
+                         blob_buffer_t *blobs, size_t maxblobs, int origflags,
+                         int *rrn)
+{
+    if (!sc_live || iq->usedb->sc_from != iq->usedb) {
+        return 0;
+    }
+
+    int stripe = get_dtafile_from_genid(genid);
+    if (stripe < 0 || stripe >= gbl_dtastripe) {
+        logmsg(LOGMSG_ERROR,
+               "live_sc_post_add: genid 0x%llx stripe %d out of range!\n",
+               genid, stripe);
+        return 0;
+    }
+    unsigned long long *sc_genids = iq->usedb->sc_to->sc_genids;
+    if (!sc_genids[stripe]) {
+        /* A genid of zero is invalid.  So, if the schema change cursor is at
+         * genid zero it means pretty conclusively that it hasn't done anything
+         * yet so we cannot possibly be behind the cursor. */
+        return 0;
+    }
+    if (is_genid_right_of_stripe_pointer(iq->usedb->handle, genid,
+                                         sc_genids[stripe])) {
+        return 0;
+    }
+    return live_sc_post_add_record(iq, trans, genid, od_dta, ins_keys, blobs,
+                                   maxblobs, origflags, rrn);
 }
 
 int live_sc_post_add(struct ireq *iq, void *trans, unsigned long long genid,
@@ -577,31 +617,10 @@ int live_sc_post_add(struct ireq *iq, void *trans, unsigned long long genid,
 {
     int rc = 0;
     pthread_rwlock_rdlock(&sc_live_rwlock);
-    if (!sc_live || iq->usedb->sc_from != iq->usedb) {
-        goto out;
-    }
 
-    int stripe = get_dtafile_from_genid(genid);
-    if (stripe < 0 || stripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR,
-               "live_sc_post_add: genid 0x%llx stripe %d out of range!\n",
-               genid, stripe);
-        goto out;
-    }
-    unsigned long long *sc_genids = iq->usedb->sc_to->sc_genids;
-    if (!sc_genids[stripe]) {
-        /* A genid of zero is invalid.  So, if the schema change cursor is at
-         * genid zero it means pretty conclusively that it hasn't done anything
-         * yet so we cannot possibly be behind the cursor. */
-        goto out;
-    }
-    if (is_genid_right_of_stripe_pointer(iq->usedb->handle, genid,
-                                         sc_genids[stripe])) {
-        goto out;
-    }
     rc = live_sc_post_add_int(iq, trans, genid, od_dta, ins_keys, blobs,
                               maxblobs, origflags, rrn);
-out:
+
     pthread_rwlock_unlock(&sc_live_rwlock);
     return rc;
 }
@@ -613,8 +632,10 @@ int live_sc_delayed_key_adds(struct ireq *iq, void *trans,
 {
     int rc = 0;
     pthread_rwlock_rdlock(&sc_live_rwlock);
+
     rc = live_sc_post_update_delayed_key_adds_int(iq, trans, newgenid, od_dta,
                                                   ins_keys, od_len);
+
     pthread_rwlock_unlock(&sc_live_rwlock);
     return rc;
 }
@@ -639,19 +660,17 @@ int live_sc_delayed_key_adds(struct ireq *iq, void *trans,
                                ^__SC ptr
        actually_update(oldgen to newgenid)
 */
-int live_sc_post_update(struct ireq *iq, void *trans,
-                        unsigned long long oldgenid, const void *old_dta,
-                        unsigned long long newgenid, const void *new_dta,
-                        unsigned long long ins_keys,
-                        unsigned long long del_keys, int od_len, int *updCols,
-                        blob_buffer_t *blobs, size_t maxblobs, int origflags,
-                        int rrn, int deferredAdd, blob_buffer_t *oldblobs,
-                        blob_buffer_t *newblobs)
+int live_sc_post_update_int(struct ireq *iq, void *trans,
+                            unsigned long long oldgenid, const void *old_dta,
+                            unsigned long long newgenid, const void *new_dta,
+                            unsigned long long ins_keys,
+                            unsigned long long del_keys, int od_len,
+                            int *updCols, blob_buffer_t *blobs, size_t maxblobs,
+                            int origflags, int rrn, int deferredAdd,
+                            blob_buffer_t *oldblobs, blob_buffer_t *newblobs)
 {
-    int rc = 0;
-    pthread_rwlock_rdlock(&sc_live_rwlock);
     if (!(sc_live && iq->usedb->sc_from == iq->usedb)) {
-        goto out;
+        return 0;
     }
 
     int stripe = get_dtafile_from_genid(oldgenid);
@@ -659,14 +678,14 @@ int live_sc_post_update(struct ireq *iq, void *trans,
         logmsg(LOGMSG_ERROR,
                "live_sc_post_update: oldgenid 0x%llx stripe %d out of range!\n",
                oldgenid, stripe);
-        goto out;
+        return 0;
     }
     unsigned long long *sc_genids = iq->usedb->sc_to->sc_genids;
     if (!sc_genids[stripe]) {
         /* A genid of zero is invalid.  So, if the schema change cursor is at
          * genid zero it means pretty conclusively that it hasn't done anything
          * yet so we cannot possibly be behind the cursor. */
-        goto out;
+        return 0;
     }
     /*
     if(get_dtafile_from_genid(newgenid) != stripe)
@@ -681,6 +700,7 @@ int live_sc_post_update(struct ireq *iq, void *trans,
         iq->usedb->handle, oldgenid, sc_genids[stripe]);
     int is_newgen_gt_scptr = is_genid_right_of_stripe_pointer(
         iq->usedb->handle, newgenid, sc_genids[stripe]);
+    int rc = 0;
 
     // spelling this out for legibility, various situations:
     if (is_newgen_gt_scptr &&
@@ -697,7 +717,7 @@ int live_sc_post_update(struct ireq *iq, void *trans,
             reqprintf(
                 iq, "C2: oldgenid 0x%llx ... scptr 0x%llx ... newgenid 0x%llx ",
                 oldgenid, sc_genids[stripe], newgenid);
-        rc = live_sc_post_delete_int(iq, trans, oldgenid, old_dta, del_keys,
+        rc = live_sc_post_del_record(iq, trans, oldgenid, old_dta, del_keys,
                                      oldblobs);
     } else if (!is_newgen_gt_scptr &&
                is_oldgen_gt_scptr) // case 3) newgenid  ..^...  oldgenid
@@ -706,8 +726,8 @@ int live_sc_post_update(struct ireq *iq, void *trans,
             reqprintf(
                 iq, "C3: newgenid 0x%llx ...scptr 0x%llx ... oldgenid 0x%llx ",
                 newgenid, sc_genids[stripe], oldgenid);
-        rc = live_sc_post_add_int(iq, trans, newgenid, new_dta, ins_keys, blobs,
-                                  maxblobs, origflags, &rrn);
+        rc = live_sc_post_add_record(iq, trans, newgenid, new_dta, ins_keys,
+                                     blobs, maxblobs, origflags, &rrn);
     } else if (!is_newgen_gt_scptr &&
                !is_oldgen_gt_scptr) // case 4) newgenid and oldgenid  ...^..
     {
@@ -715,14 +735,33 @@ int live_sc_post_update(struct ireq *iq, void *trans,
             reqprintf(iq,
                       "C4: oldgenid 0x%llx newgenid 0x%llx ... scptr 0x%llx",
                       oldgenid, newgenid, sc_genids[stripe]);
-        rc = live_sc_post_update_int(
+        rc = live_sc_post_upd_record(
             iq, trans, oldgenid, old_dta, newgenid, new_dta, ins_keys, del_keys,
             od_len, updCols, blobs, deferredAdd, oldblobs, newblobs);
     }
 
     if (iq->debug) reqpopprefixes(iq, 1);
 
-out:
+    return rc;
+}
+
+int live_sc_post_update(struct ireq *iq, void *trans,
+                        unsigned long long oldgenid, const void *old_dta,
+                        unsigned long long newgenid, const void *new_dta,
+                        unsigned long long ins_keys,
+                        unsigned long long del_keys, int od_len, int *updCols,
+                        blob_buffer_t *blobs, size_t maxblobs, int origflags,
+                        int rrn, int deferredAdd, blob_buffer_t *oldblobs,
+                        blob_buffer_t *newblobs)
+{
+    int rc = 0;
+    pthread_rwlock_rdlock(&sc_live_rwlock);
+
+    rc = live_sc_post_update_int(iq, trans, oldgenid, old_dta, newgenid,
+                                 new_dta, ins_keys, del_keys, od_len, updCols,
+                                 blobs, maxblobs, origflags, rrn, deferredAdd,
+                                 oldblobs, newblobs);
+
     pthread_rwlock_unlock(&sc_live_rwlock);
     return rc;
 }


### PR DESCRIPTION
Two commits:
- Added rwlock to prevent races between live_sc_post*() and live_sc_off()
- get_hostname_with_crc32 could return NULL if db was moved to another machine and we should check for NULL