### PR TITLE
rootpgleaktest: instead of let, use posix math to compute mem diff

### DIFF
--- a/tests/rootpagememleak.test/runit
+++ b/tests/rootpagememleak.test/runit
@@ -22,6 +22,7 @@ cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm 'select max(rootpage) from sqlite_mas
 
 
 numberbefore=`cdb2sql --tabs --host $mach ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $4}'`
+echo numberbefore $numberbefore
 
 # 10 Clients
 for i in `seq 1 10`; do
@@ -32,9 +33,10 @@ wait
 sleep 10
 
 numberafter=`cdb2sql --tabs --host $mach ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $4}'`
-let numberdelta=$numberafter-$numberbefore
+echo numberafter $numberafter
+numberdelta=$((numberafter-numberbefore))
 
-echo $numberdelta
+echo numberdelta $numberdelta
 # Give a little breathing room - 256KiB
 if [ $numberdelta -ge 262144 ]; then
   echo "This may be a leak."


### PR DESCRIPTION
let a=0  causes script to exit as it thinks failure (set -e), so when diff is zero test would fail.
Using posix math fixes this issue:
13:05:30> (max(rootpage)=103)
13:05:30> numberbefore 17027072
13:05:45> numberafter 17108992
13:05:45> numberdelta 81920
13:05:45> Passed.
