### PR TITLE
More constraints fixes

### DIFF
--- a/db/constraints.c
+++ b/db/constraints.c
@@ -1334,15 +1334,14 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
         *errout = OP_FAILED_INTERNAL;
         return ERR_INTERNAL;
     }
-    unsigned long long sc_genid = 0ULL;
+    unsigned long long genid = 0ULL;
     unsigned long long cached_index_genid = 0ULL;
+    unsigned long long ins_keys = 0ULL;
     while (rc == 0) {
         cte *ctrq = (cte *)bdb_temp_table_data(cur);
         struct forward_ct *curop = NULL;
         int addrrn = -1, ixnum = -1;
         int ondisk_size = 0;
-        unsigned long long genid = 0LL;
-        unsigned long long ins_keys = 0ULL;
         /* do something */
         if (ctrq == NULL) {
             if (iq->debug)
@@ -1356,6 +1355,12 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
         /*    fprintf(stderr, "%d %d %s\n", ctrq->ct_type,
          * ctrq->ctop.fwdct.optype,ctrq->ctop.fwdct.usedb->tablename);*/
         curop = &ctrq->ctop.fwdct;
+
+        /* Only do once per genid --
+         * (Same as LIVE_SC_DELAYED_KEY_ADDS in delayed_key_adds) */
+        if (genid && genid != curop->genid) {
+            verify_schema_change_constraint(iq, trans, genid, od_dta, ins_keys);
+        }
 
         iq->usedb = curop->usedb;
         addrrn = curop->rrn;
@@ -1427,12 +1432,6 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
                 *errout = OP_FAILED_INTERNAL;
                 close_constraint_table_cursor(cur);
                 return ERR_INTERNAL;
-            }
-
-            if (sc_genid != genid) {
-                verify_schema_change_constraint(iq, trans, genid, od_dta,
-                                                ins_keys);
-                sc_genid = genid;
             }
 
             for (cidx = 0; cidx < nct; cidx++) {
@@ -1624,11 +1623,15 @@ int verify_add_constraints(struct javasp_trans_state *javasp_trans_handle,
         /* get next record from table */
         rc = bdb_temp_table_next(thedb->bdb_env, cur, &err);
     }
-    free_cached_delayed_indexes(iq);
     close_constraint_table_cursor(cur);
+
     if (rc == IX_EMPTY || rc == IX_PASTEOF) {
+        verify_schema_change_constraint(iq, trans, genid, od_dta, ins_keys);
+        free_cached_delayed_indexes(iq);
         return 0;
     }
+
+    free_cached_delayed_indexes(iq);
     if (iq->debug)
         reqprintf(iq, "VERKYCNSTRT ERROR READING ADD TABLE");
     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -401,7 +401,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         return rc;
     }
 
-    db->sc_to = newdb = create_db_from_schema(thedb, s, db->dbnum, foundix, -1);
+    newdb = create_db_from_schema(thedb, s, db->dbnum, foundix, -1);
 
     if (newdb == NULL) {
         sc_errf(s, "Internal error\n");

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -167,9 +167,9 @@ int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
 {
     int stripe = get_dtafile_from_genid(genid);
     if (stripe < 0 || stripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
+        logmsg(LOGMSG_FATAL, "%s: genid 0x%llx stripe %d out of range!\n",
                __func__, genid, stripe);
-        return -1;
+        abort();
     }
     if (!sc_genids[stripe]) {
         /* A genid of zero is invalid.  So, if the schema change cursor is at
@@ -185,9 +185,9 @@ unsigned long long get_genid_stripe_pointer(unsigned long long genid,
 {
     int stripe = get_dtafile_from_genid(genid);
     if (stripe < 0 || stripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
+        logmsg(LOGMSG_FATAL, "%s: genid 0x%llx stripe %d out of range!\n",
                __func__, genid, stripe);
-        return -1ULL;
+        abort();
     }
     return sc_genids[stripe];
 }

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -163,9 +163,33 @@ static int reload_rowlocks(bdb_state_type *bdb_state, scdone_t type)
  * that point */
 int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
                                      unsigned long long genid,
-                                     unsigned long long stripe_ptr)
+                                     unsigned long long *sc_genids)
 {
-    return bdb_inplace_cmp_genids(bdb_state, genid, stripe_ptr) > 0;
+    int stripe = get_dtafile_from_genid(genid);
+    if (stripe < 0 || stripe >= gbl_dtastripe) {
+        logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
+               __func__, genid, stripe);
+        return -1;
+    }
+    if (!sc_genids[stripe]) {
+        /* A genid of zero is invalid.  So, if the schema change cursor is at
+         * genid zero it means pretty conclusively that it hasn't done anything
+         * yet so we cannot possibly be behind the cursor. */
+        return 1;
+    }
+    return bdb_inplace_cmp_genids(bdb_state, genid, sc_genids[stripe]) > 0;
+}
+
+unsigned long long get_genid_stripe_pointer(unsigned long long genid,
+                                            unsigned long long *sc_genids)
+{
+    int stripe = get_dtafile_from_genid(genid);
+    if (stripe < 0 || stripe >= gbl_dtastripe) {
+        logmsg(LOGMSG_ERROR, "%s: genid 0x%llx stripe %d out of range!\n",
+               __func__, genid, stripe);
+        return -1ULL;
+    }
+    return sc_genids[stripe];
 }
 
 /* delete from new btree when genid is older than schemachange position
@@ -285,17 +309,8 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
 #endif
     /* need to check where the cursor is, even tho that check was done once in
      * post_update */
-    int stripe = get_dtafile_from_genid(newgenid);
-    if (stripe < 0 || stripe >= gbl_dtastripe) {
-        logmsg(LOGMSG_ERROR,
-               "live_sc_post_update_delayed_key_adds_int: newgenid 0x%llx "
-               "stripe %d out of range!\n",
-               newgenid, stripe);
-        return 0;
-    }
-
     int is_gen_gt_scptr = is_genid_right_of_stripe_pointer(
-        iq->usedb->handle, newgenid, usedb->sc_to->sc_genids[stripe]);
+        iq->usedb->handle, newgenid, usedb->sc_to->sc_genids);
     if (is_gen_gt_scptr) {
         if (iq->debug) {
             reqprintf(iq, "live_sc_post_update_delayed_key_adds_int: skip "

--- a/schemachange/sc_callbacks.h
+++ b/schemachange/sc_callbacks.h
@@ -21,7 +21,10 @@
 
 int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
                                      unsigned long long genid,
-                                     unsigned long long stripe_ptr);
+                                     unsigned long long *sc_genids);
+
+unsigned long long get_genid_stripe_pointer(unsigned long long genid,
+                                            unsigned long long *sc_genids);
 
 int live_sc_post_del_record(struct ireq *iq, void *trans,
                             unsigned long long genid, const void *old_dta,

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2713,7 +2713,7 @@ static int live_sc_redo_update(struct convert_record_data *data, DB_LOGC *logc,
 
     if (!data->s->sc_convert_done[rec->dtastripe] &&
         is_genid_right_of_stripe_pointer(data->to->handle, genid,
-                                         data->sc_genids[rec->dtastripe])) {
+                                         data->sc_genids)) {
         /* if the newgenid is to the right of the sc cursor, we only need to
          * delete the old record */
         rc = del_new_record(&data->iq, data->trans, oldgenid, -1ULL,
@@ -2791,7 +2791,7 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
     }
     if (!data->s->sc_convert_done[rec->dtastripe] &&
         is_genid_right_of_stripe_pointer(data->to->handle, rec->genid,
-                                         data->sc_genids[rec->dtastripe])) {
+                                         data->sc_genids)) {
         /* skip those still to the right of sc cursor */
         return 0;
     }

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -20,6 +20,7 @@
 #include "sc_util.h"
 #include "sc_global.h"
 #include "sc_schema.h"
+#include "sc_callbacks.h"
 #include "intern_strings.h"
 #include "views.h"
 #include "logmsg.h"
@@ -622,6 +623,11 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
 
     if (usedb->sc_to->n_constraints == 0)
         goto done;
+
+    if (is_genid_right_of_stripe_pointer(usedb->handle, newgenid,
+                                         usedb->sc_to->sc_genids)) {
+        goto done;
+    }
 
     if (usedb->sc_to->ix_blob) {
         rc =

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -617,11 +617,13 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
     if (usedb->sc_live_logical)
         goto done;
 
-    /* if (is_schema_change_doomed()) */
     if (gbl_sc_abort || usedb->sc_abort || iq->sc_should_abort)
         goto done;
 
-    if (iq->usedb->sc_to->ix_blob) {
+    if (usedb->sc_to->n_constraints == 0)
+        goto done;
+
+    if (usedb->sc_to->ix_blob) {
         rc =
             save_old_blobs(iq, trans, ".ONDISK", od_dta, 2, newgenid, oldblobs);
         if (rc) {
@@ -662,12 +664,17 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
     if (verify_record_constraint(iq, usedb->sc_to, trans, new_dta, ins_keys,
                                  add_idx_blobs, add_idx_blobs ? MAXBLOBS : 0,
                                  ".NEW..ONDISK", rebuild, 0) != 0) {
+        logmsg(LOGMSG_ERROR, "%s: verify constraints for genid %llx failed.\n",
+               __func__, newgenid);
         usedb->sc_abort = 1;
         MEMORY_SYNC;
     }
 
 done:
     if (rc) {
+        logmsg(LOGMSG_ERROR,
+               "%s: verify constraints for genid %llx failed, rc=%d.\n",
+               __func__, newgenid, rc);
         usedb->sc_abort = 1;
         MEMORY_SYNC;
     }

--- a/tests/sc_constraints.test/runit
+++ b/tests/sc_constraints.test/runit
@@ -711,6 +711,16 @@ EOF
     fi
     rm failedalter
 
+    echo "rebuild t10 and make sure we dont mistakenly fail schemachange"
+    do_alter t10_1 &
+    sleep 10
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "update t10 set a = 2, blb = x'aaaa'"
+    wait
+    if [ -f failedalter ] ; then
+        failexit "SC should not fail for rebuild t10.1"
+    fi
+    rm failedalter
+
     cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "put schemachange convertsleep 0"
     cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "alter table t10 { `cat t10.csc2 ` }"
     cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "put schemachange convertsleep 20"


### PR DESCRIPTION
- always assign `sc_to` under mutex
- verify schema change constraints once per genid *after* processing all indexes from the `ct_add_table` temp table
- refactor is_genid_right_of_stripe_pointer to reduce duplicate code
- only verify sc constraints if genid is to the left of sc pointers