### PR TITLE
Generate and run tests based on options in testopts file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ tests/tools/cdb2api_unit
 tests/tools/cdb2_close_early
 
 
+tests/*_generated.test
 tests/test_*
 tests/pmux.sqlite
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -36,7 +36,7 @@ ifeq ($(MAKECMDGOALS),)
 TOTAL=$(words $(ALL_TESTS) )     # if no targets passed, will do ALL_TESTS
 endif
 
-all: init basicops all_tests
+all: generated_tests init basicops all_tests
 
 init:
 	@mkdir -p ${TESTDIR}
@@ -76,6 +76,10 @@ showparams:
 
 $(patsubst %.test,%,$(shell ls -d *.test)): basicops
 
+
+generated_tests:
+	$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
+
 %: %.test
 	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
 	@cp -r $< $(TESTDIR)/
@@ -107,5 +111,5 @@ testtotalclean: $(patsubst %.test,%.clean,$(shell ls -d *.test))
 clean: testclean
 
 testclean:
-	@rm -rf test_[0-9]* $(TESTDIR)/
+	@rm -rf test_[0-9]* $(TESTDIR)/ *_generated.test/
 	@$(foreach n, $(CLUSTER), ssh $(n) 'rm -rf $(TESTSROOTDIR)/test_[0-9]* $(TESTDIR)/' < /dev/null;)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,14 +26,15 @@ endif
 
 export DISABLED_TESTS
 
-ifeq ($(MAKECMDGOALS),all)  # targets passed to make
-$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
+DOALL:=0
+
+ifeq ($(subst all,,$(MAKECMDGOALS)),) #if cmdgoals empty or 'all'
+DOALL:=1
 endif
 
-ifeq ($(MAKECMDGOALS),)
+ifeq ($(DOALL),1)
 $(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
 endif
-
 
 # List of all tests that need to run. This is essentially a list of all
 # non-disabled tests.
@@ -42,10 +43,7 @@ export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
 
 
 TOTAL=$(words $(MAKECMDGOALS) )
-ifeq ($(MAKECMDGOALS),all)
-TOTAL=$(words $(ALL_TESTS) )
-endif
-ifeq ($(MAKECMDGOALS),)
+ifeq ($(DOALL),1)
 TOTAL=$(words $(ALL_TESTS) )
 endif
 
@@ -76,6 +74,7 @@ basicops: basicops_nokey
 
 showparams: 
 	@echo MAKECMDGOALS=${MAKECMDGOALS}
+	@echo DOALL=${DOALL}
 	@echo TESTSROOTDIR=${TESTSROOTDIR}
 	@echo SRCHOME=${SRCHOME}
 	@echo TESTID=${TESTID}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,15 +26,14 @@ endif
 
 export DISABLED_TESTS
 
-ifeq ($(MAKECMDGOALS),)  # targets passed to make
-DOALL=1                  # if no targets passed, will do ALL_TESTS
-else ifeq ($(MAKECMDGOALS),all)
-DOALL=1
-endif
-
-ifeq ($(DOALL),1)
+ifeq ($(MAKECMDGOALS),all)  # targets passed to make
 $(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
 endif
+
+ifeq ($(MAKECMDGOALS),)
+$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
+endif
+
 
 # List of all tests that need to run. This is essentially a list of all
 # non-disabled tests.
@@ -43,7 +42,10 @@ export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
 
 
 TOTAL=$(words $(MAKECMDGOALS) )
-ifeq ($(DOALL),1)
+ifeq ($(MAKECMDGOALS),all)
+TOTAL=$(words $(ALL_TESTS) )
+endif
+ifeq ($(MAKECMDGOALS),)
 TOTAL=$(words $(ALL_TESTS) )
 endif
 
@@ -73,6 +75,7 @@ basicops: basicops_nokey
 	$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" TESTSROOTDIR="${TESTSROOTDIR}" COMDB2_EXE=${COMDB2_EXE} CDB2SQL_EXE=${CDB2SQL_EXE} COMDB2AR_EXE=${COMDB2AR_EXE} PMUX_EXE=${PMUX_EXE} PMUXPORT=${PMUXPORT} ${TESTSROOTDIR}/tools/copy_files_to_cluster.sh > ${TESTDIR}/copy_files_to_cluster.log 2>&1 || echo "exit 1 copy_files_to_cluster failed" )
 
 showparams: 
+	@echo MAKECMDGOALS=${MAKECMDGOALS}
 	@echo TESTSROOTDIR=${TESTSROOTDIR}
 	@echo SRCHOME=${SRCHOME}
 	@echo TESTID=${TESTID}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,17 +26,24 @@ endif
 
 export DISABLED_TESTS
 
+ifeq ($(MAKECMDGOALS),)
+DOALL=1
+else ifeq ($(MAKECMDGOALS),all)
+DOALL=1
+endif
+
 # List of all tests that need to run. This is essentially a list of all
 # non-disabled tests.
 export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
     $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
 
+
 TOTAL=$(words $(MAKECMDGOALS) )  # targets passed to make
-ifeq ($(MAKECMDGOALS),)
+ifeq ($(DOALL),1)
 TOTAL=$(words $(ALL_TESTS) )     # if no targets passed, will do ALL_TESTS
 endif
 
-all: generated_tests init basicops all_tests
+all: init basicops all_tests
 
 init:
 	@mkdir -p ${TESTDIR}
@@ -74,11 +81,13 @@ showparams:
 	@echo CDB2_SQLREPLAY_EXE=${CDB2_SQLREPLAY_EXE}
 	@echo PMUX_EXE=${PMUX_EXE}
 
-$(patsubst %.test,%,$(shell ls -d *.test)): basicops
+
+$(patsubst %.test,%,$(ALL_TESTS)): basicops
 
 
 generated_tests:
 	$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
+
 
 %: %.test
 	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -26,10 +26,14 @@ endif
 
 export DISABLED_TESTS
 
-ifeq ($(MAKECMDGOALS),)
-DOALL=1
+ifeq ($(MAKECMDGOALS),)  # targets passed to make
+DOALL=1                  # if no targets passed, will do ALL_TESTS
 else ifeq ($(MAKECMDGOALS),all)
 DOALL=1
+endif
+
+ifeq ($(DOALL),1)
+$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
 endif
 
 # List of all tests that need to run. This is essentially a list of all
@@ -38,9 +42,9 @@ export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
     $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
 
 
-TOTAL=$(words $(MAKECMDGOALS) )  # targets passed to make
+TOTAL=$(words $(MAKECMDGOALS) )
 ifeq ($(DOALL),1)
-TOTAL=$(words $(ALL_TESTS) )     # if no targets passed, will do ALL_TESTS
+TOTAL=$(words $(ALL_TESTS) )
 endif
 
 all: init basicops all_tests
@@ -82,12 +86,15 @@ showparams:
 	@echo PMUX_EXE=${PMUX_EXE}
 
 
+
+%_generated: basicops %_generated.test 
+
+%_generated.test:
+	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
+	@cp -r $< $(TESTDIR)/
+	@$(MAKE) -skC $(TESTDIR)/$<
+
 $(patsubst %.test,%,$(ALL_TESTS)): basicops
-
-
-generated_tests:
-	$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
-
 
 %: %.test
 	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
@@ -102,6 +109,9 @@ generated_tests:
 
 %.tool: %.test
 	+$(MAKE) -C $(patsubst %.tool,%,$<) tool
+
+generated_tests:
+	$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
 
 stop:
 	@./stopall

--- a/tests/basic.test/snapshot.testopts
+++ b/tests/basic.test/snapshot.testopts
@@ -1,0 +1,1 @@
+enable_snapshot_isolation

--- a/tests/tools/create_generated_tests.sh
+++ b/tests/tools/create_generated_tests.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# will be called by tests makefile to create all the generated tests:
+# for every .testopts file in a test directory, will generate a new test
+# with those features (in the .testopts file) appended to the lrl.options
+# of the test in question.
+
+for i in `ls *.test/*.testopts | grep -v '_generated.test'`; do 
+    TST=`dirname $i | sed 's/.test$//g'`
+    OPTFL=`basename $i | sed 's/.testopts$//g'`
+    NDIR=${TST}_${OPTFL}_generated.test
+    mkdir -p $NDIR/
+    cp ${TST}.test/* $NDIR/
+    cat $i >> $NDIR/lrl.options
+done


### PR DESCRIPTION
* Makefile will generate tests based on the existence of a .testopts file in a test directory: if such file exists, it will copy the test dir and append content of the .testopts file to lrl.options of the generated test 
* Example usage in basic.test which will run a generated test with snapshot isolation enabled
* `make all' will now also run the new generated tests