### PR TITLE
Maven mirror not working. Use apache central repository instead.

### DIFF
--- a/contrib/docker/Dockerfile.jdbc.build
+++ b/contrib/docker/Dockerfile.jdbc.build
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 # Download maven
 RUN \
-  wget http://apache.mirrors.tds.net/maven/maven-3/3.5.0/binaries/apache-maven-3.5.0-bin.tar.gz && \
+  wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.tar.gz && \
   tar -xvf apache-maven-3.5.0-bin.tar.gz -C /bin && \
   mv /bin/apache-maven-3.5.0 bin/maven
 


### PR DESCRIPTION
This should fix the smoke test.