### PR TITLE
SSL hostname match: honor RFC 6125 6.4.3

### DIFF
--- a/tests/tools/keygen.sh
+++ b/tests/tools/keygen.sh
@@ -19,7 +19,7 @@ fi
 
 echo $CN
 if [ "$CN" = "" ]; then
-    CN=`hostname -f`
+    CN=*`hostname -f`
 fi
 
 # Setup ssl certificate

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -102,14 +102,8 @@ static int hostname_wildcard_match(const char *s, const char *p)
         return 0;
 
     /* RFC6125 Rule 1 */
-    dotasterisk = strstr(p, ".*");
-    if (dotasterisk != NULL)
-        return 1;
-
-    /* RFC6125 Rule 3 */
-    if (strlen(p) < 3 ||
-            p[0] != '*' ||
-            p[1] != '.')
+    dotasterisk = strstr(p, "*");
+    if (strcspn(p, ".") < dotasterisk - p)
         return 1;
 
     ts = s;


### PR DESCRIPTION
The original logic misinterprets it.