### PR TITLE
Refactor before I can log bound params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # binaries -- still installing these in-source for test suite
 /build*
+/ninja*
 /deps
 /cdb2_dump
 /cdb2_printlog

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1992,4 +1992,7 @@ void bdb_set_fld_hints(bdb_state_type *, uint16_t *);
 void bdb_cleanup_fld_hints(bdb_state_type *bdb_state);
 void rename_bdb_state(bdb_state_type *bdb_state, const char *newname);
 
+int request_durable_lsn_from_master(bdb_state_type *, uint32_t *, uint32_t *,
+                                    uint32_t *);
+
 #endif

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -611,7 +611,6 @@ int gbl_disable_stable_for_ipu = 1;
 int gbl_disable_exit_on_thread_error = 0;
 
 int gbl_berkdb_iomap = 1;
-int gbl_catch_response_on_retry = 1;
 int gbl_check_dbnum_conflicts = 1;
 int gbl_requeue_on_tran_dispatch = 1;
 int gbl_crc32c = 1;
@@ -4608,9 +4607,6 @@ static void register_all_int_switches()
     register_switch("berkdb_iomap",
                     "enable berkdb writing memptrickle status to a mapped file",
                     iomap_on, iomap_off, int_stat_fn, &gbl_berkdb_iomap);
-    register_int_switch("catch_response_on_retry",
-                        "print trace when we try to send replies on a retry",
-                        &gbl_catch_response_on_retry);
     register_int_switch("requeue_on_tran_dispatch",
                         "Requeue transactional statement if not enough threads",
                         &gbl_requeue_on_tran_dispatch);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -418,6 +418,7 @@ enum RCODES {
     , ERR_VERIFY_PI = 319
     , ERR_UNCOMMITABLE_TXN = 404 /* txn is uncommitable, returns ERR_VERIFY rather than retry */
     , ERR_INCOHERENT = 996 /* prox2 understands it should retry another node for 996 */
+    , ERR_SQL_PREPARE = 1003
     , ERR_NO_AUXDB = 2000 /* requested auxiliary database not available */
     , ERR_SQL_PREP = 2001 /* block sql error in sqlite3_prepare */
     , ERR_LIMIT = 2002 /* sql request exceeds max cost */

--- a/db/dbglog_support.c
+++ b/db/dbglog_support.c
@@ -285,6 +285,61 @@ void dump_client_query_stats(SBUF2 *sb, struct client_query_stats *st)
         free(buf);
 }
 
+/* TODO: This whole file must go.
+ * Will be reintroduced in fastsql plugin */
+#define fsqlreq_put(...) 0
+#define fsqlresp_put(...) 0
+#define fsqlresp_get(...) 0
+/* higher numbers to not clash with sqlnet.c.  In fact, this should
+   merge into sqlnet at some point in the distant future */
+/* requests for fastsql */
+enum fsql_request {
+    FSQL_EXECUTE_INLINE_PARAMS = 100,
+    FSQL_EXECUTE_STOP = 101,
+    FSQL_SET_ISOLATION_LEVEL = 102,
+    FSQL_SET_TIMEOUT = 103,
+    FSQL_SET_INFO = 104,
+    FSQL_EXECUTE_INLINE_PARAMS_TZ = 105,
+    FSQL_SET_HEARTBEAT = 106,
+    FSQL_PRAGMA = 107,
+    FSQL_RESET = 108,
+    FSQL_EXECUTE_REPLACEABLE_PARAMS = 109,
+    FSQL_SET_SQL_DEBUG = 110,
+    FSQL_GRAB_DBGLOG = 111,
+    FSQL_SET_USER = 112,
+    FSQL_SET_PASSWORD = 113,
+    FSQL_SET_ENDIAN = 114,
+    FSQL_EXECUTE_REPLACEABLE_PARAMS_TZ = 115,
+    FSQL_GET_EFFECTS = 116,
+    FSQL_SET_PLANNER_EFFORT = 117,
+    FSQL_SET_REMOTE_ACCESS = 118,
+    FSQL_OSQL_MAX_TRANS = 119,
+    FSQL_SET_DATETIME_PRECISION = 120,
+    FSQL_SSLCONN = 121
+};
+/* responses for fastsql */
+enum fsql_response {
+    FSQL_COLUMN_DATA = 200,
+    FSQL_ROW_DATA = 201,
+    FSQL_NO_MORE_DATA = 202,
+    FSQL_ERROR = 203,
+    FSQL_QUERY_STATS = 204,
+    FSQL_HEARTBEAT = 205,
+    FSQL_SOSQL_TRAN_RESPONSE = 206,
+    FSQL_DEBUG_TRACE = 207,
+    FSQL_NEW_ROW_DATA = 208,
+    FSQL_QUERY_EFFECTS = 209
+};
+struct fsqlresp {
+    int response; /* enum fsql_response */
+    int flags;    /* response flags */
+    int rcode;
+    int parm;      /* extra word of info differs per request type */
+    int followlen; /* how much data follows header*/
+};
+enum { FSQLRESP_LEN = 4 + 4 + 4 + 4 + 4 };
+BB_COMPILE_TIME_ASSERT(fsqlresp_size, sizeof(struct fsqlresp) == FSQLRESP_LEN);
+
 #define RETURN_DBGLOG_ERROR(errstr)                                            \
     {                                                                          \
         int errstr_len = strlen(errstr) + 1;                                   \

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -603,7 +603,7 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
         osql_shadtbl_begin_query(thedb->bdb_env, clnt);
     }
 
-    thd->sqlclntstate = clnt;
+    thd->clnt = clnt;
     bzero(pCur, sizeof(*pCur));
     pCur->genid = genid;
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1209,7 +1209,7 @@ static int _failed_AddAndLockTable(sqlite3 *db, const char *dbname, int errcode,
                                    const char *prefix)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     logmsg(LOGMSG_WARN, "Error \"%s\" for db \"%s\"\n", prefix, dbname);
 
@@ -1456,7 +1456,7 @@ static int __lock_wrlock_exclusive(char *dbname)
                 if (thd) {
                     rc = recover_deadlock(
                         thedb->bdb_env, thd, NULL,
-                        100 * thd->sqlclntstate->deadlock_recovered++);
+                        100 * thd->clnt->deadlock_recovered++);
                     if (rc) {
                         fprintf(stderr, "%s:%d recover_deadlock returned %d\n",
                                 __func__, __LINE__, rc);
@@ -2929,7 +2929,7 @@ static int fdb_cursor_reopen(BtCursor *pCur)
         return FDB_ERR_BUG;
     }
 
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
     tran = pCur->fdbc->impl->trans;
     need_ssl = pCur->fdbc->impl->need_ssl;
 
@@ -3320,7 +3320,7 @@ fdb_sqlstat_cache_t *fdb_sqlstats_get(fdb_t *fdb)
     thd = pthread_getspecific(query_info_key);
     if (!thd) return NULL;
 
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
 
     /* remote sql stats are implemented as a critical region
        I was told that mutex is faster, lul
@@ -4087,7 +4087,7 @@ int fdb_cursor_access(BtCursor *pCur, int how)
     if (!thd)
         return FDB_NOERR;
 
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
     if (!clnt)
         return FDB_NOERR;
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6222,8 +6222,8 @@ static int conv_rc_sql2blkop(struct ireq *iq, int step, int ixnum, int rc,
         break;
 
     case ERR_SQL_PREP:
-        reqerrstr(iq, FSQL_PREPARE, "sql query syntax error");
-        ret = FSQL_PREPARE;
+        reqerrstr(iq, ERR_SQL_PREPARE, "sql query syntax error");
+        ret = ERR_SQL_PREPARE;
         break;
 
     case OSQL_FAILDISPATCH:

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5703,7 +5703,7 @@ int osql_comm_check_bdb_lock(void)
         struct sql_thread *thd = pthread_getspecific(query_info_key);
         if (!thd) return 0;
 
-        struct sqlclntstate *clnt = thd->sqlclntstate;
+        struct sqlclntstate *clnt = thd->clnt;
         int sleepms;
 
         logmsg(LOGMSG_DEBUG, "%s bdb_lock_desired so calling recover_deadlock\n",

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -258,7 +258,7 @@ static shad_tbl_t *open_shadtbl(struct BtCursor *pCur)
 
     tbl = get_shadtbl(pCur);
     if (!tbl) {
-        struct sqlclntstate *clnt = thd->sqlclntstate;
+        struct sqlclntstate *clnt = thd->clnt;
         if (!clnt) {
             /* this is a bug */
             static int once = 0;
@@ -698,7 +698,7 @@ static shad_tbl_t *get_shadtbl(struct BtCursor *pCur)
        meantime? case in mind, index and data both recording
        genids */
     thd = pthread_getspecific(query_info_key);
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
 
     return osql_get_shadow_bydb(clnt, pCur->db);
 }
@@ -866,7 +866,7 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                      int nData)
 {
 
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     shad_tbl_t *tbl = NULL;
@@ -893,8 +893,8 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     set_genid_upd(&tmp);
 
     if (is_genid_synthetic(pCur->genid)) {
-        if (thd->sqlclntstate->dbtran.shadow_tran)
-            bdb_set_check_shadows(thd->sqlclntstate->dbtran.shadow_tran);
+        if (thd->clnt->dbtran.shadow_tran)
+            bdb_set_check_shadows(thd->clnt->dbtran.shadow_tran);
 
         /* Need to know if the synthetic genid is generated as a result of a
            insert or update
@@ -1000,8 +1000,8 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     }
 
     if (gbl_partial_indexes && pCur->db->ix_partial &&
-        (save_ins_keys(thd->sqlclntstate, tbl, tmp) ||
-         save_del_keys(thd->sqlclntstate, tbl, pCur->genid))) {
+        (save_ins_keys(thd->clnt, tbl, tmp) ||
+         save_del_keys(thd->clnt, tbl, pCur->genid))) {
         logmsg(LOGMSG_ERROR, "%s: error saving the shadow dirty keys\n", __func__);
         return -1;
     }
@@ -1022,7 +1022,7 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                      int nData)
 {
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     shad_tbl_t *tbl = NULL;
@@ -1051,8 +1051,8 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 #ifdef TEST_OSQL
     uuidstr_t us;
     fprintf(stdout, "[%llu %s] Inserted seq=%llu (%u) rc=%d pCur->genid=%llu\n",
-            thd->sqlclntstate->osql.rqid,
-            comdb2uuidstr(thd->sqlclntstate->osql.uuid, us), tmp,
+            thd->clnt->osql.rqid,
+            comdb2uuidstr(thd->clnt->osql.uuid, us), tmp,
             pthread_self(), rc, pCur->genid);
 #endif
 
@@ -1062,8 +1062,8 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
         return -1;
     }
 
-    if (thd->sqlclntstate->dbtran.shadow_tran)
-        bdb_set_check_shadows(thd->sqlclntstate->dbtran.shadow_tran);
+    if (thd->clnt->dbtran.shadow_tran)
+        bdb_set_check_shadows(thd->clnt->dbtran.shadow_tran);
 
     /* if this is recom, snapisol or serial, we need to update the index shadows
      */
@@ -1074,7 +1074,7 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     }
 
     if (gbl_partial_indexes && pCur->db->ix_partial &&
-        save_ins_keys(thd->sqlclntstate, tbl, tmp)) {
+        save_ins_keys(thd->clnt, tbl, tmp)) {
         logmsg(LOGMSG_ERROR, "%s: error saving the shadow dirty keys\n", __func__);
         return -1;
     }
@@ -1082,14 +1082,14 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     tbl->seq = increment_seq(tbl->seq);
     /*++tbl->seq;*/
 
-    thd->sqlclntstate->osql.dirty = 1;
+    thd->clnt->osql.dirty = 1;
 
     return 0;
 }
 
 int osql_save_delrec(struct BtCursor *pCur, struct sql_thread *thd)
 {
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     shad_tbl_t *tbl = NULL;
     int rc = 0;
     int bdberr = 0;
@@ -1120,12 +1120,12 @@ int osql_save_delrec(struct BtCursor *pCur, struct sql_thread *thd)
     }
 
     if (gbl_partial_indexes && pCur->db->ix_partial &&
-        save_del_keys(thd->sqlclntstate, tbl, pCur->genid)) {
+        save_del_keys(thd->clnt, tbl, pCur->genid)) {
         logmsg(LOGMSG_ERROR, "%s: error saving the shadow dirty keys\n", __func__);
         return -1;
     }
 
-    thd->sqlclntstate->osql.dirty = 1;
+    thd->clnt->osql.dirty = 1;
 
     return 0;
 }
@@ -1133,7 +1133,7 @@ int osql_save_delrec(struct BtCursor *pCur, struct sql_thread *thd)
 int osql_save_index(struct BtCursor *pCur, struct sql_thread *thd,
                     int is_update, int is_delete)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     osqlstate_t *osql = &clnt->osql;
     shad_tbl_t *tbl = NULL;
     int rc = 0;
@@ -1215,7 +1215,7 @@ int osql_save_dbq_consume(struct sqlclntstate *clnt, const char *spname,
 int osql_save_updcols(struct BtCursor *pCur, struct sql_thread *thd,
                       int *updCols)
 {
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int bdberr = 0;
     shad_tbl_t *tbl = NULL;
     unsigned long long tmp = 0;
@@ -1314,7 +1314,7 @@ int osql_save_updcols(struct BtCursor *pCur, struct sql_thread *thd,
 
     tbl->updcols = 1;
 
-    thd->sqlclntstate->osql.dirty = 1;
+    thd->clnt->osql.dirty = 1;
 
     return 0;
 }
@@ -1323,7 +1323,7 @@ int osql_save_qblobs(struct BtCursor *pCur, struct sql_thread *thd,
                      blob_buffer_t *blobs, int maxblobs, int is_update)
 {
 
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     shad_tbl_t *tbl = NULL;
@@ -2059,19 +2059,19 @@ static int insert_record_indexes(BtCursor *pCur, struct sql_thread *thd,
     char *datacopy;
     int datacopylen;
 
-    if (thd->sqlclntstate && thd->sqlclntstate->dbtran.mode == TRANLEVEL_SOSQL)
+    if (thd->clnt && thd->clnt->dbtran.mode == TRANLEVEL_SOSQL)
         return 0;
 
     /* Add all the keys to the shadow indices */
     for (ix = 0; ix < pCur->db->nix; ix++) {
         /* only add keys when told */
         if (gbl_partial_indexes && pCur->db->ix_partial &&
-            !(thd->sqlclntstate->ins_keys & (1ULL << ix)))
+            !(thd->clnt->ins_keys & (1ULL << ix)))
             continue;
 
         snprintf(namebuf, sizeof(namebuf), ".ONDISK_IX_%d", ix);
         if (gbl_expressions_indexes && pCur->db->ix_expr) {
-            memcpy(key, thd->sqlclntstate->idxInsert[ix],
+            memcpy(key, thd->clnt->idxInsert[ix],
                    pCur->db->ix_keylen[ix]);
         } else {
             rc = stag_to_stag_buf(pCur->db->tablename, ".ONDISK",
@@ -2083,10 +2083,10 @@ static int insert_record_indexes(BtCursor *pCur, struct sql_thread *thd,
         }
 
         tmpcur = bdb_cursor_open(
-            pCur->db->handle, thd->sqlclntstate->dbtran.cursor_tran,
-            thd->sqlclntstate->dbtran.shadow_tran, ix, BDB_OPEN_SHAD,
+            pCur->db->handle, thd->clnt->dbtran.cursor_tran,
+            thd->clnt->dbtran.shadow_tran, ix, BDB_OPEN_SHAD,
             osql_get_shadtbl_addtbl_newcursor(pCur), 0, 0, NULL, NULL, NULL,
-            NULL, NULL, thd->sqlclntstate->bdb_osql_trak, bdberr);
+            NULL, NULL, thd->clnt->bdb_osql_trak, bdberr);
         if (tmpcur == NULL) {
             logmsg(LOGMSG_ERROR, "%s: bdb_cursor_open ix %d rc %d\n", __func__, ix, *bdberr);
             return SQLITE_INTERNAL;
@@ -2139,14 +2139,14 @@ static int delete_record_indexes(BtCursor *pCur, char *pdta, int dtasize,
     char namebuf[MAXTAGLEN];
     struct dbtable *db = pCur->db;
     char *key;
-    void *tran = thd->sqlclntstate->dbtran.shadow_tran;
+    void *tran = thd->clnt->dbtran.shadow_tran;
     bdb_cursor_ifn_t *tmpcur = NULL;
     int rc = 0;
     unsigned long long genid = pCur->genid;
     void *dta = pCur->dtabuf;
     key = alloca(MAXKEYLEN + sizeof(genid));
 
-    if (thd->sqlclntstate && thd->sqlclntstate->dbtran.mode == TRANLEVEL_SOSQL)
+    if (thd->clnt && thd->clnt->dbtran.mode == TRANLEVEL_SOSQL)
         return 0;
 
     /* none synthetic genids are added to the skip list
@@ -2164,12 +2164,12 @@ static int delete_record_indexes(BtCursor *pCur, char *pdta, int dtasize,
     for (ix = 0; ix < db->nix; ix++) {
         /* only delete keys when told */
         if (gbl_partial_indexes && db->ix_partial &&
-            !(thd->sqlclntstate->del_keys & (1ULL << ix)))
+            !(thd->clnt->del_keys & (1ULL << ix)))
             continue;
 
         snprintf(namebuf, sizeof(namebuf), ".ONDISK_IX_%d", ix);
         if (gbl_expressions_indexes && db->ix_expr) {
-            memcpy(key, thd->sqlclntstate->idxDelete[ix], db->ix_keylen[ix]);
+            memcpy(key, thd->clnt->idxDelete[ix], db->ix_keylen[ix]);
         } else {
             rc = stag_to_stag_buf(db->tablename, ".ONDISK", dta, namebuf, key,
                                   NULL);
@@ -2181,10 +2181,10 @@ static int delete_record_indexes(BtCursor *pCur, char *pdta, int dtasize,
         memcpy(&key[db->ix_keylen[ix]], &genid, sizeof(genid));
 
         tmpcur = bdb_cursor_open(
-            db->handle, thd->sqlclntstate->dbtran.cursor_tran,
-            thd->sqlclntstate->dbtran.shadow_tran, ix, BDB_OPEN_SHAD,
+            db->handle, thd->clnt->dbtran.cursor_tran,
+            thd->clnt->dbtran.shadow_tran, ix, BDB_OPEN_SHAD,
             osql_get_shadtbl_addtbl_newcursor(pCur), 0, 0, NULL, NULL, NULL,
-            NULL, NULL, thd->sqlclntstate->bdb_osql_trak, bdberr);
+            NULL, NULL, thd->clnt->bdb_osql_trak, bdberr);
         if (tmpcur == NULL) {
             logmsg(LOGMSG_ERROR, "%s:bdb_cursor_open ix %d rc %d\n", __func__, ix, *bdberr);
             return -1;
@@ -2604,7 +2604,7 @@ static int unpack_recgenid_key(recgenid_key_t *key, const uint8_t *buf, int len)
 int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
                           unsigned long long genid)
 {
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     shad_tbl_t *tbl = NULL;
@@ -2614,7 +2614,7 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
 
     /*create a common verify */
     if (!osql->verify_tbl) {
-        rc = osql_create_verify_temptbl(thedb->bdb_env, thd->sqlclntstate,
+        rc = osql_create_verify_temptbl(thedb->bdb_env, thd->clnt,
                                         &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: failed to create verify rc=%d bdberr=%d\n",
@@ -2657,7 +2657,7 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
 int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
                       unsigned long long genid)
 {
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     recgenid_key_t key;
@@ -2781,8 +2781,8 @@ static int process_local_shadtbl_recgenids(struct sqlclntstate *clnt,
 int osql_save_schemachange(struct sql_thread *thd,
                            struct schema_change_type *sc, int usedb)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    struct sqlclntstate *clnt = thd->clnt;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     void *packed_sc_data = NULL;
@@ -2791,7 +2791,7 @@ int osql_save_schemachange(struct sql_thread *thd,
     int packed_sc_key[2] = {0, -1};
 
     if (!osql->sc_tbl) {
-        rc = osql_create_schemachange_temptbl(thedb->bdb_env, thd->sqlclntstate,
+        rc = osql_create_schemachange_temptbl(thedb->bdb_env, thd->clnt,
                                               &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: failed to create sc rc=%d bdberr=%d\n",
@@ -2928,15 +2928,15 @@ static int process_local_shadtbl_sc(struct sqlclntstate *clnt, int *bdberr)
 
 int osql_save_bpfunc(struct sql_thread *thd, BpfuncArg *arg)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
-    osqlstate_t *osql = &thd->sqlclntstate->osql;
+    struct sqlclntstate *clnt = thd->clnt;
+    osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
     void *bpfunc_data = NULL;
     size_t bpfunc_data_len = bpfunc_arg__get_packed_size(arg);
 
     if (!osql->bpfunc_tbl) {
-        rc = osql_create_bpfunc_temptbl(thedb->bdb_env, thd->sqlclntstate,
+        rc = osql_create_bpfunc_temptbl(thedb->bdb_env, thd->clnt,
                                         &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR,

--- a/db/sql.h
+++ b/db/sql.h
@@ -73,15 +73,6 @@ typedef struct stmt_hash_entry {
 struct sqlthdstate {
     struct reqlogger *logger;
     struct sql_thread *sqlthd;
-
-    /* Scratch buffer. */
-    char *buf;
-    int maxbuflen;
-    int buflen;
-
-    struct column_info *cinfo;
-    struct sqlfield *offsets;
-
     struct thr_handle *thr_self;
     sqlite3 *sqldb;
 
@@ -94,7 +85,6 @@ struct sqlthdstate {
     int dbopen_gen;
     int analyze_gen;
     int views_gen;
-    int ncols;
     int started_backend;
 };
 
@@ -275,8 +265,60 @@ struct lua_State;
 enum early_verify_error { EARLY_ERR_VERIFY = 1, EARLY_ERR_SELECTV = 2 };
 #define FINGERPRINTSZ 16
 
+/* write response */
+enum {
+    RESPONSE_COLUMNS,
+    RESPONSE_COLUMNS_LUA,
+    RESPONSE_COLUMNS_STR,
+    RESPONSE_COST,
+    RESPONSE_DEBUG,
+    RESPONSE_EFFECTS,
+    RESPONSE_ERROR,
+    RESPONSE_ERROR_ACCESS,
+    RESPONSE_ERROR_BAD_STATE,
+    RESPONSE_ERROR_PREPARE,
+    RESPONSE_ERROR_PREPARE_RETRY,
+    RESPONSE_ERROR_REJECT,
+    RESPONSE_FLUSH,
+    RESPONSE_HEARTBEAT,
+    RESPONSE_ROW,
+    RESPONSE_ROW_LAST,
+    RESPONSE_ROW_LAST_DUMMY,
+    RESPONSE_ROW_LUA,
+    RESPONSE_ROW_STR,
+    RESPONSE_TRACE,
+};
+
+/* read response */
+enum {
+    RESPONSE_PING_PONG,
+};
+
+struct response_data {
+    sqlite3_stmt *stmt;
+    uint64_t row_id;
+    /* For RESPONSE_COLUMNS_LUA, RESPONSE_ROW_LUA */
+    int ncols;
+    int pingpong;
+    struct stored_proc *sp;
+};
+
+char *sp_column_name(struct response_data *, int);
+int sp_column_type(struct response_data *, int, size_t, int);
+int sp_column_nil(struct response_data *, int);
+int sp_column_val(struct response_data *, int, int, void *);
+void *sp_column_ptr(struct response_data *, int, int, size_t *);
+
+typedef int(*response_func)(struct sqlclntstate *, int, void *, int);
+
 /* Client specific sql state */
 struct sqlclntstate {
+    /* newsql_write_response, fastsql_write_response, etc */
+    response_func write_response;
+    /* newsql_read_response */
+    response_func read_response;
+    /* appsock plugin specific data */
+    void *appdata;
 
     dbtran_type dbtran;
     pthread_mutex_t dtran_mtx; /* protect dbtran.dtran, if any,
@@ -388,9 +430,6 @@ struct sqlclntstate {
 
     int have_password;
     char password[MAX_PASSWORD_LEN];
-
-    int have_endian;
-    int endian;
 
     int no_transaction;
 
@@ -724,8 +763,6 @@ struct sql_thread {
     char *error;
     struct master_entry *rootpages;
     int rootpage_nentries;
-    CDB2SQLRESPONSE__Column **columns;
-    int columns_count;
     unsigned char had_temptables;
     unsigned char had_tablescans;
 };
@@ -774,10 +811,6 @@ void reset_query_effects(struct sqlclntstate *);
 int sqlite_to_ondisk(struct schema *s, const void *inp, int len, void *outp,
                      const char *tzname, blob_buffer_t *outblob, int maxblobs,
                      struct convert_failure *fail_reason, BtCursor *pCur);
-
-int emit_sql_row(struct sqlthdstate *thd, struct column_info *cols,
-                 struct sqlfield *offsets, struct sqlclntstate *clnt,
-                 sqlite3_stmt *stmt, int *irc, char *errstr, int maxerrstr);
 
 int has_sqlcache_hint(const char *sql, const char **start, const char **end);
 
@@ -847,5 +880,8 @@ int get_data(BtCursor *pCur, struct schema *sc, uint8_t *in, int fnum, Mem *m,
              uint8_t flip_orig, const char *tzname);
 
 #define cur_is_remote(pCur) (pCur->cursor_class == CURSORCLASS_REMOTE)
+
+int sql_writer(SBUF2 *, const char *, int);
+int typestr_to_type(const char *ctype);
 
 #endif

--- a/db/sql.h
+++ b/db/sql.h
@@ -719,7 +719,7 @@ struct sql_thread {
     LISTC_T(struct query_path_component) query_stats;
     hash_t *query_hash;
     double cost;
-    struct sqlclntstate *sqlclntstate; /* pointer to originating sqlclnt */
+    struct sqlclntstate *clnt;
     /* custom error message to send to client */
     char *error;
     struct master_entry *rootpages;

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -458,7 +458,7 @@ int analyze_get_nrecs(int iTable)
 
     /* get client structures */
     thd = pthread_getspecific(query_info_key);
-    client = thd->sqlclntstate;
+    client = thd->clnt;
 
     /* comdb2-ize table-num and ixnum */
     db = get_sqlite_db(thd, iTable, &ixnum);
@@ -491,7 +491,7 @@ int64_t analyze_get_sampled_nrecs(const char *dbname, int ixnum)
 
     /* get client structures */
     thd = pthread_getspecific(query_info_key);
-    client = thd->sqlclntstate;
+    client = thd->clnt;
 
     /* Punt if this wasn't sampled. */
     if (NULL == client->sampled_idx_tbl || client->n_cmp_idx <= 0) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -538,7 +538,7 @@ static int sql_tick(struct sql_thread *thd, int uses_bdb_locking)
 
     gbl_sqltick++;
 
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
 
     if (clnt == NULL)
         return 0;
@@ -979,7 +979,7 @@ static int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info,
             struct sql_thread *thd = pthread_getspecific(query_info_key);
             struct sqlclntstate *clnt;
             if (thd) {
-                clnt = thd->sqlclntstate;
+                clnt = thd->clnt;
                 if (m->n > 0 && m->z[m->n - 1] != 0) {
                     s = alloca(m->n + 1);
                     memcpy(s, m->z, m->n);
@@ -1970,7 +1970,7 @@ int new_indexes_syntax_check(struct ireq *iq)
     struct sql_thread *sqlthd = start_sql_thread();
     sql_get_query_id(sqlthd);
     client.debug_sqlclntstate = pthread_self();
-    sqlthd->sqlclntstate = &client;
+    sqlthd->clnt = &client;
 
     get_copy_rootpages_nolock(sqlthd);
 
@@ -2015,7 +2015,7 @@ done:
 static int has_no_read_dirty_data(int tblnum)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (clnt->dbtran.mode != TRANLEVEL_SERIAL &&
         clnt->dbtran.mode != TRANLEVEL_SNAPISOL &&
@@ -2118,7 +2118,7 @@ static int cursor_move_preprop(BtCursor *pCur, int *pRes, int how, int *done,
         return rc;
     }
 
-    if (thd->sqlclntstate->is_analyze &&
+    if (thd->clnt->is_analyze &&
         (gbl_schema_change_in_progress || get_analyze_abort_requested())) {
         if (gbl_schema_change_in_progress)
             logmsg(LOGMSG_ERROR, 
@@ -2228,7 +2228,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
     int rc = SQLITE_OK;
     int outrc = SQLITE_OK;
     uint8_t ver;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (access_control_check_sql_read(pCur, thd)) {
         return SQLITE_ACCESS;
@@ -2240,7 +2240,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
     }
 
     /* If no tablescans are allowed, return an error */
-    if (!thd->sqlclntstate->limits.tablescans_ok) {
+    if (!thd->clnt->limits.tablescans_ok) {
         return SQLITE_LIMIT;
     }
 
@@ -2274,13 +2274,13 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
     if (bdberr == BDBERR_DEADLOCK) {
         logmsg(LOGMSG_ERROR, "%s: too much contention, retried %d times [%llx]\n",
                 __func__, gbl_move_deadlk_max_attempt,
-                (thd->sqlclntstate && thd->sqlclntstate->osql.rqid)
-                    ? thd->sqlclntstate->osql.rqid
+                (thd->clnt && thd->clnt->osql.rqid)
+                    ? thd->clnt->osql.rqid
                     : 0);
         ctrace("%s: too much contention, retried %d times [%llx]\n", __func__,
                gbl_move_deadlk_max_attempt,
-               (thd->sqlclntstate && thd->sqlclntstate->osql.rqid)
-                   ? thd->sqlclntstate->osql.rqid
+               (thd->clnt && thd->clnt->osql.rqid)
+                   ? thd->clnt->osql.rqid
                    : 0);
         return SQLITE_DEADLOCK;
     }
@@ -2336,7 +2336,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 
         if (!gbl_selectv_rangechk) {
             if ((rc == IX_FND || rc == IX_FNDMORE) && pCur->is_recording &&
-                thd->sqlclntstate->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
                 rc = osql_record_genid(pCur, thd, pCur->genid);
                 if (rc) {
                     logmsg(LOGMSG_ERROR, "%s: failed to record genid %llx (%llu)\n",
@@ -2375,7 +2375,7 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
     int done = 0;
     int rc = SQLITE_OK;
     int outrc = SQLITE_OK;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (access_control_check_sql_read(pCur, thd)) {
         return SQLITE_ACCESS;
@@ -2427,8 +2427,8 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
                 gbl_move_deadlk_max_attempt);
         ctrace("%s: too much contention, retried %d times [%llx]\n", __func__,
                gbl_move_deadlk_max_attempt,
-               (thd->sqlclntstate && thd->sqlclntstate->osql.rqid)
-                   ? thd->sqlclntstate->osql.rqid
+               (thd->clnt && thd->clnt->osql.rqid)
+                   ? thd->clnt->osql.rqid
                    : 0);
         return SQLITE_DEADLOCK;
     } else if (rc == IX_FND || rc == IX_NOTFND) {
@@ -2487,7 +2487,7 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
 
         if (!gbl_selectv_rangechk) {
             if ((rc == IX_FND || rc == IX_FNDMORE) && pCur->is_recording &&
-                thd->sqlclntstate->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
 
                 rc = osql_record_genid(pCur, thd, pCur->genid);
                 if (rc) {
@@ -2701,7 +2701,7 @@ static int cursor_move_master(BtCursor *pCur, int *pRes, int how)
 static int cursor_move_remote(BtCursor *pCur, int *pRes, int how)
 {
     struct sql_thread *thd = pCur->thd;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int done = 0;
     int rc = 0;
 
@@ -2832,7 +2832,7 @@ static inline int sqlite3VdbeCompareRecordPacked(KeyInfo *pKeyInfo, int k1len,
 static int cursor_move_postop(BtCursor *pCur)
 {
     struct sql_thread *thd = pCur->thd;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     extern int gbl_sql_release_locks_on_si_lockwait;
     extern int gbl_locks_check_waiters;
     int rc = 0;
@@ -3164,8 +3164,8 @@ int sqlite3BtreeClose(Btree *pBt)
 done:
 
     /*
-     * if (thd->sqlclntstate->freemewithbt)
-     * free(thd->sqlclntstate);
+     * if (thd->clnt->freemewithbt)
+     * free(thd->clnt);
      */
 
     reqlog_logf(pBt->reqlogger, REQL_TRACE, "Close(pBt %d)      = %s\n",
@@ -3437,7 +3437,7 @@ int sqlite3BtreeLast(BtCursor *pCur, int *pRes)
     void *buf;
 
     struct sql_thread *thd = pCur->thd;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     CurRangeArr **append_to;
     if (pCur->range) {
         if (pCur->range->idxnum == -1 && pCur->range->islocked == 0) {
@@ -3504,7 +3504,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
     int rc = SQLITE_OK;
     int bdberr = 0;
     struct sql_thread *thd = pCur->thd;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     /* only record for temp tables - writes for real tables are recorded in
      * block code */
@@ -3692,7 +3692,7 @@ int sqlite3BtreeFirst(BtCursor *pCur, int *pRes)
     void *buf;
 
     struct sql_thread *thd = pCur->thd;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     CurRangeArr **append_to;
     if (pCur->range) {
         if (pCur->range->idxnum == -1 && pCur->range->islocked == 0) {
@@ -3898,7 +3898,7 @@ int sqlite3BtreeIsInStmt(Btree *pBt)
 {
     /* don't care for now. if one was started, return that one is in progress */
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    int rc = (thd && thd->sqlclntstate) ? thd->sqlclntstate->intrans : 0;
+    int rc = (thd && thd->clnt) ? thd->clnt->intrans : 0;
 
     reqlog_logf(pBt->reqlogger, REQL_TRACE, "IsInTrans(pBt %d)      = %s\n",
                 pBt->btreeid, rc ? "yes" : "no");
@@ -4435,7 +4435,7 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag)
 {
     int rc = SQLITE_OK;
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
 #ifdef DEBUG_TRAN
     if (gbl_debug_sql_opcodes) {
@@ -4562,7 +4562,7 @@ done:
 int sqlite3BtreeCommit(Btree *pBt)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int rc = SQLITE_OK;
     int irc = 0;
     int bdberr = 0;
@@ -4691,7 +4691,7 @@ int sqlite3BtreeCommit(Btree *pBt)
             }
         } else {
             rc = osql_sock_commit(clnt, OSQL_SOCK_REQ);
-            osqlstate_t *osql = &thd->sqlclntstate->osql;
+            osqlstate_t *osql = &thd->clnt->osql;
             if (osql->xerr.errval == COMDB2_SCHEMACHANGE_OK) {
                 osql->xerr.errval = 0;
             }
@@ -4747,7 +4747,7 @@ done:
 int sqlite3BtreeRollback(Btree *pBt, int dummy, int writeOnlyDummy)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int rc = SQLITE_OK;
     int irc = 0;
     int bdberr = 0;
@@ -4855,7 +4855,7 @@ done:
 int sqlite3BtreeIsInTrans(Btree *pBt)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    int rc = (thd && thd->sqlclntstate) ? thd->sqlclntstate->intrans : 0;
+    int rc = (thd && thd->clnt) ? thd->clnt->intrans : 0;
 
 /* UNIMPLEMENTED */
 /* FIXME TODO XXX #if 0'ed out the foll */
@@ -4938,7 +4938,7 @@ int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
         goto done;
     }
 
-    if (!thd->sqlclntstate->limits.temptables_ok)
+    if (!thd->clnt->limits.temptables_ok)
         return SQLITE_LIMIT;
 
     /* creating a temporary table */
@@ -5534,7 +5534,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
 
             if (!gbl_selectv_rangechk) {
                 if ((rc == IX_FND || rc == IX_FNDMORE) && pCur->is_recording &&
-                    thd->sqlclntstate->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                    thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
                     rc = osql_record_genid(pCur, thd, pCur->genid);
                     if (rc) {
                         logmsg(LOGMSG_ERROR, 
@@ -5586,7 +5586,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
         }
     } else { /* find by key */
         int ondisk_len;
-        struct convert_failure *fail_reason = &thd->sqlclntstate->fail_reason;
+        struct convert_failure *fail_reason = &thd->clnt->fail_reason;
 
         struct bias_info info = {.bias = bias,
                                  .truncated = 0,
@@ -5597,7 +5597,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
             sqlite_unpacked_to_ondisk(pCur, pIdxKey, fail_reason, &info);
         if (rc < 0) {
             char errs[128];
-            convert_failure_reason_str(&thd->sqlclntstate->fail_reason,
+            convert_failure_reason_str(&thd->clnt->fail_reason,
                                        pCur->db->tablename, "SQLite format",
                                        ".ONDISK", errs, sizeof(errs));
             reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
@@ -5732,7 +5732,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
 
             if (!gbl_selectv_rangechk) {
                 if (goodrc && pCur->is_recording &&
-                    thd->sqlclntstate->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                    thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
                     rc = osql_record_genid(pCur, thd, pCur->genid);
                     if (rc) {
                         logmsg(LOGMSG_ERROR, 
@@ -5770,11 +5770,11 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
                     ctrace(
                         "%s: too much contention, retried %d times [%llx %s]\n",
                         __func__, gbl_move_deadlk_max_attempt,
-                        (thd->sqlclntstate && thd->sqlclntstate->osql.rqid)
-                            ? thd->sqlclntstate->osql.rqid
+                        (thd->clnt && thd->clnt->osql.rqid)
+                            ? thd->clnt->osql.rqid
                             : 0,
-                        (thd->sqlclntstate && thd->sqlclntstate->osql.rqid)
-                            ? comdb2uuidstr(thd->sqlclntstate->osql.uuid, us)
+                        (thd->clnt && thd->clnt->osql.rqid)
+                            ? comdb2uuidstr(thd->clnt->osql.uuid, us)
                             : "invalid-uuid");
                 }
                 /*
@@ -5909,7 +5909,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
      * the db. */
     if (thd == NULL)
         return 0;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     CurRangeArr **append_to;
 
 #if 0
@@ -6113,7 +6113,7 @@ int sqlite3BtreeClearTable(Btree *pBt, int iTable, int *pnChange)
     int bdberr;
     int ixnum;
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (pnChange)
         *pnChange = 0;
@@ -6792,7 +6792,7 @@ sqlite3BtreeCursor_analyze(Btree *pBt,      /* The btree */
     int bdberr = 0;
     int key_size;
     int sz;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     struct dbtable *db;
 
     assert(iTable >= RTPAGE_START);
@@ -7116,7 +7116,7 @@ static inline int has_compressed_index(int iTable, BtCursor *cur,
 {
     int ixnum;
     int rc;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     struct dbtable *db;
 
     if (!clnt->is_analyze) {
@@ -7172,7 +7172,7 @@ int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         return 0;
 
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (NULL == clnt->dbtran.cursor_tran) {
         return 0;
@@ -7472,7 +7472,7 @@ sqlite3BtreeCursor_remote(Btree *pBt,      /* The btree */
                           BtCursor *cur,   /* Write new cursor here */
                           struct sql_thread *thd)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     fdb_tran_t *trans;
     fdb_t *fdb;
     uuid_t tid;
@@ -7558,7 +7558,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
                           BtCursor *cur,   /* Write new cursor here */
                           struct sql_thread *thd)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     size_t key_size;
     int rowlocks = use_rowlocks(clnt);
     int rc = SQLITE_OK;
@@ -7578,7 +7578,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
     assert(cur->db);
 
     /* initialize the shadow, if any  */
-    cur->shadtbl = osql_get_shadow_bydb(thd->sqlclntstate, cur->db);
+    cur->shadtbl = osql_get_shadow_bydb(thd->clnt, cur->db);
 
     if (cur->ixnum == -1) {
         if (is_stat2(cur->db->tablename) || is_stat4(cur->db->tablename)) {
@@ -7782,7 +7782,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
 void init_cursor(BtCursor *cur, Vdbe *vdbe, Btree *bt)
 {
     cur->thd = pthread_getspecific(query_info_key);
-    cur->clnt = cur->thd->sqlclntstate;
+    cur->clnt = cur->thd->clnt;
     cur->vdbe = vdbe;
     cur->sqlite = vdbe ? vdbe->db : NULL;
     cur->bt = bt;
@@ -7917,7 +7917,7 @@ static int make_stat_record(struct sql_thread *thd, BtCursor *pCur,
 
     /* extract first n fields from packed record */
     if (sqlite_to_ondisk(sc, pData, nData, pCur->ondisk_buf, pCur->clnt->tzname,
-                         blobs, MAXBLOBS, &thd->sqlclntstate->fail_reason,
+                         blobs, MAXBLOBS, &thd->clnt->fail_reason,
                          pCur) < 0) {
         logmsg(LOGMSG_ERROR, "%s failed\n", __func__);
         return SQLITE_INTERNAL;
@@ -8022,7 +8022,7 @@ int sqlite3BtreeInsert(
         rc = make_stat_record(thd, pCur, pData, nData, blobs);
         if (rc) {
             char errs[128];
-            convert_failure_reason_str(&thd->sqlclntstate->fail_reason,
+            convert_failure_reason_str(&thd->clnt->fail_reason,
                                        pCur->db->tablename, "SQLite format",
                                        ".ONDISK_IX_0", errs, sizeof(errs));
             fprintf(stderr, "%s: sqlite -> ondisk conversion failed!\n   %s\n",
@@ -8149,11 +8149,11 @@ int sqlite3BtreeInsert(
                 rc = sqlite_to_ondisk(pCur->db->ixschema[pCur->ixnum], pKey,
                                       nKey, pCur->ondisk_key, clnt->tzname,
                                       blobs, MAXBLOBS,
-                                      &thd->sqlclntstate->fail_reason, pCur);
+                                      &thd->clnt->fail_reason, pCur);
                 if (rc != getkeysize(pCur->db, pCur->ixnum)) {
                     char errs[128];
                     convert_failure_reason_str(
-                        &thd->sqlclntstate->fail_reason, pCur->db->tablename,
+                        &thd->clnt->fail_reason, pCur->db->tablename,
                         "SQLite format", ".ONDISK_ix", errs, sizeof(errs));
                     reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                                 "Moveto: sqlite_to_ondisk failed [%s]\n", errs);
@@ -8198,10 +8198,10 @@ int sqlite3BtreeInsert(
             likely(pCur->bt == NULL || pCur->bt->is_remote == 0)) {
             rc = sqlite_to_ondisk(
                 pCur->db->schema, pData, nData, pCur->ondisk_buf, clnt->tzname,
-                blobs, MAXBLOBS, &thd->sqlclntstate->fail_reason, pCur);
+                blobs, MAXBLOBS, &thd->clnt->fail_reason, pCur);
             if (rc < 0) {
                 char errs[128];
-                convert_failure_reason_str(&thd->sqlclntstate->fail_reason,
+                convert_failure_reason_str(&thd->clnt->fail_reason,
                                            pCur->db->tablename, "SQLite format",
                                            ".ONDISK", errs, sizeof(errs));
                 reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
@@ -8545,7 +8545,7 @@ i64 sqlite3BtreeNewRowid(BtCursor *pCur)
     if (pCur->bt->is_temporary && pCur->tmptable) {
         return pCur->cursor_rowid(pCur->tmptable->tbl, pCur);
     }
-    return bdb_recno_to_genid(++thd->sqlclntstate->recno);
+    return bdb_recno_to_genid(++thd->clnt->recno);
 }
 
 char *sqlite3BtreeGetTblName(BtCursor *pCur)
@@ -8561,9 +8561,9 @@ void cancel_sql_statement(int id)
     pthread_mutex_lock(&gbl_sql_lock);
     LISTC_FOR_EACH(&thedb->sql_threads, thd, lnk)
     {
-        if (thd->id == id && thd->sqlclntstate) {
+        if (thd->id == id && thd->clnt) {
             found = 1;
-            thd->sqlclntstate->stop_this_statement = 1;
+            thd->clnt->stop_this_statement = 1;
         }
     }
     pthread_mutex_unlock(&gbl_sql_lock);
@@ -8585,8 +8585,8 @@ void cancel_sql_statement_with_cnonce(const char *cnonce)
     LISTC_FOR_EACH(&thedb->sql_threads, thd, lnk)
     {
         found = 1;
-        if (thd->sqlclntstate && thd->sqlclntstate->sql_query && 
-            thd->sqlclntstate->sql_query->has_cnonce) {
+        if (thd->clnt && thd->clnt->sql_query &&
+            thd->clnt->sql_query->has_cnonce) {
             const char *sptr = cnonce;
             int cnt = 0;
             void luabb_fromhex(uint8_t *out, const uint8_t *in, size_t len);
@@ -8595,18 +8595,18 @@ void cancel_sql_statement_with_cnonce(const char *cnonce)
                 luabb_fromhex(&num, (const uint8_t *)sptr, 2);
                 sptr+=2;
 
-                if (cnt > thd->sqlclntstate->sql_query->cnonce.len || 
-                        thd->sqlclntstate->sql_query->cnonce.data[cnt] != num) {
+                if (cnt > thd->clnt->sql_query->cnonce.len ||
+                        thd->clnt->sql_query->cnonce.data[cnt] != num) {
                     found = 0;
                     break;
                 }
                 cnt++;
             }
-            if (found && cnt != thd->sqlclntstate->sql_query->cnonce.len)
+            if (found && cnt != thd->clnt->sql_query->cnonce.len)
                 found = 0;
 
             if (found) {
-                thd->sqlclntstate->stop_this_statement = 1;
+                thd->clnt->stop_this_statement = 1;
                 break;
             }
         }
@@ -8643,21 +8643,21 @@ void sql_dump_running_statements(void)
         localtime_r((time_t *)&t, &tm);
         pthread_mutex_lock(&thd->lk);
 
-        if (thd->sqlclntstate && thd->sqlclntstate->sql) {
-            if (thd->sqlclntstate->osql.rqid) {
+        if (thd->clnt && thd->clnt->sql) {
+            if (thd->clnt->osql.rqid) {
                 uuidstr_t us;
                 snprintf(rqid, sizeof(rqid), "txn %016llx %s",
-                         thd->sqlclntstate->osql.rqid,
-                         comdb2uuidstr(thd->sqlclntstate->osql.uuid, us));
+                         thd->clnt->osql.rqid,
+                         comdb2uuidstr(thd->clnt->osql.uuid, us));
             } else
                 rqid[0] = 0;
 
             logmsg(LOGMSG_USER, "id %d %02d/%02d/%02d %02d:%02d:%02d %s%s\n", thd->id,
                    tm.tm_mon + 1, tm.tm_mday, 1900 + tm.tm_year, tm.tm_hour,
-                   tm.tm_min, tm.tm_sec, rqid, thd->sqlclntstate->origin);
-            log_cnonce((char *)thd->sqlclntstate->sql_query->cnonce.data,
-                       thd->sqlclntstate->sql_query->cnonce.len);
-            logmsg(LOGMSG_USER, "%s\n", thd->sqlclntstate->sql);
+                   tm.tm_min, tm.tm_sec, rqid, thd->clnt->origin);
+            log_cnonce((char *)thd->clnt->sql_query->cnonce.data,
+                       thd->clnt->sql_query->cnonce.len);
+            logmsg(LOGMSG_USER, "%s\n", thd->clnt->sql);
 
             if (thd->bt) {
                 LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
@@ -8858,7 +8858,7 @@ int put_curtran(bdb_state_type *bdb_state, struct sqlclntstate *clnt)
 int count_pagelock_cursors(void *arg)
 {
     struct sql_thread *thd = (struct sql_thread *)arg;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int rc, count = 0;
 
     pthread_mutex_lock(&thd->lk);
@@ -8873,7 +8873,7 @@ int pause_pagelock_cursors(void *arg)
 {
     BtCursor *cur = NULL;
     struct sql_thread *thd = (struct sql_thread *)arg;
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int bdberr, rc;
 
     /* Return immediately if nothing is holding a pagelock */
@@ -8918,7 +8918,7 @@ static int recover_deadlock_int(bdb_state_type *bdb_state,
                                 bdb_cursor_ifn_t *bdbcur, int sleepms,
                                 int ptrace)
 {
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     BtCursor *cur = NULL;
     int error = 0;
     int rc = 0;
@@ -9126,7 +9126,7 @@ static int ddguard_bdb_cursor_find(struct sql_thread *thd, BtCursor *pCur,
     int cmp;
 
     struct sqlclntstate *clnt;
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
     CurRangeArr **append_to;
     if (pCur->range) {
         if (pCur->range->idxnum == -1 && pCur->range->islocked == 0) {
@@ -9331,7 +9331,7 @@ static int ddguard_bdb_cursor_find_last_dup(struct sql_thread *thd,
     int cmp;
 
     struct sqlclntstate *clnt;
-    clnt = thd->sqlclntstate;
+    clnt = thd->clnt;
     CurRangeArr **append_to;
     if (pCur->range) {
         if (pCur->range->idxnum == -1 && pCur->range->islocked == 0) {
@@ -9531,7 +9531,7 @@ static int ddguard_bdb_cursor_move(struct sql_thread *thd, BtCursor *pCur,
     int rc = 0;
     int deadlock_on_last = 0;
 
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     /* check authentication */
     if (authenticate_cursor(pCur, AUTHENTICATE_READ) != 0)
@@ -10302,7 +10302,7 @@ int sqlite3BtreeCount(BtCursor *pCur, i64 *pnEntry)
         while (res == 0 && rc == 0) {
             if (!gbl_selectv_rangechk) {
                 if (pCur->is_recording &&
-                    thd->sqlclntstate->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                    thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
                     rc = osql_record_genid(pCur, thd, pCur->genid);
                     if (rc) {
                         logmsg(LOGMSG_ERROR, 
@@ -10558,8 +10558,8 @@ int sqlite3PagerSetJournalMode(Pager *pPager, int eMode) { return 0; }
 void sqlite3SetConversionError(void)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    if (thd && thd->sqlclntstate)
-        thd->sqlclntstate->fail_reason.reason =
+    if (thd && thd->clnt)
+        thd->clnt->fail_reason.reason =
             CONVERT_FAILED_INCOMPATIBLE_VALUES;
 }
 
@@ -10622,7 +10622,7 @@ int is_comdb2_index_blob(const char *dbname, int icol)
 void comdb2SetWriteFlag(int wrflag)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     /* lets make sure we don't downgrade write to readonly */
     if (clnt->writeTransaction < wrflag)
@@ -10774,7 +10774,7 @@ int sqlite3UpdateMemCollAttr(BtCursor *pCur, int idx, Mem *mem)
 int comdb2_get_planner_effort()
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     return clnt->planner_effort;
 }
@@ -10792,7 +10792,7 @@ const char *comdb2_get_sql(void)
     struct sql_thread *thd = pthread_getspecific(query_info_key);
 
     if (thd)
-        return thd->sqlclntstate->sql;
+        return thd->clnt->sql;
 
     return NULL;
 }
@@ -10861,7 +10861,7 @@ void sqlite3BtreeCursorHint(BtCursor *pCur, int eHintType, ...)
 int comdb2_sqlitecursor_is_hinted(int id)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     int i;
 
     if (!clnt->hinted_cursors || !clnt->hinted_cursors_used)
@@ -10878,7 +10878,7 @@ int comdb2_sqlitecursor_is_hinted(int id)
 int comdb2_sqlitecursor_set_hinted(int id)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
 
     if (!clnt->hinted_cursors) {
         clnt->hinted_cursors = (int *)calloc(16, sizeof(int));
@@ -11023,7 +11023,7 @@ int fdb_add_remote_time(BtCursor *pCur, unsigned long long start,
                         unsigned long long end)
 {
     struct sql_thread *thd = pCur->thd;
-    fdbtimings_t *timings = &thd->sqlclntstate->osql.fdbtimes;
+    fdbtimings_t *timings = &thd->clnt->osql.fdbtimes;
     unsigned long long duration = end - start;
 
     timings->total_calls++;
@@ -11076,7 +11076,7 @@ void stat4dump(int more, char *table, int istrace)
 
     struct sql_thread *thd = start_sql_thread();
     get_copy_rootpages(thd);
-    thd->sqlclntstate = &clnt;
+    thd->clnt = &clnt;
     sql_get_query_id(thd);
     if ((rc = get_curtran(thedb->bdb_env, &clnt)) != 0) {
         goto out;
@@ -11176,7 +11176,7 @@ close:
 put:
     put_curtran(thedb->bdb_env, &clnt);
 out:
-    thd->sqlclntstate = NULL;
+    thd->clnt = NULL;
     done_sql_thread();
     sql_mem_shutdown(NULL);
     thread_memdestroy();
@@ -11400,7 +11400,7 @@ void clearClientSideRow(struct sqlclntstate *clnt)
             logmsg(LOGMSG_FATAL, "%s: running in non sql thread!n", __func__);
             abort();
         }
-        clnt = thd->sqlclntstate;
+        clnt = thd->clnt;
     }
     osqlstate_t *osql = &clnt->osql;
     clnt->keyDdl = 0ULL;
@@ -12188,11 +12188,11 @@ void comdb2_set_verify_remote_schemas(void)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
 
-    if (thd && thd->sqlclntstate) {
-        if (thd->sqlclntstate->verify_remote_schemas == 0)
-            thd->sqlclntstate->verify_remote_schemas = 1;
+    if (thd && thd->clnt) {
+        if (thd->clnt->verify_remote_schemas == 0)
+            thd->clnt->verify_remote_schemas = 1;
         else /* anything else disables it */
-            thd->sqlclntstate->verify_remote_schemas = 2;
+            thd->clnt->verify_remote_schemas = 2;
     }
 }
 
@@ -12200,8 +12200,8 @@ int comdb2_get_verify_remote_schemas(void)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
 
-    if (thd && thd->sqlclntstate)
-        return thd->sqlclntstate->verify_remote_schemas == 1;
+    if (thd && thd->clnt)
+        return thd->clnt->verify_remote_schemas == 1;
 
     return 0;
 }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -698,7 +698,6 @@ void done_sql_thread(void)
             thd->query_hash = 0;
         }
         destroy_sqlite_master(thd->rootpages, thd->rootpage_nentries);
-        free(thd->columns);
         free(thd);
     }
 }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3267,7 +3267,7 @@ int newsql_send_column_info(struct sqlclntstate *clnt,
 int release_locks(const char *trace)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    struct sqlclntstate *clnt = thd ? thd->sqlclntstate : NULL;
+    struct sqlclntstate *clnt = thd ? thd->clnt : NULL;
     int rc = 0;
 
     if (clnt && clnt->dbtran.cursor_tran) {
@@ -5592,7 +5592,7 @@ static int prepare_engine(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     clnt->debug_sqlclntstate = pthread_self();
     struct sql_thread *sqlthd;
     if ((sqlthd = pthread_getspecific(query_info_key)) != NULL) {
-        sqlthd->sqlclntstate = clnt;
+        sqlthd->clnt = clnt;
     }
 
 check_version:
@@ -5810,7 +5810,7 @@ void sqlengine_work_appsock(void *thddata, void *work)
     struct sqlclntstate *clnt = work;
     struct sql_thread *sqlthd = thd->sqlthd;
     if (sqlthd) {
-        sqlthd->sqlclntstate = clnt;
+        sqlthd->clnt = clnt;
     } else {
         abort();
     }
@@ -6147,14 +6147,14 @@ void sqlengine_thd_end(struct thdpool *pool, struct sqlthdstate *thd)
         /* sqlclntstate shouldn't be set: sqlclntstate is memory on another
          * thread's stack that will not be valid at this point. */
 
-        if (sqlthd->sqlclntstate) {
+        if (sqlthd->clnt) {
             logmsg(LOGMSG_ERROR,
-                   "%s:%d sqlthd->sqlclntstate set in thd-teardown\n", __FILE__,
+                   "%s:%d sqlthd->clnt set in thd-teardown\n", __FILE__,
                    __LINE__);
             if (gbl_abort_invalid_query_info_key) {
                 abort();
             }
-            sqlthd->sqlclntstate = NULL;
+            sqlthd->clnt = NULL;
         }
     }
 
@@ -6668,7 +6668,7 @@ static void switch_context(struct sqlconn *conn, struct statement_handle *h)
     /* reset client handle - we need one per statement */
     for (i = 0; i < db->nDb; i++) {
          if (db->aDb[i].pBt) {
-            db->aDb[i].pBt->sqlclntstate = &h->clnt;
+            db->aDb[i].pBt->clnt = &h->clnt;
          }
     }
 #endif
@@ -6727,7 +6727,7 @@ struct client_query_stats *get_query_stats_from_thd()
     if (!thd)
         return NULL;
 
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     if (!clnt)
         return NULL;
 
@@ -6743,7 +6743,7 @@ char *comdb2_get_prev_query_cost()
     if (!thd)
         return NULL;
 
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     if (!clnt)
         return NULL;
 
@@ -6756,7 +6756,7 @@ void comdb2_free_prev_query_cost()
     if (!thd)
         return;
 
-    struct sqlclntstate *clnt = thd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->clnt;
     if (!clnt)
         return;
 
@@ -6977,7 +6977,7 @@ done:
         gbl_who--;
     }
     if (clnt->client_understands_query_stats) {
-        record_query_cost(thd, thd->sqlclntstate);
+        record_query_cost(thd, thd->clnt);
     }
     /* if we turned on case sensitive like, turn it off since the sql handle we
        just used may be used by another connection with this disabled */
@@ -7043,7 +7043,7 @@ static void sql_reset_sqlthread(sqlite3 *db, struct sql_thread *thd)
     int i;
 
     if (thd) {
-        thd->sqlclntstate = NULL;
+        thd->clnt = NULL;
     }
 }
 
@@ -7778,7 +7778,7 @@ void comdb2_set_sqlite_vdbe_tzname(Vdbe *p)
     struct sql_thread *sqlthd = pthread_getspecific(query_info_key);
     if (!sqlthd)
         return;
-    comdb2_set_sqlite_vdbe_tzname_int(p, sqlthd->sqlclntstate);
+    comdb2_set_sqlite_vdbe_tzname_int(p, sqlthd->clnt);
 }
 
 void comdb2_set_sqlite_vdbe_dtprec(Vdbe *p)
@@ -7786,7 +7786,7 @@ void comdb2_set_sqlite_vdbe_dtprec(Vdbe *p)
     struct sql_thread *sqlthd = pthread_getspecific(query_info_key);
     if (!sqlthd)
         return;
-    comdb2_set_sqlite_vdbe_dtprec_int(p, sqlthd->sqlclntstate);
+    comdb2_set_sqlite_vdbe_dtprec_int(p, sqlthd->clnt);
 }
 
 void run_internal_sql(char *sql)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -172,144 +172,6 @@ void comdb2_set_sqlite_vdbe_tzname(Vdbe *p);
 void comdb2_set_sqlite_vdbe_dtprec(Vdbe *p);
 static int execute_sql_query_offload(struct sqlthdstate *,
                                      struct sqlclntstate *);
-static int _push_row_new(struct sqlclntstate *clnt, int type,
-                         CDB2SQLRESPONSE *sql_response,
-                         CDB2SQLRESPONSE__Column **columns, int ncols,
-                         void *(*alloc)(size_t size), int flush);
-struct sql_state;
-static int send_ret_column_info(struct sqlthdstate *thd,
-                                struct sqlclntstate *clnt,
-                                struct sql_state *rec, int ncols,
-                                CDB2SQLRESPONSE__Column **columns);
-static int send_row(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                    int new_row_data_type, int ncols, int row_id, int rc,
-                    CDB2SQLRESPONSE__Column **columns);
-void send_prepare_error(struct sqlclntstate *clnt, const char *errstr,
-                        int clnt_retry);
-static int send_err_but_msg(struct sqlclntstate *clnt, const char *errstr,
-                            int irc);
-static int flush_row(struct sqlclntstate *clnt);
-static int send_dummy(struct sqlclntstate *clnt);
-static void send_last_row(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                          const char *func, int line);
-
-uint8_t *fsqlreq_put(const struct fsqlreq *p_fsqlreq, uint8_t *p_buf,
-                     const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || FSQLREQ_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_put(&(p_fsqlreq->request), sizeof(p_fsqlreq->request), p_buf,
-                    p_buf_end);
-    p_buf = buf_put(&(p_fsqlreq->flags), sizeof(p_fsqlreq->flags), p_buf,
-                    p_buf_end);
-    p_buf =
-        buf_put(&(p_fsqlreq->parm), sizeof(p_fsqlreq->parm), p_buf, p_buf_end);
-    p_buf = buf_put(&(p_fsqlreq->followlen), sizeof(p_fsqlreq->followlen),
-                    p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-uint8_t *fsqlresp_put(const struct fsqlresp *p_fsqlresp, uint8_t *p_buf,
-                      const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || FSQLRESP_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_put(&(p_fsqlresp->response), sizeof(p_fsqlresp->response),
-                    p_buf, p_buf_end);
-    p_buf = buf_put(&(p_fsqlresp->flags), sizeof(p_fsqlresp->flags), p_buf,
-                    p_buf_end);
-    p_buf = buf_put(&(p_fsqlresp->rcode), sizeof(p_fsqlresp->rcode), p_buf,
-                    p_buf_end);
-    p_buf = buf_put(&(p_fsqlresp->parm), sizeof(p_fsqlresp->parm), p_buf,
-                    p_buf_end);
-    p_buf = buf_put(&(p_fsqlresp->followlen), sizeof(p_fsqlresp->followlen),
-                    p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-const uint8_t *fsqlresp_get(struct fsqlresp *p_fsqlresp, const uint8_t *p_buf,
-                            const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || FSQLRESP_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_get(&(p_fsqlresp->response), sizeof(p_fsqlresp->response),
-                    p_buf, p_buf_end);
-    p_buf = buf_get(&(p_fsqlresp->flags), sizeof(p_fsqlresp->flags), p_buf,
-                    p_buf_end);
-    p_buf = buf_get(&(p_fsqlresp->rcode), sizeof(p_fsqlresp->rcode), p_buf,
-                    p_buf_end);
-    p_buf = buf_get(&(p_fsqlresp->parm), sizeof(p_fsqlresp->parm), p_buf,
-                    p_buf_end);
-    p_buf = buf_get(&(p_fsqlresp->followlen), sizeof(p_fsqlresp->followlen),
-                    p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-static uint8_t *column_info_put(const struct column_info *p_column_info,
-                                uint8_t *p_buf, const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || COLUMN_INFO_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_put(&(p_column_info->type), sizeof(p_column_info->type), p_buf,
-                    p_buf_end);
-    p_buf =
-        buf_no_net_put(&(p_column_info->column_name),
-                       sizeof(p_column_info->column_name), p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-static const uint8_t *column_info_get(struct column_info *p_column_info,
-                                      const uint8_t *p_buf,
-                                      const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || COLUMN_INFO_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_get(&(p_column_info->type), sizeof(p_column_info->type), p_buf,
-                    p_buf_end);
-    p_buf =
-        buf_no_net_get(&(p_column_info->column_name),
-                       sizeof(p_column_info->column_name), p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-static uint8_t *sqlfield_put(const struct sqlfield *p_sqlfield, uint8_t *p_buf,
-                             const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || SQLFIELD_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_put(&(p_sqlfield->offset), sizeof(p_sqlfield->offset), p_buf,
-                    p_buf_end);
-    p_buf =
-        buf_put(&(p_sqlfield->len), sizeof(p_sqlfield->len), p_buf, p_buf_end);
-
-    return p_buf;
-}
-
-static const uint8_t *sqlfield_get(struct sqlfield *p_sqlfield,
-                                   const uint8_t *p_buf,
-                                   const uint8_t *p_buf_end)
-{
-    if (p_buf_end < p_buf || SQLFIELD_LEN > (p_buf_end - p_buf))
-        return NULL;
-
-    p_buf = buf_get(&(p_sqlfield->offset), sizeof(p_sqlfield->offset), p_buf,
-                    p_buf_end);
-    p_buf =
-        buf_get(&(p_sqlfield->len), sizeof(p_sqlfield->len), p_buf, p_buf_end);
-
-    return p_buf;
-}
 
 static inline void comdb2_set_sqlite_vdbe_tzname_int(Vdbe *p,
                                                      struct sqlclntstate *clnt)
@@ -332,98 +194,13 @@ int disable_server_sql_timeouts(void)
             gbl_sql_no_timeouts_on_release_locks);
 }
 
-int send_heartbeat(struct sqlclntstate *clnt);
+#define WRITE_RESPONSE(R, D) clnt->write_response(clnt, R, (void *)D, 0)
 
-static void send_fsql_error(struct sqlclntstate *clnt, int rc, char *errstr)
+void handle_failed_dispatch(struct sqlclntstate *clnt, char *errstr)
 {
-    struct fsqlresp resp = {0};
-    resp.response = FSQL_ERROR;
-    resp.rcode = rc;
-    fsql_write_response(clnt, &resp, (void *)errstr, strlen(errstr) + 1, 1,
-                        __func__, __LINE__);
-}
-
-int handle_failed_dispatch(struct sqlclntstate *clnt, char *errstr)
-{
-    struct fsqlresp resp;
-
-    bzero(&resp, sizeof(resp));
-    resp.response = FSQL_ERROR;
-    resp.rcode = CDB2ERR_REJECTED;
-
     pthread_mutex_lock(&clnt->wait_mutex);
-    fsql_write_response(clnt, &resp, (void *)errstr, strlen(errstr) + 1, 1,
-                        __func__, __LINE__);
+    WRITE_RESPONSE(RESPONSE_ERROR_REJECT, errstr);
     pthread_mutex_unlock(&clnt->wait_mutex);
-
-    return 0;
-}
-
-static char *fsql_reqcode_str(int req)
-{
-    switch (req) {
-    case FSQL_EXECUTE_INLINE_PARAMS:
-        return "FSQL_EXECUTE_INLINE_PARAMS";
-    case FSQL_EXECUTE_STOP:
-        return "FSQL_EXECUTE_STOP";
-    case FSQL_SET_ISOLATION_LEVEL:
-        return "FSQL_SET_ISOLATION_LEVEL";
-    case FSQL_SET_TIMEOUT:
-        return "FSQL_SET_TIMEOUT";
-    case FSQL_SET_INFO:
-        return "FSQL_SET_INFO";
-    case FSQL_EXECUTE_INLINE_PARAMS_TZ:
-        return "FSQL_EXECUTE_INLINE_PARAMS_TZ";
-    case FSQL_SET_HEARTBEAT:
-        return "FSQL_SET_HEARTBEAT";
-    case FSQL_PRAGMA:
-        return "FSQL_PRAGMA";
-    case FSQL_RESET:
-        return "FSQL_RESET";
-    case FSQL_EXECUTE_REPLACEABLE_PARAMS:
-        return "FSQL_EXECUTE_REPLACEABLE_PARAMS";
-    case FSQL_SET_SQL_DEBUG:
-        return "FSQL_SET_SQL_DEBUG";
-    case FSQL_GRAB_DBGLOG:
-        return "FSQL_GRAB_DBGLOG";
-    case FSQL_SET_USER:
-        return "FSQL_SET_USER";
-    case FSQL_SET_PASSWORD:
-        return "FSQL_SET_PASSWORD";
-    case FSQL_SET_ENDIAN:
-        return "FSQL_SET_ENDIAN";
-    case FSQL_EXECUTE_REPLACEABLE_PARAMS_TZ:
-        return "FSQL_EXECUTE_REPLACEABLE_PARAMS_TZ";
-    case FSQL_SET_DATETIME_PRECISION:
-        return "FSQL_SET_DATETIME_PRECISION";
-    default:
-        return "???";
-    };
-}
-
-static char *fsql_respcode_str(int rsp)
-{
-    switch (rsp) {
-    case FSQL_COLUMN_DATA:
-        return "FSQL_COLUMN_DATA";
-    case FSQL_ROW_DATA:
-        return "FSQL_ROW_DATA";
-    case FSQL_NO_MORE_DATA:
-        return "FSQL_NO_MORE_DATA";
-    case FSQL_ERROR:
-        return "FSQL_ERROR";
-    case FSQL_QUERY_STATS:
-        return "FSQL_QUERY_STATS";
-    case FSQL_HEARTBEAT:
-        return "FSQL_HEARTBEAT";
-    case FSQL_SOSQL_TRAN_RESPONSE:
-        return "FSQL_SOSQL_TRAN_RESPONSE";
-    case FSQL_DONE:
-        return "FSQL_DONE";
-    default: {
-        return "???";
-    }
-    }
 }
 
 char *tranlevel_tostr(int lvl)
@@ -438,350 +215,6 @@ char *tranlevel_tostr(int lvl)
     default:
         return "???";
     };
-}
-
-static inline int verify_sqlresponse_error_code(int error_code,
-                                                const char *func, int line)
-{
-    switch (error_code) {
-    case CDB2__ERROR_CODE__OK:
-    case CDB2__ERROR_CODE__DUP_OLD:
-    case CDB2__ERROR_CODE__CONNECT_ERROR:
-    case CDB2__ERROR_CODE__NOTCONNECTED:
-    case CDB2__ERROR_CODE__PREPARE_ERROR:
-    case CDB2__ERROR_CODE__PREPARE_ERROR_OLD:
-    case CDB2__ERROR_CODE__IO_ERROR:
-    case CDB2__ERROR_CODE__INTERNAL:
-    case CDB2__ERROR_CODE__NOSTATEMENT:
-    case CDB2__ERROR_CODE__BADCOLUMN:
-    case CDB2__ERROR_CODE__BADSTATE:
-    case CDB2__ERROR_CODE__ASYNCERR:
-    case CDB2__ERROR_CODE__OK_ASYNC:
-    case CDB2__ERROR_CODE__INVALID_ID:
-    case CDB2__ERROR_CODE__RECORD_OUT_OF_RANGE:
-    case CDB2__ERROR_CODE__REJECTED:
-    case CDB2__ERROR_CODE__STOPPED:
-    case CDB2__ERROR_CODE__BADREQ:
-    case CDB2__ERROR_CODE__DBCREATE_FAILED:
-    case CDB2__ERROR_CODE__THREADPOOL_INTERNAL:
-    case CDB2__ERROR_CODE__READONLY:
-    case CDB2__ERROR_CODE__NOMASTER:
-    case CDB2__ERROR_CODE__UNTAGGED_DATABASE:
-    case CDB2__ERROR_CODE__CONSTRAINTS:
-    case CDB2__ERROR_CODE__DEADLOCK:
-    case CDB2__ERROR_CODE__TRAN_IO_ERROR:
-    case CDB2__ERROR_CODE__ACCESS:
-    case CDB2__ERROR_CODE__TRAN_MODE_UNSUPPORTED:
-    case CDB2__ERROR_CODE__MASTER_TIMEOUT:
-    case CDB2__ERROR_CODE__WRONG_DB:
-    case CDB2__ERROR_CODE__VERIFY_ERROR:
-    case CDB2__ERROR_CODE__FKEY_VIOLATION:
-    case CDB2__ERROR_CODE__NULL_CONSTRAINT:
-    case CDB2__ERROR_CODE__CONV_FAIL:
-    case CDB2__ERROR_CODE__NONKLESS:
-    case CDB2__ERROR_CODE__MALLOC:
-    case CDB2__ERROR_CODE__NOTSUPPORTED:
-    case CDB2__ERROR_CODE__TRAN_TOO_BIG:
-    case CDB2__ERROR_CODE__DUPLICATE:
-    case CDB2__ERROR_CODE__TZNAME_FAIL:
-    case CDB2__ERROR_CODE__CHANGENODE:
-    case CDB2__ERROR_CODE__NOTSERIAL:
-    case CDB2__ERROR_CODE__SCHEMACHANGE:
-    case CDB2__ERROR_CODE__UNKNOWN:
-        break;
-
-    default:
-        logmsg(LOGMSG_ERROR, "%s line %d returning non-standard "
-                             "sqlresponse.error_code %d\n",
-               func, line, error_code);
-        cheap_stack_trace();
-        break;
-    }
-    return error_code;
-}
-
-extern int gbl_catch_response_on_retry;
-int fsql_write_response(struct sqlclntstate *clnt, struct fsqlresp *resp,
-                        void *dta, int len, int flush, const char *func,
-                        uint32_t line)
-{
-    int rc;
-    SBUF2 *sb;
-
-    sb = clnt->sb;
-
-    if (gbl_dump_fsql_response && resp)
-        logmsg(LOGMSG_USER, "Sending response=%d dta length %d to node %s for sql "
-                        "%s newsql-flag %d\n",
-                resp->response, len, clnt->origin, clnt->sql, clnt->is_newsql);
-
-    if (gbl_catch_response_on_retry && clnt->osql.replay == OSQL_RETRY_DO &&
-        resp && resp->response != FSQL_HEARTBEAT) {
-        logmsg(LOGMSG_ERROR, "Error: writing a response on a retry\n");
-        if (resp) {
-            logmsg(LOGMSG_ERROR, "<- %s (%d) rcode %d\n",
-                    fsql_respcode_str(resp->response), resp->response,
-                    resp->rcode);
-        }
-        if (flush)
-            logmsg(LOGMSG_USER, "<- flush\n");
-        cheap_stack_trace();
-    }
-    rc = pthread_mutex_lock(&clnt->write_lock);
-
-    if (rc != 0) {
-        logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-        exit(1);
-    }
-
-    if (resp) {
-        if (clnt->is_newsql) {
-            CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-            if (gbl_dump_fsql_response) {
-                logmsg(LOGMSG_USER, "td=%u %s line %d sending newsql response "
-                                "sent_column_data=%d\n",
-                        (uint32_t)pthread_self(), __func__, __LINE__,
-                        clnt->osql.sent_column_data);
-            }
-            if (clnt->osql.sent_column_data) {
-                sql_response.response_type = RESPONSE_TYPE__COLUMN_VALUES;
-            } else {
-                sql_response.response_type = RESPONSE_TYPE__COLUMN_NAMES;
-            }
-
-            sql_response.n_value = 0;
-            sql_response.value = NULL;
-            sql_response.error_code =
-                verify_sqlresponse_error_code(resp->rcode, __func__, __LINE__);
-            if (resp->rcode) {
-                sql_response.error_string = (char *)dta;
-            } else {
-                sql_response.error_string = NULL;
-            }
-            sql_response.effects = NULL;
-            int len = cdb2__sqlresponse__get_packed_size(&sql_response);
-            void *buf = malloc(len + 1);
-            struct newsqlheader hdr;
-            hdr.type = ntohl(RESPONSE_HEADER__SQL_RESPONSE);
-            hdr.compression = 0;
-            hdr.dummy = 0;
-            hdr.length = ntohl(len);
-            rc = sbuf2write((char *)&hdr, sizeof(hdr), sb);
-
-            if (rc != sizeof(hdr)) {
-
-                if (gbl_dump_fsql_response) {
-                    logmsg(LOGMSG_USER, 
-                           "td %u response for %s error writing header, rc=%d\n",
-                           (uint32_t)pthread_self(), clnt->sql, rc);
-                }
-
-                rc = pthread_mutex_unlock(&clnt->write_lock);
-                if (rc != 0) {
-                    logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
-                    exit(1);
-                }
-                free(buf);
-                return -1;
-            }
-
-            if (sql_response.error_code == 1) {
-                logmsg(LOGMSG_ERROR, "%s line %d returning DUP from %s line %d\n",
-                        __func__, __LINE__, func, line);
-            }
-
-            if (gbl_dump_fsql_response) {
-                logmsg(LOGMSG_USER, 
-                        "td %u Response for %s: response_type=%d error_code=%d "
-                        "error_string=%s\n",
-                        (uint32_t)pthread_self(), clnt->sql,
-                        sql_response.response_type, sql_response.error_code,
-                        sql_response.error_string ? sql_response.error_string
-                                                  : "(NULL)");
-            }
-
-            if (gbl_dump_fsql_response) {
-                logmsg(LOGMSG_USER, "td %u %s line %d Sql %s sending response "
-                                "resp->response=%d\n",
-                        (uint32_t)pthread_self(), __func__, __LINE__, clnt->sql,
-                        resp->response);
-            }
-            cdb2__sqlresponse__pack(&sql_response, buf);
-
-            rc = sbuf2write(buf, len, sb);
-            free(buf);
-            buf = NULL;
-
-            if (rc != len) {
-                if (gbl_dump_fsql_response) {
-                    logmsg(LOGMSG_USER, "td %u %s line %d Sql %s: error writing, "
-                                    "rc=%d len=%d\n",
-                            (uint32_t)pthread_self(), __func__, __LINE__,
-                            clnt->sql, rc, len);
-                }
-                rc = pthread_mutex_unlock(&clnt->write_lock);
-                if (rc != 0) {
-                    logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
-                    exit(1);
-                }
-                return -1;
-            }
-
-            sbuf2flush(sb);
-            rc = pthread_mutex_unlock(&clnt->write_lock);
-            if (rc != 0) {
-                logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-                exit(1);
-            }
-            return 0;
-
-        } else {
-
-            if (flush &&
-                active_appsock_conns >=
-                    bdb_attr_get(thedb->bdb_attr, BDB_ATTR_MAXSOCKCACHED))
-                resp->flags |= FRESP_FLAG_CLOSE;
-
-            uint8_t buf_resp[FSQLRESP_LEN];
-
-            resp->followlen = len;
-
-            /* pack the response */
-            if (!fsqlresp_put(resp, buf_resp, buf_resp + sizeof(buf_resp))) {
-                rc = pthread_mutex_unlock(&clnt->write_lock);
-                if (rc != 0) {
-                    logmsg(LOGMSG_FATAL, "couldnt put clnt->write_lock\n");
-                    exit(1);
-                }
-
-                return -1;
-            }
-
-            rc = sbuf2write((char *)buf_resp, sizeof(buf_resp), sb);
-            if (rc != sizeof(buf_resp)) {
-                rc = pthread_mutex_unlock(&clnt->write_lock);
-                if (rc != 0) {
-                    logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-                    exit(1);
-                }
-
-                return -1;
-            }
-        }
-    }
-
-    if (dta) {
-        rc = sbuf2write(dta, len, sb);
-        if (rc != len) {
-            rc = pthread_mutex_unlock(&clnt->write_lock);
-            if (rc != 0) {
-                logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-                exit(1);
-            }
-
-            return -1;
-        }
-    }
-
-    if (flush) {
-        sbuf2flush(sb);
-    }
-
-    rc = pthread_mutex_unlock(&clnt->write_lock);
-    if (rc != 0) {
-        logmsg(LOGMSG_FATAL, "couldnt get clnt->write_lock\n");
-        exit(1);
-    }
-
-    return 0;
-}
-
-int newsql_write_response(struct sqlclntstate *clnt, int type,
-                          CDB2SQLRESPONSE *sql_response, int flush,
-                          void *(*alloc)(size_t size), const char *func,
-                          int line)
-{
-    struct newsqlheader hdr;
-    int rc = 0;
-    int len = 0;
-    void *dta = NULL;
-
-    if (gbl_dump_fsql_response) {
-        char cnonce[256] = {0};
-        int file = -1, offset = -1, response_type = -1;
-        if (sql_response && sql_response->snapshot_info) {
-            file = sql_response->snapshot_info->file;
-            offset = sql_response->snapshot_info->offset;
-            response_type = sql_response->response_type;
-        }
-        if (clnt->sql_query) {
-            snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
-        }
-        logmsg(LOGMSG_USER,
-               "td=%u %s line %d cnonce='%s' Sending response=%d "
-               "sqlresponse_type=%d "
-               "lsn[%d][%d] dta length %d to %s for sql %s from %s line %d\n",
-               (uint32_t)pthread_self(), __func__, __LINE__, cnonce, type, file,
-               offset, response_type, len, clnt->origin, clnt->sql, func, line);
-    }
-
-    if (clnt->in_client_trans && clnt->sql_query &&
-        clnt->sql_query->skip_rows == -1 && (clnt->isselect != 0)) {
-        // Client doesn't expect any response at this point.
-        logmsg(LOGMSG_DEBUG, "sending nothing back to client \n");
-        return 0;
-    }
-
-    /* payload */
-    if (sql_response) {
-        len = cdb2__sqlresponse__get_packed_size(sql_response);
-        dta = (*alloc)(len + 1);
-        cdb2__sqlresponse__pack(sql_response, dta);
-    }
-
-    /* header */
-    hdr.type = ntohl(type);
-    hdr.compression = 0;
-    hdr.dummy = 0;
-    hdr.length = ntohl(len);
-
-    rc = pthread_mutex_lock(&clnt->write_lock);
-    if (rc != 0) {
-        logmsg(LOGMSG_FATAL, "Failed to lock clnt->write_lock\n");
-        exit(1);
-    }
-
-    SBUF2 *sb = clnt->sb;
-    int wlen = sbuf2write((char *)&hdr, sizeof(struct newsqlheader), sb);
-    if (wlen != sizeof(struct newsqlheader)) {
-        rc = -1;
-        goto done;
-    }
-
-    if (dta) {
-        wlen = sbuf2write(dta, len, sb);
-        if (wlen != len) {
-            if (gbl_dump_fsql_response)
-                logmsg(LOGMSG_USER, "sbuf2write error for %s wlen=%d\n",
-                       clnt->sql, wlen);
-            rc = -1;
-            goto done;
-        }
-    }
-
-    if (flush)
-        sbuf2flush(sb);
-
-done:
-    if (pthread_mutex_unlock(&clnt->write_lock) != 0) {
-        logmsg(LOGMSG_FATAL, "Failed to unlock clnt->write_lock\n");
-        exit(1);
-    }
-
-    if (dta)
-        free(dta);
-
-    return rc;
 }
 
 int gbl_debug_high_availability_flag = 0;
@@ -804,266 +237,6 @@ int get_high_availability(struct sqlclntstate *clnt)
         cheap_stack_trace();
     }
     return clnt->high_availability_flag;
-}
-
-int request_durable_lsn_from_master(bdb_state_type *bdb_state, uint32_t *file,
-                                    uint32_t *offset, uint32_t *durable_gen);
-
-static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
-{
-    char cnonce[256];
-    int rcode = 0;
-    if (gbl_extended_sql_debug_trace && clnt->sql_query) {
-        snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
-    }
-    if (clnt->sql_query && clnt->sql_query->snapshot_info &&
-        clnt->sql_query->snapshot_info->file > 0) {
-        *file = clnt->sql_query->snapshot_info->file;
-        *offset = clnt->sql_query->snapshot_info->offset;
-
-        if (gbl_extended_sql_debug_trace) {
-            logmsg(LOGMSG_USER, 
-                    "%s line %d cnonce '%s' sql_query->snapinfo is [%d][%d], "
-                    "clnt->snapinfo is [%d][%d]: use client snapinfo!\n",
-                    __func__, __LINE__, cnonce,
-                    clnt->sql_query->snapshot_info->file,
-                    clnt->sql_query->snapshot_info->offset, clnt->snapshot_file,
-                    clnt->snapshot_offset);
-        }
-        return 0;
-    }
-
-    if (*file == 0 && clnt->sql_query &&
-        (clnt->in_client_trans || clnt->is_hasql_retry) &&
-        clnt->snapshot_file) {
-        if (gbl_extended_sql_debug_trace) {
-            logmsg(LOGMSG_USER, 
-                    "%s line %d cnonce '%s' sql_query->snapinfo is [%d][%d], "
-                    "clnt->snapinfo is [%d][%d]\n",
-                    __func__, __LINE__, cnonce,
-                    (clnt->sql_query && clnt->sql_query->snapshot_info)
-                        ? clnt->sql_query->snapshot_info->file
-                        : -1,
-                    (clnt->sql_query && clnt->sql_query->snapshot_info)
-                        ? clnt->sql_query->snapshot_info->offset
-                        : -1,
-                    clnt->snapshot_file, clnt->snapshot_offset);
-        }
-
-        *file = clnt->snapshot_file;
-        *offset = clnt->snapshot_offset;
-        logmsg(LOGMSG_USER, 
-                "%s line %d setting newsql snapinfo retry info is [%d][%d]\n",
-                __func__, __LINE__, *file, *offset);
-        return 0;
-    }
-
-    if (*file == 0 && clnt->is_newsql && clnt->sql_query &&
-        clnt->ctrl_sqlengine == SQLENG_STRT_STATE) {
-
-        if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS)) {
-            uint32_t durable_file, durable_offset, durable_gen;
-
-            int rc = request_durable_lsn_from_master(
-                thedb->bdb_env, &durable_file, &durable_offset, &durable_gen);
-
-            if (rc == 0) {
-                *file = durable_file;
-                *offset = durable_offset;
-
-                if (gbl_extended_sql_debug_trace) {
-                    logmsg(LOGMSG_USER, "%s line %d cnonce='%s' master "
-                                        "returned durable-lsn "
-                                        "[%d][%d], clnt->is_hasql_retry=%d\n",
-                           __func__, __LINE__, cnonce, *file, *offset,
-                           clnt->is_hasql_retry);
-                }
-            } else {
-                if (gbl_extended_sql_debug_trace) {
-                    logmsg(LOGMSG_USER,
-                           "%s line %d cnonce='%s' durable-lsn request "
-                           "returns %d "
-                           "clnt->snapshot_file=%d clnt->snapshot_offset=%d "
-                           "clnt->is_hasql_retry=%d\n",
-                           __func__, __LINE__, cnonce, rc, clnt->snapshot_file,
-                           clnt->snapshot_offset, clnt->is_hasql_retry);
-                }
-                rcode = -1;
-            }
-            return rcode;
-        }
-    }
-
-    if (*file == 0) {
-        bdb_tran_get_start_file_offset(thedb->bdb_env, clnt->dbtran.shadow_tran,
-                                       file, offset);
-        if (gbl_extended_sql_debug_trace) {
-            logmsg(LOGMSG_USER, "%s line %d start_file_offset snapinfo is "
-                                "[%d][%d], sqlengine-state is %d\n",
-                   __func__, __LINE__, *file, *offset, clnt->ctrl_sqlengine);
-        }
-    }
-    return rcode;
-}
-
-#define _has_effects(clnt, sql_response)                                       \
-    CDB2EFFECTS effects = CDB2__EFFECTS__INIT;                                 \
-                                                                               \
-    clnt->effects.num_affected = clnt->effects.num_updated +                   \
-                                 clnt->effects.num_deleted +                   \
-                                 clnt->effects.num_inserted;                   \
-    effects.num_affected = clnt->effects.num_affected;                         \
-    effects.num_selected = clnt->effects.num_selected;                         \
-    effects.num_updated = clnt->effects.num_updated;                           \
-    effects.num_deleted = clnt->effects.num_deleted;                           \
-    effects.num_inserted = clnt->effects.num_inserted;                         \
-                                                                               \
-    sql_response.effects = &effects;
-
-#define _has_features(clnt, sql_response)                                      \
-    CDB2ServerFeatures features[10];                                           \
-    int n_features = 0;                                                        \
-                                                                               \
-    if (clnt->skip_feature) {                                                  \
-        features[n_features] = CDB2_SERVER_FEATURES__SKIP_ROWS;                \
-        n_features++;                                                          \
-    }                                                                          \
-                                                                               \
-    if (n_features) {                                                          \
-        sql_response.n_features = n_features;                                  \
-        sql_response.features = features;                                      \
-    }
-
-#define _has_snapshot(clnt, sql_response)                                      \
-    CDB2SQLRESPONSE__Snapshotinfo snapshotinfo =                               \
-        CDB2__SQLRESPONSE__SNAPSHOTINFO__INIT;                                 \
-                                                                               \
-    if (get_high_availability(clnt)) {                                         \
-        int file = 0, offset = 0, rc;                                          \
-        if (fill_snapinfo(clnt, &file, &offset)) {                             \
-            sql_response.error_code = verify_sqlresponse_error_code(           \
-                CDB2ERR_CHANGENODE, __func__, __LINE__);                       \
-        }                                                                      \
-        if (file) {                                                            \
-            snapshotinfo.file = file;                                          \
-            snapshotinfo.offset = offset;                                      \
-            sql_response.snapshot_info = &snapshotinfo;                        \
-        }                                                                      \
-    }
-
-int newsql_send_last_row(struct sqlclntstate *clnt, int is_begin,
-                         const char *func, int line)
-{
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    int rc;
-
-    _has_effects(clnt, sql_response);
-    _has_snapshot(clnt, sql_response);
-    _has_features(clnt, sql_response);
-
-    if (gbl_extended_sql_debug_trace) {
-        char cnonce[256] = {0};
-        snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
-        logmsg(
-            LOGMSG_USER,
-            "%lu: %s line %d cnonce='%s' [%d][%d] sql='%s' sending last_row, "
-            "selected=%u updated=%u deleted=%u inserted=%u\n",
-            pthread_self(), func, line, cnonce, clnt->snapshot_file,
-            clnt->snapshot_offset, clnt->sql ? clnt->sql : "",
-            sql_response.effects->num_selected,
-            sql_response.effects->num_updated,
-            sql_response.effects->num_deleted,
-            sql_response.effects->num_inserted);
-    }
-
-    return _push_row_new(clnt, RESPONSE_TYPE__LAST_ROW, &sql_response, NULL, 0,
-                         malloc, 1);
-}
-
-static int newsql_realloc_row(int ncols, CDB2SQLRESPONSE__Column ***columns,
-                              int *columns_count)
-{
-    if (ncols <= *columns_count)
-        return 0; /* already have more columns set up; nothing to do */
-
-    /* allocate space for the column array and the columns */
-    int arrsz = ncols * sizeof(CDB2SQLRESPONSE__Column **);
-    int newtotsize = arrsz + ncols * sizeof(CDB2SQLRESPONSE__Column);
-
-    CDB2SQLRESPONSE__Column **loc_cols = *columns;
-    char *ptr = realloc(loc_cols, newtotsize);
-    if (!ptr) {
-        return -1;
-    }
-
-    loc_cols = (CDB2SQLRESPONSE__Column **)ptr;
-    for (int i = 0; i < ncols; i++) {
-        loc_cols[i] =
-            (CDB2SQLRESPONSE__Column *)(ptr + arrsz +
-                                        i * sizeof(CDB2SQLRESPONSE__Column));
-    }
-    *columns = loc_cols;
-    *columns_count = ncols;
-    return 0;
-}
-
-CDB2SQLRESPONSE__Column **newsql_alloc_row(int ncols)
-{
-    CDB2SQLRESPONSE__Column **columns;
-    columns = (CDB2SQLRESPONSE__Column **)calloc(
-        ncols, sizeof(CDB2SQLRESPONSE__Column **));
-    if (columns) {
-        for (int i = 0; i < ncols; i++) {
-            columns[i] = malloc(sizeof(CDB2SQLRESPONSE__Column));
-            if (!columns[i]) {
-                for (i--; i >= 0; i--)
-                    free(columns[i]);
-                free(columns);
-                columns = NULL;
-                break;
-            }
-        }
-    }
-    return columns;
-}
-
-void newsql_dealloc_row(CDB2SQLRESPONSE__Column **columns, int ncols)
-{
-    for (int i = 0; i < ncols; i++) {
-        free(columns[i]);
-    }
-    free(columns);
-}
-
-void newsql_send_strbuf_response(struct sqlclntstate *clnt, const char *str,
-                                 int slen)
-{
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    CDB2SQLRESPONSE__Column **columns = NULL;
-    int ncols = 1;
-
-    columns = newsql_alloc_row(ncols);
-
-    for (int i = 0; i < ncols; i++) {
-        cdb2__sqlresponse__column__init(columns[i]);
-        columns[i]->has_type = 0;
-        columns[i]->value.len = slen;
-        columns[i]->value.data = (uint8_t *)str;
-    }
-
-    _push_row_new(clnt, RESPONSE_TYPE__COLUMN_VALUES, &sql_response, columns,
-                  ncols, malloc, 0);
-
-    newsql_dealloc_row(columns, ncols);
-}
-
-int newsql_send_dummy_resp(struct sqlclntstate *clnt, const char *func,
-                           int line)
-{
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-
-    return _push_row_new(clnt, RESPONSE_TYPE__COLUMN_NAMES, &sql_response, NULL,
-                         0, malloc, 1);
 }
 
 int toggle_case_sensitive_like(sqlite3 *db, int enable)
@@ -1790,12 +963,6 @@ static void log_client_context(struct reqlogger *logger,
 int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                      int sendresponse)
 {
-    struct fsqlresp resp;
-    struct column_info cinfo;
-    uint8_t coldata[COLUMN_INFO_LEN];
-    uint8_t *p_buf_colinfo = coldata;
-    uint8_t *p_buf_colinfo_end = (p_buf_colinfo + COLUMN_INFO_LEN);
-
     pthread_mutex_lock(&clnt->wait_mutex);
     clnt->ready_for_heartbeats = 0;
 
@@ -1809,43 +976,13 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     reqlog_logf(thd->logger, REQL_QUERY, "\"%s\" new transaction\n",
                 (clnt->sql) ? clnt->sql : "(???.)");
 
-    /* clients expect COLUMN DATA, grrr */
-    bzero(&cinfo, sizeof(cinfo));
-    cinfo.type = SQLITE_INTEGER;
-    strcpy(cinfo.column_name, "dummy");
-
     if (clnt->osql.replay)
         goto done;
 
-    bzero(&resp, sizeof(resp));
-    resp.response = FSQL_COLUMN_DATA;
-    resp.parm = 1;
-
-    if (!(column_info_put(&cinfo, p_buf_colinfo, p_buf_colinfo_end))) {
-        logmsg(LOGMSG_ERROR, "%s line %d: column_info_put failed??\n", __func__,
-                __LINE__);
-        return SQLITE_INTERNAL;
+    if (sendresponse) {
+        WRITE_RESPONSE(RESPONSE_ROW_LAST_DUMMY, NULL);
     }
-    if (sendresponse && !clnt->is_newsql)
-        fsql_write_response(clnt, &resp, coldata, sizeof(cinfo), 0, __func__,
-                            __LINE__);
 
-    bzero(&resp, sizeof(resp));
-    resp.response = FSQL_DONE;
-
-    if (sendresponse && !clnt->is_newsql)
-        fsql_write_response(clnt, &resp, NULL, 0, 1, __func__, __LINE__);
-
-    if (sendresponse && clnt->is_newsql) {
-        clnt->num_retry = clnt->sql_query->retry;
-        newsql_send_dummy_resp(clnt, __func__, __LINE__);
-        newsql_send_last_row(clnt, 1, __func__, __LINE__);
-    }
-#if 0
-   fprintf( stderr, "%p (U) begin transaction %d %d\n", clnt, pthread_self(), clnt->dbtran.mode);
-#endif
-
-/*clnt->ready_for_heartbeats = 1;*/
 done:
     pthread_mutex_unlock(&clnt->wait_mutex);
 
@@ -1861,8 +998,6 @@ static int handle_sql_wrongstate(struct sqlthdstate *thd,
                                  struct sqlclntstate *clnt)
 {
 
-    struct fsqlresp resp;
-    char *errstr = "sqlinterfaces: wrong sql handle state\n";
 
     sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_NORMAL_PROCESS);
 
@@ -1873,12 +1008,8 @@ static int handle_sql_wrongstate(struct sqlthdstate *thd,
                 "\"%s\" wrong transaction command receive\n",
                 (clnt->sql) ? clnt->sql : "(???.)");
 
-    /* send error */
-    bzero(&resp, sizeof(resp));
-    resp.response = FSQL_ERROR;
-    resp.rcode = CDB2ERR_BADSTATE;
-    fsql_write_response(clnt, &resp, (void *)errstr, strlen(errstr) + 1, 1,
-                        __func__, __LINE__);
+    WRITE_RESPONSE(RESPONSE_ERROR_BAD_STATE,
+                   "sqlinterfaces: wrong sql handle state\n");
 
     if (srs_tran_destroy(clnt))
         logmsg(LOGMSG_ERROR, "Fail to destroy transaction replay session\n");
@@ -1895,35 +1026,6 @@ void reset_query_effects(struct sqlclntstate *clnt)
 {
     bzero(&clnt->effects, sizeof(clnt->effects));
     bzero(&clnt->log_effects, sizeof(clnt->effects));
-}
-
-int send_query_effects(struct sqlclntstate *clnt)
-{
-    /* Send this only after commit, or when non-transactional query is complete.
-     */
-    struct fsqlresp effects_resp;
-    effects_resp.response = FSQL_QUERY_EFFECTS;
-    effects_resp.flags = 0;
-    effects_resp.rcode = 0;
-    effects_resp.followlen = sizeof(struct query_effects);
-
-    struct query_effects q_effects;
-
-    clnt->effects.num_affected = clnt->effects.num_updated +
-                                 clnt->effects.num_deleted +
-                                 clnt->effects.num_inserted;
-    clnt->log_effects.num_affected = clnt->log_effects.num_updated +
-                                     clnt->log_effects.num_deleted +
-                                     clnt->log_effects.num_inserted;
-
-    q_effects.num_affected = ntohl(clnt->effects.num_affected);
-    q_effects.num_selected = ntohl(clnt->effects.num_selected);
-    q_effects.num_updated = ntohl(clnt->effects.num_updated);
-    q_effects.num_deleted = ntohl(clnt->effects.num_deleted);
-    q_effects.num_inserted = ntohl(clnt->effects.num_inserted);
-
-    return fsql_write_response(clnt, &effects_resp, &q_effects,
-                               sizeof(q_effects), 1, __func__, __LINE__);
 }
 
 static char *sqlenginestate_tostr(int state)
@@ -1965,16 +1067,9 @@ inline int replicant_can_retry(struct sqlclntstate *clnt)
 int handle_sql_commitrollback(struct sqlthdstate *thd,
                               struct sqlclntstate *clnt, int sendresponse)
 {
-    int rcline = 0;
-    struct fsqlresp resp;
-    struct column_info cinfo;
     int bdberr = 0;
     int rc = 0;
-    rcline = __LINE__;
     int irc = 0;
-    uint8_t coldata[COLUMN_INFO_LEN];
-    uint8_t *p_buf_colinfo = coldata;
-    uint8_t *p_buf_colinfo_end = (p_buf_colinfo + COLUMN_INFO_LEN);
     int outrc = 0;
 
     reqlog_new_sql_request(thd->logger, clnt->sql);
@@ -1993,7 +1088,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                     (clnt->sql) ? clnt->sql : "(???.)");
 
         rc = SQLITE_OK;
-        rcline = __LINE__;
     } else {
         bzero(clnt->dirty, sizeof(clnt->dirty));
 
@@ -2007,7 +1101,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             /* here we handle the communication with bp */
             if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE) {
                 rc = recom_commit(clnt, thd->sqlthd, clnt->tzname, 0);
-                rcline = __LINE__;
                 /* if a transaction exists
                    (it doesn't for empty begin/commit */
                 if (clnt->dbtran.shadow_tran) {
@@ -2025,12 +1118,10 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                                     "transaction too big",
                                     sizeof(clnt->osql.xerr.errstr));
                             rc = CDB2__ERROR_CODE__TRAN_TOO_BIG;
-                            rcline = __LINE__;
                         } else if (rc == SQLITE_ABORT) {
                             /* convert this to user code */
                             rc = blockproc2sql_error(clnt->osql.xerr.errval,
                                                      __func__, __LINE__);
-                            rcline = __LINE__;
                         }
                         irc = trans_abort_shadow(
                             (void **)&clnt->dbtran.shadow_tran, &bdberr);
@@ -2050,7 +1141,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             } else {
                 reset_query_effects(clnt);
                 rc = recom_abort(clnt);
-                rcline = __LINE__;
                 if (rc)
                     logmsg(LOGMSG_ERROR, "%s: recom abort failed %d??\n", __func__,
                             rc);
@@ -2069,7 +1159,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE) {
                 if (clnt->dbtran.mode == TRANLEVEL_SERIAL) {
                     rc = serial_commit(clnt, thd->sqlthd, clnt->tzname);
-                    rcline = __LINE__;
                     if (gbl_extended_sql_debug_trace) {
                         logmsg(LOGMSG_USER,
                                "td=%lu serial-txn %s line %d returns %d\n",
@@ -2077,7 +1166,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                     }
                 } else {
                     rc = snapisol_commit(clnt, thd->sqlthd, clnt->tzname);
-                    rcline = __LINE__;
                     if (gbl_extended_sql_debug_trace) {
                         logmsg(LOGMSG_ERROR,
                                "td=%lu snapshot-txn %s line %d returns %d\n",
@@ -2104,12 +1192,10 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                                     "transaction too big",
                                     sizeof(clnt->osql.xerr.errstr));
                             rc = CDB2__ERROR_CODE__TRAN_TOO_BIG;
-                            rcline = __LINE__;
                         } else if (rc == SQLITE_ABORT) {
                             /* convert this to user code */
                             rc = blockproc2sql_error(clnt->osql.xerr.errval,
                                                      __func__, __LINE__);
-                            rcline = __LINE__;
                             if (gbl_extended_sql_debug_trace) {
                                 logmsg(LOGMSG_USER,
                                        "td=%lu %s line %d returning "
@@ -2165,10 +1251,8 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                 reset_query_effects(clnt);
                 if (clnt->dbtran.mode == TRANLEVEL_SERIAL) {
                     rc = serial_abort(clnt);
-                    rcline = __LINE__;
                 } else {
                     rc = snapisol_abort(clnt);
-                    rcline = __LINE__;
                 }
                 if (rc)
                     logmsg(LOGMSG_ERROR, "%s: serial abort failed %d??\n", __func__,
@@ -2209,7 +1293,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE) {
                 if (gbl_selectv_rangechk) {
                     rc = selectv_range_commit(clnt);
-                    rcline = __LINE__;
                 }
                 if (rc || clnt->early_retry) {
                     int irc = 0;
@@ -2234,13 +1317,11 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                     }
                 } else {
                     rc = osql_sock_commit(clnt, OSQL_SOCK_REQ);
-                    rcline = __LINE__;
                 }
                 if (rc == SQLITE_ABORT) {
                     /* convert this to user code */
                     rc = blockproc2sql_error(clnt->osql.xerr.errval, __func__,
                                              __LINE__);
-                    rcline = __LINE__;
                     if (clnt->osql.xerr.errval == ERR_UNCOMMITABLE_TXN) {
                         osql_set_replay(__FILE__, __LINE__, clnt,
                                         OSQL_RETRY_LAST);
@@ -2267,8 +1348,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             } else {
                 reset_query_effects(clnt);
                 rc = osql_sock_abort(clnt, OSQL_SOCK_REQ);
-                rcline = __LINE__;
-
                 reqlog_logf(thd->logger, REQL_QUERY,
                             "\"%s\" SOCKSL abort(2) rc=%d replay=%d\n",
                             (clnt->sql) ? clnt->sql : "(???.)", rc,
@@ -2304,57 +1383,21 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     if (rc == SQLITE_OK) {
         /* send return code */
 
-        if (!clnt->is_newsql && clnt->want_query_effects) {
-            rc = send_query_effects(clnt);
-            rcline = __LINE__;
-            reset_query_effects(clnt);
+        if (clnt->want_query_effects) {
+            rc = WRITE_RESPONSE(RESPONSE_EFFECTS, NULL);
+            if (!clnt->is_newsql) {
+                reset_query_effects(clnt);
+            }
         }
 
         pthread_mutex_lock(&clnt->wait_mutex);
         clnt->ready_for_heartbeats = 0;
 
-        bzero(&cinfo, sizeof(cinfo));
-        cinfo.type = SQLITE_INTEGER;
-        strcpy(cinfo.column_name, "dummy");
-
-        bzero(&resp, sizeof(resp));
-        resp.response = FSQL_COLUMN_DATA;
-        resp.parm = 1;
-
-        if (!(column_info_put(&cinfo, p_buf_colinfo, p_buf_colinfo_end))) {
-            logmsg(LOGMSG_ERROR, "%s line %d: column_info_put failed???\n", __func__,
-                    __LINE__);
-        }
-
-        if (sendresponse && !clnt->is_newsql) {
-            int retryflags;
-            /* This is a a commit, so we'll have something to send
-             * here even on a retry.  Don't trigger code in
-             * fsql_write_response
-             * that's there to catch bugs when we send back responses
-             * on a retry. */
-            retryflags = clnt->osql.replay;
-            clnt->osql.replay = OSQL_RETRY_NONE;
-            fsql_write_response(clnt, &resp, &coldata, sizeof(cinfo), 0,
-                                __func__, __LINE__);
-            clnt->osql.replay = retryflags;
-        } else if (sendresponse) {
-            clnt->want_query_effects = 0;
-            clnt->num_retry = 0;
-            newsql_send_dummy_resp(clnt, __func__, __LINE__);
-        }
-
-        bzero(&resp, sizeof(resp));
-        resp.response = FSQL_DONE;
-
-        if (sendresponse && !clnt->is_newsql) {
-            int retryflags;
-            retryflags = clnt->osql.replay;
-            clnt->osql.replay = OSQL_RETRY_NONE;
-            fsql_write_response(clnt, &resp, NULL, 0, 1, __func__, __LINE__);
-            clnt->osql.replay = retryflags;
-        } else if (sendresponse) {
-            newsql_send_last_row(clnt, 0, __func__, __LINE__);
+        if (sendresponse) {
+            /* This is a commit, so we'll have something to send here even on a
+             * retry.  Don't trigger code in fsql_write_response that's there
+             * to catch bugs when we send back responses on a retry. */
+            WRITE_RESPONSE(RESPONSE_ROW_LAST_DUMMY, NULL);
         }
 
         outrc = SQLITE_OK; /* the happy case */
@@ -2407,24 +1450,16 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_NONE);
         }
 
-        bzero(&resp, sizeof(resp));
 
         pthread_mutex_lock(&clnt->wait_mutex);
         clnt->ready_for_heartbeats = 0;
         pthread_mutex_unlock(&clnt->wait_mutex);
 
-        resp.response = FSQL_ERROR;
-        resp.rcode = rc;
 
         outrc = rc;
 
         if (sendresponse) {
-            int retryflags = clnt->osql.replay;
-            clnt->osql.replay = OSQL_RETRY_NONE;
-            rc = fsql_write_response(clnt, &resp, clnt->osql.xerr.errstr,
-                                     sizeof(clnt->osql.xerr.errstr), 1,
-                                     __func__, __LINE__);
-            clnt->osql.replay = retryflags;
+            WRITE_RESPONSE(RESPONSE_ERROR, clnt->osql.xerr.errstr);
         }
     }
 
@@ -2863,7 +1898,7 @@ static const char *type_to_typestr(int type)
     }
 }
 
-static int typestr_to_type(const char *ctype)
+int typestr_to_type(const char *ctype)
 {
     if (ctype == NULL)
         return SQLITE_TEXT;
@@ -2993,24 +2028,6 @@ static void compare_estimate_cost(sqlite3_stmt *stmt)
     }
     if (showScanStat)
         logmsg(LOGMSG_USER, "---------------------------\n");
-}
-
-void send_prepare_error(struct sqlclntstate *clnt, const char *errstr,
-                        int clnt_retry)
-{
-    struct fsqlresp resp;
-
-    resp.response = FSQL_COLUMN_DATA;
-    if (clnt_retry)
-        resp.flags = FRESP_FLAG_RETRY; /* Makes client resend the query. */
-    else
-        resp.flags = 0;
-    resp.rcode = FSQL_PREPARE; /* this specific case is handled by
-                                  the client, ugh */
-    resp.parm = 0;
-    /* no packing needed, sending a string */
-    fsql_write_response(clnt, &resp, (void *)errstr, strlen(errstr) + 1,
-                        1 /*flush*/, __func__, __LINE__);
 }
 
 static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt,
@@ -3202,68 +2219,6 @@ static int is_snap_uid_retry(struct sqlclntstate *clnt)
     return 0;
 }
 
-    
-static int _push_row_new(struct sqlclntstate *clnt, int type,
-        CDB2SQLRESPONSE *sql_response,
-        CDB2SQLRESPONSE__Column **columns, int ncols,
-        void *(*alloc)(size_t size), int flush)
-{
-
-    sql_response->response_type = type;
-    sql_response->n_value = ncols;
-    sql_response->value = columns;
-    // Don't overwrite this: it could be CHANGENODE if we fail to get a 
-    // durable_lsn at the beginning of a transaction
-    //sql_response->error_code = 0;
-    if (gbl_extended_sql_debug_trace) {
-        char cnonce[256] = {0};
-        snprintf(cnonce, clnt->sql_query->cnonce.len + 1, "%s", 
-                clnt->sql_query->cnonce.data);
-        logmsg(LOGMSG_USER, "%s line %d cnonce '%s' push-row type=%d error_code=%d\n",
-                __func__, __LINE__, cnonce, type, sql_response->error_code);
-    }
-    
-    return newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE,
-                                 sql_response, flush, alloc, 
-                                  __func__, __LINE__);
-}
-
-/* write back column information */
-int newsql_send_column_info(struct sqlclntstate *clnt,
-                            struct column_info *cinfo, int ncols,
-                            sqlite3_stmt *stmt,
-                            CDB2SQLRESPONSE__Column **columns)
-{
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    int rc = 0;
-    const char *colname;
-
-    for (int i = 0; i < ncols; i++) {
-        cdb2__sqlresponse__column__init(columns[i]);
-        columns[i]->has_type = 1;
-        columns[i]->type = cinfo[i].type;
-        /* DH: here we could use column_info only, but that would limit
-        names to 31 chars, so we need to go through sqlite for now */
-        if (stmt)
-            colname = sqlite3_column_name(stmt, i);
-        else
-            colname = cinfo[i].column_name;
-        columns[i]->value.len = strlen(colname) + 1;
-        columns[i]->value.data = (uint8_t *)colname;
-        if (!gbl_return_long_column_names && columns[i]->value.len > 31) {
-            columns[i]->value.data[31] = '\0';
-            columns[i]->value.len = 32;
-        }
-    }
-
-    rc = _push_row_new(clnt, RESPONSE_TYPE__COLUMN_NAMES, 
-                       &sql_response, columns, ncols, malloc, 0);
-
-    clnt->osql.sent_column_data = 1;
-
-    return rc;
-}
-
 int release_locks(const char *trace)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
@@ -3341,18 +2296,16 @@ error: /* pretend that a real prepare error occured */
     strcpy(buf, "near \"");
     strncat(buf + len, sql, len);
     strcat(buf, "\": syntax error");
-    send_prepare_error(clnt, buf, 0);
+    WRITE_RESPONSE(RESPONSE_ERROR_PREPARE, buf);
     return SQLITE_ERROR;
 }
 
 /* if userpassword does not match this function
  * will write error response and return a non 0 rc
  */
-static inline int check_user_password(struct sqlclntstate *clnt,
-                                      struct fsqlresp *resp)
+static inline int check_user_password(struct sqlclntstate *clnt)
 {
     int password_rc = 0;
-    char *err = "access denied";
     int valid_user;
 
     if (!gbl_uses_password)
@@ -3373,13 +2326,7 @@ static inline int check_user_password(struct sqlclntstate *clnt,
     }
 
     if (!clnt->have_user || !clnt->have_password || password_rc != 0) {
-        bzero(resp, sizeof(*resp));
-        resp->response = FSQL_ERROR;
-        resp->rcode = CDB2ERR_ACCESS;
-        if (valid_user)
-            err = "invalid password";
-        fsql_write_response(clnt, resp, err, strlen(err) + 1, 1, __func__,
-                            __LINE__);
+        WRITE_RESPONSE(RESPONSE_ERROR_ACCESS, "access denied");
         return 1;
     }
     return 0;
@@ -3390,39 +2337,6 @@ static int need_flush(struct sqlclntstate *clnt)
     return (clnt->conninfo.pid == 0 && sbuf2fileno(clnt->sb) == fileno(stdout))
                ? 0
                : 1;
-}
-
-static void get_return_row_schema(struct sqlthdstate *thd,
-                                  struct sqlclntstate *clnt, sqlite3_stmt *stmt)
-{
-    int col;
-    int ncols;
-
-    ncols = sqlite3_column_count(stmt);
-
-    thd->cinfo = realloc(thd->cinfo, ncols * sizeof(struct column_info));
-
-    for (col = 0; col < ncols; col++) {
-        if (clnt->req.parm) {
-            thd->cinfo[col].type = clnt->type_overrides[col];
-            if (!comdb2_is_valid_type(thd->cinfo[col].type)) {
-                thd->cinfo[col].type = sqlite3_column_type(stmt, col);
-            }
-        } else {
-            thd->cinfo[col].type = sqlite3_column_type(stmt, col);
-            if ((gbl_surprise) || thd->cinfo[col].type == SQLITE_NULL) {
-                thd->cinfo[col].type =
-                    typestr_to_type(sqlite3_column_decltype(stmt, col));
-            }
-        }
-        if (thd->cinfo[col].type == SQLITE_DECIMAL)
-            thd->cinfo[col].type = SQLITE_TEXT;
-
-        strncpy(thd->cinfo[col].column_name, sqlite3_column_name(stmt, col),
-                sizeof(thd->cinfo[col].column_name));
-        thd->cinfo[col].column_name[sizeof(thd->cinfo[col].column_name) - 1] =
-            '\0';
-    }
 }
 
 void thr_set_current_sql(const char *sql)
@@ -3605,37 +2519,6 @@ enum {
   ERR_CONVERSION_DT = -5,
 };
 
-struct client_comm_if {
-    int (*send_row_format)(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                           struct sql_state *rec, int ncols,
-                           CDB2SQLRESPONSE__Column **columns);
-    int (*send_row_data)(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                         int new_row_data_type, int ncols, int row_id, int rc,
-                         CDB2SQLRESPONSE__Column **columns);
-    void (*send_prepare_error)(struct sqlclntstate *clnt, const char *errstr,
-                              int clnt_retry);
-    int (*send_run_error)(struct sqlclntstate *clnt, const char *errstr,
-                          int client_rc);
-    int (*flush)(struct sqlclntstate *clnt);
-    int (*send_cost)(struct sqlclntstate *clnt);
-    int (*send_effects)(struct sqlclntstate *clnt);
-    void (*send_done)(struct sqlthdstate *thd, struct sqlclntstate *clnt, 
-                     const char *func, int line);
-    int (*send_dummy)(struct sqlclntstate *clnt);
-};
-
-struct client_comm_if client_sql_api = {
-    &send_ret_column_info,
-    &send_row,
-    &send_prepare_error,
-    &send_err_but_msg, 
-    &flush_row,
-    &_dbglog_send_cost,
-    &send_query_effects,
-    &send_last_row,
-    &send_dummy,
-};
-
 static int get_prepared_bound_param(struct sqlthdstate *thd,
                                     struct sqlclntstate *clnt,
                                     struct sql_state *rec, 
@@ -3810,12 +2693,11 @@ static int ha_retrieve_snapshot(struct sqlclntstate *clnt)
                             "ctrlengine_state=%d: i am sending the last row\n",
                     __func__, clnt->sql, clnt->ctrl_sqlengine);
         }
-        newsql_send_dummy_resp(clnt, __func__, __LINE__);
-        newsql_send_last_row(clnt, 0, __func__, __LINE__);
+        WRITE_RESPONSE(RESPONSE_ROW_LAST_DUMMY, 0);
         return 1;
     } else if (is_snap_retry == -1) {
-        send_prepare_error(clnt,
-                           "Comdb2 server not setup for high availability", 0);
+        WRITE_RESPONSE(RESPONSE_ERROR_PREPARE,
+                       "Comdb2 server not setup for high availability");
         return 1;
     }
 
@@ -3861,7 +2743,7 @@ static void _prepare_error(struct sqlthdstate *thd,
     }
 
     flush_resp = need_flush(clnt);
-    if(rc == FSQL_PREPARE && !rec->stmt)
+    if(rc == ERR_SQL_PREPARE && !rec->stmt)
         errstr = "no statement";
     else if (clnt->fdb_state.xerr.errval) {
         errstr = clnt->fdb_state.xerr.errstr;
@@ -3892,12 +2774,20 @@ static void _prepare_error(struct sqlthdstate *thd,
     }
 }
 
+static int send_run_error(struct sqlclntstate *clnt, const char *err, int rc)
+{
+    pthread_mutex_lock(&clnt->wait_mutex);
+    clnt->ready_for_heartbeats = 0;
+    pthread_mutex_unlock(&clnt->wait_mutex);
+    return clnt->write_response(clnt, RESPONSE_ERROR, (void *)err, rc);
+}
+
 static int handle_bad_engine(struct sqlclntstate *clnt)
 {
     logmsg(LOGMSG_ERROR, "unable to obtain sql engine\n");
     if (clnt->is_newsql) {
         char *errstr = "Client api should change nodes";
-        client_sql_api.send_run_error(clnt, errstr, CDB2ERR_CHANGENODE);
+        send_run_error(clnt, errstr, CDB2ERR_CHANGENODE);
     }
     clnt->query_rc = -1;
     pthread_mutex_lock(&clnt->wait_mutex);
@@ -3911,8 +2801,8 @@ static int handle_bad_transaction_mode(struct sqlthdstate *thd,
                                        struct sqlclntstate *clnt)
 {
     logmsg(LOGMSG_ERROR, "unable to set_transaction_mode\n");
-    send_prepare_error(clnt, "Failed to set transaction mode.", 0);
-    reqlog_logf(thd->logger, REQL_TRACE, "Failed to set transaction mode.\n");
+    WRITE_RESPONSE(RESPONSE_ERROR_PREPARE, "Failed to set transaction mode");
+    reqlog_logf(thd->logger, REQL_TRACE, "Failed to set transaction mode\n");
     if (put_curtran(thedb->bdb_env, clnt)) {
         logmsg(LOGMSG_ERROR, "%s: unable to destroy a CURSOR transaction!\n",
                __func__);
@@ -3985,7 +2875,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         thr_set_current_sql(rec->sql);
     } else if (rc == 0) {
         // No stmt and no error -> Empty sql string or just comment.
-        rc = FSQL_PREPARE;
+        rc = ERR_SQL_PREPARE;
     }
     if (gbl_fingerprint_queries) {
         reqlog_set_fingerprint(thd->logger, sqlite3_fingerprint(thd->sqldb),
@@ -4141,42 +3031,21 @@ static void handle_expert_query(struct sqlthdstate *thd,
         rc = sqlite3_expert_analyze(p, &zErr);
     }
 
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    sql_response.response_type = RESPONSE_TYPE__SP_TRACE;
-    sql_response.n_value = 0;
-    sql_response.value = NULL;
-    sql_response.error_code = 0;
-
     if (rc == SQLITE_OK) {
         int nQuery = sqlite3_expert_count(p);
         const char *zCand =
             sqlite3_expert_report(p, 0, EXPERT_REPORT_CANDIDATES);
         fprintf(stdout, "-- Candidates -------------------------------\n");
         fprintf(stdout, "%s\n", zCand);
-        sql_response.info_string =
-            "---------- Recommended Indexes --------------\n";
-        newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE_TRACE,
-                              &sql_response, 1 /*flush*/, malloc, __func__,
-                              __LINE__);
-        sql_response.info_string = (char *)zCand;
-        newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE_TRACE,
-                              &sql_response, 1 /*flush*/, malloc, __func__,
-                              __LINE__);
-        sql_response.info_string =
-            "---------------------------------------------\n";
-        /* This will be flushed at end */
-
+        WRITE_RESPONSE(RESPONSE_TRACE, "---------- Recommended Indexes --------------\n");
+        WRITE_RESPONSE(RESPONSE_TRACE, zCand);
+        WRITE_RESPONSE(RESPONSE_TRACE, "---------------------------------------------\n");
     } else {
-        sql_response.info_string = zErr;
         fprintf(stderr, "Error: %s\n", zErr ? zErr : "?");
+        WRITE_RESPONSE(RESPONSE_TRACE, zErr);
     }
-    newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE_TRACE,
-                          &sql_response, 1 /*flush*/, malloc, __func__,
-                          __LINE__);
-
-    newsql_send_dummy_resp(clnt, __func__, __LINE__);
-    newsql_send_last_row(clnt, 1, __func__, __LINE__);
-
+    WRITE_RESPONSE(RESPONSE_ROW_LAST_DUMMY, NULL);
+    WRITE_RESPONSE(RESPONSE_FLUSH, NULL);
     sqlite3_expert_destroy(p);
     sqlite3_free(zErr);
     clnt->no_transaction = 0;
@@ -4249,774 +3118,35 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
     return 0;
 }
 
-static void set_ret_column_info(struct sqlthdstate *thd,
-                                struct sqlclntstate *clnt,
-                                struct sql_state *rec, int ncols)
+static int send_columns(struct sqlclntstate *clnt, struct sqlite3_stmt *stmt)
 {
-    sqlite3_stmt *stmt = rec->stmt;
-    int col;
-
-    thd->cinfo = realloc(thd->cinfo, ncols * sizeof(struct column_info));
-
-    for (col = 0; col < ncols; col++) {
-
-        /* set the return column type */
-        if (clnt->req.parm || (clnt->is_newsql && clnt->sql_query->n_types)) {
-            if (clnt->is_newsql) {
-                thd->cinfo[col].type = clnt->sql_query->types[col];
-            } else {
-                thd->cinfo[col].type = clnt->type_overrides[col];
-            }
-            if (!comdb2_is_valid_type(thd->cinfo[col].type)) {
-                thd->cinfo[col].type = sqlite3_column_type(stmt, col);
-            }
-        } else {
-            thd->cinfo[col].type = sqlite3_column_type(stmt, col);
-            if ((!clnt->is_newsql && gbl_surprise) ||
-                thd->cinfo[col].type == SQLITE_NULL) {
-                thd->cinfo[col].type =
-                    typestr_to_type(sqlite3_column_decltype(stmt, col));
-                /*thd->cinfo[col].type = sqlite3_column_type(stmt, col);*/
-            }
-        }
-        if (thd->cinfo[col].type == SQLITE_DECIMAL)
-            thd->cinfo[col].type = SQLITE_TEXT;
-
-        /* set return column name */
-        strncpy(thd->cinfo[col].column_name, sqlite3_column_name(stmt, col),
-                sizeof(thd->cinfo[col].column_name));
-        thd->cinfo[col].column_name[sizeof(thd->cinfo[col].column_name) - 1] =
-            '\0';
-    }
-}
-
-static int send_ret_column_info_oldsql(struct sqlthdstate *thd,
-                                       struct sqlclntstate *clnt, int ncols,
-                                       int flush_resp)
-{
-    struct fsqlresp resp;
-    size_t buf_cinfos_len;
-    uint8_t *p_buf_cinfos_start;
-    uint8_t *p_buf_cinfos;
-    uint8_t *p_buf_cinfos_end;
-    int did_malloc = 0;
-    int rc = 0;
-    int i;
-
-    if (!flush_resp)
-        return 0;
-
-    resp.response = FSQL_COLUMN_DATA;
-    resp.flags = clnt->conninfo.pid;
-    resp.rcode = 0;
-    resp.parm = ncols;
-
-    /* pack column info */
-    buf_cinfos_len = ncols * COLUMN_INFO_LEN;
-    if (buf_cinfos_len > 4096) {
-        p_buf_cinfos_start = sqlite3_malloc(buf_cinfos_len);
-        did_malloc = 1;
-    } else {
-        p_buf_cinfos_start = alloca(buf_cinfos_len);
-    }
-    p_buf_cinfos = p_buf_cinfos_start;
-    p_buf_cinfos_end = p_buf_cinfos_start + buf_cinfos_len;
-
-    for (i = 0; i < ncols; ++i) {
-        if (!(p_buf_cinfos = column_info_put(&thd->cinfo[i], p_buf_cinfos,
-                                             p_buf_cinfos_end))) {
-            rc = -1;
-            if (did_malloc)
-                sqlite3_free(p_buf_cinfos_start);
-            p_buf_cinfos_start = NULL;
-            goto error;
-        }
-    }
-
-    if (clnt->osql.replay != OSQL_RETRY_DO)
-        rc =
-            fsql_write_response(clnt, &resp, p_buf_cinfos_start, buf_cinfos_len,
-                                0 /*flush*/, __func__, __LINE__);
-
-    if (did_malloc)
-        sqlite3_free(p_buf_cinfos_start);
-
-    p_buf_cinfos_start = NULL;
-    if (rc)
-        goto error;
-
-error:
-    return rc;
-}
-
-static int send_ret_column_info(struct sqlthdstate *thd,
-                                struct sqlclntstate *clnt,
-                                struct sql_state *rec, int ncols,
-                                CDB2SQLRESPONSE__Column **columns)
-{
-    int flush_resp = need_flush(clnt);
     int rc = 0;
     if ((!clnt->osql.replay || (clnt->dbtran.mode == TRANLEVEL_RECOM &&
                                 !clnt->osql.sent_column_data)) &&
         !((clnt->want_query_effects && !is_with_statement(clnt->sql)) &&
           clnt->in_client_trans && !clnt->isselect)) {
-        if (clnt->is_newsql) {
-            newsql_send_column_info(clnt, thd->cinfo, ncols, rec->stmt,
-                                    columns);
-            rc = 0;
-        } else {
-            rc = send_ret_column_info_oldsql(thd, clnt, ncols, flush_resp);
-            if (rc)
-                goto error;
-        }
-
-        if (flush_resp) {
-            rc = fsql_write_response(clnt, NULL /*resp*/, NULL /*dta*/,
-                                     0 /*len*/, 1, __func__, __LINE__);
-            if (rc < 0)
-                goto error;
-        }
-
+        rc = WRITE_RESPONSE(RESPONSE_COLUMNS, stmt);
         clnt->osql.sent_column_data = 1;
     }
-error:
     return rc;
 }
 
-static inline int is_new_row_data(struct sqlclntstate *clnt)
-{
-    return (!clnt->iswrite && (clnt->req.flags & SQLF_WANT_NEW_ROW_DATA) &&
-            gbl_new_row_data);
-}
-
-static int send_err_but_msg_new(struct sqlclntstate *clnt, const char *errstr,
-                                int irc)
-{
-    int rc = 0;
-
-    clnt->had_errors = 1;
-    if (clnt->num_retry == clnt->sql_query->retry) {
-        CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-        if (clnt->osql.sent_column_data) {
-            sql_response.response_type = RESPONSE_TYPE__COLUMN_VALUES;
-        } else {
-            sql_response.response_type = RESPONSE_TYPE__COLUMN_NAMES;
-        }
-        sql_response.n_value = 0;
-        sql_response.error_code =
-            verify_sqlresponse_error_code(irc, __func__, __LINE__);
-        sql_response.error_string = (char*)errstr;
-
-        rc = newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE,
-                                   &sql_response, 1 /*flush*/, malloc, __func__,
-                                   __LINE__);
-    }
-    return rc;
-}
-
-static int send_err_but_msg_old(struct sqlclntstate *clnt, const char *errstr,
-                                int irc)
-{
-    int rc = 0;
-    struct fsqlresp resp;
-    int flush_resp = need_flush(clnt);
-    if (flush_resp) {
-        resp.rcode = irc;
-        resp.response = FSQL_ERROR;
-        rc = fsql_write_response(clnt, &resp, (void *)errstr,
-                                 strlen(errstr) + 1, 0, __func__, __LINE__);
-    } else {
-        if (clnt->saved_errstr)
-            free(clnt->saved_errstr);
-        clnt->saved_errstr = strdup(errstr);
-    }
-    return rc;
-}
-
-static int send_err_but_msg(struct sqlclntstate *clnt, const char *errstr, int irc)
-{
-    int rc;
-    pthread_mutex_lock(&clnt->wait_mutex);
-    clnt->ready_for_heartbeats = 0;
-    pthread_mutex_unlock(&clnt->wait_mutex);
-
-    if (clnt->is_newsql) {
-        rc = send_err_but_msg_new(clnt, errstr, irc);
-    } else {
-        rc = send_err_but_msg_old(clnt, errstr, irc);
-    }
-
-    return rc;
-}
-
-static inline int new_retrow_has_header(int is_null, int type)
-{
-    if (is_null)
-        return 1;
-
-    switch (type) {
-    case SQLITE_INTEGER:
-    case SQLITE_FLOAT:
-    case SQLITE_INTERVAL_YM:
-    case CLIENT_INTV_DS_LEN:
-        return 0;
-    }
-    return 1;
-}
-
-static int new_retrow_get_column_nulls_and_count(sqlite3_stmt *stmt,
-                                                 int new_row_data_type,
-                                                 int ncols,
-                                                 struct column_info *cinfo,
-                                                 uint8_t *isNullCol)
-{
-    int total_col, col;
-
-    total_col = 0;
-    for (col = 0; col < ncols; col++) {
-        /* need to know if *this* col content is SQLITE_NULL */
-        isNullCol[col] = sqlite3_isColumnNullType(stmt, col);
-#ifdef DEBUG
-        if ((sqlite3_column_type(stmt, col) == SQLITE_NULL) != isNullCol[col]) {
-            logmsg(LOGMSG_FATAL, "Did not evaluate to NULL col %d \n", col);
-            abort();
-        }
-#endif
-        if (new_row_data_type) {
-            total_col += new_retrow_has_header(isNullCol[col], cinfo[col].type);
-        }
-    }
-    return total_col;
-}
-
-static void *thd_adjust_space(struct sqlthdstate *thd)
-{
-    /* does the thread buffer fits ? */
-    if (thd->buflen > thd->maxbuflen) {
-        char *p;
-        thd->maxbuflen = thd->buflen;
-        if (thd->buf == NULL && thd->maxbuflen > gbl_blob_sz_thresh_bytes)
-            p = comdb2_bmalloc(blobmem, thd->maxbuflen);
-        else
-            p = realloc(thd->buf, thd->maxbuflen);
-        if (!p) {
-            logmsg(LOGMSG_ERROR, "%s: out of memory realloc %d\n", __func__,
-                    thd->maxbuflen);
-            return NULL;
-        }
-        thd->buf = p;
-    }
-    return thd->buf;
-}
-
-static int update_retrow_schema(struct sqlthdstate *thd,
-                                struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                                int new_row_data_type, int ncols, int total_col,
-                                uint8_t *isNullCol, struct errstat *err)
-{
-    int offset, fldlen;
-    int buflen = 0;
-    int col;
-
-    /* header */
-    if (new_row_data_type)
-        offset = sizeof(int) + total_col * sizeof(struct sqlfield);
-    else
-        offset = ncols * sizeof(struct sqlfield);
-
-    /* compute offsets and buffer size */
-    for (col = 0, buflen = 0; col < ncols; col++) {
-        if (isNullCol[col]) {
-            thd->offsets[col].offset = -1;
-            if (new_row_data_type) {
-                thd->offsets[col].offset = col;
-            }
-            thd->offsets[col].len = -1;
-            buflen = offset;
-            continue;
-        }
-
-        switch (thd->cinfo[col].type) {
-        case SQLITE_INTEGER:
-            if (!new_row_data_type) {
-                if (offset % sizeof(long long))
-                    offset += sizeof(long long) - offset % sizeof(long long);
-            }
-            buflen = offset + sizeof(long long);
-            thd->offsets[col].offset = offset;
-            thd->offsets[col].len = sizeof(long long);
-            offset += sizeof(long long);
-            break;
-        case SQLITE_FLOAT:
-            if (!new_row_data_type) {
-                if (offset % sizeof(double))
-                    offset += sizeof(double) - offset % sizeof(double);
-            }
-            buflen = offset + sizeof(double);
-            thd->offsets[col].len = sizeof(double);
-            thd->offsets[col].offset = offset;
-            offset += sizeof(double);
-            break;
-        case SQLITE_DATETIME:
-        case SQLITE_DATETIMEUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            if (clnt->have_extended_tm && clnt->extended_tm) {
-                fldlen = CLIENT_DATETIME_EXT_LEN;
-            } else {
-                fldlen = CLIENT_DATETIME_LEN;
-            }
-            buflen = offset + fldlen;
-            thd->offsets[col].offset = offset;
-            thd->offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_INTERVAL_YM:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_YM_LEN;
-            buflen = offset + fldlen;
-            thd->offsets[col].offset = offset;
-            thd->offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_INTERVAL_DS:
-        case SQLITE_INTERVAL_DSUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_DS_LEN;
-            buflen = offset + fldlen;
-            thd->offsets[col].offset = offset;
-            thd->offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_TEXT:
-        case SQLITE_BLOB:
-            fldlen = sqlite3_column_bytes(stmt, col);
-            /* sqlite3_column_bytes returns a 0 on error - check for
-             * error or if it's really 0 */
-            if (fldlen == 0 &&
-                sqlite3_errcode(thd->sqldb) == SQLITE_CONV_ERROR) {
-                errstat_set_rcstrf(err, ERR_ROW_HEADER, "%s", 
-                                   (char*)sqlite3_errmsg(thd->sqldb));
-                return -1;
-            }
-            if (thd->cinfo[col].type == SQLITE_TEXT)
-                fldlen++;
-            buflen = offset + fldlen;
-            thd->offsets[col].offset = offset;
-            thd->offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        }
-
-        if (new_row_data_type) {
-            thd->offsets[col].offset = col;
-        }
-    }
-
-    thd->buflen = buflen;
-    return 0;
-}
-
-/* creates the row header */
-static int set_retrow_header(struct sqlthdstate *thd, int new_row_data_type,
-                             int ncols, int total_col, uint8_t *isNullCol)
-{
-    uint8_t *p_buf;
-    uint8_t *p_buf_end;
-    int i;
-
-    p_buf = (uint8_t *)thd->buf;
-    p_buf_end = (uint8_t *)(thd->buf + thd->buflen);
-
-    /* new row format has a counter as first field */
-    if (new_row_data_type) {
-        p_buf = buf_put(&total_col, sizeof(total_col), p_buf, p_buf_end);
-    }
-
-    /* columns that have header info are added next */
-    for (i = 0; i < ncols; ++i) {
-        if (!new_row_data_type ||
-            new_retrow_has_header(isNullCol[i], thd->cinfo[i].type)) {
-            if (!(p_buf = sqlfield_put(&thd->offsets[i], p_buf, p_buf_end)))
-                return -1;
-        }
-    }
-
-    return 0;
-}
-
-static int set_retrow_columns(struct sqlthdstate *thd,
-                              struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                              int new_row_data_type, int ncols,
-                              uint8_t *isNullCol, int total_col, int rowcount,
-                              struct errstat *err)
-{
-    uint8_t *p_buf_end = (uint8_t *)thd->buf + thd->buflen;
-    int little_endian = 0;
-    int fldlen;
-    double dval;
-    long long ival;
-    char *tval;
-    int offset;
-    int col;
-
-    /* flip our data if the client asked for little endian data */
-    if (clnt->have_endian && clnt->endian == FSQL_ENDIAN_LITTLE_ENDIAN) {
-        little_endian = 1;
-    }
-
-    if (new_row_data_type) {
-        offset = sizeof(int) + total_col * sizeof(struct sqlfield);
-    } else {
-        offset = ncols * sizeof(struct sqlfield);
-    }
-
-    reqlog_logf(thd->logger, REQL_RESULTS, "row %d = (", rowcount + 1);
-
-    for (col = 0; col < ncols; col++) {
-
-        if (col > 0) {
-            reqlog_logl(thd->logger, REQL_RESULTS, ", ");
-        }
-
-        if (isNullCol[col]) {
-            reqlog_logl(thd->logger, REQL_RESULTS, "NULL");
-            continue;
-        }
-
-        switch (thd->cinfo[col].type) {
-        case SQLITE_INTEGER:
-            if (!new_row_data_type) {
-                if (offset % sizeof(long long))
-                    offset += sizeof(long long) - offset % sizeof(long long);
-            }
-            ival = sqlite3_column_int64(stmt, col);
-            reqlog_logf(thd->logger, REQL_RESULTS, "%lld", ival);
-            if (little_endian)
-                ival = flibc_llflip(ival);
-            if (!buf_put(&ival, sizeof(ival), (uint8_t *)(thd->buf + offset),
-                         p_buf_end))
-                goto error;
-            offset += sizeof(long long);
-            break;
-        case SQLITE_FLOAT:
-            if (!new_row_data_type) {
-                if (offset % sizeof(double))
-                    offset += sizeof(double) - offset % sizeof(double);
-            }
-            dval = sqlite3_column_double(stmt, col);
-            reqlog_logf(thd->logger, REQL_RESULTS, "%f", dval);
-            if (little_endian)
-                dval = flibc_dblflip(dval);
-            if (!buf_put(&dval, sizeof(dval), (uint8_t *)(thd->buf + offset),
-                         p_buf_end))
-                goto error;
-            offset += sizeof(double);
-            break;
-        case SQLITE_TEXT:
-            fldlen = sqlite3_column_bytes(stmt, col) + 1;
-            tval = (char *)sqlite3_column_text(stmt, col);
-            reqlog_logf(thd->logger, REQL_RESULTS, "'%s'", tval);
-            /* text doesn't need to be packed */
-            if (tval)
-                memcpy(thd->buf + offset, tval, fldlen);
-            else
-                thd->buf[offset] = 0; /* null string */
-            offset += fldlen;
-            break;
-        case SQLITE_DATETIME:
-        case SQLITE_DATETIMEUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            if (clnt->have_extended_tm && clnt->extended_tm) {
-                fldlen = CLIENT_DATETIME_EXT_LEN;
-            } else {
-                fldlen = CLIENT_DATETIME_LEN;
-            }
-            {
-                cdb2_client_datetime_t cdt;
-
-                tval = (char *)sqlite3_column_datetime(stmt, col);
-                if (!tval ||
-                    convDttz2ClientDatetime((dttz_t *)tval,
-                                            ((Vdbe *)stmt)->tzname, &cdt,
-                                            thd->cinfo[col].type)) {
-                    bzero(thd->buf + offset, fldlen);
-                    logmsg(LOGMSG_ERROR, "%s: datetime conversion "
-                                    "failure\n",
-                            __func__);
-                    errstat_set_rcstrf(err, ERR_CONVERSION_DT, 
-                                       "failed to convert sqlite to client "
-                                       "datetime for field \"%s\"",
-                                       sqlite3_column_name(stmt, col));
-                    goto error;
-                }
-
-                if (little_endian) {
-                    cdt.tm.tm_sec = flibc_intflip(cdt.tm.tm_sec);
-                    cdt.tm.tm_min = flibc_intflip(cdt.tm.tm_min);
-                    cdt.tm.tm_hour = flibc_intflip(cdt.tm.tm_hour);
-                    cdt.tm.tm_mday = flibc_intflip(cdt.tm.tm_mday);
-                    cdt.tm.tm_mon = flibc_intflip(cdt.tm.tm_mon);
-                    cdt.tm.tm_year = flibc_intflip(cdt.tm.tm_year);
-                    cdt.tm.tm_wday = flibc_intflip(cdt.tm.tm_wday);
-                    cdt.tm.tm_yday = flibc_intflip(cdt.tm.tm_yday);
-                    cdt.tm.tm_isdst = flibc_intflip(cdt.tm.tm_isdst);
-                    cdt.msec = flibc_intflip(cdt.msec);
-                }
-
-                /* Old linux sql clients will have extended_tms's. */
-                if (clnt->have_extended_tm && clnt->extended_tm) {
-                    if (!client_extended_datetime_put(
-                            &cdt, (uint8_t *)(thd->buf + offset), p_buf_end))
-                        goto error;
-                } else {
-
-                    if (!client_datetime_put(
-                            &cdt, (uint8_t *)(thd->buf + offset), p_buf_end))
-                        goto error;
-                }
-            }
-            offset += fldlen;
-            break;
-        case SQLITE_INTERVAL_YM:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_YM_LEN;
-            {
-                cdb2_client_intv_ym_t ym;
-                const intv_t *tv =
-                    sqlite3_column_interval(stmt, col, SQLITE_AFF_INTV_MO);
-
-                if (little_endian) {
-                    ym.sign = flibc_intflip(tv->sign);
-                    ym.years = flibc_intflip(tv->u.ym.years);
-                    ym.months = flibc_intflip(tv->u.ym.months);
-                } else {
-                    ym.sign = tv->sign;
-                    ym.years = tv->u.ym.years;
-                    ym.months = tv->u.ym.months;
-                }
-
-                if (!client_intv_ym_put(&ym, (uint8_t *)(thd->buf + offset),
-                                        p_buf_end))
-                    goto error;
-                offset += fldlen;
-            }
-            break;
-        case SQLITE_INTERVAL_DS:
-        case SQLITE_INTERVAL_DSUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_DS_LEN;
-            {
-                cdb2_client_intv_ds_t ds;
-                intv_t *tv;
-                tv = (intv_t *)sqlite3_column_interval(stmt, col,
-                                                       SQLITE_AFF_INTV_SE);
-
-                /* Adjust fraction based on client precision. */
-                if (thd->cinfo[col].type == SQLITE_INTERVAL_DS && tv->u.ds.prec == 6)
-                    tv->u.ds.frac /= 1000;
-                else if (thd->cinfo[col].type == SQLITE_INTERVAL_DSUS && tv->u.ds.prec == 3)
-                    tv->u.ds.frac *= 1000;
-
-                if (little_endian) {
-                    ds.sign = flibc_intflip(tv->sign);
-                    ds.days = flibc_intflip(tv->u.ds.days);
-                    ds.hours = flibc_intflip(tv->u.ds.hours);
-                    ds.mins = flibc_intflip(tv->u.ds.mins);
-                    ds.sec = flibc_intflip(tv->u.ds.sec);
-                    ds.msec = flibc_intflip(tv->u.ds.frac);
-                } else {
-                    ds.sign = tv->sign;
-                    ds.days = tv->u.ds.days;
-                    ds.hours = tv->u.ds.hours;
-                    ds.mins = tv->u.ds.mins;
-                    ds.sec = tv->u.ds.sec;
-                    ds.msec = tv->u.ds.frac;
-                }
-
-                if (!client_intv_ds_put(&ds, (uint8_t *)(thd->buf + offset),
-                                        p_buf_end))
-                    goto error;
-                offset += fldlen;
-            }
-            break;
-        case SQLITE_BLOB:
-            fldlen = sqlite3_column_bytes(stmt, col);
-            tval = (char *)sqlite3_column_blob(stmt, col);
-            memcpy(thd->buf + offset, tval, fldlen);
-            reqlog_logl(thd->logger, REQL_RESULTS, "x'");
-            reqlog_loghex(thd->logger, REQL_RESULTS, tval, fldlen);
-            reqlog_logl(thd->logger, REQL_RESULTS, "'");
-            offset += fldlen;
-            break;
-        }
-    }
-    reqlog_logl(thd->logger, REQL_RESULTS, ")\n");
-    return 0;
-error:
-    return -1;
-}
-
-/* based on current sqlite result row, create a client formatted row */
-int make_retrow(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                struct sql_state *rec, int new_row_data_type, int ncols,
-                int rowcount, int *fast_error, struct errstat *err)
-{
-    uint8_t *isNullCol = NULL;
-    int total_col;
-    int offset;
-    int rc;
-
-    *fast_error = 1;
-
-    isNullCol = (uint8_t *)alloca(sizeof(uint8_t) * ncols);
-    if (!isNullCol)
-        return -1;
-
-    total_col = new_retrow_get_column_nulls_and_count(
-        rec->stmt, new_row_data_type, ncols, thd->cinfo, isNullCol);
-
-    rc = update_retrow_schema(thd, clnt, rec->stmt, new_row_data_type, ncols,
-                              total_col, isNullCol, err);
-    if (rc) { /* done */
-        assert(errstat_get_rc(err) == ERR_ROW_HEADER);
-        *fast_error = 0;
-        goto out;
-    }
-
-    if (!thd_adjust_space(thd)) {
-        rc = -1; /* error */
-        goto out;
-    }
-
-    rc = set_retrow_header(thd, new_row_data_type, ncols, total_col, isNullCol);
-    if (rc) /* error */
-        goto out;
-
-    rc = set_retrow_columns(thd, clnt, rec->stmt, new_row_data_type, ncols,
-                            isNullCol, total_col, rowcount, err);
-out:
-    return rc; /*error */
-}
-
-static void *blob_alloc_override(size_t len)
-{
-    return comdb2_bmalloc(blobmem, len + 1);
-}
-
-#define DATALEN_THRESHOLD 1024
-
-static int send_row_new(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                        int ncols, int row_id,
-                        CDB2SQLRESPONSE__Column **columns)
-{
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    int rc = 0;
-    int i;
-    size_t data_len = 0;
-
-    for (i = 0; i < ncols; i++) {
-        cdb2__sqlresponse__column__init(columns[i]);
-        columns[i]->has_type = 0;
-        if (thd->offsets[i].len == -1) {
-            columns[i]->has_isnull = 1;
-            columns[i]->isnull = 1;
-            columns[i]->value.len = 0;
-            columns[i]->value.data = NULL;
-        } else {
-            columns[i]->value.len = thd->offsets[i].len;
-            columns[i]->value.data =
-                (uint8_t *)thd->buf + thd->offsets[i].offset;
-        }
-        data_len += columns[i]->value.len;
-    }
-
-    if (clnt->num_retry) {
-        sql_response.has_row_id = 1;
-        sql_response.row_id = row_id;
-    }
-
-    _has_snapshot(clnt, sql_response);
-
-    if (gbl_extended_sql_debug_trace) {
-        int sz = clnt->sql_query->cnonce.len;
-        int file = -1, offset = -1;
-        if (sql_response.snapshot_info) {
-            file = sql_response.snapshot_info->file;
-            offset = sql_response.snapshot_info->offset;
-        }
-        char cnonce[256];
-        snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
-        logmsg(LOGMSG_USER, "%s: cnonce '%s' snapshot is [%d][%d]\n", __func__,
-                cnonce, file, offset);
-    }
-
-    sql_response.value = columns;
-
-    void *(*alloc_func)(size_t size) = malloc;
-    if (gbl_blob_sz_thresh_bytes > 0 && data_len > DATALEN_THRESHOLD) {
-        int pksize = cdb2__sqlresponse__get_packed_size(&sql_response);
-        if (pksize + 1 > gbl_blob_sz_thresh_bytes)
-            alloc_func = blob_alloc_override;
-    }
-
-    return _push_row_new(clnt, RESPONSE_TYPE__COLUMN_VALUES, &sql_response,
-                         columns, ncols, alloc_func, 0);
-}
-
-static int send_row_old(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                        int new_row_data_type)
-{
-    struct fsqlresp resp;
-
-    if (new_row_data_type) {
-        resp.response = FSQL_NEW_ROW_DATA;
-    } else {
-        resp.response = FSQL_ROW_DATA;
-    }
-    resp.flags = 0;
-    resp.rcode = FSQL_OK;
-    resp.parm = 0;
-
-    return fsql_write_response(clnt, &resp, thd->buf, thd->buflen, 0, __func__,
-                               __LINE__);
-}
-
-static int send_row(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                    int new_row_data_type, int ncols, int row_id, int rc,
-                    CDB2SQLRESPONSE__Column **columns)
+static int send_row(struct sqlclntstate *clnt, struct sqlite3_stmt *stmt,
+                    uint64_t row_id, int rc, int postpone)
 {
     int irc = 0;
+    struct response_data arg = {0};
+    arg.stmt = stmt;
+    arg.row_id = row_id;
     if (clnt->is_newsql) {
         if (!rc && (clnt->num_retry == clnt->sql_query->retry) &&
                 (clnt->num_retry == 0 || clnt->sql_query->has_skip_rows == 0 ||
                  (clnt->sql_query->skip_rows < row_id)))
-            irc = send_row_new(thd, clnt, ncols, row_id, columns);
+            irc = clnt->write_response(clnt, RESPONSE_ROW, &arg, postpone);
     } else {
-        irc = send_row_old(thd, clnt, new_row_data_type);
+        irc = clnt->write_response(clnt, RESPONSE_ROW, &arg, postpone);
     }
     return irc;
-}
-
-static int flush_row(struct sqlclntstate *clnt)
-{
-    if (gbl_sqlflush_freq && clnt->recno % gbl_sqlflush_freq == 0) {
-        if (fsql_write_response(clnt, NULL, NULL, 0, 1, __func__,
-                                __LINE__) < 0)
-            return -1;
-    }
-    return 0;
 }
 
 /* will do a tiny cleanup of clnt */
@@ -5093,45 +3223,10 @@ static int rc_sqlite_to_client(struct sqlthdstate *thd,
     return irc;
 }
 
-static void send_last_row_old(struct sqlclntstate *clnt, int now,
-                              const char *func, int line)
-{
-    struct fsqlresp resp;
-    int flush_resp = need_flush(clnt);
-    int rc;
-
-    if (!clnt->intrans && clnt->want_query_effects) {
-        if (!clnt->iswrite)
-            rc = send_query_effects(clnt);
-        reset_query_effects(clnt);
-    }
-    if (flush_resp) {
-        bzero(&resp, sizeof resp);
-        resp.response = FSQL_ROW_DATA;
-        resp.flags = 0;
-        resp.rcode = FSQL_DONE;
-        resp.parm = now;
-        fsql_write_response(clnt, &resp, NULL, 0, 1, func, line);
-    }
-}
-
-static void send_last_row(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                          const char *func, int line)
-{
-    if (clnt->is_newsql) {
-        newsql_send_last_row(clnt, 0, func, line);
-    } else {
-        send_last_row_old(clnt, (thd->sqlthd) ? thd->sqlthd->stime : 0, func,
-                          line);
-    }
-}
-
 static int post_sqlite_processing(struct sqlthdstate *thd,
                                   struct sqlclntstate *clnt,
                                   struct sql_state *rec, int postponed_write,
-                                  int ncols, int row_id,
-                                  CDB2SQLRESPONSE__Column **columns,
-                                  struct client_comm_if *comm)
+                                  int ncols, uint64_t row_id)
 {
     char *errstr = NULL;
     int rc;
@@ -5139,8 +3234,7 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
 
     if (clnt->client_understands_query_stats) {
         record_query_cost(thd->sqlthd, clnt);
-        if(comm->send_cost)
-            comm->send_cost(clnt);
+        WRITE_RESPONSE(RESPONSE_COST, 0);
     } else if (clnt->get_cost) {
         if (clnt->prev_cost_string) {
             free(clnt->prev_cost_string);
@@ -5158,48 +3252,35 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
           !(rc && !clnt->had_errors))) {
 
         if (clnt->iswrite && postponed_write) {
-            if (comm->send_row_data) {
-                int irc;
-                irc = comm->send_row_data(thd, clnt, rc, ncols, row_id, rc, columns);
-                if (irc)
-                    return irc;
-            }
+            int irc = send_row(clnt, NULL, row_id, rc, 0);
+            if (irc)
+                return irc;
         }
 
         if (rc == SQLITE_OK) {
-
             pthread_mutex_lock(&clnt->wait_mutex);
             clnt->ready_for_heartbeats = 0;
             pthread_mutex_unlock(&clnt->wait_mutex);
-
-            if(comm->send_done)
-                comm->send_done(thd, clnt, __func__, __LINE__);
+            WRITE_RESPONSE(RESPONSE_ROW_LAST, 0);
         } else {
-            if(comm->send_run_error) {
-                comm->send_run_error(clnt, errstr, rc);
-                if (rc)
-                    return rc;
-            }
+            send_run_error(clnt, errstr, rc);
+            if (rc)
+                return rc;
         }
     } else if ((clnt->osql.replay == OSQL_RETRY_NONE ||
                 clnt->osql.replay == OSQL_RETRY_HALT) &&
                clnt->want_query_effects &&
                (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS) &&
                !clnt->isselect) {
-        if(comm->send_effects) {
-            rc = comm->send_effects(clnt);
+            rc = WRITE_RESPONSE(RESPONSE_EFFECTS, 0);
             if (rc)
                 return rc;
-        }
     } else if (clnt->want_query_effects && !clnt->isselect &&
                clnt->send_one_row) {
         assert(clnt->is_newsql);
-        if(comm->send_dummy)
-            comm->send_dummy(clnt);
         clnt->send_one_row = 0;
         clnt->skip_feature = 1;
-        if(comm->send_done)
-            comm->send_done(thd, clnt, __func__, __LINE__);
+        WRITE_RESPONSE(RESPONSE_ROW_LAST_DUMMY, 0);
     }
 
     return 0;
@@ -5211,24 +3292,19 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
  */   
 static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                     struct sql_state *rec, int *fast_error, 
-                    struct errstat *err,
-                    struct client_comm_if *comm)
+                    struct errstat *err)
 {
-    sqlite3_stmt *stmt = rec->stmt;
-    int new_row_data_type = 0;
-    int ncols;
-    int steprc;
-    int rowcount = 0;
-    ;
-    int row_id = 0;
-    int postponed_write = 0;
     int rc;
+    int steprc;
+    uint64_t row_id = 0;
+    int rowcount = 0;
+    int postponed_write = 0;
+    sqlite3_stmt *stmt = rec->stmt;
 
     reqlog_set_event(thd->logger, "sql");
-    run_stmt_setup(clnt, rec->stmt);
+    run_stmt_setup(clnt, stmt);
 
-    new_row_data_type = is_new_row_data(clnt);
-    ncols = sqlite3_column_count(rec->stmt);
+    int ncols = sqlite3_column_count(stmt);
 
     /* Get first row to figure out column structure */
     steprc = sqlite3_step(stmt);
@@ -5250,17 +3326,8 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         return 0;
     }
 
-    /* create the row format and send it to client */
-    rc = newsql_realloc_row(ncols, &thd->sqlthd->columns,
-                            &thd->sqlthd->columns_count);
-    if (rc)
-        return -1;
-
-    set_ret_column_info(thd, clnt, rec, ncols);
-    if(comm->send_row_format) {
-        rc = comm->send_row_format(thd, clnt, rec, ncols, thd->sqlthd->columns);
-        if (rc)
-            goto out;
+    if ((rc = send_columns(clnt, stmt)) != 0) {
+        goto out;
     }
 
     if (clnt->intrans == 0) {
@@ -5274,10 +3341,6 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         goto postprocessing;
     }
 
-    thd->offsets = realloc(thd->offsets, ncols * sizeof(struct sqlfield));
-    if(!thd->offsets)
-        return -1;
-
     do {
         /* replication contention reduction */
         release_locks_on_emit_row(thd, clnt);
@@ -5288,56 +3351,19 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
             clnt->nrows++;
         }
 
-#ifdef DEBUG
-        int hasn;
-        if (!(hasn = sqlite3_hasNColumns(stmt, ncols))) {
-            printf("Does not have %d cols\n", ncols);
-            abort();
-        }
-#endif
-
-        /* create return row */
-        rc = make_retrow(thd, clnt, rec, new_row_data_type, ncols, rowcount,
-                         fast_error, err);
-        if (rc)
-            goto out;
-
-        char cnonce[256];
-        cnonce[0] = '\0';
-
-        if (gbl_extended_sql_debug_trace && clnt->sql_query) {
-            bzero(cnonce, sizeof(cnonce));
-            snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
-            logmsg(LOGMSG_USER, "%s: cnonce '%s': iswrite=%d replay=%d "
-                    "want_query_effects is %d, isselect is %d\n", 
-                    __func__, cnonce, clnt->iswrite, clnt->osql.replay, 
-                    clnt->want_query_effects, 
-                    clnt->isselect);
-        }
-
         /* return row, if needed */
         if (!clnt->iswrite && clnt->osql.replay != OSQL_RETRY_DO) {
             postponed_write = 0;
-            row_id++;
+            ++row_id;
 
             if (!clnt->want_query_effects || clnt->isselect) {
-                if(comm->send_row_data) {
-                    if (gbl_extended_sql_debug_trace) {
-                        logmsg(LOGMSG_USER, "%s: cnonce '%s' sending row\n", __func__, cnonce);
-                    }
-                    rc =
-                        comm->send_row_data(thd, clnt, new_row_data_type, ncols,
-                                            row_id, rc, thd->sqlthd->columns);
-                    if (rc)
-                        goto out;
-                }
+                rc = send_row(clnt, stmt, row_id, 0, 0);
+                if (rc)
+                    goto out;
             }
         } else {
-            if (gbl_extended_sql_debug_trace) {
-                logmsg(LOGMSG_USER, "%s: cnonce '%s' setting postponed_write\n", 
-                        __func__, cnonce);
-            }
             postponed_write = 1;
+            send_row(clnt, stmt, row_id, 0, 1);
         }
 
         rowcount++;
@@ -5346,12 +3372,6 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         if (clnt->rawnodestats)
             clnt->rawnodestats->sql_rows++;
 
-        /* flush */
-        if(comm->flush && !clnt->iswrite) {
-            rc = comm->flush(clnt);
-            if (rc)
-                goto out;
-        }
     } while ((rc = sqlite3_step(stmt)) == SQLITE_ROW);
 
 /* whatever sqlite returns in sqlite3_step is only used to step out of the loop,
@@ -5363,8 +3383,7 @@ postprocessing:
         rc = 0;
 
     /* closing: error codes, postponed write result and so on*/
-    rc = post_sqlite_processing(thd, clnt, rec, postponed_write, ncols, row_id,
-                                thd->sqlthd->columns, comm);
+    rc = post_sqlite_processing(thd, clnt, rec, postponed_write, ncols, row_id);
 
 out:
     return rc;
@@ -5436,7 +3455,10 @@ static void handle_stored_proc(struct sqlthdstate *thd,
     if (rc) {
         int irc = errstat_get_rc(&err);
         assert(irc == ERR_PREPARE || irc == ERR_PREPARE_RETRY);
-        send_prepare_error(clnt, err.errstr, (irc == ERR_PREPARE_RETRY));
+        if (irc == ERR_PREPARE)
+            WRITE_RESPONSE(RESPONSE_ERROR_PREPARE, err.errstr);
+        else if (irc == ERR_PREPARE_RETRY)
+            WRITE_RESPONSE(RESPONSE_ERROR_PREPARE_RETRY, err.errstr);
         return;
     }
 
@@ -5445,7 +3467,7 @@ static void handle_stored_proc(struct sqlthdstate *thd,
         clnt->had_errors = 1;
         if (rc == -1)
             rc = -3;
-        send_fsql_error(clnt, rc, (errstr) ? errstr : "");
+        clnt->write_response(clnt, RESPONSE_ERROR, errstr, rc);
         if (errstr) {
             free(errstr);
         }
@@ -5457,8 +3479,7 @@ static void handle_stored_proc(struct sqlthdstate *thd,
 }
 
 static int handle_sqlite_requests(struct sqlthdstate *thd,
-                                  struct sqlclntstate *clnt,
-                                  struct client_comm_if *comm)
+                                  struct sqlclntstate *clnt)
 {
     int rc;
     int fast_error;
@@ -5477,11 +3498,10 @@ static int handle_sqlite_requests(struct sqlthdstate *thd,
         if (rc) {
             int irc = errstat_get_rc(&err);
             /* certain errors are saved, in that case we don't send anything */
-            if (irc == ERR_PREPARE || irc == ERR_PREPARE_RETRY) {
-                if(comm->send_prepare_error)
-                    comm->send_prepare_error(clnt, err.errstr, 
-                                             (irc == ERR_PREPARE_RETRY));
-            }
+            if (irc == ERR_PREPARE)
+                WRITE_RESPONSE(RESPONSE_ERROR_PREPARE, err.errstr);
+            else if (irc == ERR_PREPARE_RETRY)
+                WRITE_RESPONSE(RESPONSE_ERROR_PREPARE_RETRY, err.errstr);
             goto errors;
         }
 
@@ -5491,18 +3511,16 @@ static int handle_sqlite_requests(struct sqlthdstate *thd,
         if (clnt->statement_query_effects)
             reset_query_effects(clnt);
 
-        rc = run_stmt(thd, clnt, &rec, &fast_error, &err, comm);
+        rc = run_stmt(thd, clnt, &rec, &fast_error, &err);
         if (rc) {
             int irc = errstat_get_rc(&err);
             switch(irc) {
                 case ERR_ROW_HEADER:
-                    if(comm->send_run_error)
-                        comm->send_run_error(clnt, errstat_get_str(&err), 
+                        send_run_error(clnt, errstat_get_str(&err), 
                                              CDB2ERR_CONV_FAIL);
                     break;
                 case ERR_CONVERSION_DT:
-                    if(comm->send_run_error)
-                        comm->send_run_error(clnt, errstat_get_str(&err), 
+                        send_run_error(clnt, errstat_get_str(&err), 
                                              DB_ERR_CONV_FAIL);
                     break;
             }
@@ -5530,12 +3548,11 @@ errors:
 
 static int check_sql_access(struct sqlthdstate *thd, struct sqlclntstate *clnt)
 {
-    struct fsqlresp resp;
     if (gbl_check_access_controls) {
         check_access_controls(thedb);
         gbl_check_access_controls = 0;
     }
-    int rc = check_user_password(clnt, &resp);
+    int rc = check_user_password(clnt);
     if (rc == 0) {
         if (thd->lastuser[0] != '\0' && strcmp(thd->lastuser, clnt->user) != 0)
             delete_prepared_stmts(thd);
@@ -5573,7 +3590,7 @@ int execute_sql_query(struct sqlthdstate *thd, struct sqlclntstate *clnt)
     }
 
     /* This is a request that require a sqlite engine */
-    rc = handle_sqlite_requests(thd, clnt, &client_sql_api);
+    rc = handle_sqlite_requests(thd, clnt);
 
     return rc;
 }
@@ -5834,7 +3851,7 @@ void sqlengine_work_appsock(void *thddata, void *work)
         /* Tell newsql client to CHANGENODE */
         if (clnt->is_newsql) {
             char *errstr = "Client api should change nodes";
-            client_sql_api.send_run_error(clnt, errstr, CDB2ERR_CHANGENODE);
+            send_run_error(clnt, errstr, CDB2ERR_CHANGENODE);
         }
         clnt->query_rc = -1;
         pthread_mutex_lock(&clnt->wait_mutex);
@@ -5923,11 +3940,8 @@ static void sqlengine_work_appsock_pp(struct thdpool *pool, void *work,
     }
 }
 
-int send_heartbeat(struct sqlclntstate *clnt)
+static int send_heartbeat(struct sqlclntstate *clnt)
 {
-    int rc;
-    struct fsqlresp resp;
-
     /* if client didnt ask for heartbeats, dont send them */
     if (!clnt->heartbeat)
         return 0;
@@ -5936,17 +3950,7 @@ int send_heartbeat(struct sqlclntstate *clnt)
         return 0;
     }
 
-    if (clnt->is_newsql) {
-        newsql_write_response(clnt, FSQL_HEARTBEAT, NULL, 1, malloc, __func__,
-                              __LINE__);
-    } else {
-        bzero(&resp, sizeof(resp));
-        resp.response = FSQL_HEARTBEAT;
-        resp.parm = 1;
-
-        /* send a noop packet on clnt->sb */
-        fsql_write_response(clnt, &resp, NULL, 0, 1, __func__, __LINE__);
-    }
+    WRITE_RESPONSE(RESPONSE_HEARTBEAT, 0);
 
     return 0;
 }
@@ -6118,12 +4122,6 @@ void sqlengine_thd_start(struct thdpool *pool, struct sqlthdstate *thd,
         thd->thr_self = thrman_register(type);
 
     thd->logger = thrman_get_reqlogger(thd->thr_self);
-    thd->buf = NULL;
-    thd->maxbuflen = 0;
-    thd->buflen = 0;
-    thd->ncols = 0;
-    thd->cinfo = NULL;
-    thd->offsets = NULL;
     thd->sqldb = NULL;
     thd->stmt_caching_table = NULL;
     thd->lastuser[0] = '\0';
@@ -6162,12 +4160,6 @@ void sqlengine_thd_end(struct thdpool *pool, struct sqlthdstate *thd)
         delete_stmt_caching_table(thd->stmt_caching_table);
     if (thd->sqldb)
         sqlite3_close(thd->sqldb);
-    if (thd->buf)
-        free(thd->buf);
-    if (thd->cinfo)
-        free(thd->cinfo);
-    if (thd->offsets)
-        free(thd->offsets);
 
     /* AZ moved after the close which uses thd for rollbackall */
     done_sql_thread();
@@ -6276,7 +4268,6 @@ void cleanup_clnt(struct sqlclntstate *clnt)
 void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
 {
     int wrtimeoutsec = 0;
-
     if (initial) {
         bzero(clnt, sizeof(*clnt));
     }
@@ -6316,10 +4307,6 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     /* reset the password */
     clnt->have_password = 0;
     bzero(clnt->password, sizeof(clnt->password));
-
-    /* reset endianess */
-    clnt->have_endian = 0;
-    clnt->endian = 0;
 
     /* reset extended_tm */
     clnt->have_extended_tm = 0;
@@ -6477,7 +4464,7 @@ int sbuf_is_local(SBUF2 *sb)
     return 0;
 }
 
-int fsql_writer(SBUF2 *sb, const char *buf, int nbytes)
+int sql_writer(SBUF2 *sb, const char *buf, int nbytes)
 {
     extern int gbl_sql_release_locks_on_slow_reader;
     ssize_t nwrite, written = 0;
@@ -7380,11 +5367,6 @@ static void sql_thread_describe(void *obj, FILE *out)
     }
 }
 
-const char *get_saved_errstr_from_clnt(struct sqlclntstate *clnt)
-{
-    return clnt ? clnt->saved_errstr : NULL;
-}
-
 int watcher_warning_function(void *arg, int timeout, int gap)
 {
     struct sqlclntstate *clnt = (struct sqlclntstate *)arg;
@@ -7414,358 +5396,6 @@ void sql_dump_hints(void)
         lrucache_foreach(sql_hints, dump_sql_hint_entry, &count);
     }
     pthread_mutex_unlock(&gbl_sql_lock);
-}
-
-/* Fetch a row from sqlite, and pack it into a buffer ready to send back to a
- * client.
- * My hope is that one day lua and sqlinterfaces will call this code. */
-int emit_sql_row(struct sqlthdstate *thd, struct column_info *cols,
-                 struct sqlfield *offsets, struct sqlclntstate *clnt,
-                 sqlite3_stmt *stmt, int *irc, char *errstr, int maxerrstr)
-{
-    int offset;
-    int ncols;
-    int col;
-    int fldlen;
-    int buflen;
-    int little_endian = 0;
-    uint8_t *p_buf, *p_buf_end;
-    int rc = 0;
-    int created_cols = 0;
-    int created_offsets = 0;
-
-    *irc = 0;
-
-    /* flip our data if the client asked for little endian data */
-    if (clnt->have_endian && clnt->endian == FSQL_ENDIAN_LITTLE_ENDIAN) {
-        little_endian = 1;
-    }
-
-    ncols = sqlite3_column_count(stmt);
-
-    if (offsets == NULL) {
-        offsets = malloc(ncols * sizeof(struct sqlfield));
-        created_offsets = 1;
-    }
-    if (cols == NULL) {
-        cols = malloc(ncols * sizeof(struct column_info));
-        for (col = 0; col < ncols; col++) {
-            const char *ctype = sqlite3_column_decltype(stmt, col);
-            const size_t size = sizeof(cols[col].column_name);
-            cols[col].type = typestr_to_type(ctype);
-            snprintf(cols[col].column_name, size, "%s",
-                     sqlite3_column_name(stmt, col));
-        }
-        created_cols = 1;
-    }
-
-    offset = ncols * sizeof(struct sqlfield);
-    /* compute offsets and buffer size */
-    for (col = 0, buflen = 0; col < ncols; col++) {
-        if (sqlite3_column_type(stmt, col) == SQLITE_NULL) {
-            offsets[col].offset = -1;
-            offsets[col].len = -1;
-            buflen = offset;
-            continue;
-        }
-
-        switch (cols[col].type) {
-        case SQLITE_INTEGER:
-            if (offset % sizeof(long long))
-                offset += sizeof(long long) - offset % sizeof(long long);
-            buflen = offset + sizeof(long long);
-            offsets[col].offset = offset;
-            offsets[col].len = sizeof(long long);
-            offset += sizeof(long long);
-            break;
-        case SQLITE_FLOAT:
-            if (offset % sizeof(double))
-                offset += sizeof(double) - offset % sizeof(double);
-            buflen = offset + sizeof(double);
-            offsets[col].len = sizeof(double);
-            offsets[col].offset = offset;
-            offset += sizeof(double);
-            break;
-        case SQLITE_DATETIME:
-        case SQLITE_DATETIMEUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            if (clnt->have_extended_tm && clnt->extended_tm) {
-                fldlen = CLIENT_DATETIME_EXT_LEN;
-            } else {
-                fldlen = CLIENT_DATETIME_LEN;
-            }
-            buflen = offset + fldlen;
-            offsets[col].offset = offset;
-            offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_INTERVAL_YM:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_YM_LEN;
-            buflen = offset + fldlen;
-            offsets[col].offset = offset;
-            offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_INTERVAL_DS:
-        case SQLITE_INTERVAL_DSUS:
-            if (offset & 3) { /* align on 32 bit boundary */
-                offset = (offset | 3) + 1;
-            }
-            fldlen = CLIENT_INTV_DS_LEN;
-            buflen = offset + fldlen;
-            offsets[col].offset = offset;
-            offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        case SQLITE_TEXT:
-        case SQLITE_BLOB:
-            fldlen = sqlite3_column_bytes(stmt, col);
-            if (cols[col].type == SQLITE_TEXT)
-                fldlen++;
-            buflen = offset + fldlen;
-            offsets[col].offset = offset;
-            offsets[col].len = fldlen;
-            offset += fldlen;
-            break;
-        default:
-            logmsg(LOGMSG_ERROR, "unknown type\n");
-            break;
-        }
-    }
-    /*buflen += ncols * sizeof(struct sqlfield);*/
-    if (buflen > thd->maxbuflen) {
-        char *p;
-        thd->maxbuflen = buflen;
-        p = realloc(thd->buf, thd->maxbuflen);
-        if (!p) {
-            logmsg(LOGMSG_ERROR, "%s: out of memory realloc %d\n", __func__,
-                    thd->maxbuflen);
-            buflen = -1;
-            goto done;
-        }
-        thd->buf = p;
-    }
-    p_buf = (uint8_t *)thd->buf;
-    p_buf_end = (uint8_t *)(thd->buf + buflen);
-    for (col = 0; col < ncols; ++col) {
-        if (!(p_buf = sqlfield_put(&offsets[col], p_buf, p_buf_end))) {
-            buflen = -1;
-            goto done;
-        }
-    }
-    offset = ncols * sizeof(struct sqlfield);
-
-    /* copy record to buffer */
-    for (col = 0; col < ncols; col++) {
-        double dval;
-        long long ival;
-        char *tval;
-
-        if (col > 0) {
-            reqlog_logl(thd->logger, REQL_RESULTS, ", ");
-        }
-
-        if (sqlite3_column_type(stmt, col) != SQLITE_NULL) {
-            switch (cols[col].type) {
-            case SQLITE_INTEGER:
-                if (offset % sizeof(long long))
-                    offset += sizeof(long long) - offset % sizeof(long long);
-                ival = sqlite3_column_int64(stmt, col);
-                reqlog_logf(thd->logger, REQL_RESULTS, "%lld", ival);
-                if (little_endian)
-                    ival = flibc_llflip(ival);
-                if (!buf_put(&ival, sizeof(ival),
-                             (uint8_t *)(thd->buf + offset), p_buf_end)) {
-                    buflen = -1;
-                    goto done;
-                }
-                offset += sizeof(long long);
-                break;
-            case SQLITE_FLOAT:
-                if (offset % sizeof(double))
-                    offset += sizeof(double) - offset % sizeof(double);
-                dval = sqlite3_column_double(stmt, col);
-                reqlog_logf(thd->logger, REQL_RESULTS, "%f", dval);
-                if (little_endian)
-                    dval = flibc_dblflip(dval);
-                if (!buf_put(&dval, sizeof(dval),
-                             (uint8_t *)(thd->buf + offset), p_buf_end)) {
-                    buflen = -1;
-                    goto done;
-                }
-                offset += sizeof(double);
-                break;
-            case SQLITE_TEXT:
-                fldlen = sqlite3_column_bytes(stmt, col) + 1;
-                tval = (char *)sqlite3_column_text(stmt, col);
-                reqlog_logf(thd->logger, REQL_RESULTS, "'%s'", tval);
-                /* text doesn't need to be packed */
-                if (tval)
-                    memcpy(thd->buf + offset, tval, fldlen);
-                else
-                    thd->buf[offset] = 0; /* null string */
-                offset += fldlen;
-                break;
-            case SQLITE_DATETIME:
-            case SQLITE_DATETIMEUS:
-                if (offset & 3) { /* align on 32 bit boundary */
-                    offset = (offset | 3) + 1;
-                }
-                if (clnt->have_extended_tm && clnt->extended_tm) {
-                    fldlen = CLIENT_DATETIME_EXT_LEN;
-                } else {
-                    fldlen = CLIENT_DATETIME_LEN;
-                }
-                {
-                    cdb2_client_datetime_t cdt;
-
-                    tval = (char *)sqlite3_column_datetime(stmt, col);
-                    if (!tval ||
-                        convDttz2ClientDatetime((dttz_t *)tval,
-                                                ((Vdbe *)stmt)->tzname, &cdt,
-                                                cols[col].type)) {
-                        bzero(thd->buf + offset, fldlen);
-                        logmsg(LOGMSG_ERROR, "%s: datetime conversion "
-                                "failure\n",
-                                __func__);
-                        snprintf(errstr, maxerrstr, "failed to convert sqlite "
-                                                    "to client datetime for "
-                                                    "field \"%s\"",
-                                 sqlite3_column_name(stmt, col));
-                        rc = DB_ERR_CONV_FAIL;
-                        buflen = -2;
-                        goto done;
-                    }
-
-                    if (little_endian) {
-                        cdt.tm.tm_sec = flibc_intflip(cdt.tm.tm_sec);
-                        cdt.tm.tm_min = flibc_intflip(cdt.tm.tm_min);
-                        cdt.tm.tm_hour = flibc_intflip(cdt.tm.tm_hour);
-                        cdt.tm.tm_mday = flibc_intflip(cdt.tm.tm_mday);
-                        cdt.tm.tm_mon = flibc_intflip(cdt.tm.tm_mon);
-                        cdt.tm.tm_year = flibc_intflip(cdt.tm.tm_year);
-                        cdt.tm.tm_wday = flibc_intflip(cdt.tm.tm_wday);
-                        cdt.tm.tm_yday = flibc_intflip(cdt.tm.tm_yday);
-                        cdt.tm.tm_isdst = flibc_intflip(cdt.tm.tm_isdst);
-                        cdt.msec = flibc_intflip(cdt.msec);
-                    }
-
-                    /* Old linux sql clients will have extended_tms's. */
-                    if (clnt->have_extended_tm && clnt->extended_tm) {
-                        if (!client_extended_datetime_put(
-                                &cdt, (uint8_t *)(thd->buf + offset),
-                                p_buf_end)) {
-                            buflen = -1;
-                            goto done;
-                        }
-                    } else {
-
-                        if (!client_datetime_put(&cdt,
-                                                 (uint8_t *)(thd->buf + offset),
-                                                 p_buf_end)) {
-                            buflen = -1;
-                            goto done;
-                        }
-                    }
-                }
-                offset += fldlen;
-                break;
-            case SQLITE_INTERVAL_YM:
-                if (offset & 3) { /* align on 32 bit boundary */
-                    offset = (offset | 3) + 1;
-                }
-                fldlen = CLIENT_INTV_YM_LEN;
-                {
-                    cdb2_client_intv_ym_t ym;
-                    const intv_t *tv =
-                        sqlite3_column_interval(stmt, col, SQLITE_AFF_INTV_MO);
-
-                    if (little_endian) {
-                        ym.sign = flibc_intflip(tv->sign);
-                        ym.years = flibc_intflip(tv->u.ym.years);
-                        ym.months = flibc_intflip(tv->u.ym.months);
-                    } else {
-                        ym.sign = tv->sign;
-                        ym.years = tv->u.ym.years;
-                        ym.months = tv->u.ym.months;
-                    }
-
-                    if (!client_intv_ym_put(&ym, (uint8_t *)(thd->buf + offset),
-                                            p_buf_end)) {
-                        buflen = -1;
-                        goto done;
-                    }
-                    offset += fldlen;
-                }
-                break;
-            case SQLITE_INTERVAL_DS:
-            case SQLITE_INTERVAL_DSUS:
-                if (offset & 3) { /* align on 32 bit boundary */
-                    offset = (offset | 3) + 1;
-                }
-                fldlen = CLIENT_INTV_DS_LEN;
-                {
-                    cdb2_client_intv_ds_t ds;
-                    intv_t *tv;
-                    tv = (intv_t *)sqlite3_column_interval(stmt, col,
-                                                           SQLITE_AFF_INTV_SE);
-
-                    /* Adjust fraction based on client precision. */
-                    if (cols[col].type == SQLITE_INTERVAL_DS && tv->u.ds.prec == 6)
-                        tv->u.ds.frac /= 1000;
-                    else if (cols[col].type == SQLITE_INTERVAL_DSUS && tv->u.ds.prec == 3)
-                        tv->u.ds.frac *= 1000;
-
-                    if (little_endian) {
-                        ds.sign = flibc_intflip(tv->sign);
-                        ds.days = flibc_intflip(tv->u.ds.days);
-                        ds.hours = flibc_intflip(tv->u.ds.hours);
-                        ds.mins = flibc_intflip(tv->u.ds.mins);
-                        ds.sec = flibc_intflip(tv->u.ds.sec);
-                        ds.msec = flibc_intflip(tv->u.ds.frac);
-                    } else {
-                        ds.sign = tv->sign;
-                        ds.days = tv->u.ds.days;
-                        ds.hours = tv->u.ds.hours;
-                        ds.mins = tv->u.ds.mins;
-                        ds.sec = tv->u.ds.sec;
-                        ds.msec = tv->u.ds.frac;
-                    }
-
-                    if (!client_intv_ds_put(&ds, (uint8_t *)(thd->buf + offset),
-                                            p_buf_end)) {
-                        buflen = -1;
-                        goto done;
-                    }
-                    offset += fldlen;
-                }
-                break;
-            case SQLITE_BLOB:
-                fldlen = sqlite3_column_bytes(stmt, col);
-                tval = (char *)sqlite3_column_blob(stmt, col);
-                memcpy(thd->buf + offset, tval, fldlen);
-                reqlog_logl(thd->logger, REQL_RESULTS, "x'");
-                reqlog_loghex(thd->logger, REQL_RESULTS, tval, fldlen);
-                reqlog_logl(thd->logger, REQL_RESULTS, "'");
-                offset += fldlen;
-                break;
-            }
-        } else {
-            reqlog_logl(thd->logger, REQL_RESULTS, "NULL");
-        }
-    }
-
-done:
-    if (created_cols)
-        free(cols);
-    if (created_offsets)
-        free(offsets);
-    return buflen;
 }
 
 /**
@@ -7799,7 +5429,6 @@ void run_internal_sql(char *sql)
     pthread_mutex_init(&clnt.write_lock, NULL);
     pthread_mutex_init(&clnt.dtran_mtx, NULL);
     clnt.dbtran.mode = tdef_to_tranlevel(gbl_sql_tranlevel_default);
-    // clnt.high_availability = 0;
     set_high_availability(&clnt, 0);
     clnt.sql = skipws(sql);
 
@@ -7835,7 +5464,6 @@ void start_internal_sql_clnt(struct sqlclntstate *clnt)
     pthread_mutex_init(&clnt->write_lock, NULL);
     pthread_mutex_init(&clnt->dtran_mtx, NULL);
     clnt->dbtran.mode = tdef_to_tranlevel(gbl_sql_tranlevel_default);
-    // clnt->high_availability = 0;
     set_high_availability(clnt, 0);
     clnt->is_newsql = 0;
 }
@@ -7876,11 +5504,4 @@ void end_internal_sql_clnt(struct sqlclntstate *clnt)
     pthread_cond_destroy(&clnt->wait_cond);
     pthread_mutex_destroy(&clnt->write_lock);
     pthread_mutex_destroy(&clnt->dtran_mtx);
-}
-
-static int send_dummy(struct sqlclntstate *clnt)
-{
-    if(clnt->is_newsql)
-        return newsql_send_dummy_resp(clnt, __func__, __LINE__);
-    return 0;
 }

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -46,92 +46,6 @@
 #include "comdb2uuid.h"
 #include <sqlresponse.pb-c.h>
 
-
-struct newsqlheader {
-    int type;        /*  newsql request/response type */
-    int compression; /*  Some sort of compression done? */
-    int dummy;       /*  Make it equal to fsql header. */
-    int length;      /*  length of response */
-};
-
-struct column_info {
-    int type; /* SQLITE_INTEGER   SQLITE_FLOAT   SQLITE_DOUBLE   SQLITE_BLOB
-                 (not supported yet) */
-    char column_name[32]; /* fixed column sizes */
-};
-
-enum { COLUMN_INFO_LEN = 4 + (1 * 32) };
-BB_COMPILE_TIME_ASSERT(column_info_size,
-                       sizeof(struct column_info) == COLUMN_INFO_LEN);
-
-/* higher numbers to not clash with sqlnet.c.  In fact, this should
-   merge into sqlnet at some point in the distant future */
-/* requests for fastsql */
-enum fsql_request {
-    FSQL_EXECUTE_INLINE_PARAMS = 100,
-    FSQL_EXECUTE_STOP = 101,
-    FSQL_SET_ISOLATION_LEVEL = 102,
-    FSQL_SET_TIMEOUT = 103,
-    FSQL_SET_INFO = 104,
-    FSQL_EXECUTE_INLINE_PARAMS_TZ = 105,
-    FSQL_SET_HEARTBEAT = 106,
-    FSQL_PRAGMA = 107,
-    FSQL_RESET = 108,
-    FSQL_EXECUTE_REPLACEABLE_PARAMS = 109,
-    FSQL_SET_SQL_DEBUG = 110,
-    FSQL_GRAB_DBGLOG = 111,
-    FSQL_SET_USER = 112,
-    FSQL_SET_PASSWORD = 113,
-    FSQL_SET_ENDIAN = 114,
-    FSQL_EXECUTE_REPLACEABLE_PARAMS_TZ = 115,
-    FSQL_GET_EFFECTS = 116,
-    FSQL_SET_PLANNER_EFFORT = 117,
-    FSQL_SET_REMOTE_ACCESS = 118,
-    FSQL_OSQL_MAX_TRANS = 119,
-    FSQL_SET_DATETIME_PRECISION = 120,
-    FSQL_SSLCONN = 121
-};
-
-/* responses for fastsql */
-enum fsql_response {
-    FSQL_COLUMN_DATA = 200,
-    FSQL_ROW_DATA = 201,
-    FSQL_NO_MORE_DATA = 202,
-    FSQL_ERROR = 203,
-    FSQL_QUERY_STATS = 204,
-    FSQL_HEARTBEAT = 205,
-    FSQL_SOSQL_TRAN_RESPONSE = 206,
-    FSQL_DEBUG_TRACE = 207,
-    FSQL_NEW_ROW_DATA = 208,
-    FSQL_QUERY_EFFECTS = 209
-};
-
-/* Response types for an FSQL_QUERY_STATS response.  Must correspond to values
-   in comdb2_api.c. */
-enum { FSQL_RESP_QUERY_COST = 1, FSQL_RESP_QUERY_INFO = 2 };
-
-/* Endian values for FSQL_SET_ENDIAN */
-enum { FSQL_ENDIAN_BIG_ENDIAN = 1, FSQL_ENDIAN_LITTLE_ENDIAN = 2 };
-
-union sql_dbglog_info {
-    struct {
-        int dbgtype;
-        int sqltype;
-    } type;
-
-    struct record_per_info {
-        int dbgtype;
-        int sqltype;
-
-        int nixmv;   /* index first/next/prev/last */
-        int nixfnd;  /* index finds */
-        int ndtamv;  /* dta first/next/prev/last */
-        int ndtafnd; /* dta finds */
-    } record_per_info;
-
-    unsigned char pad[128];
-};
-
 struct fsqlreq {
     int request;   /* enum fsql_request */
     int flags;     /* request flags */
@@ -141,102 +55,12 @@ struct fsqlreq {
 enum { FSQLREQ_LEN = 4 + 4 + 4 + 4 };
 BB_COMPILE_TIME_ASSERT(fsqlreq_size, sizeof(struct fsqlreq) == FSQLREQ_LEN);
 
-/* fsqslreq is needed for dbglog_support */
-uint8_t *fsqlreq_put(const struct fsqlreq *p_fsqlreq, uint8_t *p_buf,
-                     const uint8_t *p_buf_end);
-
-struct fsqlresp {
-    int response; /* enum fsql_response */
-    int flags;    /* response flags */
-    int rcode;
-    int parm;      /* extra word of info differs per request type */
-    int followlen; /* how much data follows header*/
-};
-enum { FSQLRESP_LEN = 4 + 4 + 4 + 4 + 4 };
-BB_COMPILE_TIME_ASSERT(fsqlresp_size, sizeof(struct fsqlresp) == FSQLRESP_LEN);
-
-/* fsqlresp_put is needed for dbglog_support */
-uint8_t *fsqlresp_put(const struct fsqlresp *p_fsqlresp, uint8_t *p_buf,
-                      const uint8_t *p_buf_end);
-
-/* fsqlresp_get is needed for dbglog_support */
-const uint8_t *fsqlresp_get(struct fsqlresp *p_fsqlresp, const uint8_t *p_buf,
-                            const uint8_t *p_buf_end);
-
-/* return codes */
-enum fsql_return_code {
-    FSQL_OK = 0,
-    FSQL_DONE = 1,       /* no more records to read */
-    FSQL_CONNECT = 1002, /* can't connect to db (shouldn't happen) */
-    FSQL_PREPARE = 1003, /* prepare failed */
-    FSQL_EXEC = 1004,    /* error during execute */
-};
-
-struct sqlfield {
-    int offset;
-    int len;
-};
-enum { SQLFIELD_LEN = 4 + 4 };
-BB_COMPILE_TIME_ASSERT(sqlfield_size, sizeof(struct sqlfield) == SQLFIELD_LEN);
-
-/* SQL REQUEST FLAGS */
-enum {
-    /* don't use 1-3 */
-    SQLREQ_FLAG_CLIENT_UNDERSTANDS_STATS = 4
-};
-
-struct tag_osql {
-    char *tag;
-    void *tagbuf;
-    int tagbuflen;
-    void *nullbits;
-    int numnullbits;
-    int numblobs;
-    void **blobs;
-    int *bloblens;
-};
-
-struct sqlclntstate;
-struct sql_thread;
-struct query_limits;
-
-void set_lua_mspace(void *space);
-void set_thread_mspace(void *space);
-void *get_sql_mspace();
-
 char *tranlevel_tostr(int lvl);
-
-int newsql_send_column_info(struct sqlclntstate *clnt, struct column_info *col, 
-                             int ncols, sqlite3_stmt *stmt, 
-                             CDB2SQLRESPONSE__Column **columns);
-void newsql_send_strbuf_response(struct sqlclntstate *clnt, const char *str,
-                                 int slen);
-int newsql_send_dummy_resp(struct sqlclntstate *clnt, const char *func, int line);
-int newsql_send_last_row(struct sqlclntstate *clnt, int is_begin, const char *func, int line);
-
-int newsql_write_response(struct sqlclntstate *clnt, int type,
-                          CDB2SQLRESPONSE *sql_response,
-                          int flush, void* (*alloc)(size_t size),
-                          const char *func, int line);
-
-/* requests for fastsql */
-int fsql_write_response(struct sqlclntstate *clnt, struct fsqlresp *resp,
-                        void *dta, int len, int flush, const char *func, uint32_t line);
 
 int sql_check_errors(struct sqlclntstate *clnt, sqlite3 *sqldb,
                      sqlite3_stmt *stmt, const char **errstr);
 
 void sql_dump_hist_statements(void);
-
-int handle_offloadsql_pool(char *sql, int sqllen, char *host,
-                           unsigned long long rqid, uuid_t uuid, char *tzname,
-                           int queryid, int flags, struct query_limits *limits,
-                           struct tag_osql *taginfo);
-
-int handle_offloadsql_remotesql(char *sql, int sqllen, char *host,
-                                unsigned long long rqid, uuid_t uuid,
-                                char *tzname, int queryid, int flags,
-                                SBUF2 *sb);
 
 enum {
     SQL_PRAGMA_CASE_SENSITIVE_LIKE = 1,
@@ -253,16 +77,12 @@ enum {
     SQL_PRAGMA_ERROR = 12
 };
 
+struct sql_thread;
 double query_cost(struct sql_thread *thd);
-
-const char *get_saved_errstr_from_clnt(struct sqlclntstate *);
-
 void run_internal_sql(char *sql);
 void start_internal_sql_clnt(struct sqlclntstate *clnt);
 int run_internal_sql_clnt(struct sqlclntstate *clnt, char *sql);
 void end_internal_sql_clnt(struct sqlclntstate *clnt);
-CDB2SQLRESPONSE__Column** newsql_alloc_row(int ncols);
-void newsql_dealloc_row(CDB2SQLRESPONSE__Column **columns, int ncols);
 void reset_clnt_flags(struct sqlclntstate *);
 
 #endif

--- a/db/types.h
+++ b/db/types.h
@@ -109,6 +109,13 @@ typedef struct intv {
     } u;
 } intv_t;
 
+typedef struct {
+    struct tm tm;
+    unsigned int frac;
+    unsigned int prec;
+    char tzname[CDB2_MAX_TZNAME];
+} datetime_t;
+
 /* Used for collecting blob data before a keyless add/upd/del.
  * An array of these also supplements */
 typedef struct blob_buffer {

--- a/db/views.c
+++ b/db/views.c
@@ -917,7 +917,7 @@ static int _convert_time(char *sql)
     thd = pthread_getspecific(query_info_key);
     sql_get_query_id(thd);
     client.debug_sqlclntstate = pthread_self();
-    thd->sqlclntstate = &client;
+    thd->clnt = &client;
 
     if ((rc = get_curtran(thedb->bdb_env, &client)) != 0) {
         logmsg(LOGMSG_ERROR, "%s: failed to open a new curtran, rc=%d\n", __func__, rc);
@@ -935,7 +935,7 @@ static int _convert_time(char *sql)
                msg ? msg : "<unknown error>");
         goto cleanup;
     }
-    thd->sqlclntstate = NULL;
+    thd->clnt = NULL;
 
     if ((crc = sqlite3_close(sqldb)) != 0)
         logmsg(LOGMSG_ERROR, "close rc %d\n", crc);
@@ -947,7 +947,7 @@ cleanup:
             logmsg(LOGMSG_ERROR, "%s: failed to close curtran\n", __func__);
     }
 
-    thd->sqlclntstate = NULL;
+    thd->clnt = NULL;
     done_sql_thread();
     return ret;
 }

--- a/db/views_serial.c
+++ b/db/views_serial.c
@@ -1308,10 +1308,10 @@ char *convert_epoch_to_time_string(int epoch, char *buf, int buflen)
     }
 
     isnull = outlen = 0;
-    if(!thd || !thd->sqlclntstate)
+    if(!thd || !thd->clnt)
 	    strcpy(outopts.tzname, "UTC");
     else
-	    strcpy(outopts.tzname, thd->sqlclntstate->tzname);
+	    strcpy(outopts.tzname, thd->clnt->tzname);
     outopts.flags |= FLD_CONV_TZONE;
     rc = SERVER_DATETIME_to_CLIENT_CSTR(
         &dt, sizeof(dt), NULL, NULL, buf, buflen, &isnull, &outlen,
@@ -1333,10 +1333,10 @@ int convert_time_string_to_epoch(const char *time_str)
     int isnull = 0;
     struct sql_thread *thd =pthread_getspecific(query_info_key);
 
-    if(!thd || !thd->sqlclntstate)
+    if(!thd || !thd->clnt)
 	    strcpy(convopts.tzname, "UTC");
     else
-	    strcpy(convopts.tzname, thd->sqlclntstate->tzname);
+	    strcpy(convopts.tzname, thd->clnt->tzname);
     convopts.flags = FLD_CONV_TZONE;
 
     if (CLIENT_CSTR_to_SERVER_DATETIME(time_str, strlen(time_str) + 1, 0,

--- a/lua/ltypes.h
+++ b/lua/ltypes.h
@@ -119,13 +119,6 @@ typedef struct {
 } lua_dec_t;
 
 typedef struct {
-    struct tm tm;
-    unsigned int frac;
-    unsigned int prec;
-    char tzname[CDB2_MAX_TZNAME];
-} datetime_t;
-
-typedef struct {
     DBTYPES_COMMON;
     datetime_t val;
 } lua_datetime_t;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -478,15 +478,155 @@ static void ping(Lua L)
 static void pong(Lua L)
 {
     SP sp = getsp(L);
-    struct newsqlheader hdr;
-    int num = 1;
-    if (sbuf2fread((void *)&hdr, sizeof(hdr), num, sp->clnt->sb) != num) {
-        luaL_error(L, "client disconnect");
-    }
-    if (ntohl(hdr.type) != RESPONSE_HEADER__SQL_RESPONSE_PONG) {
+    struct sqlclntstate *clnt = sp->clnt;
+    if (clnt->read_response(clnt, RESPONSE_PING_PONG, NULL, 0) != 0) {
         luaL_error(L, "client protocol error");
     }
     sp->pingpong = 0;
+}
+
+static int dbtype_to_client_type(lua_dbtypes_t *t)
+{
+    switch (t->dbtype) {
+    case DBTYPES_INTEGER: return SQLITE_INTEGER;
+    case DBTYPES_DECIMAL:
+    case DBTYPES_CSTRING: return SQLITE_TEXT;
+    case DBTYPES_REAL: return SQLITE_FLOAT;
+    case DBTYPES_DATETIME: {
+        lua_datetime_t *ldt = (lua_datetime_t *)t;
+        return (ldt->val.prec == DTTZ_PREC_MSEC) ? SQLITE_DATETIME
+                                                 : SQLITE_DATETIMEUS;
+    }
+    case DBTYPES_BLOB: return SQLITE_BLOB;
+    case DBTYPES_INTERVALYM: return SQLITE_INTERVAL_YM;
+    case DBTYPES_INTERVALDS: {
+        lua_intervalds_t *lds = (lua_intervalds_t *)t;
+        return (lds->val.u.ds.prec == DTTZ_PREC_MSEC) ? SQLITE_INTERVAL_DS
+                                                      : SQLITE_INTERVAL_DSUS;
+    }
+    default: return -1;
+    }
+}
+
+static int lua_to_client_type(Lua lua, int idx)
+{
+    if (lua_isnumber(lua, idx)) {
+        return SQLITE_FLOAT;
+    } else if (lua_isstring(lua, idx)) {
+        return SQLITE_TEXT;
+    } else if (lua_type(lua, idx) == LUA_TUSERDATA) {
+        lua_dbtypes_t *t = lua_touserdata(lua, idx);
+        return dbtype_to_client_type(t);
+    } else {
+        return -1;
+    }
+}
+
+#define col_to_idx(narg, col) lua_gettop(L) - narg + col + 1
+
+int sp_column_type(struct response_data *arg, int col, size_t typed_stmt, int type)
+{
+    SP parent = arg->sp->parent;
+    if (typed_stmt) {
+        parent->clnttype[col] = type;
+        return type;
+    }
+    if (parent->clnttype[col] > 0) {
+        return parent->clnttype[col];
+    }
+    if (type > 0) {
+        parent->clnttype[col] = type;
+        return type;
+    }
+    Lua L = arg->sp->lua;
+    int idx = col_to_idx(arg->ncols, col);
+    type = lua_to_client_type(L, idx);
+    if (type == -1) {
+        type = SQLITE_TEXT;
+    }
+    parent->clnttype[col] = type;
+    return type;
+}
+
+int sp_column_nil(struct response_data *arg, int col)
+{
+    SP sp = arg->sp;
+    Lua L = sp->lua;
+    int idx = col_to_idx(arg->ncols, col);
+    return lua_isnil(L, idx) || luabb_isnull(L, idx);
+}
+
+int sp_column_val(struct response_data *arg, int col, int type, void *out)
+{
+    SP sp = arg->sp;
+    Lua L = sp->lua;
+    int idx = col_to_idx(arg->ncols, col);
+    switch (type) {
+    case SQLITE_INTEGER: luabb_tointeger(L, idx, out); return 0;
+    case SQLITE_FLOAT: luabb_toreal(L, idx, out); return 0;
+    case SQLITE_DATETIME: /* fall through */
+    case SQLITE_DATETIMEUS: luabb_todatetime(L, idx, out); return 0;
+    case SQLITE_INTERVAL_YM: luabb_tointervalym(L, idx, out); return 0;
+    case SQLITE_INTERVAL_DS: /* fall through */
+    case SQLITE_INTERVAL_DSUS: luabb_tointervalds(L, idx, out); return 0;
+    }
+    return -1;
+}
+
+void *sp_column_ptr(struct response_data *arg, int col, int type, size_t *len)
+{
+    SP sp = arg->sp;
+    Lua L = sp->lua;
+    int idx = col_to_idx(arg->ncols, col);
+    char *c;
+    blob_t b;
+    lua_cstring_t *cs;
+    switch (type) {
+    case SQLITE_TEXT:
+        switch (luabb_type(L, idx)) {
+        case DBTYPES_LNUMBER:
+        case DBTYPES_LSTRING:
+            c = (char *)lua_tolstring(L, idx, len);
+            break;
+        case DBTYPES_CSTRING:
+            cs = lua_touserdata(L, idx);
+            c = cs->val;
+            *len = strlen(c);
+            break;
+        default:
+            c = strdup(luabb_tostring(L, idx));
+            *len = strlen(c);
+            luabb_pushcstring_dl(L, c);
+            lua_replace(L, idx);
+        }
+        return c;
+    case SQLITE_BLOB:
+        luabb_toblob(L, idx, &b);
+        if (luabb_type(L, idx) != DBTYPES_BLOB) {
+            luabb_pushblob_dl(L, &b);
+            lua_replace(L, idx);
+        }
+        *len = b.length;
+        return b.data;
+    }
+    return NULL;
+}
+
+char *sp_column_name(struct response_data *arg, int col)
+{
+    SP parent = arg->sp->parent;
+    if (parent->clntname[col] == NULL) {
+        sqlite3_stmt *stmt = arg->stmt;
+        if (stmt) {
+            parent->clntname[col] = strdup(sqlite3_column_name(stmt, col));
+        } else {
+            size_t n = snprintf(NULL, 0, "$%d", col);
+            char *name = malloc(n + 1);
+            snprintf(name, n + 1, "$%d", col);
+            parent->clntname[col] = name;
+        }
+    }
+    return parent->clntname[col];
 }
 
 static int dbq_pushargs(Lua L, dbconsumer_t *q, struct qfound *f)
@@ -791,22 +931,6 @@ static void new_col_info(SP sp, int ntypes)
     parent->ntypes = ntypes;
 }
 
-static int sqlite_type_to_client_type(int type)
-{
-    switch (type) {
-    case SQLITE_INTEGER: return CDB2_INTEGER;
-    case SQLITE_FLOAT: return CDB2_REAL;
-    case SQLITE_BLOB: return CDB2_BLOB;
-    case SQLITE_DATETIME: return CDB2_DATETIME;
-    case SQLITE_DATETIMEUS: return CDB2_DATETIMEUS;
-    case SQLITE_INTERVAL_YM: return CDB2_INTERVALYM;
-    case SQLITE_INTERVAL_DS: return CDB2_INTERVALDS;
-    case SQLITE_INTERVAL_DSUS: return CDB2_INTERVALDSUS;
-    case SQLITE_DECIMAL:
-    default: return CDB2_CSTRING;
-    }
-}
-
 /* TODO: delete it once typestr_to_type starts giving decimals. */
 static int sqlite_str_to_type(const char *ctype)
 {
@@ -853,68 +977,6 @@ static dbtypes_enum sqlite_type_to_dbtype(int sqltype)
     }
 }
 
-int dbtype_to_client_type(lua_dbtypes_t *t)
-{
-    switch (t->dbtype) {
-    case DBTYPES_INTEGER: return CDB2_INTEGER;
-    case DBTYPES_DECIMAL:
-    case DBTYPES_CSTRING: return CDB2_CSTRING;
-    case DBTYPES_REAL: return CDB2_REAL;
-    case DBTYPES_DATETIME: {
-        lua_datetime_t *ldt = (lua_datetime_t *)t;
-        return (ldt->val.prec == DTTZ_PREC_MSEC) ? CDB2_DATETIME
-                                                 : CDB2_DATETIMEUS;
-    }
-    case DBTYPES_BLOB: return CDB2_BLOB;
-    case DBTYPES_INTERVALYM: return CDB2_INTERVALYM;
-    case DBTYPES_INTERVALDS: {
-        lua_intervalds_t *lds = (lua_intervalds_t *)t;
-        return (lds->val.u.ds.prec == DTTZ_PREC_MSEC) ? CDB2_INTERVALDS
-                                                      : CDB2_INTERVALDSUS;
-    }
-    default: return -1;
-    }
-}
-
-int lua_to_client_type(Lua lua, int idx)
-{
-    if (lua_isnumber(lua, idx)) {
-        return CDB2_REAL;
-    } else if (lua_isstring(lua, idx)) {
-        return CDB2_CSTRING;
-    } else if (lua_type(lua, idx) == LUA_TUSERDATA) {
-        lua_dbtypes_t *t = lua_touserdata(lua, idx);
-        return dbtype_to_client_type(t);
-    } else {
-        return -1;
-    }
-}
-
-static void setup_cinfo_from_sqlite(SP sp, sqlite3_stmt *stmt, int nargs,
-                                    int *types)
-{
-    SP parent = sp->parent;
-    for (int col = 0; col < nargs; ++col) {
-        char *colname = (char *)sqlite3_column_name(stmt, col);
-        if (parent->clntname[col] == NULL) {
-            if (colname) {
-                parent->clntname[col] = strdup(colname);
-            }
-        }
-        int sql_type = sqlite3_column_type(stmt, col);
-        if (sql_type == SQLITE_NULL) {
-            sql_type = sqlite_str_to_type(sqlite3_column_decltype(stmt, col));
-        }
-        if (types) {
-            parent->clnttype[col] = types[col];
-        } else if (parent->clnt->req.parm) {
-            parent->clnttype[col] = parent->clnt->type_overrides[col];
-        } else if (parent->clnttype[col] == -1) {
-            parent->clnttype[col] = sqlite_type_to_client_type(sql_type);
-        }
-    }
-}
-
 static int check_param_count(struct sqlclntstate *clnt, int num)
 {
     CDB2SQLQUERY *query = clnt->sql_query;
@@ -942,102 +1004,6 @@ static int typed_stmt(struct sqlclntstate *clnt)
     if ((query && query->n_types) || clnt->req.parm) {
         return 1;
     }
-    return 0;
-}
-static int send_col_data(Lua lua, SP sp, sqlite3_stmt *stmt, int nargs)
-{
-    SP parent = sp->parent;
-    struct sqlclntstate *clnt = parent->clnt;
-    CDB2SQLQUERY *query = clnt->sql_query;
-    int *types = NULL;
-    if (query && query->n_types) types = query->types;
-
-    assert(nargs > 0);
-    if (check_param_count(clnt, nargs) != 0) {
-        luabb_error(lua, sp, "num of overrides:%d and columns:%d don't match",
-                    types ? query->n_types : clnt->req.parm, nargs);
-        return 1;
-    }
-    if (parent->ntypes != nargs) {
-        new_col_info(sp, nargs);
-    }
-    if (stmt) {
-        setup_cinfo_from_sqlite(sp, stmt, nargs, types);
-    }
-    if (parent->ntypes != nargs) {
-        return luabb_error(lua, sp, "can't send %d columns. need %d", nargs,
-                           parent->ntypes);
-    }
-    size_t infosz = sizeof(struct column_info) * nargs;
-    struct column_info *info = malloc(infosz);
-    for (int i = 0; i < nargs; ++i) {
-        if (types) {
-            parent->clnttype[i] = types[i];
-        } else if (clnt->req.parm) {
-            parent->clnttype[i] = clnt->type_overrides[i];
-        } else if (parent->clnttype[i] == -1) {
-            parent->clnttype[i] = lua_to_client_type(lua, i + 1);
-        }
-
-        if (parent->clnttype[i] == -1) {
-            // Did not find override, db:column_type, sql or lua type.
-            // Default to string; can convert anything to string
-            parent->clnttype[i] = CDB2_CSTRING;
-        }
-
-        info[i].type = htonl(parent->clnttype[i]);
-        if (parent->clntname[i] == NULL) {
-            parent->clntname[i] = malloc(16);
-            sprintf(parent->clntname[i], "$%d", i);
-        }
-        strncpy0(info[i].column_name, parent->clntname[i],
-                 sizeof(info[i].column_name));
-    }
-
-    /* write columns */
-    if (sp->clnt->is_newsql) {
-        CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-        CDB2SQLRESPONSE__Column column[nargs];
-        CDB2SQLRESPONSE__Column *column_ptr[nargs];
-        sql_response.response_type = 1;
-        sql_response.n_value = nargs;
-
-        for (int i = 0; i < nargs; i++) {
-            column_ptr[i] = &column[i];
-            cdb2__sqlresponse__column__init(&column[i]);
-            column[i].has_type = 1;
-            column[i].type = parent->clnttype[i];
-            const char *colname = NULL;
-            if (gbl_return_long_column_names) {
-                column[i].value.len = strlen(parent->clntname[i]) + 1;
-                column[i].value.data = (uint8_t *)parent->clntname[i];
-            } else {
-                column[i].value.len = 32;
-                column[i].value.data = (uint8_t *)info[i].column_name;
-            }
-        }
-        sql_response.value = column_ptr;
-        sql_response.error_code = 0;
-
-        sp->rc = newsql_write_response(sp->clnt, RESPONSE_HEADER__SQL_RESPONSE,
-                                       &sql_response, 1 /*flush*/, malloc,
-                                       __func__, __LINE__);
-    } else {
-        struct fsqlresp rsp;
-        rsp.response = FSQL_COLUMN_DATA;
-        rsp.flags = 0;
-        rsp.rcode = 0;
-        rsp.parm = nargs;
-        rsp.followlen = sizeof(info);
-        sp->rc = fsql_write_response(sp->clnt, &rsp, info, infosz, 0, __func__,
-                                     __LINE__);
-    }
-    free(info);
-    if (sp->rc) {
-        luabb_error(lua, sp, "%s: couldn't send result back", __func__);
-        return 1;
-    }
-    parent->clnt->osql.sent_column_data = 1;
     return 0;
 }
 
@@ -1258,7 +1224,6 @@ static int lua_sql_step(Lua lua, sqlite3_stmt *stmt)
         return luaL_error(lua, sqlite3_errmsg(getdb(sp)));
     }
 
-    release_locks_on_emit_row(thd, clnt);
     lua_newtable(lua);
 
     int ncols = sqlite3_column_count(stmt);
@@ -1332,8 +1297,7 @@ static int lua_sql_step(Lua lua, sqlite3_stmt *stmt)
         }
         default:
             return luaL_error(lua, "unknown field type:%d for col:%s",
-                              thd->cinfo[col].type,
-                              thd->cinfo[col].column_name);
+                              type, sqlite3_column_name(stmt, col));
         }
         lua_setfield(lua, -2, sqlite3_column_name(stmt, col));
     }
@@ -1385,27 +1349,15 @@ typedef struct client_info {
 
 static int send_sp_trace(SP sp, const char *trace, int want_response)
 {
-    CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-    if (want_response) {
-        sql_response.response_type = RESPONSE_TYPE__SP_DEBUG;
-    } else {
-        sql_response.response_type = RESPONSE_TYPE__SP_TRACE;
-    }
-    sql_response.n_value = 0;
-    sql_response.value = NULL;
-    sql_response.error_code = 0;
-    sql_response.info_string = (char *)trace;
-    sp->rc = newsql_write_response(
-        sp->clnt, RESPONSE_HEADER__SQL_RESPONSE_TRACE, &sql_response,
-        1 /*flush*/, malloc, __func__, __LINE__);
-    return sp->rc;
+    struct sqlclntstate *clnt = sp->clnt;
+    int type = want_response ? RESPONSE_DEBUG : RESPONSE_TRACE;
+    return clnt->write_response(clnt, type, (void *)trace, 0);
 }
 
 static clnt_info info_buf;
 
 static int get_remote_input(lua_State *lua, char *buffer)
 {
-    struct fsqlresp rsp;
     int rc = 0;
 
     SP sp = getsp(lua);
@@ -1413,21 +1365,19 @@ static int get_remote_input(lua_State *lua, char *buffer)
     info_buf.has_buffer = 0;
 
     char *trace = "\ncomdb2_lua> ";
-    if (sp->debug_clnt->is_newsql) {
-        sp->rc = send_sp_trace(sp, trace, 1);
-    } else {
-        rsp.response = FSQL_DEBUG_TRACE;
-        rsp.flags = 0;
-        rsp.rcode = 0;
-        rsp.parm = 0;
-        sp->rc = fsql_write_response(sp->debug_clnt, &rsp, (char *)trace,
-                                     strlen(trace) + 1, 1, __func__, __LINE__);
-    }
+    sp->rc = send_sp_trace(sp, trace, 1);
     if (sp->rc) {
         return luabb_error(lua, sp,
                            "get_remote_input: couldn't send results back");
     }
     pthread_mutex_lock(&lua_debug_mutex);
+    /*
+       AKSHAT
+       */
+    abort();
+    /*
+    clnt->read_response() ???
+
     if (!sp->debug_clnt->is_newsql) {
         if (info_buf.has_buffer == 0) {
             rc = sbuf2fread(buffer, 250, 1, sp->debug_clnt->sb);
@@ -1453,6 +1403,7 @@ static int get_remote_input(lua_State *lua, char *buffer)
         free(cmddata);
         cdb2__query__free_unpacked(query, NULL);
     }
+    */
     pthread_mutex_unlock(&lua_debug_mutex);
     return rc;
 }
@@ -1488,7 +1439,6 @@ static void InstructionCountHook(Lua, lua_Debug *);
 static int db_debug(lua_State *lua)
 {
     int nargs = lua_gettop(lua);
-    struct fsqlresp rsp;
     const char *trace;
     int rc;
 
@@ -1509,16 +1459,7 @@ static int db_debug(lua_State *lua)
 
     if (sp->debug_clnt->want_stored_procedure_debug) {
         trace = lua_tostring(lua, -1);
-        if (sp->clnt->is_newsql) {
-            rc = send_sp_trace(sp, trace, 0);
-        } else {
-            rsp.response = FSQL_DEBUG_TRACE;
-            rsp.flags = 0;
-            rsp.rcode = 0;
-            rsp.parm = 0;
-            rc = fsql_write_response(sp->debug_clnt, &rsp, (void *)trace,
-                                     strlen(trace) + 1, 1, __func__, __LINE__);
-        }
+        rc = send_sp_trace(sp, trace, 0);
         if (rc) {
             if (sp->debug_clnt != sp->clnt) {
                 /* To be given as lrl value. */
@@ -1650,7 +1591,6 @@ static int db_db_debug(Lua lua)
 static int db_trace(lua_State *lua)
 {
     int nargs = lua_gettop(lua);
-    struct fsqlresp rsp;
     const char *trace;
     int rc;
 
@@ -1664,19 +1604,7 @@ static int db_trace(lua_State *lua)
     SP sp = getsp(lua);
 
     if (sp->clnt->want_stored_procedure_trace) {
-        if (!sp->clnt->is_newsql) {
-            rsp.response = FSQL_DEBUG_TRACE;
-            rsp.flags = 0;
-            rsp.rcode = 0;
-            rsp.parm = 0;
-            rc = fsql_write_response(sp->clnt, &rsp, (char *)trace,
-                                     strlen(trace) + 1, 1, __func__, __LINE__);
-            if (rc)
-                return luabb_error(lua, sp, "%s: couldn't send results back",
-                                   __func__);
-        } else {
-            sp->rc = send_sp_trace(sp, trace, 0);
-        }
+        sp->rc = send_sp_trace(sp, trace, 0);
     }
 
     return 0;
@@ -2171,16 +2099,6 @@ static int lua_prepare_sql(Lua L, SP sp, const char *sql, sqlite3_stmt **stmt)
     return lua_prepare_sql_int(L, sp, sql, stmt, NULL);
 }
 
-static void push_sql_cols(Lua lua, sqlite3_stmt *stmt)
-{
-    int cols = sqlite3_column_count(stmt);
-    lua_checkstack(lua, cols + 10);
-    for (int i = 0; i < cols; ++i) {
-        lua_getfield(lua, -1, sqlite3_column_name(stmt, i));
-        lua_insert(lua, -2);
-    }
-}
-
 static void push_clnt_cols(Lua L, SP sp)
 {
     SP parent = sp->parent;
@@ -2207,8 +2125,6 @@ static int luatable_emit(Lua L)
     SP sp = getsp(L);
     sqlite3_stmt *stmt = get_sqlrow_stmt(L);
     if (stmt) {
-        push_sql_cols(L, stmt);
-        lua_pop(L, 1);
         cols = sqlite3_column_count(stmt);
     } else if (sp->parent->ntypes) {
         push_clnt_cols(L, sp);
@@ -2449,102 +2365,6 @@ static int dbtable_where(lua_State *lua)
     return 2;
 }
 
-#if 0
-/* Get column information from the first row (if any) and send it.
- * Sorry - I realize something very very similar already exists.
- * Needed for a quick change - hoping to re-unite duplicated code soon.
- * */
-static int send_column_info_for_result_set(SP sp, sqlite3_stmt *stmt, struct column_info *cols, int have_a_row) {
-    int rc;
-    int col;
-    int ncols;
-    struct sqlthdstate *thd;
-    SP parent;
-    struct fsqlresp resp;
-
-    parent = sp->parent;
-
-    ncols = sqlite3_column_count(stmt);
-    thd = sp->thd;
-
-    if (sp->clnt->req.parm && sp->clnt->req.parm != ncols)
-        return luabb_error(sp->lua, sp,
-          "number of type overrides doesn't match #columns in result set");
-    else if (sp->clnt->req.parm) {
-        if (sp->clnt->req.parm)
-            cols[col].type = htonl(sp->clnt->type_overrides[col]);
-    }
-    else if (rc == SQLITE_DONE) {
-        /* Don't have first row to make type decisions, fall
-         * back overrides, or to sqlite's at last resort. */
-        for (col = 0; col < ncols; col++) {
-            cols[col].type = htonl(
-              sqlite_str_to_type(sqlite3_column_decltype(stmt, col)));
-        }
-    } else {
-        for (col = 0; col < ncols; col++) {
-            int type;
-            type = sqlite3_column_type(stmt, col);
-            if (type == SQLITE_NULL)
-                type = sqlite_str_to_type(
-                  sqlite3_column_decltype(stmt, col));
-            else
-                type = sqlite_type_to_client_type(type);
-
-            cols[col].type = htonl(type);
-        }
-    }
-    for (col = 0; col < ncols; col++) {
-        strncpy(cols[col].column_name, sqlite3_column_name(stmt, col),
-          sizeof(cols[col].column_name));
-        cols[col].column_name[sizeof(cols[0].column_name)-1] = 0;
-    }
-
-    if (sp->clnt->is_newsql) {
-      for (col = 0; col < ncols; col++)
-          cols[col].type = ntohl(cols[col].type);
-      CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-      CDB2SQLRESPONSE__Column column[ncols];
-      CDB2SQLRESPONSE__Column *column_ptr[ncols];
-      sql_response.response_type = 1;
-      sql_response.n_value = ncols;
-
-      for(int i = 0; i < ncols; i++)
-      {
-         column_ptr[i] = &column[i];
-         cdb2__sqlresponse__column__init(&column[i]);
-         column[i].has_type = 1;
-         column[i].type = cols[i].type;
-         column[i].value.len = 32;
-         column[i].value.data = cols[i].column_name;
-      }
-      sql_response.value = column_ptr;
-      sql_response.error_code = 0;
-
-      sp->rc = newsql_write_response(sp->clnt, 1002, &sql_response,
-                                     1 /*flush*/, malloc, __func__, __LINE__);
-    } else {
-      resp.response = FSQL_COLUMN_DATA;
-      resp.flags = 0;
-      resp.rcode = FSQL_OK;
-      resp.parm = ncols;
-      pthread_mutex_lock(parent->emit_mutex);
-      rc = fsql_write_response(sp->clnt, &resp, cols, ncols * sizeof(struct column_info), 0, __func__, __LINE__);
-      pthread_mutex_unlock(parent->emit_mutex);
-      if (rc)
-          return luabb_error(sp->lua, sp, "error sending back column data");
-      /* flip back because code expects native values later */
-      for (col = 0; col < ncols; col++)
-          cols[col].type = ntohl(cols[col].type);
-    }
-
-
-    parent->clnt->osql.sent_column_data = 1;
-
-    return 0;
-}
-#endif
-
 static inline const char *bad_handle()
 {
     return "Wrong sql handle state";
@@ -2731,6 +2551,7 @@ static void *dispatch_lua_thread(void *lt)
         l_thread->clnt->want_stored_procedure_trace;
     clnt.dbtran.mode = l_thread->clnt->dbtran.mode;
     clnt.is_newsql = l_thread->clnt->is_newsql;
+    clnt.write_response = l_thread->clnt->write_response;
     clnt.sp = l_thread->sp;
     clnt.sql = l_thread->sql;
     clnt.must_close_sb = 0;
@@ -2740,21 +2561,11 @@ static void *dispatch_lua_thread(void *lt)
     pthread_cond_init(&clnt.wait_cond, NULL);
     pthread_mutex_init(&clnt.write_lock, NULL);
     pthread_mutex_init(&clnt.dtran_mtx, NULL);
-
     strcpy(clnt.tzname, l_thread->clnt->tzname);
-    if (l_thread->clnt->have_endian &&
-        l_thread->clnt->endian == FSQL_ENDIAN_LITTLE_ENDIAN) {
-        clnt.have_endian = 1;
-        clnt.endian = FSQL_ENDIAN_LITTLE_ENDIAN;
-    } else {
-        clnt.have_endian = 0;
-        clnt.endian = FSQL_ENDIAN_BIG_ENDIAN;
-    }
 
     dispatch_sql_query(&clnt); // --> exec_thread()
 
     cleanup_clnt(&clnt);
-
     pthread_mutex_destroy(&clnt.wait_mutex);
     pthread_cond_destroy(&clnt.wait_cond);
     pthread_mutex_destroy(&clnt.write_lock);
@@ -3339,9 +3150,7 @@ static int dbstmt_emit(Lua L)
     sqlite3_stmt *stmt = dbstmt->stmt;
     int cols = sqlite3_column_count(stmt);
     int rc;
-    while ((rc = lua_sql_step(L, stmt)) == SQLITE_ROW) {
-        push_sql_cols(L, stmt);
-        lua_pop(L, 1);
+    while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
         l_send_back_row(L, stmt, cols);
     }
     reset_stmt(sp, dbstmt);
@@ -3713,19 +3522,12 @@ static int db_emit(Lua L)
 static int db_emiterror(lua_State *lua)
 {
     SP sp = getsp(lua);
-    struct fsqlresp resp;
-
     const char *errstr = lua_tostring(lua, -1);
-
     if (errstr) {
         logmsg(LOGMSG_ERROR, "err: %s\n", errstr);
-        resp.response = FSQL_ERROR;
-        resp.flags = 0;
         if (sp->rc == 0) sp->rc = -1;
-        resp.rcode = sp->rc;
-        resp.parm = 0;
-        fsql_write_response(sp->clnt, &resp, (void *)errstr, strlen(errstr) + 1,
-                            1, __func__, __LINE__);
+        struct sqlclntstate *clnt = sp->clnt;
+        clnt->write_response(clnt, RESPONSE_ERROR, (void *)errstr, sp->rc);
     }
     return 0;
 }
@@ -3789,29 +3591,25 @@ static int db_column_type(Lua L)
     if (strcmp(name, "short") == 0 || strcmp(name, "int") == 0 ||
         strcmp(name, "integer") == 0 || strcmp(name, "longlong") == 0 ||
         strcmp(name, "u_short") == 0 || strcmp(name, "u_int") == 0) {
-        clnttype = CDB2_INTEGER;
+        clnttype = SQLITE_INTEGER;
     } else if (strcmp(name, "float") == 0 || strcmp(name, "double") == 0 ||
                strcmp(name, "number") == 0 || strcmp(name, "real") == 0) {
-        clnttype = CDB2_REAL;
+        clnttype = SQLITE_FLOAT;
     } else if (strcmp(name, "blob") == 0 || strcmp(name, "byte") == 0) {
-        clnttype = CDB2_BLOB;
-    } else if (strcmp(name, "datetimeus") == 0) {
-        clnttype = CDB2_DATETIMEUS;
-    } else if (strcmp(name, "datetime") == 0) {
-        clnttype = CDB2_DATETIME;
-    } else if (strncmp(name, "date", 4) == 0) {
-        /* The type is deprecated. */
-        clnttype = CDB2_DATETIME;
+        clnttype = SQLITE_BLOB;
+    } else if (strcmp(name, "datetime") == 0 || strcmp(name, "datetimeus") == 0 ||
+               strncmp(name, "date", 4) == 0) {
+        clnttype = SQLITE_DATETIME;
     } else if (strcmp(name, "intervaldsus") == 0) {
-        clnttype = CDB2_INTERVALDSUS;
+        clnttype = SQLITE_INTERVAL_DSUS;
     } else if (strcmp(name, "intervalds") == 0) {
-        clnttype = CDB2_INTERVALDS;
+        clnttype = SQLITE_INTERVAL_DS;
     } else if (strcmp(name, "intervalym") == 0) {
-        clnttype = CDB2_INTERVALYM;
+        clnttype = SQLITE_INTERVAL_YM;
     } else {
         /* If the type is not known lets have the type as
         ** TEXT just like sqlite. */
-        clnttype = CDB2_CSTRING;
+        clnttype = SQLITE_TEXT;
     }
     free(name);
     pthread_mutex_lock(parent->emit_mutex);
@@ -3908,24 +3706,16 @@ static int db_copyrow(Lua lua)
 static int db_print(Lua lua)
 {
     int nargs = lua_gettop(lua);
-    struct fsqlresp rsp;
-    const char *trace;
-    int rc;
 
     if (nargs > 2)
         return luabb_error(lua, NULL, "wrong number of  arguments %d", nargs);
 
     SP sp = getsp(lua);
-    trace = lua_tostring(lua, -1);
-
+    const char *trace = lua_tostring(lua, -1);
     if (trace == NULL) return 0;
 
-    rsp.response = FSQL_DEBUG_TRACE;
-    rsp.flags = 0;
-    rsp.rcode = 0;
-    rsp.parm = 0;
-    rc = fsql_write_response(sp->clnt, &rsp, (char *)trace, strlen(trace) + 1,
-                             1, __func__, __LINE__);
+    struct sqlclntstate *clnt = sp->clnt;
+    int rc  = clnt->write_response(clnt, RESPONSE_DEBUG, (void*)trace, 0);
     if (rc)
         return luabb_error(lua, sp, "%s: couldn't send results back", __func__);
 
@@ -4707,7 +4497,6 @@ static int is_array(Lua L)
     if (n < 1) return 0;
     lua_pushnumber(L, n);
     if (lua_next(L, -2)) {
-        luabb_dumpcstack(L);
         // not array: there is stuff after numeric index
         lua_pop(L, 2);
         return 0;
@@ -4883,381 +4672,44 @@ annotate:
 
 static int l_send_back_row(Lua lua, sqlite3_stmt *stmt, int nargs)
 {
-    struct fsqlresp rsp;
-    int col;
-    int rc;
-    int len = 0;
-    int offset = 0;
-    struct sqlfield fld[MAXCOLUMNS], *ffld /*flipped*/;
-    char *s;
-    char err[MAXCOLUMNS];
-    int little_endian = 0;
-    int is_type_set;
-
+    int rc = 0;
     SP sp = getsp(lua);
-    SP parent = sp->parent;
-
     assert(nargs > 0);
     if (nargs > MAXCOLUMNS) {
         return luabb_error(lua, sp, "attempt to read %d cols (maxcols:%d)",
                            nargs, MAXCOLUMNS);
     }
-
-    if (sp->thd->ncols && sp->thd->ncols != nargs) {
-        return luabb_error(
-            lua, sp,
-            "row() call has %d columns, prior call to column_names() had %d",
-            nargs, sp->thd->ncols);
-    }
-
-    /* flip our data if the client asked for little endian data */
-    if (sp->clnt->have_endian &&
-        sp->clnt->endian == FSQL_ENDIAN_LITTLE_ENDIAN) {
-        little_endian = 1;
-    }
-
-    if (!parent->clnt->osql.sent_column_data) {
-        rc = 0;
-        pthread_mutex_lock(parent->emit_mutex);
-        if (!parent->clnt->osql.sent_column_data) {
-            rc = send_col_data(lua, sp, stmt, nargs);
+    release_locks_on_emit_row(sp->thd, sp->clnt);
+    struct response_data arg = {0};
+    arg.ncols = nargs;
+    arg.stmt = stmt;
+    arg.sp = sp;
+    arg.pingpong = sp->pingpong;
+    struct sqlclntstate *clnt = sp->parent->clnt;
+    if (clnt->osql.sent_column_data == 0) {
+        pthread_mutex_lock(sp->emit_mutex);
+        if (clnt->osql.sent_column_data == 0) {
+            new_col_info(sp, nargs);
+            rc = clnt->write_response(clnt, RESPONSE_COLUMNS_LUA, &arg, 0);
+            clnt->osql.sent_column_data = 1;
         }
-        pthread_mutex_unlock(parent->emit_mutex);
+        pthread_mutex_unlock(sp->emit_mutex);
         if (rc) return rc;
     }
-
-    if (parent->ntypes != nargs)
-        return luabb_error(lua, sp, "expected %d columns, got %d",
-                           parent->ntypes, nargs);
-
-    const int stack_offset = lua_gettop(lua) - nargs;
-
-    /* compute offsets for data, check types */
-    offset = sizeof(struct sqlfield) * nargs;
-    for (col = 0; col < nargs; col++) {
-        int idx = stack_offset + col + 1; // col is 0-based
-        if (lua_isnil(lua, idx) || luabb_isnull(lua, idx)) {
-            fld[col].offset = -1;
-            fld[col].len = -1;
-            continue;
-        }
-
-        switch (parent->clnttype[col]) {
-
-        case CDB2_INTEGER:
-            if (offset % sizeof(long long))
-                offset += sizeof(long long) - (offset % sizeof(long long));
-            fld[col].offset = offset;
-            fld[col].len = sizeof(long long);
-            break;
-
-        case CDB2_CSTRING: {
-            const char *c = luabb_tostring(lua, idx);
-            fld[col].offset = offset;
-            /* Space for \0 at the end. */
-            fld[col].len = strlen(c) + 1;
-            break;
-        }
-
-        case CDB2_REAL:
-            if (offset % sizeof(double))
-                offset += sizeof(double) - (offset % sizeof(double));
-            fld[col].offset = offset;
-            fld[col].len = sizeof(double);
-            break;
-
-        case CDB2_DATETIME:
-        case CDB2_DATETIMEUS:
-            if (offset % sizeof(cdb2_client_datetime_t))
-                offset += sizeof(cdb2_client_datetime_t) -
-                          (offset % sizeof(cdb2_client_datetime_t));
-            fld[col].offset = offset;
-            fld[col].len = sizeof(cdb2_client_datetime_t);
-            break;
-
-        case CDB2_INTERVALYM:
-            if (offset % CLIENT_INTV_YM_LEN)
-                offset += CLIENT_INTV_YM_LEN - (offset % CLIENT_INTV_YM_LEN);
-            fld[col].offset = offset;
-            fld[col].len = CLIENT_INTV_YM_LEN;
-            break;
-
-        case CDB2_INTERVALDS:
-        case CDB2_INTERVALDSUS:
-            if (offset % CLIENT_INTV_DS_LEN)
-                offset += CLIENT_INTV_DS_LEN - (offset % CLIENT_INTV_DS_LEN);
-            fld[col].offset = offset;
-            fld[col].len = CLIENT_INTV_DS_LEN;
-            break;
-
-        case CDB2_BLOB: {
-            blob_t blb;
-            luabb_toblob(lua, idx, &blb);
-            fld[col].offset = offset;
-            fld[col].len = blb.length;
-            break;
-        }
-
-        default:
-            logmsg(LOGMSG_ERROR, "%s() unknown type:%d for col:%d", __func__,
-                   parent->clnttype[col], col);
-            break;
-        }
-        offset += fld[col].len;
-    }
-
-    if (sp->bufsz < offset) {
-        sp->buf = realloc(sp->buf, offset);
-        sp->bufsz = offset;
-    }
-
-    ffld = (struct sqlfield *)sp->buf;
-
-    /* loop again, write data and offsets */
-    for (col = 0; col < nargs; col++) {
-        int idx = stack_offset + col + 1; // col is 0-based
-        double dv;
-        long long lv;
-        cdb2_client_datetime_t cdt;
-
-        ffld[col].offset = htonl(fld[col].offset);
-        ffld[col].len = htonl(fld[col].len);
-
-        if (lua_isnil(lua, idx) || luabb_isnull(lua, idx)) {
-            continue;
-        }
-
-        switch (parent->clnttype[col]) {
-        case CDB2_INTEGER:
-            luabb_tointeger(lua, idx, &lv);
-            if (little_endian) lv = flibc_llflip(lv);
-            if (!buf_put(&lv, sizeof(lv),
-                         (uint8_t *)(sp->buf + fld[col].offset),
-                         sp->buf + sp->bufsz))
-                return luabb_error(lua, sp, "error adding column in buffer.");
-
-            break;
-
-        case CDB2_CSTRING: {
-            const char *v = luabb_tostring(lua, idx);
-            memcpy(sp->buf + fld[col].offset, v, fld[col].len);
-            break;
-        }
-
-        case CDB2_REAL:
-            luabb_toreal(lua, idx, &dv);
-            if (little_endian) dv = flibc_dblflip(dv);
-            if (!buf_put(&dv, sizeof(dv),
-                         (uint8_t *)(sp->buf + fld[col].offset),
-                         sp->buf + sp->bufsz))
-                return luabb_error(lua, sp, "error adding column in buffer.");
-            break;
-
-        case CDB2_DATETIMEUS:
-        case CDB2_DATETIME: {
-            /* Put this logic in function, can be used by cursor. */
-            datetime_t dtv;
-            luabb_todatetime(lua, idx, &dtv);
-
-            /* Adjust fraction as per client precision. */
-            if (parent->clnttype[col] == CDB2_DATETIME && dtv.prec == 6)
-                dtv.frac /= 1000;
-            else if (parent->clnttype[col] == CDB2_DATETIMEUS && dtv.prec == 3)
-                dtv.frac *= 1000;
-
-            if (little_endian) {
-                cdt.tm.tm_sec = flibc_intflip(dtv.tm.tm_sec);
-                cdt.tm.tm_min = flibc_intflip(dtv.tm.tm_min);
-                cdt.tm.tm_hour = flibc_intflip(dtv.tm.tm_hour);
-                cdt.tm.tm_mday = flibc_intflip(dtv.tm.tm_mday);
-                cdt.tm.tm_mon = flibc_intflip(dtv.tm.tm_mon);
-                cdt.tm.tm_year = flibc_intflip(dtv.tm.tm_year);
-                cdt.tm.tm_wday = flibc_intflip(dtv.tm.tm_wday);
-                cdt.tm.tm_yday = flibc_intflip(dtv.tm.tm_yday);
-                cdt.tm.tm_isdst = flibc_intflip(dtv.tm.tm_isdst);
-                cdt.msec = flibc_intflip(dtv.frac);
-            } else {
-                cdt.tm.tm_sec = dtv.tm.tm_sec;
-                cdt.tm.tm_min = dtv.tm.tm_min;
-                cdt.tm.tm_hour = dtv.tm.tm_hour;
-                cdt.tm.tm_mday = dtv.tm.tm_mday;
-                cdt.tm.tm_mon = dtv.tm.tm_mon;
-                cdt.tm.tm_year = dtv.tm.tm_year;
-                cdt.tm.tm_wday = dtv.tm.tm_wday;
-                cdt.tm.tm_yday = dtv.tm.tm_yday;
-                cdt.tm.tm_isdst = dtv.tm.tm_isdst;
-                cdt.msec = dtv.frac;
-            }
-            strcpy(cdt.tzname, dtv.tzname);
-            if (!client_datetime_put(&cdt,
-                                     (uint8_t *)(sp->buf + fld[col].offset),
-                                     sp->buf + sp->bufsz)) {
-                return luabb_error(lua, sp, "Invalid datetime.");
-            }
-            break;
-        }
-
-        case CDB2_BLOB: {
-            blob_t blb;
-            luabb_toblob(lua, idx, &blb);
-            memcpy(sp->buf + fld[col].offset, blb.data, fld[col].len);
-            break;
-        }
-
-        case CDB2_INTERVALYM: {
-            intv_t val;
-            luabb_tointervalym(lua, idx, &val);
-            cdb2_client_intv_ym_t ym;
-            if (little_endian) {
-                ym.sign = flibc_intflip(val.sign);
-                ym.years = flibc_intflip(val.u.ym.years);
-                ym.months = flibc_intflip(val.u.ym.months);
-            } else {
-                ym.sign = val.sign;
-                ym.years = val.u.ym.years;
-                ym.months = val.u.ym.months;
-            }
-            if (!client_intv_ym_put(&ym, (uint8_t *)(sp->buf + fld[col].offset),
-                                    sp->buf + sp->bufsz)) {
-                return luabb_error(lua, sp, "Invalid interval.");
-            }
-            break;
-        }
-
-        case CDB2_INTERVALDSUS:
-        case CDB2_INTERVALDS: {
-            intv_t val;
-            luabb_tointervalds(lua, idx, &val);
-
-            /* Adjust fraction as per client precision. */
-            if (parent->clnttype[col] == CDB2_INTERVALDS && val.u.ds.prec == 6)
-                val.u.ds.frac /= 1000;
-            else if (parent->clnttype[col] == CDB2_INTERVALDSUS &&
-                     val.u.ds.prec == 3)
-                val.u.ds.frac *= 1000;
-
-            cdb2_client_intv_ds_t ds;
-            if (little_endian) {
-                ds.sign = flibc_intflip(val.sign);
-                ds.days = flibc_intflip(val.u.ds.days);
-                ds.hours = flibc_intflip(val.u.ds.hours);
-                ds.mins = flibc_intflip(val.u.ds.mins);
-                ds.sec = flibc_intflip(val.u.ds.sec);
-                ds.msec = flibc_intflip(val.u.ds.frac);
-            } else {
-                ds.sign = val.sign;
-                ds.days = val.u.ds.days;
-                ds.hours = val.u.ds.hours;
-                ds.mins = val.u.ds.mins;
-                ds.sec = val.u.ds.sec;
-                ds.msec = val.u.ds.frac;
-            }
-            if (!client_intv_ds_put(&ds, (uint8_t *)(sp->buf + fld[col].offset),
-                                    sp->buf + sp->bufsz)) {
-                return luabb_error(lua, sp, "Invalid interval.");
-            }
-            break;
-        }
-
-        default: return luabb_error(lua, sp, "didn't expect to get here...");
-        }
-    }
-
-    if (sp->clnt->is_newsql) {
-        CDB2SQLRESPONSE sql_response = CDB2__SQLRESPONSE__INIT;
-        CDB2SQLRESPONSE__Column column[nargs];
-        CDB2SQLRESPONSE__Column *column_ptr[nargs];
-        sql_response.response_type = 2;
-        sql_response.n_value = nargs;
-
-        for (int i = 0; i < nargs; i++) {
-            column_ptr[i] = &column[i];
-            cdb2__sqlresponse__column__init(&column[i]);
-            column[i].has_type = 0;
-            if (fld[i].len == -1) {
-                column[i].has_isnull = 1;
-                column[i].isnull = 1;
-                column[i].value.len = 0;
-                column[i].value.data = NULL;
-            } else {
-                column[i].value.len = fld[i].len;
-                column[i].value.data = sp->buf + fld[i].offset;
-            }
-        }
-        sql_response.value = column_ptr;
-        sql_response.error_code = 0;
-
-        sp->rc = newsql_write_response(
-            sp->clnt, sp->pingpong ? RESPONSE_HEADER__SQL_RESPONSE_PING
-                                   : RESPONSE_HEADER__SQL_RESPONSE,
-            &sql_response, 1 /*flush*/, malloc, __func__, __LINE__);
-    } else {
-        /* write row */
-        if (sp->pingpong) {
-            luaL_error(lua, NULL, "consumer:emit() requires cdb2-api");
-        }
-        rsp.response = FSQL_ROW_DATA;
-        rsp.flags = 0;
-        rsp.rcode = FSQL_OK;
-        rsp.parm = 0;
-        rsp.followlen = offset;
-
-        pthread_mutex_lock(parent->emit_mutex);
-        sp->rc = fsql_write_response(sp->clnt, &rsp, sp->buf, offset, 0,
-                                     __func__, __LINE__);
-        pthread_mutex_unlock(parent->emit_mutex);
-    }
-
-    if (sp->rc) {
-        /* This is non recoverable error, exit lua machine from here. */
-        return luabb_error(lua, sp, "%s: couldn't send results back", __func__);
-    }
-    sp->nrows++;
-    parent->nrows++;
-
-    lua_pop(lua, nargs);
-
-    return 0;
+    int type = stmt ? RESPONSE_ROW : RESPONSE_ROW_LUA;
+    return clnt->write_response(clnt, type, &arg, 0);
 }
 
 static int flush_rows(SP sp)
 {
-    if (sp->clnt->sb == NULL) // && sp->clnt->trigger_arg)
+    if (sp->clnt->sb == NULL)
         return 0;
-    int rc;
-    struct fsqlresp rsp;
-
-    /* If we didn't send back any rows, we need to send a columns header,
-       or the client will get confused - comdb2_api expects a FSQL_COLUMN_DATA
-       response before anything else */
+    struct sqlclntstate *clnt = sp->clnt;
     if ((sp->parent && !sp->parent->clnt->osql.sent_column_data) ||
         (!sp->parent && sp->nrows == 0)) {
-        if (sp->clnt->is_newsql) {
-            newsql_send_dummy_resp(sp->clnt, __func__, __LINE__);
-        } else {
-            rsp.response = FSQL_COLUMN_DATA;
-            rsp.flags = 0;
-            rsp.rcode = 0;
-            rsp.parm = 0;
-            rsp.followlen = 0;
-            rc = fsql_write_response(sp->clnt, &rsp, NULL, 0, 0, __func__,
-                                     __LINE__);
-            if (rc) return rc;
-        }
+        return clnt->write_response(clnt, RESPONSE_ROW_LAST_DUMMY, NULL, 0);
     }
-
-    if (sp->clnt->is_newsql) {
-        rc = newsql_send_last_row(sp->clnt, 0, __func__, __LINE__);
-    } else {
-        rsp.response = FSQL_ROW_DATA;
-        rsp.flags = 0;
-        rsp.rcode = FSQL_DONE;
-        rsp.parm = 0;
-        rsp.followlen = 0;
-        rc = fsql_write_response(sp->clnt, &rsp, NULL, 0, 1 /*flush*/, __func__,
-                                 __LINE__);
-    }
-    return rc;
+    return clnt->write_response(clnt, RESPONSE_ROW_LAST, NULL, 0);
 }
 
 static int push_param(Lua lua, struct sqlclntstate *clnt, struct schema *params,
@@ -6616,10 +6068,10 @@ int db_verify_table_callback(void *v, const char *buf)
         luabb_error(L, sp, "client disconnect");
         return -2;
     }
-
     if (buf[0] == '!' || buf[0] == '?') buf++;
-    int len = strlen(buf);
-    newsql_send_strbuf_response(sp->clnt, buf, len + 1);
+    char *row[] = {(char*)buf};
+    struct sqlclntstate *clnt = sp->clnt;
+    clnt->write_response(clnt, RESPONSE_ROW_STR, row, 1);
     return 0;
 }
 

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -156,7 +156,8 @@ static int setup_dbconsumer(dbconsumer_t *q, struct consumer *consumer,
     q->iq.usedb = qdb;
     q->consumer = consumer;
     q->info = *info;
-    strcpy(q->info.spname, info->spname);
+    // memcpy because variable size struct breaks fortify checks in strcpy.
+    memcpy(q->info.spname, info->spname, spname_len + 1);
     strcpy(q->info.spname + spname_len + 1, info->spname + spname_len + 1);
     return bdb_trigger_subscribe(qdb->handle, &q->cond, &q->lock, &q->open);
 }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -6633,7 +6633,7 @@ void lua_final(sqlite3_context *context)
     lua_func_arg_t *arg = sqlite3_user_data(context);
     struct sqlthdstate *thd = arg->thd;
     char *spname = arg->name;
-    struct sqlclntstate *clnt = thd->sqlthd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->sqlthd->clnt;
     char *err = NULL;
     struct sp_state *state = sqlite3_aggregate_context(context, sizeof(*state));
     if (state->sp == NULL) {
@@ -6661,7 +6661,7 @@ void lua_step(sqlite3_context *context, int argc, sqlite3_value **argv)
     lua_func_arg_t *arg = sqlite3_user_data(context);
     struct sqlthdstate *thd = arg->thd;
     char *spname = arg->name;
-    struct sqlclntstate *clnt = thd->sqlthd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->sqlthd->clnt;
     char *err = NULL;
     struct sp_state *state = sqlite3_aggregate_context(context, sizeof(*state));
     if (state->sp == NULL) {
@@ -6694,7 +6694,7 @@ void lua_func(sqlite3_context *context, int argc, sqlite3_value **argv)
     lua_func_arg_t *arg = sqlite3_user_data(context);
     struct sqlthdstate *thd = arg->thd;
     char *spname = arg->name;
-    struct sqlclntstate *clnt = thd->sqlthd->sqlclntstate;
+    struct sqlclntstate *clnt = thd->sqlthd->clnt;
     char *err = NULL;
     struct sp_state state = {0};
     check_sp(spname, clnt, &state);
@@ -6723,7 +6723,7 @@ void *exec_trigger(trigger_reg_t *reg)
     struct sqlthdstate thd;
     sqlengine_thd_start(NULL, &thd, THRTYPE_TRIGGER);
     thrman_set_subtype(thd.thr_self, THRSUBTYPE_LUA_SQL);
-    thd.sqlthd->sqlclntstate = &clnt;
+    thd.sqlthd->clnt = &clnt;
 
     // We're making unprotected calls to lua below.
     // luaL_error() will cause abort()

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -207,15 +207,9 @@ static int db_comdb_verify(Lua L) {
         tbl = (char *) lua_tostring(L, -1);
     }
 
-    struct column_info col;
-    col.type = SQLITE_TEXT;
-    strncpy(col.column_name, "out", sizeof(col.column_name));
-
-    CDB2SQLRESPONSE__Column **columns = newsql_alloc_row(1);
-    if(!columns)
-        return luaL_error(L, "Alloc error.");
-    newsql_send_column_info(sp->clnt, &col, 1, NULL, columns);
-    newsql_dealloc_row(columns,1);
+    char *cols[] = {"out"};
+    struct sqlclntstate *clnt = sp->clnt;
+    clnt->write_response(clnt, RESPONSE_COLUMNS_STR, &cols, 1);
 
     int rc = 0;
 

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -34,19 +34,880 @@ extern int active_appsock_conns;
 extern ssl_mode gbl_client_ssl_mode;
 extern SSL_CTX *gbl_ssl_ctx;
 
-void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial);
 int disable_server_sql_timeouts(void);
 int tdef_to_tranlevel(int tdef);
 int osql_clean_sqlclntstate(struct sqlclntstate *clnt);
 int watcher_warning_function(void *arg, int timeout, int gap);
 void handle_sql_intrans_unrecoverable_error(struct sqlclntstate *clnt);
-int send_heartbeat(struct sqlclntstate *clnt);
-void send_prepare_error(struct sqlclntstate *clnt, const char *errstr,
-                        int clnt_retry);
 int fdb_access_control_create(struct sqlclntstate *clnt, char *str);
 int handle_failed_dispatch(struct sqlclntstate *clnt, char *errstr);
 int sbuf_is_local(SBUF2 *sb);
-int fsql_writer(SBUF2 *sb, const char *buf, int nbytes);
+
+struct newsqlheader {
+    int type;        /*  newsql request/response type */
+    int compression; /*  Some sort of compression done? */
+    int dummy;       /*  Make it equal to fsql header. */
+    int length;      /*  length of response */
+};
+
+struct newsql_postponed_data {
+    size_t len;
+    struct newsqlheader hdr;
+    uint8_t *row;
+};
+
+struct newsql_appdata {
+    struct newsql_postponed_data *postponed;
+    CDB2SQLQUERY *query;
+    int count;
+    int capacity;
+    int type[0];
+};
+
+static inline int verify_sqlresponse_error_code(int error_code,
+                                                const char *func, int line)
+{
+    switch (error_code) {
+    case CDB2__ERROR_CODE__OK:
+    case CDB2__ERROR_CODE__DUP_OLD:
+    case CDB2__ERROR_CODE__CONNECT_ERROR:
+    case CDB2__ERROR_CODE__NOTCONNECTED:
+    case CDB2__ERROR_CODE__PREPARE_ERROR:
+    case CDB2__ERROR_CODE__PREPARE_ERROR_OLD:
+    case CDB2__ERROR_CODE__IO_ERROR:
+    case CDB2__ERROR_CODE__INTERNAL:
+    case CDB2__ERROR_CODE__NOSTATEMENT:
+    case CDB2__ERROR_CODE__BADCOLUMN:
+    case CDB2__ERROR_CODE__BADSTATE:
+    case CDB2__ERROR_CODE__ASYNCERR:
+    case CDB2__ERROR_CODE__OK_ASYNC:
+    case CDB2__ERROR_CODE__INVALID_ID:
+    case CDB2__ERROR_CODE__RECORD_OUT_OF_RANGE:
+    case CDB2__ERROR_CODE__REJECTED:
+    case CDB2__ERROR_CODE__STOPPED:
+    case CDB2__ERROR_CODE__BADREQ:
+    case CDB2__ERROR_CODE__DBCREATE_FAILED:
+    case CDB2__ERROR_CODE__THREADPOOL_INTERNAL:
+    case CDB2__ERROR_CODE__READONLY:
+    case CDB2__ERROR_CODE__NOMASTER:
+    case CDB2__ERROR_CODE__UNTAGGED_DATABASE:
+    case CDB2__ERROR_CODE__CONSTRAINTS:
+    case CDB2__ERROR_CODE__DEADLOCK:
+    case CDB2__ERROR_CODE__TRAN_IO_ERROR:
+    case CDB2__ERROR_CODE__ACCESS:
+    case CDB2__ERROR_CODE__TRAN_MODE_UNSUPPORTED:
+    case CDB2__ERROR_CODE__MASTER_TIMEOUT:
+    case CDB2__ERROR_CODE__WRONG_DB:
+    case CDB2__ERROR_CODE__VERIFY_ERROR:
+    case CDB2__ERROR_CODE__FKEY_VIOLATION:
+    case CDB2__ERROR_CODE__NULL_CONSTRAINT:
+    case CDB2__ERROR_CODE__CONV_FAIL:
+    case CDB2__ERROR_CODE__NONKLESS:
+    case CDB2__ERROR_CODE__MALLOC:
+    case CDB2__ERROR_CODE__NOTSUPPORTED:
+    case CDB2__ERROR_CODE__TRAN_TOO_BIG:
+    case CDB2__ERROR_CODE__DUPLICATE:
+    case CDB2__ERROR_CODE__TZNAME_FAIL:
+    case CDB2__ERROR_CODE__CHANGENODE:
+    case CDB2__ERROR_CODE__NOTSERIAL:
+    case CDB2__ERROR_CODE__SCHEMACHANGE:
+    case CDB2__ERROR_CODE__UNKNOWN:
+        break;
+
+    default:
+        logmsg(LOGMSG_ERROR, "%s line %d returning non-standard "
+                             "sqlresponse.error_code %d\n",
+               func, line, error_code);
+        cheap_stack_trace();
+        break;
+    }
+    return error_code;
+}
+
+static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
+{
+    char cnonce[256];
+    int rcode = 0;
+    if (gbl_extended_sql_debug_trace && clnt->sql_query) {
+        snprintf(cnonce, 256, "%s", clnt->sql_query->cnonce.data);
+    }
+    if (clnt->sql_query && clnt->sql_query->snapshot_info &&
+        clnt->sql_query->snapshot_info->file > 0) {
+        *file = clnt->sql_query->snapshot_info->file;
+        *offset = clnt->sql_query->snapshot_info->offset;
+
+        if (gbl_extended_sql_debug_trace) {
+            logmsg(LOGMSG_USER,
+                    "%s line %d cnonce '%s' sql_query->snapinfo is [%d][%d], "
+                    "clnt->snapinfo is [%d][%d]: use client snapinfo!\n",
+                    __func__, __LINE__, cnonce,
+                    clnt->sql_query->snapshot_info->file,
+                    clnt->sql_query->snapshot_info->offset, clnt->snapshot_file,
+                    clnt->snapshot_offset);
+        }
+        return 0;
+    }
+
+    if (*file == 0 && clnt->sql_query &&
+        (clnt->in_client_trans || clnt->is_hasql_retry) &&
+        clnt->snapshot_file) {
+        if (gbl_extended_sql_debug_trace) {
+            logmsg(LOGMSG_USER,
+                    "%s line %d cnonce '%s' sql_query->snapinfo is [%d][%d], "
+                    "clnt->snapinfo is [%d][%d]\n",
+                    __func__, __LINE__, cnonce,
+                    (clnt->sql_query && clnt->sql_query->snapshot_info)
+                        ? clnt->sql_query->snapshot_info->file
+                        : -1,
+                    (clnt->sql_query && clnt->sql_query->snapshot_info)
+                        ? clnt->sql_query->snapshot_info->offset
+                        : -1,
+                    clnt->snapshot_file, clnt->snapshot_offset);
+        }
+
+        *file = clnt->snapshot_file;
+        *offset = clnt->snapshot_offset;
+        logmsg(LOGMSG_USER,
+                "%s line %d setting newsql snapinfo retry info is [%d][%d]\n",
+                __func__, __LINE__, *file, *offset);
+        return 0;
+    }
+
+    if (*file == 0 && clnt->is_newsql && clnt->sql_query &&
+        clnt->ctrl_sqlengine == SQLENG_STRT_STATE) {
+
+        if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS)) {
+            uint32_t durable_file, durable_offset, durable_gen;
+
+            int rc = request_durable_lsn_from_master(
+                thedb->bdb_env, &durable_file, &durable_offset, &durable_gen);
+
+            if (rc == 0) {
+                *file = durable_file;
+                *offset = durable_offset;
+
+                if (gbl_extended_sql_debug_trace) {
+                    logmsg(LOGMSG_USER, "%s line %d cnonce='%s' master "
+                                        "returned durable-lsn "
+                                        "[%d][%d], clnt->is_hasql_retry=%d\n",
+                           __func__, __LINE__, cnonce, *file, *offset,
+                           clnt->is_hasql_retry);
+                }
+            } else {
+                if (gbl_extended_sql_debug_trace) {
+                    logmsg(LOGMSG_USER,
+                           "%s line %d cnonce='%s' durable-lsn request "
+                           "returns %d "
+                           "clnt->snapshot_file=%d clnt->snapshot_offset=%d "
+                           "clnt->is_hasql_retry=%d\n",
+                           __func__, __LINE__, cnonce, rc, clnt->snapshot_file,
+                           clnt->snapshot_offset, clnt->is_hasql_retry);
+                }
+                rcode = -1;
+            }
+            return rcode;
+        }
+    }
+
+    if (*file == 0) {
+        bdb_tran_get_start_file_offset(thedb->bdb_env, clnt->dbtran.shadow_tran,
+                                       file, offset);
+        if (gbl_extended_sql_debug_trace) {
+            logmsg(LOGMSG_USER, "%s line %d start_file_offset snapinfo is "
+                                "[%d][%d], sqlengine-state is %d\n",
+                   __func__, __LINE__, *file, *offset, clnt->ctrl_sqlengine);
+        }
+    }
+    return rcode;
+}
+
+#define _has_effects(clnt, sql_response)                                       \
+    CDB2EFFECTS effects = CDB2__EFFECTS__INIT;                                 \
+                                                                               \
+    clnt->effects.num_affected = clnt->effects.num_updated +                   \
+                                 clnt->effects.num_deleted +                   \
+                                 clnt->effects.num_inserted;                   \
+    effects.num_affected = clnt->effects.num_affected;                         \
+    effects.num_selected = clnt->effects.num_selected;                         \
+    effects.num_updated = clnt->effects.num_updated;                           \
+    effects.num_deleted = clnt->effects.num_deleted;                           \
+    effects.num_inserted = clnt->effects.num_inserted;                         \
+                                                                               \
+    sql_response.effects = &effects;
+
+#define _has_features(clnt, sql_response)                                      \
+    CDB2ServerFeatures features[10];                                           \
+    int n_features = 0;                                                        \
+                                                                               \
+    if (clnt->skip_feature) {                                                  \
+        features[n_features] = CDB2_SERVER_FEATURES__SKIP_ROWS;                \
+        n_features++;                                                          \
+    }                                                                          \
+                                                                               \
+    if (n_features) {                                                          \
+        sql_response.n_features = n_features;                                  \
+        sql_response.features = features;                                      \
+    }
+
+#define _has_snapshot(clnt, sql_response)                                      \
+    CDB2SQLRESPONSE__Snapshotinfo snapshotinfo =                               \
+        CDB2__SQLRESPONSE__SNAPSHOTINFO__INIT;                                 \
+                                                                               \
+    if (get_high_availability(clnt)) {                                         \
+        int file = 0, offset = 0, rc;                                          \
+        if (fill_snapinfo(clnt, &file, &offset)) {                             \
+            sql_response.error_code = verify_sqlresponse_error_code(           \
+                CDB2ERR_CHANGENODE, __func__, __LINE__);                       \
+        }                                                                      \
+        if (file) {                                                            \
+            snapshotinfo.file = file;                                          \
+            snapshotinfo.offset = offset;                                      \
+            sql_response.snapshot_info = &snapshotinfo;                        \
+        }                                                                      \
+    }
+
+
+static int newsql_send_hdr(struct sqlclntstate *clnt, int h)
+{
+    struct newsqlheader hdr = {0};
+    hdr.type = ntohl(h);
+    int rc;
+    pthread_mutex_lock(&clnt->write_lock);
+    if ((rc = sbuf2write((char *)&hdr, sizeof(hdr), clnt->sb)) != sizeof(hdr))
+        goto done;
+    if ((rc = sbuf2flush(clnt->sb)) < 0)
+        goto done;
+    rc = 0;
+done:
+    pthread_mutex_unlock(&clnt->write_lock);
+    return rc;
+}
+
+#define RESPONSE_STACK_SIZE (16 * 1024)
+
+static int newsql_response_int(struct sqlclntstate *clnt,
+                               const CDB2SQLRESPONSE *r, int h, int flush)
+{
+    size_t len = cdb2__sqlresponse__get_packed_size(r);
+    uint8_t *malloc_buf = NULL, *buf;
+    if (len < RESPONSE_STACK_SIZE) {
+        buf = alloca(len);
+    } else {
+        buf = malloc_buf = malloc(len);
+    }
+    cdb2__sqlresponse__pack(r, buf);
+
+    struct newsqlheader hdr = {0};
+    hdr.type = ntohl(h);
+    hdr.length = ntohl(len);
+
+    int rc;
+    pthread_mutex_lock(&clnt->write_lock);
+    if ((rc = sbuf2write((char *)&hdr, sizeof(hdr), clnt->sb)) != sizeof(hdr))
+        goto done;
+    if ((rc = sbuf2write((char *)buf, len, clnt->sb)) != len)
+        goto done;
+    if (flush && (rc = sbuf2flush(clnt->sb)) < 0)
+        goto done;
+    rc = 0;
+done:
+    pthread_mutex_unlock(&clnt->write_lock);
+    free(malloc_buf);
+    return rc;
+}
+
+static int newsql_response(struct sqlclntstate *c, const CDB2SQLRESPONSE *r,
+                           int flush)
+{
+    return newsql_response_int(c, r, RESPONSE_HEADER__SQL_RESPONSE, flush);
+}
+
+static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col)
+{
+    int type = -1;
+    if (clnt->sql_query->n_types) {
+        type = clnt->sql_query->types[col];
+    } else if (stmt) {
+        type = sqlite3_column_type(stmt, col);
+    }
+    if (type == SQLITE_NULL) {
+        type = typestr_to_type(sqlite3_column_decltype(stmt, col));
+    }
+    if (type == SQLITE_DECIMAL) {
+        type = SQLITE_TEXT;
+    }
+    return type;
+}
+
+static struct newsql_appdata *get_newsql_appdata(struct sqlclntstate *clnt,
+                                                 int ncols)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    if (appdata == NULL) {
+        appdata = clnt->appdata =
+            calloc(1, sizeof(struct newsql_appdata) + ncols * sizeof(int));
+        appdata->capacity = ncols;
+    } else if (appdata->capacity < ncols) {
+        appdata = clnt->appdata = realloc(
+            appdata, sizeof(struct newsql_appdata) + ncols * sizeof(int));
+        appdata->capacity = ncols;
+    }
+    appdata->count = ncols;
+    return appdata;
+}
+
+static void free_newsql_appdata(struct sqlclntstate *clnt)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    if (appdata == NULL) {
+        return;
+    }
+    if (appdata->postponed) {
+        free(appdata->postponed->row);
+        free(appdata->postponed);
+        appdata->postponed = NULL;
+    }
+    free(appdata);
+    clnt->appdata = NULL;
+}
+
+static int newsql_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
+{
+    int ncols = sqlite3_column_count(stmt);
+    struct newsql_appdata *appdata = get_newsql_appdata(clnt, ncols);
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        const char *name = sqlite3_column_name(stmt, i);
+        cols[i].value.data = (uint8_t *)name;
+        cols[i].value.len = strlen(name) + 1;
+        cols[i].has_type = 1;
+        cols[i].type = appdata->type[i] = get_col_type(clnt, stmt, i);
+    }
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
+    resp.n_value = ncols;
+    resp.value = value;
+    return newsql_response(clnt, &resp, 0);
+}
+
+/*
+** Derive types from cdb2_run_statement_typed, or defined in sp, or
+** from sql statement.
+*/
+static int newsql_columns_lua(struct sqlclntstate *clnt,
+                              struct response_data *arg)
+{
+    int ncols = arg->ncols;
+    sqlite3_stmt *stmt = arg->stmt;
+    if (stmt && sqlite3_column_count(stmt) != ncols) {
+        return -1;
+    }
+    struct newsql_appdata *appdata = get_newsql_appdata(clnt, ncols);
+    size_t n_types = appdata->query ? appdata->query->n_types : 0;
+    if (n_types && n_types != ncols) {
+        return -2;
+    }
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        const char *name = sp_column_name(arg, i);
+        cols[i].value.data = (uint8_t *)name;
+        cols[i].value.len = strlen(name) + 1;
+        cols[i].has_type = 1;
+        cols[i].type = appdata->type[i] =
+            sp_column_type(arg, i, n_types, get_col_type(clnt, stmt, i));
+    }
+    clnt->osql.sent_column_data = 1;
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
+    resp.n_value = ncols;
+    resp.value = value;
+    return newsql_response(clnt, &resp, 0);
+}
+
+static int newsql_columns_str(struct sqlclntstate *clnt, char **names,
+                              int ncols)
+{
+    struct newsql_appdata *appdata = get_newsql_appdata(clnt, ncols);
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        const char *name = names[i];
+        cols[i].value.data = (uint8_t *)name;
+        cols[i].value.len = strlen(name) + 1;
+        cols[i].has_type = 1;
+        cols[i].type = appdata->type[i] = SQLITE_TEXT;
+    }
+    clnt->osql.sent_column_data = 1;
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
+    resp.n_value = ncols;
+    resp.value = value;
+    return newsql_response(clnt, &resp, 0);
+}
+
+static int newsql_debug(struct sqlclntstate *c, char *info)
+{
+    CDB2SQLRESPONSE r = CDB2__SQLRESPONSE__INIT;
+    r.response_type = RESPONSE_TYPE__SP_DEBUG;
+    r.info_string = info;
+    return newsql_response_int(c, &r, RESPONSE_HEADER__SQL_RESPONSE_TRACE, 1);
+}
+
+static int newsql_error(struct sqlclntstate *c, char *r, int e)
+{
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.error_code = verify_sqlresponse_error_code(e, __func__, __LINE__);
+    resp.error_string = r;
+    resp.response_type = c->osql.sent_column_data ? RESPONSE_TYPE__COLUMN_VALUES
+                                                  : RESPONSE_TYPE__COLUMN_NAMES;
+    return newsql_response(c, &resp, 1);
+}
+
+static int newsql_flush(struct sqlclntstate *clnt)
+{
+    pthread_mutex_lock(&clnt->write_lock);
+    int rc = sbuf2flush(clnt->sb);
+    pthread_mutex_unlock(&clnt->write_lock);
+    return rc < 0;
+}
+
+static int newsql_heartbeat(struct sqlclntstate *c)
+{
+    return newsql_send_hdr(c, 0);
+}
+
+static int newsql_save_postponed_row(struct sqlclntstate *clnt,
+                                     CDB2SQLRESPONSE *resp)
+{
+    size_t len = cdb2__sqlresponse__get_packed_size(resp);
+    struct newsql_appdata *appdata = clnt->appdata;
+    if (appdata->postponed == NULL) {
+        appdata->postponed = calloc(1, sizeof(struct newsql_postponed_data));
+        appdata->postponed->hdr.type = ntohl(RESPONSE_HEADER__SQL_RESPONSE);
+    }
+    appdata->postponed->len = len;
+    appdata->postponed->hdr.length = htonl(len);
+    appdata->postponed->row = realloc(appdata->postponed->row, len);
+    cdb2__sqlresponse__pack(resp, appdata->postponed->row);
+    return 0;
+}
+
+static int newsql_send_postponed_row(struct sqlclntstate *clnt)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    char *hdr = (char *)&appdata->postponed->hdr;
+    size_t hdrsz = sizeof(struct newsqlheader);
+    char *row = appdata->postponed->row;
+    size_t len = appdata->postponed->len;
+    int rc;
+    pthread_mutex_lock(&clnt->write_lock);
+    if ((rc = sbuf2write(hdr, hdrsz, clnt->sb)) != hdrsz)
+        goto done;
+    if ((rc = sbuf2write(row, len, clnt->sb)) != len)
+        goto done;
+    rc = 0;
+done:
+    pthread_mutex_unlock(&clnt->write_lock);
+    return rc;
+}
+
+#define newsql_null(cols, i)                                                   \
+    do {                                                                       \
+        cols[i].has_isnull = 1;                                                \
+        cols[i].isnull = 1;                                                    \
+    } while (0)
+
+#define newsql_integer(cols, i, val, flip)                                     \
+    do {                                                                       \
+        int64_t *pi64 = alloca(sizeof(int64_t));                               \
+        *pi64 = flip ? flibc_llflip(val) : val;                                \
+        cols[i].value.len = sizeof(int64_t);                                   \
+        cols[i].value.data = (uint8_t *)pi64;                                  \
+    } while (0)
+
+#define newsql_double(cols, i, val, flip)                                      \
+    do {                                                                       \
+        double *pd = alloca(sizeof(double));                                   \
+        *pd = flip ? flibc_dblflip(val) : val;                                 \
+        cols[i].value.len = sizeof(double);                                    \
+        cols[i].value.data = (uint8_t *)pd;                                    \
+    } while (0)
+
+#define newsql_ym(cols, i, val, flip)                                          \
+    do {                                                                       \
+        cdb2_client_intv_ym_t *c = alloca(sizeof(cdb2_client_intv_ym_t));      \
+        if (flip) {                                                            \
+            c->sign = val->sign;                                               \
+            c->years = val->u.ym.years;                                        \
+            c->months = val->u.ym.months;                                      \
+        } else {                                                               \
+            c->sign = flibc_intflip(val->sign);                                \
+            c->years = flibc_intflip(val->u.ym.years);                         \
+            c->months = flibc_intflip(val->u.ym.months);                       \
+        }                                                                      \
+        cols[i].value.len = sizeof(*c);                                        \
+        cols[i].value.data = (uint8_t *)c;                                     \
+    } while (0)
+
+#define newsql_ds(cols, i, val, flip)                                          \
+    do {                                                                       \
+        int frac = val->u.ds.frac;                                             \
+        if (type == SQLITE_INTERVAL_DS && val->u.ds.prec == 6) {               \
+            frac /= 1000;                                                      \
+        } else if (type == SQLITE_INTERVAL_DSUS && val->u.ds.prec == 3) {      \
+            frac *= 1000;                                                      \
+        }                                                                      \
+        cdb2_client_intv_ds_t *c = alloca(sizeof(cdb2_client_intv_ds_t));      \
+        if (flip) {                                                            \
+            c->sign = flibc_intflip(val->sign);                                \
+            c->days = flibc_intflip(val->u.ds.days);                           \
+            c->hours = flibc_intflip(val->u.ds.hours);                         \
+            c->mins = flibc_intflip(val->u.ds.mins);                           \
+            c->sec = flibc_intflip(val->u.ds.sec);                             \
+            c->msec = flibc_intflip(frac);                                     \
+        } else {                                                               \
+            c->sign = val->sign;                                               \
+            c->days = val->u.ds.days;                                          \
+            c->hours = val->u.ds.hours;                                        \
+            c->mins = val->u.ds.mins;                                          \
+            c->sec = val->u.ds.sec;                                            \
+            c->msec = frac;                                                    \
+        }                                                                      \
+        cols[i].value.len = sizeof(*c);                                        \
+        cols[i].value.data = (uint8_t *)c;                                     \
+    } while (0)
+
+#ifndef BYTE_ORDER
+#   error "Missing BYTE_ORDER"
+#endif
+
+static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
+                      int postpone)
+{
+    sqlite3_stmt *stmt = arg->stmt;
+    if (stmt == NULL) {
+        return newsql_send_postponed_row(clnt);
+    }
+    int ncols = sqlite3_column_count(stmt);
+    struct newsql_appdata *appdata = get_newsql_appdata(clnt, ncols);
+    assert(ncols == appdata->count);
+    int flip = 0;
+#   if BYTE_ORDER == BIG_ENDIAN
+    if (appdata->query->little_endian)
+#   elif BYTE_ORDER == LITTLE_ENDIAN
+    if (!appdata->query->little_endian)
+#   endif
+        flip = 1;
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        if (sqlite3_column_type(stmt, i) == SQLITE_NULL) {
+            newsql_null(cols, i);
+            continue;
+        }
+        int type = appdata->type[i];
+        switch (type) {
+        case SQLITE_INTEGER: {
+            int64_t i64 = sqlite3_column_int64(stmt, i);
+            newsql_integer(cols, i, i64, flip);
+            break;
+        }
+        case SQLITE_FLOAT: {
+            double d = sqlite3_column_double(stmt, i);
+            newsql_double(cols, i, d, flip);
+            break;
+        }
+        case SQLITE_TEXT: {
+            cols[i].value.len = sqlite3_column_bytes(stmt, i) + 1;
+            cols[i].value.data = (uint8_t *)sqlite3_column_blob(stmt, i);
+            break;
+        }
+        case SQLITE_BLOB: {
+            cols[i].value.len = sqlite3_column_bytes(stmt, i);
+            cols[i].value.data = (uint8_t *)sqlite3_column_blob(stmt, i);
+            break;
+        }
+        case SQLITE_DATETIME:
+        case SQLITE_DATETIMEUS: {
+            const dttz_t *d = sqlite3_column_datetime(stmt, i);
+            cdb2_client_datetime_t *c = alloca(sizeof(*c));
+            convDttz2ClientDatetime(d, stmt_tzname(stmt), c, type);
+            if (flip) {
+                c->msec = flibc_intflip(c->msec);
+                c->tm.tm_sec = flibc_intflip(c->tm.tm_sec);
+                c->tm.tm_min = flibc_intflip(c->tm.tm_min);
+                c->tm.tm_hour = flibc_intflip(c->tm.tm_hour);
+                c->tm.tm_mday = flibc_intflip(c->tm.tm_mday);
+                c->tm.tm_mon = flibc_intflip(c->tm.tm_mon);
+                c->tm.tm_year = flibc_intflip(c->tm.tm_year);
+                c->tm.tm_wday = flibc_intflip(c->tm.tm_wday);
+                c->tm.tm_yday = flibc_intflip(c->tm.tm_yday);
+                c->tm.tm_isdst = flibc_intflip(c->tm.tm_isdst);
+            }
+            cols[i].value.len = sizeof(*c);
+            cols[i].value.data = (uint8_t *)c;
+            break;
+        }
+        case SQLITE_INTERVAL_YM: {
+            const intv_t *val =
+                sqlite3_column_interval(stmt, i, SQLITE_AFF_INTV_MO);
+            newsql_ym(cols, i, val, flip);
+            break;
+        }
+        case SQLITE_INTERVAL_DS:
+        case SQLITE_INTERVAL_DSUS: {
+            const intv_t *val =
+                sqlite3_column_interval(stmt, i, SQLITE_AFF_INTV_SE);
+            newsql_ds(cols, i, val, flip);
+            break;
+        }
+        case SQLITE_DECIMAL:
+        default: return -1;
+        }
+    }
+    CDB2SQLRESPONSE r = CDB2__SQLRESPONSE__INIT;
+    r.response_type = RESPONSE_TYPE__COLUMN_VALUES;
+    r.n_value = ncols;
+    r.value = value;
+    if (clnt->num_retry) {
+        r.has_row_id = 1;
+        r.row_id = arg->row_id;
+    }
+    if (postpone) {
+        return newsql_save_postponed_row(clnt, &r);
+    } else if (arg->pingpong == 0) {
+        return newsql_response(clnt, &r, 0);
+    }
+    return newsql_response_int(clnt, &r, RESPONSE_HEADER__SQL_RESPONSE_PING, 1);
+}
+
+static int newsql_row_last(struct sqlclntstate *clnt)
+{
+    /*
+       AKSHAT
+       TODO
+       XXX
+       HANDLE BEGIN ARG
+    */
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__LAST_ROW;
+    _has_effects(clnt, resp);
+    _has_snapshot(clnt, resp);
+    _has_features(clnt, resp);
+    return newsql_response(clnt, &resp, 1);
+}
+
+static int newsql_row_last_dummy(struct sqlclntstate *clnt)
+{
+    int rc;
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
+    if ((rc = newsql_response(clnt, &resp, 0)) != 0) {
+        return rc;
+    }
+    return newsql_row_last(clnt);
+}
+
+static int newsql_row_lua(struct sqlclntstate *clnt, struct response_data *arg)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    int ncols = arg->ncols;
+    assert(ncols == appdata->count);
+    int flip = 0;
+#   if BYTE_ORDER == BIG_ENDIAN
+    if (appdata->query->little_endian)
+#   elif BYTE_ORDER == LITTLE_ENDIAN
+    if (!appdata->query->little_endian)
+#   endif
+        flip = 1;
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        if (sp_column_nil(arg, i)) {
+            newsql_null(cols, i);
+            continue;
+        }
+        int type = appdata->type[i];
+        switch (type) {
+        case SQLITE_INTEGER: {
+            int64_t i64;
+            sp_column_val(arg, i, type, &i64);
+            newsql_integer(cols, i, i64, flip);
+            break;
+        }
+        case SQLITE_FLOAT: {
+            double d;
+            sp_column_val(arg, i, type, &d);
+            newsql_double(cols, i, d, flip);
+            break;
+        }
+        case SQLITE_TEXT: {
+            size_t l;
+            cols[i].value.data = sp_column_ptr(arg, i, type, &l);
+            cols[i].value.len = l + 1;
+            break;
+        }
+        case SQLITE_BLOB: {
+            size_t l;
+            cols[i].value.data = sp_column_ptr(arg, i, type, &l);
+            cols[i].value.len = l;
+            break;
+        }
+        case SQLITE_DATETIME:
+        case SQLITE_DATETIMEUS: {
+            datetime_t d;
+            sp_column_val(arg, i, type, &d);
+            if (d.prec == DTTZ_PREC_MSEC && type == SQLITE_DATETIMEUS)
+                d.frac *= 1000;
+            else if (d.prec == DTTZ_PREC_USEC && type == SQLITE_DATETIME)
+                d.frac /= 1000;
+            cdb2_client_datetime_t *c = alloca(sizeof(*c));
+            strcpy(c->tzname, d.tzname);
+            if (flip) {
+                c->msec = flibc_intflip(d.frac);
+                c->tm.tm_sec = flibc_intflip(d.tm.tm_sec);
+                c->tm.tm_min = flibc_intflip(d.tm.tm_min);
+                c->tm.tm_hour = flibc_intflip(d.tm.tm_hour);
+                c->tm.tm_mday = flibc_intflip(d.tm.tm_mday);
+                c->tm.tm_mon = flibc_intflip(d.tm.tm_mon);
+                c->tm.tm_year = flibc_intflip(d.tm.tm_year);
+                c->tm.tm_wday = flibc_intflip(d.tm.tm_wday);
+                c->tm.tm_yday = flibc_intflip(d.tm.tm_yday);
+                c->tm.tm_isdst = flibc_intflip(d.tm.tm_isdst);
+            } else {
+                c->msec = d.frac;
+                c->tm.tm_sec = d.tm.tm_sec;
+                c->tm.tm_min = d.tm.tm_min;
+                c->tm.tm_hour = d.tm.tm_hour;
+                c->tm.tm_mday = d.tm.tm_mday;
+                c->tm.tm_mon = d.tm.tm_mon;
+                c->tm.tm_year = d.tm.tm_year;
+                c->tm.tm_wday = d.tm.tm_wday;
+                c->tm.tm_yday = d.tm.tm_yday;
+                c->tm.tm_isdst = d.tm.tm_isdst;
+            }
+            cols[i].value.len = sizeof(*c);
+            cols[i].value.data = (uint8_t *)c;
+            break;
+        }
+        case SQLITE_INTERVAL_YM: {
+            intv_t in, *val = &in;
+            sp_column_val(arg, i, type, val);
+            cdb2_client_intv_ym_t *c = alloca(sizeof(*c));
+            newsql_ym(cols, i, val, flip);
+            break;
+        }
+        case SQLITE_INTERVAL_DS:
+        case SQLITE_INTERVAL_DSUS: {
+            intv_t in, *val = &in;
+            sp_column_val(arg, i, type, &in);
+            newsql_ds(cols, i, val, flip);
+            break;
+        }
+        default: return -1;
+        }
+    }
+    CDB2SQLRESPONSE r = CDB2__SQLRESPONSE__INIT;
+    r.response_type = RESPONSE_TYPE__COLUMN_VALUES;
+    r.n_value = ncols;
+    r.value = value;
+    if (arg->pingpong == 0) {
+        return newsql_response(clnt, &r, 0);
+    }
+    return newsql_response_int(clnt, &r, RESPONSE_HEADER__SQL_RESPONSE_PING, 1);
+}
+
+static int newsql_row_str(struct sqlclntstate *clnt, char **data, int ncols)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    assert(ncols == appdata->count);
+    CDB2SQLRESPONSE__Column cols[ncols];
+    CDB2SQLRESPONSE__Column *value[ncols];
+    for (int i = 0; i < ncols; ++i) {
+        value[i] = &cols[i];
+        cdb2__sqlresponse__column__init(&cols[i]);
+        if (data[i] == NULL) {
+            cols[i].has_isnull = 1;
+            cols[i].isnull = 1;
+            continue;
+        }
+        cols[i].value.data = data[i];
+        cols[i].value.len = strlen(data[i]) + 1;
+    }
+    CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
+    resp.response_type = RESPONSE_TYPE__COLUMN_VALUES;
+    resp.n_value = ncols;
+    resp.value = value;
+    return newsql_response(clnt, &resp, 0);
+}
+
+static int newsql_trace(struct sqlclntstate *clnt, char *info)
+{
+    CDB2SQLRESPONSE r = CDB2__SQLRESPONSE__INIT;
+    r.response_type = RESPONSE_TYPE__SP_TRACE;
+    r.info_string = info;
+    return newsql_response_int(clnt, &r, RESPONSE_HEADER__SQL_RESPONSE_TRACE, 1);
+}
+
+static int newsql_write_response(struct sqlclntstate *c, int t, void *a, int i)
+{
+    switch (t) {
+    case RESPONSE_COLUMNS: return newsql_columns(c, a);
+    case RESPONSE_COLUMNS_LUA: return newsql_columns_lua(c, a);
+    case RESPONSE_COLUMNS_STR: return newsql_columns_str(c, a, i);
+    case RESPONSE_DEBUG: return newsql_debug(c, a);
+    case RESPONSE_ERROR: return newsql_error(c, a, i);
+    case RESPONSE_ERROR_ACCESS: return newsql_error(c, a, CDB2ERR_ACCESS);
+    case RESPONSE_ERROR_BAD_STATE: return newsql_error(c, a, CDB2ERR_BADSTATE);
+    case RESPONSE_ERROR_PREPARE: return newsql_error(c, a, CDB2ERR_PREPARE_ERROR);
+    case RESPONSE_ERROR_REJECT: return newsql_error(c, a, CDB2ERR_REJECTED);
+    case RESPONSE_FLUSH: return newsql_flush(c);
+    case RESPONSE_HEARTBEAT: return newsql_heartbeat(c);
+    case RESPONSE_ROW: return newsql_row(c, a, i);
+    case RESPONSE_ROW_LAST: return newsql_row_last(c);
+    case RESPONSE_ROW_LAST_DUMMY: return newsql_row_last_dummy(c);
+    case RESPONSE_ROW_LUA: return newsql_row_lua(c, a);
+    case RESPONSE_ROW_STR: return newsql_row_str(c, a, i);
+    case RESPONSE_TRACE: return newsql_trace(c, a);
+    /* fastsql only messages */
+    case RESPONSE_COST:
+    case RESPONSE_EFFECTS:
+    case RESPONSE_ERROR_PREPARE_RETRY: return 0;
+    default: abort();
+    }
+}
+
+static int newsql_ping_pong(struct sqlclntstate *clnt)
+{
+    struct newsqlheader hdr;
+    if (sbuf2fread((void *)&hdr, sizeof(hdr), 1, clnt->sb) != 1) {
+        return -1;
+    }
+    if (ntohl(hdr.type) != RESPONSE_HEADER__SQL_RESPONSE_PONG) {
+        return -2;
+    }
+    return 0;
+}
+
+static int newsql_read_response(struct sqlclntstate *c, int t, void *r, int e)
+{
+    switch (t) {
+    case RESPONSE_PING_PONG: return newsql_ping_pong(c);
+    default: abort();
+    }
+}
 
 /* Skip spaces and tabs, requires at least one space */
 static inline char *skipws(char *str)
@@ -76,7 +937,7 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
             err[0] = '\0';
             if (gbl_extended_sql_debug_trace) {
                 logmsg(LOGMSG_ERROR,
-                       "td %u %s line %d processing set command '%s'\n",
+                       "td %lu %s line %d processing set command '%s'\n",
                        pthread_self(), __func__, __LINE__, sqlstr);
             }
             sqlstr += 3;
@@ -86,7 +947,6 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                 sqlstr = skipws(sqlstr);
                 clnt->dbtran.mode = TRANLEVEL_INVALID;
                 set_high_availability(clnt, 0);
-                // clnt->high_availability = 0;
                 if (strncasecmp(sqlstr, "read", 4) == 0) {
                     sqlstr += 4;
                     sqlstr = skipws(sqlstr);
@@ -97,7 +957,6 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                     clnt->dbtran.mode = TRANLEVEL_SERIAL;
                     if (clnt->hasql_on == 1) {
                         set_high_availability(clnt, 1);
-                        // clnt->high_availability = 1;
                     }
                 } else if (strncasecmp(sqlstr, "blocksql", 7) == 0) {
                     clnt->dbtran.mode = TRANLEVEL_SOSQL;
@@ -107,7 +966,6 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                     clnt->verify_retries = 0;
                     if (clnt->hasql_on == 1) {
                         set_high_availability(clnt, 1);
-                        // clnt->high_availability = 1;
                         logmsg(
                             LOGMSG_ERROR,
                             "Enabling snapshot isolation high availability\n");
@@ -156,13 +1014,13 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                 if (!sqlite3IsCorrectlyQuoted(sqlstr)) {
                     snprintf(err, sizeof(err),
                              "set user: '%s' is an incorrectly quoted string",
-                             sqlstr, sizeof(clnt->user) - 1);
+                             sqlstr);
                     rc = ii + 1;
                 } else {
                     sqlite3Dequote(sqlstr);
                     if (strlen(sqlstr) >= sizeof(clnt->user)) {
                         snprintf(err, sizeof(err),
-                                 "set user: '%s' exceeds %d characters", sqlstr,
+                                 "set user: '%s' exceeds %zu characters", sqlstr,
                                  sizeof(clnt->user) - 1);
                         rc = ii + 1;
                     } else {
@@ -176,13 +1034,13 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                 if (!sqlite3IsCorrectlyQuoted(sqlstr)) {
                     snprintf(err, sizeof(err),
                              "set user: '%s' is an incorrectly quoted string",
-                             sqlstr, sizeof(clnt->user) - 1);
+                             sqlstr);
                     rc = ii + 1;
                 } else {
                     sqlite3Dequote(sqlstr);
                     if (strlen(sqlstr) >= sizeof(clnt->password)) {
                         snprintf(err, sizeof(err),
-                                 "set password: '%s' exceeds %d characters",
+                                 "set password: '%s' exceeds %zu characters",
                                  sqlstr, sizeof(clnt->password) - 1);
                         rc = ii + 1;
                     } else {
@@ -267,21 +1125,19 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                     if (clnt->dbtran.mode == TRANLEVEL_SERIAL ||
                         clnt->dbtran.mode == TRANLEVEL_SNAPISOL) {
                         set_high_availability(clnt, 1);
-                        // clnt->high_availability = 1;
                         if (gbl_extended_sql_debug_trace) {
                             logmsg(
                                 LOGMSG_USER,
-                                "td %u %s line %d setting high_availability\n",
+                                "td %lu %s line %d setting high_availability\n",
                                 pthread_self(), __func__, __LINE__);
                         }
                     }
                 } else {
                     clnt->hasql_on = 0;
                     set_high_availability(clnt, 0);
-                    // clnt->high_availability = 0;
                     if (gbl_extended_sql_debug_trace) {
                         logmsg(LOGMSG_USER,
-                               "td %u %s line %d clearing high_availability\n",
+                               "td %lu %s line %d clearing high_availability\n",
                                pthread_self(), __func__, __LINE__);
                     }
                 }
@@ -369,7 +1225,7 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                 if (err[0] == '\0')
                     snprintf(err, sizeof(err) - 1, "Invalid set command '%s'",
                              sqlstr);
-                send_prepare_error(clnt, err, 0);
+                newsql_write_response(clnt, RESPONSE_ERROR_PREPARE, err, 0);
             }
         }
     }
@@ -378,26 +1234,24 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
 
 static void send_dbinforesponse(struct dbenv *dbenv, SBUF2 *sb)
 {
-    struct newsqlheader hdr;
     CDB2DBINFORESPONSE *dbinfo_response = malloc(sizeof(CDB2DBINFORESPONSE));
     cdb2__dbinforesponse__init(dbinfo_response);
-
     fill_dbinfo(dbinfo_response, dbenv->bdb_env);
-
     int len = cdb2__dbinforesponse__get_packed_size(dbinfo_response);
-    void *buf = malloc(len);
+    uint8_t *buf, *malloc_buf = NULL;
+    if (len > RESPONSE_STACK_SIZE) {
+        buf = malloc_buf = malloc(len);
+    } else {
+        buf = alloca(len);
+    }
     cdb2__dbinforesponse__pack(dbinfo_response, buf);
-
-    hdr.type = ntohl(RESPONSE_HEADER__DBINFO_RESPONSE);
-    hdr.compression = 0;
-    hdr.dummy = 0;
-    hdr.length = ntohl(len);
-
+    struct newsqlheader hdr = {0};
+    hdr.type = htonl(RESPONSE_HEADER__DBINFO_RESPONSE);
+    hdr.length = htonl(len);
     sbuf2write((char *)&hdr, sizeof(hdr), sb);
-
-    sbuf2write(buf, len, sb);
+    sbuf2write((char *)buf, len, sb);
     sbuf2flush(sb);
-    free(buf);
+    free(malloc_buf);
     cdb2__dbinforesponse__free_unpacked(dbinfo_response, &pb_alloc);
 }
 
@@ -460,7 +1314,7 @@ retry_read:
     hdr.compression = ntohl(hdr.compression);
     hdr.length = ntohl(hdr.length);
 
-    if (hdr.type == FSQL_SSLCONN) {
+    if (hdr.type == CDB2_REQUEST_TYPE__SSLCONN) {
 #if WITH_SSL
         /* If client requires SSL and we haven't done that,
            do SSL_accept() now. handle_newsql_request()
@@ -491,13 +1345,8 @@ retry_read:
         }
 
         if (sslio_verify(sb, gbl_client_ssl_mode, NULL, 0) != 0) {
-            char *err = "Client certificate authentication failed.";
-            struct fsqlresp resp;
-            bzero(&resp, sizeof(resp));
-            resp.response = FSQL_ERROR;
-            resp.rcode = CDB2ERR_CONNECT_ERROR;
-            rc = fsql_write_response(clnt, &resp, err, strlen(err) + 1, 1,
-                                     __func__, __LINE__);
+            newsql_error(clnt, "Client certificate authentication failed.",
+                       CDB2ERR_CONNECT_ERROR);
             logmsg(LOGMSG_DEBUG, "sslio_verify returned non zero rc\n");
             return NULL;
         }
@@ -509,7 +1358,7 @@ retry_read:
         }
 #endif
         goto retry_read;
-    } else if (hdr.type == FSQL_RESET) { /* Reset from sockpool.*/
+    } else if (hdr.type == CDB2_REQUEST_TYPE__RESET) { /* Reset from sockpool.*/
 
         if (clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
             /* Discard the pending transaction when receiving RESET from the
@@ -559,7 +1408,7 @@ retry_read:
                 pre_enabled = 1;
                 clnt->ready_for_heartbeats = 1;
             }
-            send_heartbeat(clnt);
+            newsql_heartbeat(clnt);
             fdb_heartbeats(clnt);
             pthread_mutex_unlock(&clnt->wait_mutex);
         }
@@ -586,7 +1435,7 @@ retry_read:
     CDB2QUERY *query;
     assert(errno == 0); // precondition for the while loop
     while (1) {
-        query = cdb2__query__unpack(&pb_alloc, bytes, p);
+        query = cdb2__query__unpack(&pb_alloc, bytes, (uint8_t *)p);
         // errno can be set by cdb2__query__unpack
         // we retry malloc on out of memory condition
 
@@ -600,7 +1449,7 @@ retry_read:
             pre_enabled = 1;
             clnt->ready_for_heartbeats = 1;
         }
-        send_heartbeat(clnt);
+        newsql_heartbeat(clnt);
         fdb_heartbeats(clnt);
         pthread_mutex_unlock(&clnt->wait_mutex);
     }
@@ -648,10 +1497,7 @@ retry_read:
                 sql_response.error_string = "Get effects not supported in "
                                             "transaction with verifyretry on";
             }
-
-            newsql_write_response(clnt, RESPONSE_HEADER__SQL_EFFECTS,
-                                  &sql_response, 1 /*flush*/, malloc, __func__,
-                                  __LINE__);
+            newsql_response_int(clnt, &sql_response, RESPONSE_HEADER__SQL_EFFECTS, 1);
         } else {
             send_dbinforesponse(dbenv, sb);
         }
@@ -681,19 +1527,12 @@ retry_read:
         }
 
         if (client_supports_ssl) {
-            newsql_write_response(clnt, RESPONSE_HEADER__SQL_RESPONSE_SSL, NULL,
-                                  1, malloc, __func__, __LINE__);
-            /* Client is going to reuse the connection. Don't drop it. */
+            newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_SSL);
             cdb2__query__free_unpacked(query, &pb_alloc);
             goto retry_read;
         } else {
-            char *err = "The database requires SSL connections.";
-            struct fsqlresp resp;
-            bzero(&resp, sizeof(resp));
-            resp.response = FSQL_ERROR;
-            resp.rcode = CDB2ERR_CONNECT_ERROR;
-            rc = fsql_write_response(clnt, &resp, err, strlen(err) + 1, 1,
-                                     __func__, __LINE__);
+            newsql_error(clnt, "The database requires SSL connections.",
+                       CDB2ERR_CONNECT_ERROR);
         }
         cdb2__query__free_unpacked(query, &pb_alloc);
         logmsg(LOGMSG_DEBUG, "SSL is required by db, client doesnt support\n");
@@ -762,6 +1601,8 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     thrman_change_type(thr_self, THRTYPE_APPSOCK_SQL);
 
     reset_clnt(&clnt, sb, 1);
+    clnt.write_response = newsql_write_response;
+    clnt.read_response = newsql_read_response;
     clnt.tzname[0] = '\0';
     clnt.is_newsql = 1;
 
@@ -775,13 +1616,8 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         logmsg(LOGMSG_WARN,
                "%s: Exhausted appsock connections, total %d connections \n",
                __func__, active_appsock_conns);
-        char *err = "Exhausted appsock connections.";
-        struct fsqlresp resp;
-        bzero(&resp, sizeof(resp));
-        resp.response = FSQL_ERROR;
-        resp.rcode = SQLHERR_APPSOCK_LIMIT;
-        rc = fsql_write_response(&clnt, &resp, err, strlen(err) + 1, 1,
-                                 __func__, __LINE__);
+        newsql_error(&clnt, "Exhausted appsock connections.",
+                   CDB2__ERROR_CODE__APPSOCK_LIMIT);
         goto done;
     }
 
@@ -799,6 +1635,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         goto done;
     }
     assert(query->sqlquery);
+    struct newsql_appdata *appdata = get_newsql_appdata(&clnt, 32);
 
     CDB2SQLQUERY *sql_query = query->sqlquery;
     clnt.query = query;
@@ -809,7 +1646,6 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     clnt.osql.count_changes = 1;
     clnt.dbtran.mode = tdef_to_tranlevel(gbl_sql_tranlevel_default);
     set_high_availability(&clnt, 0);
-    // clnt.high_availability = 0;
 
     int notimeout = disable_server_sql_timeouts();
     sbuf2settimeout(
@@ -817,7 +1653,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         notimeout ? 0 : gbl_sqlwrtimeoutms);
 
     sbuf2flush(sb);
-    net_set_writefn(sb, fsql_writer);
+    net_set_writefn(sb, sql_writer);
 
     int wrtimeoutsec;
     if (gbl_sqlwrtimeoutms == 0 || notimeout)
@@ -833,14 +1669,13 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
      * sqlthd will be NULL */
     struct sql_thread *sqlthd = pthread_getspecific(query_info_key);
     if (sqlthd) {
-        bzero(&sqlthd->sqlclntstate->conn, sizeof(struct conninfo));
-        sqlthd->sqlclntstate->origin[0] = 0;
+        bzero(&sqlthd->clnt->conn, sizeof(struct conninfo));
+        sqlthd->clnt->origin[0] = 0;
     }
 
     while (query) {
         assert(query->sqlquery);
-        sql_query = query->sqlquery;
-        clnt.sql_query = sql_query;
+        appdata->query = clnt.sql_query = sql_query = query->sqlquery;
         clnt.sql = sql_query->sql_query;
         clnt.query = query;
         clnt.added_to_hist = 0;
@@ -868,14 +1703,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                      "DB name mismatch query:%s actual:%s", sql_query->dbname,
                      dbenv->envname);
             logmsg(LOGMSG_ERROR, "%s\n", errstr);
-            struct fsqlresp resp;
-
-            resp.response = FSQL_COLUMN_DATA;
-            resp.flags = 0;
-            resp.rcode = CDB2__ERROR_CODE__WRONG_DB;
-            fsql_write_response(&clnt, &resp, (void *)errstr,
-                                strlen(errstr) + 1, 1 /*flush*/, __func__,
-                                __LINE__);
+            newsql_error(&clnt, errstr, CDB2__ERROR_CODE__WRONG_DB);
             goto done;
         }
 
@@ -921,13 +1749,6 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (gbl_rowlocks && clnt.dbtran.mode != TRANLEVEL_SERIAL)
             clnt.dbtran.mode = TRANLEVEL_SNAPISOL;
 
-        if (sql_query->little_endian) {
-            clnt.have_endian = 1;
-            clnt.endian = FSQL_ENDIAN_LITTLE_ENDIAN;
-        } else {
-            clnt.have_endian = 0;
-        }
-
         /* avoid new accepting new queries/transaction on opened connections
            if we are incoherent (and not in a transaction). */
         if (clnt.ignore_coherency == 0 && !bdb_am_i_coherent(thedb->bdb_env) &&
@@ -951,7 +1772,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                 rc = dispatch_sql_query(&clnt);
             } else {
                 /* Do Nothing */
-                send_heartbeat(&clnt);
+                newsql_heartbeat(&clnt);
             }
         } else if (clnt.had_errors) {
             /* Do Nothing */
@@ -1037,9 +1858,10 @@ done:
         }
     }
 
+    free_newsql_appdata(&clnt);
+
     /* XXX free logical tran?  */
     close_appsock(sb);
-
     cleanup_clnt(&clnt);
 
     pthread_mutex_destroy(&clnt.wait_mutex);

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -55,6 +55,7 @@ enum CDB2_ErrorCode {
 
     TRAN_MODE_UNSUPPORTED   = -107;
     MASTER_TIMEOUT          = -109;
+    APPSOCK_LIMIT           = -110;
     WRONG_DB                = -111;
 
     VERIFY_ERROR            = 2;

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -61,7 +61,7 @@ static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
     if (bdb_table_version_select(newtable, tran, &db->tableversion, &bdberr)) {
         logmsg(LOGMSG_ERROR,
                "%s: failed to retrieve table version for new %s \n", __func__,
-               name, newtable);
+               newtable);
         return -1;
     }
 
@@ -72,7 +72,7 @@ static int reload_rename_table(bdb_state_type *bdb_state, const char *name,
     bdb_set_tran_lockerid(tran, lid);
     rc = bdb_tran_abort(thedb->bdb_env, tran, &bdberr);
     if (rc)
-        logmsg(LOGMSG_FATAL, "%s failed to abort transaction\n", __func__, rc);
+        logmsg(LOGMSG_FATAL, "%s failed to abort transaction rc:%d\n", __func__, rc);
 
     sc_set_running((char *)name, 0 /*running*/, 0 /*seed*/, NULL, 0);
 

--- a/sqlite/dttz.c
+++ b/sqlite/dttz.c
@@ -126,7 +126,7 @@ int convMem2ClientDatetime(Mem *pMem, void *out) {
         _convMem2ClientDatetime(pMem, out, sizeof(cdb2_client_datetime_t), &outdtsz, 0);
 }
 
-int convDttz2ClientDatetime(dttz_t *dttz, const char *tzname, void *out, int sqltype) {
+int convDttz2ClientDatetime(const dttz_t *dttz, const char *tzname, void *out, int sqltype) {
 
     int     outdtsz;
     Mem     mem;

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -93,7 +93,7 @@ static int checkRowidAccess(systbl_columns_cursor *pCur) {
     char *x = pDb->tablename;
     int bdberr;
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    int rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->sqlclntstate->user, x, ACCESS_READ, &bdberr);
+    int rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->clnt->user, x, ACCESS_READ, &bdberr);
     if (rc == 0)
        return SQLITE_OK;
     pCur->iRowid++;

--- a/sqlite/ext/comdb2/tablepermissions.c
+++ b/sqlite/ext/comdb2/tablepermissions.c
@@ -83,7 +83,7 @@ static int permissionsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
   if( pCur==0 ) return SQLITE_NOMEM;
   memset(pCur, 0, sizeof(*pCur));
   struct sql_thread *thd = pthread_getspecific(query_info_key);
-  char *usr = thd->sqlclntstate->user;
+  char *usr = thd->clnt->user;
   rdlock_schema_lk();
   pCur->ppTables = sqlite3_malloc(sizeof(char*) * thedb->num_dbs);
   for(int i=0;i<thedb->num_dbs;++i) {

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -72,7 +72,7 @@ static int checkRowidAccess(systbl_tables_cursor *pCur) {
     char *x = pDb->tablename;
     int bdberr;
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    int rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->sqlclntstate->user, x, ACCESS_READ, &bdberr);
+    int rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->clnt->user, x, ACCESS_READ, &bdberr);
     if (rc == 0)
        return SQLITE_OK;
     pCur->iRowid++;

--- a/sqlite/vdbeInt.h
+++ b/sqlite/vdbeInt.h
@@ -685,7 +685,7 @@ int sqlite3VdbeMemHandleBom(Mem *pMem);
 /* COMDB2 MODIFICATION */
 int convMem2ClientDatetime(Mem *pMem, void *out);
 int convMem2ClientDatetimeStr(Mem *pMem, void *out, int outlen, int *outdtsz);
-int convDttz2ClientDatetime(dttz_t *dttz, const char *tzname, void *out, int sqltype);
+int convDttz2ClientDatetime(const dttz_t *, const char *tzname, void *out, int sqltype);
 
 int sqliteVdbeMemDecimalBasicArithmetics(Mem *a, Mem *b, int opcode, Mem * res, int flipped);
 


### PR DESCRIPTION
Make write_response independent of client API

Plugin should not decide when to send a row or skip. This should
be done entirely in sqlinterfaces.c. If plugin is requested to send
a row, it will send the row - no smarts there.

Highlights:
* Stop double copying into fsql buffers; let plugin handle encoding
* Simplify returning rows from SP
* Unify sql row handling
* Delete dead code. Less code is running faster
* Reduce memory allocations
* Remove (almost) all references to FSQL_*

For some next steps:
* Move dbglog to fastsql plugin
* Factor out code to bind parameters; remove cnlt->req, clnt->sql_query
* Delete clnt->is_newsql. Code in sqlinterfaces.c should be independent
    of where a query originated
* Fix send_dbinforesponse: its pushing client protocol down into bdb!