### PR TITLE
fix foreign constraint check in time partition code

### DIFF
--- a/db/constraints.c
+++ b/db/constraints.c
@@ -2006,7 +2006,7 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
                 n_errors++;
                 continue;
             } else {
-                if (timepart_is_shard(rdb->tablename, 1, NULL)) {
+                if (timepart_is_shard(rdb->tablename, (!s || !s->views_locked), NULL)) {
                     constraint_err(s, from_db, ct, jj,
                                    "foreign table is a shard");
                     n_errors++;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -2006,7 +2006,8 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
                 n_errors++;
                 continue;
             } else {
-                if (timepart_is_shard(rdb->tablename, (!s || !s->views_locked), NULL)) {
+                if (timepart_is_shard(rdb->tablename, (!s || !s->views_locked),
+                                      NULL)) {
                     constraint_err(s, from_db, ct, jj,
                                    "foreign table is a shard");
                     n_errors++;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1080,6 +1080,7 @@ int sc_timepart_add_table(const char *existingTableName,
     /* prepare sc */
     sc.onstack = 1;
     sc.type = DBTYPE_TAGGED_TABLE;
+    sc.views_locked = 1;
 
     snprintf(sc.tablename, sizeof(sc.tablename), "%s", newTableName);
     sc.tablename[sizeof(sc.tablename) - 1] = '\0';

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -204,6 +204,8 @@ struct schema_change_type {
      * *****************************/
 
     size_t packed_len;
+
+    bool views_locked : 1;
 };
 
 struct ireq;

--- a/tests/timepart_frgncnst.test/Makefile
+++ b/tests/timepart_frgncnst.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/timepart_frgncnst.test/README
+++ b/tests/timepart_frgncnst.test/README
@@ -1,0 +1,1 @@
+This checks foreign constraints code when a time partition depends on a non-partitioned table.

--- a/tests/timepart_frgncnst.test/lrl.options
+++ b/tests/timepart_frgncnst.test/lrl.options
@@ -1,0 +1,4 @@
+table t t.csc2
+table t2 t2.csc2
+logmsg level user
+setattr DEBUG_TIMEPART_CRON 1

--- a/tests/timepart_frgncnst.test/run.log
+++ b/tests/timepart_frgncnst.test/run.log
@@ -1,0 +1,7 @@
+cdb2sql --cdb2cfg /tmp/test_9866/timepartfrgncnst52729/comdb2db.cfg timepartfrgncnst52729 default exec procedure sys.cmd.send('partitions')
+[]
+
+cdb2sql --cdb2cfg /tmp/test_9866/timepartfrgncnst52729/comdb2db.cfg timepartfrgncnst52729 default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+cdb2sql --cdb2cfg /tmp/test_9866/timepartfrgncnst52729/comdb2db.cfg timepartfrgncnst52729 default select name, shardname from comdb2_timepartshards
+cdb2sql --cdb2cfg /tmp/test_9866/timepartfrgncnst52729/comdb2db.cfg timepartfrgncnst52729 default select name, arg1, arg2, arg3 from comdb2_timepartevents
+cdb2sql --cdb2cfg /tmp/test_9866/timepartfrgncnst52729/comdb2db.cfg timepartfrgncnst52729 default exec procedure sys.cmd.send('partitions')

--- a/tests/timepart_frgncnst.test/run.log.alpha
+++ b/tests/timepart_frgncnst.test/run.log.alpha
@@ -1,0 +1,32 @@
+cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[]
+
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
+cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "testview1",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t2",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$1_14AC98FD",
+  },
+  {
+   "TABLENAME"    : "$0_B1ED0A83",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='testview1', period='daily', retention=2, nshards=2, version=0, shard0name='t2')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='testview1', shardname='$1_14AC98FD')
+(name='testview1', shardname='$0_B1ED0A83')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
+(name='AddShard', arg1='testview1', arg2=NULL, arg3=NULL)
+cdb2sql ${CDB2_OPTIONS} dorintdb default DROP TIME PARTITION testview1

--- a/tests/timepart_frgncnst.test/runit
+++ b/tests/timepart_frgncnst.test/runit
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Time partition testcase for comdb2
+################################################################################
+
+
+# args
+# <dbname>
+dbname=$1
+
+VIEW1="testview1"
+OUT="run.log"
+
+rm $OUT 2>/dev/null
+touch $OUT
+
+
+function timepart_stats
+{
+    # check the current partitions 
+    echo cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | 
+        egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >> $OUT
+    cdb2sql -tabs ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" |
+        egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >> $OUT
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+
+    echo cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, period, retention, nshards, version,shard0name from comdb2_timepartitions " >> $OUT
+    cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, period, retention, nshards, version,shard0name from comdb2_timepartitions " >> $OUT
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+
+    echo cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, shardname from comdb2_timepartshards" >> $OUT
+    cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, shardname from comdb2_timepartshards" >> $OUT
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+
+    #randomly we catch a drop event here; sleep to skip the deterministically
+    sleep 6
+    echo cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, arg1, arg2, arg3 from comdb2_timepartevents" >> $OUT
+    cdb2sql ${CDB2_OPTIONS} --host ${master} $dbname default  "select name, arg1, arg2, arg3 from comdb2_timepartevents" >> $OUT
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+}
+
+master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbname default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
+
+timepart_stats
+
+# create the partition
+#echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'test2min' RETENTION 2 START '`date +\"%Y-%m-%dT%H%M%S America/New_York\" --date \"now 1 minutes\"`'" 
+#cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'test2min' RETENTION 2 START '`date +\"%Y-%m-%dT%H%M%S America/New_York\" --date \"now 1 minutes\"`'" >> $OUT
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(3*24*3600))'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t2 as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t2 as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+
+sleep 15
+
+timepart_stats
+
+
+# destroy partition
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "DROP TIME PARTITION ${VIEW1}" >> $OUT
+cdb2sql ${CDB2_OPTIONS} $dbname default "DROP TIME PARTITION ${VIEW1}" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+# we need to scrub dbname from alpha
+sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
+
+
+difs=`diff $OUT $OUT.alpha.actual`
+if [[ ! -z "${difs}" ]] ; then
+   echo "diff $OUT $OUT.alpha.actual"
+   echo ${difs}
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/timepart_frgncnst.test/t.csc2
+++ b/tests/timepart_frgncnst.test/t.csc2
@@ -1,0 +1,10 @@
+schema
+{
+   int      a
+   cstring  b[10]
+   blob     c
+}
+keys
+{
+   "pk"  = a
+}

--- a/tests/timepart_frgncnst.test/t2.csc2
+++ b/tests/timepart_frgncnst.test/t2.csc2
@@ -1,0 +1,12 @@
+schema
+{
+   int      a
+}
+keys
+{
+   "pk"  = a
+}
+constraints
+{
+    "pk" -> <"t":"pk">
+}


### PR DESCRIPTION
When a time partition has a foreign constraint on a non-partition table, code abort. Fixing this.