### PR TITLE
Forbid remote admin

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -218,6 +218,7 @@ extern int gbl_physrep_register_interval;
 extern int gbl_logdelete_lock_trace;
 extern int gbl_flush_log_at_checkpoint;
 extern int gbl_online_recovery;
+extern int gbl_forbid_remote_admin;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1656,8 +1656,8 @@ REGISTER_TUNABLE("online_recovery",
 
 REGISTER_TUNABLE("forbid_remote_admin",
                  "Forbid non-local admin requests.  (Default: on)",
-                 TUNABLE_BOOLEAN, &gbl_forbid_remote_admin,
-                 0, NULL, NULL, NULL, NULL);
+                 TUNABLE_BOOLEAN, &gbl_forbid_remote_admin, 0, NULL, NULL, NULL,
+                 NULL);
 
 REGISTER_TUNABLE(
     "pbkdf2_iterations",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1654,6 +1654,11 @@ REGISTER_TUNABLE("online_recovery",
                  TUNABLE_BOOLEAN, &gbl_online_recovery, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("forbid_remote_admin",
+                 "Forbid non-local admin requests.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_forbid_remote_admin,
+                 0, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE(
     "pbkdf2_iterations",
     "Number of iterations of PBKDF2 algorithm for password hashing.",

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -867,6 +867,7 @@ These options are toggle-able at runtime.
 |location | | Sets up default file locations - see [file locations](#lrl-files)
 |include | | Include file given as argument.  Named file will be processed before continuing processing the current file.
 |temptable_limit | 8192 | Set the maximum number of temporary tables the database can create
+|forbid_remote_admin | set | Disallow admin SQL sessions unless it is on the same machine as the database
 |disable_temptable_pool | | Disables the pool of temp tables set by `temptable_limit`, temp tables are created as needed.
 |enable_upgrade_ahead | not set | Occasionally update read records to the newest schema version (saves some processing when reading them later)
 |disable_upgrade_ahead | | Disables `enable_upgrade_ahead`

--- a/net/net.c
+++ b/net/net.c
@@ -5880,11 +5880,13 @@ static void *accept_thread(void *arg)
             if (firstbyte == '@') {
                 findpeer(new_fd, paddr, sizeof(paddr));
                 if (!gbl_forbid_remote_admin ||
-                        (cliaddr.sin_addr.s_addr == htonl(INADDR_LOOPBACK))) {
-                    logmsg(LOGMSG_INFO, "Accepting admin user from %s\n", paddr);
+                    (cliaddr.sin_addr.s_addr == htonl(INADDR_LOOPBACK))) {
+                    logmsg(LOGMSG_INFO, "Accepting admin user from %s\n",
+                           paddr);
                     admin = 1;
                 } else {
-                    logmsg(LOGMSG_INFO, "Rejecting non-local admin user from %s\n", paddr);
+                    logmsg(LOGMSG_INFO,
+                           "Rejecting non-local admin user from %s\n", paddr);
                     sbuf2close(sb);
                     continue;
                 }

--- a/tests/setup
+++ b/tests/setup
@@ -156,6 +156,7 @@ setup_db() {
     fi
 
     echo -e "name    ${DBNAME}\ndir     ${DBDIR}\n\nsetattr MASTER_REJECT_REQUESTS 0" >> ${LRL}
+    echo -e "forbid_remote_admin false" >> ${LRL}
 
     if [[ -n "$CUSTOMLRLPATH" ]]; then
         cat $CUSTOMLRLPATH >> ${LRL}

--- a/tests/setup
+++ b/tests/setup
@@ -156,7 +156,7 @@ setup_db() {
     fi
 
     echo -e "name    ${DBNAME}\ndir     ${DBDIR}\n\nsetattr MASTER_REJECT_REQUESTS 0" >> ${LRL}
-    echo -e "forbid_remote_admin false" >> ${LRL}
+    echo -e "forbid_remote_admin off" >> ${LRL}
 
     if [[ -n "$CUSTOMLRLPATH" ]]; then
         cat $CUSTOMLRLPATH >> ${LRL}

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=907)
+(TUNABLES_COUNT=908)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -305,6 +305,7 @@
 (name='fix_pinref', description='fix_pinref', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_check_active_peer', description='Check if still have active connection when trying to flush', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_scan_dbs_first', description='Don't hold bufpool mutex while opening files for flush', type='BOOLEAN', value='OFF', read_only='N')
+(name='forbid_remote_admin', description='Forbid non-local admin requests.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='forbid_ulonglong', description='Disallow u_longlong. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='force_highslot', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='force_old_cursors', description='Replicant will use old cursors', type='BOOLEAN', value='OFF', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -305,7 +305,7 @@
 (name='fix_pinref', description='fix_pinref', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_check_active_peer', description='Check if still have active connection when trying to flush', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_scan_dbs_first', description='Don't hold bufpool mutex while opening files for flush', type='BOOLEAN', value='OFF', read_only='N')
-(name='forbid_remote_admin', description='Forbid non-local admin requests.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='forbid_remote_admin', description='Forbid non-local admin requests.  (Default: on)', type='BOOLEAN', value='OFF', read_only='N')
 (name='forbid_ulonglong', description='Disallow u_longlong. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='force_highslot', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='force_old_cursors', description='Replicant will use old cursors', type='BOOLEAN', value='OFF', read_only='N')

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -732,9 +732,10 @@ static void *thdpool_thd(void *voidarg)
         /* might this is set at a certain point by work_fn */
         thread_util_donework();
         if (check_exit) {
-            LOCK(&pool->mutex) {
-                if (pool->maxnthd > 0 && listc_size(&pool->thdlist) >
-                        pool->maxnthd) {
+            LOCK(&pool->mutex)
+            {
+                if (pool->maxnthd > 0 &&
+                    listc_size(&pool->thdlist) > pool->maxnthd) {
                     listc_rfl(&pool->thdlist, thd);
                     if (thd->on_freelist)
                         abort();
@@ -742,7 +743,8 @@ static void *thdpool_thd(void *voidarg)
                     errUNLOCK(&pool->mutex);
                     goto thread_exit;
                 }
-            } UNLOCK(&pool->mutex);
+            }
+            UNLOCK(&pool->mutex);
         }
 
         // before acquiring next request, yield

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -615,6 +615,7 @@ static inline void free_work_persistent_info(struct thd *thd,
 
 static void *thdpool_thd(void *voidarg)
 {
+    int check_exit = 0;
     struct thd *thd = voidarg;
     struct thdpool *pool = thd->pool;
     void *thddata = NULL;
@@ -650,6 +651,11 @@ static void *thdpool_thd(void *voidarg)
             struct timespec timeout;
             struct timespec *ts = NULL;
             int thr_exit = 0;
+
+            if (pool->maxnthd > 0 && listc_size(&pool->thdlist) > pool->maxnthd)
+                check_exit = 1;
+            else
+                check_exit = 0;
 
             if (pool->wait && pool->waiting_for_thread)
                 Pthread_cond_signal(&pool->wait_for_thread);
@@ -725,6 +731,19 @@ static void *thdpool_thd(void *voidarg)
 
         /* might this is set at a certain point by work_fn */
         thread_util_donework();
+        if (check_exit) {
+            LOCK(&pool->mutex) {
+                if (pool->maxnthd > 0 && listc_size(&pool->thdlist) >
+                        pool->maxnthd) {
+                    listc_rfl(&pool->thdlist, thd);
+                    if (thd->on_freelist)
+                        abort();
+                    pool->num_exits++;
+                    errUNLOCK(&pool->mutex);
+                    goto thread_exit;
+                }
+            } UNLOCK(&pool->mutex);
+        }
 
         // before acquiring next request, yield
         comdb2bma_yield_all();


### PR DESCRIPTION
Port the forbid_remote_admin tunable back to R7: by default we will only allow 'admin' connections which originate from localhost.
