### PR TITLE
Safely remove an element from a SQLite hashtable while looping over it.

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3272,10 +3272,13 @@ int sqlite3BtreeClose(Btree *pBt)
         // assert( pBt->temp_table_mtx==thd->clnt->temp_table_mtx );
         Pthread_mutex_lock(pBt->temp_table_mtx);
 
-        for(pElem=sqliteHashFirst(&pBt->temp_tables); pElem;
-                pElem=sqliteHashNext(pElem)){
+        for(pElem=sqliteHashFirst(&pBt->temp_tables); pElem; ){
             /* internally this will close cursors open on the table */
             struct temptable_entry *pEntry = pElem->data;
+
+            /* releaseTempTableRef may free pElem. So we get the next element
+               now before invoking releaseTempTableRef(). */
+            pElem=sqliteHashNext(pElem);
 
             if (pEntry != NULL) {
                 assert( pEntry->value );


### PR DESCRIPTION
Make sure we don't read from freed memory.

(DRQS 141427848)
