### PR TITLE
Stat clnt fix

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -544,6 +544,7 @@ struct rawnodestats {
     (offsetof(struct rawnodestats, svc_time) / sizeof(unsigned))
 
 struct summary_nodestats {
+    int node;
     char *host;
     struct in_addr addr;
     char *task;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2411,6 +2411,7 @@ struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
 
         snap_nodestats_ll(nodestats, &snap, disp_rates);
 
+        summaries[ii].node = machine_num(nodestats->host);
         summaries[ii].host = nodestats->host;
         memcpy(&summaries[ii].addr, &(nodestats->addr), sizeof(struct in_addr));
         summaries[ii].task = strcmp(nodestats->task, UNKNOWN_NAME)
@@ -2624,14 +2625,13 @@ void nodestats_report(FILE *fh, const char *prefix, int disp_rates)
         logmsgf(LOGMSG_USER, fh, "%sTOTAL REQUESTS SUMMARY\n", prefix);
     }
     logmsgf(LOGMSG_USER, fh,
-            "%snode | regular fstsnds                 |  blockops          "
-            "                                     | sql\n",
-            prefix);
+            "%s%5s | regular fstsnds                 |  blockops               "
+            "                                | sql\n",
+            prefix, "node");
     logmsgf(LOGMSG_USER, fh,
-            "%s     |   finds rngexts  writes   other |    adds    upds    "
-            "dels blk/sql   recom snapisl  serial | queries   steps    "
-            "rows\n",
-            prefix);
+            "%s%5s |   finds rngexts  writes   other |    adds    upds    dels "
+            "blk/sql   recom snapisl  serial | queries   steps    rows\n",
+            prefix, "");
 
     summaries = get_nodestats_summary(&max_clients, disp_rates);
     if (summaries == NULL)
@@ -2643,12 +2643,13 @@ void nodestats_report(FILE *fh, const char *prefix, int disp_rates)
                 summaries[ii].task, summaries[ii].stack, summaries[ii].host,
                 inet_ntoa(summaries[ii].addr), summaries[ii].ref);
         logmsgf(LOGMSG_USER, fh,
-                "%s | %7u %7u %7u %7u | %7u %7u %7u %7u %7u %7u %7u | %7u "
+                "%s%5d | %7u %7u %7u %7u | %7u %7u %7u %7u %7u %7u %7u | %7u "
                 "%7u %7u\n",
-                prefix, summaries[ii].finds, summaries[ii].rngexts,
-                summaries[ii].writes, summaries[ii].other_fstsnds,
-                summaries[ii].adds, summaries[ii].upds, summaries[ii].dels,
-                summaries[ii].bsql, summaries[ii].recom, summaries[ii].snapisol,
+                prefix, summaries[ii].node, summaries[ii].finds,
+                summaries[ii].rngexts, summaries[ii].writes,
+                summaries[ii].other_fstsnds, summaries[ii].adds,
+                summaries[ii].upds, summaries[ii].dels, summaries[ii].bsql,
+                summaries[ii].recom, summaries[ii].snapisol,
                 summaries[ii].serial, summaries[ii].sql_queries,
                 summaries[ii].sql_steps, summaries[ii].sql_rows);
     }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4607,6 +4607,10 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
         release_node_stats(clnt->argv0, clnt->stack, clnt->origin);
         clnt->rawnodestats = NULL;
     }
+    if (clnt->argv0) {
+        free(clnt->argv0);
+        clnt->argv0 = NULL;
+    }
     clnt->sb = sb;
     clnt->must_close_sb = 1;
     clnt->recno = 1;


### PR DESCRIPTION
- make send stat clnt output backwards compatible
- ported Mark's argv0 memory leak fix from R6
- patch bbplugin to track stat clnt for fastsql

/plugin-branch stat_clnt