### PR TITLE
cleanup clnt when done, issue was context from sp

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -783,6 +783,7 @@ void sql_mem_shutdown(void *dummy);
 int sqlite3_open_serial(const char *filename, sqlite3 **, struct sqlthdstate *);
 
 void reset_clnt(struct sqlclntstate *, SBUF2 *, int initial);
+void cleanup_clnt(struct sqlclntstate *);
 void reset_query_effects(struct sqlclntstate *);
 
 int sqlite_to_ondisk(struct schema *s, const void *inp, int len, void *outp,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6349,7 +6349,7 @@ void cleanup_clnt(struct sqlclntstate *clnt)
     if (clnt->saved_errstr) {
         free(clnt->saved_errstr);
         clnt->saved_errstr = NULL;
-    }    
+    }
 
     if (clnt->context) {
         for (int i = 0; i < clnt->ncontext; i++) {
@@ -6358,7 +6358,6 @@ void cleanup_clnt(struct sqlclntstate *clnt)
         free(clnt->context);
         clnt->context = NULL;
     }
-
 
     if (clnt->selectv_arr) {
         currangearr_free(clnt->selectv_arr);
@@ -6376,18 +6375,17 @@ void cleanup_clnt(struct sqlclntstate *clnt)
     }
 
     if (clnt->numallocblobs) {
-            free(clnt->alloc_blobs);
-            clnt->alloc_blobs = NULL;
-            free(clnt->alloc_bloblens);
-            clnt->alloc_bloblens = NULL;
-        }
+        free(clnt->alloc_blobs);
+        clnt->alloc_blobs = NULL;
+        free(clnt->alloc_bloblens);
+        clnt->alloc_bloblens = NULL;
+    }
 
     if (clnt->query_stats) {
         free(clnt->query_stats);
         clnt->query_stats = NULL;
     }
 }
-
 
 void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
 {

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2749,7 +2749,7 @@ static void *dispatch_lua_thread(void *lt)
 
     dispatch_sql_query(&clnt); // --> exec_thread()
 
-    if (clnt.query_stats) free(clnt.query_stats);
+    cleanup_clnt(&clnt);
 
     pthread_mutex_destroy(&clnt.wait_mutex);
     pthread_cond_destroy(&clnt.wait_cond);
@@ -6794,7 +6794,7 @@ void *exec_trigger(trigger_reg_t *reg)
         luabb_trigger_unregister(q);
     }
     close_sp(&clnt);
-    reset_clnt(&clnt, NULL, 0);
+    cleanup_clnt(&clnt);
     sqlengine_thd_end(NULL, &thd);
     return NULL;
 }


### PR DESCRIPTION
Cleanup clnt object when clnt is about to go out of scope. 
Currently we are leaking by not performing such cleanup, ex. context member from SP execution.