### PR TITLE
add test that causes deadlock when writing to index

### DIFF
--- a/tests/index_deadlock_loop_print.test/Makefile
+++ b/tests/index_deadlock_loop_print.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/index_deadlock_loop_print.test/README
+++ b/tests/index_deadlock_loop_print.test/README
@@ -1,0 +1,21 @@
+This tests runs two transactions which deadlock with each other 
+insert N records into t1 one index.
+* first transaction deletes from t1 where a=1, then a=N
+* second transaction deletes from t1 where a=N-1 then a=2
+
+deadlock being on the index pages (first and last),
+and the test checks that we report the deadlock in the events log of the db
+allowing us to identify the two deadlocking transactions, thus the 
+sql stmts in those transactions, by means of their cnonce. Notice
+that transactions will deadlock in the master node, and the sql 
+will be logged in the replicant nodes, thus one would need to find
+the sql stmts in replicant node by using cnonce retrieved from 
+transaction cnonce on master node.
+
+
+Eventlog for the deadlock loop will appear only if setting is turned on:
+  on print_deadlock_cycles
+
+Eventlog entry will look like this:
+
+{"time": 1499873882991794,"host": "node1","deadlock_cycle": [{"cnonce": "8323329-27057-959039-1013043383","lid": "0x80000012","lcount": 5},{"cnonce": "8323329-27056-958938-1013043383","lid": "0x80000010","lcount": 5,"victim": true}]}

--- a/tests/index_deadlock_loop_print.test/runit
+++ b/tests/index_deadlock_loop_print.test/runit
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+set -x
+################################################################################
+
+function getmaster {
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'
+}
+
+failexit()
+{
+    echo "Failed $1"
+    exit -1
+}
+
+
+
+# debug=1
+
+# args
+dbnm=$1
+
+
+cdb2sql ${CDB2_OPTIONS} $DBNAME default <<"EOF"
+create table t1 {
+schema
+{   
+    int  i
+}
+keys
+{
+    dup "PK"=i
+}
+}
+EOF
+
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into t1 select * from generate_series(1,1002)'
+
+
+cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
+for node in $cluster ; do
+#    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('debg 500')"
+#    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('ndebg 500')"
+#    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb verbdeadlock 1')"
+#    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('on verbose_deadlocks')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr DELAY_LOCK_TABLE_RECORD_C 1000')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('print_deadlock_cycles on')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('track_curtran_locks on')"
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('reql events detailed on')"
+done
+
+f1() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default <<"EOF"
+begin
+delete from t1 where i=1
+delete from t1 where i=1001
+commit
+EOF
+}
+
+f2() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default <<"EOF"
+begin
+delete from t1 where i=1002
+delete from t1 where i=2
+commit
+EOF
+}
+
+#run two transactions that will get in a deadlock
+#will see DEADLOCK-CYCLE: in db log
+f1 &
+f2 &
+
+wait
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "select i as value from t1 order by i" > content1.out
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'select * from generate_series(3,1000)' > content2.out
+
+if ! diff $PWD/{content1.out,content2.out} ; then 
+    failexit "content not what it is supposed to be"
+fi
+
+master=`getmaster`
+logfl=`cdb2sql ${CDB2_OPTIONS} --tabs $dbnm --host $master "exec procedure sys.cmd.send('reql stat')" | grep "Eventlog enabled" | cut -f2 -d ':'`
+if [ "x$logfl" == "x" ]; then
+    cdb2sql ${CDB2_OPTIONS} --tabs $dbnm --host $master "exec procedure sys.cmd.send('reql stat')"
+    failexit "cant find events logfile in reql stat on $master"
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.send('reql events roll')"
+
+sleep 4
+
+if [ $master != `hostname` ]; then
+    scp $master:$logfl $logfl
+fi
+
+logflunziped=${logfl}.unzipped 
+zcat $logfl > $logflunziped
+
+cnt=`grep deadlock_cycle $logflunziped | head -1 | sed 's/}/}\n/' | grep -c cnonce`
+
+if [ $cnt != 2 ]; then
+    failexit 'expected two cnonces reported part of deadlock_cycle in eventslog'
+fi
+
+echo "Testcase passed."


### PR DESCRIPTION
Add a testcase in which two transactions writing to the same index
will cause a deadlock; deadlock loop will be output in event log.