### PR TITLE
bdb: More accurate online page compaction request size limit.

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1787,6 +1787,14 @@ void poke_updateid(void *buf, int updateid);
 void bdb_genid_sanity_check(bdb_state_type *bdb_state, unsigned long long genid,
                             int stripe);
 
+/* If the page is from a dta file, `data` is a genid and `size` is 8 bytes.
+   If the page is from an index file, `data` is (ixdata + genid) and
+   `size` is sizeof(genid) + max record size. */
+
+#include <cdb2_constants.h> /* for COMDB2_MAX_RECORD_SIZE */
+#include "genid.h"          /* for genid_t */
+#define PGCOMPMAXLEN (sizeof(genid_t) + COMDB2_MAX_RECORD_SIZE)
+
 /* Request on the wire */
 typedef struct pgcomp_snd {
     int32_t id;

--- a/bdb/bdb_net.c
+++ b/bdb/bdb_net.c
@@ -912,12 +912,6 @@ int send_pg_compact_req(bdb_state_type *bdb_state, int32_t fileid,
     uint8_t *p_buf;
     repinfo_type *repinfo;
 
-/* If the page is from a dta file, `data` is a genid and `size` is 8 bytes.
-   However we may have variant-length data if the page is from ix where `data`
-   is (ixdata + genid).  Given the fact that we don't touch overflow pages
-   and comdb2 maximum page size is 64K, `size` can't be larger than 32K. */
-#define PGCOMPMAXLEN (1U << 15)
-
     if (size > PGCOMPMAXLEN)
         return E2BIG;
 

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4395,6 +4395,12 @@ int enqueue_pg_compact_work(bdb_state_type *bdb_state, int32_t fileid,
     pgcomp_rcv_t *rcv;
     int rc;
 
+    if (size > PGCOMPMAXLEN) {
+        logmsg(LOGMSG_WARN, "%s %d: page compaction request too long.\n",
+               __FILE__, __LINE__);
+        return E2BIG;
+    }
+
     rcv = malloc(sizeof(pgcomp_rcv_t) + size);
     if (rcv == NULL)
         rc = ENOMEM;


### PR DESCRIPTION
The maximum size should be maximum key size which is sizeof genid + max record size.
