### PR TITLE
Disable min truncate

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3344,6 +3344,7 @@ static int bdb_calc_min_truncate(bdb_state_type *bdb_state)
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp)
 {
+    return 0;
     if (gbl_min_truncate_file < 1)
         bdb_calc_min_truncate(bdb_state);
     Pthread_rwlock_rdlock(&min_trunc_lk);

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -273,6 +273,7 @@ static int db_comdb_truncate_log(Lua L) {
     gbl_truncating_log = 1;
     logdelete_unlock(__func__, __LINE__);
 
+#if 0
     bdb_min_truncate(thedb->bdb_env, &min_file, &min_offset, NULL);
 
     if (min_file == 0) {
@@ -285,7 +286,8 @@ static int db_comdb_truncate_log(Lua L) {
         return luaL_error(L, 
                 "Minimum truncate lsn is {%d:%d}", min_file, min_offset);
     }
-    logmsg(LOGMSG_USER, "applying log from lsn {%u:%u}\n", file, offset);
+#endif
+    logmsg(LOGMSG_INFO, "applying log from lsn {%u:%u}\n", file, offset);
 
     rc = truncate_log(file, offset, 1);
     gbl_truncating_log = 0;
@@ -320,6 +322,7 @@ static int db_comdb_truncate_time(Lua L) {
     gbl_truncating_log = 1;
     logdelete_unlock(__func__, __LINE__);
 
+#if 0
     bdb_min_truncate(thedb->bdb_env, NULL, NULL, &min_time);
 
     if (time < min_time)
@@ -329,7 +332,8 @@ static int db_comdb_truncate_time(Lua L) {
                 min_time);
     }
 
-    logmsg(LOGMSG_USER, "Finding earliest log before stated time: %ld.\n", time);
+#endif
+    logmsg(LOGMSG_INFO, "Finding earliest log before stated time: %ld.\n", time);
 
     rc = truncate_timestamp(time);
     gbl_truncating_log = 0;


### PR DESCRIPTION
This is causing issues with 'checkpoint only' databases - disable for now
