### PR TITLE
Tests: add transaction size parameter to insert lots test

### DIFF
--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -455,9 +455,25 @@ test_t1() {
 	$CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $dbnm default "select * from t1" &> select_all.out
 }
 
+
+test_bulk() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t6 (i int unique, j int, k int)"
+    CNT=5000
+    echo -n "insert into t6 values(1,1,1)" > gg.in
+    for i in `seq 2 $CNT` ; do echo -n ",($i, $i, $i)" ; done >> gg.in
+
+    for j in `seq 1 2` ; do
+        cdb2sql -s ${CDB2_OPTIONS} $dbnm default -f gg.in
+        assertcnt t6 $CNT
+        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from t6 where 1"
+    done
+}
+
 test_t1
+test_bulk
 
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("sql hist")'
+
 
 res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
 assertres $res 1

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -85,11 +85,12 @@ assertres ()
 }
 
 echo $CDB2_CONFIG
-THRDS=20
-CNT=100
-ITERATIONS=500
+THRDS=2
+CNT=10000
+ITERATIONS=1
+TRANSIZE=2800
 
-${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS> ins.out
+${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins.out
 
 assertcnt $((THRDS * CNT * ITERATIONS))
 

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -88,10 +88,15 @@ echo $CDB2_CONFIG
 THRDS=2
 CNT=10000
 ITERATIONS=1
+TRANSIZE=0
+
+${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins1.out
+assertcnt $((THRDS * CNT * ITERATIONS))
+
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "truncate t1"
+
 TRANSIZE=2800
-
-${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins.out
-
+${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins2.out
 assertcnt $((THRDS * CNT * ITERATIONS))
 
 echo "Success"

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -85,18 +85,18 @@ assertres ()
 }
 
 echo $CDB2_CONFIG
-THRDS=2
+THRDS=20
 CNT=10000
-ITERATIONS=1
+ITERATIONS=10
 TRANSIZE=0
 
-${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins1.out
+time ${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins1.out
 assertcnt $((THRDS * CNT * ITERATIONS))
 
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "truncate t1"
 
 TRANSIZE=2800
-${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins2.out
+time ${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins2.out
 assertcnt $((THRDS * CNT * ITERATIONS))
 
 echo "Success"

--- a/tests/tools/insert_lots_mt.cpp
+++ b/tests/tools/insert_lots_mt.cpp
@@ -129,7 +129,7 @@ void *thr(void *arg)
         //runtag(db, s, types);
         cdb2_clearbindings(db);
         if((++count & 0xff) == 0) std::cout << "Thr " << i << " Items " << count << std::endl;
-        if (count >= transize) {
+        if (transize > 0 && (count % transize) == 0) {
             runsql(db, commit);
             runsql(db, begin);
         }


### PR DESCRIPTION
Tests: add transaction size parameter to insertlots test:
* Change task to take transaction size argument
* Add a bulk insert to basic test
* Call insert_lots_mt twice, once with tran 0 the other time with large transaction size--I see some deadlocks in the later case, will be useful in seeing if reordering indices should help with lowering the number of deadlocks.