### PR TITLE
improve generated tests operations

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -32,15 +32,10 @@ ifeq ($(subst all,,$(MAKECMDGOALS)),) #if cmdgoals empty or 'all'
 DOALL:=1
 endif
 
-ifeq ($(DOALL),1)
-$(shell $(TESTSROOTDIR)/tools/create_generated_tests.sh)
-endif
-
 # List of all tests that need to run. This is essentially a list of all
 # non-disabled tests.
 export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
     $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
-
 
 TOTAL=$(words $(MAKECMDGOALS) )
 ifeq ($(DOALL),1)
@@ -89,17 +84,15 @@ showparams:
 
 
 
-%_generated: basicops %_generated.test 
-
-%_generated.test:
-	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
-	@cp -r $< $(TESTDIR)/
-	@$(MAKE) -skC $(TESTDIR)/$<
+%_generated: basicops
+	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} rrunning in $(TESTDIR) $@ $$N/${TOTAL}
+	@tools/create_generated_tests.sh `tools/get_testopts_path.sh $@` $(TESTDIR)
+	@$(MAKE) -skC $(TESTDIR)/$@.test
 
 $(patsubst %.test,%,$(ALL_TESTS)): basicops
 
 %: %.test
-	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $< $$N/${TOTAL}
+	@N=`$(TESTSROOTDIR)/tools/get_test_counter.sh` && echo TESTID=${TESTID} running in $(TESTDIR) $* $$N/${TOTAL}
 	@cp -r $< $(TESTDIR)/
 	@$(MAKE) -skC $(TESTDIR)/$<
 

--- a/tests/setup
+++ b/tests/setup
@@ -134,11 +134,11 @@ fi
 
 echo "logmsg level debug" >> ${LRL}
 
-if [[ -f ${TESTSROOTDIR}/${TESTCASE}.test/lrl ]]; then
-    cat ${TESTSROOTDIR}/${TESTCASE}.test/lrl >> ${LRL}
+if [[ -f lrl ]]; then
+    cat lrl >> ${LRL}
 fi
-if [[ -f "${TESTSROOTDIR}/${TESTCASE}.test/lrl.options" ]]; then
-    cat ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options >> ${LRL}
+if [[ -f lrl.options ]]; then
+    cat lrl.options >> ${LRL}
 fi
 
 cat >> ${LRL} <<EOPTIONS

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -71,7 +71,7 @@ CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST   # needed to run setup script
-echo round_robin_stripes > ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options
+echo round_robin_stripes > lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits
@@ -122,7 +122,7 @@ CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
 
 unset COMDB2_UNITTEST
-rm ${TESTSROOTDIR}/${TESTCASE}.test/lrl.options
+rm lrl.options
 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
 # Trap to call_unsetup if the test exits

--- a/tests/tools/create_generated_tests.sh
+++ b/tests/tools/create_generated_tests.sh
@@ -1,14 +1,44 @@
 #!/usr/bin/env bash
+
 # will be called by tests makefile to create all the generated tests:
 # for every .testopts file in a test directory, will generate a new test
 # with those features (in the .testopts file) appended to the lrl.options
-# of the test in question.
+# of the test in question into destination directory passed in $2.
+
+DEST=$PWD
+
+
+# generate a single test by running $0 basic.test/snapshot.testopts
+generate_test()
+{
+    local gtst=$1
+    if [ "x$gtst" == "x" ] ; then
+        return
+    fi
+
+    TST=`dirname $gtst | sed 's/.test$//g'`
+    OPTFL=`basename $gtst | sed 's/.testopts$//g'`
+    NDIR=${TST}_${OPTFL}_generated.test
+    mkdir -p $DEST/$NDIR/
+    cp ${TST}.test/* $DEST/$NDIR/
+    cat $gtst >> $DEST/$NDIR/lrl.options
+}
+
+
+if [ "x$1" != "x" ] ; then
+    one_test=$1
+    shift
+fi
+
+if [ "x$1" != "x" ] ; then
+    DEST=$1
+fi
+
+if [ "x$one_test" != "x" ] ; then
+    generate_test $one_test
+    exit
+fi
 
 for i in `ls *.test/*.testopts | grep -v '_generated.test'`; do 
-    TST=`dirname $i | sed 's/.test$//g'`
-    OPTFL=`basename $i | sed 's/.testopts$//g'`
-    NDIR=${TST}_${OPTFL}_generated.test
-    mkdir -p $NDIR/
-    cp ${TST}.test/* $NDIR/
-    cat $i >> $NDIR/lrl.options
+    generate_test $i
 done

--- a/tests/tools/get_testopts_path.sh
+++ b/tests/tools/get_testopts_path.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# take a string of the form abc_snapshot or abc_snapshot_generated.test and
+# return full path of the testopts from which it was derived ex.
+# abc.test/snapshot.testopts
+
+TST=$1
+
+for i in *.test/*.testopts ; do 
+    echo $i | sed 's#\.testopts#_generated#g; s#/#_#g; s#\.test##g; s#$#.test#' | xargs echo $i ; 
+done | grep $TST | cut -f1 -d' '
+

--- a/tests/tools/get_tests_inorder.sh
+++ b/tests/tools/get_tests_inorder.sh
@@ -3,8 +3,13 @@
 #get list of tests in order from longest to shortest test to run
 DEFAULT_TIMEOUT=5
 
-for i in ` ls -d *.test` ; do 
+tests=`ls -d *.test | grep -v '_generated.test'`
+for i in $tests ; do 
     a=`cat $i/Makefile | grep TEST_TIMEOUT | egrep -v "ifeq" | cut -f2 -d'=' | sed 's/m//'` ; 
     [ -z "$a" ] && a=$DEFAULT_TIMEOUT; 
     echo $a $i; 
+    for j in `ls $i/*.testopts 2> /dev/null` ; do 
+        gen=`echo $j | sed 's#\.testopts#_generated#g; s#/#_#g; s#\.test##g; s#$#.test#'`
+        echo $a $gen;
+    done
 done | sort -nr | cut -d' ' -f2

--- a/tests/tools/get_tests_inorder.sh
+++ b/tests/tools/get_tests_inorder.sh
@@ -3,13 +3,19 @@
 #get list of tests in order from longest to shortest test to run
 DEFAULT_TIMEOUT=5
 
-tests=`ls -d *.test | grep -v '_generated.test'`
-for i in $tests ; do 
-    a=`cat $i/Makefile | grep TEST_TIMEOUT | egrep -v "ifeq" | cut -f2 -d'=' | sed 's/m//'` ; 
-    [ -z "$a" ] && a=$DEFAULT_TIMEOUT; 
-    echo $a $i; 
-    for j in `ls $i/*.testopts 2> /dev/null` ; do 
-        gen=`echo $j | sed 's#\.testopts#_generated#g; s#/#_#g; s#\.test##g; s#$#.test#'`
-        echo $a $gen;
-    done
-done | sort -nr | cut -d' ' -f2
+#get the tests with custom times
+custom_times=`grep "TEST_TIMEOUT=" *.test/Makefile | sed 's#export TEST_TIMEOUT=##; s#/Makefile:# #; s#m$##'`
+
+#get the tests with default times
+default_times=`grep -c "TEST_TIMEOUT=" *.test/Makefile  | grep ":0" | sed "s#/Makefile:0# $DEFAULT_TIMEOUT#"`
+IFS=$'\n'; 
+
+#get the generated tests
+generated=$(for j in `ls */*.testopts` ; do 
+    gen=`echo $j | sed 's#\.testopts#_generated#g; s#/#_#g; s#\.test##g; s#$#.test#'`
+    name=`dirname $j`
+    time=`echo -e "${custom_times[*]} \n${default_times[*]}" | grep $name | awk '{print $2}'`
+    echo $gen $time
+done )
+
+echo -e "${custom_times[*]} \n${default_times[*]} \n${generated[*]}" | awk '{print $2,$1}'| sort -nr | awk '{print $2}'


### PR DESCRIPTION
* improve generated tests to not need to create directory in tests/ (ie we don't need to run `make generated_tests` anymore). 
* Allow for tab completion in bash for instance `make basic_<tab>` will now autocomplete to `make basic_snapshot_generated` and also will run the test without generating the directory in tests/.
* speedup significantly get_tests_inorder.sh so shell autocomplete for make command feels instantaneous