### PR TITLE
 Remove thedb->exiting because it is never set 

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -992,9 +992,7 @@ void no_new_requests(struct dbenv *dbenv)
     MEMORY_SYNC;
 }
 
-int db_is_stopped(void) { return (thedb->stopped || thedb->exiting); }
-
-int db_is_exiting(void) { return (thedb->exiting); }
+int db_is_stopped(void) { return thedb->stopped; }
 
 void print_dbsize(void);
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -992,7 +992,10 @@ void no_new_requests(struct dbenv *dbenv)
     MEMORY_SYNC;
 }
 
-int db_is_stopped(void) { return thedb->stopped; }
+int db_is_stopped(void)
+{
+    return thedb->stopped;
+}
 
 void print_dbsize(void);
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -943,7 +943,6 @@ struct dbenv {
     /* stupid - is the purge_old_blkseq thread running? */
     int purge_old_blkseq_is_running;
     int purge_old_files_is_running;
-    int exiting; /* are we exiting? */
     int stopped; /* if set, drop requests */
     int no_more_sql_connections;
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -943,7 +943,7 @@ struct dbenv {
     /* stupid - is the purge_old_blkseq thread running? */
     int purge_old_blkseq_is_running;
     int purge_old_files_is_running;
-    int stopped; /* if set, drop requests */
+    int stopped; /* set when exiting -- if set, drop requests */
     int no_more_sql_connections;
 
     LISTC_T(struct sql_thread) sql_threads;

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -319,7 +319,7 @@ int refresh_metrics(void)
 #endif
 
     /* Check whether the server is exiting. */
-    if (thedb->stopped)
+    if (db_is_stopped())
         return 1;
 
     stats.commits = n_commits;

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -319,7 +319,7 @@ int refresh_metrics(void)
 #endif
 
     /* Check whether the server is exiting. */
-    if (thedb->exiting || thedb->stopped)
+    if (thedb->stopped)
         return 1;
 
     stats.commits = n_commits;

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -205,7 +205,7 @@ queue_consume(struct ireq *iq, const void *fnd, int consumern)
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
                 iq->usedb->tablename, consumern);
-        if(thedb->stopped || thedb->exiting || thedb->master != gbl_mynode)
+        if(thedb->stopped || thedb->master != gbl_mynode)
             return -1;
         sleep(sleeptime);
     }

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -205,7 +205,7 @@ queue_consume(struct ireq *iq, const void *fnd, int consumern)
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
                 iq->usedb->tablename, consumern);
-        if(thedb->stopped || thedb->master != gbl_mynode)
+        if(db_is_stopped() || thedb->master != gbl_mynode)
             return -1;
         sleep(sleeptime);
     }

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -205,7 +205,7 @@ queue_consume(struct ireq *iq, const void *fnd, int consumern)
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
                 iq->usedb->tablename, consumern);
-        if(db_is_stopped() || thedb->master != gbl_mynode)
+        if (db_is_stopped() || thedb->master != gbl_mynode)
             return -1;
         sleep(sleeptime);
     }

--- a/db/glue.c
+++ b/db/glue.c
@@ -3406,7 +3406,7 @@ static void net_flush_all(void *hndl, void *uptr, char *fromnode, int usertype,
                           void *dtap, int dtalen, uint8_t is_tcp)
 {
     logmsg(LOGMSG_DEBUG, "Received NET_FLUSH_ALL\n");
-    if (!thedb || thedb->stopped || gbl_exit || !gbl_ready) {
+    if (!thedb || db_is_stopped() || gbl_exit || !gbl_ready) {
         logmsg(LOGMSG_WARN, "I am not ready, ignoring NET_FLUSH_ALL\n");
         return;
     }
@@ -3548,7 +3548,7 @@ static void net_forgetmenot(void *hndl, void *uptr, char *fromnode,
 {
 
     /* if this arrives too early, it will crash the master */
-    if (thedb->stopped || gbl_exit || !gbl_ready) {
+    if (db_is_stopped() || gbl_exit || !gbl_ready) {
         logmsg(LOGMSG_ERROR, "%s: received trap during lunch time\n", __func__);
         return;
     }

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -918,7 +918,7 @@ static int init_ireq(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     if (iq->origdb == NULL)
         iq->origdb = &thedb->static_table;
     iq->usedb = iq->origdb;
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         errUNLOCK(&lock);
         return reterr(curswap, NULL, iq, ERR_REJECTED);
     }

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -290,7 +290,7 @@ int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err)
     }
 
     /* please stop !!! */
-    if (thedb->stopped || thedb->exiting) {
+    if (thedb->stopped) {
         if (stop_time == 0) {
             stop_time = comdb2_time_epoch();
         } else {

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -290,7 +290,7 @@ int osql_bplog_finish_sql(struct ireq *iq, struct block_err *err)
     }
 
     /* please stop !!! */
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         if (stop_time == 0) {
             stop_time = comdb2_time_epoch();
         } else {

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5485,7 +5485,7 @@ static void net_osql_poked(void *hndl, void *uptr, char *fromhost, int usertype,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->exiting || thedb->stopped) {
+    if (thedb->stopped) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5539,7 +5539,7 @@ static void net_osql_poked_uuid(void *hndl, void *uptr, char *fromhost,
     bool found = false;
     int rc = 0;
 
-    if (thedb->exiting || thedb->stopped) {
+    if (thedb->stopped) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5598,7 +5598,7 @@ static void net_osql_master_check(void *hndl, void *uptr, char *fromhost,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->exiting || thedb->stopped) {
+    if (thedb->stopped) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5693,7 +5693,7 @@ static void net_osql_master_checked(void *hndl, void *uptr, char *fromhost,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->exiting || thedb->stopped) {
+    if (thedb->stopped) {
         /* don't do anything, we're going down */
         return;
     }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5485,7 +5485,7 @@ static void net_osql_poked(void *hndl, void *uptr, char *fromhost, int usertype,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5539,7 +5539,7 @@ static void net_osql_poked_uuid(void *hndl, void *uptr, char *fromhost,
     bool found = false;
     int rc = 0;
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5598,7 +5598,7 @@ static void net_osql_master_check(void *hndl, void *uptr, char *fromhost,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         /* don't do anything, we're going down */
         return;
     }
@@ -5693,7 +5693,7 @@ static void net_osql_master_checked(void *hndl, void *uptr, char *fromhost,
 
     comdb2uuid_clear(uuid);
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         /* don't do anything, we're going down */
         return;
     }

--- a/db/prefault_net.c
+++ b/db/prefault_net.c
@@ -449,7 +449,7 @@ int process_broadcast_prefault(struct dbenv *dbenv, unsigned char *dta,
     if (dbenv == NULL)
         return 0;
 
-    if (thedb->stopped)
+    if (db_is_stopped())
         return 0;
 
     qdata = malloc(sizeof(pfrq_t));

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -472,7 +472,7 @@ static int thrman_check_threads_stopped_ll(void *context)
         all_gone = 1;
 
     /* if we're exiting then we don't want a schema change thread running */
-    if (thedb->stopped && 0 != thr_type_counts[THRTYPE_SCHEMACHANGE])
+    if (db_is_stopped() && 0 != thr_type_counts[THRTYPE_SCHEMACHANGE])
         all_gone = 0;
 
     if (self)

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -472,7 +472,7 @@ static int thrman_check_threads_stopped_ll(void *context)
         all_gone = 1;
 
     /* if we're exiting then we don't want a schema change thread running */
-    if (thedb->exiting && 0 != thr_type_counts[THRTYPE_SCHEMACHANGE])
+    if (thedb->stopped && 0 != thr_type_counts[THRTYPE_SCHEMACHANGE])
         all_gone = 0;
 
     if (self)

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -165,7 +165,7 @@ static void *watchdog_thread(void *arg)
     while (!gbl_ready)
         sleep(1);
 
-    while (!thedb->exiting) {
+    while (!thedb->stopped) {
         gbl_epoch_time = comdb2_time_epoch();
 
         if (!gbl_nowatch) {
@@ -409,9 +409,9 @@ static void *watchdog_watcher_thread(void *arg)
     extern int gbl_watchdog_watch_threshold;
     int failed_once = 0;
 
-    while (!thedb->exiting) {
+    while (!thedb->stopped) {
         sleep(10);
-        if (gbl_nowatch || thedb->exiting)
+        if (gbl_nowatch || thedb->stopped)
             continue;
 
         int tmstmp = comdb2_time_epoch();

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -165,7 +165,7 @@ static void *watchdog_thread(void *arg)
     while (!gbl_ready)
         sleep(1);
 
-    while (!thedb->stopped) {
+    while (!db_is_stopped()) {
         gbl_epoch_time = comdb2_time_epoch();
 
         if (!gbl_nowatch) {
@@ -409,9 +409,9 @@ static void *watchdog_watcher_thread(void *arg)
     extern int gbl_watchdog_watch_threshold;
     int failed_once = 0;
 
-    while (!thedb->stopped) {
+    while (!db_is_stopped()) {
         sleep(10);
-        if (gbl_nowatch || thedb->stopped)
+        if (gbl_nowatch || db_is_stopped())
             continue;
 
         int tmstmp = comdb2_time_epoch();

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -384,7 +384,7 @@ static int check_retry_conditions(Lua L, int skip_incoherent)
 {
     SP sp = getsp(L);
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         luabb_error(L, sp, "database exiting");
         return -1;
     }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -384,7 +384,7 @@ static int check_retry_conditions(Lua L, int skip_incoherent)
 {
     SP sp = getsp(L);
 
-    if (thedb->stopped || thedb->exiting) {
+    if (thedb->stopped) {
         luabb_error(L, sp, "database exiting");
         return -1;
     }

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -459,7 +459,7 @@ static void admin(struct dbenv *dbenv, int type)
     Pthread_mutex_unlock(&dbqueuedb_admin_lk);
 
     /* If we are master then make sure all the queues are running */
-    if (iammaster && !dbenv->stopped && !dbenv->exiting) {
+    if (iammaster && !dbenv->stopped) {
         for (int ii = 0; ii < dbenv->num_qdbs; ii++) {
             if (dbenv->qdbs[ii] == NULL)
                 continue;

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -1478,7 +1478,7 @@ void change_schemas_recover(char *table)
     backout_schemas(table);
     live_sc_off(db);
 
-    if (thedb->stopped) {
+    if (db_is_stopped()) {
         resume_threads(thedb);
     }
 }

--- a/sqlite/ext/comdb2/repl_stats.c
+++ b/sqlite/ext/comdb2/repl_stats.c
@@ -95,7 +95,7 @@ static int systblReplStatsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor)
     }
     memset(cur, 0, sizeof(*cur));
 
-    if (thedb->exiting || thedb->stopped)
+    if (thedb->stopped)
         return SQLITE_INTERNAL;
 
     cur->stats = bdb_get_repl_wait_and_net_stats(thedb->bdb_env, &cur->cluster_size);

--- a/sqlite/ext/comdb2/repl_stats.c
+++ b/sqlite/ext/comdb2/repl_stats.c
@@ -95,7 +95,7 @@ static int systblReplStatsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor)
     }
     memset(cur, 0, sizeof(*cur));
 
-    if (thedb->stopped)
+    if (db_is_stopped())
         return SQLITE_INTERNAL;
 
     cur->stats = bdb_get_repl_wait_and_net_stats(thedb->bdb_env, &cur->cluster_size);


### PR DESCRIPTION
Remove thedb->exiting because it is never set 
Call db_is_stopped() accessor instead of checking thedb->stopped directly