### PR TITLE
properly deregister with pmux on test exit for several tests

### DIFF
--- a/tests/incremental_backup.test/runit
+++ b/tests/incremental_backup.test/runit
@@ -161,19 +161,23 @@ function test_restoredb {
   ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
-  if [[ $? -ne 0 ]] ; then
+  rc=$?
+  echo shutting down ${dbname}_restore
+  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+  echo deregister from pmux ${dbname}_restore
+  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+
+  if [[ $rc -ne 0 ]] ; then
     echo "  ^^^^^^^^^^^^"
     echo "The above testcase (${testname}) has failed!!!"
     echo " "
     echo " "
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
     exit 1
   fi
 
   echo "${testname} passed"
   echo " "
 
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
   rm -rf ${LOCTMPDIR}/restore/*
 }
 

--- a/tests/incremental_backup_load.test/runit
+++ b/tests/incremental_backup_load.test/runit
@@ -176,20 +176,24 @@ function test_restoredb {
   ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
-  if [[ $? -ne 0 ]] ; then
+  rc=$?
+  echo shutting down ${dbname}_restore
+  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+  echo deregister from pmux ${dbname}_restore
+  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+
+  if [[ $rc -ne 0 ]] ; then
     killwriters
     echo "  ^^^^^^^^^^^^"
     echo "The above testcase (${testname}) has failed!!!"
     echo " "
     echo " "
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
     exit 1
   fi
 
   echo "${testname} passed"
   echo " "
 
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
   rm -rf ${LOCTMPDIR}/restore/*
 }
 

--- a/tests/incremental_backup_usenames.test/runit
+++ b/tests/incremental_backup_usenames.test/runit
@@ -147,19 +147,23 @@ function test_restoredb {
   ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
-  if [[ $? -ne 0 ]] ; then
+  rc=$?
+  echo shutting down ${dbname}_restore
+  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+  echo deregister from pmux ${dbname}_restore
+  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+
+  if [[ $rc -ne 0 ]] ; then
     echo "  ^^^^^^^^^^^^"
     echo "The above testcase (${testname}) has failed!!!"
     echo " "
     echo " "
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
     exit 1
   fi
 
   echo "${testname} passed"
   echo " "
 
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
   rm -rf ${LOCTMPDIR}/restore/*
 }
 

--- a/tests/localrep.test/runit
+++ b/tests/localrep.test/runit
@@ -160,6 +160,9 @@ dest=$(cdb2sql ${CDB2_OPTIONS} $destdb local "select * from t1" | sort | md5sum)
 echo "src $src dest $dest"
 kill -9 $(cat $DBDIR/${destdb}.pid)
 
+echo deregister from pmux ${destdb}
+${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${destdb} " ${pmux_port}
+
 if [[ "$src" != "$dest" ]]; then
     exit 1
 else

--- a/tests/qcopy.test/runit
+++ b/tests/qcopy.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
+set -x
 set -e
 
 COPYDIR=$DBDIR/copy
@@ -10,10 +11,20 @@ cd $COPYDIR
 grep -v name ${DBNAME}.lrl | grep -v "cluster nodes" > tmp && mv tmp ${DBNAME}.lrl
 NEWNAME="qcopy$$test"
 echo "name $NEWNAME" >> ${DBNAME}.lrl
+echo creating new db with name $NEWNAME
 $COMDB2_EXE $NEWNAME --create --lrl ${DBNAME}.lrl
+echo starting new db $NEWNAME
 $COMDB2_EXE $NEWNAME --lrl ${DBNAME}.lrl &
 
-trap "$CDB2SQL_EXE $NEWNAME \"exec procedure sys.cmd.send('exit')\"" EXIT
+function exiting {
+    echo send exit to $NEWNAME
+    $CDB2SQL_EXE $NEWNAME "exec procedure sys.cmd.send('exit')"
+
+    echo deregister from pmux $NEWNAME
+    ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${NEWNAME} " ${pmux_port}
+}
+
+trap exiting EXIT
 
 while :; do 
     # cdb2sql may fail if the db isn't up yet
@@ -24,4 +35,6 @@ while :; do
     sleep 1
 done
 
-exit 0
+exiting
+
+echo Success

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -9,18 +9,19 @@ SETUP_TIMEOUT=${SETUP_TIMEOUT:-2m}
 
 export CLEANUPDBDIR=${CLEANUPDBDIR:-1}
 export PATH="${TESTDIR}/:${PATH}"
+export pmux_port=${PMUXPORT:-5105}  # assign to 5105 if it was not set as a make parameter
 successful=0
 
 DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
 echo Starting $TESTCASE with id $TESTID at $DATETIME >> $TESTDIR/test.log
 mkdir -p ${TESTDIR}/logs/
 
-function call_unsetup {
+call_unsetup() {
     [[ $COMDB2_UNITTEST == 1 ]] && return
     ${TESTSROOTDIR}/unsetup $successful &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
 }
 
-function warn_long_setup {
+warn_long_setup() {
     start=$(date +%s)
     ( ${TESTSROOTDIR}/setup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.setup | cut -c11- | grep "^!" ) ) &
     pid=$!
@@ -54,7 +55,7 @@ find_cores() {
     done
 }
 
-function call_setup {
+call_setup() {
     [[ $COMDB2_UNITTEST == 1 ]] && return
 
     if [[ $SETUP_WARN ]]; then

--- a/tests/sc_repeated_updates.test/runit
+++ b/tests/sc_repeated_updates.test/runit
@@ -53,7 +53,7 @@ function assertcnt
     target=$1
     comment=$2
     a=$RANDOM
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "select * from $tbl" > select_$a.out
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "select * from $tbl" > select_$a.out
     cnt=$(wc -l select_$a.out | awk '{print $1}')
     if [[ $cnt != $target ]] ; then
         failexit "$comment: count is $cnt but should be $target"
@@ -64,7 +64,7 @@ function assertcnt
 
 function do_verify
 {
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('$tbl')" &> verify.out
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('$tbl')" &> verify.out
 
     if ! grep succeeded verify.out > /dev/null ; then
         failexit "Verify"
@@ -82,7 +82,7 @@ function do_rebuild_track_pid
     while `kill -0 $track_pid 2>/dev/null` && [[ $scnt -lt $max_nusc ]]; do
 
         echo "Running rebuild iteration $scnt"
-        cdb2sql ${CDB2_OPTIONS} $loc_dbnm default "rebuild $loc_tbl"
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $loc_dbnm default "rebuild $loc_tbl"
 
         if [[ $? != 0 ]]; then
             failexit "Error schema-changing on iteration $scnt. Testcase failed."
@@ -112,7 +112,7 @@ function update_same_record
     echo "update_same_record: Updating same record in background (update1)"
 
     while [[ $j -lt $loc_recs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1 where a = $nrecs" >> update1.out 2>&1
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1 where a = $nrecs" >> update1.out 2>&1
         rc=$?
         if [[ $rc -ne 0 ]] ; then
             failexit "update_same_record: this update should succeed but error $rc was returned"
@@ -137,7 +137,7 @@ function update_same_record_fail
     echo "update_same_record_fail: Updating same record resulting in failure for dups (update3)"
 
     while [[ $j -lt $loc_recs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1 where a = 10" >> update3.out 2>&1
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1 where a = 10" >> update3.out 2>&1
         assertcnt $nrecs "update_same_record_fail"
         let j=j+1
     done
@@ -162,7 +162,7 @@ function update_records
         j=1
         > update2.out
         while [[ $j -le $nrecs ]]; do 
-            cdb2sql ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1, e=e+$nrecs where a = $j" >> update2.out 2>&1
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1, e=e+$nrecs where a = $j" >> update2.out 2>&1
             rc=$?
             if [[ $rc -ne 0 ]] ; then
                 failexit "update_records: this update should succeed but error $rc was returned"
@@ -191,7 +191,7 @@ function update_records_fail
     > update4.out
 
     while [[ $j -le $((nrecs-dist)) ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1, e=e+$dist where a = $j" >> update4.out 2>&1
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "update $tbl set d=d+1, e=e+$dist where a = $j" >> update4.out 2>&1
         if [[ $? -eq 0 ]] ; then
             echo "update_records_fail: update $tbl set d=d+1, e=e+10 where a = $j" 
             failexit "update_records_fail: this update should not succeed"
@@ -231,7 +231,7 @@ function insert_records
             loc_tran=0
         fi
 	let j=j+1
-    done  | cdb2sql ${CDB2_OPTIONS} $dbnm default - >> insert.out 2>&1
+    done  | $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - >> insert.out 2>&1
 }
 
 function run_test
@@ -239,7 +239,7 @@ function run_test
     typeset upid=''
     nrecs=$1
 
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate $tbl"
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "truncate $tbl"
 
     insert_records 0 
     assertcnt $nrecs "run_test"
@@ -302,16 +302,16 @@ trap exiting EXIT
 
 echo "running test in machine $(hostname):${PWD}"
 
-#cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table $tbl"
+#$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "drop table $tbl"
 
 rm -f failexit
 
 g=100
 while [[ $g -le 400 ]] ; do 
 	echo "run_test $g"
-    cdb2sql -s ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('setipu $tbl on')" >/dev/null 2>&1
+    $CDB2SQL_EXE -s ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('setipu $tbl on')" >/dev/null 2>&1
 	run_test $g
-    cdb2sql -s ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('setipu $tbl off')" >/dev/null 2>&1
+    $CDB2SQL_EXE -s ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('setipu $tbl off')" >/dev/null 2>&1
 	run_test $g
     let g=g+g
 done

--- a/tests/setup
+++ b/tests/setup
@@ -12,7 +12,7 @@ while [[ $# -gt 0 && $1 = -* ]]; do
     shift
 done
 
-vars="TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE"
+vars="TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE pmux_port"
 for required in $vars; do
     q=${!required}
     if [[ -z "$q" ]]; then
@@ -163,12 +163,11 @@ echo "comdb2_config:allow_pmux_route:true" >> $CDB2_CONFIG
 myhostname=`hostname`
 set +e
 
-pmux_port=5105
+#pmux_port is assigned in runtestcase
 pmux_cmd="$PMUX_EXE -l"
 
 # If PMUXPORT is defined we will overwrite the default pmux port with that
 if [ -n "$PMUXPORT" ] ; then
-    pmux_port=$PMUXPORT
     pmux_socket=/tmp/pmux.socket.$PMUXPORT
     pmux_port_range="-r $((pmux_port+1)):$((pmux_port+200))"
     pmux_cmd="$PMUX_EXE -l -p $PMUXPORT -b $pmux_socket $pmux_port_range"

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -77,10 +77,7 @@ function cleanup_cluster {
     done
 }
 
-pmux_port=5105
-if [ -n "$PMUXPORT" ] ; then
-    pmux_port=$PMUXPORT
-fi
+echo deregistering $DBNAME from pmux:$pmux_port
 deregister_db="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
 
 if [[ "$NOKILL_ON_TIMEOUT" -eq 1 && "$successful" -eq "-1" ]]; then


### PR DESCRIPTION
* properly deregister with pmux on test exit for the following tests: incremental backups, local rep, qcopy.
* pmux_port set and exported in runtestcase script