### PR TITLE
Fix cdb2api READ_INTRANS_RESULTS mode.

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -649,8 +649,8 @@ tran_type *bdb_tran_begin_serializable(bdb_state_type *bdb_state, int trak,
                                        int *bdberr, int epoch, int file,
                                        int offset, int is_ha_retry);
 tran_type *bdb_tran_begin_snapisol(bdb_state_type *bdb_state, int trak,
-                                   int *bdberr, int epoch, int file,
-                                   int offset, int is_ha_retry);
+                                   int *bdberr, int epoch, int file, int offset,
+                                   int is_ha_retry);
 
 /* commit the transaction referenced by the tran handle */
 int bdb_tran_commit(bdb_state_type *bdb_handle, tran_type *tran, int *bdberr);

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -647,10 +647,10 @@ tran_type *bdb_tran_begin_readcommitted(bdb_state_type *, int trak,
 
 tran_type *bdb_tran_begin_serializable(bdb_state_type *bdb_state, int trak,
                                        int *bdberr, int epoch, int file,
-                                       int offset);
+                                       int offset, int is_ha_retry);
 tran_type *bdb_tran_begin_snapisol(bdb_state_type *bdb_state, int trak,
                                    int *bdberr, int epoch, int file,
-                                   int offset);
+                                   int offset, int is_ha_retry);
 
 /* commit the transaction referenced by the tran handle */
 int bdb_tran_commit(bdb_state_type *bdb_handle, tran_type *tran, int *bdberr);

--- a/bdb/bdb_osqltrn.c
+++ b/bdb/bdb_osqltrn.c
@@ -288,8 +288,9 @@ bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
                 DB_LSN my_lsn, dur_lsn, arg_lsn;
                 uint32_t my_gen;
 
-                if ((rc = request_durable_lsn_from_master(bdb_state, &dur_lsn.file, 
-                                &dur_lsn.offset, &durable_gen)) != 0) {
+                if ((rc = request_durable_lsn_from_master(
+                         bdb_state, &dur_lsn.file, &dur_lsn.offset,
+                         &durable_gen)) != 0) {
                     *bdberr = BDBERR_NOT_DURABLE;
                     return NULL;
                 }
@@ -298,24 +299,27 @@ bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
 
                 bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &my_gen);
                 __log_txn_lsn(bdb_state->dbenv, &my_lsn, NULL, NULL);
-                // bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &my_lsn, &my_gen);
                 BDB_RELLOCK();
 
-                // if we're not at least this current send request to another node
+                /* if we're not at least this current
+                   send request to another */
                 if (file) {
                     arg_lsn.file = file;
                     arg_lsn.offset = offset;
                 }
 
-                if (my_gen != durable_gen || (log_compare(&my_lsn, &dur_lsn) < 0) ||
-                        (file && log_compare(&my_lsn, &arg_lsn) < 0))
-                {
+                if (my_gen != durable_gen ||
+                    (log_compare(&my_lsn, &dur_lsn) < 0) ||
+                    (file && log_compare(&my_lsn, &arg_lsn) < 0)) {
                     if (gbl_extended_sql_debug_trace) {
-                        logmsg(LOGMSG_USER, "%s line %d: returning not-durable, durable_gen=%u,"
-                                " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
-                                "arg_lsn=[%d][%d]\n", __func__, __LINE__, durable_gen, 
-                                my_gen, dur_lsn.file, dur_lsn.offset, my_lsn.file, 
-                                my_lsn.offset, file, offset);
+                        logmsg(
+                            LOGMSG_USER,
+                            "%s line %d: returning not-durable, durable_gen=%u,"
+                            " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
+                            "arg_lsn=[%d][%d]\n",
+                            __func__, __LINE__, durable_gen, my_gen,
+                            dur_lsn.file, dur_lsn.offset, my_lsn.file,
+                            my_lsn.offset, file, offset);
                     }
                     *bdberr = BDBERR_NOT_DURABLE;
                     return NULL;

--- a/bdb/bdb_osqltrn.c
+++ b/bdb/bdb_osqltrn.c
@@ -251,7 +251,7 @@ int request_durable_lsn_from_master(bdb_state_type *bdb_state,
 bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
                                       tran_type *shadow_tran, int trak,
                                       int *bdberr, int epoch, int file,
-                                      int offset)
+                                      int offset, int is_ha_retry)
 {
     bdb_osql_trn_t *trn = NULL;
     DB_LSN lsn;
@@ -259,7 +259,7 @@ bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
     bdb_state_type *parent;
     DB_LSN durable_lsn = {0};
     uint32_t durable_gen;
-    int backfill_required = 0, requested_from_master = 0, have_lsn = 0;
+    int backfill_required = 0;
     struct bfillhndl *bkfill_hndl = NULL;
 
     if (gbl_extended_sql_debug_trace) {
@@ -273,64 +273,59 @@ bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
         parent = bdb_state;
 
     if ((shadow_tran->tranclass == TRANCLASS_SNAPISOL ||
-         shadow_tran->tranclass == TRANCLASS_SERIALIZABLE)) {
+         shadow_tran->tranclass == TRANCLASS_SERIALIZABLE) && is_ha_retry) {
         if (epoch || file || offset) {
             backfill_required = 1;
-            have_lsn = 1;
-        }
-        else if (gbl_rowlocks) {
+        } else if (gbl_rowlocks) {
             backfill_required = 1;
-            have_lsn = 0;
-        }
-    }
-
-    // Always get the durable lsn from master
-    if ((shadow_tran->tranclass == TRANCLASS_SNAPISOL ||
-         shadow_tran->tranclass == TRANCLASS_SERIALIZABLE) &&
-        durable_lsns) {
-        DB_LSN my_lsn, dur_lsn, arg_lsn;
-        uint32_t my_gen;
-
-        if ((rc = request_durable_lsn_from_master(bdb_state, &dur_lsn.file, 
-                        &dur_lsn.offset, &durable_gen)) != 0) {
-            *bdberr = BDBERR_NOT_DURABLE;
-            return NULL;
         }
 
-        BDB_READLOCK("bdb_durable_check");
+        // Always get the durable lsn from master
+        if (durable_lsns) {
+            DB_LSN my_lsn, dur_lsn, arg_lsn;
+            uint32_t my_gen;
 
-        bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &my_gen);
-        __log_txn_lsn(bdb_state->dbenv, &my_lsn, NULL, NULL);
-        // bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &my_lsn, &my_gen);
-        BDB_RELLOCK();
-
-        // if we're not at least this current send request to another node
-        if (file) {
-            arg_lsn.file = file;
-            arg_lsn.offset = offset;
-        }
-
-        if (my_gen != durable_gen || (log_compare(&my_lsn, &dur_lsn) < 0) ||
-                (file && log_compare(&my_lsn, &arg_lsn) < 0))
-        {
-            if (gbl_extended_sql_debug_trace) {
-                logmsg(LOGMSG_USER, "%s line %d: returning not-durable, durable_gen=%u,"
-                        " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
-                        "arg_lsn=[%d][%d]\n", __func__, __LINE__, durable_gen, 
-                        my_gen, dur_lsn.file, dur_lsn.offset, my_lsn.file, 
-                        my_lsn.offset, file, offset);
+            if ((rc = request_durable_lsn_from_master(bdb_state, &dur_lsn.file, 
+                            &dur_lsn.offset, &durable_gen)) != 0) {
+                *bdberr = BDBERR_NOT_DURABLE;
+                return NULL;
             }
-            *bdberr = BDBERR_NOT_DURABLE;
-            return NULL;
-        }
 
-        /* If this isn't an asof query, backfill to the durable-lsn  */
-        if (!epoch && !file) {
-            file = dur_lsn.file;
-            offset = dur_lsn.offset;
-        }
+            BDB_READLOCK("bdb_durable_check");
 
-        backfill_required = 1;
+            bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &my_gen);
+            __log_txn_lsn(bdb_state->dbenv, &my_lsn, NULL, NULL);
+            // bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &my_lsn, &my_gen);
+            BDB_RELLOCK();
+
+            // if we're not at least this current send request to another node
+            if (file) {
+                arg_lsn.file = file;
+                arg_lsn.offset = offset;
+            }
+
+            if (my_gen != durable_gen || (log_compare(&my_lsn, &dur_lsn) < 0) ||
+                    (file && log_compare(&my_lsn, &arg_lsn) < 0))
+            {
+                if (gbl_extended_sql_debug_trace) {
+                    logmsg(LOGMSG_USER, "%s line %d: returning not-durable, durable_gen=%u,"
+                            " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
+                            "arg_lsn=[%d][%d]\n", __func__, __LINE__, durable_gen, 
+                            my_gen, dur_lsn.file, dur_lsn.offset, my_lsn.file, 
+                            my_lsn.offset, file, offset);
+                }
+                *bdberr = BDBERR_NOT_DURABLE;
+                return NULL;
+            }
+
+            /* If this isn't an asof query, backfill to the durable-lsn  */
+            if (!epoch && !file) {
+                file = dur_lsn.file;
+                offset = dur_lsn.offset;
+            }
+
+            backfill_required = 1;
+        }
     }
 
     rc = pthread_mutex_lock(&trn_repo_mtx);

--- a/bdb/bdb_osqltrn.c
+++ b/bdb/bdb_osqltrn.c
@@ -273,58 +273,62 @@ bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
         parent = bdb_state;
 
     if ((shadow_tran->tranclass == TRANCLASS_SNAPISOL ||
-         shadow_tran->tranclass == TRANCLASS_SERIALIZABLE) && is_ha_retry) {
-        if (epoch || file || offset) {
+         shadow_tran->tranclass == TRANCLASS_SERIALIZABLE)) {
+        if (epoch)
             backfill_required = 1;
-        } else if (gbl_rowlocks) {
-            backfill_required = 1;
-        }
-
-        // Always get the durable lsn from master
-        if (durable_lsns) {
-            DB_LSN my_lsn, dur_lsn, arg_lsn;
-            uint32_t my_gen;
-
-            if ((rc = request_durable_lsn_from_master(bdb_state, &dur_lsn.file, 
-                            &dur_lsn.offset, &durable_gen)) != 0) {
-                *bdberr = BDBERR_NOT_DURABLE;
-                return NULL;
+        else if (is_ha_retry) {
+            if (file || offset) {
+                backfill_required = 1;
+            } else if (gbl_rowlocks) {
+                backfill_required = 1;
             }
 
-            BDB_READLOCK("bdb_durable_check");
+            // Always get the durable lsn from master
+            if (durable_lsns) {
+                DB_LSN my_lsn, dur_lsn, arg_lsn;
+                uint32_t my_gen;
 
-            bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &my_gen);
-            __log_txn_lsn(bdb_state->dbenv, &my_lsn, NULL, NULL);
-            // bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &my_lsn, &my_gen);
-            BDB_RELLOCK();
-
-            // if we're not at least this current send request to another node
-            if (file) {
-                arg_lsn.file = file;
-                arg_lsn.offset = offset;
-            }
-
-            if (my_gen != durable_gen || (log_compare(&my_lsn, &dur_lsn) < 0) ||
-                    (file && log_compare(&my_lsn, &arg_lsn) < 0))
-            {
-                if (gbl_extended_sql_debug_trace) {
-                    logmsg(LOGMSG_USER, "%s line %d: returning not-durable, durable_gen=%u,"
-                            " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
-                            "arg_lsn=[%d][%d]\n", __func__, __LINE__, durable_gen, 
-                            my_gen, dur_lsn.file, dur_lsn.offset, my_lsn.file, 
-                            my_lsn.offset, file, offset);
+                if ((rc = request_durable_lsn_from_master(bdb_state, &dur_lsn.file, 
+                                &dur_lsn.offset, &durable_gen)) != 0) {
+                    *bdberr = BDBERR_NOT_DURABLE;
+                    return NULL;
                 }
-                *bdberr = BDBERR_NOT_DURABLE;
-                return NULL;
-            }
 
-            /* If this isn't an asof query, backfill to the durable-lsn  */
-            if (!epoch && !file) {
-                file = dur_lsn.file;
-                offset = dur_lsn.offset;
-            }
+                BDB_READLOCK("bdb_durable_check");
 
-            backfill_required = 1;
+                bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &my_gen);
+                __log_txn_lsn(bdb_state->dbenv, &my_lsn, NULL, NULL);
+                // bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &my_lsn, &my_gen);
+                BDB_RELLOCK();
+
+                // if we're not at least this current send request to another node
+                if (file) {
+                    arg_lsn.file = file;
+                    arg_lsn.offset = offset;
+                }
+
+                if (my_gen != durable_gen || (log_compare(&my_lsn, &dur_lsn) < 0) ||
+                        (file && log_compare(&my_lsn, &arg_lsn) < 0))
+                {
+                    if (gbl_extended_sql_debug_trace) {
+                        logmsg(LOGMSG_USER, "%s line %d: returning not-durable, durable_gen=%u,"
+                                " my_gen=%u durable_lsn=[%d][%d], my_lsn=[%d][%d], "
+                                "arg_lsn=[%d][%d]\n", __func__, __LINE__, durable_gen, 
+                                my_gen, dur_lsn.file, dur_lsn.offset, my_lsn.file, 
+                                my_lsn.offset, file, offset);
+                    }
+                    *bdberr = BDBERR_NOT_DURABLE;
+                    return NULL;
+                }
+
+                /* If this isn't an asof query, backfill to the durable-lsn  */
+                if (!epoch && !file) {
+                    file = dur_lsn.file;
+                    offset = dur_lsn.offset;
+                }
+
+                backfill_required = 1;
+            }
         }
     }
 

--- a/bdb/bdb_osqltrn.h
+++ b/bdb/bdb_osqltrn.h
@@ -51,7 +51,7 @@ int bdb_osql_trn_repo_unlock();
 bdb_osql_trn_t *bdb_osql_trn_register(bdb_state_type *bdb_state,
                                       struct tran_tag *shadow_tran, int trak,
                                       int *bdberr, int epoch, int file,
-                                      int offset);
+                                      int offset, int is_ha_retry);
 
 /**
  *  Unregister a shadow transaction with the repository

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1275,8 +1275,9 @@ tran_type *bdb_tran_begin_shadow_int(bdb_state_type *bdb_state, int tranclass,
             }
 
             /* register transaction so we start receiving log undos */
-            tran->osql = bdb_osql_trn_register(bdb_state, tran, trak, bdberr,
-                                               epoch, file, offset, is_ha_retry);
+            tran->osql =
+                bdb_osql_trn_register(bdb_state, tran, trak, bdberr, epoch,
+                                      file, offset, is_ha_retry);
             if (!tran->osql) {
                 if (*bdberr != BDBERR_NOT_DURABLE)
                     logmsg(LOGMSG_ERROR, "%s %d\n", __func__, *bdberr);
@@ -1428,8 +1429,8 @@ tran_type *bdb_tran_begin_snapisol(bdb_state_type *bdb_state, int trak,
 }
 
 tran_type *bdb_tran_begin_serializable(bdb_state_type *bdb_state, int trak,
-                                       int *bdberr, int epoch, int file, int offset,
-                                       int is_ha_retry)
+                                       int *bdberr, int epoch, int file,
+                                       int offset, int is_ha_retry)
 {
     return bdb_tran_begin_shadow_int(bdb_state, TRANCLASS_SERIALIZABLE, trak,
                                      bdberr, epoch, file, offset, is_ha_retry);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1214,7 +1214,7 @@ static tran_type *bdb_tran_begin_berk_int(bdb_state_type *bdb_state,
 
 tran_type *bdb_tran_begin_shadow_int(bdb_state_type *bdb_state, int tranclass,
                                      int trak, int *bdberr, int epoch, int file,
-                                     int offset)
+                                     int offset, int is_ha_retry)
 {
     tran_type *tran;
     int rc = 0;
@@ -1276,7 +1276,7 @@ tran_type *bdb_tran_begin_shadow_int(bdb_state_type *bdb_state, int tranclass,
 
             /* register transaction so we start receiving log undos */
             tran->osql = bdb_osql_trn_register(bdb_state, tran, trak, bdberr,
-                                               epoch, file, offset);
+                                               epoch, file, offset, is_ha_retry);
             if (!tran->osql) {
                 if (*bdberr != BDBERR_NOT_DURABLE)
                     logmsg(LOGMSG_ERROR, "%s %d\n", __func__, *bdberr);
@@ -1409,28 +1409,30 @@ tran_type *bdb_tran_begin_readcommitted(bdb_state_type *bdb_state, int trak,
                                         int *bdberr)
 {
     return bdb_tran_begin_shadow_int(bdb_state, TRANCLASS_READCOMMITTED, trak,
-                                     bdberr, 0, 0, 0);
+                                     bdberr, 0, 0, 0, 0);
 }
 
 tran_type *bdb_tran_begin_socksql(bdb_state_type *bdb_state, int trak,
                                   int *bdberr)
 {
     return bdb_tran_begin_shadow_int(bdb_state, TRANCLASS_SOSQL, trak, bdberr,
-                                     0, 0, 0);
+                                     0, 0, 0, 0);
 }
 
 tran_type *bdb_tran_begin_snapisol(bdb_state_type *bdb_state, int trak,
-                                   int *bdberr, int epoch, int file, int offset)
+                                   int *bdberr, int epoch, int file, int offset,
+                                   int is_ha_retry)
 {
     return bdb_tran_begin_shadow_int(bdb_state, TRANCLASS_SNAPISOL, trak,
-                                     bdberr, epoch, file, offset);
+                                     bdberr, epoch, file, offset, is_ha_retry);
 }
 
 tran_type *bdb_tran_begin_serializable(bdb_state_type *bdb_state, int trak,
-                                       int *bdberr, int epoch, int file, int offset)
+                                       int *bdberr, int epoch, int file, int offset,
+                                       int is_ha_retry)
 {
     return bdb_tran_begin_shadow_int(bdb_state, TRANCLASS_SERIALIZABLE, trak,
-                                     bdberr, epoch, file, offset);
+                                     bdberr, epoch, file, offset, is_ha_retry);
 }
 
 /*

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3622,8 +3622,8 @@ retry_queries:
         PRINT_RETURN(err_val);
     }
 
-    if (!hndl->read_intrans_results && !hndl->is_read && 
-         (hndl->in_trans || !hndl->is_hasql)) {
+    if (!hndl->read_intrans_results && !hndl->is_read &&
+        (hndl->in_trans || !hndl->is_hasql)) {
         if (hndl->debug_trace) {
             fprintf(stderr, "td %u %s:%d in_trans=%d is_hasql=%d\n",
                     (uint32_t)pthread_self(), __func__, __LINE__,

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -753,7 +753,7 @@ struct cdb2_hndl {
     int num_set_commands_sent;
     int is_read;
     unsigned long long rows_read;
-    int skip_feature;
+    int read_intrans_results;
     int first_record_read;
     char **commands;
     int ack;
@@ -2282,7 +2282,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     }
 
     if (hndl && !(hndl->flags & CDB2_READ_INTRANS_RESULTS) && is_begin) {
-        features[n_features] = CDB2_CLIENT_FEATURES__SKIP_ROWS;
+        features[n_features] = CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS;
         n_features++;
     }
 
@@ -2557,9 +2557,9 @@ retry_next_record:
             hndl->num_set_commands_sent = hndl->num_set_commands;
         }
         for (ii = 0; ii < hndl->lastresponse->n_features; ii++) {
-            if (hndl->in_trans && (CDB2_SERVER_FEATURES__SKIP_ROWS ==
+            if (hndl->in_trans && (CDB2_SERVER_FEATURES__SKIP_INTRANS_RESULTS ==
                                    hndl->lastresponse->features[ii]))
-                hndl->skip_feature = 1;
+                hndl->read_intrans_results = 0;
         }
 
         PRINT_RETURN_OK(CDB2_OK_DONE);
@@ -2574,7 +2574,7 @@ int cdb2_next_record(cdb2_hndl_tp *hndl)
 
     pthread_once(&init_once, do_init_once);
 
-    if (hndl->in_trans && hndl->skip_feature && !hndl->is_read) {
+    if (hndl->in_trans && !hndl->read_intrans_results && !hndl->is_read) {
         rc = CDB2_OK_DONE;
     } else if (hndl->lastresponse && hndl->first_record_read == 0) {
         hndl->first_record_read = 1;
@@ -2919,7 +2919,7 @@ static int retry_query_list(cdb2_hndl_tp *hndl, int num_retry, int run_last)
     hndl->is_retry = num_retry;
 
     clear_responses(hndl);
-    hndl->skip_feature = 0;
+    hndl->read_intrans_results = 1;
 
     hndl->in_trans = 0;
     if (hndl->debug_trace) {
@@ -3059,7 +3059,7 @@ static int retry_query_list(cdb2_hndl_tp *hndl, int num_retry, int run_last)
         int len = 0;
         i++;
 
-        if (hndl->skip_feature && !item->is_read) {
+        if (!hndl->read_intrans_results && !item->is_read) {
             item = item->next;
             continue;
         }
@@ -3193,7 +3193,7 @@ static inline void cleanup_query_list(cdb2_hndl_tp *hndl,
     if (hndl->debug_trace && line)
         fprintf(stderr, "%s:%d called from line %d\n", __func__, __LINE__,
                 line);
-    hndl->skip_feature = 0;
+    hndl->read_intrans_results = 1;
     hndl->snapshot_file = 0;
     hndl->snapshot_offset = 0;
     hndl->is_retry = 0;
@@ -3572,7 +3572,7 @@ retry_queries:
     int len;
     int type = 0;
     int err_val = hndl->error_in_trans;
-    int skip_feature = hndl->skip_feature;
+    int read_intrans_results = hndl->read_intrans_results;
 
     if (is_rollback || is_commit) {
         if (is_commit && hndl->snapshot_file) {
@@ -3583,7 +3583,7 @@ retry_queries:
             hndl->query_list = NULL;
             is_hasql_commit = 1;
         }
-        hndl->skip_feature = 0;
+        hndl->read_intrans_results = 1;
         clear_snapshot_info(hndl, __LINE__);
         hndl->error_in_trans = 0;
         if (hndl->debug_trace) {
@@ -3602,7 +3602,7 @@ retry_queries:
         }
         hndl->query_list = NULL;
 
-        if (skip_feature && !hndl->client_side_error) {
+        if (!read_intrans_results && !hndl->client_side_error) {
             if (err_val) {
                 if (is_rollback) {
                     PRINT_RETURN(0);
@@ -3612,7 +3612,7 @@ retry_queries:
             }
         } else if (err_val) {
             hndl->client_side_error = 0;
-            /* With skip_feature off, we need to read the 1st response
+            /* With read_intrans_results on, we need to read the 1st response
                of commit/rollback even if there is an in-trans error. */
             goto read_record;
         }
@@ -3622,7 +3622,7 @@ retry_queries:
         PRINT_RETURN(err_val);
     }
 
-    if (hndl->skip_feature && !hndl->is_read && 
+    if (!hndl->read_intrans_results && !hndl->is_read && 
          (hndl->in_trans || !hndl->is_hasql)) {
         if (hndl->debug_trace) {
             fprintf(stderr, "td %u %s:%d in_trans=%d is_hasql=%d\n",
@@ -5244,6 +5244,7 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
     hndl->dbnum = 1;
     hndl->connected_host = -1;
     hndl->send_stack = 1;
+    hndl->read_intrans_results = 1;
 #if WITH_SSL
     /* We don't do dbinfo if DIRECT_CPU. So we'd default peer SSL mode to
        ALLOW. We will find it out later when we send SSL negotitaion packet

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3622,8 +3622,7 @@ retry_queries:
         PRINT_RETURN(err_val);
     }
 
-    if (!hndl->read_intrans_results && !hndl->is_read &&
-        (hndl->in_trans || !hndl->is_hasql)) {
+    if (!hndl->read_intrans_results && !hndl->is_read && hndl->in_trans) {
         if (hndl->debug_trace) {
             fprintf(stderr, "td %u %s:%d in_trans=%d is_hasql=%d\n",
                     (uint32_t)pthread_self(), __func__, __LINE__,

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -109,7 +109,7 @@ public class Comdb2Handle extends AbstractConnection {
     private int isRetry;
     private int nSetsSent;
     private int errorInTxn = 0;
-    private boolean skipFeature = false;
+    private boolean readIntransResults = true;
     private boolean firstRecordRead = false;
 
     /* The last Throwable. */
@@ -465,7 +465,7 @@ public class Comdb2Handle extends AbstractConnection {
 
         clearResp();
         isRetry = nretry;
-        skipFeature = false;
+        readIntransResults = true;
         inTxn = false;
 
         // Either we have a snapshot or the querylist is 0: send a begin
@@ -554,10 +554,10 @@ public class Comdb2Handle extends AbstractConnection {
 
             clearResp();
 
-            if (skipFeature && !item.isRead) {
+            if (!readIntransResults && !item.isRead) {
                 tdlog(Level.FINEST,
-                      "retryQueries continuing because skipFeature is %b and item.isRead is %b",
-                      skipFeature, item.isRead);
+                      "retryQueries continuing because readIntransResults is %b and item.isRead is %b",
+                      readIntransResults, item.isRead);
                 continue;
             }
 
@@ -634,11 +634,11 @@ public class Comdb2Handle extends AbstractConnection {
               "sendQuery sql='%s' isBegin=%b skipNRows=%d nretry=%d doAppend=%b",
               sql, isBegin, skipNRows, nretry, doAppend);
 
-        /* SKIP_ROWS optimization is disabled temporarily
+        /* SKIP_INTRANS_RESULTS optimization is disabled temporarily
            in cdb2jdbc to make executeUpdate() work. */
         /*
         if (isBegin)
-            sqlQuery.features.add(CDB2ClientFeatures.SKIP_ROWS_VALUE);
+            sqlQuery.features.add(CDB2ClientFeatures.SKIP_INTRANS_RESULTS_VALUE);
         */
 
         sqlQuery.features.add(CDB2ClientFeatures.ALLOW_MASTER_DBINFO_VALUE);
@@ -789,7 +789,7 @@ public class Comdb2Handle extends AbstractConnection {
 
     private void cleanup_query_list() {
         tdlog(Level.FINEST, "In cleanup_query_list");
-        skipFeature = false;
+        readIntransResults = true;
         snapshotFile = 0;
         snapshotOffset = 0;
         isRetry = 0;
@@ -949,7 +949,7 @@ public class Comdb2Handle extends AbstractConnection {
 
             if (dbHostConnected < 0) { /* connect to a node */
                 if (is_rollback) {
-                    skipFeature = false;
+                    readIntransResults = true;
                     snapshotFile = 0;
                     snapshotOffset = 0;
                     isRetry = 0;
@@ -1006,7 +1006,7 @@ public class Comdb2Handle extends AbstractConnection {
             runLast = false;
 
             int errVal = errorInTxn;
-            boolean _skipFeature = skipFeature;
+            boolean _readIntransResults = readIntransResults;
 
             do { /* poor man's goto in java */
                 if (is_commit || is_rollback) {
@@ -1019,7 +1019,7 @@ public class Comdb2Handle extends AbstractConnection {
                         queryList = new ArrayList<QueryItem>();
                         isHASqlCommit = true;
                     }
-                    skipFeature = false;
+                    readIntransResults = true;
                     snapshotFile = 0;
                     snapshotOffset = 0;
                     isRetry = 0;
@@ -1027,7 +1027,7 @@ public class Comdb2Handle extends AbstractConnection {
                     inTxn = false;
                     queryList.clear();
 
-                    if (_skipFeature) {
+                    if (!_readIntransResults) {
                         if (errVal != 0) {
                             if (is_rollback) {
                                 tdlog(Level.FINER, "Rollback returning 0 on errVal %d", errVal);
@@ -1038,14 +1038,14 @@ public class Comdb2Handle extends AbstractConnection {
                             }
                         }
                     } else if (errVal != 0) {
-                        tdlog(Level.FINEST, "Commit errVal is %d is_rollback=%b skipFeature=%b",
-                              errVal, is_rollback, _skipFeature);
-                        /* With skip_feature off, we need to read the 1st response
+                        tdlog(Level.FINEST, "Commit errVal is %d is_rollback=%b readIntransResults=%b",
+                              errVal, is_rollback, _readIntransResults);
+                        /* With read_intrans_results on, we need to read the 1st response
                            of commit/rollback even if there is an in-trans error. */
                         break;
                     } else {
-                        tdlog(Level.FINEST, "Commit errVal (2) is %d is_rollback=%b skipFeature=%b",
-                              errVal, is_rollback, _skipFeature);
+                        tdlog(Level.FINEST, "Commit errVal (2) is %d is_rollback=%b readIntransResults=%b",
+                              errVal, is_rollback, _readIntransResults);
                     }
                 }
 
@@ -1054,8 +1054,8 @@ public class Comdb2Handle extends AbstractConnection {
                     return is_rollback? 0 : errVal;
                 }
 
-                if (skipFeature && !isRead && (inTxn || !isHASql)) {
-                    tdlog(Level.FINER, "skipFeature is enabled and !isRead: %b returning 0", !isRead);
+                if (!readIntransResults && !isRead && (inTxn || !isHASql)) {
+                    tdlog(Level.FINER, "readIntransResults is disabled and !isRead: %b returning 0", !isRead);
                     return 0;
                 }
             } while (false);
@@ -1461,7 +1461,7 @@ public class Comdb2Handle extends AbstractConnection {
 
     @Override
     public synchronized int next() {
-        if (inTxn && skipFeature && !isRead) {
+        if (inTxn && !readIntransResults && !isRead) {
             return Errors.CDB2_OK_DONE;
         }
 
@@ -1635,8 +1635,8 @@ readloop:
 
             if (inTxn && lastResp.features != null) {
                 for (int feature : lastResp.features) {
-                    if (CDB2ServerFeatures.SKIP_ROWS_VALUE == feature) {
-                        skipFeature = true;
+                    if (CDB2ServerFeatures.SKIP_INTRANS_RESULTS_VALUE == feature) {
+                        readIntransResults = false;
                         break;
                     }
                 }

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1947,9 +1947,9 @@ int rowlocks_check_commit_physical(bdb_state_type *, tran_type *,
                                    int blockop_count);
 tran_type *trans_start_readcommitted(struct ireq *, int trak);
 tran_type *trans_start_serializable(struct ireq *, int trak, int epoch,
-                                    int file, int offset, int *error);
+                                    int file, int offset, int *error, int is_ha_retry);
 tran_type *trans_start_snapisol(struct ireq *, int trak, int epoch, int file,
-                                int offset, int *error);
+                                int offset, int *error, int is_ha_retry);
 tran_type *trans_start_socksql(struct ireq *, int trak);
 int trans_commit(struct ireq *iq, void *trans, char *source_host);
 int trans_commit_seqnum(struct ireq *iq, void *trans, db_seqnum_type *seqnum);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1947,7 +1947,8 @@ int rowlocks_check_commit_physical(bdb_state_type *, tran_type *,
                                    int blockop_count);
 tran_type *trans_start_readcommitted(struct ireq *, int trak);
 tran_type *trans_start_serializable(struct ireq *, int trak, int epoch,
-                                    int file, int offset, int *error, int is_ha_retry);
+                                    int file, int offset, int *error,
+                                    int is_ha_retry);
 tran_type *trans_start_snapisol(struct ireq *, int trak, int epoch, int file,
                                 int offset, int *error, int is_ha_retry);
 tran_type *trans_start_socksql(struct ireq *, int trak);

--- a/db/glue.c
+++ b/db/glue.c
@@ -450,8 +450,8 @@ tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
         logmsg(LOGMSG_USER, "td=%x %s called with epoch=%d file=%d offset=%d\n",
                (int)pthread_self(), __func__, epoch, file, offset);
     }
-    out_trans =
-        bdb_tran_begin_snapisol(bdb_handle, trak, error, epoch, file, offset, is_ha_retry);
+    out_trans = bdb_tran_begin_snapisol(bdb_handle, trak, error, epoch, file,
+                                        offset, is_ha_retry);
     iq->gluewhere = "bdb_tran_begin_snapisol done";
 
     if (out_trans == NULL) {
@@ -462,8 +462,9 @@ tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
     return out_trans;
 }
 
-tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch, int file,
-        int offset, int *error, int is_ha_retry)
+tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch,
+                                    int file, int offset, int *error,
+                                    int is_ha_retry)
 {
     void *bdb_handle = bdb_handle_from_ireq(iq);
     tran_type *out_trans = NULL;
@@ -475,8 +476,8 @@ tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch, int fi
         logmsg(LOGMSG_USER, "td=%x %s called with epoch=%d file=%d offset=%d\n",
                (int)pthread_self(), __func__, epoch, file, offset);
     }
-    out_trans = bdb_tran_begin_serializable(bdb_handle, trak, &bdberr, epoch, 
-            file, offset, is_ha_retry);
+    out_trans = bdb_tran_begin_serializable(bdb_handle, trak, &bdberr, epoch,
+                                            file, offset, is_ha_retry);
     iq->gluewhere = "bdb_tran_begin done";
 
     if (out_trans == NULL) {

--- a/db/glue.c
+++ b/db/glue.c
@@ -437,7 +437,7 @@ tran_type *trans_start_readcommitted(struct ireq *iq, int trak)
 }
 
 tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
-                                int offset, int *error)
+                                int offset, int *error, int is_ha_retry)
 {
     void *bdb_handle = bdb_handle_from_ireq(iq);
     tran_type *out_trans = NULL;
@@ -451,7 +451,7 @@ tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
                (int)pthread_self(), __func__, epoch, file, offset);
     }
     out_trans =
-        bdb_tran_begin_snapisol(bdb_handle, trak, error, epoch, file, offset);
+        bdb_tran_begin_snapisol(bdb_handle, trak, error, epoch, file, offset, is_ha_retry);
     iq->gluewhere = "bdb_tran_begin_snapisol done";
 
     if (out_trans == NULL) {
@@ -463,7 +463,7 @@ tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
 }
 
 tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch, int file,
-        int offset, int *error)
+        int offset, int *error, int is_ha_retry)
 {
     void *bdb_handle = bdb_handle_from_ireq(iq);
     tran_type *out_trans = NULL;
@@ -476,7 +476,7 @@ tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch, int fi
                (int)pthread_self(), __func__, epoch, file, offset);
     }
     out_trans = bdb_tran_begin_serializable(bdb_handle, trak, &bdberr, epoch, 
-            file, offset);
+            file, offset, is_ha_retry);
     iq->gluewhere = "bdb_tran_begin done";
 
     if (out_trans == NULL) {

--- a/db/sql.h
+++ b/db/sql.h
@@ -553,7 +553,6 @@ struct sqlclntstate {
     int snapshot_offset;
     int is_hasql_retry;
     int is_readonly;
-    int send_intransresults;
     int is_expert;
     int added_to_hist;
 
@@ -603,7 +602,7 @@ struct sqlclntstate {
 
     int8_t wrong_db;
     int8_t is_lua_sql_thread;
-    int8_t skip_feature;
+    int8_t send_intrans_results;
     int8_t high_availability_flag;
     int8_t hasql_on;
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -544,10 +544,6 @@ struct sqlclntstate {
     int isselect;   /* track if the query is a select query.*/
     int isUnlocked;
     int writeTransaction;
-    /* True iff >= SNAPSHOT && HA && SKIP_INTRANS_RESULTS,
-       in which case server sends one and only one newsql response
-       with snapshot info (Usually a LAST_ROW) back to client. */
-    int send_only_snapshot_resp;
     int verify_retries; /* how many verify retries we've borne */
     int verifyretry_off;
     int pageordertablescan;

--- a/db/sql.h
+++ b/db/sql.h
@@ -601,6 +601,46 @@ struct sqlclntstate {
 
     int8_t wrong_db;
     int8_t is_lua_sql_thread;
+
+    /*              (SERVER)
+      Default --> (val: 1)
+                      |
+                      +--> Client has SKIP feature?
+                                   |    |
+                                NO |    | YES
+                                   |    |
+      SET INTRANSRESULTS OFF ------)--->+--> (val: 0) --+
+                                   |                    |
+                                   |  +-----------------+
+                                   |  |
+                                   |  +---> Send server SKIP feature;
+                                   |        Don't send intrans results
+                                   |
+      SET INTRANSRESULTS ON        +-------> (val: 1) --+
+                |                                       |
+                | (val: -1)           +-----------------+
+                |                     |
+                +---------------------+--> Don't send server SKIP feature;
+                                           Send intrans results
+
+                    (CLIENT)
+      CDB2_READ_INTRANS_RESULTS is ON?
+                     /\
+       NO (default) /  \ YES
+                   /    \
+       Send Client       \
+       SKIP feature       \
+                /          \
+       Server has           \
+            SKIP feature?    \
+             /          \     \
+          Y /            \ N   \
+           /              \     \
+       Don't read         Read intrans results
+       intrans results    for writes
+       for writes
+
+     */
     int8_t send_intrans_results;
     int8_t high_availability_flag;
     int8_t hasql_on;

--- a/db/sql.h
+++ b/db/sql.h
@@ -547,7 +547,7 @@ struct sqlclntstate {
     /* True iff >= SNAPSHOT && HA && SKIP_INTRANS_RESULTS,
        in which case server sends one and only one newsql response
        with snapshot info (Usually a LAST_ROW) back to client. */
-    int send_one_newsql_resp;
+    int send_only_snapshot_resp;
     int verify_retries; /* how many verify retries we've borne */
     int verifyretry_off;
     int pageordertablescan;

--- a/db/sql.h
+++ b/db/sql.h
@@ -544,7 +544,10 @@ struct sqlclntstate {
     int isselect;   /* track if the query is a select query.*/
     int isUnlocked;
     int writeTransaction;
-    int send_one_row;
+    /* True iff >= SNAPSHOT && HA && SKIP_INTRANS_RESULTS,
+       in which case server sends one and only one newsql response
+       with snapshot info (Usually a LAST_ROW) back to client. */
+    int send_one_newsql_resp;
     int verify_retries; /* how many verify retries we've borne */
     int verifyretry_off;
     int pageordertablescan;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4365,7 +4365,7 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
     case TRANLEVEL_SNAPISOL:
         clnt->dbtran.shadow_tran =
             trans_start_snapisol(&iq, clnt->bdb_osql_trak, clnt->snapshot,
-                                 snapshot_file, snapshot_offset, &error);
+                                 snapshot_file, snapshot_offset, &error, clnt->is_hasql_retry);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_snapisol error %d\n", __func__,
@@ -4396,7 +4396,7 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
          */
         clnt->dbtran.shadow_tran =
             trans_start_serializable(&iq, clnt->bdb_osql_trak, clnt->snapshot,
-                                     snapshot_file, snapshot_offset, &error);
+                                     snapshot_file, snapshot_offset, &error, clnt->is_hasql_retry);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_serializable error\n", __func__);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4363,9 +4363,9 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
         goto done;
 
     case TRANLEVEL_SNAPISOL:
-        clnt->dbtran.shadow_tran =
-            trans_start_snapisol(&iq, clnt->bdb_osql_trak, clnt->snapshot,
-                                 snapshot_file, snapshot_offset, &error, clnt->is_hasql_retry);
+        clnt->dbtran.shadow_tran = trans_start_snapisol(
+            &iq, clnt->bdb_osql_trak, clnt->snapshot, snapshot_file,
+            snapshot_offset, &error, clnt->is_hasql_retry);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_snapisol error %d\n", __func__,
@@ -4394,9 +4394,9 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
          * the same data (inserts are easily skipped, but deletes
          * and updates will have visible effects otherwise
          */
-        clnt->dbtran.shadow_tran =
-            trans_start_serializable(&iq, clnt->bdb_osql_trak, clnt->snapshot,
-                                     snapshot_file, snapshot_offset, &error, clnt->is_hasql_retry);
+        clnt->dbtran.shadow_tran = trans_start_serializable(
+            &iq, clnt->bdb_osql_trak, clnt->snapshot, snapshot_file,
+            snapshot_offset, &error, clnt->is_hasql_retry);
 
         if (!clnt->dbtran.shadow_tran) {
             logmsg(LOGMSG_ERROR, "%s:trans_start_serializable error\n", __func__);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2823,7 +2823,7 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
                 write_response(clnt, RESPONSE_ROW_LAST_DUMMY, 0, 0);
             }
         } else {
-            if (postponed_write) {
+            if (postponed_write && !clnt->send_one_row) {
                 send_row(clnt, NULL, row_id, 0, NULL);
             }
             write_response(clnt, RESPONSE_EFFECTS, 0, 0);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2817,13 +2817,13 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
         clnt->ready_for_heartbeats = 0;
         pthread_mutex_unlock(&clnt->wait_mutex);
         if (skip_response(clnt)) {
-            if (clnt->send_one_newsql_resp) {
-                clnt->send_one_newsql_resp = 0;
+            if (clnt->send_only_snapshot_resp) {
+                clnt->send_only_snapshot_resp = 0;
                 clnt->send_intrans_results = 0;
                 write_response(clnt, RESPONSE_ROW_LAST_DUMMY, 0, 0);
             }
         } else {
-            if (postponed_write && !clnt->send_one_newsql_resp) {
+            if (postponed_write && !clnt->send_only_snapshot_resp) {
                 send_row(clnt, NULL, row_id, 0, NULL);
             }
             write_response(clnt, RESPONSE_EFFECTS, 0, 0);
@@ -3828,7 +3828,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->saved_rc = 0;
     clnt->want_stored_procedure_debug = 0;
     clnt->want_stored_procedure_trace = 0;
-    clnt->send_one_newsql_resp = 0;
+    clnt->send_only_snapshot_resp = 0;
     clnt->verifyretry_off = 0;
     clnt->is_expert = 0;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2817,13 +2817,13 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
         clnt->ready_for_heartbeats = 0;
         pthread_mutex_unlock(&clnt->wait_mutex);
         if (skip_response(clnt)) {
-            if (clnt->send_one_row) {
-                clnt->send_one_row = 0;
+            if (clnt->send_one_newsql_resp) {
+                clnt->send_one_newsql_resp = 0;
                 clnt->send_intrans_results = 0;
                 write_response(clnt, RESPONSE_ROW_LAST_DUMMY, 0, 0);
             }
         } else {
-            if (postponed_write && !clnt->send_one_row) {
+            if (postponed_write && !clnt->send_one_newsql_resp) {
                 send_row(clnt, NULL, row_id, 0, NULL);
             }
             write_response(clnt, RESPONSE_EFFECTS, 0, 0);
@@ -3828,7 +3828,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->saved_rc = 0;
     clnt->want_stored_procedure_debug = 0;
     clnt->want_stored_procedure_trace = 0;
-    clnt->send_one_row = 0;
+    clnt->send_one_newsql_resp = 0;
     clnt->verifyretry_off = 0;
     clnt->is_expert = 0;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2816,16 +2816,9 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
         pthread_mutex_lock(&clnt->wait_mutex);
         clnt->ready_for_heartbeats = 0;
         pthread_mutex_unlock(&clnt->wait_mutex);
-        if (skip_response(clnt)) {
-            if (clnt->send_only_snapshot_resp) {
-                clnt->send_only_snapshot_resp = 0;
-                clnt->send_intrans_results = 0;
-                write_response(clnt, RESPONSE_ROW_LAST_DUMMY, 0, 0);
-            }
-        } else {
-            if (postponed_write && !clnt->send_only_snapshot_resp) {
+        if (!skip_response(clnt)) {
+            if (postponed_write)
                 send_row(clnt, NULL, row_id, 0, NULL);
-            }
             write_response(clnt, RESPONSE_EFFECTS, 0, 0);
             write_response(clnt, RESPONSE_ROW_LAST, 0, 0);
         }
@@ -3828,7 +3821,6 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->saved_rc = 0;
     clnt->want_stored_procedure_debug = 0;
     clnt->want_stored_procedure_trace = 0;
-    clnt->send_only_snapshot_resp = 0;
     clnt->verifyretry_off = 0;
     clnt->is_expert = 0;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2679,6 +2679,8 @@ static int skip_response_int(struct sqlclntstate *clnt, int from_error)
     if (clnt->in_client_trans) {
         if (from_error && !clnt->had_errors) /* send on first error */
             return 0;
+        if (clnt->send_intrans_results)
+            return 0;
         return 1;
     }
     return 0; /* single stmt by itself (read or write) */
@@ -2817,7 +2819,7 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
         if (skip_response(clnt)) {
             if (clnt->send_one_row) {
                 clnt->send_one_row = 0;
-                clnt->skip_feature = 1;
+                clnt->send_intrans_results = 0;
                 write_response(clnt, RESPONSE_ROW_LAST_DUMMY, 0, 0);
             }
         } else {
@@ -3843,7 +3845,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->early_retry = 0;
     clnt_reset_cursor_hints(clnt);
 
-    clnt->skip_feature = 0;
+    clnt->send_intrans_results = 1;
 
     bzero(clnt->dirty, sizeof(clnt->dirty));
 
@@ -3883,7 +3885,6 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->ncontext = 0;
     clnt->statement_query_effects = 0;
     clnt->wrong_db = 0;
-    clnt->send_intransresults = 0;
 }
 
 void reset_clnt_flags(struct sqlclntstate *clnt)

--- a/docs/pages/programming/client_protocol.md
+++ b/docs/pages/programming/client_protocol.md
@@ -103,7 +103,7 @@ message CDB2_FLAG {
 }
 
 enum CDB2ClientFeatures {
-    SKIP_ROWS            = 1;
+    SKIP_INTRANS_RESULTS = 1;
     ALLOW_MASTER_EXEC    = 2;
     ALLOW_MASTER_DBINFO  = 3;
     ALLOW_QUEUING  = 4;
@@ -342,7 +342,7 @@ enum ResponseType {
 }
 
 enum CDB2ServerFeatures {
-    SKIP_ROWS    = 1;
+    SKIP_INTRANS_RESULTS = 1;
 }
 
 message CDB2_DBINFORESPONSE {

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -135,37 +135,47 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
     if (*file == 0 && sql_query &&
         clnt->ctrl_sqlengine == SQLENG_STRT_STATE) {
 
+        /* We get here when receiving BEGIN. If durable_lsn is enabled,
+           request the durable LSN from master and return it to the client.
+           Otherwise, return my current LSN. */
+
+        int rc;
+        uint32_t snapinfo_file, snapinfo_offset;
+
         if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS)) {
-            uint32_t durable_file, durable_offset, durable_gen;
+            uint32_t durable_gen;
 
-            int rc = request_durable_lsn_from_master(
-                thedb->bdb_env, &durable_file, &durable_offset, &durable_gen);
-
-            if (rc == 0) {
-                *file = durable_file;
-                *offset = durable_offset;
-
-                if (gbl_extended_sql_debug_trace) {
-                    logmsg(LOGMSG_USER, "%s line %d cnonce='%s' master "
-                                        "returned durable-lsn "
-                                        "[%d][%d], clnt->is_hasql_retry=%d\n",
-                           __func__, __LINE__, cnonce, *file, *offset,
-                           clnt->is_hasql_retry);
-                }
-            } else {
-                if (gbl_extended_sql_debug_trace) {
-                    logmsg(LOGMSG_USER,
-                           "%s line %d cnonce='%s' durable-lsn request "
-                           "returns %d "
-                           "clnt->snapshot_file=%d clnt->snapshot_offset=%d "
-                           "clnt->is_hasql_retry=%d\n",
-                           __func__, __LINE__, cnonce, rc, clnt->snapshot_file,
-                           clnt->snapshot_offset, clnt->is_hasql_retry);
-                }
-                rcode = -1;
-            }
-            return rcode;
+            rc = request_durable_lsn_from_master(
+                    thedb->bdb_env, &snapinfo_file, &snapinfo_offset, &durable_gen);
+        } else {
+            (void)bdb_get_current_lsn(thedb->bdb_env, &snapinfo_file, &snapinfo_offset);
+            rc = 0;
         }
+
+        if (rc == 0) {
+            *file = snapinfo_file;
+            *offset = snapinfo_offset;
+
+            if (gbl_extended_sql_debug_trace) {
+                logmsg(LOGMSG_USER, "%s line %d cnonce='%s' master "
+                                    "returned durable-lsn "
+                                    "[%d][%d], clnt->is_hasql_retry=%d\n",
+                       __func__, __LINE__, cnonce, *file, *offset,
+                       clnt->is_hasql_retry);
+            }
+        } else {
+            if (gbl_extended_sql_debug_trace) {
+                logmsg(LOGMSG_USER,
+                       "%s line %d cnonce='%s' durable-lsn request "
+                       "returns %d "
+                       "clnt->snapshot_file=%d clnt->snapshot_offset=%d "
+                       "clnt->is_hasql_retry=%d\n",
+                       __func__, __LINE__, cnonce, rc, clnt->snapshot_file,
+                       clnt->snapshot_offset, clnt->is_hasql_retry);
+            }
+            rcode = -1;
+        }
+        return rcode;
     }
 
     if (*file == 0) {

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -197,7 +197,7 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
 #define _has_features(clnt, sql_response)                                      \
     CDB2ServerFeatures features[10];                                           \
     int n_features = 0;                                                        \
-    if (clnt->send_intrans_results != -1) {                                    \
+    if (clnt->send_intrans_results == 0) {                                     \
         features[n_features] = CDB2_SERVER_FEATURES__SKIP_INTRANS_RESULTS;     \
         n_features++;                                                          \
     }                                                                          \

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -142,9 +142,10 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
             uint32_t durable_gen;
 
             rc = request_durable_lsn_from_master(
-                    thedb->bdb_env, &snapinfo_file, &snapinfo_offset, &durable_gen);
+                thedb->bdb_env, &snapinfo_file, &snapinfo_offset, &durable_gen);
         } else {
-            (void)bdb_get_current_lsn(thedb->bdb_env, &snapinfo_file, &snapinfo_offset);
+            (void)bdb_get_current_lsn(thedb->bdb_env, &snapinfo_file,
+                                      &snapinfo_offset);
             rc = 0;
         }
 
@@ -153,9 +154,10 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
             *offset = snapinfo_offset;
 
             if (gbl_extended_sql_debug_trace) {
-                logmsg(LOGMSG_USER, "%s line %d cnonce='%s' master "
-                                    "returned durable-lsn "
-                                    "[%d][%d], clnt->is_hasql_retry=%d\n",
+                logmsg(LOGMSG_USER,
+                       "%s line %d cnonce='%s' master "
+                       "returned durable-lsn "
+                       "[%d][%d], clnt->is_hasql_retry=%d\n",
                        __func__, __LINE__, cnonce, *file, *offset,
                        clnt->is_hasql_retry);
             }
@@ -1281,8 +1283,8 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
        on clnt even if the snapshot info has been populated.
        However, dont't attempt to restore if client overrides
        send_intrans_results by setting INTRANSRESULTS to ON. */
-    if (clnt->send_intrans_results != -1 &&
-        sqlquery->n_features > 0 && gbl_disable_skip_rows == 0) {
+    if (clnt->send_intrans_results != -1 && sqlquery->n_features > 0 &&
+        gbl_disable_skip_rows == 0) {
         for (int ii = 0; ii < sqlquery->n_features; ii++) {
             if (CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS !=
                 sqlquery->features[ii])

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1272,8 +1272,8 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
     extern int gbl_disable_skip_rows;
-    /* We need to restore send_intrans_results and
-       send_one_row on clnt even if the snapshot info has been populated. */
+    /* We need to restore send_intrans_results and send_one_newsql_resp
+       on clnt even if the snapshot info has been populated. */
     if (sqlquery->n_features > 0 && gbl_disable_skip_rows == 0) {
         for (int ii = 0; ii < sqlquery->n_features; ii++) {
             if (CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS !=
@@ -1283,7 +1283,7 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
             if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
                  clnt->dbtran.mode == TRANLEVEL_SERIAL) &&
                 newsql_has_high_availability(clnt)) {
-                clnt->send_one_row = 1;
+                clnt->send_one_newsql_resp = 1;
                 clnt->send_intrans_results = 1;
             }
         }

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1276,7 +1276,8 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
        send_one_row on clnt even if the snapshot info has been populated. */
     if (sqlquery->n_features > 0 && gbl_disable_skip_rows == 0) {
         for (int ii = 0; ii < sqlquery->n_features; ii++) {
-            if (CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS != sqlquery->features[ii])
+            if (CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS !=
+                sqlquery->features[ii])
                 continue;
             clnt->send_intrans_results = 0;
             if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1272,7 +1272,7 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
     extern int gbl_disable_skip_rows;
-    /* We need to restore send_intrans_results and send_one_newsql_resp
+    /* We need to restore send_intrans_results and send_only_snapshot_resp
        on clnt even if the snapshot info has been populated. */
     if (sqlquery->n_features > 0 && gbl_disable_skip_rows == 0) {
         for (int ii = 0; ii < sqlquery->n_features; ii++) {
@@ -1283,7 +1283,7 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
             if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
                  clnt->dbtran.mode == TRANLEVEL_SERIAL) &&
                 newsql_has_high_availability(clnt)) {
-                clnt->send_one_newsql_resp = 1;
+                clnt->send_only_snapshot_resp = 1;
                 clnt->send_intrans_results = 1;
             }
         }

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -1271,7 +1271,7 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery;
     extern int gbl_disable_skip_rows;
-    /* We need to restore send_intrans_results and send_only_snapshot_resp
+    /* We need to restore send_intrans_results
        on clnt even if the snapshot info has been populated.
        However, dont't attempt to restore if client overrides
        send_intrans_results by setting INTRANSRESULTS to ON. */
@@ -1282,12 +1282,6 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
                 sqlquery->features[ii])
                 continue;
             clnt->send_intrans_results = 0;
-            if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
-                 clnt->dbtran.mode == TRANLEVEL_SERIAL) &&
-                newsql_has_high_availability(clnt)) {
-                clnt->send_only_snapshot_resp = 1;
-                clnt->send_intrans_results = 1;
-            }
         }
     }
 

--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -135,10 +135,6 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
     if (*file == 0 && sql_query &&
         clnt->ctrl_sqlengine == SQLENG_STRT_STATE) {
 
-        /* We get here when receiving BEGIN. If durable_lsn is enabled,
-           request the durable LSN from master and return it to the client.
-           Otherwise, return my current LSN. */
-
         int rc;
         uint32_t snapinfo_file, snapinfo_offset;
 

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -13,7 +13,7 @@ enum CDB2RequestType {
 }
 
 enum CDB2ClientFeatures {
-    SKIP_ROWS            = 1;
+    SKIP_INTRANS_RESULTS = 1;
     ALLOW_MASTER_EXEC    = 2;
     ALLOW_MASTER_DBINFO  = 3;
     ALLOW_QUEUING        = 4;

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -94,7 +94,7 @@ enum ResponseType {
 }
 
 enum CDB2ServerFeatures {
-    SKIP_ROWS    = 1;
+    SKIP_INTRANS_RESULTS = 1;
 }
 
 message CDB2_DBINFORESPONSE {

--- a/tests/cdb2api.test/t36.expected
+++ b/tests/cdb2api.test/t36.expected
@@ -1,0 +1,3 @@
+[commit] failed with rc -3 near "kjskjhf": syntax error
+[insert kjskjhf kjsd] failed with rc -3 near "kjskjhf": syntax error
+[commit] failed with rc -3 near "kjskjhf": syntax error

--- a/tests/cdb2api.test/t36.expected
+++ b/tests/cdb2api.test/t36.expected
@@ -1,2 +1,0 @@
-[commit] failed with rc -3 near "kjskjhf": syntax error
-[insert kjskjhf kjsd] failed with rc -3 near "kjskjhf": syntax error

--- a/tests/cdb2api.test/t36.req
+++ b/tests/cdb2api.test/t36.req
@@ -1,0 +1,13 @@
+begin
+insert kjskjhf kjsd
+commit
+
+set intransresults on
+begin
+insert kjskjhf kjsd
+rollback
+
+set intransresults off
+begin
+insert kjskjhf kjsd
+commit

--- a/tests/cdb2api.test/t36.req
+++ b/tests/cdb2api.test/t36.req
@@ -1,8 +1,0 @@
-begin
-insert kjskjhf kjsd
-commit
-
-set intransresults on
-begin
-insert kjskjhf kjsd
-rollback

--- a/tests/cdb2api.test/t39.expected
+++ b/tests/cdb2api.test/t39.expected
@@ -1,0 +1,2 @@
+(rows inserted=1)
+(1=1)

--- a/tests/cdb2api.test/t39.req
+++ b/tests/cdb2api.test/t39.req
@@ -1,0 +1,13 @@
+create table cdb2api_t39 (i int)$$
+
+set intransresults on
+begin
+insert into cdb2api_t39 values(1)
+rollback
+
+SELECT 1
+
+set intransresults off
+begin
+insert into cdb2api_t39 values(1)
+commit

--- a/tests/read_intrans_results.test/Makefile
+++ b/tests/read_intrans_results.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/read_intrans_results.test/runit
+++ b/tests/read_intrans_results.test/runit
@@ -1,0 +1,3 @@
+#!/bin/sh
+bash -n "$0" | exit 1
+${TESTSBUILDDIR}/cdb2api_read_intrans_results $1

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -43,10 +43,11 @@ add_exe(verify_atomics_work verify_atomics_work.c)
 add_exe(cdb2api_unit cdb2api_unit.c)
 add_exe(malloc_resize_test malloc_resize_test.c)
 add_exe(cdb2_close_early cdb2_close_early.c)
+add_exe(cdb2api_read_intrans_results cdb2api_read_intrans_results.c)
 
 add_custom_target(test-tools DEPENDS ${test-tools})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results)
   target_link_libraries(${executable} cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 endforeach()
 
@@ -68,6 +69,6 @@ target_link_libraries(recom cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} $
 # everything!
 target_link_libraries(stepper cdb2api mem dlmalloc bb ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results)
     target_link_libraries(${executable} ${UNWIND_LIBRARY})
 endforeach()

--- a/tests/tools/cdb2api_read_intrans_results.c
+++ b/tests/tools/cdb2api_read_intrans_results.c
@@ -31,6 +31,25 @@ int main(int argc, char **argv)
         return 1;
     }
 
+    rc = cdb2_run_statement(hndl, "BEGIN");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    /* Should get error immediately if in READ_INTRANS_RESULTS mode. */
+    rc = cdb2_run_statement(hndl, "qwerty");
+    if (rc != CDB2ERR_PREPARE_ERROR)
+        return 1;
+
+    rc = cdb2_run_statement(hndl, "ROLLBACK");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
     rc = cdb2_run_statement(hndl, "DROP TABLE IF EXISTS read_intrans_results_test");
     if (rc != 0) {
         fprintf(stderr, "Error running query: %d: %s.\n",

--- a/tests/tools/cdb2api_read_intrans_results.c
+++ b/tests/tools/cdb2api_read_intrans_results.c
@@ -1,0 +1,69 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <strings.h>
+
+#include <cdb2api.h>
+
+int main(int argc, char **argv)
+{
+    cdb2_hndl_tp *hndl = NULL;
+    const char *conf = getenv("CDB2_CONFIG");
+    const char *db, *tier;
+    int rc;
+
+    if (argc < 2)
+        return 1;
+
+    db = argv[1];
+
+    if (argc > 2)
+        tier = argv[2];
+    else
+        tier = "default";
+
+    if (conf != NULL)
+        cdb2_set_comdb2db_config(conf);
+
+    rc = cdb2_open(&hndl, db, tier, CDB2_READ_INTRANS_RESULTS);
+    if (rc != 0) {
+        fprintf(stderr, "Error opening a handle: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    rc = cdb2_run_statement(hndl, "DROP TABLE IF EXISTS read_intrans_results_test");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    rc = cdb2_run_statement(hndl, "CREATE TABLE read_intrans_results_test (i INTEGER)");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    rc = cdb2_run_statement(hndl, "BEGIN");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    rc = cdb2_run_statement(hndl, "INSERT INTO read_intrans_results_test VALUES (1)");
+    if (rc != 0) {
+        fprintf(stderr, "Error running query: %d: %s.\n",
+                rc, cdb2_errstr(hndl));
+        return 1;
+    }
+
+    while (cdb2_next_record(hndl) != CDB2_OK_DONE) {
+        if (strcasecmp(cdb2_column_name(hndl, 0), "rows inserted") == 0 &&
+            *(unsigned long long *)cdb2_column_value(hndl, 0) == 1)
+            return 0;
+    }
+
+    return 1;
+}


### PR DESCRIPTION
The pull request changes skip_response to return false, if client has explicitly asked for intrans results.
Variables (skip_feature, skip_rows and etc) are renamed to better match their functionality.

The pull request fixes #927.