### PR TITLE
For debug builds, assert that the schema lock is held from the appropriate places...

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -847,8 +847,9 @@ dbtable *get_dbtable_by_name(const char *p_name)
     dbtable *p_db = NULL;
 
     Pthread_rwlock_rdlock(&thedb_lock);
-    schema_read_held_lk();
+    rdlock_schema_lk();
     p_db = hash_find_readonly(thedb->db_hash, &p_name);
+    unlock_schema_lk();
     Pthread_rwlock_unlock(&thedb_lock);
     if (!p_db && !strcmp(p_name, COMDB2_STATIC_TABLE))
         p_db = &thedb->static_table;
@@ -865,8 +866,9 @@ dbtable *get_dbtable_by_name_locked(tran_type *tran, const char *p_name)
         return get_dbtable_by_name(p_name);
 
     Pthread_rwlock_rdlock(&thedb_lock);
-    schema_read_held_lk();
+    rdlock_schema_lk();
     p_db = hash_find_readonly(thedb->db_hash, &p_name);
+    unlock_schema_lk();
     if (!p_db && !strcmp(p_name, COMDB2_STATIC_TABLE))
         p_db = &thedb->static_table;
     if (!p_db) {

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2595,7 +2595,7 @@ struct dbenv *newdbenv(char *dbname, char *lrlname)
         logmsg(LOGMSG_FATAL, "newdb:calloc dbenv");
         return NULL;
     }
-    thedb = dbenv;
+    thedb = dbenv; /* FIXME: Suspect, as the caller assigns as well? */
 
     dbenv->cacheszkbmin = 65536;
     dbenv->bdb_attr = bdb_attr_create();
@@ -2648,10 +2648,12 @@ struct dbenv *newdbenv(char *dbname, char *lrlname)
 
     plugin_post_dbenv_hook(dbenv);
 
+    wrlock_schema_lk();
     if (read_lrl_files(dbenv, lrlname)) {
         logmsg(LOGMSG_FATAL, "Failure in reading lrl file(s)\n");
         exit(1);
     }
+    unlock_schema_lk();
 
     logmsg(LOGMSG_INFO, "database %s starting\n", dbenv->envname);
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -847,42 +847,11 @@ dbtable *get_dbtable_by_name(const char *p_name)
     dbtable *p_db = NULL;
 
     Pthread_rwlock_rdlock(&thedb_lock);
-    rdlock_schema_lk();
+    schema_read_held_lk();
     p_db = hash_find_readonly(thedb->db_hash, &p_name);
-    unlock_schema_lk();
     Pthread_rwlock_unlock(&thedb_lock);
     if (!p_db && !strcmp(p_name, COMDB2_STATIC_TABLE))
         p_db = &thedb->static_table;
-
-    return p_db;
-}
-
-dbtable *get_dbtable_by_name_locked(tran_type *tran, const char *p_name)
-{
-    dbtable *p_db = NULL;
-    int rc = 0;
-
-    if (!tran)
-        return get_dbtable_by_name(p_name);
-
-    Pthread_rwlock_rdlock(&thedb_lock);
-    rdlock_schema_lk();
-    p_db = hash_find_readonly(thedb->db_hash, &p_name);
-    unlock_schema_lk();
-    if (!p_db && !strcmp(p_name, COMDB2_STATIC_TABLE))
-        p_db = &thedb->static_table;
-    if (!p_db) {
-        rc = bdb_lock_tablename_read(thedb->bdb_env, p_name, tran);
-    } else {
-        rc = bdb_lock_tablename_write(thedb->bdb_env, p_name, tran);
-    }
-    Pthread_rwlock_unlock(&thedb_lock);
-
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "%s Failed to lock table by name rc=%d!\n",
-               __func__, rc);
-        return NULL;
-    }
 
     return p_db;
 }

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1545,6 +1545,10 @@ void clean_exit(void)
     // TODO: would be nice but other threads need to exit first:
     // comdb2ma_exit();
 
+#ifndef NDEBUG
+    schema_term_held();
+#endif
+
     logmsg(LOGMSG_USER, "goodbye\n");
     exit(0);
 }
@@ -5435,6 +5439,10 @@ int main(int argc, char **argv)
 
     /* line buffering in stdout */
     setvbuf(stdout, 0, _IOLBF, 0);
+
+#ifndef NDEBUG
+    schema_init_held();
+#endif
 
     crc32c_init(0);
 

--- a/db/config.c
+++ b/db/config.c
@@ -974,6 +974,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
             dbenv->dbs[dbenv->num_dbs++] = db;
 
             /* Add table to the hash. */
+            if (schema_is_global_db_hash(dbenv->db_hash)) schema_write_held_lk();
             hash_add(dbenv->db_hash, db);
 
             /* just got a bunch of data. remember it so key forming

--- a/db/config.c
+++ b/db/config.c
@@ -974,7 +974,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
             dbenv->dbs[dbenv->num_dbs++] = db;
 
             /* Add table to the hash. */
-            if (schema_is_global_db_hash(dbenv->db_hash)) schema_write_held_lk();
+            maybe_schema_write_held_lk(dbenv);
             hash_add(dbenv->db_hash, db);
 
             /* just got a bunch of data. remember it so key forming

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1516,7 +1516,9 @@ clipper_usage:
         backend_thread_event(thedb, COMDB2_THR_EVENT_DONE_RDONLY);
         backend_thread_event(thedb, COMDB2_THR_EVENT_START_RDWR);
         logmsg(LOGMSG_USER, "checking schemas...\n");
+        rdlock_schema_lk();
         rc = check_current_schemas();
+        unlock_schema_lk();
         logmsg(LOGMSG_USER, "checked schemas, this database is %s\n",
                rc == 0 ? "good" : "bad");
         backend_thread_event(thedb, COMDB2_THR_EVENT_DONE_RDWR);

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -83,6 +83,7 @@ extern int __berkdb_read_alarm_ms;
 #include "sc_global.h"
 #include "logmsg.h"
 #include "comdb2_atomic.h"
+#include "schema_lk.h"
 
 extern int gbl_exit_alarm_sec;
 extern int gbl_disable_rowlocks_logging;
@@ -1364,6 +1365,14 @@ clipper_usage:
         logmsg(LOGMSG_USER, 
                 "Maximum concurrent block-processor threads is %d, maxwt is %d\n",
                 blkmax, gbl_maxwthreads);
+    }
+
+    else if (tokcmp(tok, ltok, "dump_schema_lk") == 0) {
+#ifndef NDEBUG
+        dump_schema_lk(stdout);
+#else
+        logmsg(LOGMSG_USER, "Schema lock debugging not available.\n");
+#endif
     }
 
     else if (tokcmp(tok, ltok, "temptable_clear") == 0) {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3179,6 +3179,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
     if (sql_set_transaction_mode(thd->sqldb, clnt, clnt->dbtran.mode) != 0) {
         return handle_bad_transaction_mode(thd, clnt);
     }
+    schema_read_held_lk();
     query_stats_setup(thd, clnt);
     get_cached_stmt(thd, clnt, rec);
     int sqlPrepFlags = 0;
@@ -4294,6 +4295,8 @@ static int prepare_engine(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     int rc = 0;
     int got_views_lock = 0;
     int got_curtran = 0;
+
+    schema_read_held_lk();
 
     /* Do this here, before setting up Btree structures!
        so we can get back at our "session" information */

--- a/tests/docker/Dockerfile.install
+++ b/tests/docker/Dockerfile.install
@@ -45,7 +45,7 @@ RUN cd /comdb2 &&  \
     rm -rf build && \
     mkdir build && \
     cd build && \
-    cmake -DWITH_TCL=1 .. && \
+    cmake -DCMAKE_BUILD_TYPE=Debug -DWITH_TCL=1 .. && \
     make -j4 && \
     make -j4 test-tools && \
     make install &&  \

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -65,15 +65,23 @@ include_directories(
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${PROJECT_SOURCE_DIR}/bbinc
+  ${PROJECT_SOURCE_DIR}/bdb
   ${PROJECT_SOURCE_DIR}/cdb2api
+  ${PROJECT_SOURCE_DIR}/csc2
+  ${PROJECT_SOURCE_DIR}/datetime
+  ${PROJECT_SOURCE_DIR}/dfp/dfpal
+  ${PROJECT_SOURCE_DIR}/dfp/decNumber
   ${PROJECT_SOURCE_DIR}/dlmalloc
   ${PROJECT_SOURCE_DIR}/mem
   ${PROJECT_BINARY_DIR}/mem
+  ${PROJECT_SOURCE_DIR}/net
   ${PROJECT_SOURCE_DIR}/sockpool
+  ${PROJECT_SOURCE_DIR}/sqlite/src
   ${PROJECT_SOURCE_DIR}/berkdb
   ${OPENSSL_INCLUDE_DIR}
   ${UNWIND_INCLUDE_DIR}
   ${PROJECT_SOURCE_DIR}/db
+  ${PROJECT_BINARY_DIR}/db
 )
 add_dependencies(util mem)
 set_source_files_properties(walkback.c PROPERTIES COMPILE_FLAGS -DUSE_UNWIND)

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -132,7 +132,7 @@ inline void unlock_schema_int(const char *file, const char *func, int line)
 #endif
 #ifndef NDEBUG
     pthread_t self = pthread_self();
-    pthread_t nullt = (pthread_t)NULL;
+    pthread_t nullt = (pthread_t)0;
     int needRdLock = CAS(schema_wr_thd, self, nullt);
     Pthread_mutex_lock(&schema_rd_thds_lk);
     if (hash_del(schema_rd_thds, &self) != 0) {
@@ -152,7 +152,10 @@ inline void wrlock_schema_int(const char *file, const char *func, int line)
 {
     Pthread_rwlock_wrlock(&schema_lk);
 #ifndef NDEBUG
-    XCHANGE(schema_wr_thd, pthread_self());
+    pthread_t nullt = (pthread_t)0;
+    pthread_t self = pthread_self();
+    CAS(schema_wr_thd, nullt, self);
+    assert( ATOMIC_LOAD(schema_wr_thd)==(void *)self );
 #endif
 #ifdef VERBOSE_SCHEMA_LK
     logmsg(LOGMSG_USER, "%p:WRLOCK %s:%d\n", (void *)pthread_self(), func,

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -53,7 +53,7 @@ inline void schema_term_held(void)
     Pthread_mutex_unlock(&schema_rd_thds_lk);
 }
 
-inline int schema_is_global_db_int(struct dbenv *dbenv)
+inline int schema_is_global_db_int(void *dbenv)
 {
     return dbenv == thedb;
 }
@@ -168,7 +168,7 @@ inline void wrlock_schema_int(const char *file, const char *func, int line)
 #endif
 }
 
-void maybe_rdlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_rdlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line)
 {
     if (schema_is_global_db_int(dbenv)) {
@@ -176,7 +176,7 @@ void maybe_rdlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
     }
 }
 
-void maybe_wrlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_wrlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line)
 {
     if (schema_is_global_db_int(dbenv)) {
@@ -184,7 +184,7 @@ void maybe_wrlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
     }
 }
 
-void maybe_unlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_unlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line)
 {
     if (schema_is_global_db_int(dbenv)) {

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -19,11 +19,82 @@
 #include <locks_wrap.h>
 #include <schema_lk.h>
 
+#ifndef NDEBUG
+#include <stdio.h>
+#include <stdlib.h>
+#include "comdb2_atomic.h"
+#include "plhash.h"
+
+static pthread_mutex_t schema_rd_thds_lk = PTHREAD_MUTEX_INITIALIZER;
+static hash_t *schema_rd_thds = NULL;
+static pthread_t schema_wr_thd = (pthread_t)0;
+#endif
+
 static pthread_rwlock_t schema_lk = PTHREAD_RWLOCK_INITIALIZER;
+
+#ifndef NDEBUG
+inline void schema_init_held(void)
+{
+  Pthread_mutex_lock(&schema_rd_thds_lk);
+  assert(schema_rd_thds == NULL);
+  schema_rd_thds = hash_init(sizeof(pthread_t));
+  Pthread_mutex_unlock(&schema_rd_thds_lk);
+}
+
+inline void schema_term_held(void)
+{
+  Pthread_mutex_lock(&schema_rd_thds_lk);
+  assert(schema_rd_thds != NULL);
+  hash_clear(schema_rd_thds);
+  hash_free(schema_rd_thds);
+  schema_rd_thds = NULL;
+  Pthread_mutex_unlock(&schema_rd_thds_lk);
+}
+
+inline int schema_read_held_int(const char *file, const char *func, int line)
+{
+  int rc = 0;
+  Pthread_mutex_lock(&schema_rd_thds_lk);
+  if (hash_find(schema_rd_thds, pthread_self()) != NULL) {
+    rc = 1;
+  }
+  Pthread_mutex_unlock(&schema_rd_thds_lk);
+  return rc;
+}
+
+inline int schema_write_held_int(const char *file, const char *func, int line)
+{
+  pthread_t self = pthread_self();
+  return CAS(schema_wr_thd, self, self);
+}
+
+static int schema_dump_rd_thd(void *obj, void *arg)
+{
+  logmsgf(LOGMSG_USER, (FILE *)arg, "[SCHEMA_LK] has reader %p\n", obj);
+  fflush(out);
+  return 0;
+}
+
+void dump_schema_lk(FILE *out)
+{
+    logmsgf(LOGMSG_USER, out, "[SCHEMA_LK] writer is %p\n",
+            (void *)ATOMIC_LOAD(schema_wr_thd));
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    hash_for(schema_rd_thds, schema_dump_rd_thd, out);
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
+}
+#endif
 
 inline void rdlock_schema_int(const char *file, const char *func, int line)
 {
     Pthread_rwlock_rdlock(&schema_lk);
+#ifndef NDEBUG
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    if (hash_add(schema_rd_thds, pthread_self()) != 0) {
+        abort();
+    }
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
+#endif
 #ifdef VERBOSE_SCHEMA_LK
     logmsg(LOGMSG_USER, "%p:RDLOCK %s:%d\n", (void *)pthread_self(), func,
            line);
@@ -33,6 +104,15 @@ inline void rdlock_schema_int(const char *file, const char *func, int line)
 inline int tryrdlock_schema_int(const char *file, const char *func, int line)
 {
     int rc = pthread_rwlock_tryrdlock(&schema_lk);
+#ifndef NDEBUG
+    if (rc == 0) {
+        Pthread_mutex_lock(&schema_rd_thds_lk);
+        if (hash_add(schema_rd_thds, pthread_self()) != 0) {
+            abort();
+        }
+        Pthread_mutex_unlock(&schema_rd_thds_lk);
+    }
+#endif
 #ifdef VERBOSE_SCHEMA_LK
     logmsg(LOGMSG_USER, "%p:TRYRDLOCK RC:%d %s:%d\n", (void *)pthread_self(),
            rc, func, line);
@@ -46,12 +126,25 @@ inline void unlock_schema_int(const char *file, const char *func, int line)
     logmsg(LOGMSG_USER, "%p:UNLOCK %s:%d\n", (void *)pthread_self(), func,
            line);
 #endif
+#ifndef NDEBUG
+    pthread_t self = pthread_self();
+    pthread_t nullt = (pthread_t)NULL;
+    CAS(schema_wr_thd, self, nullt);
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    if (hash_del(schema_rd_thds, self) != 0) {
+        abort();
+    }
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
+#endif
     Pthread_rwlock_unlock(&schema_lk);
 }
 
 inline void wrlock_schema_int(const char *file, const char *func, int line)
 {
     Pthread_rwlock_wrlock(&schema_lk);
+#ifndef NDEBUG
+    XCHANGE(schema_wr_thd, pthread_self());
+#endif
 #ifdef VERBOSE_SCHEMA_LK
     logmsg(LOGMSG_USER, "%p:WRLOCK %s:%d\n", (void *)pthread_self(), func,
            line);

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -36,45 +36,45 @@ static pthread_rwlock_t schema_lk = PTHREAD_RWLOCK_INITIALIZER;
 #ifndef NDEBUG
 inline void schema_init_held(void)
 {
-  Pthread_mutex_lock(&schema_rd_thds_lk);
-  assert(schema_rd_thds == NULL);
-  schema_rd_thds = hash_init(sizeof(pthread_t));
-  Pthread_mutex_unlock(&schema_rd_thds_lk);
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    assert(schema_rd_thds == NULL);
+    schema_rd_thds = hash_init(sizeof(pthread_t));
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
 }
 
 inline void schema_term_held(void)
 {
-  Pthread_mutex_lock(&schema_rd_thds_lk);
-  assert(schema_rd_thds != NULL);
-  hash_clear(schema_rd_thds);
-  hash_free(schema_rd_thds);
-  schema_rd_thds = NULL;
-  Pthread_mutex_unlock(&schema_rd_thds_lk);
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    assert(schema_rd_thds != NULL);
+    hash_clear(schema_rd_thds);
+    hash_free(schema_rd_thds);
+    schema_rd_thds = NULL;
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
 }
 
 inline int schema_read_held_int(const char *file, const char *func, int line)
 {
-  int rc = 0;
-  Pthread_mutex_lock(&schema_rd_thds_lk);
-  pthread_t self = pthread_self();
-  if (hash_find(schema_rd_thds, &self) != NULL) {
-    rc = 1;
-  }
-  Pthread_mutex_unlock(&schema_rd_thds_lk);
-  return rc;
+    int rc = 0;
+    Pthread_mutex_lock(&schema_rd_thds_lk);
+    pthread_t self = pthread_self();
+    if (hash_find(schema_rd_thds, &self) != NULL) {
+        rc = 1;
+    }
+    Pthread_mutex_unlock(&schema_rd_thds_lk);
+    return rc;
 }
 
 inline int schema_write_held_int(const char *file, const char *func, int line)
 {
-  pthread_t self = pthread_self();
-  return CAS(schema_wr_thd, self, self);
+    pthread_t self = pthread_self();
+    return CAS(schema_wr_thd, self, self);
 }
 
 static int schema_dump_rd_thd(void *obj, void *arg)
 {
-  logmsgf(LOGMSG_USER, (FILE *)arg, "[SCHEMA_LK] has reader %p\n", obj);
-  fflush((FILE *)arg);
-  return 0;
+    logmsgf(LOGMSG_USER, (FILE *)arg, "[SCHEMA_LK] has reader %p\n", obj);
+    fflush((FILE *)arg);
+    return 0;
 }
 
 void dump_schema_lk(FILE *out)

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -56,7 +56,8 @@ inline int schema_read_held_int(const char *file, const char *func, int line)
 {
   int rc = 0;
   Pthread_mutex_lock(&schema_rd_thds_lk);
-  if (hash_find(schema_rd_thds, (void *)pthread_self()) != NULL) {
+  pthread_t self = pthread_self();
+  if (hash_find(schema_rd_thds, &self) != NULL) {
     rc = 1;
   }
   Pthread_mutex_unlock(&schema_rd_thds_lk);

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -91,7 +91,8 @@ inline void rdlock_schema_int(const char *file, const char *func, int line)
     Pthread_rwlock_rdlock(&schema_lk);
 #ifndef NDEBUG
     Pthread_mutex_lock(&schema_rd_thds_lk);
-    if (hash_add(schema_rd_thds, (void *)pthread_self()) != 0) {
+    pthread_t self = pthread_self();
+    if (hash_add(schema_rd_thds, &self) != 0) {
         abort();
     }
     Pthread_mutex_unlock(&schema_rd_thds_lk);
@@ -108,7 +109,8 @@ inline int tryrdlock_schema_int(const char *file, const char *func, int line)
 #ifndef NDEBUG
     if (rc == 0) {
         Pthread_mutex_lock(&schema_rd_thds_lk);
-        if (hash_add(schema_rd_thds, (void *)pthread_self()) != 0) {
+        pthread_t self = pthread_self();
+        if (hash_add(schema_rd_thds, &self) != 0) {
             abort();
         }
         Pthread_mutex_unlock(&schema_rd_thds_lk);
@@ -132,7 +134,7 @@ inline void unlock_schema_int(const char *file, const char *func, int line)
     pthread_t nullt = (pthread_t)NULL;
     CAS(schema_wr_thd, self, nullt);
     Pthread_mutex_lock(&schema_rd_thds_lk);
-    if (hash_del(schema_rd_thds, (void *)self) != 0) {
+    if (hash_del(schema_rd_thds, &self) != 0) {
         abort();
     }
     Pthread_mutex_unlock(&schema_rd_thds_lk);

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include "comdb2.h"
 #include "comdb2_atomic.h"
 #include "plhash.h"
 
@@ -50,6 +51,11 @@ inline void schema_term_held(void)
     hash_free(schema_rd_thds);
     schema_rd_thds = NULL;
     Pthread_mutex_unlock(&schema_rd_thds_lk);
+}
+
+inline int schema_is_global_db_hash_int(hash_t *hash)
+{
+    return thedb->db_hash == hash;
 }
 
 inline int schema_read_held_int(const char *file, const char *func, int line)

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -18,22 +18,22 @@
 #define INCLUDED_SCHEMA_LK_H
 
 #include <locks_wrap.h>
+#include "comdb2.h"
 
 #ifndef NDEBUG
 #include <stdio.h>
 #include "logmsg.h"
-#include "plhash.h"
 
 void schema_init_held(void);
 void schema_term_held(void);
 
-int schema_is_global_db_hash_int(hash_t *hash);
+int schema_is_global_db_int(struct dbenv *dbenv);
 int schema_read_held_int(const char *file, const char *func, int line);
 int schema_write_held_int(const char *file, const char *func, int line);
 
 void dump_schema_lk(FILE *out);
 
-#define schema_is_global_db_hash(a) schema_is_global_db_hash_int((a))
+#define schema_is_global_db(a) schema_is_global_db_int((a))
 
 #define schema_read_held_lk() do {                                \
   if (!schema_read_held_int(__FILE__, __func__, __LINE__) &&      \
@@ -51,10 +51,21 @@ void dump_schema_lk(FILE *out);
     abort();                                                            \
   }                                                                     \
 } while (0)
+
+#define maybe_schema_read_held_lk(a) do {                  \
+  if (schema_is_global_db((a))) { schema_read_held_lk(); } \
+} while (0)
+
+#define maybe_schema_write_held_lk(a) do {                  \
+  if (schema_is_global_db((a))) { schema_write_held_lk(); } \
+} while (0)
+
 #else
-#define schema_is_global_db_hash(a) (0)
+#define schema_is_global_db(a) (0)
 #define schema_read_held_lk()
 #define schema_write_held_lk()
+#define maybe_schema_read_held_lk(a)
+#define maybe_schema_write_held_lk(a)
 #endif
 
 #define rdlock_schema_lk() rdlock_schema_int(__FILE__, __func__, __LINE__)
@@ -68,5 +79,20 @@ void unlock_schema_int(const char *file, const char *func, int line);
 
 #define wrlock_schema_lk() wrlock_schema_int(__FILE__, __func__, __LINE__)
 void wrlock_schema_int(const char *file, const char *func, int line);
+
+#define maybe_rdlock_schema_lk_for_db(a) \
+maybe_rdlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
+void maybe_rdlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+                                       const char *func, int line);
+
+#define maybe_wrlock_schema_lk_for_db(a) \
+maybe_wrlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
+void maybe_wrlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+                                       const char *func, int line);
+
+#define maybe_unlock_schema_lk_for_db(a) \
+maybe_unlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
+void maybe_unlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+                                       const char *func, int line);
 
 #endif

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -18,7 +18,6 @@
 #define INCLUDED_SCHEMA_LK_H
 
 #include <locks_wrap.h>
-#include "comdb2.h"
 
 #ifndef NDEBUG
 #include <stdio.h>
@@ -27,7 +26,7 @@
 void schema_init_held(void);
 void schema_term_held(void);
 
-int schema_is_global_db_int(struct dbenv *dbenv);
+int schema_is_global_db_int(void *dbenv);
 int schema_read_held_int(const char *file, const char *func, int line);
 int schema_write_held_int(const char *file, const char *func, int line);
 
@@ -82,17 +81,17 @@ void wrlock_schema_int(const char *file, const char *func, int line);
 
 #define maybe_rdlock_schema_lk_for_db(a) \
 maybe_rdlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
-void maybe_rdlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_rdlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line);
 
 #define maybe_wrlock_schema_lk_for_db(a) \
 maybe_wrlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
-void maybe_wrlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_wrlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line);
 
 #define maybe_unlock_schema_lk_for_db(a) \
 maybe_unlock_schema_lk_for_db_int((a), __FILE__, __func__, __LINE__)
-void maybe_unlock_schema_lk_for_db_int(struct dbenv *dbenv, const char *file,
+void maybe_unlock_schema_lk_for_db_int(void *dbenv, const char *file,
                                        const char *func, int line);
 
 #endif

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -31,12 +31,13 @@ int schema_write_held_int(const char *file, const char *func, int line);
 
 void dump_schema_lk(FILE *out);
 
-#define schema_read_held_lk() do {                                     \
-  if (!schema_read_held_int(__FILE__, __func__, __LINE__)) {           \
-    logmsg(LOGMSG_FATAL, "SCHEMA READ LOCK NOT HELD: %s:%s:%d (%p)\n", \
-           __FILE__, __func__, __LINE__, (void *)pthread_self());      \
-    abort();                                                           \
-  }                                                                    \
+#define schema_read_held_lk() do {                                \
+  if (!schema_read_held_int(__FILE__, __func__, __LINE__) &&      \
+      !schema_write_held_int(__FILE__, __func__, __LINE__)) {     \
+    logmsg(LOGMSG_FATAL, "SCHEMA LOCK NOT HELD: %s:%s:%d (%p)\n", \
+           __FILE__, __func__, __LINE__, (void *)pthread_self()); \
+    abort();                                                      \
+  }                                                               \
 } while (0)
 
 #define schema_write_held_lk() do {                                     \

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -22,14 +22,18 @@
 #ifndef NDEBUG
 #include <stdio.h>
 #include "logmsg.h"
+#include "plhash.h"
 
 void schema_init_held(void);
 void schema_term_held(void);
 
+int schema_is_global_db_hash_int(hash_t *hash);
 int schema_read_held_int(const char *file, const char *func, int line);
 int schema_write_held_int(const char *file, const char *func, int line);
 
 void dump_schema_lk(FILE *out);
+
+#define schema_is_global_db_hash(a) schema_is_global_db_hash_int((a))
 
 #define schema_read_held_lk() do {                                \
   if (!schema_read_held_int(__FILE__, __func__, __LINE__) &&      \
@@ -48,6 +52,7 @@ void dump_schema_lk(FILE *out);
   }                                                                     \
 } while (0)
 #else
+#define schema_is_global_db_hash(a) (0)
 #define schema_read_held_lk()
 #define schema_write_held_lk()
 #endif

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -19,6 +19,38 @@
 
 #include <locks_wrap.h>
 
+#ifndef NDEBUG
+#include <stdio.h>
+#include "logmsg.h"
+
+void schema_init_held(void);
+void schema_term_held(void);
+
+int schema_read_held_int(const char *file, const char *func, int line);
+int schema_write_held_int(const char *file, const char *func, int line);
+
+void dump_schema_lk(FILE *out);
+
+#define schema_read_held_lk() do {                                     \
+  if (!schema_read_held_int(__FILE__, __func__, __LINE__)) {           \
+    logmsg(LOGMSG_FATAL, "SCHEMA READ LOCK NOT HELD: %s:%s:%d (%p)\n", \
+           __FILE__, __func__, __LINE__, (void *)pthread_self());      \
+    abort();                                                           \
+  }                                                                    \
+} while (0)
+
+#define schema_write_held_lk() do {                                     \
+  if (!schema_write_held_int(__FILE__, __func__, __LINE__)) {           \
+    logmsg(LOGMSG_FATAL, "SCHEMA WRITE LOCK NOT HELD: %s:%s:%d (%p)\n", \
+           __FILE__, __func__, __LINE__, (void *)pthread_self());       \
+    abort();                                                            \
+  }                                                                     \
+} while (0)
+#else
+#define schema_read_held_lk()
+#define schema_write_held_lk()
+#endif
+
 #define rdlock_schema_lk() rdlock_schema_int(__FILE__, __func__, __LINE__)
 void rdlock_schema_int(const char *file, const char *func, int line);
 


### PR DESCRIPTION
These changes introduce a way to assert that the schema lock is held from places that should be holding it.