### PR TITLE
fix issue with lingering processes from first time running pmux

### DIFF
--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -40,17 +40,14 @@ function call_setup {
          warn_long_setup
          rc=$?
     else
-        timeout ${SETUP_TIMEOUT} ${TESTSROOTDIR}/setup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.setup | cut -c11- | grep "^!" )
-        rc=$?
-    fi
-    glist=`pgrep gawk -a | grep ${DBNAME} | cut -f1 -d' ' | xargs echo`
-    if [ "x$glist" != "x" ] ; then
-        kill -9 $glist
+        { timeout ${SETUP_TIMEOUT} ${TESTSROOTDIR}/setup 2>&1 || echo $?; } | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.setup | cut -c11- | grep "^!"
     fi
     sleep 0.1
-    if [[ $rc -ne 0 ]]; then
-        echo "!$TESTCASE: setup failed (rc=$rc)" >> ${TESTDIR}/test.log
-        echo "!$TESTCASE: setup failed (rc=$rc) see ${TESTDIR}/logs/${DBNAME}.setup"
+    #last line of .setup file will contain the error rc if any
+    ret=`tail -1 ${TESTDIR}/logs/${DBNAME}.setup | cut -c11-`
+    if [[ $ret != "setup successful" ]]; then
+        echo "!$TESTCASE: setup failed (rc=$ret)" >> ${TESTDIR}/test.log
+        echo "!$TESTCASE: setup failed (rc=$ret) see ${TESTDIR}/logs/${DBNAME}.setup"
         call_unsetup
         sleep 0.1
         exit 1
@@ -60,7 +57,7 @@ function call_setup {
 call_setup
 echo "!$TESTCASE: running with timeout ${TEST_TIMEOUT}"
 
-timeout ${TEST_TIMEOUT} ./runit ${DBNAME} 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' &> ${TESTDIR}/logs/${DBNAME}.testcase
+timeout ${TEST_TIMEOUT} ./runit ${DBNAME} 2>&1  | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' &> ${TESTDIR}/logs/${DBNAME}.testcase
 
 rc=${PIPESTATUS[0]}
 if [[ $rc -eq 0 ]]; then

--- a/tests/setup
+++ b/tests/setup
@@ -350,4 +350,4 @@ else
     done
 fi
 
-exit 0
+echo 'setup successful'


### PR DESCRIPTION
Currently when we run a test suite and pmux is not running but needs to be started, setup script will start pmux and runtestcase will prepend the time to the output of setup. Because of the way it does this prepending of time (to allow for rc of setup to propagate back to runtestcase), there are few processes left lingering (runtestcase, awk and tee) after the test is completed waiting for stdout of pmux and will linger until pmux is terminated. 
This patch changes the way the error propagates back to runtestcase thus fixing the issue with the lingering processes.