### PR TITLE
cdb2api:have a function that only reads config

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -79,7 +79,7 @@ crle: basicops_nokey tools
 	@$(MAKE) -sC crle.test
 
 %: %.test
-	@N=`tools/get_test_counter.sh` && echo TESTID=${TESTID} running $< $$N/${TOTAL}
+	@N=`tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
 	@cp -r $< $(TESTDIR)/
 	@$(MAKE) -skC $(TESTDIR)/$<
 


### PR DESCRIPTION
Instead of calling get_comdb2db_hosts() with all null parameters, just call new function that loads config only_read_config(). This way our intention is clear, but also we decrease chance of a bug in case we modify the former.