### PR TITLE
schemachange: Don't double close an SBUF object.

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -175,6 +175,7 @@ static int master_downgrading(struct schema_change_type *s)
             sbuf2printf(s->sb, "!Master node downgrading - new master will "
                                "resume schemachange\n");
             sbuf2close(s->sb);
+            s->sb = NULL;
         }
         logmsg(
             LOGMSG_WARN,

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -89,7 +89,6 @@ void free_schema_change_type(struct schema_change_type *s)
         if (s->sb && s->must_close_sb) close_appsock(s->sb);
         if (!s->onstack) {
             free(s);
-            s = NULL;
         }
     }
 }


### PR DESCRIPTION
When the master downgrades while performing a schema change, it sends an error to the schema change client and closes its SBUF. It then closes it again as part of the regular cleanup in free_schema_change_type().