### PR TITLE
put more trace for db create test

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2427,8 +2427,8 @@ struct dbenv *newdbenv(char *dbname, char *lrlname)
     
     /* make sure the database directory exists! */
     struct stat sb;
-    stat(dbenv->basedir, &sb);
-    if (!S_ISDIR(sb.st_mode)) {
+    rc = stat(dbenv->basedir, &sb);
+    if (rc || !S_ISDIR(sb.st_mode)) {
         logmsg(LOGMSG_FATAL, "DB directory '%s' does not exist\n",
                dbenv->basedir);
         return NULL;

--- a/tests/README.md
+++ b/tests/README.md
@@ -123,8 +123,16 @@ Variable | Description
 
 You can export your own `DBDIR`/`DBNAME` when running a single test. 
 
-Export `CLUSTER` to a list of machines you want to use for a clustered test.  The
-test suite will run as the user running the test suite.  It assumes you have
+Export `CLUSTER` to a list of machines you want to use for a clustered test.
+If you want to run multiple tests at the same time and have each one the tests 
+run in a subset of the $CLUSTER nodes, you can export NUMNODESTOUSE and every
+individual test will run in a cluster of $NUMNODESTOUSE as a randomly selected
+subset of $CLUSTER.
+For example, the following command will run all the tests in the tests directory, 
+each test in a randomly selected cluster of three nodes: 
+   make -j 4 -k CLUSTER='node1 node2 node3 node4 node5' NUMNODESTOUSE=3
+
+The test suite will run as the user running the test suite.  It assumes you have
 ssh and all the keys set up to allow password-less authentication between the
 current machine and the machines in the cluster.  comdb2 needs to be installed
 on the cluster machines.  Path to `${DBDIR}` must accessible to the current user.

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -29,7 +29,7 @@ ${COMDB2_EXE} --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "lrl : No such file or directory" out || failexit "expected 'No such file or directory'"
 
 echo "Check 2"
-mkdir $TSTDBDIR
+mkdir -p $TSTDBDIR
 touch $TSTDBDIR/${DB}.lrl
 #should not crash
 ${COMDB2_EXE} --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -46,6 +46,7 @@ grep "\[FATAL\] DB directory" out | grep "does not exist" || failexit "expected 
 
 echo "Check 5"
 echo "name    $DB
+logmsg level debug
 dir     ${TSTDBDIR}_nonexistent " > $TSTDBDIR/${DB}.lrl
 ${COMDB2_EXE} $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "\[FATAL\] DB directory '${TSTDBDIR}_nonexistent' does not exist" out || failexit "expected '[FATAL] DB directory does not exist'"

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -25,42 +25,42 @@ DB=$DBNAME
 TSTDBDIR=$DBDIR
 
 echo "Check 1"
-${COMDB2_EXE} --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "lrl : No such file or directory" out || failexit "expected 'No such file or directory'"
 
 echo "Check 2"
 mkdir -p $TSTDBDIR
 touch $TSTDBDIR/${DB}.lrl
 #should not crash
-${COMDB2_EXE} --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "\[FATAL\] failed to open bdb_env for " out || failexit "expected '[FATAL] failed to open bdb_env for '"
 
 echo "Check 3"
-${COMDB2_EXE} $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "\[FATAL\] DB directory" out | grep "does not exist" || failexit "expected '[FATAL] DB directory does not exist'"
 
 echo "Check 4"
 echo "name    $DB" >> $TSTDBDIR/${DB}.lrl
-${COMDB2_EXE} $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "\[FATAL\] DB directory" out | grep "does not exist" || failexit "expected '[FATAL] DB directory does not exist'"
 
 echo "Check 5"
 echo "name    $DB
 logmsg level debug
 dir     ${TSTDBDIR}_nonexistent " > $TSTDBDIR/${DB}.lrl
-${COMDB2_EXE} $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "\[FATAL\] DB directory '${TSTDBDIR}_nonexistent' does not exist" out || failexit "expected '[FATAL] DB directory does not exist'"
 
 echo "Check 6"
 echo "name    $DB
 dir     ${TSTDBDIR}" > $TSTDBDIR/${DB}.lrl
-${COMDB2_EXE} $DB --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "No such file or directory" out | grep "logs:" || failexit "expected 'No such file or directory'"
 
 echo "Check 7"
 touch $TSTDBDIR/${DB}.lrl
 df $TSTDBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" > $TSTDBDIR/${DB}.lrl 
-${COMDB2_EXE} ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
+${COMDB2_EXE} --no-global-lrl ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "Created database" out || failexit "expected 'Created database'"
 
 echo "name    $DB" >> $TSTDBDIR/${DB}.lrl

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -30,10 +30,10 @@ grep "lrl : No such file or directory" out || failexit "expected 'No such file o
 
 echo "Check 2"
 mkdir -p $TSTDBDIR
-touch $TSTDBDIR/${DB}.lrl
+echo "logmsg level debug" > $TSTDBDIR/${DB}.lrl
 #should not crash
 ${COMDB2_EXE} --no-global-lrl --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
-grep "\[FATAL\] failed to open bdb_env for " out || failexit "expected '[FATAL] failed to open bdb_env for '"
+grep "\[FATAL\] failed to open bdb_env for \| \[FATAL\] DB directory" out || failexit "expected '[FATAL] failed to open bdb_env for ' or '\[FATAL\] DB directory'"
 
 echo "Check 3"
 ${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out

--- a/tests/sc_fieldlarger.test/Makefile
+++ b/tests/sc_fieldlarger.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=2m
+	export TEST_TIMEOUT=4m
 endif


### PR DESCRIPTION
dbcreate.test sometimes fails in check 5, as if the db dir exists (it's not supposed to). Putting more trace to investigate failure. Also cleanup some warnings.