### PR TITLE
Fix new abort on sqlite mutex

### DIFF
--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -5647,9 +5647,13 @@ char *sqlite3DescribeIndexOrder(
 void sqlite3ResetFdbSchemas(sqlite3 *db){
   int i;
 
+  sqlite3_mutex_enter(sqlite3_db_mutex(db));
+
   for( i=2; i<db->nDb; i++ ){
     comdb2_dynamic_detach(db, i);
   }
+
+  sqlite3_mutex_leave(sqlite3_db_mutex(db));
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 

--- a/tests/simple_remsql.test/runit
+++ b/tests/simple_remsql.test/runit
@@ -18,14 +18,15 @@ for required in $vars; do
 done
 
 #generate testscripts in new files
-files=`ls *.req.src`
+files=`ls *.src`
 for file in $files ; do
    newfile=${file%%.src}
    sed "/^insert /!s/ t$/ LOCAL_$DBNAME.t/g" $file > $newfile.tmp
-   sed "/^insert /!s/ t / LOCAL_$DBNAME.t /g" $newfile.tmp > $newfile
+   sed "/^insert /!s/ t / LOCAL_$DBNAME.t /g" $newfile.tmp > $newfile.tmp2
+   sed "s/ t\]/ LOCAL_$DBNAME.t\]/g" $newfile.tmp2 > $newfile
    rm $newfile.tmp
+   rm $newfile.tmp2
 done
-
 
 if [[ $DBNAME == *"whitelistgenerated"* ]] ; then
     node=`cdb2sql --tabs -s ${CDB2_OPTIONS} $DBNAME default "select comdb2_host()"`


### PR DESCRIPTION
Currently we require sqlite_mutex to be held when calling alloc and free in sqlite (not needed though).   Fix one more aborting path.