### PR TITLE
Fix get_next_addrem_buffer() abort for data items smaller than genid size.

### DIFF
--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -3531,7 +3531,7 @@ static int bdb_osql_log_run_unoptimized(bdb_cursor_impl_t *cur, DB_LOGC *curlog,
 
         /* Reconstruct the delete. */
         rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page, &index, NULL,
-                                    0, dtabuf, dtalen, NULL);
+                                    sizeof(genid_t), dtabuf, dtalen, NULL);
         if (rc) {
             if (gbl_abort_on_reconstruct_failure)
                 abort();
@@ -4114,7 +4114,7 @@ static int bdb_osql_log_get_optim_data_int(bdb_state_type *bdb_state,
             ptr = dtabuf;
         }
 
-        rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, 0, ptr,
+        rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, sizeof(genid_t), ptr,
                                     del_dta->dtalen, NULL);
         if (rc) {
             if (gbl_abort_on_reconstruct_failure)
@@ -4167,7 +4167,7 @@ static int bdb_osql_log_get_optim_data_int(bdb_state_type *bdb_state,
                 bdb_state, lsn, ptr, &updlen, NULL, NULL, &offset, NULL, NULL);
 
         } else {
-            rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, 0,
+            rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, sizeof(genid_t),
                                         ptr, upd_dta->old_dta_len, NULL);
         }
         if (rc) {

--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -4114,8 +4114,9 @@ static int bdb_osql_log_get_optim_data_int(bdb_state_type *bdb_state,
             ptr = dtabuf;
         }
 
-        rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, sizeof(genid_t), ptr,
-                                    del_dta->dtalen, NULL);
+        rc =
+            bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL,
+                                   sizeof(genid_t), ptr, del_dta->dtalen, NULL);
         if (rc) {
             if (gbl_abort_on_reconstruct_failure)
                 abort();
@@ -4167,8 +4168,9 @@ static int bdb_osql_log_get_optim_data_int(bdb_state_type *bdb_state,
                 bdb_state, lsn, ptr, &updlen, NULL, NULL, &offset, NULL, NULL);
 
         } else {
-            rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL, sizeof(genid_t),
-                                        ptr, upd_dta->old_dta_len, NULL);
+            rc = bdb_reconstruct_delete(bdb_state, lsn, NULL, NULL, NULL,
+                                        sizeof(genid_t), ptr,
+                                        upd_dta->old_dta_len, NULL);
         }
         if (rc) {
             if (gbl_abort_on_reconstruct_failure)

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2132,9 +2132,9 @@ static int reconstruct_blob_records(struct convert_record_data *data,
             }
 
             /* Reconstruct the delete. */
-            if ((rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page,
-                                             &index, NULL, sizeof(genid_t), data->blb_buf,
-                                             dtalen, &dtalen)) != 0) {
+            if ((rc = bdb_reconstruct_delete(
+                     bdb_state, &rec->lsn, &page, &index, NULL, sizeof(genid_t),
+                     data->blb_buf, dtalen, &dtalen)) != 0) {
                 logmsg(LOGMSG_ERROR,
                        "%s:%d failed to reconstruct delete rc=%d\n", __func__,
                        __LINE__, rc);
@@ -2324,8 +2324,9 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
     }
 
     /* Reconstruct the add. */
-    if ((rc = bdb_reconstruct_add(bdb_state, &rec->lsn, NULL, sizeof(genid_t), data->dta_buf,
-                                  dtalen, &dtalen, &ixlen)) != 0) {
+    if ((rc = bdb_reconstruct_add(bdb_state, &rec->lsn, NULL, sizeof(genid_t),
+                                  data->dta_buf, dtalen, &dtalen, &ixlen)) !=
+        0) {
         logmsg(LOGMSG_ERROR, "%s:%d failed to reconstruct add rc=%d\n",
                __func__, __LINE__, rc);
         goto done;
@@ -2527,7 +2528,8 @@ static int live_sc_redo_delete(struct convert_record_data *data, DB_LOGC *logc,
 
     /* Reconstruct the delete. */
     if ((rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page, &index, NULL,
-                                     sizeof(genid_t), data->dta_buf, dtalen, &dtalen)) != 0) {
+                                     sizeof(genid_t), data->dta_buf, dtalen,
+                                     &dtalen)) != 0) {
         logmsg(LOGMSG_ERROR, "%s:%d failed to reconstruct delete rc=%d\n",
                __func__, __LINE__, rc);
         goto done;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -2093,7 +2093,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
 
             /* Reconstruct the add. */
             if ((rc = bdb_reconstruct_add(
-                     bdb_state, &rec->lsn, NULL, 0, data->blb_buf,
+                     bdb_state, &rec->lsn, NULL, sizeof(genid_t), data->blb_buf,
                      MAXBLOBLENGTH + ODH_SIZE, &dtalen, &ixlen)) != 0) {
                 logmsg(LOGMSG_ERROR, "%s:%d failed to reconstruct add rc=%d\n",
                        __func__, __LINE__, rc);
@@ -2133,7 +2133,7 @@ static int reconstruct_blob_records(struct convert_record_data *data,
 
             /* Reconstruct the delete. */
             if ((rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page,
-                                             &index, NULL, 0, data->blb_buf,
+                                             &index, NULL, sizeof(genid_t), data->blb_buf,
                                              dtalen, &dtalen)) != 0) {
                 logmsg(LOGMSG_ERROR,
                        "%s:%d failed to reconstruct delete rc=%d\n", __func__,
@@ -2324,7 +2324,7 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
     }
 
     /* Reconstruct the add. */
-    if ((rc = bdb_reconstruct_add(bdb_state, &rec->lsn, NULL, 0, data->dta_buf,
+    if ((rc = bdb_reconstruct_add(bdb_state, &rec->lsn, NULL, sizeof(genid_t), data->dta_buf,
                                   dtalen, &dtalen, &ixlen)) != 0) {
         logmsg(LOGMSG_ERROR, "%s:%d failed to reconstruct add rc=%d\n",
                __func__, __LINE__, rc);
@@ -2527,7 +2527,7 @@ static int live_sc_redo_delete(struct convert_record_data *data, DB_LOGC *logc,
 
     /* Reconstruct the delete. */
     if ((rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page, &index, NULL,
-                                     0, data->dta_buf, dtalen, &dtalen)) != 0) {
+                                     sizeof(genid_t), data->dta_buf, dtalen, &dtalen)) != 0) {
         logmsg(LOGMSG_ERROR, "%s:%d failed to reconstruct delete rc=%d\n",
                __func__, __LINE__, rc);
         goto done;

--- a/sqlite/ext/comdb2/logicalops.c
+++ b/sqlite/ext/comdb2/logicalops.c
@@ -729,7 +729,7 @@ static int produce_add_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
 
     /* Reconstruct record from berkley */
     if ((rc = bdb_reconstruct_add(bdb_state, &rec->lsn, 
-                    NULL, 0, packedbuf, dtalen, &dtalen, &ixlen)) != 0) {
+                    NULL, sizeof(genid_t), packedbuf, dtalen, &dtalen, &ixlen)) != 0) {
         logmsg(LOGMSG_ERROR, "%s line %d error %d reconstructing insert for "
                 "%d:%d\n", __func__, __LINE__, rc, rec->lsn.file,
                 rec->lsn.offset);
@@ -836,7 +836,7 @@ static int produce_delete_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
 
     /* Reconstruct record from berkley */
     if ((rc = bdb_reconstruct_delete(bdb_state, &rec->lsn, &page,
-                    &index, NULL, 0, packedprevbuf, dtalen, &dtalen)) != 0) {
+                    &index, NULL, sizeof(genid_t), packedprevbuf, dtalen, &dtalen)) != 0) {
         logmsg(LOGMSG_ERROR, "%s line %d error %d reconstructing delete for "
                 "%d:%d\n", __func__, __LINE__, rc, rec->lsn.file,
                 rec->lsn.offset);

--- a/tests/snapisol.test/t9_01.req
+++ b/tests/snapisol.test/t9_01.req
@@ -1,0 +1,9 @@
+1 drop table if exists t9
+1 create table t9 options odh off, ipu off, isc off, rec none, blobfield none { schema {int i} }
+2 insert into t9 values(1)
+1 set transaction snapshot isolation
+1 begin
+1 select * from t9
+2 delete from t9 where 1
+1 select * from t9
+1 commit

--- a/tests/snapisol.test/t9_01.req.exp
+++ b/tests/snapisol.test/t9_01.req.exp
@@ -1,0 +1,13 @@
+done
+done
+(rows inserted=1)
+done
+done
+done
+(i=1)
+done
+(rows deleted=1)
+done
+(i=1)
+done
+done


### PR DESCRIPTION
We pass 0 as the key length to `bdb_reconstruct_delete()`. As a result, `get_next_addrem_buffer()` will abort if the data length is smaller than 8 bytes (key is always a genid in a data or blob file).

Obviously, this does not work with an ODH'd 0-length (ODH overhead is 7 bytes) data item in a blob file (e.g. an empty blob), or a single-int-column table which does not support ODH.
