### PR TITLE
reqlog: diffstat interval is off by 1 second.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4332,7 +4332,7 @@ void *statthd(void *p)
 
         if (COMDB2_DIFFSTAT_REPORT() && !gbl_schema_change_in_progress) {
             thresh = reqlog_diffstat_thresh();
-            if ((thresh > 0) && (count > thresh)) {
+            if ((thresh > 0) && (count == thresh)) {
                 strbuf *logstr = strbuf_new();
                 diff_qtrap = nqtrap - last_report_nqtrap;
                 diff_fstrap = nfstrap - last_report_nfstrap;


### PR DESCRIPTION
#### What is the type of the change (bug fix, feature, documentation and etc.) ?

Bug fix.

#### What are the current behavior and expected behavior, if this is a bugfix?

Currently the system dumps stat diff to statreqs every `(diffstat + 1)` seconds. The frequency, however, should be every `diffstat` seconds.

#### What are the steps required to reproduce the bug, if this is a bugfix?

1. Make sure that the database has the minimal amount of activities to trigger a stat diff  (e.g., reading from/writing to a table) during the diffstat interval.

2. A stat diff will be printed every `(diffstat + 1)` seconds to the statreqs file. For example, with a diffstat of 60 seconds, 2 stat diff's were taken at 02:59:55 and 03:00:56 respectively:

```
01/06 02:59:55:   diff newsql 3 newsqlsteps 28 n_commit_time 3 ms n_cache_hits 24
01/06 02:59:55:   DIFF REQUEST STATS FOR DB 0 'sqlite_stat1'
01/06 02:59:55:   blockop              1
01/06 02:59:55:       BLOCK2_USE           1
01/06 02:59:55:       BLOCK2_TZ            1
01/06 02:59:55:       BLOCK2_SOCK_SQL      1
01/06 02:59:55:       BLOCK2_SEQV2         1
01/06 02:59:55:       OSQL_USEDB           1
01/06 02:59:55:       txns committed       1
01/06 02:59:55:   DIFF REQUEST STATS FOR DB 0 't'
01/06 02:59:55:       OSQL_INSREC          1
01/06 02:59:55:       OSQL_DONE_SNAP       1
01/06 02:59:55:       nsql                 3
01/06 02:59:55:   1 preads, 4096 bytes, avg time 0ms
01/06 02:59:55:   1 pwrites, 512 bytes, avg time 2ms
01/06 02:59:55:   LSN 62:22092474 diff 38811
01/06 03:00:56:   sqlwrops sosql snd 1 snd_failed 0 rcv 4 rcv_failed 0 rcv_redundant 0
01/06 03:00:56:   diff newsql 2 newsqlsteps 300034 n_commit_time 0 ms n_cache_hits 2936
01/06 03:00:56:   DIFF REQUEST STATS FOR DB 0 'sqlite_stat1'
01/06 03:00:56:   blockop              1
01/06 03:00:56:       BLOCK2_USE           1
01/06 03:00:56:       BLOCK2_TZ            1
01/06 03:00:56:       BLOCK2_SOCK_SQL      1
01/06 03:00:56:       BLOCK2_SEQV2         1
01/06 03:00:56:       OSQL_USEDB           1
01/06 03:00:56:       txns committed       1
01/06 03:00:56:   DIFF REQUEST STATS FOR DB 0 'employees'
01/06 03:00:56:       nsql                 1
01/06 03:00:56:   DIFF REQUEST STATS FOR DB 0 't'
01/06 03:00:56:       OSQL_INSREC          1
01/06 03:00:56:       OSQL_DONE_SNAP       1
01/06 03:00:56:       nsql                 1
01/06 03:00:56:   LSN 62:22093246 diff 772
```

  