### PR TITLE
cdb2api send timestamp of each client query 

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -5318,6 +5318,8 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         comdb2_cheapstack_char_array(hndl->stack, MAX_STACK);
 
     if (log_calls) {
+        struct timeval tv;
+        gettimeofday(&tv, NULL);
         fprintf(stderr, "%p> cdb2_open(dbname: \"%s\", type: \"%s\", flags: "
                         "%x) = %d => %p\n",
                 (void *)pthread_self(), dbname, type, hndl->flags, rc, *handle);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2276,11 +2276,6 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     if (sqlquery.n_set_flags)
         sqlquery.set_flags = &set_commands[n_set_commands_sent];
 
-    if (hndl && hndl->is_retry) {
-        sqlquery.has_retry = 1;
-        sqlquery.retry = hndl->is_retry;
-    }
-
     if (hndl && !(hndl->flags & CDB2_READ_INTRANS_RESULTS) && is_begin) {
         features[n_features] = CDB2_CLIENT_FEATURES__SKIP_ROWS;
         n_features++;
@@ -2350,6 +2345,9 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
 
     sqlquery.has_num_retries = 1;
     sqlquery.num_retries = retries_done;
+
+    sqlquery.has_retry = 1;
+    sqlquery.retry = retries_done;
 
     int len = cdb2__query__get_packed_size(&query);
     unsigned char *buf = malloc(len + 1);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3425,7 +3425,7 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
                 hndl->hint = NULL;
             }
 
-            int len = strnlen(sql, 101);
+            int len = strlen(sql);
             if (len > 100) {
                 hndl->query = malloc(len + 1);
                 strcpy(hndl->query, sql);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2348,13 +2348,15 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     gettimeofday(&tv, NULL);
     sqlquery.timestampus = ((uint64_t)tv.tv_sec) * 1000000 + tv.tv_usec;
 
+    sqlquery.has_num_retries = 1;
+    sqlquery.num_retries = retries_done;
+
     int len = cdb2__query__get_packed_size(&query);
     unsigned char *buf = malloc(len + 1);
 
     cdb2__query__pack(&query, buf);
 
     struct newsqlheader hdr;
-
     hdr.type = ntohl(CDB2_REQUEST_TYPE__CDB2QUERY);
     hdr.compression = ntohl(0);
     hdr.length = ntohl(len);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2686,6 +2686,7 @@ int cdb2_close(cdb2_hndl_tp *hndl)
                 break;
         }
         if (hndl->debug_trace) {
+            gettimeofday(&tv, NULL);
             uint64_t curr = ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000;
             fprintf(stderr, "%s: auto consume %d records took %lu ms\n",
                     __func__, nrec, curr - starttimems);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2343,6 +2343,11 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
         hndl->context_msgs.has_changed = 0;
     }
 
+    sqlquery.has_timestampus = 1;
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    sqlquery.timestampus = ((uint64_t)tv.tv_sec) * 1000000 + tv.tv_usec;
+
     int len = cdb2__query__get_packed_size(&query);
     unsigned char *buf = malloc(len + 1);
 
@@ -2354,6 +2359,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     hdr.compression = ntohl(0);
     hdr.length = ntohl(len);
 
+    // finally send header and query
     sbuf2write((char *)&hdr, sizeof(hdr), sb);
     sbuf2write((char *)buf, len, sb);
 
@@ -2665,27 +2671,24 @@ int cdb2_close(cdb2_hndl_tp *hndl)
     if (hndl->sb && !hndl->in_trans && hndl->firstresponse &&
         (!hndl->lastresponse ||
          (hndl->lastresponse->response_type != RESPONSE_TYPE__LAST_ROW))) {
-        struct timeval tv;
         int nrec = 0;
-        uint64_t starttime;
         sbuf2settimeout(hndl->sb, CDB2_AUTO_CONSUME_TIMEOUT_MS,
                         CDB2_AUTO_CONSUME_TIMEOUT_MS);
+        struct timeval tv;
         gettimeofday(&tv, NULL);
-        starttime = ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000; // in ms
+        uint64_t starttimems = ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000;
         while (cdb2_next_record_int(hndl, 0) == CDB2_OK) {
             nrec++;
             gettimeofday(&tv, NULL);
+            uint64_t curr = ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000;
             /* auto consume for up to CDB2_AUTO_CONSUME_TIMEOUT_MS */
-            if (((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000 - starttime >=
-                CDB2_AUTO_CONSUME_TIMEOUT_MS)
+            if (curr - starttimems >= CDB2_AUTO_CONSUME_TIMEOUT_MS)
                 break;
         }
         if (hndl->debug_trace) {
-            gettimeofday(&tv, NULL);
+            uint64_t curr = ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000;
             fprintf(stderr, "%s: auto consume %d records took %lu ms\n",
-                    __func__, nrec,
-                    ((uint64_t)tv.tv_sec) * 1000 + tv.tv_usec / 1000 -
-                        starttime);
+                    __func__, nrec, curr - starttimems);
         }
     }
 
@@ -2749,7 +2752,7 @@ static void make_random_str(char *str, size_t max_len, int *len)
     static __thread char cached_portion[23] = {0}; // 2*10 digits + 2 '-' + '\n'
     static __thread size_t cached_portion_len = 0;
     if (cached_portion_len == 0) {
-        cached_portion_len = snprintf(cached_portion, sizeof(cached_portion),
+        cached_portion_len = snprintf(cached_portion, sizeof(cached_portion)-1,
                                       "%d-%d-", cdb2_hostid(), _PID);
     }
     struct timeval tv;
@@ -3349,8 +3352,7 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
 
     /* sniff out 'set hasql on' here */
     if (strncasecmp(sql, "set", 3) == 0) {
-        rc = process_set_command(hndl, sql);
-        return rc;
+        return process_set_command(hndl, sql);
     }
 
     if (strncasecmp(sql, "begin", 5) == 0) {
@@ -3374,10 +3376,11 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
         is_commit = 1;
         is_rollback = 1;
     }
-    if (hndl->client_side_error == 1 && hndl->in_trans && !is_commit) {
-        return hndl->error_in_trans;
-    } else if (hndl->client_side_error == 1 && hndl->in_trans && is_commit) {
-        sql = "rollback";
+    if (hndl->client_side_error == 1 && hndl->in_trans) {
+        if (!is_commit)
+            return hndl->error_in_trans;
+        else
+            sql = "rollback";
     }
 
     if ((is_begin && hndl->in_trans) || (is_commit && !hndl->in_trans)) {
@@ -3421,7 +3424,7 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
                 hndl->hint = NULL;
             }
 
-            int len = strlen(sql);
+            int len = strnlen(sql, 101);
             if (len > 100) {
                 hndl->query = malloc(len + 1);
                 strcpy(hndl->query, sql);
@@ -5318,8 +5321,6 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
         comdb2_cheapstack_char_array(hndl->stack, MAX_STACK);
 
     if (log_calls) {
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
         fprintf(stderr, "%p> cdb2_open(dbname: \"%s\", type: \"%s\", flags: "
                         "%x) = %d => %p\n",
                 (void *)pthread_self(), dbname, type, hndl->flags, rc, *handle);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2349,7 +2349,6 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     req_info.num_retries = retries_done;
     sqlquery.req_info = &req_info;
 
-
     int len = cdb2__query__get_packed_size(&query);
     unsigned char *buf = malloc(len + 1);
 
@@ -2754,8 +2753,9 @@ static void make_random_str(char *str, size_t max_len, int *len)
     static __thread char cached_portion[23] = {0}; // 2*10 digits + 2 '-' + '\n'
     static __thread size_t cached_portion_len = 0;
     if (cached_portion_len == 0) {
-        cached_portion_len = snprintf(cached_portion, sizeof(cached_portion)-1,
-                                      "%d-%d-", cdb2_hostid(), _PID);
+        cached_portion_len =
+            snprintf(cached_portion, sizeof(cached_portion) - 1, "%d-%d-",
+                     cdb2_hostid(), _PID);
     }
     struct timeval tv;
     gettimeofday(&tv, NULL);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -142,6 +142,7 @@ extern int gbl_dump_full_net_queue;
 extern int gbl_max_clientstats_cache;
 extern int gbl_dbreg_stack_on_null_txn;
 extern int gbl_dbreg_abort_on_null_txn;
+extern int gbl_simulate_dropping_request;
 
 extern long long sampling_threshold;
 

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -292,6 +292,7 @@ void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
     cson_value *perfval = cson_value_new_object();
     cson_object *perfobj = cson_value_get_object(perfval);
 
+    //runtime is in microseconds
     cson_object_set(perfobj, "runtime", cson_new_int(end - start));
 
     if (thread_stats->n_lock_waits || thread_stats->n_preads ||
@@ -471,8 +472,9 @@ static void eventlog_add_int(cson_object *obj, const struct reqlogger *logger)
         cson_object_set(obj, "qtime", cson_new_int(logger->queuetimeus));
     if (logger->clnt) {
         uint64_t clientstarttime = get_client_starttime(logger->clnt);
-        if (clientstarttime)
-            cson_object_set(obj, "clientstart", cson_new_int(clientstarttime));
+        if (clientstarttime && logger->startus > clientstarttime)
+            cson_object_set(obj, "startdelay", /* in microseconds */
+                            cson_new_int(logger->startus - clientstarttime));
     }
 
     eventlog_context(obj, logger);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -469,6 +469,11 @@ static void eventlog_add_int(cson_object *obj, const struct reqlogger *logger)
 
     if (logger->queuetimeus)
         cson_object_set(obj, "qtime", cson_new_int(logger->queuetimeus));
+    if (logger->clnt) {
+        uint64_t clientstarttime = get_client_starttime(logger->clnt);
+        if (clientstarttime)
+            cson_object_set(obj, "clientstart", cson_new_int(clientstarttime));
+    }
 
     eventlog_context(obj, logger);
     eventlog_perfdata(obj, logger);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -284,10 +284,8 @@ void eventlog_tables(cson_object *obj, const struct reqlogger *logger)
 void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
 {
     const struct bdb_thread_stats *thread_stats = bdb_get_thread_stats();
-    int64_t start, end;
-
-    start = logger->startus;
-    end = comdb2_time_epochus();
+    int64_t start = logger->startus;
+    int64_t end = comdb2_time_epochus();
 
     cson_value *perfval = cson_value_new_object();
     cson_object *perfobj = cson_value_get_object(perfval);
@@ -473,8 +471,10 @@ static void eventlog_add_int(cson_object *obj, const struct reqlogger *logger)
     if (logger->clnt) {
         uint64_t clientstarttime = get_client_starttime(logger->clnt);
         if (clientstarttime && logger->startus > clientstarttime)
-            cson_object_set(obj, "startdelay", /* in microseconds */
+            cson_object_set(obj, "startlag", /* in microseconds */
                             cson_new_int(logger->startus - clientstarttime));
+        cson_object_set(obj, "clientretries",
+                        cson_new_int(get_client_retries(logger->clnt)));
     }
 
     eventlog_context(obj, logger);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -290,7 +290,7 @@ void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
     cson_value *perfval = cson_value_new_object();
     cson_object *perfobj = cson_value_get_object(perfval);
 
-    //runtime is in microseconds
+    // runtime is in microseconds
     cson_object_set(perfobj, "runtime", cson_new_int(end - start));
 
     if (thread_stats->n_lock_waits || thread_stats->n_preads ||

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -578,9 +578,8 @@ static void *thd_req(void *vthd)
 #endif
             pool_relablk(p_reqs, thd->iq); /* this request is done, so release
                                             * resource. */
-            nxtrq =
-                (struct dbq_entry_t *)listc_rtl(&q_reqs); /* get next item off
-                                                         *  hqueue */
+            /* get next item off hqueue */
+            nxtrq = (struct dbq_entry_t *)listc_rtl(&q_reqs);
             thd->iq = 0;
             if (nxtrq != 0) {
                 thd->iq = nxtrq->obj;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1742,7 +1742,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
         char expanded_fp[2 * FINGERPRINTSZ + 1];
         util_tohex(expanded_fp, logger->fingerprint, FINGERPRINTSZ);
         reqlog_logf(logger, REQL_INFO, "fingerprint=%.*s",
-                        FINGERPRINTSZ * 1, expanded_fp);
+                        FINGERPRINTSZ * 2, expanded_fp);
     }
 
     logger->in_request = 0;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1741,8 +1741,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
     if (gbl_fingerprint_queries && logger->have_fingerprint) {
         char expanded_fp[2 * FINGERPRINTSZ + 1];
         util_tohex(expanded_fp, logger->fingerprint, FINGERPRINTSZ);
-        reqlog_logf(logger, REQL_INFO, "fingerprint=%.*s",
-                        FINGERPRINTSZ * 2, expanded_fp);
+        reqlog_logf(logger, REQL_INFO, "fingerprint=%.*s", FINGERPRINTSZ * 2,
+                    expanded_fp);
     }
 
     logger->in_request = 0;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1739,10 +1739,10 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
     /* If fingerprinting is enabled and the logger has a fingerprint,
        log the fingerprint as well. */
     if (gbl_fingerprint_queries && logger->have_fingerprint) {
-        char hexfp[FINGERPRINTSZ << 1];
-        if (reqlog_fingerprint_to_hex(logger, hexfp, FINGERPRINTSZ << 1) > 0)
-            reqlog_logf(logger, REQL_INFO, "fingerprint=%.*s",
-                        FINGERPRINTSZ << 1, hexfp);
+        char expanded_fp[2 * FINGERPRINTSZ + 1];
+        util_tohex(expanded_fp, logger->fingerprint, FINGERPRINTSZ);
+        reqlog_logf(logger, REQL_INFO, "fingerprint=%.*s",
+                        FINGERPRINTSZ * 1, expanded_fp);
     }
 
     logger->in_request = 0;
@@ -2721,27 +2721,4 @@ void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context)
 void reqlog_set_clnt(struct reqlogger *logger, struct sqlclntstate *clnt)
 {
     logger->clnt = clnt;
-}
-
-int reqlog_fingerprint_to_hex(struct reqlogger *logger, char *hexstr, size_t n)
-{
-    static const char hex[] = "0123456789abcdef";
-    size_t i, len;
-
-    if (!gbl_fingerprint_queries)
-        return 0;
-
-    if (n & 1)
-        return 0;
-
-    if (logger == NULL)
-        return 0;
-
-    for (i = 0, len = ((n >> 1) < FINGERPRINTSZ) ? (n >> 1) : FINGERPRINTSZ;
-         i != len; ++i) {
-        hexstr[i << 1] = hex[(logger->fingerprint[i] & 0xf0) >> 4];
-        hexstr[(i << 1) + 1] = hex[logger->fingerprint[i] & 0x0f];
-    }
-
-    return (i << 1);
 }

--- a/db/sql.h
+++ b/db/sql.h
@@ -383,7 +383,7 @@ struct plugin_callbacks {
     skip_row_func *skip_row; /* newsql_skip_row */
     log_context_func *log_context; /* newsql_log_context */
     ret_uint64_func *get_client_starttime; /* newsql_get_client_starttime */
-    plugin_func *get_client_retries; /* newsql_get_client_retries */
+    plugin_func *get_client_retries;       /* newsql_get_client_retries */
 };
 
 #define make_plugin_callback(clnt, name, func)                                 \
@@ -430,7 +430,6 @@ int set_high_availability(struct sqlclntstate *);
 int clr_high_availability(struct sqlclntstate *);
 uint64_t get_client_starttime(struct sqlclntstate *);
 int get_client_retries(struct sqlclntstate *);
-
 
 /* Client specific sql state */
 struct sqlclntstate {

--- a/db/sql.h
+++ b/db/sql.h
@@ -345,6 +345,7 @@ typedef void(add_steps_func)(struct sqlclntstate *, double steps);
 typedef void(setup_client_info_func)(struct sqlclntstate *, struct sqlthdstate *, char *);
 typedef int(skip_row_func)(struct sqlclntstate *, uint64_t);
 typedef int(log_context_func)(struct sqlclntstate *, struct reqlogger *);
+typedef uint64_t(ret_uint64_func)(struct sqlclntstate *);
 
 struct plugin_callbacks {
     response_func *write_response; /* newsql_write_response */
@@ -381,6 +382,7 @@ struct plugin_callbacks {
     setup_client_info_func *setup_client_info; /* newsql_setup_client_info */
     skip_row_func *skip_row; /* newsql_skip_row */
     log_context_func *log_context; /* newsql_log_context */
+    ret_uint64_func *get_client_starttime; /* newsql_get_client_starttime*/
 };
 
 #define make_plugin_callback(clnt, name, func)                                 \
@@ -413,6 +415,7 @@ struct plugin_callbacks {
         make_plugin_callback(clnt, name, setup_client_info);                   \
         make_plugin_callback(clnt, name, skip_row);                            \
         make_plugin_callback(clnt, name, log_context);                         \
+        make_plugin_callback(clnt, name, get_client_starttime);                \
     } while (0)
 
 int param_count(struct sqlclntstate *);
@@ -423,6 +426,7 @@ int get_cnonce(struct sqlclntstate *, snap_uid_t *);
 int has_high_availability(struct sqlclntstate *);
 int set_high_availability(struct sqlclntstate *);
 int clr_high_availability(struct sqlclntstate *);
+uint64_t get_client_starttime(struct sqlclntstate *);
 
 
 /* Client specific sql state */

--- a/db/sql.h
+++ b/db/sql.h
@@ -382,7 +382,8 @@ struct plugin_callbacks {
     setup_client_info_func *setup_client_info; /* newsql_setup_client_info */
     skip_row_func *skip_row; /* newsql_skip_row */
     log_context_func *log_context; /* newsql_log_context */
-    ret_uint64_func *get_client_starttime; /* newsql_get_client_starttime*/
+    ret_uint64_func *get_client_starttime; /* newsql_get_client_starttime */
+    plugin_func *get_client_retries; /* newsql_get_client_retries */
 };
 
 #define make_plugin_callback(clnt, name, func)                                 \
@@ -416,6 +417,7 @@ struct plugin_callbacks {
         make_plugin_callback(clnt, name, skip_row);                            \
         make_plugin_callback(clnt, name, log_context);                         \
         make_plugin_callback(clnt, name, get_client_starttime);                \
+        make_plugin_callback(clnt, name, get_client_retries);                  \
     } while (0)
 
 int param_count(struct sqlclntstate *);
@@ -427,6 +429,7 @@ int has_high_availability(struct sqlclntstate *);
 int set_high_availability(struct sqlclntstate *);
 int clr_high_availability(struct sqlclntstate *);
 uint64_t get_client_starttime(struct sqlclntstate *);
+int get_client_retries(struct sqlclntstate *);
 
 
 /* Client specific sql state */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -264,6 +264,11 @@ static void setup_client_info(struct sqlclntstate *clnt, struct sqlthdstate *thd
     clnt->plugin.setup_client_info(clnt, thd, replay);
 }
 
+uint64_t get_client_starttime(struct sqlclntstate *clnt)
+{
+    return clnt->plugin.get_client_starttime(clnt);
+}
+
 static int skip_row(struct sqlclntstate *clnt, uint64_t rowid)
 {
     return clnt->plugin.skip_row(clnt, rowid);
@@ -611,7 +616,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
     else
         h->sql = strdup("unknown");
     h->cost = query_cost(thd);
-    int timems = h->time = comdb2_time_epochms() - thd->startms;
+    h->time = comdb2_time_epochms() - thd->startms;
     h->when = thd->stime;
     h->txnid = rqid;
 
@@ -5137,7 +5142,10 @@ static int internal_log_context(struct sqlclntstate *a, struct reqlogger *b)
 {
     return 0;
 }
-
+static uint64_t internal_get_client_starttime(struct sqlclntstate *a)
+{
+    return -1;
+}
 void start_internal_sql_clnt(struct sqlclntstate *clnt)
 {
     reset_clnt(clnt, NULL, 1);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -269,6 +269,11 @@ uint64_t get_client_starttime(struct sqlclntstate *clnt)
     return clnt->plugin.get_client_starttime(clnt);
 }
 
+int get_client_retries(struct sqlclntstate *clnt)
+{
+    return clnt->plugin.get_client_retries(clnt);
+}
+
 static int skip_row(struct sqlclntstate *clnt, uint64_t rowid)
 {
     return clnt->plugin.skip_row(clnt, rowid);
@@ -5143,6 +5148,10 @@ static int internal_log_context(struct sqlclntstate *a, struct reqlogger *b)
     return 0;
 }
 static uint64_t internal_get_client_starttime(struct sqlclntstate *a)
+{
+    return -1;
+}
+static int internal_get_client_retries(struct sqlclntstate *a)
 {
     return -1;
 }

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1414,6 +1414,16 @@ static int newsql_log_context(struct sqlclntstate *clnt,
     return 0;
 }
 
+static uint64_t newsql_get_client_starttime(struct sqlclntstate *clnt)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    CDB2SQLQUERY *sqlquery = appdata->sqlquery;
+    if (!sqlquery->has_timestampus) {
+        return 0;
+    }
+    return sqlquery->timestampus;
+}
+
 
 /* Process sql query if it is a set command. */
 static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1424,6 +1424,15 @@ static uint64_t newsql_get_client_starttime(struct sqlclntstate *clnt)
     return sqlquery->timestampus;
 }
 
+static int newsql_get_client_retries(struct sqlclntstate *clnt)
+{
+    struct newsql_appdata *appdata = clnt->appdata;
+    CDB2SQLQUERY *sqlquery = appdata->sqlquery;
+    if (!sqlquery->has_num_retries) {
+        return 0;
+    }
+    return sqlquery->num_retries;
+}
 
 /* Process sql query if it is a set command. */
 static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1418,18 +1418,19 @@ static uint64_t newsql_get_client_starttime(struct sqlclntstate *clnt)
 {
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
-    if (!sqlquery->has_timestampus) {
-        return 0;
+    if (sqlquery->req_info) {
+        return sqlquery->req_info->timestampus;
     }
-    return sqlquery->timestampus;
+    return 0;
 }
 
 static int newsql_get_client_retries(struct sqlclntstate *clnt)
 {
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
-    if (sqlquery->has_retry)
-        return sqlquery->retry;
+    if (sqlquery->req_info) {
+        return sqlquery->req_info->num_retries;
+    }
     return 0;
 }
 

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1428,10 +1428,9 @@ static int newsql_get_client_retries(struct sqlclntstate *clnt)
 {
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
-    if (!sqlquery->has_num_retries) {
-        return 0;
-    }
-    return sqlquery->num_retries;
+    if (sqlquery->has_retry)
+        return sqlquery->retry;
+    return 0;
 }
 
 /* Process sql query if it is a set command. */

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -63,6 +63,7 @@ message CDB2_SQLQUERY {
   optional cinfo client_info = 15;
   repeated string context    = 16; // Client context messages.
   optional int64 timestampus = 17; // client timestamp of this message.
+  optional int32 num_retries = 18; // client retry count
 }
 
 

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -50,7 +50,7 @@ message CDB2_SQLQUERY {
   }
   optional snapshotinfo snapshot_info = 11; 
   optional int64 skip_rows = 12; // number of rows to be skipped, -1 (skip all rows)
-  optional int32 retry = 13  [default = 0];
+  optional int32 retry = 13  [default = 0]; // query retry count for a disconnected connection
   // if begin retry < query retry then skip all the rows from server, if same then skip (skip_rows)
   repeated int32 features = 14; // Client can negotiate on this.
   message cinfo {
@@ -62,8 +62,11 @@ message CDB2_SQLQUERY {
   }
   optional cinfo client_info = 15;
   repeated string context    = 16; // Client context messages.
-  optional int64 timestampus = 17; // client timestamp of this message.
-  optional int32 num_retries = 18; // client retry count
+  message reqinfo {
+      required int64 timestampus = 1; // client timestamp of this message.
+      required int32 num_retries = 2; // client retry count including hops to other nodes
+  }
+  optional reqinfo req_info = 17; //request info
 }
 
 

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -62,6 +62,7 @@ message CDB2_SQLQUERY {
   }
   optional cinfo client_info = 15;
   repeated string context    = 16; // Client context messages.
+  optional int64 timestampus = 17; // client timestamp of this message.
 }
 
 


### PR DESCRIPTION
Send client start time and retry count as optional fields of sqlquery, and print them in the event log. The purpose of having this added timestamp is to be able to find out by looking at the server logs how long it took for a query to reach the server -- since a request can be dropped by a server, the api will retry next server and so on, and that time of retrying multiple servers may be significant -- even though the query may execute quickly once accepted by a server, it can look like a slow query to the client. 

Eventlog for an sql will have extra `startlag` field measured in microseconds and `clientretries` is an integer counter: `"startlag": 113,"clientretries": 1` and an event entry would look like this:
```
{"time": 1528694347141980,"type": "sql","sql": "select comdb2_dbname()",
"cnonce": "8323329-12928-141778-1589365389","rows": 1,"host": "client1","
fingerprint": "0fc4c5d02b358b64765c65fb7139ba1a","qtime": 10,
"startlag": 113,"clientretries": 1,"context": ["cdb2sql"],"perf": {"runtime": 85}}
```