### PR TITLE
Fix: Legacy defaults are not deferred options.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5103,9 +5103,8 @@ int main(int argc, char **argv)
     if (comdb2ma_stats_cron() != 0)
         abort();
 
-    process_deferred_options(thedb, DEFERRED_SEND_COMMAND, NULL,
-                             deferred_do_commands);
-    clear_deferred_options(thedb, DEFERRED_SEND_COMMAND);
+    process_deferred_options(thedb, deferred_do_commands);
+    clear_deferred_options();
 
     // db started - disable recsize kludge so
     // new schemachanges won't allow broken size.

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -512,13 +512,6 @@ enum RECORD_WRITE_TYPES {
     RECORD_WRITE_MAX = 3
 };
 
-enum deferred_option_level {
-   DEFERRED_SEND_COMMAND,
-   DEFERRED_LEGACY_DEFAULTS,
-
-   DEFERRED_OPTION_MAX
-};
-
 /* Raw stats, kept on a per origin machine basis.  This whole struct is
  * essentially an array of unsigneds.  Please don't add any other data
  * type as this allows us to easily sum it and diff it in a loop in reqlog.c.
@@ -816,13 +809,6 @@ struct coordinated_component {
     int dbnum;
 };
 
-struct deferred_option {
-    char *option;
-    int line;
-    int len;
-    LINKC_T(struct deferred_option) lnk;
-};
-
 struct lrlfile {
     char *file;
     LINKC_T(struct lrlfile) lnk;
@@ -974,7 +960,6 @@ struct dbenv {
     unsigned prev_txns_aborted;
     int wait_for_N_nodes;
 
-    LISTC_T(struct deferred_option) deferred_options[DEFERRED_OPTION_MAX];
     LISTC_T(struct lrlfile) lrl_files;
 
     int incoh_notcoherent;

--- a/db/config.h
+++ b/db/config.h
@@ -25,8 +25,9 @@ void getmyaddr();
 struct read_lrl_option_type;
 typedef int(lrl_reader)(struct dbenv *, char *, struct read_lrl_option_type *, int);
 int deferred_do_commands(struct dbenv *, char *, struct read_lrl_option_type *, int);
-void process_deferred_options(struct dbenv *, enum deferred_option_level, void *, lrl_reader *);
-void clear_deferred_options(struct dbenv *, enum deferred_option_level);
+void process_deferred_options(struct dbenv *, lrl_reader *);
+void clear_deferred_options(void);
 void add_cmd_line_tunables_to_file(FILE *);
+int pre_read_legacy_defaults(void *, void *);
 
 #endif /* CONFIG_H */

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -28,6 +28,7 @@
 #include "analyze.h"
 #include "intern_strings.h"
 #include "portmuxapi.h"
+#include "config.h"
 
 /* Maximum allowable size of the value of tunable. */
 #define MAX_TUNABLE_VALUE_SIZE 512
@@ -1326,7 +1327,7 @@ comdb2_tunable_err handle_lrl_tunable(char *name, int name_len, char *value,
 
     if (!(t = hash_find_readonly(gbl_tunables->hash, &tok))) {
         /* Do not warn in READEARLY phase. */
-        if ((flags & READEARLY == 0)) {
+        if ((flags & READEARLY) == 0) {
             logmsg(LOGMSG_WARN, "Non-registered tunable '%s'.\n", tok);
         }
         return TUNABLE_ERR_INVALID_TUNABLE;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1391,5 +1391,8 @@ REGISTER_TUNABLE("inmem_repdb_memory",
                  "Current memory usage of in-memory repdb.  (Default: 0)",
                  TUNABLE_INTEGER, &gbl_inmem_repdb_memory, READONLY, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("legacy_defaults", "Configure server with legacy defaults",
+                 TUNABLE_BOOLEAN, NULL, NOARG | INTERNAL | READONLY | READEARLY,
+                 NULL, NULL, pre_read_legacy_defaults, NULL);
 
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
These options need to run immediately when encountered. Otherwise, there
is no way to override them.