### PR TITLE
sorese: all blkseq all the time

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1037,7 +1037,6 @@ typedef struct sorese_info {
     int rcout;  /* store here the block proc main error */
 
     int verify_retries; /* how many times we verify retried this one */
-    bool use_blkseq;    /* used to force a blkseq, for locally retried txn */
     bool osql_retry;    /* if this is osql transaction, once sql part
                           finished successful, we set this to one
                           to avoid repeating it if the transaction is reexecuted

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7432,12 +7432,6 @@ static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
         iq->sorese.verify_retries += gbl_osql_verify_ext_chk;
     }
 
-    if (btst(&req.flags, OSQL_FLAGS_USE_BLKSEQ)) {
-        iq->sorese.use_blkseq = 1;
-    } else {
-        iq->sorese.use_blkseq = 0;
-    }
-
 done:
 
     if (rc) {

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -828,7 +828,6 @@ static osql_callback_t commit_callbacks[] = {
     NULL,                          /* OSQL_FLAGS_AUTH */
     osql_analyze_commit_callback,  /* OSQL_FLAGS_ANALYZE */
     NULL,                          /* OSQL_FLAGS_CHECK_SELFLOCK */
-    NULL,                          /* OSQL_FLAGS_USE_BLKSEQ */
     osql_rowlocks_commit_callback, /* OSQL_FLAGS_ROWLOCKS */
     osql_genid48_commit_callback,  /* OSQL_FLAGS_GENID48 */
     osql_scdone_commit_callback    /* OSQL_FLAGS_SCDONE */
@@ -838,7 +837,6 @@ static osql_callback_t abort_callbacks[] = {
     NULL,                      /* OSQL_FLAGS_AUTH */
     NULL,                      /* OSQL_FLAGS_ANALYZE */
     NULL,                      /* OSQL_FLAGS_CHECK_SELFLOCK */
-    NULL,                      /* OSQL_FLAGS_USE_BLKSEQ */
     NULL,                      /* OSQL_FLAGS_ROWLOCKS */
     NULL,                      /* OSQL_FLAGS_GENID48 */
     osql_scdone_abort_callback /* OSQL_FLAGS_SCDONE */

--- a/db/sqloffload.h
+++ b/db/sqloffload.h
@@ -57,11 +57,9 @@ enum {
     OSQL_FLAGS_ANALYZE = 2,
     /* sent after a verify to do the <slower> selfdeadlock test */
     OSQL_FLAGS_CHECK_SELFLOCK = 3,
-    /* sent in local case when a remote tran is retried */
-    OSQL_FLAGS_USE_BLKSEQ = 4,
-    OSQL_FLAGS_ROWLOCKS = 5,
-    OSQL_FLAGS_GENID48 = 6,
-    OSQL_FLAGS_SCDONE = 7
+    OSQL_FLAGS_ROWLOCKS = 4,
+    OSQL_FLAGS_GENID48 = 5,
+    OSQL_FLAGS_SCDONE = 6
 };
 
 int osql_open(struct dbenv *dbenv);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2763,9 +2763,6 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     }
 
     iq->blkstate->pos = 0;
-    /* if client requested blkseq, please don't skip it, probably a retry */
-    if (iq->is_sorese && iq->frommach == 0 && !iq->sorese.use_blkseq)
-        have_blkseq = 0;
 
     if (!rowlocks) {
         /* start parent transaction */
@@ -3708,16 +3705,10 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
         }
         case BLOCK_SEQ: {
             extract_blkseq(iq, p_blkstate, &found_blkseq, &have_blkseq);
-            if (iq->is_sorese && iq->frommach == 0 && !iq->sorese.use_blkseq)
-                have_blkseq = 0;
-
             break;
         }
         case BLOCK2_SEQV2: {
             extract_blkseq2(iq, p_blkstate, &found_blkseq, &have_blkseq);
-            if (iq->is_sorese && iq->frommach == 0 && !iq->sorese.use_blkseq)
-                have_blkseq = 0;
-
             break;
         }
 


### PR DESCRIPTION
- always add blkseq
- removed OSQL_FLAGS_USE_BLKSEQ (already made changes to R6 to ignore the flag; i.e. backward compatible)
