### PR TITLE
Put the abort on missing osql session logic on a tunable

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -276,6 +276,7 @@ extern int gbl_timeseries_metrics;
 extern int gbl_metric_maxpoints;
 extern int gbl_metric_maxage;
 extern int gbl_osql_check_replicant_numops;
+extern int gbl_abort_on_missing_osql_session;
 extern int gbl_abort_irregular_set_durable_lsn;
 extern int gbl_legacy_schema;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1619,4 +1619,11 @@ REGISTER_TUNABLE("force_incoherent",
                  TUNABLE_BOOLEAN, &gbl_force_incoherent,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("abort_on_missing_osql_session",
+                 "Abort if we can't find an osql session in the repository.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_abort_on_missing_osql_session,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1625,5 +1625,4 @@ REGISTER_TUNABLE("abort_on_missing_osql_session",
                  TUNABLE_BOOLEAN, &gbl_abort_on_missing_osql_session,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
-
 #endif /* _DB_TUNABLES_H */

--- a/db/osqlrepository.c
+++ b/db/osqlrepository.c
@@ -215,6 +215,7 @@ int osql_repository_add(osql_sess_t *sess, int *replaced)
     return rc;
 }
 
+int gbl_abort_on_missing_osql_session = 0;
 
 /**
  * Remove an osql session from the repository
@@ -283,7 +284,9 @@ int osql_repository_rem(osql_sess_t *sess, int lock, const char *func, const cha
             Pthread_rwlock_unlock(&theosql->hshlck);
         }
 
-        abort();
+        /* This can happen legitimately on master swing */
+        if (gbl_abort_on_missing_osql_session)
+            abort();
     }
 #ifdef TRACK_OSQL_SESSIONS
     else {

--- a/tests/cldeadlock.test/lrl.options
+++ b/tests/cldeadlock.test/lrl.options
@@ -1,4 +1,4 @@
-#enable_snapshot_isolation
+enable_snapshot_isolation
 release_locks_trace on
 maxosqltransfer 1000000
 rep_release_wait_ms 10


### PR DESCRIPTION
cldeadlock manages to trigger the osql-missing-session abort regularly.  The abort is incorrect as osql sessions can go missing legitimately on a master swing.