### PR TITLE
Fix non plugin requests dohsql

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -670,8 +670,8 @@ DEF_ATTR(
 DEF_ATTR(
     AA_REQUEST_MODE, aa_request_mode, BOOLEAN, 0,
     "Print a message to stdout instead of performing auto-analyze ourselves")
-DEF_ATTR(
-    TEST_IO_TIME, test_io_time, SECS, 10, "Check I/O in watchdog this often")
+DEF_ATTR(TEST_IO_TIME, test_io_time, SECS, 10,
+         "Check I/O in watchdog this often")
 
 /*
   BDB_ATTR_REPTIMEOUT

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1746,6 +1746,11 @@ int order_init(dohsql_t *conns, dohsql_node_t *node)
 int dohsql_is_parallel_shard(void)
 {
     GET_CLNT;
+    /* exclude statements that do not arrive
+       by a supported plugin */
+    if (!clnt->plugin.write_response)
+        return 1;
+        
     return (clnt->conns || DOHSQL_CLIENT);
 }
 

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1750,7 +1750,7 @@ int dohsql_is_parallel_shard(void)
        by a supported plugin */
     if (!clnt->plugin.write_response)
         return 1;
-        
+
     return (clnt->conns || DOHSQL_CLIENT);
 }
 

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -321,7 +321,8 @@ static void *watchdog_thread(void *arg)
                 bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TEST_IO_TIME)) {
                 if (bdb_watchdog_test_io(thedb->bdb_env)) {
                     logmsg(LOGMSG_FATAL,
-                           "%s:bdb_watchdog_test_io failed - aborting\n", __func__);
+                           "%s:bdb_watchdog_test_io failed - aborting\n",
+                           __func__);
                     abort();
                 }
                 test_io_time = gbl_epoch_time;


### PR DESCRIPTION
comdb2sqlexplain does not have proper plugin interface; ignore any request like this in parallel sql code.
