### PR TITLE
Fix a mutex/memory leak if sqlite3_step() fails in create_temp_table().

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3369,6 +3369,7 @@ int sqlite3BtreeOpen(
         int masterPgno;
         assert(tmptbl_clone == NULL);
         rc = sqlite3BtreeCreateTable(bt, &masterPgno, BTREE_INTKEY);
+        if (rc != SQLITE_OK) goto done;
         assert(masterPgno == 1); /* sqlite_temp_master root page number */
         listc_init(&bt->cursors, offsetof(BtCursor, lnk));
         if (flags & BTREE_UNORDERED) {
@@ -8064,10 +8065,10 @@ int sqlite3BtreeCursor(
             if (hash_find(pBt->temp_tables, &pgno) == NULL) {
                 assert(tmptbl_clone == NULL);
                 rc = sqlite3BtreeCreateTable(pBt, &pgno, BTREE_INTKEY);
-                assert(pgno == iTable);
             }
         }
         if (rc == SQLITE_OK) {
+            assert(pgno == iTable);
             rc = sqlite3BtreeCursor_temptable(pBt, pgno, wrFlag & BTREE_CUR_WR,
                                               temp_table_cmp, pKeyInfo, cur,
                                               thd);


### PR DESCRIPTION
These changes fix a (theoretical?) mutex and memory leak that could occur if sqlite3_step() fails within the create_temp_table() function.  This fix is only needed for R7.

In addition, it makes adjustments to account for the fact that the sqlite3BtreeCreateTable() function can fail.
