### PR TITLE
cdb2api: fix dereferencing stack variable out of scope

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2421,6 +2421,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
     int features[10]; // Max 10 client features??
     CDB2QUERY query = CDB2__QUERY__INIT;
     CDB2SQLQUERY sqlquery = CDB2__SQLQUERY__INIT;
+    CDB2SQLQUERY__Snapshotinfo snapshotinfo;
 
     // This should be sent once right after we connect, not with every query
     CDB2SQLQUERY__Cinfo cinfo = CDB2__SQLQUERY__CINFO__INIT;
@@ -2497,7 +2498,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, SBUF2 *sb, const char *dbname,
         sqlquery.cnonce.len = strlen(hndl->cnonce.str);
 
         if (hndl->snapshot_file) {
-            CDB2SQLQUERY__Snapshotinfo snapshotinfo = CDB2__SQLQUERY__SNAPSHOTINFO__INIT;
+            cdb2__sqlquery__snapshotinfo__init(&snapshotinfo);
             snapshotinfo.file = hndl->snapshot_file;
             snapshotinfo.offset = hndl->snapshot_offset;
             sqlquery.snapshot_info = &snapshotinfo;


### PR DESCRIPTION
cdb2api: fix dereferencing stack variable out of scope