### PR TITLE
testsuite:  localrep test to start via setup; write eventlog detailed 

### DIFF
--- a/db/views_cron.c
+++ b/db/views_cron.c
@@ -76,16 +76,12 @@ cron_sched_t *cron_add_event(cron_sched_t *sched, const char *name, int epoch,
     }
 
     Pthread_mutex_lock(&sched->mtx);
-
     rc = _queue_event(sched, epoch, func, arg1, arg2, arg3, source_id, err);
-    if (rc != VIEW_NOERR) {
-        Pthread_mutex_unlock(&sched->mtx);
-        goto error;
-    }
-
     Pthread_mutex_unlock(&sched->mtx);
 
-    return sched;
+    if (rc == VIEW_NOERR) {
+        return sched;
+    }
 
 error:
 

--- a/tests/localrep.test/lrl.options
+++ b/tests/localrep.test/lrl.options
@@ -1,1 +1,2 @@
 replicate_local
+do reql events detailed on

--- a/tests/localrep.test/runit
+++ b/tests/localrep.test/runit
@@ -29,6 +29,9 @@ assertcnt ()
     fi
 }
 
+if [ ! -f ${TESTSBUILDDIR}/localrep ] ; then
+    failexit "executable ${TESTSBUILDDIR}/localrep does not exist"
+fi
 
 cdb2sql ${CDB2_OPTIONS} $dbname default 'create table t1 {
 schema {
@@ -143,32 +146,19 @@ for i in $(seq 1 $NRUNS); do
     esac
 done | cdb2sql -s ${CDB2_OPTIONS} $dbname default - >/dev/null
 
+
 destdb=${TESTCASE}dest${TESTID}
-DBDIR=${DBDIR}/$destdb
-mkdir -p $DBDIR
+DBNAME=$destdb
+DBDIR=$TESTDIR/$DBNAME
+DEST_CDB2_CONFIG=$DBDIR/comdb2db.cfg
+DEST_CDB2_OPTIONS="--cdb2cfg $DEST_CDB2_CONFIG"
+CLUSTER="" #run only locally
+echo "do reql events detailed on" > lrl.options #we don't want the 'replicate_local' lrl option
 
-cat > $DBDIR/${destdb}.lrl <<EOF
-name    $destdb
-dir     $DBDIR
-EOF
+#use setup because we need the event logs
+CLUSTER=""  CDB2_CONFIG="$DEST_CDB2_CONFIG" CDB2_OPTIONS="$DEST_CDB2_OPTIONS" $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 
-df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> $DBDIR/${destdb}.lrl
-
-if [ -n "$PMUXPORT" ] ; then
-    echo "portmux_port $PMUXPORT" >> $DBDIR/${destdb}.lrl
-    echo "portmux_bind_path $pmux_socket" >> $DBDIR/${destdb}.lrl
-fi
-
-comdb2 $destdb -create -lrl $DBDIR/${destdb}.lrl 
-comdb2 $destdb -lrl $DBDIR/${destdb}.lrl -pidfile $DBDIR/${destdb}.pid &
-
-out=
-while [[ "$out" != "1" ]]; do
-    out=$(cdb2sql --tabs ${CDB2_OPTIONS} $destdb local 'select 1' 2>/dev/null)
-    sleep 1
-done
-
-cdb2sql ${CDB2_OPTIONS} $destdb local 'create table t1 {
+cdb2sql ${DEST_CDB2_OPTIONS} $destdb local 'create table t1 {
 schema {
     int id
 
@@ -192,7 +182,7 @@ keys {
 }
 '
 
-cdb2sql ${CDB2_OPTIONS} $destdb local 'create table comdb2_oplog {
+cdb2sql ${DEST_CDB2_OPTIONS} $destdb local 'create table comdb2_oplog {
 schema {
     longlong seqno
     int      blkpos
@@ -220,32 +210,35 @@ keys {
 '
 
 # finally run the replication step
-${TESTSBUILDDIR}/localrep $dbname $destdb 2>&1
+${TESTSBUILDDIR}/localrep $dbname $destdb &> replication1.out
 src=$(cdb2sql ${CDB2_OPTIONS} $dbname default "select * from t1" | sort | tee src.out | md5sum)
-dest=$(cdb2sql ${CDB2_OPTIONS} $destdb local "select * from t1" | sort | tee dest.out | md5sum)
+dest=$(cdb2sql ${DEST_CDB2_OPTIONS} $destdb local "select * from t1" | sort | tee dest.out | md5sum)
 echo "src $src dest $dest"
 
 echo "Testing truncate table"
 cdb2sql ${CDB2_OPTIONS} $dbname default "truncate t1"
 # run the replication step
-${TESTSBUILDDIR}/localrep $dbname $destdb 2>&1
+${TESTSBUILDDIR}/localrep $dbname $destdb &> replication2.out
 src2=$(cdb2sql ${CDB2_OPTIONS} $dbname default "select * from t1" | sort | tee src2.out | md5sum)
-dest2=$(cdb2sql ${CDB2_OPTIONS} $destdb local "select * from t1" | sort | tee dest2.out | md5sum)
+dest2=$(cdb2sql ${DEST_CDB2_OPTIONS} $destdb local "select * from t1" | sort | tee dest2.out | md5sum)
 echo "src2 $src2 dest2 $dest2"
 
-kill -9 $(cat $DBDIR/${destdb}.pid)
-
-echo deregister from pmux ${destdb}
-${TESTSROOTDIR}/tools/send_msg_port.sh "del comdb2/replication/${destdb} " ${pmux_port}
-
+successful=1
 if [[ "$src" != "$dest" ]]; then
     echo see diff by doing vimdiff src.out dest.out
-    exit 1
+    successful=0
 fi
 
 if [[ "$src2" != "$dest2" ]]; then
     echo "truncate failed"
     echo see diff by doing vimdiff src2.out dest2.out
+    successful=0
+fi
+
+#unsetup DBNAME which is the dest db
+CLUSTER=""  CDB2_CONFIG="$DEST_CDB2_CONFIG" CDB2_OPTIONS="$DEST_CDB2_OPTIONS" $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
+
+if [[ "$successful" != "1" ]]; then
     exit 1
 fi
 

--- a/tests/tools/localrep.c
+++ b/tests/tools/localrep.c
@@ -609,6 +609,7 @@ int apply(char *fromdb, char *todb) {
 int main(int argc, char *argv[]) {
     char *fromdb, *todb;
 
+    //setenv("CDB2_DEBUG", "1", 1);
     if (getenv("CDB2_CONFIG"))
         cdb2_set_comdb2db_config(getenv("CDB2_CONFIG"));
 


### PR DESCRIPTION
* localrep test to start via setup rather than manually
* write all sql to eventlog detailed so we can catch rare occurence of a row missing in destination db 