### PR TITLE
Fix cdb2api debug trace

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2987,7 +2987,7 @@ static int retry_query_list(cdb2_hndl_tp *hndl, int num_retry, int run_last)
         hdr.compression = ntohl(0);
         hdr.length = ntohl(item->len);
         if (hndl->debug_trace) {
-            fprintf(stderr, "td %u:%d %s resending '%s' to %s\n",
+            fprintf(stderr, "td %u %s:%d resending '%s' to %s\n",
                     (uint32_t)pthread_self(), __func__, __LINE__, item->sql,
                     host);
         }

--- a/tests/tools/insert.c
+++ b/tests/tools/insert.c
@@ -836,14 +836,15 @@ int clear(void)
         }
 
         rc = cdb2_run_statement(db, "commit");
-        if (rc == 230) {
+        if (rc == 230 || rc == 4) {
             tdprintf(stderr, db, __func__, __LINE__,
                      "clear: commit rc %d %s - retrying\n", rc,
                      cdb2_errstr(db));
             continue;
         } else if (rc) {
             tdprintf(stderr, db, __func__, __LINE__,
-                     "XXX clear: commit rc %d %s\n", rc, cdb2_errstr(db));
+                     "XXX clear: commit rc %d %s iteration %d\n", rc, 
+                     cdb2_errstr(db), iteration);
             exit(1);
         }
 
@@ -919,6 +920,10 @@ int main(int argc, char *argv[])
             myexit(__func__, __LINE__, 1);
             break;
         }
+    }
+
+    if (debug_trace) {
+        fprintf(stderr, "Staring %s pid %d\n", argv0, getpid());
     }
 
     if (errors) {


### PR DESCRIPTION
A trace bug that causes a process to crash if the debug-trace flag is enabled
