### PR TITLE
Improve make setup operations for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,9 +138,6 @@ protobuf/mem_protobuf.c
 protobuf/mem_protobuf.h
 sqlite/mem_sqlite.c
 sqlite/mem_sqlite.h
-util/mem_int.h
-util/mem_util.c
-util/mem_util.h
 schemachange/mem_schemachange.c
 schemachange/mem_schemachange.h
 lua/mem_lua.c

--- a/berkdb/dist/geninc.sh
+++ b/berkdb/dist/geninc.sh
@@ -2,7 +2,7 @@
 
 #usage
 if [[ "$#" -lt "3" ]]; then
-    print "$0 usage: <root> <hext-file> <cfile> [ <cfile2> <cfile3> .. ]"
+    echo "$0 usage: <root> <hext-file> <cfile> [ <cfile2> <cfile3> .. ]"
     exit 1
 fi
 

--- a/berkdb/dist/genrec.sh
+++ b/berkdb/dist/genrec.sh
@@ -2,7 +2,7 @@
 
 #usage
 if [[ $# != 4 ]]; then
-    print "$0 usage: <source> <cfile> <hfile> <template>"
+    echo "$0 usage: <source> <cfile> <hfile> <template>"
     exit 1
 fi
 

--- a/db/build_constants
+++ b/db/build_constants
@@ -20,7 +20,7 @@ esac
 GIT_BRANCH=${GIT_BRANCH:=$(git rev-parse --abbrev-ref HEAD)}
 GIT_REMOTE=$(git config branch.$GIT_BRANCH.remote)
 GIT_URL=$(git config remote.$GIT_REMOTE.url)
-SVNINFOTAG=${SVNINFOTAG:=$(git describe)}
+SVNINFOTAG=${SVNINFOTAG:=$(git describe 2> /dev/null)}
 GIT_LOG=$(git log --pretty=%s -1 | sed -e 's:\":\\\":g')
 
 cat <<EOF
@@ -48,7 +48,7 @@ static char s20___[] = "@(#)plink [comdb2] OSARCH  : $arch";
 static char s21___[] = "@(#)plink [comdb2] OSPLATFORM: $arch";
 static char s22___[] = "@(#)plink [comdb2] OSLEVEL : $OSLEVEL";
 static char s23___[] = "@(#)plink [comdb2] RS_VERSION: ";
-static char s24___[] = "@(#)plink [comdb2] SVNINFO : git@example.com/placeholder/til/comdb2submit/fix ($GIT_BRANCH) tag $SVNINFOTAG ($(git rev-parse --short HEAD))";
+static char s24___[] = "@(#)plink [comdb2] SVNINFO : git@github.com/bloomberg/comdb2 ($GIT_BRANCH) tag $SVNINFOTAG ($(git rev-parse --short HEAD))";
 static char s25___[] = "@(#)plink [comdb2] BUILDID : ";
 static char s26___[] = "@(#)plink [comdb2] GUID    : ";
 static char s27___[] = "@(#)plink [comdb2] LOG0001 : $GIT_LOG";

--- a/tests/setup
+++ b/tests/setup
@@ -116,7 +116,6 @@ name    $DBNAME
 dir     $DBDIR
 
 setattr MASTER_REJECT_REQUESTS 0
-do reql events detailed on
 EOPTIONS
 
 df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> ${LRL}

--- a/tests/setup
+++ b/tests/setup
@@ -12,7 +12,7 @@ while [[ $# -gt 0 && $1 = -* ]]; do
     shift
 done
 
-vars="TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG"
+vars="TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE COMDB2MD5SUM CDB2SQL_EXE "
 for required in $vars; do
     q=${!required}
     if [[ -z "$q" ]]; then
@@ -66,18 +66,25 @@ fi
 if [[ $debug -eq 1 ]]; then
     set +x
     export PATH="${SRCHOME}/:${PATH}"
-    echo "To run the ${TESTCASE} test, please run the following:"
-    echo
+    echo "To run ${TESTCASE} test, please run the following once db is ready:"
+    RUNTEST="${PWD}/runtest.sh "
+    echo "$RUNTEST"
+    echo "#!/bin/bash" > $RUNTEST
+    #echo "set +x"  >> $RUNTEST
     for env in $vars; do
-        echo "export $env=\"${!env}\""
+        echo "export $env=\"${!env}\"" >> $RUNTEST
     done
-    echo 'export PATH=${SRCHOME}/:${PATH}'
-    [[ -n "$CLUSTER" ]] && echo 'export CLUSTER="'$CLUSTER'"'
-    echo "cd ${TESTSROOTDIR}/${TESTCASE}.test/"
-    echo "./runit ${DBNAME} >${TESTDIR}/logs/${TESTCASE}.testcase 2>&1"
-    echo "${TESTSROOTDIR}/unsetup"
+    echo 'export PATH=${SRCHOME}/:${PATH}' >> $RUNTEST
+    [[ -n "$CLUSTER" ]] && echo 'export CLUSTER="'$CLUSTER'"' >> $RUNTEST
+    [[ -n "$SKIPSSL" ]] && echo 'export SKIPSSL="'$SKIPSSL'"' >> $RUNTEST
+    echo "cd ${TESTSROOTDIR}/${TESTCASE}.test/" >> $RUNTEST
+    #echo "./runit ${DBNAME} >${TESTDIR}/logs/${TESTCASE}.testcase 2>&1" >> $RUNTEST
+    echo "./runit ${DBNAME} " >> $RUNTEST
+    echo "echo; echo; echo;" >> $RUNTEST
+    echo "${TESTSROOTDIR}/unsetup" >> $RUNTEST
     echo
     echo
+    chmod +x $RUNTEST
 fi
 
 # TESTDIR looks like this: tests/test_12758
@@ -109,6 +116,7 @@ name    $DBNAME
 dir     $DBDIR
 
 setattr MASTER_REJECT_REQUESTS 0
+do reql events detailed on
 EOPTIONS
 
 df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> ${LRL}

--- a/tests/testcase.mk
+++ b/tests/testcase.mk
@@ -56,7 +56,7 @@ test:: tool unit
 clean::
 	rm -f *.res
 
-setup:
+setup: tool
 	@mkdir -p ${TESTDIR}/logs/
 	@$(TESTSROOTDIR)/setup -debug
 	@echo Ready to run

--- a/tools/comdb2ar/increment.cpp
+++ b/tools/comdb2ar/increment.cpp
@@ -267,7 +267,7 @@ ssize_t serialise_incr_file(
             ++it){
 tryagain:
         ifs.seekg(pagesize * *it, ifs.beg);
-        ifs.read(&pagebuf[0], pagesize);
+        ifs.read((char *)&pagebuf[0], pagesize);
         ssize_t bytes_read = ifs.gcount();
         if(bytes_read < pagesize) {
             std::ostringstream ss;


### PR DESCRIPTION
* Dump all exports, runit, clean cmds in one script
* Cleanup svninfo git path, compile warning, use echo instead of print