### PR TITLE
Only poll if we're not running recovery

### DIFF
--- a/berkdb/db/db_rec.c
+++ b/berkdb/db/db_rec.c
@@ -923,23 +923,28 @@ __db_pg_free_recover_int(dbenv, argp, file_dbp, lsnp, mpf, op, data)
 	DB_LSN copy_lsn;
 	PAGE *pagep;
 	db_pgno_t pgno;
+	DB_REP *db_rep;
+	REP *rep;
 	int cmp_n, cmp_p, modified, ret;
 
 	meta = NULL;
 	pagep = NULL;
 
-        if (gbl_poll_in_pg_free_recover) poll(0, 0, 100);
+	db_rep = dbenv->rep_handle;
+	rep = db_rep->region;
 
-        /*
-         * Fix up the freed page.  If we're redoing the operation we get the
-         * page and explicitly discard its contents, then update its LSN.  If
-         * we're undoing the operation, we get the page and restore its header.
-         * Create the page if necessary, we may be freeing an aborted
-         * create.
-         */
-        if ((ret = __memp_fget(mpf, &argp->pgno, DB_MPOOL_CREATE, &pagep)) != 0)
+	if (gbl_poll_in_pg_free_recover && !rep->in_recovery) poll(0, 0, 100);
+
+	/*
+	 * Fix up the freed page.  If we're redoing the operation we get the
+	 * page and explicitly discard its contents, then update its LSN.  If
+	 * we're undoing the operation, we get the page and restore its header.
+	 * Create the page if necessary, we may be freeing an aborted
+	 * create.
+	 */
+	if ((ret = __memp_fget(mpf, &argp->pgno, DB_MPOOL_CREATE, &pagep)) != 0)
 		goto out;
-	modified = 0;
+    modified = 0;
 	(void)__ua_memcpy(&copy_lsn, &LSN(argp->header.data), sizeof(DB_LSN));
 	cmp_n = log_compare(lsnp, &LSN(pagep));
 	cmp_p = log_compare(&LSN(pagep), &copy_lsn);

--- a/tests/pg_free_recovery.test/lrl.options
+++ b/tests/pg_free_recovery.test/lrl.options
@@ -1,3 +1,3 @@
 poll_in_pgfree_recover on
-setattr REP_PROCESSORS 0
-setattr REP_WORKERS 0
+setattr REP_PROCESSORS 4
+setattr REP_WORKERS 8


### PR DESCRIPTION
We get watchdogged in rep-verify-match because of artificial latency that we've added to tease out an issue where berkley wouldn't grab page-locks in compensating transactions.  Straightforward fix: don't poll in this handler if we are in recovery mode.
