### PR TITLE
tests: Correctly determine if the localhost is in the cluster node list.

### DIFF
--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -219,13 +219,16 @@ assertres $res $dbnm
 cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
 
 # this tests connecting to 'local'
-if `echo $cluster | grep $HOSTNAME > /dev/null` ; then
-    # if localhost is part of cluster, try local as cluster parameter
-    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm local "select comdb2_host()"`
-    assertres $res $HOSTNAME
-    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @localhost "select comdb2_host()"`
-    assertres $res $HOSTNAME
-fi
+for node in $cluster; do
+    if [ "$node" = "$HOSTNAME" ]; then
+        # if localhost is part of cluster, try local as cluster parameter
+        res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm local "select comdb2_host()"`
+        assertres $res $HOSTNAME
+        res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm @localhost "select comdb2_host()"`
+        assertres $res $HOSTNAME
+        break
+    fi
+done
 
 for node in $cluster ; do
     res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "select comdb2_host()"`


### PR DESCRIPTION
Fixes basic test failures if the commit hash contains "c1".