### PR TITLE
Fix pglogs, cleanup rep_process_message

### DIFF
--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -1729,7 +1729,7 @@ int bdb_clean_pglogs_queues(bdb_state_type *bdb_state, DB_LSN lsn, int truncate)
     struct pglogs_queue_heads qh;
     int count, i;
 
-    if (!gbl_new_snapisol)
+    if (!gbl_new_snapisol || !logfile_pglogs_repo_ready)
         return 0;
 
     Pthread_mutex_lock(&del_queue_lk);

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -6401,19 +6401,22 @@ recovery_getlocks(dbenv, lockid, lock_dbt, lsn)
 	return ret;
 }
 
-static int
+static void
 recovery_release_locks(dbenv, lockid)
 	DB_ENV *dbenv;
 	u_int32_t lockid;
 {
-	int ret, t_ret;
+	int ret;
 	DB_LOCKREQ req = {0};
 	req.op = DB_LOCK_PUT_ALL;
-	if ((t_ret = __lock_vec(dbenv, lockid, 0, &req, 1, NULL)) != 0 && ret == 0)
-		ret = t_ret;
-	if ((t_ret = __lock_id_free(dbenv, lockid)) != 0 && ret == 0)
-		ret = t_ret;
-	return ret;
+	if ((ret = __lock_vec(dbenv, lockid, 0, &req, 1, NULL)) != 0) {
+        logmsg(LOGMSG_FATAL, "%s: __lock_vec returns %d\n", ret);
+        abort();
+    }
+	if ((ret = __lock_id_free(dbenv, lockid)) != 0) {
+        logmsg(LOGMSG_FATAL, "%s: __lock_id_free returns %d\n", ret);
+        abort();
+    }
 }
 
 static int

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -6410,13 +6410,13 @@ recovery_release_locks(dbenv, lockid)
 	DB_LOCKREQ req = {0};
 	req.op = DB_LOCK_PUT_ALL;
 	if ((ret = __lock_vec(dbenv, lockid, 0, &req, 1, NULL)) != 0) {
-        logmsg(LOGMSG_FATAL, "%s: __lock_vec returns %d\n", ret);
-        abort();
-    }
+		logmsg(LOGMSG_FATAL, "%s: __lock_vec returns %d\n", ret);
+		abort();
+	}
 	if ((ret = __lock_id_free(dbenv, lockid)) != 0) {
-        logmsg(LOGMSG_FATAL, "%s: __lock_id_free returns %d\n", ret);
-        abort();
-    }
+		logmsg(LOGMSG_FATAL, "%s: __lock_id_free returns %d\n", ret);
+		abort();
+	}
 }
 
 static int


### PR DESCRIPTION
Simple fixes to recent merge- don't clean pglogs_queues until that subsystem has been initialized, and cleanup the logic in recovery_release_locks
