### PR TITLE
fix clustered test: analyze and pg_free_recovery

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1367,6 +1367,21 @@ int bdb_flush_up_to_lsn(bdb_state_type *bdb_state, unsigned file,
     return rc;
 }
 
+static int bdb_flush_cache(bdb_state_type *bdb_state)
+{
+
+    if (bdb_state->parent)
+        bdb_state = bdb_state->parent;
+
+    BDB_READLOCK("bdb_flush_cache");
+
+    bdb_state->dbenv->memp_sync(bdb_state->dbenv, NULL);
+
+    BDB_RELLOCK();
+
+    return 0;
+}
+
 static int bdb_flush_int(bdb_state_type *bdb_state, int *bdberr, int force)
 {
     int rc;
@@ -1381,15 +1396,19 @@ static int bdb_flush_int(bdb_state_type *bdb_state, int *bdberr, int force)
         return -1;
     }
 
-    start = time_epochms();
-    rc = ll_checkpoint(bdb_state, force);
-    if (rc != 0) {
-        logmsg(LOGMSG_ERROR, "txn_checkpoint err %d\n", rc);
-        *bdberr = BDBERR_MISC;
-        return -1;
+    if (bdb_state->repinfo->master_host != bdb_state->repinfo->myhost)
+        bdb_flush_cache(bdb_state);
+    else {
+        start = time_epochms();
+        rc = ll_checkpoint(bdb_state, force);
+        if (rc != 0) {
+            logmsg(LOGMSG_ERROR, "txn_checkpoint err %d\n", rc);
+            *bdberr = BDBERR_MISC;
+            return -1;
+        }
+        end = time_epochms();
+        ctrace("checkpoint took %dms\n", end - start);
     }
-    end = time_epochms();
-    ctrace("checkpoint took %dms\n", end - start);
 
     return 0;
 }
@@ -6607,24 +6626,6 @@ static int bdb_close_only_int(bdb_state_type *bdb_state, int *bdberr)
         }
 
     Pthread_mutex_unlock(&(parent->children_lock));
-
-    return 0;
-}
-
-int bdb_flush_cache(bdb_state_type *bdb_state)
-{
-
-    if (bdb_state->parent)
-        bdb_state = bdb_state->parent;
-
-    BDB_READLOCK("bdb_flush_cache");
-
-    logmsg(LOGMSG_DEBUG, "About to call %s, flushing the berkeleydb cache...",
-            __func__);
-    bdb_state->dbenv->memp_sync(bdb_state->dbenv, NULL);
-    logmsg(LOGMSG_DEBUG, "Done.\n");
-
-    BDB_RELLOCK();
 
     return 0;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -3335,20 +3335,6 @@ static void net_check_sc_ok(void *hndl, void *uptr, char *fromnode,
     net_ack_message(hndl, rc == 0 ? 0 : 1);
 }
 
-static void net_lua_reload(void *hndl, void *uptr, char *fromnode, int usertype,
-                           void *dtap, int dtalen)
-{
-    gbl_analyze_gen++;
-    net_ack_message(hndl, 0);
-}
-
-static void net_statistics_changed(void *hndl, void *uptr, char *fromnode,
-                                   int usertype, void *dtap, int dtalen)
-{
-    gbl_analyze_gen++;
-    net_ack_message(hndl, 0);
-}
-
 static void net_flush_all(void *hndl, void *uptr, char *fromnode, int usertype,
                           void *dtap, int dtalen, uint8_t is_tcp)
 {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3221,7 +3221,8 @@ void send_prepare_error(struct sqlclntstate *clnt, const char *errstr,
                         1 /*flush*/, __func__, __LINE__);
 }
 
-static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt)
+static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt,
+                          int analyze_gen)
 {
     // if analyze is running, don't reload
     extern volatile int analyze_running_flag;
@@ -3237,7 +3238,7 @@ static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt)
         got_curtran = 1;
     }
     if ((rc = sqlite3AnalysisLoad(thd->sqldb, 0)) == SQLITE_OK) {
-        thd->analyze_gen = gbl_analyze_gen;
+        thd->analyze_gen = analyze_gen;
     } else {
         logmsg(LOGMSG_ERROR, "%s sqlite3AnalysisLoad rc:%d\n", __func__, rc);
     }
@@ -3259,18 +3260,21 @@ static void delete_prepared_stmts(struct sqlthdstate *thd)
 // Call with schema_lk held and no_transaction == 1
 static int check_thd_gen(struct sqlthdstate *thd, struct sqlclntstate *clnt)
 {
+    /* cache analyze gen first because gbl_analyze_gen is NOT protected by
+     * schema_lk */
+    int cached_analyze_gen = gbl_analyze_gen;
     if (gbl_fdb_track)
         logmsg(LOGMSG_USER, "XXX: thd dbopen=%d vs %d thd analyze %d vs %d\n",
-                thd->dbopen_gen, gbl_dbopen_gen, thd->analyze_gen,
-                gbl_analyze_gen);
+               thd->dbopen_gen, gbl_dbopen_gen, thd->analyze_gen,
+               cached_analyze_gen);
 
     if (thd->dbopen_gen != gbl_dbopen_gen) {
         return SQLITE_SCHEMA;
     }
-    if (thd->analyze_gen != gbl_analyze_gen) {
+    if (thd->analyze_gen != cached_analyze_gen) {
         int ret;
         delete_prepared_stmts(thd);
-        ret = reload_analyze(thd, clnt);
+        ret = reload_analyze(thd, clnt, cached_analyze_gen);
         return ret;
     }
 
@@ -5845,6 +5849,9 @@ check_version:
         }
 
         if (!thd->sqldb) {
+            /* cache analyze gen first because gbl_analyze_gen is NOT protected
+             * by schema_lk */
+            thd->analyze_gen = gbl_analyze_gen;
             int rc = sqlite3_open_serial("db", &thd->sqldb, thd);
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR, "%s:sqlite3_open_serial failed %d\n", __func__,
@@ -5852,7 +5859,6 @@ check_version:
                 thd->sqldb = NULL;
             }
             thd->dbopen_gen = gbl_dbopen_gen;
-            thd->analyze_gen = gbl_analyze_gen;
         }
 
         get_copy_rootpages_nolock(thd->sqlthd);

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -23,6 +23,7 @@
 #include "sc_callbacks.h"
 #include "bbinc/cheapstack.h"
 #include "crc32c.h"
+#include "comdb2_atomic.h"
 
 pthread_rwlock_t schema_lk = PTHREAD_RWLOCK_INITIALIZER;
 pthread_mutex_t schema_change_in_progress_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -257,7 +258,7 @@ int reload_lua()
 
 int replicant_reload_analyze_stats()
 {
-    ++gbl_analyze_gen;
+    ATOMIC_ADD(gbl_analyze_gen, 1);
     logmsg(LOGMSG_DEBUG, "Replicant invalidating SQLite stats\n");
     return 0;
 }

--- a/tests/analyze.test/t10_01.sh
+++ b/tests/analyze.test/t10_01.sh
@@ -54,7 +54,6 @@ local function write()
     return 0
 end
 local function main(t)
-    db:exec("set transaction read committed")
     local rc1 = read()
     local rc2 = write()
     if rc1 ~= 0 then

--- a/tests/pg_free_recovery.test/lrl.options
+++ b/tests/pg_free_recovery.test/lrl.options
@@ -1,1 +1,3 @@
 poll_in_pgfree_recover on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0


### PR DESCRIPTION
- fix analyze cluster test
    - analyze doesnt have to get schema_lk, use ATOMIC_ADD on gbl_analyze_gen instead
    - call memp_sync on flush on replicants

- disable parallel rep for pg_free_recovery.test