### PR TITLE
getmyseqnum can legitimately return a zero'd lsn: don't wait-for-seqn…

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1814,7 +1814,7 @@ bdb_state_type *bdb_get_table_by_name(bdb_state_type *bdb_state, char *table);
 int bdb_osql_check_table_version(bdb_state_type *bdb_state, tran_type *tran,
                                  int trak, int *bdberr);
 
-void bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum);
+int bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum);
 
 void bdb_replace_handle(bdb_state_type *parent, int ix, bdb_state_type *handle);
 

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3592,7 +3592,7 @@ void send_filenum_to_all(bdb_state_type *bdb_state, int filenum, int nodelay)
     }
 }
 
-void bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum)
+int bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum)
 {
     if ((!bdb_state->caught_up) || (bdb_state->exiting)) {
         bzero(seqnum, sizeof(seqnum_type));
@@ -3605,6 +3605,7 @@ void bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum)
 
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
     }
+    return (seqnum->lsn.file > 0);
 }
 
 int get_myseqnum(bdb_state_type *bdb_state, uint8_t *p_net_seqnum)

--- a/db/glue.c
+++ b/db/glue.c
@@ -716,7 +716,7 @@ int trans_wait_for_last_seqnum(struct ireq *iq, char *source_host)
 
     if (bdb_get_myseqnum(bdb_handle, (void *)&seqnum)) {
         rc = trans_wait_for_seqnum_int(bdb_handle, dbenv, iq, source_host, -1,
-                0 /*adaptive*/, &seqnum);
+                                       0 /*adaptive*/, &seqnum);
     }
     return rc;
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -710,13 +710,15 @@ int trans_wait_for_seqnum(struct ireq *iq, char *source_host,
 int trans_wait_for_last_seqnum(struct ireq *iq, char *source_host)
 {
     db_seqnum_type seqnum;
+    int rc = -1;
     void *bdb_handle = bdb_handle_from_ireq(iq);
     struct dbenv *dbenv = dbenv_from_ireq(iq);
 
-    bdb_get_myseqnum(bdb_handle, (void *)&seqnum);
-
-    return trans_wait_for_seqnum_int(bdb_handle, dbenv, iq, source_host, -1,
-                                     0 /*adaptive*/, &seqnum);
+    if (bdb_get_myseqnum(bdb_handle, (void *)&seqnum)) {
+        rc = trans_wait_for_seqnum_int(bdb_handle, dbenv, iq, source_host, -1,
+                0 /*adaptive*/, &seqnum);
+    }
+    return rc;
 }
 
 int trans_commit_logical_tran(void *trans, int *bdberr)


### PR DESCRIPTION
toblock calls "trans_wait_for_last_seqnum" when aborting a transaction, which calls bdb_get_myseqnum to retrieve the most recent lsn.  The problem is that bdb_get_myseqnum may legitimately return 0:0 if the node is catching up, or if the database is exiting.  Simple solution: don't call wait_for_seqnum if bdb_get_myseqnum returns a 0:0 LSN.
