### PR TITLE
Add timing accounting: accumulate time spent in a given function

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1443,7 +1443,6 @@ void clean_exit(void)
     no_new_requests(thedb);
 
     print_all_time_accounting();
-    cleanup_time_accounting();
     wait_for_sc_to_stop("exit");
 
     /* let the lower level start advertising high lsns to go non-coherent

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1443,6 +1443,7 @@ void clean_exit(void)
     no_new_requests(thedb);
 
     print_all_time_accounting();
+    cleanup_time_accounting();
     wait_for_sc_to_stop("exit");
 
     /* let the lower level start advertising high lsns to go non-coherent

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -128,6 +128,7 @@ void berk_memp_sync_alarm_ms(int);
 #include "comdb2_atomic.h"
 #include "cron.h"
 #include "metrics.h"
+#include "time_accounting.h"
 #include <build/db.h>
 
 #define QUOTE_(x) #x
@@ -1405,6 +1406,7 @@ int clear_temp_tables(void)
 void clean_exit_sigwrap(int signum) {
     void *clean_exit_thd(void *unused);
     signal(SIGTERM, SIG_DFL);
+    logmsg(LOGMSG_WARN, "Received SIGTERM...exiting\n");
 
     /* Call the wrapper which checks the exit flag
        to avoid multiple clean-exit's. */
@@ -1440,6 +1442,7 @@ void clean_exit(void)
        here in a second, so letting new reads in would be bad. */
     no_new_requests(thedb);
 
+    print_all_time_accounting();
     wait_for_sc_to_stop("exit");
 
     /* let the lower level start advertising high lsns to go non-coherent

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -73,7 +73,7 @@ typedef long long tranid_t;
 #include <dlmalloc.h>
 #include <stdbool.h>
 
-#include "tag.h"
+#include "sqlinterfaces.h"
 #include "errstat.h"
 #include "comdb2_rcodes.h"
 #include "repl_wait.h"

--- a/db/debug.c
+++ b/db/debug.c
@@ -263,7 +263,8 @@ void debug_trap(char *line, int lline)
         logmsg(LOGMSG_USER, "getvers table        - get schema version for table (or all)\n");
         logmsg(LOGMSG_USER, "putvers table num    - set schema version for table\n");
         logmsg(LOGMSG_USER, "delsc   table tag    - delete a tag\n");
-        logmsg(LOGMSG_USER, "timings              - print all accumulated timing measurements \n");
+        logmsg(LOGMSG_USER, "timings              - print all accumulated "
+                            "timing measurements \n");
     } else {
         logmsg(LOGMSG_ERROR, "Unknown debug command <%.*s>\n", ltok, tok);
     }

--- a/db/debug.c
+++ b/db/debug.c
@@ -21,14 +21,15 @@
 
 #include <segstr.h>
 #include <stdarg.h>
+#include <compat.h>
 
 #include "comdb2.h"
 #include "tag.h"
 #include "net.h"
 #include "nodemap.h"
 #include "logmsg.h"
-#include <intern_strings.h>
-#include <compat.h>
+#include "time_accounting.h"
+#include "intern_strings.h"
 
 int osql_disable_net_test(void);
 int osql_enable_net_test(int testnum);
@@ -79,7 +80,7 @@ static void nettest_usage(void)
 
 char *tcmtest_routecpu_down_node;
 
-/* parse debug trap */
+/* parse debug trap @send debug <cmd> */
 void debug_trap(char *line, int lline)
 {
     char table[MAXTABLELEN];
@@ -254,14 +255,16 @@ void debug_trap(char *line, int lline)
         logmsg(LOGMSG_USER, "nodes:\n");
         for (int i = 0; i < numnodes; i++)
             logmsg(LOGMSG_USER, "  %s %d\n", hosts[i], nodeix(hosts[i]));
+    } else if (tokcmp(tok, ltok, "printchron") == 0) {
+        print_all_time_accounting();
     } else if (tokcmp(tok, ltok, "help") == 0) {
         logmsg(LOGMSG_USER, "tcmtest <test>       - enable a cdb2tcm test\n");
         logmsg(LOGMSG_USER, "tcmtest list         - list cdb2tcm tests\n");
         logmsg(LOGMSG_USER, "getvers table        - get schema version for table (or all)\n");
         logmsg(LOGMSG_USER, "putvers table num    - set schema version for table\n");
         logmsg(LOGMSG_USER, "delsc   table tag    - delete a tag\n");
+        logmsg(LOGMSG_USER, "printchron           - print all chron timer accumulation \n");
     } else {
         logmsg(LOGMSG_ERROR, "Unknown debug command <%.*s>\n", ltok, tok);
     }
 }
-

--- a/db/debug.c
+++ b/db/debug.c
@@ -255,7 +255,7 @@ void debug_trap(char *line, int lline)
         logmsg(LOGMSG_USER, "nodes:\n");
         for (int i = 0; i < numnodes; i++)
             logmsg(LOGMSG_USER, "  %s %d\n", hosts[i], nodeix(hosts[i]));
-    } else if (tokcmp(tok, ltok, "printchron") == 0) {
+    } else if (tokcmp(tok, ltok, "timings") == 0) {
         print_all_time_accounting();
     } else if (tokcmp(tok, ltok, "help") == 0) {
         logmsg(LOGMSG_USER, "tcmtest <test>       - enable a cdb2tcm test\n");
@@ -263,7 +263,7 @@ void debug_trap(char *line, int lline)
         logmsg(LOGMSG_USER, "getvers table        - get schema version for table (or all)\n");
         logmsg(LOGMSG_USER, "putvers table num    - set schema version for table\n");
         logmsg(LOGMSG_USER, "delsc   table tag    - delete a tag\n");
-        logmsg(LOGMSG_USER, "printchron           - print all chron timer accumulation \n");
+        logmsg(LOGMSG_USER, "timings              - print all accumulated timing measurements \n");
     } else {
         logmsg(LOGMSG_ERROR, "Unknown debug command <%.*s>\n", ltok, tok);
     }

--- a/db/glue.c
+++ b/db/glue.c
@@ -29,7 +29,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <strings.h>
-#include <time.h>
 #include <inttypes.h>
 
 #include <sys/types.h>
@@ -975,12 +974,10 @@ int ix_addk(struct ireq *iq, void *trans, void *key, int ixnum,
             unsigned long long genid, int rrn, void *dta, int dtalen, int isnull)
 {
     int rc;
-    CHRONO_START();
-
-    rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
-                         dtalen, isnull);
-
-    CHRONO_STOP_AND_SAVE(CHR_IXADDK);
+    ACCUMULATE_TIMING(CHR_IXADDK,
+        rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
+                           dtalen, isnull);
+    );
     return rc;
 }
 
@@ -1242,11 +1239,10 @@ int dat_add(struct ireq *iq, void *trans, void *data, int datalen,
             unsigned long long *genid, int *out_rrn)
 {
     int rc;
-    CHRONO_START();
 
-    rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
-
-    CHRONO_STOP_AND_SAVE(CHR_DATADD);
+    ACCUMULATE_TIMING(CHR_DATADD,
+        rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
+    );
 
     return rc;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -980,7 +980,7 @@ int ix_addk(struct ireq *iq, void *trans, void *key, int ixnum,
     rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
                          dtalen, isnull);
 
-    CHRONO_STOP_AND_SAVE("ix_addk");
+    CHRONO_STOP_AND_SAVE(CHR_IXADDK);
     return rc;
 }
 
@@ -1246,7 +1246,7 @@ int dat_add(struct ireq *iq, void *trans, void *data, int datalen,
 
     rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
 
-    CHRONO_STOP_AND_SAVE("dat_add");
+    CHRONO_STOP_AND_SAVE(CHR_DATADD);
 
     return rc;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -975,9 +975,8 @@ int ix_addk(struct ireq *iq, void *trans, void *key, int ixnum,
 {
     int rc;
     ACCUMULATE_TIMING(CHR_IXADDK,
-        rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
-                           dtalen, isnull);
-    );
+                      rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum,
+                                         genid, rrn, dta, dtalen, isnull););
     return rc;
 }
 
@@ -1241,8 +1240,8 @@ int dat_add(struct ireq *iq, void *trans, void *data, int datalen,
     int rc;
 
     ACCUMULATE_TIMING(CHR_DATADD,
-        rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
-    );
+                      rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen,
+                                         genid, out_rrn););
 
     return rc;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -91,6 +91,7 @@
 
 #include "views.h"
 #include "logmsg.h"
+#include "time_accounting.h"
 
 int (*comdb2_ipc_master_set)(char *host) = 0;
 
@@ -973,8 +974,14 @@ int ix_addk_auxdb(int auxdb, struct ireq *iq, void *trans, void *key, int ixnum,
 int ix_addk(struct ireq *iq, void *trans, void *key, int ixnum,
             unsigned long long genid, int rrn, void *dta, int dtalen, int isnull)
 {
-    return ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
+    int rc;
+    CHRONO_START();
+
+    rc = ix_addk_auxdb(AUXDB_NONE, iq, trans, key, ixnum, genid, rrn, dta,
                          dtalen, isnull);
+
+    CHRONO_STOP_AND_SAVE("ix_addk");
+    return rc;
 }
 
 int ix_upd_key(struct ireq *iq, void *trans, void *key, int keylen, int ixnum,
@@ -1234,7 +1241,14 @@ int dat_add_auxdb(int auxdb, struct ireq *iq, void *trans, void *data,
 int dat_add(struct ireq *iq, void *trans, void *data, int datalen,
             unsigned long long *genid, int *out_rrn)
 {
-    return dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
+    int rc;
+    CHRONO_START();
+
+    rc = dat_add_auxdb(AUXDB_NONE, iq, trans, data, datalen, genid, out_rrn);
+
+    CHRONO_STOP_AND_SAVE("dat_add");
+
+    return rc;
 }
 
 int dat_set(struct ireq *iq, void *trans, void *data, size_t length, int rrn,

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -792,9 +792,9 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
     DEBUG_PRINT_TMPBL_SAVING();
 
     ACCUMULATE_TIMING(CHR_TMPSVOP,
-        rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key, sizeof(key), rpl,
-                                   rplen, NULL, &bdberr);
-    );
+                      rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key,
+                                                 sizeof(key), rpl, rplen, NULL,
+                                                 &bdberr););
 
     if (rc_op) {
         logmsg(LOGMSG_ERROR, "%s: fail to put oplog seq=%llu rc=%d bdberr=%d\n",

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -795,7 +795,7 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
 
     rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key, sizeof(key), rpl,
                                rplen, NULL, &bdberr);
-    CHRONO_STOP_AND_SAVE("temp_table_saveop");
+    CHRONO_STOP_AND_SAVE(CHR_TMPSVOP);
 
     if (rc_op) {
         logmsg(LOGMSG_ERROR, "%s: fail to put oplog seq=%llu rc=%d bdberr=%d\n",

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -64,6 +64,7 @@
 #include "comdb2uuid.h"
 #include "bpfunc.h"
 #include "logmsg.h"
+#include "time_accounting.h"
 
 int g_osql_blocksql_parallel_max = 5;
 int gbl_osql_check_replicant_numops = 1;
@@ -790,8 +791,12 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
 
     DEBUG_PRINT_TMPBL_SAVING();
 
+    CHRONO_START();
+
     rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key, sizeof(key), rpl,
                                rplen, NULL, &bdberr);
+    CHRONO_STOP_AND_SAVE("temp_table_saveop");
+
     if (rc_op) {
         logmsg(LOGMSG_ERROR, "%s: fail to put oplog seq=%llu rc=%d bdberr=%d\n",
                __func__, sess->seq, rc_op, bdberr);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -791,11 +791,10 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
 
     DEBUG_PRINT_TMPBL_SAVING();
 
-    CHRONO_START();
-
-    rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key, sizeof(key), rpl,
-                               rplen, NULL, &bdberr);
-    CHRONO_STOP_AND_SAVE(CHR_TMPSVOP);
+    ACCUMULATE_TIMING(CHR_TMPSVOP,
+        rc_op = bdb_temp_table_put(thedb->bdb_env, tmptbl, &key, sizeof(key), rpl,
+                                   rplen, NULL, &bdberr);
+    );
 
     if (rc_op) {
         logmsg(LOGMSG_ERROR, "%s: fail to put oplog seq=%llu rc=%d bdberr=%d\n",

--- a/db/sqlthdpool.h
+++ b/db/sqlthdpool.h
@@ -17,31 +17,9 @@
 #ifndef __SQLTHDPOOL_H__
 #define __SQLTHDPOOL_H__
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <errno.h>
-#include <string.h>
-#include <stddef.h>
-#include <pthread.h>
-
-#include <plhash.h>
-#include <segstr.h>
-
-#include <list.h>
-#include <queue.h>
-
 #include <sbuf2.h>
-#include <bdb_api.h>
-
-#include "comdb2.h"
-#include "types.h"
-#include "tag.h"
-
-#include <dynschematypes.h>
-#include <dynschemaload.h>
-
-#include <sqlite3.h>
-#include "sqlinterfaces.h"
+#include <pthread.h>
+#include <queue.h>
 
 typedef struct sqlpool {
     int curnthd; /* current number of threads in

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -90,7 +90,8 @@ void free_schema_change_type(struct schema_change_type *s)
     Pthread_mutex_destroy(&s->mtx);
     Pthread_mutex_destroy(&s->livesc_mtx);
 
-    if (s->sb && s->must_close_sb) close_appsock(s->sb);
+    if (s->sb && s->must_close_sb)
+        close_appsock(s->sb);
     if (!s->onstack) {
         free(s);
     }

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -75,24 +75,24 @@ static void free_dests(struct schema_change_type *s)
 
 void free_schema_change_type(struct schema_change_type *s)
 {
-    if (s) {
-        if (s->newcsc2) {
-            free(s->newcsc2);
-            s->newcsc2 = NULL;
-        }
-        if (s->sc_convert_done) {
-            free(s->sc_convert_done);
-            s->sc_convert_done = NULL;
-        }
+    if (!s)
+        return;
+    if (s->newcsc2) {
+        free(s->newcsc2);
+        s->newcsc2 = NULL;
+    }
+    if (s->sc_convert_done) {
+        free(s->sc_convert_done);
+        s->sc_convert_done = NULL;
+    }
 
-        free_dests(s);
-        Pthread_mutex_destroy(&s->mtx);
-        Pthread_mutex_destroy(&s->livesc_mtx);
+    free_dests(s);
+    Pthread_mutex_destroy(&s->mtx);
+    Pthread_mutex_destroy(&s->livesc_mtx);
 
-        if (s->sb && s->must_close_sb) close_appsock(s->sb);
-        if (!s->onstack) {
-            free(s);
-        }
+    if (s->sb && s->must_close_sb) close_appsock(s->sb);
+    if (!s->onstack) {
+        free(s);
     }
 }
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -24,7 +24,7 @@ kill_by_pidfile() {
         if [[ $? -eq 0 ]]; then
             echo "${TESTCASE}: killing $pid"
             if [ "`echo $pstr | awk '{ print $1 }' | xargs basename`" = "comdb2" ] ; then
-                kill -9 $pid
+                kill $pid
             else
                 kill $pid
             fi
@@ -176,7 +176,7 @@ unsetup_db() {
         # will kill server on that node
         if [ -n "$pidfilelist" ] ; then
             echo "killing $pidfilelist"
-            kill -9 $pidfilelist
+            kill $pidfilelist
         fi
     fi
 

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -24,7 +24,7 @@ kill_by_pidfile() {
         if [[ $? -eq 0 ]]; then
             echo "${TESTCASE}: killing $pid"
             if [ "`echo $pstr | awk '{ print $1 }' | xargs basename`" = "comdb2" ] ; then
-                kill $pid
+                kill -9 $pid
             else
                 kill $pid
             fi
@@ -176,7 +176,7 @@ unsetup_db() {
         # will kill server on that node
         if [ -n "$pidfilelist" ] ; then
             echo "killing $pidfilelist"
-            kill $pidfilelist
+            kill -9 $pidfilelist
         fi
     fi
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -47,6 +47,7 @@ set(src
   thdpool.c
   thread_malloc.c
   thread_util.c
+  time_accounting.c
   timers.c
   tohex.c
   utilmisc.c

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -26,17 +26,6 @@ const char *CHR_NAMES[] = {"ix_addk", "dat_add", "temp_table_saveop"};
 
 unsigned long long gbl_chron_times[CHR_MAX];
 
-// return timediff in microseconds (us) from tv passed in
-int chrono_stop(struct timeval *tv)
-{
-    struct timeval tmp;
-    gettimeofday(&tmp, NULL);
-    int sec_part = (tmp.tv_sec - tv->tv_sec)*1000000;
-    int usec_part = (tmp.tv_usec - tv->tv_usec);
-
-    return sec_part + usec_part;
-}
-
 // add time accounting to appropriate slot
 void accumulate_time(int el, int us)
 {

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -135,6 +135,6 @@ void cleanup_time_accounting()
     hash_for(htimes, free_name_time_pair, NULL);
     hash_clear(htimes);
     hash_free(htimes);
-    htimes = 0;
+    htimes = NULL;
     Pthread_mutex_unlock(&hlock);
 }

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -13,7 +13,6 @@
    limitations under the License.
  */
 
-
 #include <pthread.h>
 #include <sys/time.h>
 #include "locks_wrap.h"
@@ -22,7 +21,6 @@
 
 #ifndef NDEBUG
 const char *CHR_NAMES[] = {"ix_addk", "dat_add", "temp_table_saveop"};
-
 
 unsigned long long gbl_chron_times[CHR_MAX];
 
@@ -39,8 +37,8 @@ void reset_time_accounting(int el)
 
 void print_time_accounting(int el)
 {
-    logmsg(LOGMSG_USER, "Timing information for %s: %lluus\n", 
-           CHR_NAMES[el], gbl_chron_times[el]);
+    logmsg(LOGMSG_USER, "Timing information for %s: %lluus\n", CHR_NAMES[el],
+           gbl_chron_times[el]);
 }
 
 void print_all_time_accounting()

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -104,7 +104,7 @@ void print_time_accounting(const char *name)
 static int print_name_time_pair(void *obj, void *unused)
 {
     name_time_pair_t *ptr = obj;
-    logmsg(LOGMSG_USER, "%s: str=%s %lluus\n", __func__, ptr->name, ptr->utime);
+    logmsg(LOGMSG_USER, "name=%s time=%lluus\n", ptr->name, ptr->utime);
     return 0;
 
 }

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -1,0 +1,140 @@
+/*
+   Copyright 2019 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
+#include <pthread.h>
+#include <sys/time.h>
+#include "locks_wrap.h"
+#include "plhash.h"
+#include "intern_strings.h"
+
+pthread_mutex_t hlock = PTHREAD_MUTEX_INITIALIZER;
+static hash_t *htimes = NULL;
+
+typedef struct {
+    const char *name;
+    unsigned long long utime;
+} name_time_pair_t;
+
+// return timediff in microseconds (us) from tv passed in
+int chrono_stop(struct timeval *tv)
+{
+    struct timeval tmp;
+    gettimeofday(&tmp, NULL);
+    int sec_part = (tmp.tv_sec - tv->tv_sec)*1000000;
+    int usec_part = (tmp.tv_usec - tv->tv_usec);
+
+    return sec_part + usec_part;
+}
+
+// add time accounting to appropriate slot
+void accumulate_time(const char *name, int us)
+{
+    Pthread_mutex_lock(&hlock);
+    if (!htimes) {
+        htimes = hash_init_o(offsetof(name_time_pair_t, name), sizeof(const char *));
+    }
+    name_time_pair_t *ptr;
+    const char *iptr = intern(name);
+    if ((ptr = hash_find_readonly(htimes, &iptr)) == 0) {
+        ptr = malloc(sizeof(name_time_pair_t));
+        ptr->name = intern(name);
+        ptr->utime = 0;
+        hash_add(htimes, ptr);
+    }
+    ptr->utime += us;
+    Pthread_mutex_unlock(&hlock);
+}
+
+void reset_time_accounting(const char *name)
+{
+    if (!htimes) {
+        return;
+    }
+    Pthread_mutex_lock(&hlock);
+    name_time_pair_t *ptr;
+    const char *iptr = intern(name);
+    if ((ptr = hash_find_readonly(htimes, &iptr)) != 0) {
+        ptr->utime = 0;
+    }
+    Pthread_mutex_unlock(&hlock);
+}
+static int reset_time(void *obj, void *unused)
+{
+    name_time_pair_t *ptr = obj;
+    ptr->utime = 0;
+    return 0;
+
+}
+void reset_all_time_accounting()
+{
+    if (!htimes) {
+        return;
+    }
+    hash_for(htimes, reset_time, NULL);
+}
+
+
+void print_time_accounting(const char *name)
+{
+    if (!htimes) {
+        return;
+    }
+    Pthread_mutex_lock(&hlock);
+    name_time_pair_t *ptr;
+    const char *iptr = intern(name);
+    if ((ptr = hash_find_readonly(htimes, &iptr)) != 0) {
+        logmsg(LOGMSG_USER, "Timing information for %s: %lluus\n", ptr->name, ptr->utime);
+    }
+    Pthread_mutex_unlock(&hlock);
+}
+
+static int print_name_time_pair(void *obj, void *unused)
+{
+    name_time_pair_t *ptr = obj;
+    logmsg(LOGMSG_USER, "%s: str=%s %lluus\n", __func__, ptr->name, ptr->utime);
+    return 0;
+
+}
+
+void print_all_time_accounting()
+{
+    if (!htimes) {
+        return;
+    }
+    logmsg(LOGMSG_USER, "Timing information:\n");
+    Pthread_mutex_lock(&hlock);
+    hash_for(htimes, print_name_time_pair, NULL);
+    Pthread_mutex_unlock(&hlock);
+}
+
+static int free_name_time_pair(void *obj, void *unused)
+{
+    free(obj);
+    return 0;
+}
+
+void cleanup_time_accounting()
+{
+    if (!htimes) {
+        return;
+    }
+    Pthread_mutex_lock(&hlock);
+    hash_for(htimes, free_name_time_pair, NULL);
+    hash_clear(htimes);
+    hash_free(htimes);
+    htimes = 0;
+    Pthread_mutex_unlock(&hlock);
+}

--- a/util/time_accounting.c
+++ b/util/time_accounting.c
@@ -50,4 +50,5 @@ void print_all_time_accounting()
         logmsg(LOGMSG_USER, "%s: %lluus\n", CHR_NAMES[i], gbl_chron_times[i]);
     }
 }
+
 #endif

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -1,0 +1,50 @@
+/*
+   Copyright 2019 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef _time_accounting_h
+#define _time_accounting_h
+
+#ifndef NDEBUG
+
+#define CHRONO_START()   \
+{                        \
+    struct timeval __tv; \
+    gettimeofday(&__tv, NULL);
+
+#define CHRONO_STOP_AND_SAVE(name) \
+    accumulate_time(name, chrono_stop(&__tv)); \
+}
+
+int chrono_stop(struct timeval *tv);
+void accumulate_time(const char *name, int us);
+
+void print_time_accounting(const char *name);
+void print_all_time_accounting();
+
+void reset_time_accounting(const char *name);
+void reset_all_time_accounting();
+
+void cleanup_time_accounting();
+
+#else
+#define CHRONO_START()  {}
+#define CHRONO_STOP_AND_SAVE(name) {}
+#define print_all_time_accounting() {}
+#define cleanup_time_accounting() {}
+#endif
+
+
+#endif

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -23,13 +23,16 @@
 enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX };
 
 #define ACCUMULATE_TIMING(NAME, CODE) do { \
-    struct timeval __tv; \
-    gettimeofday(&__tv, NULL); \
+    struct timeval __tv1; \
+    gettimeofday(&__tv1, NULL); \
     CODE; \
-    accumulate_time(NAME, chrono_stop(&__tv)); \
+    struct timeval __tv2; \
+    gettimeofday(&__tv2, NULL); \
+    int __sec_part = (__tv2.tv_sec - __tv1.tv_sec)*1000000; \
+    int __usec_part = (__tv2.tv_usec - __tv1.tv_usec); \
+    accumulate_time(NAME, __sec_part + __usec_part); \
 } while(0); 
 
-int chrono_stop(struct timeval *tv);
 void accumulate_time(int el, int us);
 
 void print_time_accounting(int el);

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -34,17 +34,17 @@ enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX } CHR_ENUM;
  * call print_time_accounting(CHR_FUNCTOMEASURE);
  */
 
-
-#define ACCUMULATE_TIMING(NAME, CODE) do { \
-    struct timeval __tv1; \
-    gettimeofday(&__tv1, NULL); \
-    CODE; \
-    struct timeval __tv2; \
-    gettimeofday(&__tv2, NULL); \
-    int __sec_part = (__tv2.tv_sec - __tv1.tv_sec)*1000000; \
-    int __usec_part = (__tv2.tv_usec - __tv1.tv_usec); \
-    accumulate_time(NAME, __sec_part + __usec_part); \
-} while(0); 
+#define ACCUMULATE_TIMING(NAME, CODE)                                          \
+    do {                                                                       \
+        struct timeval __tv1;                                                  \
+        gettimeofday(&__tv1, NULL);                                            \
+        CODE;                                                                  \
+        struct timeval __tv2;                                                  \
+        gettimeofday(&__tv2, NULL);                                            \
+        int __sec_part = (__tv2.tv_sec - __tv1.tv_sec) * 1000000;              \
+        int __usec_part = (__tv2.tv_usec - __tv1.tv_usec);                     \
+        accumulate_time(NAME, __sec_part + __usec_part);                       \
+    } while (0);
 
 void accumulate_time(int el, int us);
 
@@ -53,10 +53,16 @@ void print_all_time_accounting();
 
 #else
 
-#define ACCUMULATE_TIMING(NAME, CODE) do { CODE; } while(0);
-#define print_all_time_accounting() do {} while(0);
-#define print_time_accounting(el) do {} while(0);
+#define ACCUMULATE_TIMING(NAME, CODE)                                          \
+    do {                                                                       \
+        CODE;                                                                  \
+    } while (0);
+#define print_all_time_accounting()                                            \
+    do {                                                                       \
+    } while (0);
+#define print_time_accounting(el)                                              \
+    do {                                                                       \
+    } while (0);
 #endif
-
 
 #endif

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -17,7 +17,9 @@
 #ifndef _time_accounting_h
 #define _time_accounting_h
 
+
 #ifndef NDEBUG
+enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX };
 
 #define CHRONO_START()   \
 {                        \
@@ -29,15 +31,13 @@
 }
 
 int chrono_stop(struct timeval *tv);
-void accumulate_time(const char *name, int us);
+void accumulate_time(int el, int us);
 
-void print_time_accounting(const char *name);
+void print_time_accounting(int el);
 void print_all_time_accounting();
 
-void reset_time_accounting(const char *name);
+void reset_time_accounting(int el);
 void reset_all_time_accounting();
-
-void cleanup_time_accounting();
 
 #else
 #define CHRONO_START()  {}

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -14,13 +14,26 @@
    limitations under the License.
  */
 
-#ifndef _time_accounting_h
-#define _time_accounting_h
+#ifndef _TIME_ACCOUNTING_H
+#define _TIME_ACCOUNTING_H
 
 #include <sys/time.h>
 
 #ifndef NDEBUG
-enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX };
+
+enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX } CHR_ENUM;
+
+/* NB: this construct is ment to encompass a function call like this:
+ * ACCUMULATE_TIMING(CHR_FUNCTOMEASURE
+ *   rc = func_to_measure();
+ * );
+ *
+ * You will have to add CHR_FUNCTOMEASURE to the CHR_ENUM above and
+ * CHR_NAMES (in time_accounting.c for printing purposes).
+ * To print accumulated time for that function then you can
+ * call print_time_accounting(CHR_FUNCTOMEASURE);
+ */
+
 
 #define ACCUMULATE_TIMING(NAME, CODE) do { \
     struct timeval __tv1; \
@@ -38,13 +51,11 @@ void accumulate_time(int el, int us);
 void print_time_accounting(int el);
 void print_all_time_accounting();
 
-void reset_time_accounting(int el);
-void reset_all_time_accounting();
-
 #else
+
 #define ACCUMULATE_TIMING(NAME, CODE) do { CODE; } while(0);
-#define print_all_time_accounting() {}
-#define cleanup_time_accounting() {}
+#define print_all_time_accounting() do {} while(0);
+#define print_time_accounting(el) do {} while(0);
 #endif
 
 

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -17,18 +17,17 @@
 #ifndef _time_accounting_h
 #define _time_accounting_h
 
+#include <sys/time.h>
 
 #ifndef NDEBUG
 enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX };
 
-#define CHRONO_START()   \
-{                        \
+#define ACCUMULATE_TIMING(NAME, CODE) do { \
     struct timeval __tv; \
-    gettimeofday(&__tv, NULL);
-
-#define CHRONO_STOP_AND_SAVE(name) \
-    accumulate_time(name, chrono_stop(&__tv)); \
-}
+    gettimeofday(&__tv, NULL); \
+    CODE; \
+    accumulate_time(NAME, chrono_stop(&__tv)); \
+} while(0); 
 
 int chrono_stop(struct timeval *tv);
 void accumulate_time(int el, int us);
@@ -40,8 +39,7 @@ void reset_time_accounting(int el);
 void reset_all_time_accounting();
 
 #else
-#define CHRONO_START()  {}
-#define CHRONO_STOP_AND_SAVE(name) {}
+#define ACCUMULATE_TIMING(NAME, CODE) do { CODE; } while(0);
 #define print_all_time_accounting() {}
 #define cleanup_time_accounting() {}
 #endif


### PR DESCRIPTION
Add timing accounting: accumulate time spent in a given function. 
Make it simple to get timing information how much time was spent in a given function.
This is enabled only for debug mode.