### PR TITLE
Fail with verify error if generation has changed

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -354,7 +354,8 @@ enum OSQL_RPL_TYPE {
     OSQL_DELIDX = 24, /* new osql type to support indexes on expressions */
     OSQL_INSIDX = 25, /* new osql type to support indexes on expressions */
     OSQL_DBQ_CONSUME_UUID = 26,
-    MAX_OSQL_TYPES = 27
+    OSQL_STARTGEN = 27,
+    MAX_OSQL_TYPES = 28
 };
 
 enum DEBUGREQ { DEBUG_METADB_PUT = 1 };

--- a/db/config.c
+++ b/db/config.c
@@ -334,6 +334,7 @@ static char *legacy_options[] = {
     "init_with_time_based_genids",
     "logmsg level info",
     "logput window 1",
+    "osql_send_startgen off",
 };
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -192,6 +192,7 @@ extern int gbl_rand_elect_timeout;
 extern int gbl_rand_elect_min_ms;
 extern int gbl_rand_elect_max_ms;
 extern int gbl_handle_buf_add_latency_ms;
+extern int gbl_osql_send_startgen;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1439,4 +1439,11 @@ REGISTER_TUNABLE("handle_buf_latency_ms",
                  TUNABLE_INTEGER, &gbl_handle_buf_add_latency_ms,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("osql_send_startgen",
+                 "Send start-generation in osql stream.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_osql_send_startgen,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1440,10 +1440,8 @@ REGISTER_TUNABLE("handle_buf_latency_ms",
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("osql_send_startgen",
-                 "Send start-generation in osql stream.  (Default: off)",
+                 "Send start-generation in osql stream.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_osql_send_startgen,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-
-
 
 #endif /* _DB_TUNABLES_H */

--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -278,6 +278,7 @@ int srs_tran_replay(struct sqlclntstate *clnt, struct thr_handle *thr_self)
             break;
         }
         nq = 0;
+        clnt->start_gen = bdb_get_rep_gen(thedb->bdb_env);
         LISTC_FOR_EACH(&osql->history->lst, item, lnk)
         {
             restore_stmt(clnt, item);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3634,7 +3634,6 @@ int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
     return rc;
 }
 
-
 /**
  * Send USEDB op
  * It handles remote/local connectivity

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -628,6 +628,111 @@ static uint8_t *osqlcomm_del_rpl_type_put(osql_del_rpl_t *p_del_rpl,
     return p_buf;
 }
 
+/* startgen */
+typedef struct osql_startgen {
+    unsigned int start_gen;
+    int padding;
+} osql_startgen_t;
+
+enum { OSQLCOMM_STARTGEN_TYPE_LEN = 8 };
+
+BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_type_len,
+        sizeof(osql_startgen_t) == OSQLCOMM_STARTGEN_TYPE_LEN);
+
+static uint8_t *osqlcomm_startgen_type_put(const osql_startgen_t *p_osql_startgen,
+                                           uint8_t *p_buf, 
+                                           const uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_TYPE_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = buf_put(&(p_osql_startgen->start_gen),
+            sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
+    p_buf = buf_put(&(p_osql_startgen->padding),
+            sizeof(p_osql_startgen->padding), p_buf, p_buf_end);
+    return p_buf;
+}
+
+const uint8_t *osqlcomm_startgen_type_get(osql_startgen_t *p_osql_startgen,
+                                          const uint8_t *p_buf, 
+                                          const uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_TYPE_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = buf_get(&(p_osql_startgen->start_gen),
+            sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
+    return p_buf;
+}
+
+typedef struct osql_startgen_rpl {
+    osql_rpl_t hd;
+    osql_startgen_t dt;
+} osql_startgen_rpl_t;
+
+enum {
+    OSQLCOMM_STARTGEN_RPL_LEN = 
+        OSQLCOMM_RPL_TYPE_LEN + OSQLCOMM_STARTGEN_TYPE_LEN
+};
+
+BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_rpl_len, sizeof(osql_startgen_rpl_t) ==
+                           OSQLCOMM_STARTGEN_RPL_LEN);
+
+static uint8_t *osqlcomm_startgen_rpl_type_put(const osql_startgen_rpl_t *p_startgen_rpl,
+                                               uint8_t *p_buf, uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf ||
+            OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = osqlcomm_rpl_type_put(&(p_startgen_rpl->hd), p_buf, p_buf_end);
+    p_buf = osqlcomm_startgen_type_put(&(p_startgen_rpl->dt), p_buf, p_buf_end);
+    return p_buf;
+}
+
+static const uint8_t *osqlcomm_startgen_rpl_type_get(osql_startgen_rpl_t *p_startgen_rpl,
+                                               const uint8_t *p_buf,
+                                               const uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf ||
+            OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = osqlcomm_rpl_type_get(&(p_startgen_rpl->hd), p_buf, p_buf_end);
+    p_buf = osqlcomm_startgen_type_get(&(p_startgen_rpl->dt), p_buf, p_buf_end);
+    return p_buf;
+}
+
+typedef struct osql_startgen_uuid_rpl {
+    osql_uuid_rpl_t hd;
+    osql_startgen_t dt;
+} osql_startgen_uuid_rpl_t;
+
+enum { OSQLCOMM_STARTGEN_UUID_RPL_LEN = 
+    OSQLCOMM_UUID_RPL_TYPE_LEN + OSQLCOMM_STARTGEN_TYPE_LEN };
+
+BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_uuid_type_len,
+        sizeof(osql_startgen_uuid_rpl_t) == OSQLCOMM_STARTGEN_UUID_RPL_LEN);
+
+static uint8_t *osqlcomm_startgen_uuid_rpl_type_put(const osql_startgen_uuid_rpl_t *p_startgen_rpl,
+                                               uint8_t *p_buf, uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf ||
+            OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = osqlcomm_uuid_rpl_type_put(&(p_startgen_rpl->hd), p_buf, p_buf_end);
+    p_buf = osqlcomm_startgen_type_put(&(p_startgen_rpl->dt), p_buf, p_buf_end);
+    return p_buf;
+}
+
+static const uint8_t *osqlcomm_startgen_uuid_rpl_type_get(osql_startgen_uuid_rpl_t *p_startgen_rpl,
+                                               const uint8_t *p_buf,
+                                               const uint8_t *p_buf_end)
+{
+    if (p_buf_end < p_buf ||
+            OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
+        return NULL;
+    p_buf = osqlcomm_uuid_rpl_type_get(&(p_startgen_rpl->hd), p_buf, p_buf_end);
+    p_buf = osqlcomm_startgen_type_get(&(p_startgen_rpl->dt), p_buf, p_buf_end);
+    return p_buf;
+}
+
 /********* OSQL BPLOG FUNC   *****************/
 
 typedef struct osql_bpfunc {
@@ -3459,6 +3564,68 @@ int is_tablename_queue(const char * tablename, int len)
     /* See also, __db_open @ /berkdb/db/db_open.c for register_qdb */
     return (len > 3 && tablename[0] == '_' &&
             tablename[1] == '_' && tablename[2] == 'q');
+}
+
+int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
+        uint32_t start_gen, int type, SBUF2 *logsb)
+{
+    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
+    uint8_t buf[OSQLCOMM_STARTGEN_UUID_RPL_LEN > OSQLCOMM_STARTGEN_RPL_LEN ?
+        OSQLCOMM_STARTGEN_UUID_RPL_LEN : OSQLCOMM_STARTGEN_RPL_LEN];
+    int msglen;
+    int rc;
+
+    if (check_master(tohost))
+        return OSQL_SEND_ERROR_WRONGMASTER;
+
+    if (rqid == OSQL_RQID_USE_UUID) {
+        osql_startgen_uuid_rpl_t startgen_uuid_rpl = {0};
+        uint8_t *p_buf = buf;
+        uint8_t *p_buf_end = (p_buf + OSQLCOMM_STARTGEN_UUID_RPL_LEN);
+        msglen = OSQLCOMM_STARTGEN_UUID_RPL_LEN;
+        startgen_uuid_rpl.hd.type = OSQL_STARTGEN;
+        comdb2uuidcpy(startgen_uuid_rpl.hd.uuid, uuid);
+        startgen_uuid_rpl.dt.start_gen = start_gen;
+
+        if (!(p_buf = osqlcomm_startgen_uuid_rpl_type_put(&startgen_uuid_rpl,
+                        p_buf, p_buf_end))) {
+            logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
+                    "osqlcomm_startgen_uuid_rpl_type_put");
+            return -1;
+        }
+        type = osql_net_type_to_net_uuid_type(NET_OSQL_SOCK_RPL);
+
+    } else {
+        osql_startgen_rpl_t startgen_rpl = {0};
+        uint8_t *p_buf = buf;
+        uint8_t *p_buf_end = (p_buf + OSQLCOMM_STARTGEN_RPL_LEN);
+        msglen = OSQLCOMM_STARTGEN_RPL_LEN;
+        startgen_rpl.hd.type = OSQL_STARTGEN;
+        startgen_rpl.hd.sid = rqid;
+        startgen_rpl.dt.start_gen = start_gen;
+
+        if (!(p_buf = osqlcomm_startgen_rpl_type_put(&startgen_rpl,
+                        p_buf, p_buf_end))) {
+            logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
+                    "osqlcomm_startgen_rpl_type_put");
+            return -1;
+        }
+    }
+
+    if (logsb) {
+        uuidstr_t us;
+        sbuf2printf(logsb, "[%llu %s] send OSQL_STARTGEN %u\n", rqid,
+                    comdb2uuidstr(uuid, us), start_gen);
+        sbuf2flush(logsb);
+    }
+
+    rc = offload_net_send(tohost, type, &buf, msglen, 0);
+
+    if (rc)
+        logmsg(LOGMSG_ERROR, "%s offload_net_send returns rc=%d\n", __func__,
+               rc);
+
+    return rc;
 }
 
 
@@ -6584,6 +6751,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
     const unsigned char tag_name_ondisk[] = ".ONDISK";
     const size_t tag_name_ondisk_len = 8 /*includes NUL*/;
     int type;
+    unsigned long long id;
     uuidstr_t us;
 
     if (rqid == OSQL_RQID_USE_UUID) {
@@ -6592,6 +6760,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         p_buf_end = (uint8_t *)p_buf + sizeof(rpl);
         p_buf = osqlcomm_uuid_rpl_type_get(&rpl, p_buf, p_buf_end);
         type = rpl.type;
+        id = OSQL_RQID_USE_UUID;
         comdb2uuidstr(rpl.uuid, us);
         if (comdb2uuidcmp(rpl.uuid, uuid)) {
             uuidstr_t passedus;
@@ -6606,6 +6775,8 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         p_buf_end = (uint8_t *)p_buf + sizeof(rpl);
         p_buf = osqlcomm_rpl_type_get(&rpl, p_buf, p_buf_end);
         type = rpl.type;
+        id = rpl.sid;
+        comdb2uuid_clear(uuid);
     }
 
 #if 0
@@ -6941,6 +7112,27 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         (*receivedrows)++;
     } break;
+    case OSQL_STARTGEN: {
+        osql_startgen_t dt;
+        unsigned char *pData = NULL;
+        uint32_t cur_gen;
+        const uint8_t *p_buf_end;
+        p_buf_end = p_buf + sizeof(osql_startgen_t);
+        pData = (uint8_t *)osqlcomm_startgen_type_get(&dt, p_buf, p_buf_end);
+        cur_gen = bdb_get_rep_gen(thedb->bdb_env);
+        if (cur_gen != dt.start_gen) {
+            err->errcode = OP_FAILED_VERIFY;
+            if (logsb) {
+                sbuf2printf(logsb, "Startgen check failed, start_gen %u, "
+                        "cur_gen %u, return verify error\n", dt.start_gen,
+                        cur_gen);
+            }
+            logmsg(LOGMSG_DEBUG, "[%llx %s] Startgen check failed, start_gen "
+                    "%u, cur_gen %u\n", id, us, dt.start_gen, cur_gen);
+            return ERR_VERIFY;
+        }
+    } break;
+
     case OSQL_UPDREC:
     case OSQL_UPDATE: {
         osql_upd_t dt;
@@ -7967,6 +8159,15 @@ int osql_log_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         sbuf2printf(logsb, " %llx (%d:%lld)\n", lclgenid, rrn, lclgenid);
     } break;
 
+    case OSQL_STARTGEN: {
+        osql_startgen_t dt;
+        unsigned char *pData = NULL;
+        uint8_t *p_buf_end;
+        p_buf_end = p_buf + sizeof(osql_startgen_t);
+        pData = (uint8_t *)osqlcomm_startgen_type_get(&dt, p_buf, p_buf_end);
+        sbuf2printf(logsb, "[%llx %s] %s start_gen = %u\n", id, us,
+                "OSQL_STARTGEN", dt.start_gen);
+    } break;
     case OSQL_UPDREC:
     case OSQL_UPDATE: {
         osql_upd_t dt;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3428,6 +3428,7 @@ int osql_comm_is_done(char *rpl, int rpllen, int hasuuid, struct errstat **xerr,
     case OSQL_INSIDX:
     case OSQL_DELIDX:
     case OSQL_QBLOB:
+    case OSQL_STARTGEN:
         break;
     case OSQL_DONE_SNAP:
         /* The iq is passed in from bplog_saveop */

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7128,12 +7128,14 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         if (cur_gen != dt.start_gen) {
             err->errcode = OP_FAILED_VERIFY;
             if (logsb) {
-                sbuf2printf(logsb, "Startgen check failed, start_gen %u, "
-                                   "cur_gen %u, return verify error\n",
+                sbuf2printf(logsb,
+                            "Startgen check failed, start_gen %u, "
+                            "cur_gen %u, return verify error\n",
                             dt.start_gen, cur_gen);
             }
-            logmsg(LOGMSG_DEBUG, "[%llx %s] Startgen check failed, start_gen "
-                                 "%u, cur_gen %u\n",
+            logmsg(LOGMSG_DEBUG,
+                   "[%llx %s] Startgen check failed, start_gen "
+                   "%u, cur_gen %u\n",
                    id, us, dt.start_gen, cur_gen);
             return ERR_VERIFY;
         }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -637,29 +637,29 @@ typedef struct osql_startgen {
 enum { OSQLCOMM_STARTGEN_TYPE_LEN = 8 };
 
 BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_type_len,
-        sizeof(osql_startgen_t) == OSQLCOMM_STARTGEN_TYPE_LEN);
+                       sizeof(osql_startgen_t) == OSQLCOMM_STARTGEN_TYPE_LEN);
 
-static uint8_t *osqlcomm_startgen_type_put(const osql_startgen_t *p_osql_startgen,
-                                           uint8_t *p_buf, 
-                                           const uint8_t *p_buf_end)
+static uint8_t *
+osqlcomm_startgen_type_put(const osql_startgen_t *p_osql_startgen,
+                           uint8_t *p_buf, const uint8_t *p_buf_end)
 {
     if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_TYPE_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = buf_put(&(p_osql_startgen->start_gen),
-            sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
+                    sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
     p_buf = buf_put(&(p_osql_startgen->padding),
-            sizeof(p_osql_startgen->padding), p_buf, p_buf_end);
+                    sizeof(p_osql_startgen->padding), p_buf, p_buf_end);
     return p_buf;
 }
 
 const uint8_t *osqlcomm_startgen_type_get(osql_startgen_t *p_osql_startgen,
-                                          const uint8_t *p_buf, 
+                                          const uint8_t *p_buf,
                                           const uint8_t *p_buf_end)
 {
     if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_TYPE_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = buf_get(&(p_osql_startgen->start_gen),
-            sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
+                    sizeof(p_osql_startgen->start_gen), p_buf, p_buf_end);
     return p_buf;
 }
 
@@ -669,30 +669,30 @@ typedef struct osql_startgen_rpl {
 } osql_startgen_rpl_t;
 
 enum {
-    OSQLCOMM_STARTGEN_RPL_LEN = 
+    OSQLCOMM_STARTGEN_RPL_LEN =
         OSQLCOMM_RPL_TYPE_LEN + OSQLCOMM_STARTGEN_TYPE_LEN
 };
 
-BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_rpl_len, sizeof(osql_startgen_rpl_t) ==
+BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_rpl_len,
+                       sizeof(osql_startgen_rpl_t) ==
                            OSQLCOMM_STARTGEN_RPL_LEN);
 
-static uint8_t *osqlcomm_startgen_rpl_type_put(const osql_startgen_rpl_t *p_startgen_rpl,
-                                               uint8_t *p_buf, uint8_t *p_buf_end)
+static uint8_t *
+osqlcomm_startgen_rpl_type_put(const osql_startgen_rpl_t *p_startgen_rpl,
+                               uint8_t *p_buf, uint8_t *p_buf_end)
 {
-    if (p_buf_end < p_buf ||
-            OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
+    if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = osqlcomm_rpl_type_put(&(p_startgen_rpl->hd), p_buf, p_buf_end);
     p_buf = osqlcomm_startgen_type_put(&(p_startgen_rpl->dt), p_buf, p_buf_end);
     return p_buf;
 }
 
-static const uint8_t *osqlcomm_startgen_rpl_type_get(osql_startgen_rpl_t *p_startgen_rpl,
-                                               const uint8_t *p_buf,
-                                               const uint8_t *p_buf_end)
+static const uint8_t *
+osqlcomm_startgen_rpl_type_get(osql_startgen_rpl_t *p_startgen_rpl,
+                               const uint8_t *p_buf, const uint8_t *p_buf_end)
 {
-    if (p_buf_end < p_buf ||
-            OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
+    if (p_buf_end < p_buf || OSQLCOMM_STARTGEN_RPL_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = osqlcomm_rpl_type_get(&(p_startgen_rpl->hd), p_buf, p_buf_end);
     p_buf = osqlcomm_startgen_type_get(&(p_startgen_rpl->dt), p_buf, p_buf_end);
@@ -704,29 +704,34 @@ typedef struct osql_startgen_uuid_rpl {
     osql_startgen_t dt;
 } osql_startgen_uuid_rpl_t;
 
-enum { OSQLCOMM_STARTGEN_UUID_RPL_LEN = 
-    OSQLCOMM_UUID_RPL_TYPE_LEN + OSQLCOMM_STARTGEN_TYPE_LEN };
+enum {
+    OSQLCOMM_STARTGEN_UUID_RPL_LEN =
+        OSQLCOMM_UUID_RPL_TYPE_LEN + OSQLCOMM_STARTGEN_TYPE_LEN
+};
 
 BB_COMPILE_TIME_ASSERT(osqlcomm_startgen_uuid_type_len,
-        sizeof(osql_startgen_uuid_rpl_t) == OSQLCOMM_STARTGEN_UUID_RPL_LEN);
+                       sizeof(osql_startgen_uuid_rpl_t) ==
+                           OSQLCOMM_STARTGEN_UUID_RPL_LEN);
 
-static uint8_t *osqlcomm_startgen_uuid_rpl_type_put(const osql_startgen_uuid_rpl_t *p_startgen_rpl,
-                                               uint8_t *p_buf, uint8_t *p_buf_end)
+static uint8_t *osqlcomm_startgen_uuid_rpl_type_put(
+    const osql_startgen_uuid_rpl_t *p_startgen_rpl, uint8_t *p_buf,
+    uint8_t *p_buf_end)
 {
     if (p_buf_end < p_buf ||
-            OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
+        OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = osqlcomm_uuid_rpl_type_put(&(p_startgen_rpl->hd), p_buf, p_buf_end);
     p_buf = osqlcomm_startgen_type_put(&(p_startgen_rpl->dt), p_buf, p_buf_end);
     return p_buf;
 }
 
-static const uint8_t *osqlcomm_startgen_uuid_rpl_type_get(osql_startgen_uuid_rpl_t *p_startgen_rpl,
-                                               const uint8_t *p_buf,
-                                               const uint8_t *p_buf_end)
+static const uint8_t *
+osqlcomm_startgen_uuid_rpl_type_get(osql_startgen_uuid_rpl_t *p_startgen_rpl,
+                                    const uint8_t *p_buf,
+                                    const uint8_t *p_buf_end)
 {
     if (p_buf_end < p_buf ||
-            OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
+        OSQLCOMM_STARTGEN_UUID_RPL_LEN > (p_buf_end - p_buf))
         return NULL;
     p_buf = osqlcomm_uuid_rpl_type_get(&(p_startgen_rpl->hd), p_buf, p_buf_end);
     p_buf = osqlcomm_startgen_type_get(&(p_startgen_rpl->dt), p_buf, p_buf_end);
@@ -3567,11 +3572,12 @@ int is_tablename_queue(const char * tablename, int len)
 }
 
 int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
-        uint32_t start_gen, int type, SBUF2 *logsb)
+                       uint32_t start_gen, int type, SBUF2 *logsb)
 {
     netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
-    uint8_t buf[OSQLCOMM_STARTGEN_UUID_RPL_LEN > OSQLCOMM_STARTGEN_RPL_LEN ?
-        OSQLCOMM_STARTGEN_UUID_RPL_LEN : OSQLCOMM_STARTGEN_RPL_LEN];
+    uint8_t buf[OSQLCOMM_STARTGEN_UUID_RPL_LEN > OSQLCOMM_STARTGEN_RPL_LEN
+                    ? OSQLCOMM_STARTGEN_UUID_RPL_LEN
+                    : OSQLCOMM_STARTGEN_RPL_LEN];
     int msglen;
     int rc;
 
@@ -3588,9 +3594,9 @@ int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
         startgen_uuid_rpl.dt.start_gen = start_gen;
 
         if (!(p_buf = osqlcomm_startgen_uuid_rpl_type_put(&startgen_uuid_rpl,
-                        p_buf, p_buf_end))) {
+                                                          p_buf, p_buf_end))) {
             logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
-                    "osqlcomm_startgen_uuid_rpl_type_put");
+                   "osqlcomm_startgen_uuid_rpl_type_put");
             return -1;
         }
         type = osql_net_type_to_net_uuid_type(NET_OSQL_SOCK_RPL);
@@ -3604,10 +3610,10 @@ int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
         startgen_rpl.hd.sid = rqid;
         startgen_rpl.dt.start_gen = start_gen;
 
-        if (!(p_buf = osqlcomm_startgen_rpl_type_put(&startgen_rpl,
-                        p_buf, p_buf_end))) {
+        if (!(p_buf = osqlcomm_startgen_rpl_type_put(&startgen_rpl, p_buf,
+                                                     p_buf_end))) {
             logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
-                    "osqlcomm_startgen_rpl_type_put");
+                   "osqlcomm_startgen_rpl_type_put");
             return -1;
         }
     }
@@ -7124,11 +7130,12 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             err->errcode = OP_FAILED_VERIFY;
             if (logsb) {
                 sbuf2printf(logsb, "Startgen check failed, start_gen %u, "
-                        "cur_gen %u, return verify error\n", dt.start_gen,
-                        cur_gen);
+                                   "cur_gen %u, return verify error\n",
+                            dt.start_gen, cur_gen);
             }
             logmsg(LOGMSG_DEBUG, "[%llx %s] Startgen check failed, start_gen "
-                    "%u, cur_gen %u\n", id, us, dt.start_gen, cur_gen);
+                                 "%u, cur_gen %u\n",
+                   id, us, dt.start_gen, cur_gen);
             return ERR_VERIFY;
         }
     } break;
@@ -8166,7 +8173,7 @@ int osql_log_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         p_buf_end = p_buf + sizeof(osql_startgen_t);
         pData = (uint8_t *)osqlcomm_startgen_type_get(&dt, p_buf, p_buf_end);
         sbuf2printf(logsb, "[%llx %s] %s start_gen = %u\n", id, us,
-                "OSQL_STARTGEN", dt.start_gen);
+                    "OSQL_STARTGEN", dt.start_gen);
     } break;
     case OSQL_UPDREC:
     case OSQL_UPDATE: {

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -191,6 +191,8 @@ int osql_send_commit_by_uuid(char *tohost, uuid_t uuid, int nops,
                              struct errstat *xerr, int type, SBUF2 *logsb,
                              struct client_query_stats *query_stats,
                              snap_uid_t *snap_info);
+int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
+                             uint32_t start_gen, int type, SBUF2 *logsb);
 
 /**
  * Send decomission for osql net

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -192,7 +192,7 @@ int osql_send_commit_by_uuid(char *tohost, uuid_t uuid, int nops,
                              struct client_query_stats *query_stats,
                              snap_uid_t *snap_info);
 int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
-                             uint32_t start_gen, int type, SBUF2 *logsb);
+                       uint32_t start_gen, int type, SBUF2 *logsb);
 
 /**
  * Send decomission for osql net

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -810,6 +810,7 @@ again:
 }
 
 int gbl_random_blkseq_replays;
+int gbl_osql_send_startgen = 0;
 
 /**
  * Terminates a sosql session
@@ -1330,14 +1331,23 @@ static int osql_send_commit_logic(struct sqlclntstate *clnt, int is_retry,
     }
 
 retry:
-    if (osql->rqid == OSQL_RQID_USE_UUID) {
-        rc = osql_send_commit_by_uuid(osql->host, osql->uuid, osql->sentops,
-                                      &osql->xerr, nettype, osql->logsb,
-                                      clnt->query_stats, snap_info_p);
-    } else {
-        rc = osql_send_commit(osql->host, osql->rqid, osql->uuid, osql->sentops,
-                              &osql->xerr, nettype, osql->logsb,
-                              clnt->query_stats, NULL);
+    rc = 0;
+
+    if (gbl_osql_send_startgen && clnt->start_gen > 0) {
+        rc = osql_send_startgen(osql->host, osql->rqid, osql->uuid,
+                clnt->start_gen, nettype, osql->logsb);
+    }
+
+    if (rc == 0) {
+        if (osql->rqid == OSQL_RQID_USE_UUID) {
+            rc = osql_send_commit_by_uuid(osql->host, osql->uuid, osql->sentops,
+                    &osql->xerr, nettype, osql->logsb,
+                    clnt->query_stats, snap_info_p);
+        } else {
+            rc = osql_send_commit(osql->host, osql->rqid, osql->uuid, osql->sentops,
+                    &osql->xerr, nettype, osql->logsb,
+                    clnt->query_stats, NULL);
+        }
     }
 
     RESTART_SOCKSQL_KEEP_RQID(is_retry);

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -810,7 +810,7 @@ again:
 }
 
 int gbl_random_blkseq_replays;
-int gbl_osql_send_startgen = 0;
+int gbl_osql_send_startgen = 1;
 
 /**
  * Terminates a sosql session
@@ -1335,18 +1335,18 @@ retry:
 
     if (gbl_osql_send_startgen && clnt->start_gen > 0) {
         rc = osql_send_startgen(osql->host, osql->rqid, osql->uuid,
-                clnt->start_gen, nettype, osql->logsb);
+                                clnt->start_gen, nettype, osql->logsb);
     }
 
     if (rc == 0) {
         if (osql->rqid == OSQL_RQID_USE_UUID) {
             rc = osql_send_commit_by_uuid(osql->host, osql->uuid, osql->sentops,
-                    &osql->xerr, nettype, osql->logsb,
-                    clnt->query_stats, snap_info_p);
+                                          &osql->xerr, nettype, osql->logsb,
+                                          clnt->query_stats, snap_info_p);
         } else {
-            rc = osql_send_commit(osql->host, osql->rqid, osql->uuid, osql->sentops,
-                    &osql->xerr, nettype, osql->logsb,
-                    clnt->query_stats, NULL);
+            rc = osql_send_commit(osql->host, osql->rqid, osql->uuid,
+                                  osql->sentops, &osql->xerr, nettype,
+                                  osql->logsb, clnt->query_stats, NULL);
         }
     }
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -262,7 +262,11 @@ void currange_free(CurRange *cr);
 struct stored_proc;
 struct lua_State;
 
-enum early_verify_error { EARLY_ERR_VERIFY = 1, EARLY_ERR_SELECTV = 2 };
+enum early_verify_error {
+    EARLY_ERR_VERIFY = 1,
+    EARLY_ERR_SELECTV = 2,
+    EARLY_ERR_GENCHANGE = 3
+};
 #define FINGERPRINTSZ 16
 
 enum {

--- a/db/sql.h
+++ b/db/sql.h
@@ -638,6 +638,8 @@ struct sqlclntstate {
 
     int translevel_changed;
     int admin;
+
+    uint32_t start_gen;
 };
 
 /* Query stats. */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4765,8 +4765,7 @@ int sqlite3BtreeCommit(Btree *pBt)
     case TRANLEVEL_SOSQL:
         if (gbl_selectv_rangechk)
             rc = selectv_range_commit(clnt);
-        if (gbl_early_verify && !clnt->early_retry &&
-                gbl_osql_send_startgen) {
+        if (gbl_early_verify && !clnt->early_retry && gbl_osql_send_startgen) {
             if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
                 clnt->early_retry = EARLY_ERR_GENCHANGE;
         }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2866,6 +2866,9 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
 {
     int rc;
 
+    if (!clnt->in_client_trans)
+        clnt->start_gen = bdb_get_rep_gen(thedb->bdb_env);
+
     sql_update_usertran_state(clnt);
 
     switch (clnt->ctrl_sqlengine) {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1351,7 +1351,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                 }
 
                 if (gbl_early_verify && !clnt->early_retry &&
-                        gbl_osql_send_startgen && clnt->start_gen) {
+                    gbl_osql_send_startgen && clnt->start_gen) {
                     if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
                         clnt->early_retry = EARLY_ERR_GENCHANGE;
                 }
@@ -1375,7 +1375,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                     } else if (clnt->early_retry == EARLY_ERR_GENCHANGE) {
                         clnt->osql.xerr.errval = ERR_BLOCK_FAILED + ERR_VERIFY;
                         errstat_cat_str(&(clnt->osql.xerr),
-                                "verify error on master swing");
+                                        "verify error on master swing");
                     }
                     if (clnt->early_retry) {
                         clnt->early_retry = 0;

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -283,8 +283,8 @@ static int rese_commit(struct sqlclntstate *clnt, struct sql_thread *thd,
     int rc2 = 0;
     int usedb_only = 0;
 
-    if (gbl_early_verify && !clnt->early_retry &&
-            gbl_osql_send_startgen && clnt->start_gen) {
+    if (gbl_early_verify && !clnt->early_retry && gbl_osql_send_startgen &&
+        clnt->start_gen) {
         if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
             clnt->early_retry = EARLY_ERR_GENCHANGE;
     }
@@ -297,8 +297,7 @@ static int rese_commit(struct sqlclntstate *clnt, struct sql_thread *thd,
         errstat_cat_str(&(clnt->osql.xerr), "constraints error, no genid");
     } else if (clnt->early_retry == EARLY_ERR_GENCHANGE) {
         clnt->osql.xerr.errval = ERR_BLOCK_FAILED + ERR_VERIFY;
-        errstat_cat_str(&(clnt->osql.xerr),
-                "verify error on master swing");
+        errstat_cat_str(&(clnt->osql.xerr), "verify error on master swing");
     }
     if (clnt->early_retry) {
         clnt->early_retry = 0;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2190,7 +2190,6 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (!clnt.in_client_trans) {
             bzero(&clnt.effects, sizeof(clnt.effects));
             bzero(&clnt.log_effects, sizeof(clnt.log_effects));
-            clnt.start_gen = bdb_get_rep_gen(thedb->bdb_env);
         }
         if (clnt.dbtran.mode < TRANLEVEL_SOSQL) {
             clnt.dbtran.mode = TRANLEVEL_SOSQL;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2190,6 +2190,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (!clnt.in_client_trans) {
             bzero(&clnt.effects, sizeof(clnt.effects));
             bzero(&clnt.log_effects, sizeof(clnt.log_effects));
+            clnt.start_gen = bdb_get_rep_gen(thedb->bdb_env);
         }
         if (clnt.dbtran.mode < TRANLEVEL_SOSQL) {
             clnt.dbtran.mode = TRANLEVEL_SOSQL;

--- a/tests/socksql_master_swings.test/lrl.options
+++ b/tests/socksql_master_swings.test/lrl.options
@@ -9,6 +9,7 @@ logmsg level debug
 set_repinfo_master_trace on
 extended_sql_debug_trace on
 setattr WAIT_FOR_SEQNUM_TRACE 1
+osql_send_startgen on
 dump_blkseq on
 extended_sql_debug_trace on
 nowatch


### PR DESCRIPTION
This test devised to fix a socksql_master_swings test error that we see usually after a week or more of continuous testing.  Lingzhi analyzed and explained the issue: it occurs an osql stream refers to genids which have been rolled back by a new master.  In the best case, the  genids won't be found against the new master, and the transaction will return with a verify error.  In the worst case, the new master could have generated the same set of genids which might refer to different records.

The fix for this is straightforward- record the cluster's generation at the beginning of a transaction on the replicant.  If the generation has changed by the time that transaction is executed on the master, automatically fail with a verify error.
