### PR TITLE
net: Use comdb2_malloc to allocate network messages

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -884,7 +884,7 @@ struct dbtable *getqueuebyname(const char *name)
 
 int get_max_reclen(struct dbenv *dbenv)
 {
-    int max = 0;
+    int max = -1;
     char *fname, fname_tail[] = "_file_vers_map";
     int file, fnamelen;
     SBUF2 *sbfile;

--- a/db/glue.c
+++ b/db/glue.c
@@ -3956,17 +3956,16 @@ int open_bdb_env(struct dbenv *dbenv)
             return -1;
         }
 
-        net_set_pool_size(dbenv->handle_sibling, gbl_maxreclen + 300);
-        net_set_pool_size(dbenv->handle_sibling_offload, gbl_maxreclen + 300);
+        /* get the max rec len, or a sane default */
+        gbl_maxreclen = get_max_reclen(dbenv);
+        if (gbl_maxreclen < 0)
+            gbl_maxreclen = 512;
+        net_set_pool_size(dbenv->handle_sibling, (gbl_maxreclen + 300) * 1024);
+        net_set_pool_size(dbenv->handle_sibling_offload, (gbl_maxreclen + 300) * 1024);
 
         net_register_child_net(dbenv->handle_sibling,
                                dbenv->handle_sibling_offload, NET_SQL,
                                gbl_accept_on_child_nets);
-
-        /* get the max rec len, or a sane default */
-        gbl_maxreclen = get_max_reclen(dbenv);
-        if (gbl_maxreclen == 0)
-            gbl_maxreclen = 512;
 
 #if 0
         net_set_callback_data(dbenv->handle_sibling, dbenv);

--- a/db/glue.c
+++ b/db/glue.c
@@ -3961,7 +3961,8 @@ int open_bdb_env(struct dbenv *dbenv)
         if (gbl_maxreclen < 0)
             gbl_maxreclen = 512;
         net_set_pool_size(dbenv->handle_sibling, (gbl_maxreclen + 300) * 1024);
-        net_set_pool_size(dbenv->handle_sibling_offload, (gbl_maxreclen + 300) * 1024);
+        net_set_pool_size(dbenv->handle_sibling_offload,
+                          (gbl_maxreclen + 300) * 1024);
 
         net_register_child_net(dbenv->handle_sibling,
                                dbenv->handle_sibling_offload, NET_SQL,

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -426,10 +426,8 @@ static void *thd_req(void *vthd)
     int numwriterthreads;
 
     thread_started("request");
+    THREAD_TYPE("tag");
 
-#ifdef PER_THREAD_MALLOC
-    thread_type_key = "tag";
-#endif
     thr_self = thrman_register(THRTYPE_REQ);
     logger = thrman_get_reqlogger(thr_self);
 

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -4581,14 +4581,6 @@ clipper_usage:
         tok = segtok(line, lline, &st, &ltok);
         if (ltok == 0) {
             comdb2ma_stats(prefix, verbose, hr, ord, grp, 0);
-#ifndef PER_THREAD_MALLOC
-        } else if (tokcmp(tok, ltok, "net") == 0) {
-            tok = segtok(line, lline, &st, &ltok);
-            if (ltok == 0 || tokcmp(tok, ltok, "hr") != 0)
-                print_net_memstat(0);
-            else
-                print_net_memstat(1);
-#endif
         } else if (tokcmp(tok, ltok, "nice") == 0) {
             int nicerc;
             tok = segtok(line, lline, &st, &ltok);

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -111,11 +111,14 @@ struct mallinfo;
 typedef void (*stats_fn)(const struct mallinfo *mallinfo, int verbose,
                          int human_readable, void *arg);
 
-#ifdef PER_THREAD_MALLOC
 /*
 ** Thread type string.
 */
+#ifdef PER_THREAD_MALLOC
 extern __thread const char *thread_type_key;
+#define THREAD_TYPE(key) do { thread_type_key = (key); } while (0)
+#else
+#define THREAD_TYPE(key) do { (void)key; } while (0)
 #endif
 
 /*

--- a/net/net.c
+++ b/net/net.c
@@ -640,7 +640,8 @@ static int write_list(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr,
      * header) and all the data in our iovec. */
     insert = HOST_MALLOC(host_node_ptr, sizeof(write_data) + datasz);
     if (insert == NULL) {
-        logmsg(LOGMSG_ERROR, "%s: %s: %zu\n", __func__, strerror(errno), datasz);
+        logmsg(LOGMSG_ERROR, "%s: %s: %zu\n", __func__, strerror(errno),
+               datasz);
         return -1;
     }
 
@@ -2609,15 +2610,16 @@ static host_node_type *add_to_netinfo_ll(netinfo_type *netinfo_ptr,
 #ifdef PER_THREAD_MALLOC
     if (gbl_verbose_net)
         logmsg(LOGMSG_INFO, "creating %d byte buffer pool for node %s\n",
-                netinfo_ptr->pool_size, hostname);
+               netinfo_ptr->pool_size, hostname);
 
     size_t scopelen = ptr->hostname_len + sizeof(netinfo_ptr->service) + 1;
     char *scope = malloc(scopelen);
     snprintf(scope, scopelen, "%s@%s", netinfo_ptr->service, ptr->host);
-    ptr->msp = comdb2ma_create_with_scope(netinfo_ptr->pool_size,
-            0, "NET", scope, 1);
+    ptr->msp =
+        comdb2ma_create_with_scope(netinfo_ptr->pool_size, 0, "NET", scope, 1);
     if (ptr->msp == NULL) {
-        logmsg(LOGMSG_ERROR, "%s: couldn't init msp for %s\n", __func__, hostname);
+        logmsg(LOGMSG_ERROR, "%s: couldn't init msp for %s\n", __func__,
+               hostname);
         free(scope);
         free(ptr);
         return NULL;

--- a/net/net.c
+++ b/net/net.c
@@ -66,7 +66,6 @@
 #include <compat.h>
 
 #include <pool.h>
-#include <dlmalloc.h>
 #include <plhash.h>
 #include <assert.h>
 
@@ -118,6 +117,12 @@ extern int gbl_net_portmux_register_interval;
 
 int gbl_verbose_net = 0;
 int subnet_blackout_timems = 5000;
+
+#ifdef PER_THREAD_MALLOC
+#define HOST_MALLOC(h, sz) comdb2_malloc((h)->msp, (sz))
+#else
+#define HOST_MALLOC(h, sz) malloc(sz)
+#endif /* PER_THREAD_MALLOC */
 
 void net_set_subnet_blackout(int ms)
 {
@@ -633,46 +638,10 @@ static int write_list(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr,
 
     /* Malloc space for the list item struct (which includes the net message
      * header) and all the data in our iovec. */
-
-    /*
-    fprintf(stderr, "[%s] %d bytes\n", netinfo_ptr->service,
-       sizeof(write_data) + datasz);
-    */
-
-    if (sizeof(write_data) + datasz < netinfo_ptr->pool_size) {
-        Pthread_mutex_lock(&(host_node_ptr->pool_lock));
-
-        /*
-        fprintf(stderr, "[%s] using pool for %d bytes\n",
-           netinfo_ptr->service, sizeof(write_data) + datasz);
-        */
-
-        insert = pool_getablk(host_node_ptr->write_pool);
-        Pthread_mutex_unlock(&(host_node_ptr->pool_lock));
-        if (insert == NULL) {
-            logmsg(LOGMSG_ERROR, "%s: pool out of memory datasz=%u\n", __func__,
-                    (unsigned)datasz);
-            return -1;
-        }
-
-        insert->pooled = 1;
-    } else {
-/*
-fprintf(stderr, "[%s] using malloc for %d bytes\n",
-   netinfo_ptr->service, sizeof(write_data) + datasz);
-*/
-
-#ifdef PER_THREAD_MALLOC
-        insert = malloc(sizeof(write_data) + datasz);
-#else
-        insert = comdb2_malloc(host_node_ptr->msp, sizeof(write_data) + datasz);
-#endif
-        if (insert == NULL) {
-            logmsg(LOGMSG_ERROR, "%s: mspace out of memory datasz=%u\n", __func__,
-                    (unsigned)datasz);
-            return -1;
-        }
-        insert->pooled = 0;
+    insert = HOST_MALLOC(host_node_ptr, sizeof(write_data) + datasz);
+    if (insert == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: %s: %zu\n", __func__, strerror(errno), datasz);
+        return -1;
     }
 
     insert->flags = flags;
@@ -1094,19 +1063,7 @@ static int empty_write_list(host_node_type *host_node_ptr)
     nxt = ptr = host_node_ptr->write_head;
     while (nxt != NULL) {
         ptr = ptr->next;
-
-        if (nxt->pooled) {
-            Pthread_mutex_lock(&(host_node_ptr->pool_lock));
-            pool_relablk(host_node_ptr->write_pool, nxt);
-            Pthread_mutex_unlock(&(host_node_ptr->pool_lock));
-        } else {
-#ifdef PER_THREAD_MALLOC
-            free(nxt);
-#else
-            comdb2_free(nxt);
-#endif
-        }
-
+        free(nxt);
         nxt = ptr;
     }
     host_node_ptr->write_head = host_node_ptr->write_tail = NULL;
@@ -1396,7 +1353,7 @@ static int write_hello(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr)
         if (tmp_host_ptr->hostname_len > HOSTNAME_LEN)
             datasz += tmp_host_ptr->hostname_len;
     }
-    data = malloc(datasz);
+    data = HOST_MALLOC(host_node_ptr, datasz);
     memset(data, 0, datasz);
 
     p_buf = (uint8_t *)data;
@@ -1483,7 +1440,7 @@ static int write_hello_reply(netinfo_type *netinfo_ptr,
         if (tmp_host_ptr->hostname_len > HOSTNAME_LEN)
             datasz += tmp_host_ptr->hostname_len;
     }
-    data = malloc(datasz);
+    data = HOST_MALLOC(host_node_ptr, datasz);
     memset(data, 0, datasz);
 
     p_buf = (uint8_t *)data;
@@ -1563,7 +1520,7 @@ static seq_data *add_seqnum_to_waitlist(host_node_type *host_node_ptr,
                                         int seqnum)
 {
     seq_data *new_seq_node, *seq_list_ptr;
-    new_seq_node = malloc(sizeof(seq_data));
+    new_seq_node = HOST_MALLOC(host_node_ptr, sizeof(seq_data));
     new_seq_node->seqnum = seqnum;
     new_seq_node->ack = 0;
     new_seq_node->outrc = 0;
@@ -2649,6 +2606,26 @@ static host_node_type *add_to_netinfo_ll(netinfo_type *netinfo_ptr,
         abort();
     }
 
+#ifdef PER_THREAD_MALLOC
+    if (gbl_verbose_net)
+        logmsg(LOGMSG_INFO, "creating %d byte buffer pool for node %s\n",
+                netinfo_ptr->pool_size, hostname);
+
+    size_t scopelen = ptr->hostname_len + sizeof(netinfo_ptr->service) + 1;
+    char *scope = malloc(scopelen);
+    snprintf(scope, scopelen, "%s@%s", netinfo_ptr->service, ptr->host);
+    ptr->msp = comdb2ma_create_with_scope(netinfo_ptr->pool_size,
+            0, "NET", scope, 1);
+    if (ptr->msp == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: couldn't init msp for %s\n", __func__, hostname);
+        free(scope);
+        free(ptr);
+        return NULL;
+    }
+#endif /* PER_THREAD_MALLOC */
+
+    Pthread_mutex_init(&(ptr->write_lock), NULL);
+
     ptr->netinfo_ptr = netinfo_ptr;
     ptr->closed = 1;
     ptr->really_closed = 1;
@@ -2662,33 +2639,10 @@ static host_node_type *add_to_netinfo_ll(netinfo_type *netinfo_ptr,
     ptr->timestamp = time(NULL);
 
     Pthread_mutex_init(&(ptr->lock), NULL);
-    Pthread_mutex_init(&(ptr->pool_lock), NULL);
     Pthread_mutex_init(&(ptr->timestamp_lock), NULL);
 
     ptr->user_data_buf = malloc(netinfo_ptr->user_data_buf_size);
 
-    if (gbl_verbose_net)
-        logmsg(LOGMSG_INFO, "creating %d byte buffer pool for node %s\n",
-                netinfo_ptr->pool_size, hostname);
-
-    ptr->write_pool = pool_setalloc_init(
-        netinfo_ptr->pool_size, netinfo_ptr->pool_extend, malloc, free);
-
-    if (ptr->write_pool == NULL) {
-        logmsg(LOGMSG_ERROR, "%s: couldn't init write_lock for node %s\n", __func__,
-                ptr->host);
-        goto err;
-    }
-
-#ifndef PER_THREAD_MALLOC
-    ptr->msp = comdb2ma_create(0, 0, "net", 1);
-    if (ptr->msp == NULL) {
-        logmsg(LOGMSG_ERROR, "%s: couldn't init msp for %s\n", __func__, hostname);
-        goto err;
-    }
-#endif /* !PER_THREAD_MALLOC */
-
-    Pthread_mutex_init(&(ptr->write_lock), NULL);
     Pthread_mutex_init(&(ptr->enquelk), NULL);
     Pthread_mutex_init(&(ptr->wait_mutex), NULL);
     Pthread_mutex_init(&(ptr->throttle_lock), NULL);
@@ -2710,10 +2664,6 @@ static host_node_type *add_to_netinfo_ll(netinfo_type *netinfo_ptr,
     free(metric_name);
 
     return ptr;
-
-err:
-    free(ptr);
-    return NULL;
 }
 
 host_node_type *add_to_netinfo(netinfo_type *netinfo_ptr, const char hostname[],
@@ -2807,7 +2757,6 @@ static void rem_from_netinfo_ll(netinfo_type *netinfo_ptr,
     Pthread_mutex_unlock(&(host_node_ptr->lock));
     Pthread_mutex_destroy(&(host_node_ptr->lock));
     Pthread_mutex_destroy(&(host_node_ptr->timestamp_lock));
-    Pthread_mutex_destroy(&(host_node_ptr->pool_lock));
     Pthread_mutex_destroy(&(host_node_ptr->write_lock));
     Pthread_mutex_destroy(&(host_node_ptr->enquelk));
     Pthread_mutex_destroy(&(host_node_ptr->wait_mutex));
@@ -2817,10 +2766,9 @@ static void rem_from_netinfo_ll(netinfo_type *netinfo_ptr,
     Pthread_cond_destroy(&(host_node_ptr->write_wakeup));
     Pthread_cond_destroy(&(host_node_ptr->throttle_wakeup));
 
-    pool_free(host_node_ptr->write_pool);
-#ifndef PER_THREAD_MALLOC
+#ifdef PER_THREAD_MALLOC
     comdb2ma_destroy(host_node_ptr->msp);
-#endif
+#endif /* PER_THREAD_MALLOC */
 
     free(host_node_ptr->user_data_buf);
     sbuf2free(host_node_ptr->sb);
@@ -3073,138 +3021,6 @@ typedef struct netinfo_node {
 static LISTC_T(netinfo_node_t) nets_list;
 static pthread_mutex_t nets_list_lk = PTHREAD_MUTEX_INITIALIZER;
 
-#ifndef PER_THREAD_MALLOC
-
-static char *to_human_readable(int num, char buf[], int len)
-{
-    if (num >> 30) /* GB should be sufficient */
-        snprintf(buf, len, "%.2f%c", (double)num / (1 << 30), 'G');
-    else if (num >> 20)
-        snprintf(buf, len, "%.2f%c", (double)num / (1 << 20), 'M');
-    else if (num >> 10)
-        snprintf(buf, len, "%.2f%c", (double)num / (1 << 10), 'K');
-    else if (num != 0)
-        snprintf(buf, len, "%d%c", num, 'B');
-    else
-        snprintf(buf, len, "0");
-
-    return buf;
-}
-
-void print_net_memstat(int human_readable)
-{
-
-    netinfo_node_t *curpos;
-    netinfo_type *netinfo_ptr;
-    host_node_type *host_node_ptr;
-
-    size_t seq_netinfo;
-    int npool, nused, nblocks, hostlen;
-    int total_npool, total_nused, total_nblocks;
-    struct mallinfo mspinfo;
-    int total_numsp, total_nfmsp;
-    char hrn[12]; // Human Readable Number
-    int tbl_width;
-    char *tbl_breakline;
-
-    Pthread_mutex_lock(&nets_list_lk);
-
-    logmsg(LOGMSG_USER, "number of net handles created: %d\n\n", nets_list.count);
-    seq_netinfo = 1;
-
-    LISTC_FOR_EACH(&nets_list, curpos, lnk)
-    {
-        hostlen = 10;
-        netinfo_ptr = curpos->netinfo_ptr;
-        logmsg(LOGMSG_USER,
-               "netinfo #%-4zu(%p): app = %s, service = %s, instance = %s\n",
-               seq_netinfo, netinfo_ptr, netinfo_ptr->app, netinfo_ptr->service,
-               netinfo_ptr->instance);
-
-        Pthread_rwlock_rdlock(&(netinfo_ptr->lock));
-        for (host_node_ptr = netinfo_ptr->head; host_node_ptr != NULL;
-             host_node_ptr = host_node_ptr->next) {
-            if (strlen(host_node_ptr->host) > hostlen)
-                hostlen = strlen(host_node_ptr->host);
-        }
-
-        ++hostlen; // make an extra space
-
-        tbl_width =
-            logmsg(LOGMSG_USER, "%-*s | %12s | %12s | %12s | %12s | %12s | %12s\n", hostlen,
-                   "host", "pool total", "pool used", "pool free",
-                   "mspace total", "mspace used", "mspace free");
-        tbl_breakline = alloca(tbl_width);
-        memset(tbl_breakline, '-', tbl_width);
-        logmsg(LOGMSG_USER, "%.*s\n", tbl_width, tbl_breakline);
-
-        total_npool = total_nused = total_nblocks = 0;
-        total_numsp = total_nfmsp = 0;
-
-        for (host_node_ptr = netinfo_ptr->head; host_node_ptr != NULL;
-             host_node_ptr = host_node_ptr->next) {
-            npool = nused = nblocks = 0;
-            pool_info(host_node_ptr->write_pool, &npool, &nused, &nblocks);
-            npool *= netinfo_ptr->pool_size;
-            nused *= netinfo_ptr->pool_size;
-
-            total_npool += npool;
-            total_nused += nused;
-            total_nblocks += nblocks;
-
-            mspinfo = comdb2_mallinfo(host_node_ptr->msp);
-            total_numsp += mspinfo.uordblks;
-            total_nfmsp += mspinfo.fordblks;
-
-            logmsg(LOGMSG_USER, "%-*s | ", hostlen, host_node_ptr->host);
-
-            if (!human_readable)
-                logmsg(LOGMSG_USER,
-                       "%12d | %12d | %12d | %12zu | %12zu | %12zu\n", npool,
-                       nused, npool - nused,
-                       mspinfo.uordblks + mspinfo.fordblks, mspinfo.uordblks,
-                       mspinfo.fordblks);
-            else {
-                logmsg(LOGMSG_USER, "%12s | ", to_human_readable(npool, hrn, sizeof(hrn)));
-                logmsg(LOGMSG_USER, "%12s | ", to_human_readable(nused, hrn, sizeof(hrn)));
-                logmsg(LOGMSG_USER, "%12s | ",
-                       to_human_readable(npool - nused, hrn, sizeof(hrn)));
-                logmsg(LOGMSG_USER, "%12s | ",
-                       to_human_readable(mspinfo.uordblks + mspinfo.fordblks,
-                                         hrn, sizeof(hrn)));
-                logmsg(LOGMSG_USER, "%12s | ",
-                       to_human_readable(mspinfo.uordblks, hrn, sizeof(hrn)));
-                logmsg(LOGMSG_USER, "%12s\n",
-                       to_human_readable(mspinfo.fordblks, hrn, sizeof(hrn)));
-            }
-        }
-        Pthread_rwlock_unlock(&(netinfo_ptr->lock));
-
-        ++seq_netinfo;
-
-        logmsg(LOGMSG_USER, "%-*s | ", hostlen, "total");
-
-        if (!human_readable)
-            logmsg(LOGMSG_USER, "%12d | %12d | %12d | %12d | %12d | %12d\n", total_npool,
-                   total_nused, total_npool - total_nused,
-                   total_numsp + total_nfmsp, total_numsp, total_nfmsp);
-        else {
-            logmsg(LOGMSG_USER, "%12s | ", to_human_readable(total_npool, hrn, sizeof(hrn)));
-            logmsg(LOGMSG_USER, "%12s | ", to_human_readable(total_nused, hrn, sizeof(hrn)));
-            logmsg(LOGMSG_USER, "%12s | ", to_human_readable(total_npool - total_nused, hrn,
-                                                sizeof(hrn)));
-            logmsg(LOGMSG_USER, "%12s | ", to_human_readable(total_numsp + total_nfmsp, hrn,
-                                                sizeof(hrn)));
-            logmsg(LOGMSG_USER, "%12s | ", to_human_readable(total_numsp, hrn, sizeof(hrn)));
-            logmsg(LOGMSG_USER, "%12s\n", to_human_readable(total_nfmsp, hrn, sizeof(hrn)));
-        }
-        logmsg(LOGMSG_USER, "%.*s\n\n", tbl_width, tbl_breakline);
-    }
-
-    Pthread_mutex_unlock(&nets_list_lk);
-}
-#endif
-
 netinfo_type *create_netinfo_int(char myhostname[], int myportnum, int myfd,
                                  char app[], char service[], char instance[],
                                  int fake, int offload, int ischild,
@@ -3298,8 +3114,7 @@ netinfo_type *create_netinfo_int(char myhostname[], int myportnum, int myfd,
     Pthread_mutex_init(&(netinfo_ptr->watchlk), NULL);
     Pthread_mutex_init(&(netinfo_ptr->sanclk), NULL);
 
-    netinfo_ptr->pool_size = 512;
-    netinfo_ptr->pool_extend = 1024;
+    netinfo_ptr->pool_size = 512 * 1024;
     netinfo_ptr->user_data_buf_size = 256 * 1024;
 
     netinfo_ptr->throttle_percent = 50;
@@ -3573,7 +3388,7 @@ static int read_user_data(host_node_type *host_node_ptr, int *type, int *seqnum,
             *data = host_node_ptr->user_data_buf;
             *malloced = 0;
         } else {
-            *data = malloc(*datalen);
+            *data = HOST_MALLOC(host_node_ptr, *datalen);
             *malloced = 1;
         }
 
@@ -3679,7 +3494,7 @@ static int process_payload_ack(netinfo_type *netinfo_ptr,
         p_net_ack_message_payload.paylen <= 0)
         return -1;
 
-    payload = malloc(p_net_ack_message_payload.paylen);
+    payload = HOST_MALLOC(host_node_ptr, p_net_ack_message_payload.paylen);
     rc = read_stream(netinfo_ptr, host_node_ptr, host_node_ptr->sb, payload,
                      p_net_ack_message_payload.paylen);
 
@@ -3812,7 +3627,7 @@ static int process_user_message(netinfo_type *netinfo_ptr,
     if (usertype >= 0 && usertype <= MAX_USER_TYPE &&
          netinfo_ptr->userfuncs[usertype].func != NULL) {
         if (needack) {
-            ack_state = malloc(sizeof(ack_state_type));
+            ack_state = HOST_MALLOC(host_node_ptr, sizeof(ack_state_type));
             ack_state->seqnum = seqnum;
             ack_state->needack = needack;
             ack_state->fromhost = host_node_ptr->host;
@@ -4103,7 +3918,7 @@ static int process_decom_name(netinfo_type *netinfo_ptr,
                hostlen);
         return -1;
     }
-    host = malloc(hostlen);
+    host = HOST_MALLOC(host_node_ptr, hostlen);
     if (host == NULL) {
         logmsg(LOGMSG_ERROR, "%s:err can't allocate %d bytes for hostname\n",
                __func__, hostlen);
@@ -4210,6 +4025,7 @@ static void *writer_thread(void *args)
     struct timeval tv;
 #endif
     thread_started("net writer");
+    THREAD_TYPE(__func__);
 
     host_node_ptr = args;
     netinfo_ptr = host_node_ptr->netinfo_ptr;
@@ -4317,18 +4133,7 @@ static void *writer_thread(void *args)
 
                 write_list_back = write_list_ptr;
                 write_list_ptr = write_list_ptr->next;
-
-                if (write_list_back->pooled) {
-                    Pthread_mutex_lock(&(host_node_ptr->pool_lock));
-                    pool_relablk(host_node_ptr->write_pool, write_list_back);
-                    Pthread_mutex_unlock(&(host_node_ptr->pool_lock));
-                } else {
-#ifdef PER_THREAD_MALLOC
-                    free(write_list_back);
-#else
-                    comdb2_free(write_list_back);
-#endif
-                }
+                free(write_list_back);
             }
             /* we seem to set nodelay on virtually every message.  try to get
              * slightly better streaming performance by moving the flush out of
@@ -4489,6 +4294,7 @@ static void *reader_thread(void *arg)
     char fromhost[256], tohost[256];
 
     thread_started("net reader");
+    THREAD_TYPE(__func__);
 
     host_node_ptr = arg;
     netinfo_ptr = host_node_ptr->netinfo_ptr;
@@ -4902,6 +4708,7 @@ static void *connect_thread(void *arg)
     int connport = -1;
 
     thread_started("connect thread");
+    THREAD_TYPE(__func__);
 
     int len;
 
@@ -5653,10 +5460,7 @@ static void *accept_thread(void *arg)
     unsigned int last_stat_dump_time = comdb2_time_epochms();
 
     thread_started("net accept");
-
-#ifdef PER_THREAD_MALLOC
-    thread_type_key = "net_accept_thr";
-#endif
+    THREAD_TYPE(__func__);
 
     netinfo_ptr = (netinfo_type *)arg;
 

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -66,7 +66,6 @@ BB_COMPILE_TIME_ASSERT(net_write_header_type,
 typedef struct write_node_data {
     int flags;
     int enque_time;
-    int pooled;
     struct write_node_data *next;
     struct write_node_data *prev;
     size_t len;
@@ -189,7 +188,7 @@ struct host_node_tag {
     pthread_mutex_t pool_lock;
     void *write_pool;
 
-#ifndef PER_THREAD_MALLOC
+#ifdef PER_THREAD_MALLOC
     comdb2ma msp;
 #endif
 
@@ -311,7 +310,6 @@ struct netinfo_struct {
     int trace;
 
     int pool_size;
-    int pool_extend;
 
     int user_data_buf_size;
     int net_test;

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -185,9 +185,6 @@ struct host_node_tag {
     struct netinfo_struct *netinfo_ptr;
     stats_type stats; /* useful per host */
 
-    pthread_mutex_t pool_lock;
-    void *write_pool;
-
 #ifdef PER_THREAD_MALLOC
     comdb2ma msp;
 #endif

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -618,9 +618,7 @@ static void *thdpool_thd(void *voidarg)
 
     thread_started("thdpool");
 
-#ifdef PER_THREAD_MALLOC
-    thread_type_key = pool->name;
-#endif
+    THREAD_TYPE(pool->name);
     thd->archtid = getarchtid();
 
     if (pool->per_thread_data_sz > 0) {


### PR DESCRIPTION
Currently network messages are allocated from a pool (bbinc/pool.h). A pool holds memory chunks of the same size. A pool does not free its memory (unless it's being destroyed). Each host in each net has its own pool and does not share it with each other or any other components in the system. The design has a few shortcomings:

1. The pool entry size is set to the maximum row length in the database, plus 300. It wastes a lot of memory for messages shorter than the entry size.
2. It cannot handle messages longer than entry size, for which we have to fall back to malloc().
3. The memory held by a pool can never be released back to the OS or be reused by other subsystems.

comdb2_malloc has a few advantages over the pool allocation:

1. It works for an allocation of any size.
2. It not only saves memory but also runs faster than a pool for messages shorter than the pool's entry size.
3. It calls free() when necessary. Hence the memory can be released back to the OS, or at least can be reused by other subsystems in the same process.
4. Its usage is tracked under the memstat screen so that we know precisely where the memory goes in the net layer.

The patch also removes some dead code from net.

(DRQS 144060953)