### PR TITLE
removing two invalid asserts for tmp tbl cache in thd

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3179,13 +3179,10 @@ int sqlite3BtreeClose(Btree *pBt)
     /* Reset thd pointers */
     thd = pthread_getspecific(query_info_key);
     if (thd) {
-        if (pBt->is_temporary) {
-            assert(thd->bttmp == pBt);
+        if (pBt->is_temporary && thd->bttmp == pBt)
             thd->bttmp = NULL;
-        } else {
-            assert(thd->bt == pBt);
+        else if (thd->bt == pBt)
             thd->bt = NULL;
-        }
     }
 
     if (pBt->free_schema && pBt->schema) {


### PR DESCRIPTION
thd variable caches in bttmp temporary tables, but that cache
remembers only the first tmptable so the assert is not valid
for other tmptables that get created later or from calls to
sqlite3BtreeCreateTable that are not from sqlite3BtreeOpen().