### PR TITLE
Fix recursive parsing dohast

### DIFF
--- a/db/ast.h
+++ b/db/ast.h
@@ -30,9 +30,10 @@ enum ast_type {
     AST_TYPE_UPDATE = 6
 };
 
-ast_t *ast_init(void);
 struct Vdbe;
 struct sqlite3;
+struct Parse;
+ast_t *ast_init(struct Parse *pParse, const char *caller);
 int ast_push(ast_t *ast, enum ast_type op, struct Vdbe *v, void *obj);
 void ast_destroy(ast_t **ast, struct sqlite3 *db);
 void ast_print(ast_t *ast);

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -254,17 +254,29 @@ struct ast {
     ast_node_t *stack;
     int nused;
     int nalloc;
+    int unsupported;
 };
 
-ast_t *ast_init(void)
+ast_t *ast_init(Parse *pParse, const char *caller)
 {
     ast_t *ast;
+
+    if (pParse->ast)
+        return pParse->ast->unsupported?NULL:pParse->ast;
+
+    if (gbl_dohast_verbose)
+        logmsg(LOGMSG_USER, "TTT: %lu %s from %s\n", pthread_self(),
+                __func__, caller);
+
+    if (!sqlite3IsToplevel(pParse)) {
+        ast = ast_init(sqlite3ParseToplevel(pParse), __func__);
+        if (ast) ast->unsupported = 1; 
+        return NULL;
+    }
 
     ast = calloc(1, sizeof(ast_t));
     if (!ast)
         return NULL;
-
-    ast->nused = 0;
     ast->nalloc = AST_STACK_INIT;
     ast->stack = calloc(ast->nalloc, sizeof(ast_node_t));
     if (!ast->stack) {
@@ -272,7 +284,7 @@ ast_t *ast_init(void)
         ast = NULL;
     }
 
-    return ast;
+    return pParse->ast = ast;
 }
 
 void ast_destroy(ast_t **past, sqlite3 *db)
@@ -653,6 +665,9 @@ int comdb2_check_parallel(Parse *pParse)
     int i;
 
     if (gbl_dohsql_disable)
+        return 0;
+
+    if (ast && ast->unsupported)
         return 0;
 
     if (has_parallel_sql(NULL) == 0)

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -262,15 +262,16 @@ ast_t *ast_init(Parse *pParse, const char *caller)
     ast_t *ast;
 
     if (pParse->ast)
-        return pParse->ast->unsupported?NULL:pParse->ast;
+        return pParse->ast->unsupported ? NULL : pParse->ast;
 
     if (gbl_dohast_verbose)
-        logmsg(LOGMSG_USER, "TTT: %lu %s from %s\n", pthread_self(),
-                __func__, caller);
+        logmsg(LOGMSG_USER, "TTT: %lu %s from %s\n", pthread_self(), __func__,
+               caller);
 
     if (!sqlite3IsToplevel(pParse)) {
         ast = ast_init(sqlite3ParseToplevel(pParse), __func__);
-        if (ast) ast->unsupported = 1; 
+        if (ast)
+            ast->unsupported = 1;
         return NULL;
     }
 

--- a/sqlite/src/delete.c
+++ b/sqlite/src/delete.c
@@ -331,8 +331,8 @@ void sqlite3DeleteFrom(
   if( v==0 ){
     goto delete_from_cleanup;
   }
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_DELETE, v, NULL);
+  ast_t *ast = ast_init(pParse, __func__);
+  if( ast ) ast_push(ast, AST_TYPE_DELETE, v, NULL);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT

--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -2782,8 +2782,8 @@ void sqlite3CodeRhsOfIN(
 
   if( ExprHasProperty(pExpr, EP_xIsSelect) ){
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( !pParse->ast ) pParse->ast = ast_init();
-    ast_push(pParse->ast, AST_TYPE_IN, v, NULL);
+    ast_t *ast = ast_init(pParse, __func__);
+    if( ast ) ast_push(ast, AST_TYPE_IN, v, NULL);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     /* Case 1:     expr IN (SELECT ...)
     **

--- a/sqlite/src/insert.c
+++ b/sqlite/src/insert.c
@@ -726,8 +726,8 @@ void sqlite3Insert(
     int rc;             /* Result code */
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( !pParse->ast ) pParse->ast = ast_init();
-    ast_push(pParse->ast, AST_TYPE_INSERT, v, NULL);
+    ast_t *ast = ast_init(pParse, __func__);
+    if( ast ) ast_push(ast, AST_TYPE_INSERT, v, NULL);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     regYield = ++pParse->nMem;
     addrTop = sqlite3VdbeCurrentAddr(v) + 1;

--- a/sqlite/src/prepare.c
+++ b/sqlite/src/prepare.c
@@ -674,6 +674,9 @@ int sqlite3SchemaToIndex(sqlite3 *db, Schema *pSchema){
 */
 void sqlite3ParserReset(Parse *pParse){
   sqlite3 *db = pParse->db;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  if( pParse->ast ) ast_destroy(&pParse->ast, db);
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   sqlite3DbFree(db, pParse->aLabel);
   sqlite3ExprListDelete(db, pParse->pConstExpr);
   if( db ){
@@ -850,7 +853,6 @@ end_prepare:
 
   sqlite3ParserReset(&sParse);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  if( sParse.ast ) ast_destroy(&sParse.ast, db);
   if( !wasPrepareOnly && isPrepareOnly ) db->flags &= ~SQLITE_PrepareOnly;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   return rc;

--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -5885,8 +5885,8 @@ int sqlite3Select(
 #endif
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_SELECT, v, p);
+  ast_t *ast = ast_init(pParse, __func__);
+  if( ast ) ast_push(ast, AST_TYPE_SELECT, v, p);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifndef SQLITE_OMIT_COMPOUND_SELECT
   /* Handle compound SELECT statements using the separate multiSelect()

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -3271,7 +3271,7 @@ struct Parse {
   u8 eOrconf;          /* Default ON CONFLICT policy for trigger steps */
   u8 disableTriggers;  /* True to disable triggers */
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-//  ast_t *ast;
+  ast_t *ast;
   int preserve_update;    /* statement replacement, preserve flags */
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
@@ -3327,7 +3327,6 @@ struct Parse {
   RenameToken *pRename;     /* Tokens subject to renaming by ALTER TABLE */
 #endif
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  ast_t *ast;
   int recording[MAX_CURSOR_IDS/sizeof(int)]; /* which cursors are recording? */
   u8 write;                 /* Write transaction during sqlite3FinishCoding? */
   Cdb2DDL *comdb2_ddl_ctx;  /* Context for DDL commands */

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -3270,6 +3270,10 @@ struct Parse {
   u8 eTriggerOp;       /* TK_UPDATE, TK_INSERT or TK_DELETE */
   u8 eOrconf;          /* Default ON CONFLICT policy for trigger steps */
   u8 disableTriggers;  /* True to disable triggers */
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+//  ast_t *ast;
+  int preserve_update;    /* statement replacement, preserve flags */
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
   /**************************************************************************
   ** Fields above must be initialized to zero.  The fields that follow,
@@ -3280,9 +3284,6 @@ struct Parse {
 
   int aTempReg[8];        /* Holding area for temporary registers */
   Token sNameToken;       /* Token with unqualified schema object name */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  int preserve_update;    /* statement replacement, preserve flags */
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
   /************************************************************************
   ** Above is constant between recursions.  Below is reset before and after
@@ -3326,10 +3327,10 @@ struct Parse {
   RenameToken *pRename;     /* Tokens subject to renaming by ALTER TABLE */
 #endif
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
+  ast_t *ast;
   int recording[MAX_CURSOR_IDS/sizeof(int)]; /* which cursors are recording? */
   u8 write;                 /* Write transaction during sqlite3FinishCoding? */
   Cdb2DDL *comdb2_ddl_ctx;  /* Context for DDL commands */
-  ast_t *ast;
   int prepare_only;         /* Prepare-only mode, skip schema changes that
                              * originate from DDL, etc.  This is primarily
                              * of interest to the DDL integration code in

--- a/sqlite/src/update.c
+++ b/sqlite/src/update.c
@@ -241,8 +241,8 @@ void sqlite3Update(
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   v = sqlite3GetVdbe(pParse);
   if( v==0 ) goto update_cleanup;
-  if( !pParse->ast ) pParse->ast = ast_init();
-  ast_push(pParse->ast, AST_TYPE_UPDATE, v, NULL);
+  ast_t *ast = ast_init(pParse, __func__);
+  if( ast ) ast_push(ast, AST_TYPE_UPDATE, v, NULL);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifdef SQLITE_ENABLE_UPDATE_DELETE_LIMIT
   if( !isView ){


### PR DESCRIPTION
There are two types of recursive parsing: nested parsing that reusing the Parse object, and another used currently by triggers and upserts that relies on a tree of Parse objects connected by pToplevel pointers.
Fixing the tree-based recursive parsing is similar with https://github.com/bloomberg/comdb2/pull/1620, but code makes sure the dohsql is disabled for the statement.
Fixing nested parsing (for which I don't have yet a statement) requires moving the ast member from the to-be-zeroed area in Parse object to the recursive/constant part.