### PR TITLE
some cleanup of file.c

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -343,7 +343,7 @@ int bdb_get_new_prefix(char *buf, size_t buflen, int *bdberr)
         return -1;
     }
 
-    if (strlen(NEW_PREFIX) >= buflen) {
+    if (sizeof(NEW_PREFIX) - 1 >= buflen) {
         *bdberr = BDBERR_BUFSMALL;
         return -1;
     }
@@ -363,14 +363,14 @@ const char *bdb_unprepend_new_prefix(const char *tablename, int *bdberr)
 {
     /* if the input didn't start with new. report it by setting bdberr, note
      * that this may not be an error */
-    if (strncmp(tablename, NEW_PREFIX, strlen(NEW_PREFIX))) {
+    if (strncmp(tablename, NEW_PREFIX, sizeof(NEW_PREFIX) - 1)) {
         *bdberr = BDBERR_BADARGS;
         return tablename;
     }
 
     *bdberr = BDBERR_NOERROR;
     /* we want to remove the new. prefix from the tablename */
-    return tablename + strlen(NEW_PREFIX);
+    return tablename + sizeof(NEW_PREFIX) - 1;
 }
 
 /* this removes a new.SOMETHING. prefix from a tables name (if it exists)
@@ -5350,10 +5350,9 @@ bdb_open_int(int envonly, const char name[], const char dir[], int lrl,
         bdb_state->children_lock = bdb_state->parent->children_lock;
     }
 
-    bdb_state->txndir =
-        mymalloc(strlen(bdb_state->name) + strlen(bdb_state->dir) + 100);
-    bdb_state->tmpdir =
-        mymalloc(strlen(bdb_state->name) + strlen(bdb_state->dir) + 100);
+    int nlen = strlen(bdb_state->name) + strlen(bdb_state->dir) + 100;
+    bdb_state->txndir = mymalloc(nlen);
+    bdb_state->tmpdir = mymalloc(nlen);
 
     bdb_state->numdtafiles = numdtafiles;
     bdb_state->numix = numix;
@@ -6652,19 +6651,21 @@ int get_dbnum_by_handle(bdb_state_type *bdb_state)
 int get_dbnum_by_name(bdb_state_type *bdb_state, const char *name)
 {
     int i;
+    int nlen = strlen(name);
+    int found = -1;
 
     Pthread_mutex_lock(&(bdb_state->children_lock));
 
-    for (i = 0; i < bdb_state->parent->numchildren; i++)
+    for (i = 0; i < bdb_state->parent->numchildren; i++) {
         if (strncasecmp(bdb_state->parent->children[i]->name, name,
-                        strlen(name)) == 0) {
-            Pthread_mutex_unlock(&(bdb_state->children_lock));
-            return i;
+                        nlen) == 0) {
+            found = i;
+            break;
         }
+    }
 
     Pthread_mutex_unlock(&(bdb_state->children_lock));
-
-    return -1;
+    return found;
 }
 
 static int bdb_close_only_int(bdb_state_type *bdb_state, int *bdberr)
@@ -7384,9 +7385,9 @@ static inline int bdb_is_new_sc_file(bdb_state_type *bdb_state, tran_type *tran,
 int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
                             int *bdberr)
 {
-    const char *data_ext = ".data";
-    const char *index_ext = ".index";
-    const char *blob_ext = ".blob";
+    const char data_ext[] = ".data";
+    const char index_ext[] = ".index";
+    const char blob_ext[] = ".blob";
     int rc = 0;
     char table_prefix[80];
     unsigned long long file_version;
@@ -7433,8 +7434,8 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
     }
 
     /* */
-    if (snprintf(table_prefix, sizeof(table_prefix), "%s_", tblname) >=
-        sizeof(table_prefix)) {
+    int tp_len = snprintf(table_prefix, sizeof(table_prefix), "%s_", tblname);
+    if (tp_len >= sizeof(table_prefix)) {
         logmsg(LOGMSG_ERROR, "%s: tablename too long\n", __func__);
         *bdberr = BDBERR_MISC;
         free(buf);
@@ -7446,119 +7447,122 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
     while ((error = readdir_r(dirp, buf, &ent)) == 0 && ent != NULL) {
         /* if the file's name is longer then the prefix and it belongs to our
          * table */
-        if ((strlen(ent->d_name) > strlen(table_prefix)) &&
-            strncmp(ent->d_name, table_prefix, strlen(table_prefix)) == 0) {
-            const char *file_name_post_prefix;
-            unsigned long long invers;
-            char *endp;
+        if (! (strlen(ent->d_name) > tp_len &&
+               strncmp(ent->d_name, table_prefix, tp_len) == 0))
+            continue;
 
-            /* file version should start right after the prefix */
-            file_name_post_prefix = ent->d_name + strlen(table_prefix);
+        const char *file_name_post_prefix;
+        unsigned long long invers;
+        char *endp;
 
-            /* try to parse a file version */
-            invers = strtoull(file_name_post_prefix, &endp, 16 /*base*/);
+        /* file version should start right after the prefix */
+        file_name_post_prefix = ent->d_name + tp_len;
 
-            /* if no file_version was found after the prefix or the next thing
-             * after the file version isn't .blob or .data or .index */
-            if (endp == file_name_post_prefix ||
-                (strncmp(endp, data_ext, strlen(data_ext)) != 0 &&
-                 strncmp(endp, index_ext, strlen(index_ext)) != 0 &&
-                 strncmp(endp, blob_ext, strlen(blob_ext)) != 0)) {
-                file_version = 0;
-            } else {
-                uint8_t *p_buf = (uint8_t *)&invers,
-                        *p_buf_end = p_buf + sizeof(invers);
-                struct bdb_file_version_num_type p_file_version_num_type;
+        /* try to parse a file version */
+        invers = strtoull(file_name_post_prefix, &endp, 16 /*base*/);
 
-                bdb_file_version_num_get(&p_file_version_num_type, p_buf,
-                                         p_buf_end);
+        /* if no file_version was found after the prefix or the next thing
+         * after the file version isn't .blob or .data or .index */
+        if (endp == file_name_post_prefix ||
+            (strncmp(endp, data_ext, sizeof(data_ext) - 1) != 0 &&
+             strncmp(endp, index_ext, sizeof(index_ext) - 1) != 0 &&
+             strncmp(endp, blob_ext, sizeof(blob_ext) - 1) != 0)) {
+            file_version = 0;
+        } else {
+            uint8_t *p_buf = (uint8_t *)&invers,
+                    *p_buf_end = p_buf + sizeof(invers);
+            struct bdb_file_version_num_type p_file_version_num_type;
 
-                file_version = p_file_version_num_type.version_num;
+            bdb_file_version_num_get(&p_file_version_num_type, p_buf,
+                                     p_buf_end);
+
+            file_version = p_file_version_num_type.version_num;
+        }
+
+        /*fprintf(stderr, "found version %s %016llx on disk\n",*/
+        /*ent->d_name, file_version); */
+
+        if (!file_version)
+            continue;
+
+        /* brute force scan to find any files on disk that we aren't
+         * actually using */
+        int found_in_llmeta = 0;
+        int i;
+
+        /* We have to check new. prefix for schemachange first.
+         * See NOTE in bdb_is_new_sc_file()
+         */
+        rc = bdb_is_new_sc_file(bdb_state, NULL, tblname, file_version,
+                                bdberr);
+        if (rc == 1) {
+            found_in_llmeta = 1;
+            rc = 0;
+        } else if (rc) {
+            logmsg(LOGMSG_ERROR,
+                   "%s:%d failed to check llmeta for %s, rc %d, bdberr "
+                   "%d\n",
+                   __func__, __LINE__, ent->d_name, rc, *bdberr);
+            continue;
+        }
+
+        if (!found_in_llmeta) {
+            rc = bdb_process_each_table_dta_entry(
+                bdb_state, NULL, tblname, file_version, bdberr);
+            if (rc == 1) {
+                found_in_llmeta = 1;
+                rc = 0;
+            } else if (rc) {
+                logmsg(LOGMSG_ERROR,
+                       "%s:%d failed to check llmeta for %s, rc %d, "
+                       "bdberr %d\n",
+                       __func__, __LINE__, ent->d_name, rc, *bdberr);
+                continue;
             }
+        }
 
-            /*fprintf(stderr, "found version %s %016llx on disk\n",*/
-            /*ent->d_name, file_version); */
-
-            /* brute force scan to find any files on disk that we aren't
-             * actually using */
-            if (file_version) {
-                int found_in_llmeta = 0;
-                int i;
-
-                /* We have to check new. prefix for schemachange first.
-                 * See NOTE in bdb_is_new_sc_file()
-                 */
-                rc = bdb_is_new_sc_file(bdb_state, NULL, tblname, file_version,
-                                        bdberr);
-                if (rc == 1) {
-                    found_in_llmeta = 1;
-                    rc = 0;
-                } else if (rc) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s:%d failed to check llmeta for %s, rc %d, bdberr "
-                           "%d\n",
-                           __func__, __LINE__, ent->d_name, rc, *bdberr);
-                    continue;
-                }
-
-                if (!found_in_llmeta) {
-                    rc = bdb_process_each_table_dta_entry(
-                        bdb_state, NULL, tblname, file_version, bdberr);
-                    if (rc == 1) {
-                        found_in_llmeta = 1;
-                        rc = 0;
-                    } else if (rc) {
-                        logmsg(LOGMSG_ERROR,
-                               "%s:%d failed to check llmeta for %s, rc %d, "
-                               "bdberr %d\n",
-                               __func__, __LINE__, ent->d_name, rc, *bdberr);
-                        continue;
-                    }
-                }
-
-                if (!found_in_llmeta) {
-                    rc = bdb_process_each_table_idx_entry(
-                        bdb_state, NULL, tblname, file_version, bdberr);
-                    if (rc == 1) {
-                        found_in_llmeta = 1;
-                        rc = 0;
-                    } else if (rc) {
-                        logmsg(LOGMSG_ERROR,
-                               "%s:%d failed to check llmeta for %s, rc %d, "
-                               "bdberr %d\n",
-                               __func__, __LINE__, ent->d_name, rc, *bdberr);
-                        continue;
-                    }
-                }
-
-                /* if the file's version wasn't found in llmeta, delete it */
-                if (rc == 0 && !found_in_llmeta) {
-                    char munged_name[FILENAMELEN];
-
-                    if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
-                                 ent->d_name) >= sizeof(munged_name)) {
-                        logmsg(LOGMSG_ERROR,
-                               "%s: filename too long to munge: %s\n", __func__,
-                               ent->d_name);
-                        continue;
-                    }
-
-                    /* dont add filename more than once in the list */
-                    if (oldfile_list_contains(munged_name))
-                        continue;
-
-                    if (oldfile_list_add(strdup(munged_name), lognum)) {
-                        print(bdb_state,
-                              "failed to collect old file (list full) %s\n",
-                              ent->d_name);
-                        goto done;
-                    } else {
-                        logmsg(LOGMSG_INFO, "%s: requeued file %s\n", __func__,
-                               ent->d_name);
-                        print(bdb_state, "requeued old file %s\n", ent->d_name);
-                    }
-                }
+        if (!found_in_llmeta) {
+            rc = bdb_process_each_table_idx_entry(
+                bdb_state, NULL, tblname, file_version, bdberr);
+            if (rc == 1) {
+                found_in_llmeta = 1;
+                rc = 0;
+            } else if (rc) {
+                logmsg(LOGMSG_ERROR,
+                       "%s:%d failed to check llmeta for %s, rc %d, "
+                       "bdberr %d\n",
+                       __func__, __LINE__, ent->d_name, rc, *bdberr);
+                continue;
             }
+        }
+
+        if (found_in_llmeta)
+            continue;
+
+        /* if the file's version wasn't found in llmeta, delete it */
+        char munged_name[FILENAMELEN];
+
+        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
+                     ent->d_name) >= sizeof(munged_name)) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: filename too long to munge: %s\n", __func__,
+                   ent->d_name);
+            continue;
+        }
+
+        /* dont add filename more than once in the list */
+        if (oldfile_list_contains(munged_name))
+            continue;
+
+        if (oldfile_list_add(strdup(munged_name), lognum)) {
+            print(bdb_state,
+                  "failed to collect old file (list full) %s\n",
+                  ent->d_name);
+            goto done;
+        } else {
+            logmsg(LOGMSG_INFO, "%s: requeued file %s\n", __func__,
+                   ent->d_name);
+            print(bdb_state, "requeued old file %s\n", ent->d_name);
         }
     }
 
@@ -7584,10 +7588,10 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
 {
     static char *owner = NULL;
     static pthread_mutex_t owner_mtx = PTHREAD_MUTEX_INITIALIZER;
-    const char *blob_ext = ".blob";
-    const char *data_ext = ".data";
-    const char *index_ext = ".index";
-    const char *qdb_ext = ".queuedb";
+    const char blob_ext[] = ".blob";
+    const char data_ext[] = ".data";
+    const char index_ext[] = ".index";
+    const char qdb_ext[] = ".queuedb";
     int rc = 0;
     char table_prefix[80];
     unsigned long long file_version;
@@ -7649,8 +7653,9 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         return -1;
     }
 
-    if (snprintf(table_prefix, sizeof(table_prefix), "%s_", bdb_state->name) >=
-        sizeof(table_prefix)) {
+    int tp_len = snprintf(table_prefix, sizeof(table_prefix), "%s_", 
+                          bdb_state->name);
+    if (tp_len >= sizeof(table_prefix)) {
         logmsg(LOGMSG_ERROR, "%s: tablename too long\n", __func__);
         *bdberr = BDBERR_MISC;
         free(buf);
@@ -7662,159 +7667,160 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
     while ((error = bb_readdir(dirp, buf, &ent)) == 0 && ent != NULL) {
         /* if the file's name is longer then the prefix and it belongs to our
          * table */
-        if ((strlen(ent->d_name) > strlen(table_prefix)) &&
-            strncmp(ent->d_name, table_prefix, strlen(table_prefix)) == 0) {
-            const char *file_name_post_prefix;
-            unsigned long long invers;
-            char *endp;
+        if (! (strlen(ent->d_name) > tp_len && 
+               strncmp(ent->d_name, table_prefix, tp_len) == 0)) 
+            continue;
 
-            /* file version should start right after the prefix */
-            file_name_post_prefix = ent->d_name + strlen(table_prefix);
+        const char *file_name_post_prefix;
+        unsigned long long invers;
+        char *endp;
 
-            /* try to parse a file version */
-            invers = strtoull(file_name_post_prefix, &endp, 16 /*base*/);
+        /* file version should start right after the prefix */
+        file_name_post_prefix = ent->d_name + tp_len;
 
-            /* if no file_version was found after the prefix or the next thing
-             * after the file version isn't .blob or .data or .index */
-            if (endp == file_name_post_prefix ||
-                (strncmp(endp, blob_ext, strlen(blob_ext)) != 0 &&
-                 strncmp(endp, data_ext, strlen(data_ext)) != 0 &&
-                 strncmp(endp, qdb_ext, strlen(qdb_ext)) != 0 &&
-                 strncmp(endp, index_ext, strlen(index_ext)) != 0)) {
-                file_version = 0;
+        /* try to parse a file version */
+        invers = strtoull(file_name_post_prefix, &endp, 16 /*base*/);
+
+        /* if no file_version was found after the prefix or the next thing
+         * after the file version isn't .blob or .data or .index */
+        if (endp == file_name_post_prefix ||
+            (strncmp(endp, blob_ext, sizeof(blob_ext) - 1) != 0 &&
+             strncmp(endp, data_ext, sizeof(data_ext) - 1) != 0 &&
+             strncmp(endp, qdb_ext, sizeof(qdb_ext) - 1) != 0 &&
+             strncmp(endp, index_ext, sizeof(index_ext) - 1) != 0)) {
+            file_version = 0;
+        } else {
+            uint8_t *p_buf = (uint8_t *)&invers,
+                    *p_buf_end = p_buf + sizeof(invers);
+            struct bdb_file_version_num_type p_file_version_num_type;
+
+            bdb_file_version_num_get(&p_file_version_num_type, p_buf,
+                                     p_buf_end);
+
+            file_version = p_file_version_num_type.version_num;
+        }
+
+        if (file_version)
+            continue;
+
+        /* brute force scan to find any files on disk that we aren't
+         * actually using */
+        int found_in_llmeta = 0;
+        int i;
+
+        /* We have to check new. prefix for schemachange first.
+         * See NOTE in bdb_is_new_sc_file()
+         */
+        rc = bdb_is_new_sc_file(bdb_state, tran, bdb_state->name,
+                                file_version, bdberr);
+        if (rc == 1) {
+            found_in_llmeta = 1;
+            rc = 0;
+        } else if (rc) {
+            logmsg(LOGMSG_ERROR,
+                   "%s:%d failed to check llmeta for %s, rc %d, bdberr "
+                   "%d\n",
+                   __func__, __LINE__, ent->d_name, rc, *bdberr);
+            continue;
+        }
+
+        /* try to find the file version amongst the active data files */
+        for (i = 0; i < bdb_state->numdtafiles; ++i) {
+            if (bdb_state->bdbtype == BDBTYPE_QUEUEDB) {
+                rc = bdb_get_file_version_qdb(bdb_state, tran,
+                                              &version_num, bdberr);
             } else {
-                uint8_t *p_buf = (uint8_t *)&invers,
-                        *p_buf_end = p_buf + sizeof(invers);
-                struct bdb_file_version_num_type p_file_version_num_type;
-
-                bdb_file_version_num_get(&p_file_version_num_type, p_buf,
-                                         p_buf_end);
-
-                file_version = p_file_version_num_type.version_num;
+                rc = bdb_get_file_version_data(bdb_state, tran, i,
+                                               &version_num, bdberr);
             }
+            if (rc == 0 && version_num == file_version) {
+                found_in_llmeta = 1;
+                break;
+            } else if (rc == 1) {
+                /* table doesnt exist in llmeta, not an error */
+                *bdberr = BDBERR_NOERROR;
+                rc = 0;
+            } else
+                break;
+        }
 
-            /* brute force scan to find any files on disk that we aren't
-             * actually using */
-            if (file_version) {
-                int found_in_llmeta = 0;
-                int i;
-
-                /* We have to check new. prefix for schemachange first.
-                 * See NOTE in bdb_is_new_sc_file()
-                 */
-                rc = bdb_is_new_sc_file(bdb_state, tran, bdb_state->name,
-                                        file_version, bdberr);
-                if (rc == 1) {
+        /* try to find the file version amongst the active indices */
+        for (i = 0; !found_in_llmeta && i < bdb_state->numix; ++i) {
+            if (bdb_state->bdbtype == BDBTYPE_QUEUEDB)
+                break;
+            rc = bdb_get_file_version_index(
+                bdb_state, tran, i /*dtanum*/, &version_num, bdberr);
+            if (rc == 0) {
+                if (version_num == file_version)
                     found_in_llmeta = 1;
-                    rc = 0;
-                } else if (rc) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s:%d failed to check llmeta for %s, rc %d, bdberr "
-                           "%d\n",
-                           __func__, __LINE__, ent->d_name, rc, *bdberr);
-                    continue;
-                }
+            } else if (rc == 1) {
+                /* table doesnt exist in llmeta, not an error */
+                *bdberr = BDBERR_NOERROR;
+                rc = 0;
+            } else
+                break;
+        }
+        if (rc) {
+            logmsg(LOGMSG_ERROR,
+                   "%s:%d failed to check llmeta for %s, rc %d, bdberr "
+                   "%d\n",
+                   __func__, __LINE__, ent->d_name, rc, *bdberr);
+            continue;
+        }
 
-                /* try to find the file version amongst the active data files */
-                for (i = 0; i < bdb_state->numdtafiles; ++i) {
-                    if (bdb_state->bdbtype == BDBTYPE_QUEUEDB) {
-                        rc = bdb_get_file_version_qdb(bdb_state, tran,
-                                                      &version_num, bdberr);
-                    } else {
-                        rc = bdb_get_file_version_data(bdb_state, tran, i,
-                                                       &version_num, bdberr);
-                    }
-                    if (rc == 0) {
-                        if (version_num == file_version) {
-                            found_in_llmeta = 1;
-                            break;
-                        }
-                    } else if (rc == 1) {
-                        /* table doesnt exist in llmeta, not an error */
-                        *bdberr = BDBERR_NOERROR;
-                        rc = 0;
-                    } else
-                        break;
-                }
+        if (found_in_llmeta)
+            continue;
 
-                /* try to find the file version amongst the active indices */
-                for (i = 0; !found_in_llmeta && i < bdb_state->numix; ++i) {
-                    if (bdb_state->bdbtype == BDBTYPE_QUEUEDB)
-                        break;
-                    rc = bdb_get_file_version_index(
-                        bdb_state, tran, i /*dtanum*/, &version_num, bdberr);
-                    if (rc == 0) {
-                        if (version_num == file_version)
-                            found_in_llmeta = 1;
-                    } else if (rc == 1) {
-                        /* table doesnt exist in llmeta, not an error */
-                        *bdberr = BDBERR_NOERROR;
-                        rc = 0;
-                    } else
-                        break;
-                }
-                if (rc) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s:%d failed to check llmeta for %s, rc %d, bdberr "
-                           "%d\n",
-                           __func__, __LINE__, ent->d_name, rc, *bdberr);
-                    continue;
-                }
+        /* if the file's version wasn't found in llmeta, delete it */
+        char munged_name[FILENAMELEN];
 
-                /* if the file's version wasn't found in llmeta, delete it */
-                if (!found_in_llmeta) {
-                    char munged_name[FILENAMELEN];
+        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
+                     ent->d_name) >= sizeof(munged_name)) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: filename too long to munge: %s\n", __func__,
+                   ent->d_name);
+            continue;
+        }
 
-                    if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
-                                 ent->d_name) >= sizeof(munged_name)) {
-                        logmsg(LOGMSG_ERROR,
-                               "%s: filename too long to munge: %s\n", __func__,
-                               ent->d_name);
-                        continue;
-                    }
+        if (delay) {
+            /* dont add filename more than once in the list */
+            if (oldfile_list_contains(munged_name))
+                continue;
 
-                    if (delay) {
-                        /* dont add filename more than once in the list */
-                        if (oldfile_list_contains(munged_name))
-                            continue;
-
-                        if (oldfile_list_add(strdup(munged_name), lognum)) {
-                            print(bdb_state,
-                                  "failed to collect old file (list full) %s\n",
-                                  ent->d_name);
-                        } else {
-                            logmsg(LOGMSG_INFO, "%s: collected file %s\n",
-                                   __func__, ent->d_name);
-                            print(bdb_state, "collected old file %s\n",
-                                  ent->d_name);
-                        }
-                    } else {
-                        logmsg(LOGMSG_INFO, "%s: deleting file %s\n", __func__,
-                               ent->d_name);
-                        print(bdb_state, "deleting file %s\n", ent->d_name);
-                        DB_TXN *tid;
-                        if (bdb_state->dbenv->txn_begin(bdb_state->dbenv,
-                                                        tran ? tran->tid : NULL,
-                                                        &tid, 0 /*flags*/)) {
-                            logmsg(LOGMSG_ERROR,
-                                   "%s: failed to begin trans for "
-                                   "deleteing file: %s\n",
-                                   __func__, ent->d_name);
-                            continue;
-                        }
-                        if (bdb_del_file(bdb_state, tid, munged_name, bdberr)) {
-                            logmsg(LOGMSG_ERROR,
-                                   "%s: failed to delete file: %s\n", __func__,
-                                   ent->d_name);
-                            tid->abort(tid);
-                        } else if (tid->commit(tid, 0)) {
-                            logmsg(LOGMSG_ERROR,
-                                   "%s: failed to commit trans for "
-                                   "deleteing file: %s\n",
-                                   __func__, ent->d_name);
-                        }
-                    }
-                }
+            if (oldfile_list_add(strdup(munged_name), lognum)) {
+                print(bdb_state,
+                      "failed to collect old file (list full) %s\n",
+                      ent->d_name);
+            } else {
+                logmsg(LOGMSG_INFO, "%s: collected file %s\n",
+                       __func__, ent->d_name);
+                print(bdb_state, "collected old file %s\n",
+                      ent->d_name);
+            }
+        } else {
+            logmsg(LOGMSG_INFO, "%s: deleting file %s\n", __func__,
+                   ent->d_name);
+            print(bdb_state, "deleting file %s\n", ent->d_name);
+            DB_TXN *tid;
+            if (bdb_state->dbenv->txn_begin(bdb_state->dbenv,
+                                            tran ? tran->tid : NULL,
+                                            &tid, 0 /*flags*/)) {
+                logmsg(LOGMSG_ERROR,
+                       "%s: failed to begin trans for "
+                       "deleteing file: %s\n",
+                       __func__, ent->d_name);
+                continue;
+            }
+            if (bdb_del_file(bdb_state, tid, munged_name, bdberr)) {
+                logmsg(LOGMSG_ERROR,
+                       "%s: failed to delete file: %s\n", __func__,
+                       ent->d_name);
+                tid->abort(tid);
+            } else if (tid->commit(tid, 0)) {
+                logmsg(LOGMSG_ERROR,
+                       "%s: failed to commit trans for "
+                       "deleteing file: %s\n",
+                       __func__, ent->d_name);
             }
         }
     }
@@ -7989,9 +7995,7 @@ int bdb_osql_cache_table_versions(bdb_state_type *bdb_state, tran_type *tran,
             }
         }
 
-        if (bdb_state->children[i]) {
-            tran->table_version_cache[i] = bdb_state->children[i]->version_num;
-        }
+        tran->table_version_cache[i] = bdb_state->children[i]->version_num;
     }
 done:
     /*printf("Done caching\n");*/
@@ -8125,18 +8129,19 @@ static int bdb_watchdog_test_io_dir(bdb_state_type *bdb_state, char *dir)
     int rc = 0;
     const int bufsz = 4096;
     const int align = 4096;
+    const char wdog[] = "watchdog";
 
     /* We can supposedly allocate memory - that check is done before this one.
      * If memory allocation broke between then and now, we'll flag a wrong
      * failure.
      * But it'll trip the watchdog timer anyway. */
-    pathlen = strlen(dir) + strlen("/watchdog") + 1;
+    pathlen = strlen(dir) + sizeof(wdog) + 1;
     path = malloc(pathlen);
     if (path == NULL) {
         logmsg(LOGMSG_ERROR, "Can't allocate filename buffer\n");
         ERRDONE;
     }
-    sprintf(path, "%s/watchdog", dir);
+    sprintf(path, "%s/%s", dir, wdog);
 
     rc = posix_memalign(&buf, align, bufsz);
     if (rc) {
@@ -8255,11 +8260,9 @@ static inline int log_get_record(DB_LOGC *logc, DBT *logrec, DB_LSN *lsn,
     }
 
     rc = logc->get(logc, lsn, logrec, pos);
-    if (rc) {
-        if (rc != DB_NOTFOUND)
-            logmsg(LOGMSG_ERROR, "%s: failed reading log record rc=%d\n",
-                   __func__, rc);
-    }
+    if (rc && rc != DB_NOTFOUND)
+        logmsg(LOGMSG_ERROR, "%s: failed reading log record rc=%d\n",
+               __func__, rc);
     return rc;
 }
 
@@ -8467,17 +8470,18 @@ static int fnames_search(void *obj, void *arg)
     char *src = obj;
     file_set_t *fs = arg;
 
-    if (hash_find_readonly(fs->fnames, src) == NULL) {
-        struct stat sb;
+    if (hash_find_readonly(fs->fnames, src) != NULL)
+        return 0;
 
-        if (stat(src, &sb) == 0) {
-            logmsg(LOGMSG_WARN, "MISSING %s from %d:%d-%d:%d\n", src,
-                   fs->debug.file, fs->debug.offset, fs->ckp.file,
-                   fs->ckp.offset);
+    struct stat sb;
 
-            if (!oldfile_list_contains(src)) {
-                oldfile_list_add(src, fs->debug.file);
-            }
+    if (stat(src, &sb) == 0) {
+        logmsg(LOGMSG_WARN, "MISSING %s from %d:%d-%d:%d\n", src,
+               fs->debug.file, fs->debug.offset, fs->ckp.file,
+               fs->ckp.offset);
+
+        if (!oldfile_list_contains(src)) {
+            oldfile_list_add(src, fs->debug.file);
         }
     }
 
@@ -8588,9 +8592,9 @@ void rename_bdb_state(bdb_state_type *bdb_state, const char *newname)
 int bdb_list_all_fileids_for_newsi(bdb_state_type *bdb_state,
                                    hash_t *fileid_tbl)
 {
-    const char *blob_ext = ".blob";
-    const char *data_ext = ".data";
-    const char *index_ext = ".index";
+    const char blob_ext[] = ".blob";
+    const char data_ext[] = ".data";
+    const char index_ext[] = ".index";
 
     DB_ENV *dbenv;
     DB *dbp;

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -6657,8 +6657,8 @@ int get_dbnum_by_name(bdb_state_type *bdb_state, const char *name)
     Pthread_mutex_lock(&(bdb_state->children_lock));
 
     for (i = 0; i < bdb_state->parent->numchildren; i++) {
-        if (strncasecmp(bdb_state->parent->children[i]->name, name,
-                        nlen) == 0) {
+        if (strncasecmp(bdb_state->parent->children[i]->name, name, nlen) ==
+            0) {
             found = i;
             break;
         }
@@ -7447,8 +7447,8 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
     while ((error = readdir_r(dirp, buf, &ent)) == 0 && ent != NULL) {
         /* if the file's name is longer then the prefix and it belongs to our
          * table */
-        if (! (strlen(ent->d_name) > tp_len &&
-               strncmp(ent->d_name, table_prefix, tp_len) == 0))
+        if (!(strlen(ent->d_name) > tp_len &&
+              strncmp(ent->d_name, table_prefix, tp_len) == 0))
             continue;
 
         const char *file_name_post_prefix;
@@ -7493,8 +7493,7 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
         /* We have to check new. prefix for schemachange first.
          * See NOTE in bdb_is_new_sc_file()
          */
-        rc = bdb_is_new_sc_file(bdb_state, NULL, tblname, file_version,
-                                bdberr);
+        rc = bdb_is_new_sc_file(bdb_state, NULL, tblname, file_version, bdberr);
         if (rc == 1) {
             found_in_llmeta = 1;
             rc = 0;
@@ -7507,8 +7506,8 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
         }
 
         if (!found_in_llmeta) {
-            rc = bdb_process_each_table_dta_entry(
-                bdb_state, NULL, tblname, file_version, bdberr);
+            rc = bdb_process_each_table_dta_entry(bdb_state, NULL, tblname,
+                                                  file_version, bdberr);
             if (rc == 1) {
                 found_in_llmeta = 1;
                 rc = 0;
@@ -7522,8 +7521,8 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
         }
 
         if (!found_in_llmeta) {
-            rc = bdb_process_each_table_idx_entry(
-                bdb_state, NULL, tblname, file_version, bdberr);
+            rc = bdb_process_each_table_idx_entry(bdb_state, NULL, tblname,
+                                                  file_version, bdberr);
             if (rc == 1) {
                 found_in_llmeta = 1;
                 rc = 0;
@@ -7542,11 +7541,10 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
         /* if the file's version wasn't found in llmeta, delete it */
         char munged_name[FILENAMELEN];
 
-        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
-                     ent->d_name) >= sizeof(munged_name)) {
-            logmsg(LOGMSG_ERROR,
-                   "%s: filename too long to munge: %s\n", __func__,
-                   ent->d_name);
+        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s", ent->d_name) >=
+            sizeof(munged_name)) {
+            logmsg(LOGMSG_ERROR, "%s: filename too long to munge: %s\n",
+                   __func__, ent->d_name);
             continue;
         }
 
@@ -7555,8 +7553,7 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
             continue;
 
         if (oldfile_list_add(strdup(munged_name), lognum)) {
-            print(bdb_state,
-                  "failed to collect old file (list full) %s\n",
+            print(bdb_state, "failed to collect old file (list full) %s\n",
                   ent->d_name);
             goto done;
         } else {
@@ -7653,8 +7650,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         return -1;
     }
 
-    int tp_len = snprintf(table_prefix, sizeof(table_prefix), "%s_", 
-                          bdb_state->name);
+    int tp_len =
+        snprintf(table_prefix, sizeof(table_prefix), "%s_", bdb_state->name);
     if (tp_len >= sizeof(table_prefix)) {
         logmsg(LOGMSG_ERROR, "%s: tablename too long\n", __func__);
         *bdberr = BDBERR_MISC;
@@ -7667,8 +7664,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
     while ((error = bb_readdir(dirp, buf, &ent)) == 0 && ent != NULL) {
         /* if the file's name is longer then the prefix and it belongs to our
          * table */
-        if (! (strlen(ent->d_name) > tp_len && 
-               strncmp(ent->d_name, table_prefix, tp_len) == 0)) 
+        if (!(strlen(ent->d_name) > tp_len &&
+              strncmp(ent->d_name, table_prefix, tp_len) == 0))
             continue;
 
         const char *file_name_post_prefix;
@@ -7711,8 +7708,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         /* We have to check new. prefix for schemachange first.
          * See NOTE in bdb_is_new_sc_file()
          */
-        rc = bdb_is_new_sc_file(bdb_state, tran, bdb_state->name,
-                                file_version, bdberr);
+        rc = bdb_is_new_sc_file(bdb_state, tran, bdb_state->name, file_version,
+                                bdberr);
         if (rc == 1) {
             found_in_llmeta = 1;
             rc = 0;
@@ -7727,11 +7724,11 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         /* try to find the file version amongst the active data files */
         for (i = 0; i < bdb_state->numdtafiles; ++i) {
             if (bdb_state->bdbtype == BDBTYPE_QUEUEDB) {
-                rc = bdb_get_file_version_qdb(bdb_state, tran,
-                                              &version_num, bdberr);
+                rc = bdb_get_file_version_qdb(bdb_state, tran, &version_num,
+                                              bdberr);
             } else {
-                rc = bdb_get_file_version_data(bdb_state, tran, i,
-                                               &version_num, bdberr);
+                rc = bdb_get_file_version_data(bdb_state, tran, i, &version_num,
+                                               bdberr);
             }
             if (rc == 0 && version_num == file_version) {
                 found_in_llmeta = 1;
@@ -7748,8 +7745,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         for (i = 0; !found_in_llmeta && i < bdb_state->numix; ++i) {
             if (bdb_state->bdbtype == BDBTYPE_QUEUEDB)
                 break;
-            rc = bdb_get_file_version_index(
-                bdb_state, tran, i /*dtanum*/, &version_num, bdberr);
+            rc = bdb_get_file_version_index(bdb_state, tran, i /*dtanum*/,
+                                            &version_num, bdberr);
             if (rc == 0) {
                 if (version_num == file_version)
                     found_in_llmeta = 1;
@@ -7774,11 +7771,10 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
         /* if the file's version wasn't found in llmeta, delete it */
         char munged_name[FILENAMELEN];
 
-        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s",
-                     ent->d_name) >= sizeof(munged_name)) {
-            logmsg(LOGMSG_ERROR,
-                   "%s: filename too long to munge: %s\n", __func__,
-                   ent->d_name);
+        if (snprintf(munged_name, sizeof(munged_name), "XXX.%s", ent->d_name) >=
+            sizeof(munged_name)) {
+            logmsg(LOGMSG_ERROR, "%s: filename too long to munge: %s\n",
+                   __func__, ent->d_name);
             continue;
         }
 
@@ -7788,14 +7784,12 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
                 continue;
 
             if (oldfile_list_add(strdup(munged_name), lognum)) {
-                print(bdb_state,
-                      "failed to collect old file (list full) %s\n",
+                print(bdb_state, "failed to collect old file (list full) %s\n",
                       ent->d_name);
             } else {
-                logmsg(LOGMSG_INFO, "%s: collected file %s\n",
-                       __func__, ent->d_name);
-                print(bdb_state, "collected old file %s\n",
-                      ent->d_name);
+                logmsg(LOGMSG_INFO, "%s: collected file %s\n", __func__,
+                       ent->d_name);
+                print(bdb_state, "collected old file %s\n", ent->d_name);
             }
         } else {
             logmsg(LOGMSG_INFO, "%s: deleting file %s\n", __func__,
@@ -7803,8 +7797,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
             print(bdb_state, "deleting file %s\n", ent->d_name);
             DB_TXN *tid;
             if (bdb_state->dbenv->txn_begin(bdb_state->dbenv,
-                                            tran ? tran->tid : NULL,
-                                            &tid, 0 /*flags*/)) {
+                                            tran ? tran->tid : NULL, &tid,
+                                            0 /*flags*/)) {
                 logmsg(LOGMSG_ERROR,
                        "%s: failed to begin trans for "
                        "deleteing file: %s\n",
@@ -7812,9 +7806,8 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
                 continue;
             }
             if (bdb_del_file(bdb_state, tid, munged_name, bdberr)) {
-                logmsg(LOGMSG_ERROR,
-                       "%s: failed to delete file: %s\n", __func__,
-                       ent->d_name);
+                logmsg(LOGMSG_ERROR, "%s: failed to delete file: %s\n",
+                       __func__, ent->d_name);
                 tid->abort(tid);
             } else if (tid->commit(tid, 0)) {
                 logmsg(LOGMSG_ERROR,
@@ -8261,8 +8254,8 @@ static inline int log_get_record(DB_LOGC *logc, DBT *logrec, DB_LSN *lsn,
 
     rc = logc->get(logc, lsn, logrec, pos);
     if (rc && rc != DB_NOTFOUND)
-        logmsg(LOGMSG_ERROR, "%s: failed reading log record rc=%d\n",
-               __func__, rc);
+        logmsg(LOGMSG_ERROR, "%s: failed reading log record rc=%d\n", __func__,
+               rc);
     return rc;
 }
 
@@ -8477,8 +8470,7 @@ static int fnames_search(void *obj, void *arg)
 
     if (stat(src, &sb) == 0) {
         logmsg(LOGMSG_WARN, "MISSING %s from %d:%d-%d:%d\n", src,
-               fs->debug.file, fs->debug.offset, fs->ckp.file,
-               fs->ckp.offset);
+               fs->debug.file, fs->debug.offset, fs->ckp.file, fs->ckp.offset);
 
         if (!oldfile_list_contains(src)) {
             oldfile_list_add(src, fs->debug.file);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -840,7 +840,8 @@ static inline int get_char(FILE *fp, const char *buf, int *chrno)
     return ch;
 }
 
-static int read_line(char *line, int maxlen, FILE *fp, char *buf, int *chrno)
+static int read_line(char *line, int maxlen, FILE *fp, const char *buf,
+                     int *chrno)
 {
     int ch = get_char(fp, buf, chrno);
     while (ch == ' ' || ch == '\n')

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1174,7 +1174,7 @@ int process_command(struct dbenv *dbenv, char *line, int lline, int st)
             return -1;
         }
 
-       logmsg(LOGMSG_USER, "will attempt to delete unused files for %s\n", table);
+        logmsg(LOGMSG_USER, "will attempt to delete unused files for %s\n", table);
 
         rc = bdb_del_unused_files(db->handle, &bdberr);
         if (rc != 0) {

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1174,7 +1174,8 @@ int process_command(struct dbenv *dbenv, char *line, int lline, int st)
             return -1;
         }
 
-        logmsg(LOGMSG_USER, "will attempt to delete unused files for %s\n", table);
+        logmsg(LOGMSG_USER, "will attempt to delete unused files for %s\n",
+               table);
 
         rc = bdb_del_unused_files(db->handle, &bdberr);
         if (rc != 0) {

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -5,7 +5,7 @@ bash -n "$0" | exit 1
 debug=0
 
 dbnm=$1
-tblcnt=100
+tblcnt=150
 
 if [ "x$dbnm" == "x" ] ; then
     echo "need a DB name"
@@ -179,23 +179,24 @@ function flushall
 
 
 
+PRFIX=my_table_name_
 
 echo "Test with insert, SC should not fail"
-cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t0 { `cat t1_1.csc2 ` }"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}0 { `cat t1_1.csc2 ` }"
 
 #cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('debg 500')"
 for i in `seq 1 $tblcnt`; do
   echo "create t$i: "
-  time cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t$i  { `cat t1_1.csc2 ` }"
-  insert_records t$i $i
-  #echo truncate t0
-  #time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate t0"
+  time cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}$i  { `cat t1_1.csc2 ` }"
+  insert_records ${PRFIX}$i $i
+  echo truncate ${PRFIX}0
+  time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
 
-  flushall
+  #flushall
 done
 
 for i in `seq 1 $tblcnt`; do
-    assertcnt t$i $i
+    assertcnt ${PRFIX}$i $i
     #echo rebuild t1
     #time cdb2sql ${CDB2_OPTIONS} $dbnm default "rebuild t1"
     #assertcnt t$i $i
@@ -203,9 +204,9 @@ for i in `seq 1 $tblcnt`; do
     #flushall
 done
 
-RESTART_DELAY=35
-echo "killrestart all nodes"
-kill_restart_cluster $RESTART_DELAY
+#RESTART_DELAY=35
+#echo "killrestart all nodes"
+#kill_restart_cluster $RESTART_DELAY
 
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr MIN_KEEP_LOGS 1')"
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr MIN_KEEP_LOGS_AGE 10')"

--- a/tests/setup
+++ b/tests/setup
@@ -325,8 +325,8 @@ else
         fi
     done
     for node in $CLUSTER; do
-        $CDB2SQL_EXE ${CDB2_OPTIONS} -tabs $DBNAME --host $node 'exec procedure sys.cmd.send("udp stat all")'
-        $CDB2SQL_EXE ${CDB2_OPTIONS} -tabs $DBNAME --host $node 'exec procedure sys.cmd.send("udp ping all")'
+        $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME --host $node 'exec procedure sys.cmd.send("udp stat all")'
+        $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME --host $node 'exec procedure sys.cmd.send("udp ping all")'
     done
 fi
 


### PR DESCRIPTION
Cleanup file.c a bit and more:
* use length returned from snprintf rather than running strlen uselessly
* use sizeof(char array[]) - 1 instead of strlen(array) in several cases
* strlen(name) outside of loop
* shortcut with continue while loops rather than having three indentation levels
* more tables in test to check for leaks etc.