### PR TITLE
Fix getservbyname MacOS linking issue

### DIFF
--- a/util/bb_oscompat.c
+++ b/util/bb_oscompat.c
@@ -66,8 +66,7 @@ void comdb2_getservbyname(const char *name, const char *proto, short *port)
 {
     struct servent result_buf, *result = NULL;
     char buf[1024];
-#   if defined(_DARWIN_C_SOURCE) // Should be first, as _LINUX_SOURCE is
-                                 // also defined on Mac.
+#   if defined(__APPLE__) // Should be first, as _LINUX_SOURCE is also defined.
     result = getservbyname(name, proto);
 #   elif defined(_LINUX_SOURCE)
     getservbyname_r(name, proto, &result_buf, buf, sizeof(buf), &result);


### PR DESCRIPTION
MacOS does not have `getservbyname_r` function. The `getservbyname` is
reentrant by default on MacOS. From `man getservbyname`:

> These functions use a thread-specific data storage; if the data is needed for future use, it should be copied before any sub-sequent calls overwrite it.

However due to `_LINUX_SOURCE` being set while
compiling on MacOS it fails to link with:

```
Undefined symbols for architecture x86_64:
  "_getservbyname_r", referenced from:
      _comdb2_getservbyname in libutil.a(bb_oscompat.c.o)
ld: symbol(s) not found for architecture x86_64
```

This commit fixes this by using `getservbyname` in a presence of `_DARWIN_C_SOURCE`.

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
bug fix
* What are the current behavior and expected behavior, if this is a bugfix ?
The `comdb2`. does not link on MacOS. The `comdb2` should link on MacOS.
* What are the steps required to reproduce the bug, if this is a bugfix ?
```
mkdir bld && cd bld && cmake .. & make -j
```
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
