### PR TITLE
Clean exit only when the bdb env is ready

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -605,6 +605,9 @@ void bdb_newsi_mempool_stat();
 static pthread_mutex_t exiting_lock = PTHREAD_MUTEX_INITIALIZER;
 void *clean_exit_thd(void *unused)
 {
+    if (thedb->bdb_env == NULL)
+        return NULL;
+
     Pthread_mutex_lock(&exiting_lock);
     if (gbl_exit) {
         Pthread_mutex_unlock(&exiting_lock);

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -605,7 +605,7 @@ void bdb_newsi_mempool_stat();
 static pthread_mutex_t exiting_lock = PTHREAD_MUTEX_INITIALIZER;
 void *clean_exit_thd(void *unused)
 {
-    if (thedb->bdb_env == NULL)
+    if (!gbl_ready)
         return NULL;
 
     Pthread_mutex_lock(&exiting_lock);


### PR DESCRIPTION
A replicant may receive a SIGTERM (from fixcdb2) while catching up with the master, in which case the SIGTERM handler should not perform clean exit as the bdb env is not ready yet.

(DRQS 141558232)