### PR TITLE
Put jdbc statement effects on an environmental variable.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -246,6 +246,16 @@ public class Comdb2Connection implements Connection {
             hndl.setAllowPmuxRoute(false);
     }
 
+    public void setStatementQueryEffects(String val) {
+        if ("true".equalsIgnoreCase(val)
+                || "1".equalsIgnoreCase(val)
+                || "T".equalsIgnoreCase(val)
+                || "on".equalsIgnoreCase(val))
+            hndl.setStatementQueryEffects(true);
+        else
+            hndl.setStatementQueryEffects(false);
+    }
+
     public ArrayList<String> getDbHosts() throws NoDbHostFoundException{
         return hndl.getDbHosts();
     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -68,7 +68,7 @@ public class Comdb2Handle extends AbstractConnection {
     int tcpbufsz;
     int age = 180; /* default max age 180 seconds */
     boolean pmuxrte = false;
-    boolean statement_caching = false;
+    boolean statement_effects = false;
 
     private boolean in_retry = false;
     private boolean temp_trans = false;
@@ -171,8 +171,8 @@ public class Comdb2Handle extends AbstractConnection {
          * export CDB2JDBC_STATEMENT_QUERYEFFECTS=0 -> disable
          */
         String envvar = System.getenv("CDB2JDBC_STATEMENT_QUERYEFFECTS");
-        statement_caching = (envvar != null && !envvar.equals("0"));
-        if (statement_caching)
+        statement_effects = (envvar != null && !envvar.equals("0"));
+        if (statement_effects)
             sets.add("set queryeffects statement");
 
         uuid = UUID.randomUUID().toString();
@@ -235,7 +235,7 @@ public class Comdb2Handle extends AbstractConnection {
     }
 
     public void setStatementQueryEffects(boolean val) {
-        if (val == statement_caching)
+        if (val == statement_effects)
             return;
 
         if (val)
@@ -243,7 +243,7 @@ public class Comdb2Handle extends AbstractConnection {
         else
             sets.clear();
 
-        statement_caching = val;
+        statement_effects = val;
     }
 
     void addHosts(List<String> hosts) {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -166,7 +166,12 @@ public class Comdb2Handle extends AbstractConnection {
         sets = new ArrayList<String>();
         String statement_caching;
         statement_caching = System.getenv("CDB2JDBC_STATEMENT_QUERYEFFECTS");
-        if (statement_caching != null)
+
+        /* export CDB2JDBC_STATEMENT_QUERYEFFECTS   -> enable
+         * export CDB2JDBC_STATEMENT_QUERYEFFECTS=1 -> enable
+         * export CDB2JDBC_STATEMENT_QUERYEFFECTS=0 -> disable
+         */
+        if (statement_caching != null && !statement_caching.equals("0"))
             sets.add("set queryeffects statement");
         uuid = UUID.randomUUID().toString();
         tdlog(Level.FINEST, "Created handle with uuid %s", uuid);

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -164,7 +164,10 @@ public class Comdb2Handle extends AbstractConnection {
     public Comdb2Handle(String dbname, String cluster) {
         super(new ProtobufProtocol(), null);
         sets = new ArrayList<String>();
-        sets.add("set queryeffects statement");
+        String statement_caching;
+        statement_caching = System.getenv("CDB2JDBC_STATEMENT_QUERYEFFECTS");
+        if (statement_caching != null)
+            sets.add("set queryeffects statement");
         uuid = UUID.randomUUID().toString();
         tdlog(Level.FINEST, "Created handle with uuid %s", uuid);
         bindVars = new HashMap<String, Cdb2BindValue>();

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -47,6 +47,7 @@ public class Driver implements java.sql.Driver {
     public static final String PROPERTY_SSL_CAPASS = "trust_store_password";
     public static final String PROPERTY_SSL_CATYPE = "trust_store_type";
     public static final String PROPERTY_PMUX_RTE = "allow_pmux_route";
+    public static final String PROPERTY_STMT_EFFECTS = "statement_query_effects";
 
     /**
      * Register our driver statically.
@@ -98,6 +99,7 @@ public class Driver implements java.sql.Driver {
         String sslcapass = null;
         String sslcatype = null;
         String pmuxrte = null;
+        String stmteffects = null;
         String attributes = null;
 
         String policy = null;
@@ -202,6 +204,8 @@ public class Driver implements java.sql.Driver {
                         sslcatype = keyval[1];
                     else if (PROPERTY_PMUX_RTE.equalsIgnoreCase(keyval[0]))
                         pmuxrte = keyval[1];
+                    else if (PROPERTY_STMT_EFFECTS.equalsIgnoreCase(keyval[0]))
+                        stmteffects = keyval[1];
                 }
             }
         }
@@ -258,6 +262,8 @@ public class Driver implements java.sql.Driver {
             sslcatype = info.getProperty(PROPERTY_SSL_CATYPE);
         if (pmuxrte == null)
             pmuxrte = info.getProperty(PROPERTY_PMUX_RTE);
+        if (stmteffects == null)
+            stmteffects = info.getProperty(PROPERTY_STMT_EFFECTS);
 
         try {
             if (port != null) {
@@ -383,6 +389,11 @@ public class Driver implements java.sql.Driver {
             if (pmuxrte != null) {
                 logger.log(Level.FINE, String.format("Setting pmux passthrouth to %s\n", pmuxrte));
                 ret.setAllowPmuxRoute(pmuxrte);
+            }
+
+            if (stmteffects != null) {
+                logger.log(Level.FINE, String.format("Setting statement query effects to %s\n", stmteffects));
+                ret.setStatementQueryEffects(stmteffects);
             }
         } catch (NumberFormatException e1) {
             logger.log(Level.WARNING, "Incorrect configuration in: " + url, e1);

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
@@ -1,0 +1,71 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class StatementQueryEffectsTest {
+
+    String db, cluster;
+    Connection conn;
+
+    @Before public void setup() throws SQLException {
+        db = System.getProperty("cdb2jdbc.test.database");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+        Statement stmt = conn.createStatement();
+        stmt.execute("DROP TABLE IF EXISTS t_stmteffects");
+        stmt.execute("CREATE TABLE t_stmteffects (i INTEGER)");
+        stmt.execute("INSERT INTO t_stmteffects values (1)");
+
+        stmt.close();
+        conn.close();
+    }
+
+    /* Under statement query effects,
+       executeUpdate() returns the query effects made by the statement. */
+    @Test public void statementQueryEffects() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?statement_query_effects=1", cluster, db));
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+
+        int nupd;
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 2 WHERE i = 1");
+        Assert.assertEquals("Updated 1 record.", 1, nupd);
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 4 WHERE i = 3");
+        Assert.assertEquals("Updated 0 record.", 0, nupd);
+
+        conn.rollback();
+        stmt.close();
+        conn.close();
+    }
+
+    /* Under transaction query effects,
+       executeUpdate() returns the query effects made by the transaction. */
+    @Test public void transactionQueryEffects() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?statement_query_effects=0", cluster, db));
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+
+        int nupd;
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 2 WHERE i = 1");
+        Assert.assertEquals("Updated 1 record.", 1, nupd);
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 4 WHERE i = 3");
+        Assert.assertEquals("Updated 1 record.", 1, nupd);
+
+        conn.rollback();
+        stmt.close();
+        conn.close();
+    }
+
+    @After public void unsetup() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+        Statement stmt = conn.createStatement();
+        stmt.execute("DROP TABLE t_stmteffects");
+    }
+}

--- a/tests/jepsen_a6.test/runit
+++ b/tests/jepsen_a6.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_a6_nemesis.test/runit
+++ b/tests/jepsen_a6_nemesis.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_atomic_writes.test/runit
+++ b/tests/jepsen_atomic_writes.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_bank.test/runit
+++ b/tests/jepsen_bank.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_bank_nemesis.test/runit
+++ b/tests/jepsen_bank_nemesis.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=1

--- a/tests/jepsen_dirty_reads.test/runit
+++ b/tests/jepsen_dirty_reads.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_g2.test/runit
+++ b/tests/jepsen_g2.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_register.test/runit
+++ b/tests/jepsen_register.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_register_nemesis.test/runit
+++ b/tests/jepsen_register_nemesis.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=1

--- a/tests/jepsen_sets.test/runit
+++ b/tests/jepsen_sets.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_sets_nemesis.test/runit
+++ b/tests/jepsen_sets_nemesis.test/runit
@@ -3,6 +3,7 @@
 # Runs the register linearizability test
 #debug=1
 #debug_trace="-D"
+export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=1


### PR DESCRIPTION
Rivers pointed out an issue with the current scheme: our current jdbc clients will receive an error code when communicating with an R6 server.  Enabling this logic on an environmental variable seemed to be the most straightforward fix, as it allows our jepsen-testing and current clients to continue working.