### PR TITLE
Follow-up to cursor tracking segfault fix: Avoid writing uninitialized memory to log

### DIFF
--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -6708,7 +6708,7 @@ static int bdb_btree_merge(bdb_cursor_impl_t *cur, int stripe_rl, int page_rl,
     int rc = -1;
     int fidlen = (DB_FILE_ID_LEN * 2) + 1;
     char _fileid[DB_FILE_ID_LEN] = {0};
-    char hex_fid[(DB_FILE_ID_LEN * 2) + 1];
+    char hex_fid[(DB_FILE_ID_LEN * 2) + 1] = "(none)\0";
 
     if (cur->trak && cur->rl) {
         int bdberr = 0;


### PR DESCRIPTION

This change initializes a static buffer that ends up being emitted into the log file when cursor tracking is enabled.  It is related to the previous cursor tracking segfault fix.