### PR TITLE
Provide flag for retrieve log records in reverse order

### DIFF
--- a/sqlite/ext/comdb2/tranlog.h
+++ b/sqlite/ext/comdb2/tranlog.h
@@ -5,6 +5,7 @@
 enum {
     TRANLOG_FLAGS_BLOCK             = 0x1,
     TRANLOG_FLAGS_DURABLE           = 0x2,
+    TRANLOG_FLAGS_DESCENDING        = 0x4,
 };
 
 #endif


### PR DESCRIPTION
Allow requests the transaction logs in descending order via the TRANLOG_FLAGS_DESCENDING flag.
