### PR TITLE
[7.0] Having sql_tick always recover deadlock when bdb lock is desired

### DIFF
--- a/tests/recover_deadlock.test/runit
+++ b/tests/recover_deadlock.test/runit
@@ -128,5 +128,13 @@ if [[ $? != 0 ]]; then
     exit 1
 fi
 
+# Test master downgrade while running 'select sleep(120)' on master
+set -e
+master_host=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster where is_master='Y'")
+cdb2sql --host $master_host $dbnm 'SELECT SLEEP(120)' &
+sleep 5
+# This will never complete under the origin sql_tick logic.
+cdb2sql --host $master_host $dbnm 'exec procedure sys.cmd.send("downgrade")'
+
 echo "Passed."
 exit 0 


### PR DESCRIPTION
The function sql_tick() does not call recover_deadlock() for 'SELECT SLEEP(N)',
'ANALYZE' and queries on temptables. If a node where such a query gets
processed is the master and being downgraded, or the node is a replicant and
being upgraded, the downgrade or upgrade will be blocking on the bdb write lock
till the query is finished.

The patch changes sql_tick() to always recover deadlock when bdb lock is desired.

(DRQS 144712120)