### PR TITLE
Force lua to break out of sqlite_step if we fail to write a row

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3115,9 +3115,8 @@ static int dbstmt_emit(Lua L)
     int cols = sqlite3_column_count(stmt);
     int rc;
     while ((rc = sqlite3_step(stmt)) == SQLITE_ROW) {
-        rc = l_send_back_row(L, stmt, cols);
-        if (rc) {
-            logmsg(LOGMSG_ERROR, "%s failed with rc %d\n", __func__, rc);
+        if (l_send_back_row(L, stmt, cols) != 0) {
+            rc = -1;
             break;
         }
     }


### PR DESCRIPTION
Break out of lua stored procedure if sending a row back to the client fails
