### PR TITLE
Verify r7

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -228,6 +228,8 @@ DEF_ATTR(FSTDUMP_THREAD_STACKSZ, fstdump_thread_stacksz, BYTES, 256 * 1024,
 DEF_ATTR(FSTDUMP_MAXTHREADS, fstdump_maxthreads, QUANTITY, 0,
          "Maximum number of fstdump threads. (0 for single-threaded, 16 for "
          "maximum database thrashing)")
+DEF_ATTR(VERIFY_THREAD_STACKSZ, verify_thread_stacksz, BYTES, 2*1024*1024,
+         "Size of the verify thread stack.")
 DEF_ATTR(REP_LONGREQ, rep_longreq, SECS, 1,
          "Warn if replication events are taking this long to process.")
 DEF_ATTR(COMMITDELAYBEHINDTHRESH, commitdelaybehindthresh, BYTES, 1048576,

--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -228,7 +228,7 @@ DEF_ATTR(FSTDUMP_THREAD_STACKSZ, fstdump_thread_stacksz, BYTES, 256 * 1024,
 DEF_ATTR(FSTDUMP_MAXTHREADS, fstdump_maxthreads, QUANTITY, 0,
          "Maximum number of fstdump threads. (0 for single-threaded, 16 for "
          "maximum database thrashing)")
-DEF_ATTR(VERIFY_THREAD_STACKSZ, verify_thread_stacksz, BYTES, 2*1024*1024,
+DEF_ATTR(VERIFY_THREAD_STACKSZ, verify_thread_stacksz, BYTES, 2 * 1024 * 1024,
          "Size of the verify thread stack.")
 DEF_ATTR(REP_LONGREQ, rep_longreq, SECS, 1,
          "Warn if replication events are taking this long to process.")

--- a/db/verify.c
+++ b/db/verify.c
@@ -365,12 +365,7 @@ static void *verify_td(void *arg)
     return NULL;
 }
 
-static int verify_table_int(const char *table, SBUF2 *sb, int progress_report_seconds,
-             int attempt_fix, 
-             int (*lua_callback)(void *, const char *), void *lua_params)
-
-
-int verify_table(char *table, SBUF2 *sb, int progress_report_seconds, 
+int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds, 
         int attempt_fix,
         int (*lua_callback)(void *, const char *), void *lua_params)
 {

--- a/db/verify.c
+++ b/db/verify.c
@@ -365,9 +365,14 @@ static void *verify_td(void *arg)
     return NULL;
 }
 
-int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
-                 int attempt_fix, int (*lua_callback)(void *, const char *),
-                 void *lua_params)
+static int verify_table_int(const char *table, SBUF2 *sb, int progress_report_seconds,
+             int attempt_fix, 
+             int (*lua_callback)(void *, const char *), void *lua_params)
+
+
+int verify_table(char *table, SBUF2 *sb, int progress_report_seconds, 
+        int attempt_fix,
+        int (*lua_callback)(void *, const char *), void *lua_params)
 {
     int rc;
     struct verify_args v;

--- a/db/verify.c
+++ b/db/verify.c
@@ -365,9 +365,9 @@ static void *verify_td(void *arg)
     return NULL;
 }
 
-int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds, 
-        int attempt_fix,
-        int (*lua_callback)(void *, const char *), void *lua_params)
+int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
+                 int attempt_fix, int (*lua_callback)(void *, const char *),
+                 void *lua_params)
 {
     int rc;
     struct verify_args v;

--- a/db/verify.c
+++ b/db/verify.c
@@ -293,9 +293,10 @@ static int get_tbl_and_lock_in_tran(const char *table, SBUF2 *sb,
     return bdb_lock_tablename_read(thedb->bdb_env, table, loctran);
 }
 
-static int verify_table_int(const char *table, SBUF2 *sb, int progress_report_seconds,
-             int attempt_fix, 
-             int (*lua_callback)(void *, const char *), void *lua_params)
+static int verify_table_int(const char *table, SBUF2 *sb,
+                            int progress_report_seconds, int attempt_fix,
+                            int (*lua_callback)(void *, const char *),
+                            void *lua_params)
 {
     int bdberr;
     int rc;
@@ -356,7 +357,7 @@ static void *verify_td(void *arg)
     backend_thread_event(thedb, COMDB2_THR_EVENT_START_RDWR);
     pthread_mutex_lock(&v->lk);
     v->rcode = verify_table_int(v->table, v->sb, v->progress_report_seconds,
-            v->attempt_fix, v->lua_callback, v->lua_params);
+                                v->attempt_fix, v->lua_callback, v->lua_params);
     v->done = 1;
     pthread_cond_broadcast(&v->cd);
     pthread_mutex_unlock(&v->lk);
@@ -364,9 +365,9 @@ static void *verify_td(void *arg)
     return NULL;
 }
 
-int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds, 
-        int attempt_fix,
-        int (*lua_callback)(void *, const char *), void *lua_params)
+int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
+                 int attempt_fix, int (*lua_callback)(void *, const char *),
+                 void *lua_params)
 {
     int rc;
     struct verify_args v;
@@ -388,8 +389,8 @@ int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
 
     pthread_mutex_lock(&v.lk);
     if (rc = pthread_create(&v.tid, &attr, verify_td, &v)) {
-        logmsg(LOGMSG_ERROR, "%s unable to create thread for verify: %s\n", 
-                __func__, strerror(errno));
+        logmsg(LOGMSG_ERROR, "%s unable to create thread for verify: %s\n",
+               __func__, strerror(errno));
         sbuf2printf(sb, "FAILED\n");
         pthread_attr_destroy(&attr);
         pthread_mutex_destroy(&v.lk);

--- a/db/verify.c
+++ b/db/verify.c
@@ -388,8 +388,8 @@ int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
 
     pthread_mutex_lock(&v.lk);
     if (rc = pthread_create(&v.tid, &attr, verify_td, &v)) {
-        fprintf(stderr, "%s unable to create thread for verify: %s\n", 
-                strerror(errno));
+        logmsg(LOGMSG_ERROR, "%s unable to create thread for verify: %s\n", 
+                __func__, strerror(errno));
         sbuf2printf(sb, "FAILED\n");
         pthread_attr_destroy(&attr);
         pthread_mutex_destroy(&v.lk);
@@ -398,10 +398,7 @@ int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
     }
 
     while (v.done == 0) {
-        struct timespec ts;
-        clock_gettime(CLOCK_REALTIME, &ts);
-        ts.tv_sec += 1;
-        pthread_cond_timedwait(&v.cd, &v.lk, &ts);
+        pthread_cond_wait(&v.cd, &v.lk, &ts);
     }
 
     pthread_attr_destroy(&attr);
@@ -409,4 +406,3 @@ int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
     pthread_cond_destroy(&v.cd);
     return v.rcode;
 }
-

--- a/db/verify.c
+++ b/db/verify.c
@@ -398,7 +398,7 @@ int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds,
     }
 
     while (v.done == 0) {
-        pthread_cond_wait(&v.cd, &v.lk, &ts);
+        pthread_cond_wait(&v.cd, &v.lk);
     }
 
     pthread_attr_destroy(&attr);

--- a/db/verify.c
+++ b/db/verify.c
@@ -338,7 +338,7 @@ static int verify_table_int(const char *table, SBUF2 *sb, int progress_report_se
 
 struct verify_args {
     pthread_t tid;
-    char *table;
+    const char *table;
     SBUF2 *sb;
     int progress_report_seconds;
     int attempt_fix;
@@ -364,12 +364,7 @@ static void *verify_td(void *arg)
     return NULL;
 }
 
-static int verify_table_int(const char *table, SBUF2 *sb, int progress_report_seconds,
-             int attempt_fix, 
-             int (*lua_callback)(void *, const char *), void *lua_params)
-
-
-int verify_table(char *table, SBUF2 *sb, int progress_report_seconds, 
+int verify_table(const char *table, SBUF2 *sb, int progress_report_seconds, 
         int attempt_fix,
         int (*lua_callback)(void *, const char *), void *lua_params)
 {

--- a/tests/tools/testloop.sh
+++ b/tests/tools/testloop.sh
@@ -25,7 +25,6 @@ export goodtests=0
 export domail=1
 export host=$(hostname)
 export test_linger=$(( 60 * 2 ))
-
 function print_status
 {
     [[ "$debug" == "1" ]] && set -x

--- a/tests/tools/testloop.sh
+++ b/tests/tools/testloop.sh
@@ -25,6 +25,7 @@ export goodtests=0
 export domail=1
 export host=$(hostname)
 export test_linger=$(( 60 * 2 ))
+
 function print_status
 {
     [[ "$debug" == "1" ]] && set -x

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -905,6 +905,7 @@
 (name='verify_dbreg', description='Periodically check if dbreg entries are correct', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_directio', description='Run expensive checks on directio calls', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_master_lease_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
+(name='verify_thread_stacksz', description='Size of the verify thread stack.', type='INTEGER', value='2097152', read_only='N')
 (name='verifycheckpoints', description='Highly paranoid checkpoint validity checks', type='BOOLEAN', value='OFF', read_only='N')
 (name='verifylsn', description='Verify if LSN written before writing page', type='BOOLEAN', value='OFF', read_only='N')
 (name='wait_for_seqnum_trace', description='', type='BOOLEAN', value='OFF', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=910)
+(TUNABLES_COUNT=911)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')


### PR DESCRIPTION
Move verify logic from the appsock-thread (which has a very small stack) into a different thread.  The R6 version of this fixes the sc_datacopy test for our sun machines.
