### PR TITLE
berkdb: Fix a memory leak in the rep processor

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4954,6 +4954,9 @@ err1:
 	else
 		__os_free(dbenv, prep_args);
 
+	if (pglogs)
+		__os_free(dbenv, pglogs);
+
 	if (logc != NULL && (t_ret = __log_c_close(logc)) != 0 && ret == 0)
 		ret = t_ret;
 


### PR DESCRIPTION
`pglogs` is malloc'd in `bdb_pglogs_key_list_init()` and hence needs freed.

(DRQS 143278402)