### PR TITLE
comdb2makecluster: tool to create a cluster and start it.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ endif()
 add_subdirectory(tools)
 add_subdirectory(plugins)
 add_subdirectory(db)
+add_subdirectory(contrib/comdb2makecluster)
 add_subdirectory(tests/tools EXCLUDE_FROM_ALL)
 
 enable_testing()

--- a/contrib/comdb2makecluster/CMakeLists.txt
+++ b/contrib/comdb2makecluster/CMakeLists.txt
@@ -1,0 +1,6 @@
+configure_file(comdb2makecluster comdb2makecluster @ONLY)
+install(PROGRAMS
+  ${CMAKE_CURRENT_BINARY_DIR}/comdb2makecluster
+  DESTINATION bin
+)
+

--- a/contrib/comdb2makecluster/comdb2makecluster
+++ b/contrib/comdb2makecluster/comdb2makecluster
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# 
+# This script starts a comdb2 cluster
+# needs the following parameters:
+# [optionally] a directory to store the database files, if ommited
+#   it will use current working directory
+# the database name
+# cluster nodes (at least two nodes)
+
+#set -x
+
+failexit() {
+    echo $1
+    exit -1
+}
+
+usage() {
+    failexit "usage: $0 [--dir /path/to/dir] dbname node1 node2 [..nodeN]"
+}
+
+
+if [[ $# -lt 3 || $1 = "--help" || $1 = "-h" ]] ; then
+    usage
+fi
+
+CREATEDB=1
+if [[ $1 = "--nocreate" ]] ; then 
+    shift
+    CREATEDB=0
+fi
+
+
+if [[ $1 = "--dir" ]] ; then 
+    shift
+    DBDIR=$1
+    shift
+fi
+
+DBNAME=$1
+shift
+
+#what remains is the cluster line
+if [[ $# -lt 2 ]] ; then
+    echo "Error: cluster needs to have at least two nodes."
+    usage
+fi
+
+CLUSTER=$@
+
+# use --dir to specify db directory otherwise creates db in current_dir/$DBNAME
+if [[ -z $DBDIR ]]; then
+    DBDIR=`pwd`/$DBNAME/
+else
+    DBDIR=`readlink -f ${DBDIR}`
+fi
+
+if [ "x$CLUSTER" = "x" ] ; then
+    usage
+fi
+
+
+TMPDIR=${TMPDIR:-/tmp}
+CDB2_CONFIG=$DBDIR/comdb2db.cfg
+CDB2_OPTIONS="--cdb2cfg ${CDB2_CONFIG}"
+COMDB2_EXE=${COMDB2_EXE:-comdb2}
+CDB2SQL_EXE=${CDB2SQL_EXE:-cdb2sql}
+COMDB2AR_EXE=${COMDB2AR_EXE:-comdb2ar}
+COPYCOMDB2_EXE=${COPYCOMDB2_EXE:-copycomdb2}
+export comdb2ar=$COMDB2AR_EXE  # used by copycomdb2
+export COMDB2AR_EXOPTS="-x $COMDB2_EXE"
+export COMDB2_ROOT=${DBDIR}
+myhostname=`hostname`
+LOGDIR=${LOGDIR:-$DBDIR/var/log}
+
+
+check_executables_for_cluster() 
+{
+    which $CDB2SQL_EXE  > /dev/null || failexit "$CDB2SQL_EXE not in path"
+    which $COMDB2AR_EXE  > /dev/null || failexit "$COMDB2AR_EXE not in path"
+    which $COPYCOMDB2_EXE  > /dev/null || failexit "$COPYCOMDB2_EXE not in path"
+    for node in $CLUSTER; do
+        if [ $node == $myhostname ] ; then
+            if [ $CREATEDB == "1" ] ; then
+                ls $DBDIR &> /dev/null && failexit "$DBDIR already exists, please clean up before attempting to start"
+            fi
+            which $COMDB2_EXE > /dev/null || failexit "$COMDB2_EXE not in path"
+            continue
+        fi
+
+        hst=$(ssh -o StrictHostKeyChecking=no $node "hostname" < /dev/null )
+        if [ "x$hst" == "x" ] ; then
+            failexit "cant get hostname on $node"
+        fi
+
+        ssh -o StrictHostKeyChecking=no $node "ls $DBDIR > /dev/null 2>&1" < /dev/null && failexit "$DBDIR already exists in node $node, please clean up before attempting to start" < /dev/null
+        ssh -o StrictHostKeyChecking=no $node "which $COMDB2_EXE > /dev/null 2>&1" < /dev/null || failexit "$COMDB2_EXE not in path in node $node" < /dev/null
+        ssh -o StrictHostKeyChecking=no $node "which $COMDB2AR_EXE > /dev/null 2>&1" < /dev/null || failexit "$COMDB2AR_EXE not in path in node $node" < /dev/null
+    done
+}
+
+check_executables_for_cluster
+
+LRL="$DBDIR/$DBNAME.lrl"
+PARAMS="$DBNAME --no-global-lrl"
+if [ $CREATEDB == 1 ] ; then 
+    mkdir -p $DBDIR $TMPDIR
+    mkdir -p $LOGDIR $DBDIR/var/log/cdb2 $DBDIR/tmp/cdb2
+
+    # setup files:
+    echo "$DBNAME: creating"
+    > ${LRL}
+
+    cat >> $DBDIR/$DBNAME.lrl <<EOPTIONS
+name    $DBNAME
+dir     $DBDIR
+
+EOPTIONS
+
+
+    pmux_port=5105
+    pmux_cmd='pmux -n'
+    if [ -n "$PMUXPORT" ] ; then
+        pmux_port=$PMUXPORT
+        pmux_socket=/tmp/pmux.socket.$PMUXPORT
+        pmux_port_range="-r 21000:22000"
+        pmux_cmd="pmux -n -p $PMUXPORT -b $pmux_socket $pmux_port_range"
+        echo "comdb2_config:portmuxport=$PMUXPORT" >> $CDB2_CONFIG
+        echo "portmux_port $PMUXPORT" >> ${LRL}
+        echo "portmux_bind_path $pmux_socket" >> ${LRL}
+    fi
+
+    df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" > /dev/null && echo "setattr directio 0" >> ${LRL}
+
+    echo $DBNAME 0 $CLUSTER > $CDB2_CONFIG
+    echo "comdb2_config:default_type=testsuite" >> $CDB2_CONFIG
+    echo "cluster nodes $CLUSTER" >> $DBDIR/$DBNAME.lrl
+    set +e
+    $COMDB2_EXE --create --lrl ${LRL} --pidfile ${TMPDIR}/$DBNAME.pid $PARAMS &> $LOGDIR/${DBNAME}.init
+    rc=$?
+    rm -f ${DBNAME}.trap
+    if [[ $rc -ne 0 ]] ; then
+        echo "Error rc=$rc while initializing DB, see $LOGDIR/${DBNAME}.init "
+        exit 1
+    fi
+
+    echo "${DBNAME} created successfully"
+fi
+
+#set -e  # from here, a bad rc will mean failure and exit
+
+
+echo "$DBNAME: copying to cluster"
+for node in $CLUSTER; do
+    if [ $node == $myhostname ] ; then
+        continue        # no copying to self
+    fi
+
+    ssh -o StrictHostKeyChecking=no $node "mkdir -p $LOGDIR $DBDIR/var/log/cdb2 $DBDIR/tmp/cdb2" < /dev/null
+    ssh -o StrictHostKeyChecking=no $node "$pmux_cmd" &>> $LOGDIR/setup.log < /dev/null
+
+    loccomdb2ar_exopts=`ssh -o StrictHostKeyChecking=no $node "which $COMDB2_EXE"`
+    COMDB2AR_EXOPTS="-x $loccomdb2ar_exopts" $COPYCOMDB2_EXE ${LRL} ${node}: &> ${LOGDIR}/${DBNAME}.${node}.copy
+    if [[ $? -ne 0 ]]; then
+        echo "FAILED: $COPYCOMDB2_EXE ${LRL} ${node}: "
+        echo "see $LOGDIR/${DBNAME}.${node}.copy "
+        exit 1
+    fi
+done
+
+echo "export COMDB2_ROOT=$DBDIR" >> ${DBDIR}/replicant_vars
+echo "export PATH=$PATH" >> ${DBDIR}/replicant_vars
+CMD="source ${DBDIR}/replicant_vars ; $COMDB2_EXE ${DBNAME} --lrl $DBDIR/${DBNAME}.lrl"
+echo "$DBNAME: starting"
+for node in $CLUSTER; do
+    if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
+            if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
+                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
+            else
+                ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &> $LOGDIR/${DBNAME}.${node}.db &
+            fi
+        continue
+    fi
+
+    if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
+        echo -e "$DBNAME: Execute the following command on ${node}: ${TEXTCOLOR}${CMD}${NOCOLOR}"
+        continue
+    fi
+    scp -o StrictHostKeyChecking=no ${DBDIR}/replicant_vars $node:${DBDIR}/replicant_vars &>> $LOGDIR/setup.log
+    # redirect output from CMD to a subshell which runs awk to prepend time
+    ssh -n -o StrictHostKeyChecking=no -tt $node ${CMD} &>$LOGDIR/${DBNAME}.${node}.db &
+    # $! will be pid of ssh (if we had used pipe, $! would be pid of awk)
+    echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+done
+
+if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
+    exit 0
+fi
+
+set +e
+echo "$DBNAME: waiting until ready"
+sleep 1
+for node in $CLUSTER; do
+    out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
+    while  [[ "$out" != "1" ]]; do
+        sleep 2
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
+        $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $LOGDIR/${DBNAME}.${node}.conn
+    done
+done
+
+n=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME --host $node 'exec procedure sys.cmd.send("bdb cluster")' | grep "lsn" | wc -l)
+echo "$DBNAME: Cluster is running with $n nodes. You can query it with:"
+echo "   $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME default 'select 1'"
+
+exit 0

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -219,8 +219,11 @@ assertres $res $dbnm
 cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
 
 # this tests connecting to 'local'
-if [[ ! -n "$CLUSTER" ]]; then
+if `echo $cluster | grep $HOSTNAME > /dev/null` ; then
+    # if localhost is part of cluster, try local as cluster parameter
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm local "select comdb2_host()"`
+    assertres $res $HOSTNAME
+    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @localhost "select comdb2_host()"`
     assertres $res $HOSTNAME
 fi
 

--- a/tests/dbcreate.test/Makefile
+++ b/tests/dbcreate.test/Makefile
@@ -7,6 +7,4 @@ ifeq ($(TEST_TIMEOUT),)
 	export TEST_TIMEOUT=1m
 endif
 
-# this is a local test, don't need cluster
-unexport CLUSTER
 export COMDB2_UNITTEST=1

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -3,6 +3,17 @@ bash -n "$0" | exit 1
 
 set -x
 
+assertres ()
+{
+    if [ $# != 2 ] ; then 
+        failexit "res is $res, target is $target, one or more is blank"
+    fi
+    res=$1
+    target=$2
+    if [ "$res" != "$target" ] ; then
+        failexit "res is $res but should be $target"
+    fi
+}
 failexit()
 {
     echo $1
@@ -10,8 +21,8 @@ failexit()
 }
 
 i=1
-DB=testdb${i}
-TSTDBDIR=$(pwd)/$DB
+DB=$DBNAME
+TSTDBDIR=$DBDIR
 
 echo "Check 1"
 ${COMDB2_EXE} --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
@@ -48,9 +59,67 @@ grep "No such file or directory" out | grep "logs:" || failexit "expected 'No su
 echo "Check 7"
 touch $TSTDBDIR/${DB}.lrl
 df $TSTDBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" > $TSTDBDIR/${DB}.lrl 
-${COMDB2_EXE} testdb${i} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "Created database" out || failexit "expected 'Created database'"
 
-rm -rf $TSTDBDIR
+echo "name    $DB" >> $TSTDBDIR/${DB}.lrl
+echo "dir     $TSTDBDIR" >> $TSTDBDIR/${DB}.lrl
+mkdir -p $TSTDBDIR/var/log
+mkdir -p $TMPDIR
+
+echo "Check 8, bring up db and query it"
+if [[ -n "$CLUSTER" ]]; then
+    echo "Use comdb2makecluster --nocreate to copy to cluster"
+
+    ${SRCHOME}/contrib/comdb2makecluster/comdb2makecluster --nocreate --dir $TSTDBDIR $DB $CLUSTER
+    rc=$?
+    if [[ $rc -ne 0 ]] ; then
+        failexit "Makecluster returned error $rc"
+    fi
+
+
+    echo $DBNAME 0 $CLUSTER > $CDB2_CONFIG
+    echo "comdb2_config:default_type=testsuite" >> $CDB2_CONFIG
+
+    cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $DB default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
+    for node in $cluster ; do
+        res=`cdb2sql --tabs ${CDB2_OPTIONS} $DB --host $node "select comdb2_host()"`
+        assertres $res $node
+    done
+else
+    ${SRCHOME}/contrib/comdb2makecluster/comdb2makecluster --nocreate --dir $DB $TSTDBDIR
+    assertres $? 255
+
+    echo "comdb2_config:default_type=local" >> $CDB2_CONFIG
+    ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $TSTDBDIR/${DB}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
+    sleep 1
+    res=`cdb2sql --tabs ${CDB2_OPTIONS} $DB default "select comdb2_host()"`
+    assertres $res $HOSTNAME
+fi
+
+COMDB2_UNITTEST=0 CLEANUPDBDIR=1 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
+
+
+if [[ -n "$CLUSTER" ]]; then
+    echo "Check 9, Use comdb2makecluster bring up a new db"
+
+    ${SRCHOME}/contrib/comdb2makecluster/comdb2makecluster --dir $TSTDBDIR $DB $CLUSTER
+    rc=$?
+    if [[ $rc -ne 0 ]] ; then
+        failexit "Makecluster returned error $rc"
+    fi
+
+    echo $DBNAME 0 $CLUSTER > $CDB2_CONFIG
+    echo "comdb2_config:default_type=testsuite" >> $CDB2_CONFIG
+
+    cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $DB default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
+    for node in $cluster ; do
+        res=`cdb2sql --tabs ${CDB2_OPTIONS} $DB --host $node "select comdb2_host()"`
+        assertres $res $node
+    done
+
+    COMDB2_UNITTEST=0 CLEANUPDBDIR=1 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
+fi
+
 
 exit 0

--- a/tests/setup
+++ b/tests/setup
@@ -3,6 +3,12 @@
 set -e
 set -x
 
+failexit() {
+    echo $1
+    exit 1
+}
+
+
 debug=0
 
 [[ $COMDB2_UNITTEST == 1 ]] && exit 0
@@ -24,7 +30,7 @@ done
 
 source $TESTSROOTDIR/setup.common
 
-DBDIR=$(realpath $DBDIR)
+DBDIR=$(readlink -f $DBDIR)
 
 # Setup a debugger to run comdb2 server
 DEBUG_PREFIX=
@@ -187,22 +193,22 @@ mkdir -p $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2
 cd $DBDIR >/dev/null
 
 PARAMS="$DBNAME --no-global-lrl"
+export LOGDIR=$TESTDIR/logs
 
 # The script occasionally fails here. Let's find out what the rc is.
 set +e
-$COMDB2_EXE --create --lrl ${LRL} --pidfile ${TMPDIR}/$DBNAME.pid $PARAMS &> $TESTDIR/logs/${DBNAME}.init
+$COMDB2_EXE --create --lrl ${LRL} --pidfile ${TMPDIR}/$DBNAME.pid $PARAMS &> $LOGDIR/${DBNAME}.init
 rc=$?
 rm -f ${DBNAME}.trap
 if [[ $rc -ne 0 ]]; then
-    echo "Error rc=$rc while initializing DB, see $TESTDIR/logs/${DBNAME}.init "
-    exit 1
+    failexit "Error rc=$rc while initializing DB, see $LOGDIR/${DBNAME}.init "
 fi
 echo "${DBNAME} created successfully"
 
 set -e
 
 check_db_port_running_local() {
-    local dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    local dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $LOGDIR/${DBNAME}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
     if [ "x$dbport" == "x" ] ; then
         return
     fi
@@ -216,7 +222,7 @@ check_db_port_running_local() {
 
 check_db_port_running_node() {
     local node=$1
-    local dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $TESTDIR/logs/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
+    local dbport=`grep "\[ERROR\] net_listen: FAILED TO BIND to port" $LOGDIR/${DBNAME}.${node}.db | grep -Po "port [0-9]*" | cut -f2 -d" " `
     if [ "x$dbport" == "x" ] ; then
         return;
     fi
@@ -237,8 +243,8 @@ check_db_port_running_node() {
 
 
 # test largecsc2 throws error about col width
-#if grep "ERROR" $TESTDIR/logs/${DBNAME}.init | grep -v largecsc2 ; then
-#    echo "Error while initializing DB, see $TESTDIR/logs/${DBNAME}.init "
+#if grep "ERROR" $LOGDIR/${DBNAME}.init | grep -v largecsc2 ; then
+#    echo "Error while initializing DB, see $LOGDIR/${DBNAME}.init "
 #    exit 1
 #fi
 
@@ -251,7 +257,7 @@ if [[ -z "$CLUSTER" ]]; then
     fi
 
     echo "!$TESTCASE: starting single node"
-    ${DEBUG_PREFIX} $COMDB2_EXE $PARAMS --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
+    ${DEBUG_PREFIX} $COMDB2_EXE $PARAMS --pidfile ${TMPDIR}/${DBNAME}.pid &> $LOGDIR/${DBNAME}.db &
     dbpid=$!
 
     set +e
@@ -268,7 +274,7 @@ if [[ -z "$CLUSTER" ]]; then
     while [[ "$out" != "1" ]]; do
         sleep 1
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs $DBNAME default 'select 1' 2> /dev/null)
-        $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs $DBNAME 'select 1' &> $TESTDIR/logs/${DBNAME}.conn
+        $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs $DBNAME 'select 1' &> $LOGDIR/${DBNAME}.conn
     done
 else
     echo "!$TESTCASE: copying to cluster"
@@ -279,7 +285,7 @@ else
     COMDB2AR_EXOPTS="-x $COMDB2_EXE"
 
     ARFILE=$DBDIR/${DBNAME}.ar
-    $COMDB2AR_EXE $COMDB2AR_AROPTS c ${LRL} 2> $TESTDIR/logs/${DBNAME}.arstatus > $ARFILE
+    $COMDB2AR_EXE $COMDB2AR_AROPTS c ${LRL} 2> $LOGDIR/${DBNAME}.arstatus > $ARFILE
     [ ! -f $ARFILE ] && echo "failed to create $ARFILE" && exit 1
 
     i=0
@@ -288,7 +294,7 @@ else
         if [ $node == $HOSTNAME ] ; then
             continue
         fi
-        cat $ARFILE | ssh $SSH_OPT $node "cd ${DBDIR}; $COMDB2AR_EXE $COMDB2AR_EXOPTS $COMDB2AR_AROPTS -u 95 x $DBDIR" &> $TESTDIR/logs/${DBNAME}.${node}.copy &
+        cat $ARFILE | ssh $SSH_OPT $node "cd ${DBDIR}; $COMDB2AR_EXE $COMDB2AR_EXOPTS $COMDB2AR_AROPTS -u 95 x $DBDIR" &> $LOGDIR/${DBNAME}.${node}.copy &
         pids[$i]=$!
         let i=i+1
     done
@@ -299,7 +305,7 @@ else
         fi
         wait ${pids[$i]}
         if [[ $? -ne 0 ]]; then
-            echo "FAILED: copying ${LRL} ${node}: see $TESTDIR/logs/${DBNAME}.${node}.copy"
+            echo "FAILED: copying ${LRL} ${node}: see $LOGDIR/${DBNAME}.${node}.copy"
             exit 1
         fi
         let i=i+1
@@ -313,7 +319,7 @@ else
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
                 echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
             else
-                ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid &> $TESTDIR/logs/${DBNAME}.${node}.db &
+                ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid &> $LOGDIR/${DBNAME}.${node}.db &
             fi
             continue
         fi
@@ -324,7 +330,7 @@ else
             scp $SSH_OPT ${TESTDIR}/replicant_vars $node:${TESTDIR}/replicant_vars
             # redirect output from CMD to a subshell which runs awk to prepend time
             # could also use connection sharing and close master ssh session in unsetup
-            ssh -n $SSH_OPT -tt $node ${CMD} &>$TESTDIR/logs/${DBNAME}.${node}.db &
+            ssh -n $SSH_OPT -tt $node ${CMD} &>$LOGDIR/${DBNAME}.${node}.db &
             # $! will be pid of ssh (if we had used pipe, $! would be pid of awk)
             echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
         fi
@@ -348,14 +354,13 @@ else
         while  [[ "$out" != "1" ]]; do
             sleep 2
             out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
-            $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $TESTDIR/logs/${DBNAME}.${node}.conn
+            $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $LOGDIR/${DBNAME}.${node}.conn
         done
-        $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $TESTDIR/logs/${DBNAME}.${node}.conn
+        $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $LOGDIR/${DBNAME}.${node}.conn
         out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)
         if [ "$out" != "$node" ] ; then
-            echo "comdb2_host() '$out' != expected '$node'"
             sleep 1
-            exit 1
+            failexit "comdb2_host() '$out' != expected '$node'"
         fi
     done
     for node in $CLUSTER; do


### PR DESCRIPTION
Add comdb2makecluster which is a tool to create a db, copy it to cluster nodes
and start it.
Tool will create DB in current directory or use --dir to specify DB dir.

Example run:

```
bash> comdb2makecluster mydb node1 node2
mydb: creating
mydb: copying to cluster
mydb: starting
mydb: waiting until ready
mydb: Cluster is running with 2 nodes. You can query it with:
   cdb2sql --cdb2cfg mydb/comdb2.cfg mydb 'select 1'
```