### PR TITLE
Try to queue on replicants before sending sql to the master

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2448,7 +2448,8 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
         features[n_features] = CDB2_CLIENT_FEATURES__ALLOW_MASTER_DBINFO;
         n_features++;
         if ((hndl->flags & CDB2_DIRECT_CPU) ||
-            (retries_done && hndl->master == hndl->connected_host)) {
+            (retries_done >= (hndl->num_hosts * 2 - 1) && hndl->master ==
+             hndl->connected_host)) {
             features[n_features] = CDB2_CLIENT_FEATURES__ALLOW_MASTER_EXEC;
             n_features++;
         }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -666,7 +666,8 @@ public class Comdb2Handle extends AbstractConnection {
         if (nretry >= myDbHosts.size())
             sqlQuery.features.add(CDB2ClientFeatures.ALLOW_QUEUING_VALUE);
 
-        if (nretry > 0 && dbHostConnected == masterIndexInMyDbHosts)
+        if (nretry >= ((myDbHosts.size() * 2) - 1) && dbHostConnected ==
+                masterIndexInMyDbHosts)
             sqlQuery.features.add(CDB2ClientFeatures.ALLOW_MASTER_EXEC_VALUE);
 
         sqlQuery.cnonce = cnonce;


### PR DESCRIPTION
This coerces the api into avoiding sending sql to the master more aggressively than it previously did.  Prior to this change the api allowed execution on the master at the same point that it would allow queuing on any node.  We determined that the benefit of keeping sql from running directly on the master outweighed the downside of additional latency incurred by queuing.