### PR TITLE
do the preliminary check for table existence after getting schemalk

### DIFF
--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -224,7 +224,9 @@ static int db_comdb_verify(Lua L) {
         return luaL_error(L, "Verify failed.");
     }
 
+    rdlock_schema_lk();
     struct dbtable *db = get_dbtable_by_name(tblname);
+    unlock_schema_lk();
     if (db) {
         logmsg(LOGMSG_USER, "db_comdb_verify: verify table '%s'\n", tblname);
         rc = verify_table(tblname, NULL, 1, 0, db_verify_table_callback, L); //freq 1, fix 0


### PR DESCRIPTION
do the preliminary check for table existence after getting schemalk
(we correctly get schemalk in a later check, when getting the table lock).