### PR TITLE
Add experimental support for precise timing with GCC/x86 (on Linux).

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5371,6 +5371,9 @@ int main(int argc, char **argv)
     /* clean left over transactions every 5 minutes */
     int clean_mins = 5 * 60 * 1000;
 
+    /* figure out the approximate CPU frequence (if available) */
+    get_cpu_cycle_freq(1);
+
     /* allocate initializer first */
     comdb2ma_init(0, 0);
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -527,6 +527,7 @@ struct sqlclntstate {
      * the i/o thread's buf */
     char *sql;
     char *zNormSql;
+    uint64_t cpu_cycles;
     int recno;
     int client_understands_query_stats;
     char tzname[CDB2_MAX_TZNAME];
@@ -1184,6 +1185,10 @@ struct query_stats {
     int64_t npreads;
     int64_t npwrites;
 };
+
+uint64_t get_cpu_cycle_count();
+double get_cpu_cycle_freq();
+
 int get_query_stats(struct query_stats *stats);
 void add_fingerprint(const char *, const char *, int64_t, int64_t, int64_t,
                      int64_t, struct reqlogger *);

--- a/db/sql.h
+++ b/db/sql.h
@@ -1187,7 +1187,7 @@ struct query_stats {
 };
 
 uint64_t get_cpu_cycle_count();
-double get_cpu_cycle_freq();
+double get_cpu_cycle_freq(int refresh);
 
 int get_query_stats(struct query_stats *stats);
 void add_fingerprint(const char *, const char *, int64_t, int64_t, int64_t,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -256,7 +256,7 @@ double get_cpu_cycle_freq()
     if (freq == 0.0) {
         struct timespec req;
         memset(&req, 0, sizeof(struct timespec));
-        req.tv_nsec = 100000; /* 10ms */
+        req.tv_nsec = 10000000; /* 10ms */
         uint64_t y1 = get_cpu_cycle_count();
         nanosleep(&req, NULL);
         uint64_t y2 = get_cpu_cycle_count();
@@ -4867,7 +4867,7 @@ int dispatch_sql_query(struct sqlclntstate *clnt)
     }
 
 done:
-    logmsg(LOGMSG_DEBUG,
+    logmsg(LOGMSG_USER,
            "%s: CPU usage was %llu cycles / %.02f nanoseconds for: {%s}\n",
            __func__, (unsigned long long int)clnt->cpu_cycles,
            ((double)clnt->cpu_cycles / get_cpu_cycle_freq()), clnt->sql);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -250,10 +250,10 @@ uint64_t get_cpu_cycle_count()
 #endif
 }
 
-double get_cpu_cycle_freq()
+double get_cpu_cycle_freq(int refresh)
 {
     static double freq = 0.0;
-    if (freq == 0.0) {
+    if (refresh || (freq == 0.0)) {
         struct timespec req;
         memset(&req, 0, sizeof(struct timespec));
         req.tv_nsec = 10000000; /* 10ms */
@@ -4870,7 +4870,7 @@ done:
     logmsg(LOGMSG_USER,
            "%s: CPU usage was %llu cycles / %.02f nanoseconds for: {%s}\n",
            __func__, (unsigned long long int)clnt->cpu_cycles,
-           ((double)clnt->cpu_cycles / get_cpu_cycle_freq()), clnt->sql);
+           ((double)clnt->cpu_cycles / get_cpu_cycle_freq(0)), clnt->sql);
 
     if (self)
         thrman_where(self, "query done");


### PR DESCRIPTION
These changes introduce two (experimental) functions that can be used to precisely time operations within the database.  Also, example usage is included within dispatch_sql_query().