### PR TITLE
Fixed typos in documentation code to get database port

### DIFF
--- a/docs/pages/programming/client_protocol.md
+++ b/docs/pages/programming/client_protocol.md
@@ -28,9 +28,9 @@ Example code in Python to get database port:
 ```python
 def portmux_get(host, dbname):
   client_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-  service = "comdb2/replication"
-  command = "get" + service + dbname + "\n"
-  client_socket.connect(host, 5105)
+  service = "comdb2/replication/"
+  command = "get " + service + dbname + "\n"
+  client_socket.connect((host, 5105))
   client_socket.send(command)
   byts = client_socket.recv(32)
   port = int(byts)


### PR DESCRIPTION
In the comdb2 Client Protocol documentation,
the get command string is not formatted correctly, and the connect() method should be supplied as a tuple