### PR TITLE
Fix osql_shadtbl_usedb_only()

### DIFF
--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -3320,9 +3320,7 @@ int osql_shadtbl_usedb_only(struct sqlclntstate *clnt)
     unsigned long long genid = 0;
     char *data = NULL;
     int datalen = 0;
-    if (LIST_EMPTY(&clnt->osql.shadtbls) && !clnt->osql.verify_tbl &&
-        !clnt->osql.sc_tbl && !clnt->osql.bpfunc_tbl)
-        return 1;
+
     LISTC_FOR_EACH(&osql->shadtbls, tbl, linkv)
     {
         cur =
@@ -3337,5 +3335,6 @@ int osql_shadtbl_usedb_only(struct sqlclntstate *clnt)
         if (rc != IX_EMPTY)
             return 0;
     }
-    return 1;
+
+    return (!osql->verify_tbl && !osql->sc_tbl && !osql->bpfunc_tbl);
 }

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -309,7 +309,7 @@ static int rese_commit(struct sqlclntstate *clnt, struct sql_thread *thd,
 
     usedb_only = osql_shadtbl_usedb_only(clnt);
 
-    if (usedb_only && !clnt->selectv_arr && gbl_selectv_rangechk) {
+    if (usedb_only && (!gbl_selectv_rangechk || !clnt->selectv_arr)) {
         sql_debug_logf(clnt, __func__, __LINE__, "empty-sv_arr, returning\n");
         return 0;
     }


### PR DESCRIPTION
The bug causes SELECTV-only transactions to behave incorrectly under DISABLE_SELECTVONLY_TRAN_NOP.
Also port Lingzhi's snapshot-read fix.