### PR TITLE
Send an dummy response for COMMIT/ROLLBACK for a failed tx

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -198,16 +198,23 @@ typedef struct osqlstate {
 } osqlstate_t;
 
 enum ctrl_sqleng {
-    SQLENG_NORMAL_PROCESS =
-        0, /* no user specified transactions, i.e. begin/commit */
-    SQLENG_PRE_STRT_STATE =
-        1, /* "begin" was submitted, mark this as user transaction begin */
-    SQLENG_STRT_STATE = 2,     /* we are waiting for a non-"begin" user query */
-    SQLENG_INTRANS_STATE = 3,  /* we have a transaction, ignore further
-                                  BtreeTransBegin until commit/rollback */
-    SQLENG_FNSH_STATE = 4,     /* "commit" was submitted */
-    SQLENG_FNSH_RBK_STATE = 5, /* "rollback" was submitted */
-    SQLENG_WRONG_STATE = 6,     /* duplicated command submitted */
+    /* No user specified transactions, i.e. BEGIN/COMMIT */
+    SQLENG_NORMAL_PROCESS,
+    /* "BEGIN" was submitted, mark this as user transaction begin */
+    SQLENG_PRE_STRT_STATE,
+    /* We have seen 'BEGIN' and now waiting for a non-"BEGIN" user query */
+    SQLENG_STRT_STATE,
+    /* We have a transaction, ignore further BtreeTransBegin until
+     * COMMIT/ROLLBACK */
+    SQLENG_INTRANS_STATE,
+    /* "COMMIT" was submitted */
+    SQLENG_FNSH_STATE,
+    /* "ROLLBACK" was submitted */
+    SQLENG_FNSH_RBK_STATE,
+    /* Transaction has been aborted due to a bad command */
+    SQLENG_FNSH_ABORTED_STATE,
+    /* We have entered a wrong stated (possibly a bug) */
+    SQLENG_WRONG_STATE,
 };
 
 void sql_set_sqlengine_state(struct sqlclntstate *clnt, char *file, int line,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4666,7 +4666,8 @@ int sqlite3BtreeCommit(Btree *pBt)
 
     if (!clnt->intrans || clnt->no_transaction ||
         (!clnt->no_transaction && clnt->ctrl_sqlengine != SQLENG_FNSH_STATE &&
-         clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS)) {
+         clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS &&
+         clnt->ctrl_sqlengine != SQLENG_FNSH_ABORTED_STATE)) {
         rc = SQLITE_OK;
         goto done;
     }
@@ -4674,7 +4675,8 @@ int sqlite3BtreeCommit(Btree *pBt)
     clnt->recno = 0;
 
     /* reset the state of the sqlengine */
-    if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE)
+    if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE ||
+        clnt->ctrl_sqlengine == SQLENG_FNSH_ABORTED_STATE)
         sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
                                 SQLENG_NORMAL_PROCESS);
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1730,7 +1730,9 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     int rc = 0;
     int irc = 0;
     int outrc = 0;
+#ifndef NDEBUG
     int clnt_had_errors_orig = clnt->had_errors;
+#endif
 
     reqlog_new_sql_request(thd->logger, clnt->sql);
     log_queue_time(thd->logger, clnt);
@@ -2179,9 +2181,11 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
              * client. The assert below assures that the control must not
              * reach here if there had been an error prior to COMMIT/ROLLBACK.
              */
+#ifndef NDEBUG
             if (clnt->had_errors) {
                 assert(!clnt_had_errors_orig);
             }
+#endif
             write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, rc);
         }
     }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2076,7 +2076,8 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         Pthread_mutex_lock(&clnt->wait_mutex);
         clnt->ready_for_heartbeats = 0;
 
-        if (sendresponse) {
+        if (sendresponse &&
+            (send_intrans_response(clnt) || !clnt->had_errors)) {
             /* This is a commit, so we'll have something to send here even on a
              * retry.  Don't trigger code in fsql_write_response that's there
              * to catch bugs when we send back responses on a retry. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1610,6 +1610,9 @@ static char *sqlenginestate_tostr(int state)
     case SQLENG_FNSH_RBK_STATE:
         return "SQLENG_FNSH_RBK_STATE";
         break;
+    case SQLENG_FNSH_ABORTED_STATE:
+        return "SQLENG_FNSH_ABORTED_STATE";
+        break;
     case SQLENG_WRONG_STATE:
         return "SQLENG_WRONG_STATE";
         break;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -5795,6 +5795,8 @@ static int run_sp_int(struct sqlclntstate *clnt, int argcnt, char **err)
         /* Don't make new parent transaction on this rollback. */
         sp->make_parent_trans = 0;
         db_rollback_int(lua, &tmp);
+        sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
+                                SQLENG_FNSH_ABORTED_STATE);
     }
 
     if (gbl_break_lua && (gbl_break_lua == pthread_self())) {

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2279,6 +2279,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (!clnt.in_client_trans) {
             bzero(&clnt.effects, sizeof(clnt.effects));
             bzero(&clnt.log_effects, sizeof(clnt.log_effects));
+            clnt.had_errors = 0;
         }
         if (clnt.dbtran.mode < TRANLEVEL_SOSQL) {
             clnt.dbtran.mode = TRANLEVEL_SOSQL;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2380,15 +2380,21 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                 osql_set_replay(__FILE__, __LINE__, &clnt, OSQL_RETRY_NONE);
                 srs_tran_destroy(&clnt);
             } else {
-                srs_tran_replay(&clnt, arg->thr_self);
+                rc = srs_tran_replay(&clnt, arg->thr_self);
+            }
+
+            if (clnt.osql.history == NULL) {
+                query = APPDATA->query = NULL;
             }
         } else {
             /* if this transaction is done (marked by SQLENG_NORMAL_PROCESS),
                clean transaction sql history
             */
             if (clnt.osql.history &&
-                clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)
+                clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS) {
                 srs_tran_destroy(&clnt);
+                query = APPDATA->query = NULL;
+            }
         }
 
         if (rc && !clnt.in_client_trans)

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -283,11 +283,7 @@ static int is_snap_uid_retry(struct sqlclntstate *clnt)
 {
     // Retries happen with a 'begin'.  This can't be a retry if we are already
     // in a transaction
-    if (clnt->ctrl_sqlengine == SQLENG_STRT_STATE ||
-        clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE ||
-        clnt->ctrl_sqlengine == SQLENG_PRE_STRT_STATE ||
-        clnt->ctrl_sqlengine == SQLENG_FNSH_STATE ||
-        clnt->ctrl_sqlengine == SQLENG_FNSH_RBK_STATE) {
+    if (clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS) {
         return 0;
     }
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2356,11 +2356,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         clnt.heartbeat = 1;
         ATOMIC_ADD(gbl_nnewsql, 1);
 
-        bool isCommitRollback =
-            (strncasecmp(clnt.sql, "commit", 6) == 0 ||
-             strncasecmp(clnt.sql, "rollback", 8) == 0)
-                ? true
-                : false;
+        bool isCommitRollback = (strncasecmp(clnt.sql, "commit", 6) == 0 ||
+                                 strncasecmp(clnt.sql, "rollback", 8) == 0)
+                                    ? true
+                                    : false;
 
         if (!clnt.had_errors || isCommitRollback) {
             /* tell blobmem that I want my priority back

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2377,7 +2377,9 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
             clnt.had_errors = 0;
             clnt.in_client_trans = 0;
-            newsql_row_last_dummy(&clnt);
+            if (newsql_send_intrans_response(&clnt) == -1) {
+                newsql_row_last_dummy(&clnt);
+            }
             rc = -1;
         } else {
             /* tell blobmem that I want my priority back

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2377,6 +2377,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
             clnt.had_errors = 0;
             clnt.in_client_trans = 0;
+            newsql_row_last_dummy(&clnt);
             rc = -1;
         } else {
             /* tell blobmem that I want my priority back

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2380,20 +2380,6 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                 srs_tran_destroy(&clnt);
             } else {
                 rc = srs_tran_replay(&clnt, arg->thr_self);
-                /* NC: A hack to match current master behavior and fix a perf
-                 * regression caused by extra retries for uncommitable txns.
-                 * This hack would allow the connection to survive after this
-                 * (first) replay. But, since the replay has already bumped the
-                 * clnt->verify_retries, the OSQL_FLAGS_CHECK_SELFLOCK flag
-                 * gets set for the osql request forcing genid verification on
-                 * the master, causing an early "uncommitable txn" error for
-                 * the subsequent bad transaction. And since the returned error
-                 * is not-retriable, the connection gets dropped. Note: For
-                 * the second bad transaction, "uncommitable txn" is returned
-                 * on the very first attempt, avoiding retries - thus fixing
-                 * the performance regression.
-                 */
-                rc = 0;
             }
 
             if (clnt.osql.history == NULL) {

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2280,6 +2280,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
             bzero(&clnt.effects, sizeof(clnt.effects));
             bzero(&clnt.log_effects, sizeof(clnt.log_effects));
             clnt.had_errors = 0;
+            clnt.ctrl_sqlengine = SQLENG_NORMAL_PROCESS;
         }
         if (clnt.dbtran.mode < TRANLEVEL_SOSQL) {
             clnt.dbtran.mode = TRANLEVEL_SOSQL;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2359,10 +2359,11 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         clnt.heartbeat = 1;
         ATOMIC_ADD(gbl_nnewsql, 1);
 
-        bool isCommitRollback = (strncasecmp(clnt.sql, "commit", 6) == 0 ||
-                                 strncasecmp(clnt.sql, "rollback", 8) == 0)
-                                    ? true
-                                    : false;
+        bool isCommitRollback =
+            (strncasecmp(clnt.sql, "commit", 6) == 0 ||
+             strncasecmp(clnt.sql, "rollback", 8) == 0)
+                ? true
+                : false;
 
         if (!clnt.had_errors || isCommitRollback) {
             /* tell blobmem that I want my priority back

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2377,9 +2377,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
             clnt.had_errors = 0;
             clnt.in_client_trans = 0;
-            if (newsql_send_intrans_response(&clnt) == -1) {
+            if (newsql_send_intrans_response(&clnt) != 0) {
                 newsql_row_last_dummy(&clnt);
             }
+
             rc = -1;
         } else {
             /* tell blobmem that I want my priority back

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2384,6 +2384,20 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                 srs_tran_destroy(&clnt);
             } else {
                 rc = srs_tran_replay(&clnt, arg->thr_self);
+                /* NC: A hack to match current master behavior and fix a perf
+                 * regression caused by extra retries for uncommitable txns.
+                 * This hack would allow the connection to survive after this
+                 * (first) replay. But, since the replay has already bumped the
+                 * clnt->verify_retries, the OSQL_FLAGS_CHECK_SELFLOCK flag
+                 * gets set for the osql request forcing genid verification on
+                 * the master, causing an early "uncommitable txn" error for
+                 * the subsequent bad transaction. And since the returned error
+                 * is not-retriable, the connection gets dropped. Note: For
+                 * the second bad transaction, "uncommitable txn" is returned
+                 * on the very first attempt, avoiding retries - thus fixing
+                 * the performance regression.
+                 */
+                rc = 0;
             }
 
             if (clnt.osql.history == NULL) {

--- a/tests/cdb2api.test/t36.expected
+++ b/tests/cdb2api.test/t36.expected
@@ -1,3 +1,22 @@
+(test='---- test 1 ----')
 [commit] failed with rc -3 near "kjskjhf": syntax error
+(test='---- test 2 ----')
 [insert kjskjhf kjsd] failed with rc -3 near "kjskjhf": syntax error
+(test='---- test 3 ----')
 [commit] failed with rc -3 near "kjskjhf": syntax error
+(test='---- test 4 ----')
+(1=1)
+[foo] failed with rc -3 near "foo": syntax error
+[select 1] failed with rc -3 
+[commit] failed with rc -3 
+(test='---- test 5 ----')
+(1=1)
+[select 1] failed with rc -3 near "foo": syntax error
+[commit] failed with rc -3 
+(test='---- test 6 ----')
+(1=1)
+[foo] failed with rc -3 near "foo": syntax error
+[select 1] failed with rc -3 
+(test='---- test 7 ----')
+(1=1)
+[select 1] failed with rc -3 near "foo": syntax error

--- a/tests/cdb2api.test/t36.req
+++ b/tests/cdb2api.test/t36.req
@@ -1,13 +1,48 @@
+select "---- test 1 ----" as test
 begin
 insert kjskjhf kjsd
 commit
 
+select "---- test 2 ----" as test
 set intransresults on
 begin
 insert kjskjhf kjsd
 rollback
 
+select "---- test 3 ----" as test
 set intransresults off
 begin
 insert kjskjhf kjsd
 commit
+
+select "---- test 4 ----" as test
+set intransresults on
+begin
+select 1
+foo
+select 1
+commit
+
+select "---- test 5 ----" as test
+set intransresults off
+begin
+select 1
+foo
+select 1
+commit
+
+select "---- test 6 ----" as test
+set intransresults on
+begin
+select 1
+foo
+select 1
+rollback
+
+select "---- test 7 ----" as test
+set intransresults off
+begin
+select 1
+foo
+select 1
+rollback


### PR DESCRIPTION
This fixes a regression where old client APIs expect a response from Comdb2.