### PR TITLE
osql: Skip saving OSQL ops for single statements.

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -268,6 +268,8 @@ int osql_delrec(struct BtCursor *pCur, struct sql_thread *thd)
                    __LINE__, __func__, rc);
             return rc;
         }
+        if (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
 
     if (gbl_expressions_indexes && pCur->db->ix_expr) {
@@ -389,6 +391,9 @@ int osql_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                    __LINE__, __func__, rc);
             return rc;
         }
+
+        if (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
 
     if (gbl_expressions_indexes && pCur->db->ix_expr) {
@@ -531,6 +536,9 @@ int osql_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                    __LINE__, __func__, rc);
             return rc;
         }
+
+        if (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
 
     if (gbl_expressions_indexes && pCur->db->ix_expr) {
@@ -1618,6 +1626,8 @@ int osql_record_genid(struct BtCursor *pCur, struct sql_thread *thd,
         }
         osql->replicant_numops++;
         DEBUG_PRINT_NUMOPS();
+        if (thd->clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
     return osql_save_recordgenid(pCur, thd, genid);
 }
@@ -1833,6 +1843,8 @@ int osql_schemachange_logic(struct schema_change_type *sc,
         }
         osql->replicant_numops++;
         DEBUG_PRINT_NUMOPS();
+        if (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
 
     rc = osql_save_schemachange(thd, sc, usedb);
@@ -1874,6 +1886,8 @@ int osql_bpfunc_logic(struct sql_thread *thd, BpfuncArg *arg)
         }
         osql->replicant_numops++;
         DEBUG_PRINT_NUMOPS();
+        if (clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+            return 0;
     }
 
     rc = osql_save_bpfunc(thd, arg);

--- a/db/sql.h
+++ b/db/sql.h
@@ -175,6 +175,7 @@ typedef struct osqlstate {
     int dirty; /* optimization to nop selectv only transactions */
     int running_ddl; /* ddl transaction */
     bool is_reorder_on : 1;
+    bool single_stmt_retry : 1; /* 1 if this is a faked verify-retry */
 } osqlstate_t;
 
 enum ctrl_sqleng {

--- a/db/sql.h
+++ b/db/sql.h
@@ -175,7 +175,7 @@ typedef struct osqlstate {
     int dirty; /* optimization to nop selectv only transactions */
     int running_ddl; /* ddl transaction */
     bool is_reorder_on : 1;
-    bool single_stmt_retry : 1; /* 1 if this is a faked verify-retry */
+    bool single_stmt_retry : 1; /* 1 if this is a fake verify-retry */
 } osqlstate_t;
 
 enum ctrl_sqleng {

--- a/tests/TODO
+++ b/tests/TODO
@@ -77,7 +77,6 @@ register_linearizable.test
 sigstopcluster.test
 cinsert_linearizable.test
 netloss.test              -- does not pass most of the time; requires kernel 4.x & docker 17.x
-restart_socksql.test      -- dont run this for now since masterbranch fails it
 phys_rep.test
 <END>
 


### PR DESCRIPTION
Do not save OSQL operations to shadow tables for a single statement unless it runs under read committed or above.
