### PR TITLE
failing tests are misreported as successful during manual runs

### DIFF
--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -250,12 +250,12 @@ DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
 echo "!$TESTCASE: started running with timeout ${TEST_TIMEOUT} at $DATETIME"
 
 timeout ${TEST_TIMEOUT} ./runit ${DBNAME} 2>&1  | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' &> ${TESTDIR}/logs/${DBNAME}.testcase
+rc=${PIPESTATUS[0]}
 
 DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
 echo "!$TESTCASE: finished running with timeout ${TEST_TIMEOUT} at $DATETIME"
 
 # get the return code from the first phase of the pipe
-rc=${PIPESTATUS[0]}
 sleep 1
 
 

--- a/tests/setup
+++ b/tests/setup
@@ -382,6 +382,7 @@ if [[ $debug -eq 1 ]]; then
         echo "export SECONDARY_DB_PREFIX=\"${SECONDARY_DB_PREFIX}\"" >> $SETENV
         echo "export SECONDARY_DBNAME=\"${SECONDARY_DBNAME}\"" >> $SETENV
         echo "export SECONDARY_DBDIR=\"${SECONDARY_DBDIR}\"" >> $SETENV
+        echo "export SECONDARY_CDB2_CONFIG=\"${SECONDARY_CDB2_CONFIG}\"" >> $SETENV
         echo "export SECONDARY_CDB2_OPTIONS=\"${SECONDARY_CDB2_OPTIONS}\"" >> $SETENV
     fi
     echo "export SP_OPTIONS=\"-s --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default\"" >> $SETENV


### PR DESCRIPTION
Currently:
tests $ make SKIPSSL=1 TESTDIR=/tmp/test_$RANDOM mismatch_class_remsql
TESTID=25801 running in /tmp/test_2141 mismatch_class_remsql 1/1
!mismatch_class_remsql: creating db mismatchclassremsql25801
...
!mismatch_class_remsql: started running with timeout 2m at 2019-04-16 10:29:23
!mismatch_class_remsql: finished running with timeout 2m at 2019-04-16 10:29:23
!mismatch_class_remsql: success (logs in /tmp/test_2141/logs/mismatchclassremsql25801.testcase)
!mismatch_class_remsql: stopping

> But:
tests $ tail -4 /tmp/test_2141/logs/mismatchclassremsql25801.testcase
10:29:23> Starting tests
10:29:23> ./remsql.sh: line 20: insert.req: No such file or directory
10:29:23> FAILURE
Duration 10 seconds

>> With the fix:
tests $ make SKIPSSL=1 TESTDIR=/tmp/test_$RANDOM mismatch_class_remsql
TESTID=99648 running in /tmp/test_14627 mismatch_class_remsql 1/1
!mismatch_class_remsql: creating db mismatchclassremsql99648
...
!mismatch_class_remsql: started running with timeout 2m at 2019-04-16 10:48:57
!mismatch_class_remsql: finished running with timeout 2m at 2019-04-16 10:48:57
!mismatch_class_remsql: failed rc=1 (logs in /tmp/test_14627/logs/mismatchclassremsql99648.testcase)
!mismatch_class_remsql: stopping
/bb/bigstorn/systems/dhogea/comdb2/OPEN/c111/tests/testcase.mk:58: recipe for target 'test' failed
make[1]: *** [test] Error 1
Makefile:95: recipe for target 'mismatch_class_remsql' failed
make: *** [mismatch_class_remsql] Error 2


