### PR TITLE
Fix faulty assert

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1564,9 +1564,6 @@ static inline int replicant_can_retry_rc(struct sqlclntstate *clnt, int rc)
     if (clnt->verifyretry_off)
         return 0;
 
-    if (clnt->dbtran.mode == TRANLEVEL_SERIAL)
-        assert(rc != CDB2ERR_VERIFY_ERROR);
-
     /* Any isolation level can retry if nothing has been read */
     if ((rc == CDB2ERR_NOTSERIAL || rc == CDB2ERR_VERIFY_ERROR) &&
         !clnt->sent_data_to_client && !get_asof_snapshot(clnt) &&


### PR DESCRIPTION
One-line fix for a faulty assert introduced in the auto-retry merge.  A transaction can return a verify-error in serializable isolation if there's an election between the time when the sql session runs and the master attempts to execute the osql stream.
