### PR TITLE
 make generation of cnonce pthread safe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ all: comdb2
 .PHONY: clean
 clean:
 	rm -f $(TASKS) $(ARS) $(OBJS) $(GENC) $(GENH) $(GENMISC)
+	make -sC tests/tools clean
 
 # Supply our own deb builder to make packaging easier.  In case
 # there's ever an official Debian package being maintained, use 'deb'

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2502,9 +2502,9 @@ static void make_random_str(char *str, int *len)
          * To get most entropy and have zero chance of collision
          * mod by a large integer (so higher order bits will count too)
          * 65521 is the largest prime that fits in a short. */
-        rand_state[0] = (unsigned short) (tv.tv_sec % 65521);
-        rand_state[1] = (unsigned short) (tv.tv_usec % 65521);
-        rand_state[2] = (unsigned short) (pthread_self() % 65521);
+        rand_state[0] = (unsigned short)(tv.tv_sec % 65521);
+        rand_state[1] = (unsigned short)(tv.tv_usec % 65521);
+        rand_state[2] = (unsigned short)(pthread_self() % 65521);
     }
     int randval = nrand48(rand_state);
     sprintf(str, "%d-%d-%lld-%d", cdb2_hostid(), PID, tv.tv_usec, randval);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2484,8 +2484,9 @@ done:
 
 
 /* combine hashes similar to hash_combine from boost library */
-size_t val_combine( size_t lhs, size_t rhs ) {
-    lhs^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
+uint64_t val_combine(uint64_t lhs, uint64_t rhs)
+{
+    lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
     return lhs;
 }
 
@@ -2503,17 +2504,15 @@ static void make_random_str(char *str, int *len)
 
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    if (PID == 0) {
-        /* Initialize PID and rand_state once per thread
-         * PID will ensure that cnonce will be different accross processes 
-         */
+    if (PID == 0) { /* Initialize PID and rand_state once per thread */
+         /* PID will ensure that cnonce will be different accross processes */
         PID = getpid(); 
 
         /* Get the initial random state by using thread id and time info. */
         uint32_t tmp[2];
         tmp[0] = tv.tv_sec;
         tmp[1] = tv.tv_usec;
-        size_t hash = val_combine(*(size_t*) tmp, (size_t) pthread_self());
+        uint64_t hash = val_combine(*(uint64_t *)tmp, (uint64_t)pthread_self());
         rand_state[0] = hash;
         rand_state[1] = hash >> 16;
         rand_state[2] = hash >> 32;

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2510,10 +2510,13 @@ static void make_random_str(char *str, int *len)
          * If two threads have the same [truncated] usec value, their thread 
          * id will be different and therefore their seeds will be different.
          */
-        unsigned int addr = pthread_self() % 0xFFFFFFFBULL;
-        rand_state[0] = addr;
-        rand_state[1] = addr >> 16;
-        rand_state[2] = tv.tv_usec; /* will be truncated to ushort */
+        #define INSZ sizeof(struct timeval) + sizeof(pthread_t)
+        unsigned char src[INSZ];
+        unsigned char hash[16];
+        unsigned char *MD5(const unsigned char *d, unsigned long n,
+                                 unsigned char *md);
+        MD5(src, INSZ, hash);
+        memcpy(rand_state, hash, 3 * sizeof(short));
     }
     int randval = nrand48(rand_state);
     sprintf(str, "%d-%d-%lld-%d", cdb2_hostid(), PID, tv.tv_usec, randval);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2491,14 +2491,19 @@ done:
  */
 static void make_random_str(char *str, int *len)
 {
-    static int PID = 0;
+    static __thread int PID = 0;
+    static __thread unsigned short xsubi[3];
+
     struct timeval tv;
     gettimeofday(&tv, NULL);
     if (PID == 0) {
         PID = getpid();
-        srandom(tv.tv_sec);
+        xsubi[0] = tv.tv_sec;
+        xsubi[1] = tv.tv_usec;
+        xsubi[2] = pthread_self();
     }
-    sprintf(str, "%d-%d-%lld-%d", cdb2_hostid(), PID, tv.tv_usec, random());
+    int randval = nrand48(xsubi);
+    sprintf(str, "%d-%d-%lld-%d", cdb2_hostid(), PID, tv.tv_usec, randval);
     *len = strlen(str);
     return;
 }

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -1,4 +1,4 @@
-ALL=hatest selectv overflow_blobtest recom stepper serial bound localrep utf8 crle
+ALL=hatest selectv overflow_blobtest recom stepper serial bound localrep utf8 crle cdb2api_caller ptrantest
 all:$(ALL)
 
 include ../../main.mk


### PR DESCRIPTION
We use a random number as part of cnonce, which for multithreaded functions could result in same cnonce from different threads. This patch ensures thread safety for generating cnonce.