### PR TITLE
fix for coherency state logic

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -1893,7 +1893,7 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host)
         pthread_mutex_lock(&(bdb_state->coherent_state_lock));
 
         if (bdb_state->coherent_state[nodeix(host)] == STATE_COHERENT) {
-            /* 
+            /*
              * We defer waits, making sure the coherency lease expires for
              * the disconnected replicant;  the node needs to be incoherent,
              * no need to wait for it.
@@ -1919,7 +1919,7 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host)
     if (host == master_host) {
         logmsg(LOGMSG_WARN, "net_hostdown_rtn: HOSTDOWN was the master, calling "
                         "for election\n");
-        
+
         /* this is replicant, we are running election followed by recovery */
 
         call_for_election(bdb_state);


### PR DESCRIPTION
Problem: 
A disconnected node introduces a write delay, as the node is marked INCOHERENT_WAIT; this forces transactions to wait for the node, even though the replicant is disconnected. 
Fix:
This fix makes sure we don't wait for a disconnected node;  master has already postponed the writes making sure the coherency lease expired, and the node should be marked INCOHERENT.
The replicant will also detect a master connection lose due to the same event, and it will run election and recovery;  master will change the state for now reconnected replicant from INCOHERENT to INCOHERENT_WAIT when the client reconnects, and it will allow the replicant to catch-up, if it fell behind during disconnect. 