### PR TITLE
ported R6 PR918, slow bad node clear

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -4705,7 +4705,7 @@ int net_check_bad_subnet_lk(int ii)
         goto out;
     }
 
-    if (last_bad_subnet_time * 1000 + subnet_blackout_timems <
+    if (last_bad_subnet_time + subnet_blackout_timems <
         comdb2_time_epochms()) {
         if (gbl_verbose_net)
             logmsg(LOGMSG_USER, "%" PRIu64 " %s Clearing out net %d %s\n",

--- a/net/net.c
+++ b/net/net.c
@@ -4705,8 +4705,7 @@ int net_check_bad_subnet_lk(int ii)
         goto out;
     }
 
-    if (last_bad_subnet_time + subnet_blackout_timems <
-        comdb2_time_epochms()) {
+    if (last_bad_subnet_time + subnet_blackout_timems < comdb2_time_epochms()) {
         if (gbl_verbose_net)
             logmsg(LOGMSG_USER, "%" PRIu64 " %s Clearing out net %d %s\n",
                    pthread_self(), __func__, ii, subnet_suffices[ii]);


### PR DESCRIPTION
trivial bug, it affects multiple net configurations, when a net is disabled, the reset code will take forever.
