### PR TITLE
Fix cbuild again- specify tclsh8.5 first

### DIFF
--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -123,7 +123,7 @@ add_custom_command(
   COMMAND mkkeywordhash > keywordhash.h
 )
 
-find_program(tclsh NAMES tclsh tclsh8.5)
+find_program(tclsh NAMES tclsh8.5 tclsh)
 add_executable(lemon lemon.c)
 add_custom_command(
   OUTPUT parse.c parse.h


### PR DESCRIPTION
tclsh is broken on one of our build machines- hack around it: specify the versioned tclsh first in the makefile