### PR TITLE
Always allow subsequent queries from open transactions to be queued.

### DIFF
--- a/bbinc/thdpool.h
+++ b/bbinc/thdpool.h
@@ -94,7 +94,11 @@ int thdpool_get_queue_depth(struct thdpool *pool);
 
 void thdpool_print_stats(FILE *fh, struct thdpool *pool);
 
-enum { THDPOOL_ENQUEUE_FRONT = 0x1, THDPOOL_FORCE_DISPATCH = 0x2 };
+enum {
+    THDPOOL_ENQUEUE_FRONT = 0x1,
+    THDPOOL_FORCE_DISPATCH = 0x2,
+    THDPOOL_FORCE_QUEUE = 0x4
+};
 int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
                     int queue_override, char *persistent_info, uint32_t flags);
 void thdpool_stop(struct thdpool *pool);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4433,7 +4433,7 @@ int dispatch_sql_query(struct sqlclntstate *clnt)
             /* force this request to queue */
             rc = thdpool_enqueue(gbl_sqlengine_thdpool,
                                  sqlengine_work_appsock_pp, clnt, 1, sqlcpy,
-                                 flags);
+                                 flags | THDPOOL_FORCE_QUEUE);
         }
 
         if (rc) {

--- a/tests/txn_queuing.test/Makefile
+++ b/tests/txn_queuing.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/txn_queuing.test/lrl.options
+++ b/tests/txn_queuing.test/lrl.options
@@ -1,0 +1,2 @@
+sqlenginepool maxt 1
+sqlenginepool maxqover 1

--- a/tests/txn_queuing.test/runit
+++ b/tests/txn_queuing.test/runit
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Make sure that all queries go to the same node.
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+
+{ echo 'begin'; sleep 2; echo 'rollback'; } | cdb2sql -s --host $mach ${CDB2_OPTIONS} $dbnm - &
+pid=$!
+
+sleep 1
+cdb2sql -s --host $mach $dbnm 'select sleep(5)' >/dev/null &
+cdb2sql -s --host $mach $dbnm 'select sleep(5)' >/dev/null &
+
+wait $pid

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -776,6 +776,11 @@ int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
     static time_t last_dump = 0;
     int enqueue_front = (flags & THDPOOL_ENQUEUE_FRONT);
     int force_dispatch = (flags & THDPOOL_FORCE_DISPATCH);
+
+    /* If queue_override is true, try to enqueue unless hitting maxqoverride;
+       If force_queue is true, enqueue regardless. */
+    int force_queue = (flags & THDPOOL_FORCE_QUEUE);
+
     time_t crt_dump;
 
     LOCK(&pool->mutex)
@@ -886,10 +891,11 @@ int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
             pool->num_passed++;
         } else {
             if (listc_size(&pool->queue) >= pool->maxqueue) {
-                if (queue_override &&
-                    (enqueue_front || !pool->maxqueueoverride ||
-                     listc_size(&pool->queue) <
-                         (pool->maxqueue + pool->maxqueueoverride))) {
+                if (force_queue ||
+                    (queue_override &&
+                     (enqueue_front || !pool->maxqueueoverride ||
+                      listc_size(&pool->queue) <
+                          (pool->maxqueue + pool->maxqueueoverride)))) {
                     if (thdpool_alarm_on_queing(listc_size(&pool->queue))) {
                         int now = comdb2_time_epoch();
 


### PR DESCRIPTION
If a transaction has begun on a replicant, always allow subsequent queries from the transaction to be queued on the replicant.

(DRQS 138604354)