### PR TITLE
comdb2ar and cdb2api fix: correctly check return code from pmux

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1485,7 +1485,7 @@ static int cdb2portmux_route(const char *remote_host, char *app, char *service,
     sbuf2flush(ss);
     res[0] = 0;
     sbuf2gets(res, sizeof(res), ss);
-    if (res[0] == 0) {
+    if (res[0] != '0') {
         sbuf2close(ss);
         return -1;
     }

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -226,12 +226,12 @@ for node in $cluster ; do
 
     port=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_port()"`
     echo "connect to db with direct port info"
-    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @$node:port=$port "select comdb2_dbname()"`
+    res=`cdb2sql --tabs $dbnm @$node:port=$port "select comdb2_dbname()"`
     assertres $res $dbnm
 
     echo "connect with wrong db name"
     set +e
-    cdb2sql --tabs ${CDB2_OPTIONS} badname @$node:port=$port "select comdb2_dbname()" &> out.txt
+    cdb2sql --tabs badname @$node:port=$port "select comdb2_dbname()" &> out.txt
     echo "[select comdb2_dbname()] failed with rc -1 DB name mismatch query:badname actual:$dbnm" > out.exp
     rc=$?
     set -e

--- a/tests/setup
+++ b/tests/setup
@@ -154,6 +154,7 @@ fi
 
 # Configure client SSL
 echo "comdb2_config:ssl_cert_path=$TESTDIR" >>$CDB2_CONFIG
+echo "comdb2_config:allow_pmux_route:true" >> $CDB2_CONFIG
 
 myhostname=`hostname`
 set +e

--- a/tools/comdb2ar/appsock.cpp
+++ b/tools/comdb2ar/appsock.cpp
@@ -271,7 +271,7 @@ static int cdb2portmux_route(const char *remote_host, const char *app,
     sbuf2flush(ss);
     res[0] = 0;
     sbuf2gets(res, sizeof(res), ss);
-    if (res[0] == 0) {
+    if (res[0] != '0') {
         sbuf2close(ss);
         return -1;
     }


### PR DESCRIPTION
currently clustered tests are not working because copycomdb2 which
relies on comdb2ar fails--failure is from return code from portmux:
ar requests rte and portmux returns -1 which means failure but
ar does not treat it as such but rather continues operating on the
fd which is connection to portmux and requests to hold logs on that
fd fail. By checking for return code, ar will proceed correctly
(-1 would mean can't forward fd thus the db is most likely down).