### PR TITLE
cleanup freeing code and ensure sql has whitespace stripped out

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -778,7 +778,7 @@ done:
         exit(1);
     }
 
-    if (dta && alloc == malloc)
+    if (dta)
         free(dta);
 
     return rc;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -702,12 +702,9 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
                           int line)
 {
     struct newsqlheader hdr;
-    int rc;
-    SBUF2 *sb;
-    int len;
-    void *dta;
-
-    sb = clnt->sb;
+    int rc = 0;
+    int len = 0;
+    void *dta = NULL;
 
     if (gbl_dump_fsql_response) {
         char cnonce[256] = {0};
@@ -740,9 +737,6 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
         len = cdb2__sqlresponse__get_packed_size(sql_response);
         dta = (*alloc)(len + 1);
         cdb2__sqlresponse__pack(sql_response, dta);
-    } else {
-        len = 0;
-        dta = NULL;
     }
 
     /* header */
@@ -752,57 +746,42 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
     hdr.length = ntohl(len);
 
     rc = pthread_mutex_lock(&clnt->write_lock);
-
     if (rc != 0) {
         logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
         exit(1);
     }
 
-    rc = sbuf2write((char *)&hdr, sizeof(struct newsqlheader), sb);
-    if (rc != sizeof(struct newsqlheader)) {
-        rc = pthread_mutex_unlock(&clnt->write_lock);
-        if (rc != 0) {
-            logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
-            exit(1);
-        }
-        free(dta);
-        return -1;
+    SBUF2 *sb = clnt->sb;
+    int wlen = sbuf2write((char *)&hdr, sizeof(struct newsqlheader), sb);
+    if (wlen != sizeof(struct newsqlheader)) {
+        rc = -1;
+        goto done;
     }
 
     if (dta) {
-        rc = sbuf2write(dta, len, sb);
-        if (rc != len) {
-
-            if (gbl_dump_fsql_response) {
-                logmsg(LOGMSG_USER, "sbuf2write error for %s rc=%d\n", clnt->sql,
-                        rc);
-            }
-
-            rc = pthread_mutex_unlock(&clnt->write_lock);
-            if (rc != 0) {
-                logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-                exit(1);
-            }
-
-            free(dta);
-            return -1;
+        wlen = sbuf2write(dta, len, sb);
+        if (wlen != len) {
+            if (gbl_dump_fsql_response)
+                logmsg(LOGMSG_USER, "sbuf2write error for %s wlen=%d\n", 
+                       clnt->sql, wlen);
+            rc = -1;
+            goto done;
         }
     }
 
-    if (flush) {
+    if (flush)
         sbuf2flush(sb);
-    }
 
-    rc = pthread_mutex_unlock(&clnt->write_lock);
-    if (rc != 0) {
-        logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
+done:
+    if (pthread_mutex_unlock(&clnt->write_lock) != 0) {
+        logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
         exit(1);
     }
 
-    if (dta)
+    if (dta && alloc == malloc)
         free(dta);
 
-    return 0;
+    return rc;
 }
 
 int gbl_debug_high_availability_flag = 0;
@@ -1491,8 +1470,7 @@ static int retrieve_snapshot_info(char *sql, char *tzname)
     char *str = sql;
 
     if (str && *str) {
-        if (isspace(*str))
-            str = skipws(str);
+        str = skipws(str);
 
         if (str && *str) {
             /* skip "transaction" if any */
@@ -1699,9 +1677,6 @@ static void sql_update_usertran_state(struct sqlclntstate *clnt)
     if (!sql)
         return;
 
-    while (isspace(*sql))
-        ++sql;
-
     /* begin, commit, rollback should arrive over the socket only
        for socksql, recom, snapisol and serial */
     if (!strncasecmp(clnt->sql, "begin", 5)) {
@@ -1762,7 +1737,7 @@ static void log_queue_time(struct reqlogger *logger, struct sqlclntstate *clnt)
 {
     if (!gbl_track_queue_time)
         return;
-    if (clnt->deque_timeus - clnt->enque_timeus > 0)
+    if (clnt->deque_timeus > clnt->enque_timeus)
         reqlog_logf(logger, REQL_INFO, "queuetime took %dms",
                     U2M(clnt->deque_timeus - clnt->enque_timeus));
     reqlog_set_queue_time(logger, clnt->deque_timeus - clnt->enque_timeus);
@@ -3319,11 +3294,8 @@ int release_locks_on_emit_row(struct sqlthdstate *thd,
 static int check_sql(struct sqlclntstate *clnt, int *sp)
 {
     char buf[256];
-    struct fsqlresp resp;
     char *sql = clnt->sql;
-    while (isspace(*sql))
-        ++sql;
-    size_t len = 4; // strlen "exec"
+    size_t len = sizeof("exec") - 1;
     if (strncasecmp(sql, "exec", len) == 0) {
         sql += len;
         if (isspace(*sql)) {
@@ -3331,37 +3303,40 @@ static int check_sql(struct sqlclntstate *clnt, int *sp)
             return 0;
         }
     }
-    len = 6; // strlen "pragma"
+    len = sizeof("pragma") - 1;
     if (strncasecmp(sql, "pragma", len) == 0) {
         sql += len;
-        if (!isspace(*sql)) {
-            return 0;
+        if (isspace(*sql)) {
+            goto error;
         }
-    error: /* pretend that a real prepare error occured */
-        strcpy(buf, "near \"");
-        strncat(buf + len, sql, len);
-        strcat(buf, "\": syntax error");
-        send_prepare_error(clnt, buf, 0);
-        return SQLITE_ERROR;
+        return 0;
     }
-    len = 6; // strlen "create"
+    len = sizeof("create") - 1;
     if (strncasecmp(sql, "create", len) == 0) {
         char *trigger = sql;
         trigger += len;
         if (!isspace(*trigger)) {
             return 0;
         }
-        while (isspace(*trigger))
-            ++trigger;
-        if (strncasecmp(trigger, "trigger", 7) != 0) {
+        trigger = skipws(trigger);
+        len = sizeof("trigger") - 1;
+        if (strncasecmp(trigger, "trigger", len) != 0) {
             return 0;
         }
-        trigger += 7;
+        trigger += len;
         if (isspace(*trigger)) {
             goto error;
         }
     }
     return 0;
+
+error: /* pretend that a real prepare error occured */
+        strcpy(buf, "near \"");
+        strncat(buf + len, sql, len);
+        strcat(buf, "\": syntax error");
+        send_prepare_error(clnt, buf, 0);
+        return SQLITE_ERROR;
+
 }
 
 /* if userpassword does not match this function
@@ -7814,7 +7789,7 @@ void run_internal_sql(char *sql)
     clnt.dbtran.mode = tdef_to_tranlevel(gbl_sql_tranlevel_default);
     // clnt.high_availability = 0;
     set_high_availability(&clnt, 0);
-    clnt.sql = sql;
+    clnt.sql = skipws(sql);
 
     dispatch_sql_query(&clnt);
     if (clnt.query_rc || clnt.saved_errstr) {
@@ -7858,7 +7833,7 @@ int run_internal_sql_clnt(struct sqlclntstate *clnt, char *sql)
 #ifdef DEBUGQUERY
     printf("run_internal_sql_clnt() sql '%s'\n", sql);
 #endif
-    clnt->sql = sql;
+    clnt->sql = skipws(sql);
     dispatch_sql_query(clnt);
     int rc = 0;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -762,7 +762,7 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
         wlen = sbuf2write(dta, len, sb);
         if (wlen != len) {
             if (gbl_dump_fsql_response)
-                logmsg(LOGMSG_USER, "sbuf2write error for %s wlen=%d\n", 
+                logmsg(LOGMSG_USER, "sbuf2write error for %s wlen=%d\n",
                        clnt->sql, wlen);
             rc = -1;
             goto done;
@@ -3331,12 +3331,11 @@ static int check_sql(struct sqlclntstate *clnt, int *sp)
     return 0;
 
 error: /* pretend that a real prepare error occured */
-        strcpy(buf, "near \"");
-        strncat(buf + len, sql, len);
-        strcat(buf, "\": syntax error");
-        send_prepare_error(clnt, buf, 0);
-        return SQLITE_ERROR;
-
+    strcpy(buf, "near \"");
+    strncat(buf + len, sql, len);
+    strcat(buf, "\": syntax error");
+    send_prepare_error(clnt, buf, 0);
+    return SQLITE_ERROR;
 }
 
 /* if userpassword does not match this function

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -747,7 +747,7 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
 
     rc = pthread_mutex_lock(&clnt->write_lock);
     if (rc != 0) {
-        logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
+        logmsg(LOGMSG_FATAL, "Failed to lock clnt->write_lock\n");
         exit(1);
     }
 
@@ -774,7 +774,7 @@ int newsql_write_response(struct sqlclntstate *clnt, int type,
 
 done:
     if (pthread_mutex_unlock(&clnt->write_lock) != 0) {
-        logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
+        logmsg(LOGMSG_FATAL, "Failed to unlock clnt->write_lock\n");
         exit(1);
     }
 


### PR DESCRIPTION
* cleanup freeing code in newsql_write_response
* dont clean whitespace unneccessarily of the sql string since was
  already done once in dispatch request