### PR TITLE
Testsuite: fix parameter to start local node, clarify testcase output

### DIFF
--- a/tests/mem_be_nice.test/runit
+++ b/tests/mem_be_nice.test/runit
@@ -3,7 +3,7 @@ bash -n "$0" | exit 1
 
 dbnm=$1
 
-set -x
+set -e
 
 # Make sure that all queries go to the same node.
 mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
@@ -13,8 +13,7 @@ for i in `seq 1 8`; do
   cdb2sql -s --host $mach ${CDB2_OPTIONS} -f stmts.sql $dbnm default >/dev/null &
 done
 
-cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' > memstat1.out
-appsockcnt=`grep -c sqlite memstat1.out`
+appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c sqlite`
 echo "# sqlite allocators: $appsockcnt"
 if [[ $appsockcnt -gt 5 ]]; then
   echo "Expecting <= 5 (4 for per-thread and 1 for main thread) sqlite allocators."
@@ -22,7 +21,7 @@ if [[ $appsockcnt -gt 5 ]]; then
   exit 1
 fi
 
-appsockcnt=`grep -c lua memstat1.out`
+appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c lua`
 echo "# lua allocators: $appsockcnt"
 if [[ $appsockcnt -gt 5 ]]; then
   echo "Expecting <= 5 (4 for per-thread and 1 for main thread) lua allocators."
@@ -33,8 +32,7 @@ fi
 # Give the database a bit time to dispatch all queries.
 sleep 2
 
-cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' > memstat2.out
-sqlengcnt=`grep -c SQLITE memstat2.out`
+sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c SQLITE`
 echo "# SQLITE allocators: $sqlengcnt"
 if [[ $sqlengcnt -lt 9 ]]; then
   echo "Expecting >= 9 (8 open connections and myself) SQLITE allocators."
@@ -42,7 +40,7 @@ if [[ $sqlengcnt -lt 9 ]]; then
   exit 1
 fi
 
-sqlengcnt=`grep -c LUA memstat2.out`
+sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c LUA`
 echo "# LUA allocators: $sqlengcnt"
 if [[ $sqlengcnt -lt 9 ]]; then
   echo "Expecting >= 9 (8 open connections and myself) LUA allocators."

--- a/tests/mem_be_nice.test/runit
+++ b/tests/mem_be_nice.test/runit
@@ -3,7 +3,7 @@ bash -n "$0" | exit 1
 
 dbnm=$1
 
-set -e
+set -x
 
 # Make sure that all queries go to the same node.
 mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
@@ -13,7 +13,8 @@ for i in `seq 1 8`; do
   cdb2sql -s --host $mach ${CDB2_OPTIONS} -f stmts.sql $dbnm default >/dev/null &
 done
 
-appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c sqlite`
+cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' > memstat1.out
+appsockcnt=`grep -c sqlite memstat1.out`
 echo "# sqlite allocators: $appsockcnt"
 if [[ $appsockcnt -gt 5 ]]; then
   echo "Expecting <= 5 (4 for per-thread and 1 for main thread) sqlite allocators."
@@ -21,7 +22,7 @@ if [[ $appsockcnt -gt 5 ]]; then
   exit 1
 fi
 
-appsockcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c lua`
+appsockcnt=`grep -c lua memstat1.out`
 echo "# lua allocators: $appsockcnt"
 if [[ $appsockcnt -gt 5 ]]; then
   echo "Expecting <= 5 (4 for per-thread and 1 for main thread) lua allocators."
@@ -32,7 +33,8 @@ fi
 # Give the database a bit time to dispatch all queries.
 sleep 2
 
-sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c SQLITE`
+cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' > memstat2.out
+sqlengcnt=`grep -c SQLITE memstat2.out`
 echo "# SQLITE allocators: $sqlengcnt"
 if [[ $sqlengcnt -lt 9 ]]; then
   echo "Expecting >= 9 (8 open connections and myself) SQLITE allocators."
@@ -40,7 +42,7 @@ if [[ $sqlengcnt -lt 9 ]]; then
   exit 1
 fi
 
-sqlengcnt=`cdb2sql --host $mach ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat")' | grep -c LUA`
+sqlengcnt=`grep -c LUA memstat2.out`
 echo "# LUA allocators: $sqlengcnt"
 if [[ $sqlengcnt -lt 9 ]]; then
   echo "Expecting >= 9 (8 open connections and myself) LUA allocators."

--- a/tests/setup
+++ b/tests/setup
@@ -202,7 +202,7 @@ setup_db() {
     mkdir -p $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2
     cd $DBDIR >/dev/null
 
-    PARAMS="--lrl ${LRL} --no-global-lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
+    PARAMS="--no-global-lrl --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.pid"
     export LOGDIR=$TESTDIR/logs
 
     # The script occasionally fails here. Let's find out what the rc is.
@@ -301,11 +301,11 @@ setup_db() {
         echo "!$TESTCASE: starting"
         for node in $CLUSTER; do
             if [ $node == $HOSTNAME ] ; then # dont ssh to ourself -- just start db locally
-                CL_PARAMS=--no-global-lrl --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+                CL_PARAMS="--no-global-lrl --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
                 if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
                     echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${CL_PARAMS} ${NOCOLOR}"
                 else
-                    ${DEBUG_PREFIX} $COMDB2_EXE ${CL_PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
+                    ${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${CL_PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
                 fi
                 continue
             fi

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -125,6 +125,8 @@ cleanup_cluster() {
         if [ "$CLEANUPDBDIR" == "2" ] ; then
             rm -f $TESTDIR/logs/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
             rmdir ${TMPDIR}/cdb2 ${TMPDIR} 2> /dev/null
+            #if DBCLEANUP is 2 then we cleanup the logs/${DBNAME}.testcase, remark so we know
+            echo '$CLEANUPDBDIR == 2 and test was successful so we cleaned up all files related to this test' > $TESTDIR/logs/${DBNAME}.testcase
         fi
     fi
 }

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -126,7 +126,7 @@ cleanup_cluster() {
             rm -f $TESTDIR/logs/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
             rmdir ${TMPDIR}/cdb2 ${TMPDIR} 2> /dev/null
             #if DBCLEANUP is 2 then we cleanup the logs/${DBNAME}.testcase, remark so we know
-            echo '$CLEANUPDBDIR == 2 and test was successful so we cleaned up all files related to this test' > $TESTDIR/logs/${DBNAME}.testcase
+            echo '$CLEANUPDBDIR == 2 and test was successful so we cleaned up all files related to this test' >> $TESTDIR/logs/${DBNAME}.testcase
         fi
     fi
 }


### PR DESCRIPTION
Fix parameter to start local node.
Clarify in testcase file that we cleaned up all outpu if "$CLEANUPDBDIR" == "2" and test was successful