### PR TITLE
ddl schemachange: move sending tableversion in OSQL_SCHEMACHANGE

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1244,7 +1244,6 @@ struct ireq {
     uint8_t *p_buf_out_start;     /* pointer to start of output buf */
     const uint8_t *p_buf_out_end; /* pointer to just past end of output buf */
     unsigned long long rqid;
-    int usedbtablevers;
     int frompid;
     int debug;
     int opcode;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1464,8 +1464,8 @@ void *osql_commit_timepart_resuming_sc(void *p)
             sc->sc_next = sc_pending;
             sc_pending = sc;
         } else {
-            logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__, sc->tablename,
-                   sc->sc_rc);
+            logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__,
+                   sc->tablename, sc->sc_rc);
             sc_set_running(sc->tablename, 0, 0, NULL, 0);
             free_schema_change_type(sc);
             error = 1;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -139,7 +139,6 @@ static int osql_bplog_key_cmp(void *usermem, int key1len, const void *key1,
     oplog_key_t *k1 = (oplog_key_t *)key1;
     oplog_key_t *k2 = (oplog_key_t *)key2;
 #endif
-    int cmp;
 
     if (k1->seq < k2->seq) {
         return -1;
@@ -164,7 +163,6 @@ int osql_bplog_start(struct ireq *iq, osql_sess_t *sess)
     blocksql_tran_t *tran = NULL;
     blocksql_info_t *info = NULL;
     int bdberr = 0;
-    int rc;
 
     /*
        this stuff is LOCKLESS, since we have only block
@@ -235,7 +233,7 @@ int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err)
     int error = 0;
     blocksql_info_t *info = NULL, *temp = NULL;
     struct errstat generr = {0}, *xerr;
-    int rc = 0, irc = 0;
+    int rc = 0;
     int stop_time = 0;
 
     while (tran->pending.top && !error) {
@@ -372,11 +370,11 @@ int osql_bplog_schemachange(struct ireq *iq)
             sc->sc_next = iq->sc_pending;
             iq->sc_pending = sc;
         } else if (sc->sc_rc == SC_MASTER_DOWNGRADE) {
-            sc_set_running(sc->table, 0, iq->sc_seed, NULL, 0);
+            sc_set_running(sc->tablename, 0, iq->sc_seed, NULL, 0);
             free_schema_change_type(sc);
             rc = ERR_NOMASTER;
         } else {
-            sc_set_running(sc->table, 0, iq->sc_seed, NULL, 0);
+            sc_set_running(sc->tablename, 0, iq->sc_seed, NULL, 0);
             if (sc->sc_rc)
                 rc = ERR_SC;
             free_schema_change_type(sc);
@@ -445,7 +443,6 @@ char *osql_sorese_type_to_str(int stype)
 char *osql_get_tran_summary(struct ireq *iq)
 {
 
-    int i = 0;
     char *ret = NULL;
     char *nametype;
 
@@ -506,7 +503,6 @@ char *osql_get_tran_summary(struct ireq *iq)
 static pthread_mutex_t kludgelk = PTHREAD_MUTEX_INITIALIZER;
 int osql_bplog_free(struct ireq *iq, int are_sessions_linked, const char *func, const char *callfunc, int line)
 {
-    int val = 0;
     int rc = 0;
     int bdberr = 0;
     blocksql_info_t *info = NULL, *tmp = NULL;
@@ -636,11 +632,9 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     struct ireq *iq = osql_session_get_ireq(sess);
     int rc = 0, rc_op = 0;
     oplog_key_t key = {0};
-    int rpl_len = 0;
     struct errstat *xerr;
     int bdberr;
     int debug = 0;
-    uuidstr_t us;
 
     int type = 0;
     buf_get(&type, sizeof(type), rpl, rpl + rplen);
@@ -948,7 +942,6 @@ int osql_bplog_build_sorese_req(uint8_t *p_buf_start,
     /* must make sure the packed sqlq is NUL terminated later on */
 
     /* pack sql */
-    uint8_t *sqlbuf = p_buf;
     if (!(p_buf = packedreq_sql_put(&sql, p_buf, *pp_buf_end)))
         return -1;
     *sqlqret =
@@ -1067,7 +1060,6 @@ static int process_this_session(
                 struct block_err *, int *, SBUF2 *))
 {
 
-    blocksql_tran_t *tran = (blocksql_tran_t *)iq->blocksql_tran;
     unsigned long long rqid = osql_sess_getrqid(sess);
     oplog_key_t key_next, key_crt;
     int countops = 0;
@@ -1220,7 +1212,6 @@ static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
     int out_rc = 0;
     int bdberr = 0;
     struct temp_cursor *dbc = NULL;
-    bpfunc_lstnode_t *cur_bpfunc = NULL;
 
     /* lock the table (it should get no more access anway) */
     if ((rc = pthread_mutex_lock(&tran->store_mtx))) {
@@ -1358,10 +1349,7 @@ void osql_bplog_time_done(struct ireq *iq)
     blocksql_tran_t *tran = (blocksql_tran_t *)iq->blocksql_tran;
     osql_bp_timings_t *tms = &iq->timings;
     blocksql_info_t *info = NULL;
-    int rc = 0;
-    int bdberr = 0;
     char msg[4096];
-    unsigned long long rqid;
     int tottm = 0;
     int rtt = 0;
     int rtrs = 0;
@@ -1476,9 +1464,9 @@ void *osql_commit_timepart_resuming_sc(void *p)
             sc->sc_next = sc_pending;
             sc_pending = sc;
         } else {
-            logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__, sc->table,
+            logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__, sc->tablename,
                    sc->sc_rc);
-            sc_set_running(sc->table, 0, 0, NULL, 0);
+            sc_set_running(sc->tablename, 0, 0, NULL, 0);
             free_schema_change_type(sc);
             error = 1;
         }
@@ -1530,7 +1518,7 @@ void *osql_commit_timepart_resuming_sc(void *p)
             iq.usedb = iq.sc->db;
         if (finalize_schema_change(&iq, iq.sc_tran)) {
             logmsg(LOGMSG_ERROR, "%s: failed to finalize '%s'\n", __func__,
-                   iq.sc->table);
+                   iq.sc->tablename);
             goto abort_sc;
         }
         iq.usedb = NULL;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6576,112 +6576,102 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
     /*fprintf(stderr,"rpl type is %d msg=%x\n",rpl.type, msg);*/
 
-    switch (type) {
-    case OSQL_USEDB: {
-        osql_usedb_t dt;
-        p_buf_end = (uint8_t *)p_buf + sizeof(osql_usedb_t);
-        char *tablename;
-
-        tablename = (char *)osqlcomm_usedb_type_get(&dt, p_buf, p_buf_end);
-
-     } break;
-    case OSQL_SCHEMACHANGE: {
-        struct schema_change_type *sc = new_schemachange_type();
-        p_buf_end = p_buf + msglen;
-        p_buf = osqlcomm_schemachange_type_get(sc, p_buf, p_buf_end);
-
-        if (p_buf == NULL) {
-            logmsg(LOGMSG_ERROR, "%s:%d failed to read schema change object\n",
-                   __func__, __LINE__);
-            reqerrstr(iq, ERR_SC,
-                      "internal error: failed to read schema change object");
-            return ERR_SC;
-        }
-
-        logmsg(LOGMSG_ERROR, "OSQL_SCHEMACHANGE '%s' tableversion %d\n", sc->tablename, sc->usedbtablevers);
-        if (logsb) {
-            sbuf2printf(logsb, "[%llu %s] OSQL_SCHEMACHANGE %s\n", rqid,
-                        comdb2uuidstr(uuid, us), sc->tablename);
-            sbuf2flush(logsb);
-        }
-
-        if (unlikely(timepart_is_timepart(sc->tablename, 1))) {
-            char *newest_shard;
-            unsigned long long ver;
-
-            newest_shard = timepart_newest_shard(sc->tablename, &ver);
-            if (newest_shard) {
-                iq->usedbtablevers = ver;
-                free(newest_shard);
-            } else {
-                logmsg(LOGMSG_ERROR, "%s: broken time partition %s"
-                                     "\n",
-                       __func__, sc->tablename);
-
-                return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
-                                         sc->tablename, 0);
-            }
-        } else {
-            if (is_tablename_queue(sc->tablename, sc->tablename_len)) {
-                iq->usedb = getqueuebyname(sc->tablename);
-            } else {
-                iq->usedb = get_dbtable_by_name(sc->tablename);
-                iq->usedbtablevers = sc->usedbtablevers;
-            }
-            if (iq->usedb == NULL) {
-                iq->usedb = iq->origdb;
-                logmsg(LOGMSG_INFO, "%s: unable to get usedb for table %s\n",
-                       __func__, sc->tablename);
-                //return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
-                                         //sc->tablename, 0);
-            }
-        }
-
-
-        if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_ASYNC))
-            sc->nothrevent = 0;
-        else
-            sc->nothrevent = 1;
-        sc->finalize = 0;
-        if (sc->original_master_node[0] != 0 &&
-            strcmp(sc->original_master_node, gbl_mynode))
-            sc->resume = 1;
-
-        iq->sc = sc;
-        sc->iq = iq;
-        if (sc->db == NULL) {
-            sc->db = get_dbtable_by_name(sc->tablename);
-        }
-        sc->tran = NULL;
-        if (sc->db)
-            iq->usedb = sc->db;
-
-        if (!timepart_is_timepart(sc->tablename, 1)) {
-            rc = start_schema_change_tran(iq, NULL);
-            if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
-                iq->sc = NULL;
-            } else {
-                iq->sc->sc_next = iq->sc_pending;
-                iq->sc_pending = iq->sc;
-                iq->osql_flags |= OSQL_FLAGS_SCDONE;
-            }
-        } else {
-            timepart_sc_arg_t arg = {0};
-            arg.s = sc;
-            arg.s->iq = iq;
-            rc = timepart_foreach_shard(
-                sc->tablename, start_schema_change_tran_wrapper, &arg, 0);
-        }
-        iq->usedb = NULL;
-
-        if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
-            return 0;
-        else
-            return ERR_SC;
-    } break;
-    default:
+    if (type != OSQL_SCHEMACHANGE)
         return 0;
+
+    struct schema_change_type *sc = new_schemachange_type();
+    p_buf_end = p_buf + msglen;
+    p_buf = osqlcomm_schemachange_type_get(sc, p_buf, p_buf_end);
+
+    if (p_buf == NULL) {
+        logmsg(LOGMSG_ERROR, "%s:%d failed to read schema change object\n",
+               __func__, __LINE__);
+        reqerrstr(iq, ERR_SC,
+                  "internal error: failed to read schema change object");
+        return ERR_SC;
     }
+
+    logmsg(LOGMSG_DEBUG, "OSQL_SCHEMACHANGE '%s' tableversion %d\n", sc->tablename, sc->usedbtablevers);
+
+    if (logsb) {
+        sbuf2printf(logsb, "[%llu %s] OSQL_SCHEMACHANGE %s\n", rqid,
+                    comdb2uuidstr(uuid, us), sc->tablename);
+        sbuf2flush(logsb);
+    }
+
+    if (unlikely(timepart_is_timepart(sc->tablename, 1))) {
+        char *newest_shard;
+        unsigned long long ver;
+
+        newest_shard = timepart_newest_shard(sc->tablename, &ver);
+        if (newest_shard) {
+            iq->usedbtablevers = ver;
+            free(newest_shard);
+        } else {
+            logmsg(LOGMSG_ERROR, "%s: broken time partition %s"
+                                 "\n",
+                   __func__, sc->tablename);
+
+            return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
+                                     sc->tablename, 0);
+        }
+    } else {
+        if (is_tablename_queue(sc->tablename, sc->tablename_len)) {
+            iq->usedb = getqueuebyname(sc->tablename);
+        } else {
+            iq->usedb = get_dbtable_by_name(sc->tablename);
+            iq->usedbtablevers = sc->usedbtablevers;
+        }
+        if (iq->usedb == NULL) {
+            iq->usedb = iq->origdb;
+            logmsg(LOGMSG_INFO, "%s: unable to get usedb for table %s\n",
+                   __func__, sc->tablename);
+            //return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
+                                     //sc->tablename, 0);
+        }
+    }
+
+
+    if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_ASYNC))
+        sc->nothrevent = 0;
+    else
+        sc->nothrevent = 1;
+    sc->finalize = 0;
+    if (sc->original_master_node[0] != 0 &&
+        strcmp(sc->original_master_node, gbl_mynode))
+        sc->resume = 1;
+
+    iq->sc = sc;
+    sc->iq = iq;
+    if (sc->db == NULL) {
+        sc->db = get_dbtable_by_name(sc->tablename);
+    }
+    sc->tran = NULL;
+    if (sc->db)
+        iq->usedb = sc->db;
+
+    if (!timepart_is_timepart(sc->tablename, 1)) {
+        rc = start_schema_change_tran(iq, NULL);
+        if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
+            iq->sc = NULL;
+        } else {
+            iq->sc->sc_next = iq->sc_pending;
+            iq->sc_pending = iq->sc;
+            iq->osql_flags |= OSQL_FLAGS_SCDONE;
+        }
+    } else {
+        timepart_sc_arg_t arg = {0};
+        arg.s = sc;
+        arg.s->iq = iq;
+        rc = timepart_foreach_shard(
+            sc->tablename, start_schema_change_tran_wrapper, &arg, 0);
+    }
+    iq->usedb = NULL;
+
+    if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
+        return 0;
+    else
+        return ERR_SC;
 
     return 0;
 }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -831,7 +831,7 @@ static uint8_t *osqlcomm_schemachange_type_get(struct schema_change_type *sc,
     uint8_t *tmp_buf =
         buf_get_schemachange(sc, (void *)p_buf, (void *)p_buf_end);
 
-    if (sc->table_len == -1 || sc->fname_len == -1 || sc->aname_len == -1)
+    if (sc->tablename_len == -1 || sc->fname_len == -1 || sc->aname_len == -1)
         return NULL;
 
     return tmp_buf;
@@ -3454,7 +3454,6 @@ int osql_comm_send_poke(char *tohost, unsigned long long rqid, uuid_t uuid,
                         int type)
 {
     int rc = 0;
-    void *out;
 
     if (rqid == OSQL_RQID_USE_UUID) {
         uint8_t buf[OSQLCOMM_POKE_UUID_TYPE_LEN];
@@ -3549,7 +3548,6 @@ int is_tablename_queue(const char * tablename, int len)
 int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
                        uint32_t start_gen, int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     uint8_t buf[OSQLCOMM_STARTGEN_UUID_RPL_LEN > OSQLCOMM_STARTGEN_RPL_LEN
                     ? OSQLCOMM_STARTGEN_UUID_RPL_LEN
                     : OSQLCOMM_STARTGEN_RPL_LEN];
@@ -3618,7 +3616,6 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
                     char *tablename, int type, SBUF2 *logsb,
                     unsigned long long tableversion)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     unsigned short tablenamelen = strlen(tablename) + 1; /*including trailing 0*/
     int msglen;
     int rc = 0;
@@ -3707,8 +3704,6 @@ int osql_send_updcols(char *tohost, unsigned long long rqid, uuid_t uuid,
                       unsigned long long seq, int type, int *colList, int ncols,
                       SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
-    char *data = (char *)colList;
     int rc = 0;
     int didmalloc = 0;
     int i;
@@ -3798,7 +3793,6 @@ int osql_send_index(char *tohost, unsigned long long rqid, uuid_t uuid,
                     unsigned long long genid, int isDelete, int ixnum,
                     char *pData, int nData, int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     int msglen;
     uint8_t buf[OSQLCOMM_INDEX_RPL_TYPE_LEN > OSQLCOMM_INDEX_UUID_RPL_TYPE_LEN
                     ? OSQLCOMM_INDEX_RPL_TYPE_LEN
@@ -3877,7 +3871,6 @@ int osql_send_qblob(char *tohost, unsigned long long rqid, uuid_t uuid,
                     int blobid, unsigned long long seq, int type, char *data,
                     int datalen, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     int sent;
     uint8_t buf[OSQLCOMM_QBLOB_UUID_RPL_TYPE_LEN > OSQLCOMM_QBLOB_RPL_TYPE_LEN
                     ? OSQLCOMM_QBLOB_UUID_RPL_TYPE_LEN
@@ -3975,7 +3968,6 @@ int osql_send_updrec(char *tohost, unsigned long long rqid, uuid_t uuid,
                      unsigned long long del_keys, char *pData, int nData,
                      int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     uint8_t buf[OSQLCOMM_UPD_UUID_RPL_TYPE_LEN > OSQLCOMM_UPD_RPL_TYPE_LEN
                     ? OSQLCOMM_UPD_UUID_RPL_TYPE_LEN
                     : OSQLCOMM_UPD_RPL_TYPE_LEN];
@@ -4117,7 +4109,6 @@ int osql_close_connection(char *host)
 int osql_send_dbglog(char *tohost, unsigned long long rqid, uuid_t uuid,
                      unsigned long long dbglog_cookie, int queryid, int type)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     osql_dbglog_t req;
     uint8_t buf[OSQLCOMM_DBGLOG_TYPE_LEN];
     uint8_t *p_buf = buf;
@@ -4152,7 +4143,6 @@ int osql_send_updstat(char *tohost, unsigned long long rqid, uuid_t uuid,
                       unsigned long long seq, char *pData, int nData, int nStat,
                       int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     osql_updstat_rpl_t updstat_rpl = {0};
     osql_updstat_uuid_rpl_t updstat_rpl_uuid = {0};
 
@@ -4231,7 +4221,6 @@ int osql_send_insrec(char *tohost, unsigned long long rqid, uuid_t uuid,
                      char *pData, int nData, int type, SBUF2 *logsb,
                      int upsert_flags)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     int msglen;
     uint8_t buf[OSQLCOMM_INS_RPL_TYPE_LEN > OSQLCOMM_INS_UUID_RPL_TYPE_LEN
                     ? OSQLCOMM_INS_RPL_TYPE_LEN
@@ -4342,7 +4331,6 @@ int osql_send_insrec(char *tohost, unsigned long long rqid, uuid_t uuid,
 int osql_send_dbq_consume(char *tohost, unsigned long long rqid, uuid_t uuid,
                           genid_t genid, int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = comm->handle_sibling;
     union {
         osql_uuid_dbq_consume_t uuid;
         osql_dbq_consume_t rqid;
@@ -4382,7 +4370,6 @@ int osql_send_delrec(char *tohost, unsigned long long rqid, uuid_t uuid,
                      unsigned long long genid, unsigned long long dirty_keys,
                      int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     uint8_t
         buf[OSQLCOMM_OSQL_DEL_RPL_TYPE_LEN > OSQLCOMM_OSQL_DEL_UUID_RPL_TYPE_LEN
                 ? OSQLCOMM_OSQL_DEL_RPL_TYPE_LEN
@@ -4391,7 +4378,6 @@ int osql_send_delrec(char *tohost, unsigned long long rqid, uuid_t uuid,
     uint8_t *p_buf_end;
     int rc = 0;
     int msgsz;
-    uuidstr_t us;
     int send_dk = 0;
 
     if (gbl_partial_indexes && dirty_keys != -1ULL)
@@ -4469,7 +4455,6 @@ int osql_send_serial(char *tohost, unsigned long long rqid, uuid_t uuid,
                      CurRangeArr *arr, unsigned int file, unsigned int offset,
                      int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     int used_malloc = 0;
     uint8_t *buf = NULL;
     uint8_t *p_buf;
@@ -4618,7 +4603,6 @@ int osql_send_commit(char *tohost, unsigned long long rqid, uuid_t uuid,
                      struct client_query_stats *query_stats,
                      snap_uid_t *snap_info)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     osql_done_rpl_t rpl_ok = {0};
 
     osql_done_xerr_t rpl_xerr = {0};
@@ -4751,7 +4735,6 @@ int osql_send_commit_by_uuid(char *tohost, uuid_t uuid, int nops,
                              struct client_query_stats *query_stats,
                              snap_uid_t *snap_info)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     osql_done_uuid_rpl_t rpl_ok = {0};
 
     osql_done_xerr_uuid_t rpl_xerr = {0};
@@ -4923,7 +4906,6 @@ static void osql_blocksql_failed_dispatch(netinfo_type *netinfo_ptr,
    buffer (ie: network order) */
 int osql_add_to_request(osql_req_t **reqp, int type, void *buf, int len)
 {
-    int newsize;
     void *rqbuf;
     int rqsz;
     struct osql_req_tail *tail;
@@ -4973,10 +4955,6 @@ void *osql_create_request(const char *sql, int sqlen, int type,
     int rqlen = 0;
     int taglen = 0;
     uint8_t *p_buf, *p_buf_end;
-    int sz;
-    short szs;
-    int blobsizes[MAXBLOBS];
-    int blobno;
     osql_req_t req = {0};
     osql_uuid_req_t req_uuid = {0};
     void *ret;
@@ -5157,7 +5135,6 @@ int osql_comm_send_socksqlreq(char *tohost, const char *sql, int sqlen,
     void *req = NULL;
     int reqlen = 0;
     int rc = 0;
-    int retry;
     int net_type;
 
     stats[type].snd++;
@@ -5481,7 +5458,6 @@ static void net_osql_poked(void *hndl, void *uptr, char *fromhost, int usertype,
     uint8_t *p_buf_end = p_buf + dtalen;
     osql_poke_t poke;
     int found = 0;
-    osql_sess_t *sess = 0;
     int rc = 0;
     uuid_t uuid;
 
@@ -5504,7 +5480,6 @@ static void net_osql_poked(void *hndl, void *uptr, char *fromhost, int usertype,
         /* send a done with an error, lost request */
         uint8_t buf[OSQLCOMM_DONE_XERR_RPL_LEN];
         uint8_t *p_buf = buf, *p_buf_end = buf + OSQLCOMM_DONE_XERR_RPL_LEN;
-        netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
         osql_done_xerr_t rpl;
 
         rpl.hd.type = OSQL_XERR;
@@ -5539,7 +5514,6 @@ static void net_osql_poked_uuid(void *hndl, void *uptr, char *fromhost,
     uint8_t *p_buf_end = p_buf + dtalen;
     osql_poke_uuid_t poke;
     int found = 0;
-    osql_sess_t *sess = 0;
     int rc = 0;
 
     if (thedb->exiting || thedb->stopped) {
@@ -5560,7 +5534,6 @@ static void net_osql_poked_uuid(void *hndl, void *uptr, char *fromhost,
         uint8_t buf[OSQLCOMM_DONE_XERR_UUID_RPL_LEN];
         uint8_t *p_buf = buf,
                 *p_buf_end = buf + OSQLCOMM_DONE_XERR_UUID_RPL_LEN;
-        netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
         osql_done_xerr_uuid_t rpl;
 
         rpl.hd.type = OSQL_XERR;
@@ -5625,14 +5598,12 @@ static void net_osql_master_check(void *hndl, void *uptr, char *fromhost,
         rqid = poke.rqid;
     }
 
-    uuidstr_t us;
     found = osql_repository_session_exists(rqid, uuid);
 
     if (found) {
         uint8_t buf[OSQLCOMM_EXISTS_RPL_TYPE_LEN];
         uint8_t bufuuid[OSQLCOMM_EXISTS_UUID_RPL_TYPE_LEN];
         uint8_t *p_buf;
-        netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
 
         if (rqid == OSQL_RQID_USE_UUID) {
             p_buf = bufuuid;
@@ -6194,7 +6165,6 @@ static void net_osql_rpl(void *hndl, void *uptr, char *fromnode, int usertype,
             rc = -1;
         } else
             comdb2uuidcpy(uuid, p_osql_uuid_rpl.uuid);
-        uuidstr_t us;
     } else {
         osql_rpl_t p_osql_rpl;
         uint8_t *p_buf, *p_buf_end;
@@ -6533,7 +6503,7 @@ int start_schema_change_tran_wrapper(const char *tblname,
     struct ireq *iq = sc->iq;
     int rc;
 
-    strncpy0(sc->table, tblname, sizeof(sc->table));
+    strncpy0(sc->tablename, tblname, sizeof(sc->tablename));
 
     rc = start_schema_change_tran(iq, sc->tran);
     if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
@@ -6574,11 +6544,6 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
     const uint8_t *p_buf;
     const uint8_t *p_buf_end;
     int rc = 0;
-    int ii;
-    struct dbtable *db =
-        (iq->usedb) ? iq->usedb : thedb->dbs[0]; /*add to first if no usedb*/
-    const unsigned char tag_name_ondisk[] = ".ONDISK";
-    const size_t tag_name_ondisk_len = 8 /*includes NUL*/;
     int type;
     uuidstr_t us;
 
@@ -6619,43 +6584,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
         tablename = (char *)osqlcomm_usedb_type_get(&dt, p_buf, p_buf_end);
 
-        if (logsb) {
-            sbuf2printf(logsb, "[%llu %s] OSQL_USEDB %*.s\n", rqid,
-                        comdb2uuidstr(uuid, us), dt.tablenamelen, tablename);
-            sbuf2flush(logsb);
-        }
-        if (unlikely(timepart_is_timepart(tablename, 1))) {
-            char *newest_shard;
-            unsigned long long ver;
-
-            newest_shard = timepart_newest_shard(tablename, &ver);
-            if (newest_shard) {
-                iq->usedbtablevers = ver;
-                free(newest_shard);
-            } else {
-                logmsg(LOGMSG_ERROR, "%s: broken time partition %s"
-                                     "\n",
-                       __func__, tablename);
-
-                return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
-                                         tablename, 0);
-            }
-        } else {
-            if (is_tablename_queue(tablename, strlen(tablename))) {
-                iq->usedb = getqueuebyname(tablename);
-            } else {
-                iq->usedb = get_dbtable_by_name(tablename);
-                iq->usedbtablevers = dt.tableversion;
-            }
-            if (iq->usedb == NULL) {
-                iq->usedb = iq->origdb;
-                logmsg(LOGMSG_INFO, "%s: unable to get usedb for table %.*s\n",
-                       __func__, dt.tablenamelen, tablename);
-                return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
-                                         tablename, 0);
-            }
-        }
-    } break;
+     } break;
     case OSQL_SCHEMACHANGE: {
         struct schema_change_type *sc = new_schemachange_type();
         p_buf_end = p_buf + msglen;
@@ -6669,6 +6598,46 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
             return ERR_SC;
         }
 
+        logmsg(LOGMSG_ERROR, "OSQL_SCHEMACHANGE '%s' tableversion %d\n", sc->tablename, sc->usedbtablevers);
+        if (logsb) {
+            sbuf2printf(logsb, "[%llu %s] OSQL_SCHEMACHANGE %s\n", rqid,
+                        comdb2uuidstr(uuid, us), sc->tablename);
+            sbuf2flush(logsb);
+        }
+
+        if (unlikely(timepart_is_timepart(sc->tablename, 1))) {
+            char *newest_shard;
+            unsigned long long ver;
+
+            newest_shard = timepart_newest_shard(sc->tablename, &ver);
+            if (newest_shard) {
+                iq->usedbtablevers = ver;
+                free(newest_shard);
+            } else {
+                logmsg(LOGMSG_ERROR, "%s: broken time partition %s"
+                                     "\n",
+                       __func__, sc->tablename);
+
+                return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
+                                         sc->tablename, 0);
+            }
+        } else {
+            if (is_tablename_queue(sc->tablename, sc->tablename_len)) {
+                iq->usedb = getqueuebyname(sc->tablename);
+            } else {
+                iq->usedb = get_dbtable_by_name(sc->tablename);
+                iq->usedbtablevers = sc->usedbtablevers;
+            }
+            if (iq->usedb == NULL) {
+                iq->usedb = iq->origdb;
+                logmsg(LOGMSG_INFO, "%s: unable to get usedb for table %s\n",
+                       __func__, sc->tablename);
+                //return conv_rc_sql2blkop(iq, step, -1, ERR_NO_SUCH_TABLE, err,
+                                         //sc->tablename, 0);
+            }
+        }
+
+
         if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_ASYNC))
             sc->nothrevent = 0;
         else
@@ -6681,13 +6650,13 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         iq->sc = sc;
         sc->iq = iq;
         if (sc->db == NULL) {
-            sc->db = get_dbtable_by_name(sc->table);
+            sc->db = get_dbtable_by_name(sc->tablename);
         }
         sc->tran = NULL;
         if (sc->db)
             iq->usedb = sc->db;
 
-        if (!timepart_is_timepart(sc->table, 1)) {
+        if (!timepart_is_timepart(sc->tablename, 1)) {
             rc = start_schema_change_tran(iq, NULL);
             if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
                 iq->sc = NULL;
@@ -6701,7 +6670,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
             arg.s = sc;
             arg.s->iq = iq;
             rc = timepart_foreach_shard(
-                sc->table, start_schema_change_tran_wrapper, &arg, 0);
+                sc->tablename, start_schema_change_tran_wrapper, &arg, 0);
         }
         iq->usedb = NULL;
 
@@ -7371,9 +7340,6 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
     case OSQL_INSIDX: {
         osql_index_t dt;
         unsigned char *pData = NULL;
-        int jj = 0;
-        int rrn = 2;
-        unsigned long long lclgenid;
         int isDelete = (type == OSQL_DELIDX);
         const uint8_t *p_buf_end;
         uint8_t *pIdx = NULL;
@@ -7554,7 +7520,6 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         if (n_p_buf && rpl) {
             bpfunc_lstnode_t *lnode;
-            bpfunc_lstnode_t *cur_bpfunc;
             bpfunc_t *func;
             bpfunc_info info;
 
@@ -7635,7 +7600,6 @@ static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
         comdb2uuidcpy(uuid, uuid_req.uuid);
         comdb2uuidcpy(sorese_info.uuid, uuid_req.uuid);
 
-        uuidstr_t us;
     } else {
         sql = (char *)osqlcomm_req_type_get(&req, p_req_buf, p_req_buf_end);
         comdb2uuid_clear(uuid);
@@ -8060,9 +8024,6 @@ int osql_log_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
     uint8_t *p_buf = (uint8_t *)msg;
     uint8_t *p_buf_end =
         (uint8_t *)p_buf + sizeof(osql_rpl_t) + sizeof(osql_uuid_rpl_t);
-    int rc = 0;
-    struct dbtable *db =
-        (iq->usedb) ? iq->usedb : thedb->dbs[0]; /*add to first if no usedb*/
     int type;
     unsigned long long id;
     uuidstr_t us;
@@ -8378,7 +8339,6 @@ int osql_log_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 int osql_send_recordgenid(char *tohost, unsigned long long rqid, uuid_t uuid,
                           unsigned long long genid, int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     int rc = 0;
     uuidstr_t us;
 
@@ -8765,7 +8725,6 @@ int enque_osqlpfault_olddata_oldkeys_newkeys(
 static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
 {
     int rc = 0;
-    struct dbenv *dbenv;
     struct ireq iq;
     unsigned long long step;
     osqlpf_rq_t *req = (osqlpf_rq_t *)work;
@@ -8850,10 +8809,8 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
     case OSQLPFRQ_OLDDATA_OLDKEYS: {
         size_t od_len;
         int od_len_int;
-        int maxlen = 0, fndlen = 0, err = 0;
+        int fndlen = 0;
         int ixnum = 0;
-        unsigned long long genid = 0;
-        int doprimkey = 0;
         unsigned char *fnddta = malloc(32768 * sizeof(unsigned char));
 
         iq.usedb = req->db;
@@ -8953,7 +8910,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
         int od_len_int;
         int fndlen = 0;
         int ixnum = 0;
-        unsigned long long genid = 0;
         unsigned char *fnddta = malloc(32768 * sizeof(unsigned char));
 
         if (fnddta == NULL) {
@@ -9131,8 +9087,6 @@ int osql_page_prefault(char *rpl, int rplen, struct dbtable **last_db,
     case OSQL_INSERT: {
         osql_ins_t dt;
         unsigned char *pData = NULL;
-        int rrn = 0;
-        unsigned long long genid = 0;
         uint8_t *p_buf = (uint8_t *)&((osql_ins_rpl_t *)rpl)->dt;
         pData = (uint8_t *)osqlcomm_ins_type_get(&dt, p_buf, p_buf_end,
                                                  rpl_op.type == OSQL_INSREC);
@@ -9144,7 +9098,6 @@ int osql_page_prefault(char *rpl, int rplen, struct dbtable **last_db,
         osql_upd_t dt;
         uint8_t *p_buf = (uint8_t *)&((osql_upd_rpl_t *)rpl)->dt;
         unsigned char *pData;
-        int rrn = 2;
         unsigned long long genid;
         pData = (uint8_t *)osqlcomm_upd_type_get(&dt, p_buf, p_buf_end,
                                                  rpl_op.type == OSQL_UPDATE);
@@ -9168,7 +9121,6 @@ int osql_send_schemachange(char *tonode, unsigned long long rqid, uuid_t uuid,
                            struct schema_change_type *sc, int type,
                            SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
 
     schemachange_packed_size(sc);
     size_t osql_rpl_size =
@@ -9218,7 +9170,7 @@ int osql_send_schemachange(char *tonode, unsigned long long rqid, uuid_t uuid,
 
     if (logsb) {
         sbuf2printf(logsb, "[%llu %s] send OSQL_SCHEMACHANGE %s\n", rqid,
-                    comdb2uuidstr(uuid, us), sc->table);
+                    comdb2uuidstr(uuid, us), sc->tablename);
         sbuf2flush(logsb);
     }
 
@@ -9267,8 +9219,6 @@ static const uint8_t *construct_uptbl_buffer(const struct dbtable *db,
     struct packedreq_hdr op_hdr;
     struct packedreq_usekl usekl;
     struct packedreq_uptbl uptbl;
-
-    int ii;
 
     p_buf = p_buf_start;
 
@@ -9465,9 +9415,7 @@ int offload_comm_send_upgrade_record(const char *tbl, unsigned long long genid)
 static pthread_once_t uprec_sender_array_once = PTHREAD_ONCE_INIT;
 static void uprec_sender_array_init(void)
 {
-    int rc, idx;
     size_t mallocsz;
-    struct uprec_stripe_queue *queue;
     struct errstat xerr;
 
     mallocsz = sizeof(struct uprec_tag) +
@@ -9522,7 +9470,7 @@ static void uprec_sender_array_init(void)
 
 int offload_comm_send_upgrade_records(struct dbtable *db, unsigned long long genid)
 {
-    int rc = 0, stripe, idx;
+    int rc = 0;
     struct errstat xerr;
 
     if (genid == 0)
@@ -9588,7 +9536,6 @@ void upgrade_records_stats(void)
 int osql_send_bpfunc(char *tonode, unsigned long long rqid, uuid_t uuid,
                      BpfuncArg *arg, int type, SBUF2 *logsb)
 {
-    netinfo_type *netinfo_ptr = (netinfo_type *)comm->handle_sibling;
     osql_bpfunc_t *dt;
     size_t data_len = bpfunc_arg__get_packed_size(arg);
     size_t osql_bpfunc_size;

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -2961,12 +2961,13 @@ static int process_local_shadtbl_sc(struct sqlclntstate *clnt, int *bdberr)
             osql->xerr.errval = ERR_SC;
             errstat_set_strf(
                 &(osql->xerr),
-                "stale version for table:%s master:%d replicant:%d", sc->tablename,
-                comdb2_table_version(sc->tablename), packed_sc_key[1]);
+                "stale version for table:%s master:%d replicant:%d",
+                sc->tablename, comdb2_table_version(sc->tablename),
+                packed_sc_key[1]);
             return ERR_SC;
         } else if (packed_sc_key[1] >= 0) {
-            rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, sc->tablename,
-                                 NET_OSQL_SOCK_RPL, osql->logsb,
+            rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid,
+                                 sc->tablename, NET_OSQL_SOCK_RPL, osql->logsb,
                                  packed_sc_key[1]);
             if (rc) {
                 logmsg(LOGMSG_ERROR,

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -2883,13 +2883,13 @@ int osql_save_schemachange(struct sql_thread *thd,
 
     if (!osql->sc_tbl || !osql->sc_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting sc table for \'%s\'\n",
-               __func__, sc->table);
+               __func__, sc->tablename);
         return -1;
     }
 
     if (pack_schema_change_type(sc, &packed_sc_data, &packed_sc_data_len)) {
         logmsg(LOGMSG_ERROR, "%s: error packing sc table for \'%s\'\n",
-               __func__, sc->table);
+               __func__, sc->tablename);
         return -1;
     }
     if (clnt->ddl_tables) {
@@ -2897,14 +2897,14 @@ int osql_save_schemachange(struct sql_thread *thd,
                   NULL, NULL);
     }
     if (usedb) {
-        packed_sc_key[1] = comdb2_table_version(sc->table);
+        packed_sc_key[1] = comdb2_table_version(sc->tablename);
     }
     rc = bdb_temp_table_put(thedb->bdb_env, osql->sc_tbl, &packed_sc_key,
                             sizeof(packed_sc_key), packed_sc_data,
                             packed_sc_data_len, NULL, &bdberr);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: error saving sc table for \'%s\'\n", __func__,
-               sc->table);
+               sc->tablename);
         return -1;
     }
 
@@ -2956,16 +2956,16 @@ static int process_local_shadtbl_sc(struct sqlclntstate *clnt, int *bdberr)
         }
 
         if (packed_sc_key[1] >= 0 &&
-            packed_sc_key[1] != comdb2_table_version(sc->table)) {
+            packed_sc_key[1] != comdb2_table_version(sc->tablename)) {
             free_schema_change_type(sc);
             osql->xerr.errval = ERR_SC;
             errstat_set_strf(
                 &(osql->xerr),
-                "stale version for table:%s master:%d replicant:%d", sc->table,
-                comdb2_table_version(sc->table), packed_sc_key[1]);
+                "stale version for table:%s master:%d replicant:%d", sc->tablename,
+                comdb2_table_version(sc->tablename), packed_sc_key[1]);
             return ERR_SC;
         } else if (packed_sc_key[1] >= 0) {
-            rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, sc->table,
+            rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, sc->tablename,
                                  NET_OSQL_SOCK_RPL, osql->logsb,
                                  packed_sc_key[1]);
             if (rc) {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1695,7 +1695,8 @@ int osql_schemachange_logic(struct schema_change_type *sc,
 
     osql->running_ddl = 1;
 
-    if (clnt->dml_tables && hash_find_readonly(clnt->dml_tables, sc->tablename)) {
+    if (clnt->dml_tables &&
+        hash_find_readonly(clnt->dml_tables, sc->tablename)) {
         return SQLITE_DDL_MISUSE;
     }
     if (clnt->ddl_tables) {
@@ -1727,9 +1728,8 @@ int osql_schemachange_logic(struct schema_change_type *sc,
         }
 
         do {
-            rc = osql_send_schemachange(osql->host, rqid,
-                                        thd->clnt->osql.uuid, sc,
-                                        NET_OSQL_SOCK_RPL, osql->logsb);
+            rc = osql_send_schemachange(osql->host, rqid, thd->clnt->osql.uuid,
+                                        sc, NET_OSQL_SOCK_RPL, osql->logsb);
             RESTART_SOCKSQL;
         } while (restarted && rc == 0);
         if (rc) {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1695,14 +1695,14 @@ int osql_schemachange_logic(struct schema_change_type *sc,
 
     osql->running_ddl = 1;
 
-    if (clnt->dml_tables && hash_find_readonly(clnt->dml_tables, sc->table)) {
+    if (clnt->dml_tables && hash_find_readonly(clnt->dml_tables, sc->tablename)) {
         return SQLITE_DDL_MISUSE;
     }
     if (clnt->ddl_tables) {
-        if (hash_find_readonly(clnt->ddl_tables, sc->table)) {
+        if (hash_find_readonly(clnt->ddl_tables, sc->tablename)) {
             return SQLITE_DDL_MISUSE;
         } else
-            hash_add(clnt->ddl_tables, strdup(sc->table));
+            hash_add(clnt->ddl_tables, strdup(sc->tablename));
     }
 
     if (!bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_AUTOCOMMIT) ||
@@ -1711,37 +1711,25 @@ int osql_schemachange_logic(struct schema_change_type *sc,
         comdb2uuidcpy(sc->uuid, osql->uuid);
     }
 
+    sc->usedbtablevers = comdb2_table_version(sc->tablename);
+
     if (thd->clnt->dbtran.mode == TRANLEVEL_SOSQL) {
         if (usedb) {
-            if (getdbidxbyname(sc->table) < 0) { // view
-                char *viewname = timepart_newest_shard(sc->table, &version);
+            if (getdbidxbyname(sc->tablename) < 0) { // view
+                char *viewname = timepart_newest_shard(sc->tablename, &version);
                 if (viewname) {
                     free(viewname);
                 } else
                     usedb = 0;
             } else {
-                version = comdb2_table_version(sc->table);
+                version = comdb2_table_version(sc->tablename);
             }
         }
+
         do {
-            rc = 0;
-            if (usedb) {
-                if (osql->tablename) {
-                    /* free the cached tablename so that we send a new usedb for
-                     * the next op */
-                    free(osql->tablename);
-                    osql->tablename = NULL;
-                    osql->tablenamelen = 0;
-                }
-                rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid,
-                                     sc->table, NET_OSQL_SOCK_RPL, osql->logsb,
-                                     version);
-            }
-            if (rc == SQLITE_OK) {
-                rc = osql_send_schemachange(osql->host, rqid,
-                                            thd->clnt->osql.uuid, sc,
-                                            NET_OSQL_SOCK_RPL, osql->logsb);
-            }
+            rc = osql_send_schemachange(osql->host, rqid,
+                                        thd->clnt->osql.uuid, sc,
+                                        NET_OSQL_SOCK_RPL, osql->logsb);
             RESTART_SOCKSQL;
         } while (restarted && rc == 0);
         if (rc) {

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -750,7 +750,7 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                     type = alter;
                 if (type < 0 || s->db == NULL) {
                     logmsg(LOGMSG_ERROR, "%s: Skipping scdone for table %s\n",
-                           __func__, s->table);
+                           __func__, s->tablename);
                 } else {
                     rc = bdb_llog_scdone(s->db->handle, type, 1, &bdberr);
                     if (rc || bdberr != BDBERR_NOERROR) {
@@ -764,15 +764,15 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                          */
                         logmsg(LOGMSG_ERROR,
                                "%s: Failed to log scdone for table %s\n",
-                               __func__, s->table);
+                               __func__, s->tablename);
                     }
                 }
             }
-            broadcast_sc_end(iq->sc->table, iq->sc_seed);
+            broadcast_sc_end(iq->sc->tablename, iq->sc_seed);
             if (iq->sc->db)
                 sc_del_unused_files(iq->sc->db);
             if (iq->sc->fastinit && !iq->sc->drop_table)
-                autoanalyze_after_fastinit(iq->sc->table);
+                autoanalyze_after_fastinit(iq->sc->tablename);
             free_schema_change_type(iq->sc);
             iq->sc = sc_next;
         }

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -4066,14 +4066,6 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                     BACKOUT;
                 }
 
-                /*
-                  Update iq->usedbtablevers here if the request came via IPC.
-                  This is done to avoid failure due to table version mismatch.
-                */
-                if (iq->p_sinfo) {
-                    iq->usedbtablevers = iq->usedb->tableversion;
-                }
-
                 if (iq->debug)
                     reqprintf(iq, "DB '%s'", iq->usedb->tablename);
             } else {

--- a/db/views.c
+++ b/db/views.c
@@ -2399,7 +2399,7 @@ int timepart_foreach_shard(const char *view_name,
                            timepart_sc_arg_t *arg, int first_shard)
 {
     struct schema_change_type *s = arg->s;
-    const char *original_name = s->table;
+    const char *original_name = s->tablename;
     timepart_views_t *views;
     timepart_view_t *view;
     int rc;

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -217,14 +217,14 @@ int do_add_table(struct ireq *iq, struct schema_change_type *s,
 
     if ((rc = check_option_coherency(s, NULL, NULL))) return rc;
 
-    if ((db = get_dbtable_by_name(s->table))) {
-        sc_errf(s, "Table %s already exists\n", s->table);
-        logmsg(LOGMSG_ERROR, "Table %s already exists\n", s->table);
+    if ((db = get_dbtable_by_name(s->tablename))) {
+        sc_errf(s, "Table %s already exists\n", s->tablename);
+        logmsg(LOGMSG_ERROR, "Table %s already exists\n", s->tablename);
         return SC_TABLE_ALREADY_EXIST;
     }
 
     pthread_mutex_lock(&csc2_subsystem_mtx);
-    rc = add_table_to_environment(s->table, s->newcsc2, s, iq, trans);
+    rc = add_table_to_environment(s->tablename, s->newcsc2, s, iq, trans);
     pthread_mutex_unlock(&csc2_subsystem_mtx);
     if (rc) {
         sc_errf(s, "error adding new table locally\n");
@@ -261,7 +261,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     sc_printf(s, "Start add table transaction ok\n");
-    rc = load_new_table_schema_tran(thedb, tran, s->table, s->newcsc2);
+    rc = load_new_table_schema_tran(thedb, tran, s->tablename, s->newcsc2);
     if (rc != 0) {
         sc_errf(s, "error recording new table schema\n");
         return rc;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -64,7 +64,7 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
                            struct dbtable *newdb, struct scplan *theplan,
                            struct scinfo *scinfo)
 {
-    int changed = ondisk_schema_changed(s->table, newdb, stderr, s);
+    int changed = ondisk_schema_changed(s->tablename, newdb, stderr, s);
 
     if (changed == SC_BAD_NEW_FIELD) {
         /* we want to capture cases when "alter" is used
@@ -165,7 +165,7 @@ static void adjust_version(int changed, struct scinfo *scinfo,
     }
 
     /* if only index or constraints have changed don't bump version */
-    int ondisk_changed = compare_tag(s->table, ".ondisk", NULL);
+    int ondisk_changed = compare_tag(s->tablename, ".ondisk", NULL);
     if (ondisk_changed != SC_NO_CHANGE /* something changed in .ondisk */
         || s->fastinit                 /* fastinit */
         || !s->use_plan                /* full rebuild due to some prob */
@@ -383,9 +383,9 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     gbl_use_plan = 1;
     gbl_sc_last_writer_time = 0;
 
-    db = get_dbtable_by_name(s->table);
+    db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
-        sc_errf(s, "Table not found:%s\n", s->table);
+        sc_errf(s, "Table not found:%s\n", s->tablename);
         return SC_TABLE_DOESNOT_EXIST;
     }
 
@@ -475,7 +475,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (rc) {
         /* todo: clean up db */
         sc_errf(s, "failed opening new db\n");
-        change_schemas_recover(s->table);
+        change_schemas_recover(s->tablename);
         return -1;
     }
 
@@ -522,7 +522,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (init_sc_genids(newdb, s)) {
         sc_errf(s, "failed initilizing sc_genids\n");
         delete_temp_table(iq, newdb);
-        change_schemas_recover(s->table);
+        change_schemas_recover(s->tablename);
         return -1;
     }
 
@@ -601,7 +601,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
         backout_constraint_pointers(newdb, db);
         delete_temp_table(iq, newdb);
-        change_schemas_recover(s->table);
+        change_schemas_recover(s->tablename);
         return rc;
     }
     newdb->iq = NULL;
@@ -638,7 +638,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     db->sc_to = newdb;
 
     if (gbl_sc_abort || db->sc_abort || iq->sc_should_abort) {
-        sc_errf(s, "Aborting schema change %s\n", s->table);
+        sc_errf(s, "Aborting schema change %s\n", s->tablename);
         goto backout;
     }
 
@@ -679,7 +679,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         goto backout;
 
     /* load new csc2 data */
-    rc = load_new_table_schema_tran(thedb, transac, /*s->table*/ db->tablename,
+    rc = load_new_table_schema_tran(thedb, transac, /*s->tablename*/ db->tablename,
                                     s->newcsc2);
     if (rc != 0) {
         sc_errf(s, "Error loading new schema into meta tables, "
@@ -732,7 +732,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     fix_constraint_pointers(db, newdb);
 
     /* update tags in memory */
-    commit_schemas(/*s->table*/ db->tablename);
+    commit_schemas(/*s->tablename*/ db->tablename);
     update_dbstore(db); // update needs to occur after refresh of hashtbl
 
     MEMORY_SYNC;
@@ -827,7 +827,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 backout:
     live_sc_off(db);
     backout_constraint_pointers(newdb, db);
-    change_schemas_recover(/*s->table*/ db->tablename);
+    change_schemas_recover(/*s->tablename*/ db->tablename);
 
     logmsg(LOGMSG_WARN,
            "##### BACKOUT #####   %s v: %d sc:%d lrl: %d odh:%d bdb:%p\n",
@@ -854,7 +854,7 @@ int do_upgrade_table_int(struct schema_change_type *s)
     struct dbtable *db;
     struct scinfo scinfo;
 
-    db = get_dbtable_by_name(s->table);
+    db = get_dbtable_by_name(s->tablename);
     if (db == NULL) return SC_TABLE_DOESNOT_EXIST;
 
     s->db = db;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -679,8 +679,8 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         goto backout;
 
     /* load new csc2 data */
-    rc = load_new_table_schema_tran(thedb, transac, /*s->tablename*/ db->tablename,
-                                    s->newcsc2);
+    rc = load_new_table_schema_tran(thedb, transac,
+                                    /*s->tablename*/ db->tablename, s->newcsc2);
     if (rc != 0) {
         sc_errf(s, "Error loading new schema into meta tables, "
                    "trying again\n");

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -27,7 +27,7 @@ int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
                         int *foundix, struct ireq *iq)
 {
     /* load schema from string or file */
-    int rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->table);
+    int rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->tablename);
     if (rc != 0) {
         char *err;
         char *syntax_err;
@@ -40,8 +40,8 @@ int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
     }
 
     /* find which db has a matching name */
-    if ((*foundix = getdbidxbyname(s->table)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->table);
+    if ((*foundix = getdbidxbyname(s->tablename)) < 0) {
+        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
         exit(1);
     }
 

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -46,7 +46,7 @@ int do_drop_table(struct ireq *iq, struct schema_change_type *s,
                   tran_type *tran)
 {
     struct dbtable *db;
-    iq->usedb = db = s->db = get_dbtable_by_name(s->table);
+    iq->usedb = db = s->db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         sc_errf(s, "Table doesn't exists\n");
         reqerrstr(iq, ERR_SC, "Table doesn't exists");

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -41,7 +41,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     int foundix;
     struct scinfo scinfo;
 
-    iq->usedb = db = s->db = get_dbtable_by_name(s->table);
+    iq->usedb = db = s->db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         sc_errf(s, "Table doesn't exists\n");
         reqerrstr(iq, ERR_SC, "Table doesn't exists");
@@ -105,7 +105,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     if (rc) {
         /* todo: clean up db */
         sc_errf(s, "failed opening new db\n");
-        change_schemas_recover(s->table);
+        change_schemas_recover(s->tablename);
         return -1;
     }
 
@@ -145,16 +145,16 @@ int finalize_fastinit_table(struct ireq *iq, struct schema_change_type *s,
             constraint_t *cnstrt = db->rev_constraints[i];
             sc_pending = iq->sc_pending;
             while (sc_pending != NULL) {
-                if (strcasecmp(sc_pending->table,
+                if (strcasecmp(sc_pending->tablename,
                                cnstrt->lcltable->tablename) == 0)
                     break;
                 sc_pending = sc_pending->sc_next;
             }
             if (sc_pending && sc_pending->fastinit)
                 logmsg(LOGMSG_INFO,
-                       "Fastinit '%s' and %s'%s' transactionally\n", s->table,
+                       "Fastinit '%s' and %s'%s' transactionally\n", s->tablename,
                        sc_pending->drop_table ? "drop " : "",
-                       sc_pending->table);
+                       sc_pending->tablename);
             else {
                 sc_errf(s, "Can't fastinit tables with foreign constraints\n");
                 reqerrstr(iq, ERR_SC,

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -152,8 +152,8 @@ int finalize_fastinit_table(struct ireq *iq, struct schema_change_type *s,
             }
             if (sc_pending && sc_pending->fastinit)
                 logmsg(LOGMSG_INFO,
-                       "Fastinit '%s' and %s'%s' transactionally\n", s->tablename,
-                       sc_pending->drop_table ? "drop " : "",
+                       "Fastinit '%s' and %s'%s' transactionally\n",
+                       s->tablename, sc_pending->drop_table ? "drop " : "",
                        sc_pending->tablename);
             else {
                 sc_errf(s, "Can't fastinit tables with foreign constraints\n");

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -353,7 +353,7 @@ int is_table_in_schema_change(const char *tbname, tran_type *tran)
                    __func__);
             return -1;
         }
-        rc = (strcasecmp(tbname, s->table) == 0);
+        rc = (strcasecmp(tbname, s->tablename) == 0);
         free(packed_sc_data);
         free_schema_change_type(s);
         return rc;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -534,7 +534,7 @@ int do_schema_change(struct schema_change_type *s)
         s->db = get_dbtable_by_name(s->tablename);
     }
     iq->usedb = s->db;
-    s->usedbtablevers = iq->usedbtablevers = s->db ? s->db->tableversion : 0;
+    s->usedbtablevers = s->db ? s->db->tableversion : 0;
     sc_arg_t *arg = malloc(sizeof(sc_arg_t));
     arg->iq = iq;
     arg->sc = s;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -85,7 +85,7 @@ static int mark_sc_in_llmeta_tran(struct schema_change_type *s, void *trans)
     size_t packed_sc_data_len;
     uuidstr_t us;
     comdb2uuidstr(s->uuid, us);
-    logmsg(LOGMSG_INFO, "%s: table '%s' rqid [%llx %s]\n", __func__, s->table,
+    logmsg(LOGMSG_INFO, "%s: table '%s' rqid [%llx %s]\n", __func__, s->tablename,
            s->rqid, us);
     if (pack_schema_change_type(s, &packed_sc_data, &packed_sc_data_len)) {
         sc_errf(s, "could not pack the schema change data for storage in "
@@ -99,7 +99,7 @@ static int mark_sc_in_llmeta_tran(struct schema_change_type *s, void *trans)
          * retry several times */
         for (retries = 0;
              retries < max_retries &&
-             (bdb_set_in_schema_change(trans, s->table, packed_sc_data,
+             (bdb_set_in_schema_change(trans, s->tablename, packed_sc_data,
                                        packed_sc_data_len, &bdberr) ||
               bdberr != BDBERR_NOERROR);
              ++retries) {
@@ -132,7 +132,7 @@ static int mark_sc_in_llmeta(struct schema_change_type *s)
 static int propose_sc(struct schema_change_type *s)
 {
     /* Check that all nodes are ready to do this schema change. */
-    int rc = broadcast_sc_start(s->table, s->iq->sc_seed, s->iq->sc_host,
+    int rc = broadcast_sc_start(s->tablename, s->iq->sc_seed, s->iq->sc_host,
                                 time(NULL));
     if (rc != 0) {
         rc = SC_PROPOSE_FAIL;
@@ -206,7 +206,7 @@ static void stop_and_free_sc(int rc, struct schema_change_type *s, int do_free)
             sbuf2printf(s->sb, "SUCCESS\n");
         }
     }
-    sc_set_running(s->table, 0, s->iq->sc_seed, NULL, 0);
+    sc_set_running(s->tablename, 0, s->iq->sc_seed, NULL, 0);
     if (do_free) {
         free_sc(s);
     }
@@ -214,9 +214,9 @@ static void stop_and_free_sc(int rc, struct schema_change_type *s, int do_free)
 
 static int set_original_tablename(struct schema_change_type *s)
 {
-    struct dbtable *db = get_dbtable_by_name(s->table);
+    struct dbtable *db = get_dbtable_by_name(s->tablename);
     if (db) {
-        strncpy0(s->table, db->tablename, sizeof(s->table));
+        strncpy0(s->tablename, db->tablename, sizeof(s->tablename));
         return 0;
     }
     return 1;
@@ -234,7 +234,7 @@ int do_upgrade_table(struct schema_change_type *s)
     if (rc == SC_OK) rc = do_upgrade_table_int(s);
 
     if (rc) {
-        mark_schemachange_over(s->table);
+        mark_schemachange_over(s->tablename);
     } else if (s->finalize) {
         rc = finalize_upgrade_table(s);
     } else {
@@ -272,7 +272,7 @@ static int do_finalize(ddl_t func, struct ireq *iq,
     if (rc) {
         if (input_tran == NULL) {
             trans_abort(iq, tran);
-            mark_schemachange_over(s->table);
+            mark_schemachange_over(s->tablename);
             sc_del_unused_files(s->db);
         }
         return rc;
@@ -296,7 +296,7 @@ static int do_finalize(ddl_t func, struct ireq *iq,
         sc_del_unused_files(s->db);
     } else if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_DONE_SAME_TRAN)) {
         int bdberr = 0;
-        rc = bdb_llog_scdone_tran(s->db->handle, type, input_tran, s->table,
+        rc = bdb_llog_scdone_tran(s->db->handle, type, input_tran, s->tablename,
                                   &bdberr);
         if (rc || bdberr != BDBERR_NOERROR) {
             sc_errf(s, "Failed to send scdone rc=%d bdberr=%d\n", rc, bdberr);
@@ -312,10 +312,10 @@ static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
         return 0;
     int rc, bdberr;
     unsigned long long version;
-    rc = bdb_table_version_select(sc->table, NULL, &version, &bdberr);
+    rc = bdb_table_version_select(sc->tablename, NULL, &version, &bdberr);
     if (rc != 0) {
         errstat_set_strf(&iq->errstat,
-                         "failed to get version for table:%s rc:%d", sc->table,
+                         "failed to get version for table:%s rc:%d", sc->tablename,
                          rc);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
@@ -323,7 +323,7 @@ static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
     if (sc->usedbtablevers != version) {
         errstat_set_strf(&iq->errstat,
                          "stale version for table:%s master:%d replicant:%d",
-                         sc->table, version, sc->usedbtablevers);
+                         sc->tablename, version, sc->usedbtablevers);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
@@ -345,7 +345,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         set_sc_flgs(s);
     if ((rc = mark_sc_in_llmeta_tran(s, NULL))) // non-tran ??
         goto end;
-    broadcast_sc_start(s->table, iq->sc_seed, iq->sc_host,
+    broadcast_sc_start(s->tablename, iq->sc_seed, iq->sc_host,
                        time(NULL));                   // dont care rcode
     rc = pre(iq, s, NULL);                            // non-tran ??
     if (type == alter && master_downgrading(s)) {
@@ -356,15 +356,15 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         return SC_MASTER_DOWNGRADE;
     }
     if (rc) {
-        mark_schemachange_over_tran(s->table, NULL); // non-tran ??
-        broadcast_sc_end(s->table, iq->sc_seed);
+        mark_schemachange_over_tran(s->tablename, NULL); // non-tran ??
+        broadcast_sc_end(s->tablename, iq->sc_seed);
     } else if (s->finalize) {
         wrlock_schema_lk();
         rc = do_finalize(post, iq, s, tran, type);
         unlock_schema_lk();
         if (type == fastinit && gbl_replicate_local)
             local_replicant_write_clear(iq, tran, s->db);
-        broadcast_sc_end(s->table, iq->sc_seed);
+        broadcast_sc_end(s->tablename, iq->sc_seed);
     } else {
         rc = SC_COMMIT_PENDING;
     }
@@ -387,7 +387,7 @@ int do_alter_queues(struct schema_change_type *s)
 
     if (master_downgrading(s)) return SC_MASTER_DOWNGRADE;
 
-    broadcast_sc_end(s->table, s->iq->sc_seed);
+    broadcast_sc_end(s->tablename, s->iq->sc_seed);
 
     if ((s->type != DBTYPE_TAGGED_TABLE) && gbl_pushlogs_after_sc)
         push_next_log();
@@ -409,7 +409,7 @@ int do_alter_stripes(struct schema_change_type *s)
 
     if (master_downgrading(s)) return SC_MASTER_DOWNGRADE;
 
-    broadcast_sc_end(s->table, s->iq->sc_seed);
+    broadcast_sc_end(s->tablename, s->iq->sc_seed);
 
     /* if we did a regular schema change and we used the llmeta we don't need to
      * push locgs */
@@ -495,7 +495,7 @@ int do_schema_change_tran(sc_arg_t *arg)
     reset_sc_thread(oldtype, s);
     if (rc && rc != SC_COMMIT_PENDING) {
         logmsg(LOGMSG_ERROR, ">>> SCHEMA CHANGE ERROR: TABLE %s, RC %d\n",
-               s->table, rc);
+               s->tablename, rc);
         iq->sc_should_abort = 1;
     }
     s->sc_rc = rc;
@@ -531,7 +531,7 @@ int do_schema_change(struct schema_change_type *s)
     init_fake_ireq(thedb, iq);
     iq->sc = s;
     if (s->db == NULL) {
-        s->db = get_dbtable_by_name(s->table);
+        s->db = get_dbtable_by_name(s->tablename);
     }
     iq->usedb = s->db;
     s->usedbtablevers = iq->usedbtablevers = s->db ? s->db->tableversion : 0;
@@ -603,12 +603,12 @@ void *sc_resuming_watchdog(void *p)
         pthread_mutex_lock(&(iq.sc->mtx));
         stored_sc = stored_sc->sc_next;
         logmsg(LOGMSG_INFO, "%s: aborting schema change of table '%s'\n",
-               __func__, iq.sc->table);
-        mark_schemachange_over(iq.sc->table);
+               __func__, iq.sc->tablename);
+        mark_schemachange_over(iq.sc->tablename);
         if (iq.sc->addonly) {
             delete_temp_table(&iq, iq.sc->db);
             if (iq.sc->addonly == SC_DONE_ADD)
-                delete_db(iq.sc->table);
+                delete_db(iq.sc->tablename);
         }
         sc_del_unused_files(iq.sc->db);
         pthread_mutex_unlock(&(iq.sc->mtx));
@@ -650,14 +650,14 @@ static int verify_sc_resumed_for_shard(const char *shardname,
     sc = arg->s;
     while (sc) {
         /* already resumed */
-        if (strcasecmp(shardname, sc->table) == 0)
+        if (strcasecmp(shardname, sc->tablename) == 0)
             return 0;
         sc = sc->sc_next;
     }
 
     /* start a new sc for shard that was not already resumed */
     struct schema_change_type *new_sc = clone_schemachange_type(arg->s);
-    strncpy0(new_sc->table, shardname, sizeof(new_sc->table));
+    strncpy0(new_sc->tablename, shardname, sizeof(new_sc->tablename));
     new_sc->iq = NULL;
     new_sc->tran = NULL;
     new_sc->resume = 0;
@@ -669,7 +669,7 @@ static int verify_sc_resumed_for_shard(const char *shardname,
     arg->s = new_sc;
 
     logmsg(LOGMSG_INFO, "Restarting schema change for view '%s' shard '%s'\n",
-           arg->view_name, new_sc->table);
+           arg->view_name, new_sc->tablename);
     rc = start_schema_change(new_sc);
     if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {
         logmsg(LOGMSG_ERROR, "%s: failed to restart shard '%s', rc %d\n",
@@ -810,17 +810,17 @@ int resume_schema_change(void)
             logmsg(LOGMSG_INFO,
                    "%s: resuming schema change: rqid [%llx %s] "
                    "table %s, add %d, drop %d, fastinit %d, alter %d\n",
-                   __func__, s->rqid, us, s->table, s->addonly, s->drop_table,
+                   __func__, s->rqid, us, s->tablename, s->addonly, s->drop_table,
                    s->fastinit, s->alteronly);
 
             is_shard = 0;
             if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_AUTOCOMMIT) &&
                 s->rqid == 0 && comdb2uuid_is_zero(s->uuid)) {
                 s->resume = SC_RESUME;
-                if (unlikely(timepart_is_shard(s->table, 1, &viewname))) {
+                if (unlikely(timepart_is_shard(s->tablename, 1, &viewname))) {
                     logmsg(LOGMSG_INFO,
                            "Resuming schema change for view '%s' shard '%s'\n",
-                           viewname, s->table);
+                           viewname, s->tablename);
                     s->finalize = 0;
                     is_shard = 1;
                 } else {
@@ -838,7 +838,7 @@ int resume_schema_change(void)
             if (rc != SC_OK && rc != SC_ASYNC) {
                 logmsg(LOGMSG_ERROR,
                        "%s: failed to resume schema change for table '%s'\n",
-                       __func__, s->table);
+                       __func__, s->tablename);
                 free_schema_change_type(s);
                 continue;
             } else if (is_shard) {
@@ -1231,7 +1231,7 @@ int dryrun_int(struct schema_change_type *s, struct dbtable *db, struct dbtable 
         s->force_blob_rebuild = 1;
     }
 
-    changed = ondisk_schema_changed(s->table, newdb, NULL, s);
+    changed = ondisk_schema_changed(s->tablename, newdb, NULL, s);
     if (changed < 0) {
         if (changed == SC_BAD_NEW_FIELD) {
             sbuf2printf(s->sb,
@@ -1282,7 +1282,7 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
     while (s != NULL) {
         if (s->addonly) {
             if (s->addonly == SC_DONE_ADD)
-                delete_db(s->table);
+                delete_db(s->tablename);
             if (s->newdb) {
                 backout_schemas(s->newdb->tablename);
                 cleanup_newdb(s->newdb);
@@ -1309,13 +1309,13 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
 int scdone_abort_cleanup(struct ireq *iq)
 {
     struct schema_change_type *s = iq->sc;
-    mark_schemachange_over(s->table);
-    sc_set_running(s->table, 0, iq->sc_seed, gbl_mynode, time(NULL));
+    mark_schemachange_over(s->tablename);
+    sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode, time(NULL));
     if (s->addonly && s->db->handle) {
         delete_temp_table(iq, s->db);
     } else if (s->db) {
         sc_del_unused_files(s->db);
     }
-    broadcast_sc_end(s->table, iq->sc_seed);
+    broadcast_sc_end(s->tablename, iq->sc_seed);
     return 0;
 }

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -85,8 +85,8 @@ static int mark_sc_in_llmeta_tran(struct schema_change_type *s, void *trans)
     size_t packed_sc_data_len;
     uuidstr_t us;
     comdb2uuidstr(s->uuid, us);
-    logmsg(LOGMSG_INFO, "%s: table '%s' rqid [%llx %s]\n", __func__, s->tablename,
-           s->rqid, us);
+    logmsg(LOGMSG_INFO, "%s: table '%s' rqid [%llx %s]\n", __func__,
+           s->tablename, s->rqid, us);
     if (pack_schema_change_type(s, &packed_sc_data, &packed_sc_data_len)) {
         sc_errf(s, "could not pack the schema change data for storage in "
                    "low level meta table\n");
@@ -315,8 +315,8 @@ static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
     rc = bdb_table_version_select(sc->tablename, NULL, &version, &bdberr);
     if (rc != 0) {
         errstat_set_strf(&iq->errstat,
-                         "failed to get version for table:%s rc:%d", sc->tablename,
-                         rc);
+                         "failed to get version for table:%s rc:%d",
+                         sc->tablename, rc);
         iq->errstat.errval = ERR_SC;
         return SC_INTERNAL_ERROR;
     }
@@ -810,8 +810,8 @@ int resume_schema_change(void)
             logmsg(LOGMSG_INFO,
                    "%s: resuming schema change: rqid [%llx %s] "
                    "table %s, add %d, drop %d, fastinit %d, alter %d\n",
-                   __func__, s->rqid, us, s->tablename, s->addonly, s->drop_table,
-                   s->fastinit, s->alteronly);
+                   __func__, s->rqid, us, s->tablename, s->addonly,
+                   s->drop_table, s->fastinit, s->alteronly);
 
             is_shard = 0;
             if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_AUTOCOMMIT) &&

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -240,13 +240,15 @@ static int chk_versioned_sp(char *name, char *version, struct ireq *iq)
 static int del_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
 {
     int rc;
-    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0) return rc;
+    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0)
+        return rc;
     return bdb_del_versioned_sp(sc->tablename, sc->fname);
 }
 static int default_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
 {
     int rc;
-    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0) return rc;
+    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0)
+        return rc;
     return bdb_set_default_versioned_sp(sc->tran, sc->tablename, sc->fname);
 }
 
@@ -338,8 +340,8 @@ static int add_sp(struct schema_change_type *sc, int *version)
         return rc;
     }
     bdb_get_lua_highest(NULL, sc->tablename, version, INT_MAX, &bdberr);
-    sbuf2printf(sb, "!Added stored procedure: %s \t version %d.\n", sc->tablename,
-                *version);
+    sbuf2printf(sb, "!Added stored procedure: %s \t version %d.\n",
+                sc->tablename, *version);
     sbuf2printf(sb, "SUCCESS\n");
     return rc;
 }
@@ -475,7 +477,8 @@ int do_show_sp(struct schema_change_type *sc)
         if (def == -1) {
             // check versioned default
             char *def_version;
-            if (bdb_get_default_versioned_sp(sc->tablename, &def_version) == 0) {
+            if (bdb_get_default_versioned_sp(sc->tablename, &def_version) ==
+                0) {
                 sbuf2printf(sb, ">Default version is: '%s'\n", def_version);
                 free(def_version);
             } else {

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -172,7 +172,7 @@ static void show_all_versioned_sps(struct schema_change_type *sc)
 static void show_versioned_sp(struct schema_change_type *sc, int *num)
 {
     SBUF2 *sb = sc->sb;
-    char *name = sc->table;
+    char *name = sc->tablename;
     char **versions = NULL;
     int rc;
     if ((rc = bdb_get_all_for_versioned_sp(name, &versions, num)) != 0)
@@ -191,7 +191,7 @@ out:
 static int show_versioned_sp_src(struct schema_change_type *sc)
 {
     SBUF2 *sb = sc->sb;
-    char *name = sc->table;
+    char *name = sc->tablename;
     char *version = sc->newcsc2;
     char *src;
     if (bdb_get_versioned_sp(name, version, &src) != 0) {
@@ -209,7 +209,7 @@ static int show_versioned_sp_src(struct schema_change_type *sc)
 static int add_versioned_sp(struct schema_change_type *sc)
 {
     int rc, bdberr;
-    char *spname = sc->table;
+    char *spname = sc->tablename;
     char *version = sc->fname;
     int default_ver_num = bdb_get_sp_get_default_version(spname, &bdberr);
     char *default_ver_str = NULL;
@@ -240,14 +240,14 @@ static int chk_versioned_sp(char *name, char *version, struct ireq *iq)
 static int del_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
 {
     int rc;
-    if ((rc = chk_versioned_sp(sc->table, sc->fname, iq)) != 0) return rc;
-    return bdb_del_versioned_sp(sc->table, sc->fname);
+    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0) return rc;
+    return bdb_del_versioned_sp(sc->tablename, sc->fname);
 }
 static int default_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
 {
     int rc;
-    if ((rc = chk_versioned_sp(sc->table, sc->fname, iq)) != 0) return rc;
-    return bdb_set_default_versioned_sp(sc->tran, sc->table, sc->fname);
+    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0) return rc;
+    return bdb_set_default_versioned_sp(sc->tran, sc->tablename, sc->fname);
 }
 
 // ----------------
@@ -291,14 +291,14 @@ static void show_sp(struct schema_change_type *sc, int *num, int *has_default)
     *num = 0;
     *has_default = -1;
     for (;;) {
-        bdb_get_lua_highest(NULL, sc->table, &lua_ver, version, &bdberr);
+        bdb_get_lua_highest(NULL, sc->tablename, &lua_ver, version, &bdberr);
         if (lua_ver < 1) break;
         ++(*num);
         sbuf2printf(sb, ">Version: %d\n", lua_ver);
         version = lua_ver;
     }
     if (*num) {
-        *has_default = bdb_get_sp_get_default_version(sc->table, &bdberr);
+        *has_default = bdb_get_sp_get_default_version(sc->tablename, &bdberr);
         if (*has_default > 0)
             sbuf2printf(sb, ">Default version is: %d\n", *has_default);
     }
@@ -309,7 +309,7 @@ static int show_sp_src(struct schema_change_type *sc)
     int version = atoi(sc->newcsc2);
     char *src;
     int size, bdberr;
-    if (bdb_get_sp_lua_source(NULL, NULL, sc->table, &src, version, &size,
+    if (bdb_get_sp_lua_source(NULL, NULL, sc->tablename, &src, version, &size,
                               &bdberr)) {
         return -1;
     }
@@ -331,14 +331,14 @@ static int add_sp(struct schema_change_type *sc, int *version)
     SBUF2 *sb = sc->sb;
     char *schemabuf = sc->newcsc2;
     int rc, bdberr;
-    if ((rc = bdb_set_sp_lua_source(NULL, NULL, sc->table, schemabuf,
+    if ((rc = bdb_set_sp_lua_source(NULL, NULL, sc->tablename, schemabuf,
                                     strlen(schemabuf) + 1, 0, &bdberr)) != 0) {
         sbuf2printf(sb, "!Unable to add lua source. \n");
         sbuf2printf(sb, "FAILED\n");
         return rc;
     }
-    bdb_get_lua_highest(NULL, sc->table, version, INT_MAX, &bdberr);
-    sbuf2printf(sb, "!Added stored procedure: %s \t version %d.\n", sc->table,
+    bdb_get_lua_highest(NULL, sc->tablename, version, INT_MAX, &bdberr);
+    sbuf2printf(sb, "!Added stored procedure: %s \t version %d.\n", sc->tablename,
                 *version);
     sbuf2printf(sb, "SUCCESS\n");
     return rc;
@@ -354,7 +354,7 @@ static int del_sp(struct schema_change_type *sc)
     free(sc->newcsc2);
     sc->newcsc2 = NULL;
     int bdberr;
-    if (bdb_delete_sp_lua_source(NULL, NULL, sc->table, version, &bdberr)) {
+    if (bdb_delete_sp_lua_source(NULL, NULL, sc->tablename, version, &bdberr)) {
         sbuf2printf(sb, "!bad sp version number:%d\n", version);
         goto fail;
     }
@@ -380,7 +380,7 @@ static int default_sp(struct schema_change_type *sc)
         goto fail;
     }
     int bdberr;
-    if (bdb_set_sp_lua_default(NULL, NULL, sc->table, version, &bdberr)) {
+    if (bdb_set_sp_lua_default(NULL, NULL, sc->tablename, version, &bdberr)) {
         sbuf2printf(sb, "!version not found number %d\n", version);
         goto fail;
     }
@@ -459,7 +459,7 @@ static int do_default_sp_int(struct schema_change_type *sc, struct ireq *iq)
 int do_show_sp(struct schema_change_type *sc)
 {
     SBUF2 *sb = sc->sb;
-    if (sc->table[0] == 0) {
+    if (sc->tablename[0] == 0) {
         show_all_versioned_sps(sc);
         show_all_sps(sc);
     } else if (sc->newcsc2[0] == 0) {
@@ -468,14 +468,14 @@ int do_show_sp(struct schema_change_type *sc)
         show_versioned_sp(sc, &num0);
         show_sp(sc, &num1, &def);
         if (num0 == 0 && num1 == 0) {
-            sbuf2printf(sb, "!Stored procedure not found %s\n", sc->table);
+            sbuf2printf(sb, "!Stored procedure not found %s\n", sc->tablename);
             sbuf2printf(sb, "FAILED\n");
             return -1;
         }
         if (def == -1) {
             // check versioned default
             char *def_version;
-            if (bdb_get_default_versioned_sp(sc->table, &def_version) == 0) {
+            if (bdb_get_default_versioned_sp(sc->tablename, &def_version) == 0) {
                 sbuf2printf(sb, ">Default version is: '%s'\n", def_version);
                 free(def_version);
             } else {

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -70,7 +70,8 @@ int do_alter_queues_int(struct schema_change_type *sc)
     db = getqueuebyname(sc->tablename);
     if (db == NULL) {
         /* create new queue */
-        rc = add_queue_to_environment(sc->tablename, sc->avgitemsz, sc->pagesize);
+        rc = add_queue_to_environment(sc->tablename, sc->avgitemsz,
+                                      sc->pagesize);
         /* tell other nodes to follow suit */
         broadcast_add_new_queue(
             sc->tablename, sc->avgitemsz); // TODO Check the return value ??????
@@ -392,7 +393,8 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
      * other methods, we need to manage the existing consumer first. */
     if (sc->addonly) {
         /* create a procedure (needs to go away, badly) */
-        rc = javasp_do_procedure_op(JAVASP_OP_LOAD, sc->tablename, NULL, config);
+        rc =
+            javasp_do_procedure_op(JAVASP_OP_LOAD, sc->tablename, NULL, config);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: javasp_do_procedure_op returned rc %d\n",
                    __func__, rc);

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -28,7 +28,7 @@ int do_rename_table(struct ireq *iq, struct schema_change_type *s,
                     tran_type *tran)
 {
     struct dbtable *db;
-    iq->usedb = db = s->db = get_dbtable_by_name(s->table);
+    iq->usedb = db = s->db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         sc_errf(s, "Table doesn't exists\n");
         reqerrstr(iq, ERR_SC, "Table doesn't exists");

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -499,8 +499,8 @@ int fetch_schema_change_seed(struct schema_change_type *s, struct dbenv *thedb,
                              unsigned int *stored_sc_host)
 {
     int bdberr;
-    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, s->tablename, stored_sc_genid,
-                             stored_sc_host, &bdberr);
+    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, s->tablename,
+                             stored_sc_genid, stored_sc_host, &bdberr);
     if (rc == -1 && bdberr == BDBERR_FETCH_DTA) {
         /* No seed exists, proceed. */
     } else if (rc) {

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -480,7 +480,7 @@ struct dbtable *create_db_from_schema(struct dbenv *thedb,
                                  int foundix, int version)
 {
     struct dbtable *newdb =
-        newdb_from_schema(thedb, s->table, NULL, dbnum, foundix, 0);
+        newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix, 0);
 
     if (newdb == NULL) return NULL;
 
@@ -499,7 +499,7 @@ int fetch_schema_change_seed(struct schema_change_type *s, struct dbenv *thedb,
                              unsigned int *stored_sc_host)
 {
     int bdberr;
-    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, s->table, stored_sc_genid,
+    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, s->tablename, stored_sc_genid,
                              stored_sc_host, &bdberr);
     if (rc == -1 && bdberr == BDBERR_FETCH_DTA) {
         /* No seed exists, proceed. */
@@ -938,7 +938,7 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
     }
 
     char *str_constraints = "";
-    rc = ondisk_schema_changed(s->table, newdb, NULL, s);
+    rc = ondisk_schema_changed(s->tablename, newdb, NULL, s);
     if (rc == SC_CONSTRAINT_CHANGE && !plan->plan_convert &&
         newdb->n_constraints) {
         plan->plan_convert = 1;

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -172,7 +172,8 @@ void *buf_put_schemachange(struct schema_change_type *s, void *p_buf,
 
     p_buf = buf_put(&s->type, sizeof(s->type), p_buf, p_buf_end);
 
-    p_buf = buf_put(&s->tablename_len, sizeof(s->tablename_len), p_buf, p_buf_end);
+    p_buf =
+        buf_put(&s->tablename_len, sizeof(s->tablename_len), p_buf, p_buf_end);
 
     p_buf = buf_no_net_put(s->tablename, s->tablename_len, p_buf, p_buf_end);
 
@@ -281,7 +282,8 @@ void *buf_put_schemachange(struct schema_change_type *s, void *p_buf,
 
     p_buf = buf_put(&s->rename, sizeof(s->rename), p_buf, p_buf_end);
     p_buf = buf_no_net_put(s->newtable, sizeof(s->newtable), p_buf, p_buf_end);
-    p_buf = buf_put(&s->usedbtablevers, sizeof(s->usedbtablevers), p_buf, p_buf_end);
+    p_buf = buf_put(&s->usedbtablevers, sizeof(s->usedbtablevers), p_buf,
+                    p_buf_end);
 
     return p_buf;
 }
@@ -343,14 +345,15 @@ void *buf_get_schemachange(struct schema_change_type *s, void *p_buf,
 
     p_buf = (uint8_t *)buf_get(&s->type, sizeof(s->type), p_buf, p_buf_end);
 
-    p_buf = (uint8_t *)buf_get(&s->tablename_len, sizeof(s->tablename_len), p_buf,
-                               p_buf_end);
+    p_buf = (uint8_t *)buf_get(&s->tablename_len, sizeof(s->tablename_len),
+                               p_buf, p_buf_end);
     if (s->tablename_len != strlen((const char *)p_buf) + 1 ||
         s->tablename_len > sizeof(s->tablename)) {
         s->tablename_len = -1;
         return NULL;
     }
-    p_buf = (uint8_t *)buf_no_net_get(s->tablename, s->tablename_len, p_buf, p_buf_end);
+    p_buf = (uint8_t *)buf_no_net_get(s->tablename, s->tablename_len, p_buf,
+                                      p_buf_end);
 
     p_buf = (uint8_t *)buf_get(&s->fname_len, sizeof(s->fname_len), p_buf,
                                p_buf_end);
@@ -709,7 +712,8 @@ void print_schemachange_info(struct schema_change_type *s, struct dbtable *db,
     else
         sc_printf(s, info + 1);
 
-    if (s->fastinit) sc_printf(s, "fastinit starting on table %s\n", s->tablename);
+    if (s->fastinit)
+        sc_printf(s, "fastinit starting on table %s\n", s->tablename);
 
     switch (s->scanmode) {
     case SCAN_INDEX:

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -106,9 +106,10 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             pthread_mutex_unlock(&s->mtx);
             uuidstr_t us;
             comdb2uuidstr(s->uuid, us);
-            logmsg(LOGMSG_INFO, "Resuming schema change: rqid [%llx %s] "
-                                "table %s, add %d, drop %d, fastinit %d, alter "
-                                "%d, finalize_only %d\n",
+            logmsg(LOGMSG_INFO,
+                   "Resuming schema change: rqid [%llx %s] "
+                   "table %s, add %d, drop %d, fastinit %d, alter "
+                   "%d, finalize_only %d\n",
                    s->rqid, us, s->tablename, s->addonly, s->drop_table,
                    s->fastinit, s->alteronly, s->finalize_only);
 
@@ -119,8 +120,9 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             if (bdb_get_in_schema_change(trans, s->tablename, &packed_sc_data,
                                          &packed_sc_data_len, &bdberr) ||
                 bdberr != BDBERR_NOERROR) {
-                logmsg(LOGMSG_WARN, "%s: failed to discover whether table: "
-                                    "%s is in the middle of a schema change\n",
+                logmsg(LOGMSG_WARN,
+                       "%s: failed to discover whether table: "
+                       "%s is in the middle of a schema change\n",
                        __func__, s->tablename);
             }
             if (packed_sc_data) {
@@ -300,7 +302,8 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             pthread_mutex_unlock(&sc_async_mtx);
 
             free(arg);
-            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode, time(NULL));
+            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode,
+                           time(NULL));
             free_schema_change_type(s);
             rc = SC_ASYNC_FAILED;
         } else {
@@ -384,7 +387,8 @@ int finalize_schema_change(struct ireq *iq, tran_type *trans)
             logmsg(LOGMSG_ERROR,
                    "start_schema_change:pthread_create rc %d %s\n", rc,
                    strerror(errno));
-            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode, time(NULL));
+            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode,
+                           time(NULL));
             free_schema_change_type(s);
             rc = SC_ASYNC_FAILED;
         } else {
@@ -1076,8 +1080,8 @@ int sc_timepart_add_table(const char *existingTableName,
         goto error;
     }
 
-    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
-                       time(NULL)) != 0) {
+    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env),
+                       gbl_mynode, time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;
@@ -1144,8 +1148,8 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
         goto error;
     }
 
-    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
-                       time(NULL)) != 0) {
+    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env),
+                       gbl_mynode, time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -255,7 +255,6 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     arg->trans = trans;
     arg->iq = iq;
     arg->sc = iq->sc;
-    iq->sc->usedbtablevers = iq->usedbtablevers;
 
     if (s->resume && s->alteronly && !s->finalize_only) {
         if (gbl_test_sc_resume_race) {
@@ -329,7 +328,7 @@ int start_schema_change(struct schema_change_type *s)
         s->db = get_dbtable_by_name(s->tablename);
     }
     iq->usedb = s->db;
-    iq->usedbtablevers = s->db ? s->db->tableversion : 0;
+    s->usedbtablevers = s->db ? s->db->tableversion : 0;
     return start_schema_change_tran(iq, NULL);
 }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -59,13 +59,13 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         pthread_mutex_lock(&sc_resuming_mtx);
         stored_sc = sc_resuming;
         while (stored_sc) {
-            if (strcasecmp(stored_sc->table, s->table) == 0) {
+            if (strcasecmp(stored_sc->tablename, s->tablename) == 0) {
                 uuidstr_t us;
                 comdb2uuidstr(stored_sc->uuid, us);
                 logmsg(LOGMSG_INFO,
                        "Found ongoing schema change: rqid [%llx %s] "
                        "table %s, add %d, drop %d, fastinit %d, alter %d\n",
-                       stored_sc->rqid, us, stored_sc->table,
+                       stored_sc->rqid, us, stored_sc->tablename,
                        stored_sc->addonly, stored_sc->drop_table,
                        stored_sc->fastinit, stored_sc->alteronly);
                 if (stored_sc->rqid == iq->sorese.rqid &&
@@ -109,19 +109,19 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             logmsg(LOGMSG_INFO, "Resuming schema change: rqid [%llx %s] "
                                 "table %s, add %d, drop %d, fastinit %d, alter "
                                 "%d, finalize_only %d\n",
-                   s->rqid, us, s->table, s->addonly, s->drop_table,
+                   s->rqid, us, s->tablename, s->addonly, s->drop_table,
                    s->fastinit, s->alteronly, s->finalize_only);
 
         } else {
             int bdberr;
             void *packed_sc_data = NULL;
             size_t packed_sc_data_len;
-            if (bdb_get_in_schema_change(trans, s->table, &packed_sc_data,
+            if (bdb_get_in_schema_change(trans, s->tablename, &packed_sc_data,
                                          &packed_sc_data_len, &bdberr) ||
                 bdberr != BDBERR_NOERROR) {
                 logmsg(LOGMSG_WARN, "%s: failed to discover whether table: "
                                     "%s is in the middle of a schema change\n",
-                       __func__, s->table);
+                       __func__, s->tablename);
             }
             if (packed_sc_data) {
                 stored_sc = new_schemachange_type();
@@ -155,13 +155,13 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
                     logmsg(LOGMSG_INFO,
                            "Resuming schema change: rqid [%llx %s] "
                            "table %s, add %d, drop %d, fastinit %d, alter %d\n",
-                           s->rqid, us, s->table, s->addonly, s->drop_table,
+                           s->rqid, us, s->tablename, s->addonly, s->drop_table,
                            s->fastinit, s->alteronly);
                 }
                 free_schema_change_type(stored_sc);
             } else
                 logmsg(LOGMSG_INFO, "No ongoing schema change of table %s\n",
-                       s->table);
+                       s->tablename);
         }
     }
 
@@ -198,7 +198,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     }
     uuidstr_t us;
     comdb2uuidstr(s->uuid, us);
-    rc = sc_set_running(s->table, 1, seed, node, time(NULL));
+    rc = sc_set_running(s->tablename, 1, seed, node, time(NULL));
     if (rc != 0) {
         logmsg(LOGMSG_INFO, "Failed sc_set_running [%llx %s] rc %d\n", s->rqid,
                us, rc);
@@ -226,7 +226,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
                 sc_errf(s, "failed to cancel table upgrade threads\n");
                 free_schema_change_type(s);
                 return SC_CANT_SET_RUNNING;
-            } else if (sc_set_running(s->table, 1,
+            } else if (sc_set_running(s->tablename, 1,
                                       bdb_get_a_genid(thedb->bdb_env),
                                       gbl_mynode, time(NULL)) != 0) {
                 free_schema_change_type(s);
@@ -241,7 +241,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     if (thedb->master == gbl_mynode && !s->resume && iq->sc_seed != seed) {
         logmsg(LOGMSG_INFO, "Calling bdb_set_disable_plan_genid 0x%llx\n", seed);
         int bdberr;
-        int rc = bdb_set_sc_seed(thedb->bdb_env, NULL, s->table, seed,
+        int rc = bdb_set_sc_seed(thedb->bdb_env, NULL, s->tablename, seed,
                                  iq->sc_host, &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "Couldn't save schema change seed\n");
@@ -300,7 +300,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             pthread_mutex_unlock(&sc_async_mtx);
 
             free(arg);
-            sc_set_running(s->table, 0, iq->sc_seed, gbl_mynode, time(NULL));
+            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode, time(NULL));
             free_schema_change_type(s);
             rc = SC_ASYNC_FAILED;
         } else {
@@ -323,7 +323,7 @@ int start_schema_change(struct schema_change_type *s)
     iq->sc = s;
     s->iq = iq;
     if (s->db == NULL) {
-        s->db = get_dbtable_by_name(s->table);
+        s->db = get_dbtable_by_name(s->tablename);
     }
     iq->usedb = s->db;
     iq->usedbtablevers = s->db ? s->db->tableversion : 0;
@@ -384,7 +384,7 @@ int finalize_schema_change(struct ireq *iq, tran_type *trans)
             logmsg(LOGMSG_ERROR,
                    "start_schema_change:pthread_create rc %d %s\n", rc,
                    strerror(errno));
-            sc_set_running(s->table, 0, iq->sc_seed, gbl_mynode, time(NULL));
+            sc_set_running(s->tablename, 0, iq->sc_seed, gbl_mynode, time(NULL));
             free_schema_change_type(s);
             rc = SC_ASYNC_FAILED;
         } else {
@@ -408,7 +408,7 @@ int change_schema(char *table, char *fname, int odh, int compress,
     }
     bzero(s, sizeof(struct schema_change_type));
     s->type = DBTYPE_TAGGED_TABLE;
-    strncpy0(s->table, table, sizeof(s->table));
+    strncpy0(s->tablename, table, sizeof(s->tablename));
     strncpy0(s->fname, fname, sizeof(s->fname));
 
     s->headers = odh;
@@ -447,7 +447,7 @@ int create_queue(struct dbenv *dbenvin, char *queuename, int avgitem,
     }
     bzero(s, sizeof(struct schema_change_type));
     s->type = isqueuedb ? DBTYPE_QUEUEDB : DBTYPE_QUEUE;
-    strncpy0(s->table, queuename, sizeof(s->table));
+    strncpy0(s->tablename, queuename, sizeof(s->tablename));
     s->avgitemsz = avgitem;
     s->pagesize = pagesize;
     s->nothrevent = 1;
@@ -473,7 +473,7 @@ int fastinit_table(struct dbenv *dbenvin, char *table)
     }
     bzero(s, sizeof(struct schema_change_type));
     s->type = DBTYPE_TAGGED_TABLE;
-    strncpy0(s->table, db->tablename, sizeof(s->table));
+    strncpy0(s->tablename, db->tablename, sizeof(s->tablename));
 
     if (get_csc2_file(db->tablename, -1 /*highest csc2_version*/, &s->newcsc2,
                       NULL /*csc2len*/)) {
@@ -502,26 +502,26 @@ int do_dryrun(struct schema_change_type *s)
     struct dbtable *newdb = NULL;
     struct scinfo scinfo = {0};
 
-    db = get_dbtable_by_name(s->table);
+    db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         if (s->alteronly) {
-            sbuf2printf(s->sb, ">Table %s does not exists\n", s->table);
+            sbuf2printf(s->sb, ">Table %s does not exists\n", s->tablename);
             goto fail;
         } else if (s->fastinit) {
-            sbuf2printf(s->sb, ">Table %s does not exists\n", s->table);
+            sbuf2printf(s->sb, ">Table %s does not exists\n", s->tablename);
             goto fail;
         }
     } else {
         if (s->addonly) {
-            sbuf2printf(s->sb, ">Table %s already exists\n", s->table);
+            sbuf2printf(s->sb, ">Table %s already exists\n", s->tablename);
             goto fail;
         } else if (s->fastinit) {
-            sbuf2printf(s->sb, ">Table %s will be truncated\n", s->table);
+            sbuf2printf(s->sb, ">Table %s will be truncated\n", s->tablename);
             goto succeed;
         }
     }
 
-    if (dyns_load_schema_string(s->newcsc2, thedb->envname, s->table)) {
+    if (dyns_load_schema_string(s->newcsc2, thedb->envname, s->tablename)) {
         char *err;
         err = csc2_get_errors();
         sc_errf(s, "%s", err);
@@ -529,11 +529,11 @@ int do_dryrun(struct schema_change_type *s)
     }
 
     if (db == NULL) {
-        sbuf2printf(s->sb, ">Table %s will be added.\n", s->table);
+        sbuf2printf(s->sb, ">Table %s will be added.\n", s->tablename);
         goto succeed;
     }
 
-    newdb = newdb_from_schema(thedb, s->table, NULL, 0, 0, 1);
+    newdb = newdb_from_schema(thedb, s->tablename, NULL, 0, 0, 1);
     if (!newdb) {
         goto fail;
     }
@@ -836,7 +836,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     int bdberr;
     int rc;
 
-    db = get_dbtable_by_name(s->table);
+    db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         wrlock_schema_lk();
         rc = do_add_table(iq, s, NULL);
@@ -846,7 +846,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
 
     /* Shouldn't get here */
     if (s->addonly) {
-        logmsg(LOGMSG_FATAL, "table '%s' already exists\n", s->table);
+        logmsg(LOGMSG_FATAL, "table '%s' already exists\n", s->tablename);
         abort();
         return -1;
     }
@@ -858,7 +858,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
         s->header_change = s->force_dta_rebuild = s->force_blob_rebuild = 1;
     }
 
-    rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->table);
+    rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->tablename);
     if (rc != 0) {
         char *err;
         err = csc2_get_errors();
@@ -867,15 +867,15 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
         abort();
     }
 
-    if ((foundix = getdbidxbyname(s->table)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->table);
+    if ((foundix = getdbidxbyname(s->tablename)) < 0) {
+        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
         abort();
     }
 
     if (s->dbnum != -1) db->dbnum = s->dbnum;
 
     db->sc_to = newdb =
-        newdb_from_schema(thedb, s->table, NULL, db->dbnum, foundix, 0);
+        newdb_from_schema(thedb, s->tablename, NULL, db->dbnum, foundix, 0);
 
     if (newdb == NULL) return -1;
 
@@ -1013,8 +1013,8 @@ int sc_timepart_add_table(const char *existingTableName,
     sc.onstack = 1;
     sc.type = DBTYPE_TAGGED_TABLE;
 
-    snprintf(sc.table, sizeof(sc.table), "%s", newTableName);
-    sc.table[sizeof(sc.table) - 1] = '\0';
+    snprintf(sc.tablename, sizeof(sc.tablename), "%s", newTableName);
+    sc.tablename[sizeof(sc.tablename) - 1] = '\0';
 
     sc.scanmode = gbl_default_sc_scanmode;
 
@@ -1076,7 +1076,7 @@ int sc_timepart_add_table(const char *existingTableName,
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
+    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
                        time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
@@ -1112,8 +1112,8 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     sc.onstack = 1;
     sc.type = DBTYPE_TAGGED_TABLE;
 
-    snprintf(sc.table, sizeof(sc.table), "%s", tableName);
-    sc.table[sizeof(sc.table) - 1] = '\0';
+    snprintf(sc.tablename, sizeof(sc.tablename), "%s", tableName);
+    sc.tablename[sizeof(sc.tablename) - 1] = '\0';
 
     sc.scanmode = gbl_default_sc_scanmode;
 
@@ -1144,7 +1144,7 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
         goto error;
     }
 
-    if (sc_set_running(sc.table, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
+    if (sc_set_running(sc.tablename, 1, bdb_get_a_genid(thedb->bdb_env), gbl_mynode,
                        time(NULL)) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
@@ -1213,7 +1213,7 @@ int start_table_upgrade(struct dbenv *dbenv, const char *tbl,
     sc->ip_updates = 1;
     sc->instant_sc = 1;
     sc->nothrevent = sync;
-    strncpy0(sc->table, tbl, sizeof(sc->table));
+    strncpy0(sc->tablename, tbl, sizeof(sc->tablename));
     sc->fulluprecs = full;
     sc->partialuprecs = partial;
     sc->start_genid = genid;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -68,8 +68,8 @@ struct schema_change_type {
     uuid_t uuid;
     int type; /* DBTYPE_TAGGED_TABLE or DBTYPE_QUEUE or DBTYPE_QUEUEDB
                  or DBTYPE_MORESTRIPE */
-    size_t table_len;
-    char table[MAXTABLELEN]; /* name of table/queue */
+    size_t tablename_len;
+    char tablename[MAXTABLELEN]; /* name of table/queue */
     int rename;              /* new table name */
     char newtable[MAXTABLELEN]; /* rename table */
     size_t fname_len;

--- a/sqlite/comdb2lua.c
+++ b/sqlite/comdb2lua.c
@@ -204,7 +204,7 @@ void comdb2CreateTrigger(Parse *parse, int dynamic, Token *proc,
 	struct schema_change_type *sc = new_schemachange_type();
 	sc->is_trigger = 1;
 	sc->addonly = 1;
-	strcpy(sc->table, qname);
+	strcpy(sc->tablename, qname);
 	struct dest *d = malloc(sizeof(struct dest));
 	d->dest = strdup(method);
 	listc_abl(&sc->dests, d);
@@ -233,7 +233,7 @@ void comdb2DropTrigger(Parse *parse, Token *proc)
 	struct schema_change_type *sc = new_schemachange_type();
 	sc->is_trigger = 1;
 	sc->drop_table = 1;
-	strcpy(sc->table, qname);
+	strcpy(sc->tablename, qname);
 	Vdbe *v = sqlite3GetVdbe(parse);
 	comdb2prepareNoRows(v, parse, 0, sc, &comdb2SqlSchemaChange_tran,
 			    (vdbeFuncArgFree)&free_schema_change_type);

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -274,6 +274,12 @@ cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t2  { `cat alltypes.csc2 ` }"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table t2 "
 
 set +e
+cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table t2 " &> baddrop.txt
+echo "[drop table t2] failed with rc -3 no such table: t2" > baddrop.exp
+if ! diff baddrop.txt baddrop.exp ; then
+    failexit "unexpected $nosuchtbl"
+fi
+
 cdb2sql ${CDB2_OPTIONS} $dbnm default "select * from t2 " &> badsel.txt
 echo "[select * from t2] failed with rc -3 no such table: t2" > badsel.exp
 if ! diff badsel.txt badsel.exp ; then

--- a/tests/sc_timepart.test/runit
+++ b/tests/sc_timepart.test/runit
@@ -83,6 +83,7 @@ for run in 1 2 3 4 5; do
 
 
    if (( $run == 3 )) ; then
+      echo "performing 'alter table ${VIEW1}'"
       cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} { `cat $SCHEMAFILE` }"
       if (( $? != 0 )) ; then
          echo "FAILURE"


### PR DESCRIPTION
instead of sending table version via usedb, this checkin sends the tableversion for a schemachange
in the OSQL_SCHEMACHANGE osql packet.
