### PR TITLE
Documentation: Update paths on 'Installing Comdb2' page 

### DIFF
--- a/docs/pages/overview/install.md
+++ b/docs/pages/overview/install.md
@@ -85,10 +85,9 @@ Installing (from source or a package) creates a directory structure like this:
 │   ├── libcdb2api.a
 │   ├── libcdb2api.so
 └── var
-    └── cdb2
-        ├── databases
-        └── logs
-
+    ├── cdb2
+    └── logs
+        └── cdb2
 ```
 
 A quick overview:
@@ -99,5 +98,5 @@ A quick overview:
 | ```etc/cdb2/config/comdb2.lrl```   | Global database tunables, applies to all databases |
 | ```etc/cdb2/config/comdb2.d```     | Global database config files, settings in all *.lrl files in this directory apply to all databases |
 | ```include/``` and ```lib/```        | headers and libraries |
-| ```var/cdb2/databases/``` | Default location for databases. Every database gets a subdirectory at create time. |
-| ```var/cdb2/logs/``` | Default location for database informational log files |
+| ```var/cdb2/``` | Default location for databases. Every database gets a subdirectory at create time. |
+| ```var/logs/cdb2``` | Default location for database informational log files |

--- a/docs/pages/overview/install.md
+++ b/docs/pages/overview/install.md
@@ -99,4 +99,4 @@ A quick overview:
 | ```etc/cdb2/config/comdb2.d```     | Global database config files, settings in all *.lrl files in this directory apply to all databases |
 | ```include/``` and ```lib/```        | headers and libraries |
 | ```var/cdb2/``` | Default location for databases. Every database gets a subdirectory at create time. |
-| ```var/logs/cdb2``` | Default location for database informational log files |
+| ```var/logs/cdb2/``` | Default location for database informational log files |


### PR DESCRIPTION
### Overview
The page seems to list incorrect paths for database data and log files in [Installation directories](https://bloomberg.github.io/comdb2/install.html#installation-directories) section. Other pages (like [Your first Comdb2 database](https://bloomberg.github.io/comdb2/example_db.html)) include the correct paths. Additionally, installing comdb2 itself and listing the directories shows the following output:
```
$ ls var/*
var/cdb2:
testdb

var/log:
cdb2
```
This confirms that 'Installing Comdb2' page includes an outdated path that needs to be fixed.

### Type of the change
Documentation

### Current behaviour
Lists incorrect paths

### Expected behaviour
Should list correct paths 
