### PR TITLE
Don't clear gbl_cron in views.

### DIFF
--- a/db/cron.c
+++ b/db/cron.c
@@ -665,3 +665,16 @@ void cron_clear_queue_all(void)
     }
     Pthread_rwlock_unlock(&crons.rwlock);
 }
+
+void cron_clear_queue_all_except(cron_sched_t *except)
+{
+    cron_sched_t *sched = NULL;
+
+    Pthread_rwlock_rdlock(&crons.rwlock);
+    LISTC_FOR_EACH(&crons.scheds, sched, lnk)
+    {
+        if (sched != except)
+            cron_clear_queue(sched);
+    }
+    Pthread_rwlock_unlock(&crons.rwlock);
+}

--- a/db/cron.h
+++ b/db/cron.h
@@ -145,11 +145,17 @@ sched_if_t *cron_impl(cron_sched_t *sched);
  */
 void cron_signal_all(void);
 
+
 /**
  * Clear all the queues events
  *
  */
 void cron_clear_queue_all(void);
+
+/**
+ * Clear most of the queues events. Pass an exception scheduler.
+ */
+void cron_clear_queue_all_except(cron_sched_t *sched);
 
 /**
  * Returns a scheduler with name "name", if any

--- a/db/views.c
+++ b/db/views.c
@@ -1892,6 +1892,8 @@ static int _view_restart(timepart_view_t *view, struct errstat *err)
     return rc;
 }
 
+extern cron_sched_t *gbl_cron;
+
 /**
  * Queue up the necessary events to rollout time partitions 
  * Done during restart and master swing 
@@ -1907,7 +1909,7 @@ int views_cron_restart(timepart_views_t *views)
 
     /* in case of regular master swing, clear pre-existing views event,
        we will requeue them */
-    cron_clear_queue_all();
+    cron_clear_queue_all_except(gbl_cron);
 
     /* corner case: master started and schema change for time partition
        submitted before watchdog thread has time to restart it, will deadlock


### PR DESCRIPTION
Partition system clears all scheduled events - it should ignore events scheduled on gbl_cron that it didn't schedule.