### PR TITLE
mark datetime functions deterministic to allow view index optimization

### DIFF
--- a/sqlite/dttz.c
+++ b/sqlite/dttz.c
@@ -74,7 +74,8 @@ void register_date_functions(sqlite3 * db) {
 
     for(i=0;i<sizeof(aFuncs)/sizeof(aFuncs[0]); i++){
         rc = sqlite3_create_function(db, aFuncs[i].zName, aFuncs[i].nArg, 
-                SQLITE_ANY, 0, aFuncs[i].xFunc, aFuncs[i].xStep, aFuncs[i].xFinal);
+                SQLITE_ANY|SQLITE_DETERMINISTIC, 0, aFuncs[i].xFunc,
+                aFuncs[i].xStep, aFuncs[i].xFinal);
     }
 }
 

--- a/sqlite/vdbemem.c
+++ b/sqlite/vdbemem.c
@@ -1495,6 +1495,7 @@ static int valueFromFunction(
   memset(&ctx, 0, sizeof(ctx));
   ctx.pOut = pVal;
   ctx.pFunc = pFunc;
+  ctx.pVdbe = db->pVdbe;
   pFunc->xSFunc(&ctx, nVal, apVal);
   if( ctx.isError ){
     rc = ctx.isError;


### PR DESCRIPTION
Currently, comdb2 datetime functions are NOT treated as deterministic functions (i.e. if the input is constant, the output is constant). Therefore, sqlite optimizer ignores predicates including datetime functions. 
Ported from R6 https://bbgithub.dev.bloomberg.com/comdb2/comdb2/pull/818