### PR TITLE
Print txn error on eventlog of Master node

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1132,6 +1132,7 @@ static int process_this_session(
     if(rc != IX_FND)
         free(key);
     if (rc && rc != IX_EMPTY && rc != IX_NOTFND) {
+        reqlog_set_error(iq->reqlogger, "bdb_temp_table_first failed", rc);
         logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_first failed rc=%d bdberr=%d\n",
                 __func__, rc, *bdberr);
         return rc;
@@ -1154,6 +1155,7 @@ static int process_this_session(
             err->blockop_num = 0;
             err->errcode = ERR_NOMASTER;
             err->ixnum = 0;
+            reqlog_set_error(iq->reqlogger, "ERR_NOMASTER", ERR_NOMASTER);
             return ERR_NOMASTER /*OSQL_FAILDISPATCH*/;
         }
 
@@ -1167,6 +1169,7 @@ static int process_this_session(
                       blobs, step, err, &receivedrows, logsb);
 
         if (rc_out != 0 && rc_out != OSQL_RC_DONE) {
+            reqlog_set_error(iq->reqlogger, "Error processing", rc_out);
             /* error processing, can be a verify error or deadlock */
             break;
         }
@@ -1224,6 +1227,7 @@ static int process_this_session(
         logmsg(LOGMSG_ERROR, "%s:%d bdb_temp_table_next failed rc=%d bdberr=%d\n",
                 __func__, __LINE__, rc, *bdberr);
         rc_out = ERR_INTERNAL;
+        reqlog_set_error(iq->reqlogger, "Internal Error", rc);
         /* fall-through */
     }
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1221,13 +1221,11 @@ static int process_this_session(
     if (updCols)
         free(updCols);
 
-    if (rc == 0 || rc == IX_PASTEOF || rc == IX_EMPTY) {
-        rc = 0;
-    } else {
+    if (rc != 0 && rc != IX_PASTEOF && rc != IX_EMPTY) {
+        reqlog_set_error(iq->reqlogger, "Internal Error", rc);
         logmsg(LOGMSG_ERROR, "%s:%d bdb_temp_table_next failed rc=%d bdberr=%d\n",
                 __func__, __LINE__, rc, *bdberr);
         rc_out = ERR_INTERNAL;
-        reqlog_set_error(iq->reqlogger, "Internal Error", rc);
         /* fall-through */
     }
 

--- a/tests/sc_fieldlarger.test/runit
+++ b/tests/sc_fieldlarger.test/runit
@@ -142,7 +142,7 @@ echo "Alter table to t1_2 version"
 j=4001
 while [ ! -f alter1.done ] ; do
     echo "insert into t1(a,b,c) values ($j,'test1$j',$j)" >&${COPROC[1]}
-    read -t 0.5 -ru ${COPROC[0]} out
+    read -t 1.9 -ru ${COPROC[0]} out
     if [ "$out" != "(rows inserted=1)" ] ; then
         failexit " error inserting out=$out"
     fi

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -521,7 +521,7 @@ in_schema_change=$?   # SC may not have restarted yet
 while true ; do
     let j=j+1
     echo "insert into t1(a,b,c) values ($j,'test1$j',$j)" >&${COPROC[1]}
-    read -t 0.2 -ru ${COPROC[0]} out
+    read -t 1.9 -ru ${COPROC[0]} out
     if [ "$out" != "(rows inserted=1)" ] ; then
         echo "out is $out at t=$SECONDS"
     fi

--- a/tests/sc_swapfields.test/runit
+++ b/tests/sc_swapfields.test/runit
@@ -163,7 +163,7 @@ echo "Alter table to t1_2 version"
 j=4001
 while [ ! -f alter1.done ] ; do
     echo "insert into t1(a,b,c,d) values ($j,'test1$j',$j,$j)" >&${COPROC[1]}
-    read -t 0.5 -ru ${COPROC[0]} out
+    read -t 1.9 -ru ${COPROC[0]} out
     if [ "$out" != "(rows inserted=1)" ] ; then
         failexit " error inserting out=$out"
     fi


### PR DESCRIPTION
Print txn error on eventlog of Master node:
```
{"time": 1528993458803291,"type": "txn","cnonce": "296486144-103923-696750-412573114",
"id": "b768d997-ff42-4f4c-841b-06b653b00586","error_code": 4,
"error": "Error processing","host": "m1","perf": {"runtime": 100261}}
```