### PR TITLE
Reset trans_has_sp correctly

### DIFF
--- a/plugin/newsql/newsql.c
+++ b/plugin/newsql/newsql.c
@@ -2216,7 +2216,6 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (!clnt.in_client_trans) {
             bzero(&clnt.effects, sizeof(clnt.effects));
             bzero(&clnt.log_effects, sizeof(clnt.log_effects));
-            clnt.trans_has_sp = 0;
         }
         if (clnt.dbtran.mode < TRANLEVEL_SOSQL) {
             clnt.dbtran.mode = TRANLEVEL_SOSQL;


### PR DESCRIPTION
- reset trans_has_sp in sqlinterfaces instead of in client APIs
- reset trans_has_sp if clnt is no longer in a client tran