### PR TITLE
osql: Fix osql_blkseq_unregister race with osql_open()

### DIFF
--- a/db/osqlblkseq.c
+++ b/db/osqlblkseq.c
@@ -102,6 +102,12 @@ int osql_blkseq_register(struct ireq *iq)
  */
 int osql_blkseq_unregister(struct ireq *iq)
 {
+    /* Fast return if have_blkseq is false.
+       It not only saves quite a few instructions,
+       but also avoids the race condition with osql_open() */
+    if (!iq->have_blkseq)
+        return 0;
+
     assert(hiqs != NULL);
 
     Pthread_rwlock_wrlock(&hlock);

--- a/db/osqlblkseq.c
+++ b/db/osqlblkseq.c
@@ -104,7 +104,7 @@ int osql_blkseq_unregister(struct ireq *iq)
 {
     /* Fast return if have_blkseq is false.
        It not only saves quite a few instructions,
-       but also avoids the race condition with osql_open() */
+       but also avoids a race condition with osql_open() */
     if (!iq->have_blkseq)
         return 0;
 


### PR DESCRIPTION
(DRQS 141251482)
