### PR TITLE
check and return if query is empty

### DIFF
--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -431,7 +431,6 @@ static CDB2QUERY *read_newsql_query(struct dbenv *dbenv,
     int rc;
     int pre_enabled = 0;
     int was_timeout = 0;
-    char ssl_able;
 
 retry_read:
     rc = sbuf2fread_timeout((char *)&hdr, sizeof(hdr), 1, sb, &was_timeout);
@@ -464,7 +463,7 @@ retry_read:
               actual status of this node;
            2) Doing SSL_accept() immediately would cause too many
               unnecessary EAGAIN/EWOULDBLOCK's for non-blocking BIO. */
-        ssl_able = (gbl_client_ssl_mode >= SSL_ALLOW) ? 'Y' : 'N';
+        char ssl_able = (gbl_client_ssl_mode >= SSL_ALLOW) ? 'Y' : 'N';
         if ((rc = sbuf2putc(sb, ssl_able)) < 0 || (rc = sbuf2flush(sb)) < 0)
             return NULL;
 
@@ -516,16 +515,13 @@ retry_read:
     }
 
     int bytes = hdr.length;
-
     if (bytes <= 0) {
         logmsg(LOGMSG_ERROR, "%s: Junk message  %d\n", __func__, bytes);
         return NULL;
     }
 
-    CDB2QUERY *query;
-
+    assert(errno == 0);
     char *p;
-
     if (bytes <= gbl_blob_sz_thresh_bytes)
         p = malloc(bytes);
     else
@@ -558,18 +554,20 @@ retry_read:
         return NULL;
     }
 
-    if (bytes) {
-        rc = sbuf2fread(p, bytes, 1, sb);
-        if (rc != 1) {
-            free(p);
-            return NULL;
-        }
+    rc = sbuf2fread(p, bytes, 1, sb);
+    if (rc != 1) {
+        free(p);
+        return NULL;
     }
 
+    CDB2QUERY *query;
+    assert(errno == 0); // precondition for the while loop
     while (1) {
         query = cdb2__query__unpack(&pb_alloc, bytes, p);
+        // errno can be set by cdb2__query__unpack
+        // we retry malloc on out of memory condition
 
-        if (query != NULL || errno != ETIMEDOUT)
+        if (query || errno != ETIMEDOUT)
             break;
 
         pthread_mutex_lock(&clnt->wait_mutex);
@@ -591,7 +589,20 @@ retry_read:
         pthread_mutex_unlock(&clnt->wait_mutex);
     }
 
-    if (query && query->dbinfo) {
+
+    if (unlikely(errno != 0)) { // query will be null if errno is set
+        return NULL;
+    }
+
+    assert(query);
+
+    // one of dbinfo or sqlquery must be non-NULL
+    if (unlikely(!query->dbinfo && !query->sqlquery)) {
+        cdb2__query__free_unpacked(query, &pb_alloc);
+        goto retry_read;
+    }
+
+    if (query->dbinfo) {
         if (query->dbinfo->has_want_effects &&
             query->dbinfo->want_effects == 1) {
             CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
@@ -624,10 +635,6 @@ retry_read:
         } else {
             send_dbinforesponse(dbenv, sb);
         }
-        cdb2__query__free_unpacked(query, &pb_alloc);
-        goto retry_read;
-    }
-    else if (query && !query->sqlquery) {
         cdb2__query__free_unpacked(query, &pb_alloc);
         goto retry_read;
     }

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -642,7 +642,8 @@ retry_read:
               It may happen when require_ssl is first time
               enabled across the cluster. */
         int client_supports_ssl = 0;
-        for (int ii = 0; ii < query->sqlquery->n_features; ++ii) {
+        for (int ii = 0; query->sqlquery && ii < query->sqlquery->n_features; 
+             ++ii) {
             if (CDB2_CLIENT_FEATURES__SSL == query->sqlquery->features[ii]) {
                 client_supports_ssl = 1;
                 break;
@@ -762,9 +763,9 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     }
 
     CDB2QUERY *query = read_newsql_query(dbenv, &clnt, sb);
-    if (query == NULL)
+    if (!query || !query->sqlquery)
         goto done;
-    assert(query->sqlquery);
+
     CDB2SQLQUERY *sql_query = query->sqlquery;
     clnt.query = query;
 
@@ -806,8 +807,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         sqlthd->sqlclntstate->origin[0] = 0;
     }
 
-    while (query) {
-        assert(query->sqlquery);
+    while (query && query->sqlquery) {
         sql_query = query->sqlquery;
         clnt.sql_query = sql_query;
         clnt.sql = sql_query->sql_query;

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -241,6 +241,9 @@ for node in $cluster ; do
     res=`cdb2sql --tabs $dbnm --host $node:$port "select comdb2_dbname()"`
     assertres $res $dbnm
 
+    #check for empty sql stmt
+    echo -e "newsql\n\x0\x0\x0\x1\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\x0\n\x0\x0\x0\x1\x0\x0\x0\x0\x0" | nc -w 1 $node $port
+
     echo "connect with wrong db name"
     set +e
     cdb2sql --tabs badname @$node:port=$port "select comdb2_dbname()" &> out.txt


### PR DESCRIPTION
In this checkin read_newsql_query() checks that either dbinfo or sqlquery is set for a client query. 
This ensures that the db wont crash on bad input that results in sqlquery to be null.
Added testcase with bad input that previously crashed db.