### PR TITLE
Fix spurious failures in the 'sp' test caused by the (pending) creation of a time partition during subsequent SQL statement preparation.

### DIFF
--- a/tests/sp.test/sp.sh
+++ b/tests/sp.test/sp.sh
@@ -1295,8 +1295,6 @@ create lua scalar function no_ddl_proc1
 create lua aggregate function no_ddl_proc2
 create lua consumer no_ddl_proc1 on (table no_ddl_t1 for insert)
 create table comdb2_logical_cron (name cstring(128) primary key, value int)$$
-create table test_drop_tp_0(i int)$$
-create time partition on test_drop_tp_0 as test_drop_tp period 'manual' retention 2 start '1'
 EOF
 
 cdb2sql $SP_OPTIONS - <<'EOF'
@@ -1346,7 +1344,6 @@ local function main()
         "DROP LUA TRIGGER no_ddl_proc1",
         "CREATE LUA CONSUMER no_ddl_proc1 ON (TABLE no_ddl_t1 FOR INSERT OF x)",
         "DROP LUA CONSUMER no_ddl_proc1",
-        "DROP TIME PARTITION test_drop_tp",
     }
 
     db:column_type("int", 1)

--- a/tests/sp.test/t01.req.out
+++ b/tests/sp.test/t01.req.out
@@ -1781,6 +1781,5 @@ SP: exec procedure bound(@i, @u, @ll, @ull, @s, @us, @f, @d, @dt, @cstr, @ba, @b
 (exec_rc=23, prepare_rc=23, ddl='DROP LUA TRIGGER no_ddl_proc1')
 (exec_rc=23, prepare_rc=23, ddl='CREATE LUA CONSUMER no_ddl_proc1 ON (TABLE no_ddl_t1 FOR INSERT OF x)')
 (exec_rc=23, prepare_rc=23, ddl='DROP LUA CONSUMER no_ddl_proc1')
-(exec_rc=23, prepare_rc=23, ddl='DROP TIME PARTITION test_drop_tp')
 ($0='{"emoji":"hello world 😁"}')
 ($0='{"emoji":"hello world 😁"}')


### PR DESCRIPTION
These changes modify the 'sp' test.  They remove a CREATE TIME PARTITION statement that (potentially, depending on timing) ended up being processed while the subsequent stored procedure was running, causing wrong error codes to be returned, thus (correctly) failing the test.

As it turns out, (pre-)creating a time partition for this test does not appear to be necessary, as the authorizer check for DROP TIME PARTITION is performed prior to verifying that the named time partition actually exists (aside: this actually doesn't happen until the query execution phase).
