### PR TITLE
fix schema change race with backend_open

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3868,7 +3868,7 @@ static int init(int argc, char **argv)
     load_dbstore_tableversion(thedb);
 
     gbl_backend_opened = 1;
-    pthread_rwlock_wrlock(&schema_lk);
+    pthread_rwlock_unlock(&schema_lk);
 
     sqlinit();
     rc = create_sqlmaster_records(NULL);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3849,7 +3849,7 @@ static int init(int argc, char **argv)
     if (gbl_create_mode) {
         create_service_file(lrlname);
     }
-    
+
     /* open db engine */
     logmsg(LOGMSG_INFO, "starting backend db engine\n");
 


### PR DESCRIPTION
Processing schema change during the replicant node start have a race between main thread opening tables, and the schema change itself. 
This patch avoid the race.
Ported from R6 https://bbgithub.dev.bloomberg.com/comdb2/comdb2/pull/813