### PR TITLE
Bump the temptable limit for tmptbl_starve.

### DIFF
--- a/tests/tmptbl_starve.test/lrl.options
+++ b/tests/tmptbl_starve.test/lrl.options
@@ -1,1 +1,1 @@
-temptable_limit 4
+temptable_limit 6


### PR DESCRIPTION
Apparently DDL needs temptables now which breaks the prerequisites of the test.