### PR TITLE
ported R6 PR 855

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -608,6 +608,8 @@ DEF_ATTR(TIMEPART_CHECK_SHARD_EXISTENCE, timepart_check_shard_existence,
 DEF_ATTR(
     IGNORE_BAD_TABLE, ignore_bad_table, BOOLEAN, 0,
     "Allow a database with a corrupt table to come up, without that table.")
+DEF_ATTR(TIMEPART_NO_ROLLOUT, timepart_no_rollout, BOOLEAN, 0,
+         "Prevent new rollouts for time partitions.")
 /* Keep enabled for the merge */
 DEF_ATTR(DURABLE_LSNS, durable_lsns, BOOLEAN, 0, NULL)
 /* Keep disabled:  we get it when we add to the trn_repo */

--- a/db/views.c
+++ b/db/views.c
@@ -298,7 +298,8 @@ int timepart_add_view(void *tran, timepart_views_t *views,
             goto done;
         }
     } else {
-        fprintf(stderr, "Time partitions rollouts are stopped; no rollouts!\n");
+        logmsg(LOGMSG_WARN,
+               "Time partitions rollouts are stopped; no rollouts!\n");
     }
 
     /* adding the view to the list */

--- a/db/views.c
+++ b/db/views.c
@@ -282,15 +282,16 @@ int timepart_add_view(void *tran, timepart_views_t *views,
     view->roll_time = tm;
 
     if (!bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TIMEPART_NO_ROLLOUT)) {
-        print_dbg_verbose(view->name, &view->source_id, "III", "Adding phase 1 at %d\n", 
+        print_dbg_verbose(view->name, &view->source_id, "III",
+                          "Adding phase 1 at %d\n",
                           view->roll_time - preemptive_rolltime);
 
         rc = (cron_add_event(timepart_sched, NULL,
-                    view->roll_time - preemptive_rolltime,
-                    _view_cron_phase1, tmp_str = strdup(view->name), NULL,
-                    NULL, &view->source_id, err) == NULL)
-            ? err->errval
-            : VIEW_NOERR;
+                             view->roll_time - preemptive_rolltime,
+                             _view_cron_phase1, tmp_str = strdup(view->name),
+                             NULL, NULL, &view->source_id, err) == NULL)
+                 ? err->errval
+                 : VIEW_NOERR;
         if (rc != VIEW_NOERR) {
             if (tmp_str)
                 free(tmp_str);
@@ -2063,8 +2064,8 @@ int views_cron_restart(timepart_views_t *views)
 
             /* are the rollouts stopped? */
             if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TIMEPART_NO_ROLLOUT)) {
-                logmsg(LOGMSG_WARN,
-                        "Time partitions rollouts are stopped; will not start rollouts!\n");
+                logmsg(LOGMSG_WARN, "Time partitions rollouts are stopped; "
+                                    "will not start rollouts!\n");
                 goto done;
             }
 

--- a/db/views.c
+++ b/db/views.c
@@ -281,19 +281,23 @@ int timepart_add_view(void *tran, timepart_views_t *views,
 
     view->roll_time = tm;
 
-    print_dbg_verbose(view->name, &view->source_id, "III", "Adding phase 1 at %d\n", 
-                      view->roll_time - preemptive_rolltime);
+    if (!bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TIMEPART_NO_ROLLOUT)) {
+        print_dbg_verbose(view->name, &view->source_id, "III", "Adding phase 1 at %d\n", 
+                          view->roll_time - preemptive_rolltime);
 
-    rc = (cron_add_event(timepart_sched, NULL,
-                         view->roll_time - preemptive_rolltime,
-                         _view_cron_phase1, tmp_str = strdup(view->name), NULL,
-                         NULL, &view->source_id, err) == NULL)
-             ? err->errval
-             : VIEW_NOERR;
-    if (rc != VIEW_NOERR) {
-        if (tmp_str)
-            free(tmp_str);
-        goto done;
+        rc = (cron_add_event(timepart_sched, NULL,
+                    view->roll_time - preemptive_rolltime,
+                    _view_cron_phase1, tmp_str = strdup(view->name), NULL,
+                    NULL, &view->source_id, err) == NULL)
+            ? err->errval
+            : VIEW_NOERR;
+        if (rc != VIEW_NOERR) {
+            if (tmp_str)
+                free(tmp_str);
+            goto done;
+        }
+    } else {
+        fprintf(stderr, "Time partitions rollouts are stopped; no rollouts!\n");
     }
 
     /* adding the view to the list */
@@ -2056,6 +2060,14 @@ int views_cron_restart(timepart_views_t *views)
         /* queue all the events required for this */
         for(i=0;i<views->nviews; i++)
         {
+
+            /* are the rollouts stopped? */
+            if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TIMEPART_NO_ROLLOUT)) {
+                logmsg(LOGMSG_WARN,
+                        "Time partitions rollouts are stopped; will not start rollouts!\n");
+                goto done;
+            }
+
             view = views->views[i];
 
             rc = _view_restart(view, &xerr);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=872)
+(TUNABLES_COUNT=873)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -810,6 +810,7 @@
 (name='timeout_server_sockpool', description='Timeout for getting a connection to another database from sockpool.', type='INTEGER', value='10', read_only='N')
 (name='timepart_abort_on_preperror', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='timepart_check_shard_existence', description='Check at startup/time-partition creation that all shard files exist.', type='BOOLEAN', value='OFF', read_only='N')
+(name='timepart_no_rollout', description='Prevent new rollouts for time partitions.', type='BOOLEAN', value='OFF', read_only='N')
 (name='toblock_net_throttle', description='Throttle writes in apply_changes. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='toomanyskipped', description='Call for election again and delay commits if more than this many nodes are incoherent.', type='INTEGER', value='2', read_only='N')
 (name='track_berk_locks', description='', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
Option to disable rollouts;  main use case is restoring an old backup: without this option, the partitions will rollout and data will be instantly deleted.  