### PR TITLE
cdb2api: Uninstall statically linked libraries.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2487,7 +2487,8 @@ retry:
     rc = 0;
 after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AFTER_READ_RECORD, e)) != NULL) {
-        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
+        callbackrc =
+            cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
     return rc;
@@ -3017,7 +3018,8 @@ int cdb2_next_record(cdb2_hndl_tp *hndl)
 after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AT_EXIT_NEXT_RECORD, e)) !=
            NULL) {
-        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
+        callbackrc =
+            cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
 
@@ -3157,8 +3159,8 @@ int cdb2_close(cdb2_hndl_tp *hndl)
 
     curre = NULL;
     while ((curre = cdb2_next_callback(hndl, CDB2_AT_CLOSE, curre)) != NULL) {
-        callbackrc =
-            cdb2_invoke_callback(hndl, curre, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
+        callbackrc = cdb2_invoke_callback(hndl, curre, 1, CDB2_RETURN_VALUE,
+                                          (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, curre, rc, callbackrc);
     }
 

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1017,7 +1017,7 @@ after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AFTER_CONNECT, e)) != NULL) {
         callbackrc =
             cdb2_invoke_callback(hndl, e, 3, CDB2_HOSTNAME, host, CDB2_PORT,
-                                 port, CDB2_RETURN_VALUE, rc);
+                                 port, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
     return rc;
@@ -2197,7 +2197,7 @@ after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AFTER_PMUX, e)) != NULL) {
         callbackrc = cdb2_invoke_callback(
             hndl, e, 3, CDB2_HOSTNAME, remote_host, CDB2_PORT, CDB2_PORTMUXPORT,
-            CDB2_RETURN_VALUE, port);
+            CDB2_RETURN_VALUE, (intptr_t)port);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, port, callbackrc);
     }
     return port;
@@ -2487,7 +2487,7 @@ retry:
     rc = 0;
 after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AFTER_READ_RECORD, e)) != NULL) {
-        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, rc);
+        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
     return rc;
@@ -2796,7 +2796,7 @@ after_callback:
     while ((e = cdb2_next_callback(event_hndl, CDB2_AFTER_SEND_QUERY, e)) !=
            NULL) {
         callbackrc = cdb2_invoke_callback(event_hndl, e, 2, CDB2_SQL, sql,
-                                          CDB2_RETURN_VALUE, rc);
+                                          CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(event_hndl, e, rc, callbackrc);
     }
     return rc;
@@ -3017,7 +3017,7 @@ int cdb2_next_record(cdb2_hndl_tp *hndl)
 after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AT_EXIT_NEXT_RECORD, e)) !=
            NULL) {
-        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, rc);
+        callbackrc = cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
 
@@ -3158,7 +3158,7 @@ int cdb2_close(cdb2_hndl_tp *hndl)
     curre = NULL;
     while ((curre = cdb2_next_callback(hndl, CDB2_AT_CLOSE, curre)) != NULL) {
         callbackrc =
-            cdb2_invoke_callback(hndl, curre, 1, CDB2_RETURN_VALUE, rc);
+            cdb2_invoke_callback(hndl, curre, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, curre, rc, callbackrc);
     }
 
@@ -4545,7 +4545,7 @@ after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AT_EXIT_RUN_STATEMENT, e)) !=
            NULL) {
         callbackrc = cdb2_invoke_callback(hndl, e, 2, CDB2_SQL, sql,
-                                          CDB2_RETURN_VALUE, rc);
+                                          CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
 
@@ -4999,7 +4999,7 @@ static int cdb2_dbinfo_query(cdb2_hndl_tp *hndl, const char *type,
 
     while ((e = cdb2_next_callback(hndl, CDB2_BEFORE_DBINFO, e)) != NULL) {
         callbackrc = cdb2_invoke_callback(hndl, e, 2, CDB2_HOSTNAME, host,
-                                          CDB2_PORT, -1);
+                                          CDB2_PORT, port);
         PROCESS_EVENT_CTRL_BEFORE(hndl, e, rc, callbackrc, overwrite_rc);
     }
 
@@ -5161,7 +5161,7 @@ after_callback:
     while ((e = cdb2_next_callback(hndl, CDB2_AFTER_DBINFO, e)) != NULL) {
         callbackrc =
             cdb2_invoke_callback(hndl, e, 3, CDB2_HOSTNAME, host, CDB2_PORT,
-                                 port, CDB2_RETURN_VALUE, rc);
+                                 port, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_AFTER(hndl, e, rc, callbackrc);
     }
     return rc;
@@ -5798,7 +5798,7 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
 
     while ((e = cdb2_next_callback(hndl, CDB2_AT_OPEN, e)) != NULL) {
         callbackrc =
-            cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, rc);
+            cdb2_invoke_callback(hndl, e, 1, CDB2_RETURN_VALUE, (intptr_t)rc);
         PROCESS_EVENT_CTRL_BEFORE(hndl, e, rc, callbackrc, overwrite_rc);
     }
 
@@ -6100,7 +6100,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
             argv[i] = (void *)sql;
             break;
         case CDB2_RETURN_VALUE:
-            argv[i] = (void *)rc;
+            argv[i] = (void *)(intptr_t)rc;
             break;
         default:
             break;

--- a/tests/api_dl_libs.test/expected
+++ b/tests/api_dl_libs.test/expected
@@ -2,3 +2,5 @@ HELLO WORLD
 Registering BEFORE_SEND_QUERY event
 The event is registered by the dynamically loaded library
 The event is registered by the dynamically loaded library
+CLOSING A HANDLE
+UNINSTALLING LIBS

--- a/tests/odh_blobs.test/runit
+++ b/tests/odh_blobs.test/runit
@@ -119,5 +119,6 @@ EOF
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default - 2>&1
 
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT * FROM self ORDER BY b' >self
+sleep 5 ### Allow trigger to fire.
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT * FROM mirror ORDER BY b' >mirror
 diff self mirror

--- a/tests/tools/api_events.c
+++ b/tests/tools/api_events.c
@@ -39,8 +39,8 @@ static void register_once(void)
 
 static int TEST_init_once_registration(const char *db, const char *tier)
 {
-    extern void (*cdb2_init)(void);
-    cdb2_init = register_once;
+    extern void (*cdb2_install)(void);
+    cdb2_install = register_once;
     return 0;
 }
 

--- a/tests/tools/api_libs.c
+++ b/tests/tools/api_libs.c
@@ -1,12 +1,28 @@
 #include <stdio.h>
 
-#define CDB2_INIT gbl_init_once
+#define CDB2_INSTALL_LIBS gbl_init_once
+#define CDB2_UNINSTALL_LIBS gbl_uninit
 #define WITH_DL_LIBS 1
 #include <cdb2api.c>
+
+static void *my_open_hook(cdb2_hndl_tp *hndl, void *user_arg, int argc, void **argv)
+{
+    puts("CLOSING A HANDLE");
+    return NULL;
+}
+
+static cdb2_event *e;
 
 void gbl_init_once(void)
 {
     puts("HELLO WORLD");
+    e = cdb2_register_event(NULL, CDB2_AT_CLOSE, 0, my_open_hook, NULL, 0);
+}
+
+void gbl_uninit(void)
+{
+    puts("UNINSTALLING LIBS");
+    cdb2_unregister_event(NULL, e);
 }
 
 int main(int argc, char **argv)
@@ -24,5 +40,11 @@ int main(int argc, char **argv)
     cdb2_run_statement(hndl, "SELECT 1");
     cdb2_open(&hndl, db, tier, 0);
     cdb2_run_statement(hndl, "SELECT 1");
+
+    cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
+    cdb2_close(hndl);
+    cdb2_set_comdb2db_info("comdb2_config:uninstall_static_libs");
+    cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
+    cdb2_close(hndl);
     return 0;
 }


### PR DESCRIPTION
Provide a way to disable statically linked libraries (e.g. hungserv and dbstats) via comdb2db.cfg.