### PR TITLE
cdb2jdbc: Remove unused log4j dependency.

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -30,11 +30,6 @@ limitations under the License. -->
       <version>3.2.0</version>
     </dependency>
     <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
-    </dependency>
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>


### PR DESCRIPTION
cdb2jdbc uses java.util.logging.