### PR TITLE
Fix race between memp_alloc_flags and trickle_do_work

### DIFF
--- a/berkdb/mp/mp_alloc.c
+++ b/berkdb/mp/mp_alloc.c
@@ -510,7 +510,7 @@ found:		if (offsetp != NULL)
 		 */
 		ret = 0;
 		if (F_ISSET(bhp, BH_DIRTY)) {
-			if (aggressive == 0) {
+			if (aggressive == 0 || F_ISSET(bhp, BH_LOCKED)) {
 				++c_mp->stat.st_rw_evict_skip;
 				goto next_hb;
 			}

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -1076,17 +1076,16 @@ file_dead:
 		hp = hps[i];
 
 		MUTEX_UNLOCK(dbenv, &bhp->mutex);
+        if (gbl_callpgin_latency > 0)
+            poll(NULL, NULL, gbl_callpgin_latency);
 		MUTEX_LOCK(dbenv, &hp->hash_mutex);
 
 		/*
 		 * If we rewrote the page, it will need processing by the pgin
 		 * routine before reuse.
 		 */
-		if (callpgin[i]) {
-            if (gbl_callpgin_latency > 0)
-                poll(NULL, NULL, gbl_callpgin_latency);
+		if (callpgin[i])
 			F_SET(bhp, BH_CALLPGIN);
-        }
 	}
 
 	/*

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -767,7 +767,7 @@ __memp_pgwrite_int(dbenv, dbmfp, hp, bhp, wrrec)
 	return __memp_pgwrite_multi(dbenv, dbmfp, &hp, &bhp, 1, wrrec);
 }
 
-int gbl_callpgin_latency = 0;
+int gbl_callpgin_latency_ms = 0;
 
 /*
  * __memp_pgwrite_multi --
@@ -1076,8 +1076,8 @@ file_dead:
 		hp = hps[i];
 
 		MUTEX_UNLOCK(dbenv, &bhp->mutex);
-        if (gbl_callpgin_latency > 0)
-            poll(NULL, NULL, gbl_callpgin_latency);
+		if (gbl_callpgin_latency_ms > 0)
+			poll(NULL, NULL, gbl_callpgin_latency_ms);
 		MUTEX_LOCK(dbenv, &hp->hash_mutex);
 
 		/*

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -200,7 +200,7 @@ extern int gbl_rep_wait_release_ms;
 extern int gbl_rep_wait_core_ms;
 extern int gbl_random_get_curtran_failures;
 extern int gbl_fail_client_write_lock;
-extern int gbl_callpgin_latency;
+extern int gbl_callpgin_latency_ms;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -200,6 +200,7 @@ extern int gbl_rep_wait_release_ms;
 extern int gbl_rep_wait_core_ms;
 extern int gbl_random_get_curtran_failures;
 extern int gbl_fail_client_write_lock;
+extern int gbl_callpgin_latency;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1513,4 +1513,11 @@ REGISTER_TUNABLE("osql_check_replicant_numops",
                  TUNABLE_BOOLEAN, &gbl_osql_check_replicant_numops,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("callpgin_latency",
+                 "Introduce artificial latency before the pgin flag is set.  "
+                 "(Default: off)", 
+                 TUNABLE_BOOLEAN, &gbl_callpgin_latency,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1513,10 +1513,10 @@ REGISTER_TUNABLE("osql_check_replicant_numops",
                  TUNABLE_BOOLEAN, &gbl_osql_check_replicant_numops,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("callpgin_latency",
+REGISTER_TUNABLE("callpgin_latency_ms",
                  "Introduce artificial latency before the pgin flag is set.  "
                  "(Default: off)", 
-                 TUNABLE_BOOLEAN, &gbl_callpgin_latency,
+                 TUNABLE_BOOLEAN, &gbl_callpgin_latency_ms,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1515,9 +1515,8 @@ REGISTER_TUNABLE("osql_check_replicant_numops",
 
 REGISTER_TUNABLE("callpgin_latency_ms",
                  "Introduce artificial latency before the pgin flag is set.  "
-                 "(Default: off)", 
+                 "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_callpgin_latency_ms,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-
 
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Fix race between memp_alloc_flags and trickle_do_work which can double-flip a bufferpool buffer.  Add tunable which I will use to attempt to reproduce this.
