### PR TITLE
SSL: don't use a singleton memory allocator.

### DIFF
--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -269,56 +269,12 @@ int ssl_process_lrl(char *line, size_t len)
     return 0;
 }
 
-#ifndef USE_SYS_ALLOC
-#include <mem.h>
-static comdb2ma sslm;
-#  include <openssl/opensslv.h>
-#  if OPENSSL_VERSION_NUMBER >= 0x10100000L
-static void *ssl_malloc(size_t sz, const char *file, int line)
-{
-    return comdb2_malloc(sslm, sz);
-}
-
-static void *ssl_realloc(void *p, size_t sz, const char *file, int line)
-{
-    return comdb2_realloc(sslm, p, sz);
-}
-
-static void ssl_free(void *p, const char *file, int line)
-{
-    comdb2_free(p);
-}
-#  else
-static void *ssl_malloc(size_t sz)
-{
-    return comdb2_malloc(sslm, sz);
-}
-
-static void *ssl_realloc(void *p, size_t sz)
-{
-    return comdb2_realloc(sslm, p, sz);
-}
-
-static void ssl_free(void *p)
-{
-    comdb2_free(p);
-}
-#  endif
-#endif
-
 int ssl_bend_init(const char *default_certdir)
 {
     const char *ks;
     int rc;
     char errmsg[512];
     ks = (gbl_cert_dir == NULL) ? default_certdir : gbl_cert_dir;
-
-#ifndef USE_SYS_ALLOC
-    sslm = comdb2ma_create(0, 0, "ssl", 1);
-    if (sslm == NULL)
-        return ENOMEM;
-    CRYPTO_set_mem_functions(ssl_malloc, ssl_realloc, ssl_free);
-#endif
 
     rc = ssl_init(1, 1, 1, NULL, 0);
     if (rc != 0)

--- a/tests/simple_ssl.test/runit
+++ b/tests/simple_ssl.test/runit
@@ -73,12 +73,6 @@ if [ $? != 0 ]; then
   exit 1
 fi
 
-cnt=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('memstat ssl')" | wc -l`
-if [ $cnt = 0 ]; then
-  echo "SSL memory not present" >&2
-  exit 1
-fi
-
 host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()"`
 if [ "$host" != "" ]; then
     cdb2sql -v ${CDB2_OPTIONS} $dbnm --host $host 'select 1' >conn.out 2>&1


### PR DESCRIPTION
The intention of passing our allocator to openssl was to keep track of memory usage of libssl and libcrypto.

However this can cause high contention in client password authentication where we call into PKCS5_PBKDF2_HMAC() to compute the salted hash.

(DRQS 136905972)