### PR TITLE
Fix a use of uninitialized bytes as reported by valgrind.

### DIFF
--- a/sqlite/ext/comdb2/procedures.c
+++ b/sqlite/ext/comdb2/procedures.c
@@ -85,8 +85,8 @@ static void get_sp_versions(systbl_sps_cursor *c) {
 }
 
 static void get_server_versioned_sps(char ***a, int *x) {
-  char old_sp[MAX_SPNAME];
-  char new_sp[MAX_SPNAME];
+  char old_sp[MAX_SPNAME] = {0};
+  char new_sp[MAX_SPNAME] = {0};
   old_sp[0] = 127;
   char **names = NULL;
   int n = 0;


### PR DESCRIPTION
These changes fix an issue with the get_server_versioned_sps() function.  It passes the "old_sp" and "new_sp" local buffers to bdb_get_sp_name() when they have not been (fully) initialized.