### PR TITLE
Reduce contention on the private blkseq.

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -535,7 +535,7 @@ DEF_ATTR(PRIVATE_BLKSEQ_MAXAGE, private_blkseq_maxage, SECS, 600,
          "Maximum time in seconds to let 'old' transactions live.")
 DEF_ATTR(PRIVATE_BLKSEQ_MAXTRAVERSE, private_blkseq_maxtraverse, QUANTITY, 4,
          NULL)
-DEF_ATTR(PRIVATE_BLKSEQ_STRIPES, private_blkseq_stripes, QUANTITY, 1,
+DEF_ATTR(PRIVATE_BLKSEQ_STRIPES, private_blkseq_stripes, QUANTITY, 8,
          "Number of stripes for the blkseq table.")
 DEF_ATTR(PRIVATE_BLKSEQ_ENABLED, private_blkseq_enabled, BOOLEAN, 1,
          "Sets whether dupe detection is enabled.")

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -85,8 +85,7 @@ void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
 {
     if (!bdb_state) 
         return;
-    for (int stripe = 0; stripe < bdb_state->attr->private_blkseq_stripes;
-         stripe++) {
+    for (int stripe = 0; stripe < bdb_state->pvt_blkseq_stripes; stripe++) {
         DB_ENV *env = bdb_state->blkseq_env[stripe];
         if (env) {
             Pthread_mutex_destroy(&bdb_state->blkseq_lk[stripe]);
@@ -130,28 +129,21 @@ void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
 int bdb_create_private_blkseq(bdb_state_type *bdb_state)
 {
     DB_ENV *env;
-    int rc;
+    int rc, nstripes;
 
-    bdb_state->blkseq_env =
-        malloc(bdb_state->attr->private_blkseq_stripes * sizeof(DB_ENV *));
-    bdb_state->blkseq_lk = malloc(bdb_state->attr->private_blkseq_stripes *
-                                  sizeof(pthread_mutex_t));
-    bdb_state->blkseq[0] =
-        malloc(bdb_state->attr->private_blkseq_stripes * sizeof(DB *));
-    bdb_state->blkseq[1] =
-        malloc(bdb_state->attr->private_blkseq_stripes * sizeof(DB *));
-    bdb_state->blkseq_last_lsn[0] =
-        malloc(bdb_state->attr->private_blkseq_stripes * sizeof(DB_LSN));
-    bdb_state->blkseq_last_lsn[1] =
-        malloc(bdb_state->attr->private_blkseq_stripes * sizeof(DB_LSN));
+    nstripes = bdb_state->pvt_blkseq_stripes =
+        bdb_state->attr->private_blkseq_stripes;
 
-    listc_init(&bdb_state->blkseq_log_list[0],
-               offsetof(struct seen_blkseq, lnk));
-    listc_init(&bdb_state->blkseq_log_list[1],
-               offsetof(struct seen_blkseq, lnk));
+    bdb_state->blkseq_env = malloc(nstripes * sizeof(DB_ENV *));
+    bdb_state->blkseq_lk = malloc(nstripes * sizeof(pthread_mutex_t));
+    bdb_state->blkseq[0] = malloc(nstripes * sizeof(DB *));
+    bdb_state->blkseq[1] = malloc(nstripes * sizeof(DB *));
+    bdb_state->blkseq_last_lsn[0] = malloc(nstripes * sizeof(DB_LSN));
+    bdb_state->blkseq_last_lsn[1] = malloc(nstripes * sizeof(DB_LSN));
 
-    for (int stripe = 0; stripe < bdb_state->attr->private_blkseq_stripes;
-         stripe++) {
+    bdb_state->blkseq_log_list = malloc(nstripes * sizeof(listc_t));
+
+    for (int stripe = 0; stripe < nstripes; stripe++) {
         rc = db_env_create(&env, 0);
         if (rc) {
             logmsg(LOGMSG_ERROR, "db_env_create rc %d\n", rc);
@@ -182,6 +174,8 @@ int bdb_create_private_blkseq(bdb_state_type *bdb_state)
                 return -1;
             bzero(&bdb_state->blkseq_last_lsn[i][stripe], sizeof(DB_LSN));
         }
+        listc_init(&bdb_state->blkseq_log_list[stripe],
+                   offsetof(struct seen_blkseq, lnk));
     }
     bdb_state->blkseq_last_roll_time = comdb2_time_epoch();
 
@@ -197,7 +191,7 @@ static uint8_t get_stripe(bdb_state_type *bdb_state, uint8_t *bytes, int len)
         stripe ^= *bytes;
         bytes++;
     }
-    return stripe % bdb_state->attr->private_blkseq_stripes;
+    return stripe % bdb_state->pvt_blkseq_stripes;
 }
 
 /* recovery callback from berkeley (through bdb_apprec) */
@@ -701,7 +695,7 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
                 if (lsn.file != last_log_filenum && oldest_blkseq != INT_MAX) {
                     /* if we just switched a file, remember the oldest blkseq we
                      * saw in the current file */
-                    for (int i = 0; i < 2; i++) {
+                    for (int i = 0; i < bdb_state->pvt_blkseq_stripes; i++) {
                         logseq = malloc(sizeof(struct seen_blkseq));
                         logseq->logfile = lsn.file;
                         logseq->timestamp = oldest_blkseq;
@@ -739,7 +733,7 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
      * eventually be not the only log, and we need information about its
      * blkseq ages */
     if (nblkseq > 0) {
-        for (int i = 0; i < 2; i++) {
+        for (int i = 0; i < bdb_state->pvt_blkseq_stripes; i++) {
             if (bdb_state->blkseq_log_list[i].count == 0) {
                 logseq = malloc(sizeof(struct seen_blkseq));
                 logseq->logfile = lsn.file;
@@ -772,8 +766,7 @@ int bdb_blkseq_dumplogs(bdb_state_type *bdb_state)
 {
     struct seen_blkseq *logseq;
 
-    for (int stripe = 0; stripe < bdb_state->attr->private_blkseq_stripes;
-         stripe++) {
+    for (int stripe = 0; stripe < bdb_state->pvt_blkseq_stripes; stripe++) {
         Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
         LISTC_FOR_EACH(&bdb_state->blkseq_log_list[stripe], logseq, lnk)
         {
@@ -791,8 +784,7 @@ int bdb_blkseq_can_delete_log(bdb_state_type *bdb_state, int lognum)
     int found = 0;
     int now = comdb2_time_epoch();
 
-    for (int stripe = 0; stripe < bdb_state->attr->private_blkseq_stripes;
-         stripe++) {
+    for (int stripe = 0; stripe < bdb_state->pvt_blkseq_stripes; stripe++) {
         Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
         LISTC_FOR_EACH(&bdb_state->blkseq_log_list[stripe], logseq, lnk)
         {
@@ -811,8 +803,7 @@ int bdb_blkseq_can_delete_log(bdb_state_type *bdb_state, int lognum)
      * bdb_blkseq_can_delete_log will still succeed (because no
      * entries will be found) */
     if (found == num_ok) {
-        for (int stripe = 0; stripe < bdb_state->attr->private_blkseq_stripes;
-             stripe++) {
+        for (int stripe = 0; stripe < bdb_state->pvt_blkseq_stripes; stripe++) {
             Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
             LISTC_FOR_EACH_SAFE(&bdb_state->blkseq_log_list[stripe], logseq,
                                 logseqtmp, lnk)

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1019,7 +1019,8 @@ struct bdb_state_tag {
     DB **blkseq[2];
     time_t blkseq_last_roll_time;
     DB_LSN *blkseq_last_lsn[2];
-    LISTC_T(struct seen_blkseq) blkseq_log_list[2];
+    listc_t *blkseq_log_list;
+    int pvt_blkseq_stripes;
     uint32_t genid_format;
 
     /* we keep a per bdb_state copy to enhance locality */

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -634,7 +634,7 @@ sequence).  Tunables to control it are below
 |--------------|-------------
 |PRIVATE_BLKSEQ_CACHESZ | 4194304 | Cache size of the blkseq table
 |PRIVATE_BLKSEQ_MAXAGE | 20 | Maximum time in seconds to let "old" transactions live
-|PRIVATE_BLKSEQ_STRIPES | 1 | Number of stripes for the blkseq table
+|PRIVATE_BLKSEQ_STRIPES | 8 | Number of stripes for the blkseq table
 |PRIVATE_BLKSEQ_ENABLED | 1 | Sets whether dupe detection is enabled
 |PRIVATE_BLKSEQ_CLOSE_WARN_TIME | 100 | Warn when it takes longer than this many MS to roll a blkseq table
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -626,7 +626,7 @@
 (name='private_blkseq_enabled', description='Sets whether dupe detection is enabled.', type='BOOLEAN', value='ON', read_only='N')
 (name='private_blkseq_maxage', description='Maximum time in seconds to let 'old' transactions live.', type='INTEGER', value='600', read_only='N')
 (name='private_blkseq_maxtraverse', description='', type='INTEGER', value='4', read_only='N')
-(name='private_blkseq_stripes', description='Number of stripes for the blkseq table.', type='INTEGER', value='1', read_only='N')
+(name='private_blkseq_stripes', description='Number of stripes for the blkseq table.', type='INTEGER', value='8', read_only='N')
 (name='qscanmode', description='Enables queue scan mode optimisation.', type='BOOLEAN', value='OFF', read_only='N')
 (name='queuedb_genid_filename', description='Use genid in queuedb filenames.  (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='queuedb_timeout_sec', description='Unassign Lua consumer/trigger if no heartbeat received for this time', type='INTEGER', value='10', read_only='N')


### PR DESCRIPTION
Increase PRIVATE_BLKSEQ_STRIPES to 8 (same as dtastripe). Also fix the crashes when PRIVATE_BLKSEQ_STRIPES is greater than 1.
