### PR TITLE
SQLite: Fix broken parser.

### DIFF
--- a/sqlite/parse.y
+++ b/sqlite/parse.y
@@ -756,13 +756,6 @@ sortlist(A) ::= expr(Y) sortorder(Z). {
   sqlite3ExprListSetSortOrder(A,Z);
 }
 
-cmd ::= rename_comdb2table.
-
-rename_comdb2table ::= dryrun(D) ALTER TABLE nm(X) RENAME TO nm(Y). {
-    comdb2WriteTransaction(pParse);
-    sqlite3AlterRenameTable(pParse,&X,&Y,D);
-}
-
 %type sortorder {int}
 sortorder(A) ::= ASC.           {A = SQLITE_SO_ASC;}
 sortorder(A) ::= DESC.          {A = SQLITE_SO_DESC;}
@@ -2110,6 +2103,15 @@ alter_table_drop_column ::= DROP kwcolumn_opt nm(Y) . {
 kwcolumn_opt ::= .
 kwcolumn_opt ::= COLUMNKW.
 %endif
+
+
+/////////////////// COMDB2 RENAME TABLE STATEMENT  //////////////////////////////
+cmd ::= rename_comdb2table.
+
+rename_comdb2table ::= dryrun(D) ALTER TABLE nm(X) RENAME TO nm(Y). {
+    comdb2WriteTransaction(pParse);
+    sqlite3AlterRenameTable(pParse,&X,&Y,D);
+}
 
 %type dryrun {int}
 dryrun(D) ::= DRYRUN.  {D=1;}


### PR DESCRIPTION
SQLite parser is broken when compiled with GCC 5.4.0 on Ubuntu 16.04. For instance:

```
$ gcc --version
gcc (Ubuntu 5.4.0-6ubuntu1~16.04.5) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ cdb2sql mydb 'insert into t values(1)'
[insert into t values(1)] failed with rc -3 near "into": syntax error
```

It can be fixed by moving the `RENAME` rule to the end of the grammar file (See https://github.com/bloomberg/comdb2/pull/237).