### PR TITLE
Fix min truncate

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2105,6 +2105,7 @@ struct cluster_info {
 int bdb_fill_cluster_info(void **data, int *num_nodes);
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp);
+int bdb_dump_mintruncate_list(bdb_state_type *bdb_state);
 
 void wait_for_sc_to_stop(const char *operation);
 void allow_sc_to_run(void);

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2106,6 +2106,9 @@ int bdb_fill_cluster_info(void **data, int *num_nodes);
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp);
 int bdb_dump_mintruncate_list(bdb_state_type *bdb_state);
+int bdb_clear_mintruncate_list(bdb_state_type *bdb_state);
+int bdb_build_mintruncate_list(bdb_state_type *bdb_state);
+int bdb_print_mintruncate_min(bdb_state_type *bdb_state);
 
 void wait_for_sc_to_stop(const char *operation);
 void allow_sc_to_run(void);

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3324,7 +3324,6 @@ static int bdb_calc_min_truncate(bdb_state_type *bdb_state)
     int rc;
     int lowfilenum;
     int32_t timestamp;
-    return 0;
     Pthread_rwlock_wrlock(&min_trunc_lk);
     lowfilenum = get_lowfilenum_sanclist(bdb_state);
     rc = bdb_state->dbenv->min_truncate_lsn_timestamp(

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3342,10 +3342,14 @@ static int bdb_calc_min_truncate(bdb_state_type *bdb_state)
     return rc;
 }
 
+int bdb_dump_mintruncate_list(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->dump_mintruncate_list(bdb_state->dbenv);
+}
+
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp)
 {
-    return 0;
     if (gbl_min_truncate_file < 1)
         bdb_calc_min_truncate(bdb_state);
     Pthread_rwlock_rdlock(&min_trunc_lk);

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3326,7 +3326,7 @@ static int bdb_calc_min_truncate(bdb_state_type *bdb_state)
     int32_t timestamp;
     Pthread_rwlock_wrlock(&min_trunc_lk);
     lowfilenum = get_lowfilenum_sanclist(bdb_state);
-    rc = bdb_state->dbenv->min_truncate_lsn_timestamp(
+    rc = bdb_state->dbenv->mintruncate_lsn_timestamp(
         bdb_state->dbenv, lowfilenum, &lsn, &timestamp);
     if (rc == 0) {
         gbl_min_truncate_file = lsn.file;
@@ -3345,6 +3345,31 @@ int bdb_dump_mintruncate_list(bdb_state_type *bdb_state)
 {
     return bdb_state->dbenv->dump_mintruncate_list(bdb_state->dbenv);
 }
+
+int bdb_clear_mintruncate_list(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->clear_mintruncate_list(bdb_state->dbenv);
+}
+
+int bdb_build_mintruncate_list(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->build_mintruncate_list(bdb_state->dbenv);
+}
+
+int bdb_print_mintruncate_min(bdb_state_type *bdb_state)
+{
+    int32_t timestamp;
+    int rc;
+    DB_LSN lsn;
+    rc = bdb_state->dbenv->mintruncate_lsn_timestamp(
+            bdb_state->dbenv, 0, &lsn, &timestamp);
+    if (rc == 0) {
+        logmsg(LOGMSG_USER, "[%d:%d] %u\n",
+                lsn.file, lsn.offset, timestamp);
+    }
+    return rc;
+}
+
 
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp)

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3361,15 +3361,13 @@ int bdb_print_mintruncate_min(bdb_state_type *bdb_state)
     int32_t timestamp;
     int rc;
     DB_LSN lsn;
-    rc = bdb_state->dbenv->mintruncate_lsn_timestamp(
-            bdb_state->dbenv, 0, &lsn, &timestamp);
+    rc = bdb_state->dbenv->mintruncate_lsn_timestamp(bdb_state->dbenv, 0, &lsn,
+                                                     &timestamp);
     if (rc == 0) {
-        logmsg(LOGMSG_USER, "[%d:%d] %u\n",
-                lsn.file, lsn.offset, timestamp);
+        logmsg(LOGMSG_USER, "[%d:%d] %u\n", lsn.file, lsn.offset, timestamp);
     }
     return rc;
 }
-
 
 int bdb_min_truncate(bdb_state_type *bdb_state, int *file, int *offset,
                      int32_t *timestamp)

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2007,6 +2007,7 @@ struct mintruncate_entry {
 	int type;
 	int32_t timestamp;
 	DB_LSN lsn;
+	DB_LSN ckplsn;
 	LINKC_T(struct mintruncate_entry) lnk;
 };
 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2066,6 +2066,7 @@ struct __db_env {
     int (*rep_verify_match) __P((DB_ENV *, unsigned int, unsigned int, int));
     int (*min_truncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
     int (*dump_mintruncate_list) __P((DB_ENV *));
+    int (*mintruncate_delete_log) __P((DB_ENV *, int lowfile));
 
 	/*
 	 * Currently, the verbose list is a bit field with room for 32
@@ -2426,7 +2427,6 @@ struct __db_env {
 	LISTC_T(HEAP) regions;
 	int bulk_stops_on_page;
 
-	void (*recovery_start_callback)(DB_ENV *env);
 	void (*lsn_undone_callback)(DB_ENV *env, DB_LSN*);
 
 	int  (*txn_begin_set_retries)

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2008,6 +2008,9 @@ struct mintruncate_entry {
 	int32_t timestamp;
 	DB_LSN lsn;
 	DB_LSN ckplsn;
+#ifdef MINTRUNCATE_DEBUG
+    char *func;
+#endif
 	LINKC_T(struct mintruncate_entry) lnk;
 };
 
@@ -2065,8 +2068,10 @@ struct __db_env {
                 void*, int));
     size_t (*get_log_header_size) __P((DB_ENV*)); 
     int (*rep_verify_match) __P((DB_ENV *, unsigned int, unsigned int, int));
-    int (*min_truncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
+    int (*mintruncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
     int (*dump_mintruncate_list) __P((DB_ENV *));
+    int (*clear_mintruncate_list) __P((DB_ENV *));
+    int (*build_mintruncate_list) __P((DB_ENV *));
     int (*mintruncate_delete_log) __P((DB_ENV *, int lowfile));
 
 	/*
@@ -2491,7 +2496,9 @@ struct __db_env {
     int mintruncate_state;
     DB_LSN mintruncate_first;
 	LISTC_T(struct mintruncate_entry) mintruncate;
-    DB_LSN last_dbreg_start;
+    DB_LSN last_mintruncate_dbreg_start;
+    DB_LSN last_mintruncate_ckp;
+    DB_LSN last_mintruncate_ckplsn;
 	db_recops recovery_pass;
 	pthread_rwlock_t dbreglk;
 	pthread_rwlock_t recoverlk;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1,5 +1,5 @@
 /*
-after* See the file LICENSE for redistribution information.
+ * See the file LICENSE for redistribution information.
  *
  * Copyright (c) 1996-2003
  *	Sleepycat Software.  All rights reserved.
@@ -1993,9 +1993,9 @@ struct fileid_track {
 };
 
 enum {
-    MINTRUNCATE_START = 0,
-    MINTRUNCATE_SCAN = 1,
-    MINTRUNCATE_READY = 2
+	MINTRUNCATE_START = 0,
+	MINTRUNCATE_SCAN = 1,
+	MINTRUNCATE_READY = 2
 };
 
 enum {
@@ -2009,7 +2009,7 @@ struct mintruncate_entry {
 	DB_LSN lsn;
 	DB_LSN ckplsn;
 #ifdef MINTRUNCATE_DEBUG
-    char *func;
+	char *func;
 #endif
 	LINKC_T(struct mintruncate_entry) lnk;
 };
@@ -2043,8 +2043,8 @@ struct __lc_cache {
 };
 
 typedef int (*collect_locks_f)(void *args, int64_t threadid, int32_t lockerid,
-        const char *mode, const char *status, const char *table,
-        int64_t page, const char *rectype);
+		const char *mode, const char *status, const char *table,
+		int64_t page, const char *rectype);
 
 /* Database Environment handle. */
 struct __db_env {
@@ -2063,16 +2063,16 @@ struct __db_env {
 	void *(*db_realloc) __P((void *, size_t));
 	void (*db_free) __P((void *));
 
-    /* expose logging rep_apply */
-    int (*apply_log) __P((DB_ENV *, unsigned int, unsigned int, int64_t,
-                void*, int));
-    size_t (*get_log_header_size) __P((DB_ENV*)); 
-    int (*rep_verify_match) __P((DB_ENV *, unsigned int, unsigned int, int));
-    int (*mintruncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
-    int (*dump_mintruncate_list) __P((DB_ENV *));
-    int (*clear_mintruncate_list) __P((DB_ENV *));
-    int (*build_mintruncate_list) __P((DB_ENV *));
-    int (*mintruncate_delete_log) __P((DB_ENV *, int lowfile));
+	/* expose logging rep_apply */
+	int (*apply_log) __P((DB_ENV *, unsigned int, unsigned int, int64_t,
+				void*, int));
+	size_t (*get_log_header_size) __P((DB_ENV*)); 
+	int (*rep_verify_match) __P((DB_ENV *, unsigned int, unsigned int, int));
+	int (*mintruncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
+	int (*dump_mintruncate_list) __P((DB_ENV *));
+	int (*clear_mintruncate_list) __P((DB_ENV *));
+	int (*build_mintruncate_list) __P((DB_ENV *));
+	int (*mintruncate_delete_log) __P((DB_ENV *, int lowfile));
 
 	/*
 	 * Currently, the verbose list is a bit field with room for 32
@@ -2090,7 +2090,7 @@ struct __db_env {
 	void		*app_private;	/* Application-private handle. */
 
 	int (*app_dispatch)		/* User-specified recovery dispatch. */
-	    __P((DB_ENV *, DBT *, DB_LSN *, db_recops));
+		__P((DB_ENV *, DBT *, DB_LSN *, db_recops));
 
 	/* Locking. */
 	u_int8_t	*lk_conflicts;	/* Two dimensional conflict matrix. */
@@ -2126,14 +2126,14 @@ struct __db_env {
 	/* Replication */
 	char*		rep_eid;	/* environment id. */
 	int		(*rep_send)	/* Send function. */
-		    __P((DB_ENV *, const DBT *, const DBT *,
-                   const DB_LSN *, char*, int, void *));
-	int     (*txn_logical_start)
-		    __P((DB_ENV *, void *state, u_int64_t ltranid,
-		    DB_LSN *lsn));
-	int     (*txn_logical_commit)
-		    __P((DB_ENV *, void *state, u_int64_t ltranid,
-		    DB_LSN *lsn));
+			__P((DB_ENV *, const DBT *, const DBT *,
+				   const DB_LSN *, char*, int, void *));
+	int	 (*txn_logical_start)
+			__P((DB_ENV *, void *state, u_int64_t ltranid,
+			DB_LSN *lsn));
+	int	 (*txn_logical_commit)
+			__P((DB_ENV *, void *state, u_int64_t ltranid,
+			DB_LSN *lsn));
 	DB_LSN last_locked_lsn;
 	pthread_mutex_t locked_lsn_lk;
 
@@ -2151,7 +2151,7 @@ struct __db_env {
 	char		*db_log_dir;	/* Database log file directory. */
 	char		*db_tmp_dir;	/* Database tmp file directory. */
 
-	char	       **db_data_dir;	/* Database data file directories. */
+	char		   **db_data_dir;	/* Database data file directories. */
 	int		 data_cnt;	/* Database data file slots. */
 	int		 data_next;	/* Next Database data file slot. */
 
@@ -2161,8 +2161,8 @@ struct __db_env {
 	void		*reginfo;	/* REGINFO structure reference. */
 	DB_FH		*lockfhp;	/* fcntl(2) locking file handle. */
 
-	int	      (**recover_dtab)	/* Dispatch table for recover funcs. */
-			    __P((DB_ENV *, DBT *, DB_LSN *, db_recops, void *));
+	int		  (**recover_dtab)	/* Dispatch table for recover funcs. */
+				__P((DB_ENV *, DBT *, DB_LSN *, db_recops, void *));
 	size_t		 recover_dtab_size;
 					/* Slots in the dispatch table. */
 
@@ -2344,7 +2344,7 @@ struct __db_env {
 	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
-	    char **, DB_LSN *, uint32_t *, int));
+		char **, DB_LSN *, uint32_t *, int));
 	int  (*rep_verify_will_recover) __P((DB_ENV *, DBT *, DBT *));
 	int  (*rep_truncate_repdb) __P((DB_ENV *));
 	int  (*rep_start) __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
@@ -2493,12 +2493,12 @@ struct __db_env {
 	/* These fields are for changes to recovery code. */ 
 	struct fileid_track fileid_track;
 	pthread_mutex_t mintruncate_lk;
-    int mintruncate_state;
-    DB_LSN mintruncate_first;
+	int mintruncate_state;
+	DB_LSN mintruncate_first;
 	LISTC_T(struct mintruncate_entry) mintruncate;
-    DB_LSN last_mintruncate_dbreg_start;
-    DB_LSN last_mintruncate_ckp;
-    DB_LSN last_mintruncate_ckplsn;
+	DB_LSN last_mintruncate_dbreg_start;
+	DB_LSN last_mintruncate_ckp;
+	DB_LSN last_mintruncate_ckplsn;
 	db_recops recovery_pass;
 	pthread_rwlock_t dbreglk;
 	pthread_rwlock_t recoverlk;
@@ -2542,14 +2542,14 @@ struct __db_env {
 	int (*truncate_sc_callback)(DB_ENV *, DB_LSN *lsn);
 	int (*set_rep_truncate_callback) __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *lsn, int is_master)));
 	int (*rep_truncate_callback)(DB_ENV *, DB_LSN *lsn, int is_master);
-    void (*rep_set_gen)(DB_ENV *, uint32_t gen);
+	void (*rep_set_gen)(DB_ENV *, uint32_t gen);
 	int (*set_rep_recovery_cleanup) __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *lsn, int is_master)));
-    int (*rep_recovery_cleanup)(DB_ENV *, DB_LSN *lsn, int is_master);
-    int (*lock_recovery_lock)(DB_ENV *);
-    int (*unlock_recovery_lock)(DB_ENV *);
+	int (*rep_recovery_cleanup)(DB_ENV *, DB_LSN *lsn, int is_master);
+	int (*lock_recovery_lock)(DB_ENV *);
+	int (*unlock_recovery_lock)(DB_ENV *);
 	/* Trigger/consumer signalling support */
 	int(*trigger_subscribe) __P((DB_ENV *, const char *, pthread_cond_t **,
-				     pthread_mutex_t **, const uint8_t **active));
+					 pthread_mutex_t **, const uint8_t **active));
 	int(*trigger_unsubscribe) __P((DB_ENV *, const char *));
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
@@ -2766,19 +2766,19 @@ extern int gbl_bb_berkdb_enable_memp_pg_timing;
 extern int gbl_bb_berkdb_enable_shalloc_timing;
 
 struct berkdb_deadlock_info {
-    u_int32_t lid;
+	u_int32_t lid;
 };
 
 struct __heap {
-    void *mem;
-    char *description;
-    size_t size;
-    int used;
-    int blocks;
-    int blocksz[32];
-    DB_MUTEX *lock;
-    comdb2ma msp;
-    LINKC_T(HEAP) lnk;
+	void *mem;
+	char *description;
+	size_t size;
+	int used;
+	int blocks;
+	int blocksz[32];
+	DB_MUTEX *lock;
+	comdb2ma msp;
+	LINKC_T(HEAP) lnk;
 
 };
 
@@ -2791,28 +2791,28 @@ int berkdb_get_max_rep_retries();
 /* COMDB2 MODIFICATION */
 int berkdb_is_recovering(DB_ENV *dbenv);
 
-#define TIMEIT(x)               \
-do {                            \
-    int start, end, diff;       \
-    start = comdb2_time_epochms(); \
-    x                           \
-    end = comdb2_time_epochms();\
-    diff = end - start;         \
-    if (diff > 100)             \
-        printf(">> %d %dms\n", __LINE__, diff); \
+#define TIMEIT(x)			   \
+do {							\
+	int start, end, diff;	   \
+	start = comdb2_time_epochms(); \
+	x						   \
+	end = comdb2_time_epochms();\
+	diff = end - start;		 \
+	if (diff > 100)			 \
+		printf(">> %d %dms\n", __LINE__, diff); \
 } while(0)
 
-#define TIMEITX(x, y)           \
-do {                            \
-    int start, end, diff;       \
-    start = comdb2_time_epochms(); \
-    x                           \
-    end = comdb2_time_epochms();\
-    diff = end - start;         \
-    if (diff > 100) {           \
-        printf(">> %d %dms\n", __LINE__, diff); \
-        y                       \
-    }                           \
+#define TIMEITX(x, y)		   \
+do {							\
+	int start, end, diff;	   \
+	start = comdb2_time_epochms(); \
+	x						   \
+	end = comdb2_time_epochms();\
+	diff = end - start;		 \
+	if (diff > 100) {		   \
+		printf(">> %d %dms\n", __LINE__, diff); \
+		y					   \
+	}						   \
 } while(0)
 
 struct __db_checkpoint {
@@ -2938,7 +2938,7 @@ int __recover_logfile_pglogs(DB_ENV *, void *);
 //#################################### THREAD POOL FOR LOADING PAGES ASYNCHRNOUSLY (WELL NO CALLBACK YET.....) 
 
 int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn,
-    void *work, int queue_override, char *persistent_info, uint32_t flags);
+	void *work, int queue_override, char *persistent_info, uint32_t flags);
 
 
 typedef struct {

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1,5 +1,5 @@
 /*
- * See the file LICENSE for redistribution information.
+after* See the file LICENSE for redistribution information.
  *
  * Copyright (c) 1996-2003
  *	Sleepycat Software.  All rights reserved.
@@ -2065,6 +2065,7 @@ struct __db_env {
     size_t (*get_log_header_size) __P((DB_ENV*)); 
     int (*rep_verify_match) __P((DB_ENV *, unsigned int, unsigned int, int));
     int (*min_truncate_lsn_timestamp) __P((DB_ENV *, int file, DB_LSN *outlsn, int32_t *timestamp));
+    int (*dump_mintruncate_list) __P((DB_ENV *));
 
 	/*
 	 * Currently, the verbose list is a bit field with room for 32
@@ -2487,6 +2488,7 @@ struct __db_env {
 	struct fileid_track fileid_track;
 	pthread_mutex_t mintruncate_lk;
     int mintruncate_state;
+    DB_LSN mintruncate_first;
 	LISTC_T(struct mintruncate_entry) mintruncate;
     DB_LSN last_dbreg_start;
 	db_recops recovery_pass;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1992,6 +1992,24 @@ struct fileid_track {
 	int numids;
 };
 
+enum {
+    MINTRUNCATE_START = 0,
+    MINTRUNCATE_SCAN = 1,
+    MINTURNCATE_READY = 2
+};
+
+enum {
+	MINTRUNCATE_DBREG_START = 1,
+	MINTRUNCATE_CHECKPOINT = 2
+};
+
+struct mintruncate_entry {
+	int type;
+	int32_t timestamp;
+	DB_LSN lsn;
+	LINKC_T(struct mintruncate_entry) lnk;
+};
+
 /* hoisted out of rep.h */
 struct __lsn_collection {
 	int nlsns;
@@ -2467,6 +2485,10 @@ struct __db_env {
 
 	/* These fields are for changes to recovery code. */ 
 	struct fileid_track fileid_track;
+	Pthread_mutex_t mintruncate_lk;
+    int mintruncate_state;
+	LISTC_T(struct mintruncate_entry) mintruncate;
+    DB_LSN last_dbreg_start;
 	db_recops recovery_pass;
 	pthread_rwlock_t dbreglk;
 	pthread_rwlock_t recoverlk;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1995,7 +1995,7 @@ struct fileid_track {
 enum {
     MINTRUNCATE_START = 0,
     MINTRUNCATE_SCAN = 1,
-    MINTURNCATE_READY = 2
+    MINTRUNCATE_READY = 2
 };
 
 enum {
@@ -2485,7 +2485,7 @@ struct __db_env {
 
 	/* These fields are for changes to recovery code. */ 
 	struct fileid_track fileid_track;
-	Pthread_mutex_t mintruncate_lk;
+	pthread_mutex_t mintruncate_lk;
     int mintruncate_state;
 	LISTC_T(struct mintruncate_entry) mintruncate;
     DB_LSN last_dbreg_start;

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -96,8 +96,10 @@ int __dbenv_apply_log __P((DB_ENV *, unsigned int, unsigned int, int64_t,
             void*, int));
 size_t __dbenv_get_log_header_size __P((DB_ENV*)); 
 int __dbenv_rep_verify_match __P((DB_ENV*, unsigned int, unsigned int, int));
-int __dbenv_min_truncate_lsn_timestamp __P((DB_ENV*, int file, DB_LSN *lsn, int32_t *timestamp));
+int __dbenv_mintruncate_lsn_timestamp __P((DB_ENV*, int file, DB_LSN *lsn, int32_t *timestamp));
 int __dbenv_dump_mintruncate_list __P((DB_ENV*));
+int __dbenv_clear_mintruncate_list __P((DB_ENV*));
+int __dbenv_build_mintruncate_list __P((DB_ENV*));
 
 /*
  * db_env_create --
@@ -273,8 +275,10 @@ __dbenv_init(dbenv)
 
         dbenv->get_log_header_size = __dbenv_get_log_header_size;
         dbenv->rep_verify_match = __dbenv_rep_verify_match;
-        dbenv->min_truncate_lsn_timestamp = __dbenv_min_truncate_lsn_timestamp;
+        dbenv->mintruncate_lsn_timestamp = __dbenv_mintruncate_lsn_timestamp;
         dbenv->dump_mintruncate_list = __dbenv_dump_mintruncate_list;
+        dbenv->clear_mintruncate_list = __dbenv_clear_mintruncate_list;
+        dbenv->build_mintruncate_list = __dbenv_build_mintruncate_list;
 #ifdef	HAVE_RPC
 	}
 #endif

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -97,6 +97,7 @@ int __dbenv_apply_log __P((DB_ENV *, unsigned int, unsigned int, int64_t,
 size_t __dbenv_get_log_header_size __P((DB_ENV*)); 
 int __dbenv_rep_verify_match __P((DB_ENV*, unsigned int, unsigned int, int));
 int __dbenv_min_truncate_lsn_timestamp __P((DB_ENV*, int file, DB_LSN *lsn, int32_t *timestamp));
+int __dbenv_dump_mintruncate_list __P((DB_ENV*));
 
 /*
  * db_env_create --
@@ -273,6 +274,7 @@ __dbenv_init(dbenv)
         dbenv->get_log_header_size = __dbenv_get_log_header_size;
         dbenv->rep_verify_match = __dbenv_rep_verify_match;
         dbenv->min_truncate_lsn_timestamp = __dbenv_min_truncate_lsn_timestamp;
+        dbenv->dump_mintruncate_list = __dbenv_dump_mintruncate_list;
 #ifdef	HAVE_RPC
 	}
 #endif

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -371,6 +371,7 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		Pthread_mutex_init(&dbenv->locked_lsn_lk, NULL);
 	}
     dbenv->mintruncate_state = MINTRUNCATE_START;
+    ZERO_LSN(dbenv->mintruncate_first);
     ZERO_LSN(dbenv->last_dbreg_start);
 	Pthread_mutex_init(&dbenv->mintruncate_lk, NULL);
 	listc_init(&dbenv->mintruncate,

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -371,8 +371,8 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		Pthread_mutex_init(&dbenv->locked_lsn_lk, NULL);
 	}
     dbenv->mintruncate_state = MINTRUNCATE_START;
-    ZERO_LSN(&dbenv->last_dbreg_start);
-	Pthread_mutex_init(&dbenv->mintruncate_lk);
+    ZERO_LSN(dbenv->last_dbreg_start);
+	Pthread_mutex_init(&dbenv->mintruncate_lk, NULL);
 	listc_init(&dbenv->mintruncate,
 			offsetof(struct mintruncate_entry, lnk));
 

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -372,7 +372,7 @@ __dbenv_open(dbenv, db_home, flags, mode)
 	}
 	dbenv->mintruncate_state = MINTRUNCATE_START;
 	ZERO_LSN(dbenv->mintruncate_first);
-	ZERO_LSN(dbenv->last_dbreg_start);
+	ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
 	Pthread_mutex_init(&dbenv->mintruncate_lk, NULL);
 	listc_init(&dbenv->mintruncate,
 			offsetof(struct mintruncate_entry, lnk));

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -370,9 +370,9 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		Pthread_mutex_init(&dbenv->ltrans_active_lk, NULL);
 		Pthread_mutex_init(&dbenv->locked_lsn_lk, NULL);
 	}
-    dbenv->mintruncate_state = MINTRUNCATE_START;
-    ZERO_LSN(dbenv->mintruncate_first);
-    ZERO_LSN(dbenv->last_dbreg_start);
+	dbenv->mintruncate_state = MINTRUNCATE_START;
+	ZERO_LSN(dbenv->mintruncate_first);
+	ZERO_LSN(dbenv->last_dbreg_start);
 	Pthread_mutex_init(&dbenv->mintruncate_lk, NULL);
 	listc_init(&dbenv->mintruncate,
 			offsetof(struct mintruncate_entry, lnk));

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -370,6 +370,11 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		Pthread_mutex_init(&dbenv->ltrans_active_lk, NULL);
 		Pthread_mutex_init(&dbenv->locked_lsn_lk, NULL);
 	}
+    dbenv->mintruncate_state = MINTRUNCATE_START;
+    ZERO_LSN(&dbenv->last_dbreg_start);
+	Pthread_mutex_init(&dbenv->mintruncate_lk);
+	listc_init(&dbenv->mintruncate,
+			offsetof(struct mintruncate_entry, lnk));
 
 	if (LF_ISSET(DB_INIT_TXN)) {
 		if ((ret = __txn_open(dbenv)) != 0)

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -621,7 +621,7 @@ __dbenv_mintruncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 
 	/* Delete old entries */
 	while ((mt = LISTC_BOT(&dbenv->mintruncate)) != NULL &&
-			mt->lsn.file < lowfile) {
+			mt->lsn.file <= lowfile) {
 		mt = listc_rbl(&dbenv->mintruncate);
 		free(mt);
 	}

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -721,7 +721,7 @@ int __dbenv_build_mintruncate_list(dbenv)
 			ret = __log_c_get(logc, &lsn, &rec, DB_NEXT)) {
 
 		LOGCOPY_32(&type, rec.data);
-		if (type ==  DB___db_debug) {
+		if (type == DB___db_debug) {
 			if ((ret = __db_debug_read(dbenv, rec.data, &debug_args))!=0)
 				abort();
 			LOGCOPY_32(&optype, debug_args->op.data);

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -544,6 +544,21 @@ static char *mt_string(int mt)
 }
 
 int
+__dbenv_clear_mintruncate_list(dbenv)
+    DB_ENV *dbenv;
+{
+	struct mintruncate_entry *mt;
+	Pthread_mutex_lock(&dbenv->mintruncate_lk);
+    while ((mt = listc_rtl(&dbenv->mintruncate)) != NULL)
+        free(mt);
+    dbenv->mintruncate_state = MINTRUNCATE_START;
+    ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
+    ZERO_LSN(dbenv->last_mintruncate_ckplsn);
+	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+    return 0;
+}
+
+int
 __dbenv_dump_mintruncate_list(dbenv)
 	DB_ENV *dbenv;
 {
@@ -554,17 +569,25 @@ __dbenv_dump_mintruncate_list(dbenv)
 			mt_string(dbenv->mintruncate_state));
 	for (mt = LISTC_BOT(&dbenv->mintruncate); mt != NULL ;
 				mt = mt->lnk.prev) {
-		logmsg(LOGMSG_USER, "%s @ [%d:%d] timestamp %d ckplsn [%d:%d]\n",
+		logmsg(LOGMSG_USER, "%s @ [%d:%d] timestamp %d ckplsn [%d:%d] "
+#ifdef MINTRUNCATE_DEBUG
+                "added by %s"
+#endif
+                "\n",
 				mt->type == MINTRUNCATE_DBREG_START ? "dbreg" : "chkpt",
 				mt->lsn.file, mt->lsn.offset, mt->timestamp, mt->ckplsn.file,
-                mt->ckplsn.offset);
+                mt->ckplsn.offset
+#ifdef MINTRUNCATE_DEBUG
+                ,mt->func
+#endif
+                );
 	}
 	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 	return 0;
 }
 
 int
-__dbenv_min_truncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
+__dbenv_mintruncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 	DB_ENV *dbenv;
 	int lowfile;
 	DB_LSN *outlsn;
@@ -574,6 +597,7 @@ __dbenv_min_truncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 	__txn_ckp_args *ckp_args = NULL;
 	DBT rec = { 0 };
 	DB_LOGC *logc = NULL;
+    DB_LSN lowlsn = {0};
 	int ret;
 
 	if ((ret = __txn_getckp(dbenv, outlsn)) != 0 ||
@@ -602,16 +626,21 @@ __dbenv_min_truncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 		free(mt);
 	}
 
-	/* Find first DBREG >= lowfile */
+	/* Find first DBREG (we've deleted all below lowfile) */
 	for (mt = LISTC_BOT(&dbenv->mintruncate) ;
 			mt && (mt->type != MINTRUNCATE_DBREG_START) ;
 			mt = mt->lnk.prev)
 		;
 
-	/* Find first checkpoint after that */
-	while (mt && mt->type != MINTRUNCATE_CHECKPOINT)
+    if (mt)
+        lowlsn = mt->lsn;
+
+	/* Find first checkpoint with ckplsn > than that */
+	while (mt && (mt->type != MINTRUNCATE_CHECKPOINT || 
+             log_compare(&mt->ckplsn, &lowlsn) < 0))
 		mt = mt->lnk.prev;
 
+    /* If we found it, that's our minimum truncate point */
 	if (mt) {
 		ret = 0;
 		*outlsn = mt->lsn;
@@ -624,21 +653,60 @@ err:
 	return ret;
 }
 
-int __build_min_truncate_map(dbenv)
+/* Must be holding mintruncate_lk while calling this */
+void __dbenv_reset_mintruncate_vars(dbenv)
+    DB_ENV *dbenv;
+{
+    int found_dbreg=0, found_ckp=0;
+	struct mintruncate_entry *mt;
+    ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
+    ZERO_LSN(dbenv->last_mintruncate_ckplsn);
+    for (mt = LISTC_TOP(&dbenv->mintruncate); mt; mt = mt->lnk.next) {
+        if (!found_dbreg && mt->type == MINTRUNCATE_DBREG_START) {
+            dbenv->last_mintruncate_dbreg_start = mt->lsn;
+            found_dbreg = 1;
+        }
+
+        if (!found_ckp && mt->type == MINTRUNCATE_CHECKPOINT) {
+            dbenv->last_mintruncate_ckplsn = mt->ckplsn;
+            found_ckp = 1;
+        }
+
+        if (found_dbreg && found_ckp)
+            break;
+    }
+}
+
+#ifdef MINTRUNCATE_DEBUG
+void verify_list(dbenv)
 	DB_ENV *dbenv;
 {
-	struct mintruncate_entry *mt, *newmt, *prev_mt, *last_start = NULL;
+	struct mintruncate_entry *mt;
+	DB_LSN last = {0};
+	for (mt = LISTC_BOT(&dbenv->mintruncate) ; mt ; mt = mt->lnk.prev) {
+		if (log_compare(&last, &mt->lsn) >= 0)
+			abort();
+		last = mt->lsn;
+	}
+}
+#endif
+
+int __dbenv_build_mintruncate_list(dbenv)
+	DB_ENV *dbenv;
+{
+	struct mintruncate_entry *mt, *newmt, *prev_mt;
+
 	u_int32_t type;
 	int optype = 0;
 	__txn_ckp_args *ckp_args;
 	__db_debug_args *debug_args;
 	DBT rec = {0};
-	DB_LSN lsn, last_ckp_lsn = {0}, last_dbreg_start = {0};
+	DB_LSN lsn, last_ckp_lsn = {0}, last_dbreg_start = {0}, last_add;
 	DB_LOGC *logc = NULL;
-	int ret = 0;
+	int ret = 0, caught_up = 0;
 
-	if (dbenv->mintruncate_state != MINTRUNCATE_START) {
-		logmsg(LOGMSG_INFO, "%s: \n", __func__);
+	if (dbenv->mintruncate_state == MINTRUNCATE_READY) {
+		logmsg(LOGMSG_WARN, "%s: no need to build map\n", __func__);
 		return 0;
 	}
 
@@ -649,7 +717,8 @@ int __build_min_truncate_map(dbenv)
 
 	rec.flags = DB_DBT_REALLOC;
 	for (ret = __log_c_get(logc, &lsn, &rec, DB_FIRST);
-			ret == 0 ; ret = __log_c_get(logc, &lsn, &rec, DB_NEXT)) {
+			ret == 0 && caught_up == 0;
+			ret = __log_c_get(logc, &lsn, &rec, DB_NEXT)) {
 
 		LOGCOPY_32(&type, rec.data);
 		if (type ==  DB___db_debug) {
@@ -665,53 +734,80 @@ int __build_min_truncate_map(dbenv)
 				/* Normal log traffic can be adding to the other end: find
 				 * correct place to insert */
 
-				for (prev_mt = NULL, mt = LISTC_TOP(&dbenv->mintruncate) ;
-						mt && log_compare(&mt->lsn, &lsn) > 0;
-						prev_mt = mt, mt = mt->lnk.next)
+				for (prev_mt = NULL, mt = LISTC_BOT(&dbenv->mintruncate) ;
+						mt && log_compare(&mt->lsn, &lsn) < 0;
+						prev_mt = mt, mt = mt->lnk.prev)
 					;
 				if (!mt || log_compare(&mt->lsn, &lsn) > 0) {
-					last_start = newmt = malloc(sizeof(*newmt));
+					newmt = malloc(sizeof(*newmt));
+#ifdef MINTRUNCATE_DEBUG
+					newmt->func = __func__;
+#endif
 					newmt->type = MINTRUNCATE_DBREG_START;
 					newmt->timestamp = 0;
 					last_dbreg_start = newmt->lsn = lsn;
-                    ZERO_LSN(newmt->ckplsn);
-					if (!prev_mt)
+					ZERO_LSN(newmt->ckplsn);
+					if (!mt) {
 						listc_atl(&dbenv->mintruncate, newmt);
-					else
-						listc_add_after(&dbenv->mintruncate, newmt, prev_mt);
+					} else {
+						listc_add_after(&dbenv->mintruncate, newmt, mt);
+					}
+#ifdef MINTRUNCATE_DEBUG
+					verify_list(dbenv);
+#endif
 				} else if (mt) {
 					assert(log_compare(&mt->lsn, &lsn) == 0);
 					assert(mt->type == MINTRUNCATE_DBREG_START);
+					caught_up = 1;
 				}
-            }
+			}
 
-            Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+			Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 		}
 
-		if (type == DB___txn_ckp && last_start) {
-			Pthread_mutex_lock(&dbenv->mintruncate_lk);
-			mt = LISTC_TOP(&dbenv->mintruncate);
-			if (mt->type == MINTRUNCATE_DBREG_START) {
-				if ((ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
-					abort();
-				if (log_compare(&ckp_args->ckp_lsn,
-							&last_dbreg_start) >= 0) {
+		if (type == DB___txn_ckp) {
+			if ((ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
+				abort();
+
+			if (ckp_args->ckp_lsn.file > last_ckp_lsn.file) {
+				Pthread_mutex_lock(&dbenv->mintruncate_lk);
+				for (prev_mt = NULL, mt = LISTC_BOT(&dbenv->mintruncate) ;
+						mt && log_compare(&mt->lsn, &lsn) < 0;
+						prev_mt = mt, mt = mt->lnk.prev)
+					;
+
+				if (!mt || log_compare(&mt->lsn, &lsn) > 0) {
 					newmt = malloc(sizeof(*newmt));
+#ifdef MINTRUNCATE_DEBUG
+					newmt->func = __func__;
+#endif
 					newmt->type = MINTRUNCATE_CHECKPOINT;
 					newmt->timestamp = ckp_args->timestamp;
 					newmt->lsn = lsn;
-                    newmt->ckplsn = ckp_args->ckp_lsn;
-					listc_add_after(&dbenv->mintruncate, newmt, last_start);
-					/* Ignore checkpoints until I see another dbreg */
-					last_start = NULL;
+					last_ckp_lsn = newmt->ckplsn = ckp_args->ckp_lsn;
+					if (!mt) { 
+						listc_atl(&dbenv->mintruncate, newmt);
+					} else {
+						listc_add_after(&dbenv->mintruncate, newmt, mt);
+					}
+#ifdef MINTRUNCATE_DEBUG
+					verify_list(dbenv);
+#endif
+				} else if (mt) {
+					assert(log_compare(&mt->lsn, &lsn) == 0);
+					assert(mt->type == MINTRUNCATE_CHECKPOINT);
+					caught_up = 1;
 				}
-				__os_free(dbenv, ckp_args);
+				Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 			}
-			Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+			__os_free(dbenv, ckp_args);
 		}
 	}
 
+	Pthread_mutex_lock(&dbenv->mintruncate_lk);
+	__dbenv_reset_mintruncate_vars(dbenv);
 	dbenv->mintruncate_state = MINTRUNCATE_READY;
+	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
 err:
 	if (logc)
@@ -721,7 +817,7 @@ err:
 }
 
 int __rep_check_applied_lsns(DB_ENV * dbenv, LSN_COLLECTION * lc,
-    int inrecovery);
+	int inrecovery);
 
 static int
 full_recovery_check(DB_ENV *dbenv, DB_LSN *max_lsn)
@@ -743,17 +839,17 @@ full_recovery_check(DB_ENV *dbenv, DB_LSN *max_lsn)
 
 	ret = __log_cursor(dbenv, &logc);
 	for (ret = __log_c_get(logc, &lsn, &logrec, DB_FIRST);
-	    ret == 0 && (max_lsn == NULL || log_compare(&lsn, max_lsn) <= 0);
-	    ret = __log_c_get(logc, &lsn, &logrec, DB_NEXT)) {
+		ret == 0 && (max_lsn == NULL || log_compare(&lsn, max_lsn) <= 0);
+		ret = __log_c_get(logc, &lsn, &logrec, DB_NEXT)) {
 		last = lsn;
 		LOGCOPY_32(&type, logrec.data);
 		if (IS_ZERO_LSN(first))
 			first = lsn;
 		if (type == DB___txn_regop || type == DB___txn_regop_gen ||
-		    type == DB___txn_regop_rowlocks) {
+			type == DB___txn_regop_rowlocks) {
 			cpy = lsn;
 			ret =
-			    __rep_collect_txn(dbenv, &cpy, &lc, &ignore, NULL);
+				__rep_collect_txn(dbenv, &cpy, &lc, &ignore, NULL);
 			if (lc.nlsns > maxnlsns)
 				maxnlsns = lc.nlsns;
 			if (ret) {
@@ -765,8 +861,8 @@ full_recovery_check(DB_ENV *dbenv, DB_LSN *max_lsn)
 				 * warn
 				 */
 				logmsg(LOGMSG_ERROR, 
-                "can't collect records for transaction at "
-				    PR_LSN "\n", PARM_LSN(lsn));
+				"can't collect records for transaction at "
+					PR_LSN "\n", PARM_LSN(lsn));
 				ret = 0;
 				continue;
 			}
@@ -774,12 +870,12 @@ full_recovery_check(DB_ENV *dbenv, DB_LSN *max_lsn)
 			ret = __rep_check_applied_lsns(dbenv, &lc, 1);
 			if (ret) {
 				logmsg(LOGMSG_ERROR, 
-                "verification failed for txn at " PR_LSN
-				    "\n", PARM_LSN(last));
+				"verification failed for txn at " PR_LSN
+					"\n", PARM_LSN(last));
 				if (ret) {
 					ret =
-					    __rep_check_applied_lsns(dbenv, &lc,
-					    1);
+						__rep_check_applied_lsns(dbenv, &lc,
+						1);
 					break;
 				}
 			}
@@ -793,7 +889,7 @@ full_recovery_check(DB_ENV *dbenv, DB_LSN *max_lsn)
 	free(lc.array);
 	__log_c_close(logc);
 	logmsg(LOGMSG_INFO, "ran full_recovery_check from " PR_LSN " to " PR_LSN
-	    ", ret %d\n", PARM_LSN(first), PARM_LSN(last), ret);
+		", ret %d\n", PARM_LSN(first), PARM_LSN(last), ret);
 	return ret;
 }
 
@@ -837,7 +933,7 @@ void log_recovery_progress(int stage, int progress)
  * to work.  See __log_backup for details.
  *
  * PUBLIC: int __db_apprec __P((DB_ENV *, DB_LSN *, DB_LSN *, u_int32_t,
- * PUBLIC:    u_int32_t));
+ * PUBLIC:	u_int32_t));
  */
 int
 __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
@@ -880,7 +976,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 * during recovery.
 	 */
 	log_size =
-	    ((LOG *)(((DB_LOG *)dbenv->lg_handle)->reginfo.primary))->log_size;
+		((LOG *)(((DB_LOG *)dbenv->lg_handle)->reginfo.primary))->log_size;
 
 	/*
 	 * If we need to, update the env handle timestamp.  The timestamp
@@ -889,8 +985,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 * replication.
 	 */
 	if (update && (db_rep = dbenv->rep_handle) != NULL &&
-	    (rep = db_rep->region) != NULL)
-        (void)time(&rep->timestamp);
+		(rep = db_rep->region) != NULL)
+		(void)time(&rep->timestamp);
 
 	/* Set in-recovery flags. */
 	F_SET((DB_LOG *)dbenv->lg_handle, DBLOG_RECOVER);
@@ -914,7 +1010,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 			goto err;
 		if ((int32_t)dbenv->tx_timestamp < low) {
 			(void)snprintf(t1, sizeof(t1),
-			    "%s", ctime(&dbenv->tx_timestamp));
+				"%s", ctime(&dbenv->tx_timestamp));
 			if ((p = strchr(t1, '\n')) != NULL)
 				*p = '\0';
 			tlow = (time_t)low;
@@ -922,8 +1018,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 			if ((p = strchr(t2, '\n')) != NULL)
 				*p = '\0';
 			__db_err(dbenv,
-		    "Invalid recovery timestamp %s; earliest time is %s",
-			    t1, t2);
+			"Invalid recovery timestamp %s; earliest time is %s",
+				t1, t2);
 			ret = EINVAL;
 			goto err;
 		}
@@ -962,15 +1058,15 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 * Pass #2:
 	 *	Read backward through the log undoing any uncompleted TXNs.
 	 *	There are four cases:
-	 *	    1.  If doing catastrophic recovery, we read to the
+	 *		1.  If doing catastrophic recovery, we read to the
 	 *		beginning of the log
-	 *	    2.  If we are doing normal reovery, then we have to roll
+	 *		2.  If we are doing normal reovery, then we have to roll
 	 *		back to the most recent checkpoint LSN.
-	 *	    3.  If we are recovering to a point in time, then we have
+	 *		3.  If we are recovering to a point in time, then we have
 	 *		to roll back to the checkpoint whose ckp_lsn is earlier
 	 *		than the specified time.  __log_earliest will figure
 	 *		this out for us.
-	 *	    4.	If we are recovering back to a particular LSN, then
+	 *		4.	If we are recovering back to a particular LSN, then
 	 *		we have to roll back to the checkpoint whose ckp_lsn
 	 *		is earlier than the max_lsn.  __log_backup will figure
 	 *		that out for us.
@@ -987,9 +1083,9 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 * ckp_lsn   -- lsn of the last checkpoint or the first in the log.
 	 * first_lsn -- the lsn where the forward passes begin.
 	 * last_lsn  -- the last lsn in the log, used for feedback
-	 * lowlsn    -- the lsn we are rolling back to, if we are recovering
+	 * lowlsn	-- the lsn we are rolling back to, if we are recovering
 	 *		to a point in time.
-	 * lsn       -- temporary use lsn.
+	 * lsn	   -- temporary use lsn.
 	 * stop_lsn  -- the point at which forward roll should stop
 	 */
 
@@ -1087,27 +1183,27 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		if (!start_recovery_at_dbregs || ret != 0) {
 			if ((ret = __checkpoint_get(dbenv, &logged_checkpoint_lsn) == 0)) {
 				logmsg(LOGMSG_DEBUG, "loaded %u:%u\n",
-				    logged_checkpoint_lsn.file,
-				    logged_checkpoint_lsn.offset);
+					logged_checkpoint_lsn.file,
+					logged_checkpoint_lsn.offset);
 				have_rec = 0;
 				first_lsn = logged_checkpoint_lsn;
 			} else {
 				__db_err(dbenv,
-				    "can't get recovery lsn rc %d", ret);
+					"can't get recovery lsn rc %d", ret);
 				goto err;
 			}
 
 			if ((ret = __log_c_get(logc, &logged_checkpoint_lsn,
-			    &data, DB_SET)) != 0) {
+				&data, DB_SET)) != 0) {
 				__db_err(dbenv,
 	"can't read checkpoint lsn %u:%u, falling back to full recovery.",
-				    logged_checkpoint_lsn.file,
-				    logged_checkpoint_lsn.offset);
+					logged_checkpoint_lsn.file,
+					logged_checkpoint_lsn.offset);
 				/* We read this above as the first LSN */
 				first_lsn = ckp_lsn;
 			} else {
 				if ((ret = __txn_ckp_read(dbenv, data.data,
-				    &ckp_args)) != 0) {
+					&ckp_args)) != 0) {
 					__db_err(dbenv,
 					  "invalid checkpoint record at %u:%u",
 					  (unsigned)logged_checkpoint_lsn.file,
@@ -1117,9 +1213,9 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 				first_lsn = ckp_args->ckp_lsn;
 				have_rec = 0;
 				logmsg(LOGMSG_DEBUG, "checkpoint %u:%u points to last lsn %u:%u\n",
-				    logged_checkpoint_lsn.file,
-				    logged_checkpoint_lsn.offset,
-				    first_lsn.file, first_lsn.offset);
+					logged_checkpoint_lsn.file,
+					logged_checkpoint_lsn.offset,
+					first_lsn.file, first_lsn.offset);
 			}
 		}
 
@@ -1142,7 +1238,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		 * the logs and before the timestamp.
 		 */
 		if ((dbenv->tx_timestamp != 0 || max_lsn != NULL) &&
-		    log_compare(&lowlsn, &first_lsn) < 0) {
+			log_compare(&lowlsn, &first_lsn) < 0) {
 			DB_ASSERT(have_rec == 0);
 			first_lsn = lowlsn;
 		}
@@ -1153,7 +1249,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 			first_lsn = dbenv->recovery_start_lsn;
 		} else if (start_recovery_at_dbregs) {
 			ret = __db_find_earliest_recover_point_after_file(dbenv,
-                    &first_lsn, 0);
+					&first_lsn, 0);
 			if (ret) {
 				__db_err(dbenv,
 						"__db_find_recovery_start_int rc %d\n", ret);
@@ -1166,19 +1262,19 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 
 	/* Get the record at first_lsn if we don't have it already. */
 	if (!have_rec &&
-	    (ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) != 0) {
+		(ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) != 0) {
 		__db_err(dbenv, "Checkpoint LSN record [%ld][%ld] not found",
-		    (u_long)first_lsn.file, (u_long)first_lsn.offset);
+			(u_long)first_lsn.file, (u_long)first_lsn.offset);
 		goto err;
 	}
 
 	if (last_lsn.file == first_lsn.file)
 		nfiles = (double)
-		    (last_lsn.offset - first_lsn.offset) / log_size;
+			(last_lsn.offset - first_lsn.offset) / log_size;
 	else
 		nfiles = (double)(last_lsn.file - first_lsn.file) +
-		    (double)(log_size - first_lsn.offset +
-		    last_lsn.offset) / log_size;
+			(double)(log_size - first_lsn.offset +
+			last_lsn.offset) / log_size;
 	/* We are going to divide by nfiles; make sure it isn't 0. */
 	if (nfiles == 0)
 		nfiles = (double)0.001;
@@ -1189,7 +1285,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		do {
 			/* txnid is after rectype, which is a u_int32. */
 			LOGCOPY_32(&txnid,
-			    (u_int8_t *)data.data + sizeof(u_int32_t));
+				(u_int8_t *)data.data + sizeof(u_int32_t));
 
 			if (txnid != 0)
 				break;
@@ -1204,16 +1300,16 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 
 	/* Reset to the first lsn. */
 	if (ret != 0 ||
-	    (ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) != 0)
+		(ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) != 0)
 		goto err;
 
 	/* Initialize the transaction list. */
 	if ((ret =
 		__db_txnlist_init(dbenv, txnid, hi_txn, max_lsn,
-		    &txninfo)) != 0)
+			&txninfo)) != 0)
 		goto err;
 
-    __fileid_track_free(dbenv);
+	__fileid_track_free(dbenv);
 
 	log_recovery_progress(0, -1);
 	dbenv->recovery_pass = DB_TXN_OPENFILES;
@@ -1224,9 +1320,9 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 */
 	log_recovery_progress(1, -1);
 	logmsg(LOGMSG_WARN, "running forward pass from %u:%u -> %u:%u\n",
-	    first_lsn.file, first_lsn.offset, last_lsn.file, last_lsn.offset);
+		first_lsn.file, first_lsn.offset, last_lsn.file, last_lsn.offset);
 	if ((ret = __env_openfiles(dbenv, logc,
-		    txninfo, &data, &first_lsn, &last_lsn, nfiles, 1)) != 0)
+			txninfo, &data, &first_lsn, &last_lsn, nfiles, 1)) != 0)
 		goto err;
 
 	/* If there were no transactions, then we can bail out early. */
@@ -1260,16 +1356,16 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 
 	if (FLD_ISSET(dbenv->verbose, DB_VERB_RECOVERY))
 		__db_err(dbenv, "Recovery starting from [%lu][%lu]",
-		    (u_long)first_lsn.file, (u_long)first_lsn.offset);
+			(u_long)first_lsn.file, (u_long)first_lsn.offset);
 
 	pass = "backward";
 	ret = __log_c_get(logc, &lsn, &data, DB_LAST);
 	if (ret)
 		goto err;
 	logmsg(LOGMSG_WARN, "running backward pass from %u:%u <- %u:%u\n",
-	    first_lsn.file, first_lsn.offset, lsn.file, lsn.offset);
+		first_lsn.file, first_lsn.offset, lsn.file, lsn.offset);
 	for (; ret == 0 && log_compare(&lsn, &first_lsn) >= 0;
-	    ret = __log_c_get(logc, &lsn, &data, DB_PREV)) {
+		ret = __log_c_get(logc, &lsn, &data, DB_PREV)) {
 #if 0
 		progress = 34 + (int)(33 * (__lsn_diff(&first_lsn,
 #else
@@ -1283,8 +1379,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		}
 
 		ret = __db_dispatch(dbenv, dbenv->recover_dtab,
-		    dbenv->recover_dtab_size, &data, &lsn,
-		    DB_TXN_BACKWARD_ROLL, txninfo);
+			dbenv->recover_dtab_size, &data, &lsn,
+			DB_TXN_BACKWARD_ROLL, txninfo);
 		if (ret != 0) {
 			if (ret != DB_TXN_CKP)
 				goto msgerr;
@@ -1318,9 +1414,9 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		stop_lsn = ((DB_TXNHEAD *)txninfo)->maxlsn;
 
 	logmsg(LOGMSG_WARN, "running forward pass from %u:%u -> %u:%u\n",
-	    lsn.file, lsn.offset, stop_lsn.file, stop_lsn.offset);
+		lsn.file, lsn.offset, stop_lsn.file, stop_lsn.offset);
 	for (ret = __log_c_get(logc, &lsn, &data, DB_NEXT);
-	    ret == 0; ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
+		ret == 0; ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
 		/*
 		 * If we are recovering to a timestamp or an LSN,
 		 * we need to make sure that we don't try to roll
@@ -1342,8 +1438,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		}
 
 		ret = __db_dispatch(dbenv, dbenv->recover_dtab,
-		    dbenv->recover_dtab_size, &data, &lsn,
-		    DB_TXN_FORWARD_ROLL, txninfo);
+			dbenv->recover_dtab_size, &data, &lsn,
+			DB_TXN_FORWARD_ROLL, txninfo);
 		if (ret != 0) {
 			if (ret != DB_TXN_CKP)
 				goto msgerr;
@@ -1362,8 +1458,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	 * the free list.  Do this before checkpointing the database.
 	 */
 	if ((ret = __db_do_the_limbo(dbenv, NULL, NULL, txninfo,
-		    dbenv->tx_timestamp !=
-		    0 ? LIMBO_TIMESTAMP : LIMBO_RECOVER)) != 0)
+			dbenv->tx_timestamp !=
+			0 ? LIMBO_TIMESTAMP : LIMBO_RECOVER)) != 0)
 		 goto err;
 
 	if (max_lsn == NULL)
@@ -1381,7 +1477,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 
 		region->last_ckp = ((DB_TXNHEAD *)txninfo)->ckplsn;
 		__log_vtruncate(dbenv, &((DB_TXNHEAD *)txninfo)->maxlsn,
-		    &((DB_TXNHEAD *)txninfo)->ckplsn, trunclsn);
+			&((DB_TXNHEAD *)txninfo)->ckplsn, trunclsn);
 		/*
 		 * Generate logging compensation records.
 		 * If we crash during/after vtruncate we may have
@@ -1390,19 +1486,19 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		 * These pages are only known in memory at this pont.
 		 */
 		 if ((ret = __db_do_the_limbo(dbenv,
-		     NULL, NULL, txninfo, LIMBO_COMPENSATE)) != 0)
+			 NULL, NULL, txninfo, LIMBO_COMPENSATE)) != 0)
 			goto err;
 	}
 
 	/* Take a checkpoint here to force any dirty data pages to disk. */
-    if (gbl_is_physical_replicant || LF_ISSET(DB_RECOVER_NOCKP)) {
-        if (MPOOL_ON(dbenv) && (ret = __memp_sync_restartable(dbenv,
-                        NULL, 0, 0)) != 0) {
-            logmsg(LOGMSG_ERROR, "memp_sync returned %d\n", ret);
-            goto err;
-        }
-    } else if ((ret = __txn_checkpoint(dbenv, 0, 0, DB_FORCE)) != 0)
-        goto err;
+	if (gbl_is_physical_replicant || LF_ISSET(DB_RECOVER_NOCKP)) {
+		if (MPOOL_ON(dbenv) && (ret = __memp_sync_restartable(dbenv,
+						NULL, 0, 0)) != 0) {
+			logmsg(LOGMSG_ERROR, "memp_sync returned %d\n", ret);
+			goto err;
+		}
+	} else if ((ret = __txn_checkpoint(dbenv, 0, 0, DB_FORCE)) != 0)
+		goto err;
 
 
 	/* Close all the db files that are open. */
@@ -1412,81 +1508,81 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 done:
 	if (max_lsn != NULL || gbl_is_physical_replicant) {
 
-            /*
-             * When I truncate, I am running replicated recovery.
-             * I am synced all the way to the last checkpoint, so
-             * dropping the all the checkpoints in the truncation
-             * log phase does not make me bad
-             */
-        if (max_lsn != NULL) {
+			/*
+			 * When I truncate, I am running replicated recovery.
+			 * I am synced all the way to the last checkpoint, so
+			 * dropping the all the checkpoints in the truncation
+			 * log phase does not make me bad
+			 */
+		if (max_lsn != NULL) {
 
-            DB_LSN last_valid_checkpoint = { 0 };
+			DB_LSN last_valid_checkpoint = { 0 };
 
-            /*
-             * We can't truncate before we write a valid
-             * checkpoint into the checkpoint file.  We don't know
-             * what that is.  Find it.  By this point we already
-             * did recovery, so any checkpoint LSN < max_lsn is
-             * valid.
-             */
-            if ((ret =
-                __log_find_latest_checkpoint_before_lsn(dbenv, logc,
-                    max_lsn, &last_valid_checkpoint)) != 0) {
-                __db_err(dbenv,
-                    "can't find last logged checkpoint max_lsn %u:%u",
-                    max_lsn->file, max_lsn->offset);
-                ret =
-                    __log_find_latest_checkpoint_before_lsn_try_harder
-                    (dbenv, logc, max_lsn, &last_valid_checkpoint);
-                if (ret == 0)
-                    logmsg(LOGMSG_DEBUG, "tried harder and found %u:%u\n",
-                        last_valid_checkpoint.file,
-                        last_valid_checkpoint.offset);
-                else {
-                    logmsg(LOGMSG_DEBUG, "tried harder and still failed rc; I'll be good unless I crash %d\n",
-                        ret);
-                    /* Here we are gonna write a checkpoint FILE containing 0:0 as recovery lsn, claiming all it 
-                     * is good at this point */
-                    /*goto err; */
-                }
-            }
+			/*
+			 * We can't truncate before we write a valid
+			 * checkpoint into the checkpoint file.  We don't know
+			 * what that is.  Find it.  By this point we already
+			 * did recovery, so any checkpoint LSN < max_lsn is
+			 * valid.
+			 */
+			if ((ret =
+				__log_find_latest_checkpoint_before_lsn(dbenv, logc,
+					max_lsn, &last_valid_checkpoint)) != 0) {
+				__db_err(dbenv,
+					"can't find last logged checkpoint max_lsn %u:%u",
+					max_lsn->file, max_lsn->offset);
+				ret =
+					__log_find_latest_checkpoint_before_lsn_try_harder
+					(dbenv, logc, max_lsn, &last_valid_checkpoint);
+				if (ret == 0)
+					logmsg(LOGMSG_DEBUG, "tried harder and found %u:%u\n",
+						last_valid_checkpoint.file,
+						last_valid_checkpoint.offset);
+				else {
+					logmsg(LOGMSG_DEBUG, "tried harder and still failed rc; I'll be good unless I crash %d\n",
+						ret);
+					/* Here we are gonna write a checkpoint FILE containing 0:0 as recovery lsn, claiming all it 
+					 * is good at this point */
+					/*goto err; */
+				}
+			}
 
-            /* Save the checkpoint. */
-            if ((ret =
-                __checkpoint_save(dbenv, &last_valid_checkpoint,
-                    1)) != 0) {
-                __db_err(dbenv, "can't save checkpoint %u:%u",
-                    last_valid_checkpoint.file,
-                    last_valid_checkpoint.offset);
-                goto err;
-            }
+			/* Save the checkpoint. */
+			if ((ret =
+				__checkpoint_save(dbenv, &last_valid_checkpoint,
+					1)) != 0) {
+				__db_err(dbenv, "can't save checkpoint %u:%u",
+					last_valid_checkpoint.file,
+					last_valid_checkpoint.offset);
+				goto err;
+			}
 
-            logmsg(LOGMSG_WARN, "TRUNCATING to %u:%u checkpoint lsn is %u:%u\n",
-                max_lsn->file, max_lsn->offset,
-                last_valid_checkpoint.file, last_valid_checkpoint.offset);
+			logmsg(LOGMSG_WARN, "TRUNCATING to %u:%u checkpoint lsn is %u:%u\n",
+				max_lsn->file, max_lsn->offset,
+				last_valid_checkpoint.file, last_valid_checkpoint.offset);
 
-            region->last_ckp = ((DB_TXNHEAD *) txninfo)->ckplsn;
-            logmsg(LOGMSG_DEBUG, "%s:%d last_ckp is %u:%u\n", __FILE__, __LINE__,
-                region->last_ckp.file, region->last_ckp.offset);
+			region->last_ckp = ((DB_TXNHEAD *) txninfo)->ckplsn;
+			logmsg(LOGMSG_DEBUG, "%s:%d last_ckp is %u:%u\n", __FILE__, __LINE__,
+				region->last_ckp.file, region->last_ckp.offset);
 
-            if (IS_ZERO_LSN(region->last_ckp)) {
-                /* I still don't understand how this ends up as 0:0 */
-                logmsg(LOGMSG_DEBUG, "last_ckp zero lsn? Let's try %u:%u\n",
-                    last_valid_checkpoint.file,
-                    last_valid_checkpoint.offset);
-                region->last_ckp = last_valid_checkpoint;
+			if (IS_ZERO_LSN(region->last_ckp)) {
+				/* I still don't understand how this ends up as 0:0 */
+				logmsg(LOGMSG_DEBUG, "last_ckp zero lsn? Let's try %u:%u\n",
+					last_valid_checkpoint.file,
+					last_valid_checkpoint.offset);
+				region->last_ckp = last_valid_checkpoint;
 
-            }
+			}
 
-            /* We are going to truncate, so we'd best close the cursor. */
-            if (logc != NULL && (ret = __log_c_close(logc)) != 0)
-                goto err;
+			/* We are going to truncate, so we'd best close the cursor. */
+			if (logc != NULL && (ret = __log_c_close(logc)) != 0)
+				goto err;
 
-            __log_vtruncate(dbenv, max_lsn, &region->last_ckp, trunclsn);
+			__log_vtruncate(dbenv, max_lsn, &region->last_ckp, trunclsn);
 
-            logmsg(LOGMSG_WARN, "TRUNCATED TO is %u:%u \n", trunclsn->file,
-                trunclsn->offset);
-        }
+			logmsg(LOGMSG_WARN, "TRUNCATED TO is %u:%u \n", trunclsn->file,
+				trunclsn->offset);
+		}
 
 
 		/*
@@ -1505,14 +1601,14 @@ done:
 			goto err;
 		}
 		if ((ret = __txn_getckp(dbenv, &first_lsn)) == 0 &&
-		    (ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) == 0) {
+			(ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) == 0) {
 			/* We have a recent checkpoint.  This is LSN (1). */
 			if ((ret = __txn_ckp_read(dbenv,
-				    data.data, &ckp_args)) != 0) {
+					data.data, &ckp_args)) != 0) {
 				__db_err(dbenv,
-				    "Invalid checkpoint record at [%ld][%ld]",
-				    (u_long) first_lsn.file,
-				    (u_long) first_lsn.offset);
+					"Invalid checkpoint record at [%ld][%ld]",
+					(u_long) first_lsn.file,
+					(u_long) first_lsn.offset);
 				goto err;
 			}
 			first_lsn = ckp_args->ckp_lsn;
@@ -1520,37 +1616,37 @@ done:
 		if ((ret = __log_c_get(logc, &first_lsn, &data, DB_SET)) != 0)
 			goto err;
 		if ((ret = __env_openfiles(dbenv, logc,
-			    txninfo, &data, &first_lsn, NULL, nfiles, 1)) != 0)
+				txninfo, &data, &first_lsn, NULL, nfiles, 1)) != 0)
 			goto err;
 	} else if (region->stat.st_nrestores == 0) {
 		/*
 		 * If there are no prepared transactions that need resolution,
 		 * we need to reset the transaction ID space and log this fact.
 		 */
-        assert(!gbl_is_physical_replicant);
+		assert(!gbl_is_physical_replicant);
 
-        if ((ret = __txn_reset(dbenv)) != 0)
-            goto err;
-    }
+		if ((ret = __txn_reset(dbenv)) != 0)
+			goto err;
+	}
 
 
 	if (FLD_ISSET(dbenv->verbose, DB_VERB_RECOVERY)) {
 		(void)time(&now);
 		__db_err(dbenv, "Recovery complete at %.24s", ctime(&now));
 		__db_err(dbenv, "%s %lx %s [%lu][%lu]",
-		    "Maximum transaction ID",
-		    (u_long) (txninfo == NULL ?
+			"Maximum transaction ID",
+			(u_long) (txninfo == NULL ?
 			TXN_MINIMUM : ((DB_TXNHEAD *) txninfo)->maxid),
-		    "Recovery checkpoint",
-		    (u_long) region->last_ckp.file,
-		    (u_long) region->last_ckp.offset);
+			"Recovery checkpoint",
+			(u_long) region->last_ckp.file,
+			(u_long) region->last_ckp.offset);
 	}
 	log_recovery_progress(3, -1);
 
 	if (0) {
 msgerr:	__db_err(dbenv,
-		    "Recovery function for LSN %lu %lu failed on %s pass",
-		    (u_long) lsn.file, (u_long) lsn.offset, pass);
+			"Recovery function for LSN %lu %lu failed on %s pass",
+			(u_long) lsn.file, (u_long) lsn.offset, pass);
 	}
 
 err:	if (logc != NULL && (t_ret = __log_c_close(logc)) != 0 && ret == 0)
@@ -1611,19 +1707,19 @@ __lsn_diff(low, high, current, max, is_forward)
 			nf = (double)(current->offset - low->offset) / max;
 		else if (current->offset < low->offset)
 			nf = (double)(current->file - low->file - 1) +
-			    (double)(max - low->offset + current->offset) / max;
+				(double)(max - low->offset + current->offset) / max;
 		else
 			nf = (double)(current->file - low->file) +
-			    (double)(current->offset - low->offset) / max;
+				(double)(current->offset - low->offset) / max;
 	} else {
 		if (current->file == high->file)
 			nf = (double)(high->offset - current->offset) / max;
 		else if (current->offset > high->offset)
 			nf = (double)(high->file - current->file - 1) + (double)
-			    (max - current->offset + high->offset) / max;
+				(max - current->offset + high->offset) / max;
 		else
 			nf = (double)(high->file - current->file) +
-			    (double)(high->offset - current->offset) / max;
+				(double)(high->offset - current->offset) / max;
 	}
 	return (nf);
 }
@@ -1635,7 +1731,7 @@ __lsn_diff(low, high, current, max, is_forward)
  * this routine, but I'd rather not break things. */
 static int
 __log_find_latest_checkpoint_before_lsn(DB_ENV * dbenv, DB_LOGC * logc,
-    DB_LSN * max_lsn, DB_LSN * start_lsn)
+	DB_LSN * max_lsn, DB_LSN * start_lsn)
 {
 	DB_LSN lsn;
 	DBT data;
@@ -1684,7 +1780,7 @@ __log_find_latest_checkpoint_before_lsn(DB_ENV * dbenv, DB_LOGC * logc,
  * checkpoint chain is broken (ie: last_ckp points to 0:0) */
 static int
 __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV * dbenv,
-    DB_LOGC * logc, DB_LSN * max_lsn, DB_LSN * foundlsn)
+	DB_LOGC * logc, DB_LSN * max_lsn, DB_LSN * foundlsn)
 {
 	DB_LSN lsn;
 	DBT data;
@@ -1736,7 +1832,7 @@ __test_last_checkpoint(DB_ENV * dbenv, int file, int offset)
 	logmsg(LOGMSG_USER, "start: %u:%u\n", lsn.file, lsn.offset);
 	do {
 		rc = __log_find_latest_checkpoint_before_lsn(dbenv, logc, &lsn,
-		    &outlsn);
+			&outlsn);
 		logmsg(LOGMSG_USER, "next: %u:%u\n", outlsn.file, outlsn.offset);
 		lsn = outlsn;
 	} while (rc == 0);
@@ -1823,7 +1919,7 @@ __log_earliest(dbenv, logc, lowtime, lowlsn)
 	 */
 
 	for (ret = __log_c_get(logc, &first_lsn, &data, DB_FIRST);
-	    ret == 0; ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
+		ret == 0; ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
 		LOGCOPY_32(&rectype, data.data);
 		if (rectype != DB___txn_ckp)
 			continue;
@@ -1855,11 +1951,11 @@ __log_earliest(dbenv, logc, lowtime, lowlsn)
  * processing and in_recovery is zero), then last_lsn can be NULL.
  *
  * PUBLIC: int __env_openfiles __P((DB_ENV *, DB_LOGC *,
- * PUBLIC:     void *, DBT *, DB_LSN *, DB_LSN *, double, int));
+ * PUBLIC:	 void *, DBT *, DB_LSN *, DB_LSN *, double, int));
  */
 int
 __env_openfiles(dbenv, logc, txninfo,
-    data, open_lsn, last_lsn, nfiles, in_recovery)
+	data, open_lsn, last_lsn, nfiles, in_recovery)
 	DB_ENV *dbenv;
 	DB_LOGC *logc;
 	void *txninfo;
@@ -1879,11 +1975,11 @@ __env_openfiles(dbenv, logc, txninfo,
 	 * during recovery.
 	 */
 	log_size =
-	    ((LOG *) (((DB_LOG *) dbenv->lg_handle)->reginfo.primary))->
-	    log_size;
+		((LOG *) (((DB_LOG *) dbenv->lg_handle)->reginfo.primary))->
+		log_size;
 
 	logmsg(LOGMSG_INFO, "%s: open files from lsn %u:%u\n", __func__, open_lsn->file,
-	    open_lsn->offset);
+		open_lsn->offset);
 	lsn = *open_lsn;
 
 	for (;;) {
@@ -1902,42 +1998,42 @@ __env_openfiles(dbenv, logc, txninfo,
 			}
 		}
 		ret = __db_dispatch(dbenv,
-		    dbenv->recover_dtab, dbenv->recover_dtab_size, data, &lsn,
-		    in_recovery ? DB_TXN_OPENFILES : DB_TXN_POPENFILES,
-		    txninfo);
+			dbenv->recover_dtab, dbenv->recover_dtab_size, data, &lsn,
+			in_recovery ? DB_TXN_OPENFILES : DB_TXN_POPENFILES,
+			txninfo);
 		if (ret != 0 && ret != DB_TXN_CKP) {
 			__db_err(dbenv,
-			    "Recovery function for LSN %lu %lu failed",
-			    (u_long) lsn.file, (u_long) lsn.offset);
+				"Recovery function for LSN %lu %lu failed",
+				(u_long) lsn.file, (u_long) lsn.offset);
 
 			break;
 		}
 		if ((ret = __log_c_get(logc, &lsn, data, DB_NEXT)) != 0) {
 			if (ret == DB_NOTFOUND) {
-            /* if we fail to get this lsn, and this is NOT the last
-            record, it can be a corrupted record in the middle, abort! */
-            DB_LSN cmp_lsn;
-            if (last_lsn == NULL) {
-               /* get here the know tail of the log */
-               ret = __log_c_get(logc, &cmp_lsn, data, DB_LAST);
-               if (ret)
-                  abort();  
-            } else {
-               cmp_lsn = *last_lsn;
-            }
-            if (last_good_lsn.file != cmp_lsn.file || last_good_lsn.offset != cmp_lsn.offset) {
-               __db_err(dbenv,
-                     "Recovery open file failed in the middle lsn %d.%d\n",
-                     last_good_lsn.file, last_good_lsn.offset);
-               abort();
-            }
+			/* if we fail to get this lsn, and this is NOT the last
+			record, it can be a corrupted record in the middle, abort! */
+			DB_LSN cmp_lsn;
+			if (last_lsn == NULL) {
+			   /* get here the know tail of the log */
+			   ret = __log_c_get(logc, &cmp_lsn, data, DB_LAST);
+			   if (ret)
+				  abort();  
+			} else {
+			   cmp_lsn = *last_lsn;
+			}
+			if (last_good_lsn.file != cmp_lsn.file || last_good_lsn.offset != cmp_lsn.offset) {
+			   __db_err(dbenv,
+					 "Recovery open file failed in the middle lsn %d.%d\n",
+					 last_good_lsn.file, last_good_lsn.offset);
+			   abort();
+			}
 
 				ret = 0;
-         }
-         break;
+		 }
+		 break;
 		} else  {
-         last_good_lsn = lsn;
-      }
+		 last_good_lsn = lsn;
+	  }
 	}
 
 	return (ret);
@@ -1945,17 +2041,17 @@ __env_openfiles(dbenv, logc, txninfo,
 
 void bdb_set_gbl_recoverable_lsn(void *lsn, int32_t timestamp);
 int bdb_update_logfile_pglogs(void *bdb_state, void *pglogs, unsigned int nkeys,
-    DB_LSN logical_commit_lsn, hash_t *fileid_tbl);
+	DB_LSN logical_commit_lsn, hash_t *fileid_tbl);
 int bdb_update_ltran_pglogs_hash(void *bdb_state, void *pglogs,
-    unsigned int nkeys, unsigned long long logical_tranid,
-    int is_logical_commit, DB_LSN logical_commit_lsn, hash_t *fileid_tbl);
+	unsigned int nkeys, unsigned long long logical_tranid,
+	int is_logical_commit, DB_LSN logical_commit_lsn, hash_t *fileid_tbl);
 int transfer_ltran_pglogs_to_gbl(void *bdb_state,
-    unsigned long long logical_tranid, DB_LSN logical_commit_lsn);
+	unsigned long long logical_tranid, DB_LSN logical_commit_lsn);
 int bdb_relink_logfile_pglogs(void *bdb_state, unsigned char *fileid,
-    db_pgno_t pgno, db_pgno_t prev_pgno, db_pgno_t next_pgno, DB_LSN lsn,
-    hash_t *fileid_tbl);
+	db_pgno_t pgno, db_pgno_t prev_pgno, db_pgno_t next_pgno, DB_LSN lsn,
+	hash_t *fileid_tbl);
 int bdb_update_timestamp_lsn(void *bdb_state, int32_t timestamp, DB_LSN lsn,
-    unsigned long long context);
+	unsigned long long context);
 int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp);
 extern DB_LSN bdb_latest_commit_lsn;
 extern pthread_mutex_t bdb_asof_current_lsn_mutex;
@@ -1969,7 +2065,7 @@ extern pthread_mutex_t bdb_asof_current_lsn_mutex;
 #define GOTOERR do{ lineno=__LINE__; goto err; } while(0);
 
 extern int bdb_push_pglogs_commit(void *in_bdb_state, DB_LSN commit_lsn,
-    uint32_t gen, unsigned long long ltranid, int push);
+	uint32_t gen, unsigned long long ltranid, int push);
 
 int
 __recover_logfile_pglogs(dbenv, fileid_tbl)
@@ -2006,37 +2102,37 @@ __recover_logfile_pglogs(dbenv, fileid_tbl)
 		return ret;
 
 	for (ret = __log_c_get(logc, &first_lsn, &data, DB_FIRST), lsn =
-	    first_lsn; ret == 0;
-	    ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
+		first_lsn; ret == 0;
+		ret = __log_c_get(logc, &lsn, &data, DB_NEXT)) {
 		LOGCOPY_32(&rectype, data.data);
 		switch (rectype) {
 		case DB___txn_ckp:
 			if ((ret =
 				__txn_ckp_read(dbenv, data.data,
-				    &ckp_args)) != 0) {
+					&ckp_args)) != 0) {
 				GOTOERR;
-         }
-         free_ptr = ckp_args;
+		 }
+		 free_ptr = ckp_args;
 
 			ret =
-			    bdb_checkpoint_list_push(lsn, ckp_args->ckp_lsn,
-			    ckp_args->timestamp);
+				bdb_checkpoint_list_push(lsn, ckp_args->ckp_lsn,
+				ckp_args->timestamp);
 			if (ret) {
 				logmsg(LOGMSG_ERROR, 
-                  "%s: failed to push to checkpoint list, ret %d\n",
-				    __func__, ret);
+				  "%s: failed to push to checkpoint list, ret %d\n",
+					__func__, ret);
 		   	GOTOERR;
-         }
+		 }
 
 			if (!got_recoverable_lsn) {
 				ret =
-				    log_compare(&ckp_args->ckp_lsn, &first_lsn);
+					log_compare(&ckp_args->ckp_lsn, &first_lsn);
 				if (ret >= 0) {
 					bdb_set_gbl_recoverable_lsn(&lsn,
-					    ckp_args->timestamp);
+						ckp_args->timestamp);
 					got_recoverable_lsn = 1;
 					logmsg(LOGMSG_WARN, "set gbl_recoverable_lsn as [%d][%d]\n",
-					    lsn.file, lsn.offset);
+						lsn.file, lsn.offset);
 				}
 			}
 
@@ -2044,120 +2140,120 @@ __recover_logfile_pglogs(dbenv, fileid_tbl)
 		case DB___txn_regop_gen:
 			if ((ret =
 				__txn_regop_gen_read(dbenv, data.data,
-				    &txn_gen_args)) != 0) {
+					&txn_gen_args)) != 0) {
 				GOTOERR;
-         }
-         bdb_push_pglogs_commit(dbenv->app_private, lsn, 
-               txn_gen_args->generation, 0, 0);
+		 }
+		 bdb_push_pglogs_commit(dbenv->app_private, lsn, 
+			   txn_gen_args->generation, 0, 0);
 			free_ptr = txn_gen_args;
 
 			ret =
-			    bdb_update_timestamp_lsn(dbenv->app_private,
-			    txn_gen_args->timestamp, lsn,
-			    txn_gen_args->context);
+				bdb_update_timestamp_lsn(dbenv->app_private,
+				txn_gen_args->timestamp, lsn,
+				txn_gen_args->context);
 			if (ret) {
 				GOTOERR;
-         }
+		 }
 		   ret = lock_list_parse_pglogs(dbenv, &txn_gen_args->locks, &lsn, 
-               &keylist, &keycnt);
+			   &keylist, &keycnt);
 			if (ret) {
 				not_newsi_log_format = 1;
 				break;
 			}
 			ret =
-			    bdb_update_logfile_pglogs(dbenv->app_private,
-			    keylist, keycnt, lsn, fileid_tbl);
+				bdb_update_logfile_pglogs(dbenv->app_private,
+				keylist, keycnt, lsn, fileid_tbl);
 			if (ret) {
 				GOTOERR;
-         }
-         break;
+		 }
+		 break;
 		case DB___txn_regop:
 			if ((ret =
 				__txn_regop_read(dbenv, data.data,
-				    &txn_args)) != 0) {
+					&txn_args)) != 0) {
 				GOTOERR;
-         }
-         bdb_push_pglogs_commit(dbenv->app_private, lsn, 0, 0, 0);
+		 }
+		 bdb_push_pglogs_commit(dbenv->app_private, lsn, 0, 0, 0);
 			free_ptr = txn_args;
 
 			ret =
-			    bdb_update_timestamp_lsn(dbenv->app_private,
-			    txn_args->timestamp, lsn,
-			    __txn_regop_read_context(txn_args));
+				bdb_update_timestamp_lsn(dbenv->app_private,
+				txn_args->timestamp, lsn,
+				__txn_regop_read_context(txn_args));
 			if (ret) {
 				GOTOERR;
-         }
+		 }
 		   ret = lock_list_parse_pglogs(dbenv,
-				    &txn_args->locks, &lsn, &keylist, &keycnt);
+					&txn_args->locks, &lsn, &keylist, &keycnt);
 			if (ret) {
 				not_newsi_log_format = 1;
 				break;
 			}
 			ret =
-			    bdb_update_logfile_pglogs(dbenv->app_private,
-			    keylist, keycnt, lsn, fileid_tbl);
+				bdb_update_logfile_pglogs(dbenv->app_private,
+				keylist, keycnt, lsn, fileid_tbl);
 			if (ret) {
 				GOTOERR;
-         }
-         break;
+		 }
+		 break;
 		case DB___txn_regop_rowlocks:
 			if ((ret =
 				__txn_regop_rowlocks_read(dbenv, data.data,
-				    &txn_rl_args)) != 0) {
+					&txn_rl_args)) != 0) {
 				GOTOERR;
-         }
-         bdb_push_pglogs_commit(dbenv->app_private, lsn, 
-               txn_rl_args->generation, 0, 0);
+		 }
+		 bdb_push_pglogs_commit(dbenv->app_private, lsn, 
+			   txn_rl_args->generation, 0, 0);
 			free_ptr = txn_rl_args;
 
 			ret = bdb_update_timestamp_lsn(dbenv->app_private,
-			    txn_rl_args->timestamp, lsn, txn_rl_args->context);
+				txn_rl_args->timestamp, lsn, txn_rl_args->context);
 			if (ret) {
 				GOTOERR;
-         }
+		 }
 		   ret = lock_list_parse_pglogs(dbenv,
-				    &txn_rl_args->locks, &lsn, &keylist,
-				    &keycnt);
+					&txn_rl_args->locks, &lsn, &keylist,
+					&keycnt);
 			if (ret) {
 				logmsg(LOGMSG_ERROR, 
-                "%s line %d: couldn't parse pagelogs for regop_rowlocks at lsn %d:%d\n",
-				    __func__, __LINE__, lsn.file, lsn.offset);
+				"%s line %d: couldn't parse pagelogs for regop_rowlocks at lsn %d:%d\n",
+					__func__, __LINE__, lsn.file, lsn.offset);
 				not_newsi_log_format = 1;
 				break;
 			}
 
 			ret =
-			    bdb_update_ltran_pglogs_hash(dbenv->app_private,
-			    keylist, keycnt, txn_rl_args->ltranid,
-			    (txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT), lsn, fileid_tbl);
+				bdb_update_ltran_pglogs_hash(dbenv->app_private,
+				keylist, keycnt, txn_rl_args->ltranid,
+				(txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT), lsn, fileid_tbl);
 			if (ret) {
 				GOTOERR;
-         }
- 	      if (txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT) {
+		 }
+ 		  if (txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT) {
 					ret = transfer_ltran_pglogs_to_gbl(dbenv->
-					    app_private, txn_rl_args->ltranid,
-					    lsn);
+						app_private, txn_rl_args->ltranid,
+						lsn);
 					if (ret) {
 						GOTOERR;
-               }
-         }
+			   }
+		 }
 
 						break;
 		case DB___bam_split:
 					if ((ret =
 						__bam_split_read(dbenv,
-						    data.data,
-						    &split_args)) != 0) {
+							data.data,
+							&split_args)) != 0) {
 						GOTOERR;
-               }
-               free_ptr = split_args;
+			   }
+			   free_ptr = split_args;
 
 					if ((ret =
 						__dbreg_id_to_db(dbenv,
-						    split_args->txnid,
-						    &file_dbp,
-						    split_args->fileid, 1, &lsn,
-						    0)) != 0) {
+							split_args->txnid,
+							&file_dbp,
+							split_args->fileid, 1, &lsn,
+							0)) != 0) {
 						// Assume this was later fastinit'd
 						break;
 					}
@@ -2165,71 +2261,71 @@ __recover_logfile_pglogs(dbenv, fileid_tbl)
 					mpf = file_dbp->mpf;
 
 					ret =
-					    bdb_relink_logfile_pglogs(dbenv->
-					    app_private, mpf->fileid,
-					    split_args->left, split_args->right,
-					    PGNO_INVALID, lsn, fileid_tbl);
+						bdb_relink_logfile_pglogs(dbenv->
+						app_private, mpf->fileid,
+						split_args->left, split_args->right,
+						PGNO_INVALID, lsn, fileid_tbl);
 					if (ret) { 
 						GOTOERR;
-               }
-               break;
+			   }
+			   break;
 		case DB___bam_rsplit:
 					if ((ret =
 						__bam_rsplit_read(dbenv,
-						    data.data,
-						    &rsplit_args)) != 0) {
+							data.data,
+							&rsplit_args)) != 0) {
 						GOTOERR;
-               }
-               free_ptr = rsplit_args;
+			   }
+			   free_ptr = rsplit_args;
 
 					if ((ret =
 						__dbreg_id_to_db(dbenv,
-						    rsplit_args->txnid,
-						    &file_dbp,
-						    rsplit_args->fileid, 1,
-						    &lsn, 0)) != 0)
+							rsplit_args->txnid,
+							&file_dbp,
+							rsplit_args->fileid, 1,
+							&lsn, 0)) != 0)
 						break;
 
 					mpf = file_dbp->mpf;
 
 					ret =
-					    bdb_relink_logfile_pglogs(dbenv->
-					    app_private, mpf->fileid,
-					    rsplit_args->pgno,
-					    rsplit_args->root_pgno,
-					    PGNO_INVALID, lsn, fileid_tbl);
+						bdb_relink_logfile_pglogs(dbenv->
+						app_private, mpf->fileid,
+						rsplit_args->pgno,
+						rsplit_args->root_pgno,
+						PGNO_INVALID, lsn, fileid_tbl);
 					if (ret) {
 						GOTOERR;
-               }
-               break;
+			   }
+			   break;
 		case DB___db_relink:
 					if ((ret =
 						__db_relink_read(dbenv,
-						    data.data,
-						    &relink_args)) != 0) {
+							data.data,
+							&relink_args)) != 0) {
 						GOTOERR;
-               }
-               free_ptr = relink_args;
+			   }
+			   free_ptr = relink_args;
 
 					if ((ret =
 						__dbreg_id_to_db(dbenv,
-						    relink_args->txnid,
-						    &file_dbp,
-						    relink_args->fileid, 1,
-						    &lsn, 0)) != 0)
+							relink_args->txnid,
+							&file_dbp,
+							relink_args->fileid, 1,
+							&lsn, 0)) != 0)
 						break;
 					mpf = file_dbp->mpf;
 
 					ret =
-					    bdb_relink_logfile_pglogs(dbenv->
-					    app_private, mpf->fileid,
-					    relink_args->pgno,
-					    relink_args->prev,
-					    relink_args->next, lsn, fileid_tbl);
+						bdb_relink_logfile_pglogs(dbenv->
+						app_private, mpf->fileid,
+						relink_args->pgno,
+						relink_args->prev,
+						relink_args->next, lsn, fileid_tbl);
 					if (ret) {
 						GOTOERR;
-               }
-               break;
+			   }
+			   break;
 		default:
 					free_ptr = NULL;
 					break;
@@ -2246,7 +2342,7 @@ __recover_logfile_pglogs(dbenv, fileid_tbl)
 
 		if (not_newsi_log_format) {
 			logmsg(LOGMSG_ERROR, 
-               "NEWSI recovery error: lack of pglogs info on some commit records\n");
+			   "NEWSI recovery error: lack of pglogs info on some commit records\n");
 			ret = -1;
 		} else {
 			ret = 0;
@@ -2298,7 +2394,7 @@ __env_find_verify_recover_start(dbenv, lsnp)
 	rec.flags = DB_DBT_REALLOC;
 
 	/* Step 1: Find the 1st matchable commit record
-	           lower than the last sync LSN. */
+			   lower than the last sync LSN. */
 	if ((ret = __log_sync_lsn(dbenv, &s_lsn)) != 0)
 		goto err;
 	if ((ret = __log_cursor(dbenv, &logc)) != 0)
@@ -2309,13 +2405,13 @@ __env_find_verify_recover_start(dbenv, lsnp)
 	do {
 		LOGCOPY_32(&rectype, rec.data);
 	} while ((!matchable_log_type(rectype) || log_compare(lsnp, &s_lsn) >= 0) &&
-	         (ret = __log_c_get(logc, lsnp, &rec, DB_PREV)) == 0);
+			 (ret = __log_c_get(logc, lsnp, &rec, DB_PREV)) == 0);
 
 	if (ret != 0)
 		goto err;
 
 	/* Step 2: find the checkpoint LSN of the checkpoint
-	           preceding the commit record. */
+			   preceding the commit record. */
 	if ((ret = __txn_getckp(dbenv, &txnlsn)) != 0)
 		goto err;
 

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -610,7 +610,10 @@ __dbenv_mintruncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 		goto err;
 	}
 
+	logc->close(logc, 0);
+
 	*outtime = ckp_args->timestamp;
+	free(rec.data);
 	free(ckp_args);
 
 	Pthread_mutex_lock(&dbenv->mintruncate_lk);
@@ -812,6 +815,9 @@ int __dbenv_build_mintruncate_list(dbenv)
 err:
 	if (logc)
 		__log_c_close(logc);
+
+	if (rec.data)
+		free(rec.data);
 
 	return ret;
 }

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -9,9 +9,9 @@
 
 #ifndef lint
 static const char copyright[] =
-    "Copyright (c) 1996-2003\nSleepycat Software Inc.  All rights reserved.\n";
+	"Copyright (c) 1996-2003\nSleepycat Software Inc.  All rights reserved.\n";
 static const char revid[] =
-    "$Id: env_recover.c,v 11.112 2003/09/13 18:46:20 bostic Exp $";
+	"$Id: env_recover.c,v 11.112 2003/09/13 18:46:20 bostic Exp $";
 #endif
 
 #include <arpa/inet.h>
@@ -64,8 +64,8 @@ int bdb_is_open(void *bdb_state);
 
 extern int gbl_is_physical_replicant;
 
-#define BDB_WRITELOCK(idstr)    bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
-#define BDB_RELLOCK()           bdb_rellock(bdb_state, __func__, __LINE__)
+#define BDB_WRITELOCK(idstr)	bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
+#define BDB_RELLOCK()		   bdb_rellock(bdb_state, __func__, __LINE__)
 
 #else
 
@@ -82,9 +82,9 @@ extern int gbl_is_physical_replicant;
 static int __log_earliest __P((DB_ENV *, DB_LOGC *, int32_t *, DB_LSN *));
 static double __lsn_diff __P((DB_LSN *, DB_LSN *, DB_LSN *, u_int32_t, int));
 static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
-    DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *start_lsn);
+	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *start_lsn);
 static int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
-    DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
+	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
 
 /* Get the recovery LSN. */
 int
@@ -161,7 +161,7 @@ __checkpoint_get(DB_ENV *dbenv, DB_LSN *lsnout)
 	rc = pread(dbenv->checkpoint->fd, &ckpt, 512, 0);
 	if (rc != 512) {
 		__db_err(dbenv, "can't read checkpoint record rc %d %s\n",
-		    errno, strerror(errno));
+			errno, strerror(errno));
 		return EINVAL;
 	}
 
@@ -235,7 +235,7 @@ __fileid_track_free(dbenv)
 
 				if (ret) {
 					logmsg(LOGMSG_ERROR, "__db_close %s rc %d\n",
-					    r->dbp->fname, ret);
+						r->dbp->fname, ret);
 					return ret;
 				}
 			}
@@ -269,8 +269,8 @@ __fileid_track_dump(dbenv)
 			r = ft->ranges[i].top;
 			while (r) {
 				logmsg(LOGMSG_USER, "  %u:%u -> %u:%u %s\n", r->start.file,
-				    r->start.offset, r->end.file, r->end.offset,
-				    r->fname);
+					r->start.offset, r->end.file, r->end.offset,
+					r->fname);
 				r = r->lnk.next;
 			}
 		}
@@ -298,10 +298,10 @@ static int
 __db_find_earliest_recover_point_after_file(dbenv, outlsn, file)
 	DB_ENV *dbenv;
 	DB_LSN *outlsn;
-    int file;
+	int file;
 {
 	int ret = 0;
-    int flags = DB_FIRST;
+	int flags = DB_FIRST;
 	DB_LOGC *logc = NULL;
 	u_int32_t type;
 	DB_LSN lsn, start_lsn = {0};
@@ -313,12 +313,12 @@ __db_find_earliest_recover_point_after_file(dbenv, outlsn, file)
 	if ((ret = __log_cursor(dbenv, &logc)) != 0)
 		goto err;
 
-    if (file > 0) {
-        lsn.file = file;
-        lsn.offset = 28;
-        if (0 == __log_c_get(logc, &lsn, &rec, DB_SET))
-            flags = DB_SET;
-    }
+	if (file > 0) {
+		lsn.file = file;
+		lsn.offset = 28;
+		if (0 == __log_c_get(logc, &lsn, &rec, DB_SET))
+			flags = DB_SET;
+	}
 
 	for (ret = __log_c_get(logc, &lsn, &rec, flags);
 			ret == 0; ret = __log_c_get(logc, &lsn, &rec, DB_NEXT)) {
@@ -380,7 +380,7 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 	/* Find a checkpoint - from the checkpoint file, if we can, or from
 	 * the log if we can't (eg: after a copy) */
 	if ((ret = __checkpoint_get(dbenv, &lsn)) != 0 &&
-	    (ret = __txn_getckp(dbenv, &lsn)) != 0) {
+		(ret = __txn_getckp(dbenv, &lsn)) != 0) {
 		ret = DB_NOTFOUND;
 		goto err;
 	}
@@ -396,23 +396,23 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 			ckp_args = NULL;
 		}
 		if ((ret = __log_c_get(logc, &lsn, &rec, DB_SET)) != 0 ||
-		    (ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0) {
+			(ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0) {
 			goto err;
 		}
 #if defined FIND_RECOVERY_START_TRACE
 		if (max_lsn) {
 			fprintf(stderr,
-			    "%s: max_lsn search: found [%d][%d] searching for the first "
-			    "checkpoint below [%d][%d]\n", __func__,
-			    ckp_args->last_ckp.file, ckp_args->last_ckp.offset,
-			    max_lsn->file, max_lsn->offset);
+				"%s: max_lsn search: found [%d][%d] searching for the first "
+				"checkpoint below [%d][%d]\n", __func__,
+				ckp_args->last_ckp.file, ckp_args->last_ckp.offset,
+				max_lsn->file, max_lsn->offset);
 		}
 		prev_lsn = lsn;
 #endif
 		lsn = ckp_args->last_ckp;
 	}
 	while (max_lsn != NULL &&
-	    log_compare(&ckp_args->ckp_lsn, max_lsn) >= 0);
+		log_compare(&ckp_args->ckp_lsn, max_lsn) >= 0);
 
 	ckp_lsn = ckp_args->ckp_lsn;
 	do {
@@ -421,14 +421,14 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 			ckp_args = NULL;
 		}
 		if ((ret = __log_c_get(logc, &lsn, &rec, DB_SET)) != 0 ||
-		    (ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
+			(ret = __txn_ckp_read(dbenv, rec.data, &ckp_args)) != 0)
 			goto err;
 #if defined FIND_RECOVERY_START_TRACE
 		fprintf(stderr,
-		    "%s: ckp_lsn search: found [%d][%d] searching for the first "
-		    "checkpoint below [%d][%d]\n", __func__,
-		    ckp_args->last_ckp.file, ckp_args->last_ckp.offset,
-		    ckp_lsn.file, ckp_lsn.offset);
+			"%s: ckp_lsn search: found [%d][%d] searching for the first "
+			"checkpoint below [%d][%d]\n", __func__,
+			ckp_args->last_ckp.file, ckp_args->last_ckp.offset,
+			ckp_lsn.file, ckp_lsn.offset);
 		prev_lsn = lsn;
 #endif
 		lsn = ckp_args->last_ckp;
@@ -438,7 +438,7 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 	checkpoint_lsn = ckp_args->ckp_lsn;
 #if defined FIND_RECOVERY_START_TRACE
 	fprintf(stderr, "%s: using lsn [%d][%d]\n", __func__,
-	    checkpoint_lsn.file, checkpoint_lsn.offset);
+		checkpoint_lsn.file, checkpoint_lsn.offset);
 #endif
 
 	ret = __log_c_get(logc, &lsn, &rec, DB_SET);
@@ -454,12 +454,12 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 	}
 	while (rectype != DB___db_debug || optype != 2) {
 		if (log_compare(&lsn, &checkpoint_lsn) &&
-		    rectype != DB___dbreg_register &&
-		    dbenv->attr.warn_nondbreg_records) {
+			rectype != DB___dbreg_register &&
+			dbenv->attr.warn_nondbreg_records) {
 			__db_err(dbenv, "non-register record type %d at %u:%u "
-			    "before checkpoint at %u:%u",
-			    rectype, lsn.file, lsn.offset,
-			    checkpoint_lsn.file, checkpoint_lsn.offset);
+				"before checkpoint at %u:%u",
+				rectype, lsn.file, lsn.offset,
+				checkpoint_lsn.file, checkpoint_lsn.offset);
 		}
 #if defined FIND_RECOVERY_START_TRACE
 		prev_lsn = lsn;
@@ -484,7 +484,7 @@ __db_find_recovery_start_int(dbenv, outlsn, max_lsn)
 		 * if this ever happens. It shouldn't - if it does we
 		 * have problems. */
 		__db_err(dbenv,
-		    "no recovery start record found prior to checkpoint");
+			"no recovery start record found prior to checkpoint");
 		if (!dbenv->attr.dbreg_errors_fatal) {
 			/* go old way for now - use the LSN at the
 			 * last trusted checkpoint */
@@ -500,17 +500,17 @@ err:
 #if defined FIND_RECOVERY_START_TRACE
 	if (ret != 0) {
 		fprintf(stderr,
-		    "%s: ret=%d for lsn [%d][%d] prev-lsn [%d][%d]\n",
-		    __func__, ret, lsn.file, lsn.offset, prev_lsn.file,
-		    prev_lsn.offset);
+			"%s: ret=%d for lsn [%d][%d] prev-lsn [%d][%d]\n",
+			__func__, ret, lsn.file, lsn.offset, prev_lsn.file,
+			prev_lsn.offset);
 		if (max_lsn)
 			fprintf(stderr, "%s: max_lsn is [%d][%d]\n", __func__,
-			    max_lsn->file, max_lsn->offset);
+				max_lsn->file, max_lsn->offset);
 	}
 #endif
    if (rec.data) {
-      __os_free(dbenv, rec.data);
-      rec.data = NULL;
+	  __os_free(dbenv, rec.data);
+	  rec.data = NULL;
    }
 	if (logc)
 		__log_c_close(logc);
@@ -545,17 +545,17 @@ static char *mt_string(int mt)
 
 int
 __dbenv_clear_mintruncate_list(dbenv)
-    DB_ENV *dbenv;
+	DB_ENV *dbenv;
 {
 	struct mintruncate_entry *mt;
 	Pthread_mutex_lock(&dbenv->mintruncate_lk);
-    while ((mt = listc_rtl(&dbenv->mintruncate)) != NULL)
-        free(mt);
-    dbenv->mintruncate_state = MINTRUNCATE_START;
-    ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
-    ZERO_LSN(dbenv->last_mintruncate_ckplsn);
+	while ((mt = listc_rtl(&dbenv->mintruncate)) != NULL)
+		free(mt);
+	dbenv->mintruncate_state = MINTRUNCATE_START;
+	ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
+	ZERO_LSN(dbenv->last_mintruncate_ckplsn);
 	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
-    return 0;
+	return 0;
 }
 
 int
@@ -571,16 +571,16 @@ __dbenv_dump_mintruncate_list(dbenv)
 				mt = mt->lnk.prev) {
 		logmsg(LOGMSG_USER, "%s @ [%d:%d] timestamp %d ckplsn [%d:%d] "
 #ifdef MINTRUNCATE_DEBUG
-                "added by %s"
+				"added by %s"
 #endif
-                "\n",
+				"\n",
 				mt->type == MINTRUNCATE_DBREG_START ? "dbreg" : "chkpt",
 				mt->lsn.file, mt->lsn.offset, mt->timestamp, mt->ckplsn.file,
-                mt->ckplsn.offset
+				mt->ckplsn.offset
 #ifdef MINTRUNCATE_DEBUG
-                ,mt->func
+				,mt->func
 #endif
-                );
+				);
 	}
 	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 	return 0;
@@ -597,7 +597,7 @@ __dbenv_mintruncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 	__txn_ckp_args *ckp_args = NULL;
 	DBT rec = { 0 };
 	DB_LOGC *logc = NULL;
-    DB_LSN lowlsn = {0};
+	DB_LSN lowlsn = {0};
 	int ret;
 
 	if ((ret = __txn_getckp(dbenv, outlsn)) != 0 ||
@@ -632,15 +632,15 @@ __dbenv_mintruncate_lsn_timestamp(dbenv, lowfile, outlsn, outtime)
 			mt = mt->lnk.prev)
 		;
 
-    if (mt)
-        lowlsn = mt->lsn;
+	if (mt)
+		lowlsn = mt->lsn;
 
 	/* Find first checkpoint with ckplsn > than that */
 	while (mt && (mt->type != MINTRUNCATE_CHECKPOINT || 
-             log_compare(&mt->ckplsn, &lowlsn) < 0))
+			 log_compare(&mt->ckplsn, &lowlsn) < 0))
 		mt = mt->lnk.prev;
 
-    /* If we found it, that's our minimum truncate point */
+	/* If we found it, that's our minimum truncate point */
 	if (mt) {
 		ret = 0;
 		*outlsn = mt->lsn;
@@ -655,26 +655,26 @@ err:
 
 /* Must be holding mintruncate_lk while calling this */
 void __dbenv_reset_mintruncate_vars(dbenv)
-    DB_ENV *dbenv;
+	DB_ENV *dbenv;
 {
-    int found_dbreg=0, found_ckp=0;
+	int found_dbreg=0, found_ckp=0;
 	struct mintruncate_entry *mt;
-    ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
-    ZERO_LSN(dbenv->last_mintruncate_ckplsn);
-    for (mt = LISTC_TOP(&dbenv->mintruncate); mt; mt = mt->lnk.next) {
-        if (!found_dbreg && mt->type == MINTRUNCATE_DBREG_START) {
-            dbenv->last_mintruncate_dbreg_start = mt->lsn;
-            found_dbreg = 1;
-        }
+	ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
+	ZERO_LSN(dbenv->last_mintruncate_ckplsn);
+	for (mt = LISTC_TOP(&dbenv->mintruncate); mt; mt = mt->lnk.next) {
+		if (!found_dbreg && mt->type == MINTRUNCATE_DBREG_START) {
+			dbenv->last_mintruncate_dbreg_start = mt->lsn;
+			found_dbreg = 1;
+		}
 
-        if (!found_ckp && mt->type == MINTRUNCATE_CHECKPOINT) {
-            dbenv->last_mintruncate_ckplsn = mt->ckplsn;
-            found_ckp = 1;
-        }
+		if (!found_ckp && mt->type == MINTRUNCATE_CHECKPOINT) {
+			dbenv->last_mintruncate_ckplsn = mt->ckplsn;
+			found_ckp = 1;
+		}
 
-        if (found_dbreg && found_ckp)
-            break;
-    }
+		if (found_dbreg && found_ckp)
+			break;
+	}
 }
 
 #ifdef MINTRUNCATE_DEBUG

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -389,7 +389,7 @@ matchable_log_type(int rectype)
 		ret = (rectype == DB___txn_regop ||
 			rectype == DB___txn_regop_gen ||
 			rectype == DB___txn_regop_rowlocks ||
-            (gbl_match_on_ckp && rectype == DB___txn_ckp));
+			(gbl_match_on_ckp && rectype == DB___txn_ckp));
 	} else {
 		switch (rectype) {
 		case DB___txn_recycle:
@@ -459,7 +459,7 @@ static void *apply_thread(void *arg)
 	LOG *lp;
 	DB_LOG *dblp;
 	DB_LSN master_lsn, my_lsn, my_last_lsn, first_repdb_lsn;
-    int last_lsn_change_time = 0;
+	int last_lsn_change_time = 0;
 	DB_ENV *dbenv = (DB_ENV *)arg;
 	struct queued_log *q;
 	struct timespec ts;
@@ -544,8 +544,8 @@ static void *apply_thread(void *arg)
 				static unsigned long long count = 0;
 				int now;
 
-                logmsg(LOGMSG_DEBUG, "%s: applying [%d:%d]\n", __func__, q->rp->lsn.file,
-                        q->rp->lsn.offset);
+				logmsg(LOGMSG_DEBUG, "%s: applying [%d:%d]\n", __func__, q->rp->lsn.file,
+						q->rp->lsn.offset);
 				ret = __rep_apply(dbenv, q->rp, &rec, &ret_lsnp, &q->gen, 1);
 				Pthread_mutex_unlock(&rep_candidate_lock);
 				if (ret == 0 || ret == DB_REP_ISPERM) {
@@ -598,9 +598,9 @@ static void *apply_thread(void *arg)
 					}
 				}
 			} else {
-                logmsg(LOGMSG_DEBUG, "%s: dropping [%d:%d], rep->gen=%d "
-                        "rec-gen=%d\n", __func__, q->rp->lsn.file,
-                        q->rp->lsn.offset, rep->gen, q->gen);
+				logmsg(LOGMSG_DEBUG, "%s: dropping [%d:%d], rep->gen=%d "
+						"rec-gen=%d\n", __func__, q->rp->lsn.file,
+						q->rp->lsn.offset, rep->gen, q->gen);
 				Pthread_mutex_unlock(&rep_candidate_lock);
 				ret = 0;
 			}
@@ -641,10 +641,10 @@ static void *apply_thread(void *arg)
 		/* IMPORTANT: backup if beyond the end of the logfile */
 		my_lsn.offset -= lp->len;
 
-        if (log_compare(&my_lsn, &my_last_lsn)) {
-            my_last_lsn = my_lsn;
-            last_lsn_change_time = comdb2_time_epochms();
-        }
+		if (log_compare(&my_lsn, &my_last_lsn)) {
+			my_last_lsn = my_lsn;
+			last_lsn_change_time = comdb2_time_epochms();
+		}
 
 		/* Delay more if we are falling further behind */
 		bytes_behind = subtract_lsn(dbenv->app_private, &master_lsn, &my_lsn);
@@ -719,15 +719,15 @@ static void *apply_thread(void *arg)
 			continue;
 		}
 
-        int request_all_records = 0;
-        if (gbl_req_all_threshold && (bytes_behind > gbl_req_all_threshold ||
-                IS_ZERO_LSN(first_repdb_lsn)))
-            request_all_records = 1;
+		int request_all_records = 0;
+		if (gbl_req_all_threshold && (bytes_behind > gbl_req_all_threshold ||
+				IS_ZERO_LSN(first_repdb_lsn)))
+			request_all_records = 1;
 
-        if (gbl_req_all_time_threshold && (comdb2_time_epochms() - 
-                    last_lsn_change_time) > gbl_req_all_time_threshold) {
-            request_all_records = 1;
-        }
+		if (gbl_req_all_time_threshold && (comdb2_time_epochms() - 
+					last_lsn_change_time) > gbl_req_all_time_threshold) {
+			request_all_records = 1;
+		}
 
 		if (request_all_records) {
 			/* Request all records from the master */
@@ -6430,11 +6430,11 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 	DB_LOGC *logc;
 	DBT *lock_dbt = NULL;
 	int ret, t_ret, undo, count=0;
-    int have_recover_lk = 0;
+	int have_recover_lk = 0;
 	int found_scdone = 0;
 	int recover_at_commit = 1;
-    int schema_lk_count = 0;
-    int i_am_master = 0;
+	int schema_lk_count = 0;
+	int i_am_master = 0;
 	int maxlocks = gbl_online_recovery_maxlocks;
 	u_int32_t rectype;
 	u_int32_t keycnt = 0;
@@ -6450,12 +6450,12 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
 
-    i_am_master = F_ISSET(rep, REP_F_MASTER);
+	i_am_master = F_ISSET(rep, REP_F_MASTER);
 
-    if (i_am_master) {
-        void wait_for_sc_to_stop(const char *operation);
-        wait_for_sc_to_stop("log-truncate");
-    }
+	if (i_am_master) {
+		void wait_for_sc_to_stop(const char *operation);
+		wait_for_sc_to_stop("log-truncate");
+	}
 
 	/* Figure out if we are backing out any commited transactions. */
 	if ((ret = __log_cursor(dbenv, &logc)) != 0)
@@ -6464,8 +6464,8 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 	if (dbenv->recovery_start_callback)
 		dbenv->recovery_start_callback(dbenv);
 
-    Pthread_rwlock_wrlock(&dbenv->recoverlk);
-    have_recover_lk = 1;
+	Pthread_rwlock_wrlock(&dbenv->recoverlk);
+	have_recover_lk = 1;
 
 restart:
 	lockid = DB_LOCK_INVALIDID;
@@ -6484,7 +6484,7 @@ restart:
 		(ret = __log_c_get(logc, &lsn, &mylog, logflags)) == 0 &&
 		log_compare(&lsn, lsnp) > 0) {
 		logflags = DB_PREV;
-        lockcnt = 0;
+		lockcnt = 0;
 		LOGCOPY_32(&rectype, mylog.data);
 		if (rectype == DB___txn_regop_rowlocks) {
 			if ((ret =
@@ -6497,7 +6497,7 @@ restart:
 
 			if (online) {
 				if (txnrlrec->lflags & DB_TXN_SCHEMA_LOCK)
-                    schema_lk_count++;
+					schema_lk_count++;
 				ret = recovery_getlocks(dbenv, lockid, &txnrlrec->locks, lsn);
 			}
 
@@ -6506,7 +6506,7 @@ restart:
 			if (ret == DB_LOCK_DEADLOCK) {
 				gbl_rep_trans_deadlocked++;
 				recovery_release_locks(dbenv, lockid);
-                lockid = DB_LOCK_INVALIDID;
+				lockid = DB_LOCK_INVALIDID;
 				goto restart;
 			}
 
@@ -6530,7 +6530,7 @@ restart:
 			if (ret == DB_LOCK_DEADLOCK) {
 				gbl_rep_trans_deadlocked++;
 				recovery_release_locks(dbenv, lockid);
-                lockid = DB_LOCK_INVALIDID;
+				lockid = DB_LOCK_INVALIDID;
 				goto restart;
 			}
 
@@ -6554,7 +6554,7 @@ restart:
 			if (ret == DB_LOCK_DEADLOCK) {
 				gbl_rep_trans_deadlocked++;
 				recovery_release_locks(dbenv, lockid);
-                lockid = DB_LOCK_INVALIDID;
+				lockid = DB_LOCK_INVALIDID;
 				goto restart;
 			}
 
@@ -6563,47 +6563,47 @@ restart:
 		}
 	}
 
-    logmsg(LOGMSG_INFO, "%s calling truncate with lsn [%d:%d]\n", __func__,
-            lsnp->file, lsnp->offset);
-    ret = __db_apprec(dbenv, lsnp, trunclsnp, undo, DB_RECOVER_NOCKP);
+	logmsg(LOGMSG_INFO, "%s calling truncate with lsn [%d:%d]\n", __func__,
+			lsnp->file, lsnp->offset);
+	ret = __db_apprec(dbenv, lsnp, trunclsnp, undo, DB_RECOVER_NOCKP);
 
-    /* Increase generation before releasing recovery lock */
-    if (i_am_master && !gbl_is_physical_replicant) {
-        uint32_t newgen = rep->gen+(20+rand()%20);
-        __rep_set_gen(dbenv, __func__, __LINE__, newgen);
-    }
+	/* Increase generation before releasing recovery lock */
+	if (i_am_master && !gbl_is_physical_replicant) {
+		uint32_t newgen = rep->gen+(20+rand()%20);
+		__rep_set_gen(dbenv, __func__, __LINE__, newgen);
+	}
 
-    /* Recovery cleanup is called holding recoverlk */
-    if (dbenv->rep_recovery_cleanup)
-        dbenv->rep_recovery_cleanup(dbenv, trunclsnp, i_am_master);
+	/* Recovery cleanup is called holding recoverlk */
+	if (dbenv->rep_recovery_cleanup)
+		dbenv->rep_recovery_cleanup(dbenv, trunclsnp, i_am_master);
 
-    logmsg(LOGMSG_INFO, "%s finished truncate, trunclsnp is [%d:%d]\n", __func__,
-            trunclsnp->file, trunclsnp->offset);
+	logmsg(LOGMSG_INFO, "%s finished truncate, trunclsnp is [%d:%d]\n", __func__,
+			trunclsnp->file, trunclsnp->offset);
 
-    Pthread_rwlock_unlock(&dbenv->recoverlk);
-    have_recover_lk = 0;
+	Pthread_rwlock_unlock(&dbenv->recoverlk);
+	have_recover_lk = 0;
 
 	if (online) {
 		recovery_release_locks(dbenv, lockid);
 		lockid = DB_LOCK_INVALIDID;
 	}
 
-    /* comdb2_reload_schemas will get the schema lock */
-    if (schema_lk_count && dbenv->truncate_sc_callback)
-        dbenv->truncate_sc_callback(dbenv, trunclsnp);
+	/* comdb2_reload_schemas will get the schema lock */
+	if (schema_lk_count && dbenv->truncate_sc_callback)
+		dbenv->truncate_sc_callback(dbenv, trunclsnp);
 
-    /* Tell replicants to truncate */
-    if (dbenv->rep_truncate_callback)
-        dbenv->rep_truncate_callback(dbenv, trunclsnp, i_am_master);
+	/* Tell replicants to truncate */
+	if (dbenv->rep_truncate_callback)
+		dbenv->rep_truncate_callback(dbenv, trunclsnp, i_am_master);
 
 err:
-    if (i_am_master) {
-        void allow_sc_to_run(void);
-        allow_sc_to_run();
-    }
+	if (i_am_master) {
+		void allow_sc_to_run(void);
+		allow_sc_to_run();
+	}
 
-    if (have_recover_lk)
-        Pthread_rwlock_unlock(&dbenv->recoverlk);
+	if (have_recover_lk)
+		Pthread_rwlock_unlock(&dbenv->recoverlk);
 
 	if ((t_ret = __log_c_close(logc)) != 0 && ret == 0)
 		ret = t_ret;
@@ -6613,14 +6613,14 @@ err:
 		lockid = DB_LOCK_INVALIDID;
 	}
 
-    Pthread_mutex_lock(&dbenv->mintruncate_lk);
-    struct mintruncate_entry *mt;
-    while ((mt = LISTC_TOP(&dbenv->mintruncate)) != NULL &&
-            log_compare(&mt->lsn, &trunclsnp) > 0) {
-        mt = listc_rtl(&dbenv->mintruncate);
-        free(mt);
-    }
-    Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+	Pthread_mutex_lock(&dbenv->mintruncate_lk);
+	struct mintruncate_entry *mt;
+	while ((mt = LISTC_TOP(&dbenv->mintruncate)) != NULL &&
+			log_compare(&mt->lsn, &trunclsnp) > 0) {
+		mt = listc_rtl(&dbenv->mintruncate);
+		free(mt);
+	}
+	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
 	return (ret);
 }
@@ -7541,7 +7541,7 @@ __rep_verify_match(dbenv, rp, savetime, online)
 	DB_ENV *dbenv;
 	REP_CONTROL *rp;
 	time_t savetime;
-    int online;
+	int online;
 {
 	DB_LOG *dblp;
 	DB_LSN trunclsn, prevlsn, purge_lsn;
@@ -7564,14 +7564,14 @@ __rep_verify_match(dbenv, rp, savetime, online)
 	 * and we lost.  We must give up.
 	 */
 
-    Pthread_mutex_lock(&apply_lk);
+	Pthread_mutex_lock(&apply_lk);
 	MUTEX_LOCK(dbenv, db_rep->db_mutexp);
 	MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
 	done = savetime != rep->timestamp;
 	MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 	if (done) {
 		MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
-        Pthread_mutex_unlock(&apply_lk);
+		Pthread_mutex_unlock(&apply_lk);
 		return (0);
 	}
 
@@ -7609,8 +7609,7 @@ __rep_verify_match(dbenv, rp, savetime, online)
 
 	/* Parallel rep threads could still be working- wait for them to complete
 	 * before grabbing the rep_mutex. */
-    if (!online) {
-        wait_for_running_transactions(dbenv);
+	wait_for_running_transactions(dbenv);
 
         /*
          * Make sure the world hasn't changed while we tried to get

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -10,7 +10,7 @@
 
 #ifndef lint
 static const char revid[] =
-    "$Id: rep_record.c,v 1.193 2003/11/14 05:32:31 ubell Exp $";
+	"$Id: rep_record.c,v 1.193 2003/11/14 05:32:31 ubell Exp $";
 #endif /* not lint */
 
 #ifndef NO_SYSTEM_INCLUDES
@@ -57,7 +57,7 @@ static const char revid[] =
 #ifndef TESTSUITE
 int bdb_am_i_coherent(void *bdb_state);
 void bdb_get_writelock(void *bdb_state,
-    const char *idstr, const char *funcname, int line);
+	const char *idstr, const char *funcname, int line);
 void bdb_rellock(void *bdb_state, const char *funcname, int line);
 int bdb_is_open(void *bdb_state);
 int rep_qstat_has_fills(void);
@@ -98,8 +98,8 @@ int __rep_set_last_locked(DB_ENV *dbenv, DB_LSN *lsn);
 extern void fsnapf(FILE *, void *, int);
 static int reset_recovery_processor(struct __recovery_processor *rp);
 
-#define BDB_WRITELOCK(idstr)    bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
-#define BDB_RELLOCK()           bdb_rellock(bdb_state, __func__, __LINE__)
+#define BDB_WRITELOCK(idstr)	bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
+#define BDB_RELLOCK()		   bdb_rellock(bdb_state, __func__, __LINE__)
 
 #else
 
@@ -111,7 +111,7 @@ static int reset_recovery_processor(struct __recovery_processor *rp);
 
 extern int bdb_purge_logical_transactions(void *statearg, DB_LSN *trunclsn);
 extern int set_commit_context(unsigned long long context, uint32_t *generation,
-    void *plsn, void *args, unsigned int rectype);
+	void *plsn, void *args, unsigned int rectype);
 extern int gbl_berkdb_verify_skip_skipables;
 
 static int __rep_apply __P((DB_ENV *, REP_CONTROL *, DBT *, DB_LSN *,
@@ -124,14 +124,14 @@ void send_master_req(DB_ENV *dbenv, const char *func, int line);
 static inline void send_dupmaster(DB_ENV *dbenv, const char *func, int line);
 
 int64_t gbl_rep_trans_parallel = 0, gbl_rep_trans_serial =
-    0, gbl_rep_trans_deadlocked = 0, gbl_rep_trans_inline =
-    0, gbl_rep_rowlocks_multifile = 0;
+	0, gbl_rep_trans_deadlocked = 0, gbl_rep_trans_inline =
+	0, gbl_rep_rowlocks_multifile = 0;
 
 static inline int wait_for_running_transactions(DB_ENV *dbenv);
 
 #define	IS_SIMPLE(R)	((R) != DB___txn_regop && (R) != DB___txn_xa_regop && \
-    (R) != DB___txn_regop_rowlocks && (R) != DB___txn_regop_gen && (R) != \
-    DB___txn_ckp && (R) != DB___dbreg_register)
+	(R) != DB___txn_regop_rowlocks && (R) != DB___txn_regop_gen && (R) != \
+	DB___txn_ckp && (R) != DB___dbreg_register)
 
 int gbl_rep_process_msg_print_rc;
 
@@ -981,7 +981,7 @@ __rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen, online)
 	char **eidp;
 	DB_LSN *ret_lsnp;
 	uint32_t *commit_gen;
-    int online;
+	int online;
 {
 	int fromline = 0;
 	DB_LOG *dblp;
@@ -2988,19 +2988,19 @@ __rep_apply_int(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled)
 	max_lsn_dbtp = NULL;
 	bzero(&max_lsn, sizeof(max_lsn));
 
-    if (rep->ignore_gen >= rp->gen) {
-        static uint32_t count=0;
-        static time_t lastpr = 0;
-        int now;
-        count++;
-        if ((now = time(NULL)) - lastpr) {
-            logmsg(LOGMSG_INFO, "%s: ignoring lsn [%d:%d] gen %d on truncate, "
-                    "count=%u\n", __func__, rp->lsn.file, rp->lsn.offset, rp->gen,
-                    count);
-            lastpr=now;
-        }
-        return 0;
-    }
+	if (rep->ignore_gen >= rp->gen) {
+		static uint32_t count=0;
+		static time_t lastpr = 0;
+		int now;
+		count++;
+		if ((now = time(NULL)) - lastpr) {
+			logmsg(LOGMSG_INFO, "%s: ignoring lsn [%d:%d] gen %d on truncate, "
+					"count=%u\n", __func__, rp->lsn.file, rp->lsn.offset, rp->gen,
+					count);
+			lastpr=now;
+		}
+		return 0;
+	}
 
 	if (gbl_verify_rep_log_records && rec->size >= HDR_NORMAL_SZ)
 		LOGCOPY_32(&rectype, rec->data);
@@ -3075,18 +3075,18 @@ __rep_apply_int(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled)
 	 * That said, I really don't want to do db operations holding the
 	 * log mutex, so the synchronization here is tricky.
 	 */
-    /* TODO: return a message telling the physical replicant to go 
-     * into matching mode */
-    if (gbl_is_physical_replicant && cmp != 0)
-    {
-        static uint32_t count=0;
-        count++;
-        logmsg(LOGMSG_INFO, "%s out-of-order lsn [%d][%d] instead of [%d][%d], "
-                "count %u\n", __func__, rp->lsn.file, rp->lsn.offset,
-                lp->ready_lsn.file, lp->ready_lsn.offset, count);
-        goto done;
-    }
-    
+	/* TODO: return a message telling the physical replicant to go 
+	 * into matching mode */
+	if (gbl_is_physical_replicant && cmp != 0)
+	{
+		static uint32_t count=0;
+		count++;
+		logmsg(LOGMSG_INFO, "%s out-of-order lsn [%d][%d] instead of [%d][%d], "
+				"count %u\n", __func__, rp->lsn.file, rp->lsn.offset,
+				lp->ready_lsn.file, lp->ready_lsn.offset, count);
+		goto done;
+	}
+	
 	if (cmp == 0) {
 		/* We got the log record that we are expecting. */
 		if (rp->rectype == REP_NEWFILE) {
@@ -3622,8 +3622,8 @@ gap_check:		max_lsn_dbtp = NULL;
 			goto err;
 		}
 		__os_free(dbenv, ckp_args);
-        if (gbl_flush_log_at_checkpoint)
-            __log_flush(dbenv, NULL);
+		if (gbl_flush_log_at_checkpoint)
+			__log_flush(dbenv, NULL);
 		__memp_sync_out_of_band(dbenv, &rp->lsn);
 		break;
 	case DB___txn_regop_rowlocks:
@@ -3725,7 +3725,7 @@ gap_check:		max_lsn_dbtp = NULL;
 		if (ret != 0) {
 			__db_err(dbenv, "Error processing txn [%lu][%lu]",
 				(u_long)rp->lsn.file, (u_long)rp->lsn.offset);
-            __log_flush(dbenv, NULL);
+			__log_flush(dbenv, NULL);
 			__db_panic(dbenv, ret);
 		}
 		break;
@@ -3819,11 +3819,11 @@ __rep_apply(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled)
 	int rc, now;
 	bbtime_t start = {0}, end = {0};
 
-    Pthread_mutex_lock(&apply_lk);
+	Pthread_mutex_lock(&apply_lk);
 	getbbtime(&start);
 	rc = __rep_apply_int(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled);
 	getbbtime(&end);
-    Pthread_mutex_unlock(&apply_lk);
+	Pthread_mutex_unlock(&apply_lk);
 	usecs = diff_bbtime(&end, &start);
 	rep_apply_count++;
 	rep_apply_usc += usecs;
@@ -3838,35 +3838,35 @@ __rep_apply(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled)
 }
 
 int __dbenv_apply_log(DB_ENV* dbenv, unsigned int file, unsigned int offset, 
-        int64_t rectype, void* blob, int blob_len)
+		int64_t rectype, void* blob, int blob_len)
 {
 
-    REP_CONTROL rp;
+	REP_CONTROL rp;
 
-    DBT rec = {0};
-    DB_LSN ret_lsnp;
-    uint32_t *commit_gen;
-    int rc, decoupled;
-    DB_REP* db_rep; 
-    REP* rep; 
+	DBT rec = {0};
+	DB_LSN ret_lsnp;
+	uint32_t *commit_gen;
+	int rc, decoupled;
+	DB_REP* db_rep; 
+	REP* rep; 
 
-    rec.data = blob;
-    rec.size = blob_len;
+	rec.data = blob;
+	rec.size = blob_len;
 
-    ret_lsnp.file = file;
-    ret_lsnp.offset = offset;
+	ret_lsnp.file = file;
+	ret_lsnp.offset = offset;
 
-    rp.rep_version = 0;
-    rp.log_version = 0;
-    rp.lsn = ret_lsnp;
-    db_rep = dbenv->rep_handle;
-    rep = db_rep->region;
-    rp.rectype = rectype;
-    rp.gen = rep->gen; 
-    rp.flags = 0;
+	rp.rep_version = 0;
+	rp.log_version = 0;
+	rp.lsn = ret_lsnp;
+	db_rep = dbenv->rep_handle;
+	rep = db_rep->region;
+	rp.rectype = rectype;
+	rp.gen = rep->gen; 
+	rp.flags = 0;
 
-    /* call of 2 to differentiate from true master */
-    return __rep_apply(dbenv, &rp, &rec, &ret_lsnp, &rep->gen, 2);
+	/* call of 2 to differentiate from true master */
+	return __rep_apply(dbenv, &rp, &rec, &ret_lsnp, &rep->gen, 2);
 
 }
 
@@ -3878,7 +3878,7 @@ size_t __dbenv_get_log_header_size(DB_ENV* dbenv)
 		hdrsize = HDR_CRYPTO_SZ;
 	}
 
-    return hdrsize;
+	return hdrsize;
 }
 
 u_int32_t gbl_rep_lockid;
@@ -4500,8 +4500,8 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 	void *pglogs = NULL;
 	u_int32_t keycnt = 0;
 
-    logmsg(LOGMSG_DEBUG, "%s processing [%d:%d]\n", __func__, maxlsn.file,
-            maxlsn.offset);
+	logmsg(LOGMSG_DEBUG, "%s processing [%d:%d]\n", __func__, maxlsn.file,
+			maxlsn.offset);
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
 
@@ -4533,9 +4533,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 		if ((ret =
 			__txn_regop_rowlocks_read(dbenv, rec->data,
 				&txn_rl_args)) != 0) {
-            logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
+			logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
 			return (ret);
-        }
+		}
 		if (txn_rl_args->opcode != TXN_COMMIT) {
 			__os_free(dbenv, txn_rl_args);
 			return (0);
@@ -4560,9 +4560,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 				__txn_allocate_ltrans(dbenv,
 					txn_rl_args->ltranid,
 					&txn_rl_args->begin_lsn, &lt)) != 0) {
-                line = __LINE__;
+				line = __LINE__;
 				goto err1;
-            }
+			}
 
 			if (NULL == dbenv->txn_logical_start ||
 				(ret =
@@ -4571,7 +4571,7 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 					&rctl->lsn)) != 0) {
 				logmsg(LOGMSG_ERROR, "%s: txn_logical_start error, %d\n",
 					__func__, ret);
-                line = __LINE__;
+				line = __LINE__;
 				goto err1;
 			}
 		}
@@ -4606,9 +4606,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 		 * really a commit and not an abort!
 		 */
 		if ((ret = __txn_regop_read(dbenv, rec->data, &txn_args)) != 0) {
-            logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
+			logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
 			return (ret);
-        }
+		}
 		if (txn_args->opcode != TXN_COMMIT) {
 			__os_free(dbenv, txn_args);
 			return (0);
@@ -4627,9 +4627,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 		if ((ret =
 			__txn_regop_gen_read(dbenv, rec->data,
 				&txn_gen_args)) != 0) {
-            logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
-            return (ret);
-        }
+			logmsg(LOGMSG_DEBUG, "%s failed at line %d\n", __func__, __LINE__);
+			return (ret);
+		}
 		if (txn_gen_args->opcode != TXN_COMMIT) {
 			__os_free(dbenv, txn_gen_args);
 			return (0);
@@ -4660,9 +4660,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 	} else {
 		/* Get locks. */
 		if ((ret = __lock_id(dbenv, &lockid)) != 0) {
-            line = __LINE__;
+			line = __LINE__;
 			goto err1;
-        }
+		}
 		get_locks_and_ack = 1;
 	}
 
@@ -4707,9 +4707,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 			assert(gbl_rep_lock_time_ms != 0);
 			gbl_rep_lock_time_ms = 0;
 			if (ret != 0) {
-                line = __LINE__;
+				line = __LINE__;
 				goto err;
-            }
+			}
 
 			if (ret == 0 && context) {
 				set_commit_context(context, commit_gen,
@@ -4727,9 +4727,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 			assert(gbl_rep_lock_time_ms != 0);
 			gbl_rep_lock_time_ms = 0;
 			if (ret != 0) {
-                line = __LINE__;
+				line = __LINE__;
 				goto err;
-            }
+			}
 
 			if (ret == 0 && context) {
 				set_commit_context(context, commit_gen,
@@ -4738,9 +4738,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 		}
 
 		if (ret != 0) {
-            line = __LINE__;
+			line = __LINE__;
 			goto err;
-        }
+		}
 
 		/* Set the last-locked lsn */
 		__rep_set_last_locked(dbenv, &(rctl->lsn));
@@ -4779,15 +4779,15 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 			(txn_rl_args) ? txn_rl_args->ltranid : 0, rctl->lsn,
 			*commit_gen, timestamp, context);
 		if (ret) {
-            line = __LINE__;
+			line = __LINE__;
 			goto err;
-        }
+		}
 	}
 
 	if ((ret = __log_cursor(dbenv, &logc)) != 0) {
-        line = __LINE__;
+		line = __LINE__;
 		goto err;
-    }
+	}
 
 	/* Phase 1.  Get a list of the LSNs in this transaction, and sort it. */
 	if (lcin)
@@ -4796,9 +4796,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 		/* Phase 1.  Get a list of the LSNs in this transaction, and sort it. */
 		if ((ret = __rep_collect_txn_txnid(dbenv, &prev_lsn, &lc,
 				&had_serializable_records, NULL, txnid)) != 0) {
-            line = __LINE__;
+			line = __LINE__;
 			goto err;
-        }
+		}
 		lcin = &lc;
 		/* here's the bug!!!! ! */
 		qsort(lc.array, lc.nlsns, sizeof(struct logrecord),
@@ -4825,9 +4825,9 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 	 * state between records.
 	 */
 	if ((ret = __db_txnlist_init(dbenv, 0, 0, NULL, &txninfo)) != 0) {
-        line = __LINE__;
+		line = __LINE__;
 		goto err;
-    }
+	}
 
 	/* Phase 2: Apply updates. */
 	for (i = 0; i < lc.nlsns; i++) {
@@ -4846,7 +4846,7 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 				__db_err(dbenv,
 					"failed to read the log at [%lu][%lu]",
 					(u_long)lsnp->file, (u_long)lsnp->offset);
-                line = __LINE__;
+				line = __LINE__;
 				goto err;
 			}
 			rectype = 0;
@@ -4878,7 +4878,7 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 						(u_long)lsnp->offset);
 				if (ret == DB_LOCK_DEADLOCK && rectype >= 10000)
 					ret = DB_LOCK_DEADLOCK_CUSTOM;
-                line = __LINE__;
+				line = __LINE__;
 				goto err;
 			}
 		} else
@@ -4892,9 +4892,9 @@ err:
 	req.op = DB_LOCK_PUT_ALL;
 	if ((t_ret =
 		__lock_vec(dbenv, lockid, 0, &req, 1, &lvp)) != 0 && ret == 0) {
-        line = __LINE__;
+		line = __LINE__;
 		ret = t_ret;
-    }
+	}
 
 	/*
 	 * Pthread_mutex_lock(&dbenv->recover_lk);
@@ -4910,9 +4910,9 @@ err:
 	}
 
 	if ((t_ret = __lock_id_free(dbenv, lockid)) != 0 && ret == 0) {
-        line = __LINE__;
+		line = __LINE__;
 		ret = t_ret;
-    }
+	}
 
 	if (ret == 0 && txn_rl_args &&
 		txn_rl_args->lflags & DB_TXN_LOGICAL_COMMIT) {
@@ -4924,7 +4924,7 @@ err:
 				txn_rl_args->ltranid, &rctl->lsn)) != 0) {
 			logmsg(LOGMSG_ERROR, "%s: txn_logical_commit error, %d\n",
 				__func__, ret);
-            line = __LINE__;
+			line = __LINE__;
 			ret = t_ret;
 		}
 	}
@@ -4934,10 +4934,10 @@ err:
 	}
 
 err1:
-    if (ret != 0 && ret != DB_LOCK_DEADLOCK) {
-        logmsg(LOGMSG_ERROR, "%s failed at line %d with %d\n", __func__,
-                line, ret);
-    }
+	if (ret != 0 && ret != DB_LOCK_DEADLOCK) {
+		logmsg(LOGMSG_ERROR, "%s failed at line %d with %d\n", __func__,
+				line, ret);
+	}
 
 	if (rectype == DB___txn_regop)
 		__os_free(dbenv, txn_args);
@@ -6437,7 +6437,7 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 	int recover_at_commit = 1;
 	int schema_lk_count = 0;
 	int i_am_master = 0;
-    static int truncate_count = 0;
+	static int truncate_count = 0;
 	int maxlocks = gbl_online_recovery_maxlocks;
 	u_int32_t rectype;
 	u_int32_t keycnt = 0;
@@ -6462,25 +6462,25 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 
 	Pthread_rwlock_wrlock(&dbenv->recoverlk);
 	have_recover_lk = 1;
-    if (i_am_master) {
-        if (truncate_count > 0) {
-            logmsg(LOGMSG_ERROR, "%s forbidding concurrent truncates\n", __func__);
-            Pthread_rwlock_unlock(&dbenv->recoverlk);
-            return -1;
-        }
-        truncate_count++;
-    }
+	if (i_am_master) {
+		if (truncate_count > 0) {
+			logmsg(LOGMSG_ERROR, "%s forbidding concurrent truncates\n", __func__);
+			Pthread_rwlock_unlock(&dbenv->recoverlk);
+			return -1;
+		}
+		truncate_count++;
+	}
 
 	/* Figure out if we are backing out any commited transactions. */
 	if ((ret = __log_cursor(dbenv, &logc)) != 0) {
-        Pthread_rwlock_unlock(&dbenv->recoverlk);
-        logmsg(LOGMSG_ERROR, "%s error getting log cursor\n", __func__);
-        if (i_am_master) {
-            truncate_count--;
-            assert(truncate_count == 0);
-        }
+		Pthread_rwlock_unlock(&dbenv->recoverlk);
+		logmsg(LOGMSG_ERROR, "%s error getting log cursor\n", __func__);
+		if (i_am_master) {
+			truncate_count--;
+			assert(truncate_count == 0);
+		}
 		return (ret);
-    }
+	}
 
 restart:
 	lockid = DB_LOCK_INVALIDID;
@@ -6615,13 +6615,13 @@ err:
 	if (i_am_master) {
 		void allow_sc_to_run(void);
 		allow_sc_to_run();
-        assert(truncate_count == 1);
-        truncate_count--;
+		assert(truncate_count == 1);
+		truncate_count--;
 	}
 
 	if (have_recover_lk) {
 		Pthread_rwlock_unlock(&dbenv->recoverlk);
-    }
+	}
 
 	if ((t_ret = __log_c_close(logc)) != 0 && ret == 0)
 		ret = t_ret;
@@ -6639,7 +6639,7 @@ err:
 		free(mt);
 	}
 
-    __dbenv_reset_mintruncate_vars(dbenv);
+	__dbenv_reset_mintruncate_vars(dbenv);
 
 	Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
@@ -7529,32 +7529,32 @@ extern int __dbenv_build_mintruncate_list(DB_ENV *dbenv);
  */
 int __dbenv_rep_verify_match(DB_ENV* dbenv, unsigned int file, unsigned int offset, int online)
 {
-    REP_CONTROL rp;
+	REP_CONTROL rp;
 	DB_LSN lsnp;
-    DB_REP* db_rep; 
-    REP* rep; 
-    int ret, rc;
+	DB_REP* db_rep; 
+	REP* rep; 
+	int ret, rc;
 
-    lsnp.file = file;
-    lsnp.offset = offset;
+	lsnp.file = file;
+	lsnp.offset = offset;
 
-    rp.rep_version = 0;
-    rp.log_version = 0;
-    rp.lsn = lsnp;
-    db_rep = dbenv->rep_handle;
-    rep = db_rep->region;
-    rp.gen = rep->gen; 
-    rp.flags = 0;
+	rp.rep_version = 0;
+	rp.log_version = 0;
+	rp.lsn = lsnp;
+	db_rep = dbenv->rep_handle;
+	rep = db_rep->region;
+	rp.gen = rep->gen; 
+	rp.flags = 0;
 
-    /* Do a full scan if user wants to truncate to before the first
-     * checkpoint that we actually wrote */
-    if (dbenv->mintruncate_state != MINTRUNCATE_READY &&
-            log_compare(&lsnp, &dbenv->mintruncate_first) < 0) {
-        rc = __dbenv_build_mintruncate_list(dbenv);
-        assert(rc || dbenv->mintruncate_state == MINTRUNCATE_READY);
-    }
-    ret = __rep_verify_match(dbenv, &rp, rep->timestamp, online);
-    return ret;
+	/* Do a full scan if user wants to truncate to before the first
+	 * checkpoint that we actually wrote */
+	if (dbenv->mintruncate_state != MINTRUNCATE_READY &&
+			log_compare(&lsnp, &dbenv->mintruncate_first) < 0) {
+		rc = __dbenv_build_mintruncate_list(dbenv);
+		assert(rc || dbenv->mintruncate_state == MINTRUNCATE_READY);
+	}
+	ret = __rep_verify_match(dbenv, &rp, rep->timestamp, online);
+	return ret;
 }
 
 static int
@@ -7633,16 +7633,16 @@ __rep_verify_match(dbenv, rp, savetime, online)
 	wait_for_running_transactions(dbenv);
 	if (!online) {
 
-        /*
-         * Make sure the world hasn't changed while we tried to get
-         * the lock.  If it hasn't then it's time for us to kick all
-         * operations out of DB and run recovery.
-         */
-        MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
-        if (F_ISSET(rep, REP_F_READY) || rep->in_recovery != 0) {
-            rep->stat.st_msgs_recover++;
-            goto errunlock;
-        }
+		/*
+		 * Make sure the world hasn't changed while we tried to get
+		 * the lock.  If it hasn't then it's time for us to kick all
+		 * operations out of DB and run recovery.
+		 */
+		MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
+		if (F_ISSET(rep, REP_F_READY) || rep->in_recovery != 0) {
+			rep->stat.st_msgs_recover++;
+			goto errunlock;
+		}
 
 	/* Phase 1: set REP_F_READY and wait for op_cnt to go to 0. */
 	/* This doesn't do anything anymore, but we should have gotten the 
@@ -7655,13 +7655,13 @@ __rep_verify_match(dbenv, rp, savetime, online)
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 		__os_sleep(dbenv, 1, 0);
 #ifdef DIAGNOSTIC
-            if (++wait_cnt % 60 == 0)
-                __db_err(dbenv,
-                        "Waiting for txn_cnt to run replication recovery for %d minutes",
-                        wait_cnt / 60);
+			if (++wait_cnt % 60 == 0)
+				__db_err(dbenv,
+						"Waiting for txn_cnt to run replication recovery for %d minutes",
+						wait_cnt / 60);
 #endif
-            MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
-        }
+			MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
+		}
 
 
 
@@ -7670,8 +7670,8 @@ __rep_verify_match(dbenv, rp, savetime, online)
 	 * to 0 and for the number of threads in __rep_process_message
 	 * to go to 1 (us).
 	 */
-    if (!online)
-        rep->in_recovery = 1;
+	if (!online)
+		rep->in_recovery = 1;
 
 	rep->in_recovery = 1;
 #ifdef DIAGNOSTIC
@@ -7681,23 +7681,23 @@ __rep_verify_match(dbenv, rp, savetime, online)
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 		__os_sleep(dbenv, 1, 0);
 #ifdef DIAGNOSTIC
-            if (++wait_cnt % 60 == 0)
-                __db_err(dbenv,
-                        "Waiting for handle/thread count to run replication recovery for %d minutes",
-                        wait_cnt / 60);
+			if (++wait_cnt % 60 == 0)
+				__db_err(dbenv,
+						"Waiting for handle/thread count to run replication recovery for %d minutes",
+						wait_cnt / 60);
 #endif
-            MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
-        }
+			MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
+		}
 
-        /* OK, everyone is out, we can now run recovery. */
-        MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
-    }
+		/* OK, everyone is out, we can now run recovery. */
+		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
+	}
 
 	if ((ret = __rep_dorecovery(dbenv, &rp->lsn, &trunclsn, online)) != 0) {
-        Pthread_mutex_unlock(&apply_lk);
+		Pthread_mutex_unlock(&apply_lk);
 		MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
-        if (!online)
-            rep->in_recovery = 0;
+		if (!online)
+			rep->in_recovery = 0;
 		F_CLR(rep, REP_F_READY);
 		goto errunlock;
 	}
@@ -7813,7 +7813,7 @@ errunlock:	MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 	gbl_passed_repverify = 1;
 
 err:
-    Pthread_mutex_unlock(&apply_lk);
+	Pthread_mutex_unlock(&apply_lk);
 
 	return (ret);
 }

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -6613,6 +6613,15 @@ err:
 		lockid = DB_LOCK_INVALIDID;
 	}
 
+    Pthread_mutex_lock(&dbenv->mintruncate_lk);
+    struct mintruncate_entry *mt;
+    while ((mt = LISTC_TOP(&dbenv->mintruncate)) != NULL &&
+            log_compare(&mt->lsn, &trunclsnp) > 0) {
+        mt = listc_rtl(&dbenv->mintruncate);
+        free(mt);
+    }
+    Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+
 	return (ret);
 }
 

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -7610,6 +7610,7 @@ __rep_verify_match(dbenv, rp, savetime, online)
 	/* Parallel rep threads could still be working- wait for them to complete
 	 * before grabbing the rep_mutex. */
 	wait_for_running_transactions(dbenv);
+	if (!online) {
 
         /*
          * Make sure the world hasn't changed while we tried to get

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2327,6 +2327,7 @@ do_ckp:
             newmt->type = MINTRUNCATE_DBREG_START;
             newmt->timestamp = 0;
             newmt->lsn = dbenv->last_dbreg_start = debuglsn;
+            ZERO_LSN(newmt->ckplsn);
             listc_atl(&dbenv->mintruncate, newmt);
         }
         Pthread_mutex_unlock(&dbenv->mintruncate_lk);
@@ -2368,6 +2369,7 @@ do_ckp:
             newmt->type = MINTRUNCATE_CHECKPOINT;
             newmt->timestamp = timestamp;
             newmt->lsn = ckp_lsn;
+            newmt->ckplsn = ckp_lsn_sav;
             listc_atl(&dbenv->mintruncate, newmt);
             if (dbenv->mintruncate_first.file == 0)
                 dbenv->mintruncate_first = ckp_lsn;

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -15,13 +15,13 @@
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *	notice, this list of conditions and the following disclaimer.
+ *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *	notice, this list of conditions and the following disclaimer in the
- *	documentation and/or other materials provided with the distribution.
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
  * 3. Neither the name of the University nor the names of its contributors
- *	may be used to endorse or promote products derived from this software
- *	without specific prior written permission.
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -2281,10 +2281,10 @@ do_ckp:
 		 * 3) TXN A reads pages, and has not modified any pages yet.
 		 * 4) TXN B modifies pages.
 		 * 5) Checkpoint takes place and ckp_lsn is adjusted to LSN B.
-		 *	the last checkpoint LSN becomes LSN B.
+		 *    the last checkpoint LSN becomes LSN B.
 		 * 6) TXN A modifies pages.
 		 * 7) Checkpoint takes place and ckp_lsn is adjusted to LSN A.
-		 *	LSN A is younger than the last checkpoint LSN which is LSN B.
+		 *    LSN A is younger than the last checkpoint LSN which is LSN B.
 		 *
 		 * If ckp_lsn goes backwards, we skip the checkpoint record.
 		 * It should be fine because we have a separate checkpoint file

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2371,6 +2371,8 @@ do_ckp:
             newmt->timestamp = timestamp;
             newmt->lsn = ckp_lsn;
             listc_atl(&dbenv->mintruncate, newmt);
+            if (dbenv->mintruncate_first.file == 0)
+                dbenv->mintruncate_first = ckp_lsn;
         }
         Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2322,12 +2322,11 @@ do_ckp:
 		}
 
         Pthread_mutex_lock(&dbenv->mintruncate_lk);
-        if (dbenv->mintruncate_state == MINTRUNCATE_READY &&
-                dbenv->last_dbreg_start.file < debuglsn.file) {
+        if (dbenv->last_dbreg_start.file < debuglsn.file) {
             newmt = malloc(sizeof(*newmt));
             newmt->type = MINTRUNCATE_DBREG_START;
             newmt->timestamp = 0;
-            dbenv->last_dbreg_start = debuglsn;
+            newmt->lsn = dbenv->last_dbreg_start = debuglsn;
             listc_atl(&dbenv->mintruncate, newmt);
         }
         Pthread_mutex_unlock(&dbenv->mintruncate_lk);
@@ -2363,8 +2362,7 @@ do_ckp:
 
         Pthread_mutex_lock(&dbenv->mintruncate_lk);
         mt = LISTC_TOP(&dbenv->mintruncate);
-        if (dbenv->mintruncate_state == MINTRUNCATE_READY &&
-                mt->type == MINTRUNCATE_DBREG_START &&
+        if (mt->type == MINTRUNCATE_DBREG_START &&
                 (log_compare(&ckp_lsn_sav, &dbenv->last_dbreg_start) > 0)) {
             newmt = malloc(sizeof(*newmt));
             newmt->type = MINTRUNCATE_CHECKPOINT;

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -15,13 +15,13 @@
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
+ *	notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in the
- *    documentation and/or other materials provided with the distribution.
+ *	notice, this list of conditions and the following disclaimer in the
+ *	documentation and/or other materials provided with the distribution.
  * 3. Neither the name of the University nor the names of its contributors
- *    may be used to endorse or promote products derived from this software
- *    without specific prior written permission.
+ *	may be used to endorse or promote products derived from this software
+ *	without specific prior written permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -84,7 +84,7 @@ static const char revid[] = "$Id: txn.c,v 11.219 2003/12/03 14:33:06 bostic Exp 
 #ifndef TESTSUITE
 #include <thread_util.h>
 void bdb_get_writelock(void *bdb_state,
-    const char *idstr, const char *funcname, int line);
+	const char *idstr, const char *funcname, int line);
 void bdb_rellock(void *bdb_state, const char *funcname, int line);
 int bdb_is_open(void *bdb_state);
 
@@ -93,8 +93,8 @@ void ctrace(char *format, ...);
 
 extern int gbl_is_physical_replicant;
 
-#define BDB_WRITELOCK(idstr)    bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
-#define BDB_RELLOCK()           bdb_rellock(bdb_state, __func__, __LINE__)
+#define BDB_WRITELOCK(idstr)	bdb_get_writelock(bdb_state, (idstr), __func__, __LINE__)
+#define BDB_RELLOCK()		   bdb_rellock(bdb_state, __func__, __LINE__)
 
 #else
 
@@ -107,27 +107,27 @@ extern int gbl_is_physical_replicant;
 static int
 
 __txn_begin_int_set_retries(DB_TXN *txn, u_int32_t retries,
-    DB_LSN *we_start_at_this_lsn, u_int32_t flags);
+	DB_LSN *we_start_at_this_lsn, u_int32_t flags);
 
 extern int __lock_locker_getpriority(DB_LOCKTAB *lt, u_int32_t locker,
-    int *priority);
+	int *priority);
 
 #define	SET_LOG_FLAGS_ROWLOCKS(dbenv, txnp, ltranflags, lflags) \
 	do {								\
 		lflags = DB_LOG_COMMIT;			\
-        if (ltranflags & DB_TXN_LOGICAL_COMMIT) \
-            lflags |= DB_LOG_PERM; \
+		if (ltranflags & DB_TXN_LOGICAL_COMMIT) \
+			lflags |= DB_LOG_PERM; \
 		if (F_ISSET(txnp, TXN_SYNC))				\
 			lflags |= DB_FLUSH;				\
 		else if (!F_ISSET(txnp, TXN_NOSYNC) &&			\
-		    !F_ISSET(dbenv, DB_ENV_TXN_NOSYNC)) {		\
+			!F_ISSET(dbenv, DB_ENV_TXN_NOSYNC)) {		\
 			if (F_ISSET(dbenv, DB_ENV_TXN_WRITE_NOSYNC))	\
 				lflags |= DB_LOG_WRNOSYNC;		\
 			else						\
 				lflags |= DB_FLUSH;			\
 		}							\
-        if (LF_ISSET(DB_TXN_REP_ACK))       \
-            lflags |= DB_LOG_REP_ACK; \
+		if (LF_ISSET(DB_TXN_REP_ACK))	   \
+			lflags |= DB_LOG_REP_ACK; \
 	} while (0)
 
 
@@ -137,14 +137,14 @@ extern int __lock_locker_getpriority(DB_LOCKTAB *lt, u_int32_t locker,
 		if (F_ISSET(txnp, TXN_SYNC))				\
 			lflags |= DB_FLUSH;				\
 		else if (!F_ISSET(txnp, TXN_NOSYNC) &&			\
-		    !F_ISSET(dbenv, DB_ENV_TXN_NOSYNC)) {		\
+			!F_ISSET(dbenv, DB_ENV_TXN_NOSYNC)) {		\
 			if (F_ISSET(dbenv, DB_ENV_TXN_WRITE_NOSYNC))	\
 				lflags |= DB_LOG_WRNOSYNC;		\
 			else						\
 				lflags |= DB_FLUSH;			\
 		}							\
-        if (LF_ISSET(DB_TXN_REP_ACK))       \
-            lflags |= DB_LOG_REP_ACK; \
+		if (LF_ISSET(DB_TXN_REP_ACK))	   \
+			lflags |= DB_LOG_REP_ACK; \
 	} while (0)
 
 /*
@@ -191,10 +191,10 @@ __txn_begin_pp_int(dbenv, parent, txnpp, flags, retries)
 	ENV_REQUIRES_CONFIG(dbenv, dbenv->tx_handle, "txn_begin", DB_INIT_TXN);
 
 	if ((ret = __db_fchk(dbenv,
-	    "txn_begin", flags,
-	    DB_DIRTY_READ | DB_TXN_NOWAIT |
-	    DB_TXN_NOSYNC | DB_TXN_SYNC | DB_TXN_RECOVERY |
-        DB_TXN_INTERNAL)) != 0)
+		"txn_begin", flags,
+		DB_DIRTY_READ | DB_TXN_NOWAIT |
+		DB_TXN_NOSYNC | DB_TXN_SYNC | DB_TXN_RECOVERY |
+		DB_TXN_INTERNAL)) != 0)
 		return (ret);
 	if ((ret = __db_fcchk(dbenv,
 		"txn_begin", flags, DB_TXN_NOSYNC, DB_TXN_SYNC)) != 0)
@@ -238,9 +238,9 @@ __txn_begin_set_retries_pp(dbenv, parent, txnpp, flags, retries)
 }
 
 int bdb_txn_pglogs_init(void *bdb_state, void **pglogs_hashtbl,
-    pthread_mutex_t * mutexp);
+	pthread_mutex_t * mutexp);
 int bdb_txn_pglogs_close(void *bdb_state, void **pglogs_hashtbl,
-    pthread_mutex_t * mutexp);
+	pthread_mutex_t * mutexp);
 
 /*
  * __txn_begin --
@@ -295,7 +295,7 @@ __txn_begin_main(dbenv, parent, txnpp, flags, retries)
 
 	if ((ret =
 		__txn_begin_int_set_retries(txn, retries,
-		    &we_start_at_this_lsn, flags)) != 0)
+			&we_start_at_this_lsn, flags)) != 0)
 		goto err;
 
 	if (!parent) {
@@ -309,7 +309,7 @@ __txn_begin_main(dbenv, parent, txnpp, flags, retries)
 		region = ((DB_LOCKTAB *)dbenv->lk_handle)->reginfo.primary;
 		if (parent != NULL) {
 			ret = __lock_inherit_timeout(dbenv,
-			    parent->txnid, txn->txnid);
+				parent->txnid, txn->txnid);
 			/* No parent locker set yet. */
 			if (ret == EINVAL) {
 				parent = NULL;
@@ -326,7 +326,7 @@ __txn_begin_main(dbenv, parent, txnpp, flags, retries)
 		 */
 		if (parent == NULL && region->tx_timeout != 0)
 			if ((ret = __lock_set_timeout(dbenv, txn->txnid,
-			    region->tx_timeout, DB_SET_TXN_TIMEOUT)) != 0)
+				region->tx_timeout, DB_SET_TXN_TIMEOUT)) != 0)
 				goto err;
 	}
 
@@ -343,7 +343,7 @@ __txn_begin_main(dbenv, parent, txnpp, flags, retries)
 		   begin LSN. Do not rush to get the begin LSN as
 		   it may not be needed (eg, readonly txn's). */
 		if (pthread_getspecific(txn_key) == NULL)
-		    Pthread_setspecific(txn_key, (void *)txn);
+			Pthread_setspecific(txn_key, (void *)txn);
 	}
 	return (0);
 
@@ -454,8 +454,8 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 	size_t off;
 	u_int32_t id, *ids;
 	int nids, ret;
-    int internal = LF_ISSET(DB_TXN_INTERNAL);
-    int recovery = LF_ISSET(DB_TXN_RECOVERY);
+	int internal = LF_ISSET(DB_TXN_INTERNAL);
+	int recovery = LF_ISSET(DB_TXN_RECOVERY);
 
 
 	/*
@@ -491,8 +491,8 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 	if (we_start_at_this_lsn)
 		*we_start_at_this_lsn = begin_lsn;
 
-    if (!recovery)
-        Pthread_rwlock_rdlock(&dbenv->recoverlk);
+	if (!recovery)
+		Pthread_rwlock_rdlock(&dbenv->recoverlk);
 
 	R_LOCK(dbenv, &mgr->reginfo);
 	if (!F_ISSET(txn, TXN_COMPENSATE) && F_ISSET(region, TXN_IN_RECOVERY)) {
@@ -504,7 +504,7 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 	/* Make sure that we aren't still recovering prepared transactions. */
 	if (!internal && region->stat.st_nrestores != 0) {
 		__db_err(dbenv,
-    "recovery of prepared but not yet committed transactions is incomplete");
+	"recovery of prepared but not yet committed transactions is incomplete");
 		ret = EINVAL;
 		goto err;
 	}
@@ -514,28 +514,28 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 	 * the maximum valid value, so check for it and wrap manually.
 	 */
 	if (region->last_txnid == TXN_MAXIMUM &&
-	    region->cur_maxid != TXN_MAXIMUM)
+		region->cur_maxid != TXN_MAXIMUM)
 		region->last_txnid = TXN_MINIMUM - 1;
 
 	if (region->last_txnid == region->cur_maxid) {
 		if ((ret = __os_malloc(dbenv,
-		    sizeof(u_int32_t) * region->maxtxns, &ids)) != 0)
+			sizeof(u_int32_t) * region->maxtxns, &ids)) != 0)
 			goto err;
 		nids = 0;
 		for (td = SH_TAILQ_FIRST(&region->active_txn, __txn_detail);
-		    td != NULL;
-		    td = SH_TAILQ_NEXT(td, links, __txn_detail))
+			td != NULL;
+			td = SH_TAILQ_NEXT(td, links, __txn_detail))
 			ids[nids++] = td->txnid;
 		region->last_txnid = TXN_MINIMUM - 1;
 		region->cur_maxid = TXN_MAXIMUM;
 		if (nids != 0)
 			__db_idspace(ids, nids,
-			    &region->last_txnid, &region->cur_maxid);
+				&region->last_txnid, &region->cur_maxid);
 		__os_free(dbenv, ids);
 		if (DBENV_LOGGING(dbenv) &&
-		    (ret = __txn_recycle_log(dbenv, NULL,
-			    &null_lsn, 0, region->last_txnid,
-			    region->cur_maxid)) != 0)
+			(ret = __txn_recycle_log(dbenv, NULL,
+				&null_lsn, 0, region->last_txnid,
+				region->cur_maxid)) != 0)
 			 goto err;
 	}
 
@@ -545,9 +545,9 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 #else
 	if ((ret =
 		__db_shalloc(mgr->reginfo.addr, sizeof(TXN_DETAIL), 0,
-		    &td)) != 0) {
+			&td)) != 0) {
 		__db_err(dbenv,
-		    "Unable to allocate memory for transaction detail");
+			"Unable to allocate memory for transaction detail");
 		goto err;
 	}
 #endif
@@ -596,7 +596,7 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 	 */
 	if (txn->parent != NULL && LOCKING_ON(dbenv))
 		if ((ret = __lock_addfamilylocker_set_retries(dbenv,
-			    txn->parent->txnid, txn->txnid, retries)) != 0)
+				txn->parent->txnid, txn->txnid, retries)) != 0)
 			return (ret);
 
 	if (F_ISSET(txn, TXN_MALLOC)) {
@@ -631,29 +631,29 @@ __txn_begin_int_set_retries(txn, retries, we_start_at_this_lsn, flags)
 	u_int32_t flags;
 {
 	return __txn_begin_int_int(txn, retries,
-	    we_start_at_this_lsn, flags);
+		we_start_at_this_lsn, flags);
 }
 
 int
 
 __txn_regop_log_commit(DB_ENV *dbenv, DB_TXN *txnid, DB_LSN *ret_lsnp,
-    u_int64_t * ret_contextp, u_int32_t flags, u_int32_t opcode,
-    int32_t timestamp, const DBT *locks, void *usr_ptr);
+	u_int64_t * ret_contextp, u_int32_t flags, u_int32_t opcode,
+	int32_t timestamp, const DBT *locks, void *usr_ptr);
 
 int
 
 __txn_regop_gen_log(DB_ENV *dbenv, DB_TXN *txnid, DB_LSN *ret_lsnp,
-    u_int64_t * ret_contextp, u_int32_t flags, u_int32_t opcode,
-    u_int32_t generation, u_int64_t timestamp, const DBT *locks, void *usr_ptr);
+	u_int64_t * ret_contextp, u_int32_t flags, u_int32_t opcode,
+	u_int32_t generation, u_int64_t timestamp, const DBT *locks, void *usr_ptr);
 
 
 int
 
 __txn_regop_rowlocks_log(DB_ENV *dbenv, DB_TXN *txnid, DB_LSN *ret_lsnp,
-    u_int64_t *ret_contextp, u_int32_t flags, u_int32_t opcode,
-    u_int64_t ltranid, DB_LSN *begin_lsn, DB_LSN *last_commit_lsn,
-    u_int64_t timestamp, u_int32_t lflags, u_int32_t generation,
-    const DBT *locks, const DBT *rowlocks, void *usr_ptr);
+	u_int64_t *ret_contextp, u_int32_t flags, u_int32_t opcode,
+	u_int64_t ltranid, DB_LSN *begin_lsn, DB_LSN *last_commit_lsn,
+	u_int64_t timestamp, u_int32_t lflags, u_int32_t generation,
+	const DBT *locks, const DBT *rowlocks, void *usr_ptr);
 
 static int
 __txn_check_applied_lsns(DB_ENV *dbenv, DB_TXN *txnp)
@@ -670,13 +670,13 @@ __txn_check_applied_lsns(DB_ENV *dbenv, DB_TXN *txnp)
 	if (ret) {
 		/* this should probably also be fatal? */
 		__db_err(dbenv,
-		    "Unable to collect log records for txn %x, lsn " PR_LSN
-		    "\n", txnp->txnid, PARM_LSN(lsn));
+			"Unable to collect log records for txn %x, lsn " PR_LSN
+			"\n", txnp->txnid, PARM_LSN(lsn));
 	} else {
 		/* collected log records successfully - now check that they've been applied */
 
 		int __rep_check_applied_lsns(DB_ENV *dbenv, LSN_COLLECTION * lc,
-		    int inrecovery);
+			int inrecovery);
 		ret = __rep_check_applied_lsns(dbenv, &lc, 0);
 	}
 
@@ -735,10 +735,10 @@ __txn_ltrans_find_lowest_lsn(dbenv, lsnp)
 
 int
 __txn_allocate_ltrans(dbenv, ltranid, begin_lsn, rlt)
-    DB_ENV *dbenv;
-    unsigned long long ltranid;
-    DB_LSN *begin_lsn;
-    LTDESC **rlt;
+	DB_ENV *dbenv;
+	unsigned long long ltranid;
+	DB_LSN *begin_lsn;
+	LTDESC **rlt;
 {
 	LTDESC *lt = NULL;
 	int ret = 0;
@@ -858,9 +858,9 @@ __txn_deallocate_ltrans(dbenv, lt)
 extern int gbl_new_snapisol;
 extern int gbl_new_snapisol_logging;
 int bdb_transfer_txn_pglogs(void *bdb_state, void *pglogs_hashtbl, 
-    pthread_mutex_t *mutexp, DB_LSN commit_lsn, uint32_t flags,
-    unsigned long long logical_tranid, int32_t timestamp,
-    unsigned long long context);
+	pthread_mutex_t *mutexp, DB_LSN commit_lsn, uint32_t flags,
+	unsigned long long logical_tranid, int32_t timestamp,
+	unsigned long long context);
 int __lock_set_parent_has_pglk_lsn(DB_ENV *dbenv, u_int32_t parentid, u_int32_t lockid);
 
 /* This prevents dbreg logs from being logged between the LOCK_PUT_READ and
@@ -875,7 +875,7 @@ extern pthread_rwlock_t gbl_dbreg_log_lock;
  */
 static int
 __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
-    nrlocks, begin_lsn, lsn_out, usr_ptr)
+	nrlocks, begin_lsn, lsn_out, usr_ptr)
 	DB_TXN *txnp;
 	u_int32_t flags;
 	u_int64_t ltranid;
@@ -979,7 +979,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 	 * ancestor will write synchronously.
 	 */
 #ifndef NDEBUG
-    int iszero = 0;
+	int iszero = 0;
 	if (IS_ZERO_LSN(txnp->last_lsn)) {
 		/* Put a breakpoint here */
 		iszero = 1;
@@ -1005,7 +1005,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			 */
 			if ((ret =
 				__txn_doevents(dbenv, txnp, TXN_PREPARE,
-				    1)) != 0) {
+					1)) != 0) {
 				goto err;
 			}
 
@@ -1017,12 +1017,12 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			if (LOCKING_ON(dbenv)) {
 				request.op = DB_LOCK_PUT_READ;
 				if (IS_REP_MASTER(dbenv) &&
-				    !IS_ZERO_LSN(txnp->last_lsn)) {
+					!IS_ZERO_LSN(txnp->last_lsn)) {
 					memset(&list_dbt, 0, sizeof(list_dbt));
 					request.obj = &list_dbt;
 				}
 				ret = __lock_vec(dbenv,
-				    txnp->txnid, 0, &request, 1, NULL);
+					txnp->txnid, 0, &request, 1, NULL);
 
 				assert(ret == 0);
 			}
@@ -1031,30 +1031,30 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 				if(ltranid != 0) {
 					int ignore = 0;
 					ltranflags = (flags & 
-						      (DB_TXN_LOGICAL_BEGIN |
-						       DB_TXN_LOGICAL_COMMIT |
-						       DB_TXN_SCHEMA_LOCK));
+							  (DB_TXN_LOGICAL_BEGIN |
+							   DB_TXN_LOGICAL_COMMIT |
+							   DB_TXN_SCHEMA_LOCK));
 
 					SET_LOG_FLAGS_ROWLOCKS(dbenv,
-							       txnp,
-							       ltranflags,
-							       lflags);
+								   txnp,
+								   ltranflags,
+								   lflags);
 
 					if ((ltranflags &
-					     DB_TXN_LOGICAL_BEGIN) &&
-					    (ltranflags &
-					     DB_TXN_LOGICAL_COMMIT))
+						 DB_TXN_LOGICAL_BEGIN) &&
+						(ltranflags &
+						 DB_TXN_LOGICAL_COMMIT))
 						ignore = 1;
 
 					if (!ignore &&
-					    (ltranflags &
-					     DB_TXN_LOGICAL_BEGIN)) {
+						(ltranflags &
+						 DB_TXN_LOGICAL_BEGIN)) {
 						if ((ret = 
-						     __txn_allocate_ltrans(
-							     dbenv, 
-							     ltranid,
-							     begin_lsn,
-							     &lt)) != 0) {
+							 __txn_allocate_ltrans(
+								 dbenv, 
+								 ltranid,
+								 begin_lsn,
+								 &lt)) != 0) {
 							Pthread_rwlock_unlock(&gbl_dbreg_log_lock);
 							goto err;
 						}
@@ -1062,7 +1062,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 
 					else if (!ignore && (ret =
 						__txn_find_ltrans(dbenv,
-						    ltranid, &lt)) != 0) {
+							ltranid, &lt)) != 0) {
 						logmsg(LOGMSG_FATAL, "Couldn't find ltrans?");
 						abort();
 						Pthread_rwlock_unlock(&gbl_dbreg_log_lock);
@@ -1075,29 +1075,29 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 
 					if (elect_highest_committed_gen) {
 						MUTEX_LOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 						gen = rep->gen;
 						MUTEX_UNLOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 						ltranflags |= DB_TXN_LOGICAL_GEN;
 					} else
 						gen = 0;
 
 					ret =
-					    __txn_regop_rowlocks_log(dbenv,
-					    txnp, lsn_out, &context, lflags,
-					    TXN_COMMIT, ltranid, begin_lsn,
-					    last_commit_lsn, timestamp,
-					    ltranflags, gen, request.obj,
-					    &list_dbt_rl, usr_ptr);
+						__txn_regop_rowlocks_log(dbenv,
+						txnp, lsn_out, &context, lflags,
+						TXN_COMMIT, ltranid, begin_lsn,
+						last_commit_lsn, timestamp,
+						ltranflags, gen, request.obj,
+						&list_dbt_rl, usr_ptr);
 
 					if (elect_highest_committed_gen) {
 						MUTEX_LOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 						rep->committed_gen = gen;
-                        rep->committed_lsn = txnp->last_lsn;
+						rep->committed_lsn = txnp->last_lsn;
 						MUTEX_UNLOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 					}
 
 					txnp->last_lsn = *lsn_out;
@@ -1106,7 +1106,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						lt->last_lsn = txnp->last_lsn;
 
 						if (ltranflags &
-						    DB_TXN_LOGICAL_COMMIT) {
+							DB_TXN_LOGICAL_COMMIT) {
 							__txn_deallocate_ltrans(
 								dbenv, lt);
 						}
@@ -1118,39 +1118,39 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 					if (elect_highest_committed_gen) {
 
 						MUTEX_LOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 						gen = rep->gen;
 						MUTEX_UNLOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 
 						ret =
-						    __txn_regop_gen_log(dbenv,
-						    txnp, &txnp->last_lsn,
-						    &context, lflags,
-						    TXN_COMMIT, gen, timestamp,
-						    request.obj, usr_ptr);
+							__txn_regop_gen_log(dbenv,
+							txnp, &txnp->last_lsn,
+							&context, lflags,
+							TXN_COMMIT, gen, timestamp,
+							request.obj, usr_ptr);
 
 						MUTEX_LOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 						rep->committed_gen = gen;
-                        rep->committed_lsn = txnp->last_lsn;
+						rep->committed_lsn = txnp->last_lsn;
 						MUTEX_UNLOCK(dbenv,
-						    db_rep->rep_mutexp);
+							db_rep->rep_mutexp);
 					} else {
 						ret =
-						    __txn_regop_log_commit
-						    (dbenv, txnp,
-						    &txnp->last_lsn, &context,
-						    lflags, TXN_COMMIT,
-						    timestamp, request.obj,
-						    usr_ptr);
+							__txn_regop_log_commit
+							(dbenv, txnp,
+							&txnp->last_lsn, &context,
+							lflags, TXN_COMMIT,
+							timestamp, request.obj,
+							usr_ptr);
 					}
 
 					if (lsn_out) {
 						lsn_out->file = 
-						    txnp->last_lsn.file;
+							txnp->last_lsn.file;
 						lsn_out->offset =
-						    txnp->last_lsn.offset;
+							txnp->last_lsn.offset;
 					}
 				}
 				Pthread_rwlock_unlock(&gbl_dbreg_log_lock);
@@ -1158,20 +1158,20 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 				if (gbl_new_snapisol) {
 					if (!txnp->pglogs_hashtbl) {
 						DB_ASSERT(
-						    F_ISSET(
+							F_ISSET(
 							txnp. TXN_COMPENSATE));
 					} else {
 						bdb_transfer_txn_pglogs(
-						    dbenv->app_private,
-						    txnp->pglogs_hashtbl,
-						    &txnp->pglogs_mutex,
-						    txnp->last_lsn,
-						    (flags & 
-						     (DB_TXN_LOGICAL_COMMIT |
-						      DB_TXN_DONT_GET_REPO_MTX
-							     )),
-						    ltranid, timestamp,
-						    context);
+							dbenv->app_private,
+							txnp->pglogs_hashtbl,
+							&txnp->pglogs_mutex,
+							txnp->last_lsn,
+							(flags & 
+							 (DB_TXN_LOGICAL_COMMIT |
+							  DB_TXN_DONT_GET_REPO_MTX
+								 )),
+							ltranid, timestamp,
+							context);
 					}
 				}
 			}
@@ -1189,9 +1189,9 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			/* Log the commit in the parent! */
 			timestamp = comdb2_time_epoch();
 			if (!IS_ZERO_LSN(txnp->last_lsn) &&
-			    (ret = __txn_child_log(dbenv,
-				    txnp->parent, &txnp->parent->last_lsn,
-				    0, txnp->txnid, &txnp->last_lsn)) != 0) {
+				(ret = __txn_child_log(dbenv,
+					txnp->parent, &txnp->parent->last_lsn,
+					0, txnp->txnid, &txnp->last_lsn)) != 0) {
 				goto err;
 			}
 
@@ -1200,21 +1200,21 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 				txnp->parent->txnid, txnp->txnid) != 0)
 				abort();
 
-			if (gbl_new_snapisol) {     
-				if (!txnp->pglogs_hashtbl) {        
+			if (gbl_new_snapisol) {	 
+				if (!txnp->pglogs_hashtbl) {		
 					DB_ASSERT(F_ISSET(txnp. 
 							  TXN_COMPENSATE));
 				} else {
 					uint32_t fl = 
-					    (flags & DB_TXN_DONT_GET_REPO_MTX) |
-					    DB_TXN_LOGICAL_COMMIT;
+						(flags & DB_TXN_DONT_GET_REPO_MTX) |
+						DB_TXN_LOGICAL_COMMIT;
 					bdb_transfer_txn_pglogs(
-					    dbenv->app_private,
-					    txnp->pglogs_hashtbl,       
-					    &txnp->pglogs_mutex,
-					    txnp->parent->last_lsn,
-					    fl, 0, timestamp, 0);
-				}      
+						dbenv->app_private,
+						txnp->pglogs_hashtbl,	   
+						&txnp->pglogs_mutex,
+						txnp->parent->last_lsn,
+						fl, 0, timestamp, 0);
+				}	  
 			}
 
 
@@ -1248,7 +1248,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 	 */
 	if (txnp->txn_list != NULL) {
 		t_ret = __db_do_the_limbo(dbenv,
-		      NULL, txnp, txnp->txn_list, LIMBO_NORMAL);
+			  NULL, txnp, txnp->txn_list, LIMBO_NORMAL);
 		__db_txnlist_end(dbenv, txnp->txn_list);
 		txnp->txn_list = NULL;
 		if (t_ret != 0 && ret == 0)
@@ -1291,7 +1291,7 @@ __txn_commit(txnp, flags)
 	u_int32_t flags;
 {
 	return __txn_commit_int(txnp, flags, 0, 0, NULL, NULL, NULL, 0, NULL,
-	    NULL, NULL);
+		NULL, NULL);
 }
 
 
@@ -1310,8 +1310,8 @@ __txn_commit_pp(txnp, flags)
 	dbenv = txnp->mgrp->dbenv;
 	not_child = txnp->parent == NULL;
 	ret =
-	    __txn_commit_int(txnp, flags, 0, 0, NULL, NULL, NULL, 0, NULL, NULL,
-	    NULL);
+		__txn_commit_int(txnp, flags, 0, 0, NULL, NULL, NULL, 0, NULL, NULL,
+		NULL);
 	if (not_child && IS_ENV_REPLICATED(dbenv))
 		__op_rep_exit(dbenv);
 	return (ret);
@@ -1337,8 +1337,8 @@ __txn_commit_getlsn_pp(txnp, flags, lsn_out, usr_ptr)
 	dbenv = txnp->mgrp->dbenv;
 	not_child = txnp->parent == NULL;
 	ret =
-	    __txn_commit_int(txnp, flags, ltranid, 0, NULL, NULL, NULL, 0, NULL,
-	    lsn_out, usr_ptr);
+		__txn_commit_int(txnp, flags, ltranid, 0, NULL, NULL, NULL, 0, NULL,
+		lsn_out, usr_ptr);
 	if (not_child && IS_ENV_REPLICATED(dbenv))
 		__op_rep_exit(dbenv);
 
@@ -1347,7 +1347,7 @@ __txn_commit_getlsn_pp(txnp, flags, lsn_out, usr_ptr)
 
 static int
 __txn_commit_rl_pp(txnp, flags, ltranid, llid, last_commit_lsn, rlocks,
-    lks, nrlocks, begin_lsn, lsn_out, usr_ptr)
+	lks, nrlocks, begin_lsn, lsn_out, usr_ptr)
 	DB_TXN *txnp;
 	u_int32_t flags;
 	u_int64_t ltranid;
@@ -1367,7 +1367,7 @@ __txn_commit_rl_pp(txnp, flags, ltranid, llid, last_commit_lsn, rlocks,
 	not_child = txnp->parent == NULL;
 
 	ret = __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn,
-	    rlocks, lks, nrlocks, begin_lsn, lsn_out, usr_ptr);
+		rlocks, lks, nrlocks, begin_lsn, lsn_out, usr_ptr);
 	if (not_child && IS_ENV_REPLICATED(dbenv))
 		__op_rep_exit(dbenv);
 
@@ -1454,17 +1454,17 @@ __txn_abort(txnp)
 
 		/* Turn off timeouts. */
 		if ((ret = __lock_set_timeout(dbenv,
-		    txnp->txnid, 0, DB_SET_TXN_TIMEOUT)) != 0)
+			txnp->txnid, 0, DB_SET_TXN_TIMEOUT)) != 0)
 			return (__db_panic(dbenv, ret));
 
 		if ((ret = __lock_set_timeout(dbenv,
-		    txnp->txnid, 0, DB_SET_LOCK_TIMEOUT)) != 0)
+			txnp->txnid, 0, DB_SET_LOCK_TIMEOUT)) != 0)
 			return (__db_panic(dbenv, ret));
 
 		request.op = DB_LOCK_UPGRADE_WRITE;
 		request.obj = NULL;
 		if ((ret = __lock_vec(
-		    dbenv, txnp->txnid, 0, &request, 1, NULL)) != 0)
+			dbenv, txnp->txnid, 0, &request, 1, NULL)) != 0)
 			return (__db_panic(dbenv, ret));
 	}
 	if ((ret = __txn_undo(txnp)) != 0)
@@ -1479,8 +1479,8 @@ __txn_abort(txnp)
 	SET_LOG_FLAGS(dbenv, txnp, lflags);
 
 	if (DBENV_LOGGING(dbenv) && td->status == TXN_PREPARED &&
-	    (ret = __txn_regop_log(dbenv, txnp, &txnp->last_lsn, NULL,
-		    lflags, TXN_ABORT, (int32_t)comdb2_time_epoch(), NULL)) != 0)
+		(ret = __txn_regop_log(dbenv, txnp, &txnp->last_lsn, NULL,
+			lflags, TXN_ABORT, (int32_t)comdb2_time_epoch(), NULL)) != 0)
 		 return (__db_panic(dbenv, ret));
 
 	if (F_ISSET(txnp, TXN_RECOVER_LOCK)) {
@@ -1558,7 +1558,7 @@ __txn_discard(txnp, flags)
 	}
 
 	if (dbenv->tx_perfect_ckp)
-        Pthread_setspecific(txn_key, NULL);
+		Pthread_setspecific(txn_key, NULL);
 
 	return (0);
 }
@@ -1595,8 +1595,8 @@ __txn_prepare(txnp, gid)
 			return (ret);
 
 	if (txnp->txn_list != NULL  &&
-	    (ret = __db_do_the_limbo(dbenv,
-	    NULL, txnp, txnp->txn_list, LIMBO_PREPARE)) != 0)
+		(ret = __db_do_the_limbo(dbenv,
+		NULL, txnp, txnp->txn_list, LIMBO_PREPARE)) != 0)
 		return (ret);
 	/*
 	 * In XA, the global transaction ID in the txn_detail structure is
@@ -1612,19 +1612,19 @@ __txn_prepare(txnp, gid)
 	if (LOCKING_ON(dbenv)) {
 		request.op = DB_LOCK_PUT_READ;
 		if (IS_REP_MASTER(dbenv) &&
-		    IS_ZERO_LSN(txnp->last_lsn)) {
+			IS_ZERO_LSN(txnp->last_lsn)) {
 			memset(&list_dbt, 0, sizeof(list_dbt));
 			request.obj = &list_dbt;
 		}
 		if ((ret = __lock_vec(dbenv,
-		    txnp->txnid, 0, &request, 1, NULL)) != 0)
+			txnp->txnid, 0, &request, 1, NULL)) != 0)
 			return (ret);
 
 	}
 	if (DBENV_LOGGING(dbenv)) {
 		memset(&xid, 0, sizeof(xid));
 		if (td->xa_status != TXN_XA_ENDED &&
-		    td->xa_status != TXN_XA_SUSPENDED)
+			td->xa_status != TXN_XA_SUSPENDED)
 			/* Regular prepare; fill in the gid. */
 			memcpy(td->xid, gid, sizeof(td->xid));
 
@@ -1633,10 +1633,10 @@ __txn_prepare(txnp, gid)
 
 		lflags = DB_LOG_COMMIT | DB_LOG_PERM | DB_FLUSH;
 		if ((ret = __txn_xa_regop_log(dbenv, txnp, &txnp->last_lsn,
-		    lflags, TXN_PREPARE, &xid, td->format, td->gtrid, td->bqual,
-		    &td->begin_lsn, request.obj)) != 0) {
+			lflags, TXN_PREPARE, &xid, td->format, td->gtrid, td->bqual,
+			&td->begin_lsn, request.obj)) != 0) {
 			__db_err(dbenv, "DB_TXN->prepare: log_write failed %s",
-			    db_strerror(ret));
+				db_strerror(ret));
 		}
 		if (request.obj != NULL && request.obj->data != NULL)
 			__os_free(dbenv, request.obj->data);
@@ -1680,7 +1680,7 @@ __txn_set_timeout(txnp, timeout, op)
 		return (__db_ferr(txnp->mgrp->dbenv, "DB_TXN->set_timeout", 0));
 
 	return (__lock_set_timeout(
-	    txnp->mgrp->dbenv, txnp->txnid, timeout, op));
+		txnp->mgrp->dbenv, txnp->txnid, timeout, op));
 }
 
 /*
@@ -1702,9 +1702,9 @@ __txn_isvalid(txnp, tdp, op)
 
 	/* Check for recovery. */
 	if (!F_ISSET(txnp, TXN_COMPENSATE) &&
-	    F_ISSET(region, TXN_IN_RECOVERY)) {
+		F_ISSET(region, TXN_IN_RECOVERY)) {
 		__db_err(mgrp->dbenv,
-		    "operation not permitted during recovery");
+			"operation not permitted during recovery");
 		goto err;
 	}
 
@@ -1736,7 +1736,7 @@ __txn_isvalid(txnp, tdp, op)
 		 * restored transaction.
 		 */
 		if (tp->status != TXN_PREPARED &&
-		    !F_ISSET(tp, TXN_DTL_RESTORED)) {
+			!F_ISSET(tp, TXN_DTL_RESTORED)) {
 			__db_err(mgrp->dbenv, "not a restored transaction");
 			return (__db_panic(mgrp->dbenv, EINVAL));
 		}
@@ -1752,7 +1752,7 @@ __txn_isvalid(txnp, tdp, op)
 			 * someone doing it.
 			 */
 			__db_err(mgrp->dbenv,
-			    "Prepare disallowed on child transactions");
+				"Prepare disallowed on child transactions");
 			return (EINVAL);
 		}
 		break;
@@ -1780,7 +1780,7 @@ __txn_isvalid(txnp, tdp, op)
 	case TXN_COMMITTED:
 	default:
 		__db_err(mgrp->dbenv, "transaction already %s",
-		    tp->status == TXN_COMMITTED ? "committed" : "aborted");
+			tp->status == TXN_COMMITTED ? "committed" : "aborted");
 		goto err;
 	}
 
@@ -1818,7 +1818,7 @@ __txn_end(txnp, is_commit)
 
 	/* Process commit events. */
 	if ((ret = __txn_doevents(dbenv,
-	    txnp, is_commit ? TXN_COMMIT : TXN_ABORT, 0)) != 0)
+		txnp, is_commit ? TXN_COMMIT : TXN_ABORT, 0)) != 0)
 		return (__db_panic(dbenv, ret));
 
 	/*
@@ -1832,10 +1832,10 @@ __txn_end(txnp, is_commit)
 	 */
 	if (LOCKING_ON(dbenv)) {
 		request.op = txnp->parent == NULL ||
-		    is_commit == 0 ? DB_LOCK_PUT_ALL : DB_LOCK_INHERIT;
+			is_commit == 0 ? DB_LOCK_PUT_ALL : DB_LOCK_INHERIT;
 		request.obj = NULL;
 		if ((ret = __lock_vec(dbenv,
-		    txnp->txnid, 0, &request, 1, NULL)) != 0)
+			txnp->txnid, 0, &request, 1, NULL)) != 0)
 			return (__db_panic(dbenv, ret));
 	}
 
@@ -1867,7 +1867,7 @@ __txn_end(txnp, is_commit)
 	 * if any.
 	 */
 	if (LOCKING_ON(dbenv) && (ret =
-	    __lock_freefamilylocker(dbenv->lk_handle, txnp->txnid)) != 0)
+		__lock_freefamilylocker(dbenv->lk_handle, txnp->txnid)) != 0)
 		return (__db_panic(dbenv, ret));
 	if (txnp->parent != NULL)
 		TAILQ_REMOVE(&txnp->parent->kids, txnp, klinks);
@@ -1900,7 +1900,7 @@ __txn_end(txnp, is_commit)
 	}
 
 	if (dbenv->tx_perfect_ckp)
-        Pthread_setspecific(txn_key, NULL);
+		Pthread_setspecific(txn_key, NULL);
 
 	return (0);
 }
@@ -1929,12 +1929,12 @@ __txn_getpriority(txnp, priority)
 
 	if (LOCKING_ON(dbenv) && (ret =
 		__lock_locker_getpriority(dbenv->lk_handle, txnp->txnid,
-		    priority)) != 0)
+			priority)) != 0)
 		return (__db_panic(dbenv, ret));
 
 #ifdef TEST_DEADLOCKS
 	printf("%d %s:%d lockerid %x has priority %d\n",
-	    pthread_self(), __FILE__, __LINE__, txnp->txnid, *priority);
+		pthread_self(), __FILE__, __LINE__, txnp->txnid, *priority);
 #endif
 
 	return (0);
@@ -1951,13 +1951,13 @@ __txn_dispatch_undo(dbenv, txnp, rdbt, key_lsn, txnlist)
 	int ret;
 
 	ret = __db_dispatch(dbenv, dbenv->recover_dtab,
-	    dbenv->recover_dtab_size, rdbt, key_lsn, DB_TXN_ABORT, txnlist);
+		dbenv->recover_dtab_size, rdbt, key_lsn, DB_TXN_ABORT, txnlist);
 	if (F_ISSET(txnp, TXN_CHILDCOMMIT))
 		(void)__db_txnlist_lsnadd(dbenv,
-		    txnlist, key_lsn, 0);
+			txnlist, key_lsn, 0);
 	if (ret == DB_SURPRISE_KID) {
 		if ((ret = __db_txnlist_lsninit(
-		    dbenv, txnlist, key_lsn)) == 0)
+			dbenv, txnlist, key_lsn)) == 0)
 			F_SET(txnp, TXN_CHILDCOMMIT);
 	}
 
@@ -2016,7 +2016,7 @@ __txn_undo(txnp)
 		ptxn->txn_list = txnlist;
 
 	if (F_ISSET(txnp, TXN_CHILDCOMMIT) &&
-	    (ret = __db_txnlist_lsninit(dbenv, txnlist, &txnp->last_lsn)) != 0)
+		(ret = __db_txnlist_lsninit(dbenv, txnlist, &txnp->last_lsn)) != 0)
 		return (ret);
 
 	/*
@@ -2024,16 +2024,16 @@ __txn_undo(txnp)
 	 * then from the log.
 	 */
 	for (lr = STAILQ_FIRST(&txnp->logs);
-	    lr != NULL; lr = STAILQ_NEXT(lr, links)) {
+		lr != NULL; lr = STAILQ_NEXT(lr, links)) {
 		rdbt.data = lr->data;
 		rdbt.size = 0;
 		LSN_NOT_LOGGED(key_lsn);
 		ret =
-		    __txn_dispatch_undo(dbenv, txnp, &rdbt, &key_lsn, txnlist);
+			__txn_dispatch_undo(dbenv, txnp, &rdbt, &key_lsn, txnlist);
 		if (ret != 0) {
 			__db_err(dbenv,
-			    "DB_TXN->abort: In-memory log undo failed: %s",
-			    db_strerror(ret));
+				"DB_TXN->abort: In-memory log undo failed: %s",
+				db_strerror(ret));
 			goto err;
 		}
 	}
@@ -2041,7 +2041,7 @@ __txn_undo(txnp)
 	key_lsn = txnp->last_lsn;
 
 	if (!IS_ZERO_LSN(key_lsn) &&
-	     (ret = __log_cursor(dbenv, &logc)) != 0)
+		 (ret = __log_cursor(dbenv, &logc)) != 0)
 		goto err;
 
 	while (!IS_ZERO_LSN(key_lsn)) {
@@ -2051,11 +2051,11 @@ __txn_undo(txnp)
 		 */
 		if ((ret = __log_c_get(logc, &key_lsn, &rdbt, DB_SET)) == 0) {
 			if ((ret = __txn_dispatch_undo(dbenv,
-				    txnp, &rdbt, &key_lsn, txnlist)) != 0) {
+					txnp, &rdbt, &key_lsn, txnlist)) != 0) {
 				__db_err(dbenv,
-				    "DB_TXN->abort: txn-undo failed for LSN: %lu %lu: %s",
-				    (u_long) key_lsn.file,
-				    (u_long) key_lsn.offset, db_strerror(ret));
+					"DB_TXN->abort: txn-undo failed for LSN: %lu %lu: %s",
+					(u_long) key_lsn.file,
+					(u_long) key_lsn.offset, db_strerror(ret));
 				goto err;
 			}
 		}
@@ -2063,8 +2063,8 @@ __txn_undo(txnp)
 		if (ret != 0) {
 			__db_err(dbenv,
 		"DB_TXN->abort: undo failure in log_c_get for LSN: %lu %lu: %s",
-			    (u_long) key_lsn.file, (u_long) key_lsn.offset,
-			    db_strerror(ret));
+				(u_long) key_lsn.file, (u_long) key_lsn.offset,
+				db_strerror(ret));
 			goto err;
 		}
 	}
@@ -2084,7 +2084,7 @@ err:	if (logc != NULL && (t_ret = __log_c_close(logc)) != 0 && ret == 0)
  *	DB_ENV->txn_checkpoint pre/post processing.
  *
  * PUBLIC: int __txn_checkpoint_pp
- * PUBLIC:     __P((DB_ENV *, u_int32_t, u_int32_t, u_int32_t));
+ * PUBLIC:	 __P((DB_ENV *, u_int32_t, u_int32_t, u_int32_t));
  */
 int
 __txn_checkpoint_pp(dbenv, kbytes, minutes, flags)
@@ -2097,7 +2097,7 @@ __txn_checkpoint_pp(dbenv, kbytes, minutes, flags)
 
 	PANIC_CHECK(dbenv);
 	ENV_REQUIRES_CONFIG(dbenv,
-	    dbenv->tx_handle, "txn_checkpoint", DB_INIT_TXN);
+		dbenv->tx_handle, "txn_checkpoint", DB_INIT_TXN);
 
 	/*
 	 * On a replication client, all transactions are read-only; therefore,
@@ -2137,7 +2137,7 @@ __txn_checkpoint(dbenv, kbytes, minutes, flags)
 	DB_ENV *dbenv;
 	u_int32_t kbytes, minutes, flags;
 {
-    struct mintruncate_entry *mt, *newmt;
+	struct mintruncate_entry *mt, *newmt;
 	DB_LSN ckp_lsn, last_ckp, ltrans_ckp_lsn, ckp_lsn_sav;
 	DB_TXNMGR *mgr;
 	DB_TXNREGION *region;
@@ -2158,8 +2158,8 @@ __txn_checkpoint(dbenv, kbytes, minutes, flags)
 	if (IS_REP_CLIENT(dbenv)) {
 		if (MPOOL_ON(dbenv) && (ret = __memp_sync(dbenv, NULL)) != 0) {
 			__db_err(dbenv,
-		    "txn_checkpoint: failed to flush the buffer cache %s",
-			    db_strerror(ret));
+			"txn_checkpoint: failed to flush the buffer cache %s",
+				db_strerror(ret));
 			return (ret);
 		} else
 			return (0);
@@ -2187,7 +2187,7 @@ __txn_checkpoint(dbenv, kbytes, minutes, flags)
 		 * last checkpoint.
 		 */
 		if (kbytes != 0 &&
-		    mbytes * 1024 + bytes / 1024 >= (u_int32_t)kbytes)
+			mbytes * 1024 + bytes / 1024 >= (u_int32_t)kbytes)
 			goto do_ckp;
 
 		if (minutes != 0) {
@@ -2210,12 +2210,12 @@ __txn_checkpoint(dbenv, kbytes, minutes, flags)
 	}
 
 do_ckp:	
-    Pthread_rwlock_rdlock(&dbenv->recoverlk);
+	Pthread_rwlock_rdlock(&dbenv->recoverlk);
 
-    /* Retrieve lsn again after locking */
+	/* Retrieve lsn again after locking */
 	__log_txn_lsn(dbenv, &ckp_lsn, &mbytes, &bytes);
 
-    /*
+	/*
 	 * Find the oldest active transaction and figure out its "begin" LSN.
 	 * This is the lowest LSN we can checkpoint, since any record written
 	 * after it may be involved in a transaction and may therefore need
@@ -2223,17 +2223,17 @@ do_ckp:
 	 */
 	R_LOCK(dbenv, &mgr->reginfo);
 	for (txnp = SH_TAILQ_FIRST(&region->active_txn, __txn_detail);
-	    txnp != NULL;
-	    txnp = SH_TAILQ_NEXT(txnp, links, __txn_detail))
+		txnp != NULL;
+		txnp = SH_TAILQ_NEXT(txnp, links, __txn_detail))
 		if (!IS_ZERO_LSN(txnp->begin_lsn) &&
-		    log_compare(&txnp->begin_lsn, &ckp_lsn) < 0)
+			log_compare(&txnp->begin_lsn, &ckp_lsn) < 0)
 			ckp_lsn = txnp->begin_lsn;
 
 	__txn_ltrans_find_lowest_lsn(dbenv, &ltrans_ckp_lsn);
 	R_UNLOCK(dbenv, &mgr->reginfo);
 
 	if (!IS_ZERO_LSN(ltrans_ckp_lsn) &&
-	    log_compare(&ltrans_ckp_lsn, &ckp_lsn) < 0)
+		log_compare(&ltrans_ckp_lsn, &ckp_lsn) < 0)
 		ckp_lsn = ltrans_ckp_lsn;
 
 	if (unlikely(gbl_ckp_sleep_before_sync > 0))
@@ -2243,11 +2243,11 @@ do_ckp:
 	/* If flag is DB_FORCE, don't run perfect checkpoints. */
 	if (MPOOL_ON(dbenv) &&
 			(ret = __memp_sync_restartable(dbenv,
-			       (LF_ISSET(DB_FORCE) ? NULL : &ckp_lsn), 0, 0)) != 0) {
+				   (LF_ISSET(DB_FORCE) ? NULL : &ckp_lsn), 0, 0)) != 0) {
 		__db_err(dbenv,
-		    "txn_checkpoint: failed to flush the buffer cache %s",
-		    db_strerror(ret));
-        Pthread_rwlock_unlock(&dbenv->recoverlk);
+			"txn_checkpoint: failed to flush the buffer cache %s",
+			db_strerror(ret));
+		Pthread_rwlock_unlock(&dbenv->recoverlk);
 		return (ret);
 	}
 
@@ -2260,7 +2260,7 @@ do_ckp:
 	 * it to write a log message, LOGGING_ON is the correct macro here.
 	 */
 	if (LOGGING_ON(dbenv) && !gbl_is_physical_replicant &&
-            !LF_ISSET(DB_RECOVER_NOCKP)) {
+			!LF_ISSET(DB_RECOVER_NOCKP)) {
 		DB_LSN debuglsn;
 		DBT op = { 0 };
 		int debugtype;
@@ -2281,10 +2281,10 @@ do_ckp:
 		 * 3) TXN A reads pages, and has not modified any pages yet.
 		 * 4) TXN B modifies pages.
 		 * 5) Checkpoint takes place and ckp_lsn is adjusted to LSN B.
-		 *    the last checkpoint LSN becomes LSN B.
+		 *	the last checkpoint LSN becomes LSN B.
 		 * 6) TXN A modifies pages.
 		 * 7) Checkpoint takes place and ckp_lsn is adjusted to LSN A.
-		 *    LSN A is younger than the last checkpoint LSN which is LSN B.
+		 *	LSN A is younger than the last checkpoint LSN which is LSN B.
 		 *
 		 * If ckp_lsn goes backwards, we skip the checkpoint record.
 		 * It should be fine because we have a separate checkpoint file
@@ -2293,9 +2293,9 @@ do_ckp:
 		 * __txn_checkpoint() writes a checkpoint in the log.
 		 */
 		if (dbenv->tx_perfect_ckp && log_compare(&ckp_lsn, &last_ckp) <= 0) {
-            Pthread_rwlock_unlock(&dbenv->recoverlk);
+			Pthread_rwlock_unlock(&dbenv->recoverlk);
 			return (0);
-        }
+		}
 
 		if (REP_ON(dbenv))
 			__rep_get_gen(dbenv, &gen);
@@ -2312,28 +2312,28 @@ do_ckp:
 		op.size = sizeof(int);
 		debugtype = htonl(2);
 		ret =
-		    __db_debug_log(dbenv, NULL, &debuglsn, DB_LOG_DONT_LOCK,
-		    &op, -1, NULL, NULL, 0);
+			__db_debug_log(dbenv, NULL, &debuglsn, DB_LOG_DONT_LOCK,
+			&op, -1, NULL, NULL, 0);
 		if (ret) {
 			Pthread_rwlock_unlock(&dbenv->dbreglk);
 			MUTEX_UNLOCK(dbenv, &lp->fq_mutex);
-            Pthread_rwlock_unlock(&dbenv->recoverlk);
+			Pthread_rwlock_unlock(&dbenv->recoverlk);
 			return ret;
 		}
 
-        Pthread_mutex_lock(&dbenv->mintruncate_lk);
-        if (dbenv->last_mintruncate_dbreg_start.file < debuglsn.file) {
-            newmt = malloc(sizeof(*newmt));
+		Pthread_mutex_lock(&dbenv->mintruncate_lk);
+		if (dbenv->last_mintruncate_dbreg_start.file < debuglsn.file) {
+			newmt = malloc(sizeof(*newmt));
 #ifdef MINTRUNCATE_DEBUG
-            newmt->func = __func__;
+			newmt->func = __func__;
 #endif
-            newmt->type = MINTRUNCATE_DBREG_START;
-            newmt->timestamp = 0;
-            newmt->lsn = dbenv->last_mintruncate_dbreg_start = debuglsn;
-            ZERO_LSN(newmt->ckplsn);
-            listc_atl(&dbenv->mintruncate, newmt);
-        }
-        Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+			newmt->type = MINTRUNCATE_DBREG_START;
+			newmt->timestamp = 0;
+			newmt->lsn = dbenv->last_mintruncate_dbreg_start = debuglsn;
+			ZERO_LSN(newmt->ckplsn);
+			listc_atl(&dbenv->mintruncate, newmt);
+		}
+		Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
 		/*
 		 * Put out records for the open files before we log
@@ -2347,46 +2347,46 @@ do_ckp:
 		timestamp = (int32_t)time(NULL);
 
 		if ((ret = __dbreg_open_files_checkpoint(dbenv)) != 0 ||
-		    (ret = __txn_ckp_log(dbenv, NULL,
-			    &ckp_lsn,
-			    DB_FLUSH |DB_LOG_PERM |DB_LOG_CHKPNT |
-			    DB_LOG_DONT_LOCK, &ckp_lsn, &last_ckp, timestamp,
-			    gen)) != 0) {
+			(ret = __txn_ckp_log(dbenv, NULL,
+				&ckp_lsn,
+				DB_FLUSH |DB_LOG_PERM |DB_LOG_CHKPNT |
+				DB_LOG_DONT_LOCK, &ckp_lsn, &last_ckp, timestamp,
+				gen)) != 0) {
 			__db_err(dbenv,
-			    "txn_checkpoint: log failed at LSN [%ld %ld] %s",
-			    (long)ckp_lsn.file, (long)ckp_lsn.offset,
-			    db_strerror(ret));
+				"txn_checkpoint: log failed at LSN [%ld %ld] %s",
+				(long)ckp_lsn.file, (long)ckp_lsn.offset,
+				db_strerror(ret));
 			Pthread_rwlock_unlock(&dbenv->dbreglk);
 			MUTEX_UNLOCK(dbenv, &lp->fq_mutex);
-            Pthread_rwlock_unlock(&dbenv->recoverlk);
+			Pthread_rwlock_unlock(&dbenv->recoverlk);
 			return (ret);
 		}
 		Pthread_rwlock_unlock(&dbenv->dbreglk);
 		MUTEX_UNLOCK(dbenv, &lp->fq_mutex);
 
-        Pthread_mutex_lock(&dbenv->mintruncate_lk);
-        if (ckp_lsn_sav.file > dbenv->last_mintruncate_ckplsn.file) {
-            newmt = malloc(sizeof(*newmt));
+		Pthread_mutex_lock(&dbenv->mintruncate_lk);
+		if (ckp_lsn_sav.file > dbenv->last_mintruncate_ckplsn.file) {
+			newmt = malloc(sizeof(*newmt));
 #ifdef MINTRUNCATE_DEBUG
-            newmt->func = __func__;
+			newmt->func = __func__;
 #endif
-            newmt->type = MINTRUNCATE_CHECKPOINT;
-            newmt->timestamp = timestamp;
-            newmt->lsn = ckp_lsn;
-            newmt->ckplsn = ckp_lsn_sav;
-            listc_atl(&dbenv->mintruncate, newmt);
-            if (dbenv->mintruncate_first.file == 0)
-                dbenv->mintruncate_first = ckp_lsn;
-            dbenv->last_mintruncate_ckplsn = ckp_lsn_sav;
-        }
-        Pthread_mutex_unlock(&dbenv->mintruncate_lk);
+			newmt->type = MINTRUNCATE_CHECKPOINT;
+			newmt->timestamp = timestamp;
+			newmt->lsn = ckp_lsn;
+			newmt->ckplsn = ckp_lsn_sav;
+			listc_atl(&dbenv->mintruncate, newmt);
+			if (dbenv->mintruncate_first.file == 0)
+				dbenv->mintruncate_first = ckp_lsn;
+			dbenv->last_mintruncate_ckplsn = ckp_lsn_sav;
+		}
+		Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
 		ret = bdb_checkpoint_list_push(ckp_lsn, ckp_lsn_sav, timestamp);
 		if (ret) {
 			logmsg(LOGMSG_ERROR, 
-                "%s: failed to push to checkpoint list, ret %d\n",
-			    __func__, ret);
-            Pthread_rwlock_unlock(&dbenv->recoverlk);
+				"%s: failed to push to checkpoint list, ret %d\n",
+				__func__, ret);
+			Pthread_rwlock_unlock(&dbenv->recoverlk);
 			return ret;
 		}
 
@@ -2394,7 +2394,7 @@ do_ckp:
 		if (ret == 0)
 			__txn_updateckp(dbenv, &ckp_lsn);	/* this is the output lsn from txn_ckp_log */
 	}
-    Pthread_rwlock_unlock(&dbenv->recoverlk);
+	Pthread_rwlock_unlock(&dbenv->recoverlk);
 	return (ret);
 }
 
@@ -2491,7 +2491,7 @@ __txn_force_abort(dbenv, buffer)
 		key = db_cipher->mac_key;
 		sum_len = DB_MAC_KEY;
 		if ((ret = db_cipher->decrypt(dbenv, db_cipher->data,
-		    &hdr->iv[0], buffer + hdrsize, rec_len)) != 0)
+			&hdr->iv[0], buffer + hdrsize, rec_len)) != 0)
 			return (__db_panic(dbenv, ret));
 	} else {
 		key = NULL;
@@ -2502,8 +2502,8 @@ __txn_force_abort(dbenv, buffer)
 	memcpy(bp, &opcode, sizeof(opcode));
 
 	if (CRYPTO_ON(dbenv) &&
-	    (ret = db_cipher->encrypt(dbenv,
-	    db_cipher->data, &hdr->iv[0], buffer + hdrsize, rec_len)) != 0)
+		(ret = db_cipher->encrypt(dbenv,
+		db_cipher->data, &hdr->iv[0], buffer + hdrsize, rec_len)) != 0)
 		return (__db_panic(dbenv, ret));
 
 	__db_chksum(buffer + hdrsize, rec_len, key, chksum);
@@ -2534,8 +2534,8 @@ __txn_preclose(dbenv)
 
 	R_LOCK(dbenv, &mgr->reginfo);
 	if (region != NULL &&
-	    region->stat.st_nrestores
-	    <= mgr->n_discards && mgr->n_discards != 0)
+		region->stat.st_nrestores
+		<= mgr->n_discards && mgr->n_discards != 0)
 		do_closefiles = 1;
 	R_UNLOCK(dbenv, &mgr->reginfo);
 	if (do_closefiles) {
@@ -2566,16 +2566,16 @@ __txn_reset(dbenv)
 	DB_LSN scrap;
 	DB_TXNREGION *region;
 
-    /* physical replicants cannot log the reset */
-    if (gbl_is_physical_replicant)
-        return 0;
+	/* physical replicants cannot log the reset */
+	if (gbl_is_physical_replicant)
+		return 0;
 
 	region = ((DB_TXNMGR *)dbenv->tx_handle)->reginfo.primary;
 	region->last_txnid = TXN_MINIMUM;
 
 	DB_ASSERT(LOGGING_ON(dbenv));
 	return (__txn_recycle_log(dbenv,
-	    NULL, &scrap, 0, TXN_MINIMUM, TXN_MAXIMUM));
+		NULL, &scrap, 0, TXN_MINIMUM, TXN_MAXIMUM));
 }
 
 /*
@@ -2614,7 +2614,7 @@ __txn_updateckp(dbenv, lsnp)
 		region->last_ckp = *lsnp;
 		(void)time(&region->time_ckp);
 		ctrace("DBENV->region last_ckp = %d:%d\n", lsnp->file,
-		    lsnp->offset);
+			lsnp->offset);
 	}
 	if (IS_ZERO_LSN(region->last_ckp))
 		logmsg(LOGMSG_INFO, "%s:%d last_ckp is 0:0\n", __FILE__, __LINE__);
@@ -2646,11 +2646,11 @@ dumptxn(DB_ENV * dbenv, DB_LSN * lsnpp)
 
 	dbt.flags |= DB_DBT_REALLOC;
 	ret =
-	    __rep_collect_txn(dbenv, lsnp, &lc, &had_serializable_records,
-	    NULL);
+		__rep_collect_txn(dbenv, lsnp, &lc, &had_serializable_records,
+		NULL);
 	if (ret) {
 		__db_err(dbenv, "can't find logs for txn at " PR_LSN "\n",
-		    PARM_LSNP(lsnp));
+			PARM_LSNP(lsnp));
 		goto done;
 	}
 	// qsort(lc.array, lc.nlsns, sizeof(struct logrecord), cmp_by_lsn);
@@ -2672,8 +2672,8 @@ dumptxn(DB_ENV * dbenv, DB_LSN * lsnpp)
 		ret = __log_c_get(logc, &lc.array[i].lsn, &dbt, DB_SET);
 		if (ret) {
 			__db_err(dbenv,
-			    "can't fetch log record at " PR_LSN " ret %d\n",
-			    PARM_LSN(lc.array[i].lsn), ret);
+				"can't fetch log record at " PR_LSN " ret %d\n",
+				PARM_LSN(lc.array[i].lsn), ret);
 			goto done;
 		}
 		LOGCOPY_32(&type, dbt.data);
@@ -2688,8 +2688,8 @@ dumptxn(DB_ENV * dbenv, DB_LSN * lsnpp)
 			}
 
 			ret =
-			    __dbreg_id_to_db(dbenv, NULL, &db, a->fileid, 0,
-			    &lc.array[i].lsn, 0);
+				__dbreg_id_to_db(dbenv, NULL, &db, a->fileid, 0,
+				&lc.array[i].lsn, 0);
 			if (ret == DB_DELETED)
 				name = "deleted";
 			else if (ret)
@@ -2699,14 +2699,14 @@ dumptxn(DB_ENV * dbenv, DB_LSN * lsnpp)
 
 			if (a->opcode == DB_ADD_DUP) {
 				logmsg(LOGMSG_USER, "addrem: " PR_LSN " %s ",
-				    PARM_LSN(lc.array[i].lsn), name);
+					PARM_LSN(lc.array[i].lsn), name);
 				void fsnapf(FILE * fil, const void *buf,
-				    int len);
+					int len);
 				fsnapf(stdout, a->dbt.data, a->dbt.size);
 			}
 		} else if (type == 10019) {
 			logmsg(LOGMSG_USER, "blkseq: " PR_LSN "\n",
-			    PARM_LSN(lc.array[i].lsn));
+				PARM_LSN(lc.array[i].lsn));
 		}
 	}
 	logmsg(LOGMSG_USER, "} commit at " PR_LSN "\n", PARM_LSNP(lsnpp));

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2514,11 +2514,6 @@ static int db_finalize_and_sanity_checks(struct dbenv *dbenv)
 {
     int have_bad_schema = 0, ii, jj;
 
-    if (!dbenv->num_dbs) {
-        have_bad_schema = 1;
-        logmsg(LOGMSG_FATAL, "No tables have been loaded.");
-    }
-
     for (ii = 0; ii < dbenv->num_dbs; ii++) {
         dbenv->dbs[ii]->dtastripe = 1;
 

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -219,6 +219,7 @@ comdb2_metric gbl_metrics[] = {
     {"standing_queue_time", "How long the database has had a standing queue",
      STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
      &stats.standing_queue_time, NULL},
+#if 0
     {"minimum_truncation_file", "Minimum truncation file", STATISTIC_INTEGER,
      STATISTIC_COLLECTION_TYPE_LATEST, &stats.minimum_truncation_file, NULL},
     {"minimum_truncation_offset", "Minimum truncation offset",
@@ -226,7 +227,9 @@ comdb2_metric gbl_metrics[] = {
      &stats.minimum_truncation_offset, NULL},
     {"minimum_truncation_timestamp", "Minimum truncation timestamp",
      STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
-     &stats.minimum_truncation_timestamp, NULL}};
+     &stats.minimum_truncation_timestamp, NULL},
+#endif
+};
 
 const char *metric_collection_type_string(comdb2_collection_type t) {
     switch (t) {
@@ -301,6 +304,10 @@ int refresh_metrics(void)
     int rc;
     const struct bdb_thread_stats *pstats;
     extern int active_appsock_conns; int bdberr;
+#if 0
+    int min_file, min_offset;
+    int32_t min_timestamp;
+#endif
 
     /* Check whether the server is exiting. */
     if (thedb->exiting || thedb->stopped)
@@ -431,10 +438,12 @@ int refresh_metrics(void)
 
     stats.standing_queue_time = metrics_standing_queue_time();
 
+#if 0
     bdb_min_truncate(thedb->bdb_env, &min_file, &min_offset, &min_timestamp);
     stats.minimum_truncation_file = min_file;
     stats.minimum_truncation_offset = min_offset;
     stats.minimum_truncation_timestamp = min_timestamp;
+#endif
     return 0;
 }
 

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -82,6 +82,9 @@ struct comdb2_metrics_store {
     int64_t rep_deadlocks;
     int64_t rw_evicts;
     int64_t standing_queue_time;
+    int64_t minimum_truncation_file;
+    int64_t minimum_truncation_offset;
+    int64_t minimum_truncation_timestamp;
 };
 
 static struct comdb2_metrics_store stats;
@@ -215,8 +218,15 @@ comdb2_metric gbl_metrics[] = {
      STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.rw_evicts, NULL},
     {"standing_queue_time", "How long the database has had a standing queue",
      STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
-     &stats.standing_queue_time, NULL}
-};
+     &stats.standing_queue_time, NULL},
+    {"minimum_truncation_file", "Minimum truncation file", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_LATEST, &stats.minimum_truncation_file, NULL},
+    {"minimum_truncation_offset", "Minimum truncation offset",
+     STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
+     &stats.minimum_truncation_offset, NULL},
+    {"minimum_truncation_timestamp", "Minimum truncation timestamp",
+     STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
+     &stats.minimum_truncation_timestamp, NULL}};
 
 const char *metric_collection_type_string(comdb2_collection_type t) {
     switch (t) {
@@ -420,6 +430,11 @@ int refresh_metrics(void)
     bdb_rep_stats(thedb->bdb_env, &stats.rep_deadlocks);
 
     stats.standing_queue_time = metrics_standing_queue_time();
+
+    bdb_min_truncate(thedb->bdb_env, &min_file, &min_offset, &min_timestamp);
+    stats.minimum_truncation_file = min_file;
+    stats.minimum_truncation_offset = min_offset;
+    stats.minimum_truncation_timestamp = min_timestamp;
     return 0;
 }
 

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -4384,6 +4384,8 @@ clipper_usage:
             logmsg(LOGMSG_ERROR, "11    - DB_LOCK_YOUNGEST_EVER\n");
             logmsg(LOGMSG_ERROR, "12    - DB_LOCK_MINWRITE_EVER\n");
         }
+    } else if (tokcmp(tok, ltok, "dump_mintruncate") == 0) {
+        bdb_dump_mintruncate_list(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "detect") == 0) {
         bdb_detect(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "lsum") == 0) {

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -4386,6 +4386,12 @@ clipper_usage:
         }
     } else if (tokcmp(tok, ltok, "dump_mintruncate") == 0) {
         bdb_dump_mintruncate_list(thedb->bdb_env);
+    } else if (tokcmp(tok, ltok, "clear_mintruncate") == 0) {
+        bdb_clear_mintruncate_list(thedb->bdb_env);
+    } else if (tokcmp(tok, ltok, "build_mintruncate") == 0) {
+        bdb_build_mintruncate_list(thedb->bdb_env);
+    } else if (tokcmp(tok, ltok, "print_mintruncate") == 0) {
+        bdb_print_mintruncate_min(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "detect") == 0) {
         bdb_detect(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "lsum") == 0) {

--- a/tests/pg_free_recovery.test/Makefile
+++ b/tests/pg_free_recovery.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=15m
 endif

--- a/tests/pg_free_recovery.test/runit
+++ b/tests/pg_free_recovery.test/runit
@@ -83,8 +83,10 @@ function deleteall
     [[ "$debug" == 1 ]] && set -x
     [[ "$trace" == 1 ]] && echo "Running deleteall"
     xxx=$(cdb2sql ${CDB2_OPTIONS} $dbname $stage "delete from t1 limit 10000") ; xx=${xxx##*=} ; x=${xx%\)}
+    echo "Deleted $x records"
     while [[ -n "$x" && "$x" != 0 ]]; do
         xxx=$(cdb2sql ${CDB2_OPTIONS} $dbname $stage "delete from t1 limit 10000") ; xx=${xxx##*=} ; x=${xx%\)}
+        echo "Deleted $x records"
     done
 }
 

--- a/tests/truncatesc.test/runit
+++ b/tests/truncatesc.test/runit
@@ -317,7 +317,7 @@ function assert_stripe
     typeset stp=$(get_dtastripe)
     while [[ "$1" != "$stp" ]] ; do 
         let tries=tries-1
-        [[ "$tries" == 0 ]] &&  failexit $func "was expecting $1 stripes but have $stp"
+        [[ "$tries" == 0 ]] && failexit $func "was expecting $1 stripes but have $stp"
         sleep 1
         stp=$(get_dtastripe)
     done


### PR DESCRIPTION
Keep track of checkpoints to maintain a minimal truncation point.  Don't bother filling in untracked possibilities unless a user attempts to truncate beyond the databases LSN at startup.
