### PR TITLE
unlock mutex in pmux before returning

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -187,6 +187,7 @@ int client_func(int fd)
             syslog(LOG_WARNING, "reg request from %s, but not an active service?\n",
                    cmd);
             close(fd);
+            active_services_mutex.unlock();
             return -1;
         }
         active_services_mutex.unlock();


### PR DESCRIPTION
Pmux was left in an unresponsive state, the bug is we should unlock before returning.