### PR TITLE
fix timepart: reload table version on replicants

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -648,6 +648,7 @@ int views_handle_replicant_reload(const char *name)
             view = NULL;
             goto done;
         }
+        db->tableversion = table_version_select(db, NULL);
     }
 
 alter_struct:


### PR DESCRIPTION
  fix timepart: reload table version on replicants
This should fix sc_timepart and simple_timepart clustered tests