### PR TITLE
CSC2: Remove named constraint from gbl_legacy_schema's purview

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -116,11 +116,6 @@ void set_constraint_mod(int start, int op, int type)
 
 void set_constraint_name(char *name)
 {
-    if (gbl_legacy_schema) {
-        csc2_syntax_error("ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");
-        any_errors++;
-        return;
-    }
     constraints[nconstraints].consname = name;
 }
 


### PR DESCRIPTION
Since, names constraint has been backported to R6 csc2 parser, it should be safe to use when running under legacy settings.