### PR TITLE
add conv_flags to comdb2_appsock_arg for internal fastdump

### DIFF
--- a/bbinc/comdb2_appsock.h
+++ b/bbinc/comdb2_appsock.h
@@ -33,6 +33,7 @@ struct comdb2_appsock_arg {
     struct thr_handle *thr_self;
     struct dbenv *dbenv;
     struct dbtable *tab; /* Changed on the execution of 'use' */
+    int conv_flags;      /* Changed on the execution of 'lendian' */
     SBUF2 *sb;
     char *cmdline;
     int *keepsocket;
@@ -53,5 +54,14 @@ struct comdb2_appsock {
     int (*appsock_handler)(struct comdb2_appsock_arg *);
 };
 typedef struct comdb2_appsock comdb2_appsock_t;
+
+#define APPSOCK_PLUGIN_DESC(X)                                                 \
+    comdb2_appsock_t X##_plugin = {                                            \
+        #X,                  /* Name */                                        \
+        "",                  /* Usage info */                                  \
+        0,                   /* Execution count */                             \
+        0,                   /* Flags */                                       \
+        handle_##X##_request /* Handler function */                            \
+    };
 
 #endif /* ! __INCLUDED_COMDB2_APPSOCK_H */

--- a/db/appsock_handler.c
+++ b/db/appsock_handler.c
@@ -165,6 +165,7 @@ static void *thd_appsock_int(SBUF2 *sb, int *keepsocket,
     comdb2_appsock_t *appsock;
     comdb2_appsock_arg_t arg;
     struct dbtable *tab;
+    int conv_flags = 0;
     char line[128];
     char command[128];
     char *ptr;
@@ -216,6 +217,7 @@ static void *thd_appsock_int(SBUF2 *sb, int *keepsocket,
         arg.thr_self = thr_self;
         arg.dbenv = thedb;
         arg.tab = tab;
+        arg.conv_flags = conv_flags;
         arg.sb = sb;
         arg.cmdline = line;
         arg.keepsocket = keepsocket;


### PR DESCRIPTION
- added conv_flags to comdb2_appsock_arg for internal fastdump
- also added APPSOCK_PLUGIN_DESC macro to reduce typing