### PR TITLE
Timepart systables and fixes

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -2027,6 +2027,10 @@ int views_cron_restart(timepart_views_t *views)
     int rc;
     struct errstat xerr = {0};
 
+    /* in case of regular master swing, clear pre-existing views event,
+       we will requeue them */
+    cron_clear_queue(timepart_sched);
+
     pthread_rwlock_wrlock(&views_lk);
 
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START_RDWR);

--- a/db/views.h
+++ b/db/views.h
@@ -134,7 +134,7 @@ int views_write(const char *str);
 
 /**
  *  Write a CSON representation of a view
- *  TGhe view is internally saved as a parameter "viewname" for the table
+ *  The view is internally saved as a parameter "viewname" for the table
  *"sys_views"
  *
  *  NOTE: writing a NULL or 0 length string deletes existing entry if any

--- a/db/views.h
+++ b/db/views.h
@@ -63,9 +63,13 @@ typedef struct timepart_sc_arg {
 enum systable_columns {
     VIEWS_NAME
     ,VIEWS_PERIOD
+    ,VIEWS_SHARDNAME=VIEWS_PERIOD
     ,VIEWS_RETENTION
+    ,VIEWS_START=VIEWS_RETENTION
     ,VIEWS_NSHARDS
+    ,VIEWS_END=VIEWS_NSHARDS
     ,VIEWS_VERSION
+    ,VIEWS_SHARDS_MAXCOLUMN=VIEWS_VERSION
     ,VIEWS_SHARD0NAME
     ,VIEWS_STARTTIME
     ,VIEWS_SOURCEID
@@ -342,16 +346,30 @@ void views_unlock(void);
 char *timepart_newest_shard(const char *view_name, unsigned long long *version);
 
 /**
- * Returned a malloced string for the "iRowid"-th view, column iCol 
+ * Returned a malloced string for the "iRowid"-th timepartition, column iCol 
  * NOTE: this is called with a read lock in views structure
  */
-void timepart_systable_get_column(sqlite3_context *ctx, int iRowid, enum systable_columns iCol);
+void timepart_systable_column(sqlite3_context *ctx, int iRowid, enum systable_columns iCol);
+
+/**
+ * Returned a malloced string for the "iRowid"-th shard, column iCol of 
+ * timepart iTimepartId
+ * NOTE: this is called with a read lock in views structure
+ */
+void timepart_systable_shard_column(sqlite3_context *ctx, int iTimepartId, int iRowid,
+        enum systable_columns iCol);
+
+/** 
+ *  Move iRowid to point to the next shard, switching shards in the process
+ *  NOTE: this is called with a read lock in views structure
+ */
+void timepart_systable_next_shard(int *piTimepartId, int *piRowid);
 
 /**
  * Get number of views
  *
  */
-int timepart_get_views(void);
+int timepart_get_num_views(void);
 
 #endif
 

--- a/db/views.h
+++ b/db/views.h
@@ -59,6 +59,20 @@ typedef struct timepart_sc_arg {
     void *tran; /*remove?*/
 } timepart_sc_arg_t;
 
+
+enum systable_columns {
+    VIEWS_NAME
+    ,VIEWS_PERIOD
+    ,VIEWS_RETENTION
+    ,VIEWS_NSHARDS
+    ,VIEWS_VERSION
+    ,VIEWS_SHARD0NAME
+    ,VIEWS_STARTTIME
+    ,VIEWS_SOURCEID
+    ,VIEWS_MAXCOLUMN
+};
+
+
 /**
  * Initialize the views
  *
@@ -116,7 +130,7 @@ int views_write(const char *str);
 
 /**
  *  Write a CSON representation of a view
- *  The view is internally saved as a parameter "viewname" for the table
+ *  TGhe view is internally saved as a parameter "viewname" for the table
  *"sys_views"
  *
  *  NOTE: writing a NULL or 0 length string deletes existing entry if any
@@ -326,6 +340,18 @@ void views_unlock(void);
  *
  */
 char *timepart_newest_shard(const char *view_name, unsigned long long *version);
+
+/**
+ * Returned a malloced string for the "iRowid"-th view, column iCol 
+ * NOTE: this is called with a read lock in views structure
+ */
+void timepart_systable_get_column(sqlite3_context *ctx, int iRowid, enum systable_columns iCol);
+
+/**
+ * Get number of views
+ *
+ */
+int timepart_get_views(void);
 
 #endif
 

--- a/db/views_cron.c
+++ b/db/views_cron.c
@@ -195,8 +195,6 @@ static void _destroy_event(cron_sched_t *sched, cron_event_t *event)
       free(event->arg2);
    if(event->arg3)
       free(event->arg3);
-   if(event->arg4)
-      free(event->arg4);
    free(event);
 }
 
@@ -361,7 +359,7 @@ void cron_clear_queue(cron_sched_t *sched)
 
    pthread_mutex_lock(&sched->mtx);
 
-   if (sched->running_call)
+   if (sched->running)
    {
       clock_gettime(CLOCK_REALTIME, &now);
       now.tv_sec += 1;

--- a/db/views_cron.h
+++ b/db/views_cron.h
@@ -32,5 +32,10 @@ cron_sched_t *cron_add_event(cron_sched_t *sched, const char *name, int epoch,
  */
 void cron_signal_worker(cron_sched_t *sched);
 
-#endif
+/** 
+ * Clear queue of events
+ * 
+ */ 
+void cron_clear_queue(cron_sched_t *sched);
 
+#endif

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -25,7 +25,7 @@ add_library(sqlite
   ext/comdb2/procedures.c
   ext/comdb2/tablepermissions.c
   ext/comdb2/tables.c
-  ext/comdb2/tables.c
+  ext/comdb2/timepartitions.c
   ext/comdb2/tablesizes.c
   ext/comdb2/threadpools.c
   ext/comdb2/triggers.c

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -20,6 +20,7 @@ const sqlite3_module systblTunablesModule;
 const sqlite3_module systblThreadPoolsModule;
 const sqlite3_module completionModule; // in ext/misc
 const sqlite3_module systblTimepartModule;
+const sqlite3_module systblTimepartShardsModule;
 
 /* Simple yes/no answer for booleans */
 #define YESNO(x) ((x) ? "Y" : "N")

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -19,6 +19,7 @@ const sqlite3_module systblLimitsModule;
 const sqlite3_module systblTunablesModule;
 const sqlite3_module systblThreadPoolsModule;
 const sqlite3_module completionModule; // in ext/misc
+const sqlite3_module systblTimepartModule;
 
 /* Simple yes/no answer for booleans */
 #define YESNO(x) ((x) ? "Y" : "N")

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -239,6 +239,8 @@ int comdb2SystblInit(
     rc = sqlite3_create_module(db, "comdb2_threadpools", &systblThreadPoolsModule, 0);
   if (rc == SQLITE_OK)
     rc = sqlite3_create_module(db, "comdb2_completion", &completionModule, 0);
+  if (rc == SQLITE_OK)
+    rc = sqlite3_create_module(db, "comdb2_timepartitions", &systblTimepartModule, 0);
 #endif
   return rc;
 }

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -241,6 +241,8 @@ int comdb2SystblInit(
     rc = sqlite3_create_module(db, "comdb2_completion", &completionModule, 0);
   if (rc == SQLITE_OK)
     rc = sqlite3_create_module(db, "comdb2_timepartitions", &systblTimepartModule, 0);
+  if (rc == SQLITE_OK)
+    rc = sqlite3_create_module(db, "comdb2_timepartshards", &systblTimepartShardsModule, 0);
 #endif
   return rc;
 }

--- a/sqlite/ext/comdb2/timepartitions.c
+++ b/sqlite/ext/comdb2/timepartitions.c
@@ -1,0 +1,179 @@
+/*
+   Copyright 2018 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+#if (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \
+    && !defined(SQLITE_OMIT_VIRTUALTABLE)
+
+#if defined(SQLITE_BUILDING_FOR_COMDB2) && !defined(SQLITE_CORE)
+# define SQLITE_CORE 1
+#endif
+
+#include "views.h"
+
+typedef struct systbl_timepart_cursor systbl_timepart_cursor;
+struct systbl_timepart_cursor {
+  sqlite3_vtab_cursor base;  /* Base class - must be first */
+  sqlite3_int64 iRowid;      /* The rowid */
+  int maxRowid;
+};
+
+/*
+** Constructor for sqlite3_vtab object
+*/
+static int systblTimepartConnect(
+  sqlite3 *db,
+  void *pAux,
+  int argc,
+  const char *const*argv,
+  sqlite3_vtab **ppVtab,
+  char **pErr
+){
+  sqlite3_vtab *pNew;
+  int rc;
+
+  rc = sqlite3_declare_vtab(db, "CREATE TABLE comdb2_timepart(name, period, retention, nshards, version, shard0name, starttime, source_id)");
+  if( rc==SQLITE_OK ){
+    pNew = *ppVtab = sqlite3_malloc( sizeof(*pNew) );
+    if( pNew==0 ) return SQLITE_NOMEM;
+    memset(pNew, 0, sizeof(*pNew));
+  }
+  return rc;
+}
+
+/*
+** Destructor for sqlite3_vtab objects.
+*/
+static int systblTimepartDisconnect(sqlite3_vtab *pVtab){
+  sqlite3_free(pVtab);
+  return SQLITE_OK;
+}
+
+/*
+** Constructor for systbl_tables_cursor objects.
+*/
+static int systblTimepartOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
+  systbl_timepart_cursor *pCur;
+
+  pCur = sqlite3_malloc( sizeof(*pCur) );
+  if( pCur==0 ) return SQLITE_NOMEM;
+  memset(pCur, 0, sizeof(*pCur));
+  *ppCursor = &pCur->base;
+  pCur->iRowid = -1;
+  views_lock();
+  pCur->maxRowid = timepart_get_views();
+
+  return SQLITE_OK;
+}
+
+/*
+** Destructor for systbl_tables_cursor.
+*/
+static int systblTimepartClose(sqlite3_vtab_cursor *cur){
+  views_unlock();
+  sqlite3_free(cur);
+  return SQLITE_OK;
+}
+
+/*
+** Advance to the next table name from thedb.
+*/
+static int systblTimepartNext(sqlite3_vtab_cursor *cur){
+  systbl_timepart_cursor *pCur = (systbl_timepart_cursor*)cur;
+  int rc;
+
+  if(pCur->iRowid<pCur->maxRowid)
+      pCur->iRowid++;
+
+  return SQLITE_OK;
+}
+
+/*
+** Return the table name for the current row.
+*/
+static int systblTimepartColumn(
+  sqlite3_vtab_cursor *cur,
+  sqlite3_context *ctx,
+  int i
+){
+  systbl_timepart_cursor *pCur = (systbl_timepart_cursor*)cur;
+
+  timepart_systable_get_column(ctx, pCur->iRowid, i);
+  return SQLITE_OK;
+};
+
+/*
+** Return the rowid for the current row (which is the index of the view
+** in the view array 
+*/
+static int systblTimepartRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
+  systbl_timepart_cursor *pCur = (systbl_timepart_cursor*)cur;
+
+  *pRowid = pCur->iRowid;
+  return SQLITE_OK;
+}
+
+/*
+** Return TRUE if the cursor has been moved off of the last row of output.
+*/
+static int systblTimepartEof(sqlite3_vtab_cursor *cur){
+  systbl_timepart_cursor *pCur = (systbl_timepart_cursor*)cur;
+
+  return pCur->iRowid >= pCur->maxRowid;
+}
+
+static int systblTimepartFilter(
+  sqlite3_vtab_cursor *pVtabCursor,
+  int idxNum, const char *idxStr,
+  int argc, sqlite3_value **argv
+){
+  systbl_timepart_cursor *pCur = (systbl_timepart_cursor*)pVtabCursor;
+
+  pCur->iRowid = 0;
+  return SQLITE_OK;
+}
+
+static int systblTimepartBestIndex(
+  sqlite3_vtab *tab,
+  sqlite3_index_info *pIdxInfo
+){
+  return SQLITE_OK;
+}
+
+
+
+const sqlite3_module systblTimepartModule = {
+  0,                         /* iVersion */
+  0,                         /* xCreate */
+  systblTimepartConnect,     /* xConnect */
+  systblTimepartBestIndex,   /* xBestIndex */
+  systblTimepartDisconnect,  /* xDisconnect */
+  0,                         /* xDestroy */
+  systblTimepartOpen,        /* xOpen - open a cursor */
+  systblTimepartClose,       /* xClose - close a cursor */
+  systblTimepartFilter,      /* xFilter - configure scan constraints */
+  systblTimepartNext,        /* xNext - advance a cursor */
+  systblTimepartEof,         /* xEof - check for end of scan */
+  systblTimepartColumn,      /* xColumn - read data */
+  systblTimepartRowid,       /* xRowid - read data */
+  0,                         /* xUpdate */
+  0,                         /* xBegin */
+  0,                         /* xSync */
+  0,                         /* xCommit */
+  0,                         /* xRollback */
+  0,                         /* xFindMethod */
+  0,                         /* xRename */
+};
+
+#endif /* SQLITE_BUILDING_FOR_COMDB2 */


### PR DESCRIPTION
1) Systables to expose time partition information:
'select * from comdb2_timepartitions':
(name='tv', period='daily', retention=4, nshards=4, version=0, shard0name='t', starttime=1516856400, source_id='31438f5e-dd6d-4ccf-aff2-c193221027fe')
...
'select shardname, cast(start as datetime) as start, cast(end as datetime) as end from comdb2_timepartshards where name="tv"':
(shardname='$1_E5EE49E6', start="2018-01-30T000000.000 America/New_York", end="2038-01-18T221407.000 America/New_York")
....
2) port from R6: multiple master swings during rollout generate multiple events