### PR TITLE
Fix segfault when using cursor tracking.

### DIFF
--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -6710,7 +6710,7 @@ static int bdb_btree_merge(bdb_cursor_impl_t *cur, int stripe_rl, int page_rl,
     char _fileid[DB_FILE_ID_LEN] = {0};
     char hex_fid[(DB_FILE_ID_LEN * 2) + 1];
 
-    if (cur->trak) {
+    if (cur->trak && cur->rl) {
         int bdberr = 0;
         cur->rl->fileid(cur->rl, _fileid, &bdberr);
         hex_fid[fidlen - 1] = '\0';


### PR DESCRIPTION
This change fixes a segfault which can occur when tracking diagnostics are enabled for a cursor (seen while running the 'snapblob' test).
