### PR TITLE
Fix checkpoint handling on backwards roll

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -162,7 +162,7 @@ __checkpoint_save(DB_ENV *dbenv, DB_LSN *lsn, int in_recovery)
 	int rc;
 	size_t niop = 0;
 
-    logmsg(LOGMSG_WARN, "ckpt lsn: %u:%u\n", lsn->file, lsn->offset);
+    logmsg(LOGMSG_DEBUG, "ckpt lsn: %u:%u\n", lsn->file, lsn->offset);
 
 	LOGCOPY_TOLSN(&ckpt.lsn, lsn);
 

--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -634,10 +634,28 @@ __txn_ckp_recover(dbenv, dbtp, lsnp, op, info)
 		return (ret);
 
 	if (op == DB_TXN_BACKWARD_ROLL) {
+        DB_LOGC *logc;
 		DB_LSN last_ckp = argp->last_ckp;
+        DBT data_dbt;
 		__db_txnlist_ckp(dbenv, info, lsnp);
-		__checkpoint_save(dbenv, &last_ckp, 1);
-		region->last_ckp = argp->last_ckp;
+        if ((ret = __log_cursor(dbenv, &logc)) != 0) {
+            logmsg(LOGMSG_FATAL, "%s unable to allocate log_cursor, rc=%d\n",
+                    __func__, ret);
+            return (ret);
+        }
+
+        memset(&data_dbt, 0, sizeof(data_dbt));
+        data_dbt.flags = DB_DBT_USERMEM | DB_DBT_PARTIAL;
+        data_dbt.ulen = 0;
+
+        if ((ret = __log_c_get(logc, &last_ckp, &data_dbt, DB_SET)) == 0) {
+            __checkpoint_save(dbenv, &last_ckp, 1);
+            region->last_ckp = argp->last_ckp;
+        } else {
+            logmsg(LOGMSG_DEBUG, "%s not saving lsn %d:%d on backwards roll\n",
+                    __func__, last_ckp.file, last_ckp.offset);
+        }
+        __log_c_close(logc);
 	}
 
 	if (op == DB_TXN_FORWARD_ROLL) {


### PR DESCRIPTION
Fixed a bug where the backwards roll phase of recovery blindly replaces the checkpoint with the previous checkpoint.  This breaks if recovery needs to start near the beginning of the first log we have, and the previous checkpoint lsn points to a log which we don't have.  Simple solution: only update if the log record exists.