### PR TITLE
Display deadlock steps aborted and worst wait time

### DIFF
--- a/bbinc/thread_stats.h
+++ b/bbinc/thread_stats.h
@@ -1,4 +1,17 @@
 /*
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
  */
 
 #ifndef _THREAD_STATS_H_

--- a/bbinc/thread_stats.h
+++ b/bbinc/thread_stats.h
@@ -1,0 +1,35 @@
+/*
+ */
+
+#ifndef _THREAD_STATS_H_
+#define _THREAD_STATS_H_
+
+#include <stdint.h>
+
+struct berkdb_thread_stats {
+    unsigned n_lock_waits;
+    uint64_t lock_wait_time_us;
+    uint64_t worst_lock_wait_time_us;
+
+    unsigned n_preads;
+    unsigned pread_bytes;
+    uint64_t pread_time_us;
+
+    unsigned n_pwrites;
+    unsigned pwrite_bytes;
+    uint64_t pwrite_time_us;
+
+    unsigned n_memp_fgets;
+    uint64_t memp_fget_time_us;
+
+    unsigned n_memp_pgs;
+    uint64_t memp_pg_time_us;
+
+    unsigned n_shallocs;
+    uint64_t shalloc_time_us;
+
+    unsigned n_shalloc_frees;
+    uint64_t shalloc_free_time_us;
+};
+
+#endif

--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -45,8 +45,9 @@
 
 #include <segstring.h>
 #include "nodemap.h"
-#include <logmsg.h>
-#include <locks_wrap.h>
+#include "thread_stats.h"
+#include "logmsg.h"
+#include "locks_wrap.h"
 
 extern void berkdb_dumptrans(DB_ENV *);
 extern int __db_panic(DB_ENV *dbenv, int err);
@@ -710,30 +711,30 @@ void bdb_reset_thread_stats(void)
 }
 
 /* Call this at the end of a request to get our stats. */
-const struct bdb_thread_stats *bdb_get_thread_stats(void)
+const struct berkdb_thread_stats *bdb_get_thread_stats(void)
 {
 #ifdef BERKDB_4_2
-    return (const struct bdb_thread_stats *)bb_berkdb_get_thread_stats();
+    return (const struct berkdb_thread_stats *)bb_berkdb_get_thread_stats();
 #else
-    static struct bdb_thread_stats zero = {0};
+    static struct berkdb_thread_stats zero = {0};
     return &zero;
 #endif
 }
 
 /* Call this any time to get process wide stats (which get updated locklessly)
  */
-const struct bdb_thread_stats *bdb_get_process_stats(void)
+const struct berkdb_thread_stats *bdb_get_process_stats(void)
 {
 #ifdef BERKDB_4_2
-    return (const struct bdb_thread_stats *)bb_berkdb_get_process_stats();
+    return (const struct berkdb_thread_stats *)bb_berkdb_get_process_stats();
 #else
-    static struct bdb_thread_stats zero = {0};
+    static struct berkdb_thread_stats zero = {0};
     return &zero;
 #endif
 }
 
 /* Report bdb stats into the given logging function. */
-void bdb_print_stats(const struct bdb_thread_stats *st, const char *prefix,
+void bdb_print_stats(const struct berkdb_thread_stats *st, const char *prefix,
                      int (*printfn)(const char *, void *), void *context)
 {
     char s[128];
@@ -773,7 +774,7 @@ void bdb_print_stats(const struct bdb_thread_stats *st, const char *prefix,
     }
 }
 
-void bdb_fprintf_stats(const struct bdb_thread_stats *st, const char *prefix,
+void bdb_fprintf_stats(const struct berkdb_thread_stats *st, const char *prefix,
                        FILE *out)
 {
     bdb_print_stats(st, "  ", (int (*)(const char *, void *))fputs, out);

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1799,8 +1799,9 @@ void bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum);
 
 void bdb_replace_handle(bdb_state_type *parent, int ix, bdb_state_type *handle);
 
-int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,                                                                          
-        int64_t *deadlock_locks, int64_t *waits, int64_t *requests);
+int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
+                          int64_t *deadlock_locks, int64_t *waits,
+                          int64_t *requests);
 
 int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits,
                            int64_t *bpool_misses, int64_t *rw_evicts);

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -135,7 +135,8 @@ struct bdb_queue_stats {
     unsigned n_physical_gets;
 };
 
-/* This is identical to bb_berkdb_thread_stats in db.h */
+/* Forward declare, this is defined in thread_stats.h */
+struct berkdb_thread_stats;
 
 /*
  * Multiplication usually takes fewer CPU cycles than division. Therefore
@@ -148,30 +149,8 @@ struct bdb_queue_stats {
 #ifndef M2U
 #define M2U(msec) ((msec)*1000ULL)
 #endif
-struct bdb_thread_stats {
-    unsigned n_lock_waits;
-    uint64_t lock_wait_time_us;
 
-    unsigned n_preads;
-    unsigned pread_bytes;
-    uint64_t pread_time_us;
 
-    unsigned n_pwrites;
-    unsigned pwrite_bytes;
-    uint64_t pwrite_time_us;
-
-    unsigned n_memp_fgets;
-    uint64_t memp_fget_time_us;
-
-    unsigned n_memp_pgs;
-    uint64_t memp_pg_time_us;
-
-    unsigned n_shallocs;
-    uint64_t shalloc_time_us;
-
-    unsigned n_shalloc_frees;
-    uint64_t shalloc_free_time_us;
-};
 
 /* these are the values that "bdberr" can be */
 enum {
@@ -1316,16 +1295,16 @@ extern int gbl_bb_berkdb_enable_memp_timing;
 extern int gbl_bb_berkdb_enable_memp_pg_timing;
 extern int gbl_bb_berkdb_enable_shalloc_timing;
 void bdb_reset_thread_stats(void);
-const struct bdb_thread_stats *bdb_get_thread_stats(void);
-const struct bdb_thread_stats *bdb_get_process_stats(void);
+const struct berkdb_thread_stats *bdb_get_thread_stats(void);
+const struct berkdb_thread_stats *bdb_get_process_stats(void);
 
 /* Format and print the thread stats.  printfn() is a function which accepts
  * a line to print (\n\0 terminated) and a context pointer. Its return value
  * is ignored.  bdb_fprintf_stats is a convenience wrapper which uses fputs()
  * as the printing function. */
-void bdb_print_stats(const struct bdb_thread_stats *st, const char *prefix,
+void bdb_print_stats(const struct berkdb_thread_stats *st, const char *prefix,
                      int (*printfn)(const char *, void *), void *context);
-void bdb_fprintf_stats(const struct bdb_thread_stats *st, const char *prefix,
+void bdb_fprintf_stats(const struct berkdb_thread_stats *st, const char *prefix,
                        FILE *out);
 
 int bdb_find_oldest_genid(bdb_state_type *bdb_state, tran_type *tran,
@@ -1820,8 +1799,8 @@ void bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum);
 
 void bdb_replace_handle(bdb_state_type *parent, int ix, bdb_state_type *handle);
 
-int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks, int64_t *waits, 
-                          int64_t *requests);
+int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,                                                                          
+        int64_t *deadlock_locks, int64_t *waits, int64_t *requests);
 
 int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits,
                            int64_t *bpool_misses, int64_t *rw_evicts);

--- a/bdb/fstdump.c
+++ b/bdb/fstdump.c
@@ -54,7 +54,8 @@
 #include <str0.h>
 
 #include <sbuf2.h>
-#include <logmsg.h>
+#include "logmsg.h"
+#include "thread_stats.h"
 
 struct error_extension {
     uint32_t length; /* length of this struct in bytes */
@@ -425,7 +426,7 @@ static void *fstdump_thread_inner(fstdump_per_thread_t *fstdump, void *sendrec,
         ms_after = comdb2_time_epochms();
         ms_diff = ms_after - ms_before;
         if (ms_diff > common->bdb_parent_state->attr->fstdump_longreq) {
-            const struct bdb_thread_stats *thread_stats =
+            const struct berkdb_thread_stats *thread_stats =
                 bdb_get_thread_stats();
             logmsg(LOGMSG_ERROR, "fstdump_thread: LONG REQUEST dbcp->c_get %d ms\n",
                     ms_diff);

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -193,7 +193,7 @@ static void log_stats(FILE *out, bdb_state_type *bdb_state)
 }
 
 int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
-    int64_t *deadlock_locks, int64_t *waits, int64_t *requests)
+    int64_t *locks_aborted, int64_t *waits, int64_t *requests)
 {
     int rc;
     DB_LOCK_STAT *lock_stats = NULL;
@@ -203,8 +203,8 @@ int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
         return rc;
     if (deadlocks)
         *deadlocks = lock_stats->st_ndeadlocks;
-    if (deadlock_locks)
-        *deadlock_locks = lock_stats->st_ndeadlock_locks;
+    if (locks_aborted)
+        *locks_aborted = lock_stats->st_locks_aborted;
     if (waits)
         *waits = lock_stats->st_nconflicts;
     if (requests)

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -193,7 +193,8 @@ static void log_stats(FILE *out, bdb_state_type *bdb_state)
 }
 
 int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
-    int64_t *locks_aborted, int64_t *waits, int64_t *requests)
+                          int64_t *locks_aborted, int64_t *waits,
+                          int64_t *requests)
 {
     int rc;
     DB_LOCK_STAT *lock_stats = NULL;

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -41,6 +41,7 @@
 #include "nodemap.h"
 #include "sqlresponse.pb-c.h"
 #include "logmsg.h"
+#include "thread_stats.h"
 #include <compat.h>
 
 extern char *lsn_to_str(char lsn_str[], DB_LSN *lsn);
@@ -191,8 +192,8 @@ static void log_stats(FILE *out, bdb_state_type *bdb_state)
     free(stats);
 }
 
-int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks, int64_t *waits, 
-    int64_t *requests)
+int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
+    int64_t *deadlock_locks, int64_t *waits, int64_t *requests)
 {
     int rc;
     DB_LOCK_STAT *lock_stats = NULL;
@@ -202,6 +203,8 @@ int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks, int64_t
         return rc;
     if (deadlocks)
         *deadlocks = lock_stats->st_ndeadlocks;
+    if (deadlock_locks)
+        *deadlock_locks = lock_stats->st_ndeadlock_locks;
     if (waits)
         *waits = lock_stats->st_nconflicts;
     if (requests)
@@ -1753,7 +1756,7 @@ void bdb_process_user_command(bdb_state_type *bdb_state, char *line, int lline,
            logmsg(LOGMSG_USER, "Attribute set\n");
         }
     } else if (tokcmp(tok, ltok, "bbstat") == 0) {
-        const struct bdb_thread_stats *p = bdb_get_process_stats();
+        const struct berkdb_thread_stats *p = bdb_get_process_stats();
         unsigned n_lock_waits = p->n_lock_waits ? p->n_lock_waits : 1;
         unsigned n_preads = p->n_preads ? p->n_preads : 1;
         unsigned n_pwrites = p->n_pwrites ? p->n_pwrites : 1;

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3865,7 +3865,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
     time2 = comdb2_time_epoch();
 
     if ((time2 - time1) > bdb_state->attr->rep_longreq) {
-        const struct bdb_thread_stats *t = bdb_get_thread_stats();
+        const struct berkdb_thread_stats *t = bdb_get_thread_stats();
         logmsg(LOGMSG_WARN, "LONG rep_process_message: %d seconds, type %d r %d\n",
                 time2 - time1, rep_control->rectype, r);
         bdb_fprintf_stats(t, "  ", stderr);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -501,7 +501,7 @@ struct __db_lock_stat {
 	u_int64_t st_nnowaits;		/* Number of requests that would have
 					   waited, but NOWAIT was set. */
 	u_int64_t st_ndeadlocks;	/* Number of lock deadlocks. */
-	u_int64_t st_ndeadlock_locks;	/* Number of locks involved in deadlocks. */
+	u_int64_t st_locks_aborted;	/* Number of locks released on deadlocks.*/
 	db_timeout_t st_locktimeout;	/* Lock timeout. */
 	u_int64_t st_nlocktimeouts;	/* Number of lock timeouts. */
 	db_timeout_t st_txntimeout;	/* Transaction timeout. */

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -501,6 +501,7 @@ struct __db_lock_stat {
 	u_int64_t st_nnowaits;		/* Number of requests that would have
 					   waited, but NOWAIT was set. */
 	u_int64_t st_ndeadlocks;	/* Number of lock deadlocks. */
+	u_int64_t st_ndeadlock_locks;	/* Number of locks involved in deadlocks. */
 	db_timeout_t st_locktimeout;	/* Lock timeout. */
 	u_int64_t st_nlocktimeouts;	/* Number of lock timeouts. */
 	db_timeout_t st_txntimeout;	/* Transaction timeout. */
@@ -2713,37 +2714,6 @@ void __db_hdestroy __P((void));
 #endif
 
 
-
-/* SJ - jamming this into berkeley.  If you change this struct, recompile
- * everything.  Note that there is an identical copy of this struct in
- * bdb_api.h just to make the code maintenance issue even worse.  And even
- * worse than that, this stuff is all duplicated in build_ibm/db.h and
- * build_sundev1/db.h */
-struct bb_berkdb_thread_stats {
-	unsigned n_lock_waits;
-	uint64_t lock_wait_time_us;
-
-	unsigned n_preads;
-	unsigned pread_bytes;
-	uint64_t pread_time_us;
-
-	unsigned n_pwrites;
-	unsigned pwrite_bytes;
-	uint64_t pwrite_time_us;
-
-	unsigned n_memp_fgets;
-	uint64_t memp_fget_time_us;
-
-	unsigned n_memp_pgs;
-	uint64_t memp_pg_time_us;
-
-	unsigned n_shallocs;
-	uint64_t shalloc_time_us;
-
-	unsigned n_shalloc_frees;
-	uint64_t shalloc_free_time_us;
-};
-
 /*
  * Helper macros for microsecond-granularity event logging.
  * Multiplication usually takes fewer CPU cycles than division. Therefore
@@ -2757,8 +2727,8 @@ struct bb_berkdb_thread_stats {
 #define M2U(msec) ((msec) * 1000ULL)
 #endif
 uint64_t bb_berkdb_fasttime(void);
-struct bb_berkdb_thread_stats *bb_berkdb_get_thread_stats(void);
-struct bb_berkdb_thread_stats *bb_berkdb_get_process_stats(void);
+struct berkdb_thread_stats *bb_berkdb_get_thread_stats(void);
+struct berkdb_thread_stats *bb_berkdb_get_process_stats(void);
 void bb_berkdb_thread_stats_init(void);
 void bb_berkdb_thread_stats_reset(void);
 

--- a/berkdb/dbinc/locker_info.h
+++ b/berkdb/dbinc/locker_info.h
@@ -30,7 +30,6 @@ typedef struct {
 	snap_uid_t *snap_info; /* contains cnonce */
 	roff_t last_lock;
 	u_int32_t count;
-	u_int32_t lock_count;
 	u_int32_t id;
 	u_int32_t last_locker_id;
 	db_pgno_t pgno;

--- a/berkdb/dbinc/locker_info.h
+++ b/berkdb/dbinc/locker_info.h
@@ -30,6 +30,7 @@ typedef struct {
 	snap_uid_t *snap_info; /* contains cnonce */
 	roff_t last_lock;
 	u_int32_t count;
+	u_int32_t lock_count;
 	u_int32_t id;
 	u_int32_t last_locker_id;
 	db_pgno_t pgno;

--- a/berkdb/env/db_salloc.c
+++ b/berkdb/env/db_salloc.c
@@ -21,6 +21,7 @@ static const char revid[] = "$Id: db_salloc.c,v 11.17 2003/01/08 04:42:01 bostic
 #endif
 
 #include "db_int.h"
+#include "thread_stats.h"
 #include "logmsg.h"
 
 /* Switch to control whether we allocate regions using malloc. */
@@ -149,7 +150,7 @@ static void
 bb_shalloc_hit(uint64_t start_time_us)
 {
 	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
-	struct bb_berkdb_thread_stats *stats;
+	struct berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_shallocs++;
@@ -164,7 +165,7 @@ static void
 bb_shalloc_free_hit(uint64_t start_time_us)
 {
 	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
-	struct bb_berkdb_thread_stats *stats;
+	struct berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_shalloc_frees++;

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2737,12 +2737,12 @@ upgrade:
 			p = bb_berkdb_get_process_stats();
             uint64_t d = (x2 - x1);
 			p->lock_wait_time_us += d;
-            if (p->worst_lock_wait_time_us < d)
-                p->worst_lock_wait_time_us = d;
+			if (p->worst_lock_wait_time_us < d)
+				p->worst_lock_wait_time_us = d;
 			p->n_lock_waits++;
 			t->lock_wait_time_us += d;
-            if (t->worst_lock_wait_time_us < d)
-                t->worst_lock_wait_time_us = d;
+			if (t->worst_lock_wait_time_us < d)
+				t->worst_lock_wait_time_us = d;
 			t->n_lock_waits++;
 
 			if (gbl_bb_log_lock_waits_fn) {

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -43,6 +43,7 @@ static const char revid[] = "$Id: lock.c,v 11.134 2003/11/18 21:30:38 ubell Exp 
 #include "logmsg.h"
 #include "util.h"
 #include "locks_wrap.h"
+#include "thread_stats.h"
 #include "tohex.h"
 
 
@@ -2725,8 +2726,8 @@ upgrade:
 		MUTEX_LOCK(dbenv, &newl->mutex);
 
 		if (gbl_bb_berkdb_enable_thread_stats) {
-			struct bb_berkdb_thread_stats *t;
-			struct bb_berkdb_thread_stats *p;
+			struct berkdb_thread_stats *t;
+			struct berkdb_thread_stats *p;
 			if (gbl_bb_berkdb_enable_lock_timing) {
 				x2 = bb_berkdb_fasttime();
 			} else {
@@ -2734,9 +2735,14 @@ upgrade:
 			}
 			t = bb_berkdb_get_thread_stats();
 			p = bb_berkdb_get_process_stats();
-			p->lock_wait_time_us += (x2 - x1);
+            uint64_t d = (x2 - x1);
+			p->lock_wait_time_us += d;
+            if (p->worst_lock_wait_time_us < d)
+                p->worst_lock_wait_time_us = d;
 			p->n_lock_waits++;
-			t->lock_wait_time_us += (x2 - x1);
+			t->lock_wait_time_us += d;
+            if (t->worst_lock_wait_time_us < d)
+                t->worst_lock_wait_time_us = d;
 			t->n_lock_waits++;
 
 			if (gbl_bb_log_lock_waits_fn) {

--- a/berkdb/lock/lock_deadlock.c
+++ b/berkdb/lock/lock_deadlock.c
@@ -1870,7 +1870,7 @@ __dd_abort(dbenv, info)
 	MUTEX_UNLOCK(dbenv, &lockp->mutex);
 
 	region->stat.st_ndeadlocks++;
-    region->stat.st_ndeadlock_locks += lockerp->nlocks;
+    region->stat.st_locks_aborted += lockerp->nlocks;
 ounlock:unlock_obj_partition(region, partition);
 unlock:unlock_locker_partition(region, lockerp->partition);
 out:unlock_lockers(region);

--- a/berkdb/lock/lock_deadlock.c
+++ b/berkdb/lock/lock_deadlock.c
@@ -763,7 +763,7 @@ __lock_detect_int(dbenv, atype, abortp, can_retry)
 				break;
 			case DB_LOCK_MAXLOCKS:
 			case DB_LOCK_MAXWRITE:
-				if (idmap[i].count <idmap[killid].count)
+				if (idmap[i].count < idmap[killid].count)
 					 continue;
 				keeper = i;
 
@@ -773,7 +773,7 @@ __lock_detect_int(dbenv, atype, abortp, can_retry)
 			case DB_LOCK_MINLOCKS:
 			case DB_LOCK_MINWRITE:
 			case DB_LOCK_MINWRITE_NOREAD:
-				if (idmap[i].count >idmap[killid].count) {
+				if (idmap[i].count > idmap[killid].count) {
 					if (idmap[i].count >100) {
 						/*
 						 * fprintf(stderr, "sparing %d cause he has %d locks\n",
@@ -788,7 +788,7 @@ __lock_detect_int(dbenv, atype, abortp, can_retry)
 
 			case DB_LOCK_YOUNGEST_EVER:
 				/* if current younger, keep it */
-				if (idmap[i].count <idmap[killid].count) {
+				if (idmap[i].count < idmap[killid].count) {
 					continue;
 				}
 				keeper = i;
@@ -939,7 +939,7 @@ __init_lockerid_priority(dbenv, atype, lip, ptr_idarr)
 	case DB_LOCK_MINWRITE_NOREAD:
 		/* bias by the number of times we retried this txn */
 		ptr_idarr->count = lip->nretries * dbenv->lk_max;
-		ptr_idarr->count +=lip->nwrites;
+		ptr_idarr->count += lip->nwrites;
 
 		break;
 	case DB_LOCK_YOUNGEST_EVER:
@@ -948,7 +948,7 @@ __init_lockerid_priority(dbenv, atype, lip, ptr_idarr)
 		break;
 	case DB_LOCK_MINWRITE_EVER:
 		ptr_idarr->count = lip->nretries;
-		ptr_idarr->count +=lip->nwrites;
+		ptr_idarr->count += lip->nwrites;
 
 		break;
 	}
@@ -964,24 +964,24 @@ __adjust_lockerid_priority(dbenv, atype, lip, ptr_idarr)
 	switch (atype) {
 	case DB_LOCK_MINLOCKS:
 	case DB_LOCK_MAXLOCKS:
-		ptr_idarr->count +=lip->nlocks;
+		ptr_idarr->count += lip->nlocks;
 
 		break;
 	case DB_LOCK_MINWRITE:
 	case DB_LOCK_MINWRITE_NOREAD:
 		/* bias by the number of times we retried this txn */
-		ptr_idarr->count +=lip->nretries * dbenv->lk_max;
-		ptr_idarr->count +=lip->nwrites;
+		ptr_idarr->count += lip->nretries * dbenv->lk_max;
+		ptr_idarr->count += lip->nwrites;
 
 		break;
 	case DB_LOCK_YOUNGEST_EVER:
-		if (ptr_idarr->count >lip->nretries)
+		if (ptr_idarr->count > lip->nretries)
 			ptr_idarr->count = lip->nretries;	/* this is the age in epoch seconds */
 
 		break;
 	case DB_LOCK_MINWRITE_EVER:
-		ptr_idarr->count +=lip->nretries;
-		ptr_idarr->count +=lip->nwrites;
+		ptr_idarr->count += lip->nretries;
+		ptr_idarr->count += lip->nwrites;
 
 		break;
 	}
@@ -1870,6 +1870,7 @@ __dd_abort(dbenv, info)
 	MUTEX_UNLOCK(dbenv, &lockp->mutex);
 
 	region->stat.st_ndeadlocks++;
+    region->stat.st_ndeadlock_locks += lockerp->nlocks;
 ounlock:unlock_obj_partition(region, partition);
 unlock:unlock_locker_partition(region, lockerp->partition);
 out:unlock_lockers(region);

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -34,8 +34,9 @@ static const char revid[] = "$Id: mp_bh.c,v 11.86 2003/07/02 20:02:37 mjc Exp $"
 #include <sys/types.h>
 #include <dirent.h>
 
-#include <logmsg.h>
-#include <locks_wrap.h>
+#include "logmsg.h"
+#include "locks_wrap.h"
+#include "thread_stats.h"
 #include "comdb2_atomic.h"
 
 char *bdb_trans(const char infile[], char outfile[]);
@@ -1131,7 +1132,7 @@ static void
 bb_memp_pg_hit(uint64_t start_time_us)
 {
 	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
-	struct bb_berkdb_thread_stats *stats;
+	struct berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_memp_pgs++;

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -37,8 +37,9 @@ static const char revid[] = "$Id: mp_fget.c,v 11.81 2003/09/25 02:15:16 sue Exp 
 #include "dbinc/txn.h"
 
 #include "logmsg.h"
-#include <locks_wrap.h>
+#include "locks_wrap.h"
 #include "comdb2_atomic.h"
+#include "thread_stats.h"
 
 
 struct bdb_state_tag;
@@ -132,7 +133,7 @@ static void
 bb_memp_hit(uint64_t start_time_us)
 {
 	uint64_t time_diff = bb_berkdb_fasttime() - start_time_us;
-	struct bb_berkdb_thread_stats *stats;
+	struct berkdb_thread_stats *stats;
 
 	stats = bb_berkdb_get_thread_stats();
 	stats->n_memp_fgets++;

--- a/berkdb/os/os_rw.c
+++ b/berkdb/os/os_rw.c
@@ -1553,7 +1553,7 @@ bb_berkdb_get_process_stats(void)
 
 void bb_berkdb_reset_worst_lock_wait_time_us(void)
 {
-	bb_berkdb_get_thread_stats()->worst_lock_wait_time_us = 0;
+	bb_berkdb_get_process_stats()->worst_lock_wait_time_us = 0;
 }
 
 void

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4240,7 +4240,8 @@ void *statthd(void *p)
         bdb_get_bpool_counters(thedb->bdb_env, (int64_t *)&bpool_hits,
                                (int64_t *)&bpool_misses, &rw_evicts);
 
-        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlocks_aborted, &nlockwaits, NULL);
+        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlocks_aborted,
+                              &nlockwaits, NULL);
         diff_deadlocks = ndeadlocks - last_ndeadlocks;
         diff_locks_aborted = nlocks_aborted - last_nlocks_aborted;
         diff_lockwaits = nlockwaits - last_nlockwaits;
@@ -4482,10 +4483,12 @@ void *statthd(void *p)
                                       last_bdb_stats.n_lock_waits;
                     reqlog_logf(statlogger, REQL_INFO,
                                 "%u locks, avg time %ums, worst time %ums\n",
-                                nwaits, U2M(cur_bdb_stats.lock_wait_time_us -
-                                    last_bdb_stats.lock_wait_time_us) / nwaits,
+                                nwaits,
+                                U2M(cur_bdb_stats.lock_wait_time_us -
+                                    last_bdb_stats.lock_wait_time_us) /
+                                    nwaits,
                                 U2M(cur_bdb_stats.worst_lock_wait_time_us));
-                   bb_berkdb_reset_worst_lock_wait_time_us();
+                    bb_berkdb_reset_worst_lock_wait_time_us();
                 }
                 if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
                     unsigned npreads =
@@ -4517,8 +4520,10 @@ void *statthd(void *p)
 
                 if (diff_deadlocks || diff_lockwaits || diff_vreplays)
                     reqlog_logf(statlogger, REQL_INFO,
-                                "ndeadlocks %d, nlockwaits %d, vreplays %d, locks aborted %d\n",
-                                diff_deadlocks, diff_lockwaits, diff_vreplays, diff_locks_aborted);
+                                "ndeadlocks %d, nlockwaits %d, vreplays %d, "
+                                "locks aborted %d\n",
+                                diff_deadlocks, diff_lockwaits, diff_vreplays,
+                                diff_locks_aborted);
 
                 bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes, curlsn,
                                     sizeof(curlsn));

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4139,7 +4139,7 @@ void *statthd(void *p)
     long long newsql_steps;
     int nretries;
     int64_t ndeadlocks = 0;
-    int64_t ndeadlock_locks = 0;
+    int64_t nlocks_aborted = 0;
     int64_t nlockwaits = 0;
     int64_t vreplays;
 
@@ -4152,7 +4152,7 @@ void *statthd(void *p)
     int diff_newsql;
     int diff_nretries;
     int diff_deadlocks;
-    int diff_deadlock_locks;
+    int diff_locks_aborted;
     int diff_lockwaits;
     int diff_vreplays;
 
@@ -4164,7 +4164,7 @@ void *statthd(void *p)
     long long last_ncommit_time = 0;
     int last_newsql = 0;
     int last_nretries = 0;
-    int64_t last_ndeadlocks = 0, last_ndeadlock_locks = 0, last_nlockwaits = 0;
+    int64_t last_ndeadlocks = 0, last_nlocks_aborted = 0, last_nlockwaits = 0;
     int64_t last_vreplays = 0;
 
     int count = 0;
@@ -4240,9 +4240,9 @@ void *statthd(void *p)
         bdb_get_bpool_counters(thedb->bdb_env, (int64_t *)&bpool_hits,
                                (int64_t *)&bpool_misses, &rw_evicts);
 
-        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &ndeadlock_locks, &nlockwaits, NULL);
+        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlocks_aborted, &nlockwaits, NULL);
         diff_deadlocks = ndeadlocks - last_ndeadlocks;
-        diff_deadlock_locks = ndeadlock_locks - last_ndeadlock_locks;
+        diff_locks_aborted = nlocks_aborted - last_nlocks_aborted;
         diff_lockwaits = nlockwaits - last_nlockwaits;
 
         diff_qtrap = nqtrap - last_qtrap;
@@ -4267,7 +4267,7 @@ void *statthd(void *p)
         last_newsql = newsql;
         last_nretries = nretries;
         last_ndeadlocks = ndeadlocks;
-        last_ndeadlock_locks = ndeadlock_locks;
+        last_nlocks_aborted = nlocks_aborted;
         last_nlockwaits = nlockwaits;
         last_vreplays = vreplays;
         last_ncommits = ncommits;
@@ -4517,8 +4517,8 @@ void *statthd(void *p)
 
                 if (diff_deadlocks || diff_lockwaits || diff_vreplays)
                     reqlog_logf(statlogger, REQL_INFO,
-                                "ndeadlocks %d, nlockwaits %d, vreplays %d deadlock steps %d\n",
-                                diff_deadlocks, diff_lockwaits, diff_vreplays, diff_deadlock_locks);
+                                "ndeadlocks %d, nlockwaits %d, vreplays %d, locks aborted %d\n",
+                                diff_deadlocks, diff_lockwaits, diff_vreplays, diff_locks_aborted);
 
                 bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes, curlsn,
                                     sizeof(curlsn));

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -58,6 +58,7 @@ void berk_memp_sync_alarm_ms(int);
 #include <logmsg.h>
 #include <epochlib.h>
 #include <segstr.h>
+#include "thread_stats.h"
 
 #include <list.h>
 #include <mem.h>
@@ -167,6 +168,7 @@ void berkdb_use_malloc_for_regions_with_callbacks(void *mem,
                                                   void *(*alloc)(void *, int),
                                                   void (*free)(void *, void *));
 
+extern void bb_berkdb_reset_worst_lock_wait_time_us();
 extern int has_low_headroom(const char *path, int headroom, int debug);
 extern void *clean_exit_thd(void *unused);
 extern void bdb_durable_lsn_for_single_node(void *in_bdb_state);
@@ -4136,7 +4138,9 @@ void *statthd(void *p)
     int newsql;
     long long newsql_steps;
     int nretries;
-    int64_t ndeadlocks = 0, nlockwaits = 0;
+    int64_t ndeadlocks = 0;
+    int64_t ndeadlock_locks = 0;
+    int64_t nlockwaits = 0;
     int64_t vreplays;
 
     int diff_qtrap;
@@ -4148,6 +4152,7 @@ void *statthd(void *p)
     int diff_newsql;
     int diff_nretries;
     int diff_deadlocks;
+    int diff_deadlock_locks;
     int diff_lockwaits;
     int diff_vreplays;
 
@@ -4159,7 +4164,7 @@ void *statthd(void *p)
     long long last_ncommit_time = 0;
     int last_newsql = 0;
     int last_nretries = 0;
-    int64_t last_ndeadlocks = 0, last_nlockwaits = 0;
+    int64_t last_ndeadlocks = 0, last_ndeadlock_locks = 0, last_nlockwaits = 0;
     int64_t last_vreplays = 0;
 
     int count = 0;
@@ -4192,9 +4197,9 @@ void *statthd(void *p)
     int64_t last_report_curr_conns=0;
 
     struct reqlogger *statlogger = NULL;
-    struct bdb_thread_stats last_bdb_stats = {0};
-    struct bdb_thread_stats cur_bdb_stats;
-    const struct bdb_thread_stats *pstats;
+    struct berkdb_thread_stats last_bdb_stats = {0};
+    struct berkdb_thread_stats cur_bdb_stats;
+    const struct berkdb_thread_stats *pstats;
     char lastlsn[63] = "", curlsn[64];
     uint64_t lastlsnbytes = 0, curlsnbytes;
     int ii;
@@ -4235,8 +4240,9 @@ void *statthd(void *p)
         bdb_get_bpool_counters(thedb->bdb_env, (int64_t *)&bpool_hits,
                                (int64_t *)&bpool_misses, &rw_evicts);
 
-        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlockwaits, NULL);
+        bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &ndeadlock_locks, &nlockwaits, NULL);
         diff_deadlocks = ndeadlocks - last_ndeadlocks;
+        diff_deadlock_locks = ndeadlock_locks - last_ndeadlock_locks;
         diff_lockwaits = nlockwaits - last_nlockwaits;
 
         diff_qtrap = nqtrap - last_qtrap;
@@ -4261,6 +4267,7 @@ void *statthd(void *p)
         last_newsql = newsql;
         last_nretries = nretries;
         last_ndeadlocks = ndeadlocks;
+        last_ndeadlock_locks = ndeadlock_locks;
         last_nlockwaits = nlockwaits;
         last_vreplays = vreplays;
         last_ncommits = ncommits;
@@ -4326,7 +4333,7 @@ void *statthd(void *p)
 
         if (!gbl_schema_change_in_progress) {
             thresh = reqlog_diffstat_thresh();
-            if ((thresh > 0) && (count == thresh)) {
+            if ((thresh > 0) && (count == thresh)) { /* every thresh-seconds */
                 strbuf *logstr = strbuf_new();
                 diff_qtrap = nqtrap - last_report_nqtrap;
                 diff_fstrap = nfstrap - last_report_nfstrap;
@@ -4471,13 +4478,14 @@ void *statthd(void *p)
                 pstats = bdb_get_process_stats();
                 cur_bdb_stats = *pstats;
                 if (cur_bdb_stats.n_lock_waits > last_bdb_stats.n_lock_waits) {
-                    unsigned nreads = cur_bdb_stats.n_lock_waits -
+                    unsigned nwaits = cur_bdb_stats.n_lock_waits -
                                       last_bdb_stats.n_lock_waits;
                     reqlog_logf(statlogger, REQL_INFO,
-                                "%u locks, avg time %ums\n", nreads,
-                                U2M(cur_bdb_stats.lock_wait_time_us -
-                                    last_bdb_stats.lock_wait_time_us) /
-                                    nreads);
+                                "%u locks, avg time %ums, worst time %ums\n",
+                                nwaits, U2M(cur_bdb_stats.lock_wait_time_us -
+                                    last_bdb_stats.lock_wait_time_us) / nwaits,
+                                U2M(cur_bdb_stats.worst_lock_wait_time_us));
+                   bb_berkdb_reset_worst_lock_wait_time_us();
                 }
                 if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
                     unsigned npreads =
@@ -4509,8 +4517,8 @@ void *statthd(void *p)
 
                 if (diff_deadlocks || diff_lockwaits || diff_vreplays)
                     reqlog_logf(statlogger, REQL_INFO,
-                                "ndeadlocks %d, nlockwaits %d, vreplays %d\n",
-                                diff_deadlocks, diff_lockwaits, diff_vreplays);
+                                "ndeadlocks %d, nlockwaits %d, vreplays %d deadlock steps %d\n",
+                                diff_deadlocks, diff_lockwaits, diff_vreplays, diff_deadlock_locks);
 
                 bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes, curlsn,
                                     sizeof(curlsn));

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -22,6 +22,7 @@
 #include "metrics.h"
 #include "bdb_api.h"
 #include "net.h"
+#include "thread_stats.h"
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -311,7 +312,7 @@ static time_t metrics_standing_queue_time(void);
 int refresh_metrics(void)
 {
     int rc;
-    const struct bdb_thread_stats *pstats;
+    const struct berkdb_thread_stats *pstats;
     extern int active_appsock_conns; int bdberr;
 #if 0
     int min_file, min_offset;
@@ -329,7 +330,7 @@ int refresh_metrics(void)
     stats.sql_count = gbl_nsql + gbl_nnewsql;
     stats.current_connections = net_get_num_current_non_appsock_accepts(thedb->handle_sibling) + active_appsock_conns;
 
-    rc = bdb_get_lock_counters(thedb->bdb_env, &stats.deadlocks,
+    rc = bdb_get_lock_counters(thedb->bdb_env, &stats.deadlocks, NULL,
                                &stats.lockwaits, &stats.lockrequests);
     if (rc) {
         logmsg(LOGMSG_ERROR, "failed to refresh statistics (%s:%d)\n", __FILE__,

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -336,8 +336,9 @@ int refresh_metrics(void)
     stats.sql_count = gbl_nsql + gbl_nnewsql;
     stats.current_connections = net_get_num_current_non_appsock_accepts(thedb->handle_sibling) + active_appsock_conns;
 
-    rc = bdb_get_lock_counters(thedb->bdb_env, &stats.deadlocks, &stats.locks_aborted,
-                               &stats.lockwaits, &stats.lockrequests);
+    rc = bdb_get_lock_counters(thedb->bdb_env, &stats.deadlocks,
+                               &stats.locks_aborted, &stats.lockwaits,
+                               &stats.lockrequests);
     if (rc) {
         logmsg(LOGMSG_ERROR, "failed to refresh statistics (%s:%d)\n", __FILE__,
                __LINE__);
@@ -412,7 +413,8 @@ int refresh_metrics(void)
     stats.handle_buf_queue_time =
         time_metric_average(thedb->handle_buf_queue_time);
     stats.concurrent_connections = time_metric_average(thedb->connections);
-    int master = bdb_whoismaster((bdb_state_type *)thedb->bdb_env) == gbl_mynode ? 1 : 0; 
+    int master =
+        bdb_whoismaster((bdb_state_type *)thedb->bdb_env) == gbl_mynode ? 1 : 0;
     stats.ismaster = master;
     rc = bdb_get_num_sc_done(((bdb_state_type *)thedb->bdb_env), NULL,
                              (unsigned long long *)&stats.num_sc_done, &bdberr);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -37,6 +37,7 @@
 #include "tohex.h"
 #include "plhash.h"
 #include "logmsg.h"
+#include "thread_stats.h"
 #include "dbinc/locker_info.h"
 
 #include "cson_amalgamation_core.h"
@@ -321,7 +322,7 @@ void eventlog_tables(cson_object *obj, const struct reqlogger *logger)
 
 void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
 {
-    const struct bdb_thread_stats *thread_stats = bdb_get_thread_stats();
+    const struct berkdb_thread_stats *thread_stats = bdb_get_thread_stats();
     int64_t start = logger->startus;
     int64_t end = comdb2_time_epochus();
 

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -97,7 +97,7 @@ static int shortest_long_request_ms = -1;
 
 static struct output *default_out;
 
-int diffstat_thresh = 60; /* every minute */
+int diffstat_thresh = 60; /* every sixty seconds */
 static struct output *stat_request_out = NULL;
 
 /* These global lockless variables define what we will log for all requests
@@ -1540,7 +1540,7 @@ static void print_client_query_stats(struct reqlogger *logger,
 /* print the request header for the request. */
 static void log_header_ll(struct reqlogger *logger, struct output *out)
 {
-    const struct bdb_thread_stats *thread_stats = bdb_get_thread_stats();
+    const struct berkdb_thread_stats *thread_stats = bdb_get_thread_stats();
     struct reqlog_print_callback_args args;
 
     if (out == long_request_out) {

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -171,7 +171,7 @@ static inline void lkcounter_check(struct convert_record_data *data, int now)
      */
 
     int64_t ndeadlocks = 0, nlockwaits = 0;
-    bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlockwaits, NULL);
+    bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, NULL, &nlockwaits, NULL);
 
     int64_t diff_deadlocks = ndeadlocks - data->cmembers->ndeadlocks;
     int64_t diff_lockwaits = nlockwaits - data->cmembers->nlockwaits;

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -110,7 +110,7 @@ cleanup_cluster() {
             scp -r -o StrictHostKeyChecking=no $node:${TESTDIR}/var/log/cdb2/${DBNAME}* $DBDIR/$node/ < /dev/null &
         elif [ "$CLEANUPDBDIR" != "0" ] ; then 
             ssh -o StrictHostKeyChecking=no $node "rm -rf ${DBDIR} $TMPDIR/${DBNAME}" < /dev/null &
-            ssh -o StrictHostKeyChecking=no $node "rm -f ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
+#ssh -o StrictHostKeyChecking=no $node "rm -f ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
             if [ "$CLEANUPDBDIR" == "2" ] ; then 
                 ssh -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*" < /dev/null &
             fi
@@ -121,7 +121,7 @@ cleanup_cluster() {
     # the local node always has a copy of DBDIR even if not part of cluster
     if [ "$CLEANUPDBDIR" != "0" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
         rm -rf ${DBDIR} ${TMPDIR}/${DBNAME}
-        rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
+#rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
         if [ "$CLEANUPDBDIR" == "2" ] ; then
             rm -f $TESTDIR/logs/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
             rmdir ${TMPDIR}/cdb2 ${TMPDIR} 2> /dev/null


### PR DESCRIPTION
We already show every second in .statreqs file number of deadlocks (and lockwaits) and number of locks gotten in that interval and average time they took. 
Here we add the following data points for that interval:
  - Aggregate number of locks aborted when transactions aborted because of deadlock.
  - Worst wait time for any lock.
```
    ndeadlocks 362, nlockwaits 1203, vreplays 0, locks aborted 10
    399 locks, avg time 37ms, worst time 432ms
```
