### PR TITLE
cdb2sql.cpp: Add const qualifier to function int state parameters.

### DIFF
--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -167,7 +167,7 @@ static const char *usage_text =
     "@strblobs            Display blobs as strings\n"
     "@time                Toggle between time modes\n";
 
-void cdb2sql_usage(int exit_val)
+void cdb2sql_usage(const int exit_val)
 {
     fputs(usage_text, (exit_val == EXIT_SUCCESS) ? stdout : stderr);
     exit(exit_val);
@@ -196,7 +196,7 @@ const char *char_atglyph_words[] = {
     "send",       "strblobs", "time",     NULL, // must be terminated by NULL
 };
 
-static char *char_atglyph_generator(const char *text, int state)
+static char *char_atglyph_generator(const char *text, const int state)
 {
     static int list_index, len;
     const char *name;
@@ -214,7 +214,7 @@ static char *char_atglyph_generator(const char *text, int state)
 }
 
 // Generator function for word completion.
-static char *level_one_generator(const char *text, int state)
+static char *level_one_generator(const char *text, const int state)
 {
     static int list_index, len;
     const char *name;
@@ -231,7 +231,7 @@ static char *level_one_generator(const char *text, int state)
     return (NULL); // If no names matched, then return NULL.
 }
 
-static char *db_generator(int state, const char *sql)
+static char *db_generator(const int state, const char *sql)
 {
     static char **db_words;
     static int list_index, len;
@@ -312,7 +312,7 @@ static char *db_generator(int state, const char *sql)
     return (NULL); // If no names matched, then return NULL.
 }
 
-static char *tunables_generator(const char *text, int state)
+static char *tunables_generator(const char *text, const int state)
 {
     char sql[256];
     if (*text)
@@ -327,7 +327,7 @@ static char *tunables_generator(const char *text, int state)
     return db_generator(state, sql);
 }
 
-static char *generic_generator_no_systables(const char *text, int state)
+static char *generic_generator_no_systables(const char *text, const int state)
 {
     char sql[256];
     snprintf(sql, sizeof(sql),
@@ -338,7 +338,7 @@ static char *generic_generator_no_systables(const char *text, int state)
     return db_generator(state, sql);
 }
 
-static char *generic_generator(const char *text, int state)
+static char *generic_generator(const char *text, const int state)
 {
     char sql[256];
     //TODO: escape text


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
Refactoring
* What are the current behavior and expected behavior, if this is a bugfix ?
This is not a bugfix.
* What are the steps required to reproduce the bug, if this is a bugfix ?
This is not a bugfix.
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
Currently the functions take an `int state` variable as a parameter, but the variable is not modified in the functions.  Therefore, I added a `const` qualifier to the `int state` parameter for those functions where the `int state` is not modified in the functions.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
Specifying the `const` qualifier helps the compiler come up with additional optimizations.
