### PR TITLE
Disable page-order-tablescan by default

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -299,7 +299,7 @@ DEF_ATTR(LOG_DEBUG_CTRACE_THRESHOLD, log_debug_ctrace_threshold, QUANTITY, 20,
 DEF_ATTR(DISABLE_UPDATE_STRIPE_CHANGE, disable_update_stripe_change, BOOLEAN, 1,
          "Enable to move records between stripes on an update.")
 DEF_ATTR(REP_SKIP_PHASE_3, rep_skip_phase_3, BOOLEAN, 0, NULL)
-DEF_ATTR(PAGE_ORDER_TABLESCAN, page_order_tablescan, BOOLEAN, 1,
+DEF_ATTR(PAGE_ORDER_TABLESCAN, page_order_tablescan, BOOLEAN, 0,
          "Scan tables in order of pages, not in order of rowids (faster for "
          "non-sparse tables).")
 DEF_ATTR_2(

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -573,7 +573,7 @@
 (name='page_compact_udp', description='Enables sending of page compact requests over UDP.', type='BOOLEAN', value='OFF', read_only='N')
 (name='page_extent_size', description='If set, allocate pages in blocks of this many (extents).', type='INTEGER', value='0', read_only='N')
 (name='page_latches', description='If set, in rowlocks mode, will acquire fast latches on pages instead of full locks. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
-(name='page_order_tablescan', description='Scan tables in order of pages, not in order of rowids (faster for non-sparse tables).', type='BOOLEAN', value='ON', read_only='N')
+(name='page_order_tablescan', description='Scan tables in order of pages, not in order of rowids (faster for non-sparse tables).', type='BOOLEAN', value='OFF', read_only='N')
 (name='pagedeadlock_maxpoll', description='If retrying on deadlock (see pagedeadlock_retries), poll up to this many ms on each retry.', type='INTEGER', value='5', read_only='N')
 (name='pagedeadlock_retries', description='On a page deadlock, retry the page operation up to this many times.', type='INTEGER', value='500', read_only='N')
 (name='pagesizedta', description='', type='INTEGER', value='4096', read_only='N')


### PR DESCRIPTION
Tables with a lot of pages on the free-list don't play nicely with page-order-tablescan.  I'm considering ideas for fixing this, but until a fix is in-place, revert the database default disable page-order-tablescans (which is also the R6 default).