### PR TITLE
Assert isn't valid unless this code is enabled

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4644,8 +4644,6 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
             static int lastpr = 0;
             int now;
 
-            if (*commit_gen == 0 && rectype != DB___txn_regop) 
-                abort();
             if (gbl_early_ack_trace && ((now = time(NULL)) - lastpr)) {
                 logmsg(LOGMSG_USER, "%s line %d send early-ack for %d:%d "
                         "commit-gen %d\n", __func__, __LINE__, maxlsn.file,


### PR DESCRIPTION
This abort isn't valid: to be compatible with R6 as we move it out, elect_highest_committed_gen is disabled.
