### PR TITLE
Fix rep all req

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2109,6 +2109,7 @@ int bdb_is_standalone(void *dbenv, void *in_bdb_state)
 }
 
 extern int gbl_commit_delay_trace;
+extern int gbl_nonames;
 
 static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
 {
@@ -2538,7 +2539,7 @@ static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
 
     /* now open the environment */
 
-    if (bdb_state->attr->nonames)
+    if (gbl_nonames)
         sprintf(txndir, "XXX.logs");
     else
         sprintf(txndir, "XXX.%s.txn", bdb_state->name);

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -72,6 +72,7 @@ extern int gbl_reallyearly;
 extern int gbl_rep_process_txn_time;
 int gbl_rep_badgen_trace;
 int gbl_decoupled_logputs = 1;
+int gbl_use_rep_log_fill = 1;
 int gbl_max_apply_dequeue = 100000;
 int gbl_master_req_waitms = 200;
 int gbl_fills_waitms = 1000;
@@ -1408,7 +1409,7 @@ skip:				/*
 			goto errlock;
 		}
 
-		type = gbl_decoupled_logputs ?  REP_LOG_FILL : REP_LOG;
+		type = (gbl_decoupled_logputs && gbl_use_rep_log_fill) ? REP_LOG_FILL : REP_LOG;
 		flags = IS_ZERO_LSN(rp->lsn) ||
 			IS_INIT_LSN(rp->lsn) ? DB_FIRST : DB_SET;
 		sendflags = DB_REP_SENDACK;
@@ -1691,7 +1692,7 @@ more:		   if (type == REP_LOG_MORE) {
 		int resp_rc;
 		sendflags = DB_REP_SENDACK;
 
-		type = gbl_decoupled_logputs ? REP_LOG_FILL : REP_LOG;
+		type = (gbl_decoupled_logputs && gbl_use_rep_log_fill) ? REP_LOG_FILL : REP_LOG;
 		if (gbl_verbose_fills) {
 			if (rec && rec->size != 0) {
 				logmsg(LOGMSG_USER, "%s line %d received REP_LOG_REQ from %s %d:%d to "

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -994,7 +994,6 @@ __rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen)
 	REP_VOTE_INFO *vi;
 	REP_GEN_VOTE_INFO *vig;
 	u_int32_t bytes, egen, committed_gen, flags, sendflags, gen, gbytes, rectype, type;
-	u_int32_t maxlookahead;
 	unsigned long long bytes_sent;
 	int check_limit, cmp, done, do_req, rc, starttime, endtime, tottime;
 	int match, old, recovering, ret, t_ret, st, ed, sendtime;
@@ -1358,10 +1357,9 @@ skip:				/*
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 		check_limit = gbytes != 0 || bytes != 0;
 		fromline = __LINE__;
-		dbenv->get_lg_max(dbenv, &maxlookahead);
-		if ((ret = __log_cursor_complete(dbenv, &logc, maxlookahead + 100000,
-						0)) != 0)
+		if ((ret = __log_cursor(dbenv, &logc)) != 0)
 			goto errlock;
+
 		/* A confused replicant can send a request
 		 * for an invalid log record, and cause the master
 		 * to panic.  Don't let that happen. */
@@ -1656,9 +1654,7 @@ more:		   if (type == REP_LOG_MORE) {
 		 */
 		oldfilelsn = lsn = rp->lsn;
 		fromline = __LINE__;
-		dbenv->get_lg_max(dbenv, &maxlookahead);
-		if ((ret = __log_cursor_complete(dbenv, &logc,
-						maxlookahead + 100000, 0)) != 0)
+		if ((ret = __log_cursor(dbenv, &logc)) != 0)
 			goto errlock;
 		F_SET(logc, DB_LOG_NO_PANIC);
 		memset(&data_dbt, 0, sizeof(data_dbt));

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -323,23 +323,28 @@ static inline void send_dupmaster(DB_ENV *dbenv, const char *func, int line)
 	logmsg(LOGMSG_DEBUG, "%s line %d sending DUPMASTER\n", func, line);
 }
 
+/*
+ * PUBLIC: int send_all_req __P((DB_ENV *, char *, DB_LSN *, int, const char *, int));
+ */
 int send_all_req(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags,
-        const char *func, int line)
+		 const char *func, int line)
 {
 	static unsigned long long call_count = 0, req_count = 0;
 	static int lastpr = 0;
-	int now, spanms=0, rc=0;
+	int now, spanms = 0, rc = 0;
 
-    call_count++;
-    if (gbl_verbose_rep_all_req && ((now = time(NULL)) - lastpr)) {
-        logmsg(LOGMSG_USER, "%s line %d sending REP_ALL_REQ to %s for "
-                "[%d:%d], call-count=%llu req-count=%llu\n", func, line,
-                master_eid, lsn->file, lsn->offset, call_count, req_count);
-        lastpr = now;
-    }
-    rc = __rep_send_message(dbenv, master_eid, REP_ALL_REQ, lsn, NULL, flags,
-            NULL);
-    return rc;
+	call_count++;
+	if (gbl_verbose_rep_all_req && ((now = time(NULL)) - lastpr)) {
+		logmsg(LOGMSG_USER,
+		       "%s line %d sending REP_ALL_REQ to %s for "
+		       "[%d:%d], call-count=%llu req-count=%llu\n",
+		       func, line, master_eid, lsn->file, lsn->offset,
+		       call_count, req_count);
+		lastpr = now;
+	}
+	rc = __rep_send_message(dbenv, master_eid, REP_ALL_REQ, lsn, NULL,
+				flags, NULL);
+	return rc;
 }
 
 void send_master_req(DB_ENV *dbenv, const char *func, int line)
@@ -598,7 +603,7 @@ static void *apply_thread(void *arg)
 					int flags = (DB_REP_NODROP|DB_REP_NOBUFFER);
 					if (master_eid != db_eid_invalid && 
 							(rc = send_all_req(dbenv, master_eid, &lsn, flags,
-											   __func__, __LINE__)) == 0) {
+									   __func__, __LINE__)) == 0) {
 						last_fill = comdb2_time_epochms();
 						if (gbl_verbose_fills) {
 							logmsg(LOGMSG_USER, "%s line %d continue "
@@ -732,7 +737,7 @@ static void *apply_thread(void *arg)
 				IS_ZERO_LSN(first_repdb_lsn)) {
 			/* Request all records from the master */
 			if ((ret = send_all_req(dbenv, master_eid, &my_lsn, 0, __func__,
-							__LINE__)) == 0){
+						__LINE__)) == 0){
 				last_fill = comdb2_time_epochms();
 				if (gbl_verbose_fills) {
 					logmsg(LOGMSG_USER, "%s line %d successful REP_ALL_REQ from %d:%d "
@@ -1594,7 +1599,7 @@ more:		   if (type == REP_LOG_MORE) {
 			if (master == db_eid_invalid)
 				ret = 0;
 			else if (send_all_req(dbenv, master, &lsn, DB_REP_NODROP, __func__,
-						__LINE__) != 0) {
+					      __LINE__) != 0) {
 				if (gbl_verbose_fills) {
 					logmsg(LOGMSG_USER, "%s line %d failed continue REP_ALL_REQ"
 							" lsn %d:%d\n", __func__, __LINE__, lsn.file,
@@ -7434,7 +7439,7 @@ finish:ZERO_LSN(lp->waiting_lsn);
 		lp->wait_recs = rep->max_gap;
 		MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
 		if (send_all_req(dbenv, master, &rp->lsn, DB_REP_NODROP, __func__,
-					__LINE__) == 0) {
+				 __LINE__) == 0) {
 			last_fill = comdb2_time_epochms();
 			if (gbl_verbose_fills) {
 				logmsg(LOGMSG_USER, "%s line %d successful REP_ALL_REQ for "

--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -369,8 +369,6 @@ __rep_set_egen(dbenv, func, line, egen)
 int gbl_abort_on_incorrect_upgrade;
 extern int last_fill;
 extern int gbl_decoupled_logputs;
-int send_all_req(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags,
-        const char *func, int line);
 
 int
 __rep_new_master(dbenv, cntrl, eid)
@@ -472,7 +470,7 @@ __rep_new_master(dbenv, cntrl, eid)
 			/* Let the apply-thread make this request */
 			if (log_compare(&lsn, &cntrl->lsn) < 0 && !gbl_decoupled_logputs) {
 				if (send_all_req(dbenv, eid, &lsn, DB_REP_NODROP|DB_REP_NOBUFFER,
-							__func__, __LINE__) == 0) {
+						 __func__, __LINE__) == 0) {
 					if (gbl_verbose_fills) {
 						logmsg(LOGMSG_USER, "%s line %d sending REP_ALL_REQ "
 								"for %d:%d\n", __func__, __LINE__, lsn.file,
@@ -521,7 +519,7 @@ empty:		MUTEX_LOCK(dbenv, db_rep->db_mutexp);
 			lp->wait_recs = rep->max_gap;
 			MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
 			if (send_all_req(dbenv, rep->master_id, &lsn, DB_REP_NODROP,
-						__func__, __LINE__) == 0) {
+					 __func__, __LINE__) == 0) {
 				last_fill = comdb2_time_epochms();
 			}
 		} else

--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -369,6 +369,8 @@ __rep_set_egen(dbenv, func, line, egen)
 int gbl_abort_on_incorrect_upgrade;
 extern int last_fill;
 extern int gbl_decoupled_logputs;
+int send_all_req(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags,
+        const char *func, int line);
 
 int
 __rep_new_master(dbenv, cntrl, eid)
@@ -469,8 +471,8 @@ __rep_new_master(dbenv, cntrl, eid)
 		} else {
 			/* Let the apply-thread make this request */
 			if (log_compare(&lsn, &cntrl->lsn) < 0 && !gbl_decoupled_logputs) {
-				if (__rep_send_message(dbenv, eid, REP_ALL_REQ, &lsn, 
-							NULL, DB_REP_NODROP|DB_REP_NOBUFFER, NULL) == 0) {
+				if (send_all_req(dbenv, eid, &lsn, DB_REP_NODROP|DB_REP_NOBUFFER,
+							__func__, __LINE__) == 0) {
 					if (gbl_verbose_fills) {
 						logmsg(LOGMSG_USER, "%s line %d sending REP_ALL_REQ "
 								"for %d:%d\n", __func__, __LINE__, lsn.file,
@@ -518,10 +520,10 @@ empty:		MUTEX_LOCK(dbenv, db_rep->db_mutexp);
 			 */
 			lp->wait_recs = rep->max_gap;
 			MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
-			if (__rep_send_message(dbenv, rep->master_id,
-				REP_ALL_REQ, &lsn, NULL, DB_REP_NODROP, NULL) == 0) {
+			if (send_all_req(dbenv, rep->master_id, &lsn, DB_REP_NODROP,
+						__func__, __LINE__) == 0) {
 				last_fill = comdb2_time_epochms();
-			} 
+			}
 		} else
 			MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
 

--- a/db/config.c
+++ b/db/config.c
@@ -335,6 +335,7 @@ static char *legacy_options[] = {
     "logmsg level info",
     "logput window 1",
     "osql_send_startgen off",
+    "finish_fill_threshold 0",
 };
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)

--- a/db/config.c
+++ b/db/config.c
@@ -330,7 +330,7 @@ static char *legacy_options[] = {
     "setattr SC_DONE_SAME_TRAN 0",
     "logmsg notimestamp",
     "queuedb_genid_filename off",
-    "decoupled_logputs off",
+    "use_rep_log_fill off",
     "init_with_time_based_genids",
     "logmsg level info",
     "logput window 1",

--- a/db/copycomdb2
+++ b/db/copycomdb2
@@ -192,6 +192,10 @@ for arg in "$@" ; do
             echo >&2 "-S option is now ignored"
             shift
             ;;
+        -x)
+            comdb2task="$2"
+            shift 2
+            ;;
         -f)
             # Several tools specify -f explicitly, so be silent about 
             # ignoring it for now.
@@ -411,6 +415,9 @@ touch $arstatus $exstatus
 
 aropts="-C $cluster_info"
 exopts="-C $cluster_info -u $max_du_percent "
+if [[ -n "$comdb2task" ]]; then
+    exopts="$exopts -x $comdb2task"
+fi
 
 [ $copy_data = no ]             && aropts="$aropts -s"
 [ $disable_log_delete = no ]    && aropts="$aropts -L"

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -79,6 +79,7 @@ extern int gbl_max_lua_instructions;
 extern int gbl_max_sqlcache;
 extern int __gbl_max_mpalloc_sleeptime;
 extern int gbl_mem_nice;
+extern int gbl_verbose_net;
 extern int gbl_netbufsz;
 extern int gbl_net_lmt_upd_incoherent_nodes;
 extern int gbl_net_max_mem;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -145,6 +145,7 @@ extern int gbl_incoherent_logput_window;
 extern int gbl_dump_full_net_queue;
 extern int gbl_max_clientstats_cache;
 extern int gbl_decoupled_logputs;
+extern int gbl_use_rep_log_fill;
 extern int gbl_apply_queue_memory;
 extern int gbl_inmem_repdb_maxlog;
 extern int gbl_inmem_repdb_memory;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -132,6 +132,7 @@ extern int gbl_dump_zero_coherency_timestamp;
 extern int gbl_allow_incoherent_sql;
 extern int gbl_rep_process_msg_print_rc;
 extern int gbl_verbose_master_req;
+extern int gbl_verbose_rep_all_req;
 extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -79,7 +79,6 @@ extern int gbl_max_lua_instructions;
 extern int gbl_max_sqlcache;
 extern int __gbl_max_mpalloc_sleeptime;
 extern int gbl_mem_nice;
-extern int gbl_verbose_net;
 extern int gbl_netbufsz;
 extern int gbl_net_lmt_upd_incoherent_nodes;
 extern int gbl_net_max_mem;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -132,7 +132,7 @@ extern int gbl_dump_zero_coherency_timestamp;
 extern int gbl_allow_incoherent_sql;
 extern int gbl_rep_process_msg_print_rc;
 extern int gbl_verbose_master_req;
-extern int gbl_verbose_rep_all_req;
+extern int gbl_verbose_log_req;
 extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1224,8 +1224,8 @@ REGISTER_TUNABLE("verbose_master_req",
                  NULL, NULL);
 REGISTER_TUNABLE("verbose_log_req",
                  "Print trace showing all request-log requests.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_verbose_log_req,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+                 TUNABLE_BOOLEAN, &gbl_verbose_log_req, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("verbose_send_cohlease",
                  "Print trace from lease-issue thread.", TUNABLE_BOOLEAN,
                  &gbl_verbose_send_coherency_lease, EXPERIMENTAL | INTERNAL,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -664,10 +664,6 @@ REGISTER_TUNABLE("name", NULL, TUNABLE_STRING, &name, DEPRECATED | READONLY,
 REGISTER_TUNABLE("natural_types", "Same as 'nosurprise'", TUNABLE_BOOLEAN,
                  &gbl_surprise, INVERSE_VALUE | READONLY | NOARG, NULL, NULL,
                  NULL, NULL);
-REGISTER_TUNABLE("verbose_net",
-                 "Print verbose net messages.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_verbose_net, EXPERIMENTAL | INTERNAL,
-                 NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("netbufsz", "Size of the network buffer (per "
                              "node) for the replication network. "
                              "(Default: 1MB)",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1222,9 +1222,9 @@ REGISTER_TUNABLE("verbose_master_req",
                  "Print trace showing master-req protocol.", TUNABLE_BOOLEAN,
                  &gbl_verbose_master_req, EXPERIMENTAL | INTERNAL, NULL, NULL,
                  NULL, NULL);
-REGISTER_TUNABLE("verbose_rep_all_req",
-                 "Print trace showing rep-all-req protocol.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_verbose_rep_all_req,
+REGISTER_TUNABLE("verbose_log_req",
+                 "Print trace showing all request-log requests.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_verbose_log_req,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("verbose_send_cohlease",
                  "Print trace from lease-issue thread.", TUNABLE_BOOLEAN,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -664,6 +664,10 @@ REGISTER_TUNABLE("name", NULL, TUNABLE_STRING, &name, DEPRECATED | READONLY,
 REGISTER_TUNABLE("natural_types", "Same as 'nosurprise'", TUNABLE_BOOLEAN,
                  &gbl_surprise, INVERSE_VALUE | READONLY | NOARG, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("verbose_net",
+                 "Print verbose net messages.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_verbose_net, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("netbufsz", "Size of the network buffer (per "
                              "node) for the replication network. "
                              "(Default: 1MB)",
@@ -1223,9 +1227,9 @@ REGISTER_TUNABLE("verbose_master_req",
                  &gbl_verbose_master_req, EXPERIMENTAL | INTERNAL, NULL, NULL,
                  NULL, NULL);
 REGISTER_TUNABLE("verbose_rep_all_req",
-                 "Print trace showing rep-all-req protocol.", TUNABLE_BOOLEAN,
-                 &gbl_verbose_rep_all_req, EXPERIMENTAL | INTERNAL, NULL, NULL,
-                 NULL, NULL);
+                 "Print trace showing rep-all-req protocol.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_verbose_rep_all_req,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("verbose_send_cohlease",
                  "Print trace from lease-issue thread.", TUNABLE_BOOLEAN,
                  &gbl_verbose_send_coherency_lease, EXPERIMENTAL | INTERNAL,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1237,6 +1237,10 @@ REGISTER_TUNABLE("decoupled_logputs",
                  "Perform logputs out-of-band. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_decoupled_logputs, EXPERIMENTAL | INTERNAL, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("use_rep_log_fill",
+                 "Use distinct rep-log-fill response. (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_use_rep_log_fill,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("apply_pollms",
                  "Apply-thread poll time before checking queue. "
                  "(Default: 100ms)",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1222,6 +1222,10 @@ REGISTER_TUNABLE("verbose_master_req",
                  "Print trace showing master-req protocol.", TUNABLE_BOOLEAN,
                  &gbl_verbose_master_req, EXPERIMENTAL | INTERNAL, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("verbose_rep_all_req",
+                 "Print trace showing rep-all-req protocol.", TUNABLE_BOOLEAN,
+                 &gbl_verbose_rep_all_req, EXPERIMENTAL | INTERNAL, NULL, NULL,
+                 NULL, NULL);
 REGISTER_TUNABLE("verbose_send_cohlease",
                  "Print trace from lease-issue thread.", TUNABLE_BOOLEAN,
                  &gbl_verbose_send_coherency_lease, EXPERIMENTAL | INTERNAL,

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2256,8 +2256,9 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
         /* avoid new accepting new queries/transaction on opened connections
            if we are incoherent (and not in a transaction). */
-        if (clnt.ignore_coherency == 0 && !bdb_am_i_coherent(thedb->bdb_env) &&
-            (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
+        if (!clnt.admin && clnt.ignore_coherency == 0 && 
+                !bdb_am_i_coherent(thedb->bdb_env) && 
+                (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
             logmsg(LOGMSG_ERROR,
                    "%s line %d td %u new query on incoherent node, "
                    "dropping socket\n",

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2256,9 +2256,9 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
         /* avoid new accepting new queries/transaction on opened connections
            if we are incoherent (and not in a transaction). */
-        if (!clnt.admin && clnt.ignore_coherency == 0 && 
-                !bdb_am_i_coherent(thedb->bdb_env) && 
-                (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
+        if (!clnt.admin && clnt.ignore_coherency == 0 &&
+            !bdb_am_i_coherent(thedb->bdb_env) &&
+            (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
             logmsg(LOGMSG_ERROR,
                    "%s line %d td %u new query on incoherent node, "
                    "dropping socket\n",

--- a/tools/comdb2ar/deserialise.cpp
+++ b/tools/comdb2ar/deserialise.cpp
@@ -448,8 +448,8 @@ void deserialise_database(
             // Create the copylock file to indicate that this copy isn't
             // done yet.
             copylock_file = lrldestdir + "/" + dbname + ".copylock";
-#if 0
             struct stat statbuf;
+#if 0
             rc = stat(copylock_file.c_str(), &statbuf);
             if (rc == 0)
             {
@@ -471,16 +471,34 @@ void deserialise_database(
             // remove logs
             std::string logsdir = datadestdir + "/logs";
             std::list<std::string> logfiles;
-            listdir(logfiles, logsdir);
-            for (std::list<std::string>::const_iterator it = logfiles.begin();
-                    it != logfiles.end();
-                    ++it) {
-                std::string log = logsdir + "/" + *it;
-                std::cout << "unlink " << log << std::endl;
-                unlink(log.c_str());
-            }
 
-            inited_txn_dir = true;
+            rc = stat(logsdir.c_str(), &statbuf);
+            if (rc == 0) {
+                listdir(logfiles, logsdir);
+                for (std::list<std::string>::const_iterator it = logfiles.begin();
+                        it != logfiles.end();
+                        ++it) {
+                    std::string log = logsdir + "/" + *it;
+                    std::cout << "unlink " << log << std::endl;
+                    unlink(log.c_str());
+                }
+
+                inited_txn_dir = true;
+            }
+            logsdir = datadestdir + "/" + dbname + ".txn";
+            rc = stat(logsdir.c_str(), &statbuf);
+            if (rc == 0) {
+                listdir(logfiles, logsdir);
+                for (std::list<std::string>::const_iterator it = logfiles.begin();
+                        it != logfiles.end();
+                        ++it) {
+                    std::string log = logsdir + "/" + *it;
+                    std::cout << "unlink " << log << std::endl;
+                    unlink(log.c_str());
+                }
+
+                inited_txn_dir = true;
+            }
         }
 
         // Read the tar block header
@@ -892,15 +910,25 @@ void deserialise_database(
                 /* Remove old log files.  This used to remove all files in the directory,
                    which can be problematic if hi. */
                 if (!legacy_mode) {
+                    int rc;
+                    struct stat statbuf;
+
                    // remove files in the txn directory
                    std::string dbtxndir(datadestdir + "/" + dbname + ".txn");
-                   make_dirs( dbtxndir );
-                   if (!incr_mode)
-                       remove_all_old_files( dbtxndir );
+
+                   rc = stat(dbtxndir.c_str(), &statbuf);
+                   if (rc == 0) {
+                       make_dirs( dbtxndir );
+                       if (!incr_mode)
+                           remove_all_old_files( dbtxndir );
+                   }
                    dbtxndir = datadestdir + "/" + "logs";
-                   make_dirs( dbtxndir );
-                   if (!incr_mode)
-                       remove_all_old_files( dbtxndir );
+                   rc = stat(dbtxndir.c_str(), &statbuf);
+                   if (rc == 0) {
+                       make_dirs( dbtxndir );
+                       if (!incr_mode)
+                           remove_all_old_files( dbtxndir );
+                   }
                 }
             }
         }

--- a/tools/comdb2ar/incr_deserialise.cpp
+++ b/tools/comdb2ar/incr_deserialise.cpp
@@ -447,10 +447,16 @@ void clear_log_folder(
 // unless in keep_all_logs mode
 {
     // remove files in the txn directory
+    int rc;
+    struct stat statbuf;
     std::string dbtxndir(datadestdir + "/" + dbname + ".txn");
-    make_dirs( dbtxndir );
-    remove_all_old_files( dbtxndir );
+    rc = stat(dbtxndir.c_str(), &statbuf);
+    if (rc == 0) {
+        remove_all_old_files( dbtxndir );
+    } 
     dbtxndir = datadestdir + "/" + "logs";
-    make_dirs( dbtxndir );
-    remove_all_old_files( dbtxndir );
+    rc = stat(dbtxndir.c_str(), &statbuf);
+    if (rc == 0) {
+        remove_all_old_files( dbtxndir );
+    }
 }


### PR DESCRIPTION
Fixing a bug introduced by my work on the fast-catchup project.  The main fix is to remove the code which allocates an extraordinarily large cursor-buffer.  Akshat brought this to my attention (thank you).
