### PR TITLE
Several instances of strncpy are off by one

### DIFF
--- a/bdb/info.c
+++ b/bdb/info.c
@@ -2148,7 +2148,7 @@ repl_wait_and_net_use_t *bdb_get_repl_wait_and_net_stats(
 
     for (i = 0; i != nnodes; ++i) {
         pos = rv + i;
-        strncpy(pos->host, nodes[i].host, sizeof(pos->host));
+        strncpy0(pos->host, nodes[i].host, sizeof(pos->host));
         host = nodes[i].host;
 
         /* net_get_nodes_info() returns all nodes. Exclude myself. */

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -2847,7 +2847,7 @@ int bdb_new_csc2(tran_type *input_trans, /* if this is !NULL it will be used as
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
     strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
-            sizeof(p_file_type_dbname_csc2_vers_key.dbname));
+             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
 
@@ -3001,7 +3001,7 @@ int bdb_get_csc2_highest(tran_type *trans, /* transaction to use, may be NULL */
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
     strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
-            sizeof(p_file_type_dbname_csc2_vers_key.dbname));
+             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
 
@@ -3158,7 +3158,7 @@ int bdb_get_csc2(tran_type *tran, /* transaction to use, may be NULL */
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
     strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
-            sizeof(p_file_type_dbname_csc2_vers_key.dbname));
+             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
     /* zero this out for now */
@@ -4018,7 +4018,7 @@ static int bdb_set_high_genid_int(
     /* BTW- There's NO NULL BYTE!  So the stripe ends up using 3 bytes
        rather than 4 */
     strncpy0(high_genid_key_type.dbname, db_name,
-            sizeof(high_genid_key_type.dbname));
+             sizeof(high_genid_key_type.dbname));
     high_genid_key_type.dbname_len = strlen(high_genid_key_type.dbname);
 
     /* add stripe to key */
@@ -4192,7 +4192,7 @@ int bdb_get_high_genid(
     /* BTW- There's NO NULL BYTE!  So the stripe ends up using 3 bytes
        rather than 4 */
     strncpy0(high_genid_key_type.dbname, db_name,
-            sizeof(high_genid_key_type.dbname));
+             sizeof(high_genid_key_type.dbname));
     high_genid_key_type.dbname_len = strlen(high_genid_key_type.dbname);
 
     /* add stripe to key */
@@ -5266,10 +5266,10 @@ static int bdb_tbl_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -5388,10 +5388,10 @@ int bdb_tbl_op_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
     tbl_access_data.command_type = command_type;
 
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_op_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -5479,10 +5479,10 @@ int bdb_tbl_op_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
     tbl_access_data.file_type = LLMETA_TABLE_USER_OP;
     tbl_access_data.command_type = command_type;
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_op_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -5516,10 +5516,10 @@ int bdb_tbl_op_access_delete(bdb_state_type *bdb_state, tran_type *input_trans,
     tbl_access_data.file_type = LLMETA_TABLE_USER_OP;
     tbl_access_data.command_type = command_type;
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_op_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -5766,10 +5766,10 @@ static int bdb_tbl_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -5815,7 +5815,7 @@ int bdb_tbl_access_userschema_get(bdb_state_type *bdb_state,
     tbl_access_data.file_type = LLMETA_TABLE_USER_SCHEMA;
 
     strncpy0(tbl_access_data.tablename, username,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     bzero(tbl_access_data.username, sizeof(tbl_access_data.username));
 
@@ -5844,7 +5844,7 @@ int bdb_tbl_access_userschema_get(bdb_state_type *bdb_state,
             return -1;
         }
         strncpy0(userschema, tbl_access_data.username,
-                sizeof(tbl_access_data.username));
+                 sizeof(tbl_access_data.username));
         logmsg(LOGMSG_INFO, "User Schema for username %s is %s\n", username,
                 userschema);
     } else {
@@ -5881,10 +5881,10 @@ static int bdb_tbl_access_delete(bdb_state_type *bdb_state,
     }
 
     strncpy0(tbl_access_data.tablename, tblname,
-            sizeof(tbl_access_data.tablename));
+             sizeof(tbl_access_data.tablename));
 
     strncpy0(tbl_access_data.username, username,
-            sizeof(tbl_access_data.username));
+             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
     if (!(llmeta_tbl_access_put(&tbl_access_data, p_buf, p_buf_end))) {
@@ -6588,7 +6588,7 @@ int bdb_get_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
 
     analyzecoverage_key.file_type = LLMETA_ANALYZECOVERAGE_TABLE;
     strncpy0(analyzecoverage_key.dbname, tbl_name,
-            sizeof(analyzecoverage_key.dbname));
+             sizeof(analyzecoverage_key.dbname));
     analyzecoverage_key.dbname_len = strlen(analyzecoverage_key.dbname);
 
     /* set pointers to start and end of buffer */
@@ -6677,7 +6677,7 @@ int bdb_set_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
 
     analyzecoverage_key.file_type = LLMETA_ANALYZECOVERAGE_TABLE;
     strncpy0(analyzecoverage_key.dbname, tbl_name,
-            sizeof(analyzecoverage_key.dbname));
+             sizeof(analyzecoverage_key.dbname));
     analyzecoverage_key.dbname_len = strlen(analyzecoverage_key.dbname);
 
     /* set pointers to start and end of buffer */
@@ -6827,7 +6827,7 @@ int bdb_get_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
 
     analyzethreshold_key.file_type = LLMETA_ANALYZETHRESHOLD_TABLE;
     strncpy0(analyzethreshold_key.dbname, tbl_name,
-            sizeof(analyzethreshold_key.dbname));
+             sizeof(analyzethreshold_key.dbname));
     analyzethreshold_key.dbname_len = strlen(analyzethreshold_key.dbname);
 
     /* set pointers to start and end of buffer */
@@ -7082,7 +7082,7 @@ int bdb_set_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
 
     analyzethreshold_key.file_type = LLMETA_ANALYZETHRESHOLD_TABLE;
     strncpy0(analyzethreshold_key.dbname, tbl_name,
-            sizeof(analyzethreshold_key.dbname));
+             sizeof(analyzethreshold_key.dbname));
     analyzethreshold_key.dbname_len = strlen(analyzethreshold_key.dbname);
 
     /* set pointers to start and end of buffer */
@@ -7351,7 +7351,7 @@ static int __llmeta_preop_alias(struct llmeta_tablename_alias_key *key,
 
     key->file_type = LLMETA_FDB_TABLENAME_ALIAS;
     strncpy0(key->tablename_alias, tablename_alias,
-            sizeof(key->tablename_alias));
+             sizeof(key->tablename_alias));
 
     if (llmeta_tablename_alias_key_put(key, (uint8_t *)key_buf,
                                        (uint8_t *)(key_buf + key_buf_len)) ==
@@ -7734,7 +7734,7 @@ static int bdb_table_version_upsert_int(bdb_state_type *bdb_state,
     bzero(&schema_version, sizeof(schema_version));
     schema_version.file_type = LLMETA_TABLE_VERSION;
     strncpy0(schema_version.tblname, bdb_state->name,
-            sizeof(schema_version.tblname));
+             sizeof(schema_version.tblname));
 
     p_buf = (uint8_t *)key;
     p_buf_end = p_buf + LLMETA_IXLEN;
@@ -7854,7 +7854,7 @@ int bdb_table_version_delete(bdb_state_type *bdb_state, tran_type *tran,
     bzero(&schema_version, sizeof(schema_version));
     schema_version.file_type = LLMETA_TABLE_VERSION;
     strncpy0(schema_version.tblname, bdb_state->name,
-            sizeof(schema_version.tblname));
+             sizeof(schema_version.tblname));
 
     p_buf = (uint8_t *)key;
     p_buf_end = p_buf + LLMETA_IXLEN;

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -29,6 +29,7 @@
 #include <openssl/evp.h>
 #include <openssl/rand.h>
 #include "logmsg.h"
+#include "str0.h"
 
 #include <sys/time.h>
 
@@ -1347,8 +1348,8 @@ int bdb_llmeta_set_tables(
     for (i = 0; i < numdbs && offset < buflen; ++i) {
         struct llmeta_table_name llmeta_tbl;
 
-        strncpy(llmeta_tbl.table_name, tblnames[i],
-                sizeof(llmeta_tbl.table_name));
+        strncpy0(llmeta_tbl.table_name, tblnames[i],
+                 sizeof(llmeta_tbl.table_name));
         llmeta_tbl.table_name_len = strlen(llmeta_tbl.table_name) + 1;
         llmeta_tbl.dbnum = dbnums[i];
 
@@ -1627,8 +1628,8 @@ static int bdb_new_file_version(
 
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
-    strncpy(file_type_dbname_file_num_key.dbname, db_name,
-            sizeof(file_type_dbname_file_num_key.dbname));
+    strncpy0(file_type_dbname_file_num_key.dbname, db_name,
+             sizeof(file_type_dbname_file_num_key.dbname));
     file_type_dbname_file_num_key.dbname_len =
         strlen(file_type_dbname_file_num_key.dbname) + 1;
 
@@ -1771,7 +1772,7 @@ bdb_chg_file_versions_int(tran_type *trans, /* must be !NULL */
 
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
-    strncpy(skey.dbname, tbl_name, sizeof(skey.dbname));
+    strncpy0(skey.dbname, tbl_name, sizeof(skey.dbname));
     skey.dbname_len = strlen(skey.dbname) + 1;
 
     p_buf_start = p_buf = (uint8_t *)key;
@@ -1792,7 +1793,7 @@ bdb_chg_file_versions_int(tran_type *trans, /* must be !NULL */
     memcpy(key_orig, key, key_offset);
 
     if (new_tbl_name) {
-        strncpy(new_skey.dbname, new_tbl_name, sizeof(new_skey.dbname));
+        strncpy0(new_skey.dbname, new_tbl_name, sizeof(new_skey.dbname));
         new_skey.dbname_len = strlen(new_skey.dbname) + 1;
 
         p_buf_start = p_buf = (uint8_t *)new_key;
@@ -2046,8 +2047,8 @@ bdb_set_pagesize(tran_type *input_trans, /* if this is !NULL it will be used as
         /* copy the db_name and check its length so that it fit
            with enough room left for the rest of the key */
         file_type_dbname_key.file_type = file_type;
-        strncpy(file_type_dbname_key.dbname, db_name,
-                sizeof(file_type_dbname_key.dbname));
+        strncpy0(file_type_dbname_key.dbname, db_name,
+                 sizeof(file_type_dbname_key.dbname));
         file_type_dbname_key.dbname_len =
             strlen(file_type_dbname_key.dbname) + 1;
 
@@ -2384,8 +2385,8 @@ static int bdb_get_file_version(
     /*add the file_type (ie dta, ix) */
     file_type_dbname_file_num_key.file_type = file_type;
 
-    strncpy(file_type_dbname_file_num_key.dbname, db_name,
-            sizeof(file_type_dbname_file_num_key.dbname));
+    strncpy0(file_type_dbname_file_num_key.dbname, db_name,
+             sizeof(file_type_dbname_file_num_key.dbname));
     file_type_dbname_file_num_key.dbname_len =
         strlen(file_type_dbname_file_num_key.dbname) + 1;
 
@@ -2598,8 +2599,8 @@ static int bdb_get_pagesize(tran_type *tran, /* transaction to use */
         /* copy the db_name and check its length so that it fit
            with enough room left for the rest of the key */
         file_type_dbname_key.file_type = file_type;
-        strncpy(file_type_dbname_key.dbname, db_name,
-                sizeof(file_type_dbname_key.dbname));
+        strncpy0(file_type_dbname_key.dbname, db_name,
+                 sizeof(file_type_dbname_key.dbname));
         file_type_dbname_key.dbname_len =
             strlen(file_type_dbname_key.dbname) + 1;
 
@@ -2845,7 +2846,7 @@ int bdb_new_csc2(tran_type *input_trans, /* if this is !NULL it will be used as
 
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
-    strncpy(p_file_type_dbname_csc2_vers_key.dbname, db_name,
+    strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
@@ -2999,7 +3000,7 @@ int bdb_get_csc2_highest(tran_type *trans, /* transaction to use, may be NULL */
 
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
-    strncpy(p_file_type_dbname_csc2_vers_key.dbname, db_name,
+    strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
@@ -3090,7 +3091,7 @@ int bdb_reset_csc2_version(tran_type *trans, const char *dbname, int ver)
     p_buf_end = p_buf_start + LLMETA_IXLEN;
 
     vers_key.file_type = LLMETA_CSC2;
-    strncpy(vers_key.dbname, dbname, sizeof(vers_key.dbname));
+    strncpy0(vers_key.dbname, dbname, sizeof(vers_key.dbname));
     vers_key.dbname_len = strlen(vers_key.dbname) + 1;
 
     while (ver) {
@@ -3156,7 +3157,7 @@ int bdb_get_csc2(tran_type *tran, /* transaction to use, may be NULL */
 
     /* copy the db_name and check its length so that it fit with enough room
      * left for the rest of the key */
-    strncpy(p_file_type_dbname_csc2_vers_key.dbname, db_name,
+    strncpy0(p_file_type_dbname_csc2_vers_key.dbname, db_name,
             sizeof(p_file_type_dbname_csc2_vers_key.dbname));
     p_file_type_dbname_csc2_vers_key.dbname_len =
         strlen(p_file_type_dbname_csc2_vers_key.dbname) + 1;
@@ -3451,7 +3452,7 @@ int bdb_set_in_schema_change(
     schema_change.file_type = LLMETA_IN_SCHEMA_CHANGE;
 
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, db_name, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, db_name, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     p_buf_start = p_buf = (uint8_t *)key;
@@ -3582,7 +3583,7 @@ int bdb_get_in_schema_change(
     schema_change.file_type = LLMETA_IN_SCHEMA_CHANGE;
 
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, db_name, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, db_name, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     p_buf_start = p_buf = (uint8_t *)key;
@@ -3728,7 +3729,7 @@ int bdb_set_schema_change_status(tran_type *input_trans, const char *db_name,
     schema_change.file_type = LLMETA_SCHEMACHANGE_STATUS;
 
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, db_name, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, db_name, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     p_buf_start = p_buf = (uint8_t *)key;
@@ -4016,7 +4017,7 @@ static int bdb_set_high_genid_int(
     /*copy the table name and check its length so that we have a clean key*/
     /* BTW- There's NO NULL BYTE!  So the stripe ends up using 3 bytes
        rather than 4 */
-    strncpy(high_genid_key_type.dbname, db_name,
+    strncpy0(high_genid_key_type.dbname, db_name,
             sizeof(high_genid_key_type.dbname));
     high_genid_key_type.dbname_len = strlen(high_genid_key_type.dbname);
 
@@ -4190,7 +4191,7 @@ int bdb_get_high_genid(
     /*copy the table name and check its length so that we have a clean key*/
     /* BTW- There's NO NULL BYTE!  So the stripe ends up using 3 bytes
        rather than 4 */
-    strncpy(high_genid_key_type.dbname, db_name,
+    strncpy0(high_genid_key_type.dbname, db_name,
             sizeof(high_genid_key_type.dbname));
     high_genid_key_type.dbname_len = strlen(high_genid_key_type.dbname);
 
@@ -5012,7 +5013,7 @@ int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
@@ -5061,7 +5062,7 @@ int bdb_set_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
@@ -5123,7 +5124,7 @@ int bdb_delete_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
@@ -5264,10 +5265,10 @@ static int bdb_tbl_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
         break;
     }
 
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -5386,10 +5387,10 @@ int bdb_tbl_op_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
 
     tbl_access_data.command_type = command_type;
 
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -5477,10 +5478,10 @@ int bdb_tbl_op_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
 
     tbl_access_data.file_type = LLMETA_TABLE_USER_OP;
     tbl_access_data.command_type = command_type;
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -5514,10 +5515,10 @@ int bdb_tbl_op_access_delete(bdb_state_type *bdb_state, tran_type *input_trans,
 
     tbl_access_data.file_type = LLMETA_TABLE_USER_OP;
     tbl_access_data.command_type = command_type;
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -5764,10 +5765,10 @@ static int bdb_tbl_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
         break;
     }
 
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -5813,7 +5814,7 @@ int bdb_tbl_access_userschema_get(bdb_state_type *bdb_state,
 
     tbl_access_data.file_type = LLMETA_TABLE_USER_SCHEMA;
 
-    strncpy(tbl_access_data.tablename, username,
+    strncpy0(tbl_access_data.tablename, username,
             sizeof(tbl_access_data.tablename));
 
     bzero(tbl_access_data.username, sizeof(tbl_access_data.username));
@@ -5842,7 +5843,7 @@ int bdb_tbl_access_userschema_get(bdb_state_type *bdb_state,
             *bdberr = BDBERR_BADARGS;
             return -1;
         }
-        strncpy(userschema, tbl_access_data.username,
+        strncpy0(userschema, tbl_access_data.username,
                 sizeof(tbl_access_data.username));
         logmsg(LOGMSG_INFO, "User Schema for username %s is %s\n", username,
                 userschema);
@@ -5879,10 +5880,10 @@ static int bdb_tbl_access_delete(bdb_state_type *bdb_state,
         break;
     }
 
-    strncpy(tbl_access_data.tablename, tblname,
+    strncpy0(tbl_access_data.tablename, tblname,
             sizeof(tbl_access_data.tablename));
 
-    strncpy(tbl_access_data.username, username,
+    strncpy0(tbl_access_data.username, username,
             sizeof(tbl_access_data.username));
 
     /* form llmeta record with file_type endianized */
@@ -6015,8 +6016,8 @@ static int bdb_sqlite_stat1_read_int(bdb_state_type *bdb_state,
 
     /* setup key */
     sqlstats.file_type = file_type;
-    strncpy(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
-    strncpy(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
+    strncpy0(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
+    strncpy0(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
 
     /* endianize key */
     if (!(p_buf = llmeta_sqlstat1_key_put(&sqlstats, p_buf, p_buf_end))) {
@@ -6098,8 +6099,8 @@ static int bdb_sqlite_stat1_delete_stale_int(bdb_state_type *bdb_state,
 
     /* create stats structure */
     sqlstats.file_type = file_type;
-    strncpy(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
-    strncpy(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
+    strncpy0(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
+    strncpy0(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
 
     /* endianize key */
     if (!(p_buf = llmeta_sqlstat1_stale_key_put(&sqlstats, p_buf, p_buf_end))) {
@@ -6161,8 +6162,8 @@ static int bdb_sqlite_stat1_write_int(bdb_state_type *bdb_state,
 
     /* create stats structure */
     sqlstats.file_type = file_type;
-    strncpy(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
-    strncpy(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
+    strncpy0(sqlstats.table_name, tbl, sizeof(sqlstats.table_name));
+    strncpy0(sqlstats.index_name, idx, sizeof(sqlstats.index_name));
 
     /* endianize key */
     if (!(p_buf = llmeta_sqlstat1_key_put(&sqlstats, p_buf, p_buf_end))) {
@@ -6586,7 +6587,7 @@ int bdb_get_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
     }
 
     analyzecoverage_key.file_type = LLMETA_ANALYZECOVERAGE_TABLE;
-    strncpy(analyzecoverage_key.dbname, tbl_name,
+    strncpy0(analyzecoverage_key.dbname, tbl_name,
             sizeof(analyzecoverage_key.dbname));
     analyzecoverage_key.dbname_len = strlen(analyzecoverage_key.dbname);
 
@@ -6675,7 +6676,7 @@ int bdb_set_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
     }
 
     analyzecoverage_key.file_type = LLMETA_ANALYZECOVERAGE_TABLE;
-    strncpy(analyzecoverage_key.dbname, tbl_name,
+    strncpy0(analyzecoverage_key.dbname, tbl_name,
             sizeof(analyzecoverage_key.dbname));
     analyzecoverage_key.dbname_len = strlen(analyzecoverage_key.dbname);
 
@@ -6825,7 +6826,7 @@ int bdb_get_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
     }
 
     analyzethreshold_key.file_type = LLMETA_ANALYZETHRESHOLD_TABLE;
-    strncpy(analyzethreshold_key.dbname, tbl_name,
+    strncpy0(analyzethreshold_key.dbname, tbl_name,
             sizeof(analyzethreshold_key.dbname));
     analyzethreshold_key.dbname_len = strlen(analyzethreshold_key.dbname);
 
@@ -7080,7 +7081,7 @@ int bdb_set_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
     }
 
     analyzethreshold_key.file_type = LLMETA_ANALYZETHRESHOLD_TABLE;
-    strncpy(analyzethreshold_key.dbname, tbl_name,
+    strncpy0(analyzethreshold_key.dbname, tbl_name,
             sizeof(analyzethreshold_key.dbname));
     analyzethreshold_key.dbname_len = strlen(analyzethreshold_key.dbname);
 
@@ -7349,7 +7350,7 @@ static int __llmeta_preop_alias(struct llmeta_tablename_alias_key *key,
     }
 
     key->file_type = LLMETA_FDB_TABLENAME_ALIAS;
-    strncpy(key->tablename_alias, tablename_alias,
+    strncpy0(key->tablename_alias, tablename_alias,
             sizeof(key->tablename_alias));
 
     if (llmeta_tablename_alias_key_put(key, (uint8_t *)key_buf,
@@ -7398,7 +7399,7 @@ int llmeta_set_tablename_alias(void *ptran, const char *tablename_alias,
         return -1;
     }
 
-    strncpy(data.url, url, sizeof(data.url));
+    strncpy0(data.url, url, sizeof(data.url));
 
     if (llmeta_tablename_alias_data_put(
             &data, (uint8_t *)data_buf,
@@ -7732,7 +7733,7 @@ static int bdb_table_version_upsert_int(bdb_state_type *bdb_state,
     /* add the key type */
     bzero(&schema_version, sizeof(schema_version));
     schema_version.file_type = LLMETA_TABLE_VERSION;
-    strncpy(schema_version.tblname, bdb_state->name,
+    strncpy0(schema_version.tblname, bdb_state->name,
             sizeof(schema_version.tblname));
 
     p_buf = (uint8_t *)key;
@@ -7852,7 +7853,7 @@ int bdb_table_version_delete(bdb_state_type *bdb_state, tran_type *tran,
     /* add the key type */
     bzero(&schema_version, sizeof(schema_version));
     schema_version.file_type = LLMETA_TABLE_VERSION;
-    strncpy(schema_version.tblname, bdb_state->name,
+    strncpy0(schema_version.tblname, bdb_state->name,
             sizeof(schema_version.tblname));
 
     p_buf = (uint8_t *)key;
@@ -7924,7 +7925,7 @@ int bdb_table_version_select(const char *tblname, tran_type *tran,
 
     bzero(&schema_version, sizeof(schema_version));
     schema_version.file_type = LLMETA_TABLE_VERSION;
-    strncpy(schema_version.tblname, tblname, sizeof(schema_version.tblname));
+    strncpy0(schema_version.tblname, tblname, sizeof(schema_version.tblname));
 
     p_buf = (uint8_t *)key;
     p_buf_end = (p_buf + LLMETA_IXLEN);
@@ -8925,8 +8926,8 @@ int bdb_get_versioned_sp(char *name, char *version, char **src)
         uint8_t buf[LLMETA_IXLEN];
     } u = {{0}};
     u.sp.key = htonl(LLMETA_VERSIONED_SP);
-    strncpy(u.sp.name, name, sizeof(u.sp.name));
-    strncpy(u.sp.version, version, sizeof(u.sp.version));
+    strncpy0(u.sp.name, name, sizeof(u.sp.name));
+    strncpy0(u.sp.version, version, sizeof(u.sp.version));
     char **srcs;
     int rc, bdberr, num;
     rc = kv_get(&u, sizeof(u), (void ***)&srcs, &num, &bdberr);
@@ -9022,7 +9023,7 @@ int bdb_get_default_versioned_sp(char *name, char **version)
     u.sp.key = htonl(LLMETA_DEFAULT_VERSIONED_SP);
     if (strlen(name) >= LLMETA_IXLEN)
         return -1;
-    strncpy(u.sp.name, name, sizeof(u.sp.name));
+    strncpy0(u.sp.name, name, sizeof(u.sp.name));
     char **versions;
     int rc, bdberr, num;
     rc = kv_get(&u, sizeof(u), (void ***)&versions, &num, &bdberr);
@@ -9201,7 +9202,7 @@ static int bdb_process_each_table_entry(bdb_state_type *bdb_state,
         bdb_state = bdb_state->parent;
 
     key_struct.file_type = type;
-    strncpy(key_struct.dbname, tblname, sizeof(key_struct.dbname));
+    strncpy0(key_struct.dbname, tblname, sizeof(key_struct.dbname));
     key_struct.dbname_len = strlen(key_struct.dbname) + 1 /* NULL byte */;
 
     if (key_struct.dbname_len > LLMETA_TBLLEN) {
@@ -9470,10 +9471,10 @@ int bdb_rename_csc2_version(tran_type *trans, const char *tblname,
            __func__, tblname, newtblname, ver);
 
     vers_key.file_type = LLMETA_CSC2;
-    strncpy(vers_key.dbname, tblname, sizeof(vers_key.dbname));
+    strncpy0(vers_key.dbname, tblname, sizeof(vers_key.dbname));
     vers_key.dbname_len = strlen(vers_key.dbname) + 1;
     new_vers_key.file_type = LLMETA_CSC2;
-    strncpy(new_vers_key.dbname, newtblname, sizeof(new_vers_key.dbname));
+    strncpy0(new_vers_key.dbname, newtblname, sizeof(new_vers_key.dbname));
     new_vers_key.dbname_len = strlen(new_vers_key.dbname) + 1;
 
     while (ver) {
@@ -9612,7 +9613,7 @@ int bdb_get_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
 
     schema_change.file_type = LLMETA_SC_START_LSN;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
@@ -9669,7 +9670,7 @@ int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
 
     schema_change.file_type = LLMETA_SC_START_LSN;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
@@ -9759,7 +9760,7 @@ int bdb_delete_sc_start_lsn(tran_type *tran, const char *table, int *bdberr)
 
     schema_change.file_type = LLMETA_SC_START_LSN;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -72,6 +72,7 @@
 #include "phys_rep_lsn.h"
 #include "logmsg.h"
 #include <compat.h>
+#include "str0.h"
 
 #include <inttypes.h>
 
@@ -4367,7 +4368,7 @@ void receive_coherency_lease(void *ack_handle, void *usr_ptr, char *from_host,
         return;
     }
 
-    strncpy(coherency_master, from_host, sizeof(coherency_master));
+    strncpy0(coherency_master, from_host, sizeof(coherency_master));
 
     /* Choose most conservative possible expiration: the lessor of
      * 'mytime + leasetime' and 'mastertime + leasetime' */

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -36,6 +36,7 @@
 
 #include "sqlquery.pb-c.h"
 #include "sqlresponse.pb-c.h"
+#include "str0.h"
 
 /*
 *******************************************************************************
@@ -347,8 +348,7 @@ static char *ibm_getargv0(void)
 
     if (1 == (rc = getprocs(&p, sizeof(p), NULL, 0, &idx, 1)) &&
         _PID == p.pi_pid) {
-        strncpy(argv0, p.pi_comm, PATH_MAX);
-        argv0[PATH_MAX - 1] = '\0';
+        strncpy(argv0, p.pi_comm, PATH_MAX - 1);
     } else {
         fprintf(stderr, "%s getprocs returns %d for pid %d\n", __func__, _PID);
         return NULL;
@@ -1279,33 +1279,28 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
             } else if (strcasecmp(SSL_CERT_PATH_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcertpath, tok, PATH_MAX);
-                    cdb2_sslcertpath[PATH_MAX - 1] = '\0';
+                    strncpy(cdb2_sslcertpath, tok, PATH_MAX - 1);
                 }
             } else if (strcasecmp(SSL_CERT_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcert, tok, PATH_MAX);
-                    cdb2_sslcert[PATH_MAX - 1] = '\0';
+                    strncpy(cdb2_sslcert, tok, PATH_MAX - 1);
                 }
             } else if (strcasecmp(SSL_KEY_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslkey, tok, PATH_MAX);
-                    cdb2_sslkey[PATH_MAX - 1] = '\0';
+                    strncpy(cdb2_sslkey, tok, PATH_MAX - 1);
                 }
             } else if (strcasecmp(SSL_CA_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslca, tok, PATH_MAX);
-                    cdb2_sslca[PATH_MAX - 1] = '\0';
+                    strncpy(cdb2_sslca, tok, PATH_MAX - 1);
                 }
 #if HAVE_CRL
             } else if (strcasecmp(SSL_CRL_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcrl, tok, PATH_MAX);
-                    cdb2_sslcrl[PATH_MAX - 1] = '\0';
+                    strncpy(cdb2_sslcrl, tok, PATH_MAX - 1);
                 }
 #endif /* HAVE_CRL */
             } else if (strcasecmp("ssl_session_cache", tok) == 0) {
@@ -1582,7 +1577,7 @@ static int open_sockpool_ll(void)
 
     struct sockaddr_sun addr = {0};
     addr.sun_family = AF_UNIX;
-    strncpy(addr.sun_path, SOCKPOOL_SOCKET_NAME, sizeof(addr.sun_path));
+    strncpy(addr.sun_path, SOCKPOOL_SOCKET_NAME, sizeof(addr.sun_path) - 1);
 
     if (connect(fd, (const struct sockaddr *)&addr, sizeof(addr)) == -1) {
         close(fd);
@@ -1943,8 +1938,7 @@ static int try_ssl(cdb2_hndl_tp *hndl, SBUF2 *sb, int indx)
             hndl->sess_list->list = p;
 
             for (i = 0; i != hndl->num_hosts; ++i, ++p) {
-                strncpy(p->host, hndl->hosts[i], sizeof(p->host));
-                p->host[sizeof(p->host) - 1] = '\0';
+                strncpy(p->host, hndl->hosts[i], sizeof(p->host) - 1);
                 p->sess = NULL;
             }
         }
@@ -5689,7 +5683,7 @@ static int cdb2_set_ssl_sessions(cdb2_hndl_tp *hndl, cdb2_ssl_sess_list *arg)
         return ENOMEM;
 
     for (i = 0, p = r; i != hndl->num_hosts; ++i, ++p) {
-        strncpy(p->host, hndl->hosts[i], sizeof(p->host));
+        strncpy(p->host, hndl->hosts[i], sizeof(p->host) - 1);
         p->host[sizeof(p->host) - 1] = '\0';
         p->sess = NULL;
         for (j = 0, q = arg->list; j != arg->n; ++q) {

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -36,7 +36,6 @@
 
 #include "sqlquery.pb-c.h"
 #include "sqlresponse.pb-c.h"
-#include "str0.h"
 
 /*
 *******************************************************************************
@@ -348,7 +347,8 @@ static char *ibm_getargv0(void)
 
     if (1 == (rc = getprocs(&p, sizeof(p), NULL, 0, &idx, 1)) &&
         _PID == p.pi_pid) {
-        strncpy(argv0, p.pi_comm, PATH_MAX - 1);
+        strncpy(argv0, p.pi_comm, PATH_MAX);
+        argv0[PATH_MAX - 1] = '\0';
     } else {
         fprintf(stderr, "%s getprocs returns %d for pid %d\n", __func__, _PID);
         return NULL;
@@ -1279,28 +1279,33 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, FILE *fp,
             } else if (strcasecmp(SSL_CERT_PATH_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcertpath, tok, PATH_MAX - 1);
+                    strncpy(cdb2_sslcertpath, tok, PATH_MAX);
+                    cdb2_sslcertpath[PATH_MAX - 1] = '\0';
                 }
             } else if (strcasecmp(SSL_CERT_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcert, tok, PATH_MAX - 1);
+                    strncpy(cdb2_sslcert, tok, PATH_MAX);
+                    cdb2_sslcert[PATH_MAX - 1] = '\0';
                 }
             } else if (strcasecmp(SSL_KEY_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslkey, tok, PATH_MAX - 1);
+                    strncpy(cdb2_sslkey, tok, PATH_MAX);
+                    cdb2_sslkey[PATH_MAX - 1] = '\0';
                 }
             } else if (strcasecmp(SSL_CA_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslca, tok, PATH_MAX - 1);
+                    strncpy(cdb2_sslca, tok, PATH_MAX);
+                    cdb2_sslca[PATH_MAX - 1] = '\0';
                 }
 #if HAVE_CRL
             } else if (strcasecmp(SSL_CRL_OPT, tok) == 0) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
-                    strncpy(cdb2_sslcrl, tok, PATH_MAX - 1);
+                    strncpy(cdb2_sslcrl, tok, PATH_MAX);
+                    cdb2_sslcrl[PATH_MAX - 1] = '\0';
                 }
 #endif /* HAVE_CRL */
             } else if (strcasecmp("ssl_session_cache", tok) == 0) {
@@ -1939,6 +1944,7 @@ static int try_ssl(cdb2_hndl_tp *hndl, SBUF2 *sb, int indx)
 
             for (i = 0; i != hndl->num_hosts; ++i, ++p) {
                 strncpy(p->host, hndl->hosts[i], sizeof(p->host) - 1);
+                p->host[sizeof(p->host) - 1] = '\0';
                 p->sess = NULL;
             }
         }

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -273,8 +273,8 @@ typedef enum cdb2_event_type {
     CDB2_AT_EXIT_NEXT_RECORD = 1 << 13,
 
     /* Lifecycle events */
-    CDB2_AT_OPEN = 1 << 30,
-    CDB2_AT_CLOSE = 1 << 31,
+    CDB2_AT_OPEN = 1 << 29,
+    CDB2_AT_CLOSE = 1 << 30,
 } cdb2_event_type;
 
 typedef enum cdb2_event_arg {

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -27,6 +27,7 @@
 
 #include <strbuf.h>
 #include <logmsg.h>
+#include "str0.h"
 
 extern int yyparse(void);
 extern int compute_key_data(void);
@@ -977,7 +978,7 @@ static void key_add_comn(int ix, char *tag, char *exprname,
                 return;
             }
         }
-        strncpy(keys[ii]->keytag, tag, sizeof(keys[ii]->keytag));
+        strncpy0(keys[ii]->keytag, tag, sizeof(keys[ii]->keytag));
     } else {
         sprintf(keys[ii]->keytag, "DEFAULT_ix_%d", ix);
     }
@@ -2393,8 +2394,8 @@ static int dyns_load_schema_int(char *filename, char *schematxt, char *dbname,
     sprintf(fullname, "%s_%s", dbname, tablename);
     opt_dbname = fullname;
     opt_copycsc = 0;
-    strncpy(opt_maindbname, dbname, sizeof(opt_maindbname));
-    strncpy(opt_tblname, tablename, sizeof(opt_tblname));
+    strncpy0(opt_maindbname, dbname, sizeof(opt_maindbname));
+    strncpy0(opt_tblname, tablename, sizeof(opt_tblname));
 
     /* check args for an input filename or any options */
     if (schematxt) {

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2916,7 +2916,7 @@ static void clear_queue_extents(void)
             q = malloc(sizeof(ExtentsQueue));
             q->count = 0;
             LIST_INIT(&q->head);
-            strncpy(q->name, name, sizeof(q->name));
+            strncpy0(q->name, name, sizeof(q->name));
             hash_add(hash_table, q);
         }
         ExtentsEntry *e = malloc(sizeof(ExtentsEntry));

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -22,6 +22,7 @@
 #include "localrep.h"
 #include "endian_core.h"
 #include <flibc.h>
+#include "str0.h"
 
 typedef struct {
     char name[32];    /* name of field as a \0 terminated string */
@@ -793,7 +794,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
         return 0;
     }
 
-    strncpy(table, db->tablename, sizeof(table));
+    strncpy0(table, db->tablename, sizeof(table));
 
     table[31] = 0;
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -272,7 +272,7 @@ int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err)
             /* this is socksql, recom, snapisol or serial; no retry here
              */
             generr.errval = ERR_INTERNAL;
-            strncpy(generr.errstr, "master cancelled transaction",
+            strncpy0(generr.errstr, "master cancelled transaction",
                     sizeof(generr.errstr));
             xerr = &generr;
             error = 1;
@@ -615,7 +615,7 @@ void setup_reorder_key(int type, osql_sess_t *sess, struct ireq *iq, char *rpl,
         const char *tablename = get_tablename_from_rpl(rpl);
         assert(tablename); // table or queue name
         if (tablename && !is_tablename_queue(tablename, strlen(tablename))) {
-            strncpy(sess->tablename, tablename, sizeof(sess->tablename));
+            strncpy0(sess->tablename, tablename, sizeof(sess->tablename));
             sess->tbl_idx = get_dbtable_idx_by_name(tablename) + 1;
             key->tbl_idx = sess->tbl_idx;
 
@@ -703,7 +703,7 @@ static void send_error_to_replicant(int rqid, const char *host, int errval,
     sorese_info.type = -1; /* I don't need it */
 
     generr.errval = errval;
-    strncpy(generr.errstr, errstr, sizeof(generr.errstr));
+    strncpy0(generr.errstr, errstr, sizeof(generr.errstr));
 
     int rc =
         osql_comm_signal_sqlthr_rc(&sorese_info, &generr, RC_INTERNAL_RETRY);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -273,7 +273,7 @@ int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err)
              */
             generr.errval = ERR_INTERNAL;
             strncpy0(generr.errstr, "master cancelled transaction",
-                    sizeof(generr.errstr));
+                     sizeof(generr.errstr));
             xerr = &generr;
             error = 1;
             break;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3612,7 +3612,8 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         comdb2uuidcpy(usedb_uuid_rpl.hd.uuid, uuid);
         usedb_uuid_rpl.dt.tablenamelen = tablenamelen;
         usedb_uuid_rpl.dt.tableversion = tableversion;
-        strncpy0(usedb_uuid_rpl.dt.tablename, tablename,
+        /* tablename field needs to be NOT null terminated if larger than 4 chars */
+        strncpy(usedb_uuid_rpl.dt.tablename, tablename,
                 sizeof(usedb_uuid_rpl.dt.tablename));
 
         if (!(p_buf = osqlcomm_usedb_uuid_rpl_type_put(&usedb_uuid_rpl, p_buf,
@@ -3635,7 +3636,8 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         usedb_rpl.hd.sid = rqid;
         usedb_rpl.dt.tablenamelen = tablenamelen;
         usedb_rpl.dt.tableversion = tableversion;
-        strncpy0(usedb_rpl.dt.tablename, tablename,
+        /* tablename field needs to be NOT null terminated if larger than 4 chars */
+        strncpy(usedb_rpl.dt.tablename, tablename,
                 sizeof(usedb_rpl.dt.tablename));
 
         if (!(p_buf =
@@ -3653,6 +3655,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         sbuf2flush(logsb);
     }
 
+    /* tablename field is not null terminated -- send rest of tablename */
     if (tablenamelen > sent) {
         rc = offload_net_send_tail(tohost, type, &buf, msglen, 0,
                                    tablename + sent, tablenamelen - sent);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6678,10 +6678,8 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
     if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
         return 0;
-    else
-        return ERR_SC;
-
-    return 0;
+    
+    return ERR_SC;
 }
 
 /* get the table name part of the rpl request

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3612,7 +3612,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         comdb2uuidcpy(usedb_uuid_rpl.hd.uuid, uuid);
         usedb_uuid_rpl.dt.tablenamelen = tablenamelen;
         usedb_uuid_rpl.dt.tableversion = tableversion;
-        strncpy(usedb_uuid_rpl.dt.tablename, tablename,
+        strncpy0(usedb_uuid_rpl.dt.tablename, tablename,
                 sizeof(usedb_uuid_rpl.dt.tablename));
 
         if (!(p_buf = osqlcomm_usedb_uuid_rpl_type_put(&usedb_uuid_rpl, p_buf,
@@ -3635,7 +3635,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         usedb_rpl.hd.sid = rqid;
         usedb_rpl.dt.tablenamelen = tablenamelen;
         usedb_rpl.dt.tableversion = tableversion;
-        strncpy(usedb_rpl.dt.tablename, tablename,
+        strncpy0(usedb_rpl.dt.tablename, tablename,
                 sizeof(usedb_rpl.dt.tablename));
 
         if (!(p_buf =
@@ -4903,7 +4903,7 @@ static void osql_blocksql_failed_dispatch(netinfo_type *netinfo_ptr,
     rpl_xerr.hd.sid = rqid;
 
     rpl_xerr.dt.errval = rc;
-    strncpy(rpl_xerr.dt.errstr, "cannot dispatch sql request",
+    strncpy0(rpl_xerr.dt.errstr, "cannot dispatch sql request",
             sizeof(rpl_xerr.dt.errstr));
 
     if (!(osqlcomm_done_xerr_type_put(&rpl_xerr, p_buf, p_buf_end))) {
@@ -5016,7 +5016,7 @@ void *osql_create_request(const char *sql, int sqlen, int type,
         req_uuid.sqlqlen = sqlen;
 
         if (tzname)
-            strncpy(r_uuid_ptr->tzname, tzname, sizeof(r_uuid_ptr->tzname));
+            strncpy0(r_uuid_ptr->tzname, tzname, sizeof(r_uuid_ptr->tzname));
 
         p_buf = osqlcomm_req_uuid_type_put(&req_uuid, p_buf, p_buf_end);
         r_uuid_ptr->rqlen = rqlen;
@@ -5048,7 +5048,7 @@ void *osql_create_request(const char *sql, int sqlen, int type,
         r_ptr->rqlen = rqlen;
 
         if (tzname)
-            strncpy(r_ptr->tzname, tzname, sizeof(r_ptr->tzname));
+            strncpy0(r_ptr->tzname, tzname, sizeof(r_ptr->tzname));
     }
 
     p_buf = buf_no_net_put(sql, sqlen, p_buf, p_buf_end);
@@ -7736,10 +7736,10 @@ done:
 
         generr.errval = ERR_TRAN_FAILED;
         if (rc == -4) {
-            strncpy(generr.errstr, "fail to create block processor log",
+            strncpy0(generr.errstr, "fail to create block processor log",
                     sizeof(generr.errstr));
         } else {
-            strncpy(generr.errstr, "failed to create transaction",
+            strncpy0(generr.errstr, "failed to create transaction",
                     sizeof(generr.errstr));
         }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3612,7 +3612,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         comdb2uuidcpy(usedb_uuid_rpl.hd.uuid, uuid);
         usedb_uuid_rpl.dt.tablenamelen = tablenamelen;
         usedb_uuid_rpl.dt.tableversion = tableversion;
-        /* tablename field needs to be NOT null terminated if larger than 4 chars */
+        /* tablename field needs to be NOT null-terminated if > than 4 chars */
         strncpy(usedb_uuid_rpl.dt.tablename, tablename,
                 sizeof(usedb_uuid_rpl.dt.tablename));
 
@@ -3636,7 +3636,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         usedb_rpl.hd.sid = rqid;
         usedb_rpl.dt.tablenamelen = tablenamelen;
         usedb_rpl.dt.tableversion = tableversion;
-        /* tablename field needs to be NOT null terminated if larger than 4 chars */
+        /* tablename field needs to be NOT null-terminated if > than 4 chars */
         strncpy(usedb_rpl.dt.tablename, tablename,
                 sizeof(usedb_rpl.dt.tablename));
 
@@ -3655,7 +3655,7 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
         sbuf2flush(logsb);
     }
 
-    /* tablename field is not null terminated -- send rest of tablename */
+    /* tablename field is not null-terminated -- send rest of tablename */
     if (tablenamelen > sent) {
         rc = offload_net_send_tail(tohost, type, &buf, msglen, 0,
                                    tablename + sent, tablenamelen - sent);
@@ -4907,7 +4907,7 @@ static void osql_blocksql_failed_dispatch(netinfo_type *netinfo_ptr,
 
     rpl_xerr.dt.errval = rc;
     strncpy0(rpl_xerr.dt.errstr, "cannot dispatch sql request",
-            sizeof(rpl_xerr.dt.errstr));
+             sizeof(rpl_xerr.dt.errstr));
 
     if (!(osqlcomm_done_xerr_type_put(&rpl_xerr, p_buf, p_buf_end))) {
         logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
@@ -6681,7 +6681,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
     if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
         return 0;
-    
+
     return ERR_SC;
 }
 
@@ -7738,10 +7738,10 @@ done:
         generr.errval = ERR_TRAN_FAILED;
         if (rc == -4) {
             strncpy0(generr.errstr, "fail to create block processor log",
-                    sizeof(generr.errstr));
+                     sizeof(generr.errstr));
         } else {
             strncpy0(generr.errstr, "failed to create transaction",
-                    sizeof(generr.errstr));
+                     sizeof(generr.errstr));
         }
 
         rc2 = osql_comm_signal_sqlthr_rc(&sorese_info, &generr,

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -30,6 +30,7 @@
 #include "debug_switches.h"
 
 #include <uuid/uuid.h>
+#include "str0.h"
 
 static int osql_poke_replicant(osql_sess_t *sess);
 static void _destroy_session(osql_sess_t **prq, int phase);
@@ -771,7 +772,7 @@ osql_sess_t *osql_sess_create_sock(const char *sql, int sqlen, char *tzname,
     sess->is_reorder_on = is_reorder_on;
 
     if (tzname)
-        strncpy(sess->tzname, tzname, sizeof(sess->tzname));
+        strncpy0(sess->tzname, tzname, sizeof(sess->tzname));
 
     sess->iq = iq;
     sess->iqcopy = iq;

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -30,6 +30,7 @@
 #include <net_types.h>
 #include "comdb2uuid.h"
 #include "logmsg.h"
+#include "str0.h"
 
 extern int g_osql_max_trans;
 extern int gbl_partial_indexes;
@@ -440,7 +441,7 @@ static shad_tbl_t *create_shadtbl(struct BtCursor *pCur,
 
     tbl->seq = 0;
     tbl->env = env;
-    strncpy(tbl->tablename, db->tablename, sizeof(tbl->tablename));
+    strncpy0(tbl->tablename, db->tablename, sizeof(tbl->tablename));
     tbl->tableversion = db->tableversion;
     tbl->nix = db->nix;
     tbl->ix_expr = db->ix_expr;
@@ -2774,7 +2775,7 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
     }
 
     key.tablename_len = strlen(pCur->db->tablename) + 1;
-    strncpy(key.tablename, pCur->db->tablename, sizeof(key.tablename));
+    strncpy0(key.tablename, pCur->db->tablename, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2818,7 +2819,7 @@ int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
     }
 
     key.tablename_len = strlen(pCur->db->tablename) + 1;
-    strncpy(key.tablename, pCur->db->tablename, sizeof(key.tablename));
+    strncpy0(key.tablename, pCur->db->tablename, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2894,7 +2895,7 @@ static int process_local_shadtbl_recgenids(struct sqlclntstate *clnt,
                         __func__, __LINE__);
                 return SQLITE_INTERNAL;
             }
-            strncpy(old_tablename, key.tablename, MAXTABLELEN);
+            strncpy0(old_tablename, key.tablename, MAXTABLELEN);
         }
 
 #if 0

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -36,6 +36,7 @@
 #include <comdb2_atomic.h>
 #include <ctrace.h>
 #include <logmsg.h>
+#include "str0.h"
 
 /* amount of thread-memory initialized for this thread */
 #ifndef PER_THREAD_MALLOC
@@ -256,7 +257,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
     struct temp_table *tmptbl = NULL;
 
     /* cache the tablename for sqlglue */
-    strncpy(s_ix->name, tbl->tablename, sizeof(s_ix->name));
+    strncpy0(s_ix->name, tbl->tablename, sizeof(s_ix->name));
 
     /* ask bdb to put a summary of this into a temp-table */
     rc = bdb_summarize_table(tbl->handle, ix, sampling_pct, &tmptbl,
@@ -1028,7 +1029,7 @@ int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta)
     td.sb = sb;
     td.scale = scale;
     td.override_llmeta = override_llmeta;
-    strncpy(td.table, table, sizeof(td.table));
+    strncpy0(td.table, table, sizeof(td.table));
 
     /* dispatch */
     int rc = dispatch_table_thread(&td);
@@ -1086,7 +1087,7 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
         td[idx].sb = sb;
         td[idx].scale = scale;
         td[idx].override_llmeta = override_llmeta;
-        strncpy(td[idx].table, thedb->dbs[i]->tablename, sizeof(td[idx].table));
+        strncpy0(td[idx].table, thedb->dbs[i]->tablename, sizeof(td[idx].table));
 
         /* dispatch analyze table thread */
         rc = dispatch_table_thread(&td[idx]);

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -1087,7 +1087,8 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
         td[idx].sb = sb;
         td[idx].scale = scale;
         td[idx].override_llmeta = override_llmeta;
-        strncpy0(td[idx].table, thedb->dbs[i]->tablename, sizeof(td[idx].table));
+        strncpy0(td[idx].table, thedb->dbs[i]->tablename,
+                 sizeof(td[idx].table));
 
         /* dispatch analyze table thread */
         rc = dispatch_table_thread(&td[idx]);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -996,7 +996,7 @@ static int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info,
      * conversion */
     if (f->type == SERVER_DATETIME || f->type == SERVER_DATETIMEUS) {
         if (convopts && tzname && tzname[0]) {
-            strncpy(convopts->tzname, tzname, sizeof(convopts->tzname));
+            strncpy0(convopts->tzname, tzname, sizeof(convopts->tzname));
             convopts->flags |= FLD_CONV_TZONE;
         }
     }
@@ -12613,7 +12613,7 @@ long long run_sql_thd_return_ll(const char *query, struct sql_thread *thd,
     long long ret = LLONG_MIN;
 
     reset_clnt(&client, NULL, 1);
-    strncpy(client.tzname, "UTC", sizeof(client.tzname));
+    strncpy0(client.tzname, "UTC", sizeof(client.tzname));
     sql_set_sqlengine_state(&client, __FILE__, __LINE__, SQLENG_NORMAL_PROCESS);
     client.dbtran.mode = TRANLEVEL_SOSQL;
     client.sql = (char *)query;

--- a/db/tag.c
+++ b/db/tag.c
@@ -2188,8 +2188,8 @@ static int t2t_with_plan(const struct t2t_plan *plan, const void *from_buf,
 
     if (tzname) {
         if (tzname[0]) {
-            strncpy(tzopts1.tzname, tzname, sizeof(tzopts1.tzname));
-            strncpy(tzopts2.tzname, tzname, sizeof(tzopts2.tzname));
+            strncpy0(tzopts1.tzname, tzname, sizeof(tzopts1.tzname));
+            strncpy0(tzopts2.tzname, tzname, sizeof(tzopts2.tzname));
         } else {
             tzname = NULL;
         }
@@ -2921,7 +2921,7 @@ static int ctag_to_stag_int(const char *table, const char *ctag,
                     memcpy(&tzopts, &from_field->convopts,
                            sizeof(struct field_conv_opts));
                     tzopts.flags |= FLD_CONV_TZONE;
-                    strncpy(tzopts.tzname, tzname, sizeof(tzopts.tzname));
+                    strncpy0(tzopts.tzname, tzname, sizeof(tzopts.tzname));
 
                     /* The client data is little endian. */
                     if (flags & CONVERT_LITTLE_ENDIAN_CLIENT)
@@ -3378,7 +3378,7 @@ static int _stag_to_ctag_buf(const char *table, const char *stag,
 
                     if (tzname && tzname[0]) {
                         tzopts.flags |= FLD_CONV_TZONE;
-                        strncpy(tzopts.tzname, tzname, DB_MAX_TZNAMEDB);
+                        strncpy0(tzopts.tzname, tzname, DB_MAX_TZNAMEDB);
 
                         rc = SERVER_to_CLIENT(
                             from_field->out_default,
@@ -3424,7 +3424,7 @@ static int _stag_to_ctag_buf(const char *table, const char *stag,
                            from_field->len - rec_srt_off);
                 if (tzname && tzname[0]) {
                     tzopts.flags |= FLD_CONV_TZONE;
-                    strncpy(tzopts.tzname, tzname, DB_MAX_TZNAMEDB);
+                    strncpy0(tzopts.tzname, tzname, DB_MAX_TZNAMEDB);
 
                     rc = SERVER_to_CLIENT(
                         inbuf + from_field->offset, field_len, from_field->type,
@@ -4013,7 +4013,7 @@ static int stag_to_stag_field(const char *inbuf, char *outbuf, int flags,
         bzero(&tzopts, sizeof(tzopts));
         memcpy(&tzopts, &to_field->convopts, sizeof(struct field_conv_opts));
         tzopts.flags |= FLD_CONV_TZONE;
-        strncpy(tzopts.tzname, tzname, sizeof(tzopts.tzname));
+        strncpy0(tzopts.tzname, tzname, sizeof(tzopts.tzname));
 
         rc = SERVER_to_SERVER(inbuf + from_field->offset, from_field->len,
                               from_field->type, &from_field->convopts, inblob,

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -49,6 +49,7 @@
 #include "thread_util.h"
 #include "osqlrepository.h"
 #include "logmsg.h"
+#include "str0.h"
 
 struct thr_handle {
     pthread_t tid;
@@ -251,7 +252,7 @@ void thrman_origin(struct thr_handle *thr, const char *origin)
 {
     if (thr) {
         if (origin) {
-            strncpy(thr->corigin, origin, sizeof(thr->corigin));
+            strncpy0(thr->corigin, origin, sizeof(thr->corigin));
             thr->corigin[sizeof(thr->corigin) - 1] = 0;
         } else
             thr->corigin[0] = 0;

--- a/db/toblob.c
+++ b/db/toblob.c
@@ -290,8 +290,8 @@ void *cache_blob_data_int(struct ireq *iq, int rrn, unsigned long long genid,
     blob->key.rrn = rrn;
     blob->key.genid = genid;
     blob->key.total_length = (unsigned)total_length;
-    strncpy(blob->key.tablename, table, sizeof(blob->key.tablename));
-    strncpy(blob->key.tagname, tag, sizeof(blob->key.tagname));
+    strncpy0(blob->key.tablename, table, sizeof(blob->key.tablename));
+    strncpy0(blob->key.tagname, tag, sizeof(blob->key.tagname));
     if (*extra1 == 0 && *extra2 == 0 && strcasecmp(tag, ".DYNT.") == 0) {
         /* assign the "extra" value for dynamic tags if it is not already
          * assigned. */
@@ -597,8 +597,8 @@ int toblobask(struct ireq *iq)
     key.total_length = req.total_length;
     key.dyntag_extra1 = req.extra1;
     key.dyntag_extra2 = req.extra2;
-    strncpy(key.tablename, table, sizeof(key.tablename));
-    strncpy(key.tagname, cachetag, sizeof(key.tagname));
+    strncpy0(key.tablename, table, sizeof(key.tablename));
+    strncpy0(key.tagname, cachetag, sizeof(key.tagname));
     reqlog_logf(iq->reqlogger, REQL_INFO, "key=%d:0x%llx:%u:%u:%u:%s:%s",
                 key.rrn, key.genid, key.total_length, key.dyntag_extra1,
                 key.dyntag_extra2, key.tablename, key.tagname);

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -38,6 +38,7 @@
 #include <tcputil.h>
 #include <unistd.h>
 #include <logmsg.h>
+#include "str0.h"
 
 struct javasp_trans_state {
     /* Which events we are subscribed for. */
@@ -896,7 +897,7 @@ struct javasp_rec *javasp_alloc_rec(const void *od_dta, size_t od_len,
     }
     bzero(rec, sizeof(struct javasp_rec));
 
-    strncpy(rec->tablename, tblname, sizeof(rec->tablename));
+    strncpy0(rec->tablename, tblname, sizeof(rec->tablename));
     rec->ondisk_dta = od_dta;
     rec->ondisk_dta_len = od_len;
     rec->schema = schema;

--- a/db/types.c
+++ b/db/types.c
@@ -7368,7 +7368,7 @@ static int structdatetimeus2string_ISO(cdb2_client_datetimeus_t *in, char *out,
         if (!cdt.tzname[0])                                                    \
             strncpy(cdt.tzname,                                                \
                     ((struct field_conv_opts_tz *)outopts)->tzname,            \
-                    sizeof(cdt.tzname));                                       \
+                    sizeof(cdt.tzname) - 1);                                       \
         /* IF CLIENT THE TIMEZONELESS FIELD WAS STORED IN A DIFFERENT TIMEZONE \
          */                                                                    \
         /* THE PROVIDED CLIENT_DATETIME IS WRONG. THIS IS AS MUCH WE CAN DO */ \
@@ -7783,7 +7783,7 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
                                                                                \
         if (!cdt.tzname[0])                                                    \
             strncpy(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname));                                       \
+                    sizeof(cdt.tzname) - 1);                                       \
                                                                                \
         if (inopts)                                                            \
             memcpy(&tzopts, inopts, sizeof(*inopts));                          \
@@ -7823,7 +7823,7 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         cdt.tm.tm_isdst = 1;                                                   \
         if (!cdt.tzname[0])                                                    \
             strncpy(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname));                                       \
+                    sizeof(cdt.tzname) - 1);                                       \
                                                                                \
         if (!(p_buf = client_##dt##_put(&cdt, cdt_buf, p_cdt_buf_end))) {      \
             return -1;                                                         \
@@ -13268,7 +13268,7 @@ void _setIntervalDSUS(intv_ds_t *ds, long long sec, int usec)
     fracdt frac;                                                               \
     bzero(opts, sizeof(*opts));                                                \
     opts->flags |= 2 /*FLD_CONV_TZONE*/;                                       \
-    strncpy(opts->tzname, tz, sizeof(opts->tzname));                           \
+    strncpy(opts->tzname, tz, sizeof(opts->tzname) - 1);                           \
     if (datetime_check_range(in->dttz_sec, in->dttz_frac))                     \
         return -1;                                                             \
     /* brr, ugly */                                                            \
@@ -13387,7 +13387,7 @@ int str_to_dttz(const char *z, int n, const char *tz, dttz_t *dt, int precision)
     /* provide the timezone to the conversion routines */
     bzero(&tzopts, sizeof(tzopts));
     tzopts.flags |= 2 /*FLD_CONV_TZONE*/;
-    strncpy(tzopts.tzname, tz, sizeof(tzopts.tzname));
+    strncpy(tzopts.tzname, tz, sizeof(tzopts.tzname) - 1);
 
     if (is_usec_dt(z, n)) {
         dt->dttz_prec = DTTZ_PREC_USEC;
@@ -13511,7 +13511,7 @@ int timespec_to_dttz(const struct timespec *ts, dttz_t *dt, int precision)
     if (little_endian)                                                         \
         optstz.flags |= FLD_CONV_LENDIAN;                                      \
                                                                                \
-    strncpy(optstz.tzname, outtz, sizeof(optstz.tzname));                      \
+    strncpy(optstz.tzname, outtz, sizeof(optstz.tzname) - 1);                      \
                                                                                \
     /* convert to a server datetime first */                                   \
     rc = CLIENT_##UDT##_to_SERVER_##UDT(in, sizeof(*in), 0, opts, NULL, &sdt,  \

--- a/db/types.c
+++ b/db/types.c
@@ -6625,7 +6625,7 @@ static TYPES_INLINE int SERVER_BLOB_to_SERVER_BYTEARRAY(
 
     if (len <= inlen - BLOB_ON_DISK_LEN) {
         int rc;
-        rc = bytearray_copy(in + BLOB_ON_DISK_LEN, len, inopts, NULL,
+        rc = bytearray_copy(cin + BLOB_ON_DISK_LEN, len, inopts, NULL,
                             ((char *)out) + 1, outlen - 1, outdtsz, outopts,
                             outblob);
         /* set data bit */

--- a/db/types.c
+++ b/db/types.c
@@ -7367,9 +7367,9 @@ static int structdatetimeus2string_ISO(cdb2_client_datetimeus_t *in, char *out,
             return ret;                                                        \
                                                                                \
         if (!cdt.tzname[0])                                                    \
-            strncpy0(cdt.tzname,                                                \
-                    ((struct field_conv_opts_tz *)outopts)->tzname,            \
-                    sizeof(cdt.tzname));                                       \
+            strncpy0(cdt.tzname,                                               \
+                     ((struct field_conv_opts_tz *)outopts)->tzname,           \
+                     sizeof(cdt.tzname));                                      \
         /* IF CLIENT THE TIMEZONELESS FIELD WAS STORED IN A DIFFERENT TIMEZONE \
          */                                                                    \
         /* THE PROVIDED CLIENT_DATETIME IS WRONG. THIS IS AS MUCH WE CAN DO */ \
@@ -7783,8 +7783,9 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         }                                                                      \
                                                                                \
         if (!cdt.tzname[0])                                                    \
-            strncpy0(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname));                                       \
+            strncpy0(cdt.tzname,                                               \
+                     ((struct field_conv_opts_tz *)inopts)->tzname,            \
+                     sizeof(cdt.tzname));                                      \
                                                                                \
         if (inopts)                                                            \
             memcpy(&tzopts, inopts, sizeof(*inopts));                          \
@@ -7823,8 +7824,9 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         }                                                                      \
         cdt.tm.tm_isdst = 1;                                                   \
         if (!cdt.tzname[0])                                                    \
-            strncpy0(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname));                                       \
+            strncpy0(cdt.tzname,                                               \
+                     ((struct field_conv_opts_tz *)inopts)->tzname,            \
+                     sizeof(cdt.tzname));                                      \
                                                                                \
         if (!(p_buf = client_##dt##_put(&cdt, cdt_buf, p_cdt_buf_end))) {      \
             return -1;                                                         \
@@ -13269,7 +13271,7 @@ void _setIntervalDSUS(intv_ds_t *ds, long long sec, int usec)
     fracdt frac;                                                               \
     bzero(opts, sizeof(*opts));                                                \
     opts->flags |= 2 /*FLD_CONV_TZONE*/;                                       \
-    strncpy0(opts->tzname, tz, sizeof(opts->tzname));                           \
+    strncpy0(opts->tzname, tz, sizeof(opts->tzname));                          \
     if (datetime_check_range(in->dttz_sec, in->dttz_frac))                     \
         return -1;                                                             \
     /* brr, ugly */                                                            \
@@ -13512,7 +13514,7 @@ int timespec_to_dttz(const struct timespec *ts, dttz_t *dt, int precision)
     if (little_endian)                                                         \
         optstz.flags |= FLD_CONV_LENDIAN;                                      \
                                                                                \
-    strncpy0(optstz.tzname, outtz, sizeof(optstz.tzname));                      \
+    strncpy0(optstz.tzname, outtz, sizeof(optstz.tzname));                     \
                                                                                \
     /* convert to a server datetime first */                                   \
     rc = CLIENT_##UDT##_to_SERVER_##UDT(in, sizeof(*in), 0, opts, NULL, &sdt,  \

--- a/db/types.c
+++ b/db/types.c
@@ -53,6 +53,7 @@
 #include "logmsg.h"
 #include "util.h"
 #include "tohex.h"
+#include "str0.h"
 
 struct thr_handle;
 struct reqlogger *thrman_get_reqlogger(struct thr_handle *thr);
@@ -7366,9 +7367,9 @@ static int structdatetimeus2string_ISO(cdb2_client_datetimeus_t *in, char *out,
             return ret;                                                        \
                                                                                \
         if (!cdt.tzname[0])                                                    \
-            strncpy(cdt.tzname,                                                \
+            strncpy0(cdt.tzname,                                                \
                     ((struct field_conv_opts_tz *)outopts)->tzname,            \
-                    sizeof(cdt.tzname) - 1);                                       \
+                    sizeof(cdt.tzname));                                       \
         /* IF CLIENT THE TIMEZONELESS FIELD WAS STORED IN A DIFFERENT TIMEZONE \
          */                                                                    \
         /* THE PROVIDED CLIENT_DATETIME IS WRONG. THIS IS AS MUCH WE CAN DO */ \
@@ -7409,7 +7410,7 @@ static int structdatetimeus2string_ISO(cdb2_client_datetimeus_t *in, char *out,
         /*error */                                                             \
         return -1;                                                             \
     }                                                                          \
-/* END OF SERVER_BCSTR_to_CLIENT_DT_func_body */
+    /* END OF SERVER_BCSTR_to_CLIENT_DT_func_body */
 
 int SERVER_BCSTR_to_CLIENT_DATETIME(S2C_FUNKY_ARGS)
 {
@@ -7782,8 +7783,8 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         }                                                                      \
                                                                                \
         if (!cdt.tzname[0])                                                    \
-            strncpy(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname) - 1);                                       \
+            strncpy0(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
+                    sizeof(cdt.tzname));                                       \
                                                                                \
         if (inopts)                                                            \
             memcpy(&tzopts, inopts, sizeof(*inopts));                          \
@@ -7822,8 +7823,8 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         }                                                                      \
         cdt.tm.tm_isdst = 1;                                                   \
         if (!cdt.tzname[0])                                                    \
-            strncpy(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
-                    sizeof(cdt.tzname) - 1);                                       \
+            strncpy0(cdt.tzname, ((struct field_conv_opts_tz *)inopts)->tzname, \
+                    sizeof(cdt.tzname));                                       \
                                                                                \
         if (!(p_buf = client_##dt##_put(&cdt, cdt_buf, p_cdt_buf_end))) {      \
             return -1;                                                         \
@@ -7871,7 +7872,7 @@ static TYPES_INLINE int CLIENT_DATETIMEUS_to_SERVER_BREAL(C2S_FUNKY_ARGS)
         /* error */                                                            \
         return -1;                                                             \
     }                                                                          \
-/* END OF CLIENT_CSTR_to_SERVER_DT_func_body */
+    /* END OF CLIENT_CSTR_to_SERVER_DT_func_body */
 
 int CLIENT_CSTR_to_SERVER_DATETIME(C2S_FUNKY_ARGS)
 {
@@ -13268,7 +13269,7 @@ void _setIntervalDSUS(intv_ds_t *ds, long long sec, int usec)
     fracdt frac;                                                               \
     bzero(opts, sizeof(*opts));                                                \
     opts->flags |= 2 /*FLD_CONV_TZONE*/;                                       \
-    strncpy(opts->tzname, tz, sizeof(opts->tzname) - 1);                           \
+    strncpy0(opts->tzname, tz, sizeof(opts->tzname));                           \
     if (datetime_check_range(in->dttz_sec, in->dttz_frac))                     \
         return -1;                                                             \
     /* brr, ugly */                                                            \
@@ -13387,7 +13388,7 @@ int str_to_dttz(const char *z, int n, const char *tz, dttz_t *dt, int precision)
     /* provide the timezone to the conversion routines */
     bzero(&tzopts, sizeof(tzopts));
     tzopts.flags |= 2 /*FLD_CONV_TZONE*/;
-    strncpy(tzopts.tzname, tz, sizeof(tzopts.tzname) - 1);
+    strncpy0(tzopts.tzname, tz, sizeof(tzopts.tzname));
 
     if (is_usec_dt(z, n)) {
         dt->dttz_prec = DTTZ_PREC_USEC;
@@ -13511,7 +13512,7 @@ int timespec_to_dttz(const struct timespec *ts, dttz_t *dt, int precision)
     if (little_endian)                                                         \
         optstz.flags |= FLD_CONV_LENDIAN;                                      \
                                                                                \
-    strncpy(optstz.tzname, outtz, sizeof(optstz.tzname) - 1);                      \
+    strncpy0(optstz.tzname, outtz, sizeof(optstz.tzname));                      \
                                                                                \
     /* convert to a server datetime first */                                   \
     rc = CLIENT_##UDT##_to_SERVER_##UDT(in, sizeof(*in), 0, opts, NULL, &sdt,  \
@@ -13527,7 +13528,7 @@ int timespec_to_dttz(const struct timespec *ts, dttz_t *dt, int precision)
     out->dttz_prec = prec;                                                     \
     out->dttz_conv = 0;                                                        \
     return rc;                                                                 \
-/* END OF client_dt_to_dttz_func_body */
+    /* END OF client_dt_to_dttz_func_body */
 
 int client_datetime_to_dttz(const cdb2_client_datetime_t *in, const char *outtz,
                             dttz_t *out, int little_endian)

--- a/lua/ltypes.c
+++ b/lua/ltypes.c
@@ -545,7 +545,7 @@ static int l_datetime_change_timezone(lua_State *lua)
     newtimezone = lua_tostring(lua,2);
     sdt.sec = db_struct2time(d->val.tzname, &(d->val.tm));
     if( db_time2struct(newtimezone, &sdt.sec, &(newtm)) == 0) {
-        strncpy(d->val.tzname, newtimezone, sizeof(d->val.tzname));
+        strncpy(d->val.tzname, newtimezone, sizeof(d->val.tzname) - 1);
         d->val.tm = newtm;
         lua_pushinteger(lua, 0);
         return 1;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3082,7 +3082,7 @@ static int dbthread_join(Lua lua1)
     Lua lua2 = thd->lua;
     SP sp2 = thd->sp;
     int num_returns = copy_state_stacks(lua2, lua1, 0);
-    if (sp2->error) strncpy(thd->error, sp2->error, sizeof(thd->error));
+    if (sp2->error) strncpy(thd->error, sp2->error, sizeof(thd->error) - 1);
     close_sp_int(sp2, 1);
     return num_returns;
 }

--- a/net/net.c
+++ b/net/net.c
@@ -1006,7 +1006,7 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
         if (rc != namelen)
             return -1;
     } else {
-        strncpy(my_hostname, connect_message.my_hostname, HOSTNAME_LEN);
+        strncpy0(my_hostname, connect_message.my_hostname, HOSTNAME_LEN);
         my_hostname[HOSTNAME_LEN - 1] = 0;
     }
 
@@ -1021,7 +1021,7 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
         if (rc != namelen)
             return -1;
     } else {
-        strncpy(to_hostname, connect_message.to_hostname, HOSTNAME_LEN);
+        strncpy0(to_hostname, connect_message.to_hostname, HOSTNAME_LEN);
         to_hostname[HOSTNAME_LEN - 1] = 0;
     }
 
@@ -1146,7 +1146,7 @@ static int write_connect_message(netinfo_type *netinfo_ptr,
                  host_node_ptr->hostname_len);
         append_to = 1;
     } else {
-        strncpy(connect_message.to_hostname, host_node_ptr->host,
+        strncpy0(connect_message.to_hostname, host_node_ptr->host,
                 sizeof(connect_message.to_hostname));
     }
     connect_message.to_portnum = host_node_ptr->port;
@@ -1163,7 +1163,7 @@ static int write_connect_message(netinfo_type *netinfo_ptr,
                  netinfo_ptr->myhostname_len);
         append_from = 1;
     } else {
-        strncpy(connect_message.my_hostname, netinfo_ptr->myhostname,
+        strncpy0(connect_message.my_hostname, netinfo_ptr->myhostname,
                 sizeof(connect_message.my_hostname));
     }
     if (netinfo_ptr->myport)
@@ -1242,11 +1242,11 @@ static int write_message_int(netinfo_type *netinfo_ptr,
     /* The writer thread will fill in these details later.. for now, we don't
      * necessarily know the correct details anyway. */
     /*
-    strncpy(wire_header.fromhost, netinfo_ptr->myhostname,
+    strncpy0(wire_header.fromhost, netinfo_ptr->myhostname,
        sizeof(wire_header.fromhost));
     wire_header.fromport = netinfo_ptr->myport;
     wire_header.fromnode = netinfo_ptr->mynode;
-    strncpy(wire_header.tohost, host_node_ptr->host,
+    strncpy0(wire_header.tohost, host_node_ptr->host,
        sizeof(wire_header.tohost));
     wire_header.toport = host_node_ptr->port;
     wire_header.tonode = host_node_ptr->node;
@@ -1333,8 +1333,7 @@ static int read_message_header(netinfo_type *netinfo_ptr,
         if (rc != namelen)
             return 1;
     } else {
-        strncpy(fromhost, wire_header->fromhost, HOSTNAME_LEN);
-        fromhost[HOSTNAME_LEN - 1] = 0;
+        strncpy0(fromhost, wire_header->fromhost, HOSTNAME_LEN);
     }
     if (wire_header->tohost[0] == '.') {
         wire_header->tohost[HOSTNAME_LEN - 1] = 0;
@@ -1346,8 +1345,7 @@ static int read_message_header(netinfo_type *netinfo_ptr,
         if (rc != namelen)
             return 1;
     } else {
-        strncpy(tohost, wire_header->tohost, HOSTNAME_LEN);
-        tohost[HOSTNAME_LEN - 1] = 0;
+        strncpy0(tohost, wire_header->tohost, HOSTNAME_LEN);
     }
 
     return 0;
@@ -3311,9 +3309,9 @@ netinfo_type *create_netinfo_int(char myhostname[], int myportnum, int myfd,
     netinfo_ptr->fake = fake;
     netinfo_ptr->offload = offload;
 
-    strncpy(netinfo_ptr->app, app, sizeof(netinfo_ptr->app));
-    strncpy(netinfo_ptr->service, service, sizeof(netinfo_ptr->service));
-    strncpy(netinfo_ptr->instance, instance, sizeof(netinfo_ptr->instance));
+    strncpy0(netinfo_ptr->app, app, sizeof(netinfo_ptr->app));
+    strncpy0(netinfo_ptr->service, service, sizeof(netinfo_ptr->service));
+    strncpy0(netinfo_ptr->instance, instance, sizeof(netinfo_ptr->instance));
 
     netinfo_ptr->stats.bytes_read = netinfo_ptr->stats.bytes_written = 0;
     netinfo_ptr->stats.throttle_waits = netinfo_ptr->stats.reorders = 0;
@@ -4275,7 +4273,7 @@ static void *writer_thread(void *args)
                                  sizeof(tmp_wire_hdr.fromhost), ".%d",
                                  netinfo_ptr->myhostname_len);
                     } else {
-                        strncpy(tmp_wire_hdr.fromhost, netinfo_ptr->myhostname,
+                        strncpy0(tmp_wire_hdr.fromhost, netinfo_ptr->myhostname,
                                 sizeof(tmp_wire_hdr.fromhost));
                     }
                     tmp_wire_hdr.fromport = netinfo_ptr->myport;
@@ -4285,7 +4283,7 @@ static void *writer_thread(void *args)
                                  sizeof(tmp_wire_hdr.tohost), ".%d",
                                  host_node_ptr->hostname_len);
                     } else {
-                        strncpy(tmp_wire_hdr.tohost, host_node_ptr->host,
+                        strncpy0(tmp_wire_hdr.tohost, host_node_ptr->host,
                                 sizeof(tmp_wire_hdr.tohost));
                     }
                     tmp_wire_hdr.toport = host_node_ptr->port;
@@ -4847,7 +4845,7 @@ static int get_dedicated_conhost(host_node_type *host_node_ptr, struct in_addr *
         strcpy(rephostname, host_node_ptr->host);
         if (subnet[0]) {
             strcat(rephostname, subnet);
-            strncpy(host_node_ptr->subnet, subnet, HOSTNAME_LEN);
+            strncpy0(host_node_ptr->subnet, subnet, HOSTNAME_LEN);
 
 #ifdef DEBUG
             host_node_printf(

--- a/net/net.c
+++ b/net/net.c
@@ -1007,7 +1007,6 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
             return -1;
     } else {
         strncpy0(my_hostname, connect_message.my_hostname, HOSTNAME_LEN);
-        my_hostname[HOSTNAME_LEN - 1] = 0;
     }
 
     if (connect_message.to_hostname[0] == '.') {
@@ -1022,7 +1021,6 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
             return -1;
     } else {
         strncpy0(to_hostname, connect_message.to_hostname, HOSTNAME_LEN);
-        to_hostname[HOSTNAME_LEN - 1] = 0;
     }
 
     if (strcmp(netinfo_ptr->myhostname, to_hostname) == 0)
@@ -1147,7 +1145,7 @@ static int write_connect_message(netinfo_type *netinfo_ptr,
         append_to = 1;
     } else {
         strncpy0(connect_message.to_hostname, host_node_ptr->host,
-                sizeof(connect_message.to_hostname));
+                 sizeof(connect_message.to_hostname));
     }
     connect_message.to_portnum = host_node_ptr->port;
     /* It was `to_nodenum`. */
@@ -1164,7 +1162,7 @@ static int write_connect_message(netinfo_type *netinfo_ptr,
         append_from = 1;
     } else {
         strncpy0(connect_message.my_hostname, netinfo_ptr->myhostname,
-                sizeof(connect_message.my_hostname));
+                 sizeof(connect_message.my_hostname));
     }
     if (netinfo_ptr->myport)
         connect_message.my_portnum =
@@ -4274,7 +4272,7 @@ static void *writer_thread(void *args)
                                  netinfo_ptr->myhostname_len);
                     } else {
                         strncpy0(tmp_wire_hdr.fromhost, netinfo_ptr->myhostname,
-                                sizeof(tmp_wire_hdr.fromhost));
+                                 sizeof(tmp_wire_hdr.fromhost));
                     }
                     tmp_wire_hdr.fromport = netinfo_ptr->myport;
                     tmp_wire_hdr.fromnode = 0;
@@ -4284,7 +4282,7 @@ static void *writer_thread(void *args)
                                  host_node_ptr->hostname_len);
                     } else {
                         strncpy0(tmp_wire_hdr.tohost, host_node_ptr->host,
-                                sizeof(tmp_wire_hdr.tohost));
+                                 sizeof(tmp_wire_hdr.tohost));
                     }
                     tmp_wire_hdr.toport = host_node_ptr->port;
                     tmp_wire_hdr.tonode = 0;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1510,7 +1510,7 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
             } else if (strncasecmp(sqlstr, "timezone", 8) == 0) {
                 sqlstr += 8;
                 sqlstr = skipws(sqlstr);
-                strncpy(clnt->tzname, sqlstr, sizeof(clnt->tzname));
+                strncpy0(clnt->tzname, sqlstr, sizeof(clnt->tzname));
             } else if (strncasecmp(sqlstr, "datetime", 8) == 0) {
                 sqlstr += 8;
                 sqlstr = skipws(sqlstr);
@@ -1582,8 +1582,7 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                 }
                 *sqlstr = 0;
                 if ((sqlstr - spname) < MAX_SPNAME) {
-                    strncpy(clnt->spname, spname, MAX_SPNAME);
-                    clnt->spname[MAX_SPNAME] = '\0';
+                    strncpy0(clnt->spname, spname, MAX_SPNAME);
                 } else {
                     rc = ii + 1;
                 }
@@ -2259,7 +2258,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         clnt.stop_this_statement = 0;
 
         if ((clnt.tzname[0] == '\0') && sql_query->tzname)
-            strncpy(clnt.tzname, sql_query->tzname, sizeof(clnt.tzname));
+            strncpy0(clnt.tzname, sql_query->tzname, sizeof(clnt.tzname));
 
         if (sql_query->dbname && dbenv->envname &&
             strcasecmp(sql_query->dbname, dbenv->envname)) {

--- a/sockpool/sockpool.c
+++ b/sockpool/sockpool.c
@@ -245,7 +245,7 @@ static int open_sockpool_ll(void)
     }
 
     struct sockaddr_un addr = {.sun_family = AF_UNIX};
-    strncpy(addr.sun_path, SOCKPOOL_SOCKET_NAME, sizeof(addr.sun_path));
+    strncpy(addr.sun_path, SOCKPOOL_SOCKET_NAME, sizeof(addr.sun_path) - 1);
 
     if (connect(fd, (const struct sockaddr *)&addr, sizeof(addr)) == -1) {
         fprintf(stderr, "%s:connect(%s): %d %s\n", __func__,
@@ -306,7 +306,7 @@ static void default_destructor(enum socket_pool_event event,
                 int rc;
                 struct sockpool_msg_vers0 msg = {
                     .request = SOCKPOOL_DONATE, .dbnum = dbnum, .timeout = ttl};
-                strncpy(msg.typestr, typestr, sizeof(msg.typestr));
+                strncpy(msg.typestr, typestr, sizeof(msg.typestr) - 1);
                 msg.typestr[sizeof(msg.typestr) - 1] = 0;
 
                 errno = 0;
@@ -610,8 +610,7 @@ socket_pool_get_ext_ll(const char *typestr, int dbnum, int flags,
             struct sockpool_msg_vers0 msg = {.request = SOCKPOOL_REQUEST,
                                              .dbnum = dbnum};
 
-            strncpy(msg.typestr, typestr, sizeof(msg.typestr));
-            msg.typestr[sizeof(msg.typestr) - 1] = 0;
+            strncpy(msg.typestr, typestr, sizeof(msg.typestr) - 1);
 
             /* Please may I have a file descriptor */
             errno = 0;

--- a/sqlite/ext/comdb2/activelocks.c
+++ b/sqlite/ext/comdb2/activelocks.c
@@ -6,6 +6,7 @@
 #include "comdb2systblInt.h"
 #include "ezsystables.h"
 #include "cdb2api.h"
+#include "str0.h"
 
 typedef struct systable_activelocks {
     int64_t                 threadid;
@@ -50,13 +51,13 @@ static int collect(void *args, int64_t threadid, int32_t lockerid,
         l->page_isnull = 0;
     }
     if (object)
-        strncpy(l->object_str, object, sizeof(l->object_str));
+        strncpy0(l->object_str, object, sizeof(l->object_str));
     else
         l->object_str[0] = '\0';
     l->object = l->object_str;
 
     if (rectype)
-        strncpy(l->type_str, rectype, sizeof(l->type_str));
+        strncpy0(l->type_str, rectype, sizeof(l->type_str));
     else 
         l->type_str[0] = '\0';
     l->type = l->type_str;

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -138,7 +138,7 @@ static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
         char* username = strchr(table_name, '@');
         if (username) {
             /* Do nothing. */
-            strncpy(dst, table_name, MAXTABLELEN);
+            strncpy0(dst, table_name, MAXTABLELEN);
         } else { /* Add user nmame. */
             /* Make it part of user schema. */
             char userschema[MAXTABLELEN];
@@ -168,7 +168,7 @@ static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
             }
         }
     } else {
-       strncpy(dst, table_name, MAXTABLELEN);
+       strncpy0(dst, table_name, MAXTABLELEN);
     }
 
     // Check whether the user is allowed perform this schema change.
@@ -306,7 +306,7 @@ static inline int chkAndCopyPartitionTokens(Parse *pParse, char *dst, Token *t1,
         goto cleanup;
     }
 
-    strncpy(dst, table_name, MAXTABLELEN);
+    strncpy0(dst, table_name, MAXTABLELEN);
 
 cleanup:
     free(table_name);
@@ -2441,7 +2441,7 @@ void sqlite3AlterRenameTable(Parse *pParse, Token *pSrcName, Token *pName,
     sc->nothrevent = 1;
     sc->live = 1;
     sc->rename = 1;
-    strncpy(sc->newtable, newTable, sizeof(sc->newtable));
+    strncpy0(sc->newtable, newTable, sizeof(sc->newtable));
 
     comdb2prepareNoRows(v, pParse, 0, sc, &comdb2SqlSchemaChange_usedb,
                         (vdbeFuncArgFree)&free_schema_change_type);

--- a/sqlite/src/vdbemem.c
+++ b/sqlite/src/vdbemem.c
@@ -27,6 +27,7 @@
 #include <util.h>
 #include "debug_switches.h"
 #include "logmsg.h"
+#include "str0.h"
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifdef SQLITE_DEBUG
@@ -2941,7 +2942,7 @@ static int _dttz_to_native_datetime(cdb2_client_datetime_t * cdt, const Mem *inp
     bzero(&tzopts, sizeof(tzopts));
     tzopts.flags |= 2 /*FLD_CONV_TZONE*/;
     if( !inp->tz ) return SQLITE_ERROR;
-    strncpy(tzopts.tzname, inp->tz, sizeof(tzopts.tzname));
+    strncpy0(tzopts.tzname, inp->tz, sizeof(tzopts.tzname));
 
     /* ugly, arghh */
     bzero(tmp, sizeof(tmp));
@@ -2988,7 +2989,7 @@ static int _dttz_to_native_datetimeus(cdb2_client_datetimeus_t * cdt, const Mem 
     bzero(&tzopts, sizeof(tzopts));
     tzopts.flags |= 2 /*FLD_CONV_TZONE*/;
     if(!inp->tz) return SQLITE_ERROR;
-    strncpy(tzopts.tzname, inp->tz, sizeof(tzopts.tzname));
+    strncpy0(tzopts.tzname, inp->tz, sizeof(tzopts.tzname));
 
     /* ugly, arghh */
     bzero(tmp, sizeof(tmp));

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -409,9 +409,6 @@ if [[ "$out" == "0" ]]; then
     failexit "Inplace update should update updateid to nonzero"
 fi
 
-
-
-
 test_t1() {
 	INITNUMREC=100
 

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -446,15 +446,15 @@ test_t1() {
 
 
 test_bulk() {
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t6 (i int unique, j int, k int)"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "create table mytable6 (i int unique, j int, k int)"
     CNT=5000
-    echo -n "insert into t6 values(1,1,1)" > gg.in
+    echo -n "insert into mytable6 values(1,1,1)" > gg.in
     for i in `seq 2 $CNT` ; do echo -n ",($i, $i, $i)" ; done >> gg.in
 
     for j in `seq 1 2` ; do
         cdb2sql -s ${CDB2_OPTIONS} $dbnm default -f gg.in
-        assertcnt t6 $CNT
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from t6 where 1"
+        assertcnt mytable6 $CNT
+        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from mytable6 where 1"
     done
 }
 

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -220,4 +220,26 @@ done
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.send('delfiles t$i ')"
 #done
 
+
+#create tables with increasing longer tablenames
+test_create_tbls() {
+    i=0
+    tbl="f"
+    while [ $i -lt 30 ] ; do
+        tbl=$tbl$((i%10))
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "create table $tbl (i int unique)"
+        val=$RANDOM
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "insert into $tbl values ($val)"
+        res=`$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --tabs default "select * from $tbl"`
+        assertres $res $val
+        let i=i+1
+    done
+
+}
+
+test_create_tbls
+
+
+
+
 echo "Success"

--- a/tests/tools/hatest.c
+++ b/tests/tools/hatest.c
@@ -258,7 +258,7 @@ static int process_escape(const char *cmdstr)
 
     int len = strlen(cmdstr);
 
-    strncpy(copy, cmdstr, sizeof(copy));
+    strncpy(copy, cmdstr, sizeof(copy) - 1);
     copy[len] = '\0';
 
     /* get first token, skip @ */

--- a/tests/tools/insert.c
+++ b/tests/tools/insert.c
@@ -154,7 +154,7 @@ int insert(cdb2_hndl_tp **indb, const char *readnode)
         }
     }
 
-    strncpy(cnonce_begin, cdb2_cnonce(db), sizeof(cnonce_begin));
+    strncpy(cnonce_begin, cdb2_cnonce(db), sizeof(cnonce_begin) - 1);
 
     for (int j = 0; j < inserts_per_txn; j++) {
         snprintf(sql, sizeof(sql),
@@ -280,7 +280,7 @@ int insert(cdb2_hndl_tp **indb, const char *readnode)
             return rc;
         }
 
-        strncpy(cnonce_begin, cdb2_cnonce(db), sizeof(cnonce_begin));
+        strncpy(cnonce_begin, cdb2_cnonce(db), sizeof(cnonce_begin) - 1);
 
         snprintf(sql, sizeof(sql),
                  "insert into jepsen(id, value) values(%d, %d)", i, val);

--- a/tools/comdb2ar/tar_header.cpp
+++ b/tools/comdb2ar/tar_header.cpp
@@ -27,7 +27,7 @@ void TarHeader::clear() throw()
 {
     m_used_gnu = false;
     memset(&m_head, 0, sizeof(m_head));
-    strncpy(m_head.h.ustar, "ustar", sizeof(m_head.h.ustar));
+    strncpy(m_head.h.ustar, "ustar", sizeof(m_head.h.ustar) - 1);
     m_head.h.ustar_version[0] = '0';
     m_head.h.ustar_version[1] = '0';
 }
@@ -40,7 +40,7 @@ void TarHeader::set_filename(const std::string& filename)
         throw SerialiseError(filename, "file name too long for tar header");
     }
     strncpy(m_head.h.filename, filename.c_str(),
-            sizeof(m_head.h.filename));
+            sizeof(m_head.h.filename) - 1);
 }
 
 void TarHeader::set_attrs(const struct stat& st)
@@ -71,13 +71,13 @@ void TarHeader::set_attrs(const struct stat& st)
     if(pwd == NULL) {
         std::clog << "getpwuid(" << st.st_uid << ") failed." << std::endl;
     } else {
-        strncpy(m_head.h.uname, pwd->pw_name, sizeof(m_head.h.uname));
+        strncpy(m_head.h.uname, pwd->pw_name, sizeof(m_head.h.uname) - 1);
     }
     struct group *grp = getgrgid(st.st_gid);
     if(grp == NULL) {
         std::clog << "getgrgid(" << st.st_gid << ") failed." << std::endl;
     } else {
-        strncpy(m_head.h.gname, grp->gr_name, sizeof(m_head.h.gname));
+        strncpy(m_head.h.gname, grp->gr_name, sizeof(m_head.h.gname) - 1);
     }
 }
 

--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -298,7 +298,7 @@ static void init_router_mode()
 
     memset(&serv_addr, 0, sizeof(serv_addr));
     serv_addr.sun_family = AF_UNIX;
-    strncpy(serv_addr.sun_path, unix_bind_path, sizeof(serv_addr.sun_path));
+    strncpy(serv_addr.sun_path, unix_bind_path, sizeof(serv_addr.sun_path) - 1);
 
     if (bind(listenfd, (const struct sockaddr *)&serv_addr,
              sizeof(serv_addr)) == -1) {
@@ -1010,7 +1010,7 @@ int main(int argc, char **argv)
                 fprintf(stderr, "Filename too long: %s\n", optarg);
                 exit(2);
             }
-            strncpy(unix_bind_path, optarg, sizeof(unix_bind_path));
+            strncpy(unix_bind_path, optarg, sizeof(unix_bind_path) - 1);
             break;
         case 'p':
             if (default_ports) {

--- a/util/ctrace.c
+++ b/util/ctrace.c
@@ -202,7 +202,7 @@ static void ctrace_openlog_taskname_lk(const char *directory,
 
     snprintf(logfilename, sizeof(logfilename), "%s/%s.trc.c", directory,
              taskname);
-    strncpy(savetaskname, taskname, sizeof(savetaskname));
+    strncpy(savetaskname, taskname, sizeof(savetaskname) - 1);
 
     CTRACE_TIMER_START(IOLIMIT_SLOW);
     {

--- a/util/flibc.c
+++ b/util/flibc.c
@@ -147,7 +147,7 @@ int flibc_snprintf_dbl(char *p_str, const size_t str_buf_len, double d)
 /*for(i = 0; i < sizeof(test_fixup_cases) / sizeof(test_fixup_cases[0]); ++i)*/
 /*{*/
 /*char str_buf[128];*/
-/*strncpy(str_buf, test_fixup_cases[i][0], sizeof(str_buf));*/
+/*strncpy(str_buf, test_fixup_cases[i][0], sizeof(str_buf) - 1);*/
 
 /*|+ do fixup +|*/
 /*if(fixup_sigfigs_real_cstr(str_buf, sizeof(str_buf)))*/

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -521,7 +521,7 @@ static int portmux_get_unix_socket(const char *unix_bind_path)
                 unix_bind_path);
         return -1;
     }
-    strncpy(addr.sun_path, unix_bind_path, sizeof(addr.sun_path));
+    strncpy(addr.sun_path, unix_bind_path, sizeof(addr.sun_path) - 1);
     len += offsetof(struct sockaddr_un, sun_path);
 
     if (fcntl(listenfd, F_SETFD, 1 /*TRUE: close-on-exec*/) < 0) {
@@ -1556,9 +1556,9 @@ portmux_fd_t *portmux_listen_options_setup(const char *app, const char *service,
     fds->listenfd = listenfd;
     fds->tcplistenfd = tcplistenfd;
     fds->port = port;
-    strncpy(fds->app, app, sizeof(fds->app));
-    strncpy(fds->service, service, sizeof(fds->service));
-    strncpy(fds->instance, instance, sizeof(fds->instance));
+    strncpy(fds->app, app, sizeof(fds->app) - 1);
+    strncpy(fds->service, service, sizeof(fds->service) - 1);
+    strncpy(fds->instance, instance, sizeof(fds->instance) - 1);
     fds->options = options;
 
     /*check if we have connection on portmux unix socket*/


### PR DESCRIPTION
fix instances where strncpy can leave string without a terminating character
fix warning: pointer to void or function used in arithmetic