### PR TITLE
Fix resizing a LIFO object pool

### DIFF
--- a/tests/objpool.test/Makefile
+++ b/tests/objpool.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/objpool.test/runit
+++ b/tests/objpool.test/runit
@@ -1,0 +1,10 @@
+#!/bin/sh
+bash -n "$0" | exit 1
+dbnm=$1
+
+#### Test resizing object pool at runtime ####
+cat << EOF | cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default -
+SELECT 1 UNION SELECT 2
+EXEC PROCEDURE sys.cmd.send("bdb temptable capacity 1024")
+SELECT 1 UNION SELECT 2
+EOF

--- a/util/object_pool.c
+++ b/util/object_pool.c
@@ -1120,8 +1120,8 @@ static int opt_capacity(comdb2_objpool_t op, int value)
 
     free(op->objs);
     op->objs = resized;
-    op->out = 0;
     op->in = ntotalcpy;
+    op->out = (op->type == OP_LIFO) ? (op->in - 1) : 0;
     op->nobjs = ntotalcpy + op->nactiveobjs;
     op->capacity = value;
 


### PR DESCRIPTION
The `out` counter is mistakenly set to 0 after a resizing. As a result, the 2nd object_borrow() call on a resized LIFO pool would crash.

(DRQS 141952925)
