### PR TITLE
pmux.cpp: Remove duplicate if check.

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -682,18 +682,16 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
     } else if (strcmp(cmd, "hello") == 0) {
         svc = strtok_r(NULL, " ", &sav);
         if (c.writable && svc != nullptr) {
-            if (svc != nullptr) {
-                c.is_hello = true;
-                {
-                    std::lock_guard<std::mutex> l(active_services_mutex);
-                    active_services.insert(std::string(svc));
-                }
-                c.service = std::string(svc);
-                conn_printf(c, "ok\n");
+          c.is_hello = true;
+          {
+            std::lock_guard<std::mutex> l(active_services_mutex);
+            active_services.insert(std::string(svc));
+          }
+          c.service = std::string(svc);
+          conn_printf(c, "ok\n");
 #ifdef VERBOSE
-                std::cout << "hello from " << svc << std::endl;
+          std::cout << "hello from " << svc << std::endl;
 #endif
-            }
         } else if (svc == nullptr) {
             conn_printf(c, "-1 missing service name\n");
         } else {

--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -682,15 +682,15 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
     } else if (strcmp(cmd, "hello") == 0) {
         svc = strtok_r(NULL, " ", &sav);
         if (c.writable && svc != nullptr) {
-          c.is_hello = true;
-          {
-            std::lock_guard<std::mutex> l(active_services_mutex);
-            active_services.insert(std::string(svc));
-          }
-          c.service = std::string(svc);
-          conn_printf(c, "ok\n");
+            c.is_hello = true;
+            {
+                std::lock_guard<std::mutex> l(active_services_mutex);
+                active_services.insert(std::string(svc));
+            }
+            c.service = std::string(svc);
+            conn_printf(c, "ok\n");
 #ifdef VERBOSE
-          std::cout << "hello from " << svc << std::endl;
+            std::cout << "hello from " << svc << std::endl;
 #endif
         } else if (svc == nullptr) {
             conn_printf(c, "-1 missing service name\n");


### PR DESCRIPTION
This is a logic check improvement/change.
Rather than running `if (c.writable && svc != nullptr)` followed immediately by the already verified `if (svc != nullptr)`, this PR removes the 2nd check and merges the code into the main `if (c.writable && svc != nullptr)` block.
The current behavior involves doing a 2nd check on the 2nd half of a previously if statement's compound boolean check. Removing this 2nd already verified check should help simplify the code and perhaps even speed up the processing.