### PR TITLE
fix: sp error string should not be null for fastsql codepath

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -6207,7 +6207,8 @@ static int exec_procedure_int(struct sqlthdstate *thd,
     if ((rc = commit_sp(L, err)) != 0) return rc;
 
     if (sprc) {
-        *err = strdup("emit_result error");
+        if (!*err)
+            *err = strdup("emit_result error");
         return sprc;
     }
 

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -1908,10 +1908,14 @@ static int load_debugging_information(struct stored_proc *sp, char **err)
             rc = -1;
         }
 
-        if (err)
+        if (err_str) {
             logmsg(LOGMSG_ERROR, "err: [%d] %s\n", rc, err_str);
-        else
+            *err = strdup(err_str);
+        }
+        else {
             logmsg(LOGMSG_ERROR, "err: [%d]\n", rc);
+            *err = strdup("Error with lua_pcall");
+        }
         stack_trace(sp->lua);
     }
     free(sp_source);
@@ -5261,7 +5265,7 @@ out:
     return arg->type;
 }
 
-static int debug_sp(struct sqlclntstate *clnt)
+static void debug_sp(struct sqlclntstate *clnt)
 {
     int arg1 = 0;
     char *carg1 = NULL;
@@ -5306,7 +5310,6 @@ do_continue:
     clnt->sp = NULL;
     sleep(2);
     logmsg(LOGMSG_USER, "Exit debugging \n");
-    return 0;
 }
 
 static int get_spname(struct sqlclntstate *clnt, const char **exec,
@@ -6175,7 +6178,10 @@ static int exec_procedure_int(struct sqlthdstate *thd,
     if ((rc = get_spname(clnt, &s, spname, err)) != 0)
         return rc;
 
-    if (strcmp(spname, "debug") == 0) return debug_sp(clnt);
+    if (strcmp(spname, "debug") == 0) {
+        debug_sp(clnt);
+        return 0;
+    }
 
     if ((rc = setup_sp(spname, thd, clnt, &new_vm, err)) != 0) return rc;
 
@@ -6200,7 +6206,10 @@ static int exec_procedure_int(struct sqlthdstate *thd,
 
     if ((rc = commit_sp(L, err)) != 0) return rc;
 
-    if (sprc) return sprc;
+    if (sprc) {
+        *err = strdup("emit_result error");
+        return sprc;
+    }
 
     return flush_sp(sp, err);
 }

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -21,23 +21,16 @@
  * Shamelessly based on Peter Martin's bigsnd thread pool.
  */
 
-#include "limit_fortify.h"
 #include <assert.h>
 #include <alloca.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
-#include <strings.h>
 #include <sys/time.h>
 #include "ctrace.h"
-
-#include <unistd.h>
-
 #include <epochlib.h>
 #include <segstring.h>
-
 #include "lockmacros.h"
 #include "list.h"
 #include "pool.h"
@@ -46,14 +39,13 @@
 #include "thdpool.h"
 #include "thread_util.h"
 #include "thread_malloc.h"
-#include <locks_wrap.h>
-
+#include "locks_wrap.h"
 #include "debug_switches.h"
+#include "logmsg.h"
 
 #ifdef MONITOR_STACK
 #include "comdb2_pthread_create.h"
 #endif
-#include "logmsg.h"
 
 extern int gbl_throttle_sql_overload_dump_sec;
 extern int thdpool_alarm_on_queing(int len);


### PR DESCRIPTION
Fastsql codepath crashes when lua sp err str is null. 
Make sure we set it in a few codepaths that were previously missed.
Also set it to generic error in case there are other paths that don't set it.