### PR TITLE
Allow 'comdb2' transaction mode.

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5045,6 +5045,7 @@ static void thdpool_sqlengine_dque(struct thdpool *pool, struct workitem *item,
 int tdef_to_tranlevel(int tdef)
 {
     switch (tdef) {
+    case SQL_TDEF_COMDB2:
     case SQL_TDEF_SOCK:
         return TRANLEVEL_SOSQL;
 


### PR DESCRIPTION
The only thing this does on the database side is not light flags indicating that blocksql is the default.