### PR TITLE
pmux.cpp: Changed NULLs to nullptrs.

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -584,7 +584,7 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
                    connection &c)
 {
     int bad = 0;
-    char *cmd = NULL, *svc = NULL, *sav;
+    char *cmd = nullptr, *svc = nullptr, *sav;
 
 #ifdef VERBOSE
     syslog(LOG_INFO, "%d: cmd: %s\n", fd.fd, in);
@@ -592,13 +592,13 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
 #endif
 
     cmd = strtok_r(in, " ", &sav);
-    if (cmd == NULL)
+    if (cmd == nullptr)
         goto done;
 
     if (strcmp(cmd, "reg") == 0) {
         if (c.writable) {
-            svc = strtok_r(NULL, " ", &sav);
-            if (svc == NULL) {
+            svc = strtok_r(nullptr, " ", &sav);
+            if (svc == nullptr) {
                 conn_printf(c, "-1 missing service name\n");
             } else {
                 int port = get_svc_port(svc);
@@ -611,17 +611,17 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
             disallowed_write(c, cmd);
         }
     } else if (strcmp(cmd, "get") == 0) {
-        char *echo = strtok_r(NULL, " ", &sav);
-        if (echo == NULL) {
+        char *echo = strtok_r(nullptr, " ", &sav);
+        if (echo == nullptr) {
             conn_printf(c, "-1 missing service name\n");
         } else {
             if (strcmp(echo, "/echo") == 0) {
-                svc = strtok_r(NULL, " ", &sav);
+                svc = strtok_r(nullptr, " ", &sav);
             } else {
                 svc = echo;
-                echo = NULL;
+                echo = nullptr;
             }
-            if (svc == NULL) {
+            if (svc == nullptr) {
                 conn_printf(c, "-1\n");
             } else {
                 int port = get_svc_port(svc);
@@ -632,8 +632,8 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
             }
         }
     } else if (strcmp(cmd, "rte") == 0) {
-        char *svc = strtok_r(NULL, " ", &sav);
-        if (svc == NULL) {
+        char *svc = strtok_r(nullptr, " ", &sav);
+        if (svc == nullptr) {
             conn_printf(c, "-1\n");
         } else {
             int rc = route_to_instance(svc, fd.fd);
@@ -646,8 +646,8 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
         }
     } else if (strcmp(cmd, "del") == 0) {
         if (c.writable) {
-            svc = strtok_r(NULL, " ", &sav);
-            if (svc == NULL) {
+            svc = strtok_r(nullptr, " ", &sav);
+            if (svc == nullptr) {
                 conn_printf(c, "-1 missing service name\n");
             } else {
                 int rc = dealloc_port(svc);
@@ -658,11 +658,11 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
         }
     } else if (strcmp(cmd, "use") == 0) {
         if (c.writable) {
-            svc = strtok_r(NULL, " ", &sav);
-            if (svc == NULL) {
+            svc = strtok_r(nullptr, " ", &sav);
+            if (svc == nullptr) {
                 conn_printf(c, "-1 missing service name\n");
             } else {
-                char *p = strtok_r(NULL, " ", &sav);
+                char *p = strtok_r(nullptr, " ", &sav);
                 int use = p ? atoi(p) : 0;
                 if (use == 0) {
                     conn_printf(c, "-1 missing/invalid port\n");
@@ -682,7 +682,7 @@ static int run_cmd(struct pollfd &fd, std::vector<struct pollfd> &fds, char *in,
     } else if (strcmp(cmd, "used") == 0 || strcmp(cmd, "list") == 0) {
         used(c);
     } else if (strcmp(cmd, "hello") == 0) {
-        svc = strtok_r(NULL, " ", &sav);
+        svc = strtok_r(nullptr, " ", &sav);
         if (c.writable && svc != nullptr) {
             c.is_hello = true;
             {
@@ -819,7 +819,7 @@ static bool init_local_names()
     struct hostent *me;
     me = gethostbyname("localhost");
 
-    if (me == NULL) {
+    if (me == nullptr) {
         syslog(LOG_ERR, "gethostbyname(\"localhost\") %d\n", h_errno);
         return false;
     }
@@ -917,8 +917,8 @@ static int make_range(char *s, std::pair<int, int> &range)
     std::string orig(s);
     char *sav;
     char *first = strtok_r(s, ":", &sav);
-    char *second = strtok_r(NULL, ":", &sav);
-    if (first == NULL || second == NULL) {
+    char *second = strtok_r(nullptr, ":", &sav);
+    if (first == nullptr || second == nullptr) {
         syslog(LOG_ERR, "bad port range -> %s\n", orig.c_str());
         return 1;
     }
@@ -962,7 +962,7 @@ int main(int argc, char **argv)
         syslog(LOG_WARNING, "setting open_max to:%ld\n", open_max);
     }
     char *host = getenv("HOSTNAME");
-    if (host == NULL) {
+    if (host == nullptr) {
         long hostname_max = sysconf(_SC_HOST_NAME_MAX);
         if (hostname_max == -1) {
             syslog(LOG_WARNING, "sysconf(_SC_HOST_NAME_MAX): %d %s ", errno,
@@ -976,7 +976,7 @@ int main(int argc, char **argv)
         if (rc == 0)
             host = strdup(myhost);
     }
-    if (host == NULL) {
+    if (host == nullptr) {
         syslog(LOG_CRIT,
                "Can't figure out hostname: please export HOSTNAME.\n");
         return EXIT_FAILURE;


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
This is a small feature update.  
* What are the current behavior and expected behavior, if this is a bugfix ?
This is not a bugfix.
* What are the steps required to reproduce the bug, if this is a bugfix ?
This is not a bugfix.
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
The current pmux.cpp used NULL pointers, which can lead to undefined behavior.  This PR changes the usages of NULL to nullptr in line with C++11 recommendations.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
The pmux test passes with this change, and using nullptr instead of NULL is a recommended practice starting with C++11.  
