### PR TITLE
fix plain ddl in recom or higher

### DIFF
--- a/tests/snapisol.test/t7_01.req
+++ b/tests/snapisol.test/t7_01.req
@@ -27,3 +27,7 @@
 2 commit
 1 select * from t7
 1 select csc2 from sqlite_master where name = 't70'
+1 truncate t7
+1 select * from t7
+1 drop table t7
+1 select * from t7

--- a/tests/snapisol.test/t7_01.req.out
+++ b/tests/snapisol.test/t7_01.req.out
@@ -38,3 +38,8 @@ done
 done
 (csc2='schema {int a int b null=yes}')
 done
+done
+done
+done
+[select * from t7] failed with rc -3 no such table: t7
+done


### PR DESCRIPTION
Backgrounds:
Schema change uuid will be set to 0 if a ddl is not used inside begin-commit and `BDB_ATTR_SC_RESUME_AUTOCOMMIT` is set. This tunable means that for a plain ddl, in the case of `resume_schema_change`, master doesn't need to wait for osql re-submission but simply commit the schema change if possible (i.e. same as R6's behavior).

Transactional DDLs' behavior:
In the case of master swings, new master will start resuming ongoing schemachange immediately as part of the new master callback but it will not commit until master sees re-submission osql packets for the same uuid. Timeout is set through `SC_RESUME_WATCHDOG_TIMER`.
