### PR TITLE
Don't skip sqlite_stat* tables on a repoplrl

### DIFF
--- a/db/db_util.c
+++ b/db/db_util.c
@@ -400,10 +400,6 @@ int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
 
     /* add table definitions */
     for (i = 0; i < num_tables; ++i) {
-        if (strncmp(p_table_names[i], "sqlite_stat",
-                    sizeof("sqlite_stat") - 1) == 0)
-            continue;
-
         sbuf2printf(sb_out, "table %s %s", p_table_names[i], p_csc2_paths[i]);
 
         if (table_nums[i])


### PR DESCRIPTION
Legacy database creation needs to have those tables present.