### PR TITLE
Significantly improving SQLite sort performance on large datasets with BLOB or TEXT: Genid-based Sort.

### DIFF
--- a/db/types.h
+++ b/db/types.h
@@ -71,6 +71,15 @@ extern int gbl_datetime_precision;
 
 #include <plbitlib.h>
 
+/* Internal data structure used by SQLite genid-based sort.
+   No corresponding client and server types exist for the
+   data structure. */
+typedef struct curgenid_st {
+    long long genid;
+    int cur; /* Which cursor the genid is from. */
+    int idx; /* position in the original schema. */
+} curgenid_t;
+
 typedef struct dttz {
     /* this need to be signed so the datetimes before epoch compare correctly*/
     long long dttz_sec;       /* datetime extension, epoch seconds */

--- a/sqlite/expr.c
+++ b/sqlite/expr.c
@@ -3244,7 +3244,7 @@ int sqlite3ExprCodeGetColumn(
   sqlite3ExprCodeGetColumnOfTable(v, pTab, iTable, iColumn, iReg);
   if( p5 ){
     sqlite3VdbeChangeP5(v, p5);
-  }else{   
+  }else{
     sqlite3ExprCacheStore(pParse, iTable, iColumn, iReg);
   }
   return iReg;
@@ -3260,6 +3260,35 @@ void sqlite3ExprCodeGetColumnToReg(
   if( r1!=iReg ) sqlite3VdbeAddOp2(pParse->pVdbe, OP_SCopy, r1, iReg);
 }
 
+/*
+** Return true if P5 is OPFLAG_GENID.
+*/
+int sqlite3ExprCodeGetColumnGenidToRegIfApplicable(
+  Parse *pParse,   /* Parsing and code generating context */
+  Table *pTab,     /* Description of the table we are reading from */
+  int iColumn,     /* Index of the table column */
+  int iTable,      /* The cursor pointing to the table */
+  int iReg         /* Store results here */
+){
+  int rv = 0;
+  Vdbe *p = pParse->pVdbe;
+  int r1 = sqlite3ExprCodeGetColumn(pParse, pTab, iColumn, iTable, iReg, 0);
+  if( sqlite3VdbeGetOp(p, -1)->opcode==OP_Column ){
+    int colaff = sqlite3TableColumnAffinity(pTab, iColumn);
+    if( colaff==SQLITE_AFF_BLOB || colaff==SQLITE_AFF_TEXT ){
+      int gsthresh = sqlite3_gbl_tunables.genidsort_sz_thresh;
+      /* If genid sort is disabled, don't alter the query plan. */
+      if (gsthresh >= 0) {
+        /* Store the threshold into P4 to improve locality. */
+        sqlite3VdbeChangeP4(p, -1, SQLITE_INT_TO_PTR(gsthresh), P4_INT32);
+        sqlite3VdbeChangeP5(p, OPFLAG_GENID);
+        rv = 1;
+      }
+    }
+  }
+  if( r1!=iReg ) sqlite3VdbeAddOp2(p, OP_SCopy, r1, iReg);
+  return rv;
+}
 
 /*
 ** Clear all column cache entries.
@@ -4120,7 +4149,7 @@ void sqlite3ExprCodeAndCache(Parse *pParse, Expr *pExpr, int target){
 ** Generate code that pushes the value of every element of the given
 ** expression list into a sequence of registers beginning at target.
 **
-** Return the number of elements evaluated.
+** Return true if the expressions can be potentially optimized for genid sort.
 **
 ** The SQLITE_ECEL_DUP flag prevents the arguments from being
 ** filled using OP_SCopy.  OP_Copy must be used instead.
@@ -4140,7 +4169,7 @@ int sqlite3ExprCodeExprList(
   u8 flags           /* SQLITE_ECEL_* flags */
 ){
   struct ExprList_item *pItem;
-  int i, j, n;
+  int i, j, n, rv;
   u8 copyOp = (flags & SQLITE_ECEL_DUP) ? OP_Copy : OP_SCopy;
   Vdbe *v = pParse->pVdbe;
   assert( pList!=0 );
@@ -4148,7 +4177,7 @@ int sqlite3ExprCodeExprList(
   assert( pParse->pVdbe!=0 );  /* Never gets this far otherwise */
   n = pList->nExpr;
   if( !ConstFactorOk(pParse) ) flags &= ~SQLITE_ECEL_FACTOR;
-  for(pItem=pList->a, i=0; i<n; i++, pItem++){
+  for(rv=0, pItem=pList->a, i=0; i<n; i++, pItem++){
     Expr *pExpr = pItem->pExpr;
     if( (flags & SQLITE_ECEL_REF)!=0 && (j = pList->a[i].u.x.iOrderByCol)>0 ){
       sqlite3VdbeAddOp2(v, copyOp, j+srcReg-1, target+i);
@@ -4156,6 +4185,23 @@ int sqlite3ExprCodeExprList(
       sqlite3ExprCodeAtInit(pParse, pExpr, target+i, 0);
     }else{
       int inReg = sqlite3ExprCodeTarget(pParse, pExpr, target+i);
+      /* If caller has requested genid sort optimization
+         and the last opcode is COLUMN, change P5 now. */
+      if( flags&SQLITE_ECEL_GENID &&
+          sqlite3VdbeGetOp(v, -1)->opcode==OP_Column &&
+          pExpr->pTab!=NULL ){
+        int colaff = sqlite3TableColumnAffinity(pExpr->pTab, pExpr->iColumn);
+        if( colaff==SQLITE_AFF_BLOB || colaff==SQLITE_AFF_TEXT ){
+          int gsthresh = sqlite3_gbl_tunables.genidsort_sz_thresh;
+          /* If genid sort is disabled, don't alter the query plan. */
+          if (gsthresh >= 0) {
+            /* Store the threshold into P4 to improve locality. */
+            sqlite3VdbeChangeP4(v, -1, SQLITE_INT_TO_PTR(gsthresh), P4_INT32);
+            sqlite3VdbeChangeP5(v, OPFLAG_GENID);
+            rv = 1;
+          }
+        }
+      }
       if( inReg!=target+i ){
         VdbeOp *pOp;
         if( copyOp==OP_Copy
@@ -4170,7 +4216,7 @@ int sqlite3ExprCodeExprList(
       }
     }
   }
-  return n;
+  return rv;
 }
 
 /*

--- a/sqlite/expr.c
+++ b/sqlite/expr.c
@@ -4187,9 +4187,9 @@ int sqlite3ExprCodeExprList(
       int inReg = sqlite3ExprCodeTarget(pParse, pExpr, target+i);
       /* If caller has requested genid sort optimization
          and the last opcode is COLUMN, change P5 now. */
-      if( flags&SQLITE_ECEL_GENID &&
-          sqlite3VdbeGetOp(v, -1)->opcode==OP_Column &&
-          pExpr->pTab!=NULL ){
+      if( /* Enable only if it is SQLITE_ECEL_GENID exclusive */
+          flags==SQLITE_ECEL_GENID &&
+          sqlite3VdbeGetOp(v, -1)->opcode==OP_Column && pExpr->pTab!=NULL ){
         int colaff = sqlite3TableColumnAffinity(pExpr->pTab, pExpr->iColumn);
         if( colaff==SQLITE_AFF_BLOB || colaff==SQLITE_AFF_TEXT ){
           int gsthresh = sqlite3_gbl_tunables.genidsort_sz_thresh;

--- a/sqlite/sqliteInt.h
+++ b/sqlite/sqliteInt.h
@@ -3137,6 +3137,9 @@ struct AuthContext {
 #ifdef SQLITE_ENABLE_PREUPDATE_HOOK
 #define OPFLAG_ISNOOP        0x40    /* OP_Delete does pre-update-hook only */
 #endif
+/* vvv COMDB2 MODIFICATION vvv */
+#define OPFLAG_GENID         0x20    /* OP_Column only fetches genids */
+/* ^^^ COMDB2 MODIFICATION ^^^ */
 #define OPFLAG_LENGTHARG     0x40    /* OP_Column only used for length() */
 #define OPFLAG_TYPEOFARG     0x80    /* OP_Column only used for typeof() */
 #define OPFLAG_BULKCSR       0x01    /* OP_Open** used to open bulk cursor */
@@ -3779,6 +3782,8 @@ void sqlite3DeleteFrom(Parse*, SrcList*, Expr*);
 void sqlite3Update(Parse*, SrcList*, ExprList*, Expr*, int);
 WhereInfo *sqlite3WhereBegin(Parse*,SrcList*,Expr*,ExprList*,ExprList*,u16,int);
 void sqlite3WhereEnd(WhereInfo*);
+void sqlite3WhereEndExt(WhereInfo*, int);
+void sqlite3WhereCloseCursors(WhereInfo*);
 LogEst sqlite3WhereOutputRowCount(WhereInfo*);
 int sqlite3WhereIsDistinct(WhereInfo*);
 int sqlite3WhereIsOrdered(WhereInfo*);
@@ -3793,6 +3798,7 @@ int sqlite3WhereOkOnePass(WhereInfo*, int*);
 void sqlite3ExprCodeLoadIndexColumn(Parse*, Index*, int, int, int);
 int sqlite3ExprCodeGetColumn(Parse*, Table*, int, int, int, u8);
 void sqlite3ExprCodeGetColumnToReg(Parse*, Table*, int, int, int);
+int sqlite3ExprCodeGetColumnGenidToRegIfApplicable(Parse*,Table*,int,int,int);
 void sqlite3ExprCodeGetColumnOfTable(Vdbe*, Table*, int, int, int);
 void sqlite3ExprCodeMove(Parse*, int, int, int);
 void sqlite3ExprCacheStore(Parse*, int, int, int);
@@ -3812,6 +3818,8 @@ int sqlite3ExprCodeExprList(Parse*, ExprList*, int, int, u8);
 #define SQLITE_ECEL_DUP      0x01  /* Deep, not shallow copies */
 #define SQLITE_ECEL_FACTOR   0x02  /* Factor out constant terms */
 #define SQLITE_ECEL_REF      0x04  /* Use ExprList.u.x.iOrderByCol */
+/* COMDB2 MODIFICATION */
+#define SQLITE_ECEL_GENID    0x08  /* Get only genids for blobs and strings */
 void sqlite3ExprIfTrue(Parse*, Expr*, int, int);
 void sqlite3ExprIfFalse(Parse*, Expr*, int, int);
 void sqlite3ExprIfFalseDup(Parse*, Expr*, int, int);
@@ -4488,5 +4496,5 @@ void sqlite3FingerprintDelete(sqlite3 *db, SrcList *pTabList, Expr *pWhere);
 void sqlite3FingerprintInsert(sqlite3 *db, SrcList *, Select *, IdList *, With *);
 void sqlite3FingerprintUpdate(sqlite3 *db, SrcList *pTabList, ExprList *pChanges, Expr *pWhere, int onError);
 void comdb2WriteTransaction(Parse*);
-
+void sqlite3VdbeMemSetGenid(Mem*, BtCursor*, int, int);
 #endif /* _SQLITEINT_H_ */

--- a/sqlite/sqlite_btree.h
+++ b/sqlite/sqlite_btree.h
@@ -62,6 +62,7 @@ int sqlite3BtreeOpen(
 #define BTREE_MEMORY        2  /* This is an in-memory DB */
 #define BTREE_SINGLE        4  /* The file contains at most 1 b-tree */
 #define BTREE_UNORDERED     8  /* Use of a hash implementation is OK */
+#define BTREE_ORDERBY      16  /* Do not create or use a rollback journal */
 
 int sqlite3BtreeClose(Btree*);
 int sqlite3BtreeSetCacheSize(Btree*,int);

--- a/sqlite/sqlite_tunables.h
+++ b/sqlite/sqlite_tunables.h
@@ -11,3 +11,6 @@ DEF_ATTR(STAT4_SAMPLES_MULTIPLIER, stat4_samples_multiplier, QUANTITY, 0)
 DEF_ATTR(STAT4_EXTRA_SAMPLES, stat4_extra_samples, QUANTITY, 0)
 /* build sqlite_stat1 table entries for empty tables */
 DEF_ATTR(ANALYZE_EMPTY_TABLES, analyze_empty_tables, BOOLEAN, 0)
+/* The threshold of blob/vutf8 length from which
+   SQLite will write genid-s into the sorter. */
+DEF_ATTR(GENIDSORT_SZ_THRESH, genidsort_sz_thresh, QUANTITY, 4096)

--- a/sqlite/vdbemem.c
+++ b/sqlite/vdbemem.c
@@ -3098,4 +3098,5 @@ done:
 }
 
 
+
 #endif /* SQLITE_BUILDING_FOR_COMDB2 */

--- a/sqlite/vdbesort.c
+++ b/sqlite/vdbesort.c
@@ -1801,7 +1801,8 @@ static int vdbeSorterFlushPMA(VdbeSorter *pSorter){
 */
 int sqlite3VdbeSorterWrite(
   const VdbeCursor *pCsr,         /* Sorter cursor */
-  Mem *pVal                       /* Memory cell containing record */
+  Mem *pVal,                      /* Memory cell containing record */
+  u8 *pbFlush                     /* Destination to write bFlush to */
 ){
   VdbeSorter *pSorter;
   int rc = SQLITE_OK;             /* Return Code */
@@ -1864,6 +1865,9 @@ int sqlite3VdbeSorterWrite(
       pSorter->list.szPMA = 0;
       pSorter->iMemory = 0;
       assert( rc!=SQLITE_OK || pSorter->list.pList==0 );
+    }
+    if ( pbFlush!=NULL ){
+      *pbFlush = (u8)bFlush;
     }
   }
 

--- a/tests/genid_based_sort.test/Makefile
+++ b/tests/genid_based_sort.test/Makefile
@@ -1,0 +1,10 @@
+include $(TESTSROOTDIR)/testcase.mk
+export TEST_TIMEOUT=5m
+
+CDB2LIBS=$(SYSPATH) $(SRCHOME)/cdb2api/libcdb2api.a -lprotobuf-c -lpthread -lssl -lcrypto
+CFLAGS+=-D_GNU_SOURCE -Wall -I$(SRCHOME)/cdb2api
+
+tool: genidsort
+
+genidsort: genidsort.c
+	$(CC) -g -o $@ $< $(CFLAGS) $(CDB2LIBS)

--- a/tests/genid_based_sort.test/genidsort.c
+++ b/tests/genid_based_sort.test/genidsort.c
@@ -1,0 +1,205 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <time.h>
+
+#include <cdb2api.h>
+
+int main(int argc, char **argv)
+{
+    cdb2_hndl_tp *hndl = NULL;
+    int rc, ninserts, nselects;
+    char *conf = getenv("CDB2_CONFIG");
+    void *data;
+    unsigned long tm, delta11, delta12, delta13, delta21, delta22, delta23;
+    const char *tier;
+
+    if (argc < 2) {
+        fprintf(stderr,
+                "%s database [tier][ninserts][nselects]\n",
+                argv[0]);
+        exit(1);
+    }
+
+    if (argc > 2)
+        tier = argv[2];
+    else
+        tier = "default";
+
+    if (argc > 3)
+        ninserts = atoi(argv[3]);
+    else
+        ninserts = 1024;
+
+    if (argc > 3)
+        nselects = atoi(argv[4]);
+    else
+        nselects = 10;
+
+    if (conf != NULL)
+        cdb2_set_comdb2db_config(conf);
+
+    /* Open handle */
+    rc = cdb2_open(&hndl, argv[1], tier, 0);
+    if (rc != 0) {
+        fprintf(stderr, "%d: Error opening handle: %d: %s.\n",
+                __LINE__, rc, cdb2_errstr(hndl));
+        exit(1);
+    }
+
+    /* Create table */
+    rc = cdb2_run_statement(hndl, "create table t { tag ondisk { int i blob b } }");
+    if (rc != 0) {
+        fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                __LINE__, rc, cdb2_errstr(hndl));
+        exit(1);
+    }
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK);
+    if (rc != CDB2_OK_DONE) {
+        fprintf(stderr, "%d: Error next record: %d: %s.\n",
+                __LINE__, rc, cdb2_errstr(hndl));
+        exit(1);
+    }
+
+    int tot = ninserts;
+    data = malloc(512 * 1024 + tot);
+
+    while (ninserts-- > 0) {
+        int key = rand();
+        /* Bind params */
+        cdb2_bind_param(hndl, "i", CDB2_INTEGER, &key, sizeof(key));
+
+        /* Make it *not* a multiple of page size. */
+        cdb2_bind_param(hndl, "b", CDB2_BLOB, data, 512 * 1024 + ninserts);
+
+        /* insert */
+        rc = cdb2_run_statement(hndl, "insert into t values(@i, @b)");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+
+        while ((rc = cdb2_next_record(hndl)) == CDB2_OK);
+        if (rc != CDB2_OK_DONE) {
+            fprintf(stderr, "%d: Error next record: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+
+        cdb2_clearbindings(hndl);
+    }
+
+    /* Warm up */
+    rc = cdb2_run_statement(hndl, "select b from t order by i");
+    if (rc != 0) {
+        fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                __LINE__, rc, cdb2_errstr(hndl));
+        exit(1);
+    }
+
+    int cnt;
+    for (cnt = 0; cdb2_next_record(hndl) == CDB2_OK; ++cnt);
+    if (cnt != tot) {
+        fprintf(stderr, "%d: Expecting %d rows, got %d.\n",
+                __LINE__, tot, cnt);
+        exit(1);
+    }
+
+    /* Time sqlite sort */
+    tm = (unsigned long)time(NULL);
+    int i;
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t order by i");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta11 = ((unsigned long)time(NULL)) - tm;
+
+    tm = (unsigned long)time(NULL);
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t order by i limit 10");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta12 = ((unsigned long)time(NULL)) - tm;
+
+    tm = (unsigned long)time(NULL);
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t group by i");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta13 = ((unsigned long)time(NULL)) - tm;
+
+    rc = cdb2_run_statement(hndl,
+            "exec procedure sys.cmd.send('setsqlattr genidsort_sz_thresh 4096')");
+    for (; cdb2_next_record(hndl) == CDB2_OK; );
+
+    /* Time genid sort */
+    tm = (unsigned long)time(NULL);
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t order by i");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta21 = ((unsigned long)time(NULL)) - tm;
+
+    tm = (unsigned long)time(NULL);
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t order by i limit 10");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta22 = ((unsigned long)time(NULL)) - tm;
+
+    tm = (unsigned long)time(NULL);
+    for (i = 0; i != nselects; ++i) {
+        rc = cdb2_run_statement(hndl, "select b from t group by i");
+        if (rc != 0) {
+            fprintf(stderr, "%d: Error running query: %d: %s.\n",
+                    __LINE__, rc, cdb2_errstr(hndl));
+            exit(1);
+        }
+        while (cdb2_next_record(hndl) == CDB2_OK);
+    }
+    delta23 = ((unsigned long)time(NULL)) - tm;
+
+    free(data);
+    cdb2_close(hndl);
+
+    fprintf(stderr, "sqlite order-by runtime %lu seconds.\n", delta11);
+    fprintf(stderr, "genid  order-by runtime %lu seconds.\n", delta21);
+    fprintf(stderr, "sqlite order-by with limit runtime %lu seconds.\n", delta12);
+    fprintf(stderr, "genid  order-by with limit runtime %lu seconds.\n", delta22);
+    fprintf(stderr, "sqlite group-by runtime %lu seconds.\n", delta13);
+    fprintf(stderr, "genid  group-by runtime %lu seconds.\n", delta23);
+
+    if (delta11 <= delta21 || delta12 <= delta22 || delta13 <= delta23) {
+        fprintf(stderr,
+                "genid sort is supposed to be faster than sqlite sort\n");
+        return 1;
+    }
+
+    return 0;
+}

--- a/tests/genid_based_sort.test/lrl.options
+++ b/tests/genid_based_sort.test/lrl.options
@@ -1,0 +1,5 @@
+sqlsortermem 100000
+cachekbmin 0
+cache 768 mb
+setsqlattr GENIDSORT_SZ_THRESH -1
+ssl_client_mode ALLOW

--- a/tests/genid_based_sort.test/output.expected
+++ b/tests/genid_based_sort.test/output.expected
@@ -1,0 +1,23 @@
+0	Init	0	21	0		00	Start at 21
+1	SorterOpen	1	3	0	k(1,B)	00	
+2	OpenRead	0	4	0	2	00	root=4 iDb=0; t
+3	ColumnsUsed	0	0	0	3	00	
+4	Explain	0	0	0	SCAN TABLE t (1048576 rows)	00	
+5	Rewind	0	11	0		00	
+6	Column	0	1	2	4096	20	r[2]=t.b
+7	Column	0	0	1		00	r[1]=t.i
+8	MakeRecord	1	2	3		00	r[3]=mkrec(r[1..2])
+9	SorterInsert	1	3	0		00	
+10	Next	0	6	0		01	
+11	OpenPseudo	2	4	3		00	3 columns in r[4]
+12	SorterSort	1	19	0		00	
+13	SorterData	1	4	2		00	r[4]=data
+14	Column	2	1	2		00	r[2]=b
+15	SeekRowid	-1	17	2		00	intkey=r[2]
+16	Column	-1	-1	2		00	r[2]=b
+17	ResultRow	2	1	0		00	output=r[2]
+18	SorterNext	1	13	0		00	
+19	Close	0	0	0		00	
+20	Halt	0	0	0		00	
+21	Transaction	0	0	0	0	01	usesStmtJournal=0
+22	Goto	0	1	0		00	

--- a/tests/genid_based_sort.test/runit
+++ b/tests/genid_based_sort.test/runit
@@ -1,0 +1,20 @@
+#!/bin/sh
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+./genidsort $dbnm
+if [ "$?" != "0" ]; then
+  echo "genidsort failed." >&2
+  exit 1
+fi
+
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "explain select b from t order by i" >output.actual
+diff output.actual output.expected
+if [ "$?" != "0" ]; then
+  echo "Query plan mismatch." >&2
+  exit 1
+fi
+
+echo "Passed."
+exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=899)
+(TUNABLES_COUNT=900)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -328,6 +328,7 @@
 (name='genid_comp_threshold', description='Try to compress rowids if the record data is smaller than this size.', type='INTEGER', value='60', read_only='N')
 (name='genidplusplus', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='genids', description='', type='BOOLEAN', value='ON', read_only='N')
+(name='genidsort_sz_thresh', description='', type='INTEGER', value='4096', read_only='N')
 (name='gofast', description='', type='BOOLEAN', value='ON', read_only='N')
 (name='goose_replication_for_incoherent_nodes', description='Call for election for nodes affected by COMMITDELAYBEHINDTHRESH.', type='BOOLEAN', value='OFF', read_only='N')
 (name='goslow', description='', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
When sorting rows, SQLite writes the complete row content into the sorter. After all rows are written into the sorter, SQlite simply walks the sorter to get the sorted rows. It is the most efficient implementation on small datasets.

However the implementation may suffer from high memory usage and poor performance on large datasets, especially those with blob and text. Take the following schema and query as an example:
```SQL
CREATE TABLE T1 (i INTEGER, b BLOB);

SELECT i, b FROM T1 ORDER BY i;
```
Suppose the table contains 1M rows and each row has a 1MB blob. The SQLite implementation requires more than 1TB RAM to run the select query completely in memory, which makes it almost impossible to accomplish. We then have to use external sorting with high disk I/O cost.

Moreover, the SQLite implementation will unnecessarily fetch all the blobs for LIMIT queries where only a handful are actually needed, for instance:
```SQL
SELECT i, b FROM T1 ORDER BY i LIMIT 10;
```

The genid-base sort, when applicable, only writes the genid-s of the blobs to the sorter. Those blobs are fetched after all the partial rows are sorted and only when they are needed. It uses far less RAM and is much faster than the SQLite implementation for ORDER-BY and GROUP-BY queries with blobs.