### PR TITLE
net: Fix self-deadlock on a failed write_connect_message.

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -4990,7 +4990,6 @@ static void *connect_thread(void *arg)
         sin.sin_port = htons(connport);
 
         if (netinfo_ptr->exiting) {
-            Pthread_mutex_unlock(&(host_node_ptr->lock));
             break;
         }
 

--- a/net/net.c
+++ b/net/net.c
@@ -5135,9 +5135,9 @@ static void *connect_thread(void *arg)
                                    host_node_ptr->sb);
         if (rc != 0) {
             host_node_printf(LOGMSG_ERROR, host_node_ptr,
-                             "%s: couldnt send connect message\n", __func__);
+                             "%s: couldn't send connect message\n", __func__);
             Pthread_mutex_unlock(&(host_node_ptr->write_lock));
-            close_hostnode(host_node_ptr);
+            close_hostnode_ll(host_node_ptr);
             goto again;
         }
         sbuf2flush(host_node_ptr->sb);


### PR DESCRIPTION
We already hold `host_node_ptr->lock`. Since `host_node_ptr->lock` isn't recursive, relocking it would hang.

(DRQS 141973376)