### PR TITLE
Track and report SQL query preparation time for use with fingerprints

### DIFF
--- a/db/db_fingerprint.c
+++ b/db/db_fingerprint.c
@@ -33,7 +33,8 @@ extern int gbl_verbose_normalized_queries;
 int gbl_fingerprint_max_queries = 1000; /* TODO: Tunable? */
 
 void add_fingerprint(const char *zSql, const char *zNormSql, int64_t cost,
-                     int64_t time, int64_t nrows, struct reqlogger *logger) {
+                     int64_t time, int64_t prepTime, int64_t nrows,
+                     struct reqlogger *logger) {
     assert(zSql);
     assert(zNormSql);
     size_t nNormSql = strlen(zNormSql);
@@ -66,6 +67,7 @@ void add_fingerprint(const char *zSql, const char *zNormSql, int64_t cost,
         t->count = 1;
         t->cost = cost;
         t->time = time;
+        t->prepTime = prepTime;
         t->rows = nrows;
         t->zNormSql = strdup(zNormSql);
         t->nNormSql = nNormSql;
@@ -80,6 +82,7 @@ void add_fingerprint(const char *zSql, const char *zNormSql, int64_t cost,
         t->count++;
         t->cost += cost;
         t->time += time;
+        t->prepTime += prepTime;
         t->rows += nrows;
         assert( memcmp(t->fingerprint,fingerprint,FINGERPRINTSZ)==0 );
         assert( t->zNormSql!=zNormSql );

--- a/db/sql.h
+++ b/db/sql.h
@@ -1187,7 +1187,7 @@ struct query_stats {
 };
 int get_query_stats(struct query_stats *stats);
 void add_fingerprint(const char *, const char *, int64_t, int64_t, int64_t,
-                     struct reqlogger *);
+                     int64_t, struct reqlogger *);
 
 long long run_sql_return_ll(const char *query, struct errstat *err);
 long long run_sql_thd_return_ll(const char *query, struct sql_thread *thd,

--- a/db/sql.h
+++ b/db/sql.h
@@ -63,12 +63,13 @@ enum { RTPAGE_SQLITE_MASTER = 1, RTPAGE_START = 2 };
 
 struct fingerprint_track {
     char fingerprint[FINGERPRINTSZ]; /* md5 digest hex string */
-    int64_t count;   /* Cumulative number of times executed */
-    int64_t cost;    /* Cumulative cost */
-    int64_t time;    /* Cumulative execution time */
-    int64_t rows;    /* Cumulative number of rows selected */
-    char *zNormSql;  /* The normalized SQL query */
-    size_t nNormSql; /* Length of normalized SQL query */
+    int64_t count;    /* Cumulative number of times executed */
+    int64_t cost;     /* Cumulative cost */
+    int64_t time;     /* Cumulative preparation and execution time */
+    int64_t prepTime; /* Cumulative preparation time only */
+    int64_t rows;     /* Cumulative number of rows selected */
+    char *zNormSql;   /* The normalized SQL query */
+    size_t nNormSql;  /* Length of normalized SQL query */
 };
 
 typedef struct stmt_hash_entry {
@@ -959,6 +960,7 @@ struct sql_hist {
     char *sql;
     double cost;
     int time;
+    int prepTime;
     int when;
     int64_t txnid;
     struct conninfo conn;
@@ -969,6 +971,7 @@ struct sql_thread {
     pthread_mutex_t lk;
     struct Btree *bt, *bttmp;
     int startms;
+    int prepms;
     int stime;
     int nmove;
     int nfind;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1068,6 +1068,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
         h->sql = strdup("unknown");
     h->cost = query_cost(thd);
     h->time = comdb2_time_epochms() - thd->startms;
+    h->prepTime = thd->prepms;
     h->when = thd->stime;
     h->txnid = rqid;
 
@@ -1082,7 +1083,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
     if (gbl_fingerprint_queries) {
         if (h->sql && clnt->zNormSql && sqlite3_is_success(clnt->prep_rc)) {
             add_fingerprint(h->sql, clnt->zNormSql, h->cost, h->time,
-                            clnt->nrows, logger);
+                            h->prepTime, clnt->nrows, logger);
         } else {
             reqlog_reset_fingerprint(logger, FINGERPRINTSZ);
         }

--- a/sqlite/ext/comdb2/fingerprints.c
+++ b/sqlite/ext/comdb2/fingerprints.c
@@ -24,12 +24,13 @@
 
 struct fingerprint_track_systbl {
     systable_blobtype fp_blob;
-    int64_t count;   /* Cumulative number of times executed */
-    int64_t cost;    /* Cumulative cost */
-    int64_t time;    /* Cumulative execution time */
-    int64_t rows;    /* Cumulative number of rows selected */
-    char *zNormSql;  /* The normalized SQL query */
-    size_t nNormSql; /* Length of normalized SQL query */
+    int64_t count;    /* Cumulative number of times executed */
+    int64_t cost;     /* Cumulative cost */
+    int64_t time;     /* Cumulative preparation and execution time */
+    int64_t prepTime; /* Cumulative preparation time only */
+    int64_t rows;     /* Cumulative number of rows selected */
+    char *zNormSql;   /* The normalized SQL query */
+    size_t nNormSql;  /* Length of normalized SQL query */
 };
 
 extern hash_t *gbl_fingerprint_hash;
@@ -79,6 +80,7 @@ static int fingerprints_callback(void **data, int *npoints)
                     pFp[copied].count = pEntry->count;
                     pFp[copied].cost = pEntry->cost;
                     pFp[copied].time = pEntry->time;
+                    pFp[copied].prepTime = pEntry->prepTime;
                     pFp[copied].rows = pEntry->rows;
                     if (pEntry->zNormSql != NULL) {
                         pFp[copied].zNormSql = strdup(pEntry->zNormSql);
@@ -122,6 +124,8 @@ int systblFingerprintsInit(sqlite3 *db)
         offsetof(struct fingerprint_track, cost),
         CDB2_INTEGER, "total_time", -1,
         offsetof(struct fingerprint_track, time),
+        CDB2_INTEGER, "total_prep_time", -1,
+        offsetof(struct fingerprint_track, prepTime),
         CDB2_INTEGER, "total_rows", -1,
         offsetof(struct fingerprint_track, rows),
         CDB2_CSTRING, "normalized_sql", -1,


### PR DESCRIPTION
These changes are designed to keep track of the SQL query preparation time and report it based on the normalized SQL (via the comdb2_fingerprints system table) and via the SQL history log messages.