### PR TITLE
Better error messages for disabled features

### DIFF
--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -4900,6 +4900,12 @@ static void comdb2AddIndexInt(
         char *where_clause;
         size_t where_sz;
 
+        if (gbl_noenv_messages == 0) {
+            extern int gbl_noenv_messages;
+            setError(pParse, SQLITE_ERROR, "Partial index not enabled");
+            goto cleanup;
+        }
+
         where_sz = zEnd - zStart;
         assert(where_sz > 0);
         where_clause = comdb2_strndup(ctx->mem, zStart, where_sz + 1);

--- a/sqlite/src/insert.c
+++ b/sqlite/src/insert.c
@@ -860,6 +860,13 @@ void sqlite3Insert(
   }
 #ifndef SQLITE_OMIT_UPSERT
   if( pUpsert ){
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    extern int gbl_noenv_messages;
+    if (gbl_noenv_messages == 0) {
+      sqlite3ErrorMsg(pParse, "UPSERT not enabled");
+      goto insert_cleanup;
+    }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     if( IsVirtual(pTab) ){
       sqlite3ErrorMsg(pParse, "UPSERT not implemented for virtual table \"%s\"",
               pTab->zName);


### PR DESCRIPTION
```
# noenv_messages off

nctdb> insert into t1 values(1) on conflict do nothing;
[insert into t1 values(1) on conflict do nothing] failed with rc -3 UPSERT not enabled
nctdb> create index idx on t1(i) where (i>10);
[create index idx on t1(i) where (i>10)] failed with rc -3 Partial index not enabled

# legacy_schema on (already handled in csc2 parser)

nctdb> create table t1(i int unique)$$
[create table t1(i int unique)] failed with rc 240 ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE
```