### PR TITLE
remove a few unnecessary commands when running tests

### DIFF
--- a/tests/analyze_insert_burst.test/Makefile
+++ b/tests/analyze_insert_burst.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=2m
 endif

--- a/tests/analyze_insert_burst.test/runit
+++ b/tests/analyze_insert_burst.test/runit
@@ -14,12 +14,14 @@ nsamples=$(cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT cast(value as
 
 echo nSamples is $nsamples
 
-while true; do
-cat << EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - >/dev/null 2>&1
+cat << EOF > in.sql
 BEGIN
 $(for i in `seq 1 $nsamples`; do echo 'INSERT INTO t values('$i')'; done)
 COMMIT
 EOF
+
+while true; do
+cdb2sql ${CDB2_OPTIONS} $dbnm default -f in.sql >/dev/null 2>&1
 done &
 
 keep_inserting=$!

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -135,17 +135,6 @@ update_all_records()
     done
 }
 
-update_records()
-{
-    j=0
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
 
 
 insert_records()

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -200,7 +200,7 @@ cat logfls.txt | xargs ls -1t | head -2 > lastfls.txt
 echo lastfls 
 cat lastfls.txt
 
-res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(2000)' | grep '"type": "sql"'| wc -l)
+res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(2000)' | grep -c '"type": "sql"')
 assertres $res 1
 
 exit 0

--- a/tests/largeindex.test/runit
+++ b/tests/largeindex.test/runit
@@ -91,8 +91,7 @@ function insert_records_oneshot
     echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-        str=`echo $j | awk '{printf ("0x%06X", $1)}'`
-        echo "insert into t1(a,b,c) values ($j,'hex $str',$j)"  
+        printf "insert into t1(a,b,c) values ($j,'hex 0x%06X',$j)\n" $j
         let j=j+1
     done | cdb2sql ${CDB2_OPTIONS} $dbnm default - &> $insfl
 }
@@ -328,9 +327,10 @@ assertcnt $NEWCNT
 do_verify
 
 > shouldhave.txt
-for i in `seq 1 $NEWCNT` ; do 
-    str=`echo $i | awk '{printf ("0x%06X", $1)}'`
-    echo "(a=$i, b='hex $str', c=$i)" >> shouldhave.txt
+i=1
+while [ $i -le $NEWCNT ] ; do 
+    printf "(a=$i, b='hex 0x%06X', c=$i)\n" $i >> shouldhave.txt
+    let i=i+1
 done
 
 cdb2sql ${CDB2_OPTIONS} $dbnm default "select a,b,c from t1 order by a" > have_a.txt
@@ -351,9 +351,10 @@ fi
 
 cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set c=c+100000, a=a+100000 where 1" > update.txt
 > shouldhave.txt
-for i in `seq 1 $NEWCNT` ; do 
-    str=`echo $i | awk '{printf ("0x%06X", $1)}'`
-    echo "(a=$((100000+i)), b='hex $str', c=$((100000+i)))" >> shouldhave.txt
+i=1
+while [ $i -le $NEWCNT ] ; do 
+    printf "(a=$((100000+i)), b='hex 0x%06X', c=$((100000+i)))\n" $i >> shouldhave.txt
+    let i=i+1
 done
 
 cdb2sql ${CDB2_OPTIONS} $dbnm default "select a,b,c from t1 order by a" > have_a.txt
@@ -377,12 +378,13 @@ do_verify
 cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where c % 2 = 1"
 
 > shouldhave.txt
-for i in `seq 1 $NEWCNT` ; do 
+i=0
+while [ $i -lt $NEWCNT ] ; do 
+    let i=i+1
     if [ $((i%2)) -eq 1 ]; then 
         continue 
     fi
-    str=`echo $i | awk '{printf ("0x%06X", $1)}'`
-    echo "(a=$((100000+i)), b='hex $str', c=$((100000+i)))" >> shouldhave.txt
+    printf "(a=$((100000+i)), b='hex 0x%06X', c=$((100000+i)))\n" $i >> shouldhave.txt
 done
 
 cdb2sql ${CDB2_OPTIONS} $dbnm default "select a,b,c from t1 order by a" > have_a.txt

--- a/tests/logarchive.test/runit
+++ b/tests/logarchive.test/runit
@@ -131,7 +131,7 @@ for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.i
     if [[ "$onenode" != "$master" ]]; then
         echo Doing $onenode
         cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb log_archive")'
-        numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb log_archive")' | grep 'log.00' | wc -l`
+        numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $onenode 'exec procedure sys.cmd.send("bdb log_archive")' | grep -c 'log.00'`
 
         if [[ $numlogs -ne 0 ]]; then
             echo The replicant $onenode will not recover correctly! >&2
@@ -141,7 +141,7 @@ for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.i
 done
 
 cdb2sql $CDB2_OPTIONS $TABS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb log_archive")'
-numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb log_archive")' | grep 'log.00' | wc -l`
+numlogs=`cdb2sql $CDB2_OPTIONS $dbnm $HOST $master 'exec procedure sys.cmd.send("bdb log_archive")' | grep -c 'log.00'`
 
 if [[ $numlogs -ne 0 ]]; then
     echo Master will not recover correctly after downgrade! >&2

--- a/tests/morestripe.test/runit
+++ b/tests/morestripe.test/runit
@@ -115,7 +115,7 @@ function run_blobstripe_test
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into bstripe select *, x'11' from generate_series limit 1000" 2>/dev/null
     x=$(count bstripe)
     [[ "$x" == "2000" ]] || failexit "incorrect count for bstripe, $x"
-    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from bstripe" | egrep -v 11 | wc -l)
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from bstripe" | egrep -c -v 11)
     [[ "$x" == "0" ]] || failexit "incorrect blobs for blobstripe"
 }
 

--- a/tests/sc_repeated_updates.test/runit
+++ b/tests/sc_repeated_updates.test/runit
@@ -120,7 +120,7 @@ function update_same_record
         assertcnt $nrecs "update_same_record"
         let j=j+1
     done
-    succ=`grep "rows updated=1" update1.out | wc -l`
+    succ=`grep -c "rows updated=1" update1.out`
     if [[ $succ -ne $loc_recs ]] ; then
 	failexit "update_same_record: all $loc_recs should have resulted in successful update instead of $succ"
     fi
@@ -141,7 +141,7 @@ function update_same_record_fail
         assertcnt $nrecs "update_same_record_fail"
         let j=j+1
     done
-    failed=`grep failed update3.out | wc -l`
+    failed=`grep -c failed update3.out`
     if [[ $failed -ne $((loc_recs-1)) ]] ; then
 	failexit "update_same_record_fail: number failed is only $failed -ne $((loc_recs-1))"
     fi
@@ -173,7 +173,7 @@ function update_records
         done
         let t=t+1
 
-        succ=`grep "rows updated=1" update2.out | wc -l`
+        succ=`grep -c "rows updated=1" update2.out`
         if [[ $succ -ne $nrecs ]] ; then
             failexit "update_records: all $nrecs should have resulted in successful update instead of $succ"
         fi
@@ -201,7 +201,7 @@ function update_records_fail
         #sleep 0.1
     done
 
-    failed=`grep failed update4.out | wc -l`
+    failed=`grep -c failed update4.out`
     if [[ $failed -ne $((nrecs-dist)) ]] ; then
 	failexit "update_records_fail: number failed is only $failed -ne $((nrecs-dist))"
     fi

--- a/tests/sc_versmismatch.test/runit
+++ b/tests/sc_versmismatch.test/runit
@@ -62,7 +62,7 @@ function insert_records_oneshot
     echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-         echo "insert into t1(a,b,c) values ($j,'test1$j',$j)"  
+        echo "insert into t1(a,b,c) values ($j,'test1$j',$j)"  
         let j=j+1
     done | cdb2sql ${CDB2_OPTIONS} $dbnm default - &> $insfl
 }

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -96,7 +96,7 @@ cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in $dbnm default
 assertcnt t1 8
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select printf("%llx",cast(substr(comdb2_rowid,3) as integer)%16) as genid from t1' > stripes.out
 for i in `seq 1 $N` ; do
-    cnt=`grep $((i-1)) stripes.out | wc -l`
+    cnt=`grep -c $((i-1)) stripes.out`
     assertres "$cnt" "1"
 done
 
@@ -150,9 +150,9 @@ for i in `seq 1 $N` ; do
 done > entry_counts.out
 
 
-zeros=`grep "entries:0" entry_counts.out | wc -l`
+zeros=`grep -c "entries:0" entry_counts.out`
 assertres "$zeros" "$((N-1))"
-other=`grep "entries:16" entry_counts.out | wc -l`
+other=`grep -c "entries:16" entry_counts.out`
 assertres "$other" "1"
 
 
@@ -169,9 +169,9 @@ for i in `seq 1 $N` ; do
 done > entry_counts2.out
 
 
-zeros=`grep "entries:2" entry_counts2.out | wc -l`
+zeros=`grep -c "entries:2" entry_counts2.out`
 assertres "$zeros" "$((N-1))"
-other=`grep "entries:18" entry_counts2.out | wc -l`
+other=`grep -c "entries:18" entry_counts2.out`
 assertres "$other" "1"
 
 


### PR DESCRIPTION
reduce few forking unnecessary commands when running tests
/skipsysbench