### PR TITLE
Create db with relative dir arg

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1411,6 +1411,7 @@ void clean_exit(void)
 
     cleanup_interned_strings();
     cleanup_peer_hash();
+    free(gbl_dbdir);
     // TODO: would be nice but other threads need to exit first:
     // comdb2ma_exit();
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -302,7 +302,6 @@ int gbl_maxretries = 500;              /* thats a lotta retries */
 int gbl_maxblobretries =
     0; /* everyone assures me this can't happen unless the data is corrupt */
 int gbl_maxcontextskips = 10000; /* that's a whole whale of a lotta retries */
-char gbl_cwd[256];               /* start directory */
 int gbl_heartbeat_check = 0, gbl_heartbeat_send = 0, gbl_decom = 0;
 int gbl_netbufsz = 1 * 1024 * 1024;
 int gbl_loghist = 0;
@@ -3084,12 +3083,6 @@ static int init(int argc, char **argv)
         logmsg(LOGMSG_FATAL, "bdb_osql_log_repo_init failed to init log repository "
                         "rc %d bdberr %d\n",
                 rc, bdberr);
-        return -1;
-    }
-
-    /* get my working directory */
-    if (getcwd(gbl_cwd, sizeof(gbl_cwd)) == 0) {
-        logmsgperror("failed to getcwd");
         return -1;
     }
 

--- a/db/config.c
+++ b/db/config.c
@@ -112,6 +112,20 @@ static int write_pidfile(const char *pidfile)
     fclose(f);
     return 0;
 }
+static void set_dbdir(char *dir)
+{
+    if (dir == NULL)
+        return;
+    if (*dir == '/') {
+        gbl_dbdir = dir;
+        return;
+    }
+    char *wd = getcwd(NULL, 0);
+    int n = snprintf(NULL, 0, "%s/%s", wd, dir);
+    gbl_dbdir = malloc(++n);
+    snprintf(gbl_dbdir, n, "%s/%s", wd, dir);
+    free(wd);
+}
 
 int handle_cmdline_options(int argc, char **argv, char **lrlname)
 {
@@ -152,7 +166,7 @@ int handle_cmdline_options(int argc, char **argv, char **lrlname)
             break;
         case 4: /* recovery_lsn */ gbl_recovery_options = optarg; break;
         case 5: /* pidfile */ write_pidfile(optarg); break;
-        case 10: /* dir */ gbl_dbdir = optarg; break;
+        case 10: /* dir */ set_dbdir(optarg); break;
         }
     }
     return 0;

--- a/db/config.c
+++ b/db/config.c
@@ -45,7 +45,6 @@ extern int gbl_bad_lrl_fatal;
 extern int gbl_disable_new_snapshot;
 
 extern char *gbl_recovery_options;
-extern char *gbl_dbdir;
 extern const char *gbl_repoplrl_fname;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern char **qdbs;
@@ -112,12 +111,13 @@ static int write_pidfile(const char *pidfile)
     fclose(f);
     return 0;
 }
+
 static void set_dbdir(char *dir)
 {
     if (dir == NULL)
         return;
     if (*dir == '/') {
-        gbl_dbdir = dir;
+        gbl_dbdir = strdup(dir);
         return;
     }
     char *wd = getcwd(NULL, 0);


### PR DESCRIPTION
Makes this work: `comdb2 akdb --create --dir foo`