### PR TITLE
fix limit when missing parameters force an early error

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -453,7 +453,7 @@ done:
     crt = p;
     while (crt) {
         crt->pLimit = NULL;
-        crt = crt->pNext;
+        crt = crt->pPrior;
     }
     p->pLimit = pLimit;
 


### PR DESCRIPTION
Corner case: parsing succeeds, but bound parameters are missing.  This generates an early error that triggers a double free.