### PR TITLE
Make clean exit on SIGTERM optional

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -768,6 +768,8 @@ int64_t gbl_temptable_spills;
 
 int gbl_osql_odh_blob = 1;
 
+int gbl_clean_exit_on_sigterm = 0;
+
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();
 int free_gbl_tunables();

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -768,7 +768,7 @@ int64_t gbl_temptable_spills;
 
 int gbl_osql_odh_blob = 1;
 
-int gbl_clean_exit_on_sigterm = 0;
+int gbl_clean_exit_on_sigterm = 1;
 
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();
@@ -5244,7 +5244,8 @@ int main(int argc, char **argv)
     sact.sa_flags = 0;
     sigaction(SIGXFSZ, &sact, NULL);
 
-    signal(SIGTERM, clean_exit_sigwrap);
+    if (gbl_clean_exit_on_sigterm)
+        signal(SIGTERM, clean_exit_sigwrap);
 
     if (debug_switch_skip_skipables_on_verify())
         gbl_berkdb_verify_skip_skipables = 1;

--- a/db/config.c
+++ b/db/config.c
@@ -344,7 +344,8 @@ static char *legacy_options[] = {"disallow write from beta if prod",
                                  "on disable_etc_services_lookup",
                                  "off osql_odh_blob",
                                  "legacy_schema on",
-                                 "online_recovery off"};
+                                 "online_recovery off",
+                                 "clean_exit_on_sigterm off"};
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)
 {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -720,7 +720,6 @@ static int update_clean_exit_on_sigterm(void *context, void *value) {
         signal(SIGTERM, clean_exit_sigwrap);
     else
         signal(SIGTERM, SIG_DFL);
-    printf("turning SIGTERM handling %s\n", val ? "on" : "off");
 
     return 0;
 }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -298,6 +298,8 @@ extern int gbl_selectv_writelock;
 
 int gbl_debug_tmptbl_corrupt_mem;
 
+extern int gbl_clean_exit_on_sigterm;
+
 /*
   =========================================================
   Value/Update/Verify functions for some tunables that need
@@ -707,6 +709,19 @@ static int deadlock_policy_override_update(void *context, void *value)
     *(int *)tunable->var = val;
     logmsg(LOGMSG_INFO, "Set deadlock policy to %s\n",
            deadlock_policy_str(val));
+    return 0;
+}
+
+extern void clean_exit_sigwrap(int signum);
+
+static int update_clean_exit_on_sigterm(void *context, void *value) {
+    int val = *(int *)value;
+    if (val)
+        signal(SIGTERM, clean_exit_sigwrap);
+    else
+        signal(SIGTERM, SIG_DFL);
+    printf("turning SIGTERM handling %s\n", val ? "on" : "off");
+
     return 0;
 }
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -721,6 +721,8 @@ static int update_clean_exit_on_sigterm(void *context, void *value) {
     else
         signal(SIGTERM, SIG_DFL);
 
+    gbl_clean_exit_on_sigterm = val;
+
     return 0;
 }
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -346,6 +346,7 @@ REGISTER_TUNABLE("enable_lowpri_snapisol",
                  "state. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_lowpri_snapisol_sessions,
                  READONLY | NOARG, NULL, NULL, NULL, NULL);
+
 /*
 REGISTER_TUNABLE("enable_new_snapshot",
                  "Enable new SNAPSHOT implementation. (Default: off)",
@@ -1700,5 +1701,11 @@ REGISTER_TUNABLE("selectv_writelock",
                  "Acquire a writelock for selectv records.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_selectv_writelock,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("clean_exit_on_sigterm",
+                 "Attempt to do orderly shutdown on SIGTERM (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_clean_exit_on_sigterm,
+                 NOARG, NULL, NULL, update_clean_exit_on_sigterm, NULL);
+
 
 #endif /* _DB_TUNABLES_H */

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -888,6 +888,7 @@ These options are toggle-able at runtime.
 |blobmem_sz_thresh_kb | not set | Sets the threshold (in kb) above which blobs are allocated by the blob allocator.
 |logmsg   |  | Controls the database logging level - accepts [logging commands](op.html#logging-commands).
 | pbkdf2_iterations | 4096 | Number of PBKDF2 iterations. PBKDF2 is used for password hashing. The higher the value, the more secure and the more computationally expensive. The mininum number of iterations is 4096.
+|clean_exit_on_sigterm | 1 | When enabled, SIGTERM will cause database to do an orderly shutdown.  When disabled follows system SIGTERM default (terminate, no core) 
 
 <!-- TODO
 |enable_datetime_truncation | |

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=913)
+(TUNABLES_COUNT=914)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -117,6 +117,7 @@
 (name='checksums', description='Checksum data pages. Turning this off is highly discouraged.', type='BOOLEAN', value='ON', read_only='N')
 (name='chk_aa_time', description='Check whether we should start analyze this often.', type='INTEGER', value='180', read_only='N')
 (name='chkpoint_alarm_time', description='Warn if checkpoints are taking more than this many seconds. (Default: 60 secs)', type='INTEGER', value='60', read_only='Y')
+(name='clean_exit_on_sigterm', description='Attempt to do orderly shutdown on SIGTERM (Default: on)', type='BOOLEAN', value='ON', read_only='N') 
 (name='coherency_lease', description='A coherency lease grants a replicant the right to be coherent for this many ms.', type='INTEGER', value='500', read_only='N')
 (name='coherency_lease_udp', description='Use udp to issue leases.', type='BOOLEAN', value='ON', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -117,7 +117,7 @@
 (name='checksums', description='Checksum data pages. Turning this off is highly discouraged.', type='BOOLEAN', value='ON', read_only='N')
 (name='chk_aa_time', description='Check whether we should start analyze this often.', type='INTEGER', value='180', read_only='N')
 (name='chkpoint_alarm_time', description='Warn if checkpoints are taking more than this many seconds. (Default: 60 secs)', type='INTEGER', value='60', read_only='Y')
-(name='clean_exit_on_sigterm', description='Attempt to do orderly shutdown on SIGTERM (Default: on)', type='BOOLEAN', value='ON', read_only='N') 
+(name='clean_exit_on_sigterm', description='Attempt to do orderly shutdown on SIGTERM (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='coherency_lease', description='A coherency lease grants a replicant the right to be coherent for this many ms.', type='INTEGER', value='500', read_only='N')
 (name='coherency_lease_udp', description='Use udp to issue leases.', type='BOOLEAN', value='ON', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
Make orderly database shutdown on SIGTERM optional.  Tunable toggles behavior.  Legacy options disable by default.