### PR TITLE
sockpool for fdb patch from r6

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -607,6 +607,9 @@ DEF_ATTR(TIMEPART_CHECK_SHARD_EXISTENCE, timepart_check_shard_existence,
 DEF_ATTR(
     IGNORE_BAD_TABLE, ignore_bad_table, BOOLEAN, 0,
     "Allow a database with a corrupt table to come up, without that table.")
+
+DEF_ATTR(TIMEOUT_FDB_TRANS_SYNC, timeout_fdb_trans_sync, MSECS, 4000, "Timeout for retrieving a foreign table transaction")
+
 DEF_ATTR(TIMEPART_NO_ROLLOUT, timepart_no_rollout, BOOLEAN, 0,
          "Prevent new rollouts for time partitions.")
 /* Keep enabled for the merge */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3374,7 +3374,7 @@ extern int gbl_max_sql_hint_cache;
 
 /* Remote cursor support */
 /* use portmux to open an SBUF2 to local db or proxied db */
-SBUF2 *connect_remote_db(const char *dbname, const char *service, char *host);
+SBUF2* connect_remote_db(const char *protocol, const char *dbname, const char *service, char *host, int use_cache);
 int get_rootpage_numbers(int nums);
 
 void sql_dump_hints(void);
@@ -3491,7 +3491,7 @@ int find_constraint(struct dbtable *db, constraint_t *ct);
 /**
  * Disconnect a socket and tries to save it in sockpool
  */
-void disconnect_remote_db(const char *dbname, const char *service, char *host,
+void disconnect_remote_db(const char *protocol, const char *dbname, const char *service, char *host,
                           SBUF2 **psb);
 
 void sbuf2gettimeout(SBUF2 *sb, int *read, int *write);

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -979,7 +979,7 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
             rc = osql_chkboard_get_clnt(*(unsigned long long *)tid, &clnt);
         if (rc && rc == -1) {
             if (deadline && comdb2_time_epochms() > deadline) {
-                fprintf(stderr, "%s: timeout waiting for transaction %d waited %u\n",
+                logmsg(LOGMSG_ERROR, "%s: timeout waiting for transaction %d waited %u\n",
                         __func__, deadline, wait);
 
                 break;

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -963,6 +963,14 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
     struct sqlclntstate *clnt;
     int rc = 0;
 
+    int                  deadline =  0;
+    int                  wait = bdb_attr_get(thedb->bdb_attr, 
+            BDB_ATTR_TIMEOUT_FDB_TRANS_SYNC);
+
+    if (wait > 0)
+        deadline = wait + comdb2_time_epochms();
+
+
     /* this returns a dtran_mtx locked structure */
     do {
         if (isuuid)
@@ -970,6 +978,13 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
         else
             rc = osql_chkboard_get_clnt(*(unsigned long long *)tid, &clnt);
         if (rc && rc == -1) {
+            if (deadline && comdb2_time_epochms() > deadline) {
+                fprintf(stderr, "%s: timeout waiting for transaction %d waited %u\n",
+                        __func__, deadline, wait);
+
+                break;
+            }
+
             /* this is a missing transaction, we need to wait for it !*/
             poll(NULL, 0, 10);
             continue;

--- a/db/sql.h
+++ b/db/sql.h
@@ -246,6 +246,7 @@ typedef struct sqlclntstate_fdb {
     char **fdb_ids;       /* the fdb for which we have affinity */
     char **fdb_nodes;     /* node numbers preferred for each fdb in fdb_ids */
     int *fdb_last_status; /* used to mark a node bad after a failure */
+    int failed_heartbeats; /* used to signal failed communication with remotes */
 } sqlclntstate_fdb_t;
 
 CurRange *currange_new();

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -10286,17 +10286,17 @@ void comdb2SetWriteFlag(int wrflag)
         clnt->writeTransaction = wrflag;
 }
 
-void _sockpool_socket_type(const char *dbname, const char *service, char *host,
+void _sockpool_socket_type(const char *protocol, const char *dbname, const char *service, char *host,
                            char *socket_type, int socket_type_len)
 {
     /* NOTE: in fdb, we want to require a specific node.
        We make the name include that node to be able to request
        sockets going to a specific node. */
-    snprintf(socket_type, socket_type_len, "comdb2/%s/%s/%s", dbname, service,
+    snprintf(socket_type, socket_type_len, "%s/%s/%s/%s", protocol, dbname, service,
              host);
 }
 
-static int _sockpool_get(const char *dbname, const char *service, char *host)
+static int _sockpool_get(const char *protocol, const char *dbname, const char *service, char *host)
 {
     char socket_type[512];
     int fd;
@@ -10305,7 +10305,7 @@ static int _sockpool_get(const char *dbname, const char *service, char *host)
             bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DISABLE_SERVER_SOCKPOOL)))
         return -1;
 
-    _sockpool_socket_type(dbname, service, host, socket_type,
+    _sockpool_socket_type(protocol, dbname, service, host, socket_type,
                           sizeof(socket_type));
 
     /* TODO: don't rely on hints yet */
@@ -10320,7 +10320,7 @@ static int _sockpool_get(const char *dbname, const char *service, char *host)
     return fd;
 }
 
-void disconnect_remote_db(const char *dbname, const char *service, char *host,
+void disconnect_remote_db(const char *protocol, const char *dbname, const char *service, char *host,
                           SBUF2 **psb)
 {
     char socket_type[512];
@@ -10337,7 +10337,7 @@ void disconnect_remote_db(const char *dbname, const char *service, char *host,
 
     fd = sbuf2fileno(sb);
 
-    _sockpool_socket_type(dbname, service, host, socket_type,
+    _sockpool_socket_type(protocol, dbname, service, host, socket_type,
                           sizeof(socket_type));
 
     if (gbl_fdb_track)
@@ -10346,7 +10346,7 @@ void disconnect_remote_db(const char *dbname, const char *service, char *host,
 
     /* this is used by fdb sql for now */
     socket_pool_donate_ext(socket_type, fd, IOTIMEOUTMS / 1000, 0,
-                           SOCKET_POOL_GET_GLOBAL, NULL, NULL);
+                           0, NULL, NULL);
 
     sbuf2free(sb);
     *psb = NULL;
@@ -10355,19 +10355,21 @@ void disconnect_remote_db(const char *dbname, const char *service, char *host,
 /* use portmux to open an SBUF2 to local db or proxied db
    it is trying to use sockpool
  */
-SBUF2 *connect_remote_db(const char *dbname, const char *service, char *host)
+SBUF2 *connect_remote_db(const char *protocol, const char *dbname, const char *service, char *host, int use_cache)
 {
     SBUF2 *sb;
     int port;
     int retry;
     int sockfd;
 
-    /* lets try to use sockpool, if available */
-    sockfd = _sockpool_get(dbname, service, host);
-    if (sockfd > 0) {
-        /*fprintf(stderr, "%s: retrieved sockpool socket for %s.%s.%s fd=%d\n",
-            __func__, dbname, service, host);*/
-        goto sbuf;
+    if (use_cache) {
+        /* lets try to use sockpool, if available */
+        sockfd = _sockpool_get(protocol, dbname, service, host);
+        if (sockfd > 0) {
+            /*fprintf(stderr, "%s: retrieved sockpool socket for %s.%s.%s fd=%d\n",
+              __func__, dbname, service, host);*/
+            goto sbuf;
+        }
     } else
         /*fprintf(stderr, "%s: no sockpool socket for %s.%s.%s\n",
             __func__, dbname, service, host);*/

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3893,7 +3893,9 @@ int dispatch_sql_query(struct sqlclntstate *clnt)
                 if (diff.tv_sec >= clnt->heartbeat) {
                     last = st;
                     send_heartbeat(clnt);
-                    fdb_heartbeats(clnt);
+                    rc = fdb_heartbeats(clnt);
+                    if (rc)
+                        return -1;
                 }
                 if (clnt->query_timeout > 0 && !clnt->statement_timedout) {
                     TIMESPEC_SUB(st, first, diff);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=884)
+(TUNABLES_COUNT=885)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -810,6 +810,7 @@
 (name='test_scindex_deadlock', description='Test index on expressions schema change deadlock', type='BOOLEAN', value='OFF', read_only='Y')
 (name='thread_stats', description='Berkeley DB will keep stats on what its threads are doing', type='BOOLEAN', value='ON', read_only='N')
 (name='throttlesqloverlog', description='On a full queue of SQL requests, dump the current thread pool this often (in secs). (Default: 5sec)', type='INTEGER', value='5', read_only='Y')
+(name='timeout_fdb_trans_sync', description='Timeout for retrieving a foreign table transaction', type='INTEGER', value='4000', read_only='N')
 (name='timeout_server_sockpool', description='Timeout for getting a connection to another database from sockpool.', type='INTEGER', value='10', read_only='N')
 (name='timepart_abort_on_preperror', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='timepart_check_shard_existence', description='Check at startup/time-partition creation that all shard files exist.', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Fix to allow foreign db requests to use sockpool (ported forward from r6)