### PR TITLE
skip hostname from cluster line correctly

### DIFF
--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -102,7 +102,10 @@ find_cores() {
     fi
 
 
-    for node in ${CLUSTER/$HOSTNAME/} ; do
+    for node in ${CLUSTER} ; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
         if [ $has_pattern -eq 1 ] ; then
             PIDFL=${TMPDIR}/${DBNAME}.pid
             local PID=`ssh -o StrictHostKeyChecking=no $node "cat ${PIDFL} 2> /dev/null" </dev/null`

--- a/tests/setup
+++ b/tests/setup
@@ -280,13 +280,19 @@ else
 
     i=0
     declare -a pids
-    for node in ${CLUSTER/$HOSTNAME/}; do
+    for node in ${CLUSTER}; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
         cat $ARFILE | ssh $SSH_OPT $node "cd ${DBDIR}; $COMDB2AR_EXE $COMDB2AR_EXOPTS $COMDB2AR_AROPTS -u 95 x $DBDIR" &> $TESTDIR/logs/${DBNAME}.${node}.copy &
         pids[$i]=$!
         let i=i+1
     done
     i=0
-    for node in ${CLUSTER/$HOSTNAME/}; do
+    for node in ${CLUSTER}; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
         wait ${pids[$i]}
         if [[ $? -ne 0 ]]; then
             echo "FAILED: copying ${LRL} ${node}: see $TESTDIR/logs/${DBNAME}.${node}.copy"

--- a/tests/tools/copy_files_to_cluster.sh
+++ b/tests/tools/copy_files_to_cluster.sh
@@ -65,17 +65,19 @@ copy_files_to_cluster()
     local node
     local i=0
     declare -a pids
-    for node in ${CLUSTER/$HOSTNAME/}; do
+    for node in ${CLUSTER}; do
         if [ $node == $HOSTNAME ] ; then
-            echo "Error: hostname is in the CLUSTER list -HOSTNAME"
-            exit 1
+            continue
         fi
         copy_files_to_node $node &
         pids[$i]=$!
         let i=i+1
     done
     i=0
-    for node in ${CLUSTER/$HOSTNAME/}; do
+    for node in ${CLUSTER}; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
         wait ${pids[$i]}
         let i=i+1
     done

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -69,9 +69,12 @@ core_all_nodes() {
         cat ${pidfl} | xargs kill -6 
     fi
 
-    for node in ${CLUSTER/$HOSTNAME/} ; do
-         pidfl=${TMPDIR}/${DBNAME}.pid
-         ssh -o StrictHostKeyChecking=no $node "cat ${pidfl} | xargs kill -6 " </dev/null
+    for node in ${CLUSTER} ; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
+        pidfl=${TMPDIR}/${DBNAME}.pid
+        ssh -o StrictHostKeyChecking=no $node "cat ${pidfl} | xargs kill -6 " </dev/null
     done
 }
 
@@ -90,7 +93,10 @@ cleanup_cluster() {
     fi
 
     local node
-    for node in ${CLUSTER/$HOSTNAME/}; do
+    for node in ${CLUSTER}; do
+        if [ $node == $HOSTNAME ] ; then
+            continue
+        fi
         dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh -h $node "get comdb2/replication/${DBNAME}" ${pmux_port}`
         echo "deregistering $DBNAME (port $dbport) from $node pmux:$pmux_port"
         ssh -o StrictHostKeyChecking=no $node "${deregister_db_port}" < /dev/null


### PR DESCRIPTION
if clusternode contains as substring client node name (ex node_c1345 and c1), the test setup will strip out the substring because of bash replace function, resulting in test failure. This checkin fixes that by simply skipping (calling continue) client node if part of cluster.