### PR TITLE
transactions that have DDLs are not retriable

### DIFF
--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -3144,6 +3144,7 @@ static int osql_create_schemachange_temptbl(bdb_state_type *bdb_state,
                                             int *bdberr)
 {
     osqlstate_t *osql = &clnt->osql;
+    osql->running_ddl = 1;
     return osql_create_temptbl(bdb_state, &osql->sc_tbl, &osql->sc_cur, bdberr);
 }
 
@@ -3151,6 +3152,7 @@ static int osql_destroy_schemachange_temptbl(bdb_state_type *bdb_state,
                                              struct sqlclntstate *clnt)
 {
     osqlstate_t *osql = &clnt->osql;
+    osql->running_ddl = 0;
     return osql_destroy_temptbl(bdb_state, &osql->sc_tbl, &osql->sc_cur);
 }
 

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -906,6 +906,14 @@ err:
        }
    }
 
+   /* DDLs are also non-retriable */
+   if (osql->xerr.errval == (ERR_BLOCK_FAILED + ERR_VERIFY) &&
+       osql->running_ddl) {
+       logmsg(LOGMSG_DEBUG, "%s: marking DDL transaction as non-retriable\n",
+              __func__);
+       osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_LAST);
+   }
+
    osql_shadtbl_close(clnt);
 
    if (clnt->dbtran.mode == TRANLEVEL_SOSQL) {

--- a/sqlite/comdb2build.c
+++ b/sqlite/comdb2build.c
@@ -311,7 +311,6 @@ int comdb2PrepareSC(Vdbe *v, Parse *pParse, int int_arg,
         sqlite3VdbeAddTable(v, t);
     }
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    thd->clnt->verifyretry_off = 1;
     return comdb2prepareNoRows(v, pParse, int_arg, arg, func, freeFunc);
 }
 

--- a/tests/verify_error.test/t2_01.req
+++ b/tests/verify_error.test/t2_01.req
@@ -1,0 +1,28 @@
+1 create table test1 (i int primary key, j int)
+2 create table test2 (i int primary key, j int)
+1 insert into test1 values (1, 1)
+2 insert into test2 values (1, 1)
+1 begin
+1 update test1 set j = j + 1
+2 update test1 set j = j + 1
+1 commit
+1 select * from test1
+1 begin
+1 update test1 set j = j + 1
+2 update test1 set j = j + 1
+1 truncate test2
+1 commit
+1 select * from test1
+1 select * from test2
+1 begin
+1 update test1 set j = j + 1
+2 update test1 set j = j + 1
+1 commit
+1 select * from test1
+1 begin
+1 update test1 set j = j + 1
+1 truncate test2
+2 create index idx on test2(j)
+1 commit
+1 select * from test1
+1 select * from test2

--- a/tests/verify_error.test/t2_01.req.out
+++ b/tests/verify_error.test/t2_01.req.out
@@ -1,0 +1,41 @@
+done
+done
+(rows inserted=1)
+done
+(rows inserted=1)
+done
+done
+done
+(rows updated=1)
+done
+done
+(i=1, j=3)
+done
+done
+done
+(rows updated=1)
+done
+done
+[commit] failed with rc 2 find old record failed unable to update record rc = 4
+done
+(i=1, j=4)
+done
+(i=1, j=1)
+done
+done
+done
+(rows updated=1)
+done
+done
+(i=1, j=6)
+done
+done
+done
+done
+done
+[commit] failed with rc 240 stale version for table:test2 master:1 replicant:0
+done
+(i=1, j=6)
+done
+(i=1, j=1)
+done


### PR DESCRIPTION
- transactions that have DDLs are not retriable (by setting `OSQL_RETRY_LAST` in `osql_sock_commit`)
- fixed #1006 
- added testcase in verify_error.test
