### PR TITLE
cdb2jdbc: Porting cdb2_clear_ack change to cdb2jdbc.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -771,5 +771,9 @@ public class Comdb2Connection implements Connection {
         }
         return _ex; 
     }
+
+    public void clearAck() {
+        hndl.clearAck();
+    }
 }
 /* vim: set sw=4 ts=4 et: */

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -1406,6 +1406,11 @@ public class Comdb2Handle extends AbstractConnection {
         }
     }
 
+    /* Clear the ack flag */
+    public void clearAck() {
+        ack = false;
+    }
+
     @Override
     public boolean nextWithException() {
 


### PR DESCRIPTION
Although the JDBC interface does not define such a method, applications can cast `java.sql.Connection` down to `Comdb2Connection` and get the definition from the subclass. The pseudo code is as follows:

```java
Connection conn = DriverManager.getConnection(...);
Comdb2Connection ext = (Comdb2Connection)conn;
ext.clearAck();
```