### PR TITLE
Test sending to master node message with bad osql session

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -9601,21 +9601,18 @@ freemem:
     return rc;
 }
 
-
-
 /* test osql stream sending a dummy uuid OSQL_DONE request */
 int osql_send_test(SBUF2 *sb)
 {
     struct errstat xerr = {0};
     int nettype = NET_OSQL_SOCK_RPL_UUID;
     snap_uid_t snap_info = {{0}};
-    //get_cnonce(clnt, &snap_info);
     snap_info.replicant_can_retry = 0;
-    snap_info.uuid[0] = 1;
+    snap_info.uuid[0] = 1; // just assign dummy cnonce here
     int rc;
 
-    rc = osql_send_commit_by_uuid(
-                    thedb->master, snap_info.uuid, 1 /*numops*/, &xerr,
-                    nettype, sb /*logsb*/, NULL /*clnt->query_stats*/, &snap_info);
+    rc = osql_send_commit_by_uuid(thedb->master, snap_info.uuid, 1 /*numops*/,
+                                  &xerr, nettype, sb /*logsb*/,
+                                  NULL /*clnt->query_stats*/, &snap_info);
     return rc;
 }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -9600,3 +9600,22 @@ freemem:
 
     return rc;
 }
+
+
+
+/* test osql stream sending a dummy uuid OSQL_DONE request */
+int osql_send_test(SBUF2 *sb)
+{
+    struct errstat xerr = {0};
+    int nettype = NET_OSQL_SOCK_RPL_UUID;
+    snap_uid_t snap_info = {0};
+    //get_cnonce(clnt, &snap_info);
+    snap_info.replicant_can_retry = 0;
+    snap_info.uuid[0] = 1;
+    int rc;
+
+    rc = osql_send_commit_by_uuid(
+                    thedb->master, snap_info.uuid, 1 /*numops*/, &xerr,
+                    nettype, sb /*logsb*/, NULL /*clnt->query_stats*/, &snap_info);
+    return rc;
+}

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -9608,7 +9608,7 @@ int osql_send_test(SBUF2 *sb)
 {
     struct errstat xerr = {0};
     int nettype = NET_OSQL_SOCK_RPL_UUID;
-    snap_uid_t snap_info = {0};
+    snap_uid_t snap_info = {{0}};
     //get_cnonce(clnt, &snap_info);
     snap_info.replicant_can_retry = 0;
     snap_info.uuid[0] = 1;

--- a/db/osqlrepository.c
+++ b/db/osqlrepository.c
@@ -334,6 +334,7 @@ osql_sess_t *osql_repository_get(unsigned long long rqid, uuid_t uuid,
         osql_sess_addclient(sess);
     }
 
+    /* NB: if session was not found we unlock */
     if (!(sess && keep_repository_lock)) {
         Pthread_rwlock_unlock(&theosql->hshlck);
     }

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -135,6 +135,7 @@ void commit_bench(void *, int, int);
 void bdb_detect(void *);
 void enable_ack_trace(void);
 void disable_ack_trace(void);
+void osql_send_test(SBUF2 *sb);
 extern unsigned long long get_genid(bdb_state_type *bdb_state,
                                     unsigned int dtafile);
 int bdb_dump_logical_tranlist(void *state, FILE *f);
@@ -4748,6 +4749,17 @@ clipper_usage:
         }
     } else if (tokcmp(tok, ltok, "logmsg") == 0) {
         logmsg_process_message(line, lline);
+    } else if (tokcmp(tok, ltok, "test") == 0) {
+        //@send test <keyword>
+        tok = segtok(line, lline, &st, &ltok);
+        if (tokcmp(tok, ltok, "locktest") == 0) {
+            Pthread_mutex_lock(&testguard);
+            bdb_locktest(thedb->bdb_env);
+            Pthread_mutex_unlock(&testguard);
+        } else if (tokcmp(tok, ltok, "osql_send_test") == 0) {
+            SBUF2 *sb = sbuf2open(fileno(stdout), 0);
+            osql_send_test(sb);
+        }
     } else {
         // see if any plugins know how to handle this
         struct message_handler *h;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -4730,14 +4730,14 @@ clipper_usage:
         logmsg_process_message(line, lline);
     } else if (tokcmp(tok, ltok, "test") == 0) { //@send test <keyword>
         tok = segtok(line, lline, &st, &ltok);
-        if (tokcmp(tok, ltok, "locktest") == 0) {
+        if (tokcmp(tok, ltok, "bdb_lock") == 0) { // was locktest
             Pthread_mutex_lock(&testguard);
             bdb_locktest(thedb->bdb_env);
             Pthread_mutex_unlock(&testguard);
-        } else if (tokcmp(tok, ltok, "osql_send_test") == 0) {
+        } else if (tokcmp(tok, ltok, "bad_osql") == 0) {
             SBUF2 *sb = sbuf2open(fileno(stdout), 0);
             osql_send_test(sb);
-        } else if (tokcmp(tok, ltok, "testrep") == 0) {
+        } else if (tokcmp(tok, ltok, "rep") == 0) { // was testrep
             int nitems;
             int size;
             tok = segtok(line, lline, &st, &ltok);

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -3623,23 +3623,6 @@ clipper_usage:
     out:
         free(dbname);
         return 0;
-    } else if (tokcmp(tok, ltok, "testrep") == 0) {
-        int nitems;
-        int size;
-        tok = segtok(line, lline, &st, &ltok);
-        if (ltok == 0)
-            goto testrep_usage;
-        nitems = toknum(tok, ltok);
-        tok = segtok(line, lline, &st, &ltok);
-        if (ltok == 0)
-            goto testrep_usage;
-        size = toknum(tok, ltok);
-
-        testrep(nitems, size);
-        return 0;
-
-    testrep_usage:
-        logmsg(LOGMSG_ERROR, "Usage: testrep num_items item_size\n");
     } else if (tokcmp(tok, ltok, "random_lock_release_interval") == 0) {
         int tmp;
         tok = segtok(line, lline, &st, &ltok);
@@ -4175,10 +4158,6 @@ clipper_usage:
         } else {
             logmsg(LOGMSG_USER, "DDLK generator turned off\n");
         }
-    } else if (tokcmp(tok, ltok, "locktest") == 0) {
-        Pthread_mutex_lock(&testguard);
-        bdb_locktest(thedb->bdb_env);
-        Pthread_mutex_unlock(&testguard);
     } else if (tokcmp(tok, ltok, "berkdelay") == 0) {
         uint32_t commit_delay_ms = 0;
         tok = segtok(line, lline, &st, &ltok);
@@ -4749,8 +4728,7 @@ clipper_usage:
         }
     } else if (tokcmp(tok, ltok, "logmsg") == 0) {
         logmsg_process_message(line, lline);
-    } else if (tokcmp(tok, ltok, "test") == 0) {
-        //@send test <keyword>
+    } else if (tokcmp(tok, ltok, "test") == 0) { //@send test <keyword>
         tok = segtok(line, lline, &st, &ltok);
         if (tokcmp(tok, ltok, "locktest") == 0) {
             Pthread_mutex_lock(&testguard);
@@ -4759,6 +4737,23 @@ clipper_usage:
         } else if (tokcmp(tok, ltok, "osql_send_test") == 0) {
             SBUF2 *sb = sbuf2open(fileno(stdout), 0);
             osql_send_test(sb);
+        } else if (tokcmp(tok, ltok, "testrep") == 0) {
+            int nitems;
+            int size;
+            tok = segtok(line, lline, &st, &ltok);
+            if (ltok == 0)
+                goto testrep_usage;
+            nitems = toknum(tok, ltok);
+            tok = segtok(line, lline, &st, &ltok);
+            if (ltok == 0)
+                goto testrep_usage;
+            size = toknum(tok, ltok);
+
+            testrep(nitems, size);
+            return 0;
+
+        testrep_usage:
+            logmsg(LOGMSG_ERROR, "Usage: testrep num_items item_size\n");
         }
     } else {
         // see if any plugins know how to handle this

--- a/tests/lkmgr.test/runit
+++ b/tests/lkmgr.test/runit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dbnm=$1
-cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('test locktest')"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('test bdb_lock')"
 rc=$?
 if [ $rc != 0 ] ; then
     echo "Failed"

--- a/tests/lkmgr.test/runit
+++ b/tests/lkmgr.test/runit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 dbnm=$1
-cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('locktest')"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('test locktest')"
 rc=$?
 if [ $rc != 0 ] ; then
     echo "Failed"

--- a/tests/random_osql_replay.test/runit
+++ b/tests/random_osql_replay.test/runit
@@ -5,15 +5,23 @@ bash -n "$0" | exit 1
 #set -x
 maxloop=5000
 
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "drop table t1"
 cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "create table t1 ( a int primary key )"
-cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "truncate t1"
+
+
+# send random osql from replicant to master, master should not crash
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "put tunable osql_random_test 'on'"
+
+
+
 
 # Enable random restarts
-cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "put tunable osql_random_restart 'on'"
 if [[ -n $CLUSTER ]]; then
     for x in $CLUSTER ; do
-        cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $x default "put tunable osql_random_restart 'on'"
+        cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $x "put tunable osql_random_restart 'on'"
     done
+else
+    cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "put tunable osql_random_restart 'on'"
 fi
 
 for x in $(seq 1 $maxloop) ; do 

--- a/tests/random_osql_replay.test/runit
+++ b/tests/random_osql_replay.test/runit
@@ -5,14 +5,22 @@ bash -n "$0" | exit 1
 #set -x
 maxloop=5000
 
-cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "drop table t1"
 cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "create table t1 ( a int primary key )"
 
-
+getmaster()
+{
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'
+}
+master=`getmaster`
 # send random osql from replicant to master, master should not crash
-cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "put tunable osql_random_test 'on'"
-
-
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $master "exec procedure sys.cmd.send('test osql_send_test')" &> test1.out
+echo "(out='[ERROR] discarding packet for 1 01000000-0000-0000-0000-000000000000, session not found')" > test1.exp
+if ! diff test1.exp test1.out ; then
+    echo "Testcase failed: diff `pwd`/{test1.exp,test1.out}"
+    exit 1
+fi
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "insert into t1 values (1)"
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "delete from t1 where a = 1"
 
 
 # Enable random restarts

--- a/tests/random_osql_replay.test/runit
+++ b/tests/random_osql_replay.test/runit
@@ -13,7 +13,7 @@ getmaster()
 }
 master=`getmaster`
 # send random osql from replicant to master, master should not crash
-cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $master "exec procedure sys.cmd.send('test osql_send_test')" &> test1.out
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $master "exec procedure sys.cmd.send('test bad_osql')" &> test1.out
 echo "(out='[ERROR] discarding packet for 1 01000000-0000-0000-0000-000000000000, session not found')" > test1.exp
 if ! diff test1.exp test1.out ; then
     echo "Testcase failed: diff `pwd`/{test1.exp,test1.out}"


### PR DESCRIPTION
Test sending to master node message with bad osql session via command `send test osql_send_test`.
Master should correctly ignore this message and return error to client.
Added `send test` message and moved locktest and testrep command,
so  we can now do:
```
send test bdb_lock
send test rep
send test bad_osql
```