### PR TITLE
ported R6 PR 833

### DIFF
--- a/sqlite/dttz.c
+++ b/sqlite/dttz.c
@@ -18,6 +18,9 @@
 #include <inttypes.h>
 #include <arpa/inet.h>
 
+#include "comdb2.h"
+#include "sql.h"
+
 #include "sqliteInt.h"
 #include "vdbeInt.h"
 #include <types.h>
@@ -335,6 +338,8 @@ static void currentTS(sqlite3_context *context, int argc, sqlite3_value **argv)
    sqlite3VdbeMemSetDatetime(context->pOut, &dt, NULL);
 }
 
+extern pthread_key_t query_info_key;
+
 static void nowFunc(sqlite3_context *context, int argc, sqlite3_value **argv)
 {
    struct timespec *tspec;
@@ -343,8 +348,16 @@ static void nowFunc(sqlite3_context *context, int argc, sqlite3_value **argv)
    const unsigned char *msus;
    assert(context->pVdbe);
 
-   if (argc == 0)
+   if (argc == 0) {
        precision = context->pVdbe->dtprec;
+       if (precision != DTTZ_PREC_MSEC
+               && precision != DTTZ_PREC_USEC) {
+           struct sql_thread *thd =pthread_getspecific(query_info_key);
+
+           if(thd && thd->clnt)
+               precision = thd->clnt->dtprec;
+       }
+   }
    else if (SQLITE_INTEGER == sqlite3_value_type(argv[0]))
        precision = sqlite3_value_int(argv[0]);
    else if (SQLITE_TEXT == sqlite3_value_type(argv[0])) {


### PR DESCRIPTION
This uses datetime precision set in the client session if not explicitly provided.
