### PR TITLE
cdb2jdbc: client info.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Cdb2Query.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Cdb2Query.java
@@ -40,12 +40,21 @@ public class Cdb2Query implements Serializable {
         byte[] value;
     }
 
+    static class Cdb2ClientInfo {
+        int pid; /* Unsupported */
+        long tid; /* Unsupported */
+        int host_id; /* Unsupported */
+        String argv0;
+        String stack;
+    }
+
     static class Cdb2SqlQuery {
         String dbName;
         String sqlQuery;
         List<Cdb2Flag> flag;
         boolean littleEndian = false;
         List<Cdb2BindValue> bindVars;
+        Cdb2ClientInfo cinfo;
         String tzName;
         List<String> setFlags;
         List<Integer> types;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
@@ -1,0 +1,42 @@
+/* Copyright 2018 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+   
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License. */
+package com.bloomberg.comdb2.jdbc;
+
+public class Comdb2ClientInfo {
+    public static String getCallerClass() {
+        String pkg = Comdb2ClientInfo.class.getPackage().getName() + ".";
+        StackTraceElement[] stes = Thread.currentThread().getStackTrace();
+        for (int i = 1, len = stes.length; i < len; ++i) {
+            StackTraceElement ste = stes[i];
+            if (!ste.getClassName().startsWith(pkg))
+                return ste.getClassName();
+        }
+        return "Unknown Java class";
+    }
+
+    public static String getCallStack(int layers) {
+        String pkg = Comdb2ClientInfo.class.getPackage().getName() + ".";
+        StringBuilder sb = new StringBuilder("");
+        StackTraceElement[] stes = Thread.currentThread().getStackTrace();
+        for (int i = 1, len = stes.length; i < len && i < layers ; ++i) {
+            StackTraceElement ste = stes[i];
+            if (!ste.getClassName().startsWith(pkg)) {
+                sb.append(ste.toString());
+                if (i < len - 1)
+                    sb.append(' ');
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -219,15 +219,8 @@ public class Comdb2Connection implements Connection {
         hndl.setMaxRetries(n);
     }
 
-    public void setDebug(String dbg) {
-        /* valid values: true, 1, T or on */
-        if ("true".equalsIgnoreCase(dbg)
-                || "1".equalsIgnoreCase(dbg)
-                || "T".equalsIgnoreCase(dbg)
-                || "on".equalsIgnoreCase(dbg))
-            hndl.setDebug(true);
-        else
-            hndl.setDebug(false);
+    public void setDebug(boolean dbg) {
+        hndl.setDebug(dbg);
     }
 
     public void setSSLMode(String mode) {
@@ -262,34 +255,21 @@ public class Comdb2Connection implements Connection {
         hndl.setSSLCRL(crl);
     }
 
-    public void setAllowPmuxRoute(String val) {
-        if ("true".equalsIgnoreCase(val)
-                || "1".equalsIgnoreCase(val)
-                || "T".equalsIgnoreCase(val)
-                || "on".equalsIgnoreCase(val))
-            hndl.setAllowPmuxRoute(true);
-        else
-            hndl.setAllowPmuxRoute(false);
+    public void setAllowPmuxRoute(boolean rte) {
+        hndl.setAllowPmuxRoute(rte);
     }
 
-    public void setStatementQueryEffects(String val) {
-        if ("true".equalsIgnoreCase(val)
-                || "1".equalsIgnoreCase(val)
-                || "T".equalsIgnoreCase(val)
-                || "on".equalsIgnoreCase(val))
-            hndl.setStatementQueryEffects(true);
-        else
-            hndl.setStatementQueryEffects(false);
+    public void setStatementQueryEffects(boolean stmtEffects) {
+        hndl.setStatementQueryEffects(stmtEffects);
     }
 
-    public void setVerifyRetry(String val) {
-        if ("true".equalsIgnoreCase(val)
-                || "1".equalsIgnoreCase(val)
-                || "T".equalsIgnoreCase(val)
-                || "on".equalsIgnoreCase(val))
-            hndl.setVerifyRetry(true);
-        else
-            hndl.setVerifyRetry(false);
+    public void setVerifyRetry(boolean vrfyRetry) {
+        hndl.setVerifyRetry(vrfyRetry);
+    }
+
+    public void setStackAtOpen(boolean sendStack) {
+        hndl.hasSendStack = true;
+        hndl.setSendStack(sendStack);
     }
 
     public ArrayList<String> getDbHosts() throws NoDbHostFoundException{

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -23,8 +23,7 @@ import java.text.MessageFormat;
 import com.google.protobuf.*;
 
 import com.bloomberg.comdb2.jdbc.SockIO;
-import com.bloomberg.comdb2.jdbc.Cdb2Query.Cdb2BindValue;
-import com.bloomberg.comdb2.jdbc.Cdb2Query.Cdb2SqlQuery;
+import com.bloomberg.comdb2.jdbc.Cdb2Query.*;
 import com.bloomberg.comdb2.jdbc.Constants.*;
 import com.bloomberg.comdb2.jdbc.Sqlquery.*;
 import com.bloomberg.comdb2.jdbc.Sqlresponse.*;
@@ -128,6 +127,11 @@ public class Comdb2Handle extends AbstractConnection {
     private String sslcrl;
     PEER_SSL_MODE peersslmode = PEER_SSL_MODE.PEER_SSL_ALLOW;
 
+    /* argv0 */
+    boolean sentClientInfo;
+    boolean hasSendStack;
+    boolean sendStack = true;
+
     static class QueryItem {
         byte[] buffer;
         boolean isRead;
@@ -180,6 +184,11 @@ public class Comdb2Handle extends AbstractConnection {
         ret.sslcapass = sslcapass;
         ret.sslcatype = sslcatype;
         ret.peersslmode = peersslmode;
+
+        ret.sentClientInfo = sentClientInfo;
+        ret.hasSendStack = hasSendStack;
+        ret.sendStack = sendStack;
+
         return ret;
     }
 
@@ -309,6 +318,10 @@ public class Comdb2Handle extends AbstractConnection {
         }
 
         verifyretry = val;
+    }
+
+    public void setSendStack(boolean val) {
+        sendStack = val;
     }
 
     void addHosts(List<String> hosts) {
@@ -621,6 +634,13 @@ public class Comdb2Handle extends AbstractConnection {
         Cdb2Query query = new Cdb2Query();
         Cdb2SqlQuery sqlQuery = new Cdb2SqlQuery();
         query.cdb2SqlQuery = sqlQuery;
+
+        if (!sentClientInfo) {
+            sqlQuery.cinfo = new Cdb2ClientInfo();
+            sqlQuery.cinfo.argv0 = Comdb2ClientInfo.getCallerClass();
+            sqlQuery.cinfo.stack = Comdb2ClientInfo.getCallStack(32);
+            sentClientInfo = true;
+        }
 
         sqlQuery.dbName = myDbName;
         sqlQuery.sqlQuery = sql;
@@ -1765,6 +1785,8 @@ readloop:
             return true;
         } else {
             rc = reopen(true);
+            if (rc)
+                sentClientInfo = false;
             tdlog(Level.FINEST, "Connection reopened returned %b", rc);
             return rc;
         }
@@ -1806,6 +1828,7 @@ readloop:
                            sslcertpass, sslca,
                            sslcatype, sslcapass,
                            sslcrl);
+            sentClientInfo = false;
             return true;
         } catch (SSLHandshakeException she) {
             /* this is NOT retry-able. */

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -123,6 +123,10 @@ public class DatabaseDiscovery {
                             logger.log(Level.WARNING, "Invalid comdb2db timeout.", e);
                         }
                     }
+                    else if (tokens[1].equalsIgnoreCase("stack_at_open")
+                            && !hndl.hasSendStack) {
+                        hndl.sendStack = tokens[2].equalsIgnoreCase("true");
+                    }
                 } else if (tokens[0].equalsIgnoreCase(hndl.comdb2dbName)) {
                     /**
                      * Gets dbnumber and hosts of comdb2db.

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -64,6 +64,24 @@ public class Driver implements java.sql.Driver {
         }
     }
 
+    protected static class BooleanOption extends Option {
+        void set(Comdb2Connection conn, String val) throws Throwable {
+            int intval = Integer.parseInt(val);
+            if ("true".equalsIgnoreCase(val)
+                    || "1".equalsIgnoreCase(val)
+                    || "T".equalsIgnoreCase(val)
+                    || "on".equalsIgnoreCase(val))
+                m.invoke(conn, true);
+            else
+                m.invoke(conn, false);
+        }
+        BooleanOption(String opt, String setter) throws Throwable {
+            Class<Comdb2Connection> cls = Comdb2Connection.class;
+            m = cls.getMethod("set" + setter, Boolean.TYPE);
+            this.opt = opt;
+        }
+    }
+
     public static Driver getInstance() throws SQLException {
         try {
             __instance.options.put("maxquerytime", new IntegerOption("maxquerytime", "QueryTimeout"));
@@ -84,7 +102,7 @@ public class Driver implements java.sql.Driver {
             __instance.options.put("microsecond_fraction", new StringOption("microsecond_fraction", "MicroSecond"));
             __instance.options.put("preferred_machine", new StringOption("preferred_machine", "PrefMach"));
             __instance.options.put("comdb2db_max_age", new IntegerOption("comdb2db_max_age", "Comdb2dbMaxAge"));
-            __instance.options.put("debug", new StringOption("debug", "Debug"));
+            __instance.options.put("debug", new BooleanOption("debug", "Debug"));
             __instance.options.put("max_retries", new IntegerOption("max_retries", "MaxRetries"));
             __instance.options.put("ssl_mode", new StringOption("ssl_mode", "SSLMode"));
             __instance.options.put("key_store", new StringOption("key_store", "SSLCrt"));
@@ -94,10 +112,11 @@ public class Driver implements java.sql.Driver {
             __instance.options.put("trust_store_password", new StringOption("trust_store_password", "SSLCAPass"));
             __instance.options.put("trust_store_type", new StringOption("trust_store_type", "SSLCAType"));
             __instance.options.put("crl", new StringOption("crl", "SSLCRL"));
-            __instance.options.put("allow_pmux_route", new StringOption("allow_pmux_route", "AllowPmuxRoute"));
+            __instance.options.put("allow_pmux_route", new BooleanOption("allow_pmux_route", "AllowPmuxRoute"));
             __instance.options.put("statement_query_effects",
-                    new StringOption("statement_query_effects", "StatementQueryEffects"));
-            __instance.options.put("verify_retry", new StringOption("verify_retry", "VerifyRetry"));
+                    new BooleanOption("statement_query_effects", "StatementQueryEffects"));
+            __instance.options.put("verify_retry", new BooleanOption("verify_retry", "VerifyRetry"));
+            __instance.options.put("stack_at_open", new BooleanOption("stack_at_open", "StackAtOpen"));
         } catch (Throwable e) {
             throw new SQLException(e);
         }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/ProtobufProtocol.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/ProtobufProtocol.java
@@ -171,6 +171,13 @@ public class ProtobufProtocol implements Protocol {
                     .setLittleEndian(cdb2SqlQuery.littleEndian)
                     .setTzname(cdb2SqlQuery.tzName)
                     .setMachClass(cdb2SqlQuery.machClass);
+
+            if (cdb2SqlQuery.cinfo != null)
+                _sqlquery.setClientInfo(CDB2_SQLQUERY.cinfo.newBuilder().
+                        setPid(cdb2SqlQuery.cinfo.pid).setThId(cdb2SqlQuery.cinfo.tid).
+                        setHostId(cdb2SqlQuery.cinfo.host_id).setArgv0(cdb2SqlQuery.cinfo.argv0).
+                        setStack(cdb2SqlQuery.cinfo.stack));
+
             if (cdb2SqlQuery.cnonce != null)
                 _sqlquery.setCnonce(ByteString.copyFrom(cdb2SqlQuery.cnonce));
 

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ClientInfoTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ClientInfoTest.java
@@ -1,0 +1,36 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class ClientInfoTest {
+
+    String db, cluster;
+    Connection conn;
+
+    @Before public void setup() throws SQLException {
+        db = System.getProperty("cdb2jdbc.test.database");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+    }
+
+    @Test public void testClientInfoTest() throws SQLException {
+        Statement stmt = conn.createStatement();
+        stmt.executeQuery("SELECT 1");
+        ResultSet rs = stmt.executeQuery("SELECT stack FROM comdb2_clientstats");
+        boolean found = false;
+        while (rs.next()) {
+            String stack = rs.getString(1);
+            if (stack != null && stack.contains("JUnit"))
+                found = true;
+        }
+        Assert.assertTrue("Should find JUnit in the call stack", found);
+
+        rs.close();
+        stmt.close();
+        conn.close();
+    }
+}


### PR DESCRIPTION
The pull request adds partial client info support in cdb2jdbc. Process ID, Thread ID and Host ID are not supported because there's no clean way to obtain such information in Java. "argv[0]" has been modified to the full name of the last method in the stack before calling into "com.bloomberg.comdb2.jdbc" domain.