### PR TITLE
Don't truncate pthread_self() to a 32-bit interger.

### DIFF
--- a/bdb/bdblock.c
+++ b/bdb/bdblock.c
@@ -841,15 +841,11 @@ void bdb_stripe_done(bdb_state_type *bdb_state)
 void bdb_thread_event(bdb_state_type *bdb_state, int event)
 {
     bdb_state_type *parent;
-    int *mallocedtid;
-    int tid;
 
     if (bdb_state->parent)
         parent = bdb_state->parent;
     else
         parent = bdb_state;
-
-    tid = (int)pthread_self();
 
     switch (event) {
     case BDBTHR_EVENT_DONE_RDONLY: /* thread done */

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4947,7 +4947,8 @@ void *watcher_thread(void *arg)
     if (bdb_state->parent)
         bdb_state = bdb_state->parent;
 
-    print(bdb_state, "watcher_thread started as 0x%x\n", (int)pthread_self());
+    print(bdb_state, "watcher_thread started as 0x%p\n",
+          (intptr_t)pthread_self());
 
     poll(NULL, 0, (rand() % 100) + 1000);
 

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -18,6 +18,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 
 #include <plbitlib.h>
 #include <alloca.h>
@@ -1836,8 +1837,8 @@ static char *get_temp_ct_dbname(long long *ctid)
     char *s;
     size_t buflen = strlen(thedb->basedir) + 64;
     s = malloc(buflen);
-    snprintf(s, buflen, "%s/%s.tmpdbs/_temp_ct_%d_%llu.db", thedb->basedir,
-             thedb->envname, (int)pthread_self(), *ctid);
+    snprintf(s, buflen, "%s/%s.tmpdbs/_temp_ct_%" PRIdPTR "_%llu.db",
+             thedb->basedir, thedb->envname, (intptr_t)pthread_self(), *ctid);
     *ctid = *ctid + 1LL;
     return s;
 }

--- a/db/tag.c
+++ b/db/tag.c
@@ -5734,7 +5734,7 @@ static char *get_unique_tag(void)
     /* Worst case: sizeof ".TEMP_-9223372036854775808_-9223372036854775808" =
        48.
        MAXTAGLEN is 64 so we're good. */
-    snprintf(tag, sizeof(tag), ".TEMP_%" PRIdPTR "_%lld",
+    snprintf(tag, MAXTAGLEN, ".TEMP_%" PRIdPTR "_%lld",
              (intptr_t)pthread_self(), thd->uniquetag++);
 
     return tag;


### PR DESCRIPTION
We're seeing crashes in tag requests, when 2 threads whose pthread_self()'s lower 32 bits are the same are accessing the same table.

The bug is caused by our 32-bit legacy code where pthread_self() is casted to an int. Casting pthread_self() to the more portable `intptr_t` fixes it.