### PR TITLE
PORTED: dont allow adding field without dbstore or nullable

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -4685,6 +4685,7 @@ int compare_tag_int(struct schema *old, struct schema *new, FILE *out,
                                  "too large forcing rebuild)\n",
                             old->tag, nidx, fnew->name);
                 }
+                break;
             } else if (fnew->in_default || allow_null) {
                 rc = SC_COLUMN_ADDED;
                 if (out) {
@@ -4698,6 +4699,7 @@ int compare_tag_int(struct schema *old, struct schema *new, FILE *out,
                             old->tag, nidx, fnew->name);
                 }
                 rc = SC_BAD_NEW_FIELD;
+                break;
             }
         }
     }

--- a/tests/sc_addfield.test/runit
+++ b/tests/sc_addfield.test/runit
@@ -243,4 +243,12 @@ if [ $? -ne 0 ] ; then
     failexit "failed to update after adding null field"
 fi
 
+echo "Add new field without dbstore or null=yes"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "DROP TABLE IF EXISTS t3"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t3 { schema {int a} }"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "ALTER TABLE t3 { schema {int a int b int c null=yes} }"
+if [ $? -eq 0 ] ; then
+    failexit "failed to detect bad schema"
+fi
+
 echo "Success"

--- a/tests/vutf8_dbstore.test/t1_4.csc2
+++ b/tests/vutf8_dbstore.test/t1_4.csc2
@@ -3,6 +3,7 @@ schema
    int      a null=yes
    blob     b1 null=yes
    vutf8    c[10] dbstore="12345678910"
+   int      d null=yes
 }
 
 keys


### PR DESCRIPTION
ported from R6
