### PR TITLE
SP's initial schema lock should work like standard SQL

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1004,9 +1004,10 @@ struct sql_state {
     const char *sql;                   /* the actual string used */
     stmt_hash_entry_type *stmt_entry;  /* fast pointer to hashed record */
 };
+int get_prepared_stmt(struct sqlthdstate *, struct sqlclntstate *,
+                      struct sql_state *, struct errstat *);
 int get_prepared_stmt_try_lock(struct sqlthdstate *, struct sqlclntstate *,
-                               struct sql_state *, struct errstat *,
-                               int initial);
+                               struct sql_state *, struct errstat *);
 void put_prepared_stmt(struct sqlthdstate *, struct sqlclntstate *,
                        struct sql_state *, int outrc);
 void sqlengine_thd_start(struct thdpool *, struct sqlthdstate *, enum thrtype);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2618,8 +2618,8 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
     return rc;
 }
 
-static int get_prepared_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                             struct sql_state *rec, struct errstat *err)
+int get_prepared_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
+                      struct sql_state *rec, struct errstat *err)
 {
     rdlock_schema_lk();
     int rc = get_prepared_stmt_int(thd, clnt, rec, err, 1);
@@ -2641,7 +2641,7 @@ static int get_prepared_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
 */
 int get_prepared_stmt_try_lock(struct sqlthdstate *thd,
                                struct sqlclntstate *clnt, struct sql_state *rec,
-                               struct errstat *err, int initial)
+                               struct errstat *err)
 {
     if (tryrdlock_schema_lk() != 0) {
         // only schemachange will wrlock(schema)
@@ -2649,7 +2649,7 @@ int get_prepared_stmt_try_lock(struct sqlthdstate *thd,
                        "Returning SQLITE_SCHEMA on tryrdlock failure\n");
         return SQLITE_SCHEMA;
     }
-    int rc = get_prepared_stmt_int(thd, clnt, rec, err, initial);
+    int rc = get_prepared_stmt_int(thd, clnt, rec, err, 0);
     unlock_schema_lk();
     return rc;
 }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2005,7 +2005,8 @@ static int lua_prepare_sql_int(Lua L, SP sp, const char *sql,
     struct sql_state rec_lcl = {0};
     struct sql_state *rec_ptr = rec ? rec : &rec_lcl;
     rec_ptr->sql = sql;
-    sp->rc = get_prepared_stmt_try_lock(sp->thd, sp->clnt, rec_ptr, &err, sp->initial);
+    sp->rc = sp->initial ? get_prepared_stmt(sp->thd, sp->clnt, rec_ptr, &err)
+                         : get_prepared_stmt_try_lock(sp->thd, sp->clnt, rec_ptr, &err);
     sp->initial = 0;
     if (sp->rc == 0) {
         *stmt = rec_ptr->stmt;


### PR DESCRIPTION
Then switch to try_lock version. This fixes race when replicant runs:
1 ddl stmt...
2 exec procedure...

1 returns with early ack
2 fails on try_lock as replication is still applying change

Desired behavior is for 2 to block until schemachange has finished.