### PR TITLE
Tests: eventlog test expected content may be in the last two event files

### DIFF
--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -208,7 +208,7 @@ delete_records()
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/constraints.test/runit
+++ b/tests/constraints.test/runit
@@ -215,7 +215,7 @@ function assertbadexitcode
 function assertres
 {
     if [ $# != 2 ] ; then
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -6,7 +6,7 @@ set -x
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -164,13 +164,14 @@ fi
 
 mv $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
 
-echo "start db again, make sure that we keep only 3 event log files of size ~2000 bytes"
+NKEEP=4
+IFS=$SAVIFS
+
+echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size ~2000 bytes"
 $DEBUGGER ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
 
-IFS=$SAVIFS
 waitfordb $DBNAME
 
-NKEEP=4
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events detailed on')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events keep $NKEEP')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 4000')"
@@ -185,11 +186,14 @@ logflcnt=`ls -1Sr $TESTDIR/var/log/cdb2/ | grep events | grep $DBNAME | wc -l`
 
 COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
 
+echo make sure we have $((NKEEP+1)) as per the lrl option
 assertres $logflcnt $((NKEEP+1))
 
-logfl=`ls -1r $TESTDIR/var/log/cdb2/ | grep events | grep $DBNAME | head -1`
-logfl=`find $TESTDIR/var/log/cdb2/ | grep $logfl`
-res=$(zcat $logfl | grep 'insert into t1 values(2000)' | wc -l)
+echo "make sure string 'insert into t1 values(2000)' is in the last 2 eventlog files:"
+cmd="ls -1 $TESTDIR/var/log/cdb2/* | grep events | grep $DBNAME | head -2"
+eval $cmd
+
+res=$(ls -1r $TESTDIR/var/log/cdb2/* | grep events | grep $DBNAME | head -2 | xargs zcat | grep 'insert into t1 values(2000)' | wc -l)
 assertres $res 1
 
 exit 0

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -6,7 +6,7 @@ set -x
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2
@@ -182,18 +182,25 @@ for i in `seq 1 2000` ; do
     cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values($i)"
 done
 
-logflcnt=`ls -1Sr $TESTDIR/var/log/cdb2/ | grep events | grep $DBNAME | wc -l`
+sleep 3
 
 COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
+
+find $TESTDIR/var/log/cdb2/ | grep $DBNAME | grep '.events.' > logfls.txt
+echo logfls
+cat logfls.txt
+
+logflcnt=$(wc -l logfls.txt | cut -f1 -d' ')
 
 echo make sure we have $((NKEEP+1)) as per the lrl option
 assertres $logflcnt $((NKEEP+1))
 
 echo "make sure string 'insert into t1 values(2000)' is in the last 2 eventlog files:"
-cmd="ls -1 $TESTDIR/var/log/cdb2/* | grep events | grep $DBNAME | head -2"
-eval $cmd
+cat logfls.txt | xargs ls -1t | head -2 > lastfls.txt
+echo lastfls 
+cat lastfls.txt
 
-res=$(ls -1r $TESTDIR/var/log/cdb2/* | grep events | grep $DBNAME | head -2 | xargs zcat | grep 'insert into t1 values(2000)' | wc -l)
+res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(2000)' | grep '"type": "sql"'| wc -l)
 assertres $res 1
 
 exit 0

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -75,7 +75,7 @@ do_verify()
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/long_db_name.test/runit
+++ b/tests/long_db_name.test/runit
@@ -199,7 +199,7 @@ delete_records()
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/restart_socksql.test/runit
+++ b/tests/restart_socksql.test/runit
@@ -50,7 +50,7 @@ assert_schema()
 assertres ()
 {
     if [ $# != 2 ] ; then 
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2

--- a/tests/sql.test/runit
+++ b/tests/sql.test/runit
@@ -203,7 +203,7 @@ function assertbadexitcode
 function assertres
 {
     if [ $# != 2 ] ; then
-        failexit "res is $res, target is $target, one or more is blank"
+        failexit "number of parameters passed is $# but expecting 2"
     fi
     res=$1
     target=$2


### PR DESCRIPTION
An eventlog file may be rotated in the wrong point and last file may not contain the expected output:
Look in the last two files for expected 'insert' command.