### PR TITLE
dont throw on trans_commit failure of an aborted sc transaction

### DIFF
--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2396,9 +2396,8 @@ static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent)
         rc = trans_commit_logical(iq, iq->sc_logical_tran, gbl_mynode, 0, 1,
                                   NULL, 0, NULL, 0);
         if (rc != 0) {
-            logmsg(LOGMSG_FATAL, "%s:%d TRANS_ABORT FAILED RC %d", __func__,
+            logmsg(LOGMSG_ERROR, "%s:%d TRANS_ABORT FAILED RC %d", __func__,
                    __LINE__, rc);
-            comdb2_die(1);
         }
     }
     iq->sc_logical_tran = NULL;


### PR DESCRIPTION
There is no need to abort() db on trans_commit failure of an aborted sc transaction. The failure can result from an incoherent node, and there is no advantage to crash the db at this point.