### PR TITLE
Make the cdb2api functions, e.g. cdb2_column_size, etc, more robust in the face of responses that have no inner value.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4426,7 +4426,7 @@ int cdb2_numcolumns(cdb2_hndl_tp *hndl)
 const char *cdb2_column_name(cdb2_hndl_tp *hndl, int col)
 {
     const char *ret;
-    if (hndl->firstresponse == NULL)
+    if ((hndl->firstresponse == NULL) || (hndl->firstresponse->value == NULL))
         ret = NULL;
     else
         ret = (const char *)hndl->firstresponse->value[col]->value.data;
@@ -4522,7 +4522,7 @@ const char *cdb2_errstr(cdb2_hndl_tp *hndl)
 int cdb2_column_type(cdb2_hndl_tp *hndl, int col)
 {
     int ret;
-    if (hndl->firstresponse == NULL)
+    if ((hndl->firstresponse == NULL) || (hndl->firstresponse->value == NULL))
         ret = 0;
     else
         ret = hndl->firstresponse->value[col]->type;
@@ -4535,14 +4535,14 @@ int cdb2_column_type(cdb2_hndl_tp *hndl, int col)
 
 int cdb2_column_size(cdb2_hndl_tp *hndl, int col)
 {
-    if (hndl->lastresponse == NULL)
+    if ((hndl->lastresponse == NULL) || (hndl->lastresponse->value == NULL))
         return -1;
     return hndl->lastresponse->value[col]->value.len;
 }
 
 void *cdb2_column_value(cdb2_hndl_tp *hndl, int col)
 {
-    if (hndl->lastresponse == NULL)
+    if ((hndl->lastresponse == NULL) || (hndl->lastresponse->value == NULL))
         return NULL;
     if (hndl->lastresponse->value[col]->value.len == 0 &&
         hndl->lastresponse->value[col]->has_isnull != 1 &&


### PR DESCRIPTION

These changes make several of the public cdb2api functions more robust when the inner value for the first and/or last response is null.  For example, when using the cdb2_column_size() function after iterating over the result set, it should return -1, not cause a segfault.