### PR TITLE
p4_opfunc overlaps with p4_table causing crashes in writes_remsql_names

### DIFF
--- a/sqlite/vdbe.h
+++ b/sqlite/vdbe.h
@@ -153,7 +153,7 @@ typedef struct VdbeOpList VdbeOpList;
 #define P4_TABLE    (-20) /* P4 is a pointer to a Table structure */
 #define P4_FUNCCTX  (-21) /* P4 is a pointer to an sqlite3_context object */
 
-#define P4_OPFUNC  (-20) /* P4 is a COMDB2 custom function */
+#define P4_OPFUNC  (-22) /* P4 is a COMDB2 custom function */
 
 /* Error message codes for OP_Halt */
 #define P5_ConstraintNotNull 1


### PR DESCRIPTION
p4_opfunc and p4_table were both defined to -20 .. this issue seems to be present in the initial release of opensource comdb2.  It sporadically causes crashes in write_remsql_names when p4free attempts to free non-mallocd memory.
