### PR TITLE
cdb2sql: Replaced while loops for level 1 and charatglyph words usage with range based for loops. Removed NULL from the arrays.

### DIFF
--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -199,11 +199,10 @@ const char *char_atglyph_words[] = {
 static char *char_atglyph_generator(const char *text, int state)
 {
     static int len;
-    const char *name;
     if (!state) { // if state is 0 get the length of text
         len = strlen(text);
     }
-    for (const char& name: char_atglyph_generator) {
+    for (auto&& name: char_atglyph_words) {
       if (len == 0 || strncasecmp(name, text, len) == 0) {
         return strdup(name);
       }
@@ -215,11 +214,10 @@ static char *char_atglyph_generator(const char *text, int state)
 static char *level_one_generator(const char *text, int state)
 {
     static int len;
-    const char *name;
     if (!state) { //if state is 0 get the length of text
         len = strlen (text);
     }
-    for (const char& name: level_one_words) {
+    for (auto&& name: level_one_words) {
       if (len == 0 || strncasecmp (name, text, len) == 0) {
         return strdup (name);
       }

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -174,26 +174,14 @@ void cdb2sql_usage(int exit_val)
 }
 
 const char *level_one_words[] = {
-  "@",
-  "ALTER", "ANALYZE",
-  "BEGIN",
-  "COMMIT",
-  "CREATE",
-  "DELETE", "DROP", "DRYRUN",
-  "EXEC", "EXPLAIN",
-  "INSERT",
-  "PUT",
-  "REBUILD",
-  "ROLLBACK",
-  "SELECT", "SELECTV", "SET",
-  "TRUNCATE",
-  "UPDATE",
-  "WITH",
+    "@",        "ALTER",  "ANALYZE", "BEGIN",   "COMMIT",   "CREATE", "DELETE",
+    "DROP",     "DRYRUN", "EXEC",    "EXPLAIN", "INSERT",   "PUT",    "REBUILD",
+    "ROLLBACK", "SELECT", "SELECTV", "SET",     "TRUNCATE", "UPDATE", "WITH",
 };
 
 const char *char_atglyph_words[] = {
-    "cdb2_close", "desc",     "hexblobs", "ls", "redirect", "row_sleep",
-    "send",       "strblobs", "time",
+    "cdb2_close", "desc", "hexblobs", "ls",   "redirect",
+    "row_sleep",  "send", "strblobs", "time",
 };
 
 static char *char_atglyph_generator(const char *text, int state)
@@ -202,10 +190,10 @@ static char *char_atglyph_generator(const char *text, int state)
     if (!state) { // if state is 0 get the length of text
         len = strlen(text);
     }
-    for (auto&& name: char_atglyph_words) {
-      if (len == 0 || strncasecmp(name, text, len) == 0) {
-        return strdup(name);
-      }
+    for (const auto &name : char_atglyph_words) {
+        if (len == 0 || strncasecmp(name, text, len) == 0) {
+            return strdup(name);
+        }
     }
     return (NULL); // If no names matched, then return NULL.
 }
@@ -217,10 +205,10 @@ static char *level_one_generator(const char *text, int state)
     if (!state) { //if state is 0 get the length of text
         len = strlen (text);
     }
-    for (auto&& name: level_one_words) {
-      if (len == 0 || strncasecmp (name, text, len) == 0) {
-        return strdup (name);
-      }
+    for (const auto &name : level_one_words) {
+        if (len == 0 || strncasecmp(name, text, len) == 0) {
+            return strdup(name);
+        }
     }
     return (NULL); // If no names matched, then return NULL.
 }

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -188,27 +188,25 @@ const char *level_one_words[] = {
   "SELECT", "SELECTV", "SET",
   "TRUNCATE",
   "UPDATE",
-  "WITH", NULL,  // must be terminated by NULL
+  "WITH",
 };
 
 const char *char_atglyph_words[] = {
     "cdb2_close", "desc",     "hexblobs", "ls", "redirect", "row_sleep",
-    "send",       "strblobs", "time",     NULL, // must be terminated by NULL
+    "send",       "strblobs", "time",
 };
 
 static char *char_atglyph_generator(const char *text, int state)
 {
-    static int list_index, len;
+    static int len;
     const char *name;
     if (!state) { // if state is 0 get the length of text
-        list_index = 0;
         len = strlen(text);
     }
-    while ((name = char_atglyph_words[list_index]) != NULL) {
-        list_index++;
-        if (len == 0 || strncasecmp(name, text, len) == 0) {
-            return strdup(name);
-        }
+    for (const char& name: char_atglyph_generator) {
+      if (len == 0 || strncasecmp(name, text, len) == 0) {
+        return strdup(name);
+      }
     }
     return (NULL); // If no names matched, then return NULL.
 }
@@ -216,17 +214,15 @@ static char *char_atglyph_generator(const char *text, int state)
 // Generator function for word completion.
 static char *level_one_generator(const char *text, int state)
 {
-    static int list_index, len;
+    static int len;
     const char *name;
     if (!state) { //if state is 0 get the length of text
-        list_index = 0;
         len = strlen (text);
     }
-    while ((name = level_one_words[list_index]) != NULL) {
-        list_index++;
-        if (len == 0 || strncasecmp (name, text, len) == 0) {
-            return strdup (name);
-        }
+    for (const char& name: level_one_words) {
+      if (len == 0 || strncasecmp (name, text, len) == 0) {
+        return strdup (name);
+      }
     }
     return (NULL); // If no names matched, then return NULL.
 }


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
This is a code refactoring.
* What are the current behavior and expected behavior, if this is a bugfix ?
This is not a bugfix.
* What are the steps required to reproduce the bug, if this is a bugfix ?
This is not a bugfix.
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
The current behavior uses a nullptr and a while loop along with additional variable assignments to range through the two arrays.  The refactor includes the removal of NULL from the end of two word arrays and the updating of the while loop into a range-based for loop for iterating through those arrays.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
The new code is more concise, follows more modern conventions (using a range-based for loop for iterating through arrays, and eliminates the need for some of the interim variables.