### PR TITLE
Fix rename

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -61,6 +61,10 @@ static int bdb_scdone_int(bdb_state_type *bdb_state_in, DB_TXN *txnid,
 {
     int rc;
     bdb_state_type *bdb_state;
+    char *db_newtable = NULL;
+
+    if (newtable && newtable[0])
+        db_newtable = strdup(newtable);
 
     if (bdb_state_in == NULL)
         return 0;
@@ -77,17 +81,17 @@ static int bdb_scdone_int(bdb_state_type *bdb_state_in, DB_TXN *txnid,
     }
 
     if (!bdb_state->callback->scdone_rtn) {
-        logmsg(LOGMSG_ERROR, "bdb_scdone_int: no scdone callback\n");
+        logmsg(LOGMSG_ERROR, "%s: no scdone callback\n", __func__);
         return -1;
     }
 
     /* TODO fail gracefully now that inline? */
     /* reload the changed table (if necesary) and update the schemas in memory*/
     if ((rc = bdb_state->callback->scdone_rtn(bdb_state_in, table,
-                                              (char *)newtable, fastinit))) {
+                                              db_newtable, fastinit))) {
         if (rc == BDBERR_DEADLOCK)
             rc = DB_LOCK_DEADLOCK;
-        logmsg(LOGMSG_ERROR, "bdb_scdone_int: callback failed\n");
+        logmsg(LOGMSG_ERROR, "%s: callback failed\n", __func__);
         return rc;
     }
 
@@ -107,8 +111,8 @@ int handle_scdone(DB_ENV *dbenv, u_int32_t rectype, llog_scdone_args *scdoneop,
     scdone_t sctype = ntohl(type);
 
     if (sctype == rename_table) {
-        assert(strlen(table) + 1 < scdoneop->table.size);
-        newtable = &table[strlen(table) + 1];
+        assert(strlen(table)+1 < scdoneop->table.size);
+        newtable = &table[strlen(table)+1];
     }
 
     switch (op) {
@@ -236,7 +240,8 @@ static int do_llog(bdb_state_type *bdb_state, scdone_t sctype, char *tbl,
 }
 
 int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
-                         tran_type *tran, const char *origtable, int *bdberr)
+                         tran_type *tran, const char *origtable,
+                         int *bdberr)
 {
     int rc = 0;
     DBT *dtbl = NULL;

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -5739,6 +5739,13 @@ __lock_get_list_int_int(dbenv, locker, flags, lock_mode, list, pcontext, maxlsn,
 			obj_dbt.data = dp;
 			obj_dbt.size = size;
 			dp = ((u_int8_t *)dp) + ALIGN(size, sizeof(u_int32_t));
+            /* skip replication handle locks */
+            if (size == sizeof(DB_LOCK_ILOCK) && 
+                    IS_WRITELOCK(lock_mode) &&
+                    ((DB_LOCK_ILOCK*)obj_dbt.data)->type == DB_HANDLE_LOCK) {
+                logmsg(LOGMSG_ERROR, "Skipped write handle lock on replicant\n");
+                continue;
+            }
 			do {
 				if (LF_ISSET(LOCK_GET_LIST_GETLOCK)) {
 					uint32_t lflags =

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -5739,11 +5739,16 @@ __lock_get_list_int_int(dbenv, locker, flags, lock_mode, list, pcontext, maxlsn,
 			obj_dbt.data = dp;
 			obj_dbt.size = size;
 			dp = ((u_int8_t *)dp) + ALIGN(size, sizeof(u_int32_t));
-            /* skip replication handle locks */
+            /* 
+             * Comdb2 early locking in replication does not support 
+             * handle locks in write mode for opened file.  We rely
+             * on table locks instead.
+             *
+             */
             if (size == sizeof(DB_LOCK_ILOCK) && 
                     IS_WRITELOCK(lock_mode) &&
                     ((DB_LOCK_ILOCK*)obj_dbt.data)->type == DB_HANDLE_LOCK) {
-                logmsg(LOGMSG_ERROR, "Skipped write handle lock on replicant\n");
+                logmsg(LOGMSG_INFO, "Skipped write handle lock on replicant\n");
                 continue;
             }
 			do {

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -49,12 +49,6 @@ static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
         return -1;
     }
 
-    if (bdb_table_version_select(newtable, NULL, &db->tableversion, &bdberr)) {
-        logmsg(LOGMSG_ERROR, "%s: failed to retrieve table version for new %s \n",
-               __func__, name, newtable);
-        return -1;
-    }
-
     tran = bdb_tran_begin(bdb_state, NULL, &bdberr);
     if (tran == NULL) {
         logmsg(LOGMSG_ERROR, "%s: failed to start tran\n", __func__);
@@ -63,6 +57,12 @@ static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
 
     bdb_get_tran_lockerid(tran, &lid);
     bdb_set_tran_lockerid(tran, gbl_rep_lockid);
+
+    if (bdb_table_version_select(newtable, tran, &db->tableversion, &bdberr)) {
+        logmsg(LOGMSG_ERROR, "%s: failed to retrieve table version for new %s \n",
+               __func__, name, newtable);
+        return -1;
+    }
 
     create_sqlmaster_records(tran);
     create_sqlite_master();

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -28,16 +28,48 @@
 #include "logmsg.h"
 #include "bdb_net.h"
 
-static int reload_rename_table(const char *name, const char *newtable)
+static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
+                               const char *newtable)
 {
+    void *tran = NULL;
+    int rc;
+    int bdberr = 0;
+    uint32_t lid = 0;
+    extern uint32_t gbl_rep_lockid;
     struct dbtable *db = get_dbtable_by_name(name);
-
+   
     if (!db) {
         logmsg(LOGMSG_ERROR, "%s: unable to find table %s\n", __func__, name);
         return -1;
     }
 
-    return rename_db(db, newtable);
+    if(rename_db(db, newtable)) {
+        logmsg(LOGMSG_ERROR, "%s: failed to rename %s to %s \n", __func__,
+               name, newtable);
+        return -1;
+    }
+
+    tran = bdb_tran_begin(bdb_state, NULL, &bdberr);
+    if (tran == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: failed to start tran\n", __func__);
+        return -1;
+    }
+
+    bdb_get_tran_lockerid(tran, &lid);
+    bdb_set_tran_lockerid(tran, gbl_rep_lockid);
+
+    create_sqlmaster_records(tran);
+    create_sqlite_master();
+    ++gbl_dbopen_gen;
+
+    bdb_set_tran_lockerid(tran, lid);
+    rc = bdb_tran_abort(thedb->bdb_env, tran, &bdberr);
+    if (rc) 
+        logmsg(LOGMSG_FATAL, "%s failed to abort transaction\n", __func__, rc);
+
+    sc_set_running(0 /*running*/, 0 /*seed*/, NULL, 0);
+
+    return rc;
 }
 
 static int set_genid_format(bdb_state_type *bdb_state, scdone_t type)
@@ -599,7 +631,7 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
     case lua_sfunc: return reload_lua_sfuncs();
     case lua_afunc: return reload_lua_afuncs();
     case rename_table:
-        return reload_rename_table(table, (char *)arg);
+        return reload_rename_table(bdb_state, table, (char *)arg);
     default:
         break;
     }

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -49,6 +49,12 @@ static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
         return -1;
     }
 
+    if (bdb_table_version_select(newtable, NULL, &db->tableversion, &bdberr)) {
+        logmsg(LOGMSG_ERROR, "%s: failed to retrieve table version for new %s \n",
+               __func__, name, newtable);
+        return -1;
+    }
+
     tran = bdb_tran_begin(bdb_state, NULL, &bdberr);
     if (tran == NULL) {
         logmsg(LOGMSG_ERROR, "%s: failed to start tran\n", __func__);


### PR DESCRIPTION
missing a few critical pieces of code that were in here https://github.com/bloomberg/comdb2/pull/480, but failed to merge cleanly and gone AWOL in https://github.com/bloomberg/comdb2/pull/486.
Basically:
1) handle locking (early locking in replication doesn't work with default berkeleydb rename/remove ops)
2) handle reload on replicant, including versioning