### PR TITLE
Throttle log-puts against incoherent nodes

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1248,6 +1248,8 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host);
 int net_newnode_rtn(netinfo_type *netinfo_ptr, char *hostname, int portnum);
 int net_cmplsn_rtn(netinfo_type *netinfo_ptr, void *x, int xlen, void *y,
                    int ylen);
+int net_getlsn_rtn(netinfo_type *netinfo_ptr, void *record, int len, 
+        int *file, int *offset);
 
 static void net_startthread_rtn(void *arg)
 {
@@ -2504,6 +2506,8 @@ static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
     /* register a routine which will re-order the out-queue to
        be in lsn order */
     net_register_netcmp(bdb_state->repinfo->netinfo, net_cmplsn_rtn);
+
+    net_register_getlsn(bdb_state->repinfo->netinfo, net_getlsn_rtn);
 
     /* set the callback data so we get our bdb_state pointer from these
      * calls. */

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -656,7 +656,7 @@ int is_incoherent(bdb_state_type *bdb_state, const char *host)
 }
 
 /* 1/10th of the logfile */
-int gbl_incoherent_logput_window = 4000000;
+int gbl_incoherent_logput_window = 1000000;
 
 static int throttle_updates_incoherent_nodes(bdb_state_type *bdb_state,
                                              const char *host)

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -655,26 +655,26 @@ int is_incoherent(bdb_state_type *bdb_state, const char *host)
     return is_incoherent;
 }
 
+/* 1/10th of the logfile */
+int gbl_incoherent_logput_window = 4000000;
+
 static int throttle_updates_incoherent_nodes(bdb_state_type *bdb_state,
                                              const char *host)
 {
+    int ret = 0;
+    int64_t cntbytes;
 
-    int limit = 0;
-    int crtusage = 0;
-    int skipme = 0;
-    int rc = 0;
-
-    if (debug_throttle_incoherent_nodes()) {
-        rc = net_get_queue_size(bdb_state->repinfo->netinfo, host, &limit,
-                                &crtusage);
-        if (rc)
-            skipme = 1;
-
-        skipme = !rc && is_incoherent(bdb_state, host) &&
-                 (crtusage * 100 > limit * gbl_net_lmt_upd_incoherent_nodes);
+    if (is_incoherent(bdb_state, host)) {
+        DB_LSN *lsnp, *masterlsn;
+        lsnp = &bdb_state->seqnum_info->seqnums[nodeix(host)].lsn;
+        masterlsn = &bdb_state->seqnum_info->seqnums[nodeix(bdb_state->repinfo->master_host)].lsn;
+        cntbytes = subtract_lsn(bdb_state, masterlsn, lsnp);
+        if (cntbytes > gbl_incoherent_logput_window) {
+            ret = 1;
+        }
     }
 
-    return skipme;
+    return ret;
 }
 
 extern int gbl_rowlocks;
@@ -951,15 +951,11 @@ int berkdb_send_rtn(DB_ENV *dbenv, const DBT *control, const DBT *rec,
                 logmsg(LOGMSG_USER, "--- sending seq %d to %s, nodelay is %d\n",
                         tmpseq, hostlist[i], nodelay);
 
-            if (bdb_state->repinfo->master_host == bdb_state->repinfo->myhost)
+            if (bdb_state->repinfo->master_host == bdb_state->repinfo->myhost) {
+                dontsend = (is_logput && 
+                        throttle_updates_incoherent_nodes(bdb_state, hostlist[i]));
+                
                 if (tran && gblcontext && nodelay) {
-                    dontsend = is_logput && throttle_updates_incoherent_nodes(
-                                                bdb_state, hostlist[i]);
-
-                    /*
-                      fprintf(stderr, "sending gblcontext  0x%08llx to %d\n",
-                      bdb_state->gblcontext, hostlist[i]);
-                    */
 
                     if (!gbl_rowlocks && !dontsend) {
 
@@ -984,6 +980,7 @@ int berkdb_send_rtn(DB_ENV *dbenv, const DBT *control, const DBT *rec,
                     }
                     */
                 }
+            }
 
             if (!dontsend) {
                 if (!is_logput) {
@@ -1667,6 +1664,20 @@ static inline int net_get_lsn(bdb_state_type *bdb_state, const void *buf,
     if (rectype != 7)
         return -1;
 
+    return 0;
+}
+
+int net_getlsn_rtn(netinfo_type *netinfo_ptr, void *record, int len, int *file, int *offset) {
+    bdb_state_type *bdb_state;
+    DB_LSN lsn;
+
+    bdb_state = net_get_usrptr(netinfo_ptr);
+
+    if ((net_get_lsn(bdb_state, record, len, &lsn)) != 0)
+        return -1;
+
+    *file = lsn.file;
+    *offset = lsn.offset;
     return 0;
 }
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -143,6 +143,9 @@ extern int gbl_rep_verify_will_recover_trace;
 extern int gbl_max_wr_rows_per_txn;
 extern int gbl_force_serial_on_writelock;
 extern int gbl_processor_thd_poll;
+extern int gbl_time_rep_apply;
+extern int gbl_incoherent_logput_window;
+extern int gbl_dump_full_net_queue;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1337,7 +1337,7 @@ REGISTER_TUNABLE("time_rep_apply", "Display rep-apply times periodically. "
                  TUNABLE_BOOLEAN, &gbl_time_rep_apply,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("logput_window", "Drop log-broadcasts for incoherent nodes "
-                 "more than this many bytes behind. (Default: 4000000)",
+                 "more than this many bytes behind. (Default: 1000000)",
                  TUNABLE_INTEGER, &gbl_incoherent_logput_window,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1328,5 +1328,21 @@ REGISTER_TUNABLE("processor_thd_poll", "Poll before dispatching worker thds. "
                                        "(Default: 0ms)",
                  TUNABLE_INTEGER, &gbl_processor_thd_poll,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("time_rep_apply", "Display rep-apply times periodically. "
+                                       "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_time_rep_apply,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("time_rep_apply", "Display rep-apply times periodically. "
+                                       "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_time_rep_apply,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("logput_window", "Drop log-broadcasts for incoherent nodes "
+                 "more than this many bytes behind. (Default: 4000000)",
+                 TUNABLE_INTEGER, &gbl_incoherent_logput_window,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("dump_full_netqueue", "Dump net-queue on full rcode. "
+                 "(Default: off)", TUNABLE_BOOLEAN, &gbl_dump_full_net_queue,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1332,15 +1332,10 @@ REGISTER_TUNABLE("time_rep_apply", "Display rep-apply times periodically. "
                                        "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_time_rep_apply,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("time_rep_apply", "Display rep-apply times periodically. "
-                                       "(Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_time_rep_apply,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("logput_window", "Drop log-broadcasts for incoherent nodes "
                  "more than this many bytes behind. (Default: 1000000)",
                  TUNABLE_INTEGER, &gbl_incoherent_logput_window,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-
 REGISTER_TUNABLE("dump_full_netqueue", "Dump net-queue on full rcode. "
                  "(Default: off)", TUNABLE_BOOLEAN, &gbl_dump_full_net_queue,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);

--- a/net/net.c
+++ b/net/net.c
@@ -2021,6 +2021,51 @@ int net_get_stack_flush_threshold(void) { return stack_flush_min; }
 
 void net_set_stack_flush_threshold(int thresh) { stack_flush_min = thresh; }
 
+int gbl_dump_full_net_queue = 0;
+
+static void dump_queue(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr)
+{
+    int now, cnt = 0, logput_cnt = 0, non_logput_cnt = 0;
+
+    if (netinfo_ptr->netcmp_rtn == NULL)
+        return;
+
+    if ((now = time(NULL)) - host_node_ptr->last_queue_dump) {
+        write_data *ptr;
+        int file, offset, rc, wl = 0;
+        logmsg(LOGMSG_USER, "Dumping net-queue for %s\n", host_node_ptr->host);
+        Pthread_mutex_lock(&(host_node_ptr->enquelk));
+        ptr = host_node_ptr->write_head;
+        while (ptr != NULL) {
+            cnt++;
+            if ((rc = (netinfo_ptr->getlsn_rtn)(netinfo_ptr, ptr->payload.raw,
+                            ptr->len, &file, &offset)) == 0) {
+                logput_cnt++;
+                if (wl == 0) {
+                    logmsg(LOGMSG_USER, "%s: ", host_node_ptr->host);
+                }
+                logmsg(LOGMSG_USER, "%d:%d ", file, offset);
+                wl = 1;
+                if ((logput_cnt % 20) == 0)  {
+                    logmsg(LOGMSG_USER, "\n");
+                    wl = 0;
+                }
+            } else {
+                non_logput_cnt++;
+            }
+            ptr = ptr->next;
+        }
+        Pthread_mutex_unlock(&(host_node_ptr->enquelk));
+
+        if (wl) {
+            logmsg(LOGMSG_USER, "\n");
+        }
+        logmsg(LOGMSG_USER, "%s: %d logputs, %d other\n", host_node_ptr->host, 
+                logput_cnt, non_logput_cnt);
+        host_node_ptr->last_queue_dump = now;
+    }
+}
+
 static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
                         int usertype, void *data, int datalen, int nodelay,
                         int numtails, void **tails, int *taillens, int nodrop,
@@ -2156,6 +2201,10 @@ static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
     }
 
 end:
+
+    if (rc == NET_SEND_FAIL_QUEUE_FULL && gbl_dump_full_net_queue)
+        dump_queue(netinfo_ptr, host_node_ptr);
+
     Pthread_rwlock_unlock(&(netinfo_ptr->lock));
     return rc;
 }
@@ -2312,6 +2361,12 @@ int net_get_all_nodes_connected(netinfo_type *netinfo_ptr,
     Pthread_rwlock_unlock(&(netinfo_ptr->lock));
 
     return count;
+}
+
+int net_register_getlsn(netinfo_type *netinfo_ptr, GETLSNFP func)
+{
+    netinfo_ptr->getlsn_rtn = func;
+    return 0;
 }
 
 int net_register_netcmp(netinfo_type *netinfo_ptr, NETCMPFP func)

--- a/net/net.h
+++ b/net/net.h
@@ -54,6 +54,8 @@ typedef int NETCMPFP(struct netinfo_struct *netinfo, void *insert_item,
                      int insert_item_len, void *current_item,
                      int current_item_len);
 
+typedef int GETLSNFP(struct netinfo_struct *netinfo, void *record, int len,
+                     int *file, int *offset);
 typedef int NEWNODEFP(struct netinfo_struct *netinfo, char hostname[],
                       int portnum);
 
@@ -115,6 +117,8 @@ int net_register_handler(netinfo_type *netinfo_ptr, int usertype, NETFP func);
 /* register your callback routine that will be called when a
    disconnect happens for a node */
 int net_register_hostdown(netinfo_type *netinfo_ptr, HOSTDOWNFP func);
+
+int net_register_getlsn(netinfo_type *netinfo_ptr, GETLSNFP func);
 
 /* register a callback that you can compare the order of things
    already on the write queue. */

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -202,6 +202,7 @@ struct host_node_tag {
     int throttle_waiters;
     pthread_mutex_t throttle_lock;
     pthread_cond_t throttle_wakeup;
+    int last_queue_dump;
 };
 
 /* Cut down data structure used for storing the sanc list. */
@@ -319,6 +320,7 @@ struct netinfo_struct {
 
     int use_getservbyname;
     int hellofd;
+    GETLSNFP *getlsn_rtn;
 };
 
 typedef struct ack_state_struct {


### PR DESCRIPTION
Current log-traffic can prevent re-transmission requests from being queued to a node which has fallen behind.  This revised version of throttle_updates_to_incoherent_nodes addresses this by only allowing log-puts to incoherent nodes which are within 1 mb of the master.
