### PR TITLE
Refactor bdb_osql_cache_table_versions

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -925,6 +925,7 @@ struct bdb_state_tag {
     unsigned int id;
     pthread_mutex_t gblcontext_lock;
     pthread_mutex_t children_lock;
+    signed char have_children_lock;
 
     FILE *bdblock_debug_fp;
     pthread_mutex_t bdblock_debug_lock;

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -8039,9 +8039,9 @@ retry:
     bdb_lock_children_lock(bdb_state);
     tran->table_version_cache_sz = tablecount = bdb_state->numchildren;
     tablenames = (char **)calloc(sizeof(char *), tablecount);
-    tran->table_version_cache = (unsigned long long *)calloc(tablecount,
-            sizeof(unsigned long long));
-    
+    tran->table_version_cache =
+        (unsigned long long *)calloc(tablecount, sizeof(unsigned long long));
+
     for (int i = 0; i < tablecount; i++) {
         if (bdb_state->children[i]) {
             tablenames[i] = strdup(bdb_state->children[i]->name);
@@ -8064,8 +8064,8 @@ retry:
             continue;
         if (tran->table_version_cache[i] == 0) {
             /* read it */
-            rc = bdb_get_file_version_data_by_name(NULL, tablenames[i], 0,
-                                           &tran->table_version_cache[i], bdberr);
+            rc = bdb_get_file_version_data_by_name(
+                NULL, tablenames[i], 0, &tran->table_version_cache[i], bdberr);
             if (rc) {
                 if (*bdberr == BDBERR_FETCH_DTA) {
                     rc = 0;
@@ -8094,9 +8094,10 @@ retry:
     for (int i = 0 ; i < tablecount && retry == 0; i++) {
         if ((tablenames[i] && !bdb_state->children[i]) ||
                 (!tablenames[i] && bdb_state->children[i]) ||
-                strcmp(tablenames[i], bdb_state->children[i]->name)) {
+                (tablenames[i] && bdb_state->children[i] &&
+                strcmp(tablenames[i], bdb_state->children[i]->name))) {
             retry = 1;
-        } else if (bdb_state->children[i]->version_num > 0 &&
+        } else if (bdb_state->children[i] && bdb_state->children[i]->version_num > 0 &&
                 bdb_state->children[i]->version_num != 
                 tran->table_version_cache[i]) {
             retry = 1;
@@ -8104,14 +8105,15 @@ retry:
     }
     if (!retry) {
         for (int i = 0; i < tablecount; i++) {
-            bdb_state->children[i]->version_num = tran->table_version_cache[i];
+            if (bdb_state->children[i])
+                bdb_state->children[i]->version_num = tran->table_version_cache[i];
         }
     }
     bdb_unlock_children_lock(bdb_state);
 
 done:
     if (tablenames) {
-        for(int i = 0; i < tablecount; i++) {
+        for (int i = 0; i < tablecount; i++) {
             if (tablenames[i])
                 free(tablenames[i]);
         }

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -8098,7 +8098,7 @@ retry:
             (tablenames[i] && bdb_state->children[i] &&
              strcmp(tablenames[i], bdb_state->children[i]->name))) {
             retry = 1;
-        /* Update children version number if it hasn't been set (is 0) */
+            /* Update children version number if it hasn't been set (is 0) */
         } else if (bdb_state->children[i] &&
                    bdb_state->children[i]->version_num > 0 &&
                    bdb_state->children[i]->version_num !=
@@ -8111,8 +8111,6 @@ retry:
             if (bdb_state->children[i])
                 bdb_state->children[i]->version_num =
                     tran->table_version_cache[i];
-
-
         }
     }
     bdb_unlock_children_lock(bdb_state);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -221,6 +221,7 @@ extern int gbl_flush_log_at_checkpoint;
 extern int gbl_online_recovery;
 extern int gbl_forbid_remote_admin;
 extern int gbl_abort_on_dta_lookup_error;
+extern int gbl_debug_children_lock;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1707,5 +1707,10 @@ REGISTER_TUNABLE("clean_exit_on_sigterm",
                  TUNABLE_BOOLEAN, &gbl_clean_exit_on_sigterm,
                  NOARG, NULL, NULL, update_clean_exit_on_sigterm, NULL);
 
+REGISTER_TUNABLE("debug_children_lock",
+                 "Stacktrace when database acquires or releases children lock."
+                 "  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_children_lock,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Don't hold the children lock while reading from berkley.
