### PR TITLE
Fix views delete limit

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -6019,25 +6019,25 @@ bdb_state_type *bdb_create_queue_tran(tran_type *tran, const char name[],
     bdb_state = parent_bdb_state;
     BDB_READLOCK("bdb_create_queue");
 
-    ret = bdb_open_int(
-        0,                    /* env only */
-        name, dir, item_size, /* pass item_size in as lrl */
-        0,                    /* numix */
-        NULL,                 /* ixlen */
-        NULL,                 /* ixdups */
-        NULL,                 /* ixrecnum */
-        NULL,                 /* ixdta */
-        NULL,                 /* ixcollattr */
-        NULL,                 /* ixnulls */
-        1,                    /* numdtafiles (berkdb queue file) */
-        NULL,                 /* bdb_attr */
-        NULL,                 /* bdb_callback */
-        NULL,                 /* usr_ptr */
-        NULL,                 /* netinfo */
-        0,                    /* upgrade */
-        1,                    /* create */
-        bdberr, parent_bdb_state, pagesize, /* pagesize override */
-        isqueuedb ? BDBTYPE_QUEUEDB : BDBTYPE_QUEUE, tid, 0, NULL);
+    ret =
+        bdb_open_int(0,                    /* env only */
+                     name, dir, item_size, /* pass item_size in as lrl */
+                     0,                    /* numix */
+                     NULL,                 /* ixlen */
+                     NULL,                 /* ixdups */
+                     NULL,                 /* ixrecnum */
+                     NULL,                 /* ixdta */
+                     NULL,                 /* ixcollattr */
+                     NULL,                 /* ixnulls */
+                     1,                    /* numdtafiles (berkdb queue file) */
+                     NULL,                 /* bdb_attr */
+                     NULL,                 /* bdb_callback */
+                     NULL,                 /* usr_ptr */
+                     NULL,                 /* netinfo */
+                     0,                    /* upgrade */
+                     1,                    /* create */
+                     bdberr, parent_bdb_state, pagesize, /* pagesize override */
+                     isqueuedb ? BDBTYPE_QUEUEDB : BDBTYPE_QUEUE, tid, 0, NULL);
 
     BDB_RELLOCK();
 
@@ -7487,7 +7487,8 @@ int bdb_purge_unused_files(bdb_state_type *bdb_state, tran_type *tran,
     /* skip already deleted files */
     char path[PATH_MAX];
     bdb_trans(munged_name, path);
-    if (stat(path, &sb)) return 0;
+    if (stat(path, &sb))
+        return 0;
 
     if (lognum && lowfilenum && lognum >= lowfilenum) {
         oldfile_list_add(munged_name, lognum);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -134,16 +134,18 @@ typedef enum {
     LLMETA_CURR_ANALYZE_COUNT = 29,
     LLMETA_LAST_ANALYZE_COUNT = 30,
     LLMETA_LAST_ANALYZE_EPOCH = 31,
-    LLMETA_FDB_TABLENAME_ALIAS =32/* table name to replace a full path
-                                  DBNAME.TABLENAME */
+    LLMETA_FDB_TABLENAME_ALIAS = 32 /* table name to replace a full path
+                                    DBNAME.TABLENAME */
     ,
-    LLMETA_TABLE_VERSION      = 33/* reliable table version, updated by any schema change
-                            */
+    LLMETA_TABLE_VERSION =
+        33 /* reliable table version, updated by any schema change
+     */
     ,
-    LLMETA_TABLE_PARAMETERS   = 34/* store various parameter values for tables stored
-                               as a blob */
+    LLMETA_TABLE_PARAMETERS =
+        34 /* store various parameter values for tables stored
+        as a blob */
     ,
-    LLMETA_ROWLOCKS_STATE     = 35
+    LLMETA_ROWLOCKS_STATE = 35
     /* for some reason we skip 36 */
     ,
     LLMETA_TABLE_USER_OP = 37 /* The user can use DDL-like commands on the table
@@ -2640,11 +2642,11 @@ int bdb_get_file_version_table(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 int bdb_get_file_version_qdb(bdb_state_type *bdb_state, tran_type *tran,
-                               unsigned long long *version_num, int *bdberr)
+                             unsigned long long *version_num, int *bdberr)
 {
     return bdb_get_file_version(tran, bdb_state->name,
-                                LLMETA_FVER_FILE_TYPE_QDB, 0,
-                                version_num, bdberr);
+                                LLMETA_FVER_FILE_TYPE_QDB, 0, version_num,
+                                bdberr);
 }
 
 int bdb_get_pagesize_data(bdb_state_type *bdb_state, tran_type *tran,

--- a/sqlite/delete.c
+++ b/sqlite/delete.c
@@ -93,6 +93,9 @@ void sqlite3MaterializeView(
   Parse *pParse,       /* Parsing context */
   Table *pView,        /* View definition */
   Expr *pWhere,        /* Optional WHERE clause to be added */
+  ExprList *pOrderBy,  /* Optional ORDER BY clause */
+  Expr *pLimit,        /* Optional LIMIT clause */
+  Expr *pOffset,       /* Optional OFFSET clause */
   int iCur             /* Cursor number for ephemeral table */
 ){
   SelectDest dest;
@@ -109,8 +112,8 @@ void sqlite3MaterializeView(
     assert( pFrom->a[0].pOn==0 );
     assert( pFrom->a[0].pUsing==0 );
   }
-  pSel = sqlite3SelectNew(pParse, 0, pFrom, pWhere, 0, 0, 0, 
-                          SF_IncludeHidden, 0, 0);
+  pSel = sqlite3SelectNew(pParse, 0, pFrom, pWhere, 0, 0, pOrderBy, 
+                          SF_IncludeHidden, pLimit, pOffset);
   sqlite3SelectDestInit(&dest, SRT_EphemTab, iCur);
   sqlite3Select(pParse, pSel, &dest);
   sqlite3SelectDelete(db, pSel);
@@ -135,12 +138,13 @@ Expr *sqlite3LimitWhere(
   Expr *pOffset,               /* The OFFSET clause.  May be null */
   char *zStmtType              /* Either DELETE or UPDATE.  For err msgs. */
 ){
-  Expr *pWhereRowid = NULL;    /* WHERE rowid .. */
+  sqlite3 *db = pParse->db;
+  Expr *pLhs = NULL;           /* LHS of IN(SELECT...) operator */
   Expr *pInClause = NULL;      /* WHERE rowid IN ( select ) */
-  Expr *pSelectRowid = NULL;   /* SELECT rowid ... */
   ExprList *pEList = NULL;     /* Expression list contaning only pSelectRowid */
   SrcList *pSelectSrc = NULL;  /* SELECT rowid FROM x ... (dup of pSrc) */
   Select *pSelect = NULL;      /* Complete SELECT tree */
+  Table *pTab;
 
   /* COMDB2 MODIFICATION */
   if (pLimit && gbl_update_delete_limit == 0) {
@@ -150,9 +154,13 @@ Expr *sqlite3LimitWhere(
 
   /* Check that there isn't an ORDER BY without a LIMIT clause.
   */
-  if( pOrderBy && (pLimit == 0) ) {
+  if( pOrderBy && pLimit==0 ) {
     sqlite3ErrorMsg(pParse, "ORDER BY without LIMIT on %s", zStmtType);
-    goto limit_where_cleanup;
+limit_where_cleanup:
+    sqlite3ExprListDelete(pParse->db, pOrderBy);
+    sqlite3ExprDelete(pParse->db, pLimit);
+    sqlite3ExprDelete(pParse->db, pOffset);
+    return 0;
   }
 
   /* We only need to generate a select expression if there
@@ -173,36 +181,48 @@ Expr *sqlite3LimitWhere(
   **   );
   */
 
-  pSelectRowid = sqlite3PExpr(pParse, TK_ROW, 0, 0, 0);
-  if( pSelectRowid == 0 ) goto limit_where_cleanup;
-  pEList = sqlite3ExprListAppend(pParse, 0, pSelectRowid);
-  if( pEList == 0 ) goto limit_where_cleanup;
+  pTab = pSrc->a[0].pTab;
+  if( HasRowid(pTab) ){
+    pLhs = sqlite3PExpr(pParse, TK_ROW, 0, 0, 0);
+    pEList = sqlite3ExprListAppend(
+        pParse, 0, sqlite3PExpr(pParse, TK_ROW, 0, 0, 0)
+    );
+  }else{
+    Index *pPk = sqlite3PrimaryKeyIndex(pTab);
+    if( pPk->nKeyCol==1 ){
+      const char *zName = pTab->aCol[pPk->aiColumn[0]].zName;
+      pLhs = sqlite3Expr(db, TK_ID, zName);
+      pEList = sqlite3ExprListAppend(pParse, 0, sqlite3Expr(db, TK_ID, zName));
+    }else{
+      int i;
+      for(i=0; i<pPk->nKeyCol; i++){
+        Expr *p = sqlite3Expr(db, TK_ID, pTab->aCol[pPk->aiColumn[i]].zName);
+        pEList = sqlite3ExprListAppend(pParse, pEList, p);
+
+      }
+      pLhs = sqlite3PExpr(pParse, TK_VECTOR, 0, 0, 0);
+      if( pLhs ){
+        pLhs->x.pList = sqlite3ExprListDup(db, pEList, 0);
+      }
+    }
+  }
 
   /* duplicate the FROM clause as it is needed by both the DELETE/UPDATE tree
   ** and the SELECT subtree. */
+  pSrc->a[0].pTab = 0;
   pSelectSrc = sqlite3SrcListDup(pParse->db, pSrc, 0);
-  if( pSelectSrc == 0 ) {
-    sqlite3ExprListDelete(pParse->db, pEList);
-    goto limit_where_cleanup;
-  }
+  pSrc->a[0].pTab = pTab;
+  pSrc->a[0].pIBIndex = 0;
 
   /* generate the SELECT expression tree. */
-  pSelect = sqlite3SelectNew(pParse,pEList,pSelectSrc,pWhere,0,0,
-                             pOrderBy,0,pLimit,pOffset);
-  if( pSelect == 0 ) return 0;
+  pSelect = sqlite3SelectNew(pParse, pEList, pSelectSrc, pWhere, 0, 0,
+                             pOrderBy,0,pLimit,pOffset
+  );
 
   /* now generate the new WHERE rowid IN clause for the DELETE/UDPATE */
-  pWhereRowid = sqlite3PExpr(pParse, TK_ROW, 0, 0, 0);
-  pInClause = pWhereRowid ? sqlite3PExpr(pParse, TK_IN, pWhereRowid, 0, 0) : 0;
+  pInClause = sqlite3PExpr(pParse, TK_IN, pLhs, 0, 0);
   sqlite3PExprAddSelect(pParse, pInClause, pSelect);
   return pInClause;
-
-limit_where_cleanup:
-  sqlite3ExprDelete(pParse->db, pWhere);
-  sqlite3ExprListDelete(pParse->db, pOrderBy);
-  sqlite3ExprDelete(pParse->db, pLimit);
-  sqlite3ExprDelete(pParse->db, pOffset);
-  return 0;
 }
 #endif /* defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) */
        /*      && !defined(SQLITE_OMIT_SUBQUERY) */
@@ -217,7 +237,10 @@ limit_where_cleanup:
 void sqlite3DeleteFrom(
   Parse *pParse,         /* The parser context */
   SrcList *pTabList,     /* The table from which we should delete things */
-  Expr *pWhere           /* The WHERE clause.  May be null */
+  Expr *pWhere,          /* The WHERE clause.  May be null */
+  ExprList *pOrderBy,    /* ORDER BY clause. May be null */
+  Expr *pLimit,          /* LIMIT clause. May be null */
+  Expr *pOffset          /* OFFSET clause. May be null */
 ){
   Vdbe *v;               /* The virtual database engine */
   Table *pTab;           /* The table from which records will be deleted */
@@ -286,6 +309,16 @@ void sqlite3DeleteFrom(
 # define isView 0
 #endif
 
+#ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
+  if( !isView ){
+    pWhere = sqlite3LimitWhere(
+        pParse, pTabList, pWhere, pOrderBy, pLimit, pOffset, "DELETE"
+    );
+    pOrderBy = 0;
+    pLimit = pOffset = 0;
+  }
+#endif
+
   /* If pTab is really a view, make sure it has been initialized.
   */
   if( sqlite3ViewGetColumnNames(pParse, pTab) ){
@@ -333,8 +366,12 @@ void sqlite3DeleteFrom(
   */
 #if !defined(SQLITE_OMIT_VIEW) && !defined(SQLITE_OMIT_TRIGGER)
   if( isView ){
-    sqlite3MaterializeView(pParse, pTab, pWhere, iTabCur);
+    sqlite3MaterializeView(pParse, pTab,
+        pWhere, pOrderBy, pLimit, pOffset, iTabCur
+    );
     iDataCur = iIdxCur = iTabCur;
+    pOrderBy = 0;
+    pLimit = pOffset = 0;
   }
 #endif
 
@@ -580,6 +617,11 @@ delete_from_cleanup:
   sqlite3AuthContextPop(&sContext);
   sqlite3SrcListDelete(db, pTabList);
   sqlite3ExprDelete(db, pWhere);
+#if defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) 
+  sqlite3ExprListDelete(db, pOrderBy);
+  sqlite3ExprDelete(db, pLimit);
+  sqlite3ExprDelete(db, pOffset);
+#endif
   sqlite3DbFree(db, aToOpen);
   return;
 }

--- a/sqlite/delete.c
+++ b/sqlite/delete.c
@@ -157,6 +157,7 @@ Expr *sqlite3LimitWhere(
   if( pOrderBy && pLimit==0 ) {
     sqlite3ErrorMsg(pParse, "ORDER BY without LIMIT on %s", zStmtType);
 limit_where_cleanup:
+    sqlite3ExprDelete(pParse->db, pWhere);
     sqlite3ExprListDelete(pParse->db, pOrderBy);
     sqlite3ExprDelete(pParse->db, pLimit);
     sqlite3ExprDelete(pParse->db, pOffset);

--- a/sqlite/fkey.c
+++ b/sqlite/fkey.c
@@ -723,7 +723,7 @@ void sqlite3FkDropTable(Parse *pParse, SrcList *pName, Table *pTab){
     }
 
     pParse->disableTriggers = 1;
-    sqlite3DeleteFrom(pParse, sqlite3SrcListDup(db, pName, 0), 0);
+    sqlite3DeleteFrom(pParse, sqlite3SrcListDup(db, pName, 0), 0, 0, 0, 0);
     pParse->disableTriggers = 0;
 
     /* If the DELETE has generated immediate foreign key constraint 

--- a/sqlite/parse.y
+++ b/sqlite/parse.y
@@ -798,9 +798,8 @@ cmd ::= with(C) DELETE FROM fullname(X) indexed_opt(I) where_opt(W)
         orderby_opt(O) limit_opt(L). {
   sqlite3WithPush(pParse, C, 1);
   sqlite3SrcListIndexedBy(pParse, X, &I);
-  W.pExpr = sqlite3LimitWhere(pParse, X, W.pExpr, O, L.pLimit, L.pOffset, "DELETE");
   sqlite3FingerprintDelete(pParse->db, X, W.pExpr);
-  sqlite3DeleteFrom(pParse,X,W.pExpr);
+  sqlite3DeleteFrom(pParse,X,W.pExpr,O,L.pLimit,L.pOffset);
 }
 %endif
 %ifndef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
@@ -808,7 +807,7 @@ cmd ::= with(C) DELETE FROM fullname(X) indexed_opt(I) where_opt(W). {
   sqlite3WithPush(pParse, C, 1);
   sqlite3SrcListIndexedBy(pParse, X, &I);
   sqlite3FingerprintDelete(pParse->db, X, W.pExpr);
-  sqlite3DeleteFrom(pParse,X,W.pExpr);
+  sqlite3DeleteFrom(pParse,X,W.pExpr,0,0,0);
 }
 %endif
 
@@ -828,7 +827,7 @@ cmd ::= with(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
   sqlite3ExprListCheckLength(pParse,Y,"set list"); 
   W.pExpr = sqlite3LimitWhere(pParse, X, W.pExpr, O, L.pLimit, L.pOffset, "UPDATE");
   sqlite3FingerprintUpdate(pParse->db, X, Y, W.pExpr, R);
-  sqlite3Update(pParse,X,Y,W.pExpr,R);
+  sqlite3Update(pParse,X,Y,W.pExpr,R,0,0,0);
 }
 %endif
 %ifndef SQLITE_ENABLE_UPDATE_DELETE_LIMIT

--- a/sqlite/parse.y
+++ b/sqlite/parse.y
@@ -825,9 +825,8 @@ cmd ::= with(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
   sqlite3WithPush(pParse, C, 1);
   sqlite3SrcListIndexedBy(pParse, X, &I);
   sqlite3ExprListCheckLength(pParse,Y,"set list"); 
-  W.pExpr = sqlite3LimitWhere(pParse, X, W.pExpr, O, L.pLimit, L.pOffset, "UPDATE");
   sqlite3FingerprintUpdate(pParse->db, X, Y, W.pExpr, R);
-  sqlite3Update(pParse,X,Y,W.pExpr,R,0,0,0);
+  sqlite3Update(pParse,X,Y,W.pExpr,R,O,L.pLimit,L.pOffset);
 }
 %endif
 %ifndef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
@@ -837,7 +836,7 @@ cmd ::= with(C) UPDATE orconf(R) fullname(X) indexed_opt(I) SET setlist(Y)
   sqlite3SrcListIndexedBy(pParse, X, &I);
   sqlite3ExprListCheckLength(pParse,Y,"set list"); 
   sqlite3FingerprintUpdate(pParse->db, X, Y, W.pExpr, R);
-  sqlite3Update(pParse,X,Y,W.pExpr,R);
+  sqlite3Update(pParse,X,Y,W.pExpr,R,0,0,0);
 }
 %endif
 
@@ -1323,7 +1322,6 @@ nexprlist(A) ::= expr(Y).
 paren_exprlist(A) ::= .   {A = 0;}
 paren_exprlist(A) ::= LP exprlist(X) RP.  {A = X;}
 %endif SQLITE_OMIT_SUBQUERY
-
 
 ///////////////////////////// The CREATE INDEX command ///////////////////////
 //

--- a/sqlite/resolve.c
+++ b/sqlite/resolve.c
@@ -629,6 +629,7 @@ static int resolveExprStep(Walker *pWalker, Expr *pExpr){
       struct SrcList_item *pItem;
       assert( pSrcList && pSrcList->nSrc==1 );
       pItem = pSrcList->a; 
+      assert( HasRowid(pItem->pTab) && pItem->pTab->pSelect==0);
       pExpr->op = TK_COLUMN;
       pExpr->pTab = pItem->pTab;
       pExpr->iTable = pItem->iCursor;

--- a/sqlite/sqliteInt.h
+++ b/sqlite/sqliteInt.h
@@ -3782,8 +3782,8 @@ void sqlite3OpenTable(Parse*, int iCur, int iDb, Table*, int);
 #if defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) && !defined(SQLITE_OMIT_SUBQUERY)
 Expr *sqlite3LimitWhere(Parse*,SrcList*,Expr*,ExprList*,Expr*,Expr*,char*);
 #endif
-void sqlite3DeleteFrom(Parse*, SrcList*, Expr*);
-void sqlite3Update(Parse*, SrcList*, ExprList*, Expr*, int);
+void sqlite3DeleteFrom(Parse*, SrcList*, Expr*, ExprList*, Expr*, Expr*);
+void sqlite3Update(Parse*, SrcList*, ExprList*,Expr*,int,ExprList*,Expr*,Expr*);
 WhereInfo *sqlite3WhereBegin(Parse*,SrcList*,Expr*,ExprList*,ExprList*,u16,int);
 void sqlite3WhereEnd(WhereInfo*);
 LogEst sqlite3WhereOutputRowCount(WhereInfo*);
@@ -3906,7 +3906,7 @@ int sqlite3SafetyCheckSickOrOk(sqlite3*);
 void sqlite3ChangeCookie(Parse*, int);
 
 #if !defined(SQLITE_OMIT_VIEW) && !defined(SQLITE_OMIT_TRIGGER)
-void sqlite3MaterializeView(Parse*, Table*, Expr*, int);
+void sqlite3MaterializeView(Parse*, Table*, Expr*, ExprList*,Expr*,Expr*,int);
 #endif
 
 #ifndef SQLITE_OMIT_TRIGGER

--- a/sqlite/trigger.c
+++ b/sqlite/trigger.c
@@ -713,7 +713,7 @@ static int codeTriggerProgram(
           targetSrcList(pParse, pStep),
           sqlite3ExprListDup(db, pStep->pExprList, 0), 
           sqlite3ExprDup(db, pStep->pWhere, 0), 
-          pParse->eOrconf
+          pParse->eOrconf, 0, 0, 0
         );
         break;
       }
@@ -729,7 +729,7 @@ static int codeTriggerProgram(
       case TK_DELETE: {
         sqlite3DeleteFrom(pParse, 
           targetSrcList(pParse, pStep),
-          sqlite3ExprDup(db, pStep->pWhere, 0)
+          sqlite3ExprDup(db, pStep->pWhere, 0), 0, 0, 0
         );
         break;
       }

--- a/sqlite/update.c
+++ b/sqlite/update.c
@@ -95,7 +95,10 @@ void sqlite3Update(
   SrcList *pTabList,     /* The table in which we should change things */
   ExprList *pChanges,    /* Things to be changed */
   Expr *pWhere,          /* The WHERE clause.  May be null */
-  int onError            /* How to handle constraint errors */
+  int onError,           /* How to handle constraint errors */
+  ExprList *pOrderBy,    /* ORDER BY clause. May be null */
+  Expr *pLimit,          /* LIMIT clause. May be null */
+  Expr *pOffset          /* OFFSET clause. May be null */
 ){
   int i, j;              /* Loop counters */
   Table *pTab;           /* The table to be updated */
@@ -173,6 +176,16 @@ void sqlite3Update(
 #ifdef SQLITE_OMIT_VIEW
 # undef isView
 # define isView 0
+#endif
+
+#ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
+  if( !isView ){
+    pWhere = sqlite3LimitWhere(
+        pParse, pTabList, pWhere, pOrderBy, pLimit, pOffset, "UPDATE"
+    );
+    pOrderBy = 0;
+    pLimit = pOffset = 0;
+  }
 #endif
 
   if( sqlite3ViewGetColumnNames(pParse, pTab) ){
@@ -345,7 +358,11 @@ void sqlite3Update(
   */
 #if !defined(SQLITE_OMIT_VIEW) && !defined(SQLITE_OMIT_TRIGGER)
   if( isView ){
-    sqlite3MaterializeView(pParse, pTab, pWhere, iDataCur);
+    sqlite3MaterializeView(pParse, pTab,
+        pWhere, pOrderBy, pLimit, pOffset, iDataCur
+    );
+    pOrderBy = 0;
+    pLimit = pOffset = 0;
   }
 #endif
 
@@ -722,6 +739,11 @@ update_cleanup:
   sqlite3SrcListDelete(db, pTabList);
   sqlite3ExprListDelete(db, pChanges);
   sqlite3ExprDelete(db, pWhere);
+#if defined(SQLITE_ENABLE_UPDATE_DELETE_LIMIT) 
+  sqlite3ExprListDelete(db, pOrderBy);
+  sqlite3ExprDelete(db, pLimit);
+  sqlite3ExprDelete(db, pOffset);
+#endif
   return;
 }
 /* Make sure "isView" and other macros defined above are undefined. Otherwise

--- a/tests/simple_timepart.test/runit
+++ b/tests/simple_timepart.test/runit
@@ -90,7 +90,7 @@ for run in 1 2 3 4 5; do
    while (( $row != 100 )) ; do
       let a=row%mod
       echo cdb2sql ${CDB2_OPTIONS} $dbname default "update ${VIEW1} set b=\"${blob_updates[${run}]}\" where a % ${mod} == ${a}" >> $OUT
-      cdb2sql ${CDB2_OPTIONS} $dbname default "update ${VIEW1} set b=\"${blob_updates[${run}]}\" where a % ${mod} == ${a}" >> $OUT
+      cdb2sql ${CDB2_OPTIONS} $dbname default "update ${VIEW1} set b=\"${blob_updates[${run}]}\" where a % ${mod} == ${a} limit 10000" >> $OUT
       #cdb2sql ${CDB2_OPTIONS} $dbname default "update ${VIEW1} set b='Moar rows' where a % ${mod} == ${a}" >> $OUT
       if (( $? != 0 )) ; then
          echo "FAILURE"
@@ -116,7 +116,7 @@ for run in 1 2 3 4 5; do
    while (( $row != 2 )) ; do
       let a=row%mod
       echo cdb2sql ${CDB2_OPTIONS} $dbname default "delete from ${VIEW1} where a % ${mod} == ${a}" >> $OUT
-      cdb2sql ${CDB2_OPTIONS} $dbname default "delete from ${VIEW1} where a % ${mod} == ${a}" >> $OUT
+      cdb2sql ${CDB2_OPTIONS} $dbname default "delete from ${VIEW1} where a % ${mod} == ${a} limit 10000" >> $OUT
       if (( $? != 0 )) ; then
          echo "FAILURE"
          exit 1

--- a/tests/yast.test/wherelimit.test
+++ b/tests/yast.test/wherelimit.test
@@ -38,6 +38,8 @@ proc create_test_data {size} {
 
 ifcapable {update_delete_limit} {
 
+  execsql { CREATE TABLE t1(x, y) }
+
   # check syntax error support
   do_test wherelimit-0.1 {
     catchsql {DELETE FROM t1 ORDER BY x}
@@ -48,6 +50,8 @@ ifcapable {update_delete_limit} {
   do_test wherelimit-0.3 {
     catchsql {UPDATE t1 SET y=1 WHERE x=1 ORDER BY x}
   } {1 {ORDER BY without LIMIT on UPDATE}}
+
+  execsql { DROP TABLE t1 }
 
   # no AS on table sources
   do_test wherelimit-0.4 {


### PR DESCRIPTION
Delete and Update LIMIT N do not work in time partitions.  This is due to a deficiency in sqlite, for which this ticket (http://sqlite.org/src/tktview/d4beea163) was raised (in general, views and tables without rowid generate plans that fail to actually delete/update rows when limit option is present).