### PR TITLE
fix cost and remote sql naming

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -5986,8 +5986,8 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
             strncpy0(fnd.lcl_tbl_name, pCur->fdbc->tblname(pCur),
                      sizeof(fnd.lcl_tbl_name));
         } else if (pCur->db) {
-                strncpy0(fnd.lcl_tbl_name, pCur->db->tablename,
-                        sizeof(fnd.lcl_tbl_name));
+            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename,
+                     sizeof(fnd.lcl_tbl_name));
         }
         fnd.ix = pCur->ixnum;
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -5983,19 +5983,22 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
             if (!pCur->fdbc)
                 goto skip; /* failed during cursor creation */
             strncpy0(fnd.rmt_db, pCur->fdbc->dbname(pCur), sizeof(fnd.rmt_db));
-        }
-        if (pCur->db)
-            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename,
+            strncpy0(fnd.lcl_tbl_name, pCur->fdbc->tblname(pCur),
                      sizeof(fnd.lcl_tbl_name));
+        } else if (pCur->db) {
+                strncpy0(fnd.lcl_tbl_name, pCur->db->tablename,
+                        sizeof(fnd.lcl_tbl_name));
+        }
         fnd.ix = pCur->ixnum;
 
         if ((qc = hash_find(thd->query_hash, &fnd)) == NULL) {
             qc = calloc(sizeof(struct query_path_component), 1);
             if (pCur->bt && pCur->bt->is_remote) {
-                strncpy0(fnd.rmt_db, pCur->fdbc->dbname(pCur),
-                         sizeof(fnd.rmt_db));
-            }
-            if (pCur->db) {
+                strncpy0(qc->rmt_db, pCur->fdbc->dbname(pCur),
+                         sizeof(qc->rmt_db));
+                strncpy0(qc->lcl_tbl_name, pCur->fdbc->tblname(pCur),
+                         sizeof(qc->lcl_tbl_name));
+            } else if (pCur->db) {
                 strncpy0(qc->lcl_tbl_name, pCur->db->tablename,
                          sizeof(qc->lcl_tbl_name));
             }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1533,6 +1533,16 @@ void sql_dump_hist_statements(void)
     pthread_mutex_unlock(&gbl_sql_lock);
 }
 
+static void clear_cost(struct sql_thread *thd)
+{
+    if (thd) {
+        hash_clear(thd->query_hash);
+        thd->cost = 0;
+        thd->had_tablescans = 0;
+        thd->had_temptables = 0;
+    }
+}
+
 /* Save copy of sql statement and performance data.  If any other code
    should run after a sql statement is completed it should end up here. */
 static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
@@ -1633,10 +1643,8 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
         free(qc);
         qc = listc_rtl(&thd->query_stats);
     }
-    hash_clear(thd->query_hash);
-    thd->cost = 0;
-    thd->had_tablescans = 0;
-    thd->had_temptables = 0;
+
+    clear_cost(thd);
 }
 
 void sql_set_sqlengine_state(struct sqlclntstate *clnt, char *file, int line,
@@ -5634,6 +5642,9 @@ static int handle_sqlite_requests(struct sqlthdstate *thd,
     rec.sql = clnt->sql;
 
     do {
+        /* clean old stats */
+        clear_cost(thd->sqlthd);
+        
         /* get an sqlite engine */
         rc = get_prepared_bound_stmt(thd, clnt, &rec, &err);
         if (rc == SQLITE_SCHEMA_REMOTE)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5644,7 +5644,7 @@ static int handle_sqlite_requests(struct sqlthdstate *thd,
     do {
         /* clean old stats */
         clear_cost(thd->sqlthd);
-        
+
         /* get an sqlite engine */
         rc = get_prepared_bound_stmt(thd, clnt, &rec, &err);
         if (rc == SQLITE_SCHEMA_REMOTE)

--- a/tests/sc_remsql.test/output.log
+++ b/tests/sc_remsql.test/output.log
@@ -34,6 +34,11 @@ Table "t" Rootp 1073741826 Remrootp 2 Version=0
 (id=23, b1=x'58')
 (id=123, b1=x'59')
 (id=11115, b1=x'60')
+Cost: 0.00 NRows: 10
+    index 0 on table DBNAME.t finds 1
+    table DBNAME.sqlite_stat1 finds 1
+    table DBNAME.sqlite_stat4 finds 1
+    index 0 on table DBNAME.t finds 1 next/prev 9
 Table "sqlite_stat1" Rootp 1073741828 Remrootp 4 Version=0
 Table "sqlite_stat4" Rootp 1073741829 Remrootp 5 Version=0
 Index "$ID_52596C31" for table "t" Rootp 1073741831 Remrootp 3 Version=1

--- a/tests/sc_remsql.test/test_sc.sh
+++ b/tests/sc_remsql.test/test_sc.sh
@@ -42,16 +42,18 @@ sleep 5
 cdb2sql --cdb2cfg ${a_remcdb2config} $a_remdbname default 'select table_version("t")' >> $output
 
 # retrieve data
-cdb2sql ${CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t order by id" >> $output 2>&1
+cdb2sql -cost ${CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t order by id" >> $output 2>&1
 
 # get the new version V2'
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
 echo cdb2sql --tabs $a_cdb2config $a_dbname default "exec procedure sys.cmd.send(\"fdb info db\")" 
 cdb2sql --tabs $a_cdb2config $a_dbname default "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
 
+sed "s/DBNAME/${a_remdbname}/g" output.log > output.log.actual
+
 # validate results 
 testcase_output=$(cat $output)
-expected_output=$(cat output.log)
+expected_output=$(cat output.log.actual)
 if [[ "$testcase_output" != "$expected_output" ]]; then
 
    # print message 
@@ -67,28 +69,5 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
    # quit
    exit 1
 fi
-
-#TEST2 test conflicts between V3 and V2 (see README)
-#gonna simulate this by dropping the table manually
-
-
-# get the version V1 
-
-# get the version V2
-
-# schema change the remote V1->V1'
-
-# get the new version V1'
-
-# get the version V2
-
-# drop the version V2 cache
-
-# retrieve the data
-
-# get the new version V2'
-
-# validate results 
-
 
 echo "Testcase passed."


### PR DESCRIPTION
Currently reprepared statements miscount cost.
Also, remote tables show as temporary indexes. 