### PR TITLE
This fixes serializable and selectv

### DIFF
--- a/bdb/serializable.c
+++ b/bdb/serializable.c
@@ -434,6 +434,8 @@ static int osql_serial_check(bdb_state_type *bdb_state, void *ranges,
             if (!rc)
                 LOGCOPY_32(&rectype, logdta.data);
             else if (rc == DB_NOTFOUND) {
+                *file = seriallsn.file;
+                *offset = seriallsn.offset;
                 break;
             } else {
                 fprintf(stderr, "Unable to get last_logical_lsn, rc %d\n", rc);

--- a/bdb/serializable.c
+++ b/bdb/serializable.c
@@ -404,6 +404,8 @@ static int osql_serial_check(bdb_state_type *bdb_state, void *ranges,
         if (!rc)
             LOGCOPY_32(&rectype, logdta.data);
         else if (rc == DB_NOTFOUND) {
+            *file = seriallsn.file;
+            *offset = seriallsn.offset;
             rc = 0;
             break;
         } else {


### PR DESCRIPTION
The txn lsn taken at the beginning of osql_serial_check may not be the actual lsn that the checking stops- if the log is truncated while osql_serial_check is running, then this may actually skip log-records.  This change fixes the sporadic verify-rather-than-selectv errors that the selectv_rcode test reproduces.