### PR TITLE
SSL: fix typos in the documentation and cdb2jdbc.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -203,9 +203,9 @@ public class Comdb2Connection implements Connection {
         SSL_MODE sslmode;
         if ("REQUIRE".equalsIgnoreCase(mode))
             sslmode = SSL_MODE.REQUIRE;
-        else if ("VERIFY-CA".equalsIgnoreCase(mode))
+        else if ("VERIFY_CA".equalsIgnoreCase(mode))
             sslmode = SSL_MODE.VERIFY_CA;
-        else if ("VERIFY-HOSTNAME".equalsIgnoreCase(mode))
+        else if ("VERIFY_HOSTNAME".equalsIgnoreCase(mode))
             sslmode = SSL_MODE.VERIFY_HOSTNAME;
         else
             sslmode = SSL_MODE.ALLOW;

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -178,7 +178,7 @@ are refused to join the cluster.
 |---|---|---|---|
 |  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
 |  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead |
-| `VERIFY-CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
-| `VERIFY-HOSTNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
+| `VERIFY_CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
+| `VERIFY_HOSTNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
 
 <a name="sslfootnote">[1]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.

--- a/docs/pages/programming/jdbc_api.md
+++ b/docs/pages/programming/jdbc_api.md
@@ -174,9 +174,9 @@ The parameters are as follows:
 
         * REQUIRE
 
-        * VERIFY-CA
+        * VERIFY_CA
 
-        * VERIFY-HOSTNAME
+        * VERIFY_HOSTNAME
       
     * _key_store_=String
 
@@ -202,7 +202,7 @@ The parameters are as follows:
 
       Type of the trusted CA keystore. The default is `"JKS"`.
 
-    *_allow_pmux_route_=Boolean
+    * _allow_pmux_route_=Boolean
 
       Allow connection forwarding via `pmux`. The default is `false`.
         


### PR DESCRIPTION
Fix typos in the documentation as well as inconsistencies between libcdb2api and cdb2jdbc.