### PR TITLE
sc_seed no timebased genid, no 2: in front of comdb2_rowid

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1951,7 +1951,6 @@ void lock_info_lockers(FILE *out, bdb_state_type *bdb_state);
 
 const char *bdb_find_net_host(bdb_state_type *bdb_state, const char *host);
 
-unsigned long long get_next_sc_seed(bdb_state_type *bdb_state);
 unsigned long long bdb_get_a_genid(bdb_state_type *bdb_state);
 
 /* Return the timestamp of the replicants coherency lease */

--- a/bdb/genid.c
+++ b/bdb/genid.c
@@ -596,8 +596,11 @@ unsigned long long get_next_sc_seed(bdb_state_type *bdb_state)
     if (gbl_llmeta_open == 0)
         return 0ULL;
 
-    /* Always use time based genids for sc seeds */
-    return get_genid_timebased(bdb_state, 0, NULL, 0);
+    /* Before we would always use time based genids for sc seeds
+     * by calling get_genid_timebased(bdb_state, 0, NULL, 0);
+     * but that updates global contex, so getting current time 
+     * for the seed should suffice */
+    return comdb2_time_epochus();
 }
 
 unsigned long long bdb_get_a_genid(bdb_state_type *bdb_state)

--- a/bdb/genid.c
+++ b/bdb/genid.c
@@ -586,23 +586,6 @@ unsigned long long get_genid(bdb_state_type *bdb_state, unsigned int dtafile)
     return get_genid_int(bdb_state, dtafile, NULL, 0);
 }
 
-/* Return the next sc seed to use for schema change. */
-unsigned long long get_next_sc_seed(bdb_state_type *bdb_state)
-{
-    extern int gbl_llmeta_open;
-    if (bdb_state->parent)
-        bdb_state = bdb_state->parent;
-
-    if (gbl_llmeta_open == 0)
-        return 0ULL;
-
-    /* Before we would always use time based genids for sc seeds
-     * by calling get_genid_timebased(bdb_state, 0, NULL, 0);
-     * but that updates global contex, so getting current time 
-     * for the seed should suffice */
-    return comdb2_time_epochus();
-}
-
 unsigned long long bdb_get_a_genid(bdb_state_type *bdb_state)
 {
     return get_genid(bdb_state, 0);
@@ -1009,23 +992,6 @@ int bdb_get_active_stripe(bdb_state_type *bdb_state)
     BDB_RELLOCK();
 
     return dtafile;
-}
-
-/* get a unique genid that can be used in comdb2 prefault to reference next
- * block to allocate by database for new data records. */
-static unsigned long long bdb_get_next_genid(bdb_state_type *bdb_state,
-                                             unsigned long long *ngenid)
-{
-    bdb_state_type *parent = NULL;
-
-    if (bdb_state->parent)
-        parent = bdb_state->parent;
-    else
-        parent = bdb_state;
-
-    *ngenid = get_genid(bdb_state, bdb_get_active_stripe_int(bdb_state));
-
-    return *ngenid;
 }
 
 /* this is called by writers on the master */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8518,6 +8518,7 @@ int sqlite3BtreeRecordID(BtCursor *pCur, void *memp)
     return SQLITE_OK;
 }
 
+/* print comdb2_rowid */
 int sqlite3BtreeRecordIDString(BtCursor *pCur, unsigned long long rowid,
                                char **memp, size_t maxsz)
 {
@@ -8538,7 +8539,7 @@ int sqlite3BtreeRecordIDString(BtCursor *pCur, unsigned long long rowid,
         rc = enque_pfault_olddata_oldkeys(pCur->db, rowid, 0, -1, 0, 1, 1, 1);
     }
     prgenid = flibc_htonll(rowid);
-    snprintf(*memp, maxsz, "2:%llu", prgenid);
+    snprintf(*memp, maxsz, "%llu", prgenid);
     return SQLITE_OK;
 }
 

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -829,17 +829,3 @@ done:
     sc_set_running((char *)table, 0 /*running*/, 0 /*seed*/, NULL, 0);
     return rc; /* success */
 }
-
-void getMachineAndTimeFromFstSeed(uint64_t seed, uint32_t host,
-                                  const char **mach, time_t *timet)
-{
-    /* fastseeds are formed from an epoch time, machine number and
-     * duplication factor, so we can decode the fastseed to get the
-     * master machine that started the schema change and the time at which
-     * it was done. */
-    unsigned int *iptr = (unsigned int *)&seed;
-
-    *mach = get_hostname_with_crc32(thedb->bdb_env, host);
-    *timet = ntohl(iptr[0]);
-    return;
-}

--- a/schemachange/sc_callbacks.h
+++ b/schemachange/sc_callbacks.h
@@ -56,7 +56,4 @@ void sc_del_unused_files(struct dbtable *);
 void sc_del_unused_files_tran(struct dbtable *, tran_type *);
 void sc_del_unused_files_check_progress(void);
 
-void getMachineAndTimeFromFstSeed(uint64_t seed, uint32_t host,
-                                  const char **mach, time_t *timet);
-
 #endif

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -249,9 +249,8 @@ void sc_status(struct dbenv *dbenv)
     if (sc_tables)
         sctbl = hash_first(sc_tables, &ent, &bkt);
     while (gbl_schema_change_in_progress && sctbl) {
-        const char *mach;
-        time_t timet;
-        getMachineAndTimeFromFstSeed(sctbl->seed, sctbl->host, &mach, &timet);
+        const char *mach = get_hostname_with_crc32(thedb->bdb_env, sctbl->host);
+        time_t timet = sctbl->time;
         struct tm tm;
         localtime_r(&timet, &tm);
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1064,8 +1064,8 @@ int sc_timepart_add_table(const char *existingTableName,
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env),
-                       gbl_mynode, time(NULL)) != 0) {
+    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
+                       time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;
@@ -1132,8 +1132,8 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env),
-                       gbl_mynode, time(NULL)) != 0) {
+    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
+                       time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -193,7 +193,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             return SC_MASTER_DOWNGRADE;
         }
     } else {
-        seed = get_next_sc_seed(thedb->bdb_env);
+        seed = bdb_get_a_genid(thedb->bdb_env);
         logmsg(LOGMSG_INFO, "Starting schema change: new seed 0x%llx\n", seed);
     }
 
@@ -222,7 +222,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
                 free_schema_change_type(s);
                 return SC_CANT_SET_RUNNING;
             } else if (sc_set_running(s->table, 1,
-                                      get_next_sc_seed(thedb->bdb_env),
+                                      bdb_get_a_genid(thedb->bdb_env),
                                       gbl_mynode, time(NULL)) != 0) {
                 free_schema_change_type(s);
                 return SC_CANT_SET_RUNNING;
@@ -1064,7 +1064,7 @@ int sc_timepart_add_table(const char *existingTableName,
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, get_next_sc_seed(thedb->bdb_env),
+    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env),
                        gbl_mynode, time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
@@ -1132,7 +1132,7 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, get_next_sc_seed(thedb->bdb_env),
+    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env),
                        gbl_mynode, time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -318,7 +318,7 @@ int live_sc_delayed_key_adds(struct ireq *iq, void *trans,
 int add_schema_change_tables();
 
 extern unsigned long long get_genid(bdb_state_type *, unsigned int dtastripe);
-extern unsigned long long get_next_sc_seed(bdb_state_type *);
+extern unsigned long long bdb_get_a_genid(bdb_state_type *bdb_state);
 
 void handle_setcompr(SBUF2 *sb);
 

--- a/tests/Makefile.common
+++ b/tests/Makefile.common
@@ -12,6 +12,6 @@ export COPYCOMDB2_EXE?=${BUILDDIR}/db/copycomdb2
 export CDB2DUMP_EXE?=${BUILDDIR}/db/cdb2_dump
 export CDB2_SQLREPLAY_EXE?=${BUILDDIR}/tools/cdb2_sqlreplay/cdb2_sqlreplay
 export PMUX_EXE?=${BUILDDIR}/tools/pmux/pmux
+export pmux_port?=5105
 export MAKEFILE_COMMON_INCLUDED=1
-
 endif

--- a/tests/misstable_remsql.test/runit
+++ b/tests/misstable_remsql.test/runit
@@ -43,7 +43,7 @@ done
 
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 function old()
 {
@@ -235,7 +235,7 @@ echo ./test_missing.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 ./test_missing.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 result=$?
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 function old_clenaup(){
 if (( $is_local == 0 )) ; then

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -304,7 +304,7 @@ done
 set -e
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 echo running $CDB2_SQLREPLAY_EXE $alterdbname $logflunziped
 $CDB2_SQLREPLAY_EXE $alterdbname $logflunziped > sqlreplay.out
@@ -318,7 +318,7 @@ if ! diff orig.txt replayed.txt ; then
 fi
 
 set -e
-$TESTSROOTDIR/unsetup $success
+$TESTSROOTDIR/unsetup $success &> $TESTDIR/logs/$DBNAME.unsetup
 set +e
 
 if [ $success != 1 ] ; then

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -74,7 +74,7 @@ find_cores() {
     local has_pattern=0  # We assume core pattern is same for all machines
     grep '%e\|%t\|%u\|%g\|%s\|%h\|%p' /proc/sys/kernel/core_pattern > /dev/null && has_pattern=1
     local COREFL="$COREDIR/$CPAT"
-    local CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '$COREFL'"
+    local CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '$COREFL' 2> /dev/null"
     local PIDFL=${TMPDIR}/${DBNAME}.pid
     if [[ -z "$CLUSTER" ]] || [[ `echo $CLUSTER | grep $HOSTNAME ` ]]; then
         if [[ -n "$CLUSTER" ]] ; then
@@ -85,7 +85,7 @@ find_cores() {
             local PID=$(cat ${PIDFL} 2> /dev/null)
             COREFL=`echo $CPAT | sed "s/%e/comdb2/g; s/.%t/.[^.]*/g; s/.%u/.[^.]*/g; s/.%g/.[^.]*/; s/.%s/.[^.]*/; s/.%h/.[^.]*/; s/%p/$PID/g"`
             COREFL=$COREDIR/$COREFL
-            CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '${COREFL}.*'"
+            CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '${COREFL}.*' 2> /dev/null"
             if [ "x$PID" == "x" ] ; then
                 CORECMD="echo ''"
             fi
@@ -109,7 +109,7 @@ find_cores() {
             fi
             COREFL=`echo $CPAT | sed "s/%e/comdb2/g; s/.%t/.[^.]*/g; s/.%u/.[^.]*/g; s/.%g/.[^.]*/; s/.%s/.[^.]*/; s/.%h/.[^.]*/; s/%p/$PID/g"`
             COREFL=$COREDIR/$COREFL
-            CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '${COREFL}.*'"
+            CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '${COREFL}.*' 2> /dev/null"
         fi
 
         cr=`ssh -o StrictHostKeyChecking=no $node "$CORECMD" < /dev/null`

--- a/tests/sc_addcolumn_remsql.test/runit
+++ b/tests/sc_addcolumn_remsql.test/runit
@@ -44,7 +44,7 @@ done
 
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select comdb2_dbname(), comdb2_host()"
 
 
@@ -56,7 +56,7 @@ echo ./test_sc.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 result=$?
 
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 
 if (( $result != 0 )) ; then

--- a/tests/sc_remsql.test/runit
+++ b/tests/sc_remsql.test/runit
@@ -44,7 +44,7 @@ done
 
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select comdb2_dbname(), comdb2_host()"
 
 
@@ -65,7 +65,7 @@ echo ./test_sc.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 result=$?
 
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 
 if (( $result != 0 )) ; then

--- a/tests/setup
+++ b/tests/setup
@@ -316,8 +316,9 @@ else
     #check for failure in starting any of the nodes
     sleep 1
     for node in $CLUSTER; do
-        if [ kill -0 `cat $TESTDIR/logs/${DBNAME}.${node}.db` ] ; then
-            echo "pid $TESTDIR/logs/${DBNAME}.${node}.db: `cat $TESTDIR/logs/${DBNAME}.${node}.db` is not alive"
+        kill -0 `cat ${TMPDIR}/${DBNAME}.${node}.pid` > /dev/null
+        if [ $? -eq 1 ] ; then
+            echo "pid ${TMPDIR}/${DBNAME}.${node}.pid: `cat ${TMPDIR}/${DBNAME}.${node}.pid` is not alive"
             check_db_port_running_node $node # this error is immediate so we should be able to catch it early
         fi
     done

--- a/tests/setup
+++ b/tests/setup
@@ -12,7 +12,7 @@ while [[ $# -gt 0 && $1 = -* ]]; do
     shift
 done
 
-vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR BUILDDIR TESTSBUILDDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE pmux_port"
+vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR BUILDDIR TESTSBUILDDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE PMUX_EXE pmux_port"
 for required in $vars; do
     q=${!required}
     if [[ -z "$q" ]]; then
@@ -124,11 +124,11 @@ fi
 
 echo "logmsg level info" >> ${LRL}
 
-if [[ -f ${TESTDIR}/${TESTCASE}.test/lrl ]]; then
-    cat ${TESTDIR}/${TESTCASE}.test/lrl >> ${LRL}
+if [[ -f ${TESTSROOTDIR}/${TESTCASE}.test/lrl ]]; then
+    cat ${TESTSROOTDIR}/${TESTCASE}.test/lrl >> ${LRL}
 fi
-if [[ -f "${TESTDIR}/${TESTCASE}.test/lrl.options" ]]; then
-    cat ${TESTDIR}/${TESTCASE}.test/lrl.options >> ${LRL}
+if [[ -f "${TESTSROOTDIR}/${TESTCASE}.test/lrl.options" ]]; then
+    cat ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options >> ${LRL}
 fi
 
 cat >> ${LRL} <<EOPTIONS

--- a/tests/setup
+++ b/tests/setup
@@ -221,7 +221,7 @@ check_db_port_running_node() {
         netstat -na | grep $dbport
         opid=`fuser -n tcp $dbport`
         echo "pid running on dbport: $opid"
-    [ -n "$opid" ] && ps -p $opid -o comm,args
+        [ -n "$opid" ] && ps -p $opid -o comm,args
     else
         ssh $SSH_OPT $node "netstat -na | grep $dbport" </dev/null
         opid=`ssh $SSH_OPT $node "fuser -n tcp $dbport" </dev/null`
@@ -282,8 +282,7 @@ else
     for node in ${CLUSTER/$HOSTNAME/}; do
         wait ${pids[$i]}
         if [[ $? -ne 0 ]]; then
-            echo "FAILED: $COPYCOMDB2_EXE ${LRL} ${node}: "
-            echo "see $TESTDIR/logs/${DBNAME}.${node}.copy "
+            echo "FAILED: copying ${LRL} ${node}: see $TESTDIR/logs/${DBNAME}.${node}.copy"
             exit 1
         fi
         let i=i+1
@@ -314,15 +313,24 @@ else
         fi
     done
 
+    #check for failure in starting any of the nodes
+    sleep 1
+    for node in $CLUSTER; do
+        if [ kill -0 `cat $TESTDIR/logs/${DBNAME}.${node}.db` ] ; then
+            echo "pid $TESTDIR/logs/${DBNAME}.${node}.db: `cat $TESTDIR/logs/${DBNAME}.${node}.db` is not alive"
+            check_db_port_running_node $node # this error is immediate so we should be able to catch it early
+        fi
+    done
+
     echo "!$TESTCASE: waiting until ready"
     for node in $CLUSTER; do
         set +e
+        echo "If we can't talk to any of the nodes the test will timeout"
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
         while  [[ "$out" != "1" ]]; do
             sleep 2
             out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
             $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $TESTDIR/logs/${DBNAME}.${node}.conn
-            [[ "$out" != "1" ]] && check_db_port_running_node $node
         done
         $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $TESTDIR/logs/${DBNAME}.${node}.conn
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)

--- a/tests/simple_remsql.test/runit
+++ b/tests/simple_remsql.test/runit
@@ -43,7 +43,7 @@ done
 
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 function old()
 {
@@ -229,7 +229,7 @@ echo "Starting tests"
 ./remsql_curmoves.sh $dbname $cdb2config $srcdbname  $dbdir $testdir 
 result=$?
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 function old_clenaup(){
 if (( $is_local == 0 )) ; then

--- a/tests/sp.test/runit
+++ b/tests/sp.test/runit
@@ -33,7 +33,7 @@ timeout 2m ${TESTSROOTDIR}/setup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; f
 rc=$?
 if [[ $rc -ne 0 ]]; then
     echo "snapshot db setup failed (rc=$rc)"
-    $TESTSROOTDIR/unsetup
+    $TESTSROOTDIR/unsetup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
     DBNAME=$dbname
     DBDIR=$dbdir
     CDB2_CONFIG=$cdb2config

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -71,7 +71,7 @@ CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST   # needed to run setup script
-echo round_robin_stripes > lrl.options
+echo round_robin_stripes > ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits
@@ -122,7 +122,7 @@ CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
-rm lrl.options
+rm ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -52,7 +52,7 @@ assertcnt()
 }
 
 call_unsetup() {
-    $TESTSROOTDIR/unsetup
+    $TESTSROOTDIR/unsetup > $DBNAME.unsetup
 }
 
 
@@ -78,7 +78,7 @@ CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
 echo round_robin_stripes > lrl.options
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup > $DBNAME.setup
 
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"Cancelling test\"" INT EXIT
@@ -101,6 +101,13 @@ cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in $dbnm default
 #cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure addrecs('t1', $N)"
 
 assertcnt t1 8
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select printf("%llx",comdb2_rowid%16) as genid from t1' > stripes.out
+for i in `seq 1 $N` ; do
+    cnt=`grep $((i-1)) stripes.out | wc -l`
+    assertres "$cnt" "1"
+done
+
+# verify via pgdump command -- same thing as above but checks the actual btrees
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb dblist')" > dblist.out
 for i in `seq 1 $N` ; do
     fileid=`cat dblist.out | grep "XXX.t1_" | grep datas$((i-1)) | awk '{print $1}'`
@@ -108,7 +115,7 @@ for i in `seq 1 $N` ; do
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:2" || failexit "page does not contain 1 row"
 done
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup > $DBNAME.unsetup
 trap - INT EXIT
 
 
@@ -122,7 +129,7 @@ CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
 rm lrl.options
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup > $DBNAME.setup
 
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"Cancelling test\"" INT EXIT
@@ -151,7 +158,7 @@ for i in `seq 1 $N` ; do
 done > entry_counts.out
 
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup > $DBNAME.unsetup
 trap - INT EXIT
 
 zeros=`grep "entries:0" entry_counts.out | wc -l`

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -7,13 +7,6 @@ set -x
 # Debug variable
 debug=0
 
-dbnm=$1
-
-if [ "x$dbnm" == "x" ] ; then
-    echo "need a DB name"
-    exit 1
-fi
-
 # Number of insert_records function calls
 nins=0
 
@@ -68,7 +61,7 @@ call_unsetup() {
 
 N=8   # number of stripes
 
-echo "Rounnd robin"
+echo "Round robin"
 
 dbnm=rrdb$TESTID
 DBNAME=$dbnm
@@ -76,7 +69,7 @@ DBDIR=$TESTDIR/$DBNAME
 CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
-unset COMDB2_UNITTEST
+unset COMDB2_UNITTEST   # needed to run setup script
 echo round_robin_stripes > lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -45,7 +45,8 @@ assertcnt()
 }
 
 call_unsetup() {
-    $TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
+    local successful=$1
+    $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
 }
 
 
@@ -74,7 +75,7 @@ echo round_robin_stripes > lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits
-trap "call_unsetup \"Cancelling test\"" INT EXIT
+trap "call_unsetup \"0\"" INT EXIT
 
 res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
 assertres $res 1
@@ -108,7 +109,7 @@ for i in `seq 1 $N` ; do
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:2" || failexit "page does not contain 1 row"
 done
 
-$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
+call_unsetup 1
 trap - INT EXIT
 
 
@@ -151,7 +152,7 @@ for i in `seq 1 $N` ; do
 done > entry_counts.out
 
 
-$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
+call_unsetup 1
 trap - INT EXIT
 
 zeros=`grep "entries:0" entry_counts.out | wc -l`

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -52,7 +52,7 @@ assertcnt()
 }
 
 call_unsetup() {
-    $TESTSROOTDIR/unsetup > $DBNAME.unsetup
+    $TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 }
 
 
@@ -78,7 +78,7 @@ CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
 echo round_robin_stripes > lrl.options
-$TESTSROOTDIR/setup > $DBNAME.setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"Cancelling test\"" INT EXIT
@@ -115,7 +115,7 @@ for i in `seq 1 $N` ; do
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:2" || failexit "page does not contain 1 row"
 done
 
-$TESTSROOTDIR/unsetup > $DBNAME.unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 trap - INT EXIT
 
 
@@ -129,7 +129,7 @@ CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
 rm lrl.options
-$TESTSROOTDIR/setup > $DBNAME.setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"Cancelling test\"" INT EXIT
@@ -158,7 +158,7 @@ for i in `seq 1 $N` ; do
 done > entry_counts.out
 
 
-$TESTSROOTDIR/unsetup > $DBNAME.unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 trap - INT EXIT
 
 zeros=`grep "entries:0" entry_counts.out | wc -l`

--- a/tests/tools/copy_files_to_cluster.sh
+++ b/tests/tools/copy_files_to_cluster.sh
@@ -31,9 +31,16 @@ SSH_OPT="-o StrictHostKeyChecking=no "
 #use connection sharing via master node
 SSH_MSTR="-o ControlPath=$TESTDIR/%r%h%p"
 
+close_master_ssh_session() {
+    ssh $SSH_OPT $SSH_MSTR -O exit $node #close master ssh session
+}
+
 copy_files_to_node() {
     local node=$1
     echo "copying to node $node"
+    # TRAP to close_master_ssh_session if the script is killed in mid copy
+    trap "close_master_ssh_session \"closing\"" INT EXIT
+      
     ssh $SSH_OPT $SSH_MSTR -MNf $node   #start master ssh session for node
     ssh $SSH_OPT $SSH_MSTR $node "mkdir -p $d1 $d2 $d3 $PMUX_DIR $TESTDIR/logs/ $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2" < /dev/null
     scp $SSH_OPT $SSH_MSTR $COMDB2AR_EXE $node:$COMDB2AR_EXE
@@ -48,6 +55,7 @@ copy_files_to_node() {
     echo start pmux on $node if not running 
     ssh $SSH_OPT $SSH_MSTR $node "COMDB2_PMUX_FILE='$PMUX_DIR/pmux.sqlite' $pmux_cmd" < /dev/null
     ssh $SSH_OPT $SSH_MSTR -O exit $node #close master ssh session
+    trap - INT EXIT  #Clear TRAP
     set -e
 }
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -62,20 +62,23 @@ core_all_nodes() {
     done
 }
 
-deregister_db_port="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
-
 cleanup_cluster() {    
-    local node
-    echo deregistering $DBNAME from $HOSTNAME pmux:$pmux_port
-    eval $deregister_db_port
+    local deregister_db_port="pgrep pmux > /dev/null && (exec 3<>/dev/tcp/localhost/${pmux_port}; echo del comdb2/replication/${DBNAME} >&3 )"
+    local dbport
+    if [[ -z "$CLUSTER" ]] || [[ `echo $CLUSTER | grep $HOSTNAME ` ]]; then
+        dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh -h $HOSTNAME "get comdb2/replication/${DBNAME}" ${pmux_port}`
+        echo "deregistering $DBNAME (port $dbport) from $HOSTNAME pmux:$pmux_port"
+        eval $deregister_db_port
 
-    if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
-        rm -rf ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*
+        if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
+            rm -rf ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*
+        fi
     fi
 
+    local node
     for node in ${CLUSTER/$HOSTNAME/}; do
-        ${TESTSROOTDIR}/tools/send_msg_port.sh -h $node "get comdb2/replication/${DBNAME}" ${pmux_port}
-        echo deregistering $DBNAME from $node pmux:$pmux_port
+        dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh -h $node "get comdb2/replication/${DBNAME}" ${pmux_port}`
+        echo "deregistering $DBNAME (port $dbport) from $node pmux:$pmux_port"
         ssh -o StrictHostKeyChecking=no $node "${deregister_db_port}" < /dev/null
         if [ "x$DBDIR" == "x" ] ; then 
             continue

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -69,10 +69,11 @@ cleanup_cluster() {
         dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh -h $HOSTNAME "get comdb2/replication/${DBNAME}" ${pmux_port}`
         echo "deregistering $DBNAME (port $dbport) from $HOSTNAME pmux:$pmux_port"
         eval $deregister_db_port
+    fi
 
-        if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
-            rm -rf ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*
-        fi
+    # the local node always has a copy of DBDIR even if not part of cluster
+    if [ "$CLEANUPDBDIR" == "1" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
+        rm -rf ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*
     fi
 
     local node
@@ -87,7 +88,7 @@ cleanup_cluster() {
         if [ "$successful" != "1" ] ; then 
             echo copy $node:${TESTDIR} content locally to $TESTDIR/$node for investigation
             scp -r -o StrictHostKeyChecking=no $node:${DBDIR} $DBDIR/$node < /dev/null &
-        elif [ "$CLEANUPDBDIR" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
+        elif [ "$CLEANUPDBDIR" == "1" ] ; then 
             ssh -o StrictHostKeyChecking=no $node "rm -rf ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
         fi
     done

--- a/tests/writes_remsql.test/runit
+++ b/tests/writes_remsql.test/runit
@@ -30,7 +30,7 @@ CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 #setup remode db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 #run tests
 echo "Starting tests"
@@ -38,7 +38,7 @@ echo ./test_writes.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 ./test_writes.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 result=$?
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 if (( $result != 0 )) ; then
    echo "FAILURE"

--- a/tests/writes_remsql_names.test/runit
+++ b/tests/writes_remsql_names.test/runit
@@ -32,7 +32,7 @@ CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 
 #setup remote db
-$TESTSROOTDIR/setup
+$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 
 #run tests
@@ -41,7 +41,7 @@ echo ./writes_remsql_names.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 ./writes_remsql_names.sh $dbname $cdb2config $srcdbname $dbdir $testdir
 result=$?
 
-$TESTSROOTDIR/unsetup
+$TESTSROOTDIR/unsetup &> $TESTDIR/logs/$DBNAME.unsetup
 
 
 if (( $result != 0 )) ; then

--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -672,7 +672,8 @@ again:
         conn_printf(c, "del service             : forget port assignment for service\n");
         conn_printf(c, "use service port        : set specific port registration for service\n");
         conn_printf(c, "stat                    : dump some stats\n");
-        conn_printf(c, "used (or list)          : dump active port assignments\n");
+        conn_printf(c,
+                    "used (or list)          : dump active port assignments\n");
         conn_printf(c, "rte                     : get route to instance service/port\n");
         conn_printf(c, "hello service           : keep active connection\n");
         conn_printf(c, "active                  : list active connections\n");

--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -672,7 +672,7 @@ again:
         conn_printf(c, "del service             : forget port assignment for service\n");
         conn_printf(c, "use service port        : set specific port registration for service\n");
         conn_printf(c, "stat                    : dump some stats\n");
-        conn_printf(c, "used                    : dump active port assignments\n");
+        conn_printf(c, "used (or list)          : dump active port assignments\n");
         conn_printf(c, "rte                     : get route to instance service/port\n");
         conn_printf(c, "hello service           : keep active connection\n");
         conn_printf(c, "active                  : list active connections\n");


### PR DESCRIPTION
sc_seed to not have timebased genid because it screws with the genid48 generation and more:
* Use real get_genid for seed, machine and time info from hash value
* dont print '2:' in front of comdb2_rowid
* add to stripe test to print genid in hex and getting stripe from genid by modding it with 16
* better dumping to logs when setup and unsetup dbs from tests
* in setup, check for used port by checking pid as soon as possible rather than when a failing 'select 1'
* in unsetup, clean DBDIR from test runner node as well even when not part of cluster