### PR TITLE
refactor a bit watchog thread, remove superflous function

### DIFF
--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -265,18 +265,18 @@ static void *watchdog_thread(void *arg)
 
                     /* try to create a thread */
                     rc = pthread_create(&dummy_tid, &gbl_pthread_joinable_attr,
-                            dummy_thread, thedb);
+                                        dummy_thread, thedb);
                     if (rc) {
                         logmsg(LOGMSG_WARN, "watchdog: Can't create thread\n");
                         its_bad_slow = its_bad = 1;
                     } else {
                         rc = pthread_join(dummy_tid, NULL);
                         if (rc) {
-                            logmsg(LOGMSG_WARN, "watchdog: Can't join thread\n");
+                            logmsg(LOGMSG_WARN,
+                                   "watchdog: Can't join thread\n");
                             its_bad_slow = its_bad = 1;
                         }
                     }
-
 
                     if (!coherent && master > 0 && master != gbl_mynode) {
                         bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes,
@@ -287,22 +287,22 @@ static void *watchdog_thread(void *arg)
                         if (!lastlsnbytes) {
                             lastlsnbytes = curlsnbytes;
                             master_lastlsnbytes = master_curlsnbytes;
-                        } 
-                        /* time for deadlock test; 
+                        }
+                        /* time for deadlock test;
                            for now we ignore master progress */
                         else if (lastlsnbytes == curlsnbytes &&
-                                /* earth did not moved in the meantime */
-                                master_curlsnbytes > curlsnbytes &&
-                                master_lastlsnbytes > curlsnbytes) {
-                                /* we were behind last run, we are still
-                                   behind and we did not move: DEADLOCK */
+                                 /* earth did not moved in the meantime */
+                                 master_curlsnbytes > curlsnbytes &&
+                                 master_lastlsnbytes > curlsnbytes) {
+                            /* we were behind last run, we are still
+                               behind and we did not move: DEADLOCK */
 
-                                logmsg(LOGMSG_WARN, 
-                                        "watchdog: DATABASE MAKES NO PROGRESS; "
-                                        "DEADLOCK ALERT %s %s!\n",
-                                        curlsn, master_curlsn);
-                                its_bad = 1;
-                                its_bad_slow = 1;
+                            logmsg(LOGMSG_WARN,
+                                   "watchdog: DATABASE MAKES NO PROGRESS; "
+                                   "DEADLOCK ALERT %s %s!\n",
+                                   curlsn, master_curlsn);
+                            its_bad = 1;
+                            its_bad_slow = 1;
                         }
                     }
                 }

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -155,7 +155,6 @@ static void *watchdog_thread(void *arg)
     uint64_t lastlsnbytes = 0, curlsnbytes;
     char master_lastlsn[63] = "", master_curlsn[64];
     uint64_t master_lastlsnbytes = 0, master_curlsnbytes;
-    char *master;
     int sockpool_timeout;
 
     rc = pthread_mutex_init(&gbl_watchdog_kill_mutex, NULL);
@@ -173,7 +172,7 @@ static void *watchdog_thread(void *arg)
         sleep(1);
 
     while (!thedb->exiting) {
-        gbl_epoch_time = comdb2_time_epoch(); /* updated every second */
+        gbl_epoch_time = comdb2_time_epoch();
 
         if (!gbl_nowatch) {
             int stop_thds_time;
@@ -188,27 +187,12 @@ static void *watchdog_thread(void *arg)
             }
 
             /* try to malloc something */
-            ptr = malloc(128 * 1024);
+            ptr = calloc(1, 128 * 1024);
             if (!ptr) {
-                logmsg(LOGMSG_WARN, "watchdog: Can't malloc\n");
+                logmsg(LOGMSG_WARN, "watchdog: Can't allocate memory\n");
                 its_bad = 1;
             }
-
             free(ptr);
-
-            /* try to create a thread */
-            rc = pthread_create(&dummy_tid, &gbl_pthread_joinable_attr,
-                                dummy_thread, thedb);
-            if (rc) {
-                logmsg(LOGMSG_WARN, "watchdog: Can't create thread\n");
-                its_bad = 1;
-            } else {
-                rc = pthread_join(dummy_tid, NULL);
-                if (rc) {
-                    logmsg(LOGMSG_WARN, "watchdog: Can't join thread\n");
-                    its_bad = 1;
-                }
-            }
 
             /* try to get a file descriptor */
             fd = open("/", O_RDONLY);
@@ -274,10 +258,25 @@ static void *watchdog_thread(void *arg)
                    if this is not the case, it means I am deadlock
                    we run this for each 10 iterations of watchdog
                  */
-                master = thedb->master;
                 if (counter % 10 == 0) {
+                    char *master = thedb->master;
                     /* testing slow event time */
                     its_bad_slow = 0;
+
+                    /* try to create a thread */
+                    rc = pthread_create(&dummy_tid, &gbl_pthread_joinable_attr,
+                            dummy_thread, thedb);
+                    if (rc) {
+                        logmsg(LOGMSG_WARN, "watchdog: Can't create thread\n");
+                        its_bad_slow = its_bad = 1;
+                    } else {
+                        rc = pthread_join(dummy_tid, NULL);
+                        if (rc) {
+                            logmsg(LOGMSG_WARN, "watchdog: Can't join thread\n");
+                            its_bad_slow = its_bad = 1;
+                        }
+                    }
+
 
                     if (!coherent && master > 0 && master != gbl_mynode) {
                         bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes,
@@ -288,27 +287,22 @@ static void *watchdog_thread(void *arg)
                         if (!lastlsnbytes) {
                             lastlsnbytes = curlsnbytes;
                             master_lastlsnbytes = master_curlsnbytes;
-                        } else {
-
-                            /* time for deadlock test;
-                               for now we ignore master progress
-                             */
-                            if (lastlsnbytes == curlsnbytes) {
+                        } 
+                        /* time for deadlock test; 
+                           for now we ignore master progress */
+                        else if (lastlsnbytes == curlsnbytes &&
                                 /* earth did not moved in the meantime */
-                                if (master_curlsnbytes > curlsnbytes &&
-                                    master_lastlsnbytes > curlsnbytes) {
-                                    /* we were behind last run, we are still
-                                       behind
-                                       and we did not move: DEADLOCK */
+                                master_curlsnbytes > curlsnbytes &&
+                                master_lastlsnbytes > curlsnbytes) {
+                                /* we were behind last run, we are still
+                                   behind and we did not move: DEADLOCK */
 
-                                    logmsg(LOGMSG_WARN, 
+                                logmsg(LOGMSG_WARN, 
                                         "watchdog: DATABASE MAKES NO PROGRESS; "
                                         "DEADLOCK ALERT %s %s!\n",
                                         curlsn, master_curlsn);
-                                    its_bad = 1;
-                                    its_bad_slow = 1;
-                                }
-                            }
+                                its_bad = 1;
+                                its_bad_slow = 1;
                         }
                     }
                 }
@@ -361,12 +355,9 @@ static void *watchdog_thread(void *arg)
         }
 
         /* we use counter to downsample the run events for lower frequence
-           tasks,
-           like deadlock detector */
+           tasks, like deadlock detector */
         counter++;
 
-        /* please don't change the amount of sleep here (1 second)
-           because we rely on gbl_epoch_time to be updated every second */
         sleep(1);
     }
     return NULL;

--- a/sqlite/func.c
+++ b/sqlite/func.c
@@ -827,22 +827,6 @@ static void comdb2StartTimeFunc(
 }
 
 /*
-** Implementation of the comdb2_uptime() SQL function.
-** This returns the number of seconds this node has been up.
-** gbl_epoch_time variable is updated every second in watchdog_thread()
-*/
-static void comdb2UptimeFunc(
-  sqlite3_context *context,
-  int NotUsed,
-  sqlite3_value **NotUsed2
-){
-  UNUSED_PARAMETER2(NotUsed, NotUsed2);
-  int comdb2_time_epoch(void);
-  extern int gbl_starttime;
-  extern int gbl_epoch_time;
-  sqlite3_result_int64(context, gbl_epoch_time - gbl_starttime);
-}
-
 
 
 /*
@@ -2242,8 +2226,7 @@ void sqlite3RegisterBuiltinFunctions(void){
     FUNCTION(comdb2_port,       0, 0, 0, comdb2PortFunc),
     FUNCTION(comdb2_dbname,     0, 0, 0, comdb2DbnameFunc),
     FUNCTION(comdb2_prevquerycost,0,0,0, comdb2PrevquerycostFunc),
-    FUNCTION(comdb2_uptime,0, 0, 0, comdb2UptimeFunc),
-    FUNCTION(comdb2_starttime,0, 0, 0,comdb2StartTimeFunc),
+    FUNCTION(comdb2_starttime,  0, 0, 0, comdb2StartTimeFunc),
 #endif
 #ifdef SQLITE_ENABLE_UNKNOWN_SQL_FUNCTION
     FUNCTION(unknown,           -1, 0, 0, unknownFunc      ),

--- a/tests/bb_getopt_long.test/runit
+++ b/tests/bb_getopt_long.test/runit
@@ -233,5 +233,11 @@ glib_compatible_tests
 transform_args
 missing_required_argument
 
+# cleanup if this was a successful run
+if [ $error -eq 0 ] && [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -f *.gl *.bb
+fi
+
+
 # Comdb2 specific: we transform '-option' into '--option'
 exit $error

--- a/tests/biginplace.test/runit
+++ b/tests/biginplace.test/runit
@@ -58,7 +58,7 @@ echo "out is $out"
 # Snapshot should remain the same after update from small to a large record #
 #############################################################################
 
-results1=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.1
+results1=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.1
 bigrec1=$(cat bigrec1.txt)
 echo "begin" >&${COPROC[1]}
 echo >&${COPROC[1]} "@redirect $results1"
@@ -66,7 +66,7 @@ echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"
 cdb2sql -s ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bigrec1' where a=1" &>/dev/null
 
-results2=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.2
+results2=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.2
 echo >&${COPROC[1]} "@redirect $results2"
 echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"
@@ -82,7 +82,7 @@ diff $results1 $results2
 # Snapshot should remain the same after update from large to a large record #
 #############################################################################
 
-results1=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.1
+results1=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.1
 bigrec2=$(cat bigrec2.txt)
 echo >&${COPROC[1]} "begin"
 echo >&${COPROC[1]} "@redirect $results1"
@@ -90,7 +90,7 @@ echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"
 cdb2sql -s ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bigrec2' where a=1" &>/dev/null
 
-results2=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.2
+results2=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.2
 echo >&${COPROC[1]} "@redirect $results2"
 echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"
@@ -106,14 +106,14 @@ diff $results1 $results2
 # Snapshot should remain the same after update from large to a small record #
 #############################################################################
 
-results1=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.1
+results1=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.1
 echo >&${COPROC[1]} "begin"
 echo >&${COPROC[1]} "@redirect $results1"
 echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"
 cdb2sql -s ${CDB2_OPTIONS} $db default "update t1 set b1=x'1234' where a=1" &>/dev/null
 
-results2=${TMPDIR}/cdb2tst_big.$$.$RANDOM.tmp.2
+results2=${TMPDIR}/$DBNAME.cdb2tst_big.$$.$RANDOM.tmp.2
 echo >&${COPROC[1]} "@redirect $results2"
 echo >&${COPROC[1]} "select * from t1"
 echo >&${COPROC[1]} "@redirect"

--- a/tests/drop_tblnum.test/runit
+++ b/tests/drop_tblnum.test/runit
@@ -3,7 +3,6 @@
 # Test rootpages when db array changes during sql processing
 ##############################################################################
 
-DBNAME=$1
 SQL="cdb2sql ${CDB2_OPTIONS} $DBNAME default"
 
 # $SQL "select comdb2_version(), comdb2_hosts()" > 

--- a/tests/incremental_backup.test/runit
+++ b/tests/incremental_backup.test/runit
@@ -3,13 +3,13 @@
 export debug=1
 [[ $debug == 1 ]] && set -x
 
-export dbname=$1
+export DBNAME=$1
 
-LOCTMPDIR=$TMPDIR/$dbname
+LOCTMPDIR=$TMPDIR/$DBNAME
 mkdir $LOCTMPDIR
 
-if [[ -z "$dbname" ]] ; then
-  echo dbname missing
+if [[ -z "$DBNAME" ]] ; then
+  echo DBNAME missing
   exit 1
 fi
 
@@ -42,40 +42,40 @@ function deletelogs
     [[ $debug == 1 ]] && set -x
     if [[ -n "${CLUSTER}" ]]; then
         for node in ${CLUSTER} ; do 
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('deletelogs')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('deletelogs')\"" < /dev/null
         done
     else
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('deletelogs')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('deletelogs')"
     fi
     sleep 2
 }
 
 function force_checkpoint {
   [[ $debug == 1 ]] && set -x
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "insert into load (id, name, data) values(1, 'xxx', x'1234')"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "insert into load (id, name, data) values(1, 'xxx', x'1234')"
 
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
-      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
       for node in ${CLUSTER} ; do 
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
       done
   else
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
   fi
   sleep 10
   if [[ -n "${CLUSTER}" ]]; then
       for node in ${CLUSTER} ; do 
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
       done
   else
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
   fi
   sleep 10
 }
@@ -86,9 +86,9 @@ function make_base {
   basename=${LOCTMPDIR}/backups/t1-1_base.tar
   backuplist+=(t1-1_base.tar)
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $basename < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $basename < /dev/null
   else
-      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $basename
+      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $basename
   fi
   echo "~~~~~~~~~~"
   echo $basename
@@ -104,9 +104,9 @@ function make_backup {
   backuplist+=($backupname)
   backuploc=${LOCTMPDIR}/backups/${backupname}
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $backuploc < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $backuploc < /dev/null
   else
-      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $backuploc
+      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $backuploc
   fi
   echo "~~~~~~~~~~"
   echo ${LOCTMPDIR}/backups/${backupname}
@@ -131,41 +131,41 @@ function test_restoredb {
 
   echo $restorecmd
   $restorecmd | $COMDB2AR_EXE x -x $COMDB2_EXE -I restore ${LOCTMPDIR}/restore/ ${LOCTMPDIR}/restore || failexit "Restore Failed"
-  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${dbname}.lrl > ${LOCTMPDIR}/restore/${dbname}.single.lrl
+  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${DBNAME}.lrl > ${LOCTMPDIR}/restore/${DBNAME}.single.lrl
 
   # Rename some files
-  mv ${LOCTMPDIR}/restore/${dbname}.txn ${LOCTMPDIR}/restore/${dbname}_restore.txn
-  mv ${LOCTMPDIR}/restore/${dbname}.llmeta.dta ${LOCTMPDIR}/restore/${dbname}_restore.llmeta.dta
-  mv ${LOCTMPDIR}/restore/${dbname}.metadata.dta ${LOCTMPDIR}/restore/${dbname}_restore.metadata.dta
-  mv ${LOCTMPDIR}/restore/${dbname}_file_vers_map ${LOCTMPDIR}/restore/${dbname}_restore_file_vers_map
+  mv ${LOCTMPDIR}/restore/${DBNAME}.txn ${LOCTMPDIR}/restore/${DBNAME}_restore.txn
+  mv ${LOCTMPDIR}/restore/${DBNAME}.llmeta.dta ${LOCTMPDIR}/restore/${DBNAME}_restore.llmeta.dta
+  mv ${LOCTMPDIR}/restore/${DBNAME}.metadata.dta ${LOCTMPDIR}/restore/${DBNAME}_restore.metadata.dta
+  mv ${LOCTMPDIR}/restore/${DBNAME}_file_vers_map ${LOCTMPDIR}/restore/${DBNAME}_restore_file_vers_map
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${dbname}_restore --lrl ${LOCTMPDIR}/restore/${dbname}.single.lrl -pidfile ${TMPDIR}/${dbname}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
-  ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+  ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
   sqloutput=$(cat ./sqloutput)
   while [ "$sqloutput" != "(1=1)" -a $count -le 30 ]; do
       sleep 1
       let count=count+1
-      ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+      ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
       sqloutput=$(cat ./sqloutput)
   done
 
   if [ $count -ge 30 ] ; then
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+    kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
     failexit "DB Startup exceeded"
   fi
   echo " "
 
-  ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
+  ${CDB2SQL_EXE} -f $1 ${DBNAME}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
   rc=$?
-  echo shutting down ${dbname}_restore
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
-  echo deregister from pmux ${dbname}_restore
-  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+  echo shutting down ${DBNAME}_restore
+  kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
+  echo deregister from pmux ${DBNAME}_restore
+  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${DBNAME}_restore " ${pmux_port}
 
   if [[ $rc -ne 0 ]] ; then
     echo "  ^^^^^^^^^^^^"
@@ -187,23 +187,23 @@ function resetdb {
   rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
   mkdir -p ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
 
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE t1"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE t1"
   force_checkpoint
   make_base
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
   force_checkpoint
   make_backup t1-2_create_table
 }
 
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE load"
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE load"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
 
 # BASIC FUNCTIONALITY TEST
 resetdb
 deletelogs
 
 for statement in `ls t1-*.stmt`; do
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $dbname default
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $DBNAME default
   force_checkpoint
   make_backup $statement
   deletelogs
@@ -224,19 +224,20 @@ done
 # PUSH NEXT TEST FOR RECOVERY WITH LOG HOLES
 resetdb
 for i in $(seq 1 10); do
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
   # Need to sleep briefly so that multiple pushnext's aren't processed as the same one
   sleep 2
 done
-${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $dbname default
+${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $DBNAME default
 make_backup push_next_inserts
 deletelogs
 copy_to_local
 test_restoredb t2.req 2
 
 # cleanup since this was a successful run
-if [ "$CLEANUPDBDIR" == "1" ] ; then
-    rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -rf ${LOCTMPDIR} ${DBNAME}_restore
+    rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}_restore.* ${TESTDIR}/tmp/${DBNAME}_restore.* ${TMPDIR}/cdb2/${DBNAME}_restore.*
 fi
 
 echo "Test Successful"

--- a/tests/incremental_backup_load.test/runit
+++ b/tests/incremental_backup_load.test/runit
@@ -4,14 +4,12 @@ export debug=1
 export sleeptime=30
 [[ $debug == 1 ]] && set -x
 
-export dbname=$1
-
-if [[ -z "$dbname" ]] ; then
-  echo dbname missing
+if [[ -z "$DBNAME" ]] ; then
+  echo DBNAME missing
   exit 1
 fi
 
-LOCTMPDIR=$TMPDIR/$dbname
+LOCTMPDIR=$TMPDIR/$DBNAME
 mkdir $LOCTMPDIR
 
 function getmaster {
@@ -49,10 +47,10 @@ function deletelogs
     [[ $debug == 1 ]] && set -x
     if [[ -n "${CLUSTER}" ]]; then
         for node in ${CLUSTER} ; do 
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('deletelogs')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('deletelogs')\"" < /dev/null
         done
     else
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('deletelogs')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('deletelogs')"
     fi
     sleep 2
 }
@@ -60,7 +58,7 @@ function deletelogs
 function checkload
 {
     [[ $debug == 1 ]] && set -x
-    ${CDB2SQL_EXE} -s ${CDB2_OPTIONS} $dbname default "select count(*) from load" &> /dev/null
+    ${CDB2SQL_EXE} -s ${CDB2_OPTIONS} $DBNAME default "select count(*) from load" &> /dev/null
     r=$?
     if [[ $r != 0 ]]; then
         killwriters
@@ -72,31 +70,31 @@ function checkload
 function force_checkpoint {
     [[ $debug == 1 ]] && set -x
 
-    ${CDB2SQL_EXE} ${CDB2SQL_OPTIONS} $dbname default "INSERT INTO load VALUES (100, 'xxx', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234')" > /dev/null 2>&1
+    ${CDB2SQL_EXE} ${CDB2SQL_OPTIONS} $DBNAME default "INSERT INTO load VALUES (100, 'xxx', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234')" > /dev/null 2>&1
 
     if [[ -n "${CLUSTER}" ]]; then
-        ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
-        ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+        ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+        ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
         for node in ${CLUSTER} ; do 
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
         done
     else
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
     fi
     sleep 10
-    ${CDB2SQL_EXE} ${CDB2SQL_OPTIONS} $dbname default "INSERT INTO load VALUES (100, 'xxx', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234')" > /dev/null 2>&1
+    ${CDB2SQL_EXE} ${CDB2SQL_OPTIONS} $DBNAME default "INSERT INTO load VALUES (100, 'xxx', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234', x'1234')" > /dev/null 2>&1
     if [[ -n "${CLUSTER}" ]]; then
         for node in ${CLUSTER} ; do 
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+            ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
         done
     else
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+        ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
     fi
     sleep 10
 }
@@ -107,9 +105,9 @@ function make_base {
   basename=${LOCTMPDIR}/backups/t1-1_base.tar
   backuplist+=(t1-1_base.tar)
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $basename < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $basename < /dev/null
   else
-      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $basename
+      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $basename
   fi
   echo "~~~~~~~~~~"
   echo $basename
@@ -125,9 +123,9 @@ function make_backup {
   backuplist+=($backupname)
   backuploc=${LOCTMPDIR}/backups/${backupname}
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $backuploc < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $backuploc < /dev/null
   else
-      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $backuploc
+      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $backuploc
   fi
   echo "~~~~~~~~~~"
   echo ${LOCTMPDIR}/backups/${backupname}
@@ -152,35 +150,35 @@ function test_restoredb {
 
   echo $restorecmd
   $restorecmd | $COMDB2AR_EXE x -x $COMDB2_EXE -I restore ${LOCTMPDIR}/restore/ ${LOCTMPDIR}/restore || failexit "Restore Failed"
-  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${dbname}.lrl > ${LOCTMPDIR}/restore/${dbname}.single.lrl
+  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${DBNAME}.lrl > ${LOCTMPDIR}/restore/${DBNAME}.single.lrl
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${dbname}_restore --lrl ${LOCTMPDIR}/restore/${dbname}.single.lrl -pidfile ${TMPDIR}/${dbname}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
-  ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+  ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
   sqloutput=$(cat ./sqloutput)
   while [ "$sqloutput" != "(1=1)" -a $count -le 30 ]; do
       sleep 1
       let count=count+1
-      ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+      ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
       sqloutput=$(cat ./sqloutput)
   done
 
   if [ $count -ge 30 ] ; then
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+    kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
     failexit "DB Startup exceeded"
   fi
   echo " "
 
-  ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
+  ${CDB2SQL_EXE} -f $1 ${DBNAME}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
   rc=$?
-  echo shutting down ${dbname}_restore
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
-  echo deregister from pmux ${dbname}_restore
-  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+  echo shutting down ${DBNAME}_restore
+  kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
+  echo deregister from pmux ${DBNAME}_restore
+  ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${DBNAME}_restore " ${pmux_port}
 
   if [[ $rc -ne 0 ]] ; then
     killwriters
@@ -203,17 +201,17 @@ function resetdb {
   rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
   mkdir -p ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
 
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE t1"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE t1"
   force_checkpoint
   make_base
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
   force_checkpoint
   make_backup t1-2_create_table
 }
 
 rm ./testcase.done
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE load"
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE load"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
 
 ( timeout ${TEST_TIMEOUT} ./inserter.sh ) &
 ( timeout ${TEST_TIMEOUT} ./inserter.sh ) &
@@ -234,7 +232,7 @@ deletelogs
 for statement in `ls t1-*.stmt`; do
   force_checkpoint
   sleep $sleeptime
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $dbname default
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $DBNAME default
   force_checkpoint
   make_backup $statement
   deletelogs
@@ -255,11 +253,11 @@ done
 # PUSH NEXT TEST FOR RECOVERY WITH LOG HOLES
 resetdb
 for i in $(seq 1 10); do
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
   # Need to sleep briefly so that multiple pushnext's aren't processed as the same one
   sleep 2
 done
-${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $dbname default
+${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $DBNAME default
 make_backup push_next_inserts
 deletelogs
 copy_to_local
@@ -267,8 +265,9 @@ test_restoredb t2.req 2
 killwriters
 
 # cleanup since this was a successful run
-if [ "$CLEANUPDBDIR" == "1" ] ; then
-    rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -rf ${LOCTMPDIR} ${DBNAME}_restore
+    rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}_restore.* ${TESTDIR}/tmp/${DBNAME}_restore.* ${TMPDIR}/cdb2/${DBNAME}_restore.*
 fi
 
 echo "Test Successful"

--- a/tests/incremental_backup_usenames.test/runit
+++ b/tests/incremental_backup_usenames.test/runit
@@ -3,20 +3,20 @@
 export debug=1
 [[ $debug == 1 ]] && set -x
 
-export dbname=$1
+export DBNAME=$1
 
-LOCTMPDIR=$TMPDIR/$dbname
+LOCTMPDIR=$TMPDIR/$DBNAME
 mkdir $LOCTMPDIR
 
-if [[ -z "$dbname" ]] ; then
-  echo dbname missing
+if [[ -z "$DBNAME" ]] ; then
+  echo DBNAME missing
   exit 1
 fi
 
 function getmaster {
     r=1
     while [[ $r != 0 ]]; do 
-        x=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $dbname default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]')
+        x=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $DBNAME default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]')
         r=$?
     done
     echo $x
@@ -33,7 +33,7 @@ fi
 function failexit
 {
     [[ $debug == 1 ]] && set -x
-    ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
+    ${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${DBNAME}_restore " ${pmux_port}
     echo "Failed $1"
     exit -1
 }
@@ -42,27 +42,27 @@ function force_checkpoint {
   [[ $debug == 1 ]] && set -x
 
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
-      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
+      ssh $master "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('pushnext')\"" < /dev/null
       for node in ${CLUSTER} ; do 
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
       done
   else
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
   fi
   sleep 10
   if [[ -n "${CLUSTER}" ]]; then
       for node in ${CLUSTER} ; do 
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
-          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('flush')\"" < /dev/null
+          ssh $node "${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME local \"exec procedure sys.cmd.send('bdb logstat')\"" < /dev/null
       done
   else
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('flush')"
-      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('bdb logstat')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('flush')"
+      ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb logstat')"
   fi
   sleep 10
 }
@@ -73,9 +73,9 @@ function make_base {
   basename=${LOCTMPDIR}/backups/t1-1_base.tar
   backuplist+=(t1-1_base.tar)
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $basename < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $basename < /dev/null
   else
-      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $basename
+      $COMDB2AR_EXE c -I create -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $basename
   fi
   echo "~~~~~~~~~~"
   echo $basename
@@ -91,9 +91,9 @@ function make_backup {
   backuplist+=($backupname)
   backuploc=${LOCTMPDIR}/backups/${backupname}
   if [[ -n "${CLUSTER}" ]]; then
-      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl" > $backuploc < /dev/null
+      ssh $machine "$COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl" > $backuploc < /dev/null
   else
-      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${dbname}.lrl > $backuploc
+      $COMDB2AR_EXE c -I inc -b ${LOCTMPDIR}/increment ${DBDIR}/${DBNAME}.lrl > $backuploc
   fi
   echo "~~~~~~~~~~"
   echo ${LOCTMPDIR}/backups/${backupname}
@@ -118,39 +118,39 @@ function test_restoredb {
 
   echo $restorecmd
   $restorecmd | $COMDB2AR_EXE x -x $COMDB2_EXE -I restore ${LOCTMPDIR}/restore/ ${LOCTMPDIR}/restore || failexit "Restore Failed"
-  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${dbname}.lrl > ${LOCTMPDIR}/restore/${dbname}.single.lrl
+  egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${DBNAME}.lrl > ${LOCTMPDIR}/restore/${DBNAME}.single.lrl
 
   # Rename some files
-  mv ${LOCTMPDIR}/restore/${dbname}.txn ${LOCTMPDIR}/restore/${dbname}_restore.txn
-  mv ${LOCTMPDIR}/restore/${dbname}.llmeta.dta ${LOCTMPDIR}/restore/${dbname}_restore.llmeta.dta
-  mv ${LOCTMPDIR}/restore/${dbname}.metadata.dta ${LOCTMPDIR}/restore/${dbname}_restore.metadata.dta
-  mv ${LOCTMPDIR}/restore/${dbname}_file_vers_map ${LOCTMPDIR}/restore/${dbname}_restore_file_vers_map
+  mv ${LOCTMPDIR}/restore/${DBNAME}.txn ${LOCTMPDIR}/restore/${DBNAME}_restore.txn
+  mv ${LOCTMPDIR}/restore/${DBNAME}.llmeta.dta ${LOCTMPDIR}/restore/${DBNAME}_restore.llmeta.dta
+  mv ${LOCTMPDIR}/restore/${DBNAME}.metadata.dta ${LOCTMPDIR}/restore/${DBNAME}_restore.metadata.dta
+  mv ${LOCTMPDIR}/restore/${DBNAME}_file_vers_map ${LOCTMPDIR}/restore/${DBNAME}_restore_file_vers_map
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${dbname}_restore --lrl ${LOCTMPDIR}/restore/${dbname}.single.lrl -pidfile ${TMPDIR}/${dbname}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
-  ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+  ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
   sqloutput=$(cat ./sqloutput)
   while [ "$sqloutput" != "(1=1)" -a $count -le 30 ]; do
       sleep 1
       let count=count+1
-      ${CDB2SQL_EXE} ${dbname}_restore local "select 1" > ./sqloutput 2>&1
+      ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1
       sqloutput=$(cat ./sqloutput)
   done
 
   if [ $count -ge 30 ] ; then
-    kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+    kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
     failexit "DB Startup exceeded"
   fi
   echo " "
 
-  ${CDB2SQL_EXE} -f $1 ${dbname}_restore local > ${testname}.output 2>&1
+  ${CDB2SQL_EXE} -f $1 ${DBNAME}_restore local > ${testname}.output 2>&1
   cat ${testname}.output
   diff ${testname}.expected ${testname}.output
   rc=$?
-  echo shutting down ${dbname}_restore
-  kill -9 $(cat ${TMPDIR}/${dbname}_restore.pid)
+  echo shutting down ${DBNAME}_restore
+  kill -9 $(cat ${TMPDIR}/${DBNAME}_restore.pid)
 
   if [[ $rc -ne 0 ]] ; then
     echo "  ^^^^^^^^^^^^"
@@ -169,21 +169,21 @@ function resetdb {
   rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
   mkdir -p ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
 
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE t1"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE t1"
   force_checkpoint
   make_base
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE t1  { `cat t1.csc2 ` }" || failexit "create failed"
   force_checkpoint
   make_backup t1-2_create_table
 }
 
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "DROP TABLE load"
-${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "DROP TABLE load"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "CREATE TABLE load  { `cat load.csc2 ` }" || failexit "create failed"
 
 # BASIC FUNCTIONALITY TEST
 resetdb
 for statement in `ls t1-*.stmt`; do
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $dbname default
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} -f $statement $DBNAME default
   force_checkpoint
   make_backup $statement
 done
@@ -203,20 +203,22 @@ done
 # PUSH NEXT TEST FOR RECOVERY WITH LOG HOLES
 resetdb
 for i in $(seq 1 10); do
-  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('pushnext')"
+  ${CDB2SQL_EXE} ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('pushnext')"
   # Need to sleep briefly so that multiple pushnext's aren't processed as the same one
   sleep 2
 done
-${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $dbname default
+${CDB2SQL_EXE} ${CDB2_OPTIONS} -f t1-3_insert.stmt $DBNAME default
 make_backup push_next_inserts
 copy_to_local
 test_restoredb t2.req 2
 
+${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${DBNAME}_restore " ${pmux_port}
+
 # cleanup since this was a successful run
-if [ "$CLEANUPDBDIR" == "1" ] ; then
-    rm -rf ${LOCTMPDIR}/backups ${LOCTMPDIR}/restore ${LOCTMPDIR}/increment
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -rf ${LOCTMPDIR} ${DBNAME}_restore
+    rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}_restore.* ${TESTDIR}/tmp/${DBNAME}_restore.* ${TMPDIR}/cdb2/${DBNAME}_restore.*
 fi
 
-${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${dbname}_restore " ${pmux_port}
 echo "Test Successful"
 exit 0

--- a/tests/incrementalcopy.test/runit
+++ b/tests/incrementalcopy.test/runit
@@ -125,4 +125,10 @@ if [[ $target_count != $cnt ]]; then
     echo "Wrong count expected $(($nrecs + $morerecs)) got $target_count"
     exit 1
 fi
+
+# cleanup since this was a successful run
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -rf ${LOCTMPDIR}
+fi
+
 exit 0

--- a/tests/pmux.test/runit
+++ b/tests/pmux.test/runit
@@ -90,7 +90,11 @@ fi
 echo "At start had $atstart fds, during run had $atrun fds, gone at end"
 
 #delete testdb{i} dir now that test is successful
-for i in $(seq 1 10); do 
-    rm -rf testdb${i}
-done
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    for i in $(seq 1 10); do 
+        rm -rf testdb${i}
+        rm -f ${TESTDIR}/var/log/cdb2/testdb${i}.* ${TESTDIR}/tmp/testdb${i}.* ${TMPDIR}/cdb2/testdb${i}.*
+    done
+fi
+
 exit 0

--- a/tests/pmux_hello.test/runit
+++ b/tests/pmux_hello.test/runit
@@ -279,5 +279,12 @@ function runtest
 
 runtest
 
+
+#test is successful so we can cleanup
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -rf $DBDIR
+    rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TESTDIR}/tmp/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
+fi
+
 echo "Success"
 exit 0

--- a/tests/qcopy.test/runit
+++ b/tests/qcopy.test/runit
@@ -44,4 +44,9 @@ done
 
 exiting
 
+#test is successful so we can cleanup
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    rm -f ${TESTDIR}/var/log/cdb2/${NEWNAME}.* ${TESTDIR}/tmp/${NEWNAME}.* ${TMPDIR}/cdb2/${NEWNAME}.*
+fi
+
 echo Success

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -325,7 +325,7 @@ if [ $success != 1 ] ; then
     failexit "replayed.txt content is not the same as original.txt"
 fi
 
-if [ "$CLEANUPDBDIR" == "1" ] ; then
+if [ "$CLEANUPDBDIR" != "0" ] ; then
     #delete files now that test is successful
     rm orig.txt replayed.txt sqlreplay.out
 fi

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -18,7 +18,7 @@ fi
 
 
 export HOSTNAME=${HOSTNAME:-`hostname`}
-export CLEANUPDBDIR=${CLEANUPDBDIR:-1}
+export CLEANUPDBDIR=${CLEANUPDBDIR:-2}
 source $TESTSROOTDIR/setup.common
 export PATH="${paths}/:${PATH}"
 export pmux_port=${PMUXPORT:-5105}  # assign to 5105 if it was not set as a make parameter

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -152,12 +152,12 @@ for i in `seq 1 $N` ; do
 done > entry_counts.out
 
 
-call_unsetup 1
-trap - INT EXIT
-
 zeros=`grep "entries:0" entry_counts.out | wc -l`
 assertres "$zeros" "$((N-1))"
 other=`grep "entries:16" entry_counts.out | wc -l`
 assertres "$other" "1"
+
+call_unsetup 1
+trap - INT EXIT
 
 echo "Success"

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -105,19 +105,22 @@ cleanup_cluster() {
             scp -r -o StrictHostKeyChecking=no $node:${DBDIR} $DBDIR/$node/ < /dev/null &
             scp -r -o StrictHostKeyChecking=no $node:${TESTDIR}/var/log/cdb2/${DBNAME}* $DBDIR/$node/ < /dev/null &
         elif [ "$CLEANUPDBDIR" != "0" ] ; then 
-            ssh -o StrictHostKeyChecking=no $node "rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
+            ssh -o StrictHostKeyChecking=no $node "rm -rf ${DBDIR} $TMPDIR/${DBNAME}" < /dev/null &
+            ssh -o StrictHostKeyChecking=no $node "rm -f ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
+            if [ "$CLEANUPDBDIR" == "2" ] ; then 
+                ssh -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*" < /dev/null &
+            fi
         fi
     done
     wait
 
     # the local node always has a copy of DBDIR even if not part of cluster
     if [ "$CLEANUPDBDIR" != "0" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
-        rm -rf ${DBDIR}
-        rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
+        rm -rf ${DBDIR} ${TMPDIR}/${DBNAME}
+        rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
         if [ "$CLEANUPDBDIR" == "2" ] ; then
-            rm -f $TESTDIR/logs/${DBNAME}.* `ls $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
-            rmdir ${TMPDIR}/cdb2 /${TMPDIR} 2> /dev/null
-            rmdir  ${TESTDIR}/var/log/cdb2/ ${TESTDIR}/var/log/ ${TESTDIR}/var/ 2> /dev/null
+            rm -f $TESTDIR/logs/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
+            rmdir ${TMPDIR}/cdb2 ${TMPDIR} 2> /dev/null
         fi
     fi
 }

--- a/tests/yast.test/runit
+++ b/tests/yast.test/runit
@@ -76,7 +76,7 @@ do
 done
 
 # cleanup since this was a successful run
-if [[ $RC -eq 0 ]] && [[ "$CLEANUPDBDIR" == "1" ]] ; then
+if [[ $RC -eq 0 ]] && [[ "$CLEANUPDBDIR" != "0" ]] ; then
     rm -rf $FILEPATH
 fi
 


### PR DESCRIPTION
* Dont create threads every second in watchdog thread, rather
  at a more reasonable frequency, once in 10 seconds
* Use calloc instead of malloc to actually write to allocated area
  since linux may return non null even when out of memory
* Remove unneeded function comdb2_uptime because its value can be
  gotten simply via 'select cast (now() - comdb2_starttime() as INT)'
* Cleanup a bit better after tests in cluster nodes, enable more cleanup