### PR TITLE
Port fix string in indexes

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1025,7 +1025,6 @@ extern struct dbenv *thedb;
 extern comdb2_tunables *gbl_tunables;
 
 extern pthread_key_t unique_tag_key;
-extern pthread_key_t sqlite3VDBEkey;
 extern pthread_key_t query_info_key;
 
 struct req_hdr {

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -2961,7 +2961,7 @@ done:
 static int fdb_cursor_move_sql(BtCursor *pCur, int how)
 {
     fdb_cursor_t *fdbc = pCur->fdbc->impl;
-    sqlclntstate_fdb_t *state = pCur->clnt?&pCur->clnt->fdb_state:NULL;
+    sqlclntstate_fdb_t *state = pCur->clnt ? &pCur->clnt->fdb_state : NULL;
     int rc = 0;
     enum run_sql_flags flags = FDB_RUN_SQL_NORMAL;
     unsigned long long start_rpc;
@@ -3078,13 +3078,14 @@ static int fdb_cursor_move_sql(BtCursor *pCur, int how)
                             state->preserve_err = 1;
                             errstat_set_rc(&state->xerr, FDB_ERR_READ_IO);
                             errstat_set_str(&state->xerr,
-                                             errstr?errstr:
-                                             "error string not set");
+                                            errstr ? errstr
+                                                   : "error string not set");
                         }
-                        logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming "
-                                             "row rc=%d \"%s\"\n",
-                               __func__, rc, errstr?errstr:
-                               "error string not set");
+                        logmsg(LOGMSG_ERROR,
+                               "%s: failed to retrieve streaming "
+                               "row rc=%d \"%s\"\n",
+                               __func__, rc,
+                               errstr ? errstr : "error string not set");
                         fdbc->streaming = FDB_CUR_ERROR;
                     }
                 }
@@ -3166,7 +3167,7 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
      */
 
     fdb_cursor_t *fdbc = pCur->fdbc->impl;
-    sqlclntstate_fdb_t *state = pCur->clnt?&pCur->clnt->fdb_state:NULL;
+    sqlclntstate_fdb_t *state = pCur->clnt ? &pCur->clnt->fdb_state : NULL;
     int rc = 0;
     char *packed_key = NULL;
     int packed_keylen = 0;
@@ -3278,13 +3279,14 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
                             state->preserve_err = 1;
                             errstat_set_rc(&state->xerr, FDB_ERR_READ_IO);
                             errstat_set_str(&state->xerr,
-                                             errstr?errstr:
-                                             "error string not set");
+                                            errstr ? errstr
+                                                   : "error string not set");
                         }
-                        logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming"
-                                             " row rc=%d \"%s\"\n",
-                               __func__, rc, errstr?errstr:
-                               "error string not set");
+                        logmsg(LOGMSG_ERROR,
+                               "%s: failed to retrieve streaming"
+                               " row rc=%d \"%s\"\n",
+                               __func__, rc,
+                               errstr ? errstr : "error string not set");
                         fdbc->streaming = FDB_CUR_ERROR;
                     }
                 }

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -553,6 +553,7 @@ static void destroy_fdb(fdb_t *fdb)
     fdb->users--;
     if (fdb->users == 0) {
         __cache_unlink_fdb(fdb);
+        Pthread_mutex_unlock(&fdb->users_mtx);
         __free_fdb(fdb);
     } else {
         Pthread_mutex_unlock(&fdb->users_mtx);
@@ -1359,7 +1360,6 @@ retry_fdb_creation:
             perrstr = "remote db requires SSL";
             break;
         }
-
         default: {
             perrstr = "error adding remote table";
         }
@@ -2961,6 +2961,7 @@ done:
 static int fdb_cursor_move_sql(BtCursor *pCur, int how)
 {
     fdb_cursor_t *fdbc = pCur->fdbc->impl;
+    sqlclntstate_fdb_t *state = pCur->clnt?&pCur->clnt->fdb_state:NULL;
     int rc = 0;
     enum run_sql_flags flags = FDB_RUN_SQL_NORMAL;
     unsigned long long start_rpc;
@@ -3073,9 +3074,17 @@ static int fdb_cursor_move_sql(BtCursor *pCur, int how)
 #endif
                 } else {
                     if (rc != FDB_ERR_SSL) {
+                        if (state) {
+                            state->preserve_err = 1;
+                            errstat_set_rc(&state->xerr, FDB_ERR_READ_IO);
+                            errstat_set_str(&state->xerr,
+                                             errstr?errstr:
+                                             "error string not set");
+                        }
                         logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming "
                                              "row rc=%d \"%s\"\n",
-                               __func__, rc, errstr);
+                               __func__, rc, errstr?errstr:
+                               "error string not set");
                         fdbc->streaming = FDB_CUR_ERROR;
                     }
                 }
@@ -3157,6 +3166,7 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
      */
 
     fdb_cursor_t *fdbc = pCur->fdbc->impl;
+    sqlclntstate_fdb_t *state = pCur->clnt?&pCur->clnt->fdb_state:NULL;
     int rc = 0;
     char *packed_key = NULL;
     int packed_keylen = 0;
@@ -3264,9 +3274,17 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
                     rc = SQLITE_SCHEMA_REMOTE;
                 } else {
                     if (rc != FDB_ERR_SSL) {
-                        logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming "
-                                             "row rc=%d \"%s\"\n",
-                               __func__, rc, errstr);
+                        if (state) {
+                            state->preserve_err = 1;
+                            errstat_set_rc(&state->xerr, FDB_ERR_READ_IO);
+                            errstat_set_str(&state->xerr,
+                                             errstr?errstr:
+                                             "error string not set");
+                        }
+                        logmsg(LOGMSG_ERROR, "%s: failed to retrieve streaming"
+                                             " row rc=%d \"%s\"\n",
+                               __func__, rc, errstr?errstr:
+                               "error string not set");
                         fdbc->streaming = FDB_CUR_ERROR;
                     }
                 }

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -434,8 +434,6 @@ static shad_tbl_t *create_shadtbl(struct BtCursor *pCur,
     int rc = 0;
     int bdberr = 0;
 
-    /*pBt->vdbe = pthread_getspecific(sqlite3VDBEkey);*/
-
     tbl = calloc(1, sizeof(shad_tbl_t));
     if (!tbl)
         return NULL;

--- a/db/sql.h
+++ b/db/sql.h
@@ -234,7 +234,6 @@ typedef struct sqlclntstate_fdb {
     int trim_keylen; /* lenght of the trim key */
     fdb_access_t *access; /* access control */
     int version;          /* version of the remote-cached object */
-    errstat_t err;        /* remote execution specific error */
     char *dbname;  /* if err is set, this indicate which fdb is responsible, if
                       any */
     char *tblname; /* if err is set, this indicate which tablename is

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7642,10 +7642,10 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             }
 
             if (short_version != clnt->fdb_state.version) {
-                clnt->fdb_state.err.errval = SQLITE_SCHEMA;
+                clnt->fdb_state.xerr.errval = SQLITE_SCHEMA;
                 /* NOTE: first word of the error string is the actual version,
                    expected on the other side; please do not change */
-                errstat_set_strf(&clnt->fdb_state.err,
+                errstat_set_strf(&clnt->fdb_state.xerr,
                                  "%llu Stale version local %u != received %u",
                                  version, short_version,
                                  clnt->fdb_state.version);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5496,19 +5496,20 @@ done:
                     "%s: sqloff_block_send_done failed to write reply\n",
                     __func__);
     } else {
-      if (ret) {
-         const char *tmp = errstat_get_str(&clnt->osql.xerr);
-         tmp = tmp?tmp:"error string not set";
-         rc = fdb_svc_sql_row(clnt->fdb_state.remote_sql_sb, cid,
-               (char*)tmp, strlen(tmp)+1, errstat_get_rc(&clnt->osql.xerr),
-               clnt->osql.rqid == OSQL_RQID_USE_UUID);
-         if (rc) {
-            logmsg(LOGMSG_ERROR, "%s failed to send back error rc=%d errstr=%s\n",
-               __func__, errstat_get_rc(&clnt->osql.xerr), tmp); 
-         }
-      }
-   }
-
+        if (ret) {
+            const char *tmp = errstat_get_str(&clnt->osql.xerr);
+            tmp = tmp ? tmp : "error string not set";
+            rc = fdb_svc_sql_row(clnt->fdb_state.remote_sql_sb, cid,
+                                 (char *)tmp, strlen(tmp) + 1,
+                                 errstat_get_rc(&clnt->osql.xerr),
+                                 clnt->osql.rqid == OSQL_RQID_USE_UUID);
+            if (rc) {
+                logmsg(LOGMSG_ERROR,
+                       "%s failed to send back error rc=%d errstr=%s\n",
+                       __func__, errstat_get_rc(&clnt->osql.xerr), tmp);
+            }
+        }
+    }
 
     sqlite_done(poolthd, clnt, &rec, ret);
 
@@ -5557,8 +5558,8 @@ int sql_check_errors(struct sqlclntstate *clnt, sqlite3 *sqldb,
 
     rc = sqlite3_reset(stmt);
 
-    if (clnt->fdb_state.preserve_err && 
-            (fdb_rc =errstat_get_rc(&clnt->fdb_state.xerr))) {
+    if (clnt->fdb_state.preserve_err &&
+        (fdb_rc = errstat_get_rc(&clnt->fdb_state.xerr))) {
         rc = fdb_rc;
         *errstr = errstat_get_str(&clnt->fdb_state.xerr);
         goto done;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4300,10 +4300,6 @@ void sqlengine_work_appsock(void *thddata, void *work)
 
     if (clnt->fdb_state.remote_sql_sb) {
         clnt->query_rc = execute_sql_query_offload(thd, clnt);
-        /* execute sql query might have generated an overriding fdb error;
-           reset it here before returning */
-        bzero(&clnt->fdb_state.xerr, sizeof(clnt->fdb_state.xerr));
-        clnt->fdb_state.preserve_err = 0;
     } else if (clnt->verify_indexes) {
         clnt->query_rc = execute_verify_indexes(thd, clnt);
     } else {

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -2750,13 +2750,14 @@ int fdb_bend_run_sql(SBUF2 *sb, fdb_msg_t *msg, svc_callback_arg_t *arg)
     }
 
     /* was there any error processing? */
-    if (clnt->fdb_state.err.errval != 0) {
+    int irc;
+    if ((irc = errstat_get_rc(&clnt->fdb_state.xerr))!= 0) {
         /* we need to send back a rc code */
+        const char *tmp = errstat_get_str(&clnt->fdb_state.xerr);
         rc = fdb_svc_sql_row(
             clnt->fdb_state.remote_sql_sb, cid,
-            clnt->fdb_state.err.errstr, /* the actual row is the errstr */
-            strlen(clnt->fdb_state.err.errstr) + 1, clnt->fdb_state.err.errval,
-            arg->isuuid);
+            (char*)tmp, /* the actual row is the errstr */
+            strlen(tmp) + 1, irc, arg->isuuid);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: fdb_send_rc failed rc=%d\n", __func__,
                    rc);

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -2751,13 +2751,12 @@ int fdb_bend_run_sql(SBUF2 *sb, fdb_msg_t *msg, svc_callback_arg_t *arg)
 
     /* was there any error processing? */
     int irc;
-    if ((irc = errstat_get_rc(&clnt->fdb_state.xerr))!= 0) {
+    if ((irc = errstat_get_rc(&clnt->fdb_state.xerr)) != 0) {
         /* we need to send back a rc code */
         const char *tmp = errstat_get_str(&clnt->fdb_state.xerr);
-        rc = fdb_svc_sql_row(
-            clnt->fdb_state.remote_sql_sb, cid,
-            (char*)tmp, /* the actual row is the errstr */
-            strlen(tmp) + 1, irc, arg->isuuid);
+        rc = fdb_svc_sql_row(clnt->fdb_state.remote_sql_sb, cid,
+                             (char *)tmp, /* the actual row is the errstr */
+                             strlen(tmp) + 1, irc, arg->isuuid);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: fdb_send_rc failed rc=%d\n", __func__,
                    rc);

--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -5235,7 +5235,7 @@ char *getIndexCond(sqlite3 *db, const char *colName, const char *op, Mem *m)
   }else if( flgs == MEM_Real ){
     value = sqlite3_mprintf("%lf", m->u.r);
   }else if( flgs & MEM_Str ){
-    value = sqlite3_mprintf("\'%.*s\'", m->n, m->z);
+    value = sqlite3_mprintf("\'%.*q\'", m->n, m->z);
   }else if( flgs & MEM_Blob ){
     char * key = alloca(2*m->n+1);
     int  i;

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -6282,9 +6282,10 @@ default_prec:
     }
     case TK_COLUMN: {
       if( atRuntime ){
-        return sqlite3_mprintf("\"%s\"",  pExpr->u.zToken);
+        assert(pExpr->y.pTab && pExpr->y.pTab->nCol > pExpr->iColumn);
+        return sqlite3_mprintf("\"%s\"",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
       }else{
-        return sqlite3_mprintf("%s",  pExpr->u.zToken);
+        return sqlite3_mprintf("%s",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
       }
     }
     case TK_AGG_FUNCTION:

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -6283,9 +6283,9 @@ default_prec:
     case TK_COLUMN: {
       if( atRuntime ){
         assert(pExpr->y.pTab && pExpr->y.pTab->nCol > pExpr->iColumn);
-        return sqlite3_mprintf("\"%s\"",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
+        return sqlite3_mprintf("\"%q\"",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
       }else{
-        return sqlite3_mprintf("%s",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
+        return sqlite3_mprintf("%q",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
       }
     }
     case TK_AGG_FUNCTION:

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -6281,11 +6281,27 @@ default_prec:
       }
     }
     case TK_COLUMN: {
+      char *name;
+      assert(pExpr->y.pTab &&
+        (pExpr->iColumn >= -3 && pExpr->y.pTab->nCol > pExpr->iColumn));
+      switch(pExpr->iColumn) {
+      case -3:
+        name = "comdb2_rowtimestamp";
+        break;
+      case -2:
+        name = "comdb2_rowid";
+        break;
+      case -1:
+        name = "rowid";
+        break;
+      default:
+        name = pExpr->y.pTab->aCol[pExpr->iColumn].zName;
+        break;
+      }
       if( atRuntime ){
-        assert(pExpr->y.pTab && pExpr->y.pTab->nCol > pExpr->iColumn);
-        return sqlite3_mprintf("\"%q\"",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
+        return sqlite3_mprintf("\"%q\"", name);
       }else{
-        return sqlite3_mprintf("%q",  pExpr->y.pTab->aCol[pExpr->iColumn].zName);
+        return sqlite3_mprintf("%q", name);
       }
     }
     case TK_AGG_FUNCTION:

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -5491,7 +5491,7 @@ static char *print_mem(Mem *m){
     case MEM_Null:
       return sqlite3_mprintf("null");
     case MEM_Str: 
-      return sqlite3_mprintf("'%.*s'", m->n, m->z);
+      return sqlite3_mprintf("'%.*q'", m->n, m->z);
     case MEM_Int:
       return  sqlite3_mprintf("%lld", m->u.i);
     case MEM_Real:

--- a/sqlite/src/wherecode.c
+++ b/sqlite/src/wherecode.c
@@ -890,7 +890,10 @@ static int codeCursorHintFixExpr(Walker *pWalker, Expr *pExpr){
       pExpr->iTable = reg;
     }else if( pHint->pIdx!=0 ){
       pExpr->iTable = pHint->iIdxCur;
-      pExpr->iColumn = sqlite3ColumnOfIndex(pHint->pIdx, pExpr->iColumn);
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+      /* NOTE: this breaks remote sql; discussion in progress to push this upstream */
+      /*pExpr->iColumn = sqlite3ColumnOfIndex(pHint->pIdx, pExpr->iColumn);*/
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
       assert( pExpr->iColumn>=0 );
     }
   }else if( pExpr->op==TK_AGG_FUNCTION ){
@@ -1438,6 +1441,7 @@ Bitmask sqlite3WhereCodeOneLoopStart(
       pStart = pEnd;
       pEnd = pTerm;
     }
+
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
     codeCursorHint(pTabItem, pWInfo, pLevel, pEnd, iLevel);
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
@@ -1676,9 +1680,7 @@ Bitmask sqlite3WhereCodeOneLoopStart(
     ** and store the values of those terms in an array of registers
     ** starting at regBase.
     */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-    codeCursorHint(pTabItem, pWInfo, pLevel, pRangeEnd, iLevel);
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+#if !defined(SQLITE_BUILDING_FOR_COMDB2)
     codeCursorHint(pTabItem, pWInfo, pLevel, pRangeEnd);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     regBase = codeAllEqualityTerms(pParse,pLevel,bRev,nExtraReg,&zStartAff);

--- a/tests/sc_addcolumn_remsql.test/Makefile
+++ b/tests/sc_addcolumn_remsql.test/Makefile
@@ -1,3 +1,5 @@
+export SECONDARY_DB_PREFIX=srcdb
+
 ifeq ($(TESTSROOTDIR),)
   include ../testcase.mk
 else

--- a/tests/sc_addcolumn_remsql.test/lrl.options
+++ b/tests/sc_addcolumn_remsql.test/lrl.options
@@ -1,2 +1,5 @@
 round_robin_stripes
 ssl_allow_remsql 1
+fdbdebg 1
+nowatch
+notimeout

--- a/tests/sc_addcolumn_remsql.test/runit
+++ b/tests/sc_addcolumn_remsql.test/runit
@@ -3,13 +3,10 @@
 # Remote cursor moves testcase for comdb2
 ################################################################################
 
-dbnm=$1
-cdb2sql ${CDB2_OPTIONS} $dbnm default "select comdb2_dbname(), comdb2_host()"
-
 # args
 # <dbname> <dbdir> <testdir> <autodbname> <autodbnum> <cluster> <task>
 echo "main db vars"
-vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG"
+vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG SECONDARY_DBNAME SECONDARY_DBDIR SECONDARY_CDB2_OPTIONS"
 for required in $vars; do
     q=${!required}
     echo "$required=$q" 
@@ -18,50 +15,13 @@ for required in $vars; do
         exit 1
     fi
 done
-
-dbname=$1
-srcdbname=srcdb$DBNAME
-dbdir=$DBDIR
-testdir=$TESTDIR
-cdb2config=$CDB2_CONFIG
-
-DBNAME=$srcdbname
-DBDIR=$TESTDIR/$DBNAME
-#effectively srcdb config -- needed to setup srcdb
-CDB2_CONFIG=$DBDIR/comdb2db.cfg
-CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
-
-echo "remote db vars"
-vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG"
-for required in $vars; do
-    q=${!required}
-    echo "$required=$q" 
-    if [[ -z "$q" ]]; then
-        echo "$required not set" >&2
-        exit 1
-    fi
-done
-
-
-#setup remode db
-$TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "select comdb2_dbname(), comdb2_host()"
-
 
 #run tests
 echo "Starting tests"
 
-echo ./test_sc.sh $dbname $cdb2config $srcdbname $dbdir $testdir
-./test_sc.sh $dbname $cdb2config $srcdbname $dbdir $testdir
+echo ./test_sc.sh $DBNAME $CDB2_CONFIG $SECONDARY_DBNAME $DBDIR $TESTDIR
+./test_sc.sh $DBNAME $CDB2_CONFIG $SECONDARY_DBNAME $DBDIR $TESTDIR
 result=$?
-
-if (( $result == 0 )) ; then
-   successful=1
-fi
-
-$TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
-
-
 
 if (( $result != 0 )) ; then
    echo "FAILURE"

--- a/tests/sc_addcolumn_remsql.test/test_sc.sh
+++ b/tests/sc_addcolumn_remsql.test/test_sc.sh
@@ -79,7 +79,12 @@ if (( $# > 5 )); then
 fi
 
 # Make sure we talk to the same host
-mach=`cdb2sql --tabs ${CDB2_OPTIONS} $a_dbname default "SELECT comdb2_host()"`
+echo cdb2sql --tabs --cdb2cfg ${a_remcdb2config} ${a_remdbname} default "SELECT comdb2_host()"
+mach=`cdb2sql --tabs --cdb2cfg ${a_remcdb2config} ${a_remdbname} default "SELECT comdb2_host()"`
+if (( $? != 0 )); then
+    echo "Failed to get a machine"
+    exit 1
+fi
 
 test=1
 if (( $test >= $test1 && $test<= $test2 )) ; then

--- a/tests/testcase.mk
+++ b/tests/testcase.mk
@@ -9,7 +9,7 @@ ifeq ($(TESTSROOTDIR),)
   # (will check assumption few lines later)
   # needs to expand to a full path, otherwise it propagates as '../'
   export TESTSROOTDIR=$(shell readlink -f $(PWD)/..)
-#  export SKIPSSL=1   #force SKIPSSL for local test -- easier to debug
+  export SKIPSSL=1   #force SKIPSSL for local test -- easier to debug
   export INSETUP=yes
 else
   export INSETUP=


### PR DESCRIPTION
Fixes:
Changes in upstream sqlite Expr for TK_COLUMN broke remote sql in R7.
Errors parsing to auto-generated strings are now passed back to local server and to the client.
Quoting in predicates containing string values are now properly handled.

