### PR TITLE
Remote db class overrides

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -91,6 +91,7 @@ set(src
   shard_range.c
   dohsql.c
   dohast.c
+  machclass.c
   ${PROJECT_BINARY_DIR}/protobuf/bpfunc.pb-c.c
   ${PROJECT_SOURCE_DIR}/tools/cdb2_dump/cdb2_dump.c
   ${PROJECT_SOURCE_DIR}/tools/cdb2_printlog/cdb2_printlog.c

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3247,6 +3247,11 @@ static int init(int argc, char **argv)
 
     toblock_init();
 
+    if(mach_class_init()) {
+        logmsg(LOGMSG_FATAL, "Failed to initialize machine classes\n");
+        exit(1);
+    }
+
     handle_cmdline_options(argc, argv, &lrlname);
 
     if (gbl_create_mode) {        /*  10  */

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3247,7 +3247,7 @@ static int init(int argc, char **argv)
 
     toblock_init();
 
-    if(mach_class_init()) {
+    if (mach_class_init()) {
         logmsg(LOGMSG_FATAL, "Failed to initialize machine classes\n");
         exit(1);
     }

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1591,6 +1591,7 @@ extern int gbl_maxthreads;   /* max number of threads allowed */
 extern int gbl_maxqueue;     /* max number of requests to be queued up */
 extern int gbl_thd_linger;   /* number of seconds for threads to linger */
 extern char *gbl_mynode;     /* my hostname */
+extern char *gbl_machine_class; /* my machine class */
 struct in_addr gbl_myaddr;   /* my IPV4 address */
 extern char *gbl_myhostname; /* my hostname */
 extern int gbl_mynodeid;     /* node number, for backwards compatibility */
@@ -1815,6 +1816,7 @@ int schema_init(void);
 int osqlpfthdpool_init(void);
 int init_opcode_handlers();
 void toblock_init(void);
+int mach_class_init(void);
 
 /* deinit routines */
 int destroy_appsock(void);
@@ -2537,7 +2539,6 @@ void hash_set_cmpfunc(hash_t *h, cmpfunc_t cmpfunc);
 enum mach_class get_my_mach_class(void);
 enum mach_class get_mach_class(const char *host);
 const char *get_mach_class_str(char *host);
-const char *get_class_str(enum mach_class cls);
 int allow_write_from_remote(const char *host);
 int allow_cluster_from_remote(const char *host);
 int allow_broadcast_to_remote(const char *host);

--- a/db/config.c
+++ b/db/config.c
@@ -379,7 +379,8 @@ static int lrl_if(char **tok_inout, char *line, int line_len, int *st,
         char *label = strndup(tok, *ltok);
         int value = mach_class_name2class(label);
 
-        if (my_class == value) return 0;
+        if (my_class == value)
+            return 0;
 
         tok = segtok(line, line_len, st, ltok);
         *tok_inout = tok;

--- a/db/config.c
+++ b/db/config.c
@@ -376,14 +376,10 @@ static int lrl_if(char **tok_inout, char *line, int line_len, int *st,
     if (tokcmp(tok, *ltok, "if") == 0) {
         enum mach_class my_class = get_my_mach_class();
         tok = segtok(line, line_len, st, ltok);
-        if (my_class == CLASS_TEST && tokcmp(tok, *ltok, "test") &&
-            tokcmp(tok, *ltok, "dev"))
-            return 0;
-        if (my_class == CLASS_ALPHA && tokcmp(tok, *ltok, "alpha")) return 0;
-        if (my_class == CLASS_UAT && tokcmp(tok, *ltok, "uat")) return 0;
-        if (my_class == CLASS_BETA && tokcmp(tok, *ltok, "beta")) return 0;
-        if (my_class == CLASS_PROD && tokcmp(tok, *ltok, "prod")) return 0;
-        if (my_class == CLASS_UNKNOWN) return 0;
+        char *label = strndup(tok, *ltok);
+        int value = mach_class_name2class(label);
+
+        if (my_class == value) return 0;
 
         tok = segtok(line, line_len, st, ltok);
         *tok_inout = tok;
@@ -757,6 +753,16 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
                 }
             }
             dbenv->sibling_hostname[0] = gbl_mynode;
+        }
+    } else if (tokcmp(tok, ltok, "machine_classes") == 0) {
+        int classval = 1;
+        tok = segtok(line, len, &st, &ltok);
+        while (ltok) {
+            int lrc = mach_class_addclass(tok, classval);
+            if (lrc)
+                return -1;
+            tok = segtok(line, len, &st, &ltok);
+            classval++;
         }
     } else if (tokcmp(tok, ltok, "pagesize") == 0) {
         tok = segtok(line, len, &st, &ltok);

--- a/db/config.c
+++ b/db/config.c
@@ -379,7 +379,7 @@ static int lrl_if(char **tok_inout, char *line, int line_len, int *st,
         char *label = strndup(tok, *ltok);
         int value = mach_class_name2class(label);
 
-        if (my_class == value)
+        if (my_class == CLASS_UNKNOWN || my_class != value)
             return 0;
 
         tok = segtok(line, line_len, st, ltok);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -234,6 +234,7 @@ extern char *gbl_spfile_name;
 extern char *gbl_timepart_file_name;
 extern char *gbl_exec_sql_on_new_connect;
 extern char *gbl_portmux_unix_socket;
+extern char *gbl_machine_class;
 
 /* util/ctrace.c */
 extern int nlogs;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1664,4 +1664,11 @@ REGISTER_TUNABLE(
     "Number of iterations of PBKDF2 algorithm for password hashing.",
     TUNABLE_INTEGER, &gbl_pbkdf2_iterations, NOZERO | SIGNED, NULL, NULL,
     pbkdf2_iterations_update, NULL);
+
+REGISTER_TUNABLE(
+    "machine_class",
+    "override for the machine class from this db perspective.",
+    TUNABLE_STRING, &gbl_machine_class, READEARLY | READONLY, 
+    NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1665,10 +1665,9 @@ REGISTER_TUNABLE(
     TUNABLE_INTEGER, &gbl_pbkdf2_iterations, NOZERO | SIGNED, NULL, NULL,
     pbkdf2_iterations_update, NULL);
 
-REGISTER_TUNABLE(
-    "machine_class",
-    "override for the machine class from this db perspective.",
-    TUNABLE_STRING, &gbl_machine_class, READEARLY | READONLY, 
-    NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("machine_class",
+                 "override for the machine class from this db perspective.",
+                 TUNABLE_STRING, &gbl_machine_class, READEARLY | READONLY, NULL,
+                 NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/fdb_boots.c
+++ b/db/fdb_boots.c
@@ -77,8 +77,8 @@ static int _fdb_refresh_location(const char *dbname, fdb_location_t *loc)
 
     assert(loc);
 
-    lvl = get_class_str(loc->class);
-    if (strncasecmp(lvl, "???", 3) == 0) {
+    lvl = mach_class_class2name(loc->class);
+    if (strncasecmp(lvl, "unknown", 7) == 0) {
         return FDB_ERR_CLASS_UNKNOWN;
     }
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1095,7 +1095,7 @@ static enum mach_class get_fdb_class(const char **p_dbname, int *local)
     if ((tmpname = strchr(dbname, '_')) != NULL) {
         class = strndup(dbname, tmpname - dbname);
         dbname = tmpname + 1;
-        if (strncasecmp(dbname, "LOCAL_", 6) == 0) {
+        if (strncasecmp(class, "LOCAL", 6) == 0) {
             *local = 1;
             remote_lvl = my_lvl;
             /* accessed allowed implicitely */

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1084,33 +1084,23 @@ static enum mach_class get_fdb_class(const char **p_dbname, int *local)
     const char *dbname = *p_dbname;
     enum mach_class my_lvl = CLASS_UNKNOWN;
     enum mach_class remote_lvl = CLASS_UNKNOWN;
+    const char *tmpname;
+    const char *class;
 
     *local = 0;
 
     my_lvl = get_my_mach_class();
 
     /* extract class if any */
-    if (strchr(dbname, '_') != NULL) {
+    if ((tmpname = strchr(dbname, '_')) != NULL) {
+        class = strndup(dbname, tmpname-dbname);
+        dbname = tmpname+1;
         if (strncasecmp(dbname, "LOCAL_", 6) == 0) {
             *local = 1;
             remote_lvl = my_lvl;
-            ; /* accessed allowed implicitely */
-            dbname += 6;
-        } else if (strncasecmp(dbname, "PROD_", 5) == 0) {
-            remote_lvl = CLASS_PROD;
-            dbname += 5;
-        } else if (strncasecmp(dbname, "BETA_", 5) == 0) {
-            remote_lvl = CLASS_BETA;
-            dbname += 5;
-        } else if (strncasecmp(dbname, "ALPHA_", 6) == 0) {
-            remote_lvl = CLASS_ALPHA;
-            dbname += 6;
-        } else if (strncasecmp(dbname, "TEST_", 5) == 0) {
-            remote_lvl = CLASS_TEST;
-            dbname += 5;
-        } else if (strncasecmp(dbname, "UAT_", 4) == 0) {
-            remote_lvl = CLASS_UAT;
-            dbname += 4;
+            /* accessed allowed implicitely */
+        } else {
+            remote_lvl = mach_class_name2class(class);
         }
 
         *p_dbname = dbname;
@@ -4889,21 +4879,6 @@ void fdb_cursor_use_table(fdb_cursor_t *cur, struct fdb *fdb,
     cur->ent = get_fdb_tbl_ent_by_name_from_fdb(fdb, tblname);
 }
 
-static const char *get_cdb2_class_str(enum mach_class cls)
-{
-    switch (cls) {
-    default:
-        return "default";
-    case CLASS_TEST:
-        return "dev";
-    case CLASS_ALPHA:
-        return "alpha";
-    case CLASS_BETA:
-        return "beta";
-    case CLASS_PROD:
-        return "prod";
-    }
-}
 
 /**
  * Retrieve the schema of a remote table
@@ -4923,7 +4898,7 @@ int fdb_get_remote_version(const char *dbname, const char *table,
         location = "localhost";
         flags = CDB2_DIRECT_CPU;
     } else {
-        location = get_cdb2_class_str(class);
+        location = mach_class_class2name(class);
         flags = 0;
     }
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1093,8 +1093,8 @@ static enum mach_class get_fdb_class(const char **p_dbname, int *local)
 
     /* extract class if any */
     if ((tmpname = strchr(dbname, '_')) != NULL) {
-        class = strndup(dbname, tmpname-dbname);
-        dbname = tmpname+1;
+        class = strndup(dbname, tmpname - dbname);
+        dbname = tmpname + 1;
         if (strncasecmp(dbname, "LOCAL_", 6) == 0) {
             *local = 1;
             remote_lvl = my_lvl;

--- a/db/machclass.c
+++ b/db/machclass.c
@@ -1,0 +1,146 @@
+/*
+   Copyright 2017, Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <pthread.h>
+#include "plhash.h"
+#include "machclass.h"
+#include "lockmacros.h"
+
+char *gbl_machine_class = NULL;
+
+typedef struct machine_class {
+    char *name;
+    int value;
+} machine_class_t;
+
+pthread_mutex_t mtx = PTHREAD_MUTEX_INITIALIZER;
+hash_t *classes;
+hash_t *class_names;
+
+static machine_class_t default_classes[] = {
+    {"unknown", 0}, /* 0 indexed! */
+    {"test", 1}, /* CLASS_TEST == 1 */
+    {"dev", 1}, /* CLASS_TEST == 1 */
+    {"alpha", 2}, /* CLASS_ALPHA == 2 */
+    {"uat", 3}, /* CLASS_UAT == 3 */
+    {"beta", 4}, /* CLASS_BETA == 4  */
+    {"prod", 5}, /* CLASS_PROD == 5 */
+};
+
+int is_default = 0;
+
+static int _mach_class_add(machine_class_t *class, int *added);
+
+int mach_class_init(void)
+{
+    int i;
+    int rc = 0;
+
+    Pthread_mutex_lock(&mtx);
+    classes = hash_init_strptr(offsetof(struct machine_class, name));
+    class_names = hash_init_i4(offsetof(struct machine_class, value));
+    if(!classes || !class_names) {
+        return -1;
+    }
+
+    for(i=0; i<sizeof(default_classes)/sizeof(default_classes[0]); i++) {
+        rc = _mach_class_add(&default_classes[i], NULL);
+        if (rc) 
+            break;
+    }
+    is_default = 1;
+    Pthread_mutex_unlock(&mtx);
+    return rc; 
+}
+
+static int _mach_class_add(machine_class_t *class, int *added)
+{
+    if (!hash_find(classes, &class->name)) {
+        logmsg(LOGMSG_DEBUG, "Adding class %s value %d\n", class->name, class->value);
+        hash_add(classes, class);
+        hash_add(class_names, class);
+        if (added)
+            *added = 1;
+    }
+    return 0;
+}
+
+int mach_class_addclass(const char *name, int value) 
+{
+    machine_class_t *class = calloc(1, sizeof(machine_class_t));
+    int rc = 0;
+    int added = 0;
+
+    if (!class)
+        return -1;
+
+    class->name = strdup(name);
+    if (!class->name) {
+        free(class);
+        return -1;
+    }
+    class->value = value;
+        
+    Pthread_mutex_lock(&mtx);
+    if (is_default) {
+        /* override the default with client classes */
+        hash_clear(classes);
+        classes = NULL;
+        is_default = 0;
+    }
+    rc = _mach_class_add(class, &added);
+
+    Pthread_mutex_unlock(&mtx);
+
+    if(!added) {
+        free(class->name);
+        free(class);
+    }
+    return rc;
+}
+
+int mach_class_name2class(const char *name)
+{
+    machine_class_t *class;
+    int value = CLASS_UNKNOWN;
+
+    Pthread_mutex_lock(&mtx);
+
+    class = hash_find(classes, &name);
+    if (class)
+        value = class->value;
+
+    Pthread_mutex_unlock(&mtx);
+
+    return value;
+}
+
+const char* mach_class_class2name(int value)
+{
+    machine_class_t *class;
+    const char *name = NULL;
+
+    Pthread_mutex_lock(&mtx);
+
+    class = hash_find(class_names, &value);
+    if (class)
+        name = class->name;
+
+    Pthread_mutex_unlock(&mtx);
+
+    return name;
+}

--- a/db/machclass.c
+++ b/db/machclass.c
@@ -33,12 +33,12 @@ hash_t *class_names;
 
 static machine_class_t default_classes[] = {
     {"unknown", 0}, /* 0 indexed! */
-    {"test", 1}, /* CLASS_TEST == 1 */
-    {"dev", 1}, /* CLASS_TEST == 1 */
-    {"alpha", 2}, /* CLASS_ALPHA == 2 */
-    {"uat", 3}, /* CLASS_UAT == 3 */
-    {"beta", 4}, /* CLASS_BETA == 4  */
-    {"prod", 5}, /* CLASS_PROD == 5 */
+    {"test", 1},    /* CLASS_TEST == 1 */
+    {"dev", 1},     /* CLASS_TEST == 1 */
+    {"alpha", 2},   /* CLASS_ALPHA == 2 */
+    {"uat", 3},     /* CLASS_UAT == 3 */
+    {"beta", 4},    /* CLASS_BETA == 4  */
+    {"prod", 5},    /* CLASS_PROD == 5 */
 };
 
 int is_default = 0;
@@ -53,24 +53,25 @@ int mach_class_init(void)
     Pthread_mutex_lock(&mtx);
     classes = hash_init_strptr(offsetof(struct machine_class, name));
     class_names = hash_init_i4(offsetof(struct machine_class, value));
-    if(!classes || !class_names) {
+    if (!classes || !class_names) {
         return -1;
     }
 
-    for(i=0; i<sizeof(default_classes)/sizeof(default_classes[0]); i++) {
+    for (i = 0; i < sizeof(default_classes) / sizeof(default_classes[0]); i++) {
         rc = _mach_class_add(&default_classes[i], NULL);
-        if (rc) 
+        if (rc)
             break;
     }
     is_default = 1;
     Pthread_mutex_unlock(&mtx);
-    return rc; 
+    return rc;
 }
 
 static int _mach_class_add(machine_class_t *class, int *added)
 {
     if (!hash_find(classes, &class->name)) {
-        logmsg(LOGMSG_DEBUG, "Adding class %s value %d\n", class->name, class->value);
+        logmsg(LOGMSG_DEBUG, "Adding class %s value %d\n", class->name,
+               class->value);
         hash_add(classes, class);
         hash_add(class_names, class);
         if (added)
@@ -79,7 +80,7 @@ static int _mach_class_add(machine_class_t *class, int *added)
     return 0;
 }
 
-int mach_class_addclass(const char *name, int value) 
+int mach_class_addclass(const char *name, int value)
 {
     machine_class_t *class = calloc(1, sizeof(machine_class_t));
     int rc = 0;
@@ -94,7 +95,7 @@ int mach_class_addclass(const char *name, int value)
         return -1;
     }
     class->value = value;
-        
+
     Pthread_mutex_lock(&mtx);
     if (is_default) {
         /* override the default with client classes */
@@ -106,7 +107,7 @@ int mach_class_addclass(const char *name, int value)
 
     Pthread_mutex_unlock(&mtx);
 
-    if(!added) {
+    if (!added) {
         free(class->name);
         free(class);
     }
@@ -129,7 +130,7 @@ int mach_class_name2class(const char *name)
     return value;
 }
 
-const char* mach_class_class2name(int value)
+const char *mach_class_class2name(int value)
 {
     machine_class_t *class;
     const char *name = NULL;

--- a/db/machclass.h
+++ b/db/machclass.h
@@ -17,7 +17,7 @@
 #ifndef INCLUDED_MACHCLASS_H
 #define INCLUDED_MACHCLASS_H
 
-/* order is important; custom defined classes are indexed from 1 to 
+/* order is important; custom defined classes are indexed from 1 to
   < CLASS_DENIED
 */
 enum mach_class {
@@ -27,12 +27,12 @@ enum mach_class {
     CLASS_UAT = 3,
     CLASS_BETA = 4,
     CLASS_PROD = 5,
-    CLASS_DENIED = 255 
+    CLASS_DENIED = 255
 };
 
 int mach_class_init(void);
 int mach_class_addclass(const char *name, int value);
 int mach_class_name2class(const char *name);
-const char* mach_class_class2name(int value);
+const char *mach_class_class2name(int value);
 
 #endif

--- a/db/machclass.h
+++ b/db/machclass.h
@@ -17,7 +17,9 @@
 #ifndef INCLUDED_MACHCLASS_H
 #define INCLUDED_MACHCLASS_H
 
-/* order is important */
+/* order is important; custom defined classes are indexed from 1 to 
+  < CLASS_DENIED
+*/
 enum mach_class {
     CLASS_UNKNOWN = 0,
     CLASS_TEST = 1,
@@ -25,7 +27,12 @@ enum mach_class {
     CLASS_UAT = 3,
     CLASS_BETA = 4,
     CLASS_PROD = 5,
-    CLASS_DENIED = 10
+    CLASS_DENIED = 255 
 };
+
+int mach_class_init(void);
+int mach_class_addclass(const char *name, int value);
+int mach_class_name2class(const char *name);
+const char* mach_class_class2name(int value);
 
 #endif

--- a/db/rmtpolicy.c
+++ b/db/rmtpolicy.c
@@ -166,7 +166,7 @@ static int parse_mach_or_group(char *tok, int ltok, char **mach,
     *mach = NULL;
 
     *cls = mach_class_name2class(name);
-    if(!*cls) {
+    if (!*cls) {
         char *m;
         m = tokdup(tok, ltok);
         *mach = intern(m);
@@ -295,7 +295,7 @@ int process_allow_command(char *line, int lline)
         if (allow == 1) {
             bset(&pol->explicit_allow_classes, cls);
             bclr(&pol->explicit_disallow_classes, cls);
-            logmsg(LOGMSG_USER, "allowing %s %s machines\n", pol->descr, 
+            logmsg(LOGMSG_USER, "allowing %s %s machines\n", pol->descr,
                    mach_class_class2name(cls));
         } else if (allow == 0) {
             bset(&pol->explicit_disallow_classes, cls);
@@ -305,8 +305,8 @@ int process_allow_command(char *line, int lline)
         } else if (allow == -1) {
             bclr(&pol->explicit_disallow_classes, cls);
             bclr(&pol->explicit_allow_classes, cls);
-            logmsg(LOGMSG_USER, "resetting policy for %s %s machines\n", pol->descr,
-                   mach_class_class2name(cls));
+            logmsg(LOGMSG_USER, "resetting policy for %s %s machines\n",
+                   pol->descr, mach_class_class2name(cls));
         }
     } else {
         goto bad;

--- a/db/rmtpolicy.c
+++ b/db/rmtpolicy.c
@@ -56,32 +56,17 @@ static struct rmtpol cluster_pol = {"cluster with", {0}, {0}, 0, 0, 0};
 
 enum mach_class get_my_mach_class(void)
 {
+    if (gbl_machine_class)
+        return mach_class_name2class(gbl_machine_class);
     return get_mach_class(gbl_mynode);
 }
 
 enum mach_class get_mach_class(const char *host) { return machine_class(host); }
 
-const char *get_class_str(enum mach_class cls)
-{
-    switch (cls) {
-    default:
-        return "???";
-    case CLASS_TEST:
-        return "test";
-    case CLASS_ALPHA:
-        return "alpha";
-    case CLASS_BETA:
-        return "beta";
-    case CLASS_PROD:
-        return "prod";
-    case CLASS_UAT:
-        return "uat";
-    }
-}
 
 const char *get_mach_class_str(char *host)
 {
-    return get_class_str(get_mach_class(host));
+    return mach_class_class2name(get_mach_class(host));
 }
 
 static int disable_rmt_dbupdates(const char *mach)
@@ -177,21 +162,11 @@ int allow_broadcast_to_remote(const char *host)
 static int parse_mach_or_group(char *tok, int ltok, char **mach,
                                enum mach_class *cls)
 {
+    char *name = strndup(tok, ltok);
     *mach = NULL;
-    *cls = CLASS_UNKNOWN;
-    if (tokcmp(tok, ltok, "test") == 0)
-        *cls = CLASS_TEST;
-    else if (tokcmp(tok, ltok, "dev") == 0)
-        *cls = CLASS_TEST;
-    else if (tokcmp(tok, ltok, "alpha") == 0)
-        *cls = CLASS_ALPHA;
-    else if (tokcmp(tok, ltok, "beta") == 0)
-        *cls = CLASS_BETA;
-    else if (tokcmp(tok, ltok, "prod") == 0)
-        *cls = CLASS_PROD;
-    else if (tokcmp(tok, ltok, "uat") == 0)
-        *cls = CLASS_UAT;
-    else {
+
+    *cls = mach_class_name2class(name);
+    if(!*cls) {
         char *m;
         m = tokdup(tok, ltok);
         *mach = intern(m);
@@ -320,17 +295,18 @@ int process_allow_command(char *line, int lline)
         if (allow == 1) {
             bset(&pol->explicit_allow_classes, cls);
             bclr(&pol->explicit_disallow_classes, cls);
-            logmsg(LOGMSG_USER, "allowing %s %s machines\n", pol->descr, get_class_str(cls));
+            logmsg(LOGMSG_USER, "allowing %s %s machines\n", pol->descr, 
+                   mach_class_class2name(cls));
         } else if (allow == 0) {
             bset(&pol->explicit_disallow_classes, cls);
             bclr(&pol->explicit_allow_classes, cls);
             logmsg(LOGMSG_USER, "disallowing %s %s machines\n", pol->descr,
-                   get_class_str(cls));
+                   mach_class_class2name(cls));
         } else if (allow == -1) {
             bclr(&pol->explicit_disallow_classes, cls);
             bclr(&pol->explicit_allow_classes, cls);
             logmsg(LOGMSG_USER, "resetting policy for %s %s machines\n", pol->descr,
-                   get_class_str(cls));
+                   mach_class_class2name(cls));
         }
     } else {
         goto bad;

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -163,6 +163,17 @@ and to wait for all nodes to acknowledge a transaction before returning success.
 |log-delete-age-set  |                     |Takes epoch time in seconds, log files older than the given time are eligible for deletion when not needed
 |log-delete          |on                   |`on` enables log deletion, `off` disables it
 
+### Machine class configuration overrides
+
+By default, the risk machine class names are, from the least risky deployment to the highest risk: 'dev'/'test', 'alpha', 'uat', 'prod'. The following lrl option overrides this hierarchy to a client custom configuration that matches a different deployment stage scheme.
+
+    classes <lowest_risk_name> <higher_risk_name> ... <highest_risk_name>
+
+The machine specific, as perceived by the server using the involved lrl file, can be overridden using the following lrl option:
+
+    machine_class <name>
+
+NOTE: the overriding name should match one of the existing class names, otherwise the client access will be denied.
 
 ### Allow/Disallow commands
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -72,6 +72,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/berkdb
   ${OPENSSL_INCLUDE_DIR}
   ${UNWIND_INCLUDE_DIR}
+  ${PROJECT_SOURCE_DIR}/db
 )
 add_dependencies(util mem)
 set_source_files_properties(walkback.c PROPERTIES COMPILE_FLAGS -DUSE_UNWIND)

--- a/util/rtcpu.c
+++ b/util/rtcpu.c
@@ -129,15 +129,8 @@ static int machine_class_default(const char *host)
 
         envclass = getenv("COMDB2_CLASS");
         if (envclass) {
-            if (strcmp(envclass, "dev") == 0 || strcmp(envclass, "test") == 0)
-                my_class = CLASS_TEST;
-            else if (strcmp(envclass, "alpha") == 0)
-                my_class = CLASS_ALPHA;
-            else if (strcmp(envclass, "beta") == 0)
-                my_class = CLASS_BETA;
-            else if (strcmp(envclass, "prod") == 0)
-                my_class = CLASS_PROD;
-            else
+            my_class = mach_class_name2class(envclass);
+            if (my_class == CLASS_UNKNOWN)
                 logmsg(LOGMSG_ERROR,
                        "envclass set to \"%s\", don't recognize it\n",
                        envclass);
@@ -176,14 +169,7 @@ static int machine_class_default(const char *host)
                 goto done;
             }
             envclass = cdb2_column_value(db, 0);
-            if (strcmp(envclass, "dev") == 0 || strcmp(envclass, "test") == 0)
-                my_class = CLASS_TEST;
-            else if (strcmp(envclass, "alpha") == 0)
-                my_class = CLASS_ALPHA;
-            else if (strcmp(envclass, "beta") == 0)
-                my_class = CLASS_BETA;
-            else if (strcmp(envclass, "prod") == 0)
-                my_class = CLASS_PROD;
+            my_class = mach_class_name2class(envclass);
             do {
                 rc = cdb2_next_record(db);
             } while (rc == CDB2_OK);


### PR DESCRIPTION
Remove redundant code when checking machine/database class.  A more generic lrl option to define the classes, and specify the intended class for the database.