### PR TITLE
Single-line change to make compiler warning disappear

### DIFF
--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1188,7 +1188,7 @@ int process_bind(const char *sql)
 
     if (debug_trace)
         fprintf(stderr, "binding: type %d, param %s, value %s\n", type,
-                parameter, value);
+                parameter, (char *)value);
     if (isdigit(parameter[0])) {
         int index = atoi(parameter);
         if (index <= 0)


### PR DESCRIPTION
Fix a compiler warning in cdb2sql by casting a void-pointer to a (char *)
