### PR TITLE
Fix access to comdb2_fingerprints system table

### DIFF
--- a/sqlite/ext/comdb2/activelocks.c
+++ b/sqlite/ext/comdb2/activelocks.c
@@ -80,9 +80,13 @@ static void free_activelocks(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblActiveLocksModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblActivelocksInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_locks", get_activelocks,
-            free_activelocks, sizeof(systable_activelocks_t),
+    return create_system_table(db, "comdb2_locks", &systblActiveLocksModule,
+            get_activelocks, free_activelocks, sizeof(systable_activelocks_t),
             CDB2_INTEGER, "thread", -1, offsetof(systable_activelocks_t, threadid),
             CDB2_INTEGER, "lockerid", -1, offsetof(systable_activelocks_t, lockerid),
             CDB2_CSTRING, "mode", -1, offsetof(systable_activelocks_t, mode),

--- a/sqlite/ext/comdb2/activeosqls.c
+++ b/sqlite/ext/comdb2/activeosqls.c
@@ -150,10 +150,15 @@ static void free_osqls(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblActiveOsqlsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblActiveOsqlsInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_active_osqls", get_osqls, free_osqls, sizeof(systable_osqlsession_t),
+        db, "comdb2_active_osqls", &systblActiveOsqlsModule,
+        get_osqls, free_osqls, sizeof(systable_osqlsession_t),
         CDB2_CSTRING, "type", -1, offsetof(systable_osqlsession_t, type),
         CDB2_CSTRING, "origin", -1, offsetof(systable_osqlsession_t, origin),
         CDB2_CSTRING, "argv0", -1, offsetof(systable_osqlsession_t, argv0),

--- a/sqlite/ext/comdb2/blkseq.c
+++ b/sqlite/ext/comdb2/blkseq.c
@@ -103,10 +103,15 @@ static void free_blkseq(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblBlkseqModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblBlkseqInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_blkseq", get_blkseq, free_blkseq, sizeof(systable_blkseq_t),
+        db, "comdb2_blkseq", &systblBlkseqModule,
+        get_blkseq, free_blkseq, sizeof(systable_blkseq_t),
         CDB2_INTEGER, "stripe", -1, offsetof(systable_blkseq_t, stripe),
         CDB2_INTEGER, "index", -1, offsetof(systable_blkseq_t, ix),
         CDB2_CSTRING, "id", -1, offsetof(systable_blkseq_t, id),

--- a/sqlite/ext/comdb2/cluster.c
+++ b/sqlite/ext/comdb2/cluster.c
@@ -22,8 +22,13 @@ static void free_cluster(void *data, int num_points) {
     free(info);
 }
 
+sqlite3_module systblClusterModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblClusterInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_cluster", get_cluster, free_cluster, sizeof(struct cluster_info),
+    return create_system_table(db, "comdb2_cluster", &systblClusterModule,
+            get_cluster, free_cluster, sizeof(struct cluster_info),
             CDB2_CSTRING, "host", -1, offsetof(struct cluster_info, host),
             CDB2_INTEGER, "port",  -1, offsetof(struct cluster_info, port),
             CDB2_CSTRING, "is_master",  -1, offsetof(struct cluster_info, is_master),

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -277,6 +277,7 @@ const sqlite3_module systblColumnsModule = {
   0,                          /* xRelease */
   0,                          /* xRollbackTo */
   0,                          /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/constraints.c
+++ b/sqlite/ext/comdb2/constraints.c
@@ -299,6 +299,7 @@ const sqlite3_module systblConstraintsModule = {
   0,                             /* xRelease */
   0,                             /* xRollbackTo */
   0,                             /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/crons.c
+++ b/sqlite/ext/comdb2/crons.c
@@ -28,6 +28,13 @@
 static int systblCronSchedulersInit(sqlite3 *db);
 static int systblCronEventsInit(sqlite3 *db);
 
+sqlite3_module systblCronSchedulersModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+sqlite3_module systblCronEventsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblCronInit(sqlite3*db)
 {
     int rc;
@@ -41,8 +48,9 @@ int systblCronInit(sqlite3*db)
 static int systblCronSchedulersInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_cron_schedulers", cron_systable_schedulers_collect,
-        cron_systable_schedulers_free,  sizeof(systable_cron_scheds_t),
+        db, "comdb2_cron_schedulers", &systblCronSchedulersModule,
+        cron_systable_schedulers_collect, cron_systable_schedulers_free,
+        sizeof(systable_cron_scheds_t),
         CDB2_CSTRING, "name", -1, offsetof(systable_cron_scheds_t, name),
         CDB2_CSTRING, "type", -1, offsetof(systable_cron_scheds_t, type),
         CDB2_INTEGER, "running", -1, offsetof(systable_cron_scheds_t, running),
@@ -54,8 +62,9 @@ static int systblCronSchedulersInit(sqlite3 *db)
 static int systblCronEventsInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_cron_events", cron_systable_events_collect,
-        cron_systable_events_free,  sizeof(systable_cron_events_t),
+        db, "comdb2_cron_events", &systblCronEventsModule,
+        cron_systable_events_collect, cron_systable_events_free,
+        sizeof(systable_cron_events_t),
         CDB2_CSTRING, "name", -1, offsetof(systable_cron_events_t, name),
         CDB2_CSTRING, "type", -1, offsetof(systable_cron_events_t, type),
         CDB2_INTEGER, "epoch", -1, offsetof(systable_cron_events_t, epoch),
@@ -65,6 +74,5 @@ static int systblCronEventsInit(sqlite3 *db)
         CDB2_CSTRING, "sourceid", -1, offsetof(systable_cron_events_t, sourceid),
         SYSTABLE_END_OF_FIELDS);
 }
-
 
 #endif /* SQLITE_BUILDING_FOR_COMDB2 */

--- a/sqlite/ext/comdb2/ezsystables.h
+++ b/sqlite/ext/comdb2/ezsystables.h
@@ -10,15 +10,15 @@ enum {
 };
 
 /* All other types have enough information to determine size.  Blobs need a little help. */
-typedef struct { 
+typedef struct {
     void *value;
     size_t size;
 } systable_blobtype;
 
-int create_system_table(sqlite3 *db, char *name, 
-        int(*init_callback)(void **data, int *npoints), 
-        void(*release_callback)(void *data, int npoints), 
-        size_t struct_size, 
+int create_system_table(sqlite3 *db, char *name, sqlite3_module *module,
+        int(*init_callback)(void **data, int *npoints),
+        void(*release_callback)(void *data, int npoints),
+        size_t struct_size,
         // type, name, offset,  type2, name2, offset2, ..., SYSTABLE_END_OF_FIELDS
         ...);
 

--- a/sqlite/ext/comdb2/fingerprints.c
+++ b/sqlite/ext/comdb2/fingerprints.c
@@ -103,10 +103,15 @@ static int fingerprints_callback(void **data, int *npoints)
     return rc;
 }
 
+sqlite3_module systblFingerprintsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblFingerprintsInit(sqlite3 *db)
 {
     return create_system_table(db,
         "comdb2_fingerprints",
+        &systblFingerprintsModule,
         fingerprints_callback, release_callback,
         sizeof(struct fingerprint_track),
         CDB2_BLOB, "fingerprint", -1,

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -284,6 +284,7 @@ const sqlite3_module systblFieldsModule = {
   0,                         /* xRelease */
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -280,6 +280,7 @@ const sqlite3_module systblKeysModule = {
   0,                       /* xRelease */
   0,                       /* xRollbackTo */
   0,                       /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/keywords.c
+++ b/sqlite/ext/comdb2/keywords.c
@@ -211,6 +211,7 @@ const sqlite3_module systblKeywordsModule = {
   0,                        /* xRelease */
   0,                        /* xRollbackTo */
   0,                        /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) && \

--- a/sqlite/ext/comdb2/limits.c
+++ b/sqlite/ext/comdb2/limits.c
@@ -210,6 +210,7 @@ const sqlite3_module systblLimitsModule = {
     0,                      /* xRelease */
     0,                      /* xRollbackTo */
     0,                      /* xShadowName */
+    .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2))       \

--- a/sqlite/ext/comdb2/netuserfunc.c
+++ b/sqlite/ext/comdb2/netuserfunc.c
@@ -61,9 +61,14 @@ static void free_net_userfuncs(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblNetUserfuncsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblNetUserfuncsInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_net_userfuncs", get_net_userfuncs,
-            free_net_userfuncs, sizeof(systable_net_userfunc_t),
+    return create_system_table(db, "comdb2_net_userfuncs",
+            &systblNetUserfuncsModule, get_net_userfuncs, free_net_userfuncs,
+            sizeof(systable_net_userfunc_t),
             CDB2_CSTRING, "service", -1, offsetof(systable_net_userfunc_t, service),
             CDB2_CSTRING, "userfunc", -1, offsetof(systable_net_userfunc_t, userfunc),
             CDB2_INTEGER, "count", -1, offsetof(systable_net_userfunc_t, count),

--- a/sqlite/ext/comdb2/repnetqueue.c
+++ b/sqlite/ext/comdb2/repnetqueue.c
@@ -146,8 +146,13 @@ static void free_rep_net_queues(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblRepNetQueueStatModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblRepNetQueueStatInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_replication_netqueue", get_rep_net_queues,
+    return create_system_table(db, "comdb2_replication_netqueue",
+            &systblRepNetQueueStatModule, get_rep_net_queues,
             free_rep_net_queues, sizeof(systable_rep_qstat_t),
             CDB2_CSTRING, "machine", -1, offsetof(systable_rep_qstat_t, machine),
             CDB2_INTEGER, "total", -1, offsetof(systable_rep_qstat_t, total),

--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -130,18 +130,24 @@ void free_status(void *p, int n)
     free(sc_status_ents);
 }
 
+sqlite3_module systblScStatusModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblScStatusInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_sc_status", get_status, free_status,
-        sizeof(struct sc_status_ent), CDB2_CSTRING, "name", -1,
-        offsetof(struct sc_status_ent, name), CDB2_CSTRING, "type", -1,
-        offsetof(struct sc_status_ent, type), CDB2_CSTRING, "newcsc2", -1,
-        offsetof(struct sc_status_ent, newcsc2), CDB2_DATETIME, "start", -1,
-        offsetof(struct sc_status_ent, start), CDB2_CSTRING, "status", -1,
-        offsetof(struct sc_status_ent, status), CDB2_DATETIME, "last_updated",
-        -1, offsetof(struct sc_status_ent, lastupdated), CDB2_INTEGER,
-        "converted", -1, offsetof(struct sc_status_ent, converted),
+        db, "comdb2_sc_status", &systblScStatusModule,
+        get_status, free_status, sizeof(struct sc_status_ent),
+        CDB2_CSTRING, "name", -1, offsetof(struct sc_status_ent, name),
+        CDB2_CSTRING, "type", -1, offsetof(struct sc_status_ent, type),
+        CDB2_CSTRING, "newcsc2", -1, offsetof(struct sc_status_ent, newcsc2),
+        CDB2_DATETIME, "start", -1, offsetof(struct sc_status_ent, start),
+        CDB2_CSTRING, "status", -1, offsetof(struct sc_status_ent, status),
+        CDB2_DATETIME, "last_updated", -1, offsetof(struct sc_status_ent,
+                                                    lastupdated),
+        CDB2_INTEGER, "converted", -1, offsetof(struct sc_status_ent,
+                                                converted),
         CDB2_CSTRING, "error", -1, offsetof(struct sc_status_ent, error),
         SYSTABLE_END_OF_FIELDS);
 }

--- a/sqlite/ext/comdb2/sqlpoolqueue.c
+++ b/sqlite/ext/comdb2/sqlpoolqueue.c
@@ -63,11 +63,18 @@ static void free_sqlpoolqueue(void *p, int n)
     free(p);
 }
 
+sqlite3_module systblSqlpoolQueueModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
 int systblSqlpoolQueueInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_sqlpool_queue", get_sqlpoolqueue,
-            free_sqlpoolqueue, sizeof(systable_sqlpoolqueue_t),
-            CDB2_INTEGER, "time_in_queue_ms", -1, offsetof(systable_sqlpoolqueue_t, time_in_queue_ms),
-            CDB2_CSTRING, "sql", offsetof(systable_sqlpoolqueue_t, info_is_null),
-                offsetof(systable_sqlpoolqueue_t, info), SYSTABLE_END_OF_FIELDS);
+    return create_system_table(db, "comdb2_sqlpool_queue",
+        &systblSqlpoolQueueModule, get_sqlpoolqueue, free_sqlpoolqueue,
+        sizeof(systable_sqlpoolqueue_t),
+        CDB2_INTEGER, "time_in_queue_ms", -1, offsetof(systable_sqlpoolqueue_t,
+                                                       time_in_queue_ms),
+        CDB2_CSTRING, "sql", offsetof(systable_sqlpoolqueue_t, info_is_null),
+        offsetof(systable_sqlpoolqueue_t, info),
+        SYSTABLE_END_OF_FIELDS);
 }
 

--- a/sqlite/ext/comdb2/systables.c
+++ b/sqlite/ext/comdb2/systables.c
@@ -173,6 +173,7 @@ const sqlite3_module systblSystabsModule = {
     0,                       /* xRelease */
     0,                       /* xRollbackTo */
     0,                       /* xShadowName */
+    .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2))       \

--- a/sqlite/ext/comdb2/tablepermissions.c
+++ b/sqlite/ext/comdb2/tablepermissions.c
@@ -253,6 +253,7 @@ const sqlite3_module systblTablePermissionsModule = {
   0,                         /* xRelease */
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -202,6 +202,7 @@ const sqlite3_module systblTblSizeModule = {
   0,                       /* xRelease */
   0,                       /* xRollbackTo */
   0,                       /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/timepartitions.c
+++ b/sqlite/ext/comdb2/timepartitions.c
@@ -29,6 +29,17 @@ static int systblTimepartitionsInit(sqlite3 *db);
 static int systblTimepartitionsShardsInit(sqlite3 *db);
 static int systblTimepartitionsEventsInit(sqlite3 *db);
 
+sqlite3_module systblTimepartitionsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+sqlite3_module systblTimepartitionShardsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+sqlite3_module systblTimepartitionEventsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
+
 int systblTimepartInit(sqlite3*db)
 {
     int rc;
@@ -45,7 +56,8 @@ int systblTimepartInit(sqlite3*db)
 static int systblTimepartitionsInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_timepartitions", timepart_systable_timepartitions_collect,
+        db, "comdb2_timepartitions", &systblTimepartitionsModule,
+        timepart_systable_timepartitions_collect,
         timepart_systable_timepartitions_free,  sizeof(systable_timepartition_t),
         CDB2_CSTRING, "name", -1, offsetof(systable_timepartition_t, name),
         CDB2_CSTRING, "period", -1, offsetof(systable_timepartition_t, period),
@@ -61,7 +73,8 @@ static int systblTimepartitionsInit(sqlite3 *db)
 static int systblTimepartitionsShardsInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_timepartshards", timepart_systable_timepartshards_collect,
+        db, "comdb2_timepartshards", &systblTimepartitionShardsModule,
+        timepart_systable_timepartshards_collect,
         timepart_systable_timepartshards_free,  sizeof(systable_timepartshard_t),
         CDB2_CSTRING, "name", -1, offsetof(systable_timepartshard_t, name),
         CDB2_CSTRING, "shardname", -1, offsetof(systable_timepartshard_t, shardname),
@@ -73,7 +86,8 @@ static int systblTimepartitionsShardsInit(sqlite3 *db)
 static int systblTimepartitionsEventsInit(sqlite3 *db)
 {
     return create_system_table(
-        db, "comdb2_timepartevents", timepart_systable_timepartevents_collect,
+        db, "comdb2_timepartevents", &systblTimepartitionEventsModule,
+        timepart_systable_timepartevents_collect,
         timepart_systable_timepartevents_free,  sizeof(systable_cron_events_t),
         CDB2_CSTRING, "name", -1, offsetof(systable_cron_events_t, name),
         CDB2_CSTRING, "type", -1, offsetof(systable_cron_events_t, type),

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -294,4 +294,5 @@ const sqlite3_module systblTriggersModule = {
   0,                 /* xRelease */
   0,                 /* xRollbackTo */
   0,                 /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };

--- a/sqlite/ext/comdb2/typesamples.c
+++ b/sqlite/ext/comdb2/typesamples.c
@@ -85,8 +85,14 @@ void free_type_samples(void *p, int n) {
     free(p);
 }
 
+sqlite3_module systblTypeSamplesModule = {
+    .access_flag = CDB2_ALLOW_ALL,
+};
+
 int systblTypeSamplesInit(sqlite3 *db) {
-    return create_system_table(db, "comdb2_type_samples", get_type_samples, free_type_samples, sizeof(struct typesamples),
+    return create_system_table(db, "comdb2_type_samples",
+            &systblTypeSamplesModule, get_type_samples, free_type_samples,
+            sizeof(struct typesamples),
             CDB2_INTEGER, "integer", -1, offsetof(struct typesamples, integer),
             CDB2_REAL, "real", -1, offsetof(struct typesamples, real),
             CDB2_CSTRING, "cstring", -1, offsetof(struct typesamples, cstring),

--- a/sqlite/ext/comdb2/users.c
+++ b/sqlite/ext/comdb2/users.c
@@ -207,6 +207,7 @@ const sqlite3_module systblUsersModule = {
   0,                     /* xRelease */
   0,                     /* xRollbackTo */
   0,                     /* xShadowName */
+  .access_flag = CDB2_ALLOW_ALL,
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/tests/auth.test/t11.expected
+++ b/tests/auth.test/t11.expected
@@ -7,6 +7,7 @@
 [put password 'secret' for 'other'] rc 0
 [grant read on comdb2_transaction_logs to 'replicant'] rc 0
 [grant read on comdb2_metrics to 'sysmon'] rc 0
+[grant read on comdb2_fingerprints to 'sysmon'] rc 0
 (username='other', isOP='N')
 (username='replicant', isOP='N')
 (username='sysmon', isOP='N')
@@ -23,6 +24,8 @@
 (1=1)
 [select 1 from comdb2_cluster limit 1] rc 0
 (1=1)
+[select 1 from comdb2_fingerprints limit 1] rc 0
+(1=1)
 [select 1 from comdb2_locks limit 1] rc 0
 [select 1 from comdb2_logical_operations limit 1] rc 0
 (1=1)
@@ -31,6 +34,8 @@
 [select 1 from comdb2_net_userfuncs limit 1] rc 0
 (1=1)
 [select 1 from comdb2_opcode_handlers limit 1] rc 0
+(1=1)
+[select 1 from comdb2_plugins limit 1] rc 0
 [select 1 from comdb2_procedures limit 1] rc 0
 [select 1 from comdb2_queues limit 1] rc 0
 (count(*)=0)
@@ -75,11 +80,13 @@
 [select 1 from comdb2_appsock_handlers limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_clientstats limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_cluster limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_fingerprints limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_locks limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_metrics limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
@@ -91,7 +98,6 @@
 [select 1 from comdb2_timepartshards limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_type_samples limit 1] failed with rc -5 authorization denied
 [select " cannot access following system tables " as " replicant "] rc 0
 ( replicant =' limited access to following system tables ')
 [select " limited access to following system tables " as " replicant "] rc 0
@@ -113,6 +119,8 @@
 (1=1)
 [select 1 from comdb2_limits limit 1] rc 0
 (1=1)
+[select 1 from comdb2_type_samples limit 1] rc 0
+(1=1)
 [select 1 from comdb2_users limit 1] rc 0
 [set user 'sysmon'] rc 0
 [set password 'secret'] rc 0
@@ -124,6 +132,7 @@
 [select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
@@ -136,7 +145,6 @@
 [select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_transaction_logs limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_type_samples limit 1] failed with rc -5 authorization denied
 [select " cannot access following system tables " as " sysmon "] rc 0
 ( sysmon =' limited access to following system tables ')
 [select " limited access to following system tables " as " sysmon "] rc 0
@@ -152,11 +160,15 @@
 ( sysmon =' can access following system tables ')
 [select " can access following system tables " as " sysmon "] rc 0
 (1=1)
+[select 1 from comdb2_fingerprints limit 1] rc 0
+(1=1)
 [select 1 from comdb2_metrics limit 1] rc 0
 (1=1)
 [select 1 from comdb2_keywords limit 1] rc 0
 (1=1)
 [select 1 from comdb2_limits limit 1] rc 0
+(1=1)
+[select 1 from comdb2_type_samples limit 1] rc 0
 (1=1)
 [select 1 from comdb2_users limit 1] rc 0
 [set user 'other'] rc 0
@@ -165,11 +177,13 @@
 [select 1 from comdb2_appsock_handlers limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_clientstats limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_cluster limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_fingerprints limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_locks limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_metrics limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
@@ -182,7 +196,6 @@
 [select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_transaction_logs limit 1] failed with rc -5 authorization denied
 [select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_type_samples limit 1] failed with rc -5 authorization denied
 [select " cannot access following system tables " as " other "] rc 0
 ( other =' limited access to following system tables ')
 [select " limited access to following system tables " as " other "] rc 0
@@ -201,5 +214,7 @@
 [select 1 from comdb2_keywords limit 1] rc 0
 (1=1)
 [select 1 from comdb2_limits limit 1] rc 0
+(1=1)
+[select 1 from comdb2_type_samples limit 1] rc 0
 (1=1)
 [select 1 from comdb2_users limit 1] rc 0

--- a/tests/auth.test/t11.req
+++ b/tests/auth.test/t11.req
@@ -9,6 +9,7 @@ put password 'secret' for 'other'
 
 grant read on comdb2_transaction_logs to 'replicant'
 grant read on comdb2_metrics to 'sysmon'
+grant read on comdb2_fingerprints to 'sysmon'
 
 # The following must fail
 grant write on comdb2_metrics to 'sysmon'
@@ -22,12 +23,13 @@ select " can access all system tables " as " user1 (OP user) "
 select 1 from comdb2_appsock_handlers limit 1
 select 1 from comdb2_clientstats limit 1
 select 1 from comdb2_cluster limit 1
+select 1 from comdb2_fingerprints limit 1
 select 1 from comdb2_locks limit 1
 select 1 from comdb2_logical_operations limit 1
 select 1 from comdb2_metrics limit 1
 select 1 from comdb2_net_userfuncs limit 1
 select 1 from comdb2_opcode_handlers limit 1
-#select 1 from comdb2_plugins limit 1
+select 1 from comdb2_plugins limit 1
 select 1 from comdb2_procedures limit 1
 select 1 from comdb2_queues limit 1
 select count(*) from comdb2_repl_stats where host='dummy'
@@ -63,12 +65,13 @@ select " cannot access following system tables " as " replicant "
 select 1 from comdb2_appsock_handlers limit 1
 select 1 from comdb2_clientstats limit 1
 select 1 from comdb2_cluster limit 1
+select 1 from comdb2_fingerprints limit 1
 select 1 from comdb2_locks limit 1
 select 1 from comdb2_logical_operations limit 1
 select 1 from comdb2_metrics limit 1
 select 1 from comdb2_net_userfuncs limit 1
 select 1 from comdb2_opcode_handlers limit 1
-#select 1 from comdb2_plugins limit 1
+select 1 from comdb2_plugins limit 1
 select 1 from comdb2_procedures limit 1
 select 1 from comdb2_queues limit 1
 select 1 from comdb2_repl_stats limit 1
@@ -80,7 +83,6 @@ select 1 from comdb2_timepartitions limit 1
 select 1 from comdb2_timepartshards limit 1
 select 1 from comdb2_timeseries limit 1
 select 1 from comdb2_tunables limit 1
-select 1 from comdb2_type_samples limit 1
 
 select " limited access to following system tables " as " replicant "
 
@@ -98,6 +100,7 @@ select " can following system tables " as " replicant "
 select 1 from comdb2_transaction_logs limit 1
 select 1 from comdb2_keywords limit 1
 select 1 from comdb2_limits limit 1
+select 1 from comdb2_type_samples limit 1
 select 1 from comdb2_users limit 1
 
 # =============== sysmon ===============
@@ -114,7 +117,7 @@ select 1 from comdb2_locks limit 1
 select 1 from comdb2_logical_operations limit 1
 select 1 from comdb2_net_userfuncs limit 1
 select 1 from comdb2_opcode_handlers limit 1
-#select 1 from comdb2_plugins limit 1
+select 1 from comdb2_plugins limit 1
 select 1 from comdb2_procedures limit 1
 select 1 from comdb2_queues limit 1
 select 1 from comdb2_repl_stats limit 1
@@ -127,7 +130,6 @@ select 1 from comdb2_timepartshards limit 1
 select 1 from comdb2_timeseries limit 1
 select 1 from comdb2_transaction_logs limit 1
 select 1 from comdb2_tunables limit 1
-select 1 from comdb2_type_samples limit 1
 
 select " limited access to following system tables " as " sysmon "
 
@@ -142,9 +144,11 @@ select 1 from comdb2_triggers limit 1
 
 select " can access following system tables " as " sysmon "
 
+select 1 from comdb2_fingerprints limit 1
 select 1 from comdb2_metrics limit 1
 select 1 from comdb2_keywords limit 1
 select 1 from comdb2_limits limit 1
+select 1 from comdb2_type_samples limit 1
 select 1 from comdb2_users limit 1
 
 # =============== other ===============
@@ -157,12 +161,13 @@ select " cannot access following system tables " as " other "
 select 1 from comdb2_appsock_handlers limit 1
 select 1 from comdb2_clientstats limit 1
 select 1 from comdb2_cluster limit 1
+select 1 from comdb2_fingerprints limit 1
 select 1 from comdb2_locks limit 1
 select 1 from comdb2_logical_operations limit 1
 select 1 from comdb2_metrics limit 1
 select 1 from comdb2_net_userfuncs limit 1
 select 1 from comdb2_opcode_handlers limit 1
-#select 1 from comdb2_plugins limit 1
+select 1 from comdb2_plugins limit 1
 select 1 from comdb2_procedures limit 1
 select 1 from comdb2_queues limit 1
 select 1 from comdb2_repl_stats limit 1
@@ -175,7 +180,6 @@ select 1 from comdb2_timepartshards limit 1
 select 1 from comdb2_timeseries limit 1
 select 1 from comdb2_transaction_logs limit 1
 select 1 from comdb2_tunables limit 1
-select 1 from comdb2_type_samples limit 1
 
 select " limited access to following system tables " as " other "
 
@@ -192,5 +196,6 @@ select " can access following system tables " as " other "
 
 select 1 from comdb2_keywords limit 1
 select 1 from comdb2_limits limit 1
+select 1 from comdb2_type_samples limit 1
 select 1 from comdb2_users limit 1
 


### PR DESCRIPTION
The access property for system tables is set on per-module basis. But this was broken for tables created via ezsystables as it reuses the same object for all its tables. Fixed by having independent modules for all system tables.