### PR TITLE
Fix analyze abort crash.

### DIFF
--- a/bdb/summarize.c
+++ b/bdb/summarize.c
@@ -259,6 +259,10 @@ err:
 int sampler_close(sampler_t *sampler)
 {
     int unused;
+
+    if (sampler == NULL)
+        return 0;
+
     (void)bdb_temp_table_close(sampler->bdb_state, sampler->tmptbl, &unused);
     free(sampler->data);
     free(sampler);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2247,8 +2247,6 @@ static int cursor_move_preprop(BtCursor *pCur, int *pRes, int how, int *done)
             logmsg(LOGMSG_ERROR, 
                     "%s: Aborting Analyze because of send analyze abort\n",
                     __func__);
-        sampler_close(pCur->sampler);
-        pCur->sampler = NULL;
         *done = 1;
         rc = -1;
         return SQLITE_BUSY;

--- a/tests/analyze_sample.test/runit
+++ b/tests/analyze_sample.test/runit
@@ -19,3 +19,16 @@ cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'analyze t 100'
 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select sample from sqlite_stat4' >stat4.actual
 
 diff stat4.actual stat4.expected
+
+# test analyze abort
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+# force random recover deadlock to slow down the analyze
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("random_lock_release_interval 100")'
+# analyze in the background
+cdb2sql $dbnm --host $host 'analyze t 100' &
+# wait for it to be dispatched
+sleep 2
+# abort
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("analyze abort")'
+
+wait


### PR DESCRIPTION
Don't call `sampler_close()` in `cursor_move()` when aborting an anlyze. The sampler should be
closed in `sqlite3BtreeCloseCursor()` just once.