### PR TITLE
 Check for the terminating '\0' in bound string to adjust the supplied length

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2662,6 +2662,19 @@ int get_prepared_stmt_try_lock(struct sqlthdstate *thd,
     return rc;
 }
 
+static void fix_cstr_len(void *str /* IN */, int *len /* INOUT */)
+{
+    char *tmp = str;
+    int out_len = 0;
+
+    while (*tmp != '\0' && out_len < *len) {
+        ++tmp;
+        ++out_len;
+    }
+
+    *len = out_len;
+}
+
 static int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt,
                            struct sqlclntstate *clnt, char **err)
 {
@@ -2699,6 +2712,7 @@ static int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt,
         case CLIENT_CSTR:
         case CLIENT_PSTR:
         case CLIENT_PSTR2:
+            fix_cstr_len((char *)p.u.p, &p.len);
             rc = sqlite3_bind_text(stmt, p.pos, p.u.p, p.len, NULL);
             eventlog_bind_text(arr, p.name, p.u.p, p.len);
             break;

--- a/tests/tools/cdb2bind.c
+++ b/tests/tools/cdb2bind.c
@@ -1,83 +1,146 @@
 #include <stdlib.h>
 #include <cdb2api.h>
+#include <string.h>
 
-int main(int argc, char *argv[])
+const char *db;
+
+/* ========================== Helper functions  =========================== */
+
+/* Open a handle */
+void test_open(cdb2_hndl_tp **hndl, const char *db)
 {
-    char *dbname=argv[1];
-    cdb2_hndl_tp *hndl = NULL;
-
     int rc = 0;
-    if(NULL == dbname)
-    {
-        fprintf(stderr, "Dbname is not set!\n");
-        return -1;
+
+    if (!db) {
+        fprintf(stderr, "db is not set!\n");
+        exit(1);
     }
 
-    char * dest = "local";
+    /* Create a handle */
+    char *dest = "local";
     char *conf = getenv("CDB2_CONFIG");
     if (conf) {
         cdb2_set_comdb2db_config(conf);
         dest = "default";
     }
 
-    rc = cdb2_open(&hndl, dbname, dest, 0);
-    if(rc!=0)
-    {
-        fprintf(stderr, "error opening sql handle for %s, rc=%d\n", dbname, rc);
-        return rc;
+    rc = cdb2_open(hndl, db, dest, 0);
+    if (rc) {
+        {
+            fprintf(stderr, "error opening connection handle for %s (rc: %d)\n",
+                    db, rc);
+            exit(1);
+        }
     }
-
-    long long int id = 0;
-
-    rc = cdb2_bind_param(hndl, "id", CDB2_INTEGER, &id,  sizeof(long long int));
-    if(rc!=0) {
-        fprintf(stderr, "error binding id rc=%d \n", rc);
-         return rc;
-    }
-
-    for (id =0; id < 100; id++) {
-       rc = cdb2_run_statement(hndl, "select @id");
-       if(rc!=0) {
-           fprintf(stderr, "error running sql %d\n", rc);
-           return rc;
-       }
-       rc = cdb2_next_record(hndl);
-       if(rc!=0) {
-           fprintf(stderr, "error in cdb2_next_record %d\n", rc);
-           return rc;
-       }
-       long long *val = cdb2_column_value(hndl, 0);
-       if (*val != id) {
-           fprintf(stderr, "error got:%lld expected:%lld\n", *val, id);
-           return -1;
-       }
-    }
-    cdb2_clearbindings(hndl);
-
-    rc = cdb2_bind_index(hndl, 1, CDB2_INTEGER, &id,  sizeof(long long int));
-    if(rc!=0) {
-        fprintf(stderr, "error binding id rc=%d \n", rc);
-         return rc;
-    }
-
-    for (id =0; id < 100; id++) {
-       rc = cdb2_run_statement(hndl, "select ?");
-       if(rc!=0) {
-           fprintf(stderr, "error running sql %d\n", rc);
-           return rc;
-       }
-       rc = cdb2_next_record(hndl);
-       if(rc!=0) {
-           fprintf(stderr, "error in cdb2_next_record %d\n", rc);
-           return rc;
-       }
-       long long *val = cdb2_column_value(hndl, 0);
-       if (*val != id) {
-           fprintf(stderr, "error got:%lld expected:%lld\n", *val, id);
-           return -1;
-       }
-    }
-    cdb2_clearbindings(hndl);
-    return rc;
 }
 
+/* Bind a parameter. */
+void test_bind_param(cdb2_hndl_tp *hndl, const char *name, int type,
+                     const void *varaddr, int length)
+{
+    int rc;
+    rc = cdb2_bind_param(hndl, name, type, varaddr, length);
+    if (rc != 0) {
+        fprintf(stderr, "error binding parameter %s (err: %s)\n", name,
+                cdb2_errstr(hndl));
+        exit(1);
+    }
+}
+
+/* Bind a parameter at the specified index. */
+void test_bind_index(cdb2_hndl_tp *hndl, int index, int type,
+                     const void *varaddr, int length)
+{
+    int rc;
+    rc = cdb2_bind_index(hndl, index, type, varaddr, length);
+    if (rc != 0) {
+        fprintf(stderr, "error binding parameter %d (err: %s)\n", index,
+                cdb2_errstr(hndl));
+        exit(1);
+    }
+}
+
+/* Execute a SQL query. */
+void test_exec(cdb2_hndl_tp *hndl, const char *cmd)
+{
+    int rc;
+    rc = cdb2_run_statement(hndl, cmd);
+    if (rc != 0) {
+        fprintf(stderr, "error execing %s (err: %s)\n", cmd, cdb2_errstr(hndl));
+        exit(1);
+    }
+}
+
+/* Move to next record in the result set. */
+void test_next_record(cdb2_hndl_tp *hndl)
+{
+    int rc;
+    rc = cdb2_next_record(hndl);
+    if (rc != 0) {
+        fprintf(stderr, "error in cdb2_next_record (err: %s)\n",
+                cdb2_errstr(hndl));
+        exit(1);
+    }
+}
+
+/* Close the handle */
+void test_close(cdb2_hndl_tp *hndl)
+{
+    int rc;
+    rc = cdb2_close(hndl);
+    if (rc != 0) {
+        fprintf(stderr, "error closing handle (err: %s, rc: %d)\n",
+                cdb2_errstr(hndl), rc);
+        exit(1);
+    }
+}
+
+/* ========================== Tests  =========================== */
+
+void test_01()
+{
+    cdb2_hndl_tp *hndl = NULL;
+    long long int id = 0;
+
+    test_open(&hndl, db);
+    test_bind_param(hndl, "id", CDB2_INTEGER, &id, sizeof(long long int));
+
+    for (id = 0; id < 100; id++) {
+        long long *val;
+
+        test_exec(hndl, "select @id");
+        test_next_record(hndl);
+        val = cdb2_column_value(hndl, 0);
+        if (*val != id) {
+            fprintf(stderr, "error got:%lld expected:%lld\n", *val, id);
+            exit(1);
+        }
+    }
+    cdb2_clearbindings(hndl);
+
+    test_bind_index(hndl, 1, CDB2_INTEGER, &id, sizeof(long long int));
+
+    for (id = 0; id < 100; id++) {
+        long long *val;
+
+        test_exec(hndl, "select ?");
+        test_next_record(hndl);
+        val = cdb2_column_value(hndl, 0);
+        if (*val != id) {
+            fprintf(stderr, "error got:%lld expected:%lld\n", *val, id);
+            exit(1);
+        }
+    }
+    cdb2_clearbindings(hndl);
+
+    test_close(hndl);
+}
+
+int main(int argc, char *argv[])
+{
+    db = argv[1];
+
+    test_01();
+
+    return 0;
+}


### PR DESCRIPTION
This is needed to preserve the backwards compatibility with R6, which worked
even when the bound string's length included the terminating '\0'.