### PR TITLE
fix issue with mismatch in table version when inserting into oplog

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -1450,7 +1450,7 @@ int bdb_llmeta_get_tables(
                         * were returned */
     int *bdberr)
 {
-    int rc, fndlen, addlen = 0, retries = 0, offset = 0, tmpkey;
+    int rc, fndlen, retries = 0, offset = 0, tmpkey;
     char key[LLMETA_IXLEN] = {0};
     uint8_t *p_outbuf, *p_outbuf_start, *p_outbuf_end;
     size_t outbuflen = maxnumtbls * (LLMETA_TBLLEN + sizeof(int));
@@ -1573,7 +1573,6 @@ static int bdb_new_file_version(
 {
     int retries = 0, rc;
     char key[LLMETA_IXLEN] = {0};
-    size_t key_offset = 0;
     struct llmeta_version_number_type version_num;
     tran_type *trans;
     unsigned long long real_version_num;
@@ -1731,7 +1730,7 @@ bdb_chg_file_versions_int(tran_type *trans, /* must be !NULL */
                           int file_type, /* see FILE_VERSIONS_FILE_TYPE_* */
                           int *bdberr)
 {
-    int numfnd = 0, i, rc;
+    int numfnd = 0, rc;
     char key[LLMETA_IXLEN] = {0};
     char new_key[LLMETA_IXLEN] = {0};
     char key_orig[LLMETA_IXLEN] = {0};
@@ -3553,7 +3552,6 @@ int bdb_get_in_schema_change(
     int rc, retries = 0, datalen;
     char key[LLMETA_IXLEN] = {0};
     size_t key_offset = 0;
-    tran_type tran = {0};
     struct llmeta_schema_change_type schema_change;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
@@ -3648,7 +3646,6 @@ static int bdb_set_high_genid_int(
 {
     int retries = 0, rc;
     char key[LLMETA_IXLEN] = {0};
-    size_t key_offset = 0;
     tran_type *trans;
     struct llmeta_high_genid_key_type high_genid_key_type;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
@@ -3826,11 +3823,8 @@ int bdb_get_high_genid(
 {
     int rc, fndlen, retries = 0;
     char key[LLMETA_IXLEN] = {0};
-    size_t key_offset = 0;
-    tran_type tran = {0};
     struct llmeta_high_genid_key_type high_genid_key_type;
     unsigned long long tmpgenid = 0;
-    uint8_t *p_genid, *p_genid_end;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     /*stop here if the db isn't open*/
@@ -3919,11 +3913,8 @@ retry:
 int bdb_delete_file_lwm(bdb_state_type *bdb_state, tran_type *tran, int *bdberr)
 {
     char key[LLMETA_IXLEN] = {0};
-    int fndlen;
     int rc;
-    DB_LSN tmplsn;
     struct llmeta_file_type_key file_type_key;
-    struct llmeta_db_lsn_data_type lsn_data;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     file_type_key.file_type = LLMETA_LOGICAL_LSN_LWM;
@@ -4466,7 +4457,6 @@ int bdb_increment_num_sc_done(bdb_state_type *bdb_state, tran_type *tran,
                               int *bdberr)
 {
     int rc;
-    int started_our_own_transaction = 0;
     char key[LLMETA_IXLEN] = {0};
     unsigned long long num = 0;
 
@@ -4764,9 +4754,8 @@ static int bdb_tbl_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
 {
     uint8_t key[LLMETA_IXLEN] = {0};
     int rc;
-    DB_LSN tmplsn;
     struct llmeta_tbl_access tbl_access_data = {0};
-    uint8_t *p_buf, *p_buf_start, *p_buf_end;
+    uint8_t *p_buf, *p_buf_start = NULL, *p_buf_end;
     tran_type *trans;
     int retries = 0;
     int prev_bdberr;
@@ -4895,7 +4884,7 @@ int bdb_tbl_op_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
     uint8_t key[LLMETA_IXLEN] = {0};
     int rc;
     struct llmeta_tbl_op_access tbl_access_data = {0};
-    uint8_t *p_buf, *p_buf_start, *p_buf_end;
+    uint8_t *p_buf, *p_buf_start = NULL, *p_buf_end;
     tran_type *trans;
     int retries = 0;
     int prev_bdberr;
@@ -5122,9 +5111,8 @@ int bdb_feature_set_int(bdb_state_type *bdb_state, tran_type *input_trans,
 {
     uint8_t key[LLMETA_IXLEN] = {0};
     int rc;
-    DB_LSN tmplsn;
     struct llmeta_authentication authentication_data = {0};
-    uint8_t *p_buf, *p_buf_start, *p_buf_end;
+    uint8_t *p_buf, *p_buf_start = NULL, *p_buf_end;
     tran_type *trans;
     int retries = 0;
     int prev_bdberr;
@@ -5230,7 +5218,7 @@ static int bdb_feature_get_int(bdb_state_type *bdb_state, tran_type *tran,
     uint8_t key[LLMETA_IXLEN] = {0};
     struct llmeta_authentication authentication_data = {0};
     int fndlen;
-    uint8_t *p_buf, *p_buf_start, *p_buf_end;
+    uint8_t *p_buf, *p_buf_end;
 
     *bdberr = BDBERR_NOERROR;
 
@@ -5272,7 +5260,6 @@ static int bdb_tbl_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
 {
     uint8_t key[LLMETA_IXLEN] = {0};
     int fndlen, rc;
-    DB_LSN tmplsn;
     struct llmeta_tbl_access tbl_access_data = {0};
     uint8_t *p_buf, *p_buf_end;
 
@@ -5329,7 +5316,6 @@ int bdb_tbl_access_userschema_get(bdb_state_type *bdb_state,
     uint8_t key[LLMETA_IXLEN] = {0};
     uint8_t fndkey[LLMETA_IXLEN] = {0};
     int fndlen, rc;
-    DB_LSN tmplsn;
     struct llmeta_tbl_access tbl_access_data = {0};
     uint8_t *p_buf, *p_buf_end;
 
@@ -5519,7 +5505,6 @@ static int bdb_sqlite_stat1_read_int(bdb_state_type *bdb_state,
 {
     uint8_t key[LLMETA_IXLEN] = {0};
     struct llmeta_sqlstat1_key sqlstats = {0};
-    tran_type *trans;
     int rc;
     int stat_len;
     int retries = 0;
@@ -5971,6 +5956,11 @@ int bdb_llmeta_print_record(bdb_state_type *bdb_state, void *key, int keylen,
                "LLMETA_TABLE_VERSION table=\"%s\" version=\"%lu\"\n", tblname,
                flibc_ntohll(version));
         } break;
+        case LLMETA_TABLE_NUM_SC_DONE: {
+            unsigned long long version = *(unsigned long long *)data;
+            logmsg(LOGMSG_USER, "LLMETA_TABLE_NUM_SC_DONE version=\"%lu\"\n",
+                   flibc_ntohll(version));
+        } break;
         case LLMETA_GENID_FORMAT: {
             uint64_t genid_format;
             genid_format = flibc_htonll(*(unsigned long long *)data);
@@ -5980,8 +5970,7 @@ int bdb_llmeta_print_record(bdb_state_type *bdb_state, void *key, int keylen,
                        : (genid_format == LLMETA_GENID_48BIT)
                              ? "LLMETA_GENID_48BIT"
                              : "UNKNOWN GENID FORMAT");
-            break;
-        }
+        } break;
         default:
             logmsg(LOGMSG_USER, "Todo (type=%d)\n", type);
             break;
@@ -6038,11 +6027,8 @@ int bdb_get_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
 {
     int rc, fndlen, retries = 0;
     char key[LLMETA_IXLEN] = {0};
-    size_t key_offset = 0;
-    tran_type tran = {0};
     struct llmeta_analyzecoverage_key_type analyzecoverage_key;
     int tmpval = 0;
-    uint8_t *p_genid, *p_genid_end;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     /*stop here if the db isn't open*/
@@ -6127,7 +6113,6 @@ int bdb_set_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
     char key[LLMETA_IXLEN] = {0};
 
     tran_type *trans;
-    uint8_t *p_coveragevalue, *p_coveragevalue_end;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     /*fail if the db isn't open*/
@@ -6281,11 +6266,8 @@ int bdb_get_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
 {
     int rc, fndlen, retries = 0;
     char key[LLMETA_IXLEN] = {0};
-    size_t key_offset = 0;
-    tran_type tran = {0};
     struct llmeta_analyzethreshold_key_type analyzethreshold_key;
     long long tmpval = 0;
-    uint8_t *p_genid, *p_genid_end;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     /*stop here if the db isn't open*/
@@ -6535,7 +6517,6 @@ int bdb_set_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
     char key[LLMETA_IXLEN] = {0};
 
     tran_type *trans;
-    uint8_t *p_value, *p_value_end;
     uint8_t *p_buf, *p_buf_start, *p_buf_end;
 
     /*fail if the db isn't open*/
@@ -6665,7 +6646,6 @@ static int llmeta_get_uint64(llmetakey_t key, uint64_t *value)
     if (llmeta_bdb_state == NULL)
         return -1;
     int rc, bdberr;
-    void *tran;
     int fndlen;
     uint64_t tmp;
     char llkey[LLMETA_IXLEN] = {0};
@@ -6852,7 +6832,7 @@ int llmeta_set_tablename_alias(void *ptran, const char *tablename_alias,
                                const char *url, char **errstr)
 {
     struct llmeta_tablename_alias_key key = {0};
-    struct llmeta_tablename_alias_data data = {0};
+    struct llmeta_tablename_alias_data data = {{0}};
 
     char key_buf[LLMETA_IXLEN] = {0};
     char data_buf[LLMETA_TABLENAME_ALIAS_DATA_LEN] = {0};
@@ -6966,7 +6946,6 @@ retry:
 char *llmeta_get_tablename_alias(const char *tablename_alias, char **errstr)
 {
     struct llmeta_tablename_alias_key key = {0};
-    struct llmeta_tablename_alias_data data = {0};
 
     char key_buf[LLMETA_IXLEN] = {0};
     char *data_buf;
@@ -6974,7 +6953,6 @@ char *llmeta_get_tablename_alias(const char *tablename_alias, char **errstr)
     int bdberr = 0;
     int rc = 0;
     int fndlen = 0;
-    tran_type *trans = NULL;
 
     if (__llmeta_preop_alias(&key, tablename_alias, key_buf, sizeof(key_buf),
                              errstr))
@@ -7037,7 +7015,6 @@ int llmeta_rem_tablename_alias(const char *tablename_alias, char **errstr)
     int retries = 0;
     int bdberr = 0;
     int rc = 0;
-    int fndlen = 0;
     tran_type *trans = NULL;
 
     if (__llmeta_preop_alias(&key, tablename_alias, key_buf, sizeof(key_buf),
@@ -7148,7 +7125,6 @@ int bdb_llmeta_print_alias(bdb_state_type *bdb_state, void *key, int keylen,
 
 void llmeta_list_tablename_alias(void)
 {
-    int rc = 0;
     int bdberr = 0;
 
     if (!bdb_have_llmeta()) {
@@ -7379,7 +7355,7 @@ int bdb_table_version_select(const char *tblname, tran_type *tran,
     int fnddatalen;
     int tblnamelen;
     uint8_t *p_buf, *p_buf_end;
-    int retries;
+    int retries = 0;
     int rc;
 
     *bdberr = 0;
@@ -7948,7 +7924,7 @@ static struct queue_data *llmeta_queue_data_get(uint8_t *p_buf,
                                                 uint8_t *p_buf_end)
 {
     struct queue_data *qd = NULL;
-    int len;
+    int len = 0;
 
     qd = calloc(1, sizeof(struct queue_data));
     if (qd == NULL)
@@ -7980,7 +7956,6 @@ int bdb_llmeta_add_queue(bdb_state_type *bdb_state, tran_type *tran,
                          int *bdberr)
 {
     char key[LLMETA_IXLEN] = {0};
-    void *dta;
     int dtalen;
     uint8_t *p_buf, *p_buf_end;
     struct queue_data qd = {0};
@@ -8043,10 +8018,7 @@ int bdb_llmeta_drop_queue(bdb_state_type *bdb_state, tran_type *tran,
                           char *queue, int *bdberr)
 {
     char key[LLMETA_IXLEN] = {0};
-    void *dta;
-    int dtalen;
     uint8_t *p_buf, *p_buf_end;
-    struct queue_data qd = {0};
     struct queue_key qk = {0};
     int rc;
 
@@ -8388,7 +8360,7 @@ int bdb_add_versioned_sp(tran_type *t, char *name, char *version, char *src)
     union {
         struct versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_VERSIONED_SP);
     strcpy(u.sp.name, name);
     strcpy(u.sp.version, version);
@@ -8404,7 +8376,7 @@ int bdb_get_versioned_sp(char *name, char *version, char **src)
     union {
         struct versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_VERSIONED_SP);
     strcpy(u.sp.name, name);
     strcpy(u.sp.version, version);
@@ -8429,7 +8401,7 @@ static int bdb_del_versioned_sp_int(tran_type *t, char *name, char *version)
     union {
         struct versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_VERSIONED_SP);
     strcpy(u.sp.name, name);
     strcpy(u.sp.version, version);
@@ -8478,7 +8450,7 @@ static int bdb_set_default_versioned_sp_int(tran_type *tran, char *name,
     union {
         struct default_versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_DEFAULT_VERSIONED_SP);
     strcpy(u.sp.name, name);
     int rc, bdberr;
@@ -8499,7 +8471,7 @@ int bdb_get_default_versioned_sp(char *name, char **version)
     union {
         struct default_versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_DEFAULT_VERSIONED_SP);
     strcpy(u.sp.name, name);
     char **versions;
@@ -8523,7 +8495,7 @@ int bdb_del_default_versioned_sp(tran_type *tran, char *name)
     union {
         struct default_versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } u = {0};
+    } u = {{0}};
     u.sp.key = htonl(LLMETA_DEFAULT_VERSIONED_SP);
     strcpy(u.sp.name, name);
     int bdberr;
@@ -8564,7 +8536,7 @@ int bdb_get_all_for_versioned_sp(char *name, char ***versions, int *num)
     union {
         struct versioned_sp sp;
         uint8_t buf[LLMETA_IXLEN];
-    } k = {0}, **v;
+    } k = {{0}}, **v;
     k.sp.key = htonl(LLMETA_VERSIONED_SP);
     strcpy(k.sp.name, name);
     size_t klen = sizeof(llmetakey_t) + strlen(name) + 1;
@@ -8748,7 +8720,7 @@ typedef struct {
 #define ITERATIONS 1000
 int bdb_user_password_check(char *user, char *passwd, int *valid_user)
 {
-    passwd_key key = {0};
+    passwd_key key = {{0}};
     if (valid_user)
         *valid_user = 0;
     size_t ulen = strlen(user) + 1;
@@ -8802,7 +8774,7 @@ out:
 }
 int bdb_user_password_set(tran_type *tran, char *user, char *passwd)
 {
-    passwd_key key = {0};
+    passwd_key key = {{0}};
     size_t ulen = strlen(user) + 1;
     if (ulen > sizeof(key.passwd.user))
         return -1;
@@ -8823,7 +8795,7 @@ int bdb_user_password_set(tran_type *tran, char *user, char *passwd)
 }
 int bdb_user_password_delete(tran_type *tran, char *user)
 {
-    passwd_key key = {0};
+    passwd_key key = {{0}};
     size_t ulen = strlen(user) + 1;
     if (ulen > sizeof(key.passwd.user))
         return -1;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -801,7 +801,6 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
                         reqpushprefixf(iq, "VERBKYCNSTRT CASCADE DEL:");
                     /* TODO verify we have proper schema change locks */
 
-                    iq->usedbtablevers = iq->usedb->tableversion;
                     rc = del_record(iq, trans, NULL, rrn, genid, -1ULL, &err,
                                     &idx, BLOCK2_DELKL, 0);
                     if (iq->debug)
@@ -854,7 +853,6 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
                         reqpushprefixf(iq, "VERBKYCNSTRT CASCADE UPD:");
                     /* TODO verify we have proper schema change locks */
 
-                    iq->usedbtablevers = iq->usedb->tableversion;
                     rc = upd_record(
                         iq, trans, NULL, /*primkey*/
                         rrn, genid,

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1167,6 +1167,9 @@ static int process_this_session(
     if (updCols)
         free(updCols);
 
+    // should never have both of them set
+    assert(rc == 0 || rc_out == 0 || rc_out == OSQL_RC_DONE);
+
     if (rc != 0 && rc != IX_PASTEOF && rc != IX_EMPTY) {
         reqlog_set_error(iq->reqlogger, "Internal Error", rc);
         logmsg(LOGMSG_ERROR, "%s:%d bdb_temp_table_next failed rc=%d bdberr=%d\n",

--- a/db/record.c
+++ b/db/record.c
@@ -89,16 +89,6 @@ void free_cached_idx(uint8_t * *cached_idx);
     if (gbl_verbose_toblock_backouts)                                          \
         logmsg(LOGMSG_USER, "err line %d rc %d retrc %d\n", __LINE__, rc, retrc);           \
     goto err;
-#define VERIFY_TABLE_VERSION                                                   \
-    if (iq->usedb->tableversion != iq->usedbtablevers) {                       \
-        if (iq->debug)                                                         \
-            reqprintf(iq, "Stale buffer: usedb version %d vs curr ver %d\n",   \
-                      iq->usedbtablevers, iq->usedb->tableversion);            \
-        poll(NULL, 0, BDB_ATTR_GET(thedb->bdb_attr, SC_DELAY_VERIFY_ERROR));   \
-        *opfailcode = OP_FAILED_VERIFY;                                        \
-        retrc = ERR_VERIFY;                                                    \
-        ERR;                                                                   \
-    }
 
 int gbl_max_wr_rows_per_txn = 0;
 
@@ -295,8 +285,6 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             retrc = ERR_INTERNAL;
             ERR;
         }
-
-        VERIFY_TABLE_VERSION;
     }
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
@@ -992,8 +980,6 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         retrc = ERR_INTERNAL;
         goto err;
     }
-
-    VERIFY_TABLE_VERSION;
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
     if (rc != 0) {
@@ -1984,8 +1970,6 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         retrc = ERR_INTERNAL;
         goto err;
     }
-
-    VERIFY_TABLE_VERSION;
 
     if (primkey) {
         int fndrrn;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2994,7 +2994,7 @@ static int sqlite_unpacked_to_ondisk(BtCursor *pCur, UnpackedRecord *rec,
                                      struct convert_failure *fail_reason,
                                      bias_info *bias_info)
 {
-    int rc;
+    int rc = 0;
     int clen = 0;
     struct field *f;
     int fields;

--- a/db/types.c
+++ b/db/types.c
@@ -195,7 +195,6 @@ uint8_t *tm_put(const cdb2_tm_t *p_tm, uint8_t *p_buf, const uint8_t *p_buf_end)
 const uint8_t *tm_get(cdb2_tm_t *p_tm, const uint8_t *p_buf,
                       const uint8_t *p_buf_end)
 {
-    int lft;
     if (p_buf_end < p_buf || TM_LEN > (p_buf_end - p_buf))
         return NULL;
 
@@ -244,7 +243,6 @@ uint8_t *tm_little_put(const cdb2_tm_t *p_tm, uint8_t *p_buf,
 const uint8_t *tm_little_get(cdb2_tm_t *p_tm, const uint8_t *p_buf,
                              const uint8_t *p_buf_end)
 {
-    int lft;
     if (p_buf_end < p_buf || TM_LEN > (p_buf_end - p_buf))
         return NULL;
 

--- a/tests/localrep.test/runit
+++ b/tests/localrep.test/runit
@@ -7,6 +7,29 @@ NRUNS=10000
 
 set -x
 
+failexit()
+{
+    echo "Failed $1"
+    exit -1
+}
+
+
+assertcnt ()
+{
+    local tbl=$1
+    local target=$2
+    local cnt=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbname default "select count(*) from $tbl")
+    if [ $? -ne 0 ] ; then
+        echo "assertcnt: select error"
+    fi
+
+    #echo "count is now $cnt"
+    if [[ $cnt != $target ]] ; then
+        failexit "tbl $tbl count is now $cnt but should be $target"
+    fi
+}
+
+
 cdb2sql ${CDB2_OPTIONS} $dbname default 'create table t1 {
 schema {
     int id
@@ -30,6 +53,7 @@ keys {
 }
 }
 '
+cdb2sql ${CDB2_OPTIONS} $dbname default 'create table t2 (i int)'
 
 cdb2sql ${CDB2_OPTIONS} $dbname default 'create table comdb2_oplog {
 schema {
@@ -59,9 +83,52 @@ keys {
 '
 
 
-for i in $(seq 1 $NRECS); do
+cdb2sql ${CDB2_OPTIONS} $dbname default 'alter table comdb2_oplog {
+schema {
+    longlong seqno
+    int      blkpos
+    int      optype
+    blob     ops         null=yes
+}
+
+tag "log" {
+    longlong seqno
+    int      optype
+    int      blkpos
+    blob     ops
+}
+
+tag "justseq" {
+    longlong seqno
+    int      blkpos
+    int      optype
+}
+
+keys {
+    "seqno" = seqno + blkpos
+}
+}
+'
+
+echo "insert into t1 (id, a, b, c, d, e, f, g, h, i, j) values (1, 1, 2, 3, 4, 5, 6.000000, 7.000000, 'eight', x'99', now());" | cdb2sql -s ${CDB2_OPTIONS} $dbname default - >/dev/null
+assertcnt t1 1
+
+i=2
+echo "begin 
+insert into t1 (id, a, b, c, d, e, f, g, h, i, j) values (2, 1, 2, 3, 4, 5, 6.000000, 7.000000, 'eight', x'99', now());
+insert into t2 values(1)
+insert into t1 (id, a, b, c, d, e, f, g, h, i, j) values (3, 1, 2, 3, 4, 5, 6.000000, 7.000000, 'eight', x'99', now());
+insert into t2 values(2) 
+commit" | cdb2sql -s ${CDB2_OPTIONS} $dbname default - >/dev/null
+
+assertcnt t1 3
+assertcnt t2 2
+
+for i in $(seq 4 $NRECS); do
     echo "insert into t1 (id, a, b, c, d, e, f, g, h, i, j) values ($i, 1, 2, 3, 4, 5, 6.000000, 7.000000, 'eight', x'99', now());"
 done | cdb2sql -s ${CDB2_OPTIONS} $dbname default - >/dev/null
+
+assertcnt t1 $NRECS
 
 for i in $(seq 1 $NRUNS); do
     what=$(($RANDOM % 3))


### PR DESCRIPTION
Table version check is incorrect when a db has local replicants and
is trying to insert into comdb2_oplog table: we keep the same version
in tableversion as the original table, and writes to oplog tbl fail.
The change to localrep.test reproduces the issue.