### PR TITLE
Don't create a new ast on recursive parse.

### DIFF
--- a/sqlite/src/delete.c
+++ b/sqlite/src/delete.c
@@ -331,8 +331,10 @@ void sqlite3DeleteFrom(
   if( v==0 ){
     goto delete_from_cleanup;
   }
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_DELETE, v, NULL);
+  if( sqlite3ParseToplevel(pParse) == pParse && !pParse->ast ) {
+      pParse->ast = ast_init();
+      ast_push(pParse->ast, AST_TYPE_DELETE, v, NULL);
+  }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -2782,8 +2782,10 @@ void sqlite3CodeRhsOfIN(
 
   if( ExprHasProperty(pExpr, EP_xIsSelect) ){
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( !pParse->ast ) pParse->ast = ast_init();
-    ast_push(pParse->ast, AST_TYPE_IN, v, NULL);
+    if( sqlite3ParseToplevel(pParse) == pParse && !pParse->ast ) {
+       if( !pParse->ast ) pParse->ast = ast_init();
+       ast_push(pParse->ast, AST_TYPE_IN, v, NULL);
+    }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     /* Case 1:     expr IN (SELECT ...)
     **

--- a/sqlite/src/insert.c
+++ b/sqlite/src/insert.c
@@ -726,8 +726,10 @@ void sqlite3Insert(
     int rc;             /* Result code */
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( !pParse->ast ) pParse->ast = ast_init();
-    ast_push(pParse->ast, AST_TYPE_INSERT, v, NULL);
+    if( sqlite3ParseToplevel(pParse) == pParse && !pParse->ast ) {
+      if( !pParse->ast ) pParse->ast = ast_init();
+      ast_push(pParse->ast, AST_TYPE_INSERT, v, NULL);
+    }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     regYield = ++pParse->nMem;
     addrTop = sqlite3VdbeCurrentAddr(v) + 1;

--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -5885,8 +5885,10 @@ int sqlite3Select(
 #endif
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_SELECT, v, p);
+  if( sqlite3ParseToplevel(pParse) == pParse && !pParse->ast ) {
+    if( !pParse->ast ) pParse->ast = ast_init();
+    ast_push(pParse->ast, AST_TYPE_SELECT, v, p);
+  }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifndef SQLITE_OMIT_COMPOUND_SELECT
   /* Handle compound SELECT statements using the separate multiSelect()

--- a/sqlite/src/update.c
+++ b/sqlite/src/update.c
@@ -241,8 +241,10 @@ void sqlite3Update(
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   v = sqlite3GetVdbe(pParse);
   if( v==0 ) goto update_cleanup;
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_UPDATE, v, NULL);
+  if( sqlite3ParseToplevel(pParse) == pParse && !pParse->ast ) {
+    if( !pParse->ast ) pParse->ast = ast_init();
+    ast_push(pParse->ast, AST_TYPE_UPDATE, v, NULL);
+  }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
   if( !isView ){


### PR DESCRIPTION
Fixes a memory leak on delete/update on time partitions.