### PR TITLE
Recreate deadlock load

### DIFF
--- a/tests/TODO
+++ b/tests/TODO
@@ -58,6 +58,7 @@ sc_resume
 # 'make all'. These tests however can be run individually.
 
 DISABLED TESTS:
+deadlock_load.test        -- re-enable after Adi merges code
 overflowblobs.test        -- timesout
 halt_processor_tds.test   -- requires a cluster
 rowlocks_blkseq.test

--- a/tests/deadlock_load.test/Makefile
+++ b/tests/deadlock_load.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=12m
+endif

--- a/tests/deadlock_load.test/lrl.options
+++ b/tests/deadlock_load.test/lrl.options
@@ -1,0 +1,18 @@
+nowatch
+logmsg level info
+enable_new_snapshot
+enable_snapshot_isolation
+berkattr abort_on_replicant_log_write 1
+init_with_genid48
+logdelete_lock_trace
+verbose_set_sc_in_progress on
+#setattr REP_PROCESSORS 0
+#setattr REP_WORKERS 0
+online_recovery on
+ack_trace
+
+reorder_socksql_no_deadlock on
+reorder_idx_writes on
+
+#reorder_socksql_no_deadlock off
+#reorder_idx_writes off

--- a/tests/deadlock_load.test/runit
+++ b/tests/deadlock_load.test/runit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=0
+[[ $debug == "1" ]] && set -x
+
+export myhost=$(hostname)
+export deadlock_load=${TESTSBUILDDIR}/deadlock_load
+export threads=10
+export records=500
+export iterations=1
+
+function write_prompt
+{
+    typeset func=$1
+    echo "[$func] $2"
+}
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="failexit"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    exit -1
+}
+
+function get_master
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="get_master"
+    typeset tries=$total_tries
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send(\"bdb cluster\")" | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'
+}
+
+function run_tests
+{
+    typeset func="run_tests"
+    start=$(date +%s)
+    $deadlock_load -d $DBNAME -T $threads -r $records -i $iterations -c $CDB2_CONFIG
+    stop=$(date +%s)
+    export r=$?
+    [[ $r != 0 ]] && failexit $func "deadlock_load test failed"
+    master=$(get_master)
+    deadlocks=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME -host $master "select value from comdb2_metrics where name='deadlocks'")
+    elapsed=$(( stop - start ))
+    echo "Number of deadlocks: $deadlocks, elapsed-time: $elapsed seconds"
+    [[ $deadlocks -gt 50 ]] && failexit $func "too many deadlocks: $deadlocks"
+}
+
+run_tests
+echo "Success"
+exit 0
+

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -48,13 +48,14 @@ add_exe(cdb2_close_early cdb2_close_early.c)
 add_exe(cdb2api_read_intrans_results cdb2api_read_intrans_results.c)
 add_exe(nowritetimeout nowritetimeout.c)
 add_exe(api_events api_events.c)
+add_exe(deadlock_load deadlock_load.c)
 add_exe(api_libs api_libs.c)
 add_library(api_hello_world_lib SHARED api_hello_world_lib.c)
 list(APPEND test-tools api_hello_world_lib)
 
 add_custom_target(test-tools DEPENDS ${test-tools})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events api_libs)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load api_libs)
   target_link_libraries(${executable} cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 endforeach()
 
@@ -77,6 +78,6 @@ target_link_libraries(recom cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} $
 # everything!
 target_link_libraries(stepper cdb2api mem dlmalloc util ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest cldeadlock comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events api_libs)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest cldeadlock comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load api_libs)
     target_link_libraries(${executable} ${UNWIND_LIBRARY})
 endforeach()

--- a/tests/tools/deadlock_load.c
+++ b/tests/tools/deadlock_load.c
@@ -1,0 +1,213 @@
+#include <alloca.h>
+#include <stdarg.h>
+#include <strings.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <poll.h>
+#include <stdint.h>
+#include <sys/time.h>
+#include <string.h>
+#include <ctype.h>
+#include <signal.h>
+#include <assert.h>
+#include "testutil.h"
+#include "nemesis.h"
+#include <cdb2api.h>
+
+static char *argv0;
+char *dbname = NULL;
+char *cltype = "default";
+int iterations = 1000;
+int numthds = 10;
+int records = 600;
+int debug_trace = 0;
+
+void usage(FILE *f)
+{
+    fprintf(f, "Usage: %s [opts]\n", argv0);
+    fprintf(f, "        -d <dbname>         - set name of the test database\n");
+    fprintf(f, "        -T <numthd>         - set the number of threads\n");
+    fprintf(f, "        -t <cltype>         - 'dev', 'alpha', 'beta', or 'prod'\n");
+    fprintf(f, "        -i <iterations>     - run this many iterations\n");
+    fprintf(f, "        -r <records>        - records per iteration\n");
+    fprintf(f, "        -c <cdb2cfg>        - set cdb2cfg file\n");
+    fprintf(f, "        -h                  - this menu\n");
+    fprintf(f, "        -D                  - enable debug trace\n");
+}
+
+void *run_test(void *x)
+{
+    cdb2_hndl_tp *insert_hndl, *update_hndl;
+    int64_t td = (int64_t)x;
+    int rc;
+
+    if ((rc = cdb2_open(&insert_hndl, dbname, cltype, 0)) != 0) {
+        fprintf(stderr, "%s error opening insert handle to %s stage %s\n",
+                __func__, dbname, cltype);
+        exit(1);
+    }
+
+    if ((rc = cdb2_open(&update_hndl, dbname, cltype, 0)) != 0) {
+        fprintf(stderr, "%s error opening update handle to %s stage %s\n",
+                __func__, dbname, cltype);
+        exit(1);
+    }
+
+    for (int i = 0; i < iterations; i++) {
+        int64_t val = ((i * numthds) + td), upval = ((i * numthds) + td);
+        for (int j = 0; j < records; j++) {
+            cdb2_clearbindings(insert_hndl);
+            rc = cdb2_bind_param(insert_hndl, "a", CDB2_INTEGER, &val, sizeof(val));
+            assert(rc == 0);
+            if ((rc = cdb2_run_statement(insert_hndl, "INSERT INTO T1 (a, b) "
+                            "VALUES(@a, 0)")) != 0) {
+                fprintf(stderr, "%s error inserting record, %d\n", __func__,
+                        rc);
+                exit(1);
+            }
+            while ((rc = cdb2_next_record(insert_hndl)) == CDB2_OK);
+            assert(rc == CDB2_OK_DONE);
+
+            cdb2_clearbindings(update_hndl);
+            rc = cdb2_bind_param(update_hndl, "a", CDB2_INTEGER, &val, sizeof(val));
+            assert(rc == 0);
+            rc = cdb2_bind_param(update_hndl, "b", CDB2_INTEGER, &upval, sizeof(upval));
+            assert(rc == 0);
+            if ((rc = cdb2_run_statement(update_hndl, "UPDATE T1 SET b=@b WHERE a=@a")) != 0) {
+                fprintf(stderr, "%s error updating record %"PRId64", %d\n", __func__,
+                        val, rc);
+                exit(1);
+            }
+            while ((rc = cdb2_next_record(update_hndl)) == CDB2_OK);
+            assert(rc == CDB2_OK_DONE);
+        }
+    }
+
+    cdb2_close(insert_hndl);
+    cdb2_close(update_hndl);
+    return NULL;
+}
+
+void drop_table(void)
+{
+    cdb2_hndl_tp *hndl;
+    int rc;
+    if ((rc = cdb2_open(&hndl, dbname, cltype, 0)) != 0) {
+        fprintf(stderr, "%s error opening handle to %s stage %s\n",
+                __func__, dbname, cltype);
+        exit(1);
+    }
+
+    cdb2_run_statement(hndl, "DROP TABLE t1");
+    cdb2_close(hndl);
+}
+
+void create_table(void)
+{
+    cdb2_hndl_tp *hndl;
+    int rc;
+    if ((rc = cdb2_open(&hndl, dbname, cltype, 0)) != 0) {
+        fprintf(stderr, "%s error opening handle to %s stage %s\n",
+                __func__, dbname, cltype);
+        exit(1);
+    }
+
+    if ((rc = cdb2_run_statement(hndl, "CREATE TABLE t1(a INTEGER NULL, b INTEGER NULL)")) 
+            != 0) {
+        fprintf(stderr, "%s error creating table, %d\n",
+                __func__, rc);
+        exit(1);
+    }
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK) ;
+    assert(rc == CDB2_OK_DONE);
+
+    if ((rc = cdb2_run_statement(hndl, "CREATE INDEX ix1 on t1(a)")) 
+            != 0) {
+        fprintf(stderr, "%s error creating index, %d\n",
+                __func__, rc);
+        exit(1);
+    }
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK) ;
+    assert(rc == CDB2_OK_DONE);
+
+    if ((rc = cdb2_run_statement(hndl, "CREATE INDEX ix2 on t1(b)")) 
+            != 0) {
+        fprintf(stderr, "%s error creating index, %d\n",
+                __func__, rc);
+        exit(1);
+    }
+    while ((rc = cdb2_next_record(hndl)) == CDB2_OK) ;
+    assert(rc == CDB2_OK_DONE);
+
+    cdb2_close(hndl);
+}
+
+int main(int argc, char *argv[])
+{
+    int c, err = 0, rc;
+    pthread_t *thds = NULL;
+    argv0 = argv[0];
+
+    while ((c = getopt(argc, argv, "d:T:t:i:r:c:hD")) != EOF) {
+        switch(c) {
+            case 'd':
+                dbname = optarg;
+                break;
+            case 'T':
+                numthds = atoi(optarg);
+                break;
+            case 't':
+                cltype = optarg;
+                break;
+            case 'r':
+                records = atoi(optarg);
+                break;
+            case 'i':
+                iterations = atoi(optarg);
+                break;
+            case 'c':
+                cdb2_set_comdb2db_config(optarg);
+                break;
+            case 'h':
+                usage(stdout);
+                exit(0);
+                break;
+            case 'D':
+                debug_trace = 1;
+                break;
+            default:
+                fprintf(stderr, "Unknown option, '%c'\n", optopt);
+                err++;
+                break;
+        }
+    }
+
+    if (err) {
+        usage(stderr);
+        exit(1);
+    }
+
+    srand(time(NULL));
+    drop_table();
+    create_table();
+
+    thds = (pthread_t *)calloc(numthds, sizeof(pthread_t));
+    for(int i = 0; i < numthds; i++) {
+        int64_t x = (int64_t)i;
+        rc = pthread_create(&thds[i], NULL, run_test, (void *)x);
+        if (rc != 0) {
+            fprintf(stderr, "pthread_create error, rc=%d errno=%d\n", rc,
+                    errno);
+            exit(1);
+        }
+    }
+
+    for(int i = 0; i < numthds; i++) {
+        pthread_join(thds[i], NULL);
+    }
+}


### PR DESCRIPTION
Test which recreates the conditions of a TS wp that occurred on Wednesday.  A single test run will produce between 6000 and 7000 deadlocks on my laptop.  Adi's reordering logic reduces this to under 20 deadlocks and provides about a 40% performance improvement.