### PR TITLE
SC: option to ignore broken timepart table versions and autofix them

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3580,4 +3580,6 @@ void plugin_post_dbenv_hook(struct dbenv *dbenv);
 
 int64_t gbl_temptable_spills;
 
+extern int gbl_disable_tpsc_tblvers;
+
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/config.c
+++ b/db/config.c
@@ -336,7 +336,8 @@ static char *legacy_options[] = {"disallow write from beta if prod",
                                  "osql_send_startgen off",
                                  "create_default_user",
                                  "allow_negative_column_size",
-                                 "osql_check_replicant_numops 0"};
+                                 "osql_check_replicant_numops 0",
+                                 "disable_tpsc_tblvers"};
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)
 {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1513,4 +1513,9 @@ REGISTER_TUNABLE("osql_check_replicant_numops",
                  TUNABLE_BOOLEAN, &gbl_osql_check_replicant_numops,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE(
+    "disable_tpsc_tblvers",
+    "Disable table version checks for time partition schema changes",
+    TUNABLE_BOOLEAN, &gbl_disable_tpsc_tblvers, NOARG, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6498,6 +6498,7 @@ static inline int is_write_request(int type)
 
 void free_cached_idx(uint8_t **cached_idx);
 
+int gbl_disable_tpsc_tblvers = 0;
 int start_schema_change_tran_wrapper(const char *tblname,
                                      timepart_sc_arg_t *arg)
 {
@@ -6506,6 +6507,9 @@ int start_schema_change_tran_wrapper(const char *tblname,
     int rc;
 
     strncpy0(sc->tablename, tblname, sizeof(sc->tablename));
+    if (gbl_disable_tpsc_tblvers) {
+        sc->fix_tp_badvers = 1;
+    }
 
     rc = start_schema_change_tran(iq, sc->tran);
     if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING) {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -783,13 +783,22 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         (!s->fastinit &&
          BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0)) {
         /* reliable per table versioning */
-        rc = table_version_upsert(db, transac, &bdberr);
+        if (unlikely(gbl_disable_tpsc_tblvers && s->fix_tp_badvers)) {
+            rc = table_version_set(transac, db->tablename,
+                                   s->usedbtablevers + 1);
+            db->tableversion = s->usedbtablevers + 1;
+        } else
+            rc = table_version_upsert(db, transac, &bdberr);
         if (rc) {
             sc_errf(s, "Failed updating table version bdberr %d\n", bdberr);
             goto failed;
         }
     } else {
-        db->tableversion = table_version_select(db, transac);
+        if (unlikely(gbl_disable_tpsc_tblvers && s->fix_tp_badvers)) {
+            rc = table_version_set(transac, db->tablename, s->usedbtablevers);
+            db->tableversion = s->usedbtablevers;
+        } else
+            db->tableversion = table_version_select(db, transac);
         sc_printf(s, "Reusing version %d for same schema\n", db->tableversion);
     }
 

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -308,7 +308,7 @@ static int do_finalize(ddl_t func, struct ireq *iq,
 
 static int check_table_version(struct ireq *iq, struct schema_change_type *sc)
 {
-    if (sc->addonly || sc->resume)
+    if (sc->addonly || sc->resume || sc->fix_tp_badvers)
         return 0;
     int rc, bdberr;
     unsigned long long version;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -166,6 +166,7 @@ struct schema_change_type {
     struct schema_change_type *sc_next;
 
     int usedbtablevers;
+    int fix_tp_badvers;
 
     /*********************** temporary fields for in progress
      * schemachange************/

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=890)
+(TUNABLES_COUNT=891)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -208,6 +208,7 @@
 (name='disable_stable_for_ipu', description='For inplace update tables, disable stable find-next cursors', type='BOOLEAN', value='ON', read_only='N')
 (name='disable_tagged_api', description='Disables 'enable_tagged_api'', type='BOOLEAN', value='ON', read_only='N')
 (name='disable_temptable_pool', description='Sets 'temptable_limit' to 0.', type='BOOLEAN', value='OFF', read_only='Y')
+(name='disable_tpsc_tblvers', description='Disable table version checks for time partition schema changes', type='BOOLEAN', value='OFF', read_only='N')
 (name='disable_update_shadows', description='stub out update shadows code', type='BOOLEAN', value='OFF', read_only='N')
 (name='disable_update_stripe_change', description='Enable to move records between stripes on an update.', type='BOOLEAN', value='ON', read_only='N')
 (name='disable_upgrade_ahead', description='Sets 'enable_upgrade_ahead' to 0.', type='BOOLEAN', value='ON', read_only='Y')


### PR DESCRIPTION
for backwards compatibility