### PR TITLE
Return lua error rather than crash if user attempt to emit nothing

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -4790,7 +4790,9 @@ static int l_send_back_row(Lua lua, sqlite3_stmt *stmt, int nargs)
 {
     int rc = 0;
     SP sp = getsp(lua);
-    assert(nargs > 0);
+    if (nargs <= 0) {
+        return luabb_error(lua, sp, "no row to send back");
+    }
     if (nargs > MAXCOLUMNS) {
         return luabb_error(lua, sp, "attempt to read %d cols (maxcols:%d)",
                            nargs, MAXCOLUMNS);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -4790,9 +4790,7 @@ static int l_send_back_row(Lua lua, sqlite3_stmt *stmt, int nargs)
 {
     int rc = 0;
     SP sp = getsp(lua);
-    if (nargs <= 0) {
-        return luabb_error(lua, sp, "no row to send back");
-    }
+    luaL_argcheck(lua, nargs > 0, 1, "no row to send back");
     if (nargs > MAXCOLUMNS) {
         return luabb_error(lua, sp, "attempt to read %d cols (maxcols:%d)",
                            nargs, MAXCOLUMNS);

--- a/tests/sp.test/t04.req
+++ b/tests/sp.test/t04.req
@@ -1,0 +1,6 @@
+create procedure testempty version 'testempty' {
+local function main()
+   db:emit()
+end
+}$$
+exec procedure testempty()

--- a/tests/sp.test/t04.req.out
+++ b/tests/sp.test/t04.req.out
@@ -1,0 +1,2 @@
+(version='testempty')
+[exec procedure testempty()] failed with rc -3 [db:emit()...]:3: calling 'emit' on bad self (no row to send back)


### PR DESCRIPTION
Discovered this when I accidentally wrote a buggy lua sp- if you attempt to emit a select from a table with no rows the database aborts on an assert.  This branch removes the assert and returns an error message.
