### PR TITLE
cdb2api:refactor newsql_connect parameters

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2059,10 +2059,10 @@ static int newsql_connect(cdb2_hndl_tp *hndl, int node_indx, int myport,
     return 0;
 }
 
-static int newsql_disconnect(cdb2_hndl_tp *hndl, SBUF2 *sb, int line)
+static void newsql_disconnect(cdb2_hndl_tp *hndl, SBUF2 *sb, int line)
 {
     if (sb == NULL)
-        return 0;
+        return;
 
     debugprint("disconnecting from %s\n", hndl->hosts[hndl->connected_host]);
     int fd = sbuf2fileno(sb);
@@ -2081,7 +2081,7 @@ static int newsql_disconnect(cdb2_hndl_tp *hndl, SBUF2 *sb, int line)
     }
     hndl->use_hint = 0;
     hndl->sb = NULL;
-    return 0;
+    return;
 }
 
 /* returns port number, or -1 for error*/
@@ -3653,7 +3653,6 @@ static int process_ssl_set_command(cdb2_hndl_tp *hndl, const char *cmd)
         /* Refresh connection if SSL config has changed. */
         if (hndl->sb != NULL) {
             newsql_disconnect(hndl, hndl->sb, __LINE__);
-            hndl->sb = NULL;
         }
     }
 

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1986,7 +1986,6 @@ static int cdb2portmux_route(cdb2_hndl_tp *hndl, const char *remote_host,
     return fd;
 }
 
-
 static void get_host_from_fd(cdb2_hndl_tp *hndl, int fd)
 {
     struct sockaddr_in addr;
@@ -1998,8 +1997,10 @@ static void get_host_from_fd(cdb2_hndl_tp *hndl, int fd)
     char ip[20];
     strcpy(ip, inet_ntoa(addr.sin_addr));
 
-    struct hostent *hp = gethostbyaddr((char *)&addr.sin_addr, sizeof(addr.sin_addr), AF_INET);
-    debugprint("sockpool gave us ip '%s', host '%s'\n", ip, (hp != NULL) ? hp->h_name : "");
+    struct hostent *hp =
+        gethostbyaddr((char *)&addr.sin_addr, sizeof(addr.sin_addr), AF_INET);
+    debugprint("sockpool gave us ip '%s', host '%s'\n", ip,
+               (hp != NULL) ? hp->h_name : "");
     // TODO: consider changing the node_indx in newsql_connect if the host which
     // sockpool had us connect to is not the same as what we intended to connect
 }

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2205,7 +2205,7 @@ static inline int cdb2_try_on_same_room(cdb2_hndl_tp *hndl)
     for (int i = 0; i < hndl->num_hosts_sameroom; i++) {
         int try_node = (hndl->node_seq + i) % hndl->num_hosts_sameroom;
         if (try_node == hndl->master || hndl->ports[try_node] <= 0 ||
-            try_node == hndl->connected_host || 
+            try_node == hndl->connected_host ||
             hndl->hosts_connected[try_node] == 1)
             continue;
         if (newsql_connect(hndl, try_node, 0, 100) == 0)

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2204,7 +2204,8 @@ static inline int cdb2_try_on_same_room(cdb2_hndl_tp *hndl)
     for (int i = 0; i < hndl->num_hosts_sameroom; i++) {
         int try_node = (hndl->node_seq + i) % hndl->num_hosts_sameroom;
         if (try_node == hndl->master || hndl->ports[try_node] <= 0 ||
-            try_node == hndl->connected_host || hndl->hosts_connected[i] == 1)
+            try_node == hndl->connected_host || 
+            hndl->hosts_connected[try_node] == 1)
             continue;
         if (newsql_connect(hndl, try_node, 0, 100) == 0)
             return 0;

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1997,11 +1997,11 @@ static void get_host_from_fd(cdb2_hndl_tp *hndl, int fd)
     }
     char ip[20];
     strcpy(ip, inet_ntoa(addr.sin_addr));
-    debugprint("sockpool gave us ip '%s'\n", ip);
 
     struct hostent *hp = gethostbyaddr((char *)&addr.sin_addr, sizeof(addr.sin_addr), AF_INET);
-    if (hp!=NULL)
-        debugprint("sockpool gave us host '%s'\n", hp->h_name);
+    debugprint("sockpool gave us ip '%s', host '%s'\n", ip, (hp != NULL) ? hp->h_name : "");
+    // TODO: consider changing the node_indx in newsql_connect if the host which
+    // sockpool had us connect to is not the same as what we intended to connect
 }
 
 /* Tries to connect to specified node using sockpool.
@@ -2206,7 +2206,7 @@ static inline int cdb2_try_on_same_room(cdb2_hndl_tp *hndl)
         if (try_node == hndl->master || hndl->ports[try_node] <= 0 ||
             try_node == hndl->connected_host || hndl->hosts_connected[i] == 1)
             continue;
-        if(newsql_connect(hndl, try_node, 0, 100) == 0)
+        if (newsql_connect(hndl, try_node, 0, 100) == 0)
             return 0;
     }
     return -1;
@@ -2220,7 +2220,7 @@ static inline int cdb2_try_connect_range(cdb2_hndl_tp *hndl, int begin, int end)
         if (i == hndl->master || hndl->ports[i] <= 0 ||
             i == hndl->connected_host || hndl->hosts_connected[i] == 1)
             continue;
-        if(newsql_connect(hndl, i, 0, 100) == 0)
+        if (newsql_connect(hndl, i, 0, 100) == 0)
             return 0;
     }
     return -1;
@@ -2323,7 +2323,7 @@ retry_connect:
         /* After this retry on other nodes. */
         bzero(hndl->hosts_connected, sizeof(hndl->hosts_connected));
         if (hndl->ports[hndl->master] > 0) {
-            if(newsql_connect(hndl, hndl->master, 0, 100) == 0)
+            if (newsql_connect(hndl, hndl->master, 0, 100) == 0)
                 return 0;
         }
     }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2176,6 +2176,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         logmsg(LOGMSG_DEBUG, "Query is NULL.\n");
         goto done;
     }
+    else
+        logmsg(LOGMSG_DEBUG, "New Query: %s\n", query->sqlquery->sql_query);
+#if 0
+#endif
     assert(query->sqlquery);
 
     CDB2SQLQUERY *sql_query = query->sqlquery;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2176,9 +2176,9 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         logmsg(LOGMSG_DEBUG, "Query is NULL.\n");
         goto done;
     }
+#if 0
     else
         logmsg(LOGMSG_DEBUG, "New Query: %s\n", query->sqlquery->sql_query);
-#if 0
 #endif
     assert(query->sqlquery);
 

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1576,6 +1576,10 @@ int main(int argc, char *argv[])
         setvbuf(stdout, 0, _IOLBF, 0);
         setvbuf(stderr, 0, _IOLBF, 0);
     }
+    
+    if (getenv("CDB2_DISABLE_SOCKPOOL")) {
+        cdb2_disable_sockpool();
+    }
 
     if (getenv("COMDB2_SQL_COST"))
         docost = 1;

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1576,7 +1576,7 @@ int main(int argc, char *argv[])
         setvbuf(stdout, 0, _IOLBF, 0);
         setvbuf(stderr, 0, _IOLBF, 0);
     }
-    
+
     if (getenv("CDB2_DISABLE_SOCKPOOL")) {
         cdb2_disable_sockpool();
     }


### PR DESCRIPTION
* Refactor newsql_connect parameters to only take node number
* make newsql_disconnect void func; also it already sets sb to null
* Add check for environment variable CDB2_DISABLE_SOCKPOOL to disable getting port from sockpool