### PR TITLE
Fix pglogs_asof_thread race with clean exit.

### DIFF
--- a/bbinc/thrman.h
+++ b/bbinc/thrman.h
@@ -44,6 +44,7 @@ enum thrtype {
     THRTYPE_PURGEFILES = 20,
     THRTYPE_BULK_IMPORT = 21,
     THRTYPE_TRIGGER = 22,
+    THRTYPE_PGLOGS_ASOF = 23,
     THRTYPE_MAX
 };
 
@@ -61,6 +62,8 @@ struct thr_handle *thrman_self(void);
 void thrman_where(struct thr_handle *thr, const char *where);
 void thrman_wheref(struct thr_handle *thr, const char *fmt, ...);
 void thrman_origin(struct thr_handle *thr, const char *origin);
+/* Forward declaration so the file can be included without including comdb2.h */
+typedef struct sqlpool sqlpool_t;
 void thrman_set_sqlpool(struct thr_handle *thr, sqlpool_t *sqlpool);
 void thrman_setid(struct thr_handle *thr, const char *idstr);
 void thrman_setfd(struct thr_handle *thr, int fd);

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -651,7 +651,9 @@ int process_command(struct dbenv *dbenv, char *line, int lline, int st)
         pthread_attr_t thd_attr;
 
         Pthread_attr_init(&thd_attr);
-        Pthread_attr_setstacksize(&thd_attr, 128 * 1024);
+        /* Stack overflows with 128KiB stack size in Debug build.
+           Slightly bump it up. */
+        Pthread_attr_setstacksize(&thd_attr, PTHREAD_STACK_MIN + 256 * 1024);
         pthread_attr_setdetachstate(&thd_attr, PTHREAD_CREATE_DETACHED);
 
         int rc = pthread_create(&thread_id, &thd_attr, clean_exit_thd, NULL);

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -351,6 +351,8 @@ const char *thrman_type2a(enum thrtype type)
         return "purge-old-files";
     case THRTYPE_TRIGGER:
         return "lua-trigger";
+    case THRTYPE_PGLOGS_ASOF:
+        return "pglogs-asof";
     default:
         return "??";
     }
@@ -464,7 +466,8 @@ static int thrman_check_threads_stopped_ll(void *context)
             thr_type_counts[THRTYPE_SQLPOOL] +
             thr_type_counts[THRTYPE_SQLENGINEPOOL] +
             thr_type_counts[THRTYPE_VERIFY] + thr_type_counts[THRTYPE_ANALYZE] +
-            thr_type_counts[THRTYPE_PURGEBLKSEQ])
+            thr_type_counts[THRTYPE_PURGEBLKSEQ] +
+            thr_type_counts[THRTYPE_PGLOGS_ASOF])
         all_gone = 1;
 
     /* if we're exiting then we don't want a schema change thread running */


### PR DESCRIPTION
pglogs_asof_thread accesses bdb_state in a loop. Ensure that clean exit waits for pglogs_asof_thread to exit before shutting down the bdb env.

(DRQS 141223321)