### PR TITLE
fix table verify for partial unique indexes

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -585,7 +585,8 @@ static int bdb_verify_ll(
 
                 rc = ckey->c_get(ckey, &dbt_key, &dbt_data, DB_SET);
                 if (!(has_keys & (1ULL << ix))) {
-                    if (!rc) {
+                    if (!rc &&
+                        (bdb_state->ixdups[ix] || genid == verify_genid)) {
                         ret = 1;
                         locprint(
                             sb, lua_callback, lua_params,

--- a/tests/rawindex.test/t14.req
+++ b/tests/rawindex.test/t14.req
@@ -1,0 +1,11 @@
+drop table if exists t14
+create table t14 (i int, j int) $$
+create unique index t14idx on t14(i) where j > 5
+insert into t14 values (1, 1)
+insert into t14 values (1, 3)
+insert into t14 values (1, 5)
+insert into t14 values (1, 7)
+insert into t14 values (1, 9)
+select * from t14 where j > 5 order by j
+select * from t14 order by j
+exec procedure sys.cmd.verify('t14')

--- a/tests/rawindex.test/t14.req.out
+++ b/tests/rawindex.test/t14.req.out
@@ -1,0 +1,11 @@
+(rows inserted=1)
+(rows inserted=1)
+(rows inserted=1)
+(rows inserted=1)
+[insert into t14 values (1, 9)] failed with rc 299 add key constraint duplicate key 'T14IDX' on table 't14' index 0
+(i=1, j=7)
+(i=1, j=1)
+(i=1, j=3)
+(i=1, j=5)
+(i=1, j=7)
+(out='Verify succeeded.')


### PR DESCRIPTION
If a row is not supposed to be part of a unique index, report errors if
we can find the same index value in the unique index btree AND the genid
is the same as the row's genid.

I had a bug before where I did not check genid and the verify code reported false positives