### PR TITLE
Call __rep_elect_master from election thread if it's us.

### DIFF
--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -1362,6 +1362,7 @@ phase2:
 				done, rep->votes, rep->nsites);
 #endif
 		if (send_vote == rep->eid && done) {
+            __rep_elect_master(dbenv, rep, eidp);
 			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s current-egen "
 					"%d\n", __func__, __LINE__, rep->eid, rep->egen);
 			ret = 0;

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -1362,7 +1362,7 @@ phase2:
 				done, rep->votes, rep->nsites);
 #endif
 		if (send_vote == rep->eid && done) {
-            __rep_elect_master(dbenv, rep, eidp);
+			__rep_elect_master(dbenv, rep, eidp);
 			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s current-egen "
 					"%d\n", __func__, __LINE__, rep->eid, rep->egen);
 			ret = 0;

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -1362,7 +1362,8 @@ phase2:
 				done, rep->votes, rep->nsites);
 #endif
 		if (send_vote == rep->eid && done) {
-			__rep_elect_master(dbenv, rep, eidp);
+            if (nsites == 1)
+                __rep_elect_master(dbenv, rep, eidp);
 			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s current-egen "
 					"%d\n", __func__, __LINE__, rep->eid, rep->egen);
 			ret = 0;

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -1362,8 +1362,8 @@ phase2:
 				done, rep->votes, rep->nsites);
 #endif
 		if (send_vote == rep->eid && done) {
-            if (nsites == 1)
-                __rep_elect_master(dbenv, rep, eidp);
+			if (nsites == 1)
+				__rep_elect_master(dbenv, rep, eidp);
 			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s current-egen "
 					"%d\n", __func__, __LINE__, rep->eid, rep->egen);
 			ret = 0;


### PR DESCRIPTION
Fixes the problem when cluster is brought down to an unelectable state, and nodes are operationally removed.  Still needs a test case.