### PR TITLE
SET INTRANSRESULTS ON/OFF

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2530,7 +2530,7 @@ retry_next_record:
         }
         for (ii = 0; ii < hndl->lastresponse->n_features; ii++) {
             if (hndl->in_trans && (CDB2_SERVER_FEATURES__SKIP_ROWS ==
-                hndl->lastresponse->features[ii]))
+                                   hndl->lastresponse->features[ii]))
                 hndl->skip_feature = 1;
         }
 

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2529,8 +2529,8 @@ retry_next_record:
             hndl->num_set_commands_sent = hndl->num_set_commands;
         }
         for (ii = 0; ii < hndl->lastresponse->n_features; ii++) {
-            if (hndl->in_trans && CDB2_SERVER_FEATURES__SKIP_ROWS &&
-                hndl->lastresponse->features[ii])
+            if (hndl->in_trans && (CDB2_SERVER_FEATURES__SKIP_ROWS ==
+                hndl->lastresponse->features[ii]))
                 hndl->skip_feature = 1;
         }
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -474,6 +474,7 @@ struct sqlclntstate {
     int snapshot_offset;
     int is_hasql_retry;
     int is_readonly;
+    int send_intransresults;
     int is_expert;
     int is_newsql;
     CDB2SQLQUERY *sql_query; /* Needed to fetch the bind variables. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -788,11 +788,11 @@ static void update_snapshot_info(struct sqlclntstate *clnt)
 
     /* We need to restore skip_feature, want_query_effects and
        send_one_row on clnt even if the snapshot info has been populated. */
-    if (clnt->is_newsql && clnt->sql_query &&
+    if (!clnt->send_intransresults && clnt->is_newsql && clnt->sql_query &&
         (clnt->sql_query->n_features > 0) && (gbl_disable_skip_rows == 0)) {
         for (int ii = 0; ii < clnt->sql_query->n_features; ii++) {
-            if (!clnt->send_intransresults && (CDB2_CLIENT_FEATURES__SKIP_ROWS ==
-                clnt->sql_query->features[ii])) {
+            if (CDB2_CLIENT_FEATURES__SKIP_ROWS ==
+                clnt->sql_query->features[ii]) {
                 clnt->skip_feature = 1;
                 clnt->want_query_effects = 1;
                 if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4379,6 +4379,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->ncontext = 0;
     clnt->statement_query_effects = 0;
     clnt->wrong_db = 0;
+    clnt->send_intransresults = 0;
 }
 
 void reset_clnt_flags(struct sqlclntstate *clnt)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -791,8 +791,8 @@ static void update_snapshot_info(struct sqlclntstate *clnt)
     if (clnt->is_newsql && clnt->sql_query &&
         (clnt->sql_query->n_features > 0) && (gbl_disable_skip_rows == 0)) {
         for (int ii = 0; ii < clnt->sql_query->n_features; ii++) {
-            if (CDB2_CLIENT_FEATURES__SKIP_ROWS ==
-                clnt->sql_query->features[ii]) {
+            if (!clnt->send_intransresults && (CDB2_CLIENT_FEATURES__SKIP_ROWS ==
+                clnt->sql_query->features[ii])) {
                 clnt->skip_feature = 1;
                 clnt->want_query_effects = 1;
                 if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1218,6 +1218,14 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt)
                 } else {
                     clnt->ignore_coherency = 0;
                 }
+            } else if (strncasecmp(sqlstr, "intransresults", 14) == 0) {
+                sqlstr += 14;
+                sqlstr = skipws(sqlstr);
+                if (strncasecmp(sqlstr, "off", 3) == 0) {
+                    clnt->send_intransresults = 0;
+                } else {
+                    clnt->send_intransresults = 1;
+                }
             } else {
                 rc = ii + 1;
             }

--- a/tests/cdb2api.test/t36.expected
+++ b/tests/cdb2api.test/t36.expected
@@ -1,0 +1,3 @@
+[commit] failed with rc -3 near "kjskjhf": syntax error
+[insert kjskjhf kjsd] failed with rc -3 near "kjskjhf": syntax error
+[commit] failed with rc -3 

--- a/tests/cdb2api.test/t36.req
+++ b/tests/cdb2api.test/t36.req
@@ -1,0 +1,8 @@
+begin
+insert kjskjhf kjsd
+commit
+
+set intransresults on
+begin
+insert kjskjhf kjsd
+commit


### PR DESCRIPTION
give back results of write queries to client instead of skipping it