### PR TITLE
After the do/while loop in osql_schemachange_logic, check the return code (rc) before calling osql_save_schemachange.

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1716,6 +1716,12 @@ int osql_schemachange_logic(struct schema_change_type *sc,
             }
             RESTART_SOCKSQL;
         } while (restarted && rc == 0);
+        if (rc) {
+            logmsg(LOGMSG_ERROR,
+                   "%s:%d %s - failed to send socksql schemachange rc=%d\n",
+                   __FILE__, __LINE__, __func__, rc);
+            return rc;
+        }
     }
 
     rc = osql_save_schemachange(thd, sc, usedb);


### PR DESCRIPTION

This pull request fixes what is seemingly a logic error in the error handling of the osql_schemachange_logic function.  Based on how the function is structured and the other (related) functions, it seems the return code should be checked after exiting the do/while loop, prior to calling osql_save_schemachange (which presumably requires a successful return code from the previous function calls as a precondition of its usage).

This change does merit careful review by people more familiar with this particular subsystem.