### PR TITLE
berkdb: use separate free_mutexp to add to free cursor list

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1381,6 +1381,7 @@ struct __db {
 	DB_MPOOLFILE *mpf;		/* Backing buffer pool. */
 
 	DB_MUTEX *mutexp;		/* Synchronization for free threading */
+	DB_MUTEX *free_mutexp;		/* Synchronization for free threading */
 
 	char *fname, *dname;		/* File/database passed to DB->open. */
 	u_int32_t open_flags;		/* Flags passed to DB->open. */

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -480,6 +480,9 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 		if ((ret = __db_mutex_setup(dbenv, dbmp->reginfo, &dbp->mutexp,
 			MUTEX_ALLOC | MUTEX_THREAD)) != 0)
 			return (ret);
+		if ((ret = __db_mutex_setup(dbenv, dbmp->reginfo, &dbp->free_mutexp,
+			MUTEX_ALLOC | MUTEX_THREAD)) != 0)
+			return (ret);
 	}
 
 	/*
@@ -971,6 +974,11 @@ never_opened:
 		dbmp = dbenv->mp_handle;
 		__db_mutex_free(dbenv, dbmp->reginfo, dbp->mutexp);
 		dbp->mutexp = NULL;
+	}
+	if (dbp->free_mutexp != NULL) {
+		dbmp = dbenv->mp_handle;
+		__db_mutex_free(dbenv, dbmp->reginfo, dbp->free_mutexp);
+		dbp->free_mutexp = NULL;
 	}
 
 	/* Discard any memory allocated for the file and database names. */

--- a/berkdb/db/db_am.c
+++ b/berkdb/db/db_am.c
@@ -80,7 +80,7 @@ __db_cursor_int(dbp, txn, dbtype, root, is_opd, lockerid, dbcp, flags)
 	 * right type.  With off page dups we may have different kinds
 	 * of cursors on the queue for a single database.
 	 */
-	MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
 	for (dbc = TAILQ_FIRST(&dbp->free_queue);
 	    dbc != NULL; dbc = TAILQ_NEXT(dbc, links))
 		if (dbtype == dbc->dbtype) {
@@ -88,7 +88,7 @@ __db_cursor_int(dbp, txn, dbtype, root, is_opd, lockerid, dbcp, flags)
 			F_CLR(dbc, ~DBC_OWN_LID);
 			break;
 		}
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
 
 	if (dbc == NULL) {
 		if ((ret = __os_calloc(dbenv, 1, sizeof(DBC), &dbc)) != 0)

--- a/berkdb/db/db_cam.c
+++ b/berkdb/db/db_cam.c
@@ -159,7 +159,7 @@ __db_c_close_ll(dbc, countmein)
 		dbc->txn->cursors--;
 
 	/* Move the cursor(s) to the free queue. */
-	MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
 	if (opd != NULL) {
 		if (dbc->txn != NULL)
 			dbc->txn->cursors--;
@@ -167,7 +167,7 @@ __db_c_close_ll(dbc, countmein)
 		opd = NULL;
 	}
 	TAILQ_INSERT_TAIL(&dbp->free_queue, dbc, links);
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
 
 	return (ret);
 }
@@ -524,9 +524,9 @@ __db_c_destroy(dbc)
 	dbenv = dbp->dbenv;
 
 	/* Remove the cursor from the free queue. */
-	MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
 	TAILQ_REMOVE(&dbp->free_queue, dbc, links);
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
+	MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
 
 	/* Free up allocated memory. */
 	if (dbc->my_rskey.data != NULL)


### PR DESCRIPTION
Berkdb uses mutexp to remove from active list and same mutex
to add to free cursor list. That same mutex is used for other
operations done on cursor.
Using a new mutex to add to free cursor list should reduce 
observed contention on mutexp.