### PR TITLE
berkdb: log deletion should take rep_verify_match into account.

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -2064,4 +2064,100 @@ err:
 		return ret;
 }
 
-/* vim: set ts=3 sw=3: */
+/*
+ * __env_find_verify_recover_start --
+ *  We need to be able to recover to the 1st matchable commit record
+ *  preceding the last sync LSN. The function returns the recovery
+ *  starting point in `lsnp'.
+ *
+ * PUBLIC: int __env_find_verify_recover_start __P((DB_ENV *, DB_LSN *));
+ */
+int
+__env_find_verify_recover_start(dbenv, lsnp)
+	DB_ENV *dbenv;
+	DB_LSN *lsnp;
+{
+	int ret;
+	u_int32_t rectype;
+	DB_LSN txnlsn;
+	__txn_ckp_args *ckp_args;
+	__db_debug_args *debug_args;
+	DBT rec = {0};
+	DB_LOGC *logc = NULL;
+	int optype = 0;
+
+	rec.flags = DB_DBT_REALLOC;
+
+	/* Step 1: Find the 1st matchable commit record
+	           lower than the last sync LSN. */
+	if ((ret = __log_sync_lsn(dbenv, lsnp)) != 0)
+		goto err;
+	if ((ret = __log_cursor(dbenv, &logc)) != 0)
+		goto err;
+	if ((ret = __log_c_get(logc, lsnp, &rec, DB_PREV)) != 0)
+		goto err;
+
+	do {
+		LOGCOPY_32(&rectype, rec.data);
+	} while(!matchable_log_type(rectype) &&
+			(ret = __log_c_get(logc, lsnp, &rec, DB_PREV)) == 0);
+
+	if (ret != 0)
+		goto err;
+
+	/* Step 2: find the checkpoint LSN of the checkpoint
+	           preceding the commit record. */
+	if ((ret = __txn_getckp(dbenv, &txnlsn)) != 0)
+		goto err;
+
+	while ((ret = __log_c_get(logc, &txnlsn, &rec, DB_SET)) == 0) {
+		if ((ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
+			return (ret);
+		if (log_compare(&txnlsn, lsnp) < 0) {
+			*lsnp = ckp_args->ckp_lsn;
+			txnlsn = ckp_args->last_ckp;
+			__os_free(dbenv, ckp_args);
+			break;
+		}
+
+		txnlsn = ckp_args->last_ckp;
+		if (IS_ZERO_LSN(txnlsn))
+			goto err;
+		__os_free(dbenv, ckp_args);
+	}
+
+	/* Step 3: find the checkpoint preceding the ckp LSN from Step 2. */
+	while ((ret = __log_c_get(logc, &txnlsn, &rec, DB_SET)) == 0) {
+		if ((ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
+			return (ret);
+		if (log_compare(&txnlsn, lsnp) < 0) {
+			*lsnp = txnlsn;
+			__os_free(dbenv, ckp_args);
+			break;
+		}
+
+		txnlsn = ckp_args->last_ckp;
+		if (IS_ZERO_LSN(txnlsn))
+			goto err;
+		__os_free(dbenv, ckp_args);
+	}
+
+	/* Step 4: find the start of DBREG records of the ckp from Step 3. */
+	do {
+		LOGCOPY_32(&rectype, rec.data);
+		optype = -1;
+		if (rectype == DB___db_debug) {
+			ret = __db_debug_read(dbenv, rec.data, &debug_args);
+			if (ret)
+				goto err;
+			LOGCOPY_32(&optype, debug_args->op.data);
+			__os_free(dbenv, debug_args);
+		}
+	} while ((rectype != DB___db_debug || optype != 2) &&
+			(ret = __log_c_get(logc, lsnp, &rec, DB_PREV)) == 0);
+
+err:
+	if (logc)
+		(void)__log_c_close(logc);
+	return (ret);
+}

--- a/berkdb/log/log.c
+++ b/berkdb/log/log.c
@@ -1272,3 +1272,25 @@ __log_autoremove(dbenv)
 	}
 	return;
 }
+
+/*
+ * __log_sync_lsn --
+ *  Return the last sync LSN.
+ *
+ * PUBLIC: int __log_sync_lsn __P((DB_ENV *, DB_LSN *));
+ */
+    int
+__log_sync_lsn(dbenv, lsnp)
+    DB_ENV *dbenv;
+    DB_LSN *lsnp;
+{
+    DB_LOG *dblp;
+    LOG *lp;
+
+    dblp = dbenv->lg_handle;
+    lp = dblp->reginfo.primary;
+    R_LOCK(dbenv, &dblp->reginfo);
+    *lsnp = lp->s_lsn;
+    R_UNLOCK(dbenv, &dblp->reginfo);
+    return (0);
+}

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -312,7 +312,12 @@ lc_free(DB_ENV *dbenv, struct __recovery_processor *rp, LSN_COLLECTION * lc)
 	lc->nalloc = 0;
 }
 
-static inline int
+/*
+ * matchable_log_type --
+ *
+ * PUBLIC: int matchable_log_type __P((int));
+ */
+int
 matchable_log_type(int rectype)
 {
 	extern int gbl_only_match_commit_records;

--- a/tests/logarchive.test/lrl.options
+++ b/tests/logarchive.test/lrl.options
@@ -1,3 +1,4 @@
+# Disable everything that actively checkpoints
 setattr CHECKPOINTTIME 3600
 setattr LOGFILESIZE 4194304
 setattr LOGMEMSIZE 1048576
@@ -5,6 +6,10 @@ setattr MEMPTRICKLEMSECS 3600000
 setattr AUTOANALYZE 0
 setattr MIN_KEEP_LOGS 1
 setattr DEBUG_LOG_DELETION 1
+# No dummy records.
+setattr NEW_MASTER_DUMMY_ADD_DELAY 3600
+# Disable txn_regop_gen
+berkattr elect_highest_committed_gen 0
 maxosqltransfer 2147483647
 override_cachekb 0
 cache 512 mb

--- a/tests/logarchive.test/runit
+++ b/tests/logarchive.test/runit
@@ -46,7 +46,7 @@ sleep 10
 loremipsum="INSERT INTO t VALUES ('Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero. Sed dignissim lacinia nunc.')"
 rm -f inserts.sql
 echo BEGIN >inserts.sql
-yes "$loremipsum" | head -20000 >>inserts.sql
+yes "$loremipsum" | head -10000 >>inserts.sql
 echo COMMIT >>inserts.sql
 
 ########################################
@@ -81,6 +81,39 @@ cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("flush")'
 ###### Get a list of log files that can be safely deleted. ######
 echo Sleep 10 seconds to process replication messages.
 sleep 10
+
+###### More flushes to get a new log file,
+###### so that the last sync LSN and the rep verify record are not in the same log file.
+######
+echo Doing checkpoints to push forward the log files even farther...
+masterlsn=`cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb txnstat")' | grep last_ckp | cut -d' ' -f2`
+masterlsnfile=`echo "$masterlsn" | cut -d':' -f1`
+masterlsnfiletarget=$masterlsnfile
+while true; do
+  ckptimes=0
+  while [ $ckptimes -le 100 ]; do
+    let ckptimes=$ckptimes+1
+    cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("flush")' >/dev/null
+  done
+  masterlsnfile=`cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb txnstat")' | grep last_ckp | cut -d' ' -f2 | cut -d':' -f1`
+  echo $masterlsnfile $masterlsnfiletarget
+  if [ $masterlsnfile -gt $masterlsnfiletarget ]; then
+    break
+  fi
+done
+echo Sleeping 10 seconds and do 1 more checkpoint
+sleep 10
+cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("flush")' >/dev/null
+
+# Let replicants catch up.
+for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.info.cluster()' | cut -d$'\t' -f1`; do
+    while true; do
+        cdb2sql $TABS $dbnm $HOST $onenode 'SELECT 1' >/dev/null
+        if [[ $? -eq 0 ]]; then
+            break;
+        fi
+    done
+done
 
 reproduced=1
 masterlsn=`cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb txnstat")' | grep last_ckp | cut -d' ' -f2`


### PR DESCRIPTION
1. Find the 1st matchable commit record that precedes last sync LSN.
2. Find the checkpoint LSN of the checkpoint that precedes the commit record.
3. Find the checkpoint that precedes the checkpoint LSN.
4. Find the DBREG records of the checkpoint.

We must preserve at least these many log files.
