### PR TITLE
Fix cdb2_verify crashes: was missing Pthread_key_create

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1750,7 +1750,6 @@ struct cursor_track {
     unsigned nframes;
     u_int32_t lockerid;
 };
-extern pthread_key_t DBG_FREE_CURSOR;
 
 
 struct __dbc {

--- a/berkdb/db/db_cam.c
+++ b/berkdb/db/db_cam.c
@@ -795,9 +795,8 @@ __db_c_idup(dbc_orig, dbcp, flags)
 #endif
 
 	{
-#ifndef TESTSUITE
-		struct __dbg_free_cursor *p =
-		    pthread_getspecific(DBG_FREE_CURSOR);
+#ifndef BERKDB_46
+		struct __dbg_free_cursor *p = pthread_getspecific(DBG_FREE_CURSOR);
 		if (p) {
 			p->counter++;
 		} else {

--- a/berkdb/db/db_iface.c
+++ b/berkdb/db/db_iface.c
@@ -368,7 +368,9 @@ __db_cursor_pp_paired(dbp, dbc_old, dbcp, flags)
 	return rc;
 }
 
+#ifndef BERKDB_46
 pthread_key_t DBG_FREE_CURSOR;
+#endif
 
 int
 transfer_cursor_ownership(DBC *cold, DBC *cnew)
@@ -698,9 +700,8 @@ __db_cursor_real(dbp, txn, txn_clone, dbcp_old, lid_clone, dbcs, dbcp, flags,
 #endif
 
 		if (countmein) {
-#ifndef TESTSUITE
-			struct __dbg_free_cursor *p =
-			    pthread_getspecific(DBG_FREE_CURSOR);
+#ifndef BERKDB_46
+			struct __dbg_free_cursor *p = pthread_getspecific(DBG_FREE_CURSOR);
 			if (p) {
 				p->counter++;
 			} else {

--- a/tools/cdb2_printlog/cdb2_printlog.c
+++ b/tools/cdb2_printlog/cdb2_printlog.c
@@ -106,7 +106,9 @@ int tool_cdb2_printlog_main(argc, argv)
 	comdb2ma_init(0, 0);
 
 	Pthread_key_create(&comdb2_open_key, NULL);
+#ifndef BERKDB_46
 	Pthread_key_create(&DBG_FREE_CURSOR, NULL);
+#endif
 
 	if ((ret = cdb2_print_version_check(progname)) != 0)
 		return (ret);

--- a/tools/cdb2_verify/cdb2_verify.c
+++ b/tools/cdb2_verify/cdb2_verify.c
@@ -25,6 +25,7 @@ static const char revid[] =
 
 #include "build/db_int.h"
 #include <crc32c.h>
+#include "locks_wrap.h"
 
 int main __P((int, char *[]));
 static int cdb2_verify_usage __P((void));
@@ -36,7 +37,6 @@ tool_cdb2_verify_main(argc, argv)
 	int argc;
 	char *argv[];
 {
-	crc32c_init(0);
 	extern char *optarg;
 	extern int optind;
 	const char *progname = "cdb2_verify";
@@ -48,9 +48,14 @@ tool_cdb2_verify_main(argc, argv)
 	char *home, passwd[1024];
 	FILE *crypto;
 
+	crc32c_init(0);
     comdb2ma_init(0, 0);
 	if ((ret = cdb2_verify_version_check(progname)) != 0)
 		return (ret);
+
+#ifndef BERKDB_46
+	Pthread_key_create(&DBG_FREE_CURSOR, NULL);
+#endif
 
 	dbenv = NULL;
 	dbp = NULL;


### PR DESCRIPTION
cdb2_verify was crashing because it was missing a call to Pthread_key_create for DBG_FREE_CURSOR. This PR fixes the crash.