### PR TITLE
fix live_sc datacopy indexes

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1622,6 +1622,8 @@ struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
                     ii, tblname);
             cleanup_newdb(tbl);
             return NULL;
+        } else if (tbl->ix_datacopy[ii]) {
+            tbl->has_datacopy_ix = 1;
         }
 
         tbl->ix_nullsallowed[ii] = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -710,6 +710,7 @@ struct dbtable {
     signed char ix_nullsallowed[MAXINDEX];
     signed char ix_disabled[MAXINDEX];
     struct ireq *iq; /* iq used at sc time */
+    int has_datacopy_ix; /* set to 1 if we have datacopy indexes */
     int ix_partial;  /* set to 1 if we have partial indexes */
     int ix_expr;     /* set to 1 if we have indexes on expressions */
     int ix_blob;     /* set to 1 if blobs are involved in indexes */

--- a/db/record.c
+++ b/db/record.c
@@ -2362,7 +2362,8 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         sc_new = NULL;
     }
 
-    if ((gbl_partial_indexes && iq->usedb->ix_partial && del_keys == -1ULL) ||
+    if (iq->usedb->has_datacopy_ix ||
+        (gbl_partial_indexes && iq->usedb->ix_partial && del_keys == -1ULL) ||
         (gbl_expressions_indexes && iq->usedb->ix_expr && !iq->idxDelete)) {
         /* save new blobs being deleted */
         sc_old = malloc(iq->usedb->lrl);
@@ -2670,7 +2671,8 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
 
     /*fprintf(stderr, "DEL NEW GENID 0x%llx\n", ngenid);*/
 
-    if ((gbl_partial_indexes && iq->usedb->ix_partial && del_keys == -1ULL) ||
+    if (iq->usedb->has_datacopy_ix ||
+        (gbl_partial_indexes && iq->usedb->ix_partial && del_keys == -1ULL) ||
         (gbl_expressions_indexes && iq->usedb->ix_expr && !iq->idxDelete)) {
         sc_old = malloc(iq->usedb->lrl);
         if (sc_old == NULL) {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -671,6 +671,8 @@ static inline int verify_sqlresponse_error_code(int error_code,
     case CDB2__ERROR_CODE__DUPLICATE:
     case CDB2__ERROR_CODE__TZNAME_FAIL:
     case CDB2__ERROR_CODE__CHANGENODE:
+    case CDB2__ERROR_CODE__NOTSERIAL:
+    case CDB2__ERROR_CODE__SCHEMACHANGE:
     case CDB2__ERROR_CODE__UNKNOWN:
         break;
 

--- a/db/tag.c
+++ b/db/tag.c
@@ -7494,6 +7494,17 @@ int create_key_from_ondisk_sch_blobs(
             }
             rc = -1; /* callers like -1 */
         } else if (tail) {
+            if ((strncmp(fromtag, ".ONDISK", 7) == 0 &&
+                 strncmp(totag, ".NEW.", 5) == 0) ||
+                (strncmp(fromtag, ".NEW.", 5) == 0 &&
+                 strncmp(totag, ".NEW.", 5) != 0)) {
+                /* Abort if new index uses old ondisk datacopy;
+                 * or if old index uses new ondisk datacopy. */
+                logmsg(LOGMSG_FATAL,
+                       "%s: BUG! BUG! Converting from tag %s to %s\n", __func__,
+                       fromtag, totag);
+                abort();
+            }
             *tail = (char *)inbuf;
             *taillen = inbuflen;
         }

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -45,6 +45,7 @@ enum CDB2_ErrorCode {
 
     NOMASTER                = -101;
     NOTSERIAL               =  230;
+    SCHEMACHANGE            =  240;
     UNTAGGED_DATABASE       = -102;
     CONSTRAINTS             = -103;
     DEADLOCK                =  203;

--- a/tests/sc_datacopy.test/Makefile
+++ b/tests/sc_datacopy.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_datacopy.test/lrl.options
+++ b/tests/sc_datacopy.test/lrl.options
@@ -1,0 +1,2 @@
+maxosqltransfer 500000
+logmsg level info

--- a/tests/sc_datacopy.test/runit
+++ b/tests/sc_datacopy.test/runit
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+maxt1=100000
+
+wrpid=-1
+
+# Grab my database name.
+dbnm=$1
+
+# Verify that the user at least supplied a dbname
+if [[ -z "$dbnm" ]]; then
+
+    echo "Testcase requires <dbname> argument."
+    exit 1
+
+fi
+
+function errquit
+{
+    typeset msg=$1
+
+    echo "ERROR: $msg"
+    echo "Testcase failed."
+
+    [[ $wrpid != "-1" ]] && kill -9 $wrpid >/dev/null 2>&1
+
+    exit 1
+}
+
+function do_verify
+{
+    typeset cnt=0
+
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify.out
+    if ! grep succeeded verify.out > /dev/null ; then
+        errquit "Verify failed. see verify.out"
+    fi
+}
+
+function update_t1
+{
+    typeset id
+    typeset out
+
+    id=$(( RANDOM % (maxt1) ))
+    cdb2sql ${CDB2_OPTIONS} $dbnm "update t1 set time = `echo $(($(date +%s%N)/1000000))` where id = $id" >> update.log
+    if [[ $? != 0 ]]; then
+        errquit "update failed, see update.log"
+    fi
+}
+
+function writer
+{
+    while true; do
+        update_t1
+    done
+}
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+drop table if exists t1
+create table t1 {
+    tag ondisk {
+        longlong id
+        u_longlong time
+    }
+    keys {
+        datacopy "ID" = id
+    }
+}$$
+EOF
+
+cdb2sql ${CDB2_OPTIONS} $dbnm "WITH RECURSIVE cnt(x) AS (SELECT 1 UNION ALL SELECT x+1 FROM cnt LIMIT $maxt1) insert into t1(id, time) SELECT x, `echo $(($(date +%s%N)/1000000))` FROM cnt"
+if [[ $? != 0 ]]; then
+    echo "initial insert failed"
+    exit 1
+fi
+
+# Trap to errquit if the user presses Ctrl-C
+trap "errquit \"Cancelling test on INT EXIT\"" INT EXIT
+
+writer &
+wrpid=$!
+echo "Background writer pid: $wrpid"
+
+echo "Starting schemachange"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "PUT SCHEMACHANGE COMMITSLEEP 3"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "PUT SCHEMACHANGE CONVERTSLEEP 3"
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+alter table t1 {
+    tag ondisk {
+        longlong id
+        longlong time
+    }
+    keys {
+        datacopy "ID" = id
+    }
+}$$
+EOF
+if [[ $? != 0 ]]; then
+    errquit "schemachange 1 failed"
+fi
+do_verify
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+alter table t1 {
+    tag ondisk {
+        longlong id
+        double time
+    }
+    keys {
+        datacopy "ID" = id
+    }
+}$$
+EOF
+if [[ $? != 0 ]]; then
+    errquit "schemachange 2 failed"
+fi
+do_verify
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+alter table t1 {
+    tag ondisk {
+        longlong id
+        u_longlong time
+    }
+    keys {
+        datacopy "ID" = (longlong)"id*1"
+    }
+}$$
+EOF
+if [[ $? != 0 ]]; then
+    errquit "schemachange 3 failed"
+fi
+do_verify
+
+# Remove trap-command.
+trap - INT EXIT
+
+[[ $wrpid != "-1" ]] && kill -9 $wrpid >/dev/null 2>&1
+
+echo "Testcase passed."
+exit 0


### PR DESCRIPTION
convert ondisk record to ".NEW.ONDISK" before calling into live_sc index add code if table has datacopy index.