### PR TITLE
Fix issue where pid and machine are zero for all but the first thread

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -80,8 +80,8 @@ static int cdb2_set_ssl_sessions(cdb2_hndl_tp *hndl,
 
 static int allow_pmux_route = 0;
 
-static __thread int _PID;
-static __thread int _MACHINE_ID;
+static int _PID;
+static int _MACHINE_ID;
 
 #define DB_TZNAME_DEFAULT "America/New_York"
 


### PR DESCRIPTION
Change was introduced in PR #474
Intention was to assign PID and machine only once.
Defect is that they should be global variables,
rather than thread specific.