### PR TITLE
SOSQL: dont lock table on every write in add record

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -640,7 +640,7 @@ DEF_ATTR(STARTUP_SYNC_ATTEMPTS, startup_sync_attempts, QUANTITY, 5, NULL)
 DEF_ATTR(DEBUG_TIMEPART_CRON, dbg_timepart_cron, BOOLEAN, 0, NULL)
 DEF_ATTR(DEBUG_TIMEPART_SQLITE, dbg_timepart_SQLITE, BOOLEAN, 0, NULL)
 DEF_ATTR(DELAY_FILE_OPEN, delay_file_open, MSECS, 0, NULL)
-DEF_ATTR(DELAY_LOCK_TABLE_RECORD_C, delay_lock_table_record_c, MSECS, 0, NULL)
+DEF_ATTR(DELAY_WRITES_IN_RECORD_C, delay_in_record_c, MSECS, 0, NULL)
 
 DEF_ATTR(NET_SEND_GBLCONTEXT, net_send_gblcontext, BOOLEAN, 0,
          "Enable net_send for USER_TYPE_GBLCONTEXT.")

--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -640,7 +640,7 @@ DEF_ATTR(STARTUP_SYNC_ATTEMPTS, startup_sync_attempts, QUANTITY, 5, NULL)
 DEF_ATTR(DEBUG_TIMEPART_CRON, dbg_timepart_cron, BOOLEAN, 0, NULL)
 DEF_ATTR(DEBUG_TIMEPART_SQLITE, dbg_timepart_SQLITE, BOOLEAN, 0, NULL)
 DEF_ATTR(DELAY_FILE_OPEN, delay_file_open, MSECS, 0, NULL)
-DEF_ATTR(DELAY_WRITES_IN_RECORD_C, delay_in_record_c, MSECS, 0, NULL)
+DEF_ATTR(DELAY_WRITES_IN_RECORD_C, delay_writes_in_record_c, MSECS, 0, NULL)
 
 DEF_ATTR(NET_SEND_GBLCONTEXT, net_send_gblcontext, BOOLEAN, 0,
          "Enable net_send for USER_TYPE_GBLCONTEXT.")

--- a/bdb/tranread.c
+++ b/bdb/tranread.c
@@ -55,7 +55,6 @@ static int bdb_fetch_last_key_tran_int(bdb_state_type *bdb_state,
     DBT key, data;
     int rc = 0;
     int flags = 0;
-    char *buf;
 
     *bdberr = 0;
 

--- a/bdb/upd.c
+++ b/bdb/upd.c
@@ -56,7 +56,6 @@ static int bdb_change_dta_genid_dtastripe(bdb_state_type *bdb_state,
                                           unsigned long long newgenid,
                                           int has_blob_opt, int *bdberr)
 {
-    unsigned long long dtagenid = oldgenid;
     int rc;
     DB *dbp;
     int dtastripe;
@@ -118,7 +117,6 @@ static int bdb_prim_add_upd_int(bdb_state_type *bdb_state, tran_type *tran,
 
     int rc;
     int stripe;
-    int *iptr;
     DB *dbp;
     DBT dbt_newdta;
 
@@ -186,10 +184,8 @@ static int bdb_prim_updvrfy_int(bdb_state_type *bdb_state, tran_type *tran,
                                 int participantstripid, int use_new_genid,
                                 int keep_genid_intact, int *bdberr)
 {
-    DBT dbt_key, dbt_data;
     int rc;
     int stripe;
-    int *iptr;
     DB *dbp;
     DBT dbt_newdta;
     DBT dbt_olddta;
@@ -275,8 +271,6 @@ static int bdb_prim_updkey_genid_int(bdb_state_type *bdb_state, tran_type *tran,
                                      int dtalen, int isnull, int *bdberr)
 {
     int rc;
-    int stripe;
-    int *iptr;
     DBT dbt_key;
     void *pKeyMaxBuf = 0;
 
@@ -284,8 +278,6 @@ static int bdb_prim_updkey_genid_int(bdb_state_type *bdb_state, tran_type *tran,
         return -1;
 
     *bdberr = BDBERR_NOERROR;
-
-    stripe = 0;
 
     /* synthetic genids should not make it here */
     if (is_genid_synthetic(genid)) {

--- a/bdb/util.c
+++ b/bdb/util.c
@@ -193,21 +193,13 @@ void bdb_lock_name(bdb_state_type *bdb_state, char *s, size_t slen,
         }
 
     } else {
-        const unsigned char *cptr = lockid;
         snprintf(s, slen, "lockid_leen=%u", (unsigned)lockid_len);
     }
 }
 
 int bdb_write_preamble(bdb_state_type *bdb_state, int *bdberr)
 {
-    bdb_state_type *parent;
-
     *bdberr = BDBERR_NOERROR;
-
-    if (bdb_state->parent)
-        parent = bdb_state->parent;
-    else
-        parent = bdb_state;
 
     if (!bdb_state->read_write) {
         *bdberr = BDBERR_READONLY;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -784,9 +784,9 @@ struct dbtable {
     pthread_rwlock_t consumer_lk;
 
     bool has_datacopy_ix : 1; /* set to 1 if we have datacopy indexes */
-    bool ix_partial : 1;  /* set to 1 if we have partial indexes */
-    bool ix_expr : 1;     /* set to 1 if we have indexes on expressions */
-    bool ix_blob : 1;     /* set to 1 if blobs are involved in indexes */
+    bool ix_partial : 1;      /* set to 1 if we have partial indexes */
+    bool ix_expr : 1;         /* set to 1 if we have indexes on expressions */
+    bool ix_blob : 1;         /* set to 1 if blobs are involved in indexes */
 
     bool sc_abort : 1;
     bool sc_downgrading : 1;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2621,7 +2621,9 @@ enum {
     /* used for upgrade record */
     RECFLAGS_UPGRADE_RECORD = RECFLAGS_DYNSCHEMA_NULLS_ONLY |
                               RECFLAGS_KEEP_GENID | RECFLAGS_NO_TRIGGERS |
-                              RECFLAGS_NO_CONSTRAINTS | RECFLAGS_NO_BLOBS | 512
+                              RECFLAGS_NO_CONSTRAINTS | RECFLAGS_NO_BLOBS | 512,
+    RECFLAGS_DONT_LOCK_TBL = 1024,
+    RECFLAGS_MAX = 2048
 };
 
 /* flag codes */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -640,6 +640,7 @@ struct dbtable {
     struct dbenv *dbenv; /*chain back to my environment*/
     char *lrlfname;
     char *tablename;
+    struct ireq *iq; /* iq used at sc time */
 
     int dbnum;
     int lrl; /*dat len in bytes*/
@@ -653,11 +654,6 @@ struct dbtable {
     signed char ix_collattr[MAXINDEX];
     signed char ix_nullsallowed[MAXINDEX];
     signed char ix_disabled[MAXINDEX];
-    struct ireq *iq; /* iq used at sc time */
-    int has_datacopy_ix; /* set to 1 if we have datacopy indexes */
-    int ix_partial;  /* set to 1 if we have partial indexes */
-    int ix_expr;     /* set to 1 if we have indexes on expressions */
-    int ix_blob;     /* set to 1 if blobs are involved in indexes */
 
     int numblobs;
 
@@ -754,8 +750,6 @@ struct dbtable {
 
     struct dbtable *sc_from; /* point to the source db, replace global sc_from */
     struct dbtable *sc_to; /* point to the new db, replace global sc_to */
-    int sc_abort;
-    int sc_downgrading;
     unsigned long long *sc_genids; /* schemachange stripe pointers */
 
     /* count the number of updates and deletes done by schemachange
@@ -768,11 +762,6 @@ struct dbtable {
 
     uint64_t sc_nrecs;
     uint64_t sc_prev_nrecs;
-    /* boolean value set to nonzero if table rebuild is in progress */
-    uint8_t doing_conversion;
-    /* boolean value set to nonzero if table upgrade is in progress */
-    uint8_t doing_upgrade;
-
     unsigned int sqlcur_ix;  /* count how many cursors where open in ix mode */
     unsigned int sqlcur_cur; /* count how many cursors where open in cur mode */
 
@@ -786,8 +775,6 @@ struct dbtable {
     int inplace_updates;
     unsigned long long tableversion;
 
-    int do_local_replication;
-
     /* map of tag fields for version to curr schema */
     unsigned int * versmap[MAXVER + 1];
     /* is tag version compatible with ondisk schema */
@@ -795,7 +782,22 @@ struct dbtable {
 
     /* lock for consumer list */
     pthread_rwlock_t consumer_lk;
-    int disableskipscan : 1;
+
+    bool has_datacopy_ix : 1; /* set to 1 if we have datacopy indexes */
+    bool ix_partial : 1;  /* set to 1 if we have partial indexes */
+    bool ix_expr : 1;     /* set to 1 if we have indexes on expressions */
+    bool ix_blob : 1;     /* set to 1 if blobs are involved in indexes */
+
+    bool sc_abort : 1;
+    bool sc_downgrading : 1;
+
+    /* boolean value set to nonzero if table rebuild is in progress */
+    bool doing_conversion : 1;
+    /* boolean value set to nonzero if table upgrade is in progress */
+    bool doing_upgrade : 1;
+
+    bool disableskipscan : 1;
+    bool do_local_replication : 1;
 };
 
 struct log_delete_state {

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -802,7 +802,7 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
                     /* TODO verify we have proper schema change locks */
 
                     rc = del_record(iq, trans, NULL, rrn, genid, -1ULL, &err,
-                                    &idx, BLOCK2_DELKL, 0);
+                                    &idx, BLOCK2_DELKL, RECFLAGS_DONT_LOCK_TBL);
                     if (iq->debug)
                         reqpopprefixes(iq, 1);
                     iq->usedb = currdb;
@@ -867,7 +867,7 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
                         0,    /*maxblobs*/
                         &newgenid, -1ULL, -1ULL, &err, &idx, BLOCK2_UPDKL,
                         0, /*blkpos*/
-                        UPDFLAGS_CASCADE);
+                        UPDFLAGS_CASCADE | RECFLAGS_DONT_LOCK_TBL);
                     if (iq->debug)
                         reqpopprefixes(iq, 1);
                     iq->usedb = currdb;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -129,7 +129,6 @@ static int cache_delayed_indexes(struct ireq *iq, unsigned long long genid)
     void *cur = NULL;
     int err = 0;
     int *pixnum;
-    int i;
 
     if (iq->idxInsert || iq->idxDelete) {
         free_cached_idx(iq->idxInsert);
@@ -566,13 +565,11 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
                            struct ireq *iq, block_state_t *blkstate,
                            void *trans, blob_buffer_t *blobs, int *errout)
 {
-    int i = 0, rc = 0, fndlen = 0, fndrrn = 0, opcode = 0, err = 0;
+    int rc = 0, fndrrn = 0, err = 0;
     int cascade;
     int del_cascade;
     int keylen;
     int upd_cascade;
-    void *od_dta = NULL;
-    char ondisk_tag[MAXTAGLEN];
     char key[MAXKEYLEN];
     unsigned char nulls[MAXNULLBITS] = {0};
     void *cur = NULL;
@@ -618,7 +615,6 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
     while (rc == 0) {
         cte *ctrq = (cte *)bdb_temp_table_data(cur);
         struct backward_ct *bct = NULL;
-        int ondisk_size = 0;
         unsigned long long genid = 0LL, fndgenid = 0LL;
         struct dbtable *currdb = NULL;
         char *skey = NULL;
@@ -956,7 +952,7 @@ int verify_del_constraints(struct javasp_trans_state *javasp_trans_handle,
 int delayed_key_adds(struct ireq *iq, block_state_t *blkstate, void *trans,
                      int *blkpos, int *ixout, int *errout)
 {
-    int i = 0, rc = 0, fndlen = 0, fndrrn = 0, err = 0, limit = 0;
+    int rc = 0, fndlen = 0, err = 0, limit = 0;
     int idx = 0, ixkeylen = -1;
     void *od_dta = NULL;
     char ondisk_tag[MAXTAGLEN];
@@ -1265,7 +1261,7 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
                            struct ireq *iq, block_state_t *blkstate,
                            void *trans, int *errout)
 {
-    int i = 0, rc = 0, fndlen = 0, fndrrn = 0, opcode = 0, err = 0;
+    int rc = 0, fndlen = 0, fndrrn = 0, opcode = 0, err = 0;
     void *od_dta = NULL;
     char ondisk_tag[MAXTAGLEN];
     char key[MAXKEYLEN];
@@ -1325,8 +1321,6 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
         struct forward_ct *curop = NULL;
         int addrrn = -1, ixnum = -1;
         int ondisk_size = 0;
-        const uint8_t *p_buf_req_start;
-        const uint8_t *p_buf_req_end;
         unsigned long long genid = 0LL;
         unsigned long long ins_keys = 0ULL;
         /* do something */
@@ -1348,8 +1342,6 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
         ixnum = curop->ixnum;
         genid = curop->genid;
         ins_keys = curop->ins_keys;
-        p_buf_req_start = curop->p_buf_req_start;
-        p_buf_req_end = curop->p_buf_req_end;
         opcode = curop->optype;
         /* if we are updating by key, check the constraints as if we're doing a
          * normal update */
@@ -1470,7 +1462,6 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
 
                 for (ridx = 0; ridx < ct->nrules; ridx++) {
                     struct dbtable *ftable = NULL, *currdb = NULL;
-                    int ftblsz = 0;
                     int fixnum = 0;
                     int fixlen = 0;
                     char fkey[MAXKEYLEN];
@@ -1489,7 +1480,6 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
                         close_constraint_table_cursor(cur);
                         return ERR_BADREQ;
                     }
-                    ftblsz = getdatsize(ftable);
                     rc = getidxnumbyname(ftable->tablename, ct->keynm[ridx],
                                          &fixnum);
                     if (rc) {
@@ -1540,7 +1530,8 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
                         }
                     }
 
-                    /*     fprintf(stderr, "%s;%d-%s;%d\n",ftable->tablename,
+                    /*     int ftblsz = getdatsize(ftable);
+                     *     fprintf(stderr, "%s;%d-%s;%d\n",ftable->tablename,
                            ftblsz, ct->keynm[ridx], fixlen);*/
 
                     /* we'll do the find on created index to make sure
@@ -2045,8 +2036,6 @@ int populate_reverse_constraints(struct dbtable *db)
         int jj = 0;
         constraint_t *cnstrt = &db->constraints[ii];
         struct schema *sc = NULL;
-        struct dbtable *ftable = NULL;
-        int keyszs = 0, keyszd = 0, keyix = 0;
 
         sc = find_tag_schema(db->tablename, cnstrt->lclkeyname);
         if (sc == NULL) {

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6913,7 +6913,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         }
 
         rc = del_record(iq, trans, NULL, 0, dt.genid, dt.dk, &err->errcode,
-                        &err->ixnum, BLOCK2_DELKL, 0);
+                        &err->ixnum, BLOCK2_DELKL, RECFLAGS_DONT_LOCK_TBL);
 
         if (iq->idxInsert || iq->idxDelete) {
             free_cached_idx(iq->idxInsert);
@@ -6972,7 +6972,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             sbuf2printf(logsb, "\n] -> ");
         }
 
-        addflags = RECFLAGS_DYNSCHEMA_NULLS_ONLY;
+        addflags = RECFLAGS_DYNSCHEMA_NULLS_ONLY | RECFLAGS_DONT_LOCK_TBL;
         if (osql_get_delayed(iq) == 0 && iq->usedb->n_constraints == 0 &&
             gbl_goslow == 0) {
             addflags |= RECFLAGS_NO_CONSTRAINTS;
@@ -7149,6 +7149,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             *updCols, blobs, MAXBLOBS, &genid, dt.ins_keys, dt.del_keys,
             &err->errcode, &err->ixnum, BLOCK2_UPDKL, step,
             RECFLAGS_DYNSCHEMA_NULLS_ONLY |
+                RECFLAGS_DONT_LOCK_TBL |
                 RECFLAGS_DONT_SKIP_BLOBS /* because we only receive info about
                                             blobs that should exist in the new
                                             record, override the update

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7148,8 +7148,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                                                      ctag2stag is called */
             *updCols, blobs, MAXBLOBS, &genid, dt.ins_keys, dt.del_keys,
             &err->errcode, &err->ixnum, BLOCK2_UPDKL, step,
-            RECFLAGS_DYNSCHEMA_NULLS_ONLY |
-                RECFLAGS_DONT_LOCK_TBL |
+            RECFLAGS_DYNSCHEMA_NULLS_ONLY | RECFLAGS_DONT_LOCK_TBL |
                 RECFLAGS_DONT_SKIP_BLOBS /* because we only receive info about
                                             blobs that should exist in the new
                                             record, override the update

--- a/db/record.c
+++ b/db/record.c
@@ -273,7 +273,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
                 reqprintf(iq, "usleep error rc %d errno %d\n", rc, errno);
         }
 
-        if(!iq->have_blkseq) {
+        if(!iq->is_sorese) {
             reqprintf(iq, "Calling bdb_lock_table_read()");
             rc = bdb_lock_table_read(iq->usedb->handle, trans);
             if (rc == BDBERR_DEADLOCK) {
@@ -968,7 +968,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         usleep(1000 * d_ms);
     }
 
-    if(!iq->have_blkseq) {
+    if(!iq->is_sorese) {
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
         if (rc == BDBERR_DEADLOCK) {
@@ -1961,7 +1961,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         usleep(1000 * d_ms);
     }
 
-    if(!iq->have_blkseq) {
+    if(!iq->is_sorese) {
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
         if (rc == BDBERR_DEADLOCK) {

--- a/db/record.c
+++ b/db/record.c
@@ -277,8 +277,6 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     if (!(flags & RECFLAGS_NEW_SCHEMA) && !(flags & RECFLAGS_DONT_LOCK_TBL)) {
         // dont lock table if adding from SC or if RECFLAGS_DONT_LOCK_TBL
         assert(!iq->is_sorese); // sorese codepaths will have locked it already
-        if (iq->is_sorese) // sorese codepaths should have locked it already
-            abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
@@ -975,8 +973,6 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
         assert(!iq->is_sorese); // sorese codepaths will have locked it already
-        if (iq->is_sorese) // sorese codepaths should have locked it already
-            abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
@@ -1972,8 +1968,6 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
         assert(!iq->is_sorese); // sorese codepaths will have locked it already
-        if (iq->is_sorese) // sorese codepaths should have locked it already
-            abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);

--- a/db/record.c
+++ b/db/record.c
@@ -276,7 +276,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
 
     if (!(flags & RECFLAGS_NEW_SCHEMA) && !(flags & RECFLAGS_DONT_LOCK_TBL)) {
         // dont lock table if adding from SC or if RECFLAGS_DONT_LOCK_TBL
-        assert(!iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); //sorese codepaths will have locked it already
+        if(iq->is_sorese); //sorese codepaths should have locked it already
+            abort();
     
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
@@ -972,7 +974,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
-        assert(!iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); //sorese codepaths will have locked it already
+        if(iq->is_sorese); //sorese codepaths should have locked it already
+            abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
@@ -1967,7 +1971,9 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
-        assert(!iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); //sorese codepaths will have locked it already
+        if(iq->is_sorese); //sorese codepaths should have locked it already
+            abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);

--- a/db/record.c
+++ b/db/record.c
@@ -266,20 +266,20 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         int d_ms = BDB_ATTR_GET(thedb->bdb_attr, DELAY_WRITES_IN_RECORD_C);
         if (d_ms) {
             if (iq->debug)
-                reqprintf(iq, "Sleeping for DELAY_WRITES_IN_RECORD_C (%dms)", d_ms);
+                reqprintf(iq, "Sleeping for DELAY_WRITES_IN_RECORD_C (%dms)",
+                          d_ms);
             int lrc = usleep(1000 * d_ms);
             if (lrc)
                 reqprintf(iq, "usleep error rc %d errno %d\n", rc, errno);
         }
     }
 
-
     if (!(flags & RECFLAGS_NEW_SCHEMA) && !(flags & RECFLAGS_DONT_LOCK_TBL)) {
         // dont lock table if adding from SC or if RECFLAGS_DONT_LOCK_TBL
-        assert(!iq->is_sorese); //sorese codepaths will have locked it already
-        if(iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); // sorese codepaths will have locked it already
+        if (iq->is_sorese) // sorese codepaths should have locked it already
             abort();
-    
+
         reqprintf(iq, "Calling bdb_lock_table_read()");
         rc = bdb_lock_table_read(iq->usedb->handle, trans);
         if (rc == BDBERR_DEADLOCK) {
@@ -974,8 +974,8 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
-        assert(!iq->is_sorese); //sorese codepaths will have locked it already
-        if(iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); // sorese codepaths will have locked it already
+        if (iq->is_sorese) // sorese codepaths should have locked it already
             abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");
@@ -1971,8 +1971,8 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
-        assert(!iq->is_sorese); //sorese codepaths will have locked it already
-        if(iq->is_sorese); //sorese codepaths should have locked it already
+        assert(!iq->is_sorese); // sorese codepaths will have locked it already
+        if (iq->is_sorese) // sorese codepaths should have locked it already
             abort();
 
         reqprintf(iq, "Calling bdb_lock_table_read()");

--- a/db/views.c
+++ b/db/views.c
@@ -415,7 +415,6 @@ int timepart_view_set_retention(timepart_views_t *views, const char *name,
                                 int retention)
 {
     timepart_view_t *view;
-    int i;
     int rc;
 
     pthread_rwlock_wrlock(&views_lk);
@@ -445,7 +444,6 @@ int timepart_view_set_period(timepart_views_t *views, const char *name,
                              enum view_timepart_period period)
 {
     timepart_view_t *view;
-    int i;
     int rc;
 
     pthread_rwlock_wrlock(&views_lk);
@@ -1154,10 +1152,10 @@ void *_view_cron_phase1(uuid_t source_id, void *arg1, void *arg2, void *arg3,
     timepart_view_t *view;
     char *name = (char *)arg1;
     char *pShardName = NULL;
-    int rc;
+    int rc = 0;
     char *tmp_str;
     int run;
-    int shardChangeTime;
+    int shardChangeTime = 0;
 
     if (!name) {
         errstat_set_rc(err, VIEW_ERR_BUG);
@@ -1310,9 +1308,9 @@ void *_view_cron_phase2(uuid_t source_id, void *arg1, void *arg2, void *arg3,
     char *pShardName = (char *)arg2;
     int run = 0;
     int timeNextRollout;
-    int timeCrtRollout;
+    int timeCrtRollout = 0;
     char *removeShardName;
-    int rc;
+    int rc = 0;
     int bdberr;
 
     if (!name || !pShardName) {
@@ -1887,7 +1885,7 @@ static int _view_restart(timepart_view_t *view, struct errstat *err)
     char next_existing_shard[MAXTABLELEN + 1];
     char evicted_shard[MAXTABLELEN + 1];
     struct dbtable *evicted_db;
-    int evicted_time;
+    int evicted_time = 0;
     int tm;
     int rc;
     char *tmp_str1;
@@ -2644,8 +2642,8 @@ int timepart_schemachange_get_shard_in_progress(const char *view_name,
 {
     timepart_views_t *views;
     timepart_view_t *view;
-    int rc;
-    int i;
+    int rc = 0;
+    int i = 0;
 
     pthread_rwlock_wrlock(&views_lk);
 

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -151,9 +151,9 @@ static void *watchdog_thread(void *arg)
     int coherent = 0;
 
     int counter = 0;
-    char lastlsn[63] = "", curlsn[64];
+    char curlsn[64];
     uint64_t lastlsnbytes = 0, curlsnbytes;
-    char master_lastlsn[63] = "", master_curlsn[64];
+    char master_curlsn[64];
     uint64_t master_lastlsnbytes = 0, master_curlsnbytes;
     int sockpool_timeout;
 
@@ -310,10 +310,8 @@ static void *watchdog_thread(void *arg)
 
             /* test netinfo lock */
             {
-                int count;
                 const char *hostlist[REPMAX];
-                count = net_get_all_nodes_connected(thedb->handle_sibling,
-                                                    hostlist);
+                net_get_all_nodes_connected(thedb->handle_sibling, hostlist);
             }
 
             /* See if we can grab the berkeley log region lock.  If we block on
@@ -382,8 +380,6 @@ void comdb2_die(int aborat)
 {
     pid_t pid;
     char pstack_cmd[128];
-    int rc;
-    pthread_t tid;
 
     /* we have 60 seconds to "print useful stuff" */
     alarm(60);
@@ -401,7 +397,7 @@ void comdb2_die(int aborat)
         sizeof(pstack_cmd)) {
         logmsg(LOGMSG_WARN, "pstack cmd too long for buffer\n");
     } else {
-        int dum = system(pstack_cmd);
+        system(pstack_cmd);
     }
 
     if (aborat)

--- a/tests/deadlock_loop_print.test/runit
+++ b/tests/deadlock_loop_print.test/runit
@@ -27,7 +27,7 @@ for node in $cluster ; do
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('debg 500')"
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb verbdeadlock 1')"
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('on verbose_deadlocks')"
-    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 1000')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 1000')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('print_deadlock_cycles on')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('track_curtran_locks on')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('reql events detailed on')"

--- a/tests/index_deadlock_loop_print.test/runit
+++ b/tests/index_deadlock_loop_print.test/runit
@@ -46,7 +46,7 @@ for node in $cluster ; do
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('ndebg 500')"
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb verbdeadlock 1')"
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('on verbose_deadlocks')"
-    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 1000')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 1000')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('print_deadlock_cycles on')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('track_curtran_locks on')"
     cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('reql events detailed on')"

--- a/tests/sc_versmismatch.test/runit
+++ b/tests/sc_versmismatch.test/runit
@@ -73,7 +73,7 @@ function test1
 {
     assertcnt $INITCNT
     #cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('debg 100')"
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 100')"
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 100')"
     echo "Alter table to t1_2 version while inserting records"
     (cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_2.csc2 ` }" &> alter1.scout; touch alter1.done) &
 
@@ -143,7 +143,7 @@ function test1
  
     rm alter2.done have.txt shouldhave.txt
 
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 0')"
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 0')"
     echo "Insert few more records from $((cnt+1)) up"
     j=$cnt
     while [ $j -lt 6000 ] ; do 
@@ -156,7 +156,7 @@ function test1
     done
 
     
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 100')"
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 100')"
 
     echo "Alter table to t1_2 version while deleting records from $j down"
     (cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_2.csc2 ` }" &> alter3.scout; touch alter3.done) &
@@ -176,7 +176,7 @@ function test1
         failexit "alter3: see alter3.scout"
     fi
 
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 0')"
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 0')"
 
     echo "checking that after delete we have correct content"
     cdb2sql ${CDB2_OPTIONS} $dbnm default "select a,b,c from t1 order by a" > have.txt

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -162,7 +162,7 @@
 (name='decom_time', description='Decomission time. (Default: 0)', type='INTEGER', value='0', read_only='Y')
 (name='default_analyze_percent', description='Controls analyze coverage.', type='INTEGER', value='20', read_only='N')
 (name='delay_file_open', description='', type='INTEGER', value='0', read_only='N')
-(name='delay_lock_table_record_c', description='', type='INTEGER', value='0', read_only='N')
+(name='delay_in_record_c', description='', type='INTEGER', value='0', read_only='N')
 (name='delayed_oldfile_cleanup', description='If set, don't delete unused data/index files in the critical path of schema change; schedule them for deletion later.', type='BOOLEAN', value='ON', read_only='N')
 (name='dflt_livesc', description='Use live schema change by default', type='BOOLEAN', value='ON', read_only='N')
 (name='dflt_plansc', description='Use planned schema change by default', type='BOOLEAN', value='ON', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -162,7 +162,7 @@
 (name='decom_time', description='Decomission time. (Default: 0)', type='INTEGER', value='0', read_only='Y')
 (name='default_analyze_percent', description='Controls analyze coverage.', type='INTEGER', value='20', read_only='N')
 (name='delay_file_open', description='', type='INTEGER', value='0', read_only='N')
-(name='delay_in_record_c', description='', type='INTEGER', value='0', read_only='N')
+(name='delay_writes_in_record_c', description='', type='INTEGER', value='0', read_only='N')
 (name='delayed_oldfile_cleanup', description='If set, don't delete unused data/index files in the critical path of schema change; schedule them for deletion later.', type='BOOLEAN', value='ON', read_only='N')
 (name='dflt_livesc', description='Use live schema change by default', type='BOOLEAN', value='ON', read_only='N')
 (name='dflt_plansc', description='Use planned schema change by default', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
For SQL writes on master we lock table when we get usedb, which locks table. We don't need to lock table on add_record, upd_record, and del_record if we come from osql. 