### PR TITLE
Fix cinsert_linearizable

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2421,6 +2421,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     int features[10]; // Max 10 client features??
     CDB2QUERY query = CDB2__QUERY__INIT;
     CDB2SQLQUERY sqlquery = CDB2__SQLQUERY__INIT;
+    CDB2SQLQUERY__Snapshotinfo snapshotinfo = CDB2__SQLQUERY__SNAPSHOTINFO__INIT;
 
     // This should be sent once right after we connect, not with every query
     CDB2SQLQUERY__Cinfo cinfo = CDB2__SQLQUERY__CINFO__INIT;
@@ -2497,7 +2498,6 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
         sqlquery.cnonce.len = strlen(hndl->cnonce.str);
 
         if (hndl->snapshot_file) {
-            CDB2SQLQUERY__Snapshotinfo snapshotinfo = CDB2__SQLQUERY__SNAPSHOTINFO__INIT;
             snapshotinfo.file = hndl->snapshot_file;
             snapshotinfo.offset = hndl->snapshot_offset;
             sqlquery.snapshot_info = &snapshotinfo;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -200,6 +200,7 @@ extern int gbl_rep_wait_release_ms;
 extern int gbl_rep_wait_core_ms;
 extern int gbl_random_get_curtran_failures;
 extern int gbl_fail_client_write_lock;
+extern int gbl_abort_on_invalid_snapinfo;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1535,4 +1535,10 @@ REGISTER_TUNABLE(
     "Disable table version checks for time partition schema changes",
     TUNABLE_BOOLEAN, &gbl_disable_tpsc_tblvers, NOARG, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("abort_invalid_snapinfo",
+                 "Abort server if client sends invalid snapinfo",
+                 TUNABLE_BOOLEAN, &gbl_abort_on_invalid_snapinfo,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/cinsert_linearizable.test/Makefile
+++ b/tests/cinsert_linearizable.test/Makefile
@@ -4,5 +4,5 @@ else
 	include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=40m
+	export TEST_TIMEOUT=20m
 endif

--- a/tests/cinsert_linearizable.test/lrl.options
+++ b/tests/cinsert_linearizable.test/lrl.options
@@ -92,3 +92,4 @@ on dump_blkseq
 #location logs /db/logs
 #
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/deadlock_policy.test/lrl.options
+++ b/tests/deadlock_policy.test/lrl.options
@@ -4,3 +4,4 @@ setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 20
 
+abort_invalid_snapinfo on

--- a/tests/halt_processor_tds.test/lrl.options
+++ b/tests/halt_processor_tds.test/lrl.options
@@ -22,3 +22,4 @@ make_slow_replicants_incoherent OFF
 
 # 'force_serial_on_writelock OFF' should reproduce corruption
 # force_serial_on_writelock OFF
+abort_invalid_snapinfo on

--- a/tests/jepsen_a6.test/lrl.options
+++ b/tests/jepsen_a6.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_a6_nemesis.test/lrl.options
+++ b/tests/jepsen_a6_nemesis.test/lrl.options
@@ -89,3 +89,4 @@ on dump_blkseq
 init_with_genid48
 
 allow_incoherent_sql on
+abort_invalid_snapinfo on

--- a/tests/jepsen_atomic_writes.test/lrl.options
+++ b/tests/jepsen_atomic_writes.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_bank.test/lrl.options
+++ b/tests/jepsen_bank.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_bank_nemesis.test/lrl.options
+++ b/tests/jepsen_bank_nemesis.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_dirty_reads.test/lrl.options
+++ b/tests/jepsen_dirty_reads.test/lrl.options
@@ -88,3 +88,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_g2.test/lrl.options
+++ b/tests/jepsen_g2.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_register.test/lrl.options
+++ b/tests/jepsen_register.test/lrl.options
@@ -94,3 +94,4 @@ init_with_genid48
 # Uncomment these to reproduce the logput-decoupled 'reads-follows-writes' error
 # rep_getlock_latency 1000
 # last_locked_seqnum off
+abort_invalid_snapinfo on

--- a/tests/jepsen_register_nemesis.test/lrl.options
+++ b/tests/jepsen_register_nemesis.test/lrl.options
@@ -127,3 +127,4 @@ gbl_reset_on_unelectable_cluster off
 
 # Don't use udp for acks
 noudp on
+abort_invalid_snapinfo on

--- a/tests/jepsen_sets.test/lrl.options
+++ b/tests/jepsen_sets.test/lrl.options
@@ -87,3 +87,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/jepsen_sets_nemesis.test/lrl.options
+++ b/tests/jepsen_sets_nemesis.test/lrl.options
@@ -90,3 +90,4 @@ on dump_blkseq
 # Log location
 #location logs /db/logs
 init_with_genid48
+abort_invalid_snapinfo on

--- a/tests/killcluster.test/lrl.options
+++ b/tests/killcluster.test/lrl.options
@@ -87,3 +87,4 @@ rep_verify_will_recover_trace on
 
 # Log location
 #location logs /db/logs
+abort_invalid_snapinfo on

--- a/tests/overflowblobs.test/lrl.options
+++ b/tests/overflowblobs.test/lrl.options
@@ -4,3 +4,4 @@ table blobtest1 blobtest1.csc2
 
 # only 2 stripes for this test
 dtastripe 2
+abort_invalid_snapinfo on

--- a/tests/register_linearizable.test/lrl.options
+++ b/tests/register_linearizable.test/lrl.options
@@ -95,3 +95,4 @@ init_with_genid48
 #dump_zero_coherency_ts on
 
 verbose_send_cohlease on
+abort_invalid_snapinfo on

--- a/tests/restart_socksql.test/lrl.options
+++ b/tests/restart_socksql.test/lrl.options
@@ -5,3 +5,4 @@ do reql events n
 do reql events detailed on
 debug.osql_random_restart on
 osql_verify_retry_max 0
+abort_invalid_snapinfo on

--- a/tests/rowlocks_blkseq.test/lrl.options
+++ b/tests/rowlocks_blkseq.test/lrl.options
@@ -1,2 +1,3 @@
 table t1 t1.csc2
 enable_snapshot_isolation
+abort_invalid_snapinfo on

--- a/tests/sigstopcluster.test/lrl.options
+++ b/tests/sigstopcluster.test/lrl.options
@@ -83,3 +83,4 @@ on dump_blkseq
 
 # Log location
 #location logs /db/logs
+abort_invalid_snapinfo on


### PR DESCRIPTION
Simple cdb2api fix: don't send snapinfo from a non-existant stackframe.  I've added a server-side sanity check which optionally cores on an insane request.
