### PR TITLE
Fix mangled port values with older comdb2

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -3505,7 +3505,8 @@ static int read_hostlist(netinfo_type *netinfo_ptr, SBUF2 *sb, char *hosts[],
     for (i = 0; i < *numhosts; i++) {
         int *p_port = (ports + i);
         p_buf = (uint8_t *)buf_get(p_port, sizeof(int), p_buf, p_buf_end);
-        /* older comdb2 will not handle mangled ports and might hello us back unmasked values */ 
+        /* older comdb2 will not handle mangled ports and might hello us back
+         * unmasked values */
         p_port[0] &= 0x0ffff;
     }
 

--- a/net/net.c
+++ b/net/net.c
@@ -3505,6 +3505,8 @@ static int read_hostlist(netinfo_type *netinfo_ptr, SBUF2 *sb, char *hosts[],
     for (i = 0; i < *numhosts; i++) {
         int *p_port = (ports + i);
         p_buf = (uint8_t *)buf_get(p_port, sizeof(int), p_buf, p_buf_end);
+        /* older comdb2 will not handle mangled ports and might hello us back unmasked values */ 
+        p_port[0] &= 0x0ffff;
     }
 
     /* read and discard node numbers */


### PR DESCRIPTION
R7 mangles port numbers with net id, example:
netinfo_ptr->myport != connect_message.to_portnum 19856 85392
85392 is 19856 | (1<<16), since it comes from a secondary net. 
We need to make sure we remove net id while processing hello messages, otherwise we might populate netinfo with wrong port values (like, when older comdb2 passes back hello messages that have ports mangled like that).