### PR TITLE
Option to build with legacy defaults

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,8 @@ if(WITH_TCL)
   find_package(Tcl REQUIRED)
 endif()
 
+option(COMDB2_LEGACY_DEFAULTS "Legacy defaults without lrl override" OFF)
+
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(prefix /opt/bb)
   if(DEFINED ENV{COMDB2_ROOT})
@@ -63,13 +65,13 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${prefix} CACHE PATH ${helpstring} FORCE)
 endif()
 
-if(DEFINED COMDB2_ROOT)
-    add_definitions(-DCOMDB2_ROOT=${COMDB2_ROOT})
-else()
-    add_definitions(-DCOMDB2_ROOT=${CMAKE_INSTALL_PREFIX})
+if(NOT DEFINED COMDB2_ROOT)
+    set(COMDB2_ROOT ${CMAKE_INSTALL_PREFIX})
 endif()
+set(COMDB2_ROOT ${COMDB2_ROOT} CACHE PATH "Directory for runtime files" FORCE)
 
 add_definitions(
+  -DCOMDB2_ROOT=${COMDB2_ROOT}
   -DCOMDB2_VERSION="2"
   -D_FILE_OFFSET_BITS=64
 )

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -103,6 +103,10 @@ if(DEBUG_TYPES)
   add_definitions(-DDEBUG_TYPES)
 endif()
 
+if(COMDB2_LEGACY_DEFAULTS)
+  add_definitions(-DLEGACY_DEFAULTS)
+endif()
+
 add_executable(comdb2 ${src})
 set(module uncategorized)
 set(MODULE UNCATEGORIZED)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -54,6 +54,9 @@ set(src
 if(WITH_SSL)
   list(APPEND src ssl_support.c)
 endif()
+if(COMDB2_LEGACY_DEFAULTS)
+  add_definitions(-DLEGACY_DEFAULTS)
+endif()
 add_library(util ${src})
 include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}

--- a/util/comdb2file.c
+++ b/util/comdb2file.c
@@ -36,10 +36,7 @@ struct location {
 
 #define LOCATION_SEP " \t\n"
 
-static void add_location(char *type, char *dir);
-static int load_locations_from(char *path);
-
-static void add_location(char *type, char *dir)
+static void add_location(char *type, const char *dir)
 {
     struct location *l;
 
@@ -152,12 +149,23 @@ void init_file_locations(char *lrlname)
     if (strlen(gbl_config_root) == 0)         /* not set */
         gbl_config_root = "/";
 
+    const char *logs, *config, *marker, *tzdata;
+#   ifdef LEGACY_DEFAULTS
+    logs = "data";
+    config = "bin";
+    marker = "bin";
+#   else
+    logs = "var/log/cdb2";
+    config = "etc/cdb2/config";
+    marker = "tmp/cdb2";
+#   endif
+
     /* init defaults */
-    DEFAULT_LOCATION("logs", "var/log/cdb2");
-    DEFAULT_LOCATION("marker", "tmp/cdb2");
+    DEFAULT_LOCATION("logs", logs);
+    DEFAULT_LOCATION("marker", marker);
     DEFAULT_LOCATION("debug", "var/log/cdb2");
     DEFAULT_LOCATION("tmp", "tmp/cdb2");
-    DEFAULT_LOCATION("config", "etc/cdb2/config");
+    DEFAULT_LOCATION("config", config);
     DEFAULT_LOCATION("scripts", "bin");
     DEFAULT_LOCATION("rtcpu", "etc/cdb2/rtcpu");
     DEFAULT_LOCATION("share", "share/cdb2");
@@ -167,14 +175,14 @@ void init_file_locations(char *lrlname)
     else
         DEFAULT_LOCATION("database", "var/cdb2");
 
-
-#if defined(_LINUX_SOURCE)
-    add_location("tzdata", "/usr/share/");
-#elif defined(_IBM_SOURCE)
-    add_location("tzdata", "/usr/share/lib");
-#elif defined(_SUN_SOURCE)
-    add_location("tzdata", "/usr/share/lib");
-#endif
+#   if defined(LEGACY_DEFAULTS)
+    tzdata = "/bb/data/datetime";
+#   elif defined(_IBM_SOURCE) || defined(_SUN_SOURCE)
+    tzdata = "/usr/share/lib";
+#   else
+    tzdata = "/usr/share/";
+#   endif
+    add_location("tzdata", tzdata);
 
     global_config = getenv("COMDB2_GLOBAL_CONFIG");
     if (global_config)


### PR DESCRIPTION
This allows us to compatibly run without editing lrl files company-wide.
Out of the box, build can walk and talk like a duck. So its a duck.