### PR TITLE
cdb2api: Configuring DNS suffix at compile time.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,10 @@ if(NOT DEFINED COMDB2_ROOT)
 endif()
 set(COMDB2_ROOT ${COMDB2_ROOT} CACHE PATH "Directory for runtime files" FORCE)
 
+if(DEFINED CDB2_DNS_SUFFIX)
+  add_definitions(-DCDB2_DNS_SUFFIX=${CDB2_DNS_SUFFIX})
+endif()
+
 add_definitions(
   -DCOMDB2_ROOT=${COMDB2_ROOT}
   -DCOMDB2_VERSION="2"

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -63,7 +63,14 @@ static char *CDB2DBCONFIG_BUF = NULL;
 
 static char cdb2_default_cluster[64] = "";
 static char cdb2_comdb2dbname[32] = "";
-static char cdb2_dnssuffix[255] = "";
+
+#define QUOTE_(x) #x
+#define QUOTE(x) QUOTE_(x)
+
+#ifndef CDB2_DNS_SUFFIX
+#define CDB2_DNS_SUFFIX
+#endif
+static char cdb2_dnssuffix[255] = QUOTE(CDB2_DNS_SUFFIX);
 static char cdb2_machine_room[16] = "";
 
 #define CDB2_PORTMUXPORT_DEFAULT 5105
@@ -1346,8 +1353,6 @@ static int cdb2_dbinfo_query(cdb2_hndl_tp *hndl, const char *type,
                              char valid_hosts[][64], int *valid_ports,
                              int *master_node, int *num_valid_hosts,
                              int *num_valid_sameroom_hosts);
-#define QUOTE_(x) #x
-#define QUOTE(x) QUOTE_(x)
 static int get_config_file(const char *dbname, char *f, size_t s)
 {
     char *root = getenv("COMDB2_ROOT");


### PR DESCRIPTION
/silent this is no applicable to cdb2jdbc.