### PR TITLE
Fix a race between clean-exit and net queue stat

### DIFF
--- a/bdb/rep_qstat.c
+++ b/bdb/rep_qstat.c
@@ -48,6 +48,11 @@ static void net_enque_write_rtn(netinfo_type *netinfo_ptr, void *netstat,
     DB_LSN lsn;
     int rectype, rc;
 
+    /* If we're exiting, some fields might have been
+       destroyed before we get here. Return now. */
+    if (net_is_exiting(netinfo_ptr))
+        return;
+
     /* Get a pointer back to our bdb_state */
     bdb_state = net_get_usrptr(netinfo_ptr);
 

--- a/net/net.c
+++ b/net/net.c
@@ -3065,6 +3065,11 @@ void net_exiting(netinfo_type *netinfo_ptr)
     netinfo_ptr->exiting = 1;
 }
 
+int net_is_exiting(netinfo_type *netinfo_ptr)
+{
+    return netinfo_ptr->exiting;
+}
+
 typedef struct netinfo_node {
     LINKC_T(struct netinfo_node) lnk;
     netinfo_type *netinfo_ptr;

--- a/net/net.h
+++ b/net/net.h
@@ -392,6 +392,7 @@ int net_get_queue_size(netinfo_type *netinfo_type, const char *host, int *limit,
                        int *usage);
 
 void net_exiting(netinfo_type *netinfo_ptr);
+int net_is_exiting(netinfo_type *netinfo_ptr);
 
 void net_trace(netinfo_type *netinfo_ptr, int on);
 


### PR DESCRIPTION
clean-exit might have destroyed the net before we get in `net_enque_write_rtn()`. Protect us from the race by checking the exiting flag in the net first.

(DRQS 142229812)
