### PR TITLE
cdb2jdbc: Configurable timeouts.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -187,12 +187,14 @@ public class BBSysUtils {
      * @param instance
      * @return
      */
-    private static int getPortMux(String host, int port, String app, String service, String instance) {
+    private static int getPortMux(String host, int port,
+            int soTimeout, int connectTimeout,
+            String app, String service, String instance) {
         SockIO io = null;
         try {
             String name = String.format("get %s/%s/%s\n", app, service, instance);
 
-            io = new SockIO(host, port, null);
+            io = new SockIO(host, port, null, soTimeout, connectTimeout);
 
             io.write(name.getBytes());
             io.flush();
@@ -245,7 +247,8 @@ public class BBSysUtils {
 
         try {
             if (dbInfoResp == null) {
-                io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null);
+                io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null,
+                                hndl.dbinfoTimeout, hndl.connectTimeout);
 
                 /*********************************
                  * Sending data...
@@ -379,7 +382,8 @@ public class BBSysUtils {
         SockIO io = null;
 
         try {
-            io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null);
+            io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null,
+                            hndl.comdb2dbTimeout, hndl.connectTimeout);
 
             /*********************************
              * Sending data...
@@ -572,7 +576,8 @@ public class BBSysUtils {
                     atLeastOneValid = true;
                 else {
                     int dbport = getPortMux(hndl.myDbHosts.get(i),
-                            hndl.portMuxPort, "comdb2", "replication", hndl.myDbName);
+                            hndl.portMuxPort, hndl.soTimeout, hndl.connectTimeout,
+                            "comdb2", "replication", hndl.myDbName);
                     if (dbport != -1) {
                         atLeastOneValid = true;
                         hndl.myDbPorts.set(i, dbport);
@@ -611,7 +616,9 @@ public class BBSysUtils {
 			int comdb2dbPort = -1;
 			String connerr = "";
             for (String comdb2dbHost : hndl.comdb2dbHosts) {
-                comdb2dbPort = BBSysUtils.getPortMux(comdb2dbHost, hndl.portMuxPort, "comdb2", "replication", hndl.comdb2dbName);
+                comdb2dbPort = BBSysUtils.getPortMux(comdb2dbHost, hndl.portMuxPort,
+                                                     hndl.soTimeout, hndl.connectTimeout,
+                                                     "comdb2", "replication", hndl.comdb2dbName);
                 if (comdb2dbPort < 0)
 					connerr = "port error";
                 else {
@@ -710,7 +717,9 @@ public class BBSysUtils {
                 if (hndl.myDbPorts.get(i) >= 0)
                     port = hndl.myDbPorts.get(i);
                 else
-                    port = getPortMux(host, hndl.portMuxPort, "comdb2", "replication", hndl.myDbName);
+                    port = getPortMux(host, hndl.portMuxPort,
+                            hndl.soTimeout, hndl.connectTimeout,
+                            "comdb2", "replication", hndl.myDbName);
 
                 if (port < 0) {
                     connerr = "port error";

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -51,8 +51,8 @@ public class Comdb2Connection implements Connection {
     private Comdb2DatabaseMetaData md = null;
     private String db, cluster;
 
-    static final int TIMEOUT_NOT_SET = -1;
-    private int timeout = TIMEOUT_NOT_SET;
+    private int timeout = -1;
+    private int querytimeout = -1;
 
     private String user;
     private String password;
@@ -74,6 +74,7 @@ public class Comdb2Connection implements Connection {
         ret.db = db;
         ret.cluster = cluster;
         ret.timeout = timeout;
+        ret.querytimeout = querytimeout;
         ret.user = user;
         ret.password = password;
         ret.usemicrodt = usemicrodt;
@@ -111,8 +112,28 @@ public class Comdb2Connection implements Connection {
     }
 
     /* Comdb2Statement needs these settings below */
-    public void setQueryTimeout(int timeout) {
+    public void setQueryTimeout(int querytimeout) {
+        this.querytimeout = querytimeout;
+    }
+
+    public void setTimeout(int timeout) {
         this.timeout = timeout;
+    }
+
+    public void setSoTimeout(int timeout) {
+        hndl.soTimeout = timeout;
+    }
+
+    public void setConnectTimeout(int timeout) {
+        hndl.connectTimeout = timeout;
+    }
+
+    public void setComdb2dbTimeout(int timeout) {
+        hndl.comdb2dbTimeout = timeout;
+    }
+
+    public void setDbinfoTimeout(int timeout) {
+        hndl.dbinfoTimeout = timeout;
     }
 
     public void setUser(String u) {
@@ -321,8 +342,10 @@ public class Comdb2Connection implements Connection {
             stmt.setUser(user);
         if (password != null)
             stmt.setPassword(password);
-        if (timeout != TIMEOUT_NOT_SET)
-            stmt.setQueryTimeout(timeout);
+        if (timeout >= 0)
+            stmt.setTimeout(timeout);
+        if (querytimeout >= 0)
+            stmt.setQueryTimeout(querytimeout);
 
         stmt.setUseMicroDt(usemicrodt);
         stmts.add(stmt);
@@ -337,8 +360,10 @@ public class Comdb2Connection implements Connection {
             stmt.setUser(user);
         if (password != null)
             stmt.setPassword(password);
-        if (timeout != TIMEOUT_NOT_SET)
-            stmt.setQueryTimeout(timeout);
+        if (timeout >= 0)
+            stmt.setTimeout(timeout);
+        if (querytimeout >= 0)
+            stmt.setQueryTimeout(querytimeout);
 
         stmt.setUseMicroDt(usemicrodt);
         stmts.add(stmt);

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -70,6 +70,10 @@ public class Comdb2Handle extends AbstractConnection {
     boolean pmuxrte = false;
     boolean statement_effects = false;
     boolean verifyretry = false;
+    int soTimeout = 5000;
+    int comdb2dbTimeout = 5000;
+    int connectTimeout = 100;
+    int dbinfoTimeout = 500;
 
     private boolean in_retry = false;
     private boolean temp_trans = false;
@@ -152,6 +156,13 @@ public class Comdb2Handle extends AbstractConnection {
         ret.tcpbufsz = tcpbufsz;
         ret.age = age;
         ret.pmuxrte = pmuxrte;
+        ret.statement_effects = statement_effects;
+        ret.verifyretry = verifyretry;
+        ret.soTimeout = soTimeout;
+        ret.comdb2dbTimeout = comdb2dbTimeout;
+        ret.connectTimeout = connectTimeout;
+        ret.dbinfoTimeout = dbinfoTimeout;
+
         ret.sslmode = sslmode;
         ret.sslcert = sslcert;
         ret.sslcertpass = sslcertpass;
@@ -1729,7 +1740,8 @@ readloop:
            we're not on it, connect to it. */
         if (prefIdx != -1 && dbHostIdx != prefIdx) {
             io = new SockIO(myDbHosts.get(prefIdx),
-                    myDbPorts.get(prefIdx), tcpbufsz, pmuxrte ? myDbName : null);
+                    myDbPorts.get(prefIdx), tcpbufsz, pmuxrte ? myDbName : null,
+                    soTimeout, connectTimeout);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1766,7 +1778,9 @@ readloop:
                         || try_node == dbHostConnected)
                     continue;
 
-                io = new SockIO(myDbHosts.get(try_node), myDbPorts.get(try_node), tcpbufsz, pmuxrte ? myDbName : null);
+                io = new SockIO(myDbHosts.get(try_node), myDbPorts.get(try_node),
+                                tcpbufsz, pmuxrte ? myDbName : null,
+                                soTimeout, connectTimeout);
                 if (io.open()) {
                     try {
                         io.write("newsql\n");
@@ -1807,7 +1821,9 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz, pmuxrte ? myDbName : null);
+            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx),
+                            tcpbufsz, pmuxrte ? myDbName : null,
+                            soTimeout, connectTimeout);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1836,7 +1852,9 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx), tcpbufsz, pmuxrte ? myDbName : null);
+            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx),
+                            tcpbufsz, pmuxrte ? myDbName : null, 
+                            soTimeout, connectTimeout);
             if (io.open()) {
                 try {
                     io.write("newsql\n");
@@ -1863,7 +1881,9 @@ readloop:
          */
         if (masterIndexInMyDbHosts >= 0) {
             io = new SockIO(myDbHosts.get(masterIndexInMyDbHosts),
-                    myDbPorts.get(masterIndexInMyDbHosts), tcpbufsz, pmuxrte ? myDbName : null);
+                            myDbPorts.get(masterIndexInMyDbHosts),
+                            tcpbufsz, pmuxrte ? myDbName : null,
+                            soTimeout, connectTimeout);
             if (io.open()) {
                 try {
                     io.write("newsql\n");

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -67,6 +67,11 @@ public class Driver implements java.sql.Driver {
     public static Driver getInstance() throws SQLException {
         try {
             __instance.options.put("maxquerytime", new IntegerOption("maxquerytime", "QueryTimeout"));
+            __instance.options.put("timeout", new IntegerOption("timeout", "Timeout"));
+            __instance.options.put("sotimeout", new IntegerOption("sotimeout", "SoTimeout"));
+            __instance.options.put("connect_timeout", new IntegerOption("connect_timeout", "ConnectTimeout"));
+            __instance.options.put("comdb2db_timeout", new IntegerOption("comdb2db_timeout", "Comdb2dbTimeout"));
+            __instance.options.put("dbinfo_timeout", new IntegerOption("dbinfo_timeout", "DbinfoTimeout"));
             __instance.options.put("user", new StringOption("user", "User"));
             __instance.options.put("password", new StringOption("password", "Password"));
             __instance.options.put("default_type", new StringOption("default_type", "DefaultType"));

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
@@ -30,6 +30,8 @@ public class SockIO implements IO {
     protected int port;
     protected int tcpbufsz;
     protected String pmuxrtedb = null;
+    protected int soTimeout;
+    protected int connectTimeout;
 
     protected boolean opened = false;
 
@@ -50,19 +52,25 @@ public class SockIO implements IO {
         opened = false;
     }
 
-    public SockIO(String host, int port, int tcpbufsz, String pmuxrtedb) {
+    public SockIO(String host, int port, int tcpbufsz, String pmuxrtedb, int soTimeout, int connectTimeout) {
         this.host = host;
         this.port = port;
         this.tcpbufsz = tcpbufsz;
         this.pmuxrtedb = pmuxrtedb;
+        this.soTimeout = soTimeout;
+        this.connectTimeout = connectTimeout;
     }
 
     public SockIO(String host, int port) {
-        this(host, port, 0, null);
+        this(host, port, 0, null, 0, 0);
     }
 
     public SockIO(String host, int port, String pmuxrtedb) {
-        this(host, port, 0, pmuxrtedb);
+        this(host, port, 0, pmuxrtedb, 0, 0);
+    }
+
+    public SockIO(String host, int port, String pmuxrtedb, int soTimeout, int connectTimeout) {
+        this(host, port, 0, pmuxrtedb, soTimeout, connectTimeout);
     }
 
     public SockIO() {
@@ -127,13 +135,13 @@ public class SockIO implements IO {
             sock = new Socket();
 
             sock.setSoLinger(true, 0); /* no lingering */
-            sock.setSoTimeout(60000); /* timeout 60 seconds */
+            sock.setSoTimeout(soTimeout);
             sock.setTcpNoDelay(true); /* no nagle */
             if (tcpbufsz > 0)
                 sock.setReceiveBufferSize(tcpbufsz);
 
             sock.bind(new InetSocketAddress(0));
-            sock.connect(new InetSocketAddress(host, port), 10000);
+            sock.connect(new InetSocketAddress(host, port), connectTimeout);
             out = new BufferedOutputStream(sock.getOutputStream());
             in = new BufferedInputStream(sock.getInputStream());
             opened = true;

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/TimeoutTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/TimeoutTest.java
@@ -1,0 +1,41 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import java.util.logging.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class TimeoutTest {
+
+    String db, cluster;
+    Connection conn1, conn2;
+
+    @Test public void testMaxQueryTimeout() throws SQLException {
+        db = System.getProperty("cdb2jdbc.test.database");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        Connection conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?maxquerytime=1", cluster, db));
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT SLEEP(5)");
+        Assert.assertEquals("Should get 1 from server", 1, rs.getInt(1));
+        rs.close();
+        stmt.close();
+        conn.close();
+    }
+
+    @Test public void testOfflineNodeDelay() {
+        long then = System.currentTimeMillis();
+        try {
+            /* Silence our logger.
+               The connectivity exception is expected.
+               we don't need the extra noise here. */
+            LogManager.getLogManager().reset();
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://example.com/db");
+            conn.close();
+        } catch (SQLException sqle) {
+            long now = System.currentTimeMillis();
+            Assert.assertEquals("Should see a delay of roughly 100 ms", true, (now - then) <= 150);
+        }
+    }
+}


### PR DESCRIPTION
The patch also fixes 10-second connect delay if a node is offline.
