### PR TITLE
Fix a memory leak in the new rootpage code.

### DIFF
--- a/bb/thdpool.c
+++ b/bb/thdpool.c
@@ -180,29 +180,29 @@ static void register_thdpool_tunables(char *name, struct thdpool *pool)
                      NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(
         name, mint, "Minimum number of threads in the pool.", TUNABLE_INTEGER,
-        &pool->minnthd, NOZERO, NULL, NULL, NULL, NULL);
+        &pool->minnthd, SIGNED, NULL, NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(
         name, maxt, "Maximum number of threads in the pool.", TUNABLE_INTEGER,
-        &pool->maxnthd, NOZERO, NULL, NULL, NULL, NULL);
+        &pool->maxnthd, SIGNED, NULL, NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(name, maxq, "Maximum size of queue.",
-                             TUNABLE_INTEGER, &pool->maxqueue, NOZERO, NULL,
+                             TUNABLE_INTEGER, &pool->maxqueue, SIGNED, NULL,
                              NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(
         name, longwait, "Long wait alarm threshold (in milliseconds).",
-        TUNABLE_INTEGER, &pool->longwaitms, NOZERO, NULL, NULL, NULL, NULL);
+        TUNABLE_INTEGER, &pool->longwaitms, SIGNED, NULL, NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(name, linger, "Thread linger time (in seconds).",
-                             TUNABLE_INTEGER, &pool->lingersecs, NOZERO, NULL,
+                             TUNABLE_INTEGER, &pool->lingersecs, SIGNED, NULL,
                              NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(name, stacksz, "Thread stack size.",
-                             TUNABLE_INTEGER, &pool->stack_sz, NOZERO, NULL,
+                             TUNABLE_INTEGER, &pool->stack_sz, SIGNED, NULL,
                              NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(name, maxqover,
                              "Maximum client forced queued items above maxq.",
-                             TUNABLE_INTEGER, &pool->maxqueueoverride, NOZERO,
+                             TUNABLE_INTEGER, &pool->maxqueueoverride, SIGNED,
                              NULL, NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(
         name, maxagems, "Maximum age for in-queue time (in milliseconds).",
-        TUNABLE_INTEGER, &pool->maxqueueagems, NOZERO, NULL, NULL, NULL, NULL);
+        TUNABLE_INTEGER, &pool->maxqueueagems, SIGNED, NULL, NULL, NULL, NULL);
     REGISTER_THDPOOL_TUNABLE(name, exit_on_error, "Exit on pthread error.",
                              TUNABLE_BOOLEAN, &pool->exit_on_create_fail, NOARG,
                              NULL, NULL, NULL, NULL);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2495,8 +2495,9 @@ void form_new_style_name(char *namebuf, int len, struct schema *schema,
 
 int get_copy_rootpages_nolock(struct sql_thread *thd);
 int get_copy_rootpages(struct sql_thread *thd);
-void free_copy_rootpages(struct sql_thread *thd);
 int create_sqlite_master(void);
+typedef struct master_entry master_entry_t;
+int destroy_sqlite_master(master_entry_t *, int);
 int new_indexes_syntax_check(struct ireq *iq);
 void handle_isql(struct dbtable *db, SBUF2 *sb);
 void handle_timesql(SBUF2 *sb, struct dbtable *db);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -682,10 +682,7 @@ void done_sql_thread(void)
             hash_free(thd->query_hash);
             thd->query_hash = 0;
         }
-        if (thd->rootpages) {
-            free(thd->rootpages);
-            thd->rootpages = NULL;
-        }
+        destroy_sqlite_master(thd->rootpages, thd->rootpage_nentries);
         free(thd);
     }
 }

--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -12,6 +12,7 @@
  */
 typedef struct master_entry {
     char *tblname;
+    int isstrdup; /* True if tblname is obtained from strdup(). */
     int ixnum;
     int entry_size;
     void *entry;
@@ -26,7 +27,7 @@ static int sqlmaster_nentries;
 static void *create_sqlite_master_row(int rootpage, char *csc2_schema,
                                       int tblnum, int ixnum, int *sz);
 
-static int destroy_sqlite_master(master_entry_t *arr, int arr_len)
+int destroy_sqlite_master(master_entry_t *arr, int arr_len)
 {
     master_entry_t *ent;
     int i;
@@ -35,8 +36,8 @@ static int destroy_sqlite_master(master_entry_t *arr, int arr_len)
         return 0;
 
     for (i = 0; i < arr_len; i++) {
-        ent = &arr[i];
-        if (ent->ixnum == -1)
+        ent = arr + i;
+        if (ent->isstrdup)
             free(ent->tblname);
         free(ent->entry);
     }
@@ -76,6 +77,7 @@ int create_sqlite_master(void)
         ent = &new_arr[i];
         db = thedb->dbs[tblnum];
         ent->tblname = strdup(db->dbname);
+        ent->isstrdup = 1;
         ent->ixnum = -1;
         ent->entry = create_sqlite_master_row(i + RTPAGE_START, db->csc2_schema,
                                               tblnum, -1, &ent->entry_size);
@@ -86,6 +88,8 @@ int create_sqlite_master(void)
             ent = &new_arr[i];
             /* skip indexes that we aren't advertising to sqlite */
             if (db->ixsql[ixnum] != NULL) {
+                ent->isstrdup = 0;
+                free(ent->tblname);
                 ent->tblname = new_arr[tbl_idx].tblname;
                 ent->ixnum = ixnum; /* comdb2 index number */
                 ent->entry = create_sqlite_master_row(
@@ -267,6 +271,7 @@ int get_copy_rootpages_nolock(struct sql_thread *thd)
         thd->rootpages[i].tblname = strdup(sqlmaster[i].tblname);
         if (!thd->rootpages[i].tblname)
             return -1;
+        thd->rootpages[i].isstrdup = 1;
         thd->rootpages[i].entry = malloc(thd->rootpages[i].entry_size);
         if (!thd->rootpages[i].entry)
             return -1;

--- a/tests/rootpagememleak.test/Makefile
+++ b/tests/rootpagememleak.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/rootpagememleak.test/lrl.options
+++ b/tests/rootpagememleak.test/lrl.options
@@ -1,0 +1,5 @@
+# Don't cache thread. Don't linger.
+sqlenginepool mint 0
+sqlenginepool linger 0
+appsockpool mint 0
+appsockpool linger 0

--- a/tests/rootpagememleak.test/runit
+++ b/tests/rootpagememleak.test/runit
@@ -1,0 +1,45 @@
+#!/bin/bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Make sure that all queries go to the same node.
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+echo "target machine is $mach"
+
+# Create 100 tables
+for i in `seq 1 100`; do
+  columns='i0 INTEGER'
+  for j in `seq 1 199`; do
+    columns="$columns, i$j INTEGER"
+  done
+  cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm "create table random_table_name_$i ($columns)" >/dev/null
+done
+
+cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm 'select max(rootpage) from sqlite_master'
+
+
+numberbefore=`cdb2sql --tabs --host $mach ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $4}'`
+
+# 10 Clients
+for i in `seq 1 10`; do
+  cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm 'select sleep(5)' >/dev/null &
+done
+
+wait
+sleep 10
+
+numberafter=`cdb2sql --tabs --host $mach ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $4}'`
+let numberdelta=$numberafter-$numberbefore
+
+echo $numberdelta
+# Give a little breathing room - 256KiB
+if [ $numberdelta -ge 262144 ]; then
+  echo "This may be a leak."
+  exit 1
+fi
+
+echo "Passed."
+exit 0


### PR DESCRIPTION
Correctly free rootpage structure when exiting the SQL thread.