### PR TITLE
fix sp snapshot test

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -747,7 +747,7 @@ static int sql_tranlevel_default_update(void *context, void *value)
         gbl_sql_tranlevel_default = SQL_TDEF_SOCK;
     } else if (tokcmp(tok, ltok, "recom") == 0) {
         gbl_sql_tranlevel_default = SQL_TDEF_RECOM;
-    } else if (tokcmp(tok, ltok, "snapisol") == 0) {
+    } else if (tokcmp(tok, ltok, "snapshot") == 0) {
         gbl_sql_tranlevel_default = SQL_TDEF_SNAPISOL;
     } else if (tokcmp(tok, ltok, "serial") == 0) {
         gbl_sql_tranlevel_default = SQL_TDEF_SERIAL;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -4081,6 +4081,10 @@ static int db_consumer(Lua L)
     dbconsumer_getargs(L, &push_tid, &register_timeoutms);
 
     SP sp = getsp(L);
+    struct sqlclntstate *clnt = sp->clnt;
+    if (clnt->dbtran.mode != TRANLEVEL_SOSQL)
+        return luaL_error(L, "trigger/consumer is only supported under default transaction mode");
+
     if (sp->parent->have_consumer) {
         return 0;
     }

--- a/tests/sp.test/runit
+++ b/tests/sp.test/runit
@@ -3,66 +3,13 @@ bash -n "$0" | exit 1
 
 dbname=$1
 
-echo "Starting socksql tests"
+echo "Starting tests"
 echo "Using SP_OPTIONS: $SP_OPTIONS"
 ./test.sh $dbname
 rc=$?
 if (( $rc != 0 )) ; then
-   echo "SOCKSQL FAILURE"
+   echo "FAILURE"
    exit 1
 fi
 
-echo "SOCKSQL SUCCESS"
-
-cdb2config=$CDB2_CONFIG
-cdb2options=$CDB2_OPTIONS
-snapdb=snapshot$dbname
-dbdir=$DBDIR
-
-DBNAME=$snapdb
-DBDIR=$TESTDIR/$DBNAME
-CDB2_CONFIG=$DBDIR/comdb2db.cfg
-CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
-
-echo "sql_tranlevel_default snapisol" > "$TESTDIR/customlrl"
-export CUSTOMLRLPATH=$TESTDIR/customlrl
-
-#setup another db with default transaction snapisol
-echo "Setting up snapshot db"
-timeout 2m ${TESTSROOTDIR}/setup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.setup | cut -c11- | grep "^!" )
-rc=$?
-if [[ $rc -ne 0 ]]; then
-    echo "snapshot db setup failed (rc=$rc)"
-    $TESTSROOTDIR/unsetup &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
-    DBNAME=$dbname
-    DBDIR=$dbdir
-    CDB2_CONFIG=$cdb2config
-    CDB2_OPTIONS=$cdb2options
-    CUSTOMLRLPATH=''
-    exit 1
-fi
-
-echo "Starting snapshot tests"
-SP_OPTIONS="-s --cdb2cfg $CDB2_CONFIG $DBNAME default"
-echo "Using SP_OPTIONS: $SP_OPTIONS"
-./test.sh $snapdb
-rc=$?
-
-echo "Cleaning up snapshot db"
-successful=1
-if (( $rc != 0 )) ; then
-    successful=0
-fi
-${TESTSROOTDIR}/unsetup $successful &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
-
-DBNAME=$dbname
-DBDIR=$dbdir
-CDB2_CONFIG=$cdb2config
-CDB2_OPTIONS=$cdb2options
-
-if (( $rc != 0 )) ; then
-   echo "SNAPSHOT FAILURE"
-   exit 1
-fi
-
-echo "SNAPSHOT SUCCESS"
+echo "SUCCESS"

--- a/tests/sp.test/snapshot.testopts
+++ b/tests/sp.test/snapshot.testopts
@@ -1,0 +1,2 @@
+enable_snapshot_isolation
+sql_tranlevel_default snapshot

--- a/tests/sp.test/sp.sh
+++ b/tests/sp.test/sp.sh
@@ -735,8 +735,18 @@ for ((i=0;i<500;++i)); do
 done | cdb2sql $SP_OPTIONS - > /dev/null
 
 #START CONSUMERS
-cdb2sql $SP_OPTIONS "exec procedure cons0(true)" > /dev/null 2>&1 &
-cdb2sql $SP_OPTIONS "exec procedure cons1(false)" > /dev/null 2>&1 &
+cdb2sql $SP_OPTIONS - <<'EOF'
+set transaction snapisol
+exec procedure cons0(true)
+EOF
+cdb2sql $SP_OPTIONS - <<'EOF' > /dev/null 2>&1 &
+set transaction blocksql
+exec procedure cons0(true)
+EOF
+cdb2sql $SP_OPTIONS - <<'EOF' > /dev/null 2>&1 &
+set transaction blocksql
+exec procedure cons1(false)
+EOF
 #GENERATE DATA
 cdb2sql $SP_OPTIONS "exec procedure gen('foraudit', 500)"
 #DELETE DATA

--- a/tests/sp.test/t01.req.out
+++ b/tests/sp.test/t01.req.out
@@ -273,6 +273,7 @@ SP: exec procedure bound(@i, @u, @ll, @ull, @s, @us, @f, @d, @dt, @cstr, @ba, @b
 (version='sptest')
 (version='sptest')
 (version='sptest')
+[exec procedure cons0(true)] failed with rc -3 [local consumer = db:consumer()...]:2: trigger/consumer is only supported under default transaction mode
 (rows deleted=500)
 (name='audit', type='trigger', tbl_name='foraudit', event='add', col='i')
 (name='audit', type='trigger', tbl_name='foraudit', event='del', col='i')

--- a/tests/sp.test/t03.req
+++ b/tests/sp.test/t03.req
@@ -1,3 +1,4 @@
+set transaction blocksql
 create lua consumer cons_with_tid on (table foraudit for insert and update and delete)
 insert into foraudit values(1)
 select * from foraudit


### PR DESCRIPTION
- fixed trigger/consumer crash under read committed and higher (only allow trigger/consumer in default transaction mode)
- used @adizaimi generated test framework for snapshot sp test.