### PR TITLE
Fix queuedb deadlock handling.

### DIFF
--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -615,12 +615,10 @@ done:
         if (crc == DB_LOCK_DEADLOCK) {
             *bdberr = BDBERR_DEADLOCK;
             rc = -1;
-            goto done;
         } else if (crc) {
             logmsg(LOGMSG_ERROR, "%s: c_close berk rc %d\n", __func__, crc);
             *bdberr = BDBERR_MISC;
             rc = -1;
-            goto done;
         }
     }
     if (dbt_key.data && dbt_key.data != key)


### PR DESCRIPTION
This looks like a typo: When c_close returns DB_LOCK_DEADLOCK, we should return the error immediately to let the caller abort the transaction.

This was internally reviewed by Mike, but I'd like roborivers to eyeball as well.