### PR TITLE
Fix a couple memory leaks in cdb2api.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3062,9 +3062,33 @@ int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects)
     return rc;
 }
 
-int cdb2_close(cdb2_hndl_tp *hndl)
+static void free_events(cdb2_hndl_tp *hndl)
 {
     cdb2_event *curre, *preve;
+    curre = hndl->events.next;
+    while (curre != NULL) {
+        preve = curre;
+        curre = curre->next;
+        free(preve);
+    }
+}
+
+static void free_query_list(cdb2_hndl_tp *hndl)
+{
+    cdb2_query_list *item = hndl->query_list;
+    while (item != NULL) {
+        cdb2_query_list *ditem = item;
+        item = item->next;
+        free(ditem->sql);
+        free(ditem->buf);
+        free(ditem);
+    }
+    hndl->query_list = NULL;
+}
+
+int cdb2_close(cdb2_hndl_tp *hndl)
+{
+    cdb2_event *curre;
     void *callbackrc;
     int rc = 0;
 
@@ -3150,12 +3174,8 @@ int cdb2_close(cdb2_hndl_tp *hndl)
         PROCESS_EVENT_CTRL_AFTER(hndl, curre, rc, callbackrc);
     }
 
-    curre = hndl->events.next;
-    while (curre != NULL) {
-        preve = curre;
-        curre = curre->next;
-        free(preve);
-    }
+    free_events(hndl);
+    free_query_list(hndl);
 
     free(hndl);
     return rc;
@@ -3695,7 +3715,9 @@ static inline void cleanup_query_list(cdb2_hndl_tp *hndl,
     hndl->in_trans = 0;
     debugprint("setting in_trans to 0\n");
 
-    cdb2_query_list *item = hndl->query_list;
+    free_query_list(hndl);
+
+    cdb2_query_list *item = commit_query_list;
     while (item != NULL) {
         cdb2_query_list *ditem = item;
         item = item->next;
@@ -3703,17 +3725,6 @@ static inline void cleanup_query_list(cdb2_hndl_tp *hndl,
         free(ditem->buf);
         free(ditem);
     }
-
-    item = commit_query_list;
-    while (item != NULL) {
-        cdb2_query_list *ditem = item;
-        item = item->next;
-        free(ditem->sql);
-        free(ditem->buf);
-        free(ditem);
-    }
-
-    hndl->query_list = NULL;
 }
 
 static inline void clear_snapshot_info(cdb2_hndl_tp *hndl, int line)
@@ -4046,15 +4057,7 @@ retry_queries:
 
         hndl->in_trans = 0;
 
-        cdb2_query_list *item = hndl->query_list;
-        while (item != NULL) {
-            cdb2_query_list *ditem = item;
-            item = item->next;
-            free(ditem->sql);
-            free(ditem->buf);
-            free(ditem);
-        }
-        hndl->query_list = NULL;
+        free_query_list(hndl);
 
         if (!read_intrans_results && !hndl->client_side_error) {
             if (err_val) {
@@ -4906,6 +4909,7 @@ free_vars:
         snprintf(hndl->errstr, sizeof(hndl->errstr),
                  "%s:%d  Invalid sql response from db %s \n", __func__,
                  __LINE__, comdb2db_name);
+        free_events(&tmp);
         return -1;
     }
     if ((p != NULL) && (len != 0)) {
@@ -4920,6 +4924,7 @@ free_vars:
                  "%s: Got bad response for %s query. Reply len: %d\n", __func__,
                  comdb2db_name, len);
         sbuf2close(ss);
+        free_events(&tmp);
         return -1;
     }
 
@@ -4932,6 +4937,7 @@ free_vars:
                      "%s: Can't read dbinfo response from %s \n", __func__,
                      comdb2db_name);
             sbuf2close(ss);
+            free_events(&tmp);
             return -1;
         }
         if (p != NULL) {
@@ -4963,6 +4969,7 @@ free_vars:
                                 comdb2db_num, 5, NULL, NULL);
 
     sbuf2free(ss);
+    free_events(&tmp);
     return 0;
 }
 


### PR DESCRIPTION
1) Fix a memory leak in event handling when database discovery is performed.

2) Fix a memory leak on `cdb2_hndl_tp.query_list` if an HASQL session is closed without commit or rollback.