### PR TITLE
dont use bset/btst for osql flags (backwards compatible)

### DIFF
--- a/db/bpfunc.c
+++ b/db/bpfunc.c
@@ -483,7 +483,7 @@ static int exec_genid48_enable(void *tran, bpfunc_t *func, char *err)
     /* Set flags: we'll actually set the format in the block processor */
     struct ireq *iq = (struct ireq *)func->info->iq;
     iq->osql_genid48_enable = gn->enable;
-    bset(&iq->osql_flags, OSQL_FLAGS_GENID48);
+    iq->osql_flags |= OSQL_FLAGS_GENID48;
     return 0;
 }
 
@@ -506,7 +506,7 @@ static int exec_rowlocks_enable(void *tran, bpfunc_t *func, char *err)
     if (!rc) {
         struct ireq *iq = (struct ireq *)func->info->iq;
         iq->osql_rowlocks_enable = rl->enable;
-        bset(&iq->osql_flags, OSQL_FLAGS_ROWLOCKS);
+        iq->osql_flags |= OSQL_FLAGS_ROWLOCKS;
     }
     return rc;
 }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6328,7 +6328,7 @@ int start_schema_change_tran_wrapper(const char *tblname,
         iq->sc_pending = iq->sc;
         if (arg->nshards == arg->indx + 1) {
             /* last shard was done */
-            bset(&iq->osql_flags, OSQL_FLAGS_SCDONE);
+            iq->osql_flags |= OSQL_FLAGS_SCDONE;
         } else {
             struct schema_change_type *new_sc = clone_schemachange_type(sc);
 
@@ -6479,7 +6479,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
             } else {
                 iq->sc->sc_next = iq->sc_pending;
                 iq->sc_pending = iq->sc;
-                bset(&iq->osql_flags, OSQL_FLAGS_SCDONE);
+                iq->osql_flags |= OSQL_FLAGS_SCDONE;
             }
         } else {
             timepart_sc_arg_t arg = {0};
@@ -6768,7 +6768,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
          * but since we changed the way we backup stats (used to be in llmeta)
          * this opcode is only used to reload stats now
          */
-        bset(&iq->osql_flags, OSQL_FLAGS_ANALYZE);
+        iq->osql_flags |= OSQL_FLAGS_ANALYZE;
     } break;
     case OSQL_INSREC:
     case OSQL_INSERT: {
@@ -7456,7 +7456,7 @@ static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
     /* for socksql, is this a retry that need to be checked for self-deadlock?
      */
     if ((type == OSQL_SOCK_REQ || type == OSQL_SOCK_REQ_COST) &&
-        (btst(&req.flags, OSQL_FLAGS_CHECK_SELFLOCK))) {
+        (req.flags & OSQL_FLAGS_CHECK_SELFLOCK)) {
         /* just make sure we are above the threshold */
         iq->sorese.verify_retries += gbl_osql_verify_ext_chk;
     }

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -489,7 +489,7 @@ retry:
 
     if ((type == OSQL_SOCK_REQ || type == OSQL_SOCK_REQ_COST) &&
         clnt->verify_retries > gbl_osql_verify_ext_chk)
-        bset(&flags, OSQL_FLAGS_CHECK_SELFLOCK);
+        flags |= OSQL_FLAGS_CHECK_SELFLOCK;
     else
         flags = 0;
 

--- a/db/sqloffload.h
+++ b/db/sqloffload.h
@@ -52,14 +52,14 @@ enum {
 
 /* flags for handle_offloadsql_pool */
 enum {
-    OSQL_FLAGS_RECORD_COST = 0,
-    OSQL_FLAGS_AUTH = 1,
-    OSQL_FLAGS_ANALYZE = 2,
+    OSQL_FLAGS_RECORD_COST = 0x00000001,
+    OSQL_FLAGS_AUTH = 0x00000002,
+    OSQL_FLAGS_ANALYZE = 0x00000004,
     /* sent after a verify to do the <slower> selfdeadlock test */
-    OSQL_FLAGS_CHECK_SELFLOCK = 3,
-    OSQL_FLAGS_ROWLOCKS = 4,
-    OSQL_FLAGS_GENID48 = 5,
-    OSQL_FLAGS_SCDONE = 6
+    OSQL_FLAGS_CHECK_SELFLOCK = 0x00000008,
+    OSQL_FLAGS_ROWLOCKS = 0x00000010,
+    OSQL_FLAGS_GENID48 = 0x00000020,
+    OSQL_FLAGS_SCDONE = 0x00000040
 };
 
 int osql_open(struct dbenv *dbenv);

--- a/db/sqloffload.h
+++ b/db/sqloffload.h
@@ -50,7 +50,7 @@ enum {
     OSQL_SKIPSEQ = 0x7777
 };
 
-/* flags for handle_offloadsql_pool */
+/* flags for osql requests */
 enum {
     OSQL_FLAGS_RECORD_COST = 0x00000001,
     OSQL_FLAGS_AUTH = 0x00000002,


### PR DESCRIPTION
dont use bset/btst for osql flags (backwards compatible)

This also fixes verify_error test on sun and ibm