### PR TITLE
Client API: read config only once.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1034,8 +1034,7 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
                               char comdb2db_hosts[][64], int *num_hosts,
                               int *comdb2db_num, const char *dbname,
                               char db_hosts[][64], int *num_db_hosts,
-                              int *dbnum, int *dbname_found,
-                              int *comdb2db_found, int *stack_at_open)
+                              int *dbnum, int *stack_at_open)
 {
     char line[PATH_MAX > 2048 ? PATH_MAX : 2048] = {0};
     int line_no = 0;
@@ -1058,7 +1057,6 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
                 strcpy(comdb2db_hosts[*num_hosts], tok);
                 (*num_hosts)++;
                 tok = strtok_r(NULL, " :,", &last);
-                *comdb2db_found = 1;
             }
         } else if (dbname && (strcasecmp(dbname, tok) == 0)) {
             tok = strtok_r(NULL, " :,", &last);
@@ -1070,7 +1068,6 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
                 strcpy(db_hosts[*num_db_hosts], tok);
                 tok = strtok_r(NULL, " :,", &last);
                 (*num_db_hosts)++;
-                *dbname_found = 1;
             }
         } else if (strcasecmp("comdb2_config", tok) == 0) {
             tok = strtok_r(NULL, " =:,", &last);
@@ -1218,12 +1215,13 @@ static int get_config_file(const char *dbname, char *f, size_t s)
     return 0;
 }
 
-/* read all available comdb2 configuration files
- */
+/* Read all available comdb2 configuration files.
+   The function returns -1 if the config file path is longer than PATH_MAX;
+   returns 0 otherwise. */
 static int read_available_comdb2db_configs(
     cdb2_hndl_tp *hndl, char comdb2db_hosts[][64], const char *comdb2db_name,
     int *num_hosts, int *comdb2db_num, const char *dbname, char db_hosts[][64],
-    int *num_db_hosts, int *dbnum, int *comdb2db_found, int *dbname_found)
+    int *num_db_hosts, int *dbnum)
 {
     char filename[PATH_MAX];
     FILE *fp;
@@ -1235,7 +1233,9 @@ static int read_available_comdb2db_configs(
     pthread_mutex_lock(&cdb2_cfg_lock);
     if (get_config_file(dbname, filename, sizeof(filename)) != 0) {
         pthread_mutex_unlock(&cdb2_cfg_lock);
-        return -1; // set error string?
+        snprintf(hndl->errstr, sizeof(hndl->errstr),
+                 "Config file name too long.");
+        return -1;
     }
 
     if (num_hosts)
@@ -1247,8 +1247,7 @@ static int read_available_comdb2db_configs(
     if (CDB2DBCONFIG_BUF != NULL) {
         read_comdb2db_cfg(NULL, NULL, comdb2db_name, CDB2DBCONFIG_BUF,
                           comdb2db_hosts, num_hosts, comdb2db_num, dbname,
-                          db_hosts, num_db_hosts, dbnum, dbname_found,
-                          comdb2db_found, send_stack);
+                          db_hosts, num_db_hosts, dbnum, send_stack);
         fallback_on_bb_bin = 0;
     } else {
         if (*CDB2DBCONFIG_NOBBENV != '\0') {
@@ -1256,8 +1255,7 @@ static int read_available_comdb2db_configs(
             if (fp != NULL) {
                 read_comdb2db_cfg(NULL, fp, comdb2db_name, NULL, comdb2db_hosts,
                                   num_hosts, comdb2db_num, dbname, db_hosts,
-                                  num_db_hosts, dbnum, dbname_found,
-                                  comdb2db_found, send_stack);
+                                  num_db_hosts, dbnum, send_stack);
                 fclose(fp);
                 fallback_on_bb_bin = 0;
             }
@@ -1274,8 +1272,7 @@ static int read_available_comdb2db_configs(
         if (fp != NULL) {
             read_comdb2db_cfg(NULL, fp, comdb2db_name, NULL, comdb2db_hosts,
                               num_hosts, comdb2db_num, dbname, db_hosts,
-                              num_db_hosts, dbnum, dbname_found, comdb2db_found,
-                              send_stack);
+                              num_db_hosts, dbnum, send_stack);
             fclose(fp);
         }
     }
@@ -1284,8 +1281,7 @@ static int read_available_comdb2db_configs(
     if (fp != NULL) {
         read_comdb2db_cfg(hndl, fp, comdb2db_name, NULL, comdb2db_hosts,
                           num_hosts, comdb2db_num, dbname, db_hosts,
-                          num_db_hosts, dbnum, dbname_found, comdb2db_found,
-                          send_stack);
+                          num_db_hosts, dbnum, send_stack);
         fclose(fp);
     }
     pthread_mutex_unlock(&cdb2_cfg_lock);
@@ -1342,34 +1338,39 @@ static int get_comdb2db_hosts(cdb2_hndl_tp *hndl, char comdb2db_hosts[][64],
                               const char *comdb2db_name, int *num_hosts,
                               int *comdb2db_num, const char *dbname,
                               char *dbtype, char db_hosts[][64],
-                              int *num_db_hosts, int *dbnum, int just_defaults)
+                              int *num_db_hosts, int *dbnum, int read_cfg,
+                              int dbinfo_or_dns)
 {
     int rc;
-    int comdb2db_found = 0;
-    int dbname_found = 0;
 
     if (hndl)
         debugprint("entering\n");
 
-    rc = read_available_comdb2db_configs(
-        hndl, comdb2db_hosts, comdb2db_name, num_hosts, comdb2db_num, dbname,
-        db_hosts, num_db_hosts, dbnum, &comdb2db_found, &dbname_found);
-    if (rc == -1)
-        return rc;
+    if (read_cfg) {
+        rc = read_available_comdb2db_configs(
+            hndl, comdb2db_hosts, comdb2db_name, num_hosts, comdb2db_num,
+            dbname, db_hosts, num_db_hosts, dbnum);
+        if (rc == -1)
+            return rc;
+        if (master)
+            *master = -1;
+    }
 
-    if (master)
-        *master = -1;
+    if (dbinfo_or_dns) {
+        /* If previous call to the function successfully retrieved hosts,
+           return 0. */
+        if (*num_hosts > 0 || *num_db_hosts > 0)
+            return 0;
+        /* If we have a cached connection to comdb2db in the sockpool, use it to
+           get comdb2db dbinfo. */
+        rc = cdb2_dbinfo_query(hndl, cdb2_default_cluster, comdb2db_name,
+                               *comdb2db_num, NULL, comdb2db_hosts,
+                               comdb2db_ports, master, num_hosts, NULL);
+        /* DNS lookup comdb2db hosts. */
+        if (rc != 0)
+            rc = get_host_by_name(comdb2db_name, comdb2db_hosts, num_hosts);
+    }
 
-    if (just_defaults || comdb2db_found || dbname_found)
-        return 0;
-
-    rc = cdb2_dbinfo_query(hndl, cdb2_default_cluster, comdb2db_name,
-                           *comdb2db_num, NULL, comdb2db_hosts, comdb2db_ports,
-                           master, num_hosts, NULL);
-    if (rc == 0)
-        return 0;
-
-    rc = get_host_by_name(comdb2db_name, comdb2db_hosts, num_hosts);
     return rc;
 }
 
@@ -4830,7 +4831,7 @@ static int cdb2_dbinfo_query(cdb2_hndl_tp *hndl, const char *type,
 static inline void only_read_config()
 {
     read_available_comdb2db_configs(NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-                                    NULL, NULL, NULL, NULL);
+                                    NULL, NULL);
 }
 
 static int cdb2_get_dbhosts(cdb2_hndl_tp *hndl)
@@ -4860,10 +4861,12 @@ static int cdb2_get_dbhosts(cdb2_hndl_tp *hndl)
         }
     }
 
-    get_comdb2db_hosts(hndl, comdb2db_hosts, comdb2db_ports, &master,
-                       comdb2db_name, &num_comdb2db_hosts, &comdb2db_num,
-                       hndl->dbname, hndl->cluster, hndl->hosts,
-                       &(hndl->num_hosts), &hndl->dbnum, 1);
+    rc = get_comdb2db_hosts(hndl, comdb2db_hosts, comdb2db_ports, &master,
+                            comdb2db_name, &num_comdb2db_hosts, &comdb2db_num,
+                            hndl->dbname, hndl->cluster, hndl->hosts,
+                            &(hndl->num_hosts), &hndl->dbnum, 1, 0);
+    if (rc != 0)
+        return rc;
 
     if ((cdb2_default_cluster[0] != '\0') && (cdb2_comdb2dbname[0] != '\0')) {
         strcpy(comdb2db_name, cdb2_comdb2dbname);
@@ -4892,7 +4895,7 @@ static int cdb2_get_dbhosts(cdb2_hndl_tp *hndl)
         rc = get_comdb2db_hosts(
             hndl, comdb2db_hosts, comdb2db_ports, &master, comdb2db_name,
             &num_comdb2db_hosts, &comdb2db_num, hndl->dbname, hndl->cluster,
-            hndl->hosts, &(hndl->num_hosts), &hndl->dbnum, 0);
+            hndl->hosts, &(hndl->num_hosts), &hndl->dbnum, 0, 1);
         if (rc != 0 || (num_comdb2db_hosts == 0 && hndl->num_hosts == 0)) {
             sprintf(hndl->errstr, "cdb2_get_dbhosts: no %s hosts found.",
                     comdb2db_name);

--- a/tests/cdb2api_unit.test/unit_get_comdb2db_hosts.c
+++ b/tests/cdb2api_unit.test/unit_get_comdb2db_hosts.c
@@ -37,14 +37,14 @@ static int get_comdb2db_hosts(cdb2_hndl_tp *hndl, char comdb2db_hosts[][64],
                               const char *comdb2db_name, int *num_hosts,
                               int *comdb2db_num, const char *dbname, char *dbtype,
                               char db_hosts[][64], int *num_db_hosts,
-                              int *dbnum, int just_defaults);
+                              int *dbnum, int read_cfg, int dbinfo_or_dns);
 
 
 // we need here all the functions that get_comdb2db_hosts() calls
 static int read_available_comdb2db_configs(
     cdb2_hndl_tp *hndl, char comdb2db_hosts[][64], const char *comdb2db_name,
     int *num_hosts, int *comdb2db_num, const char *dbname, char db_hosts[][64],
-    int *num_db_hosts, int *dbnum, int *comdb2db_found, int *dbname_found)
+    int *num_db_hosts, int *dbnum)
 {
     if (global_state == 1) return -1;
 
@@ -57,7 +57,6 @@ static int read_available_comdb2db_configs(
 
     if (global_state == 3) {
         printf("read_available_comdb2db_configs global_state %d\n", global_state);
-        *comdb2db_found = 1;
         strcpy(comdb2db_hosts[0], "comdb2db_node1");
         strcpy(comdb2db_hosts[1], "comdb2db_node2");
         strcpy(comdb2db_hosts[2], "comdb2db_node3");
@@ -66,7 +65,6 @@ static int read_available_comdb2db_configs(
 
     if (global_state == 4) {
         printf("read_available_comdb2db_configs global_state %d\n", global_state);
-        *dbname_found = 1;
         strcpy(db_hosts[0], "node1");
         strcpy(db_hosts[1], "node2");
         strcpy(db_hosts[2], "node3");
@@ -141,7 +139,7 @@ int main()
 
     rc = get_comdb2db_hosts(NULL,NULL, NULL, &master, 
             NULL, &num_hosts, NULL,NULL, NULL,
-            NULL, &num_db_hosts, NULL, 0);
+            NULL, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == -1);
     assert(num_hosts == -1);
@@ -154,7 +152,7 @@ int main()
 
     rc = get_comdb2db_hosts(NULL,NULL, NULL, &master, 
             NULL, &num_hosts, NULL,NULL, NULL,
-            NULL, &num_db_hosts, NULL, 1); //just get defaults
+            NULL, &num_db_hosts, NULL, 1, 0); //just get defaults
 
     assert(rc == 0);
     assert(num_hosts == 0);
@@ -169,7 +167,7 @@ int main()
     char db_hosts[MAX_NODES][64] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, NULL, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 0);
+            db_hosts, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == 0);
     assert(num_db_hosts == 0);
@@ -190,7 +188,7 @@ int main()
     char db_hosts[MAX_NODES][64] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, NULL, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 0);
+            db_hosts, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == 0);
     assert(num_hosts == 0);
@@ -211,7 +209,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 0);
+            db_hosts, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == 0);
     assert(num_hosts == 3);
@@ -233,7 +231,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 0);
+            db_hosts, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == -1);
     assert(num_hosts == 0);
@@ -251,7 +249,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 0);
+            db_hosts, &num_db_hosts, NULL, 1, 1);
 
     assert(rc == 0);
     assert(num_hosts == 3);

--- a/tests/tools/cdb2api_unit.c
+++ b/tests/tools/cdb2api_unit.c
@@ -189,8 +189,6 @@ void test_read_comdb2db_cfg()
     char *dbname = "mydb";
     int num_db_hosts = 0;
     int dbnum = 0;
-    int dbname_found = 0;
-    int comdb2db_found = 0;
     int stack_at_open = 0;
 
     const char *buf = 
@@ -200,29 +198,16 @@ void test_read_comdb2db_cfg()
 ";
 
 
-/*
-static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp, char *comdb2db_name, 
-                              const char *buf, char comdb2db_hosts[][64],
-                              int *num_hosts, int *comdb2db_num, char *dbname,
-                              char db_hosts[][64], int *num_db_hosts,
-                              int *dbnum, int *dbname_found,
-                              int *comdb2db_found, int *stack_at_open)
-                              */
-
-
     read_comdb2db_cfg(&hndl, fp, comdb2db_name,
                       buf, comdb2db_hosts,
                       &num_hosts, &comdb2db_num, dbname,
                       db_hosts, &num_db_hosts,
-                      &dbnum, &dbname_found,
-                      &comdb2db_found, &stack_at_open);
+                      &dbnum, &stack_at_open);
 
     assert(num_hosts == 0);
     assert(comdb2db_num == 0);
     assert(num_db_hosts == 0);
     assert(dbnum == 0);
-    assert(dbname_found == 0);
-    assert(comdb2db_found == 0);
 
     const char *buf2 = 
 "\n\
@@ -237,11 +222,9 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp, char *comdb2db_name,
                       buf2, comdb2db_hosts,
                       &num_hosts, &comdb2db_num, dbname,
                       db_hosts, &num_db_hosts,
-                      &dbnum, &dbname_found,
-                      &comdb2db_found, &stack_at_open);
+                      &dbnum, &stack_at_open);
 
     assert(num_hosts == 5);
-    assert(comdb2db_found == 1);
     assert(comdb2db_num == 0);
     assert(strcmp(comdb2db_hosts[0], "a") == 0);
     assert(strcmp(comdb2db_hosts[1], "b") == 0);
@@ -260,7 +243,6 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp, char *comdb2db_name,
     //TODO: this is not set: assert(strcmp(hndl.cluster, "testsuite") == 0);
 
     assert(dbnum == 0);
-    assert(dbname_found == 1);
 }
 
 


### PR DESCRIPTION
Currently cdb2api and cdb2jdbc read the config files twice when database discovery is needed.