### PR TITLE
db: Fix 10-second write timeout on connections obtained from the socket pool.

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4089,7 +4089,7 @@ void cleanup_clnt(struct sqlclntstate *clnt)
 
 void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
 {
-    int wrtimeoutsec = 0;
+    int wrtimeoutsec, notimeout = disable_server_sql_timeouts();
     if (initial) {
         bzero(clnt, sizeof(*clnt));
     }
@@ -4177,7 +4177,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
 
     bzero(clnt->dirty, sizeof(clnt->dirty));
 
-    if (gbl_sqlwrtimeoutms == 0)
+    if (gbl_sqlwrtimeoutms == 0 || notimeout)
         wrtimeoutsec = 0;
     else
         wrtimeoutsec = gbl_sqlwrtimeoutms / 1000;

--- a/tests/nowritetimeout.test/Makefile
+++ b/tests/nowritetimeout.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/nowritetimeout.test/runit
+++ b/tests/nowritetimeout.test/runit
@@ -6,6 +6,16 @@ dbnm=$1
 pgrep cdb2sockpool
 if [ $? -ne 0 ]; then
     echo 'SOCKPOOL IS REQUIRED TO RUN THE TEST.' >&2
-    exit 1
+    echo 'TRY TO BRING UP SOCKPOOL'
+    ${BUILDDIR}/tools/cdb2sockpool/cdb2sockpool
+    sleep 1
+    pgrep cdb2sockpool
+    if [ $? -ne 0 ]; then
+        echo 'FAILED THE ATTEMPT.' >&2
+        exit 1
+    fi
 fi
 ${TESTSBUILDDIR}/nowritetimeout $dbnm
+rc=$?
+pkill cdb2sockpool
+exit $rc

--- a/tests/nowritetimeout.test/runit
+++ b/tests/nowritetimeout.test/runit
@@ -16,6 +16,3 @@ if [ $? -ne 0 ]; then
     fi
 fi
 ${TESTSBUILDDIR}/nowritetimeout $dbnm
-rc=$?
-pkill cdb2sockpool
-exit $rc

--- a/tests/nowritetimeout.test/runit
+++ b/tests/nowritetimeout.test/runit
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+pgrep cdb2sockpool
+if [ $? -ne 0 ]; then
+    echo 'SOCKPOOL IS REQUIRED TO RUN THE TEST.' >&2
+    exit 1
+fi
+${TESTSBUILDDIR}/nowritetimeout $dbnm

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -45,10 +45,11 @@ add_exe(cdb2api_unit cdb2api_unit.c)
 add_exe(malloc_resize_test malloc_resize_test.c)
 add_exe(cdb2_close_early cdb2_close_early.c)
 add_exe(cdb2api_read_intrans_results cdb2api_read_intrans_results.c)
+add_exe(nowritetimeout nowritetimeout.c)
 
 add_custom_target(test-tools DEPENDS ${test-tools})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout)
   target_link_libraries(${executable} cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 endforeach()
 
@@ -70,6 +71,6 @@ target_link_libraries(recom cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} $
 # everything!
 target_link_libraries(stepper cdb2api mem dlmalloc util ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout)
     target_link_libraries(${executable} ${UNWIND_LIBRARY})
 endforeach()

--- a/tests/tools/nowritetimeout.c
+++ b/tests/tools/nowritetimeout.c
@@ -1,0 +1,59 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <cdb2api.h>
+
+int main(int argc, char **argv)
+{
+    cdb2_hndl_tp *hndl = NULL;
+    char *conf = getenv("CDB2_CONFIG");
+    char *tier = "local";
+    void *blob;
+    int i, rc;
+
+    if (conf != NULL) {
+        cdb2_set_comdb2db_config(conf);
+        tier = "default";
+    }
+
+    puts("CREATING TABLE...");
+    cdb2_open(&hndl, argv[1], tier, 0);
+    cdb2_run_statement(hndl, "DROP TABLE IF EXISTS t");
+    cdb2_run_statement(hndl, "CREATE TABLE t (b blob)");
+
+    puts("INSERTING DATA...");
+    blob = malloc(1 << 20);
+    cdb2_bind_param(hndl, "b", CDB2_BLOB, blob, 1 << 20);
+    for (i = 0; i != 8; ++i)
+        cdb2_run_statement(hndl, "INSERT INTO t VALUES(@b)");
+
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK);
+    if (rc != CDB2_OK_DONE) {
+        puts("FAILED");
+        puts(cdb2_errstr(hndl));
+        return rc;
+    }
+
+    puts("DONATING FD TO SOCK POOL...");
+    cdb2_close(hndl);
+
+    puts("REOPENING FROM SOCK POOL...");
+    hndl = NULL;
+    cdb2_open(&hndl, argv[1], tier, 0);
+
+    puts("RUNNING QUERY TO FILL UP TCP SND BUFFER ON SERVER...");
+    cdb2_run_statement(hndl, "SELECT * FROM t a, t b, t c");
+
+    puts("SLEEPING 20 SECONDS...");
+    sleep(20);
+
+    puts("I'M AWAKE. FETCHING ROWS...");
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK);
+    if (rc != CDB2_OK_DONE) {
+        puts("FAILED");
+        puts(cdb2_errstr(hndl));
+        return rc;
+    }
+    return 0;
+}


### PR DESCRIPTION
The socket pool sends RESET to the server. The server then resets the write timeout of the connection to 10 seconds.
