### PR TITLE
Support for connection initialization statements.

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/UnpooledDataSource.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/UnpooledDataSource.java
@@ -265,7 +265,7 @@ public class UnpooledDataSource implements DataSource {
 					driverType = Class.forName(driver);
 				}
 
-				DriverManager.registerDriver(new DriverProxy((Driver) driverType.newInstance()));
+				DriverManager.registerDriver(new DriverProxy((java.sql.Driver) driverType.newInstance()));
 			} catch (Exception e) {
 				throw new RuntimeException("Error setting driver (" + driver + ") on UnpooledDataSource. Cause: " + e, e);
 			}
@@ -273,9 +273,9 @@ public class UnpooledDataSource implements DataSource {
 	}
 
 	private static class DriverProxy implements java.sql.Driver {
-		private Driver driver;
+		private java.sql.Driver driver;
 
-		DriverProxy(Driver d) {
+		DriverProxy(java.sql.Driver d) {
 			this.driver = d;
 		}
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/UnpooledDataSource.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/UnpooledDataSource.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
  * Credits to mybatis.
  * http://grepcode.com/file/repo1.maven.org/maven2/org.mybatis/mybatis/3.0.4/org/apache/ibatis/datasource/unpooled/UnpooledDataSource.java
  * 
- * Cedits to apache dbcp for initialization sql logic
+ * Credits to apache dbcp for initialization sql logic
  * https://github.com/apache/commons-dbcp/blob/master/src/main/java/org/apache/commons/dbcp2/BasicDataSource.java#L1201
  * 
  * @author Sebastien Blind

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/UnpooledDataSourceTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/UnpooledDataSourceTest.java
@@ -1,0 +1,26 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import java.util.logging.*;
+import org.junit.*;
+import org.junit.Assert.*;
+import java.util.*;
+
+public class UnpooledDataSourceTest {
+
+    @Test public void testDatabaseInitSqls() throws SQLException {
+        String db = System.getProperty("cdb2jdbc.test.database");
+        String cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        UnpooledDataSource ds = new UnpooledDataSource();
+        ds.setDriver("com.bloomberg.comdb2.jdbc.Driver");
+        ds.setUrl(String.format("jdbc:comdb2://%s/%s", cluster, db));
+        ds.setConnectionInitSqls(Arrays.asList("SET TIMEZONE Zulu"));
+
+        Connection conn = ds.getConnection();
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT CAST(NOW() AS TEXT)");
+        String zulu = rs.getString(1);
+        Assert.assertTrue("Should get back a time in Zulu", zulu.contains("Zulu"));
+    }
+}

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/UnpooledDataSourceTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/UnpooledDataSourceTest.java
@@ -22,5 +22,15 @@ public class UnpooledDataSourceTest {
         ResultSet rs = stmt.executeQuery("SELECT CAST(NOW() AS TEXT)");
         String zulu = rs.getString(1);
         Assert.assertTrue("Should get back a time in Zulu", zulu.contains("Zulu"));
+
+        /* De-register myself from the driver manager to not interfere with other tests. */
+        Enumeration<java.sql.Driver> drivers = DriverManager.getDrivers();
+        while (drivers.hasMoreElements()) {
+            java.sql.Driver driver = drivers.nextElement();
+            if (!(driver instanceof com.bloomberg.comdb2.jdbc.Driver)) {
+                DriverManager.deregisterDriver(driver);
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
This PR enables the unpooled data source to return connections that have been pre-configured.

* What are the current behavior and expected behavior, if this is a bugfix ?
N/A

* What are the steps required to reproduce the bug, if this is a bugfix ?
N/A

* What is the current behavior and new behavior, if this is a feature change or enhancement ?
This allows connections to be prep'ed before usage (sor ex, w/ set timeout 0)

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
