### PR TITLE
reqlog: correctly print iovec structures.

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -222,7 +222,8 @@ static void flushdump(struct reqlogger *logger, struct output *out)
         niov++;
         if (out == default_out) {
             for (int i = 0; i < niov; i++)
-                logmsg(LOGMSG_USER, "%s", (char *)iov[i].iov_base);
+                logmsg(LOGMSG_USER, "%.*s", (int)iov[i].iov_len,
+                       (char *)iov[i].iov_base);
         } else {
             int dum = writev(out->fd, iov, niov);
         }


### PR DESCRIPTION
#### What is the type of the change (bug fix, feature, documentation and etc.) ?

Bug fix.

#### What are the current behavior and expected behavior, if this is a bugfix?

Currently when printing to stdout, the system may produce garbage output.

#### What are the steps required to reproduce the bug, if this is a bugfix?

1. Create a reqlog rule on `rows` from 0 to 100.

```SQL
exec procedure sys.cmd.send("reql rows 0..100")
```

2. Enable the rule.

```SQL
exec procedure sys.cmd.send("reql go")
```

3. Issue arbitrary queries and observe reqlog output. For instance, Issuing the following queries

```SQL
select 1
select 9999999999
```
may result in the following garbage output.
```
sql_request 0 msec from localhost rc 0
  (0) cdb2sql, queuetime took 0ms, sql=select 1, ncols=1, rowcount=1
  fingerprint=4c7c6b5a9eaf9712df7bc42458d566a91, ncols=1, rowcount=1
sql_request 0 msec from localhost rc 0
  (0) cdb2sql, queuetime took 0ms, sql=select 9999999999, ncols=1
  rowcount=1, fingerprint=4c7c6b5a9eaf9712df7bc42458d566a9ncols=1
```
