### PR TITLE
db: Fix trigger_register and trigger_clear_hash deadlock.

### DIFF
--- a/db/trigger.c
+++ b/db/trigger.c
@@ -83,11 +83,11 @@ static inline int trigger_register_int(trigger_reg_t *t)
 int trigger_register(trigger_reg_t *t)
 {
     GET_BDB_STATE(bdb_state);
-    pthread_mutex_lock(&trighash_lk);
     BDB_READLOCK("register trigger");
+    pthread_mutex_lock(&trighash_lk);
     int rc = trigger_register_int(t);
-    BDB_RELLOCK();
     pthread_mutex_unlock(&trighash_lk);
+    BDB_RELLOCK();
     return rc;
 }
 


### PR DESCRIPTION
The following chart shows how to reproduce the deadlock.

```
Master <------------- NET_TRIGGER_REGISTER ---------- Replicant
  |
trigger_register()
  |
Acquires trighash_lk
  |
  | <--- Mastership changes to another node.
  | <--- Mastership changes back to this node.
  |
  +----------------------------------------------------+
  |                                                    |
  |                                                bdb_upgrade()
  |                                                    |
  |                                     Acquires bdb write lock
  |                                                    |
  |                                        trigger_clear_hash()
  |                                                    |
Waiting for bdb readlock                Waiting for trighash_lk
```
