### PR TITLE
R6port fix caching sockets

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -164,7 +164,11 @@ typedef struct fcon_tag {
     int blah;
 } fcon_tag_t;
 
-enum fdb_cur_stream_state { FDB_CUR_IDLE = 0, FDB_CUR_STREAMING = 1 };
+enum fdb_cur_stream_state {
+    FDB_CUR_IDLE = 0,
+    FDB_CUR_STREAMING = 1,
+    FDB_CUR_ERROR = 2
+};
 
 struct fdb_cursor {
     char *cid;             /* identity of cursor id */
@@ -3074,14 +3078,19 @@ static int fdb_cursor_move_sql(BtCursor *pCur, int how)
                     pCur->bt->fdb->ssl = ssl_cfg;
 #endif
                 } else {
-                    if (rc != FDB_ERR_SSL)
+                    if (rc != FDB_ERR_SSL) {
                         logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming "
                                              "row rc=%d \"%s\"\n",
                                __func__, rc, errstr);
+                        fdbc->streaming = FDB_CUR_ERROR;
+                    }
                 }
 
                 return rc;
+            } else {
+                fdbc->streaming = (rc == IX_FNDMORE)?FDB_CUR_STREAMING:FDB_CUR_IDLE;
             }
+            
         }
 
         end_rpc = osql_log_time();
@@ -3260,13 +3269,17 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
 
                     rc = SQLITE_SCHEMA_REMOTE;
                 } else {
-                    if (rc != FDB_ERR_SSL)
+                    if (rc != FDB_ERR_SSL) {
                         logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming "
                                              "row rc=%d \"%s\"\n",
                                __func__, rc, errstr);
+                        fdbc->streaming = FDB_CUR_ERROR;
+                    }
                 }
 
                 return rc;
+            } else {
+                fdbc->streaming = (rc == IX_FNDMORE)?FDB_CUR_STREAMING:FDB_CUR_IDLE;
             }
 
             /* if we don't get a row here, it means the concocted sql did not

--- a/sqlite/expr.c
+++ b/sqlite/expr.c
@@ -1411,7 +1411,7 @@ Select *sqlite3SelectDup(sqlite3 *db, Select *p, int flags){
   pNew = sqlite3DbMallocRawNN(db, sizeof(*p) );
   if( pNew==0 ) return 0;
   /* COMDB2 MODIFICATION */
-  pNew->recording = 0;
+  pNew->recording = p->recording;
   pNew->pEList = sqlite3ExprListDup(db, p->pEList, flags);
   pNew->pSrc = sqlite3SrcListDup(db, p->pSrc, flags);
   pNew->pWhere = sqlite3ExprDup(db, p->pWhere, flags);


### PR DESCRIPTION
This affects certain sqlite plans that ask have incomplete hints about the length of the stream; sockets that still have rows piped are not cacheable.