### PR TITLE
send verify: use get_dbtable_by_name to verify table exists

### DIFF
--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -227,7 +227,7 @@ static int db_comdb_verify(Lua L) {
     }
     else {
         char buf[128] = {0};
-        snprintf(buf, sizeof(buf), "Table %s does not exist.", tblname);
+        snprintf(buf, sizeof(buf), "Table \"%s\" does not exist.", tblname);
         db_verify_table_callback(L, buf);
         rc = 1;
     }

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -33,7 +33,6 @@
  */
 static int db_cluster(Lua L)
 {
-    char *hosts[REPMAX];
     int nnodes;
     struct host_node_info nodes[REPMAX];
 
@@ -83,14 +82,12 @@ static int db_cluster(Lua L)
  *
  */
 static int db_comdbg_tables(Lua L) {
-    struct dbtable *db;
     int rownum = 1;
 
     /* TODO: locking protocol for this is... */
     lua_createtable(L, 0, 0);
     for (int dbn = 0; dbn < thedb->num_dbs; dbn++) {
-        struct dbtable *db;
-        db = thedb->dbs[dbn];
+        struct dbtable *db = thedb->dbs[dbn];
         if (db->dbnum) {
             for (int ix = 0; ix < db->nix; ix++) {
                 lua_createtable(L, 8, 0); 
@@ -207,9 +204,9 @@ static int db_comdb_analyze(Lua L) {
 static int db_comdb_verify(Lua L) {
     SP sp = getsp(L);
     sp->max_num_instructions = 1000000; //allow large number of steps
-    char *tbl = NULL;
+    char *tblname = NULL;
     if (lua_isstring(L, 1)) {
-        tbl = (char *) lua_tostring(L, -1);
+        tblname = (char *) lua_tostring(L, -1);
     }
 
     char *cols[] = {"out"};
@@ -218,26 +215,20 @@ static int db_comdb_verify(Lua L) {
 
     int rc = 0;
 
-    if (!tbl || strlen(tbl) < 1) {
+    if (!tblname || strlen(tblname) < 1) {
         db_verify_table_callback(L, "Usage: verify(\"<table>\")");
         return luaL_error(L, "Verify failed.");
     }
 
-    struct dbtable *t;
-    int found = 0;
-    for (int dbn = 0; dbn < thedb->num_dbs; dbn++) {
-        struct dbtable *t = thedb->dbs[dbn];
-        if (strcmp(tbl, t->tablename) == 0) {
-            found = 1;
-            break;
-        }
-    }
-    if (found) {
-        logmsg(LOGMSG_USER, "db_comdb_verify: verify table '%s'\n", tbl);
-        rc = verify_table(tbl, NULL, 1, 0, db_verify_table_callback, L); //freq 1, fix 0
+    struct dbtable *db = get_dbtable_by_name(tblname);
+    if (db) {
+        logmsg(LOGMSG_USER, "db_comdb_verify: verify table '%s'\n", tblname);
+        rc = verify_table(tblname, NULL, 1, 0, db_verify_table_callback, L); //freq 1, fix 0
     }
     else {
-        db_verify_table_callback(L, "Table does not exist.");
+        char buf[128] = {0};
+        snprintf(buf, sizeof(buf), "Table %s does not exist.", tblname);
+        db_verify_table_callback(L, buf);
         rc = 1;
     }
     if (rc) {

--- a/tests/sc_inserts.test/runit
+++ b/tests/sc_inserts.test/runit
@@ -135,7 +135,7 @@ if ! diff verify.exp verify.out ; then
     failexit "Verify did not fail correctly, see verify.out"
 fi
 
-echo "Table nonexistent does not exist.
+echo "Table \"nonexistent\" does not exist.
 [exec procedure sys.cmd.verify('nonexistent')] failed with rc -3 [sys.comdb_verify(tbl)...]:2: Verify failed." > verify.exp
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('nonexistent')" &> verify.out
 if ! diff verify.exp verify.out ; then

--- a/tests/sc_inserts.test/runit
+++ b/tests/sc_inserts.test/runit
@@ -127,6 +127,27 @@ cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table $tbl"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "create table $tbl  { `cat $tbl.csc2 ` }"
 
 
+#putting this here for now -- make sure verify behaves as we expect
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('')" &> verify.out
+echo "Usage: verify(\"<table>\")
+[exec procedure sys.cmd.verify('')] failed with rc -3 [sys.comdb_verify(tbl)...]:2: Verify failed." > verify.exp
+if ! diff verify.exp verify.out ; then
+    failexit "Verify did not fail correctly, see verify.out"
+fi
+
+echo "Table nonexistent does not exist.
+[exec procedure sys.cmd.verify('nonexistent')] failed with rc -3 [sys.comdb_verify(tbl)...]:2: Verify failed." > verify.exp
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('nonexistent')" &> verify.out
+if ! diff verify.exp verify.out ; then
+    failexit "Verify did not fail correctly, see verify.out"
+fi
+
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify.out
+if ! grep succeeded verify.out > /dev/null ; then
+    failexit "Verify did not succeed, see verify.out"
+fi
+
+
 master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
 
 max_iter=40

--- a/tests/sp.test/t01.req.out
+++ b/tests/sp.test/t01.req.out
@@ -366,7 +366,7 @@ SP: exec procedure bound(@i, @u, @ll, @ull, @s, @us, @f, @d, @dt, @cstr, @ba, @b
 (3=3)
 [exec procedure sys.cmd.verify(\"nonexistent\")] failed with rc -3 bad argument -> \"nonexistent\")
 (4=4)
-(out='Table does not exist.')
+(out='Table "nonexistent" does not exist.')
 [exec procedure sys.cmd.verify("nonexistent")] failed with rc -3 [sys.comdb_verify(tbl)...]:2: Verify failed.
 (5=5)
 (version='sptest')


### PR DESCRIPTION
* use get_dbtable_by_name to verify table exists instead of for loop without getting lock
* add test to check correctness of error handling for nonexistent table and empty table name 