### PR TITLE
Set the sbuf timeout before SSL negotiation

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1691,6 +1691,8 @@ static int newsql_connect(cdb2_hndl_tp *hndl, char *host, int port, int myport,
         sbuf2flush(sb);
     }
 
+    sbuf2settimeout(sb, 5000, 5000);
+
 #if WITH_SSL
     if (try_ssl(hndl, sb, indx) != 0) {
         sbuf2close(sb);
@@ -1698,7 +1700,6 @@ static int newsql_connect(cdb2_hndl_tp *hndl, char *host, int port, int myport,
     }
 #endif
 
-    sbuf2settimeout(sb, 5000, 5000);
     hndl->sb = sb;
     hndl->num_set_commands_sent = 0;
     hndl->sent_client_info = 0;


### PR DESCRIPTION
Simple one-line fix addresses timeouts for the cinsert linearizable test.
