### PR TITLE
Fix stat4 cornercase remsql

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -449,7 +449,7 @@ REGISTER_TUNABLE("exitalarmsec", NULL, TUNABLE_INTEGER, &gbl_exit_alarm_sec,
 REGISTER_TUNABLE("exit_on_internal_failure", NULL, TUNABLE_BOOLEAN,
                  &gbl_exit_on_internal_error, READONLY | NOARG, NULL, NULL,
                  NULL, NULL);
-REGISTER_TUNABLE("fdbdebg", NULL, TUNABLE_INTEGER, &gbl_fdb_track, READONLY,
+REGISTER_TUNABLE("fdbdebg", NULL, TUNABLE_INTEGER, &gbl_fdb_track, 0,
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("fdbtrackhints", NULL, TUNABLE_INTEGER, &gbl_fdb_track_hints,
                  READONLY, NULL, NULL, NULL, NULL);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -449,8 +449,8 @@ REGISTER_TUNABLE("exitalarmsec", NULL, TUNABLE_INTEGER, &gbl_exit_alarm_sec,
 REGISTER_TUNABLE("exit_on_internal_failure", NULL, TUNABLE_BOOLEAN,
                  &gbl_exit_on_internal_error, READONLY | NOARG, NULL, NULL,
                  NULL, NULL);
-REGISTER_TUNABLE("fdbdebg", NULL, TUNABLE_INTEGER, &gbl_fdb_track, 0,
-                 NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("fdbdebg", NULL, TUNABLE_INTEGER, &gbl_fdb_track, 0, NULL,
+                 NULL, NULL, NULL);
 REGISTER_TUNABLE("fdbtrackhints", NULL, TUNABLE_INTEGER, &gbl_fdb_track_hints,
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("forbid_ulonglong", "Disallow u_longlong. (Default: on)",

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1923,6 +1923,15 @@ int fdb_cursor_move_master(BtCursor *pCur, int *pRes, int how)
                         12) == 0) {
             goto sqlite_stat4;
         }
+    } else {
+        /* this is the first time we step and locate a table; we 
+        will need to position on the current table; given the order
+        chosen {table, stat1, stat4, done}, if table is stat4, we 
+        end up skipping stat1.  To fix this, we replace stat4 with
+        stat1 since we will get stat4 after this */
+        if (strncasecmp(zTblName, "sqlite_stat4",
+                        12) == 0)
+            zTblName = "sqlite_stat1";
     }
 
 search:

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1924,13 +1924,12 @@ int fdb_cursor_move_master(BtCursor *pCur, int *pRes, int how)
             goto sqlite_stat4;
         }
     } else {
-        /* this is the first time we step and locate a table; we 
+        /* this is the first time we step and locate a table; we
         will need to position on the current table; given the order
-        chosen {table, stat1, stat4, done}, if table is stat4, we 
+        chosen {table, stat1, stat4, done}, if table is stat4, we
         end up skipping stat1.  To fix this, we replace stat4 with
         stat1 since we will get stat4 after this */
-        if (strncasecmp(zTblName, "sqlite_stat4",
-                        12) == 0)
+        if (strncasecmp(zTblName, "sqlite_stat4", 12) == 0)
             zTblName = "sqlite_stat1";
     }
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -3828,12 +3828,15 @@ static fdb_tran_t *fdb_trans_dtran_get_subtran(struct sqlclntstate *clnt,
         free(msg);
 
         if (gbl_fdb_track) {
-            uuidstr_t us;
-            logmsg(LOGMSG_USER, "%s Created tid=%s db=\"%s\"\n", __func__,
-                   comdb2uuidstr((unsigned char *)tran->tid, us), fdb->dbname);
-        } else {
-            logmsg(LOGMSG_USER, "%s Created tid=%llx db=\"%s\"\n", __func__,
-                    *(unsigned long long *)tran->tid, fdb->dbname);
+            if (clnt->osql.rqid == OSQL_RQID_USE_UUID) {
+                uuidstr_t us;
+                logmsg(LOGMSG_USER, "%s Created tid=%s db=\"%s\"\n", __func__,
+                       comdb2uuidstr((unsigned char *)tran->tid, us),
+                       fdb->dbname);
+            } else {
+                logmsg(LOGMSG_USER, "%s Created tid=%llx db=\"%s\"\n", __func__,
+                       *(unsigned long long *)tran->tid, fdb->dbname);
+            }
         }
     } else {
         if (gbl_fdb_track) {

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -299,7 +299,7 @@
 (name='exitalarmsec', description='', type='INTEGER', value='300', read_only='Y')
 (name='extended_sql_debug_trace', description='Print extended trace for durable sql debugging', type='BOOLEAN', value='OFF', read_only='N')
 (name='fdb_sqlstats_cache_lock_waittime_nsec', description='', type='INTEGER', value='1000', read_only='N')
-(name='fdbdebg', description='', type='INTEGER', value='0', read_only='Y')
+(name='fdbdebg', description='', type='INTEGER', value='0', read_only='N')
 (name='fdbtrackhints', description='', type='INTEGER', value='0', read_only='Y')
 (name='fingerprint_queries', description='Compute fingerprint for SQL queries', type='BOOLEAN', value='ON', read_only='N')
 (name='fix_cstr', description='Fix validation of cstrings', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Accessing stat4 from a remote db first time fails to load stat1, though this is no impact. Accessing any other table next iteration will retrieve the stat1 for optimizer.  This patch fixes the corner case anyway.