### PR TITLE
Temparray

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1150,6 +1150,8 @@ struct temp_table *bdb_temp_table_create(bdb_state_type *bdb_state,
 struct temp_table *bdb_temp_list_create(bdb_state_type *bdb_state, int *bdberr);
 struct temp_table *bdb_temp_hashtable_create(bdb_state_type *bdb_state,
                                              int *bdberr);
+struct temp_table *bdb_temp_array_create(bdb_state_type *bdb_state,
+                                         int *bdberr);
 struct temp_table *bdb_temp_table_create_flags(bdb_state_type *bdb_state,
                                                int flags, int *bdberr);
 

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -844,7 +844,7 @@ int bdb_temp_table_update(bdb_state_type *bdb_state, struct temp_cursor *cur,
     if (cur->tbl->temp_table_type != TEMP_TABLE_TYPE_BTREE ||
         cur->tbl->temp_table_type != TEMP_TABLE_TYPE_ARRAY) {
         logmsg(LOGMSG_ERROR, "bdb_temp_table_update operation "
-                        "only supported for btree or array.\n");
+                             "only supported for btree or array.\n");
         return -1;
     }
 

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -1366,60 +1366,61 @@ int bdb_temp_table_close(bdb_state_type *bdb_state, struct temp_table *tbl,
 
     rc = bdb_temp_table_truncate(bdb_state, tbl, bdberr);
 
-    Pthread_mutex_lock(&(bdb_state->temp_list_lock));
+    if (tbl->dbenv_temp != NULL || gbl_temptable_pool_capacity == 0) {
+        Pthread_mutex_lock(&(bdb_state->temp_list_lock));
 
-    if ((tbl->dbenv_temp != NULL) &&
-        (tbl->dbenv_temp->memp_stat(tbl->dbenv_temp, &tmp, NULL,
-                                    DB_STAT_CLEAR)) == 0) {
-        bdb_state->temp_stats->st_gbytes += tmp->st_gbytes;
-        bdb_state->temp_stats->st_bytes += tmp->st_bytes;
-        bdb_state->temp_stats->st_ncache += tmp->st_ncache;
-        bdb_state->temp_stats->st_regsize += tmp->st_regsize;
-        bdb_state->temp_stats->st_map += tmp->st_map;
-        bdb_state->temp_stats->st_cache_hit += tmp->st_cache_hit;
-        bdb_state->temp_stats->st_cache_miss += tmp->st_cache_miss;
-        bdb_state->temp_stats->st_cache_ihit += tmp->st_cache_ihit;
-        bdb_state->temp_stats->st_cache_imiss += tmp->st_cache_imiss;
-        bdb_state->temp_stats->st_cache_lhit += tmp->st_cache_lhit;
-        bdb_state->temp_stats->st_cache_lmiss += tmp->st_cache_lmiss;
-        bdb_state->temp_stats->st_page_create += tmp->st_page_create;
-        bdb_state->temp_stats->st_page_pf_in += tmp->st_page_pf_in;
-        bdb_state->temp_stats->st_page_in += tmp->st_page_in;
-        bdb_state->temp_stats->st_page_out += tmp->st_page_out;
-        bdb_state->temp_stats->st_ro_merges += tmp->st_ro_merges;
-        bdb_state->temp_stats->st_rw_merges += tmp->st_rw_merges;
-        bdb_state->temp_stats->st_ro_evict += tmp->st_ro_evict;
-        bdb_state->temp_stats->st_rw_evict += tmp->st_rw_evict;
-        bdb_state->temp_stats->st_pf_evict += tmp->st_pf_evict;
-        bdb_state->temp_stats->st_rw_evict_skip += tmp->st_rw_evict_skip;
-        bdb_state->temp_stats->st_page_trickle += tmp->st_page_trickle;
-        bdb_state->temp_stats->st_pages += tmp->st_pages;
-        ATOMIC_ADD(bdb_state->temp_stats->st_page_dirty, tmp->st_page_dirty);
-        bdb_state->temp_stats->st_page_clean += tmp->st_page_clean;
-        bdb_state->temp_stats->st_hash_buckets += tmp->st_hash_buckets;
-        bdb_state->temp_stats->st_hash_searches += tmp->st_hash_searches;
-        bdb_state->temp_stats->st_hash_longest += tmp->st_hash_longest;
-        bdb_state->temp_stats->st_hash_examined += tmp->st_hash_examined;
-        bdb_state->temp_stats->st_region_nowait += tmp->st_region_nowait;
-        bdb_state->temp_stats->st_region_wait += tmp->st_region_wait;
-        bdb_state->temp_stats->st_alloc += tmp->st_alloc;
-        bdb_state->temp_stats->st_alloc_buckets += tmp->st_alloc_buckets;
-        bdb_state->temp_stats->st_alloc_max_buckets +=
-            tmp->st_alloc_max_buckets;
-        bdb_state->temp_stats->st_alloc_pages += tmp->st_alloc_pages;
-        bdb_state->temp_stats->st_alloc_max_pages += tmp->st_alloc_max_pages;
-        bdb_state->temp_stats->st_ckp_pages_sync += tmp->st_ckp_pages_sync;
-        bdb_state->temp_stats->st_ckp_pages_skip += tmp->st_ckp_pages_skip;
+        if ((tbl->dbenv_temp->memp_stat(tbl->dbenv_temp, &tmp, NULL,
+                                        DB_STAT_CLEAR)) == 0) {
+            bdb_state->temp_stats->st_gbytes += tmp->st_gbytes;
+            bdb_state->temp_stats->st_bytes += tmp->st_bytes;
+            bdb_state->temp_stats->st_ncache += tmp->st_ncache;
+            bdb_state->temp_stats->st_regsize += tmp->st_regsize;
+            bdb_state->temp_stats->st_map += tmp->st_map;
+            bdb_state->temp_stats->st_cache_hit += tmp->st_cache_hit;
+            bdb_state->temp_stats->st_cache_miss += tmp->st_cache_miss;
+            bdb_state->temp_stats->st_cache_ihit += tmp->st_cache_ihit;
+            bdb_state->temp_stats->st_cache_imiss += tmp->st_cache_imiss;
+            bdb_state->temp_stats->st_cache_lhit += tmp->st_cache_lhit;
+            bdb_state->temp_stats->st_cache_lmiss += tmp->st_cache_lmiss;
+            bdb_state->temp_stats->st_page_create += tmp->st_page_create;
+            bdb_state->temp_stats->st_page_pf_in += tmp->st_page_pf_in;
+            bdb_state->temp_stats->st_page_in += tmp->st_page_in;
+            bdb_state->temp_stats->st_page_out += tmp->st_page_out;
+            bdb_state->temp_stats->st_ro_merges += tmp->st_ro_merges;
+            bdb_state->temp_stats->st_rw_merges += tmp->st_rw_merges;
+            bdb_state->temp_stats->st_ro_evict += tmp->st_ro_evict;
+            bdb_state->temp_stats->st_rw_evict += tmp->st_rw_evict;
+            bdb_state->temp_stats->st_pf_evict += tmp->st_pf_evict;
+            bdb_state->temp_stats->st_rw_evict_skip += tmp->st_rw_evict_skip;
+            bdb_state->temp_stats->st_page_trickle += tmp->st_page_trickle;
+            bdb_state->temp_stats->st_pages += tmp->st_pages;
+            ATOMIC_ADD(bdb_state->temp_stats->st_page_dirty,
+                       tmp->st_page_dirty);
+            bdb_state->temp_stats->st_page_clean += tmp->st_page_clean;
+            bdb_state->temp_stats->st_hash_buckets += tmp->st_hash_buckets;
+            bdb_state->temp_stats->st_hash_searches += tmp->st_hash_searches;
+            bdb_state->temp_stats->st_hash_longest += tmp->st_hash_longest;
+            bdb_state->temp_stats->st_hash_examined += tmp->st_hash_examined;
+            bdb_state->temp_stats->st_region_nowait += tmp->st_region_nowait;
+            bdb_state->temp_stats->st_region_wait += tmp->st_region_wait;
+            bdb_state->temp_stats->st_alloc += tmp->st_alloc;
+            bdb_state->temp_stats->st_alloc_buckets += tmp->st_alloc_buckets;
+            bdb_state->temp_stats->st_alloc_max_buckets +=
+                tmp->st_alloc_max_buckets;
+            bdb_state->temp_stats->st_alloc_pages += tmp->st_alloc_pages;
+            bdb_state->temp_stats->st_alloc_max_pages +=
+                tmp->st_alloc_max_pages;
+            bdb_state->temp_stats->st_ckp_pages_sync += tmp->st_ckp_pages_sync;
+            bdb_state->temp_stats->st_ckp_pages_skip += tmp->st_ckp_pages_skip;
 
-        free(tmp);
-    }
+            free(tmp);
+        }
 
-    if (gbl_temptable_pool_capacity == 0) {
         tbl->next = bdb_state->temp_list;
         bdb_state->temp_list = tbl;
-    }
 
     Pthread_mutex_unlock(&(bdb_state->temp_list_lock));
+    }
 
     if (gbl_temptable_pool_capacity > 0) {
         rc = comdb2_objpool_return(bdb_state->temp_table_pool, tbl);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -118,8 +118,8 @@ static int req2blockop(int reqtype);
  *
  * key will compare by rqid, uuid, table, stripe, genid, is_rec, then sequence
  */
-static int osql_bplog_key_cmp(void *usermem, int key1len, const void *key1,
-                              int key2len, const void *key2)
+int osql_bplog_key_cmp(void *usermem, int key1len, const void *key1,
+                       int key2len, const void *key2)
 {
     assert(sizeof(oplog_key_t) == key1len);
     assert(sizeof(oplog_key_t) == key2len);
@@ -210,7 +210,7 @@ int osql_bplog_start(struct ireq *iq, osql_sess_t *sess)
     iq->blocksql_tran = tran; /* now blockproc knows about it */
 
     /* init temporary table and cursor */
-    tran->db = bdb_temp_table_create(thedb->bdb_env, &bdberr);
+    tran->db = bdb_temp_array_create(thedb->bdb_env, &bdberr);
     if (!tran->db || bdberr) {
         logmsg(LOGMSG_ERROR, "%s: failed to create temp table bdberr=%d\n",
                __func__, bdberr);
@@ -221,7 +221,7 @@ int osql_bplog_start(struct ireq *iq, osql_sess_t *sess)
     bdb_temp_table_set_cmp_func(tran->db, osql_bplog_key_cmp);
 
     if (sess->is_reorder_on) {
-        tran->db_ins = bdb_temp_table_create(thedb->bdb_env, &bdberr);
+        tran->db_ins = bdb_temp_array_create(thedb->bdb_env, &bdberr);
         if (!tran->db_ins) {
             // We can stll work without a INS table
             logmsg(LOGMSG_ERROR,

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -728,7 +728,7 @@ static int create_tablecursor(bdb_state_type *bdb_env, struct tmp_table **ptbl,
         return -1;
     }
 
-    tbl->table = bdb_temp_table_create(bdb_env, bdberr);
+    tbl->table = bdb_temp_array_create(bdb_env, bdberr);
 
     if (!tbl->table) {
         logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_create failed, bderr=%d\n",


### PR DESCRIPTION
A temparray is a lightweight replacement of a temptable. It is merely a sorted array. If the number of elements is greater than a threshold (512 by default), or the in-memory data size exceeds a pre-configured cache size (512KiB by default), a temparray will fall back to a temptable.

A temparray is more efficient than a temptable, thanks to its simple data structure.
Besides, it uses far less memory than a temptable to process small and medium-sized requests.

The pull request replaces the bplog temptable with a temparray. The table below shows the sysbench results of the change:

| Threads | oltp_insert | bulk_insert |  oltp_delete | oltp_update_index | oltp_update_non_index |
|----------|--------------|-------------|-------------|---------------------|---------------------------|
|1| +13%| ±<5% | ±<5% | +7% | ±<5% |
|2|+10%|±<5%|±<5%|±<5%|±<5%|
|4| +9% |±<5%|±<5%|±<5%|±<5%|
|8| +10% |±<5%|±<5%|±<5%|±<5%|