### PR TITLE
fix sc under rowlocks

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -637,6 +637,7 @@ tran_type *bdb_start_ltran_rep_sc(bdb_state_type *bdb_state,
 void bdb_set_tran_lockerid(tran_type *tran, uint32_t lockerid);
 void bdb_get_tran_lockerid(tran_type *tran, uint32_t *lockerid);
 void *bdb_get_physical_tran(tran_type *ltran);
+void *bdb_get_sc_parent_tran(tran_type *ltran);
 void bdb_ltran_get_schema_lock(tran_type *ltran);
 void bdb_ltran_put_schema_lock(tran_type *ltran);
 

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -447,6 +447,7 @@ struct tran_tag {
 
     /* Set to 1 if this is a schema change txn */
     int schema_change_txn;
+    struct tran_tag *sc_parent_tran;
 
     /* cache the versions of dta files to catch schema changes and fastinits */
     int table_version_cache_sz;

--- a/bdb/phys.c
+++ b/bdb/phys.c
@@ -203,7 +203,7 @@ int get_physical_transaction(bdb_state_type *bdb_state, tran_type *logical_tran,
             return rc;
         }
         if (logical_tran->single_physical_transaction &&
-            logical_tran->schema_change_txn) {
+            logical_tran->schema_change_txn && gbl_rowlocks) {
             int bdberr = 0;
             logical_tran->sc_parent_tran = logical_tran->physical_tran;
             logical_tran->physical_tran = bdb_tran_begin(

--- a/bdb/phys.c
+++ b/bdb/phys.c
@@ -190,20 +190,35 @@ int get_physical_transaction(bdb_state_type *bdb_state, tran_type *logical_tran,
             assert(!logical_tran->physical_tran);
         }
     }
-
-    if (!logical_tran->physical_tran &&
-        (rc = start_physical_transaction(bdb_state, logical_tran, outtran) !=
-              0)) {
-        int ismaster;
-        ismaster =
-            (bdb_state->repinfo->myhost == bdb_state->repinfo->master_host);
-        if (!ismaster && !bdb_state->in_recovery) {
-            logmsg(LOGMSG_ERROR,
-                   "Master change while getting physical tran.\n");
-            return BDBERR_READONLY;
+    if (!logical_tran->physical_tran) {
+        rc = start_physical_transaction(bdb_state, logical_tran, outtran);
+        if (rc != 0) {
+            int ismaster =
+                (bdb_state->repinfo->myhost == bdb_state->repinfo->master_host);
+            if (!ismaster && !bdb_state->in_recovery) {
+                logmsg(LOGMSG_ERROR,
+                       "Master change while getting physical tran.\n");
+                return BDBERR_READONLY;
+            }
+            return rc;
         }
-        return rc;
+        if (logical_tran->single_physical_transaction &&
+            logical_tran->schema_change_txn) {
+            int bdberr = 0;
+            logical_tran->sc_parent_tran = logical_tran->physical_tran;
+            logical_tran->physical_tran = bdb_tran_begin(
+                bdb_state, logical_tran->sc_parent_tran, &bdberr);
+            logical_tran->physical_tran->logical_tran = logical_tran;
+            logical_tran->physical_tran->tranclass = TRANCLASS_PHYSICAL;
+            if (logical_tran->physical_tran == NULL) {
+                logmsg(LOGMSG_ERROR,
+                       "%s:%d failed to start child tran for sc, bdberr=%d\n",
+                       __func__, __LINE__, bdberr);
+                return -1;
+            }
+        }
     }
+
     *outtran = logical_tran->physical_tran;
     return 0;
 }

--- a/db/tag.c
+++ b/db/tag.c
@@ -7022,12 +7022,12 @@ static int load_new_ondisk(struct dbtable *db, tran_type *tran)
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 
-    /* reopen db */
-    newdb->handle = bdb_open_more_tran(
+    /* reopen db no tran - i.e. auto commit */
+    newdb->handle = bdb_open_more(
         db->tablename, thedb->basedir, newdb->lrl, newdb->nix,
         (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
         newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
-        newdb->numblobs + 1, thedb->bdb_env, tran, &bdberr);
+        newdb->numblobs + 1, thedb->bdb_env, &bdberr);
 
     if (bdberr != 0 || newdb->handle == NULL) {
         logmsg(LOGMSG_ERROR, "reload_schema handle %p bdberr %d\n",

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2013,18 +2013,18 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
     if (iq->tranddl) {
         irc = trans_start_logical_sc(iq, &(iq->sc_logical_tran));
         if (gbl_rowlocks && irc == 0) { // rowlock
-            tran_type *phys_tran = NULL;
+            tran_type *sc_parent = NULL;
             if (parent_trans)
                 *parent_trans = NULL;
             *trans = iq->sc_logical_tran;
-            phys_tran = bdb_get_sc_parent_tran(iq->sc_logical_tran);
+            sc_parent = bdb_get_sc_parent_tran(iq->sc_logical_tran);
             iq->sc_logical_tran = NULL; // use trans in rowlocks
-            if (phys_tran == NULL) {
+            if (sc_parent == NULL) {
                 irc = -1;
                 logmsg(LOGMSG_ERROR, "%s:%d failed to get physical tran\n",
                        __func__, __LINE__);
             } else
-                irc = trans_start_sc(iq, phys_tran, &(iq->sc_tran));
+                irc = trans_start_sc(iq, sc_parent, &(iq->sc_tran));
         } else if (irc == 0) { // pagelock
             if (parent_trans) {
                 *parent_trans = bdb_get_physical_tran(iq->sc_logical_tran);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2013,10 +2013,18 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
     if (iq->tranddl) {
         irc = trans_start_logical_sc(iq, &(iq->sc_logical_tran));
         if (gbl_rowlocks && irc == 0) { // rowlock
+            tran_type *phys_tran = NULL;
             if (parent_trans)
                 *parent_trans = NULL;
             *trans = iq->sc_logical_tran;
-            iq->sc_tran = bdb_get_physical_tran(iq->sc_logical_tran);
+            phys_tran = bdb_get_sc_parent_tran(iq->sc_logical_tran);
+            iq->sc_logical_tran = NULL; // use trans in rowlocks
+            if (phys_tran == NULL) {
+                irc = -1;
+                logmsg(LOGMSG_ERROR, "%s:%d failed to get physical tran\n",
+                       __func__, __LINE__);
+            } else
+                irc = trans_start_sc(iq, phys_tran, &(iq->sc_tran));
         } else if (irc == 0) { // pagelock
             if (parent_trans) {
                 *parent_trans = bdb_get_physical_tran(iq->sc_logical_tran);
@@ -2374,9 +2382,20 @@ void handle_postabort_bpfunc(struct ireq *iq)
 }
 
 int backout_schema_changes(struct ireq *iq, tran_type *tran);
-static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent)
+static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent,
+                                      int rowlocks)
 {
     int rc = 0;
+    if (rowlocks) {
+        assert(parent);
+        rc = trans_abort(iq, bdb_get_physical_tran(parent));
+        if (rc != 0) {
+            logmsg(LOGMSG_FATAL, "%s:%d TRANS_ABORT FAILED RC %d", __func__,
+                   __LINE__, rc);
+            comdb2_die(1);
+        }
+        parent = bdb_get_sc_parent_tran(parent);
+    }
     if (iq->sc_tran) {
         assert(parent);
         rc = trans_abort(iq, iq->sc_tran);
@@ -5092,7 +5111,7 @@ backout:
             /* abandon our parent if we have one, we're gonna redo it all */
             if (osql_needtransaction != OSQL_BPLOG_NOTRANS && parent_trans) {
                 if (iq->tranddl)
-                    backout_and_abort_tranddl(iq, parent_trans);
+                    backout_and_abort_tranddl(iq, parent_trans, 0);
                 else
                     trans_abort(iq, parent_trans);
                 parent_trans = NULL;
@@ -5258,6 +5277,8 @@ backout:
         /* we need to abort the logical/parent transaction
            we'll skip the rest of statistics */
         if (rowlocks) {
+            if (iq->tranddl)
+                backout_and_abort_tranddl(iq, trans, 1);
             irc = trans ? trans_abort_logical(iq, trans, NULL, 0, NULL, 0) : 0;
         } else {
             if (iq->tranddl) {
@@ -5265,7 +5286,7 @@ backout:
                     trans_abort(iq, trans);
                     trans = NULL;
                 }
-                backout_and_abort_tranddl(iq, parent_trans);
+                backout_and_abort_tranddl(iq, parent_trans, 0);
             } else
                 trans_abort(iq, parent_trans);
             parent_trans = NULL;
@@ -5531,7 +5552,7 @@ add_blkseq:
                         trans_abort(iq, trans);
                         trans = NULL;
                     }
-                    backout_and_abort_tranddl(iq, parent_trans);
+                    backout_and_abort_tranddl(iq, parent_trans, 0);
                 } else {
                     trans_abort(iq, parent_trans);
                 }
@@ -5582,6 +5603,8 @@ add_blkseq:
                     Pthread_rwlock_unlock(&commit_lock);
                     hascommitlock = 0;
                 }
+                if (iq->tranddl)
+                    backout_and_abort_tranddl(iq, trans, 1);
                 trans_abort_logical(iq, trans, NULL, 0, NULL, 0);
                 rc = RC_INTERNAL_RETRY;
                 if (block_state_restore(iq, p_blkstate))
@@ -5594,7 +5617,19 @@ add_blkseq:
                and write the blkseq */
             if (!backed_out) {
                 /*fprintf(stderr, "trans_commit_logical\n");*/
-
+                if (iq->tranddl) {
+                    irc = trans_commit(iq, iq->sc_tran, source_host);
+                    if (irc != 0) { /* this shouldnt happen */
+                        logmsg(LOGMSG_FATAL, "%s:%d TRANS_COMMIT FAILED RC %d",
+                               __func__, __LINE__, irc);
+                        comdb2_die(0);
+                    }
+                    iq->sc_tran = NULL;
+                }
+                if (iq->sc_locked) {
+                    unlock_schema_lk();
+                    iq->sc_locked = 0;
+                }
                 /* TODO: private blkseq with rowlocks? */
                 rc = trans_commit_logical(
                     iq, trans, gbl_mynode, 0, 1, buf_fstblk,
@@ -5612,16 +5647,14 @@ add_blkseq:
                     Pthread_rwlock_unlock(&commit_lock);
                     hascommitlock = 0;
                 }
+                if (iq->tranddl)
+                    backout_and_abort_tranddl(iq, trans, 1);
                 rc = trans_abort_logical(
                     iq, trans, buf_fstblk,
                     p_buf_fstblk - buf_fstblk + sizeof(int), bskey, bskeylen);
 
                 if (rc == BDBERR_NOT_DURABLE)
                     rc = ERR_NOT_DURABLE;
-            }
-            if (iq->sc_locked) {
-                unlock_schema_lk();
-                iq->sc_locked = 0;
             }
         }
 

--- a/tests/basic.test/rowlocks.testopts
+++ b/tests/basic.test/rowlocks.testopts
@@ -1,0 +1,1 @@
+init_with_rowlocks

--- a/tests/sc_transactional.test/rowlocks.testopts
+++ b/tests/sc_transactional.test/rowlocks.testopts
@@ -1,0 +1,1 @@
+init_with_rowlocks


### PR DESCRIPTION
- make rowlocks same as pagelock mode when handling schema change
- create a single parent physical trans for a logical tran
- create two children from the parent, one for dml, one for ddl
- commit all in good case
- in bad case, abort ddl first, reload table (parent holds table locks for us), and abort the rest.