### PR TITLE
Fix empty blob handling for logical-op-redo schema change.

### DIFF
--- a/bdb/odh.c
+++ b/bdb/odh.c
@@ -331,7 +331,7 @@ int bdb_pack(bdb_state_type *bdb_state, const struct odh *odh, void *to,
             to = mallocmem;
         }
 
-        alg = flags & ODH_FLAG_COMPR_MASK;
+        alg = (odh->length) ? flags & ODH_FLAG_COMPR_MASK : BDB_COMPRESS_NONE;
 
         switch (alg) {
         case BDB_COMPRESS_ZLIB: {

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1975,6 +1975,7 @@ static int unpack_blob_record(struct convert_record_data *data, void *blb_buf,
                               int dtalen, blob_status_t *blb, int blbix)
 {
     int rc = 0;
+    size_t sz;
     void *unpackbuf = NULL;
     if ((rc = bdb_unpack(data->from->handle, blb_buf, dtalen, NULL, 0,
                          &data->odh, &unpackbuf)) != 0) {
@@ -1996,8 +1997,11 @@ static int unpack_blob_record(struct convert_record_data *data, void *blb_buf,
     }
     if (unpackbuf) {
         blb->blobptrs[blbix] = data->odh.recptr;
-    } else if (data->odh.length) {
-        blb->blobptrs[blbix] = malloc(data->odh.length);
+    } else {
+        sz = data->odh.length;
+        if (sz == 0)
+            sz = 1;
+        blb->blobptrs[blbix] = malloc(sz);
         if (!blb->blobptrs[blbix]) {
             logmsg(LOGMSG_ERROR, "%s:%d failed to malloc blob buffer\n",
                    __func__, __LINE__);

--- a/tests/logical_sc_empty_blob.test/Makefile
+++ b/tests/logical_sc_empty_blob.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/logical_sc_empty_blob.test/runit
+++ b/tests/logical_sc_empty_blob.test/runit
@@ -4,7 +4,6 @@ bash -n "$0" | exit 1
 dbnm=$1
 
 master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
-master=localhost
 
 cat << EOF | cdb2sql --host $master $dbnm -
 drop table t

--- a/tests/logical_sc_empty_blob.test/runit
+++ b/tests/logical_sc_empty_blob.test/runit
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
+master=localhost
+
+cat << EOF | cdb2sql --host $master $dbnm -
+drop table t
+create table t options blobfield none {schema {int id blob b}}\$\$
+insert into t values(1, x'DEADBEEF')
+insert into t values(2, x'DEADBEEF')
+insert into t values(3, x'DEADBEEF')
+exec procedure sys.cmd.send('on logical_live_sc')
+exec procedure sys.cmd.send('scdelay 2000')
+PUT SCHEMACHANGE COMMITSLEEP 3
+PUT SCHEMACHANGE CONVERTSLEEP 3
+EOF
+
+cdb2sql --host $master $dbnm 'rebuild t' &
+rebuildpid=$!
+
+sleep 4
+
+cdb2sql --host $master $dbnm "insert into t values(4, x'')"
+wait $rebuildpid


### PR DESCRIPTION
Make sure blob_status_t.blobptrs are not NULL even if the blob size is 0, because `blob_status_to_blob_buffer()` uses `blobptrs` to determine the existence of blobs.

The pull request also fixes a memory overrun in `bdb_pack()` caused by a negative length arugment being passed to LZ4/CRLE compression routine.

We do have a few sc* tests testing empty blobs. Logical SC passes those tests because of the memory overun described above, since blobs are LZ4 compressed by default. Specifically, packing an empty blob (where `odh->length` is 0) results in passing (-1) as the max output length to `LZ4_compress_default()`, which then mistakenly compresses the 0-length blob to size 1, overrunning 1 byte after the 7-byte (ODH header size [7] + blob size [0]) allocated output buffer. When reconstructing the empty blob from the logical operation, its `odh->length` will be 1, hence will be marked existent.
