### PR TITLE
Lock put read

### DIFF
--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -87,7 +87,7 @@ void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
             pthread_mutex_destroy(&bdb_state->blkseq_lk[stripe]);
             for (int i = 0; i < 2; i++) {
                 DB *to_be_deleted = bdb_state->blkseq[i][stripe];
-                to_be_deleted->close(to_be_deleted, NULL, DB_NOSYNC);
+                to_be_deleted->close(to_be_deleted, DB_NOSYNC);
             }
 
             env->close(env, 0);
@@ -496,7 +496,7 @@ int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe)
     } else
         oldname = strdup(oldname);
 
-    to_be_deleted->close(to_be_deleted, NULL, DB_NOSYNC);
+    to_be_deleted->close(to_be_deleted, DB_NOSYNC);
 
     if (oldname) {
         DB *db;

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -26,7 +26,7 @@ extern volatile int gbl_views_gen;
 typedef enum scdone {
     alter,
     fastinit,
-    add = fastinit, /* but, get_dbtable_by_name == NULL */
+    add,
     drop,
     bulkimport,
     setcompr,

--- a/bdb/berktest.c
+++ b/bdb/berktest.c
@@ -94,7 +94,7 @@ static void close_tables(berktable_t *tables, int tablecount)
     for (i = 0; i < tablecount; i++) {
         table = &tables[i];
         if (table->dbp) {
-            if ((rc = table->dbp->close(table->dbp, NULL, 0)) != 0) {
+            if ((rc = table->dbp->close(table->dbp, 0)) != 0) {
                 logmsg(LOGMSG_ERROR, "%s close error: %d\n", __func__, rc);
                 continue;
             }

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -6308,7 +6308,7 @@ static int bdb_del_file(bdb_state_type *bdb_state, DB_TXN *tid, char *filename,
         int rc;
 
         if ((rc = db_create(&dbp, dbenv, 0)) == 0 &&
-            (rc = dbp->open(dbp, tid, pname, NULL, DB_BTREE, 0, 0666)) == 0) {
+            (rc = dbp->open(dbp, NULL, pname, NULL, DB_BTREE, 0, 0666)) == 0) {
             bdb_remove_fileid_pglogs(bdb_state, dbp->fileid);
             dbp->close(dbp, DB_NOSYNC);
         }

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1314,7 +1314,7 @@ static int close_dbs_int(bdb_state_type *bdb_state, DB_TXN *tid, int flags)
         for (strnum = 0; strnum < MAXSTRIPE; strnum++) {
             if (bdb_state->dbp_data[dtanum][strnum]) {
                 rc = bdb_state->dbp_data[dtanum][strnum]->close(
-                    bdb_state->dbp_data[dtanum][strnum], tid, flags);
+                    bdb_state->dbp_data[dtanum][strnum], flags);
                 if (0 != rc) {
                     logmsg(LOGMSG_ERROR,
                            "%s: error closing %s[%d][%d]: %d %s\n", __func__,
@@ -1328,7 +1328,7 @@ static int close_dbs_int(bdb_state_type *bdb_state, DB_TXN *tid, int flags)
     if (bdb_state->bdbtype == BDBTYPE_TABLE) {
         for (i = 0; i < bdb_state->numix; i++) {
             /*fprintf(stderr, "closing ix %d\n", i);*/
-            rc = bdb_state->dbp_ix[i]->close(bdb_state->dbp_ix[i], tid, flags);
+            rc = bdb_state->dbp_ix[i]->close(bdb_state->dbp_ix[i], flags);
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR, "%s: error closing %s->dbp_ix[%d] %d %s\n",
                        __func__, bdb_state->name, i, rc, db_strerror(rc));
@@ -4045,7 +4045,7 @@ static int open_dbs_int(bdb_state_type *bdb_state, int iammaster, int upgrade,
 
                     print(bdb_state, "open_dbs: cannot open %s: %d %s\n",
                           tmpname, rc, db_strerror(rc));
-                    rc = dbp->close(dbp, tid, 0);
+                    rc = dbp->close(dbp, 0);
                     if (0 != rc)
                         logmsg(LOGMSG_ERROR, "DB->close(%s) failed: rc=%d %s\n",
                                 tmpname, rc, db_strerror(rc));
@@ -4150,7 +4150,7 @@ static int open_dbs_int(bdb_state_type *bdb_state, int iammaster, int upgrade,
 
             print(bdb_state, "open_dbs: cannot open %s: %d %s\n", tmpname, rc,
                   db_strerror(rc));
-            rc = dbp->close(dbp, tid, 0);
+            rc = dbp->close(dbp, 0);
             if (rc != 0)
                 logmsg(LOGMSG_ERROR, "bdp_dta->close(%s) failed: rc=%d %s\n",
                         tmpname, rc, db_strerror(rc));
@@ -4284,7 +4284,7 @@ static int open_dbs_int(bdb_state_type *bdb_state, int iammaster, int upgrade,
 
                 bdb_state->dbp_ix[i]->err(bdb_state->dbp_ix[i], rc, "%s",
                                           tmpname);
-                rc = bdb_state->dbp_ix[i]->close(bdb_state->dbp_ix[i], NULL, 0);
+                rc = bdb_state->dbp_ix[i]->close(bdb_state->dbp_ix[i], 0);
                 logmsg(LOGMSG_ERROR, "close ix=%d name=%s failed rc=%d\n", i,
                         tmpname, rc);
                 logmsg(LOGMSG_ERROR, "couldnt open ix db\n");
@@ -4488,7 +4488,7 @@ int bdb_create_stripes_int(bdb_state_type *bdb_state, int newdtastripe,
 
                 logmsg(LOGMSG_ERROR, "bdb_create_stripes_int: cannot open %s: %d %s\n",
                         tmpname, rc, db_strerror(rc));
-                rc = dbp->close(dbp, tid, 0);
+                rc = dbp->close(dbp, 0);
                 if (0 != rc)
                     logmsg(LOGMSG_ERROR, "DB->close(%s) failed: rc=%d %s\n", tmpname,
                             rc, db_strerror(rc));
@@ -4513,7 +4513,7 @@ int bdb_create_stripes_int(bdb_state_type *bdb_state, int newdtastripe,
 
     /* Now go and close all the tables. */
     for (ii = 0; ii < dbp_count; ii++) {
-        rc = dbp_array[ii]->close(dbp_array[ii], NULL, 0);
+        rc = dbp_array[ii]->close(dbp_array[ii], 0);
         if (0 != rc)
             logmsg(LOGMSG_ERROR,
                     "bdb_create_stripes_int: DB->close #%d failed: rc=%d %s\n",
@@ -6310,7 +6310,7 @@ static int bdb_del_file(bdb_state_type *bdb_state, DB_TXN *tid, char *filename,
         if ((rc = db_create(&dbp, dbenv, 0)) == 0 &&
             (rc = dbp->open(dbp, tid, pname, NULL, DB_BTREE, 0, 0666)) == 0) {
             bdb_remove_fileid_pglogs(bdb_state, dbp->fileid);
-            dbp->close(dbp, tid, DB_NOSYNC);
+            dbp->close(dbp, DB_NOSYNC);
         }
 
         rc = dbenv->dbremove(dbenv, tid, filename, NULL, 0);
@@ -8347,7 +8347,7 @@ int bdb_list_all_fileids_for_newsi(bdb_state_type *bdb_state,
                 logmsg(LOGMSG_DEBUG, "%s: hash_add fileid %s\n", __func__, txt);
                 free(txt);
 #endif
-                dbp->close(dbp, tid, DB_NOSYNC);
+                dbp->close(dbp, DB_NOSYNC);
             }
         }
     }

--- a/bdb/temphash.c
+++ b/bdb/temphash.c
@@ -97,8 +97,7 @@ int bdb_temp_hash_destroy(struct bdb_temp_hash *h)
 {
     int rc;
     int outrc = 0;
-    rc = h->db->close(h->db, NULL,
-                      DB_NOSYNC); /* don't care if it ever makes it to
+    rc = h->db->close(h->db, DB_NOSYNC); /* don't care if it ever makes it to
                                      disk since the db is about to be removed */
 
     if (rc) {

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -244,7 +244,7 @@ static int bdb_temp_table_init_temp_db(bdb_state_type *bdb_state,
     int rc;
 
     if (tbl->tmpdb) {
-        rc = tbl->tmpdb->close(tbl->tmpdb, NULL, 0);
+        rc = tbl->tmpdb->close(tbl->tmpdb, 0);
         if (rc) {
             *bdberr = rc;
             rc = -1;
@@ -300,7 +300,7 @@ static int bdb_temp_table_env_close(bdb_state_type *bdb_state,
     int rc;
 
     if (tbl->tmpdb) {
-        rc = tbl->tmpdb->close(tbl->tmpdb, NULL, 0);
+        rc = tbl->tmpdb->close(tbl->tmpdb, 0);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s:%d close rc %d\n", __FILE__, __LINE__, rc);
             *bdberr = rc;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1489,7 +1489,7 @@ struct __db {
 					/* Methods. */
 	int  (*associate) __P((DB *, DB_TXN *, DB *, int (*)(DB *, const DBT *,
 		const DBT *, DBT *), u_int32_t));
-	int  (*close) __P((DB *, DB_TXN *, u_int32_t));
+	int  (*close) __P((DB *, u_int32_t));
 	int  (*cursor) __P((DB *, DB_TXN *, DBC **, u_int32_t));
 	/* comdb2 addition */
 	int  (*cursor_ser) __P((DB *, DB_TXN *, DBCS *, DBC **, u_int32_t));

--- a/berkdb/db/db_iface.c
+++ b/berkdb/db/db_iface.c
@@ -229,12 +229,11 @@ __db_associate_arg(dbp, sdbp, callback, flags)
  * __db_close_pp --
  *	DB->close pre/post processing.
  *
- * PUBLIC: int __db_close_pp __P((DB *, DB_TXN *, u_int32_t));
+ * PUBLIC: int __db_close_pp __P((DB *, u_int32_t));
  */
 int
-__db_close_pp(dbp, txn, flags)
+__db_close_pp(dbp, flags)
 	DB *dbp;
-	DB_TXN *txn;
 	u_int32_t flags;
 {
 	DB_ENV *dbenv;
@@ -262,7 +261,7 @@ __db_close_pp(dbp, txn, flags)
 	    (t_ret = __db_rep_enter(dbp, 0, 0)) != 0 && ret == 0)
 		ret = t_ret;
 
-	if ((t_ret = __db_close(dbp, txn, flags)) != 0 && ret == 0)
+	if ((t_ret = __db_close(dbp, NULL, flags)) != 0 && ret == 0)
 		ret = t_ret;
 
 	/* Release replication block. */

--- a/berkdb/dbreg/dbreg.c
+++ b/berkdb/dbreg/dbreg.c
@@ -227,9 +227,6 @@ __dbreg_new_id(dbp, txn)
 	return (ret);
 }
 
-int gbl_dbreg_stack_on_null_txn = 0;
-int gbl_dbreg_abort_on_null_txn = 0;
-
 /*
  * __dbreg_get_id --
  *	Assign an unused dbreg id to this database handle.
@@ -290,19 +287,6 @@ __dbreg_get_id(dbp, txn, idp)
 	}
 	fid_dbt.data = dbp->fileid;
 	fid_dbt.size = DB_FILE_ID_LEN;
-
-	if (txn == NULL) {
-		if (gbl_dbreg_stack_on_null_txn) {
-			logmsg(LOGMSG_USER, "%s line %d: logging open with NULL txn\n",
-					__func__, __LINE__);
-			cheap_stack_trace();
-		}
-		if (gbl_dbreg_abort_on_null_txn) {
-			logmsg(LOGMSG_USER, "%s line %d: aborting on open with NULL txn\n",
-					__func__, __LINE__);
-			abort();
-		}
-	}
 
 	if ((ret = __dbreg_register_log(dbenv, txn, &unused,
 		F_ISSET(dbp, DB_AM_NOT_DURABLE) ? DB_LOG_NOT_DURABLE : 0,
@@ -526,19 +510,6 @@ __dbreg_close_id(dbp, txn)
 	fid_dbt.data = fnp->ufid;
 	__ufid_sanity_check(dbenv, fnp);
 	fid_dbt.size = DB_FILE_ID_LEN;
-
-	if (txn == NULL) {
-		if (gbl_dbreg_stack_on_null_txn) {
-			logmsg(LOGMSG_ERROR, "%s line %d: logging close with NULL txn\n",
-					__func__, __LINE__);
-			cheap_stack_trace();
-		}
-		if (gbl_dbreg_abort_on_null_txn) {
-			logmsg(LOGMSG_USER, "%s line %d: aborting on open with NULL txn\n",
-					__func__, __LINE__);
-			abort();
-		}
-	}
 
 	if ((ret = __dbreg_register_log(dbenv, txn, &r_unused,
 		F_ISSET(dbp, DB_AM_NOT_DURABLE) ? DB_LOG_NOT_DURABLE : 0,

--- a/berkdb/dbreg/dbreg.c
+++ b/berkdb/dbreg/dbreg.c
@@ -513,12 +513,12 @@ __dbreg_close_id(dbp, txn)
 	__ufid_sanity_check(dbenv, fnp);
 	fid_dbt.size = DB_FILE_ID_LEN;
 
-    pthread_rwlock_wrlock(&gbl_dbreg_log_lock);
+	pthread_rwlock_wrlock(&gbl_dbreg_log_lock);
 	ret = __dbreg_register_log(dbenv, txn, &r_unused,
 		F_ISSET(dbp, DB_AM_NOT_DURABLE) ? DB_LOG_NOT_DURABLE : 0,
 		DBREG_CLOSE, dbtp, &fid_dbt, fnp->id,
 		fnp->s_type, fnp->meta_pgno, TXN_INVALID);
-    pthread_rwlock_unlock(&gbl_dbreg_log_lock);
+	pthread_rwlock_unlock(&gbl_dbreg_log_lock);
     if (ret != 0)
 		goto err;
 

--- a/berkdb/dbreg/dbreg.c
+++ b/berkdb/dbreg/dbreg.c
@@ -227,6 +227,8 @@ __dbreg_new_id(dbp, txn)
 	return (ret);
 }
 
+pthread_mutex_t gbl_dbreg_log_lock = PTHREAD_MUTEX_INITIALIZER;
+
 /*
  * __dbreg_get_id --
  *	Assign an unused dbreg id to this database handle.
@@ -511,10 +513,13 @@ __dbreg_close_id(dbp, txn)
 	__ufid_sanity_check(dbenv, fnp);
 	fid_dbt.size = DB_FILE_ID_LEN;
 
-	if ((ret = __dbreg_register_log(dbenv, txn, &r_unused,
+    pthread_mutex_lock(&gbl_dbreg_log_lock);
+	ret = __dbreg_register_log(dbenv, txn, &r_unused,
 		F_ISSET(dbp, DB_AM_NOT_DURABLE) ? DB_LOG_NOT_DURABLE : 0,
 		DBREG_CLOSE, dbtp, &fid_dbt, fnp->id,
-		fnp->s_type, fnp->meta_pgno, TXN_INVALID)) != 0)
+		fnp->s_type, fnp->meta_pgno, TXN_INVALID);
+    pthread_mutex_unlock(&gbl_dbreg_log_lock);
+    if (ret != 0)
 		goto err;
 
 	ret = __dbreg_revoke_id(dbp, 1, DB_LOGFILEID_INVALID);

--- a/berkdb/dbreg/dbreg.c
+++ b/berkdb/dbreg/dbreg.c
@@ -227,7 +227,7 @@ __dbreg_new_id(dbp, txn)
 	return (ret);
 }
 
-pthread_mutex_t gbl_dbreg_log_lock = PTHREAD_MUTEX_INITIALIZER;
+pthread_rwlock_t gbl_dbreg_log_lock = PTHREAD_RWLOCK_INITIALIZER;
 
 /*
  * __dbreg_get_id --
@@ -513,12 +513,12 @@ __dbreg_close_id(dbp, txn)
 	__ufid_sanity_check(dbenv, fnp);
 	fid_dbt.size = DB_FILE_ID_LEN;
 
-    pthread_mutex_lock(&gbl_dbreg_log_lock);
+    pthread_rwlock_wrlock(&gbl_dbreg_log_lock);
 	ret = __dbreg_register_log(dbenv, txn, &r_unused,
 		F_ISSET(dbp, DB_AM_NOT_DURABLE) ? DB_LOG_NOT_DURABLE : 0,
 		DBREG_CLOSE, dbtp, &fid_dbt, fnp->id,
 		fnp->s_type, fnp->meta_pgno, TXN_INVALID);
-    pthread_mutex_unlock(&gbl_dbreg_log_lock);
+    pthread_rwlock_unlock(&gbl_dbreg_log_lock);
     if (ret != 0)
 		goto err;
 

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -778,15 +778,6 @@ is_pagelock(lockobj)
 	return (ilock->type == DB_PAGE_LOCK);
 }
 
-static inline int
-is_tablelock(lockobj)
-	DB_LOCKOBJ *lockobj;
-{
-	if (lockobj->lockobj.size == 32)
-        return 1;
-    return 0;
-}
-
 int
 use_page_latches(dbenv)
 	DB_ENV *dbenv;
@@ -1538,21 +1529,16 @@ __lock_vec(dbenv, locker, flags, list, nlist, elistp)
 					 * unlink the lock, so we'll have to
 					 * update counts here.
 					 */
-                    int unlock = 1;
 					if (is_pagelock(sh_obj))
 						sh_locker->npagelocks--;
 					sh_locker->nlocks--;
 					if (IS_WRITELOCK(lp->mode)) {
 						sh_locker->nwrites--;
 						nwrites--;
-					} else if (is_tablelock(sh_obj)) {
-                        ret = unlock = 0;
-                    }
-                    if (unlock) {
-                        ret = __lock_put_internal(lt, lp,
-                                NULL, lndx, &run_dd,
-                                DB_LOCK_FREE | DB_LOCK_DOALL);
-                    }
+					}
+					ret = __lock_put_internal(lt, lp,
+					    NULL, lndx, &run_dd,
+					    DB_LOCK_FREE | DB_LOCK_DOALL);
 					unlock_obj_partition(region, partition);
 					if (ret != 0)
 						break;

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -853,7 +853,7 @@ int __lock_set_parent_has_pglk_lsn(DB_ENV *dbenv, u_int32_t parentid, u_int32_t 
 
 /* This prevents dbreg logs from being logged between the LOCK_PUT_READ and
  * the commit record */
-extern pthread_mutex_t gbl_dbreg_log_lock;
+extern pthread_rwlock_t gbl_dbreg_log_lock;
 
 /*
  * __txn_commit --
@@ -998,7 +998,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			memset(&request, 0, sizeof(request));
 			memset(&list_dbt_rl, 0, sizeof(list_dbt_rl));
 
-            pthread_mutex_lock(&gbl_dbreg_log_lock);
+            pthread_rwlock_rdlock(&gbl_dbreg_log_lock);
 
 			if (LOCKING_ON(dbenv)) {
 				request.op = DB_LOCK_PUT_READ;
@@ -1041,7 +1041,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 							     ltranid,
 							     begin_lsn,
 							     &lt)) != 0) {
-                            pthread_mutex_unlock(&gbl_dbreg_log_lock);
+                            pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 							goto err;
 						}
 					}
@@ -1051,7 +1051,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						    ltranid, &lt)) != 0) {
 						logmsg(LOGMSG_FATAL, "Couldn't find ltrans?");
 						abort();
-                        pthread_mutex_unlock(&gbl_dbreg_log_lock);
+                        pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 						goto err;
 					}
 
@@ -1139,7 +1139,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						    txnp->last_lsn.offset;
 					}
 				}
-                pthread_mutex_unlock(&gbl_dbreg_log_lock);
+                pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 
 				if (gbl_new_snapisol) {
 					if (!txnp->pglogs_hashtbl) {

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -998,7 +998,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			memset(&request, 0, sizeof(request));
 			memset(&list_dbt_rl, 0, sizeof(list_dbt_rl));
 
-            pthread_rwlock_rdlock(&gbl_dbreg_log_lock);
+			pthread_rwlock_rdlock(&gbl_dbreg_log_lock);
 
 			if (LOCKING_ON(dbenv)) {
 				request.op = DB_LOCK_PUT_READ;
@@ -1041,7 +1041,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 							     ltranid,
 							     begin_lsn,
 							     &lt)) != 0) {
-                            pthread_rwlock_unlock(&gbl_dbreg_log_lock);
+							pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 							goto err;
 						}
 					}
@@ -1051,7 +1051,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						    ltranid, &lt)) != 0) {
 						logmsg(LOGMSG_FATAL, "Couldn't find ltrans?");
 						abort();
-                        pthread_rwlock_unlock(&gbl_dbreg_log_lock);
+						pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 						goto err;
 					}
 
@@ -1139,7 +1139,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						    txnp->last_lsn.offset;
 					}
 				}
-                pthread_rwlock_unlock(&gbl_dbreg_log_lock);
+				pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 
 				if (gbl_new_snapisol) {
 					if (!txnp->pglogs_hashtbl) {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1269,13 +1269,5 @@ REGISTER_TUNABLE(
     "Max number of client stats stored in comdb2_clientstats. (Default 10000)",
     TUNABLE_INTEGER, &gbl_max_clientstats_cache, DYNAMIC, NULL, NULL, NULL,
     NULL);
-REGISTER_TUNABLE("dbreg_stack_on_null_txn",
-                 "Cheap-stack on dbreg with a null txn.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_dbreg_stack_on_null_txn,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("dbreg_abort_on_null_txn",
-                 "Abort on dbreg with a null txn.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_dbreg_abort_on_null_txn,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/tools/cdb2_dump/cdb2_dump.c
+++ b/tools/cdb2_dump/cdb2_dump.c
@@ -233,7 +233,7 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 		if ((ret = __db_util_cache(dbenv, dbp, &cache, &resize)) != 0)
 			goto err;
 		if (resize) {
-			(void)dbp->close(dbp, NULL, 0);
+			(void)dbp->close(dbp, 0);
 			dbp = NULL;
 
 			(void)dbenv->close(dbenv, 0);
@@ -276,7 +276,7 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 	if (0) {
 err:		exitval = 1;
 	}
-done:	if (dbp != NULL && (ret = dbp->close(dbp, NULL, 0)) != 0) {
+done:	if (dbp != NULL && (ret = dbp->close(dbp, 0)) != 0) {
 		exitval = 1;
 		dbenv->err(dbenv, ret, "close");
 	}
@@ -443,7 +443,7 @@ dump_sub(dbenv, parent_dbp, parent_name, pflag, keyflag)
 		    __db_pr_callback, NULL, 0) ||
 		    dump(dbp, pflag, keyflag)))
 			ret = 1;
-		(void)dbp->close(dbp, NULL, 0);
+		(void)dbp->close(dbp, 0);
 		free(subdb);
 		if (ret != 0)
 			return (1);

--- a/tools/cdb2_printlog/cdb2_printlog.c
+++ b/tools/cdb2_printlog/cdb2_printlog.c
@@ -363,7 +363,7 @@ shutdown:	exitval = 1;
 	if (dbc != NULL && (ret = dbc->c_close(dbc)) != 0)
 		exitval = 1;
 
-	if (dbp != NULL && (ret = dbp->close(dbp, NULL, 0)) != 0)
+	if (dbp != NULL && (ret = dbp->close(dbp, 0)) != 0)
 		exitval = 1;
 
 	/*
@@ -495,6 +495,6 @@ open_rep_db(dbenv, dbpp, dbcp)
 	return (0);
 
 err:	if (*dbpp != NULL)
-		(void)(*dbpp)->close(*dbpp, NULL, 0);
+		(void)(*dbpp)->close(*dbpp, 0);
 	return (ret);
 }

--- a/tools/cdb2_stat/cdb2_stat.c
+++ b/tools/cdb2_stat/cdb2_stat.c
@@ -281,7 +281,7 @@ retry:	if ((ret = db_env_create(&dbenv, env_flags)) != 0) {
 			    __db_util_cache(dbenv, dbp, &cache, &resize)) != 0)
 				goto shutdown;
 			if (resize) {
-				(void)dbp->close(dbp, NULL, DB_NOSYNC);
+				(void)dbp->close(dbp, DB_NOSYNC);
 				dbp = NULL;
 
 				(void)dbenv->close(dbenv, 0);
@@ -315,11 +315,11 @@ retry:	if ((ret = db_env_create(&dbenv, env_flags)) != 0) {
 			    db, subdb, DB_UNKNOWN, DB_RDONLY, 0)) != 0) {
 				dbenv->err(dbenv,
 				   ret, "DB->open: %s:%s", db, subdb);
-				(void)alt_dbp->close(alt_dbp, NULL, DB_NOSYNC);
+				(void)alt_dbp->close(alt_dbp, DB_NOSYNC);
 				goto shutdown;
 			}
 
-			(void)dbp->close(dbp, NULL, DB_NOSYNC);
+			(void)dbp->close(dbp, DB_NOSYNC);
 			dbp = alt_dbp;
 
 			/* Need to run again to update counts */
@@ -378,7 +378,7 @@ retry:	if ((ret = db_env_create(&dbenv, env_flags)) != 0) {
 	if (0) {
 shutdown:	exitval = 1;
 	}
-	if (dbp != NULL && (ret = dbp->close(dbp, NULL, DB_NOSYNC)) != 0) {
+	if (dbp != NULL && (ret = dbp->close(dbp, DB_NOSYNC)) != 0) {
 		exitval = 1;
 		dbenv->err(dbenv, ret, "close");
 	}

--- a/tools/cdb2_verify/cdb2_verify.c
+++ b/tools/cdb2_verify/cdb2_verify.c
@@ -170,7 +170,7 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 			if ((ret = dbp1->open(dbp1, NULL,
 			    argv[0], NULL, DB_UNKNOWN, DB_RDONLY, 0)) != 0) {
 				dbenv->err(dbenv, ret, "DB->open: %s", argv[0]);
-				(void)dbp1->close(dbp1, NULL, 0);
+				(void)dbp1->close(dbp1, 0);
 				goto shutdown;
 			}
 			/*
@@ -182,12 +182,12 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 			 * get back into the for-loop.
 			 */
 			ret = __db_util_cache(dbenv, dbp1, &cache, &resize);
-			(void)dbp1->close(dbp1, NULL, 0);
+			(void)dbp1->close(dbp1, 0);
 			if (ret != 0)
 				goto shutdown;
 
 			if (resize) {
-				(void)dbp->close(dbp, NULL, 0);
+				(void)dbp->close(dbp, 0);
 				dbp = NULL;
 
 				(void)dbenv->close(dbenv, 0);
@@ -210,7 +210,7 @@ retry:	if ((ret = db_env_create(&dbenv, 0)) != 0) {
 shutdown:	exitval = 1;
 	}
 
-	if (dbp != NULL && (ret = dbp->close(dbp, NULL, 0)) != 0) {
+	if (dbp != NULL && (ret = dbp->close(dbp, 0)) != 0) {
 		exitval = 1;
 		dbenv->err(dbenv, ret, "close");
 	}


### PR DESCRIPTION
Use a pthread_rwlock to prevent dbreg-close requests from being written to the log between the time that a transaction issues a LOCK_PUT_READ and a commit record.  Backout the previous "transactional-close" code, as these changes caused dbreg-close to execute in log-file order on the master, but in transaction-order on the replicant.
