### PR TITLE
Fixes for newer gcc 8.3 compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,8 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL GNU OR ${CMAKE_C_COMPILER_ID} STREQUAL Clang
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-switch")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wignored-qualifiers")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-stringop-truncation")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-array-bounds")
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1127,7 +1127,7 @@ void cdb2_set_comdb2db_info(const char *cfg_info)
     cdb2cfg_override = 1;
     len = strlen(cfg_info) + 1;
     CDB2DBCONFIG_BUF = malloc(len);
-    strncpy(CDB2DBCONFIG_BUF, cfg_info, len);
+    strcpy(CDB2DBCONFIG_BUF, cfg_info);
     pthread_mutex_unlock(&cdb2_cfg_lock);
 }
 

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -2830,7 +2830,7 @@ int dyns_get_dtadir(char *dir, int len)
         return -1;
     }
     bzero(dir, len);
-    strncpy(dir, opt_dtadir, strlen(opt_dtadir));
+    strcpy(dir, opt_dtadir);
     return 0;
 }
 
@@ -2841,7 +2841,7 @@ int dyns_get_db_name(char *name, int len)
         return -1;
     }
     bzero(name, len);
-    strncpy(name, DBNAME, strlen(DBNAME));
+    strcpy(name, DBNAME);
     return 0;
 }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7494,7 +7494,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         iq->queryid = dbglog.queryid;
     } break;
     case OSQL_RECGENID: {
-        osql_recgenid_t dt;
+        osql_recgenid_t dt = {0};
         int bdberr = 0;
         unsigned long long lclgenid;
 
@@ -8329,7 +8329,7 @@ int osql_log_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                     errstat_get_rc(&dt), errstat_get_str(&dt));
     } break;
     case OSQL_RECGENID: {
-        osql_recgenid_t dt;
+        osql_recgenid_t dt = {0};
         unsigned long long lclgenid;
 
         uint8_t *p_buf_end = p_buf + sizeof(osql_recgenid_t);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -4279,7 +4279,7 @@ static int db_consumer(Lua L)
         return 0;
     }
     char spname[strlen(sp->spname) + 1];
-    strncpy(spname, sp->spname, strlen(sp->spname) + 1);
+    strcpy(spname, sp->spname);
     Q4SP(qname, spname);
 
     struct dbtable *db = getqueuebyname(qname);

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -326,7 +326,7 @@ static const void *buf_get_dests(struct schema_change_type *s,
             char *pdest;
             if (no_pfx) {
                 d->dest = malloc(w_len + 1);
-                strncpy(d->dest, pfx, strlen(pfx));
+                strcpy(d->dest, pfx);
                 pdest = d->dest + strlen(pfx);
                 d->dest[w_len] = '\0';
             } else {

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -545,7 +545,7 @@ static int portmux_get_unix_socket(const char *unix_bind_path)
                __func__, __LINE__);
         return -1;
     } else {
-        strncpy(addr.sun_path, gbl_portmux_unix_socket, uslen);
+        strcpy(addr.sun_path, gbl_portmux_unix_socket);
     }
 
     len = offsetof(struct sockaddr_un, sun_path) + uslen;


### PR DESCRIPTION
Fixes for newer gcc 8.3 compiler.
Note: there are some strange warnings that come out with -W-array-bounds which we should investigate at some point.