### PR TITLE
Feature: Allow running cdb2sockpool in foreground

### DIFF
--- a/tools/cdb2sockpool/cdb2sockpool.c
+++ b/tools/cdb2sockpool/cdb2sockpool.c
@@ -93,6 +93,7 @@ struct client {
 
 static char unix_bind_path[128] = SOCKPOOL_SOCKET_NAME;
 static char msgtrap_fifo[128] = "/tmp/msgtrap.sockpool";
+static int foreground_mode = 0;
 
 static struct stat save_st;
 
@@ -1135,7 +1136,7 @@ int main(int argc, char *argv[])
 
     optind = 1;
 
-    while ((c = getopt(argc, argv, "p:")) != EOF) {
+    while ((c = getopt(argc, argv, "p:f")) != EOF) {
         switch (c) {
         case 'p':
             /* Of the two limits sizeof(sun_addr.sun_path) is smaller */
@@ -1144,6 +1145,10 @@ int main(int argc, char *argv[])
                 exit(2);
             }
             strncpy(unix_bind_path, optarg, sizeof(unix_bind_path));
+            break;
+
+        case 'f':
+            foreground_mode = 1;
             break;
 
         case '?':
@@ -1220,7 +1225,9 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    bb_daemon();
+    if (!foreground_mode) {
+        bb_daemon();
+    }
 
     if (pthread_create_attrs(NULL, PTHREAD_CREATE_DETACHED, 64 * 1024,
                              accept_thd, (void *)(intptr_t)listenfd) != 0) {


### PR DESCRIPTION
# Overview
`cdb2sockpool` demonises itself by default and has no option to run in foreground. A better approach (according to *nix best practices) would be to offer both foreground and background options to the user. This is something that many daemons and other COMDB2 tools do already (e.g., `pmux` via `-f` flag). New behaviour follows this example to implement a similar flag for `cdb2sockpool` and offers user more control. If flag is unspecified, startup procedure follows the existing behaviour, so current users are unaffected. Both startup modes were tested and successfully accepted socket donations and fulfilled socket requests.

### Type of the change
Feature

### Current behaviour
Unable to run `cdb2sockpool` in foreground.

### New behaviour
Allows to run `cdb2sockpool` in foreground by passing in `-f` flag. This makes the daemon easier to integrate with a wider range of supervisors/init systems. Additionally, it makes troubleshooting easier in the development environment.  
