### PR TITLE
sqlite: Dynamically adjust periodical sampling frequency.

### DIFF
--- a/sqlite/analyze.c
+++ b/sqlite/analyze.c
@@ -666,6 +666,19 @@ static void sampleInsert(Stat4Accum *p, Stat4Sample *pNew, int nEqZero){
         iMin = i;
       }
     }
+    /* >>>>>> COMDB2 MODIFICATION */
+    if( iMin==-1 ){
+      /* Number of records has increased N times (N > ~200%) since statInit(),
+         however we don't know what N is. Assume that N is 2. It takes log3(N)
+         iterations to get the right sample frequency. Note that This approach
+         will make the sampling distribution more left skewed. */
+      p->nPSample *= 3;
+      for(i=0; i<p->mxSample; i+=3){
+        p->a[i].isPSample = 0;
+      }
+      goto find_new_min;
+    }
+    /* <<<<<< COMDB2 MODIFICATION */
     assert( iMin>=0 );
     p->iMin = iMin;
   }

--- a/tests/analyze_insert_burst.test/Makefile
+++ b/tests/analyze_insert_burst.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/analyze_insert_burst.test/runit
+++ b/tests/analyze_insert_burst.test/runit
@@ -26,8 +26,8 @@ keep_inserting=$!
 
 for i in `seq 1 500`; do
   echo iteration $i
-  cdb2sql ${CDB2_OPTIONS} $dbnm 'truncate table t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
-  cdb2sql ${CDB2_OPTIONS} $dbnm 'analyze t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
+  cdb2sql ${CDB2_OPTIONS} $dbnm default 'truncate table t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
+  cdb2sql ${CDB2_OPTIONS} $dbnm default 'analyze t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
 done
 
 kill -9 $keep_inserting || true

--- a/tests/analyze_insert_burst.test/runit
+++ b/tests/analyze_insert_burst.test/runit
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+##################################################################
+# Verify that analyze works correctly under high rate insertion. #
+##################################################################
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t (i INT)'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE INDEX t_i ON t(i)'
+
+nsamples=$(cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT cast(value as INT) + 24 FROM comdb2_tunables WHERE name = "stat4_extra_samples"')
+
+echo nSamples is $nsamples
+
+while true; do
+cat << EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - >/dev/null 2>&1
+BEGIN
+$(for i in `seq 1 $nsamples`; do echo 'INSERT INTO t values('$i')'; done)
+COMMIT
+EOF
+done &
+
+keep_inserting=$!
+
+for i in `seq 1 500`; do
+  echo iteration $i
+  cdb2sql ${CDB2_OPTIONS} $dbnm 'truncate table t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
+  cdb2sql ${CDB2_OPTIONS} $dbnm 'analyze t' >/dev/null || { kill -9 $keep_inserting; exit 1; }
+done
+
+kill -9 $keep_inserting || true


### PR DESCRIPTION
Analyze will crash if the number of records in the table has increased significantly during analyze.
The patch fixes it by increasing the peridical sampling frequency on the fly to make room for non-periodical samples.