### PR TITLE
Live SC Delete: Don't error out for null blobs

### DIFF
--- a/db/record.c
+++ b/db/record.c
@@ -2840,6 +2840,14 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
         }
     } else /* have a plan:  only delete blobs we are told to */
     {
+        /* Currently, blobs rebuilds imply data rebuild at the current
+         * implementation. The only case when blob files are touched without
+         * data files is adding a blob/vutf8 field. And since new blob/vutf8
+         * fields are guaranteed to be NULL, ideally we should not need to worry
+         * about deleting blobs in live_sc_post_delete() in this case. (i.e. The
+         * whole "else" case in the code can be removed.) However, I am keeping
+         * the code there in case we support real blob-only rebuild in the
+         * future. */
         int blobn;
 
         /* No data file.  Delete blobs manually as required. */

--- a/db/record.c
+++ b/db/record.c
@@ -2848,7 +2848,10 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
                 rc = blob_del(iq, trans, 2 /*rrn*/, ngenid, blobn);
                 if (iq->debug)
                     reqprintf(iq, "DEL GENID 0x%llx RC %d", ngenid, rc);
-                if (rc != 0) {
+                if (rc != IX_NOTFND && rc != 0) /* like in upd_new_record() */
+                {
+                    logmsg(LOGMSG_ERROR, "%s: genid 0x%llx blobn %d failed\n",
+                           __func__, ngenid, blobn);
                     retrc = rc;
                     goto err;
                 }

--- a/tests/sc_addfield.test/runit
+++ b/tests/sc_addfield.test/runit
@@ -199,22 +199,27 @@ do_verify
 
 
 
-echo "Simple rebuild while update/deleting"
+echo "Alter into t1_4.csc2 while update/deleting"
 
 master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
-cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')"
-cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('scdelay 10')"
+cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "PUT SCHEMACHANGE CONVERTSLEEP 30"
 
-(cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "rebuild t1 " &> rebuild.out || touch rebuild.failed) &
+(cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "alter table t1 { `cat t1_4.csc2 ` }" &> alter.out || touch alter.failed) &
 
 sleep 15
 cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where a % 2 = 1"
+if [ $? -ne 0 ] ; then
+    failexit "failed to delete while altering to t1_4"
+fi
 cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set a = a + 10000 where 1"
-
-
-if [ -f rebuild.failed ] ; then
-    failexit "Rebuild failed, but it should have succeeded"
+if [ $? -ne 0 ] ; then
+    failexit "failed to update while altering to t1_4"
 fi
 
+wait
+if [ -f alter.failed ] ; then
+    failexit "Alter to t1_4.csc2 failed, but it should have succeeded"
+fi
+do_verify
 
 echo "Success"

--- a/tests/sc_addfield.test/t1_4.csc2
+++ b/tests/sc_addfield.test/t1_4.csc2
@@ -1,0 +1,21 @@
+schema
+{
+    int      a
+    cstring  b[32]
+    int      e  dbstore=3
+    int      c 
+    int      d  dbstore=2
+    blob     blb null=yes
+}
+
+keys
+{
+    "A"  =  a
+    "B"  =  b
+    "AB" =  a+b
+    "BA" =  b+a
+    "C"  =  c
+dup "D"  =  d
+dup "E"  =  e
+dup "DE"  =  d+e
+}


### PR DESCRIPTION
Currently, blobs rebuilds imply data rebuild at the current implementation. The only case when only blob files are touched is adding a blob/vutf8 field. And since new blob/vutf8 fields are guaranteed to be NULL, ideally we should not need to worry about deleting blobs in live_sc_post_delete() in this case. (i.e. The whole "else" case in the code can be removed.) However, I am keeping the code there in case we support real blob-only rebuild in the future as ignoring NULL blobs is more robust.
