### PR TITLE
Fix querytimeout assignment in Comdb2Statement construction

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -54,7 +54,7 @@ public class Comdb2Statement implements Statement {
         this.hndl = hndl;
         this.conn = conn;
         this.timeout = timeout;
-        this.querytimeout = querytimeout;
+        this.querytimeout = querytime;
     }
 
     @Override


### PR DESCRIPTION
The original code was assigning a variable to itself (and ignoring an argument to the constructor).

Note that this fix will affect behavior in existing clients to the API.  Previously, the code would actually use `-1` (no timeout) regardless of specified timeout. After the fix, it will use the specified query timeout.

