### PR TITLE
Preventing tag thread from using freed resources.

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1879,11 +1879,18 @@ void appsock_get_dbinfo2_stats(uint32_t *n_appsock, uint32_t *n_sql);
 void ixstats(struct dbenv *dbenv);
 void curstats(struct dbenv *dbenv);
 
+/* Not available - this is the initial state. */
+#define REPLY_STATE_NA 0
+/* Sent - set by a tag thread. */
+#define REPLY_STATE_DONE 1
+/* Discard - set by an appsock thread if the child tag thread has timed out. */
+#define REPLY_STATE_DISCARD 2
 struct buf_lock_t {
     pthread_mutex_t req_lock;
     pthread_cond_t wait_cond;
     int rc;
-    int reply_done;
+    int reply_state; /* See REPLY_STATE_* macros above */
+    uint8_t *bigbuf;
     SBUF2 *sb;
 };
 

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -564,9 +564,23 @@ int handle_ireq(struct ireq *iq)
                         iq->frommach, iq->rqid, iq->p_buf_out_start,
                         iq->p_buf_out - iq->p_buf_out_start, rc);
                 } else {
-                    sndbak_open_socket(iq->sb, iq->p_buf_out_start,
-                                       iq->p_buf_out - iq->p_buf_out_start, rc);
-                    free_bigbuf(iq->p_buf_out_start, iq->request_data);
+                    /* The tag request is handled locally.
+                       We know for sure `request_data' is a `buf_lock_t'. */
+                    struct buf_lock_t *p_slock =
+                        (struct buf_lock_t *)iq->request_data;
+                    if (pthread_mutex_lock(&p_slock->req_lock) == 0) {
+                        if (p_slock->reply_state == REPLY_STATE_DISCARD) {
+                            pthread_mutex_unlock(&p_slock->req_lock);
+                            cleanup_lock_buffer(p_slock);
+                            free_bigbuf_nosignal(iq->p_buf_out_start);
+                        } else {
+                            sndbak_open_socket(
+                                iq->sb, iq->p_buf_out_start,
+                                iq->p_buf_out - iq->p_buf_out_start, rc);
+                            free_bigbuf(iq->p_buf_out_start, iq->request_data);
+                            pthread_mutex_unlock(&p_slock->req_lock);
+                        }
+                    }
                 }
                 iq->request_data = iq->p_buf_out_start = NULL;
             } else {

--- a/db/socket_interfaces.h
+++ b/db/socket_interfaces.h
@@ -81,4 +81,7 @@ int sndbak_open_socket(SBUF2 *sb, u_char *buf, int buflen, int rc);
 
 int handle_socketrequest(SBUF2 *sb, int *keepsocket, int wrongdb);
 
+/* Free all resources allocated in the lock buffer. */
+void cleanup_lock_buffer(struct buf_lock_t *);
+
 #endif /* #ifndef __SOCKET_INTERFACES_H__ */


### PR DESCRIPTION
A hardware controller issue can cause a tag request to take more than the time limit (1000 seconds) to finish. The parent appsock thread will then free resources, but leave the tag thread running. The tag thread will be at risk of using those freed resources.

The `reply_done` flag in `struct buf_lock_t` is extended to address the issue. If the child tag thread has timed out, the parent appsock thread marks the flag DISCARD without freeing those resources which are likely used by the tag thread. The tag thread later frees the resources.