### PR TITLE
Bug: Fix the typo in client API config initialisation

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1092,7 +1092,8 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok)
                     cdb2_tcpbufsz = atoi(tok);
-            } else if (strcasecmp("dnssufix", tok) == 0 || strcasecmp("dnssuffix", tok) == 0) {
+            } else if (strcasecmp("dnssufix", tok) == 0 ||
+                       strcasecmp("dnssuffix", tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok)
                     strcpy(cdb2_dnssuffix, tok);

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1092,7 +1092,7 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok)
                     cdb2_tcpbufsz = atoi(tok);
-            } else if (strcasecmp("dnssufix", tok) == 0) {
+            } else if (strcasecmp("dnssufix", tok) == 0 || strcasecmp("dnssuffix", tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok)
                     strcpy(cdb2_dnssuffix, tok);


### PR DESCRIPTION
# Overview
The [documentation](https://bloomberg.github.io/comdb2/clients.html#dnssuffix) indicates that `dnssuffix` is the configuration key for specifying the location of COMDB2 databases via DNS. However, the client code is currently looking for `dnssufix` key instead (seems to be a minor typo). To preserve the current behaviour, the client code was modified to support both correct and wrong spellings.

### Type of the change
Bug

### Current behaviour
Unable to provide DNS suffix via the documented configuration key.

### New behaviour
Allows providing DNS suffix with both documented and misspelled versions.
