### PR TITLE
Have the SIGTERM handler call clean_exit_thd

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1402,8 +1402,12 @@ int clear_temp_tables(void)
 }
 
 void clean_exit_sigwrap(int signum) {
-   signal(SIGTERM, SIG_DFL);
-   clean_exit();
+    void *clean_exit_thd(void *unused);
+    signal(SIGTERM, SIG_DFL);
+
+    /* Call the wrapper which checks the exit flag
+       to avoid multiple clean-exit's. */
+    clean_exit_thd(NULL);
 }
 
 static void free_sqlite_table(struct dbenv *dbenv)

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -605,7 +605,7 @@ void bdb_osql_trn_clients_status();
 void bdb_newsi_mempool_stat();
 
 static pthread_mutex_t exiting_lock = PTHREAD_MUTEX_INITIALIZER;
-static void *clean_exit_thd(void *unused)
+void *clean_exit_thd(void *unused)
 {
     Pthread_mutex_lock(&exiting_lock);
     if (gbl_exit) {


### PR DESCRIPTION
To avoid double clean-exits if the process receives SIGTERM (e.g., from can.tsk) while clean-exiting.

(DRQS 141375609)