### PR TITLE
pmux.cpp: Added ifdef VERBOSE around syslog(LOGINFO...) call.

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -573,8 +573,10 @@ static int route_to_instance(char *svc, int fd)
 void disallowed_write(connection &c, char *cmd)
 {
     char *ip = inet_ntoa(c.addr);
+#ifdef VERBOSE
     syslog(LOG_INFO, "attempt to write (%s) from remote connection %s\n", cmd,
            ip);
+#endif
     conn_printf(c, "-1 write requests not permitted from this host\n");
 }
 


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
Feature.
* What are the current behavior and expected behavior, if this is a bugfix ?
Not a bug fix.
* What are the steps required to reproduce the bug, if this is a bugfix ?
Not a bug fix.
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
Currently all of the other syslog(LOGINFO...) calls are placed within an ifdef VERBOSE block.  This PR added the ifdef VERBOSE block around a syslog(LOGINFO...) call that doesn't currently use the ifdef VERBOSE.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
This PR makes the syslog(LOGINFO...) call match the other syslog(LOGINFO...) calls that are all enclosed in ifdef VERBOSE blocks.  This would make the logging for that level only trigger under VERBOSE mode.