### PR TITLE
berkdb: log_archive returns wrong files.

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -75,7 +75,6 @@ int bdb_is_open(void *bdb_state);
 
 #include "printformats.h"
 
-static int __log_backup __P((DB_ENV *, DB_LOGC *, DB_LSN *, DB_LSN *));
 static int __log_earliest __P((DB_ENV *, DB_LOGC *, int32_t *, DB_LSN *));
 static double __lsn_diff __P((DB_LSN *, DB_LSN *, DB_LSN *, u_int32_t, int));
 static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
@@ -1532,6 +1531,7 @@ __test_last_checkpoint(DB_ENV * dbenv, int file, int offset)
 
 /*
  * __log_backup --
+ * PUBLIC: int __log_backup __P((DB_ENV *, DB_LOGC *, DB_LSN *, DB_LSN *));
  *
  * This is used to find the earliest log record to process when a client
  * is trying to sync up with a master whose max LSN is less than this
@@ -1539,7 +1539,7 @@ __test_last_checkpoint(DB_ENV * dbenv, int file, int offset)
  *
  * Find the latest checkpoint whose ckp_lsn is less than the max lsn.
  */
-static int
+int
 __log_backup(dbenv, logc, max_lsn, start_lsn)
 	DB_ENV *dbenv;
 	DB_LOGC *logc;

--- a/berkdb/log/log_archive.c
+++ b/berkdb/log/log_archive.c
@@ -243,6 +243,8 @@ __log_archive(dbenv, listp, flags)
 					(void)__log_c_close(logc);
 					goto err1;
 				}
+				if ((ret = __log_c_close(logc)) != 0)
+					goto err1;
 			} else if (dbenv->attr.dbreg_errors_fatal) {
 				*listp = NULL;
 

--- a/tests/logarchive.test/Makefile
+++ b/tests/logarchive.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/logarchive.test/lrl.options
+++ b/tests/logarchive.test/lrl.options
@@ -1,0 +1,10 @@
+setattr CHECKPOINTTIME 3600
+setattr LOGFILESIZE 4194304
+setattr LOGMEMSIZE 1048576
+setattr MEMPTRICKLEMSECS 3600000
+setattr AUTOANALYZE 0
+setattr MIN_KEEP_LOGS 1
+setattr DEBUG_LOG_DELETION 1
+maxosqltransfer 2147483647
+override_cachekb 0
+cache 512 mb

--- a/tests/logarchive.test/runit
+++ b/tests/logarchive.test/runit
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+dbnm=$1
+runs=$2
+DEFAULT=$3
+ISBB=$4
+
+if [[ "$dbnm" = "" ]]; then
+    echo 'Missing database name' >&2
+    exit 1
+fi
+
+if [[ "$runs" = "" ]]; then
+    runs=20
+fi
+
+if [[ "$DEFAULT" = "" ]]; then
+    DEFAULT="default"
+fi
+
+if [[ "$ISBB" = "" ]]; then
+    TABS='--tabs'
+    HOST='--host'
+else
+    TABS='-tabs'
+    HOST=''
+fi
+
+########################################
+#### Figure out who the master is ######
+########################################
+master=`cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.info.cluster()' | grep $'\t1\t' | cut -d$'\t' -f1`
+echo Master is $master
+
+########################################
+######        Prepare table       ######
+########################################
+echo Preparing table...
+cdb2sql $CDB2_OPTIONS $dbnm $DEFAULT "DROP TABLE t" >/dev/null 2>&1
+cdb2sql $CDB2_OPTIONS $dbnm $DEFAULT "CREATE TABLE t (c CHAR(512))" >/dev/null
+
+echo Sleep 10 seconds
+sleep 10
+
+####### Dumb. But save memory ######
+loremipsum="INSERT INTO t VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.')"
+rm -f inserts.sql
+echo BEGIN >inserts.sql
+yes "$loremipsum" | head -20000 >>inserts.sql
+echo COMMIT >>inserts.sql
+
+########################################
+############  Main loop   ##############
+########################################
+while [[ $runs -gt 0 ]]; do
+
+
+
+
+###### Do enough writes to push forward log files ######
+echo Writing...
+
+#cat << EOF | cdb2sql $dbnm - >/dev/null
+#BEGIN
+#`yes $loremipsum | head -20000`
+#COMMIT
+#EOF
+cdb2sql $CDB2_OPTIONS -f inserts.sql $dbnm $DEFAULT >/dev/null
+
+echo Flushing...
+sleep 20
+cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("flush")'
+
+###### Push forward LSN just a little bit ######
+# In order to reproduce the bug with R7, it is necessary to push the LSN a bit forward,
+# and get a new checkpoint afterwards. Reason is that R7 looks at last_ckp of the latest
+# checkpoint to determine recovery start, whereas R6 looks at ckp_lsn instead.
+cdb2sql $CDB2_OPTIONS $dbnm $DEFAULT "INSERT INTO t VALUES ('1')" >/dev/null
+cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("flush")'
+
+###### Get a list of log files that can be safely deleted. ######
+echo Sleep 10 seconds to process replication messages.
+sleep 10
+
+reproduced=1
+masterlsn=`cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb txnstat")' | grep last_ckp | cut -d' ' -f2`
+echo Master lsn is at $masterlsn
+for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.info.cluster()' | cut -d$'\t' -f1`; do
+    replsn=`cdb2sql $TABS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb txnstat")' | grep last_ckp | cut -d' ' -f2`
+    if [[ "$replsn" != "$masterlsn" ]]; then
+        reproduced=0
+        break;
+    fi
+done
+
+
+
+if [[ $reproduced -ne 1 ]]; then
+    let runs=$runs-1
+    echo Number of retries remaining: $runs
+    continue
+fi
+
+for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.info.cluster()' | cut -d$'\t' -f1`; do
+    if [[ "$onenode" != "$master" ]]; then
+        echo Doing $onenode
+        cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb log_archive")'
+        numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb log_archive")' | grep 'log.00' | wc -l`
+
+        if [[ $numlogs -ne 0 ]]; then
+            echo The replicant $onenode will not recover correctly! >&2
+            exit 1
+        fi
+    fi
+done
+
+cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb log_archive")'
+numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb log_archive")' | grep 'log.00' | wc -l`
+
+if [[ $numlogs -ne 0 ]]; then
+    echo Master will not recover correctly after downgrade! >&2
+    exit 1
+fi
+
+echo 'All good'
+exit 0
+
+done
+
+echo Could not reproduce the bug! >&2
+exit 1


### PR DESCRIPTION
We need the recovery LSN in the checkpoint prior to the dbreg record.
Consider the following example.

```
[1583][32542163]__txn_ckp: rec: 11 txnid 0 prevlsn [0][0]
        ckp_lsn: [1576][5255785]
[1583][32596639]__txn_ckp: rec: 11 txnid 0 prevlsn [0][0]
        ckp_lsn: [1583][32543779]
```

`[1583][32542163]` and `[1583][32596639]` are 2 most recent checkpoints.
The dbreg record may be somewhere between `[1583][32542163]` and `[1583][32543779]`.
A replicant may then truncate to `[1583][32542163]` whose ckp_lsn is `[1576][5255785]` to verify.
Hence log files 1576 - 1582 cannot be safely deleted.
