### PR TITLE
ported R6 PR 852

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -908,6 +908,7 @@ static int _convert_time(char *sql)
 
     struct sqlclntstate client;
     reset_clnt(&client, NULL, 1);
+    strncpy(client.tzname, "UTC", sizeof(client.tzname));
     sql_set_sqlengine_state(&client, __FILE__, __LINE__, SQLENG_NORMAL_PROCESS);
     client.dbtran.mode = TRANLEVEL_SOSQL;
     client.sql = sql;


### PR DESCRIPTION
Patch makes sure the rollout time arithmetic is done in UTC, matching the recommended way to set time partition schedule (UTC).
Currently the default is America/New_York; when a partition rollout is scheduled for the beginning of the month in UTC time, the internal arithmetic converts that to default New_York time (which can be the last day of previous month; if this is a 31 day month, arithmetic doesn't work properly).
