### PR TITLE
sqlite: sleep is not a constant function

### DIFF
--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -2398,7 +2398,7 @@ void sqlite3RegisterBuiltinFunctions(void){
     FUNCTION2(length,            1, 0, 0, lengthFunc,  SQLITE_FUNC_LENGTH),
     FUNCTION(instr,              2, 0, 0, instrFunc        ),
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    FUNCTION(sleep,              1, 0, 0, sleepFunc        ),
+    VFUNCTION(sleep,             1, 0, 0, sleepFunc        ),
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     FUNCTION(printf,            -1, 0, 0, printfFunc       ),
     FUNCTION(unicode,            1, 0, 0, unicodeFunc      ),


### PR DESCRIPTION
This will make `select sleep(1), * from generate_series limit 10` actually take 10 seconds (1s per row).