### PR TITLE
Make out-of-range key search work for bytearray.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4795,9 +4795,10 @@ static void register_all_int_switches()
                         &gbl_extended_sql_debug_trace);
     register_int_switch("dump_fsql_response", "Dump fsql out messages",
                         &gbl_dump_fsql_response);
-    register_int_switch("large_str_idx_find",
-                        "Allow index search using out-of-range strings or bytearrays",
-                        &gbl_large_str_idx_find);
+    register_int_switch(
+        "large_str_idx_find",
+        "Allow index search using out-of-range strings or bytearrays",
+        &gbl_large_str_idx_find);
     register_int_switch("fingerprint_queries",
                         "Compute fingerprint for SQL queries",
                         &gbl_fingerprint_queries);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4796,7 +4796,7 @@ static void register_all_int_switches()
     register_int_switch("dump_fsql_response", "Dump fsql out messages",
                         &gbl_dump_fsql_response);
     register_int_switch("large_str_idx_find",
-                        "Allow index search using out or range strings",
+                        "Allow index search using out-of-range strings or bytearrays",
                         &gbl_large_str_idx_find);
     register_int_switch("fingerprint_queries",
                         "Compute fingerprint for SQL queries",

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1212,7 +1212,8 @@ static int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info,
             bias_info->truncated = 1;
         }
 
-        rc = CLIENT_to_SERVER(m->z, m->n, CLIENT_BYTEARRAY, null,
+        rc =
+            CLIENT_to_SERVER(m->z, m->n, CLIENT_BYTEARRAY, null,
                              (struct field_conv_opts *)convopts, NULL /*blob */,
                              out + f->offset, f->len, f->type, 0, &outdtsz,
                              &f->convopts, &outblob[blobix] /*blob */);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1203,8 +1203,16 @@ static int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info,
                 return rc;
             }
         }
-        rc =
-            CLIENT_to_SERVER(m->z, m->n, CLIENT_BYTEARRAY, null,
+
+        if (m->n >= f->len && f->type == SERVER_BYTEARRAY &&
+            (convopts->flags & FLD_CONV_TRUNCATE)) {
+            /* if the SQLite BLOB is longer than the bytearray field
+               and find-by-truncate is enabled. */
+            convopts->step = (f->flags & INDEX_DESCEND) ? 0 : 1;
+            bias_info->truncated = 1;
+        }
+
+        rc = CLIENT_to_SERVER(m->z, m->n, CLIENT_BYTEARRAY, null,
                              (struct field_conv_opts *)convopts, NULL /*blob */,
                              out + f->offset, f->len, f->type, 0, &outdtsz,
                              &f->convopts, &outblob[blobix] /*blob */);

--- a/db/tag.c
+++ b/db/tag.c
@@ -1114,7 +1114,7 @@ static void dumpval(char *buf, int type, int len)
             logmsg(LOGMSG_USER, "\"%.*s\"", slen, buf);
             break;
         case CLIENT_PSTR2:
-            slen = pstr2lenlim(buf, len);
+            slen = len;
             logmsg(LOGMSG_USER, "\"%.*s\"", slen, buf);
             break;
         case CLIENT_BYTEARRAY:

--- a/db/types.c
+++ b/db/types.c
@@ -876,24 +876,6 @@ TYPES_INLINE int validate_pstr(const char *s, int lim)
     return 0;
 }
 
-/* pstr2 strings are not supposed to be "sniffed" to learn about their length.
-   there is an out of band length that goes along with them. */
-TYPES_INLINE int pstr2lenlim(const char *s, int lim)
-{
-
-#if 0
-    int len=0;
-    /* now check the remaining string to make sure it has no invalid chars */
-    while (*s && len < lim) {
-        s++;
-        len++;
-    }
-    return len;
-#endif
-
-    return lim;
-}
-
 TYPES_INLINE int pstrlenlim(const char *s, int lim)
 {
     const char *sp;
@@ -3295,14 +3277,12 @@ TYPES_INLINE int CLIENT_PSTR2_to_CLIENT_CSTR(
     blob_buffer_t *inblob, void *out, int outlen, int *outdtsz,
     const struct field_conv_opts *outopts, blob_buffer_t *outblob)
 {
-    int len;
     *outdtsz = 0;
-    len = pstr2lenlim(in, inlen);
-    if (len < 0 || len >= outlen)
+    if (inlen < 0 || inlen >= outlen)
         return -1;
     memset(out, 0, outlen);
-    strncpy(out, in, len);
-    *outdtsz = len;
+    strncpy(out, in, inlen);
+    *outdtsz = inlen;
     return 0;
 }
 
@@ -3365,14 +3345,12 @@ TYPES_INLINE int CLIENT_PSTR2_to_CLIENT_PSTR(
     blob_buffer_t *inblob, void *out, int outlen, int *outdtsz,
     const struct field_conv_opts *outopts, blob_buffer_t *outblob)
 {
-    int len;
     *outdtsz = 0;
-    len = pstr2lenlim(in, inlen);
-    if (len == -1 || len > outlen)
+    if (inlen == -1 || inlen > outlen)
         return -1;
     memset(out, ' ', outlen);
     *outdtsz = outlen;
-    strncpy(out, in, len);
+    strncpy(out, in, inlen);
     return 0;
 }
 
@@ -3381,13 +3359,11 @@ TYPES_INLINE int CLIENT_PSTR2_to_CLIENT_PSTR2(
     blob_buffer_t *inblob, void *out, int outlen, int *outdtsz,
     const struct field_conv_opts *outopts, blob_buffer_t *outblob)
 {
-    int len;
     *outdtsz = 0;
-    len = pstr2lenlim(in, inlen);
-    if (len == -1 || len > outlen)
+    if (inlen == -1 || inlen > outlen)
         return -1;
-    *outdtsz = len;
-    strncpy(out, in, len);
+    *outdtsz = inlen;
+    strncpy(out, in, inlen);
     return 0;
 }
 
@@ -4195,24 +4171,23 @@ TYPES_INLINE int CLIENT_PSTR2_to_SERVER_BCSTR(
     if (rc != 0)
         return -1;
 
-    int len = pstr2lenlim(in, inlen);
-    const int olen = len; // original len
-    if (len == -1)
+    const int olen = inlen; // original len
+    if (inlen == -1)
         return -1;
 
     uint8_t hdr = 0;
     bset(&hdr, data_bit);
-    if (len > outlen - 1) {
+    if (inlen > outlen - 1) {
         if (inopts && inopts->flags & FLD_CONV_TRUNCATE) {
-            len = outlen - 1;
+            inlen = outlen - 1;
         } else {
             return -1;
         }
     }
-    ++len;
-    set_data_int(out, in, len, hdr);
-    memset(out + len, 0, outlen - len);
-    *outdtsz = len;
+    ++inlen;
+    set_data_int(out, in, inlen, hdr);
+    memset(out + inlen, 0, outlen - inlen);
+    *outdtsz = inlen;
 
     if (olen > outlen - 1) {
         // Can't just set truncate bit
@@ -4223,7 +4198,7 @@ TYPES_INLINE int CLIENT_PSTR2_to_SERVER_BCSTR(
         // Walk backwards and increment first byte not 0xff
         if (inopts->step == 1) {
             uint8_t *a = (uint8_t *)out;
-            uint8_t *b = a + len - 1;
+            uint8_t *b = a + inlen - 1;
             while (b > a) {
                 if (*b != 0xff) {
                     ++(*b);
@@ -4250,6 +4225,13 @@ TYPES_INLINE int CLIENT_BYTEARRAY_to_SERVER_BYTEARRAY(
         set_null(out, outlen);
     } else {
         int rc;
+        if (inlen > outlen - 1) {
+            if (inopts && inopts->flags & FLD_CONV_TRUNCATE) {
+                inlen = outlen - 1;
+            } else {
+                return -1;
+            }
+        }
         rc = bytearray_copy(in, inlen, inopts, inblob, ((char *)out) + 1,
                             outlen - 1, outdtsz, outopts, outblob);
         if (-1 == rc)

--- a/db/types.h
+++ b/db/types.h
@@ -479,7 +479,6 @@ int cstrlenlim(const char *s, int lim);
 int cstrlenlimflipped(const unsigned char *s, int lim);
 int validate_cstr(const char *s, int lim);
 int validate_pstr(const char *s, int lim);
-int pstr2lenlim(const char *s, int lim);
 int pstrlenlim(const char *s, int lim);
 int CLIENT_UINT_to_CLIENT_UINT(const void *in, int inlen,
                                const struct field_conv_opts *inopts,

--- a/tests/outofrange_queries.test/queries
+++ b/tests/outofrange_queries.test/queries
@@ -8,10 +8,11 @@ create table t {schema {
     cstring c[4] null=yes
     u_short us null=yes
     u_int ui null=yes
+    byte b[1] null=yes
 }}$$
-insert into t values(null, null, null, null, null, null)
-insert into t values(-32768,-2147483648,-3.402823466e+38,'', 0, 0)
-insert into t values(32767,2147483647,3.402823466e+38,'zzz', 65535, 4294967295)
+insert into t values(null, null, null, null, null, null, null)
+insert into t values(-32768,-2147483648,-3.402823466e+38,'', 0, 0, x'01')
+insert into t values(32767,2147483647,3.402823466e+38,'zzz', 65535, 4294967295, x'02')
 
 drop table if exists u
 create table u {schema { cstring c[4] null=yes }}$$
@@ -24,11 +25,13 @@ drop table if exists v
 create table v {schema {
     cstring c0[4] null=yes
     cstring c1[4] null=yes
+    byte b0[1] null=yes
+    byte b1[1] null=yes
 }}$$
-insert into u values(null, null), (null, null), (null, null)
-insert into v values('aab', 'aab'), ('aab', 'aac'), ('aab', 'aad')
-insert into v values('aac', 'aab'), ('aac', 'aac'), ('aac', 'aad')
-insert into v values('aad', 'aab'), ('aad', 'aac'), ('aad', 'aad')
+insert into u values(null, null, null, null), (null, null, null, null), (null, null, null, null)
+insert into v values('aab', 'aab', x'00', x'11'), ('aab', 'aac', x'01', x'12'), ('aab', 'aad', x'02', x'13')
+insert into v values('aac', 'aab', x'20', x'31'), ('aac', 'aac', x'21', x'32'), ('aac', 'aad', x'22', x'33')
+insert into v values('aad', 'aab', x'40', x'51'), ('aad', 'aac', x'41', x'52'), ('aad', 'aad', x'42', x'53')
 EOF
 cdb2sql ${CDB2_OPTIONS} --exponent --precision 10 -s -f sqls $db $where >expected 2>&1
 
@@ -50,14 +53,18 @@ keys {
     "c" = c
     "us" = us
     "ui" = ui
+    "b" = b
 }}$$
 alter table u {schema { cstring c[4] null=yes } keys { dup "c" = c }}$$
 alter table v {schema {
     cstring c0[4] null=yes
     cstring c1[4] null=yes
+    byte b0[1] null=yes
+    byte b1[1] null=yes
 }
 keys {
     "c01" = c0 + c1
+    "b01" = b0 + b1
 }}$$
 EOF
 cdb2sql ${CDB2_OPTIONS} --exponent --precision 10 -s -f sqls $db $where >output1 2>&1
@@ -80,14 +87,18 @@ keys {
     "c" = <DESCEND> c
     "us" = <DESCEND> us
     "ui" = <DESCEND> ui
+    "b" = <DESCEND> b
 }}$$
 alter table u {schema { cstring c[4] null=yes } keys { dup "c" = <DESCEND> c }}$$
 alter table v {schema {
     cstring c0[4] null=yes
     cstring c1[4] null=yes
+    byte b0[1] null=yes
+    byte b1[1] null=yes
 }
 keys {
     "c01" = <DESCEND> c0 + <DESCEND> c1
+    "b01" = <DESCEND> b0 + <DESCEND> b1
 }}$$
 EOF
 cdb2sql ${CDB2_OPTIONS} --exponent --precision 10 -s -f sqls $db $where >output2 2>&1

--- a/tests/outofrange_queries.test/sqls
+++ b/tests/outofrange_queries.test/sqls
@@ -58,33 +58,71 @@ select  56 as query, c from u where c  = 'aadd' order by c desc
 select  57 as query, c from u where c  < 'aadd' order by c desc
 select  58 as query, c from u where c >= 'aadd' order by c desc
 select  59 as query, c from u where c <= 'aadd' order by c desc
-select  60 as query, * from v where c0  > 'aaaa' order by c0, c1
-select  61 as query, * from v where c0  = 'aaaa' order by c0, c1
-select  62 as query, * from v where c0  < 'aaaa' order by c0, c1
-select  63 as query, * from v where c0 >= 'aaaa' order by c0, c1
-select  64 as query, * from v where c0 <= 'aaaa' order by c0, c1
-select  65 as query, * from v where c0  > 'aabb' order by c0, c1
-select  66 as query, * from v where c0  = 'aabb' order by c0, c1
-select  67 as query, * from v where c0  < 'aabb' order by c0, c1
-select  68 as query, * from v where c0 >= 'aabb' order by c0, c1
-select  69 as query, * from v where c0 <= 'aabb' order by c0, c1
-select  70 as query, * from v where c0  > 'aadd' order by c0, c1
-select  71 as query, * from v where c0  = 'aadd' order by c0, c1
-select  72 as query, * from v where c0  < 'aadd' order by c0, c1
-select  73 as query, * from v where c0 >= 'aadd' order by c0, c1
-select  74 as query, * from v where c0 <= 'aadd' order by c0, c1
-select  75 as query, * from v where c0  > 'aaaa' order by c0 desc, c1 desc
-select  76 as query, * from v where c0  = 'aaaa' order by c0 desc, c1 desc
-select  77 as query, * from v where c0  < 'aaaa' order by c0 desc, c1 desc
-select  78 as query, * from v where c0 >= 'aaaa' order by c0 desc, c1 desc
-select  79 as query, * from v where c0 <= 'aaaa' order by c0 desc, c1 desc
-select  80 as query, * from v where c0  > 'aabb' order by c0 desc, c1 desc
-select  81 as query, * from v where c0  = 'aabb' order by c0 desc, c1 desc
-select  82 as query, * from v where c0  < 'aabb' order by c0 desc, c1 desc
-select  83 as query, * from v where c0 >= 'aabb' order by c0 desc, c1 desc
-select  84 as query, * from v where c0 <= 'aabb' order by c0 desc, c1 desc
-select  85 as query, * from v where c0  > 'aadd' order by c0 desc, c1 desc
-select  86 as query, * from v where c0  = 'aadd' order by c0 desc, c1 desc
-select  87 as query, * from v where c0  < 'aadd' order by c0 desc, c1 desc
-select  88 as query, * from v where c0 >= 'aadd' order by c0 desc, c1 desc
-select  89 as query, * from v where c0 <= 'aadd' order by c0 desc, c1 desc
+select  60 as query, * from v where c0  > 'aaaa' order by c0, c1, b0, b1
+select  61 as query, * from v where c0  = 'aaaa' order by c0, c1, b0, b1
+select  62 as query, * from v where c0  < 'aaaa' order by c0, c1, b0, b1
+select  63 as query, * from v where c0 >= 'aaaa' order by c0, c1, b0, b1
+select  64 as query, * from v where c0 <= 'aaaa' order by c0, c1, b0, b1
+select  65 as query, * from v where c0  > 'aabb' order by c0, c1, b0, b1
+select  66 as query, * from v where c0  = 'aabb' order by c0, c1, b0, b1
+select  67 as query, * from v where c0  < 'aabb' order by c0, c1, b0, b1
+select  68 as query, * from v where c0 >= 'aabb' order by c0, c1, b0, b1
+select  69 as query, * from v where c0 <= 'aabb' order by c0, c1, b0, b1
+select  70 as query, * from v where c0  > 'aadd' order by c0, c1, b0, b1
+select  71 as query, * from v where c0  = 'aadd' order by c0, c1, b0, b1
+select  72 as query, * from v where c0  < 'aadd' order by c0, c1, b0, b1
+select  73 as query, * from v where c0 >= 'aadd' order by c0, c1, b0, b1
+select  74 as query, * from v where c0 <= 'aadd' order by c0, c1, b0, b1
+select  75 as query, * from v where c0  > 'aaaa' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  76 as query, * from v where c0  = 'aaaa' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  77 as query, * from v where c0  < 'aaaa' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  78 as query, * from v where c0 >= 'aaaa' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  79 as query, * from v where c0 <= 'aaaa' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  80 as query, * from v where c0  > 'aabb' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  81 as query, * from v where c0  = 'aabb' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  82 as query, * from v where c0  < 'aabb' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  83 as query, * from v where c0 >= 'aabb' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  84 as query, * from v where c0 <= 'aabb' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  85 as query, * from v where c0  > 'aadd' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  86 as query, * from v where c0  = 'aadd' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  87 as query, * from v where c0  < 'aadd' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  88 as query, * from v where c0 >= 'aadd' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  89 as query, * from v where c0 <= 'aadd' order by c0 desc, c1 desc, b0 desc, b1 desc
+select  90 as query, b from t where b >= x'ff'       order by b
+select  91 as query, b from t where b >= x'00'       order by b
+select  92 as query, b from t where b >= x'ffffffff' order by b
+select  93 as query, b from t where b >= x'00000000' order by b
+select  95 as query, b from t where b <= x'ff'       order by b
+select  96 as query, b from t where b <= x'00'       order by b
+select  97 as query, b from t where b <= x'ffffffff' order by b
+select  98 as query, b from t where b <= x'00000000' order by b
+select  99 as query, * from v where b0  > x'01aa' order by b0,      b1     , c0     , c1
+select 100 as query, * from v where b0  = x'21aa' order by b0,      b1     , c0     , c1
+select 101 as query, * from v where b0  < x'41aa' order by b0,      b1     , c0     , c1
+select 102 as query, * from v where b0 >= x'02aa' order by b0,      b1     , c0     , c1
+select 103 as query, * from v where b0 <= x'22aa' order by b0,      b1     , c0     , c1
+select 104 as query, * from v where b0  > x'42bb' order by b0,      b1     , c0     , c1
+select 105 as query, * from v where b1  = x'12bb' order by b0,      b1     , c0     , c1
+select 106 as query, * from v where b1  < x'32bb' order by b0,      b1     , c0     , c1
+select 107 as query, * from v where b1 >= x'52bb' order by b0,      b1     , c0     , c1
+select 108 as query, * from v where b1 <= x'13bb' order by b0,      b1     , c0     , c1
+select 109 as query, * from v where b1  > x'33dd' order by b0,      b1     , c0     , c1
+select 110 as query, * from v where b1  = x'53dd' order by b0,      b1     , c0     , c1
+select 111 as query, * from v where b0  < x'ffdd' order by b0,      b1     , c0     , c1
+select 112 as query, * from v where b1 >= x'ffdd' order by b0,      b1     , c0     , c1
+select 113 as query, * from v where b1 <= x'ffdd' order by b0,      b1     , c0     , c1
+select 114 as query, * from v where b0  > x'01aa' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 115 as query, * from v where b0  = x'21aa' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 116 as query, * from v where b0  < x'41aa' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 117 as query, * from v where b0 >= x'02aa' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 118 as query, * from v where b0 <= x'22aa' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 119 as query, * from v where b0  > x'42bb' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 120 as query, * from v where b1  = x'12bb' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 121 as query, * from v where b1  < x'32bb' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 122 as query, * from v where b1 >= x'52bb' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 123 as query, * from v where b1 <= x'13bb' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 124 as query, * from v where b1  > x'33dd' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 125 as query, * from v where b1  = x'53dd' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 126 as query, * from v where b0  < x'ffdd' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 127 as query, * from v where b1 >= x'ffdd' order by b0 desc, b1 desc, c0 desc, c1 desc
+select 128 as query, * from v where b1 <= x'ffdd' order by b0 desc, b1 desc, c0 desc, c1 desc

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -344,7 +344,7 @@
 (name='keep_referenced_files', description='Don't remove any files that may still be referenced by the logs.', type='BOOLEAN', value='ON', read_only='N')
 (name='key_updates', description='Update non-dupe keys instead of delete/add', type='BOOLEAN', value='ON', read_only='N')
 (name='keycompr', description='Enable index compression (applies to newly allocated index pages, rebuild table to force for all pages.', type='BOOLEAN', value='ON', read_only='Y')
-(name='large_str_idx_find', description='Allow index search using out or range strings', type='BOOLEAN', value='ON', read_only='N')
+(name='large_str_idx_find', description='Allow index search using out-of-range strings or bytearrays', type='BOOLEAN', value='ON', read_only='N')
 (name='largepages', description='Enables large pages. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='latch_max_poll', description='Poll latch this many times before returning deadlock', type='INTEGER', value='5', read_only='N')
 (name='latch_max_wait', description='Block at most this many microseconds before returning deadlock', type='INTEGER', value='5000', read_only='N')


### PR DESCRIPTION
To reproduce, run the following queries:

```SQL
create table bytes (a byte(1))
create index bytes_a on bytes(a)
insert into bytes values(x'11')
select * from bytes where a >x'ffff'
```
