### PR TITLE
Send actual logs rather than random data

### DIFF
--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -427,7 +427,7 @@ static int tranlogColumn(
         }
         break;
     case TRANLOG_COLUMN_LOG:
-        sqlite3_result_blob(ctx, &pCur->data.data, pCur->data.size, NULL);
+        sqlite3_result_blob(ctx, pCur->data.data, pCur->data.size, NULL);
         break;
   }
   return SQLITE_OK;


### PR DESCRIPTION
One-character change: the previous version was sending random data, not the actual log-records