### PR TITLE
VDBE integration fix to address writing to invalid memory during query execution.

### DIFF
--- a/sqlite/vdbe.c
+++ b/sqlite/vdbe.c
@@ -5647,7 +5647,7 @@ next_tail:
   }
 
   /* COMDB2 MODIFICATION */
-  setCookCol(pC, 0);
+  if( pC->eCurType==CURTYPE_BTREE ) setCookCol(pC, 0);
   goto check_for_interrupt;
 }
 


### PR DESCRIPTION

This check-in fixes an important heap corruption issue resulting from misuse of a union when processing the "OP_SorterNext" VDBE opcode.