### PR TITLE
find what is running on port on which db is supposed to run

### DIFF
--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -504,6 +504,7 @@ static int convert_record(struct convert_record_data *data)
              * a lock to the last page of the stripe.
              */
 
+            sleep(1);
             // AZ: determine what locks we hold at this time
             // bdb_dump_active_locks(data->to->handle, stdout);
             data->sc_genids[data->stripe] = -1ULL;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -504,7 +504,6 @@ static int convert_record(struct convert_record_data *data)
              * a lock to the last page of the stripe.
              */
 
-            sleep(1);
             // AZ: determine what locks we hold at this time
             // bdb_dump_active_locks(data->to->handle, stdout);
             data->sc_genids[data->stripe] = -1ULL;

--- a/tests/qcopy.test/runit
+++ b/tests/qcopy.test/runit
@@ -16,10 +16,16 @@ echo creating new db with name $NEWNAME
 $COMDB2_EXE $NEWNAME --create --lrl ${DBNAME}.lrl
 echo starting new db $NEWNAME
 $COMDB2_EXE $NEWNAME --lrl ${DBNAME}.lrl &
+dbpid=$!
 
 function exiting {
     echo send exit to $NEWNAME
     $CDB2SQL_EXE $NEWNAME "exec procedure sys.cmd.send('exit')"
+
+
+    sleep 10
+    #just in case it is still up
+    kill -9 $dbpid
 
     echo deregister from pmux $NEWNAME
     ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${NEWNAME} " ${pmux_port}

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -7,6 +7,7 @@ if [[ "$(arch)" == "armv7l" ]] ; then
 fi
 SETUP_TIMEOUT=${SETUP_TIMEOUT:-2m}
 
+export HOSTNAME=${HOSTNAME:-`hostname`}
 export CLEANUPDBDIR=${CLEANUPDBDIR:-1}
 export PATH="${TESTDIR}/:${PATH}"
 export pmux_port=${PMUXPORT:-5105}  # assign to 5105 if it was not set as a make parameter

--- a/tests/sc_inserts.test/runit
+++ b/tests/sc_inserts.test/runit
@@ -62,42 +62,18 @@ function do_rebuild_track_pid
         cdb2sql ${CDB2_OPTIONS} $loc_dbnm default "rebuild $loc_tbl"
 
         if [[ $? != 0 ]]; then
-            echo "Error schema-changing on iteration $scnt"
-            echo "Testcase failed"
             kill -9 $track_pid
-            exit 1
+            failexit "Error schema-changing on iteration $scnt"
         fi
+        echo "Done with rebuild iteration $scnt"
 
+        echo "Running verify"
         do_verify $loc_dbnm $loc_tbl
+        echo "Done with verify"
         let scnt=scnt+1
     done
 
     echo "Success!  Performed $scnt schema-changes."
-
-    return 0
-}
-
-
-
-
-function do_rebuild
-{
-    typeset max=$1
-    typeset scnt=0
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "Running rebuild iteration $scnt"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "rebuild $tbl"
-
-        if [[ $? != 0 ]]; then
-            echo "Error schema-changing on iteration $scnt"
-            echo "Testcase failed"
-            return 1
-        fi
-        let scnt=scnt+1
-        do_verify
-        assertcnt $nrecs
-    done
 
     return 0
 }
@@ -120,6 +96,7 @@ function insert_records
             sleep 0.1
         fi
     done
+    echo "Done inserting $nrecs records."
 }
 
 
@@ -131,7 +108,6 @@ function run_test
 
     cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate $tbl"
 
-    > insert.out
     insert_records 0 &
     typeset ipid=$!
 
@@ -157,6 +133,8 @@ max_iter=40
 t=0
 while [ $t -lt ${max_iter} ] ; do
     run_test
+    mv insert.out insert.out.$t
+
     sleep 2
     let t=t+1
 done

--- a/tests/setup
+++ b/tests/setup
@@ -254,14 +254,14 @@ set -e
 
 check_db_port_running_local() {
     dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
-    if [ "x$dbport" != "x" ] ; then
+    if [ "x$dbport" == "x" ] ; then
         return
     fi
     echo "checking what is running on localhost:$dbport"
     netstat -na | grep $dbport
     opid=`fuser -n tcp $dbport`
     echo "pid running on dbport: $opid"
-    [ -n "$opid" ] && ps -p $opid
+    [ -n "$opid" ] && ps -p $opid -o comm,args
     $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host localhost:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
 }
 

--- a/tests/setup
+++ b/tests/setup
@@ -263,6 +263,7 @@ check_db_port_running_local() {
     opid=`fuser -n tcp $dbport`
     echo "pid running on dbport: $opid"
     [ -n "$opid" ] && ps -p $opid
+    $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host localhost:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
 }
 
 check_db_port_running_node() {
@@ -284,6 +285,7 @@ check_db_port_running_node() {
         echo "pid running on dbport: $opid"
         [ -n "$opid" ] && ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
     fi
+    $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
 }
 
 

--- a/tests/setup
+++ b/tests/setup
@@ -274,8 +274,13 @@ check_db_port_running_node() {
     echo "checking what is running on ${node}:$dbport"
     if [ "$node" == "$HOSTNAME" ] ; then 
         netstat -na | grep $dbport
+        opid=`fuser -n tcp $dbport`
+        echo "pid running on dbport: $opid"
+    [ -n "$opid" ] && ps -p $opid -o comm,args
     else
         ssh -o StrictHostKeyChecking=no $node "netstat -na | grep $dbport" </dev/null
+        opid=`ssh -o StrictHostKeyChecking=no $node "fuser -n tcp $dbport" </dev/null`
+        echo "pid running on dbport: $opid"
     fi
     $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
 }

--- a/tests/setup
+++ b/tests/setup
@@ -258,8 +258,7 @@ check_db_port_running_local() {
         return
     fi
     echo "checking what is running on localhost:$dbport"
-    PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
-    lsof | grep $dbport
+    netstat -na | grep $dbport
     opid=`fuser -n tcp $dbport`
     echo "pid running on dbport: $opid"
     [ -n "$opid" ] && ps -p $opid
@@ -274,16 +273,9 @@ check_db_port_running_node() {
     fi
     echo "checking what is running on ${node}:$dbport"
     if [ "$node" == "$HOSTNAME" ] ; then 
-        PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
-        lsof | grep $dbport
-        opid=`fuser -n tcp $dbport`
-        echo "pid running on dbport: $opid"
-        [ -n "$opid" ] && ps -p $opid
+        netstat -na | grep $dbport
     else
-        ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/; lsof | grep $dbport" </dev/null
-        opid=`ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/;fuser -n tcp $dbport" </dev/null`
-        echo "pid running on dbport: $opid"
-        [ -n "$opid" ] && ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
+        ssh -o StrictHostKeyChecking=no $node "netstat -na | grep $dbport" </dev/null
     fi
     $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
 }

--- a/tests/setup
+++ b/tests/setup
@@ -12,7 +12,7 @@ while [[ $# -gt 0 && $1 = -* ]]; do
     shift
 done
 
-vars="TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE pmux_port"
+vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE pmux_port"
 for required in $vars; do
     q=${!required}
     if [[ -z "$q" ]]; then
@@ -160,7 +160,6 @@ fi
 echo "comdb2_config:ssl_cert_path=$TESTDIR" >>$CDB2_CONFIG
 echo "comdb2_config:allow_pmux_route:true" >> $CDB2_CONFIG
 
-myhostname=`hostname`
 set +e
 
 #pmux_port is assigned in runtestcase
@@ -184,7 +183,7 @@ copy_files_to_cluster()
 {
     echo copying executables to each node except localhost
     for node in $CLUSTER; do
-        if [ $node == $myhostname ] ; then
+        if [ $node == $HOSTNAME ] ; then
             continue
         fi
 
@@ -253,19 +252,6 @@ echo "${DBNAME} created successfully"
 
 set -e
 
-check_db_pid_running() {
-    dbpid=$1
-    if kill -0 $dbpid &> /dev/null ; then 
-        echo "DB process is running"
-    else
-        echo "DB process is not running"
-        if ! grep "[ERROR] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db ; then
-            dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME} " ${pmux_port}`
-            echo "checking what is running on port $dbport"
-            lsof | grep $dbport
-        fi
-    fi
-}
 # test largecsc2 throws error about col width
 #if grep "ERROR" $TESTDIR/logs/${DBNAME}.init | grep -v largecsc2 ; then
 #    echo "Error while initializing DB, see $TESTDIR/logs/${DBNAME}.init "
@@ -292,12 +278,11 @@ if [[ -z "$CLUSTER" ]]; then
     while [[ "$out" != "1" ]]; do
         sleep 1
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME default 'select 1' 2> /dev/null)
-        check_db_pid_running $dbpid
     done
 else
     echo "!$TESTCASE: copying to cluster"
     for node in ${CLUSTER/$HOSTNAME/}; do
-        if [ $node == $myhostname ] ; then
+        if [ $node == $HOSTNAME ] ; then
             continue        # no copying to self
         fi
         $COPYCOMDB2_EXE ${LRL} ${node}: &> $TESTDIR/logs/${DBNAME}.${node}.copy
@@ -312,7 +297,7 @@ else
     CMD="cd ${TESTDIR}; source replicant_vars ; ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 | tee $TESTDIR/${DBNAME}.db"
     echo "!$TESTCASE: starting"
     for node in $CLUSTER; do
-        if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
+        if [ $node == $HOSTNAME ] ; then # dont ssh to ourself -- just start db locally
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
                 echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
             else

--- a/tests/setup
+++ b/tests/setup
@@ -252,6 +252,41 @@ echo "${DBNAME} created successfully"
 
 set -e
 
+check_db_port_running_local() {
+    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    if [ "x$dbport" != "x" ] ; then
+        return
+    fi
+    echo "checking what is running on localhost:$dbport"
+    PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
+    lsof | grep $dbport
+    opid=`fuser -n tcp $dbport`
+    echo "pid running on dbport: $opid"
+    [ -n "$opid" ] && ps -p $opid
+}
+
+check_db_port_running_node() {
+    node=$1
+    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    if [ "x$dbport" == "x" ] ; then
+        return;
+    fi
+    echo "checking what is running on ${node}:$dbport"
+    if [ "$node" == "$HOSTNAME" ] ; then 
+        PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
+        lsof | grep $dbport
+        opid=`fuser -n tcp $dbport`
+        echo "pid running on dbport: $opid"
+        [ -n "$opid" ] && ps -p $opid
+    else
+        ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/; lsof | grep $dbport" </dev/null
+        opid=`ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/;fuser -n tcp $dbport" </dev/null`
+        echo "pid running on dbport: $opid"
+        [ -n "$opid" ] && ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
+    fi
+}
+
+
 # test largecsc2 throws error about col width
 #if grep "ERROR" $TESTDIR/logs/${DBNAME}.init | grep -v largecsc2 ; then
 #    echo "Error while initializing DB, see $TESTDIR/logs/${DBNAME}.init "
@@ -278,6 +313,7 @@ if [[ -z "$CLUSTER" ]]; then
     while [[ "$out" != "1" ]]; do
         sleep 1
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME default 'select 1' 2> /dev/null)
+        [[ "$out" != "1" ]] && check_db_port_running_local
     done
 else
     echo "!$TESTCASE: copying to cluster"
@@ -318,7 +354,6 @@ else
     done
 
     echo "!$TESTCASE: waiting until ready"
-    sleep 1
     for node in $CLUSTER; do
         set +e
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
@@ -326,6 +361,7 @@ else
             sleep 2
             out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
             $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $TESTDIR/logs/${DBNAME}.${node}.conn
+            [[ "$out" != "1" ]] && check_db_port_running_node $node
         done
         $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $TESTDIR/logs/${DBNAME}.${node}.conn
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)

--- a/tests/tools/send_msg_port.sh
+++ b/tests/tools/send_msg_port.sh
@@ -2,6 +2,9 @@
 #
 #send message to port 
 
+host=localhost
+
+[ "$1" == "-h" ] && shift && host=$1 && shift 
 msg=$1
 port=$2
 
@@ -17,7 +20,7 @@ if [ "x$port" == "x" ] ; then
     failexit "port empty"
 fi
 
-exec 3<>/dev/tcp/localhost/$port || failexit "no listener in port $port"
+exec 3<>/dev/tcp/$host/$port || failexit "no listener in port $port"
 
 echo $msg >&3
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -122,20 +122,7 @@ else
     cleanup_cluster
 fi
 
-${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port}
-dbport=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
 eval $deregister_db_port
-out=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
-cnt=0
-while [ $cnt -lt 10 ] ; do
-    out=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
-    if [ $out == "-1" ] ; then
-       break
-    fi
-    netstat -na | grep $dbport
-    sleep 1
-    cnt=$((cnt+1))
-done
 
 if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
     rm -rf ${DBDIR}

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -80,21 +80,32 @@ function cleanup_cluster {
 check_db_port_running_local() {
     dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
     if [ "x$dbport" != "x" ] ; then
-        echo "checking what is running on localhost:$dbport"
-        lsof | grep $dbport
+        return
     fi
+    echo "checking what is running on localhost:$dbport"
+    lsof | grep $dbport
+    opid=`fuser -n tcp $dbport`
+    echo $opid
+    ps -p $opid
 }
 
 check_db_port_running_node() {
     node=$1
     dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
-    if [ "x$dbport" != "x" ] ; then
-        echo "checking what is running on ${node}:$dbport"
-        if [ "$node" == "$HOSTNAME" ] ; then 
-            lsof | grep $dbport
-        else
-            ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
-        fi
+    if [ "x$dbport" == "x" ] ; then
+        return;
+    fi
+    echo "checking what is running on ${node}:$dbport"
+    if [ "$node" == "$HOSTNAME" ] ; then 
+        lsof | grep $dbport
+        opid=`fuser -n tcp $dbport`
+        echo $opid
+        ps -p $opid
+    else
+        ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
+        opid=`ssh -o StrictHostKeyChecking=no $node "fuser -n tcp $dbport" </dev/null`
+        echo $opid
+        ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
     fi
 }
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -77,13 +77,7 @@ function cleanup_cluster {
     done
 }
 
-check_db_pid_running_local() {
-    dbpid=$(cat ${TMPDIR}/$DBNAME.pid)
-    if kill -0 $dbpid &> /dev/null ; then 
-        echo "DB process is running"
-        return
-    fi
-    echo "DB process is not running"
+check_db_port_running_local() {
     dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
     if [ "x$dbport" != "x" ] ; then
         echo "checking what is running on localhost:$dbport"
@@ -91,30 +85,24 @@ check_db_pid_running_local() {
     fi
 }
 
-check_db_pid_running_node() {
+check_db_port_running_node() {
     node=$1
-    if ssh -o StrictHostKeyChecking=no $node "[ -f ${TMPDIR}/${DBNAME}.${node}.pid ] && kill -0 \$(cat ${TMPDIR}/${DBNAME}.${node}.pid)" </dev/null ; then
-        echo "DB process is running"
-        return
-    fi
-
-    echo "DB process is not running"
     dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
     if [ "x$dbport" != "x" ] ; then
         echo "checking what is running on ${node}:$dbport"
-        ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
+        if [ "$node" == "$HOSTNAME" ] ; then 
+            lsof | grep $dbport
+        else
+            ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
+        fi
     fi
 }
 
 if [[ -z "$CLUSTER" ]]; then
-    check_db_pid_running_local 
+    check_db_port_running_local 
 else
     for node in $CLUSTER; do
-        if [ "$node" == "$HOSTNAME" ] ; then 
-            check_db_pid_running_local
-        else
-            check_db_pid_running_node $node
-        fi
+        check_db_port_running_node $node
     done
 fi
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -59,7 +59,7 @@ function core_cluster {
 function cleanup_cluster {    
     for node in $CLUSTER; do
         if [ "$node" != "$HOSTNAME" ] ; then
-            ssh -o StrictHostKeyChecking=no $node "${query_db_port}" < /dev/null
+            ${TESTSROOTDIR}/tools/send_msg_port.sh -h $node "get comdb2/replication/${DBNAME}" ${pmux_port}
             ssh -o StrictHostKeyChecking=no $node "${deregister_db_port}" < /dev/null
         fi
         if [ "x$DBDIR" == "x" ] ; then 
@@ -122,7 +122,6 @@ fi
 
 
 echo deregistering $DBNAME from pmux:$pmux_port
-query_db_port="exec 3<>/dev/tcp/localhost/${pmux_port}; echo get comdb2/replication/${DBNAME} >&3 "
 deregister_db_port="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
 
 if [[ "$NOKILL_ON_TIMEOUT" -eq 1 && "$successful" -eq "-1" ]]; then
@@ -166,6 +165,7 @@ else
     cleanup_cluster
 fi
 
+${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port}
 eval $deregister_db_port
 
 if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -59,7 +59,8 @@ function core_cluster {
 function cleanup_cluster {    
     for node in $CLUSTER; do
         if [ "$node" != "$HOSTNAME" ] ; then
-            ssh -o StrictHostKeyChecking=no $node "${deregister_db}" < /dev/null
+            ssh -o StrictHostKeyChecking=no $node "${query_db_port}" < /dev/null
+            ssh -o StrictHostKeyChecking=no $node "${deregister_db_port}" < /dev/null
         fi
         if [ "x$DBDIR" == "x" ] ; then 
             continue
@@ -121,7 +122,8 @@ fi
 
 
 echo deregistering $DBNAME from pmux:$pmux_port
-deregister_db="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
+query_db_port="exec 3<>/dev/tcp/localhost/${pmux_port}; echo get comdb2/replication/${DBNAME} >&3 "
+deregister_db_port="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
 
 if [[ "$NOKILL_ON_TIMEOUT" -eq 1 && "$successful" -eq "-1" ]]; then
     echo "Unsetup deferred"
@@ -164,7 +166,7 @@ else
     cleanup_cluster
 fi
 
-eval $deregister_db
+eval $deregister_db_port
 
 if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
     rm -rf ${DBDIR}

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -78,49 +78,6 @@ function cleanup_cluster {
     done
 }
 
-check_db_port_running_local() {
-    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
-    if [ "x$dbport" != "x" ] ; then
-        return
-    fi
-    echo "checking what is running on localhost:$dbport"
-    PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
-    lsof | grep $dbport
-    opid=`fuser -n tcp $dbport`
-    echo $opid
-    ps -p $opid
-}
-
-check_db_port_running_node() {
-    node=$1
-    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
-    if [ "x$dbport" == "x" ] ; then
-        return;
-    fi
-    echo "checking what is running on ${node}:$dbport"
-    if [ "$node" == "$HOSTNAME" ] ; then 
-        PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
-        lsof | grep $dbport
-        opid=`fuser -n tcp $dbport`
-        echo $opid
-        [ -n "$opid" ] && ps -p $opid
-    else
-        ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/; lsof | grep $dbport" </dev/null
-        opid=`ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/;fuser -n tcp $dbport" </dev/null`
-        echo $opid
-        [ -n "$opid" ] && ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
-    fi
-}
-
-if [[ -z "$CLUSTER" ]]; then
-    check_db_port_running_local 
-else
-    for node in $CLUSTER; do
-        check_db_port_running_node $node
-    done
-fi
-
-
 echo deregistering $DBNAME from pmux:$pmux_port
 deregister_db_port="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -123,7 +123,19 @@ else
 fi
 
 ${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port}
+dbport=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
 eval $deregister_db_port
+out=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
+cnt=0
+while [ $cnt -lt 10 ] ; do
+    out=$(${TESTSROOTDIR}/tools/send_msg_port.sh "get comdb2/replication/${DBNAME}" ${pmux_port})
+    if [ $out == "-1" ] ; then
+       break
+    fi
+    netstat -na | grep $dbport
+    sleep 1
+    cnt=$((cnt+1))
+done
 
 if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
     rm -rf ${DBDIR}

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -48,7 +48,7 @@ function build_pidfilelist() {
 
 function core_cluster {
     for node in $CLUSTER; do
-        if [ $node != `hostname` ] ; then
+        if [ "$node" != "$HOSTNAME" ] ; then
             ssh -o StrictHostKeyChecking=no $node "kill -6 \$(cat ${TMPDIR}/${DBNAME}.pid)" </dev/null
         else
             kill -6 $(cat ${TMPDIR}/${DBNAME}.$node.pid)
@@ -58,13 +58,13 @@ function core_cluster {
 
 function cleanup_cluster {    
     for node in $CLUSTER; do
-        if [ $node != `hostname` ] ; then
+        if [ "$node" != "$HOSTNAME" ] ; then
             ssh -o StrictHostKeyChecking=no $node "${deregister_db}" < /dev/null
         fi
         if [ "x$DBDIR" == "x" ] ; then 
             continue
         fi
-        if [ $node == `hostname` ]  ; then
+        if [ "$node" == "$HOSTNAME" ]  ; then
             continue;
         fi
 
@@ -76,6 +76,48 @@ function cleanup_cluster {
         fi
     done
 }
+
+check_db_pid_running_local() {
+    dbpid=$(cat ${TMPDIR}/$DBNAME.pid)
+    if kill -0 $dbpid &> /dev/null ; then 
+        echo "DB process is running"
+        return
+    fi
+    echo "DB process is not running"
+    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    if [ "x$dbport" != "x" ] ; then
+        echo "checking what is running on localhost:$dbport"
+        lsof | grep $dbport
+    fi
+}
+
+check_db_pid_running_node() {
+    node=$1
+    if ssh -o StrictHostKeyChecking=no $node "[ -f ${TMPDIR}/${DBNAME}.${node}.pid ] && kill -0 \$(cat ${TMPDIR}/${DBNAME}.${node}.pid)" </dev/null ; then
+        echo "DB process is running"
+        return
+    fi
+
+    echo "DB process is not running"
+    dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    if [ "x$dbport" != "x" ] ; then
+        echo "checking what is running on ${node}:$dbport"
+        ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
+    fi
+}
+
+if [[ -z "$CLUSTER" ]]; then
+    check_db_pid_running_local 
+else
+    for node in $CLUSTER; do
+        if [ "$node" == "$HOSTNAME" ] ; then 
+            check_db_pid_running_local
+        else
+            check_db_pid_running_node $node
+        fi
+    done
+fi
+
 
 echo deregistering $DBNAME from pmux:$pmux_port
 deregister_db="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -83,6 +83,7 @@ check_db_port_running_local() {
         return
     fi
     echo "checking what is running on localhost:$dbport"
+    PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
     lsof | grep $dbport
     opid=`fuser -n tcp $dbport`
     echo $opid
@@ -97,15 +98,16 @@ check_db_port_running_node() {
     fi
     echo "checking what is running on ${node}:$dbport"
     if [ "$node" == "$HOSTNAME" ] ; then 
+        PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/
         lsof | grep $dbport
         opid=`fuser -n tcp $dbport`
         echo $opid
-        ps -p $opid
+        [ -n "$opid" ] && ps -p $opid
     else
-        ssh -o StrictHostKeyChecking=no $node "lsof | grep $dbport" </dev/null
-        opid=`ssh -o StrictHostKeyChecking=no $node "fuser -n tcp $dbport" </dev/null`
+        ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/; lsof | grep $dbport" </dev/null
+        opid=`ssh -o StrictHostKeyChecking=no $node "PATH=$PATH:/usr/bin/:/usr/sbin/:/bin/:/sbin/;fuser -n tcp $dbport" </dev/null`
         echo $opid
-        ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
+        [ -n "$opid" ] && ssh -o StrictHostKeyChecking=no $node "ps -p $opid" </dev/null
     fi
 }
 


### PR DESCRIPTION
We are seeing some failures with 'FAILED TO BIND to port...' and this
checkin attempts to find out what is running on the port on which the db
is supposed to run. Previous attempt at this was targeted at single node
database; this checkin attempts to find out used ports for any node in
a cluster.
The culprit that releases port before fully exiting is qcopy test which is fixed here as well. 