### PR TITLE
Log systable

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2473,7 +2473,6 @@ struct __db_env {
 	/* Stable LSN: must be acked by majority of cluster. */
 	DB_LSN durable_lsn;
 	uint32_t durable_generation;
-	pthread_mutex_t durable_lsn_lk;
 
 	void (*set_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t));
 	void (*get_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t *));

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -1267,6 +1267,8 @@ __dbenv_set_comdb2_dirs(dbenv, data_dir, txn_dir, tmp_dir)
 	return 0;
 }
 
+pthread_mutex_t gbl_durable_lsn_lk = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t gbl_durable_lsn_cond = PTHREAD_COND_INITIALIZER;
 
 static void
 __dbenv_set_durable_lsn(dbenv, lsnp, generation)
@@ -1284,7 +1286,7 @@ __dbenv_set_durable_lsn(dbenv, lsnp, generation)
 		abort();
 	}
 
-	pthread_mutex_lock(&dbenv->durable_lsn_lk);
+	pthread_mutex_lock(&gbl_durable_lsn_lk);
 
 	if (generation > dbenv->durable_generation &&
 	    log_compare(lsnp, &dbenv->durable_lsn) < 0) {
@@ -1325,7 +1327,8 @@ __dbenv_set_durable_lsn(dbenv, lsnp, generation)
 		}
 	}
 
-	pthread_mutex_unlock(&dbenv->durable_lsn_lk);
+    pthread_cond_broadcast(&gbl_durable_lsn_cond);
+	pthread_mutex_unlock(&gbl_durable_lsn_lk);
 }
 
 static void
@@ -1335,10 +1338,10 @@ __dbenv_get_durable_lsn(dbenv, lsnp, generation)
 	uint32_t *generation;
 {
 	DB_REP *db_rep = dbenv->rep_handle;
-	pthread_mutex_lock(&dbenv->durable_lsn_lk);
+	pthread_mutex_lock(&gbl_durable_lsn_lk);
 	*lsnp = dbenv->durable_lsn;
 	*generation = dbenv->durable_generation;
-	pthread_mutex_unlock(&dbenv->durable_lsn_lk);
+	pthread_mutex_unlock(&gbl_durable_lsn_lk);
 }
 
 static int

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -225,9 +225,6 @@ __dbenv_open(dbenv, db_home, flags, mode)
 	if (LF_ISSET(DB_ROWLOCKS))
 		F_SET(dbenv, DB_ENV_ROWLOCKS);
 
-    if ((ret = pthread_mutex_init(&dbenv->durable_lsn_lk, NULL)) != 0)
-        goto err;
-
 	/* Default permissions are read-write for both owner and group. */
 	dbenv->db_mode = mode == 0 ? __db_omode("rwrw--") : mode;
 #endif
@@ -855,8 +852,6 @@ __dbenv_close(dbenv, rep_check)
 		__os_free(dbenv, dbenv->comdb2_dirs.txn_dir);
 	if (dbenv->comdb2_dirs.tmp_dir != NULL)
 		__os_free(dbenv, dbenv->comdb2_dirs.tmp_dir);
-
-        pthread_mutex_destroy(&dbenv->durable_lsn_lk);
 
 	if (dbenv->ltrans_hash != NULL) {
         hash_clear(dbenv->ltrans_hash);

--- a/berkdb/log/log_put.c
+++ b/berkdb/log/log_put.c
@@ -247,8 +247,6 @@ __log_put_int_int(dbenv, lsnp, contextp, udbt, flags, off_context, usr_ptr)
     pthread_cond_broadcast(&gbl_logput_cond);
     pthread_mutex_unlock(&gbl_logput_lk);
 
-
-
 	lsn = *lsnp;
 
 	/*if (DB_llog_ltran_start == rectype) */

--- a/berkdb/log/log_put.c
+++ b/berkdb/log/log_put.c
@@ -75,8 +75,8 @@ int __db_debug_log(DB_ENV *, DB_TXN *, DB_LSN *, u_int32_t, const DBT *,
     int32_t, const DBT *, const DBT *, u_int32_t);
 
 extern int gbl_inflate_log;
-pthread_cond_t logput_cond = PTHREAD_COND_INITIALIZER;
-pthread_mutex_t logput_lk = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t gbl_logput_cond = PTHREAD_COND_INITIALIZER;
+pthread_mutex_t gbl_logput_lk = PTHREAD_MUTEX_INITIALIZER;
 
 /*
  * __log_put_pp --
@@ -238,14 +238,14 @@ __log_put_int_int(dbenv, lsnp, contextp, udbt, flags, off_context, usr_ptr)
 
 	ZERO_LSN(old_lsn);
 
-    pthread_mutex_lock(&logput_lk);
+    pthread_mutex_lock(&gbl_logput_lk);
 	if ((ret =
 		__log_put_next(dbenv, lsnp, contextp, dbt, udbt, &hdr, &old_lsn,
 		    off_context, key, flags)) != 0)
 		goto panic_check;
 
-    pthread_cond_broadcast(&logput_cond);
-    pthread_mutex_unlock(&logput_lk);
+    pthread_cond_broadcast(&gbl_logput_cond);
+    pthread_mutex_unlock(&gbl_logput_lk);
 
 
 

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -1477,6 +1477,8 @@ __rep_get_master(dbenv, master_out, gen, egen)
 	return 0;
 }
 
+extern pthread_mutex_t gbl_durable_lsn_lk;
+
 /*
  * __rep_stat --
  *	Fetch replication statistics.
@@ -1593,10 +1595,10 @@ __rep_stat(dbenv, statp, flags)
 	stats->lc_cache_hits = rep->stat.lc_cache_hits;
 	stats->lc_cache_misses = rep->stat.lc_cache_misses;
 	stats->lc_cache_size = dbenv->lc_cache.memused;
-	pthread_mutex_lock(&dbenv->durable_lsn_lk);
+	pthread_mutex_lock(&gbl_durable_lsn_lk);
     stats->durable_lsn = dbenv->durable_lsn;
     stats->durable_gen = dbenv->durable_generation;
-	pthread_mutex_unlock(&dbenv->durable_lsn_lk);
+	pthread_mutex_unlock(&gbl_durable_lsn_lk);
 
 	*statp = stats;
 	return (0);

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -34,6 +34,7 @@ add_library(sqlite
   ext/comdb2/triggers.c
   ext/comdb2/tunables.c
   ext/comdb2/users.c
+  ext/comdb2/tranlog.c
   ext/comdb2/clientstats.c
   ext/comdb2/ezsystables.c
   ext/comdb2/typesamples.c 

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -26,7 +26,7 @@ const sqlite3_module systblClientStatsModule;
 const sqlite3_module systblTimepartModule;
 const sqlite3_module systblTimepartShardsModule;
 const sqlite3_module systblTimepartEventsModule;
-const sqlite3_module systblTransactionLogModule;
+const sqlite3_module systblTransactionLogsModule;
 
 int systblTypeSamplesInit(sqlite3 *db);
 int systblRepNetQueueStatInit(sqlite3 *db);

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -26,6 +26,7 @@ const sqlite3_module systblClientStatsModule;
 const sqlite3_module systblTimepartModule;
 const sqlite3_module systblTimepartShardsModule;
 const sqlite3_module systblTimepartEventsModule;
+const sqlite3_module systblTransactionLogModule;
 
 int systblTypeSamplesInit(sqlite3 *db);
 int systblRepNetQueueStatInit(sqlite3 *db);

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -256,6 +256,8 @@ int comdb2SystblInit(
   if (rc == SQLITE_OK)
     rc = sqlite3_create_module(db, "comdb2_timepartevents", &systblTimepartEventsModule, 0);
   if (rc == SQLITE_OK)
+    rc = sqlite3_create_module(db, "comdb2_transaction_log", &systblTransactionLogModule, 0);
+  if (rc == SQLITE_OK)
     rc = systblTypeSamplesInit(db);
   if (rc == SQLITE_OK)
     rc = systblRepNetQueueStatInit(db);

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -256,7 +256,7 @@ int comdb2SystblInit(
   if (rc == SQLITE_OK)
     rc = sqlite3_create_module(db, "comdb2_timepartevents", &systblTimepartEventsModule, 0);
   if (rc == SQLITE_OK)
-    rc = sqlite3_create_module(db, "comdb2_transaction_log", &systblTransactionLogModule, 0);
+    rc = sqlite3_create_module(db, "comdb2_transaction_logs", &systblTransactionLogsModule, 0);
   if (rc == SQLITE_OK)
     rc = systblTypeSamplesInit(db);
   if (rc == SQLITE_OK)

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Bloomberg Finance L.P.
+   Copyright 2018 Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -454,7 +454,7 @@ static int tranlogBestIndex(
 ** This following structure defines all the methods for the 
 ** generate_series virtual table.
 */
-sqlite3_module systblTransactionLogModule = {
+sqlite3_module systblTransactionLogsModule = {
   0,                         /* iVersion */
   0,                         /* xCreate */
   tranlogConnect,            /* xConnect */

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -1,0 +1,408 @@
+/*
+   Copyright 2017 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
+#include "sqlite3ext.h"
+#include "tranlog.h"
+#include <assert.h>
+#include <string.h>
+#include "comdb2.h"
+#include "build/db.h"
+#include "dbinc/db_swap.h"
+
+/* Column numbers */
+#define TRANLOG_COLUMN_START    0
+#define TRANLOG_COLUMN_STOP     1
+#define TRANLOG_COLUMN_FLAGS    2
+#define TRANLOG_COLUMN_LSN      3
+#define TRANLOG_COLUMN_RECTYPE  4
+#define TRANLOG_COLUMN_LOG      5
+
+
+/* Modeled after generate_series */
+typedef struct tranlog_cursor tranlog_cursor;
+struct tranlog_cursor {
+  sqlite3_vtab_cursor base;  /* Base class - must be first */
+  sqlite3_int64 iRowid;      /* The rowid */
+  sqlite3_int64 idx;
+  DB_LSN curLsn;             /* Current LSN */
+  DB_LSN minLsn;             /* Minimum LSN */
+  DB_LSN maxLsn;             /* Maximum LSN */
+  char *minLsnStr;
+  char *maxLsnStr;
+  char *curLsnStr;
+  int flags;           /* 1 if we should block */
+  int hitLast;
+  int openCursor;
+  DB_LOGC *logc;             /* Log Cursor */
+  DBT data;
+};
+
+static int tranlogConnect(
+  sqlite3 *db,
+  void *pAux,
+  int argc, const char *const*argv,
+  sqlite3_vtab **ppVtab,
+  char **pzErr
+){
+  sqlite3_vtab *pNew;
+  int rc;
+  rc = sqlite3_declare_vtab(db,
+     "CREATE TABLE x(minlsn hidden,maxlsn hidden, flags hidden,lsn,rectype,payload)");
+  if( rc==SQLITE_OK ){
+    pNew = *ppVtab = sqlite3_malloc( sizeof(*pNew) );
+    if( pNew==0 ) return SQLITE_NOMEM;
+    memset(pNew, 0, sizeof(*pNew));
+  }
+  return rc;
+}
+
+static int tranlogDisconnect(sqlite3_vtab *pVtab){
+  sqlite3_free(pVtab);
+  return SQLITE_OK;
+}
+
+static int tranlogOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
+  tranlog_cursor *pCur;
+  pCur = sqlite3_malloc( sizeof(*pCur) );
+  if( pCur==0 ) return SQLITE_NOMEM;
+  memset(pCur, 0, sizeof(*pCur));
+  *ppCursor = &pCur->base;
+  return SQLITE_OK;
+}
+
+static int tranlogClose(sqlite3_vtab_cursor *cur){
+  tranlog_cursor *pCur = (tranlog_cursor*)cur;
+  if (pCur->openCursor) {
+      assert(pCur->logc);
+      pCur->logc->close(pCur->logc, 0);
+      pCur->openCursor = 0;
+  }
+  if (pCur->minLsnStr)
+      sqlite3_free(pCur->minLsnStr);
+  if (pCur->maxLsnStr)
+      sqlite3_free(pCur->maxLsnStr);
+  if (pCur->curLsnStr)
+      sqlite3_free(pCur->curLsnStr);
+  sqlite3_free(pCur);
+  return SQLITE_OK;
+}
+#include <bdb/bdb_int.h>
+
+extern pthread_cond_t logput_cond;
+extern pthread_mutex_t logput_lk;
+
+/*
+** Advance a tranlog cursor to the next log entry
+*/
+static int tranlogNext(sqlite3_vtab_cursor *cur){
+  tranlog_cursor *pCur = (tranlog_cursor*)cur;
+  DB_LSN durable_lsn = {0};
+  int durable_gen = 0, rc, getflags=DB_NEXT;
+  bdb_state_type *bdb_state = thedb->bdb_env;
+
+  if (pCur->flags & TRANLOG_FLAGS_DURABLE) {
+      bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv,
+              &durable_lsn, &durable_gen);
+  }
+
+  if (!pCur->openCursor) {
+      if (rc = bdb_state->dbenv->log_cursor(bdb_state->dbenv, &pCur->logc, 0)
+              != 0) {
+          logmsg(LOGMSG_ERROR, "%s line %d error getting a log cursor rc=%d\n",
+                  __func__, __LINE__, rc);
+          return SQLITE_INTERNAL;
+      }
+      pCur->openCursor = 1;
+      pCur->data.flags = DB_DBT_REALLOC;
+
+      if (pCur->minLsn.file == 0) {
+          getflags = DB_FIRST;
+      } else {
+          pCur->curLsn = pCur->minLsn;
+          getflags = DB_SET;
+      }
+  }
+
+  if (rc = pCur->logc->get(pCur->logc, &pCur->curLsn, &pCur->data, getflags) != 0) {
+      if (getflags != DB_NEXT) {
+          return SQLITE_INTERNAL;
+      }
+      if (pCur->flags & TRANLOG_FLAGS_BLOCK) {
+          do {
+              struct timespec ts;
+              clock_gettime(CLOCK_REALTIME, &ts);
+              ts.tv_nsec += (200 * 1000000);
+              pthread_mutex_lock(&logput_lk);
+              pthread_cond_timedwait(&logput_cond, &logput_lk, &ts);
+              pthread_mutex_unlock(&logput_lk);
+          } while (rc = pCur->logc->get(pCur->logc, &pCur->curLsn, &pCur->data, DB_NEXT));
+          rc = pCur->logc->get(pCur->logc, &pCur->curLsn,
+                  &pCur->data, DB_NEXT) != 0;
+      } else {
+          pCur->hitLast = 1;
+      }
+  }
+  pCur->iRowid++;
+  return SQLITE_OK;
+}
+
+#define skipws(p) { while (*p != '\0' && *p == ' ') p++; }
+#define isnum(p) ( *p >= '0' && *p <= '9' )
+
+static inline void tranlog_lsn_to_str(char *st, DB_LSN *lsn)
+{
+    sprintf(st, "{%d:%d}", lsn->file, lsn->offset);
+}
+
+static inline int parse_lsn(const char *lsnstr, DB_LSN *lsn)
+{
+    const char *p = lsnstr;
+    int file, offset;
+    while (*p != '\0' && *p == ' ') p++;
+    skipws(p);
+
+    /* Parse opening '{' */
+    if (*p != '{')
+        return -1;
+    p++;
+    skipws(p);
+    if ( !isnum(p) )
+        return -1;
+
+    /* Parse file */
+    file = atoi(p);
+    while( isnum(p) )
+        p++;
+    skipws(p);
+    if ( *p != ':' )
+        return -1;
+    p++;
+    skipws(p);
+    if ( !isnum(p) )
+        return -1;
+
+    /* Parse offset */
+    offset = atoi(p);
+    while( isnum(p) )
+        p++;
+
+    skipws(p);
+
+    /* Parse closing '}' */
+    if (*p != '}')
+        return -1;
+    p++;
+
+    skipws(p);
+    if (*p != '\0')
+        return -1;
+
+    lsn->file = file;
+    lsn->offset = offset;
+    return 0;
+}
+
+
+
+/*
+** Return values of columns for the row at which the series_cursor
+** is currently pointing.
+*/
+static int tranlogColumn(
+  sqlite3_vtab_cursor *cur,   /* The cursor */
+  sqlite3_context *ctx,       /* First argument to sqlite3_result_...() */
+  int i                       /* Which column to return */
+){
+  tranlog_cursor *pCur = (tranlog_cursor*)cur;
+  u_int32_t rectype = -1;
+  switch( i ){
+    case TRANLOG_COLUMN_START:
+        if (!pCur->minLsnStr) {
+            pCur->minLsnStr = sqlite3_malloc(32);
+            tranlog_lsn_to_str(pCur->minLsnStr, &pCur->minLsn);
+        }
+        sqlite3_result_text(ctx, pCur->minLsnStr, -1, NULL);
+        break;
+
+    case TRANLOG_COLUMN_STOP:
+        if (!pCur->maxLsnStr) {
+            pCur->maxLsnStr = sqlite3_malloc(32);
+            tranlog_lsn_to_str(pCur->maxLsnStr, &pCur->maxLsn);
+        }
+        sqlite3_result_text(ctx, pCur->maxLsnStr, -1, NULL);
+        break;
+
+    case TRANLOG_COLUMN_FLAGS:
+        sqlite3_result_int64(ctx, pCur->flags);
+        break;
+    case TRANLOG_COLUMN_LSN:
+        if (!pCur->curLsnStr) {
+            pCur->curLsnStr = sqlite3_malloc(32);
+        }
+        tranlog_lsn_to_str(pCur->curLsnStr, &pCur->curLsn);
+        sqlite3_result_text(ctx, pCur->curLsnStr, -1, NULL);
+        break;
+    case TRANLOG_COLUMN_RECTYPE:
+        if (pCur->data.data)
+            LOGCOPY_32(&rectype, pCur->data.data); sqlite3_result_int64(ctx, rectype);
+        break;
+    case TRANLOG_COLUMN_LOG:
+        sqlite3_result_blob(ctx, &pCur->data.data, pCur->data.size, NULL);
+        break;
+  }
+  return SQLITE_OK;
+}
+
+/*
+** Return the rowid for the current row.  In this implementation, the
+** rowid is the same as the output value.
+*/
+static int tranlogRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
+  tranlog_cursor *pCur = (tranlog_cursor*)cur;
+  *pRowid = pCur->iRowid;
+  return SQLITE_OK;
+}
+
+/*
+** Return TRUE if the cursor has been moved off of the last
+** row of output.
+*/
+static int tranlogEof(sqlite3_vtab_cursor *cur){
+  tranlog_cursor *pCur = (tranlog_cursor*)cur;
+  if (pCur->hitLast)
+      return 1;
+  if (pCur->maxLsn.file > 0 && log_compare(&pCur->curLsn, &pCur->maxLsn) > 0)
+      return 1;
+  return 0;
+}
+
+static int tranlogFilter(
+  sqlite3_vtab_cursor *pVtabCursor, 
+  int idxNum, const char *idxStr,
+  int argc, sqlite3_value **argv
+){
+  tranlog_cursor *pCur = (tranlog_cursor *)pVtabCursor;
+  int i = 0;
+
+  bzero(&pCur->minLsn, sizeof(pCur->minLsn));
+  if( idxNum & 1 ){
+    const char *minLsn = sqlite3_value_text(argv[i++]);
+    if (minLsn && parse_lsn(minLsn, &pCur->minLsn)) {
+        return SQLITE_CONV_ERROR;
+    }
+  }
+  bzero(&pCur->maxLsn, sizeof(pCur->maxLsn));
+  if( idxNum & 2 ){
+    const char *maxLsn = sqlite3_value_text(argv[i++]);
+    if (maxLsn && parse_lsn(maxLsn, &pCur->maxLsn)) {
+        return SQLITE_CONV_ERROR;
+    }
+  }
+  pCur->flags = 0;
+  if( idxNum & 4 ){
+    int64_t flags = sqlite3_value_int64(argv[i++]);
+    pCur->flags = flags;
+  }
+  pCur->iRowid = 1;
+  return SQLITE_OK;
+}
+
+static int tranlogBestIndex(
+  sqlite3_vtab *tab,
+  sqlite3_index_info *pIdxInfo
+){
+  int i;                 /* Loop over constraints */
+  int idxNum = 0;        /* The query plan bitmask */
+  int startIdx = -1;     /* Index of the start= constraint, or -1 if none */
+  int stopIdx = -1;      /* Index of the stop= constraint, or -1 if none */
+  int flagsIdx = -1;     /* Index of the block= constraint, block waiting if set */
+  int nArg = 0;          /* Number of arguments that seriesFilter() expects */
+
+  const struct sqlite3_index_constraint *pConstraint;
+  pConstraint = pIdxInfo->aConstraint;
+  for(i=0; i<pIdxInfo->nConstraint; i++, pConstraint++){
+    if( pConstraint->usable==0 ) continue;
+    if( pConstraint->op!=SQLITE_INDEX_CONSTRAINT_EQ ) continue;
+    switch( pConstraint->iColumn ){
+      case TRANLOG_COLUMN_START:
+        startIdx = i;
+        idxNum |= 1;
+        break;
+      case TRANLOG_COLUMN_STOP:
+        stopIdx = i;
+        idxNum |= 2;
+        break;
+      case TRANLOG_COLUMN_FLAGS:
+        flagsIdx = i;
+        idxNum |= 4;
+        break;
+    }
+  }
+  if( startIdx>=0 ){
+    pIdxInfo->aConstraintUsage[startIdx].argvIndex = ++nArg;
+    pIdxInfo->aConstraintUsage[startIdx].omit = 1;
+  }
+  if( stopIdx>=0 ){
+    pIdxInfo->aConstraintUsage[stopIdx].argvIndex = ++nArg;
+    pIdxInfo->aConstraintUsage[stopIdx].omit = 1;
+  }
+  if( flagsIdx>=0 ){
+    pIdxInfo->aConstraintUsage[flagsIdx].argvIndex = ++nArg;
+    pIdxInfo->aConstraintUsage[flagsIdx].omit = 1;
+  }
+  if( (idxNum & 3)==3 ){
+    /* Both start= and stop= boundaries are available.  This is the 
+    ** the preferred case */
+    pIdxInfo->estimatedCost = (double)1;
+  }else{
+    /* If either boundary is missing, we have to generate a huge span
+    ** of numbers.  Make this case very expensive so that the query
+    ** planner will work hard to avoid it. */
+    pIdxInfo->estimatedCost = (double)2000000000;
+  }
+  pIdxInfo->idxNum = idxNum;
+  return SQLITE_OK;
+}
+
+/*
+** This following structure defines all the methods for the 
+** generate_series virtual table.
+*/
+sqlite3_module systblTransactionLogModule = {
+  0,                         /* iVersion */
+  0,                         /* xCreate */
+  tranlogConnect,            /* xConnect */
+  tranlogBestIndex,          /* xBestIndex */
+  tranlogDisconnect,         /* xDisconnect */
+  0,                         /* xDestroy */
+  tranlogOpen,               /* xOpen - open a cursor */
+  tranlogClose,              /* xClose - close a cursor */
+  tranlogFilter,             /* xFilter - configure scan constraints */
+  tranlogNext,               /* xNext - advance a cursor */
+  tranlogEof,                /* xEof - check for end of scan */
+  tranlogColumn,             /* xColumn - read data */
+  tranlogRowid,              /* xRowid - read data */
+  0,                         /* xUpdate */
+  0,                         /* xBegin */
+  0,                         /* xSync */
+  0,                         /* xCommit */
+  0,                         /* xRollback */
+  0,                         /* xFindMethod */
+  0,                         /* xRename */
+};
+
+

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -205,7 +205,7 @@ static int tranlogNext(sqlite3_vtab_cursor *cur){
               int sleepms = 100;
               while (bdb_the_lock_desired()) {
                   if (thd == NULL) {
-                      pthread_getspecific(query_info_key));
+                      pthread_getspecific(query_info_key);
                   }
                   recover_deadlock(thedb->bdb_env, thd, NULL, sleepms);
                   sleepms*=2;

--- a/sqlite/ext/comdb2/tranlog.h
+++ b/sqlite/ext/comdb2/tranlog.h
@@ -1,0 +1,10 @@
+#ifndef INCLUDED_TRANLOG_H
+#define INCLUDED_TRANLOG_H
+
+/* Define flags for the third argument */
+enum {
+    TRANLOG_FLAGS_BLOCK             = 0x1,
+    TRANLOG_FLAGS_DURABLE           = 0x2,
+};
+
+#endif

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -295,6 +295,7 @@ seed1=`get_sc_seed`
 #we can add feature to send('restart') where it will cleanup then exec self
 echo "sending downgrade"
 cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('downgrade')"
+sleep 5
 
 if [ ! -n "$CLUSTER" ] ; then
     assert_sc_seed $seed1

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -295,7 +295,6 @@ seed1=`get_sc_seed`
 #we can add feature to send('restart') where it will cleanup then exec self
 echo "sending downgrade"
 cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('downgrade')"
-sleep 5
 
 if [ ! -n "$CLUSTER" ] ; then
     assert_sc_seed $seed1


### PR DESCRIPTION
Expose transaction log through the comdb2_transaction_log system table.  The flags argument can change the behavior to block-on-next upon reaching the end of the log, and to return only durable log-records.
