### PR TITLE
Add a verify callback for the 'dtastripe' tunable parameter.

### DIFF
--- a/bbinc/tunables.h
+++ b/bbinc/tunables.h
@@ -193,6 +193,9 @@ const char *tunable_type(comdb2_tunable_type type);
 /* Verify whether the given value is in [0-100] range. */
 int percent_verify(void *context, void *percent);
 
+/* Verify whether the given value is in [1-16] range. */
+int dtastripe_verify(void *context, void *stripes);
+
 /* Return error string. */
 const char *tunable_error(comdb2_tunable_err code);
 

--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -535,8 +535,8 @@ DEF_ATTR(PRIVATE_BLKSEQ_MAXAGE, private_blkseq_maxage, SECS, 600,
          "Maximum time in seconds to let 'old' transactions live.")
 DEF_ATTR(PRIVATE_BLKSEQ_MAXTRAVERSE, private_blkseq_maxtraverse, QUANTITY, 4,
          NULL)
-DEF_ATTR(PRIVATE_BLKSEQ_STRIPES, private_blkseq_stripes, QUANTITY, 8,
-         "Number of stripes for the blkseq table.")
+DEF_ATTR_2(PRIVATE_BLKSEQ_STRIPES, private_blkseq_stripes, QUANTITY, 8,
+           "Number of stripes for the blkseq table.", 0, dtastripe_verify, 0)
 DEF_ATTR(PRIVATE_BLKSEQ_ENABLED, private_blkseq_enabled, BOOLEAN, 1,
          "Sets whether dupe detection is enabled.")
 DEF_ATTR(PRIVATE_BLKSEQ_CLOSE_WARN_TIME, private_blkseq_close_warn_time,

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -579,10 +579,10 @@ static int memnice_update(void *context, void *value)
     return 0;
 }
 
-static int dtastripe_verify(void *context, void *value)
+int dtastripe_verify(void *context, void *stripes)
 {
-    int iValue = *(int *)value;
-    if ((iValue < 1) || (iValue > 16)) {
+    int iStripes = *(int *)stripes;
+    if ((iStripes < 1) || (iStripes > 16)) {
         return 1;
     }
     return 0;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -579,6 +579,15 @@ static int memnice_update(void *context, void *value)
     return 0;
 }
 
+static int dtastripe_verify(void *context, void *value)
+{
+    int iValue = *(int *)value;
+    if ((iValue < 1) || (iValue > 16)) {
+        return 1;
+    }
+    return 0;
+}
+
 static int maxretries_verify(void *context, void *value)
 {
     if (*(int *)value < 2) {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -300,7 +300,7 @@ REGISTER_TUNABLE("dont_sort_nulls_with_header",
                  &gbl_sort_nulls_correctly, INVERSE_VALUE | READONLY | NOARG,
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("dtastripe", NULL, TUNABLE_INTEGER, &gbl_dtastripe,
-                 READONLY | NOZERO, NULL, NULL, NULL, NULL);
+                 READONLY | NOZERO, NULL, dtastripe_verify, NULL, NULL);
 REGISTER_TUNABLE("early",
                  "When set, replicants will ack a transaction as soon as they "
                  "acquire locks - not that replication must succeed at that "


### PR DESCRIPTION
These changes should prevent an invalid 'dtastripe' tunable value (i.e. less than one or greater than sixteen) from being used.