### PR TITLE
Simplify temp table mgmt

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -145,11 +145,9 @@ static void sqlengine_work_shard_pp(struct thdpool *pool, void *work,
     struct sqlclntstate *clnt = work;
     switch (op) {
     case THD_RUN:
-        sqlengine_setup_temp_table_mtx(clnt);
         sqlengine_work_shard(pool, work, thddata);
         break;
     case THD_FREE:
-        sqlengine_cleanup_temp_table_mtx(clnt);
         /* error, we are done */
         clnt->query_rc = -1;
         clnt->done = 1;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -107,49 +107,14 @@ unsigned long long get_id(bdb_state_type *);
 
 struct temp_cursor;
 struct temp_table;
-struct temptable {
-    struct temp_cursor *cursor;
-    struct temp_table *tbl;
-    int flags;
-    int nRef;
-    pthread_mutex_t *lk;
-#ifndef NDEBUG
-    pthread_mutex_t *temp_table_mtx; /* WARNING: For assert() only, do NOT use. */
-#endif
-};
-struct temptable_entry {
-    char keyBuf[50]; /* >= len("+18446744073709551615\0") */
-    int rootPg;
-    struct temptable *value;
-};
-
 extern int gbl_partial_indexes;
 #define SQLITE3BTREE_KEY_SET_INS(IX) (clnt->ins_keys |= (1ULL << (IX)))
 #define SQLITE3BTREE_KEY_SET_DEL(IX) (clnt->del_keys |= (1ULL << (IX)))
 extern int gbl_expressions_indexes;
 
-/*
-** Lua threads share temp tables.
-** Don't create new btree, use this one.
-*/
+// Lua threads share temp tables.
+// Don't create new btree, use this one (tmptbl_clone)
 static __thread struct temptable *tmptbl_clone = NULL;
-static __thread char hashKeyBuf[50]; /* >= len("+18446744073709551615\0") */
-
-static const char *rootPageNumToTempHashKey(
-  int iTable
-){
-  snprintf(hashKeyBuf, sizeof(hashKeyBuf), "%d", iTable);
-  return hashKeyBuf;
-}
-
-static const char *rootPageNumToPermHashKey(
-  char *zKeyBuf,
-  size_t nKeyBuf,
-  int iTable
-){
-  snprintf(zKeyBuf, nKeyBuf, "%d", iTable);
-  return zKeyBuf;
-}
 
 void free_cached_idx(uint8_t **cached_idx)
 {
@@ -3162,73 +3127,16 @@ int sqlite3BtreeCommitStmt(Btree *pBt)
     return rc;
 }
 
-static int free_hash_ent(void *obj, void *dum)
+static int temptable_free(void *obj, void *arg)
 {
-    free(obj);
+    struct temptable *tmp = obj;
+    Btree *pBt = arg;
+    if (tmp->owner == pBt) {
+        int bdberr;
+        bdb_temp_table_close(thedb->bdb_env, tmp->tbl, &bdberr);
+    }
+    free(tmp);
     return 0;
-}
-
-/*
-** WARNING: This function assumes (and requires) that the associated temp
-**          table lock pthread mutex is already held.
-*/
-static void removeTempTableEntry(
-  Hash *pHash,
-  struct temptable_entry *pEntry,
-  int iTable
-){
-  /*
-  ** NOTE: Use of rootPageNumToTempHashKey() here is fine because
-  **       the hash entry is being deleted (not stored); therefore,
-  **       the passed string hash key will not be stored.
-  */
-  assert( sqlite3HashFind(pHash, rootPageNumToTempHashKey(iTable)) );
-#ifndef NDEBUG
-  struct temptable_entry *pOldEntry =
-#endif
-  sqlite3HashInsert(pHash, rootPageNumToTempHashKey(iTable), 0);
-  assert( pOldEntry==pEntry );
-  free(pEntry);
-}
-
-/*
-** WARNING: This function assumes (and requires) that the associated temp
-**          table lock pthread mutex is already held.
-*/
-static int releaseTempTableRef(
-  Btree *pBt,
-  int iTable,
-  struct temptable_entry *pEntry,
-  struct temptable *pTbl,
-  int bRemove
-){
-    assert( pTbl->nRef>0 );
-    if (pTbl != NULL && --pTbl->nRef == 0) {
-        if (pTbl->tbl != NULL) {
-            int rc;
-            int bdberr = 0;
-
-            rc = bdb_temp_table_close(thedb->bdb_env, pTbl->tbl, &bdberr);
-            if (rc != SQLITE_OK) {
-                logmsg(LOGMSG_ERROR,
-                       "%s: bdb_temp_table_close bt %p tab %d tbl %p "
-                       "rc %d bdberr %d\n", __func__, pBt, iTable, pTbl,
-                       rc, bdberr);
-
-                ++pTbl->nRef; /* UNDO */
-                return SQLITE_INTERNAL;
-            }
-        }
-        /* pTbl->tbl = NULL; */
-        free(pTbl);
-        /* Table has been freed, remove from hash table. */
-        bRemove = 1;
-    }
-    if (bRemove) {
-        removeTempTableEntry(&pBt->temp_tables, pEntry, iTable);
-        /* pEntry = NULL; */
-    }
-    return SQLITE_OK;
 }
 
 /*
@@ -3263,43 +3171,12 @@ int sqlite3BtreeClose(Btree *pBt)
              */
         }
     }
-    assert( listc_size(&pBt->cursors)==0 );
+    assert(listc_size(&pBt->cursors) == 0);
 
     if (pBt->is_temporary) {
-        HashElem *pElem;
-
-        // TODO: The thread pool causes this to be violated.
-        // assert( pBt->temp_table_mtx==thd->clnt->temp_table_mtx );
-        Pthread_mutex_lock(pBt->temp_table_mtx);
-
-        for(pElem=sqliteHashFirst(&pBt->temp_tables); pElem; ){
-            /* internally this will close cursors open on the table */
-            struct temptable_entry *pEntry = pElem->data;
-
-            /* releaseTempTableRef may free pElem. So we get the next element
-               now before invoking releaseTempTableRef(). */
-            pElem=sqliteHashNext(pElem);
-
-            if (pEntry != NULL) {
-                assert( pEntry->value );
-                assert( pEntry->value->temp_table_mtx==pBt->temp_table_mtx );
-
-                rc = releaseTempTableRef(
-                    pBt, pEntry->rootPg, pEntry, pEntry->value, 1
-                );
-
-                if (rc != SQLITE_OK) {
-                    Pthread_mutex_unlock(pBt->temp_table_mtx);
-                    rc = SQLITE_INTERNAL;
-                    goto done;
-                }
-            }
-        }
-        if (thd)
-            thd->bttmp = NULL;
-
-        sqlite3HashClear(&pBt->temp_tables);
-        Pthread_mutex_unlock(pBt->temp_table_mtx);
+        hash_for(pBt->temp_tables, temptable_free, pBt);
+        hash_free(pBt->temp_tables);
+        pBt->temp_tables = NULL;
     } else {
         if (thd)
             thd->bt = NULL;
@@ -3316,13 +3193,10 @@ int sqlite3BtreeClose(Btree *pBt)
       pBt->tran = NULL;
    }
 #endif
-done:
-
     /*
      * if (thd->clnt->freemewithbt)
      * free(thd->clnt);
      */
-
     reqlog_logf(pBt->reqlogger, REQL_TRACE, "Close(pBt %d)      = %s\n",
                 pBt->btreeid, sqlite3ErrStr(rc));
     if (rc == 0){
@@ -3446,31 +3320,13 @@ int sqlite3BtreeOpen(
         *ppBtree = bt;
     } else if (!zFilename || strcmp(zFilename, ":memory:") == 0) {
         /* temporary connection (for temp tables and such) */
-        struct sqlclntstate *clnt = thd->clnt;
-        assert( clnt );
-        assert( clnt->temp_table_mtx );
-        bt->temp_table_mtx = clnt->temp_table_mtx;
         bt->reqlogger = thrman_get_reqlogger(thrman_self());
         bt->btreeid = id++;
         bt->is_temporary = 1;
-        Pthread_mutex_lock(bt->temp_table_mtx);
-        sqlite3HashInit(&bt->temp_tables);
-        Pthread_mutex_unlock(bt->temp_table_mtx);
-        /*
-        ** NOTE: There are no temporary tables whatsoever.  There must be a
-        **       "sqlite_temp_master" table before anything else, because it
-        **       must have a root page number of 1; therefore, create it now.
-        */
         int masterPgno;
-        assert( tmptbl_clone==NULL );
+        assert(tmptbl_clone == NULL);
         rc = sqlite3BtreeCreateTable(bt, &masterPgno, BTREE_INTKEY);
-        assert( masterPgno==1 ); /* sqlite_temp_master root page number */
-        if( rc!=SQLITE_OK ){
-            Pthread_mutex_lock(bt->temp_table_mtx);
-            sqlite3HashClear(&bt->temp_tables);
-            Pthread_mutex_unlock(bt->temp_table_mtx);
-            goto done;
-        }
+        assert(masterPgno == 1); /* sqlite_temp_master root page number */
         thd->bttmp = bt;
         listc_init(&bt->cursors, offsetof(BtCursor, lnk));
         if (flags & BTREE_UNORDERED) {
@@ -3488,16 +3344,11 @@ int sqlite3BtreeOpen(
         listc_init(&bt->cursors, offsetof(BtCursor, lnk));
         bt->is_remote = 1;
         /* NOTE: this is a lockless pointer; at the time of setting this, we got
-        a lock
-        in sqlite3AddAndLockTable, so it should be good. The sqlite engine will
-        keep
-        this structure around after fdb tables are changed. While fdb will NOT
-        go away,
-        its tables can dissapear or change schema.  Cached schema in Table
-        object needs
-        to be matched against fdb->tbl and make sure they are consistent before
-        doing anything
-        on the attached fdb
+        a lock in sqlite3AddAndLockTable, so it should be good. The sqlite engine will
+        keep this structure around after fdb tables are changed. While fdb will NOT
+        go away, its tables can dissapear or change schema.  Cached schema in Table
+        object needs to be matched against fdb->tbl and make sure they are consistent before
+        doing anything on the attached fdb
         */
         bt->fdb = get_fdb(zFilename);
         if (!bt->fdb) {
@@ -3982,32 +3833,16 @@ int sqlite3BtreeSetAutoVacuum(Btree *pBt, int autoVacuum)
  */
 int sqlite3BtreeDropTable(Btree *pBt, int iTable, int *piMoved)
 {
-    int rc = UNIMPLEMENTED;
     *piMoved = 0;
-    reqlog_logf(pBt->reqlogger, REQL_TRACE,
-                " sqlite3BtreeDropTable(pBt %d, root %d)       = %s\n",
-                pBt->btreeid, iTable, sqlite3ErrStr(rc));
-
-    if (pBt->is_temporary) {
-        // TODO: The thread pool causes this to be violated.
-        // assert( pBt->temp_table_mtx==thd->clnt->temp_table_mtx );
-        Pthread_mutex_lock(pBt->temp_table_mtx);
-
-        struct temptable_entry *pEntry = sqlite3HashFind(
-            &pBt->temp_tables, rootPageNumToTempHashKey(iTable));
-
-        if (pEntry != NULL) {
-            assert( pEntry->value );
-            assert( pEntry->value->temp_table_mtx==pBt->temp_table_mtx );
-
-            rc = releaseTempTableRef(pBt, iTable, pEntry, pEntry->value, 1);
-        } else {
-            rc = SQLITE_OK;
-        }
-
-        Pthread_mutex_unlock(pBt->temp_table_mtx);
+    if (!pBt->is_temporary) return UNIMPLEMENTED;
+    struct temptable *tmp = hash_find(pBt->temp_tables, &iTable);
+    if (tmp->owner == pBt) {
+        int bdberr;
+        bdb_temp_table_close(thedb->bdb_env, tmp->tbl, &bdberr);
     }
-    return rc;
+    hash_del(pBt->temp_tables, tmp);
+    free(tmp);
+    return SQLITE_OK;
 }
 
 /*
@@ -5112,7 +4947,10 @@ int sqlite3BtreeGetAutoVacuum(Btree *pBt)
 ** temp table between Lua threads.
 */
 static __thread pthread_mutex_t *tmptbl_lk = NULL;
-void comdb2_set_tmptbl_lk(pthread_mutex_t *lk) { tmptbl_lk = lk; }
+void comdb2_set_tmptbl_lk(pthread_mutex_t *lk)
+{
+    tmptbl_lk = lk;
+}
 
 /*
  ** Create a new BTree table.  Write into *piTable the page
@@ -5127,19 +4965,14 @@ void comdb2_set_tmptbl_lk(pthread_mutex_t *lk) { tmptbl_lk = lk; }
  */
 int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
 {
+    int bdberr = 0;
     int rc = SQLITE_OK;
     struct sql_thread *thd;
-
     if ((thd = pthread_getspecific(query_info_key)) == NULL) {
         rc = SQLITE_INTERNAL;
         logmsg(LOGMSG_ERROR, "%s rc: %d\n", __func__, rc);
         return rc;
     }
-
-    // TODO: The thread pool causes this to be violated.
-    // assert( pBt->temp_table_mtx==thd->clnt->temp_table_mtx );
-    Pthread_mutex_lock(pBt->temp_table_mtx);
-
     if (!pBt->is_temporary) { /* must go through comdb2 to do this */
         rc = UNIMPLEMENTED;
         logmsg(LOGMSG_ERROR, "%s rc: %d\n", __func__, rc);
@@ -5149,99 +4982,41 @@ int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
         rc = SQLITE_LIMIT;
         goto done;
     }
-
-    struct temptable_entry *pNewEntry = calloc(1, sizeof(struct temptable_entry));
-
-    if (unlikely(pNewEntry == NULL)) {
+    if (pBt->temp_tables == NULL) {
+        pBt->temp_tables = hash_init_i4(offsetof(struct temptable, rootpage));
+    }
+    struct temptable *pNewTbl = calloc(1, sizeof(struct temptable));
+    if (pNewTbl == NULL) {
         logmsg(LOGMSG_ERROR, "%s: calloc(%lu) failed\n", __func__,
-               sizeof(struct temptable_entry));
+               sizeof(struct temptable));
         rc = SQLITE_NOMEM;
         goto done;
     }
-
-    struct temptable *pNewTbl;
-
-    if (tmptbl_clone) {
-        assert( tmptbl_clone->temp_table_mtx==pBt->temp_table_mtx );
-        pNewTbl = pNewEntry->value = tmptbl_clone;
-        pNewTbl->nRef++;
-    } else {
-        pNewTbl = calloc(1, sizeof(struct temptable));
-
-        if (unlikely(pNewTbl == NULL)) {
-            logmsg(LOGMSG_ERROR, "%s: calloc(%lu) failed\n", __func__,
-                   sizeof(struct temptable));
-            rc = SQLITE_NOMEM;
-            goto done;
-        }
-
-        pNewEntry->value = pNewTbl;
-        pNewTbl->nRef = 1;
-
-#ifndef NDEBUG
-        pNewTbl->temp_table_mtx = pBt->temp_table_mtx;
-#endif
-    }
-
-    /* creating a temporary table */
+    pNewTbl->owner = pBt;
+    pNewTbl->flags = flags;
+    pNewTbl->lk = tmptbl_lk;
+    pNewTbl->rootpage = ++pBt->num_temp_tables;
     if (pBt->is_hashtable) {
-        struct temp_table *tbl;
-        int bdberr;
-
-        tbl = bdb_temp_hashtable_create(thedb->bdb_env, &bdberr);
-        if (tbl == NULL) {
-            free(pNewTbl);
-            logmsg(LOGMSG_ERROR, "%s: bdb_temp_hashtable_create failed: %d\n",
-                   __func__, bdberr);
-            rc = SQLITE_INTERNAL;
-            goto done;
-        }
-        pNewTbl->tbl = tbl;
-        pNewTbl->lk = NULL;
-        pNewTbl->flags = flags;
-    } else if (!tmptbl_clone) {
-        struct temp_table *tbl;
-        int bdberr;
-
-        tbl = bdb_temp_table_create(thedb->bdb_env, &bdberr);
-        if (tbl == NULL) {
-            free(pNewTbl);
-            logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_create failed: %d\n",
-                   __func__, bdberr);
-            rc = SQLITE_INTERNAL;
-            goto done;
-        }
-        pNewTbl->tbl = tbl;
-        pNewTbl->lk = tmptbl_lk;
-        pNewTbl->flags = flags;
+        pNewTbl->tbl = bdb_temp_hashtable_create(thedb->bdb_env, &bdberr);
+    } else if (tmptbl_clone) {
+        pNewTbl->lk = tmptbl_clone->lk;
+        pNewTbl->tbl = tmptbl_clone->tbl;
+        pNewTbl->owner = tmptbl_clone->owner;
+    } else {
+        pNewTbl->tbl = bdb_temp_table_create(thedb->bdb_env, &bdberr);
     }
-
-    /* at this point, we have succeeded. */
+    if (pNewTbl->tbl == NULL) {
+        --pBt->num_temp_tables;
+        free(pNewTbl);
+        logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_create failed: %d\n",
+               __func__, bdberr);
+        rc = SQLITE_INTERNAL;
+        goto done;
+    }
+    hash_add(pBt->temp_tables, pNewTbl);
     thd->had_temptables = 1;
-
-    int iTable = ++pBt->next_temp_root_pg;
-
-    assert( iTable>=1 ); /* can never be zero or negative */
-    assert( iTable>1 || pBt->temp_tables.count==0 ); /* master page == 1 */
-    assert( !sqlite3HashFind(&pBt->temp_tables,
-                             rootPageNumToTempHashKey(iTable)) );
-
-    pNewEntry->rootPg = iTable;
-
-#ifndef NDEBUG
-    struct temptable_entry *pOldEntry =
-#endif
-        sqlite3HashInsert(&pBt->temp_tables,
-                          rootPageNumToPermHashKey(pNewEntry->keyBuf,
-                                                   sizeof(pNewEntry->keyBuf),
-                                                   iTable),
-                          pNewEntry);
-
-    assert( pOldEntry==NULL );
-    *piTable = iTable;
-
+    *piTable = pNewTbl->rootpage;
 done:
-    Pthread_mutex_unlock(pBt->temp_table_mtx);
     reqlog_logf(pBt->reqlogger, REQL_TRACE,
                 "CreateTable(pBt %d, root %d, flags %d)      = %s\n",
                 pBt->btreeid, *piTable, flags, sqlite3ErrStr(rc));
@@ -6412,35 +6187,6 @@ skip:
             }
             free(pCur->tmptable);
             pCur->tmptable = NULL;
-
-            // TODO: The thread pool causes this to be violated.
-            // assert( pCur->bt->temp_table_mtx==clnt->temp_table_mtx );
-            Pthread_mutex_lock(pCur->bt->temp_table_mtx);
-
-            struct temptable_entry *pEntry = sqlite3HashFind(
-                &pCur->bt->temp_tables, rootPageNumToTempHashKey(
-                pCur->rootpage));
-
-            if (pEntry != NULL) {
-                assert( pEntry->value );
-                assert( pEntry->value->temp_table_mtx==pCur->bt->temp_table_mtx );
-
-                rc = releaseTempTableRef(
-                    pCur->bt, pCur->rootpage, pEntry, pEntry->value, 0
-                );
-                if (rc != SQLITE_OK) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s: releaseTempTableRef bt %p tab %d rc %d\n",
-                           __func__, pCur->bt, pCur->rootpage, rc);
-                    rc = SQLITE_INTERNAL;
-                    goto done;
-                }
-            } else {
-                logmsg(LOGMSG_ERROR, "%s: entry %d not found\n",
-                       __func__, pCur->rootpage);
-            }
-
-            Pthread_mutex_unlock(pCur->bt->temp_table_mtx);
         }
 
         if (pCur->bdbcur) {
@@ -6504,27 +6250,11 @@ int sqlite3BtreeClearTable(Btree *pBt, int iTable, int *pnChange)
         *pnChange = 0;
 
     if (pBt->is_temporary) {
-        assert( pBt->temp_table_mtx==clnt->temp_table_mtx );
-        Pthread_mutex_lock(pBt->temp_table_mtx);
-
-        struct temptable_entry *pEntry = sqlite3HashFind(
-            &pBt->temp_tables, rootPageNumToTempHashKey(iTable));
-
-        if (pEntry == NULL) {
-            logmsg(LOGMSG_ERROR, "%s: entry %d not found\n",
-                   __func__, iTable);
-            rc = SQLITE_INTERNAL;
-            Pthread_mutex_unlock(pBt->temp_table_mtx);
-            goto done;
-        }
-
-        struct temptable *pTbl = pEntry->value;
-
+        struct temptable *pTbl = hash_find(pBt->temp_tables, &iTable);
         if (pTbl == NULL) {
             logmsg(LOGMSG_ERROR, "%s: table %d not found\n",
                    __func__, iTable);
             rc = SQLITE_INTERNAL;
-            Pthread_mutex_unlock(pBt->temp_table_mtx);
             goto done;
         }
         rc = bdb_temp_table_truncate(thedb->bdb_env, pTbl->tbl, &bdberr);
@@ -6533,10 +6263,8 @@ int sqlite3BtreeClearTable(Btree *pBt, int iTable, int *pnChange)
                     "sqlite3BtreeClearTable: bdb_temp_table_clear error rc = %d\n",
                     rc);
             rc = SQLITE_INTERNAL;
-            Pthread_mutex_unlock(pBt->temp_table_mtx);
             goto done;
         }
-        Pthread_mutex_unlock(pBt->temp_table_mtx);
     } else {
         struct dbtable *db = get_sqlite_db(thd, iTable, &ixnum);
         if (ixnum != -1) {
@@ -7370,10 +7098,6 @@ static int lk_tmptbl_cursor_count(BtCursor *btcursor, i64 *count)
     return rc;
 }
 
-/*
-** WARNING: This function assumes (and requires) that the associated temp
-**          table lock pthread mutex is already held.
-*/
 static int
 sqlite3BtreeCursor_temptable(Btree *pBt,      /* The btree */
                              int iTable,      /* Root page of table to open */
@@ -7384,25 +7108,14 @@ sqlite3BtreeCursor_temptable(Btree *pBt,      /* The btree */
                              struct sql_thread *thd)
 {
     int bdberr = 0;
-
-    struct temptable_entry *pEntry = sqlite3HashFind(
-        &pBt->temp_tables, rootPageNumToTempHashKey(iTable));
-
-    if (pEntry == NULL) {
-        logmsg(LOGMSG_ERROR, "%s: entry %d not found\n",
-               __func__, iTable);
-        return SQLITE_INTERNAL;
-    }
-
-    struct temptable *src = pEntry->value;
-
+    struct temptable *src = hash_find(pBt->temp_tables, &iTable);
     if (src == NULL) {
         logmsg(LOGMSG_ERROR, "%s: table %d not found\n",
                __func__, iTable);
         return SQLITE_INTERNAL;
     }
 
-    assert( cur->tmptable==NULL );
+    assert(cur->tmptable == NULL);
     cur->tmptable = calloc(1, sizeof(struct temptable));
 
     if (!cur->tmptable) {
@@ -7412,10 +7125,8 @@ sqlite3BtreeCursor_temptable(Btree *pBt,      /* The btree */
     }
 
     cur->cursor_class = CURSORCLASS_TEMPTABLE;
-    assert( src->tbl );
-    assert( src->nRef>0 );
+    assert(src->tbl);
     cur->tmptable->tbl = src->tbl;
-    src->nRef++;
     if (src->lk) {
         cur->tmptable->lk = src->lk;
         cur->cursor_move = lk_tmptbl_cursor_move;
@@ -8299,36 +8010,28 @@ int sqlite3BtreeCursor(
     cur->pKeyInfo = pKeyInfo;
 
     if (pBt->is_temporary) { /* temp table */
-        // TODO: The thread pool causes this to be violated.
-        // assert( pBt->temp_table_mtx==clnt->temp_table_mtx );
-        Pthread_mutex_lock(pBt->temp_table_mtx);
-        assert( iTable>=1 ); /* can never be zero or negative */
-        if( forOpen ){
-          /*
-          ** NOTE: When being called to open a temporary (table) cursor in
-          **       response to OP_OpenRead, OP_OpenWrite, or OP_ReopenIdx
-          **       opcodes by the VDBE, the temporary table may not have
-          **       been created yet.  Attempt to do that now.
-          */
-          if( sqlite3HashFind(&pBt->temp_tables,
-                              rootPageNumToTempHashKey(iTable))==0 ){
-            int tmpPgno;
-            Pthread_mutex_unlock(pBt->temp_table_mtx);
-            assert( tmptbl_clone==NULL );
-            rc = sqlite3BtreeCreateTable(pBt, &tmpPgno, BTREE_INTKEY);
-            Pthread_mutex_lock(pBt->temp_table_mtx);
-            assert( tmpPgno==iTable );
-          }
+        assert(iTable >= 1); /* can never be zero or negative */
+        int pgno = iTable;
+        if (forOpen) {
+            /*
+            ** NOTE: When being called to open a temporary (table) cursor in
+            **       response to OP_OpenRead, OP_OpenWrite, or OP_ReopenIdx
+            **       opcodes by the VDBE, the temporary table may not have
+            **       been created yet.  Attempt to do that now.
+            */
+            if (hash_find(pBt->temp_tables, &pgno) == NULL) {
+                assert(tmptbl_clone == NULL);
+                rc = sqlite3BtreeCreateTable(pBt, &pgno, BTREE_INTKEY);
+                assert(pgno == iTable);
+            }
         }
-        if( rc==SQLITE_OK ){
-          assert( sqlite3HashFind(&pBt->temp_tables,
-                                  rootPageNumToTempHashKey(iTable)) );
-          rc = sqlite3BtreeCursor_temptable(pBt, iTable, wrFlag & BTREE_CUR_WR,
-                                            temp_table_cmp, pKeyInfo, cur, thd);
+        if (rc == SQLITE_OK) {
+            rc = sqlite3BtreeCursor_temptable(
+                pBt, pgno, wrFlag & BTREE_CUR_WR, temp_table_cmp, pKeyInfo,
+                cur, thd);
         }
         cur->find_cost = cur->move_cost = 0.1;
         cur->write_cost = 0.2;
-        Pthread_mutex_unlock(pBt->temp_table_mtx);
     }
     /* sqlite_master table */
     else if (iTable == RTPAGE_SQLITE_MASTER && fdb_master_is_local(cur)) {
@@ -11415,106 +11118,22 @@ out:
 }
 
 void clone_temp_table(sqlite3 *dest, const sqlite3 *src, const char *sql,
-                      int rootpg)
+                      struct temptable *tbl)
 {
     int rc;
     char *err = NULL;
-
-#ifndef NDEBUG
-    struct sql_thread *thd = pthread_getspecific(query_info_key);
-    assert(thd);
-#endif
-
-    Btree *pSrcBt = &src->aDb[1].pBt[0];
-
-#ifndef NDEBUG
-    assert( pSrcBt->temp_table_mtx==thd->clnt->temp_table_mtx );
-#endif
-    Pthread_mutex_lock(pSrcBt->temp_table_mtx);
-
-    // aDb[0]: sqlite_master
-    // aDb[1]: sqlite_temp_master
-    struct temptable_entry *pEntry = sqlite3HashFind(
-        &pSrcBt->temp_tables, rootPageNumToTempHashKey(rootpg));
-
-    if (pEntry == NULL) {
-        logmsg(LOGMSG_FATAL, "%s entry %d not found, sql:%s\n",
-               __func__, rootpg, sql);
-        Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
-        abort();
-    }
-
-    struct temptable *pTbl = pEntry->value;
-
-    if (pTbl == NULL) {
-        logmsg(LOGMSG_FATAL, "%s table %d not found, sql:%s\n",
-               __func__, rootpg, sql);
-        Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
-        abort();
-    }
-
     sqlite3_stmt *stmt;
-    Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
-    rc = sqlite3_prepare_v2(dest, sql, -1, &stmt, NULL);
-    Pthread_mutex_lock(pSrcBt->temp_table_mtx);
-
-    if (rc != SQLITE_OK) {
-        logmsg(LOGMSG_ERROR, "%s rc:%d err:%s sql:%s\n",
-               __func__, rc, err, sql);
-        Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
-        abort();
-    }
-
-    assert( tmptbl_clone==NULL );
-    tmptbl_clone = pTbl; 
-    Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
+    sqlite3_prepare_v2(dest, sql, -1, &stmt, NULL);
+    tmptbl_clone = tbl;
     while ((rc = sqlite3_step(stmt)) == SQLITE_ROW)
-        ; /* do nothing (no loop body) */
-    Pthread_mutex_lock(pSrcBt->temp_table_mtx);
+        ;
     tmptbl_clone = NULL;
-
     if (rc != SQLITE_DONE) {
-        logmsg(LOGMSG_ERROR, "%s rc:%d err:%s sql:%s\n",
-               __func__, rc, err, sql);
-        Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
+        logmsg(LOGMSG_FATAL, "%s rc:%d err:%s sql:%s\n", __func__, rc, err,
+               sql);
         abort();
     }
-    Pthread_mutex_unlock(pSrcBt->temp_table_mtx);
     sqlite3_finalize(stmt);
-    int srcNextRootPg = pSrcBt->next_temp_root_pg;
-
-    Btree *pDestBt = &dest->aDb[1].pBt[0];
-    if( pDestBt ){
-        int maxRootPg = -1;
-        HashElem *pElem;
-#ifndef NDEBUG
-        assert( pDestBt->temp_table_mtx==thd->clnt->temp_table_mtx );
-#endif
-        Pthread_mutex_lock(pDestBt->temp_table_mtx);
-        for(pElem=sqliteHashFirst(&pDestBt->temp_tables); pElem;
-                pElem=sqliteHashNext(pElem)){
-            struct temptable_entry *pEntry = pElem->data;
-            if( pEntry==NULL ) continue;
-            if( maxRootPg==-1 || maxRootPg<pEntry->rootPg ){
-                maxRootPg = pEntry->rootPg;
-            }
-        }
-        if( maxRootPg!=-1 ){
-            assert( maxRootPg>=1 );
-            maxRootPg++; /* advance to the next one */
-            if( maxRootPg>=pDestBt->next_temp_root_pg ){
-                pDestBt->next_temp_root_pg = maxRootPg;
-            }else{
-                logmsg(LOGMSG_ERROR,
-                       "%s max root page wrong, src:%d vs max:%d vs dst:%d\n",
-                       __func__, srcNextRootPg, maxRootPg,
-                       pDestBt->next_temp_root_pg);
-                Pthread_mutex_unlock(pDestBt->temp_table_mtx);
-                abort();
-            }
-        }
-        Pthread_mutex_unlock(pDestBt->temp_table_mtx);
-    }
 }
 
 int bt_hash_table(char *table, int szkb)
@@ -12658,4 +12277,12 @@ cleanup:
 done:
     thd->clnt = NULL;
     return ret;
+}
+
+struct temptable get_tbl_by_rootpg(const sqlite3 *db, int i)
+{
+    // aDb[1]: sqlite_temp_master
+    hash_t *h = db->aDb[1].pBt[0].temp_tables;
+    struct temptable *t = hash_find(h, &i);
+    return *t;
 }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -83,7 +83,7 @@ pthread_mutex_t lua_debug_mutex = PTHREAD_MUTEX_INITIALIZER;
 pthread_cond_t lua_debug_cond = PTHREAD_COND_INITIALIZER;
 
 struct tmptbl_info_t {
-    int rootpg;
+    struct temptable tbl;
     char *sql;
     char name[MAXTABLELEN * 2]; // namespace.name
     pthread_mutex_t *lk;
@@ -2552,8 +2552,6 @@ static void *dispatch_lua_thread(void *arg)
     clnt.exec_lua_thread = 1;
     clnt.trans_has_sp = 1;
     clnt.queue_me = 1;
-    assert(clnt.temp_table_mtx == NULL || !clnt.own_temp_table_mtx);
-    clnt.temp_table_mtx = parent_clnt->temp_table_mtx;
     Pthread_mutex_init(&clnt.wait_mutex, NULL);
     Pthread_cond_init(&clnt.wait_cond, NULL);
     Pthread_mutex_init(&clnt.write_lock, NULL);
@@ -2599,7 +2597,7 @@ int mycallback(void *arg_, int cols, char **text, char **name)
             tmptbl_info_t *tmp2 = malloc(sizeof(tmptbl_info_t));
             strcpy(tmp2->name, tmp1->name);
             tmp2->lk = tmp1->lk;
-            tmp2->rootpg = atoi(text[1]);
+            tmp2->tbl = get_tbl_by_rootpg(getdb(sp1), atoi(text[1]));
             tmp2->sql = strdup(text[2]);
             LIST_INSERT_HEAD(&sp2->tmptbls, tmp2, entries);
             return 0;
@@ -5857,7 +5855,7 @@ static void clone_temp_tables(SP sp)
         create += sizeof("CREATE TABLE");
         strbuf_appendf(sql, "CREATE TEMP TABLE %s", create);
         sp->clnt->skip_peer_chk = 1;
-        clone_temp_table(dest, src, strbuf_buf(sql), tmp->rootpg);
+        clone_temp_table(dest, src, strbuf_buf(sql), &tmp->tbl);
         sp->clnt->skip_peer_chk = 0;
         strbuf_free(sql);
     }
@@ -6382,7 +6380,6 @@ void *exec_trigger(trigger_reg_t *reg)
     sqlengine_thd_start(NULL, &thd, THRTYPE_TRIGGER);
     thrman_set_subtype(thd.thr_self, THRSUBTYPE_LUA_SQL);
     thd.sqlthd->clnt = &clnt;
-    sqlengine_setup_temp_table_mtx(&clnt);
 
     // We're making unprotected calls to lua below.
     // luaL_error() will cause abort()
@@ -6444,7 +6441,6 @@ void *exec_trigger(trigger_reg_t *reg)
         force_unregister(L, reg);
     }
     put_curtran(thedb->bdb_env, &clnt);
-    sqlengine_cleanup_temp_table_mtx(&clnt);
     close_sp(&clnt);
     cleanup_clnt(&clnt);
     thd.sqlthd->clnt = NULL;

--- a/util/locks_wrap.h
+++ b/util/locks_wrap.h
@@ -44,55 +44,26 @@
         LKDBG_TRACE(GOT, FUNC, LKWRAP_FIRST(__VA_ARGS__));                     \
     } while (0)
 
-#define Pthread_mutex_init(a, b)    WRAP_PTHREAD(pthread_mutex_init, a, b)
-#define Pthread_mutex_destroy(a)    WRAP_PTHREAD(pthread_mutex_destroy, a)
-#define Pthread_mutex_lock(a)       WRAP_PTHREAD(pthread_mutex_lock, a)
-#define Pthread_mutex_unlock(a)     WRAP_PTHREAD(pthread_mutex_unlock, a)
-#define Pthread_rwlock_init(a, b)   WRAP_PTHREAD(pthread_rwlock_init, a, b)
-#define Pthread_rwlock_destroy(a)   WRAP_PTHREAD(pthread_rwlock_destroy, a)
-#define Pthread_rwlock_rdlock(a)    WRAP_PTHREAD(pthread_rwlock_rdlock, a)
-#define Pthread_rwlock_wrlock(a)    WRAP_PTHREAD(pthread_rwlock_wrlock, a)
-#define Pthread_rwlock_unlock(a)    WRAP_PTHREAD(pthread_rwlock_unlock, a)
-#define Pthread_cond_init(a, b)     WRAP_PTHREAD(pthread_cond_init, a, b)
-#define Pthread_cond_destroy(a)     WRAP_PTHREAD(pthread_cond_destroy, a)
-#define Pthread_cond_signal(a)      WRAP_PTHREAD(pthread_cond_signal, a)
-#define Pthread_cond_broadcast(a)   WRAP_PTHREAD(pthread_cond_broadcast, a)
-#define Pthread_cond_wait(a, b)     WRAP_PTHREAD(pthread_cond_wait, a, b)
-#define Pthread_attr_init(a)        WRAP_PTHREAD(pthread_attr_init, a)
-#define Pthread_attr_destroy(a)     WRAP_PTHREAD(pthread_attr_destroy, a)
-#define Pthread_key_create(a, b)    WRAP_PTHREAD(pthread_key_create, a, b)
-#define Pthread_key_delete(a)       WRAP_PTHREAD(pthread_key_delete, a)
-#define Pthread_setspecific(a, b)   WRAP_PTHREAD(pthread_setspecific, a, b)
-#define Pthread_attr_setstacksize(a, b)                                        \
-    WRAP_PTHREAD(pthread_attr_setstacksize, a, b)
-#define Pthread_attr_setdetachstate(a, b)                                      \
-    WRAP_PTHREAD(pthread_attr_setdetachstate, a, b)
-
-#define Pthread_mutex_alloc_and_init(a, b)                                     \
-    do {                                                                       \
-        pthread_mutex_t *pMutex = calloc(1, sizeof(pthread_mutex_t));          \
-        if (pMutex == NULL) {                                                  \
-            logmsg(LOGMSG_FATAL,                                               \
-                   "%s:%d OUT OF MEMORY thd:%p\n",                             \
-                   __func__, __LINE__, (void *)pthread_self());                \
-            abort();                                                           \
-        }                                                                      \
-        Pthread_mutex_init(pMutex, (b));                                       \
-        (a) = pMutex;                                                          \
-    } while (0)
-
-#define Pthread_mutex_destroy_and_free(a)                                      \
-    do {                                                                       \
-        pthread_mutex_t *pMutex = (a);                                         \
-        if (pMutex == NULL) {                                                  \
-            logmsg(LOGMSG_FATAL,                                               \
-                   "%s:%d INVALID_MUTEX thd:%p\n",                             \
-                   __func__, __LINE__, (void *)pthread_self());                \
-            abort();                                                           \
-        }                                                                      \
-        Pthread_mutex_destroy(pMutex);                                         \
-        free(pMutex);                                                          \
-        (a) = NULL;                                                            \
-    } while (0)
+#define Pthread_mutex_init(a, b)            WRAP_PTHREAD(pthread_mutex_init, a, b)
+#define Pthread_mutex_destroy(a)            WRAP_PTHREAD(pthread_mutex_destroy, a)
+#define Pthread_mutex_lock(a)               WRAP_PTHREAD(pthread_mutex_lock, a)
+#define Pthread_mutex_unlock(a)             WRAP_PTHREAD(pthread_mutex_unlock, a)
+#define Pthread_rwlock_init(a, b)           WRAP_PTHREAD(pthread_rwlock_init, a, b)
+#define Pthread_rwlock_destroy(a)           WRAP_PTHREAD(pthread_rwlock_destroy, a)
+#define Pthread_rwlock_rdlock(a)            WRAP_PTHREAD(pthread_rwlock_rdlock, a)
+#define Pthread_rwlock_wrlock(a)            WRAP_PTHREAD(pthread_rwlock_wrlock, a)
+#define Pthread_rwlock_unlock(a)            WRAP_PTHREAD(pthread_rwlock_unlock, a)
+#define Pthread_cond_init(a, b)             WRAP_PTHREAD(pthread_cond_init, a, b)
+#define Pthread_cond_destroy(a)             WRAP_PTHREAD(pthread_cond_destroy, a)
+#define Pthread_cond_signal(a)              WRAP_PTHREAD(pthread_cond_signal, a)
+#define Pthread_cond_broadcast(a)           WRAP_PTHREAD(pthread_cond_broadcast, a)
+#define Pthread_cond_wait(a, b)             WRAP_PTHREAD(pthread_cond_wait, a, b)
+#define Pthread_attr_init(a)                WRAP_PTHREAD(pthread_attr_init, a)
+#define Pthread_attr_destroy(a)             WRAP_PTHREAD(pthread_attr_destroy, a)
+#define Pthread_key_create(a, b)            WRAP_PTHREAD(pthread_key_create, a, b)
+#define Pthread_key_delete(a)               WRAP_PTHREAD(pthread_key_delete, a)
+#define Pthread_setspecific(a, b)           WRAP_PTHREAD(pthread_setspecific, a, b)
+#define Pthread_attr_setstacksize(a, b)     WRAP_PTHREAD(pthread_attr_setstacksize, a, b)
+#define Pthread_attr_setdetachstate(a, b)   WRAP_PTHREAD(pthread_attr_setdetachstate, a, b)
 
 #endif


### PR DESCRIPTION
This reverts to original simple design but keeps the hashtable for mapping root page number to temptable.