### PR TITLE
datetime: Fix drifting timezone

### DIFF
--- a/datetime/localtimedb.c
+++ b/datetime/localtimedb.c
@@ -2222,6 +2222,8 @@ static void add_tz(const char *name, struct db_state *ptr)
 static int db_tzset(name) register const char *name;
 {
     int rc;
+    struct db_state *curr_state;
+
     if (lcl_is_set > 0 && strcmp(lcl_TZname, name) == 0) return 0;
 
     if (*name == '\0') {
@@ -2242,13 +2244,18 @@ static int db_tzset(name) register const char *name;
         /* hit hash table by name, get db_lclptr from there if found,
            else add it to hash table */
 
+        curr_state = db_lclptr;
         db_lclptr = find_tz(name);
         if (db_lclptr == NULL) {
             db_lclptr = &db_lclmem;
 
             /*fprintf(stderr, "calling db_tzload for %s\n", name);*/
             rc = db_tzload(name, db_lclptr, TRUE);
-            if (rc != 0) return -1;
+            if (rc != 0) {
+                /* Back out if tzload fails. */
+                db_lclptr = curr_state;
+                return -1;
+            }
 
             add_tz(name, db_lclptr);
         }

--- a/datetime/localtimedb.c
+++ b/datetime/localtimedb.c
@@ -2222,7 +2222,7 @@ static void add_tz(const char *name, struct db_state *ptr)
 static int db_tzset(name) register const char *name;
 {
     int rc;
-    struct db_state *curr_state;
+    struct db_state *state;
 
     if (lcl_is_set > 0 && strcmp(lcl_TZname, name) == 0) return 0;
 
@@ -2244,20 +2244,16 @@ static int db_tzset(name) register const char *name;
         /* hit hash table by name, get db_lclptr from there if found,
            else add it to hash table */
 
-        curr_state = db_lclptr;
-        db_lclptr = find_tz(name);
-        if (db_lclptr == NULL) {
-            db_lclptr = &db_lclmem;
-
-            /*fprintf(stderr, "calling db_tzload for %s\n", name);*/
-            rc = db_tzload(name, db_lclptr, TRUE);
-            if (rc != 0) {
-                /* Back out if tzload fails. */
-                db_lclptr = curr_state;
+        state = find_tz(name);
+        if (state != NULL)
+            db_lclptr = state;
+        else {
+            rc = db_tzload(name, &db_lclmem, TRUE);
+            if (rc != 0)
                 return -1;
-            }
 
-            add_tz(name, db_lclptr);
+            add_tz(name, &db_lclmem);
+            db_lclptr = &db_lclmem;
         }
     }
 

--- a/datetime/localtimedb.c
+++ b/datetime/localtimedb.c
@@ -2222,7 +2222,8 @@ static void add_tz(const char *name, struct db_state *ptr)
 static int db_tzset(name) register const char *name;
 {
     int rc;
-    struct db_state *state;
+    struct db_state *sp;
+    struct db_state state;
 
     if (lcl_is_set > 0 && strcmp(lcl_TZname, name) == 0) return 0;
 
@@ -2244,14 +2245,15 @@ static int db_tzset(name) register const char *name;
         /* hit hash table by name, get db_lclptr from there if found,
            else add it to hash table */
 
-        state = find_tz(name);
-        if (state != NULL)
-            db_lclptr = state;
+        sp = find_tz(name);
+        if (sp != NULL)
+            db_lclptr = sp;
         else {
-            rc = db_tzload(name, &db_lclmem, TRUE);
+            rc = db_tzload(name, &state, TRUE);
             if (rc != 0)
                 return -1;
 
+            memcpy(&db_lclmem, &state, sizeof(struct db_state));
             add_tz(name, &db_lclmem);
             db_lclptr = &db_lclmem;
         }

--- a/tests/datetime.test/t5_01.req
+++ b/tests/datetime.test/t5_01.req
@@ -5,5 +5,6 @@ select cast(0 as datetime)
 set timezone EST
 select cast(0 as datetime)
 select cast("1970-01-01T000000.000 MARS" as datetime)
+select cast(0 as datetime)
 set timezone EST
 select cast(0 as datetime)

--- a/tests/datetime.test/t5_01.req
+++ b/tests/datetime.test/t5_01.req
@@ -1,0 +1,9 @@
+set timezone EST
+select cast(0 as datetime)
+set timezone UTC
+select cast(0 as datetime)
+set timezone EST
+select cast(0 as datetime)
+select cast("1970-01-01T000000.000 MARS" as datetime)
+set timezone EST
+select cast(0 as datetime)

--- a/tests/datetime.test/t5_01.req.expected
+++ b/tests/datetime.test/t5_01.req.expected
@@ -3,3 +3,4 @@
 (cast(0 as datetime)="1969-12-31T190000.000 EST")
 [select cast("1970-01-01T000000.000 MARS" as datetime)] failed with rc 113 cast to datetime failed
 (cast(0 as datetime)="1969-12-31T190000.000 EST")
+(cast(0 as datetime)="1969-12-31T190000.000 EST")

--- a/tests/datetime.test/t5_01.req.expected
+++ b/tests/datetime.test/t5_01.req.expected
@@ -1,0 +1,5 @@
+(cast(0 as datetime)="1969-12-31T190000.000 EST")
+(cast(0 as datetime)="1970-01-01T000000.000 UTC")
+(cast(0 as datetime)="1969-12-31T190000.000 EST")
+[select cast("1970-01-01T000000.000 MARS" as datetime)] failed with rc 113 cast to datetime failed
+(cast(0 as datetime)="1969-12-31T190000.000 EST")


### PR DESCRIPTION
After failing to load a timezone, we don't back out the timezone pointer to the previous value,
but leave it point to the most recently loaded timezone. The following queries reproduce the bug:

```SQL
set timezone EST
select cast(0 as datetime)
-- EST is loaded
set timezone UTC
select cast(0 as datetime)
-- UTC is loaded
set timezone EST
select cast(0 as datetime)
-- timezone changed to EST
select cast("1970-01-01T000000.000 MARS" as datetime)
-- MARS is an invalid timezone. We don't change timezone back to EST
-- but leave it point to the most recently loaded timezone, which is UTC
set timezone EST
select now()
-- We end up being 5 hours ahead of EST.
--
```

The fix is to simply back out the timezone pointer to the previous value if it fails to load a timezone.

(DRQS 138630743)
