### PR TITLE
Fix memory leaks in the thdpool callbacks.

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4417,7 +4417,6 @@ static void pg_compact_do_work(struct thdpool *pool, void *work, void *thddata)
 
     __dbenv_pgcompact(dbenv, fileid, &dbt, gbl_pg_compact_thresh,
                       gbl_pg_compact_target_ff);
-    free(arg);
 }
 
 /* thread pool work function */
@@ -4821,11 +4820,8 @@ static void udppfault_do_work(struct thdpool *pool, void *work, void *thddata)
     pgno = req->pgno;
 
     if ((ret = __dbreg_id_to_db_prefault(bdb_state->dbenv, NULL, &file_dbp,
-                                         fileid, 1)) != 0) {
-        // fprintf(stderr, "udp prefault: __dbreg_id_to_db failed with ret:
-        // %d\n", ret);
-        goto out;
-    }
+                                         fileid, 1)) != 0)
+        return;
 
     mpf = file_dbp->mpf;
 
@@ -4834,10 +4830,6 @@ static void udppfault_do_work(struct thdpool *pool, void *work, void *thddata)
         sleep(gbl_prefault_latency);
 
     __dbreg_prefault_complete(bdb_state->dbenv, fileid);
-
-out:
-    free(req);
-    return;
 }
 
 void touch_page(DB_MPOOLFILE *mpf, db_pgno_t pgno)

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4428,10 +4428,8 @@ static void pg_compact_do_work_pp(struct thdpool *pool, void *work,
     case THD_RUN:
         pg_compact_do_work(pool, work, thddata);
         break;
-    case THD_FREE:
-        free(work);
-        break;
     }
+    free(work);
 }
 
 /* enqueue a page compact work */
@@ -4872,10 +4870,8 @@ static void touch_page_pp(struct thdpool *pool, void *work, void *thddata,
     case THD_RUN:
         touch_page(mpf, pgno);
         break;
-    case THD_FREE:
-        free(work);
-        break;
     }
+    free(work);
 }
 
 int enqueue_touch_page(DB_MPOOLFILE *mpf, db_pgno_t pgno)
@@ -4898,10 +4894,8 @@ static void udppfault_do_work_pp(struct thdpool *pool, void *work,
     case THD_RUN:
         udppfault_do_work(pool, work, thddata);
         break;
-    case THD_FREE:
-        free(req);
-        break;
     }
+    free(req);
 }
 
 int enque_udppfault_filepage(bdb_state_type *bdb_state, unsigned int fileid,

--- a/berkdb/btree/bt_pf.c
+++ b/berkdb/btree/bt_pf.c
@@ -447,10 +447,8 @@ start_loading_async_pp(struct thdpool *pool, void *work, void *thddata, int op)
 	case THD_RUN:
 		start_loading_async_cb(job);
 		break;
-	case THD_FREE:
-		btpf_free_job(&job);
-		break;
 	}
+    btpf_free_job(&job);
 
 }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -9009,9 +9009,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
 done:
     bdb_thread_event(thedb->bdb_env, 0);
     send_prefault_udp = 0;
-    if (req->record)
-        free(req->record);
-    free(req);
 }
 
 static void osqlpfault_do_work_pp(struct thdpool *pool, void *work,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -9022,12 +9022,9 @@ static void osqlpfault_do_work_pp(struct thdpool *pool, void *work,
     case THD_RUN:
         osqlpfault_do_work(pool, work, thddata);
         break;
-    case THD_FREE:
-        if (req->record)
-            free(req->record);
-        free(req);
-        break;
     }
+    free(req->record);
+    free(req);
 }
 
 int osql_page_prefault(char *rpl, int rplen, struct dbtable **last_db,


### PR DESCRIPTION
THD_FREE is called only when a thread pool is configured a max queue age and a work item times out.
This means that an malloc'd work item must be freed in a thdpool callback regardless of the callback type.