### PR TITLE
Eventlog: Add ability for db to delete old event log files

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1757,8 +1757,6 @@ extern int gbl_max_columns_soft_limit;
 
 extern int gbl_use_plan;
 
-extern int gbl_instant_schema_change;
-
 extern int gbl_num_record_converts;
 extern int gbl_num_record_upgrades;
 

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -108,8 +108,8 @@ static void eventlog_roll_cleanup()
     // WARNING: MAKE SURE NO SPACE BETWEEN THE TWO CHARACTERS '%s*'
     // IN THE CALL TO ls IN NEXT LINE
     snprintf(cmd, sizeof(cmd) - 1, 
-             "ls -1tr %s* | head -n -%d | xargs -d '\n' rm -f --",
-             fname, eventlog_nkeep);
+             "ls -1t %s* | grep '%s' | grep '.events.' | sed '1,%dd' | xargs rm -f",
+             fname, thedb->envname, eventlog_nkeep);
     free(fname);
 
     int rc = system(cmd);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -43,7 +43,7 @@
 
 static char *gbl_eventlog_fname = NULL;
 static char *eventlog_fname(const char *dbname);
-static int eventlog_nkeep = 10;  // keep last 10 event log files
+static int eventlog_nkeep = 10;                 // keep last 10 event log files
 static int eventlog_rollat = 100 * 1024 * 1024; // 100MB to begin
 static int eventlog_enabled = 1;
 static int eventlog_detailed = 0;
@@ -100,16 +100,17 @@ static void eventlog_roll_cleanup()
     int len = strlen(fname);
 
     // SANITY CHECK; last part of fname should match postfix
-    if (len < sizeof(postfix) || 
+    if (len < sizeof(postfix) ||
         strcmp(&(fname[len - sizeof(postfix) + 1]), postfix) != 0)
         abort();
 
     // Delete all except the most recent files
     // WARNING: MAKE SURE NO SPACE BETWEEN THE TWO CHARACTERS '%s*'
     // IN THE CALL TO ls IN NEXT LINE
-    snprintf(cmd, sizeof(cmd) - 1, 
-             "ls -1t %s* | grep '%s' | grep '.events.' | sed '1,%dd' | xargs rm -f",
-             fname, thedb->envname, eventlog_nkeep);
+    snprintf(
+        cmd, sizeof(cmd) - 1,
+        "ls -1t %s* | grep '%s' | grep '.events.' | sed '1,%dd' | xargs rm -f",
+        fname, thedb->envname, eventlog_nkeep);
     free(fname);
 
     int rc = system(cmd);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -93,11 +93,15 @@ static void eventlog_roll_cleanup()
     const char *postfix = ".events";
     char *fname = comdb2_location("logs", "%s%s", thedb->envname, postfix);
 
+    if (fname == NULL)
+        abort();
+
     // fname should look like '/dir/<dbname>.events' : see eventlog_fname()
     int len = strlen(fname);
 
     // SANITY CHECK; last part of fname should match postfix
-    if (strcmp(&(fname[len - sizeof(postfix) + 1]), postfix) != 0)
+    if (len < sizeof(postfix) || 
+        strcmp(&(fname[len - sizeof(postfix) + 1]), postfix) != 0)
         abort();
 
     // Delete all except the most recent files

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -43,7 +43,7 @@
 
 static char *gbl_eventlog_fname = NULL;
 static char *eventlog_fname(const char *dbname);
-static int eventlog_nkeep = 10;
+static int eventlog_nkeep = 0;
 static int eventlog_rollat = 100 * 1024 * 1024; // 100MB to begin
 static int eventlog_enabled = 1;
 static int eventlog_detailed = 0;
@@ -84,8 +84,11 @@ static inline void free_gbl_eventlog_fname()
     gbl_eventlog_fname = NULL;
 }
 
-static void eventlog_roll()
+static void eventlog_roll_cleanup()
 {
+    if (eventlog_nkeep == 0)
+        return;
+
     char cmd[512] = {0};
     char *fname = comdb2_location("logs", "%s.events", thedb->envname);
     snprintf(cmd, sizeof(cmd) - 1, 
@@ -102,7 +105,7 @@ static void eventlog_roll()
 
 static gzFile eventlog_open()
 {
-    eventlog_roll();
+    eventlog_roll_cleanup();
     char *fname = eventlog_fname(thedb->envname);
     gbl_eventlog_fname = fname;
     gzFile f = gzopen(fname, "2w");

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -90,13 +90,13 @@ static void eventlog_roll_cleanup()
         return;
 
     char cmd[512] = {0};
-    const char *postfix = ".events";
+    const char postfix[] = ".events.";
     char *fname = comdb2_location("logs", "%s%s", thedb->envname, postfix);
 
     if (fname == NULL)
         abort();
 
-    // fname should look like '/dir/<dbname>.events' : see eventlog_fname()
+    // fname should look like '/dir/<dbname>.events.' : see eventlog_fname()
     int len = strlen(fname);
 
     // SANITY CHECK; last part of fname should match postfix

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -187,4 +187,9 @@ COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAM
 
 assertres $logflcnt $((NKEEP+1))
 
+logfl=`ls -1r $TESTDIR/var/log/cdb2/ | grep events | grep $DBNAME | head -1`
+logfl=`find $TESTDIR/var/log/cdb2/ | grep $logfl`
+res=$(zcat $logfl | grep 'insert into t1 values(2000)' | wc -l)
+assertres $res 1
+
 exit 0

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -21,8 +21,9 @@ failexit()
 }
 
 function waitfordb() {
-	sel=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $1 "select 1" 2>&1)
+    sleep 1
     local count=0
+	sel=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $1 "select 1" 2>&1)
 	while [[ "$sel" != "1" ]] && [[ $count -lt 60 ]] ; do
 		sleep 1
 	    sel=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $1 "select 1" 2>&1)
@@ -92,6 +93,7 @@ getmembers()
     echo $1 | sed -e 's/[{}]/''/g' | awk -v k="text" '{n=split($0,a,","); for (i=1; i<=n; i++) print a[i]}' | grep "fingerprint\|error" | sed 's/[^:]*: //; s/^"//; s/"$//; s/\\"/"/g'
 }
 
+SAVIFS=$IFS
 echo check all .*sql entries for fingerprint
 echo 'ad69399b065510fec51aa4e5f74a0e2f' > exp.txt
 IFS=$'\n'
@@ -159,5 +161,30 @@ if ! diff out.txt exp.txt ; then
     failexit 'output is different from expected'
 fi
 
+
+mv $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
+
+echo "start db again, make sure that we keep only 3 event log files of size ~2000 bytes"
+$DEBUGGER ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
+
+IFS=$SAVIFS
+waitfordb $DBNAME
+
+NKEEP=4
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events detailed on')"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events keep $NKEEP')"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 4000')"
+
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int)"
+
+for i in `seq 1 2000` ; do 
+    cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values($i)"
+done
+
+logflcnt=`ls -1Sr $TESTDIR/var/log/cdb2/ | grep events | grep $DBNAME | wc -l`
+
+COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
+
+assertres $logflcnt $((NKEEP+1))
 
 exit 0


### PR DESCRIPTION
Add ability for db to delete all except the last N even log files:
* Currently set default eventlog_nkeep to 10. 
* Set to 0 to disable deletion
* Fix setting eventlog_rollat  correcly. 
* Initial size for eventlog_rollat  set to a more reasonable 100MB.