### PR TITLE
add a test that we throw error on long tablename

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -18,9 +18,9 @@ export DISABLED_TESTS:=$(shell awk '/^DISABLED/{f=1;next};/<END>/{f=0}f' TODO | 
 export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
     $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
 
-TOTAL=$(words $(MAKECMDGOALS))
+TOTAL=$(words $(MAKECMDGOALS))  # targets passed to make
 ifeq ($(TOTAL),0)
-TOTAL=$(words $(ALL_TESTS))
+TOTAL=$(words $(ALL_TESTS))     # if no targets passed, will do ALL_TESTS
 endif
 
 all: init basicops all_tests

--- a/tests/long_db_name.test/runit
+++ b/tests/long_db_name.test/runit
@@ -7,6 +7,7 @@ set -x
 # Debug variable
 debug=0
 
+#dbnm is modified to a very long string in this test's Makefile
 dbnm=$1
 
 if [ "x$dbnm" == "x" ] ; then
@@ -310,5 +311,12 @@ cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("sql hist")'
 
 res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
 assertres $res 1
+
+# make sure that long tablename throws an error
+set +e
+res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table long_table_name_which_should_fail { schema { int a } }" 2>&1`
+if [ $res != "[create table long_table_name_which_should_fail { schema { int a } }] failed with rc -3 Tablename is too long" ] ; then
+    failexit "res is $res and not 'failed with rc -3 Tablename is too long'"
+fi
 
 echo "Success"


### PR DESCRIPTION
We throw error if tablename is longer than 31 characters. 
This adds a test that we get back 'failed with rc -3 Tablename is too long' error when we try to create one such table.