### PR TITLE
cdb2api: Honor per-handle default_type config in comdb2db DNS lookup

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1526,13 +1526,14 @@ static int get_host_by_name(cdb2_hndl_tp *hndl, const char *comdb2db_name,
        #3: <comdb2db name>.<dns suffix> */
 
     if (hndl->cluster[0] != '\0') {
-        snprintf(dns_name, sizeof(dns_name), "%s-%s.%s", hndl->cluster, comdb2db_name,
-                 cdb2_dnssuffix);
+        snprintf(dns_name, sizeof(dns_name), "%s-%s.%s", hndl->cluster,
+                 comdb2db_name, cdb2_dnssuffix);
     } else if (cdb2_default_cluster[0] != '\0') {
         snprintf(dns_name, sizeof(dns_name), "%s-%s.%s", cdb2_default_cluster, comdb2db_name,
                  cdb2_dnssuffix);
     } else {
-        snprintf(dns_name, sizeof(dns_name), "%s.%s", comdb2db_name, cdb2_dnssuffix);
+        snprintf(dns_name, sizeof(dns_name), "%s.%s", comdb2db_name,
+                 cdb2_dnssuffix);
     }
 
 #ifdef __APPLE__
@@ -1596,7 +1597,8 @@ static int get_comdb2db_hosts(cdb2_hndl_tp *hndl, char comdb2db_hosts[][64],
                                comdb2db_ports, master, num_hosts, NULL);
         /* DNS lookup comdb2db hosts. */
         if (rc != 0)
-            rc = get_host_by_name(hndl, comdb2db_name, comdb2db_hosts, num_hosts);
+            rc = get_host_by_name(hndl, comdb2db_name, comdb2db_hosts,
+                                  num_hosts);
     }
 
     return rc;

--- a/tests/cdb2api_per_hndl_conf.test/Makefile
+++ b/tests/cdb2api_per_hndl_conf.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/cdb2api_per_hndl_conf.test/expected
+++ b/tests/cdb2api_per_hndl_conf.test/expected
@@ -1,0 +1,2 @@
+get_host_by_name:gethostbyname(EXAMPLE-comdb2db.): errno=0 err=Success
+cdb2_open rc -1 cdb2_get_dbhosts: no comdb2db hosts found.

--- a/tests/cdb2api_per_hndl_conf.test/runit
+++ b/tests/cdb2api_per_hndl_conf.test/runit
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+bash -n "$0" | exit 1
+dbnm=$1
+PERDBDIR=$TESTDIR/etc/cdb2/config.d/
+mkdir -p $PERDBDIR
+echo "
+comdb2_config:default_type=EXAMPLE
+" >>$PERDBDIR/$dbnm.cfg
+COMDB2_ROOT=$TESTDIR cdb2sql ${CDB2_OPTIONS} $dbnm default "SELECT 1" >actual 2>&1
+[ $? = 0 ] && { exit 1; }
+diff expected actual

--- a/tests/cdb2api_per_hndl_conf.test/runit
+++ b/tests/cdb2api_per_hndl_conf.test/runit
@@ -4,9 +4,9 @@ bash -n "$0" | exit 1
 dbnm=$1
 PERDBDIR=$TESTDIR/etc/cdb2/config.d/
 mkdir -p $PERDBDIR
-echo "
-comdb2_config:default_type=EXAMPLE
+grep comdb2_config $DBDIR/comdb2db.cfg >>$PERDBDIR/comdb2db.cfg
+echo "comdb2_config:default_type=EXAMPLE
 " >>$PERDBDIR/$dbnm.cfg
-COMDB2_ROOT=$TESTDIR cdb2sql ${CDB2_OPTIONS} $dbnm default "SELECT 1" >actual 2>&1
+COMDB2_ROOT=$TESTDIR cdb2sql --cdb2cfg $PERDBDIR/comdb2db.cfg $dbnm default "SELECT 1" >actual 2>&1
 [ $? = 0 ] && { exit 1; }
 diff expected actual


### PR DESCRIPTION
Prefer the per-handle default_type over the global config when forming comdb2db domain name.