### PR TITLE
Disable in-place update when the 'uniqnulls' option is in use and applies to the record being updated.

### DIFF
--- a/db/record.c
+++ b/db/record.c
@@ -1548,10 +1548,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (iq->osql_step_ix)
             gbl_osqlpf_step[*(iq->osql_step_ix)].step += 1;
 
-        int key_unique = (iq->usedb->ix_dupes[ixnum] == 0);
         int same_key = (memcmp(newkey, oldkey, keysize) == 0);
-        if (gbl_key_updates && (key_unique || same_genid_with_upd) &&
-            same_key &&
+        if (gbl_key_updates && same_genid_with_upd &&
+            same_key && !ix_isnullk(iq->usedb, newkey, ixnum) &&
             (!gbl_partial_indexes || !iq->usedb->ix_partial ||
              ((ins_keys & (1ULL << ixnum)) &&
               (del_keys & (1ULL << ixnum))))) { /* in place key update */

--- a/tests/sql.test/runit
+++ b/tests/sql.test/runit
@@ -295,4 +295,14 @@ assertbadexitcode $exitCode
 cdb2sql ${CDB2_OPTIONS} $a_dbn default "rebuild t4"
 cdb2sql ${CDB2_OPTIONS} $a_dbn default "exec procedure sys.cmd.verify('t4')"
 
+echo "disable in-place updates when uniqnulls are enabled"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "create table t5 options ipu off { schema{ int i null=yes } keys { uniqnulls \"IDX\" = i} }"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "exec procedure sys.cmd.verify('t5')"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t5 values (NULL)"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "exec procedure sys.cmd.verify('t5')"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "update t5 set i = NULL"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "exec procedure sys.cmd.verify('t5')"
+res=`cdb2sql --tabs ${CDB2_OPTIONS} $a_dbn default "select i from t5 order by i"`
+assertres "${res}" $'NULL'
+
 echo "Testcase passed."


### PR DESCRIPTION

Add checking in 'upd_record' to prevent an update from being done in-place when one or more NULL values are used and the 'uniqnulls' option is enabled.  This should fix the issue described in #1187.
