### PR TITLE
locktest needs ndebug since it performs checks under assert

### DIFF
--- a/bdb/locktest.c
+++ b/bdb/locktest.c
@@ -13,7 +13,9 @@
    See the License for the specific language governing permissions and
    limitations under the License.
  */
-
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
 #include "limit_fortify.h"
 
 #ifndef MYBDB5


### PR DESCRIPTION
undef ndebug if defined.