### PR TITLE
reset got_hello before socket shutdown to avoid race

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -523,7 +523,7 @@ static void close_hostnode_ll(host_node_type *host_node_ptr)
         host_node_ptr->closed = 1;
 
         /* this has to be done before notifying the sql transactions
-           that connection dropped, otherwise they will race and 
+           that connection dropped, otherwise they will race and
            send stuff before the host is reconnected; transaction is
            send to garbcan without notifying sql, or master, and they
            will never be applied */


### PR DESCRIPTION
The race involves the pending sql transactions and the net thread closing the host node.  If we shutdown the socket first, the sql transactions will be notified and will re-send the bplogs, and if the got_hello is not yet reset, they will succeed.   The buffered transaction can be flushed during the follow-up reconnect, without notifying the sql transactions, which will timeout with error after awhile (default : 10 mins).