### PR TITLE
Fix parallel sql leak

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -321,8 +321,7 @@ static dohsql_node_t *gen_oneselect(Vdbe *v, Select *p, Expr *extraRows,
 
     if (!node->sql) {
         if (node->params) {
-            if (node->params->params)
-                free(node->params->params);
+            free(node->params->params);
             free(node->params);
         }
         free(node);
@@ -344,8 +343,7 @@ static void node_free(dohsql_node_t **pnode, sqlite3 *db)
 
     /* params */
     if ((*pnode)->params) {
-        if ((*pnode)->params->params)
-            free((*pnode)->params->params);
+        free((*pnode)->params->params);
         free((*pnode)->params);
     }
 

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -320,6 +320,11 @@ static dohsql_node_t *gen_oneselect(Vdbe *v, Select *p, Expr *extraRows,
     node->ncols = p->pEList->nExpr;
 
     if (!node->sql) {
+        if (node->params) {
+            if(node->params->params)
+                free(node->params->params);
+            free(node->params);
+        }
         free(node);
         node = NULL;
     }
@@ -337,6 +342,13 @@ static void node_free(dohsql_node_t **pnode, sqlite3 *db)
         node_free(&node->nodes[i], db);
     }
 
+    /* params */
+    if ((*pnode)->params) {
+        if ((*pnode)->params->params)
+            free((*pnode)->params->params);
+        free((*pnode)->params);
+    }
+    
     /* current node */
     if ((*pnode)->sql) {
         sqlite3_free((*pnode)->sql);

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -321,7 +321,7 @@ static dohsql_node_t *gen_oneselect(Vdbe *v, Select *p, Expr *extraRows,
 
     if (!node->sql) {
         if (node->params) {
-            if(node->params->params)
+            if (node->params->params)
                 free(node->params->params);
             free(node->params);
         }
@@ -348,7 +348,7 @@ static void node_free(dohsql_node_t **pnode, sqlite3 *db)
             free((*pnode)->params->params);
         free((*pnode)->params);
     }
-    
+
     /* current node */
     if ((*pnode)->sql) {
         sqlite3_free((*pnode)->sql);

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1087,8 +1087,7 @@ static void _shard_disconnect(dohsql_connector_t *conn)
     if (conn->cols)
         free(conn->cols);
 
-    if (conn->params)
-        free(conn->params);
+    free(conn->params);
     free(clnt->sql);
     clnt->sql = NULL;
     cleanup_clnt(clnt);
@@ -1881,8 +1880,7 @@ struct params_info *dohsql_params_append(struct params_info **pparams,
     newparam = clnt_find_param(params->clnt, name + 1, index);
     if (!newparam) {
         /* clnt parameters are incorrect, fallback to single thread to err */
-        if (params->params)
-            free(params->params);
+        free(params->params);
         free(params);
         *pparams = NULL;
         return NULL;

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1087,6 +1087,8 @@ static void _shard_disconnect(dohsql_connector_t *conn)
     if (conn->cols)
         free(conn->cols);
 
+    if (conn->params)
+        free(conn->params);
     free(clnt->sql);
     clnt->sql = NULL;
     cleanup_clnt(clnt);
@@ -1879,8 +1881,10 @@ struct params_info *dohsql_params_append(struct params_info **pparams,
     newparam = clnt_find_param(params->clnt, name + 1, index);
     if (!newparam) {
         /* clnt parameters are incorrect, fallback to single thread to err */
-        free(params->params);
+        if (params->params)
+            free(params->params);
         free(params);
+        *pparams = NULL;
         return NULL;
     }
     /* found, add it to the node->params array */
@@ -1894,5 +1898,6 @@ struct params_info *dohsql_params_append(struct params_info **pparams,
     }
     params->params = temparr;
     params->params[params->nparams++] = *newparam;
+    free(newparam);
     return *pparams = params;
 }

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -5746,7 +5746,6 @@ char * binary_op(int op){
 extern const char* comdb2_get_sql(void);
 #include "comdb2.h"
 #include "dohsql.h"
-//extern struct params_info* dohsql_params_append(struct params_info**, const char*, int);
 
 static char* sqlite3ExprDescribe_inner(
   Vdbe *v,


### PR DESCRIPTION
bound parameter are repackaged for each parallel thread, and that was leaked in a few scenarios.
