### PR TITLE
cdb2api: Fast and unique cnonce generation.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -825,7 +825,7 @@ static cdb2_ssl_sess_list cdb2_ssl_sess_cache;
 typedef struct cnonce {
     long hostid;
     int pid;
-    cdb2_hndl_tp *hndl;
+    struct cdb2_hndl *hndl;
     uint64_t seq;
 } cnonce_t;
 

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -822,7 +822,6 @@ static cdb2_ssl_sess_list cdb2_ssl_sess_cache;
 #endif
 
 #define CNONCE_STR_FMT "%ld-%d-%p-"
-#define CNONCE_STR_ARG(C) (C).hostid, (C).pid, (C).hndl
 #define CNONCE_STR_SZ 52 /* 8 + 1 + 8 + 1 + 16 + 1 + 16 + 1 (NUL) */
 
 #define CNT_BITS 12

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -29,6 +29,7 @@
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <limits.h>
+#include <inttypes.h>
 
 #include "cdb2api.h"
 
@@ -322,6 +323,7 @@ static void do_init_once(void)
     _PID = getpid();
     _MACHINE_ID = gethostid();
     _ARGV0 = getargv0();
+    srand(time(NULL));
 }
 
 /* if sqlstr is a read stmt will return 1 otherwise return 0
@@ -820,7 +822,22 @@ struct cdb2_ssl_sess_list {
 static cdb2_ssl_sess_list cdb2_ssl_sess_cache;
 #endif
 
-#define MAX_CNONCE_LEN 100
+typedef struct cnonce {
+    long hostid;
+    int pid;
+    cdb2_hndl_tp *hndl;
+    uint64_t seq;
+} cnonce_t;
+
+#define CNONCE_STR_FMT_PFX "%ld-%d-%p-"
+#define CNONCE_STR_FMT_SFX "%" PRIx64
+#define CNONCE_STR_ARG_PFX(C) (C).hostid, (C).pid, (C).hndl
+#define CNONCE_STR_ARG_SFX(C) (C).seq
+#define CNONCE_STR_SZ 52 /* 8 + 1 + 8 + 1 + 16 + 1 + 16 + 1 (NUL) */
+
+#define CNT_BITS 12
+#define TIME_MASK (-1ULL << CNT_BITS)
+#define CNT_MASK (-1ULL ^ TIME_MASK)
 
 struct cdb2_hndl {
     char dbname[64];
@@ -848,8 +865,9 @@ struct cdb2_hndl {
     int use_hint;
     int flags;
     char errstr[1024];
-    char cnonce[MAX_CNONCE_LEN];
-    int cnonce_len;
+    cnonce_t cnonce;
+    int cnonce_pfx_ofs;
+    char cnonce_str[CNONCE_STR_SZ];
     char *sql;
     int ntypes;
     int *types;
@@ -2045,34 +2063,6 @@ static inline int cdb2_try_connect_range(cdb2_hndl_tp *hndl, int begin, int end)
 
 static int cdb2_get_dbhosts(cdb2_hndl_tp *hndl);
 
-/* combine hashes similar to hash_combine from boost library */
-static uint64_t val_combine(uint64_t lhs, uint64_t rhs)
-{
-    lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
-    return lhs;
-}
-
-static int cdb2_random_int()
-{
-    static __thread unsigned short rand_state[3] = {0};
-    if (rand_state[0] == 0) {
-        struct timeval tv;
-        gettimeofday(&tv, NULL);
-        /* Initialize rand_state once per thread
-         * _PID will ensure that cnonce will be different accross processes
-
-         * Get the initial random state by using thread id and time info. */
-        uint32_t tmp[2];
-        tmp[0] = tv.tv_sec;
-        tmp[1] = tv.tv_usec;
-        uint64_t hash = val_combine(*(uint64_t *)tmp, (uint64_t)pthread_self());
-        rand_state[0] = hash;
-        rand_state[1] = hash >> 16;
-        rand_state[2] = hash >> 32;
-    }
-    return nrand48(rand_state);
-}
-
 static inline int cdb2_try_resolve_ports(cdb2_hndl_tp *hndl)
 {
     for (int i = 0; i < hndl->num_hosts; i++) {
@@ -2104,10 +2094,10 @@ retry_connect:
     if ((hndl->node_seq == 0) &&
         ((hndl->flags & CDB2_RANDOM) || ((hndl->flags & CDB2_RANDOMROOM) &&
                                          (hndl->num_hosts_sameroom == 0)))) {
-        hndl->node_seq = cdb2_random_int() % hndl->num_hosts;
+        hndl->node_seq = rand() % hndl->num_hosts;
     } else if ((hndl->flags & CDB2_RANDOMROOM) && (hndl->node_seq == 0) &&
                (hndl->num_hosts_sameroom > 0)) {
-        hndl->node_seq = cdb2_random_int() % hndl->num_hosts_sameroom;
+        hndl->node_seq = rand() % hndl->num_hosts_sameroom;
         /* First try on same room. */
         if (0 == cdb2_try_on_same_room(hndl))
             return 0;
@@ -2467,12 +2457,10 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
             features[n_features++] = CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS;
         }
 
-        if (hndl->cnonce_len > 0) {
-            /* Have a query id associated with each transaction/query */
-            sqlquery.has_cnonce = 1;
-            sqlquery.cnonce.data = (uint8_t*)hndl->cnonce;
-            sqlquery.cnonce.len = hndl->cnonce_len;
-        }
+        /* Have a query id associated with each transaction/query */
+        sqlquery.has_cnonce = 1;
+        sqlquery.cnonce.data = (uint8_t *)hndl->cnonce_str;
+        sqlquery.cnonce.len = strlen(hndl->cnonce_str);
 
         if (hndl->snapshot_file) {
             CDB2SQLQUERY__Snapshotinfo snapshotinfo = CDB2__SQLQUERY__SNAPSHOTINFO__INIT;
@@ -2582,9 +2570,8 @@ static int retry_queries_and_skip(cdb2_hndl_tp *hndl, int num_retry,
     do {                                                                       \
         debugprint("%s: cnonce '%s' [%d][%d] "                                 \
                    "returning %d\n",                                           \
-                   rcode == 0 ? "" : "XXX ",                                   \
-                   hndl->cnonce ? hndl->cnonce : "(nil)", hndl->snapshot_file, \
-                   hndl->snapshot_offset, rcode);                              \
+                   rcode == 0 ? "" : "XXX ", hndl->cnonce_str,                 \
+                   hndl->snapshot_file, hndl->snapshot_offset, rcode);         \
         return (rcode);                                                        \
     } while (0)
 
@@ -2592,7 +2579,7 @@ static int retry_queries_and_skip(cdb2_hndl_tp *hndl, int num_retry,
     do {                                                                       \
         debugprint("cnonce '%s' [%d][%d] "                                     \
                    "returning %d\n",                                           \
-                   hndl->cnonce ? hndl->cnonce : "(nil)", hndl->snapshot_file, \
+                   hndl->cnonce_str, hndl->snapshot_file,                      \
                    hndl->snapshot_offset, rcode);                              \
         return (rcode);                                                        \
     } while (0)
@@ -2896,30 +2883,44 @@ int cdb2_close(cdb2_hndl_tp *hndl)
     return 0;
 }
 
-/* make_random_str() will return a randomly generated string
- * this is used to get a cnonce, composed of four components:
- * the first part is the id of this host machine
- * the second part is the PID of this client process
- * the third part is the current time usec portion
- * the fourth part is a [pseudo]random number
- */
-static void make_random_str(char *str, size_t max_len, int *len)
+static int next_cnonce(cdb2_hndl_tp *hndl)
 {
-    static __thread char cached_portion[23] = {0}; // 2*10 digits + 2 '-' + '\n'
-    static __thread size_t cached_portion_len = 0;
-    if (cached_portion_len == 0) {
-        cached_portion_len =
-            snprintf(cached_portion, sizeof(cached_portion) - 1, "%d-%d-",
-                     cdb2_hostid(), _PID);
-    }
+    int rc;
     struct timeval tv;
-    gettimeofday(&tv, NULL);
-    int randval = cdb2_random_int();
-    strncpy(str, cached_portion, cached_portion_len);
-    *len = cached_portion_len;
-    *len += snprintf(str + cached_portion_len, max_len - cached_portion_len,
-                     "%d-%d", (int)tv.tv_usec, randval);
-    return;
+    uint64_t cnt, seq, tm, now;
+    rc = gettimeofday(&tv, NULL);
+    if (rc != 0)
+        return rc;
+    seq = hndl->cnonce.seq;
+    tm = (seq & TIME_MASK) >> CNT_BITS;
+    now = tv.tv_sec * 1000000 + tv.tv_usec;
+    if (now == tm) {
+        cnt = ((seq & CNT_MASK) + 1) & CNT_MASK;
+        if (cnt == 0) {
+            snprintf(hndl->errstr, sizeof(hndl->errstr),
+                     "Transaction rate too high.");
+            rc = E2BIG;
+        } else {
+            hndl->cnonce.seq = (seq & TIME_MASK) | cnt;
+            sprintf(hndl->cnonce_str + hndl->cnonce_pfx_ofs, CNONCE_STR_FMT_SFX,
+                    CNONCE_STR_ARG_SFX(hndl->cnonce));
+        }
+    } else if (now > tm) {
+        if (tm == 0) {
+            hndl->cnonce.hostid = _MACHINE_ID;
+            hndl->cnonce.pid = _PID;
+            hndl->cnonce.hndl = hndl;
+            hndl->cnonce_pfx_ofs = sprintf(hndl->cnonce_str, CNONCE_STR_FMT_PFX,
+                                           CNONCE_STR_ARG_PFX(hndl->cnonce));
+        }
+        hndl->cnonce.seq = (now << CNT_BITS);
+        sprintf(hndl->cnonce_str + hndl->cnonce_pfx_ofs, CNONCE_STR_FMT_SFX,
+                CNONCE_STR_ARG_SFX(hndl->cnonce));
+    } else {
+        rc = EINVAL;
+    }
+
+    return rc;
 }
 
 static int cdb2_query_with_hint(cdb2_hndl_tp *hndl, const char *sqlquery,
@@ -3599,11 +3600,9 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
                 hndl->query = malloc(len + 1);
                 strcpy(hndl->query, sql);
 
-                char c_hint[128];
-                int length;
-                make_random_str(c_hint, sizeof(c_hint), &length);
-
-                cdb2_query_with_hint(hndl, sql, c_hint, &hndl->hint,
+                if ((rc = next_cnonce(hndl)) != 0)
+                    PRINT_RETURN(rc);
+                cdb2_query_with_hint(hndl, sql, hndl->cnonce_str, &hndl->hint,
                                      &hndl->query_hint);
 
                 sql = hndl->query_hint;
@@ -3613,7 +3612,8 @@ static int cdb2_run_statement_typed_int(cdb2_hndl_tp *hndl, const char *sql,
 
     if (!hndl->in_trans) { /* only one cnonce for a transaction. */
         clear_snapshot_info(hndl, __LINE__);
-        make_random_str(hndl->cnonce, MAX_CNONCE_LEN, &hndl->cnonce_len);
+        if ((rc = next_cnonce(hndl)) != 0)
+            PRINT_RETURN(rc);
     }
     hndl->retry_all = 1;
     int run_last = 1;
@@ -4295,7 +4295,7 @@ const char *cdb2_cnonce(cdb2_hndl_tp *hndl)
     if (hndl == NULL)
         return "unallocated cdb2 handle";
 
-    return hndl->cnonce;
+    return hndl->cnonce_str;
 }
 
 const char *cdb2_errstr(cdb2_hndl_tp *hndl)
@@ -4930,10 +4930,10 @@ retry:
     int node_seq = 0;
     if ((hndl->flags & CDB2_RANDOM) ||
         ((hndl->flags & CDB2_RANDOMROOM) && (hndl->num_hosts_sameroom == 0))) {
-        node_seq = cdb2_random_int() % hndl->num_hosts;
+        node_seq = rand() % hndl->num_hosts;
     } else if ((hndl->flags & CDB2_RANDOMROOM) &&
                (hndl->num_hosts_sameroom > 0)) {
-        node_seq = cdb2_random_int() % hndl->num_hosts_sameroom;
+        node_seq = rand() % hndl->num_hosts_sameroom;
         /* Try dbinfo on same room first */
         for (i = 0; i < hndl->num_hosts_sameroom; i++) {
             int try_node = (node_seq + i) % hndl->num_hosts_sameroom;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2793,8 +2793,9 @@ clipper_usage:
                 logmsg(LOGMSG_ERROR, "Usage: sql cancelcnonce CNONCE.  You can get cnonce with "
                        "\"sql dump\".\n");
             else {
-                char * cnonce = strdup(tok);
+                char *cnonce = tokdup(tok, ltok);
                 cancel_sql_statement_with_cnonce(cnonce);
+                free(cnonce);
             }
         } else if (tokcmp(tok, ltok, "wrtimeout") == 0) {
             tok = segtok(line, lline, &st, &ltok);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8701,38 +8701,23 @@ void cancel_sql_statement(int id)
         logmsg(LOGMSG_USER, "Query %d not found (finished?)\n", id);
 }
 
-/* cancel sql statement with the given hex representation of cnonce */
+/* cancel sql statement with the given cnonce */
 void cancel_sql_statement_with_cnonce(const char *cnonce)
 {
     if(!cnonce) return;
 
     struct sql_thread *thd;
     int found = 0;
+    snap_uid_t snap;
+    size_t cnonce_len = strlen(cnonce);
 
     Pthread_mutex_lock(&gbl_sql_lock);
     LISTC_FOR_EACH(&thedb->sql_threads, thd, lnk)
     {
-        found = 1;
-        snap_uid_t snap;
-
         if (thd->clnt && get_cnonce(thd->clnt, &snap) == 0) {
-            const char *sptr = cnonce;
-            int cnt = 0;
-            void luabb_fromhex(uint8_t *out, const uint8_t *in, size_t len);
-            while(*sptr) {
-                uint8_t num;
-                luabb_fromhex(&num, (const uint8_t *)sptr, 2);
-                sptr+=2;
-
-                if (cnt > snap.keylen || snap.key[cnt] != num) {
-                    found = 0;
-                    break;
-                }
-                cnt++;
-            }
-            if (found && cnt != snap.keylen)
-                found = 0;
-
+            if (snap.keylen != cnonce_len)
+                continue;
+            found = (memcmp(snap.key, cnonce, cnonce_len) == 0);
             if (found) {
                 thd->clnt->stop_this_statement = 1;
                 break;

--- a/tests/cdb2api_unit.test/Makefile
+++ b/tests/cdb2api_unit.test/Makefile
@@ -23,8 +23,8 @@ test_get_comdb2db_hosts: unit_get_comdb2db_hosts.c
 	echo "typedef struct cdb2_query_list_item cdb2_query_list;" >> test_get_comdb2db_hosts.c
 	echo "typedef struct sbuf2 SBUF2;" >> test_get_comdb2db_hosts.c
 
-	sed "/typedef struct cnonce {/,/^} cnonce_t/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define CNONCE_STR_SZ " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	sed "/typedef struct cnonce {/,/^} cnonce_t/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_NODES " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_CONTEXTS " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_STACK " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c

--- a/tests/cdb2api_unit.test/Makefile
+++ b/tests/cdb2api_unit.test/Makefile
@@ -23,7 +23,8 @@ test_get_comdb2db_hosts: unit_get_comdb2db_hosts.c
 	echo "typedef struct cdb2_query_list_item cdb2_query_list;" >> test_get_comdb2db_hosts.c
 	echo "typedef struct sbuf2 SBUF2;" >> test_get_comdb2db_hosts.c
 
-	grep "define MAX_CNONCE_LEN " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	sed "/typedef struct cnonce {/,/^} cnonce_t/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	grep "define CNONCE_STR_SZ " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_NODES " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_CONTEXTS " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_STACK " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1421,13 +1421,9 @@ void send_cancel_cnonce(const char *cnonce)
         cdb2_close(cdb2h_2);
         return;
     }
-    char expanded[256];
-    for (int i = 0; i < 256 / 2 && cnonce[i] != '\0'; i++) {
-        sprintf(&expanded[i * 2], "%2x", cnonce[i]);
-    }
     char sql[256];
     snprintf(sql, 255, "exec procedure sys.cmd.send('sql cancelcnonce %s')",
-             expanded);
+             cnonce);
     if (debug_trace) printf("Cancel sql string '%s'\n", sql);
     rc = cdb2_run_statement(cdb2h_2, sql);
     if (!rc)


### PR DESCRIPTION
The new cnonce is composed of the machine hostid, the process pid, the handle address, current epoch in microseconds and a sequence number. The epoch time and the sequence number are combined into a 64-bit integer: 52 bits for the epoch time and 12 bits for the sequence number. The allocation allows a handle to run at a maximum transaction rate of 4096 txn/us (~4 billion transactions per second) till September 17, 2112. An error will be returned if the transaction rate is higher than 4096 txn/us.

The new cnonce generation is 370% faster than the current implementation on a BTDA machine, and guarantees uniqueness.

The pull request also simplifies cancelcnonce logic.
