### PR TITLE
Fix logdelete for asof pagelogs consumer thread

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3404,9 +3404,11 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
 
         if (asoflsn.file <= lowfilenum) {
             if (bdb_state->attr->debug_log_deletion) {
-               logmsg(LOGMSG_USER, "Setting lowfilenum to %d from %d because asoflsn is "
+                logmsg(LOGMSG_USER,
+                       "Setting lowfilenum to %d from %d because asoflsn is "
                        "%d:%d\n",
-                       asoflsn.file - 1, lowfilenum, asoflsn.file, asoflsn.offset);
+                       asoflsn.file - 1, lowfilenum, asoflsn.file,
+                       asoflsn.offset);
             }
             lowfilenum = asoflsn.file - 1;
         }

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3402,13 +3402,13 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
         asoflsn = bdb_asof_current_lsn;
         pthread_mutex_unlock(&bdb_asof_current_lsn_mutex);
 
-        if (asoflsn.file < lowfilenum) {
+        if (asoflsn.file <= lowfilenum) {
             if (bdb_state->attr->debug_log_deletion) {
                logmsg(LOGMSG_USER, "Setting lowfilenum to %d from %d because asoflsn is "
                        "%d:%d\n",
-                       asoflsn.file, lowfilenum, asoflsn.file, asoflsn.offset);
+                       asoflsn.file - 1, lowfilenum, asoflsn.file, asoflsn.offset);
             }
-            lowfilenum = asoflsn.file;
+            lowfilenum = asoflsn.file - 1;
         }
     }
 


### PR DESCRIPTION
Lingzhi points out that the asof-to-pagelogs thread suffers from the same bug as our open snapshot transactions.
