### PR TITLE
indices.c: ix find to get write lock in updrec and delrec

### DIFF
--- a/bdb/bdb_fetch.h
+++ b/bdb/bdb_fetch.h
@@ -67,8 +67,9 @@
 
 typedef struct {
     uint8_t ver;
-    int ignore_incoherent;
-    int page_order;
+    uint8_t ignore_incoherent;
+    uint8_t page_order;
+    uint8_t for_write;
 } bdb_fetch_args_t;
 
 int bdb_fetch(bdb_state_type *bdb_handle, void *ix, int ixnum, int ixlen,

--- a/bdb/fetch.c
+++ b/bdb/fetch.c
@@ -735,6 +735,9 @@ static int bdb_fetch_int_ll(
             }
 
             dbp = bdb_state->dbp_data[0][dtafile];
+            if (args->for_write) {
+                 flags |= DB_RMW;
+            }
         }
 
         memcpy(tmp_key, ix, ixlen);

--- a/berkdb/btree/bt_cursor.c
+++ b/berkdb/btree/bt_cursor.c
@@ -1924,7 +1924,7 @@ __bam_c_get(dbc, key, data, flags, pgnop)
 	prefault_dbp = dbp;
 
 	newopd = 0;
-	switch (flags) {
+	switch (flags & DB_OPFLAGS_MASK) {
 	case DB_CURRENT:
 		/* It's not possible to return a deleted record. */
 		if (F_ISSET(cp, C_DELETED)) {

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2157,6 +2157,9 @@ int ix_find_by_rrn_and_genid_prefault(struct ireq *iq, int rrn,
 int ix_find_by_rrn_and_genid_tran(struct ireq *iq, int rrn,
                                   unsigned long long genid, void *fnddta,
                                   int *fndlen, int maxlen, void *trans);
+int ix_load_for_write_by_genid_tran(struct ireq *iq, int rrn,
+        unsigned long long genid, void *fnddta,
+        int *fndlen, int maxlen, void *trans);
 int ix_find_ver_by_rrn_and_genid_tran(struct ireq *iq, int rrn,
                                       unsigned long long genid, void *fnddta,
                                       int *fndlen, int maxlen, void *trans,

--- a/db/glue.c
+++ b/db/glue.c
@@ -2029,14 +2029,14 @@ int ix_find_auxdb_by_rrn_and_genid_prefault(int auxdb, struct ireq *iq, int rrn,
 int ix_find_auxdb_by_rrn_and_genid_tran(int auxdb, struct ireq *iq, int rrn,
                                         unsigned long long genid, void *fnddta,
                                         int *fndlen, int maxlen, void *trans,
-                                        int *ver)
+                                        int *ver, int for_write)
 {
     int rc;
     int retries = 0;
     void *bdb_handle;
     int bdberr;
     char *req;
-    bdb_fetch_args_t args = {0};
+    bdb_fetch_args_t args = { .for_write = for_write };
 
     bdb_handle = get_bdb_handle(iq->usedb, auxdb);
     if (!bdb_handle)
@@ -2228,13 +2228,29 @@ int ix_find_by_rrn_and_genid_tran(struct ireq *iq, int rrn,
     int rc = 0;
 
     rc = ix_find_auxdb_by_rrn_and_genid_tran(AUXDB_NONE, iq, rrn, genid, fnddta,
-                                             fndlen, maxlen, trans, NULL);
+                                             fndlen, maxlen, trans, NULL, 0 /* for_write */);
 
     if (rc == IX_EMPTY)
         rc = IX_NOTFND;
 
     return rc;
 }
+
+int ix_load_for_write_by_genid_tran(struct ireq *iq, int rrn,
+        unsigned long long genid, void *fnddta,
+        int *fndlen, int maxlen, void *trans)
+{
+    int rc = 0;
+
+    rc = ix_find_auxdb_by_rrn_and_genid_tran(AUXDB_NONE, iq, rrn, genid, fnddta,
+            fndlen, maxlen, trans, NULL, 1 /* for_write */);
+
+    if (rc == IX_EMPTY)
+        rc = IX_NOTFND;
+
+    return rc;
+}
+
 
 int ix_find_ver_by_rrn_and_genid_tran(struct ireq *iq, int rrn,
                                       unsigned long long genid, void *fnddta,
@@ -2244,7 +2260,7 @@ int ix_find_ver_by_rrn_and_genid_tran(struct ireq *iq, int rrn,
     int rc = 0;
 
     rc = ix_find_auxdb_by_rrn_and_genid_tran(AUXDB_NONE, iq, rrn, genid, fnddta,
-                                             fndlen, maxlen, trans, version);
+                                             fndlen, maxlen, trans, version, 0 /*for write */);
 
     if (rc == IX_EMPTY)
         rc = IX_NOTFND;

--- a/db/record.c
+++ b/db/record.c
@@ -943,10 +943,10 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         // other instead of relatively expensive memcpy()
         od_dta = old_dta;
     } else {
-        rc = ix_find_by_rrn_and_genid_tran(iq, rrn, vgenid, old_dta, &fndlen,
+        rc = ix_load_for_write_by_genid_tran(iq, rrn, vgenid, old_dta, &fndlen,
                                            od_len, trans);
         if (iq->debug)
-            reqprintf(iq, "ix_find_by_rrn_and_genid_tran RRN %d GENID 0x%llx "
+            reqprintf(iq, "ix_load_for_write_by_genid_tran RRN %d GENID 0x%llx "
                           "DTALEN %zu FNDLEN %d RC %d",
                       rrn, vgenid, od_len, fndlen, rc);
     }
@@ -1580,10 +1580,10 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         }
         genid = fndgenid;
     } else {
-        rc = ix_find_by_rrn_and_genid_tran(iq, rrn, genid, od_dta, &fndlen,
+        rc = ix_load_for_write_by_genid_tran(iq, rrn, genid, od_dta, &fndlen,
                                            od_len, trans);
         if (iq->debug)
-            reqprintf(iq, "ix_find_by_rrn_and_genid_tran RRN %d GENID 0x%llx "
+            reqprintf(iq, "ix_load_for_write_by_genid_tran RRN %d GENID 0x%llx "
                           "DTALEN %zu FNDLEN %u RC %d",
                       rrn, genid, od_len, fndlen, rc);
     }


### PR DESCRIPTION
In upd_rec_indices and del_rec_indices we call ix find in readl lock first to verify that records exists, then subsequently get write lock to update the record. This is the cause for a deadlocks and instead, by getting the record in write lock from the beginning, we turn the deadlocks into waits, thus improving performance by 20% in some sysbench tests, but more importantly by not busying the cpu undoing work in the case of a deadlock (which aborts one of the transactions).
This was part of https://github.com/bloomberg/comdb2/pull/1345 but checking it in separately because it is relevant on its own.