### PR TITLE
Detect when replicant tries to send to master an empty transaction

### DIFF
--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -223,6 +223,17 @@ int srs_tran_empty(struct sqlclntstate *clnt)
 
 long long gbl_verify_tran_replays = 0;
 
+void osql_print_history(struct sqlclntstate *clnt, osqlstate_t *osql)
+{
+    if (!osql->history)
+        return;
+
+    srs_tran_query_t *item = NULL;
+    LISTC_FOR_EACH(&osql->history->lst, item, lnk)
+    {
+        logmsg(LOGMSG_DEBUG, "\"%s\"\n", print_stmt(clnt, item));
+    }
+}
 /**
  * Replay transaction using the current history
  *
@@ -297,12 +308,7 @@ int srs_tran_replay(struct sqlclntstate *clnt, struct thr_handle *thr_self)
                                 "abort, nq=%d tnq=%d\n",
                         clnt, nq, tnq);
                 if (debug_switch_osql_verbose_history_replay()) {
-                    if (osql->history) {
-                        LISTC_FOR_EACH(&osql->history->lst, item, lnk)
-                        {
-                            logmsg(LOGMSG_DEBUG, "\"%s\"\n", print_stmt(clnt, item));
-                        }
-                    }
+                    osql_print_history(clnt, osql);
                 }
                 /* we should only repeat socksql and read committed */
                 assert(clnt->dbtran.mode == TRANLEVEL_SOSQL ||

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1016,11 +1016,13 @@ int osql_sock_commit(struct sqlclntstate *clnt, int type)
     assert(osql->sock_started);
 
     if (0 == osql->replicant_numops) { // transaction is empty
-        logmsg(LOGMSG_USER, "AZ: transaction is empt sql:\n");
+        logmsg(LOGMSG_ERROR, 
+               "%s: Empty transaction with following sql(s):\n", __func__);
         void osql_print_history(struct sqlclntstate *clnt, osqlstate_t *osql);
         osql_print_history(clnt, osql);
-        abort();
-        goto err;                      // don't send to master
+        abort(); // TODO: intention here is to catch if/when this happens.
+                 // In future it will suffice to simply do:
+                 // goto err; -- don't send to master
     }
 
 

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -654,7 +654,6 @@ int osql_serial_send_readset(struct sqlclntstate *clnt, int nettype)
  */
 int osql_block_commit(struct sql_thread *thd)
 {
-
     return osql_send_commit_logic(thd->clnt, 0, NET_OSQL_BLOCK_RPL);
 }
 
@@ -1007,6 +1006,11 @@ int osql_sock_commit(struct sqlclntstate *clnt, int type)
             return SQLITE_ABORT;
         }
     }
+
+    if (0 == osql->replicant_numops) { // transaction is empty
+        goto err;
+    }
+
 
     osql->timings.commit_start = osql_log_time();
 


### PR DESCRIPTION
It seems with https://github.com/bloomberg/comdb2/pull/1435 we dont send empty transactions to the master anymore. This checkin adds code to detect any cases that remain.