### PR TITLE
fix scindex

### DIFF
--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -196,7 +196,7 @@ int add_table_to_environment(char *table, const char *csc2,
         if (rc == SC_CSC2_ERROR) sc_errf(s, "New indexes syntax error\n");
         goto err;
     }
-    newdb->schema->ix_blob = newdb->ix_blob;
+    newdb->ix_blob = newdb->schema->ix_blob;
 
     /*
     ** if ((rc = write_csc2_file(newdb, csc2))) {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -386,6 +386,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         } else {
             sc_printf(s, "New indexes ok\n");
         }
+        newdb->ix_blob = newdb->schema->ix_blob;
     }
     pthread_mutex_unlock(&csc2_subsystem_mtx);
 


### PR DESCRIPTION
Bug was introduced in #863 with the new syntax check logic where the
ix_blob flag was not set properly.

Solution is to attach the schema structure to clnt so when we bootstrap
SQLite, SQLite can help us identifying whether blobs are invloved in
any of the index expressions.
