### PR TITLE
always upsert tablever if scdone is sent in a different tran

### DIFF
--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -785,7 +785,8 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     bdb_handle_reset_tran(new_bdb_handle, transac);
 
-    if (!s->same_schema) {
+    if (!s->same_schema ||
+        BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0) {
         /* reliable per table versioning */
         rc = table_version_upsert(db, transac, &bdberr);
         if (rc) {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -786,7 +786,8 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     bdb_handle_reset_tran(new_bdb_handle, transac);
 
     if (!s->same_schema ||
-        BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0) {
+        (!s->fastinit &&
+         BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0)) {
         /* reliable per table versioning */
         rc = table_version_upsert(db, transac, &bdberr);
         if (rc) {


### PR DESCRIPTION
Otherwise, new writes will not get verify errors and we could fail read
after write temporarily.

We, in R7, should always write scdone in the same tran as writing
llmeta. This is just a quick fix for legacy_defaults.