### PR TITLE
Skip vutf8 on not found

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -3451,8 +3451,12 @@ static int _stag_to_ctag_buf(const char *table, const char *stag,
                     break;
                 tlen += todatalen;
             }
-            if (rc)
-                return -1;
+            if (rc) {
+                if ((to_field->type == CLIENT_BLOB || to_field->type == CLIENT_BLOB2 || to_field->type == CLIENT_VUTF8) && (flags & CONVERT_IGNORE_BLOBS))
+                    rc = 0;
+                else
+                    return -1;
+            }
         }
     }
 

--- a/db/tag.h
+++ b/db/tag.h
@@ -107,9 +107,10 @@ enum {
 /* flags for schema conversion */
 enum {
     /* conversion for update: skip fields missing in source buffer */
-    CONVERT_UPDATE = 1,
+    CONVERT_UPDATE               = 1,
     CONVERT_LITTLE_ENDIAN_CLIENT = 2,
-    CONVERT_NULL_NO_ERROR = 4 // support instant sc for dbstore
+    CONVERT_NULL_NO_ERROR        = 4, // support instant sc for dbstore
+    CONVERT_IGNORE_BLOBS         = 8
 };
 
 typedef enum convert_errcode {

--- a/db/types.c
+++ b/db/types.c
@@ -3720,6 +3720,10 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
      * in the out buffer, then the string will just be transfered from one blob
      * to another */
     if (len > in_len && len > out_len) {
+
+        if (!outblob)
+            return -1;
+
         /* This only copies if we've passed in both an inblob and outblob, but
          * like
          * our blob-conversion code, it will always return success, whether or
@@ -3796,6 +3800,8 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
             outblob->length = len;
             outblob->exists = 1;
             outblob->collected = 1;
+        } else {
+            return -1;
         }
     }
 

--- a/db/types.c
+++ b/db/types.c
@@ -3720,10 +3720,6 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
      * in the out buffer, then the string will just be transfered from one blob
      * to another */
     if (len > in_len && len > out_len) {
-
-        if (!outblob)
-            return -1;
-
         /* This only copies if we've passed in both an inblob and outblob, but
          * like
          * our blob-conversion code, it will always return success, whether or
@@ -3800,8 +3796,6 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
             outblob->length = len;
             outblob->exists = 1;
             outblob->collected = 1;
-        } else {
-            return -1;
         }
     }
 


### PR DESCRIPTION
Older APIs skip blob/vutf8 operations if the record isn't found.  It's a strange contract, but this preserves compatibility.