### PR TITLE
testsuite: Run tests with multiple subnetworks.

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -4886,10 +4886,11 @@ static int get_dedicated_conhost(host_node_type *host_node_ptr, struct in_addr *
                 continue;
         }
 
-        char rephostname[HOSTNAME_LEN * 2 + 1];
-        strncpy(rephostname, host_node_ptr->host, HOSTNAME_LEN);
+        char *rephostname =
+            alloca(strlen(host_node_ptr->host) + strlen(subnet) + 1);
+        strcpy(rephostname, host_node_ptr->host);
         if (subnet[0]) {
-            strncat(rephostname, subnet, HOSTNAME_LEN);
+            strcat(rephostname, subnet);
             strncpy(host_node_ptr->subnet, subnet, HOSTNAME_LEN);
 
 #ifdef DEBUG
@@ -4907,8 +4908,7 @@ static int get_dedicated_conhost(host_node_type *host_node_ptr, struct in_addr *
                 "Connecting to NON dedicated hostname/subnet '%s' counter=%d\n",
                 rephostname, counter);
 #endif
-        char *name = rephostname;
-        rc = comdb2_gethostbyname(&name, addr);
+        rc = comdb2_gethostbyname(&rephostname, addr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%d) %s(): ERROR gethostbyname '%s' FAILED\n",
                     ii, __func__, rephostname);

--- a/tests/docker/client
+++ b/tests/docker/client
@@ -8,6 +8,7 @@ chmod 700 ~/.ssh/id_rsa
 cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
 export CLUSTER="$(cat common/cluster)"
 echo "CLUSTER is $CLUSTER"
+export DEDICATED_NETWORK_SUFFIXES='-n3 -n4'
 
 # wait for all the nodes to signal that they're ready
 numnodes=0

--- a/tests/docker/runit
+++ b/tests/docker/runit
@@ -39,7 +39,7 @@ export COMPOSE_PROJECT_NAME=$prefix
 rm -fr common
 mkdir common
 for node in $(seq 1 $numnodes); do
-    cluster="$cluster ${nodeprefix}${node}.${prefix}_default"
+    cluster="$cluster ${nodeprefix}${node}.${prefix}_primary"
     containers="$containers ${nodeprefix}$node"
 done
 
@@ -68,12 +68,19 @@ compose=docker-compose.yml
 cat > $compose <<EOF
 version: '2'
 
+networks:
+    primary:
+    n3:
+    n4:
+
 services:
     client:
         container_name: c1
-        hostname: c1.${prefix}_default
+        hostname: c1.${prefix}_primary
         labels:
             what: "testclient"
+        networks:
+            - primary
         build:
             context: .
             dockerfile: $src/tests/docker/Dockerfile.db
@@ -99,9 +106,17 @@ for node in $containers; do
 cat >> $compose <<EOF
     $node:
         container_name: $node
-        hostname: $node.${prefix}_default
+        hostname: $node.${prefix}_primary
         labels:
             what: "testserver"
+        networks:
+            primary:
+            n3:
+                aliases:
+                    - $node.${prefix}_primary-n3
+            n4:
+                aliases:
+                    - $node.${prefix}_primary-n4
         build:
             context: .
             dockerfile: $src/tests/docker/Dockerfile.db


### PR DESCRIPTION
The pull request changes the testsuite to run tests with two subnetworks: n3 and n4. The two subnetworks are set up using Docker Composer.

The pull request also fixes a mishandling of long hostnames in the subnet code.