### PR TITLE
move setting pmux_cmd into script instead of makefile

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -46,7 +46,7 @@ basicops_nokey: init
 basicops: basicops_nokey
 	$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" SKIPSSL="${SKIPSSL}" $(TESTSROOTDIR)/tools/keygen.sh)
 	$(shell TOTAL="${TOTAL}" $(TESTSROOTDIR)/tools/smalldelay.sh)
-	$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" TESTSROOTDIR="${TESTSROOTDIR}" COMDB2_EXE=${COMDB2_EXE} CDB2SQL_EXE=${CDB2SQL_EXE} COMDB2AR_EXE=${COMDB2AR_EXE} PMUX_EXE=${PMUX_EXE} pmux_port=${pmux_port} pmux_cmd=${pmux_cmd} ${TESTSROOTDIR}/tools/copy_files_to_cluster.sh > ${TESTDIR}/copy_files_to_cluster.log || echo "copy_files_to_cluster failed" )
+	$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" TESTSROOTDIR="${TESTSROOTDIR}" COMDB2_EXE=${COMDB2_EXE} CDB2SQL_EXE=${CDB2SQL_EXE} COMDB2AR_EXE=${COMDB2AR_EXE} PMUX_EXE=${PMUX_EXE} PMUXPORT=${PMUXPORT} ${TESTSROOTDIR}/tools/copy_files_to_cluster.sh > ${TESTDIR}/copy_files_to_cluster.log 2>&1 || echo "exit 1 copy_files_to_cluster failed" )
 
 showparams: 
 	@echo TESTSROOTDIR=${TESTSROOTDIR}

--- a/tests/Makefile.common
+++ b/tests/Makefile.common
@@ -12,15 +12,6 @@ export COPYCOMDB2_EXE?=${BUILDDIR}/db/copycomdb2
 export CDB2DUMP_EXE?=${BUILDDIR}/db/cdb2_dump
 export CDB2_SQLREPLAY_EXE?=${BUILDDIR}/tools/cdb2_sqlreplay/cdb2_sqlreplay
 export PMUX_EXE?=${BUILDDIR}/tools/pmux/pmux
-export pmux_port?=5105
 export MAKEFILE_COMMON_INCLUDED=1
 
-# See logic in setup
-ifeq ($(PMUXPORT),)
-export pmux_cmd="${PMUX_EXE} -l"
-else
-export pmux_socket=/tmp/pmux.socket.$PMUXPORT
-export pmux_port_range="-r $((pmux_port+1)):$((pmux_port+200))"
-export pmux_cmd="${PMUX_EXE} -l -p ${PMUXPORT} -b ${pmux_socket} ${pmux_port_range}"
-endif
 endif

--- a/tests/setup
+++ b/tests/setup
@@ -12,7 +12,7 @@ while [[ $# -gt 0 && $1 = -* ]]; do
     shift
 done
 
-vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR BUILDDIR TESTSBUILDDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE PMUX_EXE pmux_port"
+vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR BUILDDIR TESTSBUILDDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE pmux_port"
 for required in $vars; do
     q=${!required}
     if [[ -z "$q" ]]; then
@@ -164,16 +164,13 @@ echo "comdb2_config:allow_pmux_route:true" >> $CDB2_CONFIG
 
 set +e
 
-#pmux_port is assigned in runtestcase
-pmux_cmd="$PMUX_EXE -l"
-
 # If PMUXPORT is defined we will overwrite the default pmux port with that
-if [ -n "$PMUXPORT" ] ; then
-    echo "comdb2_config:portmuxport=$PMUXPORT" >> $CDB2_CONFIG
-    echo "portmux_port $PMUXPORT" >> ${LRL}
+if [ -n "${PMUXPORT}" ] ; then
+    pmux_socket=/tmp/pmux.socket.${PMUXPORT}
+    echo "comdb2_config:portmuxport=${PMUXPORT}" >> $CDB2_CONFIG
+    echo "portmux_port ${PMUXPORT}" >> ${LRL}
     echo "portmux_bind_path $pmux_socket" >> ${LRL}
 fi
-stop_pmux="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port} && echo exit >&3 ) || echo PMUX DOWN"
 
 export COMDB2AR_EXOPTS="-x $COMDB2_EXE"
 

--- a/tests/testcase.mk
+++ b/tests/testcase.mk
@@ -43,7 +43,7 @@ export COMDB2_UNITTEST?=0
 ifneq ($(INSETUP),)
   # we are in setup or running make from within a testdir
   $(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" SKIPSSL="${SKIPSSL}" ${TESTSROOTDIR}/tools/keygen.sh )
-  $(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" TESTSROOTDIR="${TESTSROOTDIR}" COMDB2_EXE=${COMDB2_EXE} CDB2SQL_EXE=${CDB2SQL_EXE} COMDB2AR_EXE=${COMDB2AR_EXE} PMUX_EXE=${PMUX_EXE} pmux_port=${pmux_port} pmux_cmd=${pmux_cmd} ${TESTSROOTDIR}/tools/copy_files_to_cluster.sh > ${TESTDIR}/copy_files_to_cluster.log || echo "copy_files_to_cluster failed" )
+  $(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" TESTSROOTDIR="${TESTSROOTDIR}" COMDB2_EXE=${COMDB2_EXE} CDB2SQL_EXE=${CDB2SQL_EXE} COMDB2AR_EXE=${COMDB2AR_EXE} PMUX_EXE=${PMUX_EXE} PMUXPORT=${PMUXPORT} ${TESTSROOTDIR}/tools/copy_files_to_cluster.sh > ${TESTDIR}/copy_files_to_cluster.log 2>&1 || echo "exit 1 copy_files_to_cluster failed" )
 endif
 
 test:: tool unit


### PR DESCRIPTION
* move setting pmux_cmd in script rather than makefile
* make sure that a failure from copy script will fail the make process
* forward standard error from script execution into log file