### PR TITLE
use same node to keep errors consistent

### DIFF
--- a/tests/mismatch_class_remsql.test/remsql.sh
+++ b/tests/mismatch_class_remsql.test/remsql.sh
@@ -15,8 +15,14 @@ a_cdb2config=$4
 set -e
 
 output="output.log"
-cmd_rmt="cdb2sql -s --cdb2cfg ${a_remcdb2config} $a_remdbname default -" 
-cmd="cdb2sql -s --cdb2cfg ${a_cdb2config} $a_dbname default " 
+
+mach=`cdb2sql -tabs -cdb2cfg ${a_cdb2config} $a_dbname default "select comdb2_node()"`
+if [[ -z $mach ]] ; then
+    echo "Failing to get machine node"
+fi
+
+cmd_rmt="cdb2sql -s --cdb2cfg ${a_remcdb2config} $a_remdbname --host $mach" 
+cmd="cdb2sql -s --cdb2cfg ${a_cdb2config} $a_dbname --host $mach" 
 
 echo "Inserting rows"
 $cmd_rmt < inserts.req > ${output} 2>&1


### PR DESCRIPTION
https://github.com/bloomberg/comdb2/pull/1507 introduced a test case that is failing randomly.  This is because of error differences in the output, which depends on which node is being used to test the error.  This fixes the test case.