### PR TITLE
introduce small delay when doing make for all tests

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -69,6 +69,8 @@ basicops_nokey:
 
 basicops: basicops_nokey
 	$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" SKIPSSL="${SKIPSSL}" tools/keygen.sh)
+	$(shell TOTAL="${TOTAL}" SKIPSSL="${SKIPSSL}" tools/smalldelay.sh)
+
 
 .PHONY: tools
 

--- a/tests/tools/smalldelay.sh
+++ b/tests/tools/smalldelay.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+if [ "$TOTAL" -gt "100" ] && [ "${SKIPSSL}" = "1" ]; then 
+    for i in `seq 1 80` ; do 
+        echo -n "."  1>&2; 
+        sleep 0.02 ; 
+    done ; 
+    echo
+fi


### PR DESCRIPTION
print out .... with a small delay when doing make for > 100 tests
to have time to kill make in case make was run by mistake on
the wrong directory.