### PR TITLE
Mempsync flush

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -314,8 +314,8 @@ mempsync_thd(void *p)
                     __txn_updateckp(dbenv, &sync_lsn);
                     __os_free(dbenv, data_dbt.data);
                 }
+                __log_c_close(logc);
             }
-            __log_c_close(logc);
             BDB_RELLOCK();
 
 		} else {

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -315,8 +315,8 @@ mempsync_thd(void *p)
                     __os_free(dbenv, data_dbt.data);
                 }
             }
-            BDB_RELLOCK();
             __log_c_close(logc);
+            BDB_RELLOCK();
 
 		} else {
 err:

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -221,7 +221,7 @@ mempsync_thd(void *p)
 	DB_ENV *dbenv = p;
 	DB_REP *db_rep;
 	REP *rep;
-    u_int32_t generation;
+	u_int32_t generation;
 	int rep_check = 0;
 
 	db_rep = dbenv->rep_handle;
@@ -244,14 +244,14 @@ mempsync_thd(void *p)
 			break;
 		}
 		/* latch the lsn */
-        pthread_mutex_unlock(&mempsync_lk);
+		pthread_mutex_unlock(&mempsync_lk);
 		BDB_READLOCK("mempsync_thd");
 		pthread_mutex_lock(&mempsync_lk);
 		lsn = mempsync_lsn;
 		sync_lsn = lsn;
-        generation = rep->gen;
+		generation = rep->gen;
 		pthread_mutex_unlock(&mempsync_lk);
-        BDB_RELLOCK();
+		BDB_RELLOCK();
 
 		/*
 		 * When we do parallel recovery, there are "commit" records

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -219,7 +219,13 @@ mempsync_thd(void *p)
 	DBT data_dbt;
 	DB_LSN lsn, sync_lsn;
 	DB_ENV *dbenv = p;
+	DB_REP *db_rep;
+	REP *rep;
+    u_int32_t generation;
 	int rep_check = 0;
+
+	db_rep = dbenv->rep_handle;
+	rep = db_rep->region;
 
 	/* slightly kludgy, but necessary since this code gets
 	 * called in recovery */
@@ -238,9 +244,14 @@ mempsync_thd(void *p)
 			break;
 		}
 		/* latch the lsn */
+        pthread_mutex_unlock(&mempsync_lk);
+		BDB_READLOCK("mempsync_thd");
+		pthread_mutex_lock(&mempsync_lk);
 		lsn = mempsync_lsn;
 		sync_lsn = lsn;
+        generation = rep->gen;
 		pthread_mutex_unlock(&mempsync_lk);
+        BDB_RELLOCK();
 
 		/*
 		 * When we do parallel recovery, there are "commit" records
@@ -290,17 +301,19 @@ mempsync_thd(void *p)
 			/* For the reference:  sync_lsn is the lsn of the txn_ckp in the log,
 			 * as provided by mempsync_sync_out_of_band(); 
 			 * Not sure if it safe to sync beyond ckp->ckp_lsn all the way to ckp lsn though */
-            rc = __log_flush_pp(dbenv, &sync_lsn);
-            if ((rc = __log_cursor(dbenv, &logc)) != 0)
-                goto err;
-
-            memset(&data_dbt, 0, sizeof(data_dbt));
-            data_dbt.flags = DB_DBT_REALLOC;
-
             BDB_READLOCK("mempsync_thd_ckp");
-            if ((rc = __log_c_get(logc, &sync_lsn, &data_dbt, DB_SET)) == 0) {
-                __txn_updateckp(dbenv, &sync_lsn);
-                __os_free(dbenv, data_dbt.data);
+            if (generation == rep->gen) {
+                rc = __log_flush_pp(dbenv, &sync_lsn);
+                if ((rc = __log_cursor(dbenv, &logc)) != 0)
+                    goto err;
+
+                memset(&data_dbt, 0, sizeof(data_dbt));
+                data_dbt.flags = DB_DBT_REALLOC;
+
+                if ((rc = __log_c_get(logc, &sync_lsn, &data_dbt, DB_SET)) == 0) {
+                    __txn_updateckp(dbenv, &sync_lsn);
+                    __os_free(dbenv, data_dbt.data);
+                }
             }
             BDB_RELLOCK();
             __log_c_close(logc);

--- a/tests/socksql_master_swings.test/downgrade.sh
+++ b/tests/socksql_master_swings.test/downgrade.sh
@@ -9,5 +9,5 @@ while true; do
     for node in $CLUSTER ; do
         cdb2sql ${CDB2_OPTIONS} --host $node $dbname "exec procedure sys.cmd.send('downgrade')"
     done
-    sleep 10
+    sleep 20
 done


### PR DESCRIPTION
Prevent the mempsync_thd from flushing beyond the end of the logfile.  We do this by only flushing to sync_lsn if the generation hasn't changed.
