### PR TITLE
Fix the concurrent SQL metric

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4709,7 +4709,9 @@ static int enqueue_sql_query(struct sqlclntstate *clnt)
     if (thdpool_get_nthds(gbl_sqlengine_thdpool) == thdpool_get_maxthds(gbl_sqlengine_thdpool))
         q_depth_tag_and_sql += thdpool_get_queue_depth(gbl_sqlengine_thdpool) + 1;
 
-    time_metric_add(thedb->concurrent_queries, thdpool_get_nthds(gbl_sqlengine_thdpool));
+    time_metric_add(thedb->concurrent_queries,
+                    thdpool_get_nthds(gbl_sqlengine_thdpool) -
+                        thdpool_get_nfreethds(gbl_sqlengine_thdpool));
     time_metric_add(thedb->queue_depth, q_depth_tag_and_sql);
 
     sqlcpy = strdup(msg);

--- a/tests/concurrent_sql.test/Makefile
+++ b/tests/concurrent_sql.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/concurrent_sql.test/runit
+++ b/tests/concurrent_sql.test/runit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+# Have 4 SQL threads
+cdb2sql $dbnm --host $host 'SELECT SLEEP(5)' &
+cdb2sql $dbnm --host $host 'SELECT SLEEP(5)' &
+cdb2sql $dbnm --host $host 'SELECT SLEEP(5)' &
+cdb2sql $dbnm --host $host 'SELECT SLEEP(5)' &
+
+# wait for becoming idle
+wait
+
+nthds=`cdb2sql --tabs $dbnm --host $host 'exec procedure sys.cmd.send("sqlenginepool stat")' | grep 'Current num threads' | cut -f2 -d':'`
+if [ $nthds != 4 ]; then
+    echo nthds is $nthds >&2
+    exit 1
+fi
+
+sleep 31
+
+nsql=`cdb2sql --tabs $dbnm --host $host 'SELECT CAST(value AS INT) FROM comdb2_metrics WHERE name = "concurrent_sql"'`
+if [ $nsql != 0 ]; then
+    echo nsql is $nsql >&2
+    exit 1
+fi
+
+wait


### PR DESCRIPTION
Return the actual number of running SQL queries, not the number of SQL threads.

(DRQS 146940300)
