### PR TITLE
Auth: Reject unauthorized access for direct count

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -10193,6 +10193,11 @@ int sqlite3BtreeCount(BtCursor *pCur, i64 *pnEntry)
                               ? gbl_move_deadlk_max_attempt
                               : 500;
         do {
+            if (access_control_check_sql_read(pCur, thd)) {
+                rc = SQLITE_ACCESS;
+                break;
+            }
+
             rc = bdb_direct_count(pCur->bdbcur, pCur->ixnum, (int64_t *)&count);
             if (rc == BDBERR_DEADLOCK &&
                 recover_deadlock(thedb->bdb_env, thd, NULL, 0)) {

--- a/tests/auth.test/t15.expected
+++ b/tests/auth.test/t15.expected
@@ -1,0 +1,8 @@
+(user='---------- OP user ----------')
+(rows inserted=1)
+(i=1)
+(count(*)=1)
+(user='---------- non-OP user ----------')
+[select * from 't1@user1'] failed with rc -106 Read access denied to t1@user1 for user user2 bdberr=15
+[select count(*) from 't1@user1'] failed with rc -106 Read access denied to t1@user1 for user user2 bdberr=15
+(user='---------- OP user ----------')

--- a/tests/auth.test/t15.req
+++ b/tests/auth.test/t15.req
@@ -1,0 +1,22 @@
+# OP user
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+create table t1(i int)$$
+insert into t1 values(1);
+select * from t1;
+select count(*) from t1;
+
+# non-OP user
+set user 'user2'
+set password 'new_password'
+select '---------- non-OP user ----------' as user;
+# Both the following requests must be denied
+select * from 't1@user1';
+select count(*) from 't1@user1';
+
+# Cleanup (OP user)
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+drop table t1;


### PR DESCRIPTION
Fixes the following issue where unauthorized access was allowed for count(*).
```
nctdb> select * from t1;
[select * from t1] failed with rc -106 Read access denied to t1 for user foo bdberr=15
nctdb> select count(*) from t1;
+----------+
| count(*) |
+----------+
| 3        |
+----------+
[select count(*) from t1] rc 0
```