### PR TITLE
Disable failed-dispatch message by default

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -207,6 +207,7 @@ extern int gbl_match_on_ckp;
 extern int gbl_verbose_physrep;
 extern int gbl_blocking_physrep;
 extern int gbl_verbose_set_sc_in_progress;
+extern int gbl_send_failed_dispatch_message;
 extern int gbl_physrep_reconnect_penalty;
 extern int gbl_physrep_register_interval;
 extern int gbl_logdelete_lock_trace;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1604,4 +1604,11 @@ REGISTER_TUNABLE("verbose_set_sc_in_progress",
                  TUNABLE_BOOLEAN, &gbl_verbose_set_sc_in_progress,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("send_failed_dispatch_message",
+                 "Send explicit failed-dispatch message to the api.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_send_failed_dispatch_message,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1809,6 +1809,8 @@ static int do_query_on_master_check(struct dbenv *dbenv,
     return 0;
 }
 
+int gbl_send_failed_dispatch_message = 0;
+
 static CDB2QUERY *read_newsql_query(struct dbenv *dbenv,
                                     struct sqlclntstate *clnt, SBUF2 *sb)
 {
@@ -1821,7 +1823,7 @@ static CDB2QUERY *read_newsql_query(struct dbenv *dbenv,
 retry_read:
     rc = sbuf2fread_timeout((char *)&hdr, sizeof(hdr), 1, sb, &was_timeout);
     if (rc != 1) {
-        if (was_timeout) {
+        if (was_timeout && gbl_send_failed_dispatch_message) {
             handle_failed_dispatch(clnt, "Socket read timeout.");
         }
         return NULL;


### PR DESCRIPTION
The client api handles a simple disconnect gracefully, but returns an error to the user for this case.