### PR TITLE
Destroy durable lsn mutex in __dbenv_close instead of __dbenv_refresh

### DIFF
--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -854,6 +854,8 @@ __dbenv_close(dbenv, rep_check)
 	if (dbenv->comdb2_dirs.tmp_dir != NULL)
 		__os_free(dbenv, dbenv->comdb2_dirs.tmp_dir);
 
+        pthread_mutex_destroy(&dbenv->durable_lsn_lk);
+
 	/* Release DB list */
 	__os_free(dbenv, dbenv->dbs);
 
@@ -863,6 +865,7 @@ __dbenv_close(dbenv, rep_check)
 	/* Discard the structure. */
 	memset(dbenv, CLEAR_BYTE, sizeof(DB_ENV));
 	__os_free(NULL, dbenv);
+
 
 	return (ret);
 }
@@ -1012,8 +1015,6 @@ skip:
 		__os_closehandle(dbenv, dbenv->checkpoint);
 		dbenv->checkpoint = NULL;
 	}
-
-    pthread_mutex_destroy(&dbenv->durable_lsn_lk);
 
 	return (ret);
 }


### PR DESCRIPTION
__dbenv_refresh is called in __dbenv_open before init mutex is done