### PR TITLE
Fix pthread_mutex_lock EINVAL abort in clean_queries_not_cached_in_srs

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9319,7 +9319,7 @@ int put_curtran_flags(bdb_state_type *bdb_state, struct sqlclntstate *clnt,
 
     if (!clnt->dbtran.cursor_tran) {
         logmsg(LOGMSG_DEBUG, "%s called without curtran\n", __func__);
-        return -1;
+        return 0;
     }
 
     rc = bdb_put_cursortran(bdb_state, clnt->dbtran.cursor_tran, curtran_flags,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2843,10 +2843,6 @@ static int handle_bad_engine(struct sqlclntstate *clnt)
     logmsg(LOGMSG_ERROR, "unable to obtain sql engine\n");
     send_run_error(clnt, "Client api should change nodes", CDB2ERR_CHANGENODE);
     clnt->query_rc = -1;
-    Pthread_mutex_lock(&clnt->wait_mutex);
-    clnt->done = 1;
-    Pthread_cond_signal(&clnt->wait_cond);
-    Pthread_mutex_unlock(&clnt->wait_mutex);
     return -1;
 }
 
@@ -2861,10 +2857,6 @@ static int handle_bad_transaction_mode(struct sqlthdstate *thd,
                __func__);
     }
     clnt->query_rc = 0;
-    Pthread_mutex_lock(&clnt->wait_mutex);
-    clnt->done = 1;
-    Pthread_cond_signal(&clnt->wait_cond);
-    Pthread_mutex_unlock(&clnt->wait_mutex);
     clnt->osql.timings.query_finished = osql_log_time();
     osql_log_time_done(clnt);
     return -2;


### PR DESCRIPTION
To reproduce, run the following against a database which does not enable snapshot isolation:

```
SET TRANSACTION SNAPSHOT
SELECT 1
```

The problem is caused by signaling the appsock thread in `handle_bad_transaction_mode()`. The appsock thread will then destroy the mutexes on clnt and exit, without waiting for the sql thread to invoke `clean_queries_not_cached_in_srs()`.

The pull request changes `handle_bad_engine()` and `handle_bad_transaction_mode()` to not signal the appsock thread. All signaling is done by `clean_queries_not_cached_in_srs()`, as it should be.
