### PR TITLE
cdb2api: Keep a string duplicate of the last query.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3716,8 +3716,10 @@ retry_queries:
             is_begin ? 0 : run_last, __LINE__);
     } else {
         /* Latch the SQL only if we're in a SNAPSHOT HASQL txn. */
-        if (hndl->snapshot_file != 0)
+        if (hndl->snapshot_file != 0) {
+            free(hndl->sql);
             hndl->sql = strdup(sql);
+        }
 
         hndl->query_no += run_last;
         rc = cdb2_send_query(hndl, hndl->sb, hndl->dbname, (char *)sql, 0, 0,


### PR DESCRIPTION
Currently we latch the query in case of an HASQL retry by remembering the address of the query pointer.
This is not safe if the content in the address changes. For instance, the following code will result in
an invalid read of freed memory on the HASQL retry.

```c
/* pseudo code */
char *sql = malloc(...);
sprintf(sql, "SELECT * FROM TABLE");
cdb2_run_statement(sql);
free(sql);
while (cdb2_next_record() == CDB2_OK); /* server crashes here. */
```