### PR TITLE
fix key return for create view: <cached ddl row different> spew

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4351,9 +4351,9 @@ i64 sqlite3BtreeIntegerKey(BtCursor *pCur)
             struct sql_thread *thd = pCur->thd;
             if (pCur->tblpos == thd->rootpage_nentries) {
                 assert(pCur->keyDdl);
-                size = pCur->nDataDdl;
-            }
-            size = get_sqlite_entry_size(thd, pCur->tblpos);
+                size = pCur->keyDdl;
+            } else
+                size = get_sqlite_entry_size(thd, pCur->tblpos);
         }
     } else if (pCur->ixnum == -1) {
         if (pCur->bt->is_remote || pCur->db->dtastripe)


### PR DESCRIPTION
fix new sqlite merge; time partitions started to spew after it (I still think sqlite3BtreeIntegerKey needs further review, since comdb2 doesn't have rowid-s for sqlite_master).