### PR TITLE
cdb2jdbc: Check comdb2db port before connecting.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -491,7 +491,8 @@ public class BBSysUtils {
                     hndl.comdb2dbName = COMDB2DB;
 
                 /* set cluster type if default */
-                if (hndl.myDbCluster.equalsIgnoreCase("default")) {
+                if (hndl.myDbHosts.size() == 0 &&
+                    hndl.myDbCluster.equalsIgnoreCase("default")) {
                     if (hndl.defaultType == null)
                         throw new NoDbHostFoundException(hndl.myDbName,
                                 "No default type configured?");
@@ -574,6 +575,7 @@ public class BBSysUtils {
                 } catch (IOException ioe) {
                     /* Record last error during database discovery. */
                     error_during_discovery = ioe;
+                    connerr = "An I/O error occurred.";
                 }
             }
 
@@ -583,7 +585,8 @@ public class BBSysUtils {
                     continue;
 
                 if (hndl.comdb2dbHosts.size() == 0)
-                    throw new NoDbHostFoundException(hndl.comdb2dbName, error_during_discovery);
+                    throw new NoDbHostFoundException(hndl.comdb2dbName,
+                            "Could not find comdb2db.", error_during_discovery);
                 else {
                     /* prepare diagnosis info */
                     String diagnosis = String.format("[pmux=%d][%s=%s@%d] %s",
@@ -611,6 +614,7 @@ public class BBSysUtils {
                 } catch (IOException ioe) {
                     /* Record last error during database discovery. */
                     error_during_discovery = ioe;
+                    connerr = "An I/O error occurred.";
                 }
             }
 
@@ -623,11 +627,12 @@ public class BBSysUtils {
                 } catch (IOException ioe) {
                     /* Record last error during database discovery. */
                     error_during_discovery = ioe;
+                    connerr = "An I/O error occurred.";
                 }
             }
 
             if (!found) {
-                /* Could not get machines. Retry. */
+                /* Could not get machines of the database. Retry. */
                 if (retries < hndlRetries)
                     continue;
                 throw new NoDbHostFoundException(hndl.myDbName, error_during_discovery);
@@ -684,6 +689,7 @@ public class BBSysUtils {
                     break;
                 } catch (IOException ioe) {
                     error_during_discovery = ioe;
+                    connerr = "An I/O error occurred.";
                 }
             }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/BBSysUtils.java
@@ -90,8 +90,9 @@ public class BBSysUtils {
                     else if (tokens[1].equalsIgnoreCase("room")
                             && hndl.machineRoom == null)
                         hndl.machineRoom = tokens[2];
-                    else if (tokens[1].equalsIgnoreCase("portmuxport")
-                            && !hndl.hasUserPort)
+                    else if ((tokens[1].equalsIgnoreCase("portmuxport") ||
+                              tokens[1].equalsIgnoreCase("pmuxport")) &&
+                             !hndl.hasUserPort)
                         hndl.portMuxPort = Integer.parseInt(tokens[2]);
                     else if (tokens[1].equalsIgnoreCase("comdb2dbname")
                             && hndl.comdb2dbName == null)
@@ -106,6 +107,22 @@ public class BBSysUtils {
                     else if (tokens[1].equalsIgnoreCase("dnssufix")
                             && hndl.dnssuffix == null)
                         hndl.dnssuffix = tokens[2];
+                    else if (tokens[1].equalsIgnoreCase("connect_timeout")
+                            && !hndl.hasConnectTimeout) {
+                        try {
+                            hndl.connectTimeout = Integer.parseInt(tokens[2]);
+                        } catch (NumberFormatException e) {
+                            logger.log(Level.WARNING, "Invalid connect timeout.", e);
+                        }
+                    }
+                    else if (tokens[1].equalsIgnoreCase("comdb2db_timeout")
+                            && !hndl.hasComdb2dbTimeout) {
+                        try {
+                            hndl.comdb2dbTimeout = Integer.parseInt(tokens[2]);
+                        } catch (NumberFormatException e) {
+                            logger.log(Level.WARNING, "Invalid comdb2db timeout.", e);
+                        }
+                    }
                 } else if (tokens[0].equalsIgnoreCase(hndl.comdb2dbName)) {
                     /**
                      * Gets dbnumber and hosts of comdb2db.
@@ -131,17 +148,11 @@ public class BBSysUtils {
     }
 
     private final static String COMDB2DB = "comdb2db";
-    private final static int COMDB2DB_NUM = 32432;
-    private final static String COMDB2DB_DEV = "comdb3db";
-    private final static int COMDB2DB_DEV_NUM = 192779;
 
-    /**
-     * Returns true if successfully get comdb2dbhosts.
-     * 
-     * @param hndl
-     * @return
-     */
-    private static boolean getComdb2dbHosts(Comdb2Handle hndl, boolean just_defaults) {
+    /* Get comdb2db hosts from config file or DNS.
+       Throws an IOException on error. */
+    private static void getComdb2dbHosts(Comdb2Handle hndl,
+            boolean just_defaults) throws IOException {
         /*
          * Load conf from path specified in system property
          * CDB2DBCONFIG_PROP (comdb2db.cfg), defaulting to
@@ -155,41 +166,23 @@ public class BBSysUtils {
         readComdb2dbCfg(CDB2DBCONFIG_NOBBENV_PATH + hndl.myDbName + ".cfg", hndl);
 
         if (just_defaults)
-            return true;
+            return;
 
         if (hndl.comdb2dbHosts.size() > 0 || hndl.myDbHosts.size() > 0)
-            return true;
+            return;
 
-        String comdb2db_bdns = null;
-        try {
-            comdb2db_bdns = String.format("%s-%s.%s",
-                    (hndl.defaultType == null) ? hndl.defaultType : hndl.myDbCluster,
-                    hndl.comdb2dbName, hndl.dnssuffix);
-
-            InetAddress inetAddress[] = InetAddress.getAllByName(comdb2db_bdns);
-            for (int i = 0; i < inetAddress.length; i++) {
-                hndl.comdb2dbHosts.add(inetAddress[i].getHostAddress());
-                rc = true;
-            }
-        } catch (UnknownHostException e) {
-            logger.log(Level.SEVERE, "ERROR in getting address " + comdb2db_bdns, e);
-        }
-        return rc;
+        String comdb2db_bdns = String.format("%s-%s.%s",
+                (hndl.defaultType == null) ? hndl.defaultType : hndl.myDbCluster,
+                hndl.comdb2dbName, hndl.dnssuffix);
+        InetAddress inetAddress[] = InetAddress.getAllByName(comdb2db_bdns);
+        for (int i = 0; i < inetAddress.length; i++)
+            hndl.comdb2dbHosts.add(inetAddress[i].getHostAddress());
     }
 
-    /**
-     * Returns port number.
-     * 
-     * @param host
-     * @param port
-     * @param app
-     * @param service
-     * @param instance
-     * @return
-     */
+    /* Returns port number. Throws an IOException on error. */
     private static int getPortMux(String host, int port,
             int soTimeout, int connectTimeout,
-            String app, String service, String instance) {
+            String app, String service, String instance) throws IOException {
         SockIO io = null;
         try {
             String name = String.format("get %s/%s/%s\n", app, service, instance);
@@ -201,44 +194,23 @@ public class BBSysUtils {
 
             String line = io.readLine(32);
             return Integer.parseInt(line);
-        } catch (SocketTimeoutException e) {
-            return -1;
-        } catch (IOException e) {
-            return -1;
         } finally {
             try {
                 if (io != null)
                     io.close();
             } catch (IOException e) {
-                logger.log(Level.WARNING, "Unable to close portmux connection (" + host + ":" + port + ")", e);
+                /* ignore */
             }
         }
     }
 
-    /**
-     * Gets database node information. Returns no-negative value to indicate the
-     * master node in @validHosts, and -1 to indicate no master node found.
-     * 
-     * @param dbName
-     *            who I want to know about
-     * @param dbNum
-     *            its db number
-     * @param host
-     *            ask who
-     * @param port
-     *            hndlect to which port
-     * @param validHosts
-     *            where I want the hosts of @dbName be stored.
-     * @param validPorts
-     *            where I want the ports of @dbName be stored.
-     * @return
-     * @throws NoComdb2dbHostFoundException
-     */
+    /* Get dbinfo. Return the index of the master node in validHosts.
+       Return -1 if no master. Throw an IOException on error. */
     static int dbInfoQuery(Comdb2Handle hndl,
             Cdb2DbInfoResponse dbInfoResp,
             String dbName, int dbNum, String host, int port,
             List<String> validHosts, List<Integer> validPorts)
-        throws NoDbHostFoundException {
+        throws IOException {
 
         SockIO io = null;
 
@@ -249,10 +221,6 @@ public class BBSysUtils {
             if (dbInfoResp == null) {
                 io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null,
                                 hndl.dbinfoTimeout, hndl.connectTimeout);
-
-                /*********************************
-                 * Sending data...
-                 *********************************/
 
                 io.write("newsql\n");
                 io.flush();
@@ -271,23 +239,19 @@ public class BBSysUtils {
                 protobuf.write(io.getOut());
                 io.flush();
 
-                /*********************************
-                 * Parsing response...
-                 *********************************/
-
                 byte[] res = new byte[nsh.capacity()];
                 if (io.read(res) != nsh.capacity())
-                    throw new NoDbHostFoundException(dbName);
+                    throw new IOException("Received fewer bytes than expected");
                 nsh.reconstructFromBytes(res);
 
                 res = null;
                 res = new byte[nsh.length];
                 if (io.read(res) != nsh.length)
-                    throw new NoDbHostFoundException(dbName);
+                    throw new IOException("Received fewer bytes than expected");
 
                 dbInfoResp = protobuf.unpackDbInfoResp(res);
                 if (dbInfoResp == null)
-                    throw new NoDbHostFoundException(dbName);
+                    throw new IOException("Received malformed data");
             }
 
             int master = -1;
@@ -339,7 +303,7 @@ public class BBSysUtils {
             }
 
             if (validHosts.size() <= 0)
-                throw new NoDbHostFoundException(dbName);
+                throw new IOException("Received incomplete dbinfo response");
 
             if (hndl != null) {
                 hndl.masterIndexInMyDbHosts = master;
@@ -349,31 +313,20 @@ public class BBSysUtils {
 
             return master;
 
-        } catch (IOException e) {
-            throw new NoDbHostFoundException(dbName);
         } finally {
             try {
                 if (io != null)
                     io.close();
             } catch (IOException e) {
-                logger.log(Level.WARNING,
-                        "Unable to close dbinfo_query connection ("
-                        + host + ":" + port + ")", e);
+                /* Ignore */
             }
         }
     }
 
-    /**
-     * Gets database's name, number and room by querying a comdb2db server.
-     * 
-     * @param hndl
-     * @param host
-     *            host of the comdb2db server.
-     * @param port
-     *            port of that server.
-     * @return
-     */
-    private static boolean queryDbHosts(Comdb2Handle hndl, String host, int port) {
+    /* Gets database's name, number and room by querying a comdb2db server. 
+       Throws an IOException on error. */
+    private static void queryDbHosts(Comdb2Handle hndl,
+            String host, int port) throws IOException {
 
         String sqlquery = String.format("select M.name, D.dbnum, M.room from machines M join databases D where M.cluster IN "
                 + "(select cluster_machs from clusters where name = '%s' and cluster_name = '%s') and D.name = '%s' order by (room = '%s') desc",
@@ -384,10 +337,6 @@ public class BBSysUtils {
         try {
             io = new SockIO(host, port, hndl.pmuxrte ? hndl.myDbName : null,
                             hndl.comdb2dbTimeout, hndl.connectTimeout);
-
-            /*********************************
-             * Sending data...
-             *********************************/
 
             io.write("newsql\n");
             io.flush();
@@ -404,20 +353,13 @@ public class BBSysUtils {
             protobuf.write(io.getOut());
             io.flush();
 
-            /*********************************
-             * Parsing response...
-             *********************************/
-
             byte[] res = new byte[nsh.capacity()];
 
             do {
-                if (io.read(res) != NewSqlHeader.BYTES_NEEDED) // unexpected
-                                                                // response from
-                                                                // server
-                    return false;
+                if (io.read(res) != NewSqlHeader.BYTES_NEEDED)
+                    throw new IOException("Received fewer bytes than expected");
                 nsh = NewSqlHeader.fromBytes(res);
-            } while (nsh == null || nsh.length == 0); // if heartbeat packet,
-                                                        // try again
+            } while (nsh == null || nsh.length == 0); /* if heartbeat packet, try again */
 
             nsh.reconstructFromBytes(res);
 
@@ -425,12 +367,13 @@ public class BBSysUtils {
             res = new byte[nsh.length];
 
             if (io.read(res) != nsh.length)
-                return false;
+                throw new IOException("Received fewer bytes than expected");
 
             Cdb2SqlResponse sqlResp = protobuf.unpackSqlResp(res);
             if (sqlResp == null || sqlResp.errCode != 0
-                    || (sqlResp.respType != 1 && sqlResp.value.size() != 1 && (sqlResp.value.get(0).type == -1 || sqlResp.value.get(0).type != 3)))
-                return false;
+                    || (sqlResp.respType != 1 && sqlResp.value.size() != 1 &&
+                        (sqlResp.value.get(0).type == -1 || sqlResp.value.get(0).type != 3)))
+                throw new IOException("Received malformed data");
 
             hndl.myDbHosts.clear();
 
@@ -438,13 +381,13 @@ public class BBSysUtils {
                 res = null;
                 res = new byte[nsh.capacity()];
                 if (io.read(res) != nsh.capacity())
-                    return false;
+                    throw new IOException("Received fewer bytes than expected");
                 nsh.reconstructFromBytes(res);
 
                 res = null;
                 res = new byte[nsh.length];
                 if (io.read(res) != nsh.length)
-                    return false;
+                    throw new IOException("Received fewer bytes than expected");
 
                 sqlResp = protobuf.unpackSqlResp(res);
                 if (sqlResp.errCode != 0)
@@ -473,18 +416,12 @@ public class BBSysUtils {
                     comdb2lcldb.put(hndl.myDbName + "/" + hndl.myDbCluster, record);
                 }
             }
-
-            return true;
-        } catch (SocketTimeoutException e) {
-            return false;
-        } catch (IOException e) {
-            return false;
         } finally {
             try {
                 if (io != null)
                     io.close();
             } catch (IOException e) {
-                logger.log(Level.WARNING, "Unable to close get_dbhosts connection (" + host + ":" + port + ")", e);
+                /* Ignore. */
             }
         }
     }
@@ -504,6 +441,8 @@ public class BBSysUtils {
             hndl.comdb2dbHosts.clear();
             hndl.myDbHosts.clear();
             hndl.myDbPorts.clear();
+            /* Invalidate db host cache as well. */
+            comdb2lcldb.remove(hndl.myDbName + "/" + hndl.myDbCluster);
         }
 
         if (hndl.myDbCluster.equalsIgnoreCase("local")) {
@@ -540,28 +479,30 @@ public class BBSysUtils {
             }
 
             if (hndl.myDbHosts.size() == 0) {
-                /* get default conf without DNS lookup */
-                getComdb2dbHosts(hndl, true);
-
-                /* start with "comdb2db" */
-                String comdb2db_name = COMDB2DB;
+                try {
+                    /* get default conf without DNS lookup */
+                    getComdb2dbHosts(hndl, true);
+                } catch (IOException ioe) {
+                    /* Ignore. */
+                }
 
                 /* revise comdb2db_name */
                 if (hndl.comdb2dbName == null)
-                    hndl.comdb2dbName = comdb2db_name;
+                    hndl.comdb2dbName = COMDB2DB;
 
                 /* set cluster type if default */
                 if (hndl.myDbCluster.equalsIgnoreCase("default")) {
                     if (hndl.defaultType == null)
-                        throw new NoDbHostFoundException(hndl.myDbName +
-                                "@default. No default type configured?");
+                        throw new NoDbHostFoundException(hndl.myDbName,
+                                "No default type configured?");
                     hndl.myDbCluster = hndl.defaultType;
                 }
 
-                if (!getComdb2dbHosts(hndl, false))
-                    throw new NoDbHostFoundException(hndl.myDbName +
-                            ". Wrong configuration for cluster '" +
-                            hndl.myDbCluster + "'.");
+                try {
+                    getComdb2dbHosts(hndl, false);
+                } catch (IOException ioe) {
+                    throw new NoDbHostFoundException(hndl.myDbName, ioe);
+                }
             }
         } else if (hndl.myDbHosts.size() == 0) {
             hndl.isDirectCpu = true;
@@ -575,12 +516,16 @@ public class BBSysUtils {
                 if (hndl.myDbPorts.get(i) != -1)
                     atLeastOneValid = true;
                 else {
-                    int dbport = getPortMux(hndl.myDbHosts.get(i),
-                            hndl.portMuxPort, hndl.soTimeout, hndl.connectTimeout,
-                            "comdb2", "replication", hndl.myDbName);
-                    if (dbport != -1) {
-                        atLeastOneValid = true;
-                        hndl.myDbPorts.set(i, dbport);
+                    try {
+                        int dbport = getPortMux(hndl.myDbHosts.get(i),
+                                hndl.portMuxPort, hndl.soTimeout, hndl.connectTimeout,
+                                "comdb2", "replication", hndl.myDbName);
+                        if (dbport != -1) {
+                            atLeastOneValid = true;
+                            hndl.myDbPorts.set(i, dbport);
+                        }
+                    } catch (IOException ioe) {
+                        /* Ignore. */
                     }
                 }
             }
@@ -589,62 +534,56 @@ public class BBSysUtils {
             return;
         }
 
-        /******************************************
-         * If no hosts defined, we have to query comdb2db to get necessary
-         * information.
-         ******************************************/
-        // System.out.printf("Still Looking for Db hosts");
+        /* If !DIRECT_CPU or no hosts in config file, query comdb2db. */
 
         ArrayList<String> validHosts = new ArrayList<String>();
         ArrayList<Integer> validPorts = new ArrayList<Integer>();
 
         boolean found = false;
+        Throwable error_during_discovery = null;
+        int hndlRetries = hndl.maxRetries();
 
         int retries = 0;
 
-        while (hndl.myDbHosts.size() == 0 && retries < 5) {
+        while (hndl.myDbHosts.size() == 0 && retries < hndlRetries) {
             retries++;
             if (debug) {
                 System.out.println("Querying for dbhosts, retries=" + retries);
             }
 
-            /*****************************************
-             * First, get a list of available comdb2db servers.
-             *****************************************/
-
+            /* Get comdb2db dbinfo. */
             int master = -1;
 			int comdb2dbPort = -1;
 			String connerr = "";
             for (String comdb2dbHost : hndl.comdb2dbHosts) {
-                comdb2dbPort = BBSysUtils.getPortMux(comdb2dbHost, hndl.portMuxPort,
-                                                     hndl.soTimeout, hndl.connectTimeout,
-                                                     "comdb2", "replication", hndl.comdb2dbName);
-                if (comdb2dbPort < 0)
-					connerr = "port error";
-                else {
-                    try {
+                try {
+                    comdb2dbPort = BBSysUtils.getPortMux(comdb2dbHost, hndl.portMuxPort,
+                            hndl.soTimeout, hndl.connectTimeout,
+                            "comdb2", "replication", hndl.comdb2dbName);
 
-                        master = dbInfoQuery(hndl,
-                                null, hndl.comdb2dbName, hndl.comdb2dbDbNum,
-                                comdb2dbHost, comdb2dbPort, validHosts, validPorts);
-                        found = true;
-                        break;
-                    } catch (NoDbHostFoundException e) {
-                        /**
-                         * Ignore single exception.
-                         */
-						connerr = "dbinfo error";
+                    if (comdb2dbPort < 0) {
+                        connerr = "Received invalid port from pmux.";
+                        continue;
                     }
+
+                    master = dbInfoQuery(hndl,
+                            null, hndl.comdb2dbName, hndl.comdb2dbDbNum,
+                            comdb2dbHost, comdb2dbPort, validHosts, validPorts);
+                    found = true;
+                    break;
+                } catch (IOException ioe) {
+                    /* Record last error during database discovery. */
+                    error_during_discovery = ioe;
                 }
             }
 
-            /**
-             * However, if all dbinfoquery calls failed, then an exception has
-             * to be thrown...
-             */
             if (!found) {
+                /* Could not get comdb2db dbinfo. Retry. */
+                if (retries < hndlRetries)
+                    continue;
+
                 if (hndl.comdb2dbHosts.size() == 0)
-                    throw new NoDbHostFoundException(hndl.comdb2dbName);
+                    throw new NoDbHostFoundException(hndl.comdb2dbName, error_during_discovery);
                 else {
                     /* prepare diagnosis info */
                     String diagnosis = String.format("[pmux=%d][%s=%s@%d] %s",
@@ -653,45 +592,54 @@ public class BBSysUtils {
                             hndl.comdb2dbHosts.get(hndl.comdb2dbHosts.size() - 1),
                             comdb2dbPort,
                             connerr);
-                    throw new NoDbHostFoundException(diagnosis);
+                    throw new NoDbHostFoundException(hndl.comdb2dbName,
+                            diagnosis, error_during_discovery);
                 }
 			}
 
-            /************************************************
-             * We have a list of available hosts now. Query the slave nodes
-             * one-by-one to get hosts of the database that we want hndlect to.
-             ************************************************/
+            /* Query comdb2db to get a list of machines where the database runs on. */
+            found = false;
+            error_during_discovery = null;
 
             for (int i = 0; i != validHosts.size(); ++i) {
-                if (master == i && validHosts.size() > 1)
+                if (master == i && validHosts.size() > 1 || validPorts.get(i) < 0)
                     continue;
-
-                found = queryDbHosts(hndl, validHosts.get(i), validPorts.get(i));
-                if (found)
+                try {
+                    queryDbHosts(hndl, validHosts.get(i), validPorts.get(i));
+                    found = true;
                     break;
+                } catch (IOException ioe) {
+                    /* Record last error during database discovery. */
+                    error_during_discovery = ioe;
+                }
             }
 
-            /**********************************************
-             * None of slave nodes works. Now try master.
-             **********************************************/
-            if (!found)
-                found = queryDbHosts(hndl, validHosts.get(master), validPorts.get(master));
+            if (!found && master >= 0) {
+                if (validPorts.get(master) < 0)
+                    continue;
+                try {
+                    queryDbHosts(hndl, validHosts.get(master), validPorts.get(master));
+                    found = true;
+                } catch (IOException ioe) {
+                    /* Record last error during database discovery. */
+                    error_during_discovery = ioe;
+                }
+            }
 
-            if (!found)
-                throw new NoDbHostFoundException(hndl.myDbName);
+            if (!found) {
+                /* Could not get machines. Retry. */
+                if (retries < hndlRetries)
+                    continue;
+                throw new NoDbHostFoundException(hndl.myDbName, error_during_discovery);
+            }
 
             hndl.comdb2dbHosts.clear();
             hndl.comdb2dbHosts.addAll(validHosts);
         }
 
-        /**********************************************
-         * At this stage, we should have a list of hosts stored in @myDbHosts.
-         * 
-         * Ask them one-by-one to get the host(s) and port(s) of the database we
-         * want to hndlect to.
-         **********************************************/
+        /* We have a list of machines where the database runs. */
 
-        /* If pmux route is enabled, use pmux port. */
+        /* If pmux route is enabled, use pmux port. Otherwise do dbinfo query. */
         if (hndl.pmuxrte) {
             hndl.myDbPorts.clear();
             for (int i = 0; i != hndl.myDbHosts.size(); ++i)
@@ -699,11 +647,10 @@ public class BBSysUtils {
             return;
         }
 
-
         found = false;
+        error_during_discovery = null;
 
         int port = -1;
-        int hndlRetries = hndl.maxRetries();
         int increment = hndl.myDbHosts.size();
 
         if (increment == 0)
@@ -713,20 +660,19 @@ public class BBSysUtils {
 
         for (int retry = 0; (retry < hndlRetries) && (found == false); retry += increment) {
             for (int i = 0; i != hndl.myDbHosts.size(); ++i) {
-                String host = hndl.myDbHosts.get(i);
-                if (hndl.myDbPorts.get(i) >= 0)
-                    port = hndl.myDbPorts.get(i);
-                else
-                    port = getPortMux(host, hndl.portMuxPort,
-                            hndl.soTimeout, hndl.connectTimeout,
-                            "comdb2", "replication", hndl.myDbName);
-
-                if (port < 0) {
-                    connerr = "port error";
-                    continue;
-                }
-
                 try {
+                    String host = hndl.myDbHosts.get(i);
+                    port = hndl.myDbPorts.get(i);
+                    if (port < 0)
+                        port = getPortMux(host, hndl.portMuxPort,
+                                hndl.soTimeout, hndl.connectTimeout,
+                                "comdb2", "replication", hndl.myDbName);
+
+                    if (port < 0) {
+                        connerr = "Received invalid port from pmux.";
+                        continue;
+                    }
+
                     dbInfoQuery(hndl,
                             null, hndl.myDbName, hndl.myDbNum,
                             host, port, validHosts, validPorts);
@@ -736,11 +682,8 @@ public class BBSysUtils {
                     }
                     found = true;
                     break;
-                } catch (NoDbHostFoundException e) {
-                    /**
-                     * Ignore single exception.
-                     */
-                    connerr = "dbinfo error";
+                } catch (IOException ioe) {
+                    error_during_discovery = ioe;
                 }
             }
 
@@ -762,7 +705,7 @@ public class BBSysUtils {
 
         if (!found) {
             if (hndl.myDbHosts.size() == 0)
-                throw new NoDbHostFoundException(hndl.myDbName);
+                throw new NoDbHostFoundException(hndl.myDbName, error_during_discovery);
             else {
                 // diagnosis
                 String diagnosis = String.format("[pmux=%d][%s=%s@%d] %s",
@@ -771,7 +714,7 @@ public class BBSysUtils {
                         hndl.myDbHosts.get(hndl.myDbHosts.size() - 1),
                         port,
                         connerr);
-                throw new NoDbHostFoundException(diagnosis);
+                throw new NoDbHostFoundException(hndl.myDbName, diagnosis, error_during_discovery);
             }
         }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -125,10 +125,12 @@ public class Comdb2Connection implements Connection {
     }
 
     public void setConnectTimeout(int timeout) {
+        hndl.hasConnectTimeout = true;
         hndl.connectTimeout = timeout;
     }
 
     public void setComdb2dbTimeout(int timeout) {
+        hndl.hasComdb2dbTimeout = true;
         hndl.comdb2dbTimeout = timeout;
     }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -71,7 +71,9 @@ public class Comdb2Handle extends AbstractConnection {
     boolean statement_effects = false;
     boolean verifyretry = false;
     int soTimeout = 5000;
+    boolean hasComdb2dbTimeout;
     int comdb2dbTimeout = 5000;
+    boolean hasConnectTimeout;
     int connectTimeout = 100;
     int dbinfoTimeout = 500;
 
@@ -159,7 +161,9 @@ public class Comdb2Handle extends AbstractConnection {
         ret.statement_effects = statement_effects;
         ret.verifyretry = verifyretry;
         ret.soTimeout = soTimeout;
+        ret.hasComdb2dbTimeout = hasComdb2dbTimeout;
         ret.comdb2dbTimeout = comdb2dbTimeout;
+        ret.hasConnectTimeout = hasConnectTimeout;
         ret.connectTimeout = connectTimeout;
         ret.dbinfoTimeout = dbinfoTimeout;
 
@@ -489,7 +493,7 @@ public class Comdb2Handle extends AbstractConnection {
                     BBSysUtils.dbInfoQuery(this,
                             dbinfo, myDbName, myDbNum,
                             null, 0, validHosts, validPorts);
-                } catch (NoDbHostFoundException e) {
+                } catch (IOException e) {
                     validHosts.clear();
                 }
 
@@ -1141,7 +1145,7 @@ public class Comdb2Handle extends AbstractConnection {
                         BBSysUtils.dbInfoQuery(this,
                                 dbinfo, myDbName, myDbNum,
                                 null, 0, validHosts, validPorts);
-                    } catch (NoDbHostFoundException e) {
+                    } catch (IOException e) {
                         validHosts.clear();
                     }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -216,7 +216,7 @@ public class Comdb2Handle extends AbstractConnection {
     }
 
     public void lookup() throws NoDbHostFoundException {
-        BBSysUtils.getDbHosts(this, false);
+        DatabaseDiscovery.getDbHosts(this, false);
     }
 
     /* attribute setters - bb precious */
@@ -345,7 +345,7 @@ public class Comdb2Handle extends AbstractConnection {
 
     public void setDebug(boolean on) {
         debug = on;
-        BBSysUtils.debug = on;
+        DatabaseDiscovery.debug = on;
     }
 
     public void setMaxRetries(int retries) {
@@ -490,7 +490,7 @@ public class Comdb2Handle extends AbstractConnection {
                 ArrayList<String> validHosts = new ArrayList<String>();
                 ArrayList<Integer> validPorts = new ArrayList<Integer>();
                 try {
-                    BBSysUtils.dbInfoQuery(this,
+                    DatabaseDiscovery.dbInfoQuery(this,
                             dbinfo, myDbName, myDbNum,
                             null, 0, validHosts, validPorts);
                 } catch (IOException e) {
@@ -1142,7 +1142,7 @@ public class Comdb2Handle extends AbstractConnection {
                     ArrayList<String> validHosts = new ArrayList<String>();
                     ArrayList<Integer> validPorts = new ArrayList<Integer>();
                     try {
-                        BBSysUtils.dbInfoQuery(this,
+                        DatabaseDiscovery.dbInfoQuery(this,
                                 dbinfo, myDbName, myDbNum,
                                 null, 0, validHosts, validPorts);
                     } catch (IOException e) {
@@ -1913,7 +1913,7 @@ readloop:
            Re-check information about db. */
         if (!isDirectCpu && refresh_dbinfo_if_failed) {
             try {
-                BBSysUtils.getDbHosts(this, true);
+                DatabaseDiscovery.getDbHosts(this, true);
                 reopen(false);
             } catch (NoDbHostFoundException e) {
                 logger.log(Level.SEVERE, "Failed to refresh dbinfo", e);

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -30,7 +30,7 @@ import java.util.*;
  * @author Tzvetan Mikov
  */
 public class Comdb2Statement implements Statement {
-    private static Logger logger = Logger.getLogger(BBSysUtils.class.getName());
+    private static Logger logger = Logger.getLogger(Comdb2Statement.class.getName());
 
     /**
      * `hndl` is a reference to the handle of its connection. So it should be

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/NoDbHostFoundException.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/NoDbHostFoundException.java
@@ -22,8 +22,20 @@ public class NoDbHostFoundException extends Exception {
 
     private static final long serialVersionUID = -3336167815219390728L;
 
+    public NoDbHostFoundException(String dbname, Throwable t) {
+        super(dbname, t);
+    }
+
+    public NoDbHostFoundException(String dbname, String reason, Throwable t) {
+        super(dbname + ": " + reason, t);
+    }
+
+    public NoDbHostFoundException(String dbname, String reason) {
+        this(dbname, reason, null);
+    }
+
     public NoDbHostFoundException(String dbname) {
-        super("No host found for " + dbname);
+        super(dbname);
     }
 
 }

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
@@ -8,20 +8,185 @@ import org.junit.Assert.*;
 
 public class DatabaseDiscoveryTest {
 
-    /* Verify that the driver throws proper exception when comdb2db or bdns is down. */
-    @Test public void testComdb2dbNodeDown() throws IOException, SQLException {
+    @Test
+    public void testNoDefault() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://default/db");
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("No default type configured"));
+        }
+    }
+
+    @Test
+    public void testDNSDown() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db");
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("Could not find database hosts from DNS and config files"));
+        }
+    }
+
+    @Test
+    public void testPmuxDown() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+
+            String db = System.getProperty("cdb2jdbc.test.database");
+            String cluster = System.getProperty("cdb2jdbc.test.cluster");
+            Connection conn = DriverManager.getConnection(
+                    String.format("jdbc:comdb2://%s/%s?portmuxport=8888", cluster, db));
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("Could not get database port from user supplied hosts"));
+        }
+    }
+
+    @Test
+    public void testComdb2dbMachineOffline() throws IOException, SQLException {
         try {
             LogManager.getLogManager().reset();
             String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
             BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
-            writer.write("\ndoes_not_exist 0 www.example.com\n");
+            writer.write("does_not_exist 0 www.example.com\n");
+            writer.close();
+            System.setProperty("comdb2db.cfg", fname);
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://" +
+                    "dev/db?comdb2dbname=does_not_exist&max_retries=1");
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("A network I/O error occurred"));
+        }
+    }
+
+    @Test
+    public void testComdb2dbNodeDown() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+            String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
+            writer.write("does_not_exist 0 localhost\n");
             writer.close();
             System.setProperty("comdb2db.cfg", fname);
             Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db?comdb2dbname=does_not_exist");
             Assert.assertTrue("Should not reach here", false);
         } catch (SQLException sqle) {
-            Assert.assertTrue("Should see an IO error since the destination is unreachable.",
-                    sqle.getMessage().contains("An I/O error occurred"));
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("Received invalid port from pmux"));
+        }
+    }
+
+    @Test
+    public void testMalformedComdb2db() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+            String db = System.getProperty("cdb2jdbc.test.database");
+            String cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+            Connection conn = DriverManager.getConnection(
+                    String.format("jdbc:comdb2://%s/%s", cluster, db));
+            try {
+                conn.createStatement().execute("DROP TABLE clusters");
+            } catch (SQLException sqle) {
+            }
+            try {
+                conn.createStatement().execute("DROP TABLE machines");
+            } catch (SQLException sqle) {
+            }
+            try {
+                conn.createStatement().execute("DROP TABLE databases");
+            } catch (SQLException sqle) {
+            }
+
+            String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
+            writer.write(db);
+            writer.write(" 0 ");
+            writer.write(cluster);
+            writer.close();
+            System.setProperty("comdb2db.cfg", fname);
+
+            conn = DriverManager.getConnection(
+                    String.format("jdbc:comdb2://%s/%s?comdb2dbname=%s", "dev", "does_not_exist", db));
+
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("Could not query database hosts from"));
+        }
+    }
+
+    @Test
+    public void testDbDown() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+
+            String cluster = System.getProperty("cdb2jdbc.test.cluster");
+            String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
+            writer.write("does_not_exist");
+            writer.write(" 0 ");
+            writer.write(cluster);
+            writer.close();
+            System.setProperty("comdb2db.cfg", fname);
+
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/does_not_exist?max_retries=1");
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("Received invalid port from pmux."));
+        }
+    }
+
+    @Test
+    public void testUnregisteredDb() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+
+            String db = System.getProperty("cdb2jdbc.test.database");
+            String cluster = System.getProperty("cdb2jdbc.test.cluster");
+            Connection conn = DriverManager.getConnection(
+                    String.format("jdbc:comdb2://%s/%s", cluster, db));
+
+            try {
+                conn.createStatement().execute("DROP TABLE clusters");
+            } catch (SQLException sqle) {
+            }
+            try {
+                conn.createStatement().execute("DROP TABLE machines");
+            } catch (SQLException sqle) {
+            }
+            try {
+                conn.createStatement().execute("DROP TABLE databases");
+            } catch (SQLException sqle) {
+            }
+
+            conn.createStatement().execute("CREATE TABLE clusters (name varchar(8), cluster_name varchar(31), cluster_machs varchar(31))");
+            conn.createStatement().execute("CREATE TABLE machines (name varchar(31), cluster varchar(31), room varchar(3))");
+            conn.createStatement().execute("CREATE TABLE databases (name varchar(8), dbnum integer)");
+
+            conn.close();
+
+            String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
+            writer.write(db);
+            writer.write(" 0 ");
+            writer.write(cluster);
+            writer.close();
+            System.setProperty("comdb2db.cfg", fname);
+            conn = DriverManager.getConnection("jdbc:comdb2://dev/does_not_exist?comdb2dbname=" + db);
+
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see correct error message.",
+                    sqle.getMessage().contains("No entries of does_not_exist found in"));
         }
     }
 }

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
@@ -1,0 +1,25 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.io.*;
+import java.sql.*;
+import java.util.logging.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class DatabaseDiscoveryTest {
+
+    @Test public void testComdb2dbNodeDown() throws IOException, SQLException {
+        try {
+            LogManager.getLogManager().reset();
+            String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
+            writer.write("\ndoes_not_exist 0 localhost\n");
+            writer.close();
+            System.setProperty("comdb2db.cfg", fname);
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db?comdb2dbname=does_not_exist");
+            Assert.assertTrue("Should not reach here", false);
+        } catch (SQLException sqle) {
+            Assert.assertTrue("Should see sqlexception", true);
+        }
+    }
+}

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
@@ -8,18 +8,20 @@ import org.junit.Assert.*;
 
 public class DatabaseDiscoveryTest {
 
+    /* Verify that the driver throws proper exception when comdb2db or bdns is down. */
     @Test public void testComdb2dbNodeDown() throws IOException, SQLException {
         try {
             LogManager.getLogManager().reset();
             String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
             BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
-            writer.write("\ndoes_not_exist 0 localhost\n");
+            writer.write("\ndoes_not_exist 0 www.example.com\n");
             writer.close();
             System.setProperty("comdb2db.cfg", fname);
             Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db?comdb2dbname=does_not_exist");
             Assert.assertTrue("Should not reach here", false);
         } catch (SQLException sqle) {
-            Assert.assertTrue("Should see sqlexception", true);
+            Assert.assertTrue("Should see an IO error since the destination is unreachable.",
+                    sqle.getMessage().contains("An I/O error occurred"));
         }
     }
 }

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
@@ -71,8 +71,10 @@ public class DatabaseDiscoveryTest {
         try {
             LogManager.getLogManager().reset();
             String fname = "/tmp/comdb2db.jdbc.mvn.test.cfg." + System.currentTimeMillis();
+            String cluster = System.getProperty("cdb2jdbc.test.cluster");
             BufferedWriter writer = new BufferedWriter(new FileWriter(fname));
-            writer.write("does_not_exist 0 localhost\n");
+            writer.write("does_not_exist 0 ");
+            writer.write(cluster);
             writer.close();
             System.setProperty("comdb2db.cfg", fname);
             Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db?comdb2dbname=does_not_exist");

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/PreparedStatementTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/PreparedStatementTest.java
@@ -66,6 +66,11 @@ public class PreparedStatementTest {
 
     @Test
     public void createTable() throws SQLException {
+        try {
+            conn.createStatement().execute("DROP TABLE application");
+        } catch (SQLException sqle) {
+            /* Ignore */
+        }
         PreparedStatement stmt = conn.prepareStatement(
                 "create table application (app_id int primary key, name varchar(100), update_uuid int, update_tms datetime)");
         int shouldbezero = stmt.executeUpdate();


### PR DESCRIPTION
An invalid port number results in an IllegalArgumentException which is not handled by the driver. Therefore we need to validate the port first.

The patch also tweaks BBSysUtils to throw a better exception on db discovery error.