### PR TITLE
Add destroy threadpool ability, add a test for threadpool functionality

### DIFF
--- a/bbinc/thdpool.h
+++ b/bbinc/thdpool.h
@@ -29,6 +29,7 @@ extern "C" {
 
 #include <stdio.h>
 #include <inttypes.h>
+#include "list.h"
 
 struct thdpool;
 

--- a/bbinc/thdpool.h
+++ b/bbinc/thdpool.h
@@ -76,6 +76,7 @@ typedef void (*thdpool_foreach_fn)(struct thdpool *pool, struct workitem *item,
 void thdpool_foreach(struct thdpool *pool, thdpool_foreach_fn, void *user);
 
 struct thdpool *thdpool_create(const char *name, size_t per_thread_data_sz);
+void thdpool_destroy(struct thdpool **pool_p);
 void thdpool_set_stack_size(struct thdpool *pool, size_t sz_bytes);
 void thdpool_set_init_fn(struct thdpool *pool, thdpool_thdinit_fn init_fn);
 void thdpool_set_delt_fn(struct thdpool *pool, thdpool_thddelt_fn delt_fn);

--- a/tests/threadpool.test/Makefile
+++ b/tests/threadpool.test/Makefile
@@ -1,0 +1,12 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif
+
+# this is a local test, don't need cluster
+unexport CLUSTER
+export COMDB2_UNITTEST=1

--- a/tests/threadpool.test/README
+++ b/tests/threadpool.test/README
@@ -1,0 +1,2 @@
+This test exercises the basic threadpool functionality, as well as serves
+to test the cleanup and teardown code.

--- a/tests/threadpool.test/runit
+++ b/tests/threadpool.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -e
+set -x
 
 echo run executable that tests a series of standalone functions
 ${TESTSBUILDDIR}/test_threadpool

--- a/tests/threadpool.test/runit
+++ b/tests/threadpool.test/runit
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo run executable that tests a series of standalone functions
+${TESTSBUILDDIR}/test_threadpool
+

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(comdb2_sqltest cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_L
 target_link_libraries(ptrantest cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${SQLITE3_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS} -lm)
 target_link_libraries(recom cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${SQLITE3_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS} -lm)
 
-target_link_libraries(test_threadpool util mem dlmalloc -Ibbinc )
+target_link_libraries(test_threadpool mem dlmalloc util -Ibbinc ${CMAKE_DL_LIBS})
 
 # everything!
 target_link_libraries(stepper cdb2api mem dlmalloc util ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -52,12 +52,13 @@ add_exe(deadlock_load deadlock_load.c)
 add_exe(selectv_deadlock selectv_deadlock.c)
 add_exe(selectv_rcode selectv_rcode.c)
 add_exe(api_libs api_libs.c)
+add_exe(test_threadpool test_threadpool.c)
 add_library(api_hello_world_lib SHARED api_hello_world_lib.c)
 list(APPEND test-tools api_hello_world_lib)
 
 add_custom_target(test-tools DEPENDS ${test-tools})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load selectv_deadlock selectv_rcode api_libs)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_open multithd verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load selectv_deadlock selectv_rcode api_libs test_threadpool)
   target_link_libraries(${executable} cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 endforeach()
 
@@ -77,9 +78,11 @@ target_link_libraries(comdb2_sqltest cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_L
 target_link_libraries(ptrantest cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${SQLITE3_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS} -lm)
 target_link_libraries(recom cdb2api ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${SQLITE3_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS} -lm)
 
+target_link_libraries(test_threadpool util mem dlmalloc -Ibbinc )
+
 # everything!
 target_link_libraries(stepper cdb2api mem dlmalloc util ${OPENSSL_LIBRARIES} ${PROTOBUF_C_LIBRARY} ${ZLIB_LIBRARIES} ${CMAKE_DL_LIBS})
 
-foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest cldeadlock comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load selectv_deadlock selectv_rcode api_libs)
+foreach(executable blob bound cdb2api_caller cdb2bind comdb2_blobtest insert_lots_mt leakcheck localrep overflow_blobtest selectv serial sicountbug sirace simple_ssl utf8 insert register breakloop cdb2_client hatest cldeadlock comdb2_sqltest ptrantest recom stepper multithd cdb2_open verify_atomics_work cdb2api_unit malloc_resize_test cdb2_close_early cdb2api_read_intrans_results ssl_multi_certs_one_process nowritetimeout api_events deadlock_load selectv_deadlock selectv_rcode api_libs test_threadpool)
     target_link_libraries(${executable} ${UNWIND_LIBRARY})
 endforeach()

--- a/tests/tools/test_threadpool.c
+++ b/tests/tools/test_threadpool.c
@@ -35,6 +35,7 @@ static void handler_work_pp(struct thdpool *pool, void *work, void *thddata, int
     ATOMIC_ADD(info->c->sum, info->id);
     usleep(rand() % 1000);
     ATOMIC_ADD(info->c->completed_count, 1);
+    free(work);
 }
 
 int main()
@@ -68,11 +69,12 @@ int main()
         }
     }
 
-    //while (thdpool_get_nthds() c.completed_count < c.spawned_count) {
+    //while (thdpool_get_nthds() c.completed_count < c.spawned_count) 
     while (thdpool_get_nthds(my_thdpool) + thdpool_get_nfreethds(my_thdpool) > 0) {
         printf("Waiting for thdpool %d/%d done\n", c.completed_count, c.spawned_count);
         sleep(1);
     }
+
     printf("Work completed thdpool %d/%d done\n", c.completed_count, c.spawned_count);
     if (c.sum != (MAX+1)*MAX/2)
         abort();
@@ -81,4 +83,7 @@ int main()
     thdpool_stop(my_thdpool);
     sleep(1);
     thdpool_destroy(&my_thdpool);
+    // this will remove the mspace and we won't be able to see any leaks, so comment out:
+    //comdb2ma_exit();
+    pthread_exit(NULL); // call any key destructors
 }

--- a/tests/tools/test_threadpool.c
+++ b/tests/tools/test_threadpool.c
@@ -5,6 +5,7 @@
 
 #include "thdpool.h"
 #include "comdb2_atomic.h"
+#include "mem.h"
 
 int gbl_disable_exit_on_thread_error;
 int gbl_throttle_sql_overload_dump_sec;
@@ -31,11 +32,13 @@ static void handler_work_pp(struct thdpool *pool, void *work, void *thddata, int
 {
     info_t *info = work; 
     ATOMIC_ADD(info->c->sum, info->id);
-    usleep(rand());
+    usleep(rand() % 1000);
+    ATOMIC_ADD(info->c->completed_count, 1);
 }
 
 int main()
 {
+    comdb2ma_init(0, 0);
     struct thdpool *my_thdpool = thdpool_create("my_pool", 0);
 
     assert(my_thdpool);
@@ -43,32 +46,36 @@ int main()
     //thdpool_set_init_fn(my_thdpool, my_thd_start);
     thdpool_set_minthds(my_thdpool, 0);
     thdpool_set_maxthds(my_thdpool, 8);
-    thdpool_set_linger(my_thdpool, 1);
+    thdpool_set_linger(my_thdpool, 0);
     thdpool_set_longwaitms(my_thdpool, 1000000);
     thdpool_set_maxqueue(my_thdpool, 100);
     thdpool_set_mem_size(my_thdpool, 4 * 1024);
-    common_t c;
+    common_t c = {0};
     const int MAX = 100;
 
     for (int i = 1; i <= MAX; i++) {
-        info_t *work = malloc(sizeof(info_t));
+        info_t *work = calloc(1, sizeof(info_t));
         work->id = i;
         work->c = &c;
         c.spawned_count++;
-        int rc = thdpool_enqueue(my_thdpool, 
-            handler_work_pp, &work, 0, NULL, THDPOOL_FORCE_QUEUE);
-        if (rc)
-            abort();
+        int rc = thdpool_enqueue(my_thdpool, handler_work_pp, work, 0, NULL, 
+                THDPOOL_FORCE_QUEUE);
+        if (rc) {
+            fprintf(stderr, "Error from thdpool_enqueue, rc=%d\n", rc);
+            exit(1);
+        }
     }
 
-    while (c.completed_count < c.spawned_count) {
+    //while (thdpool_get_nthds() c.completed_count < c.spawned_count) {
+    while (thdpool_get_nthds(my_thdpool) + thdpool_get_nfreethds(my_thdpool) > 0) {
         printf("Waiting for thdpool %d/%d done\n", c.completed_count, c.spawned_count);
         sleep(1);
     }
-    if (c.sum != MAX*MAX/2)
+    if (c.sum != (MAX+1)*MAX/2)
         abort();
 
     printf("Done waiting for thdpool, now cleanup\n");
     thdpool_stop(my_thdpool);
+    sleep(1);
     thdpool_destroy(&my_thdpool);
 }

--- a/tests/tools/test_threadpool.c
+++ b/tests/tools/test_threadpool.c
@@ -71,6 +71,7 @@ int main()
         printf("Waiting for thdpool %d/%d done\n", c.completed_count, c.spawned_count);
         sleep(1);
     }
+    printf("Work completed thdpool %d/%d done\n", c.completed_count, c.spawned_count);
     if (c.sum != (MAX+1)*MAX/2)
         abort();
 

--- a/tests/tools/test_threadpool.c
+++ b/tests/tools/test_threadpool.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <assert.h>
 
+#include "thread_util.h"
 #include "thdpool.h"
 #include "comdb2_atomic.h"
 #include "mem.h"
@@ -39,6 +40,7 @@ static void handler_work_pp(struct thdpool *pool, void *work, void *thddata, int
 int main()
 {
     comdb2ma_init(0, 0);
+    thread_util_init();
     struct thdpool *my_thdpool = thdpool_create("my_pool", 0);
 
     assert(my_thdpool);

--- a/tests/tools/test_threadpool.c
+++ b/tests/tools/test_threadpool.c
@@ -83,7 +83,8 @@ int main()
     thdpool_stop(my_thdpool);
     sleep(1);
     thdpool_destroy(&my_thdpool);
-    // this will remove the mspace and we won't be able to see any leaks, so comment out:
+    // this will remove the mspace and we won't be able to see any leaks,
+    // so keep this commented out:
     //comdb2ma_exit();
     pthread_exit(NULL); // call any key destructors
 }

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -284,7 +284,6 @@ void thdpool_destroy(struct thdpool **pool_p)
     free(pool->busy_hist);
     pool_free(pool->pool);
     free(pool->name);
-    //TODO: deregister_thdpool_tunables((char *)name, pool);
     free(pool);
 }
 

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -281,6 +281,7 @@ void thdpool_destroy(struct thdpool **pool_p)
     Pthread_mutex_destroy(&pool->mutex);
     Pthread_attr_destroy(&pool->attrs);
 
+    free(pool->busy_hist);
     pool_free(pool->pool);
     free(pool->name);
     //TODO: deregister_thdpool_tunables((char *)name, pool);

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -266,6 +266,27 @@ struct thdpool *thdpool_create(const char *name, size_t per_thread_data_sz)
     return pool;
 }
 
+void thdpool_destroy(struct thdpool **pool_p)
+{
+    if (!*pool_p)
+        return;
+    struct thdpool *pool = *pool_p;
+    *pool_p = NULL;
+
+    Pthread_mutex_lock(&pool_list_lk);
+    listc_rfl(&threadpools, pool);
+    Pthread_mutex_unlock(&pool_list_lk);
+
+    Pthread_cond_destroy(&pool->wait_for_thread);
+    Pthread_mutex_destroy(&pool->mutex);
+    Pthread_attr_destroy(&pool->attrs);
+
+    pool_free(pool->pool);
+    free(pool->name);
+    //TODO: deregister_thdpool_tunables((char *)name, pool);
+    free(pool);
+}
+
 void thdpool_foreach(struct thdpool *pool, thdpool_foreach_fn foreach_fn,
                      void *user)
 {


### PR DESCRIPTION
Add destroy threadpool ability.
Add a new test to create threads in a threadpool to handle a task in parallel.
At the end of running this test, valgrind reports that there are no leaks.