### PR TITLE
Show errno and str when failed to get peer address

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -5717,10 +5717,11 @@ static void *accept_thread(void *arg)
             rc = getpeername(new_fd, (struct sockaddr *)&cliaddr,
                              (socklen_t *)&clilen);
             if (rc) {
-              logmsg(LOGMSG_ERROR, "Failed to get peer address, error: %d %s\n",
-                     errno, strerror(errno));
-              close(new_fd);
-              continue;
+                logmsg(LOGMSG_ERROR,
+                       "Failed to get peer address, error: %d %s\n", errno,
+                       strerror(errno));
+                close(new_fd);
+                continue;
             }
         }
 

--- a/net/net.c
+++ b/net/net.c
@@ -5717,7 +5717,8 @@ static void *accept_thread(void *arg)
             rc = getpeername(new_fd, (struct sockaddr *)&cliaddr,
                              (socklen_t *)&clilen);
             if (rc) {
-              logmsg(LOGMSG_ERROR, "Failed to get peer address\n");
+              logmsg(LOGMSG_ERROR, "Failed to get peer address, error: %d %s\n",
+                     errno, strerror(errno));
               close(new_fd);
               continue;
             }

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -1299,7 +1299,7 @@ static int portmux_poll_v(portmux_fd_t **fds, nfds_t nfds, int timeoutms,
         return -1;
     }
 
-    int result;
+    int result = 0;
     bool build_pollfds = true;
 
     int startms = comdb2_time_epochms();


### PR DESCRIPTION
Show errno and str for case when we spew with `failed to get peer addres`