### PR TITLE
Release locks

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3579,7 +3579,7 @@ static int init(int argc, char **argv)
     if (gbl_berkdb_iomap) 
         bdb_berkdb_iomap_set(thedb->bdb_env, 1);
 
-    if (gbl_new_snapisol && gbl_snapisol) {
+    if (!gbl_exit && gbl_new_snapisol && gbl_snapisol) {
         bdb_attr_set(thedb->bdb_attr, BDB_ATTR_PAGE_ORDER_TABLESCAN, 0);
 
         if (bdb_gbl_pglogs_mem_init(thedb->bdb_env) != 0)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4837,10 +4837,10 @@ retry:
             return -1;
         }
         if (rc == 0) {
-            if (gbl_sql_release_locks_on_slow_reader &&
+            if ((gbl_sql_release_locks_on_slow_reader &&
                     (!released_locks ||
-                     bdb_curtran_has_waiters(thedb->bdb_env, clnt->dbtran.cursor_tran) ||
-                     bdb_lock_desired(thedb->bdb_env))) {
+                     bdb_curtran_has_waiters(thedb->bdb_env, clnt->dbtran.cursor_tran))) ||
+                     bdb_lock_desired(thedb->bdb_env)) {
                 rc = sql_writer_recover_deadlock(clnt);
                 if (rc == 0)
                     released_locks = 1;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4838,9 +4838,10 @@ retry:
         }
         if (rc == 0) {
             if ((gbl_sql_release_locks_on_slow_reader &&
-                    (!released_locks ||
-                     bdb_curtran_has_waiters(thedb->bdb_env, clnt->dbtran.cursor_tran))) ||
-                     bdb_lock_desired(thedb->bdb_env)) {
+                 (!released_locks ||
+                  bdb_curtran_has_waiters(thedb->bdb_env,
+                                          clnt->dbtran.cursor_tran))) ||
+                bdb_lock_desired(thedb->bdb_env)) {
                 rc = sql_writer_recover_deadlock(clnt);
                 if (rc == 0)
                     released_locks = 1;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4837,8 +4837,10 @@ retry:
             return -1;
         }
         if (rc == 0) {
-            if ((gbl_sql_release_locks_on_slow_reader && !released_locks) ||
-                bdb_lock_desired(thedb->bdb_env)) {
+            if (gbl_sql_release_locks_on_slow_reader &&
+                    (!released_locks ||
+                     bdb_curtran_has_waiters(thedb->bdb_env, clnt->dbtran.cursor_tran) ||
+                     bdb_lock_desired(thedb->bdb_env))) {
                 rc = sql_writer_recover_deadlock(clnt);
                 if (rc == 0)
                     released_locks = 1;

--- a/tests/cldeadlock.test/Makefile
+++ b/tests/cldeadlock.test/Makefile
@@ -5,5 +5,5 @@ else
 endif
 
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=40m
+	export TEST_TIMEOUT=50m
 endif

--- a/tests/cldeadlock.test/runit
+++ b/tests/cldeadlock.test/runit
@@ -220,10 +220,13 @@ function cldeadlock
     typeset iter=$1
     typeset snapshot=$2
     typeset snapshot_flag=""
+    typeset truncate=$3
+    typeset truncate_flag=""
     typeset pidfile=$pidroot.$iter
     write_prompt $func "executing $func-$iter"
     [[ "$snapshot" == "1" ]] && snapshot_flag=" -s "
-    ${TESTSBUILDDIR}/cldeadlock -d $DBNAME -f $pidfile $snapshot_flag -c $CDB2_CONFIG -t default 2>&1 | gawk "{print \"[$func-$iter]\", \$0; fflush(); }"
+    [[ "$truncate" == "1" ]] && truncate_flag=" -T "
+    ${TESTSBUILDDIR}/cldeadlock -d $DBNAME -f $pidfile $snapshot_flag $truncate_flag -c $CDB2_CONFIG -t default 2>&1 | gawk "{print \"[$func-$iter]\", \$0; fflush(); }"
 }
 
 function cldeadlock_threads
@@ -233,9 +236,10 @@ function cldeadlock_threads
     write_prompt $func "executing $func"
     typeset iters=${1:-5}
     typeset snapshot=${2:-0}
+    typeset truncate=${3:-0}
     typeset j=0
     while [[ $j -lt $iters ]]; do
-        cldeadlock $j $snapshot &
+        cldeadlock $j $snapshot $truncate &
         cl_pids[$j]=$!
         let j=j+1
     done
@@ -288,6 +292,16 @@ function normal_test
     cleanup
 }
 
+function truncate_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="truncate_test"
+    write_prompt $func "executing $func"
+    start_coherent_loop 10
+    cldeadlock_threads $cl_iters 0 1
+    cleanup
+}
+
 function downgrade_test
 {
     [[ $debug == "1" ]] && set -x
@@ -329,8 +343,9 @@ function run_test
     write_prompt $func "executing $func"
     setup_test
     normal_test
-    #snapshot_test
+    snapshot_test
     downgrade_test
+    truncate_test
     [[ -f $incoherent_fail ]] && failexit "Cluster went incoherent"
     drop_table
 }


### PR DESCRIPTION
Release locks on slow reader if there are any waiters (i.e., the replication thread which is attempting to replicate a schema change).  Add a 'truncate_test' to the cldeadlock testcase to verify that this logic works correctly.
