### PR TITLE
fix tunables that magically passed before

### DIFF
--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=910)
+(TUNABLES_COUNT=911)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -407,6 +407,7 @@
 (name='lsnerr_logflush', description='Flush log on lsn error', type='BOOLEAN', value='ON', read_only='N')
 (name='lsnerr_pgdump', description='Dump page on LSN errors', type='BOOLEAN', value='ON', read_only='N')
 (name='lsnerr_pgdump_all', description='Dump page on LSN errors on all nodes', type='BOOLEAN', value='OFF', read_only='N')
+(name='machine_class', description='override for the machine class from this db perspective.', type='STRING', value=NULL, read_only='Y')
 (name='make_slow_replicants_incoherent', description='Make slow replicants incoherent.', type='BOOLEAN', value='OFF', read_only='N')
 (name='master_lease', description='', type='INTEGER', value='500', read_only='N')
 (name='master_lease_renew_interval', description='', type='INTEGER', value='200', read_only='N')


### PR DESCRIPTION
PR https://github.com/bloomberg/comdb2/pull/1502 regression misreported this tunables as passing.  Fixing it here.