### PR TITLE
Async sc

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -480,6 +480,10 @@ DEF_ATTR(SC_RESUME_AUTOCOMMIT, sc_resume_autocommit, BOOLEAN, 1,
 DEF_ATTR(SC_RESUME_WATCHDOG_TIMER, sc_resume_watchdog_timer, QUANTITY, 60,
          "sc_resuming_watchdog timer")
 DEF_ATTR(SC_DELAY_VERIFY_ERROR, sc_delay_verify_error, MSECS, 100, NULL)
+DEF_ATTR(SC_ASYNC, sc_async, BOOLEAN, 0,
+         "Run transactional schema changes asynchronously.")
+DEF_ATTR(SC_ASYNC_MAXTHREADS, sc_async_maxthreads, QUANTITY, 5,
+         "Max number of threads for asynchronous schema changes.")
 DEF_ATTR(USE_VTAG_ONDISK_VERMAP, use_vtag_ondisk_vermap, BOOLEAN, 1,
          "Use vtag_to_ondisk_vermap conversion function from vtag_to_ondisk.")
 DEF_ATTR(UDP_DROP_DELTA_THRESHOLD, udp_drop_delta_threshold, QUANTITY, 10,

--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -480,7 +480,7 @@ DEF_ATTR(SC_RESUME_AUTOCOMMIT, sc_resume_autocommit, BOOLEAN, 1,
 DEF_ATTR(SC_RESUME_WATCHDOG_TIMER, sc_resume_watchdog_timer, QUANTITY, 60,
          "sc_resuming_watchdog timer")
 DEF_ATTR(SC_DELAY_VERIFY_ERROR, sc_delay_verify_error, MSECS, 100, NULL)
-DEF_ATTR(SC_ASYNC, sc_async, BOOLEAN, 0,
+DEF_ATTR(SC_ASYNC, sc_async, BOOLEAN, 1,
          "Run transactional schema changes asynchronously.")
 DEF_ATTR(SC_ASYNC_MAXTHREADS, sc_async_maxthreads, QUANTITY, 5,
          "Max number of threads for asynchronous schema changes.")

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -404,6 +404,7 @@ int osql_bplog_schemachange(struct ireq *iq)
     if (rc) {
         csc2_free_all();
     }
+    logmsg(LOGMSG_INFO, ">>> DDL SCHEMA CHANGE RC %d <<<\n", rc);
     return rc;
 }
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -397,12 +397,15 @@ int osql_bplog_schemachange(struct ireq *iq)
             int sc_set_running(int running, uint64_t seed, const char *host,
                                time_t time);
             sc_set_running(0, iq->sc_seed, NULL, 0);
-            rc = ERR_SC;
+            rc = sc->sc_rc ? ERR_SC : 0;
         }
         sc = iq->sc;
     }
     if (rc) {
+        extern pthread_mutex_t csc2_subsystem_mtx;
+        pthread_mutex_lock(&csc2_subsystem_mtx);
         csc2_free_all();
+        pthread_mutex_unlock(&csc2_subsystem_mtx);
     }
     logmsg(LOGMSG_INFO, ">>> DDL SCHEMA CHANGE RC %d <<<\n", rc);
     return rc;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -397,7 +397,8 @@ int osql_bplog_schemachange(struct ireq *iq)
             int sc_set_running(int running, uint64_t seed, const char *host,
                                time_t time);
             sc_set_running(0, iq->sc_seed, NULL, 0);
-            rc = sc->sc_rc ? ERR_SC : 0;
+            if (sc->sc_rc)
+                rc = ERR_SC;
         }
         sc = iq->sc;
     }

--- a/db/osqlblockproc.h
+++ b/db/osqlblockproc.h
@@ -73,6 +73,11 @@ int osql_bplog_start(struct ireq *iq, osql_sess_t *sess);
 int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err);
 
 /**
+ * Apply all schema changes
+ */
+int osql_bplog_schemachange(struct ireq *iq);
+
+/**
  * Apply all the bplog updates
  */
 int osql_bplog_commit(struct ireq *iq, void *iq_trans, int *nops,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6290,7 +6290,7 @@ int start_schema_change_tran_wrapper(const char *tblname,
     strncpy0(sc->table, tblname, sizeof(sc->table));
 
     rc = start_schema_change_tran(iq, sc->tran);
-    if (rc != SC_OK && rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
+    if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
         iq->sc = NULL;
     } else {
         iq->sc->sc_next = iq->sc_pending;
@@ -6439,7 +6439,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
         if (!timepart_is_timepart(sc->table, 1)) {
             rc = start_schema_change_tran(iq, NULL);
-            if (rc != SC_OK && rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
+            if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
                 iq->sc = NULL;
             } else {
                 iq->sc->sc_next = iq->sc_pending;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6290,7 +6290,7 @@ int start_schema_change_tran_wrapper(const char *tblname,
     strncpy0(sc->table, tblname, sizeof(sc->table));
 
     rc = start_schema_change_tran(iq, sc->tran);
-    if (rc != SC_OK && rc != SC_ASYNC) {
+    if (rc != SC_OK && rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
         iq->sc = NULL;
     } else {
         iq->sc->sc_next = iq->sc_pending;
@@ -6311,7 +6311,7 @@ int start_schema_change_tran_wrapper(const char *tblname,
         }
     }
 
-    return (rc == SC_ASYNC) ? 0 : rc;
+    return (rc == SC_ASYNC || rc == SC_COMMIT_PENDING) ? 0 : rc;
 }
 
 /**
@@ -6420,7 +6420,10 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         if (p_buf == NULL)
             return -1;
 
-        sc->nothrevent = 0;
+        if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_ASYNC))
+            sc->nothrevent = 0;
+        else
+            sc->nothrevent = 1;
         sc->finalize = 0;
         if (sc->original_master_node[0] != 0 &&
             strcmp(sc->original_master_node, gbl_mynode))
@@ -6436,7 +6439,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
         if (!timepart_is_timepart(sc->table, 1)) {
             rc = start_schema_change_tran(iq, NULL);
-            if (rc != SC_OK && rc != SC_ASYNC) {
+            if (rc != SC_OK && rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
                 iq->sc = NULL;
             } else {
                 iq->sc->sc_next = iq->sc_pending;
@@ -6452,7 +6455,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         }
         iq->usedb = NULL;
 
-        if (!rc || rc == SC_ASYNC)
+        if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
             return 0;
         else
             return ERR_SC;

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -223,6 +223,16 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                         struct block_err *err, int *receivedrows, SBUF2 *logsb);
 
 /**
+ * Handles each packet and start schema change
+ *
+ */
+int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
+                              uuid_t uuid, void *trans, char *msg, int msglen,
+                              int *flags, int **updCols,
+                              blob_buffer_t blobs[MAXBLOBS], int step,
+                              struct block_err *err, int *receivedrows,
+                              SBUF2 *logsb);
+/**
  * Sends a user command to offload net (used by "osqlnet")
  *
  */

--- a/db/tag.c
+++ b/db/tag.c
@@ -60,6 +60,7 @@
 
 extern struct dbenv *thedb;
 extern void hexdump(const void *buf, int size);
+extern pthread_mutex_t csc2_subsystem_mtx;
 
 pthread_key_t unique_tag_key;
 
@@ -6970,6 +6971,7 @@ struct schema *create_version_schema(char *csc2, int version,
     char *tag;
     int rc;
 
+    pthread_mutex_lock(&csc2_subsystem_mtx);
     rc = dyns_load_schema_string(csc2, dbenv->envname, gbl_ver_temp_table);
     if (rc) {
         logmsg(LOGMSG_ERROR, "dyns_load_schema_string failed %s:%d\n", __FILE__,
@@ -7000,6 +7002,7 @@ struct schema *create_version_schema(char *csc2, int version,
         logmsg(LOGMSG_ERROR, "malloc failed %s:%d\n", __FILE__, __LINE__);
         goto err;
     }
+    pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     sprintf(tag, gbl_ondisk_ver_fmt, version);
     struct schema *ver_schema = clone_schema(s);
@@ -7017,6 +7020,7 @@ struct schema *create_version_schema(char *csc2, int version,
     return ver_schema;
 
 err:
+    pthread_mutex_unlock(&csc2_subsystem_mtx);
     return NULL;
 }
 
@@ -7070,6 +7074,7 @@ static int load_new_ondisk(struct dbtable *db, tran_type *tran)
     int len;
     char *csc2 = NULL;
 
+    pthread_mutex_lock(&csc2_subsystem_mtx);
     rc = get_csc2_file_tran(db->tablename, version, &csc2, &len, tran);
     if (rc) {
         logmsg(LOGMSG_ERROR, "get_csc2_file failed %s:%d\n", __FILE__, __LINE__);
@@ -7114,6 +7119,7 @@ static int load_new_ondisk(struct dbtable *db, tran_type *tran)
         cheap_stack_trace();
         goto err;
     }
+    pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     set_odh_options_tran(newdb, tran);
     transfer_db_settings(db, newdb);
@@ -7133,6 +7139,7 @@ static int load_new_ondisk(struct dbtable *db, tran_type *tran)
     return 0;
 
 err:
+    pthread_mutex_unlock(&csc2_subsystem_mtx);
     free(csc2);
     return 1;
 }

--- a/db/tag.c
+++ b/db/tag.c
@@ -7157,6 +7157,7 @@ int reload_after_bulkimport(struct dbtable *db, tran_type *tran)
 
 int reload_db_tran(struct dbtable *db, tran_type *tran)
 {
+    backout_schemas(db->tablename);
     clear_existing_schemas(db);
     if (load_new_ondisk(db, tran)) {
         logmsg(LOGMSG_ERROR, "Failed to load new .ONDISK\n");

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2492,7 +2492,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     int delayed = 0;
 
     int hascommitlock = 0;
-    if (iq->tranddl) rowlocks = 1;
+    if (iq->tranddl)
+        rowlocks = 1;
 
     /* zero this out very high up or we can crash if we get to backout: without
      * having initialised this. */
@@ -4581,13 +4582,16 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             needbackout = 1;
         }
 
-        if (iq->tranddl && trans) {
-            int iirc =
-                osql_destroy_transaction(iq, have_blkseq ? &parent_trans : NULL,
-                                         &trans, &osql_needtransaction);
-            if (iirc) {
-                numerrs = 1;
-                BACKOUT;
+        if (iq->tranddl) {
+            int iirc;
+            if (trans) {
+                iirc = osql_destroy_transaction(iq, have_blkseq ? &parent_trans
+                                                                : NULL,
+                                                &trans, &osql_needtransaction);
+                if (iirc) {
+                    numerrs = 1;
+                    BACKOUT;
+                }
             }
             iirc = osql_bplog_schemachange(iq);
             if (iirc) {

--- a/schemachange/sc_add_table.h
+++ b/schemachange/sc_add_table.h
@@ -17,10 +17,10 @@
 #ifndef INCLUDE_SC_ADD_TABLES_H
 #define INCLUDE_SC_ADD_TABLES_H
 
-int do_add_table(struct ireq *, tran_type *);
+int do_add_table(struct ireq *, struct schema_change_type *, tran_type *);
 int add_table_to_environment(char *table, const char *csc2,
                              struct schema_change_type *s, struct ireq *iq,
                              tran_type *trans);
-int finalize_add_table(struct ireq *, tran_type *);
+int finalize_add_table(struct ireq *, struct schema_change_type *, tran_type *);
 
 #endif

--- a/schemachange/sc_alter_table.h
+++ b/schemachange/sc_alter_table.h
@@ -17,8 +17,10 @@
 #ifndef INCLUDE_SC_TABLES_H
 #define INCLUDE_SC_TABLES_H
 
-int do_alter_table(struct ireq *iq, tran_type *tran);
+int do_alter_table(struct ireq *iq, struct schema_change_type *s,
+                   tran_type *tran);
 int do_upgrade_table_int(struct schema_change_type *s);
-int finalize_alter_table(struct ireq *iq, tran_type *tran);
+int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
+                         tran_type *tran);
 int finalize_upgrade_table(struct schema_change_type *s);
 #endif

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -42,9 +42,9 @@ static int delete_table(struct dbtable *db, tran_type *tran)
     return 0;
 }
 
-int do_drop_table(struct ireq *iq, tran_type *tran)
+int do_drop_table(struct ireq *iq, struct schema_change_type *s,
+                  tran_type *tran)
 {
-    struct schema_change_type *s = iq->sc;
     struct dbtable *db;
     iq->usedb = db = s->db = get_dbtable_by_name(s->table);
     if (db == NULL) {
@@ -61,9 +61,9 @@ int do_drop_table(struct ireq *iq, tran_type *tran)
     return SC_OK;
 }
 
-int finalize_drop_table(struct ireq *iq, tran_type *tran)
+int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
+                        tran_type *tran)
 {
-    struct schema_change_type *s = iq->sc;
     struct dbtable *db = s->db;
     int rc = 0;
     int bdberr = 0;

--- a/schemachange/sc_drop_table.h
+++ b/schemachange/sc_drop_table.h
@@ -18,7 +18,8 @@
 #define INCLUDE_SC_DROP_H
 
 struct ireq;
-int do_drop_table(struct ireq *, tran_type *);
-int finalize_drop_table(struct ireq *, tran_type *);
+int do_drop_table(struct ireq *, struct schema_change_type *, tran_type *);
+int finalize_drop_table(struct ireq *, struct schema_change_type *,
+                        tran_type *);
 
 #endif

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -30,15 +30,15 @@
 #include "sc_drop_table.h"
 #include "sc_add_table.h"
 
-int do_fastinit(struct ireq *iq, tran_type *tran)
+int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 {
-    return do_drop_table(iq, tran);
+    return do_drop_table(iq, s, tran);
 }
 
-int finalize_fastinit_table(struct ireq *iq, tran_type *tran)
+int finalize_fastinit_table(struct ireq *iq, struct schema_change_type *s,
+                            tran_type *tran)
 {
     int rc = 0;
-    struct schema_change_type *s = iq->sc;
     extern int gbl_broken_max_rec_sz;
     int saved_broken_max_rec_sz = gbl_broken_max_rec_sz;
 
@@ -47,8 +47,8 @@ int finalize_fastinit_table(struct ireq *iq, tran_type *tran)
         gbl_broken_max_rec_sz = s->db->lrl - COMDB2_MAX_RECORD_SIZE;
     }
 
-    rc = finalize_drop_table(iq, tran) || do_add_table(iq, tran) ||
-         finalize_add_table(iq, tran);
+    rc = finalize_drop_table(iq, s, tran) || do_add_table(iq, s, tran) ||
+         finalize_add_table(iq, s, tran);
 
     gbl_broken_max_rec_sz = saved_broken_max_rec_sz;
 

--- a/schemachange/sc_fastinit_table.h
+++ b/schemachange/sc_fastinit_table.h
@@ -18,7 +18,8 @@
 #define INCLUDE_SC_FASTINIT_H
 
 struct ireq;
-int do_fastinit(struct ireq *, tran_type *);
-int finalize_fastinit_table(struct ireq *, tran_type *);
+int do_fastinit(struct ireq *, struct schema_change_type *, tran_type *);
+int finalize_fastinit_table(struct ireq *, struct schema_change_type *,
+                            tran_type *);
 
 #endif

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -42,6 +42,11 @@ int gbl_default_sc_scanmode = SCAN_PARALLEL;
 pthread_mutex_t sc_resuming_mtx = PTHREAD_MUTEX_INITIALIZER;
 struct schema_change_type *sc_resuming = NULL;
 
+/* async ddl sc */
+pthread_mutex_t sc_async_mtx = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t sc_async_cond = PTHREAD_COND_INITIALIZER;
+volatile int sc_async_threads = 0;
+
 /* Throttle settings, which you can change with message traps.  Note that if
  * you have gbl_sc_usleep=0, the important live writer threads never get to
  * run. */
@@ -185,6 +190,7 @@ int sc_set_running(int running, uint64_t seed, const char *host, time_t time)
             sc_time = 0;
             gbl_sc_resume_start = 0;
             gbl_schema_change_in_progress = 0;
+            sc_async_threads = 0;
         }
     }
     ctrace("sc_set_running(running=%d seed=0x%llx): "

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -29,6 +29,7 @@ pthread_rwlock_t schema_lk = PTHREAD_RWLOCK_INITIALIZER;
 pthread_mutex_t schema_change_in_progress_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t fastinit_in_progress_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_mutex_t schema_change_sbuf2_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_mutex_t csc2_subsystem_mtx = PTHREAD_MUTEX_INITIALIZER;
 volatile int gbl_schema_change_in_progress = 0;
 volatile int gbl_lua_version = 0;
 uint64_t sc_seed;

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -21,6 +21,7 @@ extern pthread_mutex_t schema_change_in_progress_mutex;
 extern pthread_mutex_t fastinit_in_progress_mutex;
 extern pthread_mutex_t schema_change_sbuf2_lock;
 extern pthread_mutex_t sc_resuming_mtx;
+extern pthread_mutex_t csc2_subsystem_mtx;
 extern struct schema_change_type *sc_resuming;
 extern volatile int gbl_schema_change_in_progress;
 extern volatile int gbl_lua_version;

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -31,6 +31,10 @@ extern int gbl_default_livesc;
 extern int gbl_default_plannedsc;
 extern int gbl_default_sc_scanmode;
 
+extern pthread_mutex_t sc_async_mtx;
+extern pthread_cond_t sc_async_cond;
+extern volatile int sc_async_threads;
+
 /* Throttle settings, which you can change with message traps.  Note that if
  * you have gbl_sc_usleep=0, the important live writer threads never get to
  * run. */

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -280,7 +280,7 @@ int do_upgrade_table(struct schema_change_type *s)
     return rc;
 }
 
-typedef int (*ddl_t)(struct ireq *, tran_type *);
+typedef int (*ddl_t)(struct ireq *, struct schema_change_type *, tran_type *);
 
 /*
 ** Start transaction if not passed in (comdb2sc.tsk)
@@ -288,12 +288,12 @@ typedef int (*ddl_t)(struct ireq *, tran_type *);
 **   1. also commit it
 **   2. log scdone here
 */
-static int do_finalize(ddl_t func, struct ireq *iq, tran_type *input_tran,
+static int do_finalize(ddl_t func, struct ireq *iq,
+                       struct schema_change_type *s, tran_type *input_tran,
                        scdone_t type)
 {
     int rc;
     tran_type *tran = input_tran;
-    struct schema_change_type *s = iq->sc;
 
     if (tran == NULL) {
         rc = trans_start_sc(iq, NULL, &tran);
@@ -303,7 +303,7 @@ static int do_finalize(ddl_t func, struct ireq *iq, tran_type *input_tran,
         }
     }
 
-    rc = func(iq, tran);
+    rc = func(iq, s, tran);
 
     if (rc) {
         if (input_tran == NULL) {
@@ -339,42 +339,41 @@ static int do_finalize(ddl_t func, struct ireq *iq, tran_type *input_tran,
     return rc;
 }
 
-static int check_table_version(struct ireq *iq)
+static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
 {
-    if (iq->sc->addonly || iq->sc->resume)
+    if (sc->addonly || sc->resume)
         return 0;
     int rc, bdberr;
     unsigned long long version;
-    rc = bdb_table_version_select(iq->sc->table, NULL, &version, &bdberr);
+    rc = bdb_table_version_select(sc->table, NULL, &version, &bdberr);
     if (rc != 0) {
         errstat_set_strf(&iq->errstat,
-                         "failed to get version for table:%s rc:%d",
-                         iq->sc->table, rc);
+                         "failed to get version for table:%s rc:%d", sc->table,
+                         rc);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
     if (iq->usedbtablevers != version) {
         errstat_set_strf(&iq->errstat,
                          "stale version for table:%s master:%d replicant:%d",
-                         iq->sc->table, version, iq->usedbtablevers);
+                         sc->table, version, iq->usedbtablevers);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
     return 0;
 }
 
-static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq, tran_type *tran,
-                  scdone_t type)
+static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
+                  struct schema_change_type *s, tran_type *tran, scdone_t type)
 {
     int rc;
-    struct schema_change_type *s = iq->sc;
     if (s->finalize_only) {
         return s->sc_rc;
     }
     if (type != alter)
         wrlock_schema_lk();
     set_original_tablename(s);
-    if ((rc = check_table_version(iq)) != 0) { // non-tran ??
+    if ((rc = check_table_version(iq, s)) != 0) { // non-tran ??
         goto end;
     }
     if (!s->resume)
@@ -382,7 +381,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq, tran_type *tran,
     if ((rc = mark_sc_in_llmeta_tran(s, NULL))) // non-tran ??
         goto end;
     broadcast_sc_start(sc_seed, sc_host, time(NULL)); // dont care rcode
-    rc = pre(iq, NULL); // non-tran ??
+    rc = pre(iq, s, NULL);                            // non-tran ??
     if (type == alter && master_downgrading(s)) {
         s->sc_rc = SC_MASTER_DOWNGRADE;
         errstat_set_strf(
@@ -394,7 +393,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq, tran_type *tran,
         mark_schemachange_over_tran(s->table, NULL); // non-tran ??
         broadcast_sc_end(0);
     } else if (s->finalize) {
-        rc = do_finalize(post, iq, tran, type);
+        rc = do_finalize(post, iq, s, tran, type);
         broadcast_sc_end(sc_seed);
     } else {
         rc = SC_COMMIT_PENDING;
@@ -458,15 +457,14 @@ int do_schema_change_tran(sc_arg_t *arg)
 {
     struct ireq *iq = arg->iq;
     tran_type *trans = arg->trans;
+    struct schema_change_type *s = arg->sc;
     free(arg);
 
     if (iq == NULL) {
         abort();
     }
 
-    struct schema_change_type *s = iq->sc;
     s->iq = iq;
-    pthread_mutex_lock(&s->mtx);
     enum thrtype oldtype = prepare_sc_thread(s);
     int rc = SC_OK;
 
@@ -485,18 +483,19 @@ int do_schema_change_tran(sc_arg_t *arg)
     else if (s->is_afunc)
         rc = do_lua_afunc(s);
     else if (s->fastinit && s->drop_table)
-        rc = do_ddl(do_drop_table, finalize_drop_table, iq, trans, drop);
+        rc = do_ddl(do_drop_table, finalize_drop_table, iq, s, trans, drop);
     else if (s->fastinit)
-        rc = do_ddl(do_fastinit, finalize_fastinit_table, iq, trans, fastinit);
+        rc = do_ddl(do_fastinit, finalize_fastinit_table, iq, s, trans,
+                    fastinit);
     else if (s->addonly)
-        rc = do_ddl(do_add_table, finalize_add_table, iq, trans, add);
+        rc = do_ddl(do_add_table, finalize_add_table, iq, s, trans, add);
     else if (s->rename)
-        rc = do_ddl(do_rename_table, finalize_rename_table, iq, trans,
+        rc = do_ddl(do_rename_table, finalize_rename_table, iq, s, trans,
                     rename_table);
     else if (s->fulluprecs || s->partialuprecs)
         rc = do_upgrade_table(s);
     else if (s->type == DBTYPE_TAGGED_TABLE)
-        rc = do_ddl(do_alter_table, finalize_alter_table, iq, trans, alter);
+        rc = do_ddl(do_alter_table, finalize_alter_table, iq, s, trans, alter);
     else if (s->type == DBTYPE_QUEUE)
         rc = do_alter_queues(s);
     else if (s->type == DBTYPE_MORESTRIPE)
@@ -542,7 +541,9 @@ int do_schema_change(struct schema_change_type *s)
     iq.usedbtablevers = s->db ? s->db->tableversion : 0;
     sc_arg_t *arg = malloc(sizeof(sc_arg_t));
     arg->iq = &iq;
+    arg->sc = s;
     arg->trans = NULL;
+    pthread_mutex_lock(&s->mtx);
     return do_schema_change_tran(arg);
 }
 
@@ -578,15 +579,15 @@ int finalize_schema_change_thd(struct ireq *iq, tran_type *trans)
     else if (s->is_afunc)
         rc = finalize_lua_afunc();
     else if (s->fastinit && s->drop_table)
-        rc = do_finalize(finalize_drop_table, iq, trans, drop);
+        rc = do_finalize(finalize_drop_table, iq, s, trans, drop);
     else if (s->fastinit)
-        rc = do_finalize(finalize_fastinit_table, iq, trans, fastinit);
+        rc = do_finalize(finalize_fastinit_table, iq, s, trans, fastinit);
     else if (s->addonly)
-        rc = do_finalize(finalize_add_table, iq, trans, add);
+        rc = do_finalize(finalize_add_table, iq, s, trans, add);
     else if (s->rename)
-        rc = do_finalize(finalize_rename_table, iq, trans, rename_table);
+        rc = do_finalize(finalize_rename_table, iq, s, trans, rename_table);
     else if (s->type == DBTYPE_TAGGED_TABLE)
-        rc = do_finalize(finalize_alter_table, iq, trans, alter);
+        rc = do_finalize(finalize_alter_table, iq, s, trans, alter);
     else if (s->fulluprecs || s->partialuprecs)
         rc = finalize_upgrade_table(s);
     if (!keep_sc_locked) {

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -353,7 +353,7 @@ static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
-    if (iq->usedbtablevers != version) {
+    if (sc->usedbtablevers != version) {
         errstat_set_strf(&iq->errstat,
                          "stale version for table:%s master:%d replicant:%d",
                          sc->table, version, iq->usedbtablevers);
@@ -538,7 +538,7 @@ int do_schema_change(struct schema_change_type *s)
         s->db = get_dbtable_by_name(s->table);
     }
     iq.usedb = s->db;
-    iq.usedbtablevers = s->db ? s->db->tableversion : 0;
+    s->usedbtablevers = iq.usedbtablevers = s->db ? s->db->tableversion : 0;
     sc_arg_t *arg = malloc(sizeof(sc_arg_t));
     arg->iq = &iq;
     arg->sc = s;

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -24,9 +24,9 @@
 #include "sc_global.h"
 #include "sc_callbacks.h"
 
-int do_rename_table(struct ireq *iq, tran_type *tran)
+int do_rename_table(struct ireq *iq, struct schema_change_type *s,
+                    tran_type *tran)
 {
-    struct schema_change_type *s = iq->sc;
     struct dbtable *db;
     iq->usedb = db = s->db = get_dbtable_by_name(s->table);
     if (db == NULL) {
@@ -49,9 +49,9 @@ int do_rename_table(struct ireq *iq, tran_type *tran)
     return SC_OK;
 }
 
-int finalize_rename_table(struct ireq *iq, tran_type *tran)
+int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
+                          tran_type *tran)
 {
-    struct schema_change_type *s = iq->sc;
     struct dbtable *db = s->db;
     char *newname = strdup(s->newtable);
     int rc = 0;

--- a/schemachange/sc_rename_table.h
+++ b/schemachange/sc_rename_table.h
@@ -18,7 +18,8 @@
 #define INCLUDE_SC_RENAME_H
 
 struct ireq;
-int do_rename_table(struct ireq *, tran_type *);
-int finalize_rename_table(struct ireq *, tran_type *);
+int do_rename_table(struct ireq *, struct schema_change_type *, tran_type *);
+int finalize_rename_table(struct ireq *, struct schema_change_type *,
+                          tran_type *);
 
 #endif

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -264,12 +264,8 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         if (!s->partialuprecs)
             logmsg(LOGMSG_INFO, "Executing ASYNCHRONOUSLY\n");
         pthread_t tid;
-        if (trans)
-            rc = pthread_create(&tid, &gbl_pthread_attr_detached,
-                                (void *(*)(void *))do_schema_change_tran, arg);
-        else
-            rc = pthread_create(&tid, &gbl_pthread_attr_detached,
-                                (void *(*)(void *))do_schema_change, s);
+        rc = pthread_create(&tid, &gbl_pthread_attr_detached,
+                            (void *(*)(void *))do_schema_change_tran, arg);
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "start_schema_change:pthread_create rc %d %s\n", rc,
@@ -295,6 +291,7 @@ int start_schema_change(struct schema_change_type *s)
         s->db = get_dbtable_by_name(s->table);
     }
     iq.usedb = s->db;
+    iq.usedbtablevers = s->db ? s->db->tableversion : 0;
     return start_schema_change_tran(&iq, NULL);
 }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -167,7 +167,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     strcpy(s->original_master_node, gbl_mynode);
     unsigned long long seed;
     const char *node = gbl_mynode;
-    if (trans && s->tran == trans && iq->sc_seed) {
+    if (s->tran == trans && iq->sc_seed) {
         seed = iq->sc_seed;
         logmsg(LOGMSG_INFO, "Starting schema change: "
                             "transactionally reuse seed 0x%llx\n",
@@ -971,6 +971,7 @@ int sc_timepart_add_table(const char *existingTableName,
     char *schemabuf = NULL;
     struct dbtable *db;
 
+    init_schemachange_type(&sc);
     /* prepare sc */
     sc.onstack = 1;
     sc.type = DBTYPE_TAGGED_TABLE;
@@ -1069,6 +1070,7 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     char *schemabuf = NULL;
     int rc;
 
+    init_schemachange_type(&sc);
     /* prepare sc */
     sc.onstack = 1;
     sc.type = DBTYPE_TAGGED_TABLE;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -288,15 +288,20 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
 
 int start_schema_change(struct schema_change_type *s)
 {
-    struct ireq iq;
-    init_fake_ireq(thedb, &iq);
-    iq.sc = s;
+    struct ireq *iq = NULL;
+    iq = (struct ireq *)calloc(1, sizeof(*iq));
+    if (iq == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: failed to malloc ireq\n", __func__);
+        return -1;
+    }
+    init_fake_ireq(thedb, iq);
+    iq->sc = s;
     if (s->db == NULL) {
         s->db = get_dbtable_by_name(s->table);
     }
-    iq.usedb = s->db;
-    iq.usedbtablevers = s->db ? s->db->tableversion : 0;
-    return start_schema_change_tran(&iq, NULL);
+    iq->usedb = s->db;
+    iq->usedbtablevers = s->db ? s->db->tableversion : 0;
+    return start_schema_change_tran(iq, NULL);
 }
 
 void delay_if_sc_resuming(struct ireq *iq)

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -244,6 +244,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     arg->trans = trans;
     arg->iq = iq;
     arg->sc = iq->sc;
+    iq->sc->usedbtablevers = iq->usedbtablevers;
 
     if (s->resume && s->alteronly && !s->finalize_only) {
         if (gbl_test_sc_resume_race) {

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -193,6 +193,7 @@ struct ireq;
 typedef struct {
     tran_type *trans;
     struct ireq *iq;
+    struct schema_change_type *sc;
 } sc_arg_t;
 
 struct scinfo {

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -162,7 +162,7 @@ struct schema_change_type {
 
     struct schema_change_type *sc_next;
 
-
+    int usedbtablevers;
 
     /*********************** temporary fields for in progress
      * schemachange************/

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -728,6 +728,8 @@
 (name='rowlocks_pagelock_optimization', description='Upgrade rowlocks to pagelocks if possible on cursor traversals.', type='BOOLEAN', value='ON', read_only='N')
 (name='rr_enable_count_changes', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='sbuftimeout', description='', type='INTEGER', value='0', read_only='Y')
+(name='sc_async', description='Run transactional schema changes asynchronously.', type='BOOLEAN', value='OFF', read_only='N')
+(name='sc_async_maxthreads', description='Max number of threads for asynchronous schema changes.', type='INTEGER', value='5', read_only='N')
 (name='sc_check_lockwaits_sec', description='Frequency of checking lockwaits during schemachange (in seconds).', type='INTEGER', value='1', read_only='N')
 (name='sc_decrease_thrds_on_deadlock', description='Decrease number of schema change threads on deadlock - way to have schema change backoff.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_del_unused_files_threshold', description='', type='INTEGER', value='30000', read_only='Y')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=908)
+(TUNABLES_COUNT=910)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -728,7 +728,7 @@
 (name='rowlocks_pagelock_optimization', description='Upgrade rowlocks to pagelocks if possible on cursor traversals.', type='BOOLEAN', value='ON', read_only='N')
 (name='rr_enable_count_changes', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='sbuftimeout', description='', type='INTEGER', value='0', read_only='Y')
-(name='sc_async', description='Run transactional schema changes asynchronously.', type='BOOLEAN', value='OFF', read_only='N')
+(name='sc_async', description='Run transactional schema changes asynchronously.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_async_maxthreads', description='Max number of threads for asynchronous schema changes.', type='INTEGER', value='5', read_only='N')
 (name='sc_check_lockwaits_sec', description='Frequency of checking lockwaits during schemachange (in seconds).', type='INTEGER', value='1', read_only='N')
 (name='sc_decrease_thrds_on_deadlock', description='Decrease number of schema change threads on deadlock - way to have schema change backoff.', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
* fix DDLs holding log files bug by doing the 1st phrase of schema changes before starting a transaction -- only the finalize phrase needs a tran.
* dispatch threads to do schema changes for transactional DDLs instead of doing inline.
