### PR TITLE
SSL Enhancements.

### DIFF
--- a/bbinc/ssl_support.h
+++ b/bbinc/ssl_support.h
@@ -156,14 +156,14 @@ int SBUF2_FUNC(ssl_init)(int init_openssl, int init_crypto, int locking,
  * ca          - if *ca is null, return path to trusted CA in ca;
  *               else use *ca as the trusted CA
  * sesssz      - SSL session cache size
+ * ciphers     - cipher suites. ignored in client mode.
  *
  * RETURN VALUES
  * 0 upon success
  */
-int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx,
-                          const char *dir, char **cert,
-                          char **key, char **ca, long sesssz,
-                          char *err, size_t n);
+int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, const char *dir, char **cert,
+                            char **key, char **ca, long sesssz,
+                            const char *ciphers, char *err, size_t n);
 #define ssl_new_ctx SBUF2_FUNC(ssl_new_ctx)
 
 #endif

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1516,9 +1516,8 @@ static int try_ssl(cdb2_hndl_tp *hndl, SBUF2 *sb, int indx)
         return -1;
     }
 
-    rc = ssl_new_ctx(&ctx, hndl->sslpath,
-                     &hndl->cert, &hndl->key, &hndl->ca,
-                     hndl->num_hosts, hndl->errstr, sizeof(hndl->errstr));
+    rc = ssl_new_ctx(&ctx, hndl->sslpath, &hndl->cert, &hndl->key, &hndl->ca,
+                     hndl->num_hosts, NULL, hndl->errstr, sizeof(hndl->errstr));
     if (rc != 0) {
         hndl->sslerr = 1;
         return -1;

--- a/db/ssl_bend.h
+++ b/db/ssl_bend.h
@@ -54,6 +54,9 @@ extern long gbl_sess_cache_sz;
    Turn it on at your own risk. */
 extern int gbl_ssl_allow_remsql;
 
+/* OpenSSL cipher suites. */
+extern const char *gbl_ciphers;
+
 /* Client SSL mode */
 extern ssl_mode gbl_client_ssl_mode;
 

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -112,7 +112,7 @@ ssl_client_mode VERIFY_CA
 
 Now if a client certificate is not present, the connection will be rejected as well.
 
-For maximum security, you could request host name validation by changing SSL mode the LRL:
+For maximum security, you could request host name validation by changing SSL mode in the LRL:
 
 ```shell
 ssl_client_mode VERIFY_HOSTNAME
@@ -158,6 +158,7 @@ are refused to join the cluster.
 | `ssl_cert file`| Path to the certificate | `<ssl_cert_path>/server.crt` |
 | `ssl_key file` | Path to the key | `<ssl_cert_path>/server.key` |
 | `ssl_ca file` | Path to the trusted CA certificates | `<ssl_cert_path>/root.crt` |
+| `ssl_cipher_suites string` | list of accepted ciphers | `HIGH:!aNULL:!eNULL` |
 
 
 ## Client SSL Configuration Summary


### PR DESCRIPTION
- Use [HIGH](https://wiki.openssl.org/index.php/Manual:Ciphers(1)) encryption cipher suites by default.
- Reject malicious [PTR](https://en.wikipedia.org/wiki/List_of_DNS_record_types#PTR) records.