### PR TITLE
ported R6 PR912, no stats cleanup for view

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3509,7 +3509,7 @@ check_version:
                 rc = views_sqlite_update(thedb->timepart_views, thd->sqldb,
                                          &xerr, 0);
                 if (rc != VIEW_NOERR) {
-                    logmsg(LOGMSG_ERROR, 
+                    logmsg(LOGMSG_FATAL, 
                             "failed to create views rc=%d errstr=\"%s\"\n",
                             xerr.errval, xerr.errstr);
                     /* there is no really way forward */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3512,6 +3512,8 @@ check_version:
                     logmsg(LOGMSG_ERROR, 
                             "failed to create views rc=%d errstr=\"%s\"\n",
                             xerr.errval, xerr.errstr);
+                    /* there is no really way forward */
+                    abort();
                 }
                 if (cnonce)
                     set_cnonce(clnt);

--- a/sqlite/build.c
+++ b/sqlite/build.c
@@ -2947,8 +2947,10 @@ void sqlite3DropTable(Parse *pParse, SrcList *pName, int isView, int noErr){
      ** on disk.
      */
     sqlite3BeginWriteOperation(pParse, 1, iDb);
-    sqlite3ClearStatTables(pParse, iDb, "tbl", pTab->zName);
-    sqlite3FkDropTable(pParse, pName, pTab);
+    if (!isView){
+        sqlite3ClearStatTables(pParse, iDb, "tbl", pTab->zName);
+        sqlite3FkDropTable(pParse, pName, pTab);
+    }
     sqlite3CodeDropTable(pParse, pTab, iDb, isView);
 
   }else{


### PR DESCRIPTION
- if views cannot be recreated, don't run.
- don't generate delete row operations from sqlite_stats when dropping a view, there are none there, and we end up generating a redundant transaction (sqlite patch 2f5be3a2)
