### PR TITLE
Fix timepart events race status

### DIFF
--- a/tests/timepart_events.test/Makefile
+++ b/tests/timepart_events.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=15m
+	export TEST_TIMEOUT=5m
 endif

--- a/tests/timepart_events.test/run.log.alpha
+++ b/tests/timepart_events.test/run.log.alpha
@@ -4,8 +4,8 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comd
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, shard0name, version from comdb2_timepartitions 
 (name='testview1', period='daily', retention=2, nshards=2, shard0name='t', version=0)
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='testview1', shardname='$1_E5EE49E6')
 (name='testview1', shardname='$0_F64CD191')
-(name='testview1', shardname='$2_D109E17F')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
 (name='AddShard', arg1='testview1', arg2=NULL, arg3=NULL)
 Checking previous master

--- a/tests/timepart_events.test/runit
+++ b/tests/timepart_events.test/runit
@@ -59,6 +59,9 @@ if (( $? != 0 )) ; then
    exit 1
 fi
 
+# lets wait for the rollout to avoid race between status epdate and the 3 rollouts
+sleep 20 
+
 timepart_stats
 
 get_master

--- a/tests/timepart_events.test/runit
+++ b/tests/timepart_events.test/runit
@@ -34,7 +34,7 @@ function timepart_stats
     #randomly we catch a drop event here; sleep to skip the deterministically
     sleep 6
     echo cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, arg1, arg2, arg3 from comdb2_timepartevents" >> $OUT
-    cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, arg1, arg2, arg3 from comdb2_timepartevents" >> $OUT
+    cdb2sql --host $master ${CDB2_OPTIONS} $dbname default  "select name, arg1, arg2, arg3 from comdb2_timepartevents" >> $OUT
     if (( $? != 0 )) ; then
         echo "FAILURE"
         exit 1
@@ -48,6 +48,7 @@ function get_master
 
 
 
+get_master
 timepart_stats
 
 # create the partition in the past, 3 days ago


### PR DESCRIPTION
recording the status of the time partition was racing against the partition rollout; test adapted 