### PR TITLE
Disallow an incoherent node to process newsql queries

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -731,7 +731,7 @@ int gbl_verbose_normalized_queries = 0;
 int gbl_stable_rootpages_test = 0;
 
 /* Only allows the ability to enable: must be enabled on a session via 'set' */
-int gbl_allow_incoherent_sql = 1;
+int gbl_allow_incoherent_sql = 0;
 
 char *gbl_dbdir = NULL;
 static int gbl_backend_opened = 0;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2344,7 +2344,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         /* avoid new accepting new queries/transaction on opened connections
            if we are incoherent (and not in a transaction). */
         if (!clnt.admin && clnt.ignore_coherency == 0 &&
-            !bdb_am_i_coherent(thedb->bdb_env) &&
+            !gbl_allow_incoherent_sql && !bdb_am_i_coherent(thedb->bdb_env) &&
             (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
             logmsg(LOGMSG_ERROR,
                    "%s line %d td %u new query on incoherent node, "

--- a/tests/allow_incoherent_sql.test/Makefile
+++ b/tests/allow_incoherent_sql.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/allow_incoherent_sql.test/lrl.options
+++ b/tests/allow_incoherent_sql.test/lrl.options
@@ -1,0 +1,1 @@
+allow_incoherent_sql 1

--- a/tests/allow_incoherent_sql.test/runit
+++ b/tests/allow_incoherent_sql.test/runit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Force a replicant to go incoherent
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("on rep_delay")'
+cdb2sql $dbnm --host $master 'exec procedure sys.cmd.send("pushnext")'
+
+set +e
+for i in `seq 1 60`; do
+    cdb2sql $dbnm --host $master 'exec procedure sys.cmd.send("bdb cluster")' | grep $host | grep -i incoherent
+    if [ $? = 0 ]; then
+        break
+    fi
+    sleep 1
+done
+
+cdb2sql $dbnm --host $master 'exec procedure sys.cmd.send("bdb cluster")' | grep $host | grep -i incoherent
+if [ $? != 0 ]; then
+    echo 'Took too long to go incoherent!' >&2
+    exit 1
+fi
+
+set -e
+# Because we specifically allow running a query on an incoherent node,
+# the command below should succeed.
+cdb2sql $dbnm --host $host 'SELECT 1'


### PR DESCRIPTION
The change is needed to address the sockpool connection issue when nodes in 1 data center are up but not serving requests (due to incoherence, catching up with the master, etc.)