### PR TITLE
Logical-redo-based Live SC

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -455,6 +455,8 @@ DEF_ATTR(SC_RESTART_SEC, sc_restart_sec, QUANTITY, 0,
          "startup/new master election.")
 DEF_ATTR(INDEXREBUILD_SAVE_EVERY_N, indexrebuild_save_every_n, QUANTITY, 1,
          "Save schema change state to every n-th row for index only rebuilds.")
+DEF_ATTR(SC_LOGICAL_SAVE_LSN_EVERY_N, sc_logical_save_lsn_every_n, QUANTITY, 10,
+         "Save schema change redo lsn to llmeta every n-th transactions.")
 DEF_ATTR(SC_DECREASE_THRDS_ON_DEADLOCK, sc_decrease_thrds_on_deadlock, BOOLEAN,
          1, "Decrease number of schema change threads on deadlock - way to "
             "have schema change backoff.")

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1587,6 +1587,12 @@ int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 int bdb_delete_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
                        const char *table, int *bdberr);
 
+int bdb_get_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
+                         int *bdberr);
+int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
+                         int *bdberr);
+int bdb_delete_sc_start_lsn(tran_type *tran, const char *table, int *bdberr);
+
 enum {
     ACCESS_INVALID = 0,
     ACCESS_READ = 1,

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -592,6 +592,10 @@ int bdb_cmp_genids(unsigned long long a, unsigned long long b);
 int bdb_inplace_cmp_genids(bdb_state_type *bdb_state, unsigned long long g1,
                            unsigned long long g2);
 
+/* using the bdb_state object, return the updateid for this genid */
+int get_updateid_from_genid(bdb_state_type *bdb_state,
+                            unsigned long long genid);
+
 /* Retrieve the participant stripe id which is encoded in the genid.
  * Return codes:
  *    -1    there are no bits allocated for participant stripe id

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2117,4 +2117,7 @@ int bdb_run_logical_recovery(bdb_state_type *bdb_state, int locks_only);
 
 int truncate_asof_pglogs(bdb_state_type *bdb_state, int file, int offset);
 
+void bdb_set_logical_live_sc(bdb_state_type *bdb_state);
+void bdb_clear_logical_live_sc(bdb_state_type *bdb_state);
+
 #endif

--- a/bdb/bdb_fetch.h
+++ b/bdb/bdb_fetch.h
@@ -280,6 +280,13 @@ int bdb_fetch_next_nodta_genid(bdb_state_type *bdb_handle, void *ix, int ixnum,
                                int *rrn, unsigned long long *genid,
                                bdb_fetch_args_t *arg, int *bdberr);
 
+int bdb_fetch_next_nodta_genid_tran(bdb_state_type *bdb_state, void *ix,
+                                    int ixnum, int ixlen, void *lastix,
+                                    int lastrrn, unsigned long long lastgenid,
+                                    void *ixfound, int *rrn,
+                                    unsigned long long *genid, void *tran,
+                                    bdb_fetch_args_t *args, int *bdberr);
+
 int bdb_fetch_next_nodta_genid_nl_ser(bdb_state_type *bdb_state, void *ix,
                                       int ixnum, int ixlen, void *lastix,
                                       int lastrrn, unsigned long long lastgenid,

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -441,6 +441,9 @@ struct tran_tag {
     int schema_change_txn;
     struct tran_tag *sc_parent_tran;
 
+    /* Set to 1 if this txn touches a logical live sc table */
+    int force_logical_commit;
+
     /* cache the versions of dta files to catch schema changes and fastinits */
     int table_version_cache_sz;
     unsigned long long *table_version_cache;
@@ -1023,6 +1026,8 @@ struct bdb_state_tag {
     uint16_t *fld_hints;
 
     int hellofd;
+
+    int logical_live_sc;
 };
 
 /* define our net user types */
@@ -1340,7 +1345,7 @@ int ll_dta_upgrade(bdb_state_type *bdb_state, int rrn, unsigned long long genid,
                    DB *dbp, tran_type *tran, int dtafile, int dtastripe,
                    DBT *dta);
 
-int add_snapisol_logging(bdb_state_type *bdb_state);
+int add_snapisol_logging(bdb_state_type *bdb_state, tran_type *tran);
 int phys_key_add(bdb_state_type *bdb_state, tran_type *tran,
                  unsigned long long genid, int ixnum, DBT *dbt_key,
                  DBT *dbt_data);

--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -4437,8 +4437,8 @@ static int create_logical_payload(bdb_llog_cursor *pCur, DB_LSN regop_lsn,
         return -1;
     }
 
-    if ((pCur->log = parse_log_for_shadows(bdb_state, logc, &lsn, 0,
-                                           &bdberr)) == NULL) {
+    if ((pCur->log = parse_log_for_snapisol(bdb_state, logc, &lsn, 0,
+                                            &bdberr)) == NULL) {
         logmsg(LOGMSG_DEBUG,
                "%s line %d parse_log_for_shadows failed for "
                "%d:%d\n",

--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -4461,7 +4461,8 @@ again:
         if (rc = pCur->logc->get(pCur->logc, &pCur->curLsn, &pCur->data,
                                  pCur->getflags) != 0) {
             pCur->hitLast = 1;
-        }
+        } else
+            pCur->hitLast = 0;
         pCur->getflags = DB_NEXT;
         if (pCur->data.data)
             LOGCOPY_32(&rectype, pCur->data.data);
@@ -4502,6 +4503,7 @@ int bdb_llog_cursor_first(bdb_llog_cursor *pCur)
         if (pCur->data.data) {
             free(pCur->data.data);
             pCur->data.data = NULL;
+            pCur->data.size = 0;
         }
         if (pCur->log) {
             bdb_osql_log_destroy(pCur->log);
@@ -4578,6 +4580,20 @@ void bdb_llog_cursor_close(bdb_llog_cursor *pCur)
     if (pCur->data.data) {
         free(pCur->data.data);
         pCur->data.data = NULL;
+        pCur->data.size = 0;
+    }
+    if (pCur->log) {
+        bdb_osql_log_destroy(pCur->log);
+        pCur->log = NULL;
+    }
+}
+
+void bdb_llog_cursor_cleanup(bdb_llog_cursor *pCur)
+{
+    if (pCur->data.data) {
+        free(pCur->data.data);
+        pCur->data.data = NULL;
+        pCur->data.size = 0;
     }
     if (pCur->log) {
         bdb_osql_log_destroy(pCur->log);

--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -975,6 +975,7 @@ int bdb_osql_log_destroy(bdb_osql_log_t *log)
 
     LISTC_FOR_EACH_SAFE(&log->impl->recs, rec, tmp, lnk)
     {
+        listc_rfl(&log->impl->recs, rec);
         if (rec->comprec) {
             if (rec->comprec->table)
                 free(rec->comprec->table);

--- a/bdb/bdb_osqllog.h
+++ b/bdb/bdb_osqllog.h
@@ -282,4 +282,5 @@ int bdb_llog_cursor_open(bdb_llog_cursor *pCur);
 void bdb_llog_cursor_close(bdb_llog_cursor *pCur);
 int bdb_llog_cursor_first(bdb_llog_cursor *pCur);
 int bdb_llog_cursor_next(bdb_llog_cursor *pCur);
+void bdb_llog_cursor_cleanup(bdb_llog_cursor *pCur);
 #endif

--- a/bdb/fetch.c
+++ b/bdb/fetch.c
@@ -3366,6 +3366,35 @@ int bdb_fetch_next_nodta_genid(bdb_state_type *bdb_state, void *ix, int ixnum,
     return outrc;
 }
 
+int bdb_fetch_next_nodta_genid_tran(bdb_state_type *bdb_state, void *ix,
+                                    int ixnum, int ixlen, void *lastix,
+                                    int lastrrn, unsigned long long lastgenid,
+                                    void *ixfound, int *rrn,
+                                    unsigned long long *genid, void *tran,
+                                    bdb_fetch_args_t *args, int *bdberr)
+{
+    int outrc;
+
+    *bdberr = BDBERR_NOERROR;
+
+    BDB_READLOCK("bdb_fetch_next_nodta_genid");
+
+    outrc = bdb_fetch_int(0,              /* return no data */
+                          FETCH_INT_NEXT, /* next */
+                          1,              /* lookahead */
+                          bdb_state, ix, ixnum, ixlen, lastix, lastrrn,
+                          lastgenid, NULL, 0, NULL, /* dta, dtalen, reqdtalen */
+                          ixfound, rrn, NULL,       /* recnum */
+                          genid, 0, NULL, NULL, NULL, NULL, /* no blobs */
+                          0, tran,                          /* no txn */
+                          NULL,                             /* no cur_ser */
+                          args, bdberr);
+
+    BDB_RELLOCK();
+
+    return outrc;
+}
+
 int bdb_fetch_next_nodta_genid_nl_ser(bdb_state_type *bdb_state, void *ix,
                                       int ixnum, int ixlen, void *lastix,
                                       int lastrrn, unsigned long long lastgenid,

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3423,6 +3423,13 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
         }
     }
 
+    if (bdb_state->attr->snapisol) {
+        unsigned int sc_get_logical_redo_lwm();
+        unsigned int sc_logical_lwm = sc_get_logical_redo_lwm();
+        if (sc_logical_lwm && sc_logical_lwm < lowfilenum)
+            lowfilenum = sc_logical_lwm;
+    }
+
     /* debug: print filenums from other nodes */
 
     /* if we have a maximum filenum defined in bdb attributes which is lower,

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3423,7 +3423,8 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
         }
     }
 
-    if (bdb_state->attr->snapisol) {
+    extern int gbl_logical_live_sc;
+    if (gbl_logical_live_sc) {
         unsigned int sc_get_logical_redo_lwm();
         unsigned int sc_logical_lwm = sc_get_logical_redo_lwm();
         if (sc_logical_lwm && sc_logical_lwm < lowfilenum)

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -353,7 +353,8 @@ int ll_dta_del(bdb_state_type *bdb_state, tran_type *tran, int rrn,
             dbt_key.size = sizeof(search_genid);
 
             /* Tell Berkley to allocate memory if we need it.  */
-            if (dta_out || verify_updateid || add_snapisol_logging(bdb_state)) {
+            if (dta_out || verify_updateid ||
+                add_snapisol_logging(bdb_state, tran)) {
                 dta_out_si.flags = DB_DBT_MALLOC;
             } else {
                 dta_out_si.ulen = 0;

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -159,6 +159,15 @@ static int get_row_lock_dta_minlk(bdb_state_type *bdb_state, DBC *dbcp,
 
 extern int gbl_is_physical_replicant;
 
+extern bdb_state_type *gbl_bdb_state;
+extern int gbl_snapisol;
+int bdb_logical_logging_enabled()
+{
+    if (gbl_bdb_state->attr->snapisol | gbl_snapisol | gbl_rowlocks)
+        return 1;
+    return 0;
+}
+
 int add_snapisol_logging(bdb_state_type *bdb_state)
 {
     /* physical_replicants:

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -157,25 +157,32 @@ static int get_row_lock_dta_minlk(bdb_state_type *bdb_state, DBC *dbcp,
                                      rlk, lkname, BDB_LOCK_WRITE);
 }
 
-extern int gbl_is_physical_replicant;
-
 extern bdb_state_type *gbl_bdb_state;
 extern int gbl_snapisol;
+extern int gbl_logical_live_sc;
 int bdb_logical_logging_enabled()
 {
-    if (gbl_bdb_state->attr->snapisol | gbl_snapisol | gbl_rowlocks)
+    if (gbl_bdb_state->attr->snapisol || gbl_snapisol || gbl_rowlocks ||
+        gbl_logical_live_sc)
         return 1;
     return 0;
 }
 
-int add_snapisol_logging(bdb_state_type *bdb_state)
+extern int gbl_is_physical_replicant;
+int add_snapisol_logging(bdb_state_type *bdb_state, tran_type *tran)
 {
     /* physical_replicants:
      * handle_truncation->vrfy_match->do_rcvry->reload_schemas->commit
      * reload_schemas opens btrees transactionally.  We call commit, but this
      * won't produce a log record if no other record has been written. */
-    if (bdb_state->attr->snapisol && !gbl_rowlocks &&
-        !gbl_is_physical_replicant) {
+    if ((bdb_state->attr->snapisol || bdb_state->logical_live_sc) &&
+        !gbl_rowlocks && !gbl_is_physical_replicant) {
+        if (bdb_state->logical_live_sc) {
+            if (tran->parent)
+                tran->parent->force_logical_commit = 1;
+            else
+                tran->force_logical_commit = 1;
+        }
         return 1;
     } else {
         return 0;
@@ -205,7 +212,7 @@ int ll_dta_add(bdb_state_type *bdb_state, unsigned long long genid, DB *dbp,
     /* fall through */
     case TRANCLASS_PHYSICAL:
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -220,7 +227,7 @@ int ll_dta_add(bdb_state_type *bdb_state, unsigned long long genid, DB *dbp,
                              tran ? tran->tid : NULL, dbt_key, dbt_data,
                              tran_flags);
 
-        if (!outrc && add_snapisol_logging(bdb_state)) {
+        if (!outrc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;
@@ -300,7 +307,7 @@ int ll_dta_del(bdb_state_type *bdb_state, tran_type *tran, int rrn,
     /* fall through */
     case TRANCLASS_PHYSICAL: {
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -335,7 +342,8 @@ int ll_dta_del(bdb_state_type *bdb_state, tran_type *tran, int rrn,
 
         /* If the calling code needs the record value to log an undo,
            fetch it */
-        if (dta_out || bdb_state->attr->snapisol || is_blob) {
+        if (dta_out || bdb_state->attr->snapisol ||
+            bdb_state->logical_live_sc || is_blob) {
             /* This codepath does a direct lookup on a masked genid. */
             int updateid = 0;
             int od_updateid = 0;
@@ -429,7 +437,7 @@ int ll_dta_del(bdb_state_type *bdb_state, tran_type *tran, int rrn,
 
         rc = dbcp->c_close(dbcp);
 
-        if (!rc && add_snapisol_logging(bdb_state)) {
+        if (!rc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;
@@ -499,7 +507,7 @@ int ll_key_del(bdb_state_type *bdb_state, tran_type *tran, int ixnum, void *key,
     /* fall through */
     case TRANCLASS_PHYSICAL:
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -510,7 +518,8 @@ int ll_key_del(bdb_state_type *bdb_state, tran_type *tran, int ixnum, void *key,
             }
         }
 
-        if (bdb_state->attr->snapisol && !payloadsz)
+        if ((bdb_state->attr->snapisol || bdb_state->logical_live_sc) &&
+            !payloadsz)
             payloadsz = &payloadsz_si;
 
         /* open a cursor on the index, find exact key to be deleted
@@ -588,7 +597,7 @@ int ll_key_del(bdb_state_type *bdb_state, tran_type *tran, int ixnum, void *key,
         /* now close our cursor */
         rc = dbcp->c_close(dbcp);
 
-        if (!rc && add_snapisol_logging(bdb_state)) {
+        if (!rc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;
@@ -681,7 +690,7 @@ int ll_key_upd(bdb_state_type *bdb_state, tran_type *tran, char *table_name,
     /* fall through */
     case TRANCLASS_PHYSICAL:
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -759,7 +768,7 @@ int ll_key_upd(bdb_state_type *bdb_state, tran_type *tran, char *table_name,
         /* now close our cursor */
         rc = dbcp->c_close(dbcp);
 
-        if (!rc && add_snapisol_logging(bdb_state)) {
+        if (!rc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;
@@ -829,7 +838,7 @@ int ll_key_add(bdb_state_type *bdb_state, unsigned long long ingenid,
     /* fall through */
     case TRANCLASS_PHYSICAL:
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -846,7 +855,7 @@ int ll_key_add(bdb_state_type *bdb_state, unsigned long long ingenid,
             return rc;
         }
 
-        if (!rc && add_snapisol_logging(bdb_state)) {
+        if (!rc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;
@@ -944,7 +953,7 @@ static int ll_dta_upd_int(bdb_state_type *bdb_state, int rrn,
     /* fall through */
     case TRANCLASS_PHYSICAL:
 
-        if (add_snapisol_logging(bdb_state)) {
+        if (add_snapisol_logging(bdb_state, tran)) {
             rc = bdb_state->dbenv->lock_clear_tracked_writelocks(
                 bdb_state->dbenv, tran->tid->txnid);
             if (rc) {
@@ -997,7 +1006,8 @@ static int ll_dta_upd_int(bdb_state_type *bdb_state, int rrn,
         }
 
         /* Use the inplace update shortcut for only a genid change */
-        if ((!bdb_state->attr->snapisol) && (NULL == dta) && (!old_dta_out) &&
+        if ((!bdb_state->attr->snapisol && !bdb_state->logical_live_sc) &&
+            (NULL == dta) && (!old_dta_out) &&
             (ip_updates_enabled(bdb_state)) &&
             (((0 == use_new_genid) &&
               (0 == bdb_inplace_cmp_genids(bdb_state, oldgenid, *newgenid))) ||
@@ -1331,7 +1341,7 @@ static int ll_dta_upd_int(bdb_state_type *bdb_state, int rrn,
 
         bdberr = BDBERR_NOERROR;
 
-        if (!rc && add_snapisol_logging(bdb_state)) {
+        if (!rc && add_snapisol_logging(bdb_state, tran)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran;
             DBT dbt_tbl = {0};
             int iirc;

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -162,8 +162,8 @@ extern int gbl_snapisol;
 extern int gbl_logical_live_sc;
 int bdb_logical_logging_enabled()
 {
-    if (gbl_bdb_state->attr->snapisol || gbl_snapisol || gbl_rowlocks ||
-        gbl_logical_live_sc)
+    if ((gbl_bdb_state && gbl_bdb_state->attr->snapisol) || gbl_snapisol ||
+        gbl_rowlocks || gbl_logical_live_sc)
         return 1;
     return 0;
 }

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -161,7 +161,8 @@ typedef enum {
     LLMETA_USER_PASSWORD_HASH = 45,
     LLMETA_FVER_FILE_TYPE_QDB = 46, /* file version for a dbqueue */
     LLMETA_TABLE_NUM_SC_DONE = 47,
-    LLMETA_GLOBAL_STRIPE_INFO = 48
+    LLMETA_GLOBAL_STRIPE_INFO = 48,
+    LLMETA_SC_START_LSN = 49
 } llmetakey_t;
 
 struct llmeta_file_type_key {
@@ -6046,6 +6047,26 @@ int bdb_llmeta_print_record(bdb_state_type *bdb_state, void *key, int keylen,
     case LLMETA_SC_SEEDS:
         logmsg(LOGMSG_USER, "LLMETA_SC_SEEDS\n");
         break;
+    case LLMETA_SC_START_LSN: {
+        struct llmeta_schema_change_type akey;
+        struct llmeta_db_lsn_data_type adata;
+
+        if (keylen < sizeof(akey) || datalen < sizeof(adata)) {
+            logmsg(LOGMSG_USER, "%s:%d: wrong LLMETA_SC_START_LSN entry\n",
+                   __FILE__, __LINE__);
+            *bdberr = BDBERR_MISC;
+            return -1;
+        }
+
+        p_buf_key =
+            llmeta_schema_change_type_get(&akey, p_buf_key, p_buf_end_key);
+
+        p_buf_data =
+            llmeta_db_lsn_data_type_get(&adata, p_buf_data, p_buf_end_data);
+
+        logmsg(LOGMSG_USER, "LLMETA_SC_START_LSN: table=\"%s\" [%u:%u]\n",
+               akey.dbname, adata.lsn.file, adata.lsn.offset);
+    } break;
     case LLMETA_TABLE_USER_READ:
     case LLMETA_TABLE_USER_WRITE: {
         struct llmeta_tbl_access akey;
@@ -9181,5 +9202,190 @@ int bdb_rename_table_metadata(bdb_state_type *bdb_state, tran_type *tran,
     if (rc)
         return rc;
 
+    return rc;
+}
+
+int bdb_get_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
+                         int *bdberr)
+{
+    int rc;
+    char key[LLMETA_IXLEN] = {0};
+    struct llmeta_schema_change_type schema_change;
+    int fndlen;
+    uint8_t *p_buf = (uint8_t *)key, *p_buf_end = (p_buf + LLMETA_IXLEN);
+    DB_LSN *lsn = (DB_LSN *)plsn;
+
+    DB_LSN tmplsn;
+    struct llmeta_db_lsn_data_type lsn_data;
+
+    *bdberr = BDBERR_NOERROR;
+
+    schema_change.file_type = LLMETA_SC_START_LSN;
+    /*copy the table name and check its length so that we have a clean key*/
+    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    schema_change.dbname_len = strlen(schema_change.dbname) + 1;
+
+    if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
+        logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
+               __func__);
+        logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
+               table);
+        *bdberr = BDBERR_BADARGS;
+        return -1;
+    }
+
+    rc = bdb_lite_exact_fetch_tran(llmeta_bdb_state, tran, key, &tmplsn,
+                                   sizeof(tmplsn), &fndlen, bdberr);
+    if (rc == 0) {
+        p_buf = (uint8_t *)&tmplsn;
+        p_buf_end = p_buf + sizeof(*lsn);
+        if (!(llmeta_db_lsn_data_type_get(&lsn_data, p_buf, p_buf_end))) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: llmeta_db_lsn_data_type_get returns NULL\n", __func__);
+            *bdberr = BDBERR_BADARGS;
+            return -1;
+        }
+        lsn->file = lsn_data.lsn.file;
+        lsn->offset = lsn_data.lsn.offset;
+    }
+    return rc;
+}
+
+int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
+                         int *bdberr)
+{
+    int rc;
+    int started_our_own_transaction = 0;
+    char key[LLMETA_IXLEN] = {0};
+    struct llmeta_schema_change_type schema_change;
+    uint8_t *p_buf = (uint8_t *)key, *p_buf_end = (p_buf + LLMETA_IXLEN);
+
+    DB_LSN *lsn = (DB_LSN *)plsn;
+    struct llmeta_db_lsn_data_type lsn_data_type;
+    DB_LSN oldlsn;
+    DB_LSN tmplsn;
+    uint8_t *p_data_buf, *p_data_buf_end;
+
+    *bdberr = BDBERR_NOERROR;
+
+    if (tran == NULL) {
+        started_our_own_transaction = 1;
+        tran = bdb_tran_begin(llmeta_bdb_state->parent, NULL, bdberr);
+        if (tran == NULL) {
+            logmsg(LOGMSG_ERROR, "%s: bdb_tran_begin returns NULL\n", __func__);
+            return -1;
+        }
+    }
+
+    schema_change.file_type = LLMETA_SC_START_LSN;
+    /*copy the table name and check its length so that we have a clean key*/
+    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    schema_change.dbname_len = strlen(schema_change.dbname) + 1;
+
+    if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
+        logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
+               __func__);
+        logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
+               table);
+        *bdberr = BDBERR_BADARGS;
+        rc = -1;
+        goto done;
+    }
+
+    lsn_data_type.lsn.file = lsn->file;
+    lsn_data_type.lsn.offset = lsn->offset;
+
+    p_data_buf = (uint8_t *)&tmplsn;
+    p_data_buf_end = p_data_buf + sizeof(tmplsn);
+    if (!(llmeta_db_lsn_data_type_put(&lsn_data_type, p_data_buf,
+                                      p_data_buf_end))) {
+        logmsg(LOGMSG_ERROR, "%s: llmeta_db_lsn_data_type_put returns NULL\n",
+               __func__);
+        *bdberr = BDBERR_BADARGS;
+        return -1;
+    }
+
+    rc = bdb_get_sc_start_lsn(tran, table, &oldlsn, bdberr);
+    if (rc) { // not found, just add -- should refactor
+        if (*bdberr == BDBERR_FETCH_DTA) {
+            rc = bdb_lite_add(llmeta_bdb_state, tran, &tmplsn, sizeof(tmplsn),
+                              key, bdberr);
+        }
+        goto done;
+    }
+
+    rc = bdb_lite_exact_del(llmeta_bdb_state, tran, key, bdberr);
+    if (rc && *bdberr != BDBERR_DEL_DTA) {
+        logmsg(LOGMSG_ERROR, "bdb_lite_exact_del rc %d bdberr %d\n", rc,
+               *bdberr);
+        goto done;
+    }
+
+    rc = bdb_lite_add(llmeta_bdb_state, tran, &tmplsn, sizeof(tmplsn), key,
+                      bdberr);
+
+done:
+    if (started_our_own_transaction) {
+        if (rc == 0)
+            rc = bdb_tran_commit(llmeta_bdb_state->parent, tran, bdberr);
+        else {
+            int arc;
+            arc = bdb_tran_abort(llmeta_bdb_state->parent, tran, bdberr);
+            if (arc)
+                rc = arc;
+        }
+    }
+    return rc;
+}
+
+int bdb_delete_sc_start_lsn(tran_type *tran, const char *table, int *bdberr)
+{
+    int rc;
+    int started_our_own_transaction = 0;
+    char key[LLMETA_IXLEN] = {0};
+    struct llmeta_schema_change_type schema_change;
+    uint8_t *p_buf = (uint8_t *)key, *p_buf_end = (p_buf + LLMETA_IXLEN);
+
+    *bdberr = BDBERR_NOERROR;
+
+    if (tran == NULL) {
+        started_our_own_transaction = 1;
+        tran = bdb_tran_begin(llmeta_bdb_state->parent, NULL, bdberr);
+        if (tran == NULL)
+            return -1;
+    }
+
+    schema_change.file_type = LLMETA_SC_START_LSN;
+    /*copy the table name and check its length so that we have a clean key*/
+    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    schema_change.dbname_len = strlen(schema_change.dbname) + 1;
+
+    if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
+        logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
+               __func__);
+        logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
+               table);
+        *bdberr = BDBERR_BADARGS;
+        rc = -1;
+        goto done;
+    }
+
+    rc = bdb_lite_exact_del(llmeta_bdb_state, tran, key, bdberr);
+    if (*bdberr == BDBERR_DEL_DTA) {
+        rc = 0;
+        *bdberr = BDBERR_NOERROR;
+    }
+
+done:
+    if (started_our_own_transaction) {
+        if (rc == 0)
+            rc = bdb_tran_commit(llmeta_bdb_state->parent, tran, bdberr);
+        else {
+            int arc;
+            arc = bdb_tran_abort(llmeta_bdb_state->parent, tran, bdberr);
+            if (arc)
+                rc = arc;
+        }
+    }
     return rc;
 }

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -9310,6 +9310,10 @@ int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
         if (*bdberr == BDBERR_FETCH_DTA) {
             rc = bdb_lite_add(llmeta_bdb_state, tran, &tmplsn, sizeof(tmplsn),
                               key, bdberr);
+            if (rc || *bdberr) {
+                logmsg(LOGMSG_ERROR, "%s:%d failed with rc %d bdberr %d\n",
+                       __func__, __LINE__, rc, *bdberr);
+            }
         }
         goto done;
     }
@@ -9323,12 +9327,20 @@ int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
 
     rc = bdb_lite_add(llmeta_bdb_state, tran, &tmplsn, sizeof(tmplsn), key,
                       bdberr);
+    if (rc || *bdberr) {
+        logmsg(LOGMSG_ERROR, "%s:%d failed with rc %d bdberr %d\n", __func__,
+               __LINE__, rc, *bdberr);
+    }
 
 done:
     if (started_our_own_transaction) {
-        if (rc == 0)
+        if (rc == 0) {
             rc = bdb_tran_commit(llmeta_bdb_state->parent, tran, bdberr);
-        else {
+            if (rc || *bdberr) {
+                logmsg(LOGMSG_ERROR, "%s:%d failed with rc %d bdberr %d\n",
+                       __func__, __LINE__, rc, *bdberr);
+            }
+        } else {
             int arc;
             arc = bdb_tran_abort(llmeta_bdb_state->parent, tran, bdberr);
             if (arc)

--- a/bdb/odh.c
+++ b/bdb/odh.c
@@ -1376,3 +1376,21 @@ inline void bdb_cleanup_fld_hints(bdb_state_type *bdb_state)
         bdb_state->fld_hints = NULL;
     }
 }
+
+inline void bdb_set_logical_live_sc(bdb_state_type *bdb_state)
+{
+    if (bdb_state == NULL) {
+        logmsg(LOGMSG_ERROR, "%s(NULL)!!\n", __func__);
+        return;
+    }
+    bdb_state->logical_live_sc = 1;
+}
+
+inline void bdb_clear_logical_live_sc(bdb_state_type *bdb_state)
+{
+    if (bdb_state == NULL) {
+        logmsg(LOGMSG_ERROR, "%s(NULL)!!\n", __func__);
+        return;
+    }
+    bdb_state->logical_live_sc = 0;
+}

--- a/bdb/rowlocks.c
+++ b/bdb/rowlocks.c
@@ -936,6 +936,7 @@ int bdb_reconstruct_inplace_update(bdb_state_type *bdb_state, DB_LSN *startlsn,
                 off = 0;
                 foundit = 1;
                 __os_free(bdb_state->dbenv, addrem_rec);
+                break;
             } else {
                 if (B_TYPE(kd) == B_OVERFLOW) {
                     if (LOG_SWAPPED()) {

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1546,7 +1546,9 @@ static int bdb_tran_commit_with_seqnum_int_int(
         bdb_osql_trn_repo_lock();
 
         /* only generate a log for PARENT transactions */
-        if (tran->parent == NULL && add_snapisol_logging(bdb_state) &&
+        if (tran->parent == NULL &&
+            (add_snapisol_logging(bdb_state, tran) ||
+             tran->force_logical_commit) &&
             !(tran->flags & BDB_TRAN_NOLOG)) {
             tran_type *parent = (tran->parent) ? tran->parent : tran; /*nop*/
             int iirc;

--- a/berkdb/btree/bt_put.c
+++ b/berkdb/btree/bt_put.c
@@ -569,8 +569,7 @@ user_copy:
 
 
 /* COMDB2 HACK to make snapisol & rowlocks work */
-extern int gbl_snapisol;
-extern int gbl_rowlocks;
+int bdb_logical_logging_enabled();
 
 /*
  * __bam_ritem --
@@ -594,7 +593,7 @@ __bam_ritem(dbc, h, indx, data)
 	int ret;
 	db_indx_t *inp;
 	u_int8_t *p, *t;
-	int disable_prefix_suffix_opt = (gbl_snapisol | gbl_rowlocks);
+	int disable_prefix_suffix_opt = bdb_logical_logging_enabled();
 
 	dbp = dbc->dbp;
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5008,6 +5008,10 @@ static void register_all_int_switches()
     register_int_switch("return_long_column_names",
                         "Enables returning of long column names. (Default: ON)",
                         &gbl_return_long_column_names);
+    register_int_switch(
+        "logical_live_sc",
+        "Enables online schema change with logical redo. (Default: OFF)",
+        &gbl_logical_live_sc);
 }
 
 static void getmyid(void)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2463,7 +2463,7 @@ struct dbenv *newdbenv(char *dbname, char *lrlname)
     } 
     
     /* make sure the database directory exists! */
-    struct stat sb;
+    struct stat sb = {0};
     rc = stat(dbenv->basedir, &sb);
     if (rc || !S_ISDIR(sb.st_mode)) {
         logmsg(LOGMSG_FATAL, "DB directory '%s' does not exist\n",

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1579,12 +1579,7 @@ struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
     tbl->dbenv = env;
     tbl->dbnum = dbnum;
     tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
-    if (pthread_rwlock_init(&tbl->sc_live_lk, NULL)) {
-        logmsg(LOGMSG_ERROR, "%s:%d failed to init sc_live_lk\n", __func__,
-               __LINE__);
-        cleanup_newdb(tbl);
-        return NULL;
-    }
+    Pthread_rwlock_init(&tbl->sc_live_lk, NULL);
     if (dbnum == 0) {
         /* if no dbnumber then no default tag is required ergo lrl can be 0 */
         if (tbl->lrl < 0)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1579,6 +1579,12 @@ struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
     tbl->dbenv = env;
     tbl->dbnum = dbnum;
     tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
+    if (pthread_rwlock_init(&tbl->sc_live_lk, NULL)) {
+        logmsg(LOGMSG_ERROR, "%s:%d failed to init sc_live_lk\n", __func__,
+               __LINE__);
+        cleanup_newdb(tbl);
+        return NULL;
+    }
     if (dbnum == 0) {
         /* if no dbnumber then no default tag is required ergo lrl can be 0 */
         if (tbl->lrl < 0)

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2730,7 +2730,8 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
 int upd_new_record_add2indices(struct ireq *iq, void *trans,
                                unsigned long long newgenid, const void *new_dta,
                                int nd_len, unsigned long long ins_keys,
-                               int use_new_tag, blob_buffer_t *blobs);
+                               int use_new_tag, blob_buffer_t *blobs,
+                               int verify);
 
 void blob_status_to_blob_buffer(blob_status_t *bs, blob_buffer_t *bf);
 int save_old_blobs(struct ireq *iq, void *trans, const char *tag, const void *record,
@@ -3303,6 +3304,8 @@ void osql_checkboard_check_down_nodes(char *host);
  */
 int ix_check_genid(struct ireq *iq, void *trans, unsigned long long genid,
                    int *bdberr);
+int ix_check_update_genid(struct ireq *iq, void *trans,
+                          unsigned long long genid, int *bdberr);
 
 int vtag_to_ondisk(struct dbtable *db, uint8_t *rec, int *len, uint8_t ver,
                    unsigned long long genid);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2717,7 +2717,7 @@ int add_key(struct ireq *iq, void *trans,
 
 int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
                    unsigned long long del_keys, const void *old_dta,
-                   blob_buffer_t *idx_blobs);
+                   blob_buffer_t *idx_blobs, int verify_retry);
 
 int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
                    const void *old_dta, unsigned long long newgenid,

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -771,7 +771,13 @@ struct dbtable {
 
     struct dbtable *sc_from; /* point to the source db, replace global sc_from */
     struct dbtable *sc_to; /* point to the new db, replace global sc_to */
+
+    int sc_live_logical;
     unsigned long long *sc_genids; /* schemachange stripe pointers */
+
+    /* All writer threads have to grab the lock in read/write mode.  If a live
+     * schema change is in progress then they have to do extra stuff. */
+    pthread_rwlock_t sc_live_lk;
 
     /* count the number of updates and deletes done by schemachange
      * when behind the cursor.  This helps us know how many

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1802,6 +1802,8 @@ extern int gbl_dohast_verbose;
 extern int gbl_dohsql_max_queued_kb_highwm;
 extern int gbl_dohsql_full_queue_poll_msec;
 
+extern int gbl_logical_live_sc;
+
 /* init routines */
 int appsock_init(void);
 int thd_init(void);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2724,7 +2724,8 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
                    const void *new_dta, unsigned long long ins_keys,
                    unsigned long long del_keys, int nd_len, const int *updCols,
                    blob_buffer_t *blobs, int deferredAdd,
-                   blob_buffer_t *del_idx_blobs, blob_buffer_t *add_idx_blobs);
+                   blob_buffer_t *del_idx_blobs, blob_buffer_t *add_idx_blobs,
+                   int verify_retry);
 
 int upd_new_record_add2indices(struct ireq *iq, void *trans,
                                unsigned long long newgenid, const void *new_dta,

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2651,7 +2651,7 @@ enum {
      * provided then it should be NULLed out.  In this mode all blobs for
      * the record that are non-NULL will be given. */
     RECFLAGS_DONT_SKIP_BLOBS = 128,
-    RECFLAGS_ADD_FROM_SC = 256,
+    RECFLAGS_ADD_FROM_SC_LOGICAL = 256,
     /* used for upgrade record */
     RECFLAGS_UPGRADE_RECORD = RECFLAGS_DYNSCHEMA_NULLS_ONLY |
                               RECFLAGS_KEEP_GENID | RECFLAGS_NO_TRIGGERS |

--- a/db/config.c
+++ b/db/config.c
@@ -1035,6 +1035,9 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
     } else if (tokcmp(tok, ltok, "use_llmeta") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_LLMETA, 1);
         logmsg(LOGMSG_INFO, "using low level meta table\n");
+    } else if (tokcmp(tok, ltok, "enable_logical_logging") == 0) {
+        bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
+        logmsg(LOGMSG_INFO, "Enabled logical logging\n");
     } else if (tokcmp(tok, ltok, "enable_snapshot_isolation") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_snapisol = 1;
@@ -1057,6 +1060,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         gbl_new_snapisol_logging = 1;
         logmsg(LOGMSG_INFO, "Enabled new snapshot\n");
     } else if (tokcmp(tok, ltok, "enable_new_snapshot_logging") == 0) {
+        bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_new_snapisol_logging = 1;
         logmsg(LOGMSG_INFO, "Enabled new snapshot logging\n");
     } else if (tokcmp(tok, ltok, "disable_new_snapshot") == 0) {

--- a/db/glue.c
+++ b/db/glue.c
@@ -6065,8 +6065,6 @@ int ix_check_update_genid(struct ireq *iq, void *trans,
                 rc = 1;
             else
                 rc = 0;
-            printf("%s: return rc=%d genid %llx, foundgenid %llx\n", __func__,
-                   rc, genid, foundgenid);
             return rc;
         } else if (rc < 0) {
             logmsg(LOGMSG_ERROR, "%s: failed to get next genid, rc = %d\n",

--- a/db/glue.c
+++ b/db/glue.c
@@ -2442,9 +2442,9 @@ retry:
         iq->gluewhere = "bdb_fetch_next_nodta_genid_nl_ser done";
     } else {
         iq->gluewhere = req = "bdb_fetch_next_nodta_genid";
-        ixrc = bdb_fetch_next_nodta_genid(bdb_handle, key, ixnum, keylen,
-                                          curlast, lastrrn, lastgenid, fndkey,
-                                          fndrrn, genid, args, &bdberr);
+        ixrc = bdb_fetch_next_nodta_genid_tran(
+            bdb_handle, key, ixnum, keylen, curlast, lastrrn, lastgenid, fndkey,
+            fndrrn, genid, trans, args, &bdberr);
         iq->gluewhere = "bdb_fetch_next_nodta_genid done";
     }
     if (ixrc == -1) {
@@ -6032,6 +6032,50 @@ int ix_check_genid(struct ireq *iq, void *trans, unsigned long long genid,
         return 1;
     if (rc == IX_NOTFND)
         return 0;
+    *bdberr = rc;
+    return -1;
+}
+
+/*  Returns 0 if not found, 1 if found / found newer, -1 if error */
+int ix_check_update_genid(struct ireq *iq, void *trans,
+                          unsigned long long genid, int *bdberr)
+{
+    int rc = 0;
+    int reqdtalen = 0;
+    unsigned long long foundgenid = 0ULL;
+    unsigned long long lastgenid = genid;
+    int lastrrn = 0;
+    int fndrrn = 0;
+    void *bdb_state = get_bdb_handle_ireq(iq, AUXDB_NONE);
+
+    *bdberr = 0;
+    rc = ix_find_by_rrn_and_genid_tran(iq, 2 /*rrn*/, genid, NULL, &reqdtalen,
+                                       0, trans);
+    if (rc == IX_FND) {
+        return 1;
+    }
+    if (rc == IX_NOTFND) {
+        rc = ix_next_trans(iq, trans, -1, &genid, sizeof(unsigned long long),
+                           &lastgenid, 2, genid, NULL, &fndrrn, &foundgenid,
+                           NULL, NULL, 0, 0);
+        if (rc == 1 || rc == 2) {
+            if (bdb_inplace_cmp_genids(bdb_state, genid, foundgenid) == 0 &&
+                (get_updateid_from_genid(bdb_state, genid) <=
+                 get_updateid_from_genid(bdb_state, foundgenid)))
+                rc = 1;
+            else
+                rc = 0;
+            printf("%s: return rc=%d genid %llx, foundgenid %llx\n", __func__,
+                   rc, genid, foundgenid);
+            return rc;
+        } else if (rc < 0) {
+            logmsg(LOGMSG_ERROR, "%s: failed to get next genid, rc = %d\n",
+                   __func__, rc);
+            return 0;
+        } else {
+            return 0;
+        }
+    }
     *bdberr = rc;
     return -1;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -6044,7 +6044,6 @@ int ix_check_update_genid(struct ireq *iq, void *trans,
     int reqdtalen = 0;
     unsigned long long foundgenid = 0ULL;
     unsigned long long lastgenid = genid;
-    int lastrrn = 0;
     int fndrrn = 0;
     void *bdb_state = get_bdb_handle_ireq(iq, AUXDB_NONE);
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6802,7 +6802,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             rc = finalize_schema_change(iq, iq->sc_tran);
             iq->usedb = NULL;
             if (rc != SC_OK) {
-                return rc; // Change to failed schema change error;
+                return ERR_SC;
             }
             if (iq->sc->fastinit && gbl_replicate_local)
                 local_replicant_write_clear(iq, trans, iq->sc->db);

--- a/db/record.c
+++ b/db/record.c
@@ -2782,7 +2782,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         }
 
         if (rc != 0) {
-            if (rc != IX_NOTFND)
+            if (rc != ERR_VERIFY)
                 logmsg(LOGMSG_ERROR,
                        "upd_new_record oldgenid 0x%llx ix_delk -> "
                        "ix%d, rc=%d failed\n",

--- a/db/record.c
+++ b/db/record.c
@@ -2278,6 +2278,10 @@ err:
     return retrc;
 }
 
+int verify_record_constraint(struct ireq *iq, struct dbtable *db, void *trans,
+                             const void *old_dta, unsigned long long ins_keys,
+                             blob_buffer_t *blobs, int maxblobs,
+                             const char *from, int rebuild, int convert);
 /*
  * Update a single record in the new table as part of a live schema
  * change.  This code is called to add to indices only, adding to
@@ -2295,6 +2299,13 @@ int upd_new_record_add2indices(struct ireq *iq, void *trans,
 
     if (!iq->usedb)
         return ERR_BADREQ;
+
+    int rebuild = iq->usedb->plan && iq->usedb->plan->dta_plan;
+    rc = verify_record_constraint(
+        iq, iq->usedb, trans, new_dta, ins_keys, blobs, MAXBLOBS,
+        use_new_tag ? ".NEW..ONDISK" : ".ONDISK", rebuild, 1);
+    if (rc)
+        return ERR_CONSTR;
 
     /* Add all keys */
     for (int ixnum = 0; ixnum < iq->usedb->nix; ixnum++) {

--- a/db/record.c
+++ b/db/record.c
@@ -2337,7 +2337,8 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
                    const void *new_dta, unsigned long long ins_keys,
                    unsigned long long del_keys, int nd_len, const int *updCols,
                    blob_buffer_t *blobs, int deferredAdd,
-                   blob_buffer_t *del_idx_blobs, blob_buffer_t *add_idx_blobs)
+                   blob_buffer_t *del_idx_blobs, blob_buffer_t *add_idx_blobs,
+                   int verify_retry)
 {
     int retrc = 0;
     int prefixes = 0;
@@ -2440,10 +2441,10 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         }
 
         /* dat_upv_sc requests the bdb layer to use newgenid argument */
-        rc = dat_upv_sc(iq, trans,
-                        0, /*offset to verify from, only zero is supported*/
-                        NULL, 0, oldgenid, (void *)sc_new, newrec_len, 2,
-                        &newgenidcpy, 0, iq->blkstate->modnum); /* verifydta */
+        rc = dat_upv_sc(
+            iq, trans, 0, /*offset to verify from, only zero is supported*/
+            NULL, 0, oldgenid, (void *)sc_new, newrec_len, 2, &newgenidcpy, 0,
+            iq->blkstate ? iq->blkstate->modnum : 0); /* verifydta */
 
         if (newgenid != newgenidcpy) {
             logmsg(LOGMSG_ERROR, "upd_new_record: dat_upv_sc generated genid!! newgenid "
@@ -2461,13 +2462,15 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
 
         /* workaround a bug in current schema change; if we somehow
            fail to find the row in the new btree, try again */
-        if (rc == ERR_VERIFY)
+        if (rc == ERR_VERIFY && verify_retry)
             rc = RC_INTERNAL_RETRY;
 
         if (rc != 0) {
-            logmsg(LOGMSG_ERROR, 
-                    "upd_new_record oldgenid 0x%llx dat_upv_sc -> rc %d failed\n",
-                    oldgenid, rc);
+            if (rc != ERR_VERIFY)
+                logmsg(LOGMSG_ERROR,
+                       "upd_new_record oldgenid 0x%llx dat_upv_sc -> rc %d "
+                       "failed\n",
+                       oldgenid, rc);
             retrc = rc;
             goto err;
         }
@@ -2679,13 +2682,15 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         }
 
         /* remap delete not found to retry */
-        if (rc == IX_NOTFND)
+        if (rc == IX_NOTFND && verify_retry)
             rc = RC_INTERNAL_RETRY;
 
         if (rc != 0) {
-            logmsg(LOGMSG_ERROR, "upd_new_record oldgenid 0x%llx ix_delk -> "
-                            "ix%d, rc=%d failed\n",
-                    oldgenid, ixnum, rc);
+            if (rc != IX_NOTFND)
+                logmsg(LOGMSG_ERROR,
+                       "upd_new_record oldgenid 0x%llx ix_delk -> "
+                       "ix%d, rc=%d failed\n",
+                       oldgenid, ixnum, rc);
             retrc = rc;
             goto err;
         }
@@ -2919,7 +2924,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
         }
 
         /* remap delete not found to retry */
-        if (rc == IX_NOTFND)
+        if (rc == IX_NOTFND && verify_retry)
             rc = RC_INTERNAL_RETRY;
 
         if (rc != 0) {

--- a/db/record.c
+++ b/db/record.c
@@ -2774,8 +2774,12 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         }
 
         /* remap delete not found to retry */
-        if (rc == IX_NOTFND && verify_retry)
-            rc = RC_INTERNAL_RETRY;
+        if (rc == IX_NOTFND) {
+            if (verify_retry)
+                rc = RC_INTERNAL_RETRY;
+            else
+                rc = ERR_VERIFY;
+        }
 
         if (rc != 0) {
             if (rc != IX_NOTFND)
@@ -3016,8 +3020,12 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
         }
 
         /* remap delete not found to retry */
-        if (rc == IX_NOTFND && verify_retry)
-            rc = RC_INTERNAL_RETRY;
+        if (rc == IX_NOTFND) {
+            if (verify_retry)
+                rc = RC_INTERNAL_RETRY;
+            else
+                rc = ERR_VERIFY;
+        }
 
         if (rc != 0) {
             retrc = rc;

--- a/db/record.c
+++ b/db/record.c
@@ -2722,7 +2722,7 @@ err:
  */
 int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
                    unsigned long long del_keys, const void *old_dta,
-                   blob_buffer_t *del_idx_blobs)
+                   blob_buffer_t *del_idx_blobs, int verify_retry)
 {
     int retrc = 0;
     void *sc_old = NULL;
@@ -2828,7 +2828,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
 
         /* workaround a bug in current schema change; if we somehow
            fail to find the row in the new btree, try again */
-        if (rc == ERR_VERIFY)
+        if (rc == ERR_VERIFY && verify_retry)
             rc = RC_INTERNAL_RETRY;
 
         if (rc != 0) {

--- a/db/record.c
+++ b/db/record.c
@@ -1678,6 +1678,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         }
     }
 
+    int force_inplace_blob_off = live_sc_disable_inplace_blobs(iq);
     /*
      * Now we need to change the blobs for this tag.  For each blob
      * in the user tag, get the ondisk blob number and delete/update
@@ -1729,8 +1730,8 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
         if (upgenid) {
             if (blobno < iq->usedb->numblobs) {
-                if (gbl_inplace_blobs && gbl_inplace_blob_optimization &&
-                    same_genid_with_upd) {
+                if (!force_inplace_blob_off && gbl_inplace_blobs &&
+                    gbl_inplace_blob_optimization && same_genid_with_upd) {
                     if (iq->debug)
                         reqprintf(iq, "blob_upd_genid SKIP BLOBNO %d BLOB "
                                       "OPTIMIZATION RC %d",
@@ -1754,7 +1755,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         }
 
         /* Attempt to update blobs in-place if that's enabled. */
-        if (gbl_inplace_blobs) {
+        if (!force_inplace_blob_off && gbl_inplace_blobs) {
             if (!blob->exists) {
                 rc = blob_del(iq, trans, rrn, vgenid, blobno);
                 if (iq->debug)
@@ -1811,8 +1812,8 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
     /* Update the genids of any remaining blobs */
     for (; blobno < iq->usedb->numblobs; blobno++) {
-        if (gbl_inplace_blobs && gbl_inplace_blob_optimization &&
-            same_genid_with_upd) {
+        if (!force_inplace_blob_off && gbl_inplace_blobs &&
+            gbl_inplace_blob_optimization && same_genid_with_upd) {
             if (iq->debug)
                 reqprintf(
                     iq, "blob_upd_genid SKIP BLOBNO %d BLOB OPTIMIZATION RC %d",

--- a/schemachange/CMakeLists.txt
+++ b/schemachange/CMakeLists.txt
@@ -47,4 +47,4 @@ include_directories(
   ${OPENSSL_INCLUDE_DIR}
   ${PROTOBUF_C_INCLUDE_DIR}
 )
-add_dependencies(schemachange mem protobuf)
+add_dependencies(schemachange mem protobuf bdb)

--- a/schemachange/CMakeLists.txt
+++ b/schemachange/CMakeLists.txt
@@ -41,9 +41,11 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/net
   ${PROJECT_BINARY_DIR}/protobuf
   ${PROJECT_SOURCE_DIR}/sqlite/src
-  ${PROJECT_SOURCE_DIR}/berkdb
+  ${PROJECT_BINARY_DIR}/berkdb
+  ${PROJECT_BINARY_DIR}/bdb
   ${PROJECT_SOURCE_DIR}/build/berkdb
   ${PROJECT_SOURCE_DIR}/build/bdb
+  ${PROJECT_SOURCE_DIR}/berkdb
   ${OPENSSL_INCLUDE_DIR}
   ${PROTOBUF_C_INCLUDE_DIR}
 )

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -597,8 +597,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         live_sc_off(db);
 
         for (i = 0; i < gbl_dtastripe; i++) {
-            sc_errf(s, "  > [%s] stripe %2d was at 0x%016llx\n", s->table, i,
-                    newdb->sc_genids[i]);
+            sc_errf(s, "  > [%s] stripe %2d was at 0x%016llx\n", s->tablename,
+                    i, newdb->sc_genids[i]);
         }
 
         while (s->logical_livesc) {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -526,12 +526,12 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         return -1;
     }
 
-    Pthread_rwlock_wrlock(&sc_live_rwlock);
+    Pthread_rwlock_wrlock(&db->sc_live_lk);
     db->sc_from = s->db = db;
     db->sc_to = s->newdb = newdb;
     db->sc_abort = 0;
     db->sc_downgrading = 0;
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&db->sc_live_lk);
     if (s->resume && s->alteronly && !s->finalize_only) {
         if (gbl_test_sc_resume_race && !stopsc) {
             logmsg(LOGMSG_INFO, "%s:%d sleeping 5s for sc_resume test\n",

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -650,6 +650,9 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     db->sc_to = newdb;
 
+    if (db->sc_live_logical)
+        bdb_clear_logical_live_sc(db->handle);
+
     if (gbl_sc_abort || db->sc_abort || iq->sc_should_abort) {
         sc_errf(s, "Aborting schema change %s\n", s->tablename);
         goto backout;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -447,7 +447,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         return -1;
     }
 
-    schema_change = changed = prepare_changes(s, db, newdb, &s->plan, &scinfo);
+    s->schema_change = changed =
+        prepare_changes(s, db, newdb, &s->plan, &scinfo);
     if (changed == SC_UNKNOWN_ERROR) {
         backout(newdb);
         cleanup_newdb(newdb);
@@ -456,7 +457,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     adjust_version(changed, &scinfo, s, db, newdb);
-    schema_change = changed = prepare_sc_plan(s, changed, db, newdb, &s->plan);
+    s->schema_change = changed =
+        prepare_sc_plan(s, changed, db, newdb, &s->plan);
     print_schemachange_info(s, db, newdb);
 
     /*************** open  tables ********************************************/

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -597,8 +597,12 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         live_sc_off(db);
 
         for (i = 0; i < gbl_dtastripe; i++) {
-            sc_errf(s, "  > stripe %2d was at 0x%016llx\n", i,
+            sc_errf(s, "  > [%s] stripe %2d was at 0x%016llx\n", s->table, i,
                     newdb->sc_genids[i]);
+        }
+
+        while (s->logical_livesc) {
+            usleep(200);
         }
 
         backout_constraint_pointers(newdb, db);

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -276,6 +276,10 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
         return 0;
     }
 
+    if (usedb->sc_live_logical) {
+        return 0;
+    }
+
 #ifdef DEBUG_SC
     printf("live_sc_post_update_delayed_key_adds_int: looking at genid %llx\n",
            newgenid);

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -550,7 +550,7 @@ void sc_del_unused_files_tran(struct dbtable *db, tran_type *tran)
 {
     int bdberr;
 
-    if (db == NULL)
+    if (db == NULL || db->handle == NULL)
         return;
 
     Pthread_mutex_lock(&gbl_sc_lock);

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -350,7 +350,7 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
 
     rc = upd_new_record_add2indices(iq, trans, newgenid, new_dta,
                                     usedb->sc_to->lrl, ins_keys, 1,
-                                    add_idx_blobs);
+                                    add_idx_blobs, 0);
     iq->usedb = usedb;
     if (rc != 0 && rc != RC_INTERNAL_RETRY) {
         logmsg(LOGMSG_ERROR,

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -507,7 +507,7 @@ int live_sc_post_upd_record(struct ireq *iq, void *trans,
 
     rc = upd_new_record(iq, trans, oldgenid, old_dta, newgenid, new_dta,
                         ins_keys, del_keys, od_len, updCols, blobs, deferredAdd,
-                        oldblobs, newblobs);
+                        oldblobs, newblobs, 1);
     iq->usedb = usedb;
     if (rc != 0 && rc != RC_INTERNAL_RETRY) {
         logmsg(LOGMSG_ERROR, "%s: rcode %d for update genid 0x%llx to 0x%llx\n",

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -188,7 +188,7 @@ int live_sc_post_del_record(struct ireq *iq, void *trans,
        " behind cursor - DELETE\n", genid, sc_genids[stripe]);
      */
 
-    int rc = del_new_record(iq, trans, genid, del_keys, old_dta, oldblobs);
+    int rc = del_new_record(iq, trans, genid, del_keys, old_dta, oldblobs, 1);
     iq->usedb = usedb;
     if (rc != 0 && rc != RC_INTERNAL_RETRY) {
         /* Leave this trace in.  We want to know if live schema change

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -249,9 +249,9 @@ int sc_set_running(char *table, int running, uint64_t seed, const char *host,
             hash_free(sc_tables);
             sc_tables = NULL;
 
-            pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
+            Pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
             sc_logical_redo_lwm = 0;
-            pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
+            Pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
         }
     }
     ctrace("sc_set_running(table=%s running=%d seed=0x%llx): "
@@ -401,17 +401,17 @@ int is_table_in_schema_change(const char *tbname, tran_type *tran)
 
 void sc_set_logical_redo_lwm(unsigned int file)
 {
-    pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
+    Pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
     if (!sc_logical_redo_lwm || file < sc_logical_redo_lwm)
         sc_logical_redo_lwm = file;
-    pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
+    Pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
 }
 
 unsigned int sc_get_logical_redo_lwm()
 {
     unsigned int lwm;
-    pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
+    Pthread_mutex_lock(&sc_logical_redo_lwm_mtx);
     lwm = sc_logical_redo_lwm;
-    pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
+    Pthread_mutex_unlock(&sc_logical_redo_lwm_mtx);
     return lwm;
 }

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -76,10 +76,6 @@ int log_sync_time_save;
 
 int gbl_sc_thd_failed = 0;
 
-/* All writer threads have to grab the lock in read/write mode.  If a live
- * schema change is in progress then they have to do extra stuff. */
-pthread_rwlock_t sc_live_rwlock = PTHREAD_RWLOCK_INITIALIZER;
-
 int schema_change = SC_NO_CHANGE; /*static int schema_change_doomed = 0;*/
 
 int stopsc = 0; /* stop schemachange, so it can resume */
@@ -314,7 +310,7 @@ void reset_sc_stat()
  * change (removing temp tables etc). */
 void live_sc_off(struct dbtable *db)
 {
-    Pthread_rwlock_wrlock(&sc_live_rwlock);
+    Pthread_rwlock_wrlock(&db->sc_live_lk);
     db->sc_to = NULL;
     db->sc_from = NULL;
     db->sc_abort = 0;
@@ -324,7 +320,7 @@ void live_sc_off(struct dbtable *db)
     db->sc_deletes = 0;
     db->sc_nrecs = 0;
     db->sc_prev_nrecs = 0;
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&db->sc_live_lk);
 }
 
 void sc_set_downgrading(struct schema_change_type *s)
@@ -342,13 +338,13 @@ void sc_set_downgrading(struct schema_change_type *s)
     /* make sure no one writes to the table */
     bdb_lock_table_write(s->db->handle, tran);
 
-    Pthread_rwlock_wrlock(&sc_live_rwlock);
+    Pthread_rwlock_wrlock(&s->db->sc_live_lk);
     /* live_sc_post* code will look at this and return errors properly */
     s->db->sc_downgrading = 1;
     s->db->sc_to = NULL;
     s->db->sc_from = NULL;
     s->db->sc_abort = 0;
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&s->db->sc_live_lk);
 
     trans_abort(&iq, tran);
 }

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -74,8 +74,6 @@ int rep_sync_save;
 int log_sync_save;
 int log_sync_time_save;
 
-int schema_change = SC_NO_CHANGE; /*static int schema_change_doomed = 0;*/
-
 int stopsc = 0; /* stop schemachange, so it can resume */
 
 inline int is_dta_being_rebuilt(struct scplan *plan)

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -317,7 +317,10 @@ void live_sc_off(struct dbtable *db)
     db->sc_deletes = 0;
     db->sc_nrecs = 0;
     db->sc_prev_nrecs = 0;
-    db->sc_live_logical = 0;
+    if (db->sc_live_logical) {
+        bdb_clear_logical_live_sc(db->handle);
+        db->sc_live_logical = 0;
+    }
     Pthread_rwlock_unlock(&db->sc_live_lk);
 }
 
@@ -343,6 +346,9 @@ void sc_set_downgrading(struct schema_change_type *s)
     s->db->sc_from = NULL;
     s->db->sc_abort = 0;
     Pthread_rwlock_unlock(&s->db->sc_live_lk);
+
+    if (s->db->sc_live_logical)
+        bdb_clear_logical_live_sc(s->db->handle);
 
     trans_abort(&iq, tran);
 }

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -74,8 +74,6 @@ int rep_sync_save;
 int log_sync_save;
 int log_sync_time_save;
 
-int gbl_sc_thd_failed = 0;
-
 int schema_change = SC_NO_CHANGE; /*static int schema_change_doomed = 0;*/
 
 int stopsc = 0; /* stop schemachange, so it can resume */

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -318,6 +318,7 @@ void live_sc_off(struct dbtable *db)
     db->sc_deletes = 0;
     db->sc_nrecs = 0;
     db->sc_prev_nrecs = 0;
+    db->sc_live_logical = 0;
     Pthread_rwlock_unlock(&db->sc_live_lk);
 }
 

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -76,7 +76,7 @@ void reset_sc_stat();
 int reload_lua();
 int replicant_reload_analyze_stats();
 
-void sc_set_logical_redo_lwm(unsigned int file);
+void sc_set_logical_redo_lwm(char *table, unsigned int file);
 unsigned int sc_get_logical_redo_lwm();
 
 #endif

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -63,10 +63,6 @@ extern int log_sync_time_save;
 
 extern int gbl_sc_thd_failed;
 
-/* All writer threads have to grab the lock in read/write mode.  If a live
- * schema change is in progress then they have to do extra stuff. */
-extern pthread_rwlock_t sc_live_rwlock;
-
 extern int schema_change; /*static int schema_change_doomed = 0;*/
 extern int stopsc;        /* stop schemachange, so it can resume */
 

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -76,4 +76,7 @@ void reset_sc_stat();
 int reload_lua();
 int replicant_reload_analyze_stats();
 
+void sc_set_logical_redo_lwm(unsigned int file);
+unsigned int sc_get_logical_redo_lwm();
+
 #endif

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -61,8 +61,6 @@ extern int rep_sync_save;
 extern int log_sync_save;
 extern int log_sync_time_save;
 
-extern int gbl_sc_thd_failed;
-
 extern int schema_change; /*static int schema_change_doomed = 0;*/
 extern int stopsc;        /* stop schemachange, so it can resume */
 

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -61,7 +61,6 @@ extern int rep_sync_save;
 extern int log_sync_save;
 extern int log_sync_time_save;
 
-extern int schema_change; /*static int schema_change_doomed = 0;*/
 extern int stopsc;        /* stop schemachange, so it can resume */
 
 int is_dta_being_rebuilt(struct scplan *plan);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1281,8 +1281,12 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
         wrlock_schema_lk();
         iq->sc_locked = 1;
     }
+    iq->sc_should_abort = 1;
     s = iq->sc = iq->sc_pending;
     while (s != NULL) {
+        while (s->logical_livesc) {
+            usleep(200);
+        }
         if (s->addonly) {
             if (s->addonly == SC_DONE_ADD)
                 delete_db(s->tablename);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -746,6 +746,10 @@ int resume_schema_change(void)
         int bdberr;
         void *packed_sc_data = NULL;
         size_t packed_sc_data_len;
+
+        // unset downgrading flag
+        thedb->dbs[i]->sc_downgrading = 0;
+
         if (bdb_get_in_schema_change(NULL /*tran*/, thedb->dbs[i]->tablename,
                                      &packed_sc_data, &packed_sc_data_len,
                                      &bdberr) ||

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -471,6 +471,9 @@ int do_schema_change_tran(sc_arg_t *arg)
         rc = do_alter_stripes(s);
 
     if (rc == SC_MASTER_DOWNGRADE) {
+        while (s->logical_livesc) {
+            poll(NULL, 0, 100);
+        }
         if (s && s->newdb && s->newdb->handle) {
             int bdberr;
 
@@ -1285,7 +1288,7 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
     s = iq->sc = iq->sc_pending;
     while (s != NULL) {
         while (s->logical_livesc) {
-            usleep(200);
+            poll(NULL, 0, 100);
         }
         if (s->addonly) {
             if (s->addonly == SC_DONE_ADD)

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1227,6 +1227,9 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                   s->table);
         thdData->isThread = 1;
         s->logical_livesc = 1;
+        pthread_rwlock_wrlock(&s->db->sc_live_lk);
+        s->db->sc_live_logical = 1;
+        pthread_rwlock_unlock(&s->db->sc_live_lk);
         rc = pthread_create(&thdData->tid, &gbl_pthread_attr_detached,
                             (void *(*)(void *))live_sc_logical_redo_thd,
                             thdData);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -3176,7 +3176,6 @@ cleanup:
 
     free(data->s->sc_convert_done);
     data->s->sc_convert_done = NULL;
-    bdb_clear_logical_live_sc(data->s->db->handle);
     data->s->logical_livesc = 0;
 
     free(data);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2496,7 +2496,7 @@ static int live_sc_redo_delete(struct convert_record_data *data, DB_LOGC *logc,
     data->iq.usedb = data->to;
     rc = del_new_record(&data->iq, data->trans, genid, -1ULL, data->odh.recptr,
                         data->freeblb, 0);
-    if (rc == ERR_VERIFY || rc == IX_NOTFND) {
+    if (rc == ERR_VERIFY) {
         /* not an error if we dont find it */
         rc = 0;
     }
@@ -2657,12 +2657,12 @@ static int live_sc_redo_update(struct convert_record_data *data, DB_LOGC *logc,
                             data->oldodh.recptr, genid, data->odh.recptr, -1ULL,
                             -1ULL, updlen, updCols, data->wrblb, 0,
                             data->freeblb, data->wrblb, 0);
-        if (rc == ERR_VERIFY || rc == IX_NOTFND) {
+        if (rc == ERR_VERIFY) {
             rc = del_new_record(&data->iq, data->trans, oldgenid, -1ULL,
                                 data->oldodh.recptr, data->freeblb, 0);
         }
     }
-    if (rc == ERR_VERIFY || rc == IX_NOTFND) {
+    if (rc == ERR_VERIFY) {
         /* not an error if we dont find it */
         rc = 0;
     }

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -945,7 +945,7 @@ static int convert_record(struct convert_record_data *data)
                 rc = RC_INTERNAL_RETRY;
             Pthread_mutex_unlock(&data->s->livesc_mtx);
             if (rc == RC_INTERNAL_RETRY) {
-                logmsg(LOGMSG_INFO,
+                logmsg(LOGMSG_DEBUG,
                        "%s: got DUP on genid %llx, stripe %d, waiting for "
                        "logical redo to catch up at [%u:%u]\n",
                        __func__, ngenid, data->stripe, now.file, now.offset);
@@ -1361,7 +1361,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                 return -1;
             }
         }
-        sc_set_logical_redo_lwm(thdData->start_lsn.file);
+        sc_set_logical_redo_lwm(s->tablename, thdData->start_lsn.file);
         thdData->stripe = -1;
         sc_printf(s, "[%s] starting thread for logical live schema change\n",
                   s->tablename);
@@ -2914,7 +2914,7 @@ again:
             }
             data->nrecs--;
         } else
-            sc_set_logical_redo_lwm(pCur->curLsn.file);
+            sc_set_logical_redo_lwm(data->s->tablename, pCur->curLsn.file);
     }
 
 done:

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1833,7 +1833,8 @@ static int live_sc_redo_logical_log(struct convert_record_data *data,
                __LINE__, rc);
         return -1;
     }
-    while ((rec = listc_rtl(&pCur->log->impl->recs)) != NULL) {
+    LISTC_FOR_EACH(&pCur->log->impl->recs, rec, lnk)
+    {
         if (strcasecmp(data->s->table, rec->table) != 0)
             continue;
         if (data->s->sc_thd_failed) {

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1334,7 +1334,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
         }
         *thdData = data;
         if (s->resume) {
-            rc = bdb_get_sc_start_lsn(NULL, s->table, &(thdData->start_lsn),
+            rc = bdb_get_sc_start_lsn(NULL, s->tablename, &(thdData->start_lsn),
                                       &bdberr);
             if (rc) {
                 logmsg(
@@ -1351,7 +1351,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                        __func__, __LINE__);
                 return -1;
             }
-            rc = bdb_set_sc_start_lsn(NULL, s->table, &(thdData->start_lsn),
+            rc = bdb_set_sc_start_lsn(NULL, s->tablename, &(thdData->start_lsn),
                                       &bdberr);
             if (rc) {
                 logmsg(LOGMSG_ERROR,
@@ -1364,7 +1364,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
         sc_set_logical_redo_lwm(thdData->start_lsn.file);
         thdData->stripe = -1;
         sc_printf(s, "[%s] starting thread for logical live schema change\n",
-                  s->table);
+                  s->tablename);
         thdData->isThread = 1;
 
         if (BDB_ATTR_GET(thedb->bdb_attr, SNAPISOL) == 0) {
@@ -1390,7 +1390,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                             thdData);
         if (rc) {
             sc_errf(s, "[%s] starting thread failed for logical redo\n",
-                    s->table);
+                    s->tablename);
             bdb_clear_logical_live_sc(s->db->handle);
             s->logical_livesc = 0;
             free(s->sc_convert_done);
@@ -1399,7 +1399,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
     } else {
         if (s->resume) {
             int rc = 0, bdberr = 0;
-            rc = bdb_get_sc_start_lsn(NULL, s->table, &(data.start_lsn),
+            rc = bdb_get_sc_start_lsn(NULL, s->tablename, &(data.start_lsn),
                                       &bdberr);
             if (rc == 0 || bdberr != BDBERR_FETCH_DTA) {
                 sc_errf(data.s,
@@ -2044,7 +2044,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
         logmsg(LOGMSG_DEBUG,
                "%s: [%s] redo lsn[%u:%u] type[%d] dtafile %d, "
                "datastripe %d, genid %llx\n",
-               __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+               __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
                rec->type, rec->dtafile, rec->dtastripe, rec->genid);
 #endif
 
@@ -2421,7 +2421,7 @@ done:
     logmsg(LOGMSG_DEBUG,
            "%s: [%s] redo lsn[%u:%u] type[ADD_DTA] rec->dtafile %d, "
            "rec->datastripe %d, rec->genid %llx\n",
-           __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+           __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
            rec->dtafile, rec->dtastripe, rec->genid);
 #endif
 
@@ -2526,7 +2526,7 @@ done:
     logmsg(LOGMSG_DEBUG,
            "%s: [%s] redo lsn[%u:%u] type[DEL_DTA] rec->dtafile %d, "
            "rec->datastripe %d, rec->genid %llx\n",
-           __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+           __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
            rec->dtafile, rec->dtastripe, rec->genid);
 #endif
 
@@ -2703,7 +2703,7 @@ done:
     logmsg(LOGMSG_DEBUG,
            "%s: [%s] redo lsn[%u:%u] type[UPD_DTA] rec->dtafile %d, "
            "rec->datastripe %d, rec->genid %llx, newgenid %llx\n",
-           __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+           __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
            rec->dtafile, rec->dtastripe, rec->genid, genid);
 #endif
 
@@ -2746,7 +2746,7 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s: [%s] failed to redo add lsn[%u:%u] rc=%d\n", __func__,
-                   data->s->table, rec->lsn.file, rec->lsn.offset, rc);
+                   data->s->tablename, rec->lsn.file, rec->lsn.offset, rc);
             return rc;
         }
         break;
@@ -2756,7 +2756,7 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s: [%s] failed to redo delete lsn[%u:%u] rc=%d\n",
-                   __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+                   __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
                    rc);
             return rc;
         }
@@ -2767,7 +2767,7 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s: [%s] failed to redo update lsn[%u:%u] rc=%d\n",
-                   __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
+                   __func__, data->s->tablename, rec->lsn.file, rec->lsn.offset,
                    rc);
             return rc;
         }
@@ -2793,7 +2793,7 @@ static int live_sc_redo_logical_log(struct convert_record_data *data,
     /* pre process blob recs */
     LISTC_FOR_EACH_SAFE(&pCur->log->impl->recs, rec, tmp, lnk)
     {
-        if (strcasecmp(data->s->table, rec->table) != 0)
+        if (strcasecmp(data->s->tablename, rec->table) != 0)
             continue;
 
         switch (rec->type) {
@@ -2867,7 +2867,7 @@ again:
 
     LISTC_FOR_EACH(&pCur->log->impl->recs, rec, lnk)
     {
-        if (strcasecmp(data->s->table, rec->table) != 0)
+        if (strcasecmp(data->s->tablename, rec->table) != 0)
             continue;
         if (data->s->sc_thd_failed) {
             if (!data->s->retry_bad_genids)
@@ -2880,7 +2880,7 @@ again:
         }
         if (gbl_sc_abort || data->from->sc_abort ||
             (data->s->iq && data->s->iq->sc_should_abort)) {
-            sc_errf(data->s, "[%s] Logical redo aborted\n", data->s->table);
+            sc_errf(data->s, "[%s] Logical redo aborted\n", data->s->tablename);
             rc = -1;
             goto done;
         }
@@ -2889,8 +2889,8 @@ again:
             logmsg(LOGMSG_ERROR,
                    "[%s] redo failed at record lsn[%u:%u] table[%s] type[%d] "
                    "rc=%d\n",
-                   data->s->table, rec->lsn.file, rec->lsn.offset, rec->table,
-                   rec->type, rc);
+                   data->s->tablename, rec->lsn.file, rec->lsn.offset,
+                   rec->table, rec->type, rc);
             goto done;
         }
     }
@@ -2900,8 +2900,8 @@ again:
             BDB_ATTR_GET(thedb->bdb_attr, SC_LOGICAL_SAVE_LSN_EVERY_N) ==
         0) {
         int bdberr = 0;
-        rc = bdb_set_sc_start_lsn(data->trans, data->s->table, &(pCur->curLsn),
-                                  &bdberr);
+        rc = bdb_set_sc_start_lsn(data->trans, data->s->tablename,
+                                  &(pCur->curLsn), &bdberr);
         if (rc != 0) {
             if (bdberr == BDBERR_DEADLOCK)
                 rc = RC_INTERNAL_RETRY;
@@ -2975,7 +2975,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
     }
     data->iq.reqlogger = thrman_get_reqlogger(thr_self);
 
-    sc_printf(data->s, "[%s] logical redo %s at [%u:%u]\n", data->s->table,
+    sc_printf(data->s, "[%s] logical redo %s at [%u:%u]\n", data->s->tablename,
               data->s->resume ? "resumes" : "starts", data->start_lsn.file,
               data->start_lsn.offset);
     data->lasttime = comdb2_time_epoch();
@@ -3022,12 +3022,13 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             sc_errf(data->s,
                     "[%s] Stoping work on logical redo because we are told to "
                     "abort\n",
-                    data->s->table);
+                    data->s->tablename);
             goto cleanup;
         }
         if (bdb_llog_cursor_next(pCur) != 0) {
             sc_printf(data->s, "[%s] logical redo failed at [%u:%u]\n",
-                      data->s->table, pCur->curLsn.file, pCur->curLsn.offset);
+                      data->s->tablename, pCur->curLsn.file,
+                      pCur->curLsn.offset);
             data->s->iq->sc_should_abort = 1;
             goto cleanup;
         }
@@ -3035,7 +3036,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             rc = live_sc_redo_logical_log(data, pCur);
             if (rc) {
                 sc_printf(data->s, "[%s] logical redo failed at [%u:%u]\n",
-                          data->s->table, pCur->curLsn.file,
+                          data->s->tablename, pCur->curLsn.file,
                           pCur->curLsn.offset);
                 data->s->iq->sc_should_abort = 1;
                 goto cleanup;
@@ -3087,7 +3088,7 @@ cleanup:
     sc_printf(data->s,
               "[%s] logical redo thread exiting, log cursor at [%u:%u], redid "
               "%lld txns\n",
-              data->s->table, pCur->curLsn.file, pCur->curLsn.offset,
+              data->s->tablename, pCur->curLsn.file, pCur->curLsn.offset,
               data->nrecs);
 
     pthread_mutex_lock(&data->s->livesc_mtx);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -18,19 +18,19 @@
 #include <stdbool.h>
 #include <poll.h>
 
+#include "schemachange.h"
+#include "sc_records.h"
+#include "sc_global.h"
+#include "sc_schema.h"
+#include "sc_callbacks.h"
+
 #include <bdb_fetch.h>
-#include "build/db.h"
 #include "dbinc/db_swap.h"
 #include "llog_auto.h"
 #include "llog_ext.h"
 #include "bdb_osqllog.h"
 #include "bdb_osql_log_rec.h"
 
-#include "schemachange.h"
-#include "sc_records.h"
-#include "sc_global.h"
-#include "sc_schema.h"
-#include "sc_callbacks.h"
 #include "comdb2_atomic.h"
 #include "logmsg.h"
 

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2175,7 +2175,6 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
     if (pbrecs) {
         rc = reconstruct_blob_records(data, logc, pbrecs, logdta);
         bzero(data->wrblb, sizeof(data->wrblb));
-        blob_status_to_blob_buffer(&data->blb, data->wrblb);
     }
 
     if ((rc = logc->get(logc, &rec->lsn, logdta, DB_SET)) != 0) {
@@ -2266,6 +2265,9 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
     int addflags = RECFLAGS_NO_TRIGGERS | RECFLAGS_NO_CONSTRAINTS |
                    RECFLAGS_NEW_SCHEMA | RECFLAGS_ADD_FROM_SC_LOGICAL |
                    RECFLAGS_KEEP_GENID;
+
+    if (data->to->plan && gbl_use_plan)
+        addflags |= RECFLAGS_NO_BLOBS;
 
     char *tagname = ".NEW..ONDISK";
     uint8_t *p_tagname_buf = (uint8_t *)tagname;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2729,8 +2729,11 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
     int rc = 0;
 
     if (rec->dtastripe < 0 || rec->dtastripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR, "%s:%d rec->dtastripe %d out of range\n", __func__,
-               __LINE__, rec->dtastripe);
+        /* usually it means an ignorable rec->type */
+        logmsg(LOGMSG_DEBUG,
+               "%s:%d rec->dtastripe %d out of range, type %d, lsn[%u:%u]\n",
+               __func__, __LINE__, rec->dtastripe, rec->type, rec->lsn.file,
+               rec->lsn.offset);
         return 0;
     }
     if (!data->s->sc_convert_done[rec->dtastripe] &&

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2943,8 +2943,9 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
     }
     data->iq.reqlogger = thrman_get_reqlogger(thr_self);
 
-    sc_printf(data->s, "[%s] logical redo starts at [%u:%u]\n", data->s->table,
-              data->start_lsn.file, data->start_lsn.offset);
+    sc_printf(data->s, "[%s] logical redo %s at [%u:%u]\n", data->s->table,
+              data->s->resume ? "resumes" : "starts", data->start_lsn.file,
+              data->start_lsn.offset);
     data->lasttime = comdb2_time_epoch();
     pCur->minLsn = data->start_lsn;
 

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2288,6 +2288,8 @@ done:
            __func__, data->s->table, rec->lsn.file, rec->lsn.offset,
            rec->dtafile, rec->dtastripe, rec->genid);
 
+    free_blob_status_data(&data->blbcopy);
+    bzero(data->freeblb, sizeof(data->freeblb));
     free_blob_status_data(&data->blb);
     bzero(data->wrblb, sizeof(data->wrblb));
 
@@ -2394,6 +2396,8 @@ done:
 
     free_blob_status_data(&data->blbcopy);
     bzero(data->freeblb, sizeof(data->freeblb));
+    free_blob_status_data(&data->blb);
+    bzero(data->wrblb, sizeof(data->wrblb));
 
     if (del_dta)
         free(del_dta);
@@ -2817,6 +2821,10 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
         data->s->iq->sc_should_abort = 1;
         goto cleanup;
     }
+    bzero(data->freeblb, sizeof(data->freeblb));
+    bzero(data->wrblb, sizeof(data->wrblb));
+    bzero(&data->blb, sizeof(data->blb));
+    bzero(&data->blbcopy, sizeof(data->blbcopy));
     data->tagmap = get_tag_mapping(
         data->from->schema /*tbl .ONDISK tag schema*/,
         data->to->schema /*tbl .NEW..ONDISK schema */); // free tagmap only once

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1230,9 +1230,9 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                   s->table);
         thdData->isThread = 1;
         s->logical_livesc = 1;
-        pthread_rwlock_wrlock(&s->db->sc_live_lk);
+        Pthread_rwlock_wrlock(&s->db->sc_live_lk);
         s->db->sc_live_logical = 1;
-        pthread_rwlock_unlock(&s->db->sc_live_lk);
+        Pthread_rwlock_unlock(&s->db->sc_live_lk);
         rc = pthread_create(&thdData->tid, &gbl_pthread_attr_detached,
                             (void *(*)(void *))live_sc_logical_redo_thd,
                             thdData);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1360,6 +1360,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                 return -1;
             }
         }
+        sc_set_logical_redo_lwm(thdData->start_lsn.file);
         thdData->stripe = -1;
         sc_printf(s, "[%s] starting thread for logical live schema change\n",
                   s->table);
@@ -2883,7 +2884,8 @@ again:
                 rc = ERR_INTERNAL;
             }
             data->nrecs--;
-        }
+        } else
+            sc_set_logical_redo_lwm(pCur->curLsn.file);
     }
 
 done:

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2176,6 +2176,14 @@ static int reconstruct_blob_records(struct convert_record_data *data,
                            __func__, __LINE__, rc);
                     goto error;
                 }
+            } else if (0 == bdb_inplace_cmp_genids(data->from->handle, oldgenid,
+                                                   genid)) {
+                if ((rc = unpack_blob_record(data, data->blb_buf, updlen,
+                                             &data->blb, blbix)) != 0) {
+                    logmsg(LOGMSG_ERROR, "%s:%d error unpacking buf rc=%d\n",
+                           __func__, __LINE__, rc);
+                    goto error;
+                }
             } else {
                 /* old_blb_buf has the new blob */
                 if ((rc = unpack_blob_record(data, data->old_blb_buf, prevlen,

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2071,7 +2071,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
                 free_ptr = add_dta;
             }
 
-            /* Reconstruct the delete. */
+            /* Reconstruct the add. */
             if ((rc = bdb_reconstruct_add(
                      bdb_state, &rec->lsn, NULL, 0, data->blb_buf,
                      MAXBLOBLENGTH + ODH_SIZE, &dtalen, &ixlen)) != 0) {
@@ -2200,6 +2200,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
                            __func__, __LINE__, rc);
                     goto error;
                 }
+                /* no old blob since old_dta_len == 0 */
             } else {
                 /* old_blb_buf has the new blob */
                 if ((rc = unpack_blob_record(data, data->old_blb_buf, prevlen,
@@ -2208,6 +2209,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
                            __func__, __LINE__, rc);
                     goto error;
                 }
+                /* no old blob since old_dta_len == 0 */
             }
             break;
         default:

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -38,6 +38,7 @@ struct convert_record_data {
     void *dta_buf;
     void *old_dta_buf;
     void *unpack_dta_buf;
+    void *unpack_old_dta_buf;
     void *blb_buf;
     tran_type *trans;
     enum convert_scan_mode scanmode;

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -20,6 +20,8 @@
 #include <build/db.h>
 #include <bdb/bdb_int.h>
 
+extern int gbl_logical_live_sc;
+
 struct common_members {
     int64_t ndeadlocks;
     int64_t nlockwaits;

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -72,10 +72,11 @@ struct convert_record_data {
     hash_t *blob_hash;
     struct odh odh;
     struct odh oldodh;
-    DB_LSN dup_wait; /* for logical_livesc, wait for redo thread to catup at
-                        this LSN if we get DUP when converting the records */
-    unsigned long long
-        dup_genid; /* the genid of the record that we get DUP error on */
+    DB_LSN cv_wait_lsn; /* for logical_livesc, wait for redo thread to catup at
+                           this LSN if we get constraint violations when
+                           converting the records */
+    unsigned long long cv_genid; /* the genid of the record that we get
+                                    constraint violation on */
 };
 
 int convert_all_records(struct dbtable *from, struct dbtable *to,

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -38,6 +38,7 @@ struct convert_record_data {
     void *dta_buf;
     void *old_dta_buf;
     void *unpack_dta_buf;
+    void *blb_buf;
     tran_type *trans;
     enum convert_scan_mode scanmode;
     int live, lastrrn, lasttime, outrc;

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -40,6 +40,7 @@ struct convert_record_data {
     void *unpack_dta_buf;
     void *unpack_old_dta_buf;
     void *blb_buf;
+    void *old_blb_buf;
     tran_type *trans;
     enum convert_scan_mode scanmode;
     int live, lastrrn, lasttime, outrc;

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -18,6 +18,7 @@
 #define INCLUDE_SC_RECORDS_H
 
 #include <build/db.h>
+#include <bdb/bdb_int.h>
 
 struct common_members {
     int64_t ndeadlocks;
@@ -35,6 +36,8 @@ struct convert_record_data {
     int isThread;
     struct schema_change_type *s;
     void *dta_buf;
+    void *old_dta_buf;
+    void *unpack_dta_buf;
     tran_type *trans;
     enum convert_scan_mode scanmode;
     int live, lastrrn, lasttime, outrc;
@@ -62,6 +65,8 @@ struct convert_record_data {
     unsigned int write_count; // saved write counter to this tbl
     DB_LSN start_lsn;
     hash_t *blob_hash;
+    struct odh odh;
+    struct odh oldodh;
 };
 
 int convert_all_records(struct dbtable *from, struct dbtable *to,

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -61,6 +61,7 @@ struct convert_record_data {
     struct common_members *cmembers;
     unsigned int write_count; // saved write counter to this tbl
     DB_LSN start_lsn;
+    hash_t *blob_hash;
 };
 
 int convert_all_records(struct dbtable *from, struct dbtable *to,

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -72,6 +72,10 @@ struct convert_record_data {
     hash_t *blob_hash;
     struct odh odh;
     struct odh oldodh;
+    DB_LSN dup_wait; /* for logical_livesc, wait for redo thread to catup at
+                        this LSN if we get DUP when converting the records */
+    unsigned long long
+        dup_genid; /* the genid of the record that we get DUP error on */
 };
 
 int convert_all_records(struct dbtable *from, struct dbtable *to,

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -400,6 +400,7 @@ int mark_schemachange_over_tran(const char *table, tran_type *tran)
     }
 
     bdb_delete_sc_seed(thedb->bdb_env, tran, table, &bdberr);
+    bdb_delete_sc_start_lsn(tran, table, &bdberr);
 
     if (bdb_set_in_schema_change(tran, table, NULL /*schema_change_data*/,
                                  0 /*schema_change_data_len*/, &bdberr) ||

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -590,7 +590,7 @@ void verify_schema_change_constraint(struct ireq *iq, struct dbtable *currdb,
     if (!currdb)
         return;
 
-    pthread_rwlock_rdlock(&currdb->sc_live_lk);
+    Pthread_rwlock_rdlock(&currdb->sc_live_lk);
 
     /* if there's no schema change in progress, nothing to verify */
     if (!currdb->sc_to)
@@ -611,7 +611,7 @@ void verify_schema_change_constraint(struct ireq *iq, struct dbtable *currdb,
     }
 
 done:
-    pthread_rwlock_unlock(&currdb->sc_live_lk);
+    Pthread_rwlock_unlock(&currdb->sc_live_lk);
 }
 
 /* After loading new schema file, should call this routine to see if ondisk

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -32,12 +32,12 @@ static int should_skip_constraint_for_index(struct dbtable *db, int ixnum, int n
 }
 
 int verify_record_constraint(struct ireq *iq, struct dbtable *db, void *trans,
-                             void *old_dta, unsigned long long ins_keys,
+                             const void *old_dta, unsigned long long ins_keys,
                              blob_buffer_t *blobs, int maxblobs,
                              const char *from, int rebuild, int convert)
 {
     int rc;
-    void *od_dta;
+    const void *od_dta;
     void *new_dta = NULL;
     struct convert_failure reason;
     struct ireq ruleiq;

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -595,6 +595,9 @@ void verify_schema_change_constraint(struct ireq *iq, struct dbtable *currdb,
     if (!currdb->sc_to)
         goto done;
 
+    if (currdb->sc_live_logical)
+        goto done;
+
     /* if (is_schema_change_doomed()) */
     if (gbl_sc_abort || currdb->sc_abort || iq->sc_should_abort)
         goto done;

--- a/schemachange/sc_schema.h
+++ b/schemachange/sc_schema.h
@@ -38,7 +38,7 @@ int sc_request_disallowed(SBUF2 *sb);
 int sc_cmp_fileids(unsigned long long a, unsigned long long b);
 
 int verify_record_constraint(struct ireq *iq, struct dbtable *db, void *trans,
-                             void *old_dta, unsigned long long ins_keys,
+                             const void *old_dta, unsigned long long ins_keys,
                              blob_buffer_t *blobs, int maxblobs,
                              const char *from, int rebuild, int convert);
 int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -45,6 +45,7 @@ struct schema_change_type *init_schemachange_type(struct schema_change_type *sc)
     sc->original_master_node[0] = 0;
     listc_init(&sc->dests, offsetof(struct dest, lnk));
     Pthread_mutex_init(&sc->mtx, NULL);
+    Pthread_mutex_init(&sc->livesc_mtx, NULL);
     return sc;
 }
 
@@ -82,6 +83,7 @@ void free_schema_change_type(struct schema_change_type *s)
 
         free_dests(s);
         Pthread_mutex_destroy(&s->mtx);
+        Pthread_mutex_destroy(&s->livesc_mtx);
 
         if (s->sb && s->must_close_sb) close_appsock(s->sb);
         if (!s->onstack) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -838,6 +838,17 @@ int live_sc_post_update(struct ireq *iq, void *trans,
     return rc;
 }
 
+int live_sc_disable_inplace_blobs(struct ireq *iq)
+{
+    int rc = 0;
+    pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
+    if (iq->usedb->sc_from == iq->usedb && iq->usedb->sc_live_logical &&
+        iq->usedb->sc_to->ix_blob)
+        rc = 1;
+    pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
+    return rc;
+}
+
 /**********************************************************************/
 /* I ORIGINALLY REMOVED THIS, THEN MERGING I SAW IT BACK IN COMDB2.C
     I AM LEAVING IT IN HERE FOR NOW (GOTTA ASK MARK)               */

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -586,6 +586,10 @@ int live_sc_post_delete_int(struct ireq *iq, void *trans,
         return 0;
     }
 
+    if (iq->usedb->sc_live_logical) {
+        return 0;
+    }
+
     int stripe = get_dtafile_from_genid(genid);
     if (stripe < 0 || stripe >= gbl_dtastripe) {
         logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
@@ -635,6 +639,10 @@ int live_sc_post_add_int(struct ireq *iq, void *trans, unsigned long long genid,
         return ERR_NOMASTER;
 
     if (iq->usedb->sc_from != iq->usedb) {
+        return 0;
+    }
+
+    if (iq->usedb->sc_live_logical) {
         return 0;
     }
 
@@ -730,6 +738,10 @@ int live_sc_post_update_int(struct ireq *iq, void *trans,
         return ERR_NOMASTER;
 
     if (iq->usedb->sc_from != iq->usedb) {
+        return 0;
+    }
+
+    if (iq->usedb->sc_live_logical) {
         return 0;
     }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -618,11 +618,11 @@ int live_sc_post_delete(struct ireq *iq, void *trans, unsigned long long genid,
                         blob_buffer_t *oldblobs)
 {
     int rc = 0;
-    Pthread_rwlock_rdlock(&sc_live_rwlock);
+    Pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
 
     rc = live_sc_post_delete_int(iq, trans, genid, old_dta, del_keys, oldblobs);
 
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
     return rc;
 }
 
@@ -673,12 +673,12 @@ int live_sc_post_add(struct ireq *iq, void *trans, unsigned long long genid,
         logmsg(LOGMSG_INFO, "%s: slept 30s\n", __func__);
     }
 
-    Pthread_rwlock_rdlock(&sc_live_rwlock);
+    Pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
 
     rc = live_sc_post_add_int(iq, trans, genid, od_dta, ins_keys, blobs,
                               maxblobs, origflags, rrn);
 
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
     return rc;
 }
 
@@ -688,12 +688,12 @@ int live_sc_delayed_key_adds(struct ireq *iq, void *trans,
                              unsigned long long ins_keys, int od_len)
 {
     int rc = 0;
-    Pthread_rwlock_rdlock(&sc_live_rwlock);
+    Pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
 
     rc = live_sc_post_update_delayed_key_adds_int(iq, trans, newgenid, od_dta,
                                                   ins_keys, od_len);
 
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
     return rc;
 }
 
@@ -815,14 +815,14 @@ int live_sc_post_update(struct ireq *iq, void *trans,
                         blob_buffer_t *newblobs)
 {
     int rc = 0;
-    Pthread_rwlock_rdlock(&sc_live_rwlock);
+    Pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
 
     rc = live_sc_post_update_int(iq, trans, oldgenid, old_dta, newgenid,
                                  new_dta, ins_keys, del_keys, od_len, updCols,
                                  blobs, maxblobs, origflags, rrn, deferredAdd,
                                  oldblobs, newblobs);
 
-    Pthread_rwlock_unlock(&sc_live_rwlock);
+    Pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
     return rc;
 }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -841,11 +841,11 @@ int live_sc_post_update(struct ireq *iq, void *trans,
 int live_sc_disable_inplace_blobs(struct ireq *iq)
 {
     int rc = 0;
-    pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
+    Pthread_rwlock_rdlock(&iq->usedb->sc_live_lk);
     if (iq->usedb->sc_from == iq->usedb && iq->usedb->sc_live_logical &&
         iq->usedb->sc_to->ix_blob)
         rc = 1;
-    pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
+    Pthread_rwlock_unlock(&iq->usedb->sc_live_lk);
     return rc;
 }
 

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -181,7 +181,6 @@ struct schema_change_type {
                            whole schema change (I will change this in the
                            future)*/
 
-    int got_tablelock;
     int sc_thd_failed;
     int schema_change;
 
@@ -193,6 +192,8 @@ struct schema_change_type {
 
     int logical_livesc;
     int *sc_convert_done;
+    unsigned int hitLastCnt;
+    int got_tablelock;
 
     /*********************** temporary fields for sbuf packing
      * ************************/

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -184,6 +184,7 @@ struct schema_change_type {
     int got_tablelock;
     int logical_livesc;
     int sc_thd_failed;
+    int schema_change;
 
     /*********************** temporary fields for table upgrade
      * ************************/

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -182,7 +182,6 @@ struct schema_change_type {
                            future)*/
 
     int got_tablelock;
-    int logical_livesc;
     int sc_thd_failed;
     int schema_change;
 
@@ -191,6 +190,9 @@ struct schema_change_type {
     unsigned long long start_genid;
 
     int already_finalized;
+
+    int logical_livesc;
+    int *sc_convert_done;
 
     /*********************** temporary fields for sbuf packing
      * ************************/

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -181,6 +181,10 @@ struct schema_change_type {
                            whole schema change (I will change this in the
                            future)*/
 
+    int got_tablelock;
+    int logical_livesc;
+    int sc_thd_failed;
+
     /*********************** temporary fields for table upgrade
      * ************************/
     unsigned long long start_genid;
@@ -193,9 +197,6 @@ struct schema_change_type {
      * *****************************/
 
     size_t packed_len;
-
-    int got_tablelock;
-    int logical_livesc;
 };
 
 struct ireq;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -195,6 +195,9 @@ struct schema_change_type {
     unsigned int hitLastCnt;
     int got_tablelock;
 
+    pthread_mutex_t livesc_mtx; /* mutex for logical redo */
+    void *curLsn;
+
     /*********************** temporary fields for sbuf packing
      * ************************/
     /*********************** not needed for anything else

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -332,6 +332,9 @@ int live_sc_post_add(struct ireq *iq, void *trans, unsigned long long genid,
 int live_sc_delayed_key_adds(struct ireq *iq, void *trans,
                              unsigned long long newgenid, const void *od_dta,
                              unsigned long long ins_keys, int od_len);
+
+int live_sc_disable_inplace_blobs(struct ireq *iq);
+
 int add_schema_change_tables();
 
 extern unsigned long long get_genid(bdb_state_type *, unsigned int dtastripe);

--- a/sqlite/ext/comdb2/logicalops.c
+++ b/sqlite/ext/comdb2/logicalops.c
@@ -923,8 +923,8 @@ static int unpack_logical_record(logicalops_cursor *pCur)
                    break;
                    */
             default:
-                logmsg(LOGMSG_INFO, "%s line %d skipping %d\n", __func__, __LINE__,
-                        rec->type);
+                logmsg(LOGMSG_DEBUG, "%s line %d skipping %d\n", __func__,
+                       __LINE__, rec->type);
                 break;
         }
         free(rec);

--- a/sqlite/ext/comdb2/logicalops.c
+++ b/sqlite/ext/comdb2/logicalops.c
@@ -617,9 +617,9 @@ static int produce_update_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
                    __func__, __LINE__, rc, rec->lsn.file, rec->lsn.offset);
             goto done;
         }
-        /* no old blob since old_dta_len == 0 */
+        /* no old data since old_dta_len == 0 */
     } else {
-        /* packedprevbuf has the new blob */
+        /* packedprevbuf has the new data */
         if ((rc = decompress_and_upgrade(
                  pCur, pCur->table, packedprevbuf, prevlen, dtafile == 0,
                  unpacked, &pCur->odh, &pCur->record, &pCur->reclen)) != 0) {
@@ -629,7 +629,7 @@ static int produce_update_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
                    __func__, __LINE__, rc, rec->lsn.file, rec->lsn.offset);
             goto done;
         }
-        /* no old blob since old_dta_len == 0 */
+        /* no old data since dtalen == 0 */
     }
 
     if (dtafile == 0) {

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -725,6 +725,9 @@ static inline void comdb2Rebuild(Parse *pParse, Token* nm, Token* lnm, int opt)
         sc->force_blob_rebuild = 1;
     }
 
+    if (!sc->force_rebuild)
+        sc->use_plan = 1;
+
     if (OPT_ON(opt, PAGE_ORDER))
         sc->scanmode = SCAN_PAGEORDER;
 
@@ -845,9 +848,9 @@ void comdb2RebuildIndex(Parse* pParse, Token* nm, Token* lnm, Token* index, int 
     free(indexname);
 
     sc->nothrevent = 1;
-    sc->live = 1;
     sc->rebuild_index = 1;
     sc->index_to_rebuild = index_num;
+    sc->use_plan = 1;
     sc->scanmode = gbl_default_sc_scanmode;
 
     if (OPT_ON(opt, PAGE_ORDER))
@@ -857,6 +860,16 @@ void comdb2RebuildIndex(Parse* pParse, Token* nm, Token* lnm, Token* index, int 
         sc->live = 0;
     else
         sc->live = 1;
+
+    if (OPT_ON(opt, READ_ONLY))
+        sc->live = 0;
+    else
+        sc->live = 1;
+
+    sc->commit_sleep = gbl_commit_sleep;
+    sc->convert_sleep = gbl_convert_sleep;
+
+    sc->same_schema = 1;
 
     comdb2PrepareSC(v, pParse, 0, sc, &comdb2SqlSchemaChange_usedb,
                     (vdbeFuncArgFree)&free_schema_change_type);

--- a/sqlite/src/prepare.c
+++ b/sqlite/src/prepare.c
@@ -22,6 +22,7 @@
 #include <datetime.h>
 void comdb2SetWriteFlag(int);
 
+#include "cdb2_constants.h"
 #include <logmsg.h>
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
@@ -440,7 +441,7 @@ int sqlite3Init(sqlite3 *db, char **pzErrMsg){
   int commit_internal = !(db->mDbFlags&DBFLAG_SchemaChange);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   char *tmp = 0;
-  char dbname[32];   /* ok, this needs to ship! */
+  char dbname[MAX_DBNAME_LENGTH];   /* ok, this needs to ship! */
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   
   assert( sqlite3_mutex_held(db->mutex) );

--- a/tests/constraints.test/t10.req.out
+++ b/tests/constraints.test/t10.req.out
@@ -17,7 +17,7 @@
 [begin] rc 0
 [create table c {schema{int i} keys{dup "key" = i} constraints{"key" -> <"m" : "pk">}}] rc 0
 [create table m {schema{int i} keys{"pk" = i}}] rc 0
-[commit] failed with rc 203 constraint error for table "c" key "key" -> <"m":"pk">: foreign table not found
+[commit] failed with rc 240 constraint error for table "c" key "key" -> <"m":"pk">: foreign table not found
 ("transactional create"='transactional create')
 [select "transactional create"] rc 0
 [begin] rc 0
@@ -122,20 +122,20 @@
 [begin] rc 0
 [alter table m {schema{int i}}] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
-[commit] failed with rc 203 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
 ("transactional alter (bad case 3)"='transactional alter (bad case 3)')
 [select "transactional alter (bad case 3)"] rc 0
 [begin] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
 [alter table m {schema{int i}}] rc 0
-[commit] failed with rc 203 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
 ("transactional alter (bad case 4)"='transactional alter (bad case 4)')
 [select "transactional alter (bad case 4)"] rc 0
 [begin] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
 [alter table m {schema{int i}}] rc 0
 [alter table d {schema{int i} keys{dup "key" = i}}] rc 0
-[commit] failed with rc 203 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
 ("transactional alter (good case)"='transactional alter (good case)')
 [select "transactional alter (good case)"] rc 0
 [begin] rc 0
@@ -158,7 +158,7 @@
 [drop table d] rc 0
 [alter table m {schema{int i}}] rc 0
 [drop table e] rc 0
-[commit] failed with rc 203 constraint error for table "e" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "e" key "key" -> <"m":"pk">: foreign key not found
 ("transactional alter & drop (good case)"='transactional alter & drop (good case)')
 [select "transactional alter & drop (good case)"] rc 0
 [begin] rc 0

--- a/tests/ddl_no_csc2.test/t06_fk.expected
+++ b/tests/ddl_no_csc2.test/t06_fk.expected
@@ -39,11 +39,11 @@ keys
 ("transactional alter (bad case 1)"='transactional alter (bad case 1)')
 [alter table m drop index "COMDB2_PK"] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
 ("transactional alter (bad case 2)"='transactional alter (bad case 2)')
-[commit] failed with rc 203 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
 ("transactional alter (bad case 3)"='transactional alter (bad case 3)')
-[commit] failed with rc 203 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
 ("transactional alter (bad case 4)"='transactional alter (bad case 4)')
-[commit] failed with rc 203 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
 (name='c', csc2='schema
 	{
 		int i null = yes 
@@ -179,7 +179,7 @@ keys
 	}
 ')
 ("transactional alter & drop (bad case)"='transactional alter & drop (bad case)')
-[commit] failed with rc 203 constraint error for table "e" key "$KEY_6724A8B9" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "e" key "$KEY_6724A8B9" -> <"m":"COMDB2_PK">: foreign key not found
 (name='c', csc2='schema
 	{
 		int i null = yes 

--- a/tests/instant_sc.test/logicalsc.testopts
+++ b/tests/instant_sc.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/instant_sc.test/logicalsc.testopts
+++ b/tests/instant_sc.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_add_vutf8.test/logicalsc.testopts
+++ b/tests/sc_add_vutf8.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_add_vutf8.test/logicalsc.testopts
+++ b/tests/sc_add_vutf8.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_addcolumn_remsql.test/logicalsc.testopts
+++ b/tests/sc_addcolumn_remsql.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_addcolumn_remsql.test/logicalsc.testopts
+++ b/tests/sc_addcolumn_remsql.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_addfield.test/logicalsc.testopts
+++ b/tests/sc_addfield.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_addfield.test/logicalsc.testopts
+++ b/tests/sc_addfield.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_blob_update.test/logicalsc.testopts
+++ b/tests/sc_blob_update.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_blob_update.test/logicalsc.testopts
+++ b/tests/sc_blob_update.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_constraints.test/logicalsc.testopts
+++ b/tests/sc_constraints.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_constraints.test/logicalsc.testopts
+++ b/tests/sc_constraints.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_datacopy.test/Makefile
+++ b/tests/sc_datacopy.test/Makefile
@@ -3,3 +3,6 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_datacopy.test/logicalsc.testopts
+++ b/tests/sc_datacopy.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_datacopy.test/logicalsc.testopts
+++ b/tests/sc_datacopy.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_datacopy.test/runit
+++ b/tests/sc_datacopy.test/runit
@@ -53,6 +53,7 @@ function writer
 {
     while true; do
         update_t1
+        sleep 0.02
     done
 }
 

--- a/tests/sc_dups.test/logicalsc.testopts
+++ b/tests/sc_dups.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_dups.test/logicalsc.testopts
+++ b/tests/sc_dups.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_fieldlarger.test/Makefile
+++ b/tests/sc_fieldlarger.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=4m
+	export TEST_TIMEOUT=10m
 endif

--- a/tests/sc_fieldlarger.test/logicalsc.testopts
+++ b/tests/sc_fieldlarger.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_fieldlarger.test/logicalsc.testopts
+++ b/tests/sc_fieldlarger.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_inserts.test/logicalsc.testopts
+++ b/tests/sc_inserts.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_inserts.test/logicalsc.testopts
+++ b/tests/sc_inserts.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_inserts.test/lrl.options
+++ b/tests/sc_inserts.test/lrl.options
@@ -7,3 +7,4 @@ setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
 ssl_client_mode OPTIONAL
+enable_logical_logging

--- a/tests/sc_inserts.test/lrl.options
+++ b/tests/sc_inserts.test/lrl.options
@@ -7,4 +7,3 @@ setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
 ssl_client_mode OPTIONAL
-enable_logical_logging

--- a/tests/sc_inserts_deletes.test/logicalsc.testopts
+++ b/tests/sc_inserts_deletes.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_inserts_deletes.test/logicalsc.testopts
+++ b/tests/sc_inserts_deletes.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_lotsoftables.test/Makefile
+++ b/tests/sc_lotsoftables.test/Makefile
@@ -3,3 +3,6 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
+ifeq ($(TEST_TIMEOUT),)
+    export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_lotsoftables.test/logicalsc.testopts
+++ b/tests/sc_lotsoftables.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_lotsoftables.test/logicalsc.testopts
+++ b/tests/sc_lotsoftables.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_newuniq.test/logicalsc.testopts
+++ b/tests/sc_newuniq.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_newuniq.test/logicalsc.testopts
+++ b/tests/sc_newuniq.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_parallel.test/Makefile
+++ b/tests/sc_parallel.test/Makefile
@@ -3,6 +3,3 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
-ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=2m
-endif

--- a/tests/sc_parallel.test/logicalsc.testopts
+++ b/tests/sc_parallel.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_parallel.test/logicalsc.testopts
+++ b/tests/sc_parallel.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_rebuilds.test/logicalsc.testopts
+++ b/tests/sc_rebuilds.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_rebuilds.test/logicalsc.testopts
+++ b/tests/sc_rebuilds.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_repeated_updates.test/logicalsc.testopts
+++ b/tests/sc_repeated_updates.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+on logical_live_sc

--- a/tests/sc_resume.test/logicalsc.testopts
+++ b/tests/sc_resume.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+on logical_live_sc

--- a/tests/sc_swapfields.test/Makefile
+++ b/tests/sc_swapfields.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=3m
+	export TEST_TIMEOUT=10m
 endif

--- a/tests/sc_swapfields.test/logicalsc.testopts
+++ b/tests/sc_swapfields.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_swapfields.test/logicalsc.testopts
+++ b/tests/sc_swapfields.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_tableversion.test/logicalsc.testopts
+++ b/tests/sc_tableversion.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_tableversion.test/logicalsc.testopts
+++ b/tests/sc_tableversion.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_timepart.test/logicalsc.testopts
+++ b/tests/sc_timepart.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_timepart.test/logicalsc.testopts
+++ b/tests/sc_timepart.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_transactional.test/logicalsc.testopts
+++ b/tests/sc_transactional.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_transactional.test/logicalsc.testopts
+++ b/tests/sc_transactional.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_versmismatch.test/Makefile
+++ b/tests/sc_versmismatch.test/Makefile
@@ -3,3 +3,6 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_versmismatch.test/logicalsc.testopts
+++ b/tests/sc_versmismatch.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_versmismatch.test/logicalsc.testopts
+++ b/tests/sc_versmismatch.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/sc_vutf8_blob2.test/logicalsc.testopts
+++ b/tests/sc_vutf8_blob2.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/sc_vutf8_blob2.test/logicalsc.testopts
+++ b/tests/sc_vutf8_blob2.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/schemalk.test/logicalsc.testopts
+++ b/tests/schemalk.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/schemalk.test/logicalsc.testopts
+++ b/tests/schemalk.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/scindex.test/Makefile
+++ b/tests/scindex.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=20m
 endif

--- a/tests/scindex.test/logicalsc.testopts
+++ b/tests/scindex.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/scindex.test/logicalsc.testopts
+++ b/tests/scindex.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/scindex.test/runit
+++ b/tests/scindex.test/runit
@@ -436,6 +436,8 @@ function randomwrites
         # Delete a record from t1
         [[ "1" == "$del_t1" ]] && delete_rand_t1 $dbnm
 
+        sleep 0.3
+
     done
 
     return 0

--- a/tests/scindex_deadlock.test/logicalsc.testopts
+++ b/tests/scindex_deadlock.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/scindex_deadlock.test/logicalsc.testopts
+++ b/tests/scindex_deadlock.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/scupdates.test/logicalsc.testopts
+++ b/tests/scupdates.test/logicalsc.testopts
@@ -1,1 +1,1 @@
-enable_logical_logging
+on logical_live_sc

--- a/tests/scupdates.test/logicalsc.testopts
+++ b/tests/scupdates.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+enable_logical_logging

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -388,6 +388,7 @@
 (name='logfilesize', description='Attempt to keep each log file around this size.', type='INTEGER', value='41943040', read_only='N')
 (name='loghist', description='', type='INTEGER', value='0', read_only='Y')
 (name='loghist_verbose', description='', type='BOOLEAN', value='OFF', read_only='Y')
+(name='logical_live_sc', description='Enables online schema change with logical redo. (Default: OFF)', type='BOOLEAN', value='OFF', read_only='N')
 (name='logmemsize', description='Use this much memory for a log file in-memory buffer.', type='INTEGER', value='10485760', read_only='N')
 (name='logmsg.level', description='All messages below this level will not be logged.', type='ENUM', value='DEBUG', read_only='N')
 (name='logmsg.notimestamp', description='Disables 'syslog.timestamp'.', type='BOOLEAN', value='OFF', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=896)
+(TUNABLES_COUNT=898)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -716,6 +716,7 @@
 (name='sc_delay_verify_error', description='', type='INTEGER', value='100', read_only='N')
 (name='sc_done_same_tran', description='Write scdone record in the same logical transaction as DDLs.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_force_delay', description='Force schemachange to delay after every record inserted - to have sc backoff.', type='BOOLEAN', value='OFF', read_only='N')
+(name='sc_logical_save_lsn_every_n', description='Save schema change redo lsn to llmeta every n-th transactions.', type='INTEGER', value='10', read_only='N')
 (name='sc_no_rebuild_thr_sleep', description='Sleep this many microsec when conversion threads count is at max.', type='INTEGER', value='10', read_only='N')
 (name='sc_restart_sec', description='Delay restarting schema change for this many seconds after startup/new master election.', type='INTEGER', value='0', read_only='N')
 (name='sc_resume_autocommit', description='Always resume autocommit schemachange if possible.', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Unlike existing schema change scheme which propagates any ongoing writes (applied to the old btrees) inline to the new btrees synchronously, the redo-based schema change scheme uses logical logs to capture table changes and asynchronously applies them to new btrees.
