### PR TITLE
cdb2jdbc: Porting recent cdb2api patches to cdb2jdbc

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -293,8 +293,10 @@ public class BBSysUtils {
                 System.out.println("dbinfoQuery: dbinfo response " +
                         "returns " + dbInfoResp.nodes);
             }
+
+            /* Add coherent nodes. */
             for (NodeInfo node : dbInfoResp.nodes) {
-                if (node.incoherent != 0 || node.port < 0) {
+                if (node.incoherent != 0) {
                     if (debug) {
                         System.out.println("dbinfoQuery: Skipping " +
                                 node.name + ": incoherent=" + 
@@ -319,6 +321,18 @@ public class BBSysUtils {
 
                 if (myroom == node.room)
                     ++hosts_same_room;
+            }
+
+            /* Add incoherent nodes too, but don't count them for same room hosts. */
+            for (NodeInfo node : dbInfoResp.nodes) {
+                if (node.incoherent == 0)
+                    continue;
+
+                validHosts.add(node.name);
+                validPorts.add(node.port);
+
+                if (node.name.equalsIgnoreCase(dbInfoResp.master.name))
+                    master = validHosts.size() - 1;
             }
 
             if (validHosts.size() <= 0)

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -844,6 +844,8 @@ public class Comdb2Handle extends AbstractConnection {
             is_rollback = true;
         } else if (lowerSql.startsWith("select")
                 || lowerSql.startsWith("explain")
+                || lowerSql.startsWith("with")
+                || lowerSql.startsWith("get")
                 || lowerSql.startsWith("exec")) {
             isRead = true;
         } else {

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/WithAndGetAreReadTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/WithAndGetAreReadTest.java
@@ -1,0 +1,35 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class WithAndGetAreReadTest {
+    String db, cluster;
+    Connection conn;
+    Statement stmt;
+
+    @Before public void setup() throws SQLException {
+        db = System.getProperty("cdb2jdbc.test.database");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+        stmt = conn.createStatement();
+    }
+
+    @Test public void run() throws SQLException {
+        boolean is_read;
+
+        is_read = stmt.execute("GET kw");
+        Assert.assertEquals("`GET' is read", true, is_read);
+
+        is_read = stmt.execute("WITH t(i) AS (SELECT 1) SELECT * FROM t");
+        Assert.assertEquals("`WITH' is read", true, is_read);
+    }
+
+    @After public void unsetup() throws SQLException {
+        stmt.close();
+        conn.close();
+    }
+}


### PR DESCRIPTION
Port [bbgithub/cdb2api#9](https://bbgithub.dev.bloomberg.com/comdb2/cdb2api/pull/9) and https://github.com/bloomberg/comdb2/pull/406 to cdb2jdbc.

The following patches need not to be ported because cdb2jdbc handles them correctly.
https://github.com/bloomberg/comdb2/pull/403 (Dbinfo retry fix)
https://github.com/bloomberg/comdb2/pull/374 (Cdb2api default cluster)

The following patches need not be ported because the issues are specific to cdb2sockpool.
https://github.com/bloomberg/comdb2/pull/394 (Handle wrong db by invalidating current hosts/ports and doing requery on comdb2db)
https://github.com/bloomberg/comdb2/pull/257 (Send dbnames in error in case of incorrect database)
https://github.com/bloomberg/comdb2/pull/181 (Try connecting to sockpool periodically)