### PR TITLE
Fix rename with legacy config

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -222,7 +222,7 @@ retry:
 }
 
 static int do_llog(bdb_state_type *bdb_state, scdone_t sctype, char *tbl,
-                   int wait, int *bdberr)
+                   int wait, const char *origtable, int *bdberr)
 {
     DBT *dtbl = NULL;
     if (tbl) {
@@ -230,6 +230,17 @@ static int do_llog(bdb_state_type *bdb_state, scdone_t sctype, char *tbl,
         bzero(dtbl, sizeof(DBT));
         dtbl->data = tbl;
         dtbl->size = strlen(tbl) + 1;
+        dtbl->size = strlen(bdb_state->name) + 1;
+        if (sctype == rename_table) {
+            assert(origtable);
+            int origlen = strlen(origtable) + 1;
+            int len = dtbl->size + origlen;
+            char *mashup = alloca(len);
+            memcpy(mashup, origtable, origlen);
+            memcpy(mashup + origlen, dtbl->data, dtbl->size);
+            dtbl->data = mashup;
+            dtbl->size = len;
+        }
     }
 
     DBT dtype = {0};
@@ -292,30 +303,37 @@ int bdb_llog_scdone(bdb_state_type *bdb_state, scdone_t type, int wait,
                     int *bdberr)
 {
     ++gbl_dbopen_gen;
-    return do_llog(bdb_state, type, bdb_state->name, wait, bdberr);
+    return do_llog(bdb_state, type, bdb_state->name, wait, NULL, bdberr);
+}
+
+int bdb_llog_scdone_origname(bdb_state_type *bdb_state, scdone_t type, int wait,
+                     const char *origtable, int *bdberr)
+{
+    ++gbl_dbopen_gen;
+    return do_llog(bdb_state, type, bdb_state->name, wait, origtable, bdberr);
 }
 
 int bdb_llog_analyze(bdb_state_type *bdb_state, int wait, int *bdberr)
 {
     ATOMIC_ADD(gbl_analyze_gen, 1);
-    return do_llog(bdb_state, sc_analyze, NULL, wait, bdberr);
+    return do_llog(bdb_state, sc_analyze, NULL, wait, NULL, bdberr);
 }
 
 int bdb_llog_views(bdb_state_type *bdb_state, char *name, int wait, int *bdberr)
 {
     ++gbl_views_gen;
-    return do_llog(bdb_state, views, name, wait, bdberr);
+    return do_llog(bdb_state, views, name, wait, NULL, bdberr);
 }
 
 int bdb_llog_luareload(bdb_state_type *bdb_state, int wait, int *bdberr)
 {
-    return do_llog(bdb_state, luareload, NULL, wait, bdberr);
+    return do_llog(bdb_state, luareload, NULL, wait, NULL, bdberr);
 }
 
 int bdb_llog_luafunc(bdb_state_type *bdb_state, scdone_t type, int wait,
                      int *bdberr)
 {
-    return do_llog(bdb_state, type, bdb_state->name, wait, bdberr);
+    return do_llog(bdb_state, type, bdb_state->name, wait, NULL, bdberr);
 }
 
 extern int gbl_rowlocks;
@@ -339,7 +357,7 @@ int bdb_llog_rowlocks(bdb_state_type *bdb_state, scdone_t type, int *bdberr)
         gbl_rowlocks = 1;
     else
         gbl_rowlocks = 0;
-    rc = do_llog(bdb_state, type, NULL, 0, bdberr);
+    rc = do_llog(bdb_state, type, NULL, 0, NULL, bdberr);
     return rc;
 }
 
@@ -362,7 +380,7 @@ int bdb_llog_genid_format(bdb_state_type *bdb_state, scdone_t type, int *bdberr)
     }
 
     bdb_genid_set_format(bdb_state, format);
-    rc = do_llog(bdb_state, type, NULL, 0, bdberr);
+    rc = do_llog(bdb_state, type, NULL, 0, NULL, bdberr);
     return rc;
 }
 

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -307,7 +307,7 @@ int bdb_llog_scdone(bdb_state_type *bdb_state, scdone_t type, int wait,
 }
 
 int bdb_llog_scdone_origname(bdb_state_type *bdb_state, scdone_t type, int wait,
-                     const char *origtable, int *bdberr)
+                             const char *origtable, int *bdberr)
 {
     ++gbl_dbopen_gen;
     return do_llog(bdb_state, type, bdb_state->name, wait, origtable, bdberr);

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -230,7 +230,6 @@ static int do_llog(bdb_state_type *bdb_state, scdone_t sctype, char *tbl,
         bzero(dtbl, sizeof(DBT));
         dtbl->data = tbl;
         dtbl->size = strlen(tbl) + 1;
-        dtbl->size = strlen(bdb_state->name) + 1;
         if (sctype == rename_table) {
             assert(origtable);
             int origlen = strlen(origtable) + 1;

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -52,6 +52,8 @@ typedef enum scdone {
 int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
                          tran_type *tran, const char *origtable, int *bdberr);
 int bdb_llog_scdone(bdb_state_type *, scdone_t, int wait, int *bdberr);
+int bdb_llog_scdone_origname(bdb_state_type *, scdone_t, int wait, const char *origtable,
+                    int *bdberr);
 int bdb_llog_luareload(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_analyze(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_views(bdb_state_type *, char *name, int wait, int *bdberr);

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -52,8 +52,8 @@ typedef enum scdone {
 int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
                          tran_type *tran, const char *origtable, int *bdberr);
 int bdb_llog_scdone(bdb_state_type *, scdone_t, int wait, int *bdberr);
-int bdb_llog_scdone_origname(bdb_state_type *, scdone_t, int wait, const char *origtable,
-                    int *bdberr);
+int bdb_llog_scdone_origname(bdb_state_type *, scdone_t, int wait,
+                             const char *origtable, int *bdberr);
 int bdb_llog_luareload(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_analyze(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_views(bdb_state_type *, char *name, int wait, int *bdberr);

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -735,8 +735,8 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                     logmsg(LOGMSG_ERROR, "%s: Skipping scdone for table %s\n",
                            __func__, s->tablename);
                 } else {
-                    rc = bdb_llog_scdone_origname(s->db->handle, type, 1, s->tablename,
-                            &bdberr);
+                    rc = bdb_llog_scdone_origname(s->db->handle, type, 1,
+                                                  s->tablename, &bdberr);
                     if (rc || bdberr != BDBERR_NOERROR) {
                         /* We are here because we are running in R6 compatible
                          * mode. For R7 or later, use SC_DONE_SAME_TRAN.

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -735,7 +735,8 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                     logmsg(LOGMSG_ERROR, "%s: Skipping scdone for table %s\n",
                            __func__, s->tablename);
                 } else {
-                    rc = bdb_llog_scdone(s->db->handle, type, 1, &bdberr);
+                    rc = bdb_llog_scdone_origname(s->db->handle, type, 1, s->tablename,
+                            &bdberr);
                     if (rc || bdberr != BDBERR_NOERROR) {
                         /* We are here because we are running in R6 compatible
                          * mode. For R7 or later, use SC_DONE_SAME_TRAN.


### PR DESCRIPTION
Legacy settings use a different a schema change call stack, and rename was not working in this case.  Here is the patch.
