### PR TITLE
Create berk tmptable when spilling a hash temp tbl

### DIFF
--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -389,6 +389,11 @@ static int bdb_hash_table_copy_to_temp_db(bdb_state_type *bdb_state,
     unsigned int hash_cur_buk;
     char *data;
 
+    if (tbl->dbenv_temp == NULL &&
+        create_temp_db_env(bdb_state, tbl, bdberr) != 0) {
+        bdb_temp_table_destroy_pool_wrapper(tbl, bdb_state);
+    }
+
     /* copy the hash to a btree */
     data = hash_first(tbl->temp_hash_tbl, &hash_cur, &hash_cur_buk);
     while (data) {

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -84,11 +84,30 @@ assertres ()
     fi
 }
 
+#test inserting a large number of items via generate series and query for them
+gen_series_test()
+{
+    MAX=9000
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table t2 (i int)"
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "insert into t2 select * from generate_series(1, $MAX) "
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select distinct i from t2" | sort -n > gen.out
+    i=1
+    while [ $i -le $MAX ] ; do 
+        echo $i >> gen.exp
+        let i=i+1
+    done
+    if ! diff gen.out gen.exp ; then 
+        failexit 'genseries content not what it is expected'
+    fi
+}
+
 echo $CDB2_CONFIG
 THRDS=20
 CNT=10000
 ITERATIONS=10
 TRANSIZE=0
+
+gen_series_test
 
 time ${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins1.out
 assertcnt $((THRDS * CNT * ITERATIONS))


### PR DESCRIPTION
Fix bug: create berk tmptable when spilling a hash temp tbl