### PR TITLE
@ls/@describe shortcuts to list and describe tables.

### DIFF
--- a/tests/cdb2sql.test/Makefile
+++ b/tests/cdb2sql.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/cdb2sql.test/lrl.options
+++ b/tests/cdb2sql.test/lrl.options
@@ -1,0 +1,1 @@
+dont_forbid_ulonglong

--- a/tests/cdb2sql.test/runit
+++ b/tests/cdb2sql.test/runit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbname=$1
+if [[ -z $dbname ]] ; then
+    echo dbname missing
+    exit 1
+fi
+
+for testreq in `ls t*.sql` ; do
+    testname=`echo $testreq | cut -d "." -f 1`
+    cmd="cdb2sql -s -f $testreq ${CDB2_OPTIONS} $dbname default "
+    echo $cmd "> $testname.output"
+    $cmd 2>&1 | perl -pe "s/.n_writeops_done=([0-9]+)/rows inserted='\1'/; s/BLOCK2_SEQV2\(824\)/BLOCK_SEQ(800)/; s/OP #2 BLOCK_SEQ/OP #3 BLOCK_SEQ/;" > $testname.output
+
+    cmd="diff $testname.expected $testname.output"
+    $cmd > /dev/null
+
+    if [[  $? -eq 0 ]]; then
+        echo "passed $testname"
+    else
+        echo "failed $testname"
+        echo "see diffs here: $HOSTNAME"
+        echo "> diff -u ${PWD}/{$testname.expected,$testname.output}"
+        echo
+        exit 1
+    fi
+done
+echo
+exit 0

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -19,7 +19,17 @@ t2
 unknown @ls sub-command foo
 table name required
 table name required
-schema
+Columns:
+(column='i', type='int', size=5, sqltype='int', varinlinesize=NULL, defaultvalue=NULL, dbload=NULL, isnullable='N')
+
+Keys:
+(keyname='COMDB2_PK', isunique='Y', isdatacopy='N', isrecnum='N', condition=NULL)
+
+Constraints:
+(name='$CONSTRAINT_C6A17957', tablename='t2', keyname='COMDB2_PK', foreigntablename='t1', foreignkeyname='COMDB2_PK', iscascadingdelete='N', iscascadingupdate='N')
+
+CSC2:
+(csc2='schema
 	{
 		int i 
 	}
@@ -27,8 +37,18 @@ keys
 	{
 		"COMDB2_PK" = i 
 	}
+')
+Columns:
+(column='i', type='int', size=5, sqltype='int', varinlinesize=NULL, defaultvalue=NULL, dbload=NULL, isnullable='N')
 
-schema
+Keys:
+(keyname='COMDB2_PK', isunique='Y', isdatacopy='N', isrecnum='N', condition=NULL)
+
+Constraints:
+(name='$CONSTRAINT_C6A17957', tablename='t2', keyname='COMDB2_PK', foreigntablename='t1', foreignkeyname='COMDB2_PK', iscascadingdelete='N', iscascadingupdate='N')
+
+CSC2:
+(csc2='schema
 	{
 		int i 
 	}
@@ -40,8 +60,18 @@ constraints
 	{
 		"COMDB2_PK" -> <"t1":"COMDB2_PK"> 
 	}
+')
+Columns:
+(column='i', type='int', size=5, sqltype='int', varinlinesize=NULL, defaultvalue=NULL, dbload=NULL, isnullable='N')
 
-schema
+Keys:
+(keyname='COMDB2_PK', isunique='Y', isdatacopy='N', isrecnum='N', condition=NULL)
+
+Constraints:
+(name='$CONSTRAINT_C6A17957', tablename='t2', keyname='COMDB2_PK', foreigntablename='t1', foreignkeyname='COMDB2_PK', iscascadingdelete='N', iscascadingupdate='N')
+
+CSC2:
+(csc2='schema
 	{
 		int i 
 	}
@@ -53,4 +83,4 @@ constraints
 	{
 		"COMDB2_PK" -> <"t1":"COMDB2_PK"> 
 	}
-
+')

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -1,21 +1,21 @@
 [DROP TABLE t1] failed with rc -3 no such table: t1
 [DROP TABLE t2] failed with rc -3 no such table: t2
-sqlite_stat1
-sqlite_stat4
-t1
-t2
-sqlite_stat1
-sqlite_stat4
-t1
-t2
-sqlite_stat1
-sqlite_stat4
-t1
-t2
-sqlite_stat1
-sqlite_stat4
-t1
-t2
+(tablename='sqlite_stat1')
+(tablename='sqlite_stat4')
+(tablename='t1')
+(tablename='t2')
+(tablename='sqlite_stat1')
+(tablename='sqlite_stat4')
+(tablename='t1')
+(tablename='t2')
+(tablename='sqlite_stat1')
+(tablename='sqlite_stat4')
+(tablename='t1')
+(tablename='t2')
+(tablename='sqlite_stat1')
+(tablename='sqlite_stat4')
+(tablename='t1')
+(tablename='t2')
 unknown @ls sub-command foo
 table name required
 table name required

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -1,0 +1,56 @@
+[DROP TABLE t1] failed with rc -3 no such table: t1
+[DROP TABLE t2] failed with rc -3 no such table: t2
+sqlite_stat1
+sqlite_stat4
+t1
+t2
+sqlite_stat1
+sqlite_stat4
+t1
+t2
+sqlite_stat1
+sqlite_stat4
+t1
+t2
+sqlite_stat1
+sqlite_stat4
+t1
+t2
+unknown @ls sub-command foo
+table name required
+table name required
+schema
+	{
+		int i 
+	}
+keys
+	{
+		"COMDB2_PK" = i 
+	}
+
+schema
+	{
+		int i 
+	}
+keys
+	{
+		"COMDB2_PK" = i 
+	}
+constraints
+	{
+		"COMDB2_PK" -> <"t1":"COMDB2_PK"> 
+	}
+
+schema
+	{
+		int i 
+	}
+keys
+	{
+		"COMDB2_PK" = i 
+	}
+constraints
+	{
+		"COMDB2_PK" -> <"t1":"COMDB2_PK"> 
+	}
+

--- a/tests/cdb2sql.test/t00.sql
+++ b/tests/cdb2sql.test/t00.sql
@@ -1,0 +1,18 @@
+DROP TABLE t1;
+DROP TABLE t2;
+CREATE TABLE t1(i INT PRIMARY KEY) $$
+CREATE TABLE t2(i INT PRIMARY KEY, FOREIGN KEY (i) REFERENCES t1(i)) $$
+@ls
+@list
+@ls tables
+@list tables
+@ls foo
+
+@desc
+@describe
+@desc t1
+@desc t2
+@describe t2
+
+DROP TABLE t2;
+DROP TABLE t1;

--- a/tools/cdb2sql/cdb2sql.c
+++ b/tools/cdb2sql/cdb2sql.c
@@ -476,10 +476,10 @@ static int process_escape(const char *cmdstr)
     if (!tok)
         return 0;
 
-    if (strcmp(tok, "cdb2_close") == 0) {
+    if (strcasecmp(tok, "cdb2_close") == 0) {
         cdb2_close(cdb2h);
         cdb2h = NULL;
-    } else if (strcmp(tok, "redirect") == 0) {
+    } else if (strcasecmp(tok, "redirect") == 0) {
         tok = strtok_r(NULL, delims, &lasts);
 
         /* Close the redirect file. */
@@ -511,38 +511,34 @@ static int process_escape(const char *cmdstr)
             }
             dup2(fileno(redirect), 1);
         }
-    } else if (strcmp(tok, "row_sleep") == 0) {
+    } else if (strcasecmp(tok, "row_sleep") == 0) {
         tok = strtok_r(NULL, delims, &lasts);
         if (!tok) {
             fprintf(stderr, "expected row sleep in seconds\n");
             return -1;
         }
         rowsleep = atoi(tok);
-    } else if (strcmp(tok, "strblobs") == 0) {
+    } else if (strcasecmp(tok, "strblobs") == 0) {
         string_blobs = 1;
         printf("Blobs will be displayed as strings\n");
-    } else if (strcmp(tok, "hexblobs") == 0) {
+    } else if (strcasecmp(tok, "hexblobs") == 0) {
         string_blobs = 0;
         printf("Blobs will be displayed as hex\n");
-    } else if (strcmp(tok, "time") == 0) {
+    } else if (strcasecmp(tok, "time") == 0) {
         time_mode = time_mode ? 0 : 1;
         printf("Timing mode %s\n", time_mode ? "ON" : "OFF");
-    } else if ((strcmp(tok, "ls") == 0) || (strcmp(tok, "list") == 0)) {
+    } else if ((strcasecmp(tok, "ls") == 0) || (strcasecmp(tok, "list") == 0)) {
         tok = strtok_r(NULL, delims, &lasts);
-        if (!tok || strcmp(tok, "tables") == 0) {
+        if (!tok || strcasecmp(tok, "tables") == 0) {
             int start_time_ms, run_time_ms;
             const char *sql = "SELECT tablename FROM comdb2_tables";
-            int saved_printmode;
 
-            saved_printmode = printmode;
-            printmode = TABS;
             run_statement(sql, 0, NULL, &start_time_ms, &run_time_ms);
-            printmode = saved_printmode;
         } else {
             fprintf(stderr, "unknown @ls sub-command %s\n", tok);
             return -1;
         }
-    } else if ((strcmp(tok, "desc") == 0) || (strcmp(tok, "describe") == 0)) {
+    } else if ((strcasecmp(tok, "desc") == 0) || (strcasecmp(tok, "describe") == 0)) {
         tok = strtok_r(NULL, delims, &lasts);
         if (!tok) {
             fprintf(stderr, "table name required\n");


### PR DESCRIPTION
A quick hack to list/describe tables.

```
nctdb> create table t1(i int primary key, j varchar(10)) $$
[create table t1(i int primary key, j varchar(10))] rc 0
nctdb> create table t2(i int primary key, foreign key (i) references t1(i)) $$
[create table t2(i int primary key, foreign key (i) references t1(i))] rc 0
nctdb> @ls tables
sqlite_stat1
sqlite_stat4
t1
t2
[@ls tables] rc 0
nctdb> @describe t2
Columns:
(column='i', type='int', size=5, sqltype='int', varinlinesize=NULL, defaultvalue=NULL, dbload=NULL, isnullable='N')

Keys:
(keyname='COMDB2_PK', isunique='Y', isdatacopy='N', isrecnum='N', condition=NULL)

Constraints:
(name='$CONSTRAINT_C6A17957', tablename='t2', keyname='COMDB2_PK', foreigntablename='t1', foreignkeyname='COMDB2_PK', iscascadingdelete='N', iscascadingupdate='N')

CSC2:
(csc2='schema
	{
		int i 
	}
keys
	{
		"COMDB2_PK" = i 
	}
constraints
	{
		"COMDB2_PK" -> <"t1":"COMDB2_PK"> 
	}
')
[@describe t2] rc 0
```