### PR TITLE
set cnonce to NULL if not available to avoid crashes

### DIFF
--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -3794,17 +3794,14 @@ __lock_getlocker_int(lt, locker, indx, partition, create, retries, retp,
 	 */
 	if (sh_locker == NULL && create) {
 		/* Create new locker and then insert it into hash table. */
-		if ((sh_locker =
-			SH_TAILQ_FIRST(&region->free_lockers[partition],
+		if ((sh_locker = SH_TAILQ_FIRST(&region->free_lockers[partition],
 			    __db_locker)) == NULL) {
 			unsigned i, num;
 			++region->nwlkr_scale[partition];
-			num = region->locker_p_size
-			    * region->nwlkr_scale[partition];
+			num = region->locker_p_size * region->nwlkr_scale[partition];
 			PRINTF(nwlkr_scale, "add lkr:%d part:%d sc:%d\n",
 			    num, partition, region->nwlkr_scale[partition]);
-			int ret = __os_malloc(dbenv,
-			    sizeof(DB_LOCKER) * num, &sh_locker);
+			int ret = __os_malloc(dbenv, sizeof(DB_LOCKER) * num, &sh_locker);
 			if (ret != 0) {
 				__db_err(dbenv, __db_lock_err,
 				    "locker entries");
@@ -3872,11 +3869,12 @@ __lock_getlocker_int(lt, locker, indx, partition, create, retries, retp,
 		if (gbl_print_deadlock_cycles) {
 			extern __thread snap_uid_t *osql_snap_info; /* contains cnonce */
 			if(osql_snap_info) sh_locker->snap_info = osql_snap_info;
+			else sh_locker->snap_info = NULL;
 		}
 	}
 
 	*retp = sh_locker;
-	return (0);
+	return 0;
 }
 
 /*

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -459,7 +459,7 @@ static void *apply_thread(void *arg)
 	LOG *lp;
 	DB_LOG *dblp;
 	DB_LSN master_lsn, my_lsn, my_last_lsn, first_repdb_lsn;
-    int last_lsn_change_time;
+    int last_lsn_change_time = 0;
 	DB_ENV *dbenv = (DB_ENV *)arg;
 	struct queued_log *q;
 	struct timespec ts;
@@ -6410,11 +6410,11 @@ recovery_release_locks(dbenv, lockid)
 	DB_LOCKREQ req = {0};
 	req.op = DB_LOCK_PUT_ALL;
 	if ((ret = __lock_vec(dbenv, lockid, 0, &req, 1, NULL)) != 0) {
-		logmsg(LOGMSG_FATAL, "%s: __lock_vec returns %d\n", ret);
+		logmsg(LOGMSG_FATAL, "%s: __lock_vec returns %d\n", __func__, ret);
 		abort();
 	}
 	if ((ret = __lock_id_free(dbenv, lockid)) != 0) {
-		logmsg(LOGMSG_FATAL, "%s: __lock_id_free returns %d\n", ret);
+		logmsg(LOGMSG_FATAL, "%s: __lock_id_free returns %d\n", __func__, ret);
 		abort();
 	}
 }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3341,7 +3341,9 @@ static void net_snap_uid_req(void *hndl, void *uptr, char *fromhost,
 void log_snap_info_key(snap_uid_t *snap_info)
 {
     if (snap_info)
-        logmsg(LOGMSG_USER, "%*s", snap_info->keylen, snap_info->key);
+        logmsg(LOGMSG_USER, "%*s", snap_info->keylen-3, snap_info->key);
+    else
+        logmsg(LOGMSG_USER, "NO_CNONCE"); // ex. SC
 }
 
 static void net_snap_uid_rpl(void *hndl, void *uptr, char *fromhost,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3341,7 +3341,7 @@ static void net_snap_uid_req(void *hndl, void *uptr, char *fromhost,
 void log_snap_info_key(snap_uid_t *snap_info)
 {
     if (snap_info)
-        logmsg(LOGMSG_USER, "%*s", snap_info->keylen-3, snap_info->key);
+        logmsg(LOGMSG_USER, "%*s", snap_info->keylen - 3, snap_info->key);
     else
         logmsg(LOGMSG_USER, "NO_CNONCE"); // ex. SC
 }

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -147,7 +147,7 @@ static inline int osql_should_restart(struct sqlclntstate *clnt, int rc)
 
     if (gbl_osql_random_restart && (rand() % 100) == 0) {
         uuidstr_t us;
-        snap_uid_t snap = {0};
+        snap_uid_t snap = {{0}};
         get_cnonce(clnt, &snap);
         logmsg(LOGMSG_USER,
                "Forcing random-restart of uuid=%s cnonce=%*s after nops=%d\n",

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3956,9 +3956,9 @@ int sqlite3BtreeDropTable(Btree *pBt, int iTable, int *piMoved)
             **       the passed string hash key will not be stored.
             */
 #ifndef NDEBUG
-            struct temptable_entry *pOldEntry = 
+            struct temptable_entry *pOldEntry =
 #endif
-                sqlite3HashInsert(&pBt->temp_tables, 
+                sqlite3HashInsert(&pBt->temp_tables,
                                   rootPageNumToTempHashKey(iTable), 0);
             assert( pOldEntry==pEntry );
             free(pEntry);
@@ -5190,11 +5190,13 @@ int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
     pNewEntry->rootPg = iTable;
 
 #ifndef NDEBUG
-    struct temptable_entry *pOldEntry = 
+    struct temptable_entry *pOldEntry =
 #endif
         sqlite3HashInsert(&pBt->temp_tables,
-            rootPageNumToPermHashKey(pNewEntry->keyBuf,
-                sizeof(pNewEntry->keyBuf), iTable), pNewEntry);
+                          rootPageNumToPermHashKey(pNewEntry->keyBuf,
+                                                   sizeof(pNewEntry->keyBuf),
+                                                   iTable),
+                          pNewEntry);
 
     assert( pOldEntry==NULL );
     *piTable = iTable;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3955,12 +3955,13 @@ int sqlite3BtreeDropTable(Btree *pBt, int iTable, int *piMoved)
             **       the hash entry is being deleted (not stored); therefore,
             **       the passed string hash key will not be stored.
             */
-            struct temptable_entry *pOldEntry = sqlite3HashInsert(
-                &pBt->temp_tables, rootPageNumToTempHashKey(iTable), 0
-            );
+#ifndef NDEBUG
+            struct temptable_entry *pOldEntry = 
+#endif
+                sqlite3HashInsert(&pBt->temp_tables, 
+                                  rootPageNumToTempHashKey(iTable), 0);
             assert( pOldEntry==pEntry );
             free(pEntry);
-            /* pEntry = NULL; */
         }
 
         Pthread_mutex_unlock(thd->temp_table_mtx);
@@ -5188,9 +5189,12 @@ int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
 
     pNewEntry->rootPg = iTable;
 
-    struct temptable_entry *pOldEntry = sqlite3HashInsert(&pBt->temp_tables,
-        rootPageNumToPermHashKey(pNewEntry->keyBuf, sizeof(pNewEntry->keyBuf),
-        iTable), pNewEntry);
+#ifndef NDEBUG
+    struct temptable_entry *pOldEntry = 
+#endif
+        sqlite3HashInsert(&pBt->temp_tables,
+            rootPageNumToPermHashKey(pNewEntry->keyBuf,
+                sizeof(pNewEntry->keyBuf), iTable), pNewEntry);
 
     assert( pOldEntry==NULL );
     *piTable = iTable;
@@ -9605,7 +9609,7 @@ int recover_deadlock_flags(bdb_state_type *bdb_state, struct sql_thread *thd,
                            bdb_cursor_ifn_t *bdbcur, int sleepms,
                            const char *func, int line, uint32_t flags)
 {
-    int rc, ref;
+    int rc;
     rc = thd->clnt->recover_deadlock_rcode =
         recover_deadlock_flags_int(bdb_state, thd, bdbcur, sleepms, func, line,
                 flags);
@@ -9619,9 +9623,9 @@ int recover_deadlock_flags(bdb_state_type *bdb_state, struct sql_thread *thd,
                 RECOVER_DEADLOCK_MAX_STACK);
 #endif
         recover_deadlock_sc_cleanup(thd);
-        assert((ref = bdb_lockref()) == 0);
+        assert(bdb_lockref() == 0);
     } else {
-        assert((ref = bdb_lockref()) > 0);
+        assert(bdb_lockref() > 0);
 #if INSTRUMENT_RECOVER_DEADLOCK_FAILURE
         thd->clnt->recover_deadlock_func = NULL;
         thd->clnt->recover_deadlock_line = 0;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4740,7 +4740,7 @@ int sbuf_is_local(SBUF2 *sb)
 static inline int sql_writer_recover_deadlock(struct sqlclntstate *clnt)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
-    int count = 0, ref;
+    int count = 0;
 
     /* Short circuit */
     if (!clnt) {
@@ -4751,11 +4751,11 @@ static inline int sql_writer_recover_deadlock(struct sqlclntstate *clnt)
     /* Sql thread */
     if (thd) {
         if (release_locks("slow reader") != 0) {
-            assert((ref = bdb_lockref()) == 0);
+            assert(bdb_lockref() == 0);
             logmsg(LOGMSG_ERROR, "%s release_locks failed\n", __func__);
             return 1;
         }
-        assert((ref = bdb_lockref()) > 0);
+        assert(bdb_lockref() > 0);
         return 0;
     }
 

--- a/db/types.c
+++ b/db/types.c
@@ -4176,7 +4176,7 @@ TYPES_INLINE int CLIENT_PSTR2_to_SERVER_BCSTR(
 
     uint8_t hdr = 0;
     bset(&hdr, data_bit);
-    if (inlen > outlen - 1) {
+    if ((unsigned int)inlen > (unsigned int)outlen - 1) {
         if (inopts && inopts->flags & FLD_CONV_TRUNCATE) {
             inlen = outlen - 1;
         } else {
@@ -4188,7 +4188,7 @@ TYPES_INLINE int CLIENT_PSTR2_to_SERVER_BCSTR(
     memset(out + inlen, 0, outlen - inlen);
     *outdtsz = inlen;
 
-    if (olen > outlen - 1) {
+    if ((unsigned int)olen > (unsigned int)outlen - 1) {
         // Can't just set truncate bit
         // 1. aaa
         // 2. zzz

--- a/sqlite/src/hash.c
+++ b/sqlite/src/hash.c
@@ -72,7 +72,7 @@ static unsigned int strHashN(const char *z, int n){
     /* Knuth multiplicative hashing.  (Sorting & Searching, p. 510).
     ** 0x9e3779b1 is 2654435761 which is the closest prime number to
     ** (2**32)*golden_ratio, where golden_ratio = (sqrt(5) - 1)/2. */
-    h += sqlite3UpperToLower[z[i]];
+    h += sqlite3UpperToLower[(int)z[i]];
     h *= 0x9e3779b1;
   }
   return h;

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -1108,7 +1108,7 @@ static const Mem *columnNullValue(void){
     = {
         /* .u          = */ {0},
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-        /* .du         = */ {0},
+        /* .du         = */ {{0}},
         /* .tz         = */ (char*)0,
         /* .dtprec     = */ (int)0,
         /* .flags      = */ (u32)MEM_Null,


### PR DESCRIPTION
On master side when printing deadlocks, set cnonce to NULL if not available (ex. SC thread) to avoid crashes.