### PR TITLE
db: Don't override the error code and error message from record.c.

### DIFF
--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -324,6 +324,8 @@ int srs_tran_replay(struct sqlclntstate *clnt, struct thr_handle *thr_self)
                 "transaction %llx %s failed %d times with verify errors\n",
                 clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
                 clnt->verify_retries);
+        /* Set to NONE to suppress the error from srs_tran_destroy(). */
+        osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_NONE);
     }
 
     /* replayed, free the session */

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6756,9 +6756,9 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         if (rc != 0) {
             if (rc != RC_INTERNAL_RETRY) {
-                reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
-                          "unable to delete genid =%llx rc=%d",
-                          bdb_genid_to_host_order(dt.genid), rc);
+                errstat_cat_strf(&iq->errstat,
+                                 " unable to delete genid =%llx rc=%d",
+                                 bdb_genid_to_host_order(dt.genid), rc);
             }
 
             return rc; /*this is blkproc rc */
@@ -6847,8 +6847,8 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                           get_keynm_from_db_idx(iq->usedb, err->ixnum),
                           iq->usedb->tablename, err->ixnum);
             } else if (rc != RC_INTERNAL_RETRY) {
-                reqerrstr(iq, COMDB2_ADD_RC_INVL_KEY,
-                          "unable to add record rc = %d", rc);
+                errstat_cat_strf(&iq->errstat,
+                                 " unable to add record rc = %d", rc);
             }
 
             if (logsb)
@@ -6983,8 +6983,8 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         if (rc != 0) {
             if (rc != RC_INTERNAL_RETRY) {
-                reqerrstr(iq, COMDB2_UPD_RC_INVL_KEY,
-                          "unable to update record rc = %d", rc);
+                errstat_cat_strf(&iq->errstat,
+                                 " unable to update record rc = %d", rc);
             }
             if (logsb)
                 sbuf2printf(logsb,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6847,8 +6847,8 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                           get_keynm_from_db_idx(iq->usedb, err->ixnum),
                           iq->usedb->tablename, err->ixnum);
             } else if (rc != RC_INTERNAL_RETRY) {
-                errstat_cat_strf(&iq->errstat,
-                                 " unable to add record rc = %d", rc);
+                errstat_cat_strf(&iq->errstat, " unable to add record rc = %d",
+                                 rc);
             }
 
             if (logsb)

--- a/db/record.c
+++ b/db/record.c
@@ -284,7 +284,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
                           reclen, tag, expected_dat_len);
             reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
-                      "bad data length %u tag '%s' expects data length %u\n",
+                      "bad data length %u tag '%s' expects data length %u",
                       reclen, tag, expected_dat_len);
             *opfailcode = OP_FAILED_BAD_REQUEST;
             retrc = ERR_BADREQ;
@@ -914,7 +914,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                 reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n",
                           reclen, tag, expected_dat_len);
             reqerrstr(iq, COMDB2_UPD_RC_INVL_DTA,
-                      "bad data length %u tag '%s' expects data length %u\n",
+                      "bad data length %u tag '%s' expects data length %u",
                       reclen, tag, expected_dat_len);
             *opfailcode = OP_FAILED_BAD_REQUEST;
             retrc = ERR_BADREQ;

--- a/tests/constraints.test/t2_01.req.out
+++ b/tests/constraints.test/t2_01.req.out
@@ -4,7 +4,7 @@
 [insert into t1 values (4321, 4321, 1234, 1234)] rc 0
 (rows inserted=1)
 [insert into t1 values (1321, 1321, 1234, null) -- Non default, no NULL contraint.] rc 0
-[insert into t1 values (1121, 1121, null, null) --  NULL constraint, column 3 can not be NULL.] failed with rc 4 Null constraint violation for column 'dup_value' on table 't1'. unable to add record rc = 318
+[insert into t1 values (1121, 1121, null, null) --  NULL constraint, column 3 can not be NULL.] failed with rc 4 Null constraint violation for column 'dup_value' on table 't1'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'dup_value' to bint4 field 'dup_value' for table 't1'' unable to add record rc = 318
 (uuid=1234, value=1234, dup_value=1234, allowed_null_value=1234)
 (uuid=1321, value=1321, dup_value=1234, allowed_null_value=NULL)
 (uuid=4321, value=4321, dup_value=1234, allowed_null_value=1234)

--- a/tests/ddl_no_csc2.test/t00_create_table.expected
+++ b/tests/ddl_no_csc2.test/t00_create_table.expected
@@ -609,11 +609,11 @@ constraints
 	}
 ')
 (type='index', name='$COMDB2_PK_3AE602D4', tbl_name='t5', rootpage=13, sql='create index "$COMDB2_PK_3AE602D4" on "t5" ("i");', csc2=NULL)
-[INSERT INTO t1 VALUES(NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't1'. unable to add record rc = 318
-[INSERT INTO t2 VALUES(NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't2'. unable to add record rc = 318
-[INSERT INTO t3 VALUES(1, NULL)] failed with rc 4 Null constraint violation for column 'j' on table 't3'. unable to add record rc = 318
-[INSERT INTO t3 VALUES(NULL, 1)] failed with rc 4 Null constraint violation for column 'i' on table 't3'. unable to add record rc = 318
-[INSERT INTO t3 VALUES(NULL, NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't3'. unable to add record rc = 318
+[INSERT INTO t1 VALUES(NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't1'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'i' to bint4 field 'i' for table 't1'' unable to add record rc = 318
+[INSERT INTO t2 VALUES(NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't2'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'i' to bint4 field 'i' for table 't2'' unable to add record rc = 318
+[INSERT INTO t3 VALUES(1, NULL)] failed with rc 4 Null constraint violation for column 'j' on table 't3'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'j' to bint4 field 'j' for table 't3'' unable to add record rc = 318
+[INSERT INTO t3 VALUES(NULL, 1)] failed with rc 4 Null constraint violation for column 'i' on table 't3'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'i' to bint4 field 'i' for table 't3'' unable to add record rc = 318
+[INSERT INTO t3 VALUES(NULL, NULL)] failed with rc 4 Null constraint violation for column 'i' on table 't3'. null constraint error data .ONDISK->.ONDISK 'null constraint violation from bint4 field 'i' to bint4 field 'i' for table 't3'' unable to add record rc = 318
 (COUNT(*)=0=1)
 (COUNT(*)=0=1)
 (COUNT(*)=0=1)

--- a/tests/serialstep.test/s14_01.req.out.alt2
+++ b/tests/serialstep.test/s14_01.req.out.alt2
@@ -5,5 +5,5 @@ done
 done
 (rows updated=1)
 done
-[commit] failed with rc 2 unable to update record rc = 4
+[commit] failed with rc 2 find old record failed unable to update record rc = 4
 done

--- a/tests/serialstep.test/s2_01.req.out.alt2
+++ b/tests/serialstep.test/s2_01.req.out.alt2
@@ -35,7 +35,7 @@ done
 (id=99, name='ytu', age=8, address=NULL, state='DB', zip=NULL)
 done
 done
-[commit] failed with rc 2 unable to update record rc = 4
+[commit] failed with rc 2 find old record failed unable to update record rc = 4
 done
 done
 done


### PR DESCRIPTION
These error messages from record.c are more detailed and should be returned to clients.