### PR TITLE
osql_comm_is_done: avoid getting type from hdr unnecessarily

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -636,9 +636,6 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     int bdberr;
     int debug = 0;
 
-    int ltype = 0;
-    buf_get(&ltype, sizeof(ltype), rpl, rpl + rplen);
-    assert(ltype == type);
     if (type == OSQL_SCHEMACHANGE)
         iq->tranddl++;
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -618,8 +618,7 @@ const char *osql_reqtype_str(int type)
  *
  */
 int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
-                      unsigned long long rqid, uuid_t uuid,
-                      unsigned long long seq, const char *host)
+                      unsigned long long rqid, uuid_t uuid, int type)
 {
     blocksql_tran_t *tran = (blocksql_tran_t *)osql_sess_getbptran(sess);
     if (!tran || !tran->db) {
@@ -637,17 +636,18 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     int bdberr;
     int debug = 0;
 
-    int type = 0;
-    buf_get(&type, sizeof(type), rpl, rpl + rplen);
+    int ltype = 0;
+    buf_get(&ltype, sizeof(ltype), rpl, rpl + rplen);
+    assert(ltype == type);
     if (type == OSQL_SCHEMACHANGE)
         iq->tranddl++;
 
 #if 0
     printf("Saving done bplog rqid=%llx type=%d (%s) tmp=%llu seq=%d\n",
-           rqid, type, osql_reqtype_str(type), osql_log_time(), seq);
+           rqid, type, osql_reqtype_str(type), osql_log_time(), sess->seq);
 #endif
 
-    key.seq = seq;
+    key.seq = sess->seq;
     assert (sess->rqid == rqid);
 
     /* add the op into the temporary table */
@@ -656,7 +656,7 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
         return rc;
     }
 
-    if (seq == 0 && osql_session_is_sorese(sess) && tran->rows > 0) {
+    if (sess->seq == 0 && osql_session_is_sorese(sess) && tran->rows > 0) {
         /* lets make sure that the temp table is empty since commit retries will
          * use same rqid*/
         sorese_info_t sorese_info = {0};
@@ -667,7 +667,7 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
                 __func__);
 
         sorese_info.rqid = rqid;
-        sorese_info.host = host;
+        sorese_info.host = sess->offhost;
         sorese_info.type = -1; /* I don't need it */
 
         generr.errval = RC_INTERNAL_RETRY;
@@ -696,11 +696,11 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
                                rplen, NULL, &bdberr);
     if (rc_op) {
         logmsg(LOGMSG_ERROR, "%s: fail to put oplog seq=%llu rc=%d bdberr=%d\n",
-               __func__, key.seq, rc_op, bdberr);
+               __func__, sess->seq, rc_op, bdberr);
     } else if (gbl_osqlpfault_threads) {
         osql_page_prefault(rpl, rplen, &(tran->last_db),
                            &(osql_session_get_ireq(sess)->osql_step_ix), rqid,
-                           uuid, seq);
+                           uuid, sess->seq);
     }
 
     tran->rows++;
@@ -713,8 +713,8 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     if (rc_op)
         return rc_op;
 
-    rc = osql_comm_is_done(rpl, rplen, rqid == OSQL_RQID_USE_UUID, &xerr,
-                                    osql_session_get_ireq(sess));
+    rc = osql_comm_is_done(type, rpl, rplen, rqid == OSQL_RQID_USE_UUID, &xerr,
+                           osql_session_get_ireq(sess));
     if (rc == 0)
         return 0;
 
@@ -723,7 +723,7 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     /* if we received a too early, check the coherency and mark blackout the
      * node */
     if (xerr && xerr->errval == OSQL_TOOEARLY) {
-        osql_comm_blkout_node(host);
+        osql_comm_blkout_node(sess->offhost);
     }
 
     if ((rc = osql_bplog_signal(tran))) {

--- a/db/osqlblockproc.h
+++ b/db/osqlblockproc.h
@@ -108,8 +108,7 @@ char *osql_get_tran_summary(struct ireq *iq);
  *
  */
 int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
-                      unsigned long long rqid, uuid_t uuid,
-                      unsigned long long seq, const char *host);
+                      unsigned long long rqid, uuid_t uuid, int type);
 
 /**
  * Wakeup the block processor waiting for a completed session

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3392,8 +3392,8 @@ int osql_comm_is_done(int type, char *rpl, int rpllen, int hasuuid,
         break;
     case OSQL_DONE_SNAP:
         /* iq is passed in from bplog_saveop */
-        if(iq) {
-            const uint8_t *p_buf = 
+        if (iq) {
+            const uint8_t *p_buf =
                 (uint8_t *)rpl + sizeof(osql_done_t) +
                 (hasuuid ? sizeof(osql_uuid_rpl_t) : sizeof(osql_rpl_t));
 
@@ -6166,7 +6166,6 @@ static void net_osql_rpl(void *hndl, void *uptr, char *fromnode, int usertype,
             rqid = p_osql_rpl.sid;
             type = p_osql_rpl.type;
         }
-
     }
 
 #ifdef TEST_OSQL
@@ -6215,11 +6214,11 @@ static int net_osql_rpl_tail(void *hndl, void *uptr, char *fromhost,
         dup = malloc(dtalen + tailen);
 
     if (!dup) {
-        logmsg(LOGMSG_FATAL, 
-                "%s: master running out of memory! unable to alloc %d bytes\n",
-                __func__, dtalen + tailen);
+        logmsg(LOGMSG_FATAL,
+               "%s: master running out of memory! unable to alloc %d bytes\n",
+               __func__, dtalen + tailen);
         abort(); /* rc = NET_SEND_FAIL_MALLOC_FAIL;*/
-    } 
+    }
 
 #ifdef TEST_OSQL
     fprintf(stdout, "%s: calling sorese_rcvrpl type=%d sid=%llu\n", __func__,
@@ -6239,10 +6238,10 @@ static int net_osql_rpl_tail(void *hndl, void *uptr, char *fromhost,
     if (osql_nettype_is_uuid(usertype)) {
         osql_uuid_rpl_t p_osql_rpl;
 
-        if (!(p_buf = (uint8_t *)osqlcomm_uuid_rpl_type_get(
-                        &p_osql_rpl, p_buf, p_buf_end))) {
+        if (!(p_buf = (uint8_t *)osqlcomm_uuid_rpl_type_get(&p_osql_rpl, p_buf,
+                                                            p_buf_end))) {
             logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
-                    "osqlcomm_rpl_type_get");
+                   "osqlcomm_rpl_type_get");
             rc = -1;
         } else {
             comdb2uuidcpy(uuid, p_osql_rpl.uuid);
@@ -6254,9 +6253,9 @@ static int net_osql_rpl_tail(void *hndl, void *uptr, char *fromhost,
         osql_rpl_t p_osql_rpl;
 
         if (!(p_buf = (uint8_t *)osqlcomm_rpl_type_get(&p_osql_rpl, p_buf,
-                        p_buf_end))) {
+                                                       p_buf_end))) {
             logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
-                    "osqlcomm_rpl_type_get");
+                   "osqlcomm_rpl_type_get");
             rc = -1;
         } else {
             rqid = p_osql_rpl.sid;
@@ -7725,7 +7724,8 @@ static void net_sorese_signal(void *hndl, void *uptr, char *fromhost,
     }
     osqlcomm_done_type_get(&done, p_buf, p_buf_end);
 
-    if (osql_comm_is_done(type, dtap, dtalen, rqid == OSQL_RQID_USE_UUID, &xerr, NULL) == 1) {
+    if (osql_comm_is_done(type, dtap, dtalen, rqid == OSQL_RQID_USE_UUID, &xerr,
+                          NULL) == 1) {
 
 #if 0
       printf("Done rqid=%llu tmp=%llu\n", hdr->sid, osql_log_time());

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3393,12 +3393,11 @@ int osql_comm_is_done(int type, char *rpl, int rpllen, int hasuuid,
     case OSQL_DONE_SNAP:
         /* iq is passed in from bplog_saveop */
         if(iq) {
-            osql_done_t dt = {0};
-            const uint8_t *p_buf = (uint8_t *)rpl + (hasuuid ? sizeof(osql_uuid_rpl_t) : sizeof(osql_rpl_t));
-            const uint8_t *p_buf_end = (const uint8_t *)rpl + rpllen;
-            if((p_buf = osqlcomm_done_type_get(&dt, p_buf, p_buf_end)) == NULL)
-                abort();
+            const uint8_t *p_buf = 
+                (uint8_t *)rpl + sizeof(osql_done_t) +
+                (hasuuid ? sizeof(osql_uuid_rpl_t) : sizeof(osql_rpl_t));
 
+            const uint8_t *p_buf_end = (const uint8_t *)rpl + rpllen;
             if ((p_buf = snap_uid_get(&iq->snap_info, p_buf, p_buf_end)) == NULL)
                 abort();
 

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -78,8 +78,8 @@ int offload_comm_send_blockreply(char *host, unsigned long long rqid, void *buf,
  * or -1 otherwise
  *
  */
-int osql_comm_is_done(char *rpl, int rpllen, int hasuuid, struct errstat **xerr,
-                      struct ireq *);
+int osql_comm_is_done(int type, char *rpl, int rpllen, int hasuuid,
+                      struct errstat **xerr, struct ireq *);
 
 /**
  * Send a "POKE" message to "tonode" inquering about session "rqid"

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -529,7 +529,8 @@ int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, int type, void *data,
     /* NOTE: before retrieving a session, we have to figure out if this is a
        sorese completion and lock the repository until the session is dispatched
        This prevents the race against signal_rtoff forcefully cleanup */
-    is_msg_done = osql_comm_is_done(type, data, datalen, rqid == OSQL_RQID_USE_UUID, &perr, NULL);
+    is_msg_done = osql_comm_is_done(type, data, datalen,
+                                    rqid == OSQL_RQID_USE_UUID, &perr, NULL);
 
     /* get the session */
     sess = osql_repository_get(rqid, uuid, is_msg_done);

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -516,7 +516,7 @@ int osql_sess_unlock_complete(osql_sess_t *sess)
  * Set found if the session is found or not
  *
  */
-int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, void *data,
+int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, int type, void *data,
                     int datalen, int *found)
 {
     osql_sess_t *sess = NULL;
@@ -529,8 +529,7 @@ int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, void *data,
     /* NOTE: before retrieving a session, we have to figure out if this is a
        sorese completion and lock the repository until the session is dispatched
        This prevents the race against signal_rtoff forcefully cleanup */
-    is_msg_done =
-        osql_comm_is_done(data, datalen, rqid == OSQL_RQID_USE_UUID, &perr, NULL);
+    is_msg_done = osql_comm_is_done(type, data, datalen, rqid == OSQL_RQID_USE_UUID, &perr, NULL);
 
     /* get the session */
     sess = osql_repository_get(rqid, uuid, is_msg_done);
@@ -580,8 +579,7 @@ int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, void *data,
         pthread_mutex_unlock(&sess->completed_lock);
 
         /* save op */
-        rc_out = osql_bplog_saveop(sess, data, datalen, rqid, uuid, sess->seq,
-                                   sess->offhost);
+        rc_out = osql_bplog_saveop(sess, data, datalen, rqid, uuid, type);
 
         /* if rc_out, sess is FREED! */
         if (!rc_out) {

--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -229,7 +229,7 @@ int osql_sess_unlock_complete(osql_sess_t *sess);
  * Set found if the session is found or not
  *
  */
-int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, void *data,
+int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, int type, void *data,
                     int datalen, int *found);
 
 /**


### PR DESCRIPTION
We needlessly extract type and more from buffer when osql_comm_is_done() is called. This patch reduces the amount of work by passing type into the function and only getting snapinfo DONE_SNAP message.