### PR TITLE
Smartbeat

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2157,4 +2157,6 @@ int bdb_pack_heap(bdb_state_type *bdb_state, void *in, size_t inlen, void **out,
  * Otherwise unpack the payload into heap memory. */
 int bdb_unpack_heap(bdb_state_type *bdb_state, void *in, size_t inlen,
                     void **out, size_t *outlen, void **freeptr);
+int bdb_get_lsn_node(bdb_state_type *bdb_state, char *host, int *logfile,
+                     int *offset);
 #endif

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2157,6 +2157,4 @@ int bdb_pack_heap(bdb_state_type *bdb_state, void *in, size_t inlen, void **out,
  * Otherwise unpack the payload into heap memory. */
 int bdb_unpack_heap(bdb_state_type *bdb_state, void *in, size_t inlen,
                     void **out, size_t *outlen, void **freeptr);
-int bdb_get_lsn_node(bdb_state_type *bdb_state, char *host, int *logfile,
-                     int *offset);
 #endif

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -880,7 +880,7 @@ static int cdb2_free_context_msgs(cdb2_hndl_tp *hndl);
 struct newsqlheader {
     int type;
     int compression;
-    int state; /* Node state */
+    int state; /* query state */
     int length;
 };
 
@@ -2674,7 +2674,7 @@ retry:
             int unused;
             (void)unused;
             callbackrc =
-                cdb2_invoke_callback(hndl, e, 1, CDB2_STATE, hdr.state);
+                cdb2_invoke_callback(hndl, e, 1, CDB2_QUERY_STATE, hdr.state);
             PROCESS_EVENT_CTRL_AFTER(hndl, e, unused, callbackrc);
         }
         goto retry;
@@ -6441,7 +6441,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
         case CDB2_RETURN_VALUE:
             rc = va_arg(ap, void *);
             break;
-        case CDB2_STATE:
+        case CDB2_QUERY_STATE:
             state = va_arg(ap, int);
             break;
         default:
@@ -6466,7 +6466,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
         case CDB2_RETURN_VALUE:
             argv[i] = (void *)(intptr_t)rc;
             break;
-        case CDB2_STATE:
+        case CDB2_QUERY_STATE:
             argv[i] = (void *)(intptr_t)state;
             break;
         default:

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -880,7 +880,7 @@ static int cdb2_free_context_msgs(cdb2_hndl_tp *hndl);
 struct newsqlheader {
     int type;
     int compression;
-    int dummy;
+    int state; /* Node state */
     int length;
 };
 
@@ -2646,6 +2646,7 @@ retry:
 
     hdr.type = ntohl(hdr.type);
     hdr.compression = ntohl(hdr.compression);
+    hdr.state = ntohl(hdr.state);
     hdr.length = ntohl(hdr.length);
     hndl->ack = (hdr.type == RESPONSE_HEADER__SQL_RESPONSE_PING);
 
@@ -2664,6 +2665,18 @@ retry:
     if (hdr.length == 0) {
         debugprint("hdr length (0) from mach %s - going to retry\n",
                    hndl->hosts[hndl->connected_host]);
+
+        /* If we have an AT_RECEIVE_HEARTBEAT event, invoke it now. */
+        cdb2_event *e = NULL;
+        void *callbackrc;
+        while ((e = cdb2_next_callback(hndl, CDB2_AT_RECEIVE_HEARTBEAT, e)) !=
+               NULL) {
+            int unused;
+            (void)unused;
+            callbackrc =
+                cdb2_invoke_callback(hndl, e, 1, CDB2_STATE, hdr.state);
+            PROCESS_EVENT_CTRL_AFTER(hndl, e, unused, callbackrc);
+        }
         goto retry;
     }
 
@@ -6395,6 +6408,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
     int port;
     const char *sql = NULL;
     void *rc;
+    int state;
 
     /* Fast return if no arguments need to be passed to the callback. */
     if (e->argc == 0)
@@ -6409,6 +6423,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
         port = hndl->ports[hndl->connected_host];
     }
     rc = 0;
+    state = 0;
 
     /* If the event has specified its own arguments, use them. */
     va_start(ap, argc);
@@ -6425,6 +6440,9 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
             break;
         case CDB2_RETURN_VALUE:
             rc = va_arg(ap, void *);
+            break;
+        case CDB2_STATE:
+            state = va_arg(ap, int);
             break;
         default:
             (void)va_arg(ap, void *);
@@ -6447,6 +6465,9 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
             break;
         case CDB2_RETURN_VALUE:
             argv[i] = (void *)(intptr_t)rc;
+            break;
+        case CDB2_STATE:
+            argv[i] = (void *)(intptr_t)state;
             break;
         default:
             break;

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -288,7 +288,7 @@ typedef enum cdb2_event_arg {
     CDB2_PORT,
     CDB2_SQL,
     CDB2_RETURN_VALUE,
-    CDB2_STATE
+    CDB2_QUERY_STATE
 } cdb2_event_arg;
 
 typedef struct cdb2_event cdb2_event;

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -266,14 +266,15 @@ typedef enum cdb2_event_type {
     CDB2_AFTER_SEND_QUERY = 1 << 7,
     CDB2_BEFORE_READ_RECORD = 1 << 8,
     CDB2_AFTER_READ_RECORD = 1 << 9,
+    CDB2_AT_RECEIVE_HEARTBEAT = 1 << 10,
 
     /* Logical operation events.
        A logicial operation event typically
        consists of multiple network events. */
-    CDB2_AT_ENTER_RUN_STATEMENT = 1 << 10,
-    CDB2_AT_EXIT_RUN_STATEMENT = 1 << 11,
-    CDB2_AT_ENTER_NEXT_RECORD = 1 << 12,
-    CDB2_AT_EXIT_NEXT_RECORD = 1 << 13,
+    CDB2_AT_ENTER_RUN_STATEMENT = 1 << 11,
+    CDB2_AT_EXIT_RUN_STATEMENT = 1 << 12,
+    CDB2_AT_ENTER_NEXT_RECORD = 1 << 13,
+    CDB2_AT_EXIT_NEXT_RECORD = 1 << 14,
 
     /* Lifecycle events */
     CDB2_BEFORE_DISCOVERY = 1 << 27,
@@ -286,7 +287,8 @@ typedef enum cdb2_event_arg {
     CDB2_HOSTNAME = 1,
     CDB2_PORT,
     CDB2_SQL,
-    CDB2_RETURN_VALUE
+    CDB2_RETURN_VALUE,
+    CDB2_STATE
 } cdb2_event_arg;
 
 typedef struct cdb2_event cdb2_event;

--- a/db/sql.h
+++ b/db/sql.h
@@ -658,11 +658,7 @@ struct sqlclntstate {
     uint8_t ready_for_heartbeats;
     uint8_t no_more_heartbeats;
     uint8_t done;
-    struct {
-        unsigned long long sqltick;
-        int file;
-        int offset;
-    } progress;
+    unsigned long long sqltick, sqltick_last_seen;
 
     int using_case_insensitive_like;
     int deadlock_recovered;

--- a/db/sql.h
+++ b/db/sql.h
@@ -658,6 +658,11 @@ struct sqlclntstate {
     uint8_t ready_for_heartbeats;
     uint8_t no_more_heartbeats;
     uint8_t done;
+    struct {
+        unsigned long long sqltick;
+        int file;
+        int offset;
+    } progress;
 
     int using_case_insensitive_like;
     int deadlock_recovered;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -598,6 +598,9 @@ static int sql_tick(struct sql_thread *thd)
     if (clnt == NULL)
         return 0;
 
+    /* Increment per-clnt sqltick */
+    ++clnt->sqltick;
+
     /* statement cancelled? done */
     if (clnt->stop_this_statement)
         return SQLITE_BUSY;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5656,6 +5656,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->wrong_db = 0;
     set_sent_data_to_client(clnt, 0, __func__, __LINE__);
     set_asof_snapshot(clnt, 0, __func__, __LINE__);
+    clnt->sqltick = 0;
 }
 
 void reset_clnt_flags(struct sqlclntstate *clnt)

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -82,6 +82,7 @@ extern int gbl_notimeouts;
 extern int gbl_epoch_time;
 extern int gbl_allow_lua_print;
 extern int gbl_allow_lua_dynamic_libs;
+extern int comdb2_sql_tick();
 
 char *gbl_break_spname;
 void *debug_clnt;
@@ -441,6 +442,7 @@ static int luabb_trigger_register(Lua L, trigger_reg_t *reg,
     Pthread_mutex_unlock(&consumer_sqlthds_mutex);
 
     while ((rc = trigger_register_req(reg)) != CDB2_TRIG_REQ_SUCCESS) {
+        comdb2_sql_tick();
         if (register_timeoutms) {
             if (retry == 0) {
                 luabb_error(L, sp, " trigger:%s registration timeout %dms",
@@ -689,6 +691,9 @@ static int dbq_poll_int(Lua L, dbconsumer_t *q)
     struct qfound f = {0};
     int rc = dbq_get(&q->iq, 0, NULL, (void**)&f.item, &f.len, &f.dtaoff, NULL, NULL);
     Pthread_mutex_unlock(q->lock);
+
+    comdb2_sql_tick();
+
     getsp(L)->num_instructions = 0;
     if (rc == 0) {
         return dbq_pushargs(L, q, &f);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -691,9 +691,7 @@ static int dbq_poll_int(Lua L, dbconsumer_t *q)
     struct qfound f = {0};
     int rc = dbq_get(&q->iq, 0, NULL, (void**)&f.item, &f.len, &f.dtaoff, NULL, NULL);
     Pthread_mutex_unlock(q->lock);
-
     comdb2_sql_tick();
-
     getsp(L)->num_instructions = 0;
     if (rc == 0) {
         return dbq_pushargs(L, q, &f);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -59,7 +59,7 @@ static int newsql_has_parallel_sql(struct sqlclntstate *);
 struct newsqlheader {
     int type;        /*  newsql request/response type */
     int compression; /*  Some sort of compression done? */
-    int dummy;       /*  Make it equal to fsql header. */
+    int state;       /*  State of the node */
     int length;      /*  length of response */
 };
 
@@ -359,10 +359,11 @@ static inline int newsql_to_client_type(int newsql_type)
     }
 }
 
-static int newsql_send_hdr(struct sqlclntstate *clnt, int h)
+static int newsql_send_hdr(struct sqlclntstate *clnt, int h, int state)
 {
     struct newsqlheader hdr = {0};
     hdr.type = ntohl(h);
+    hdr.state = ntohl(state);
     int rc;
     lock_client_write_lock(clnt);
     if ((rc = sbuf2write((char *)&hdr, sizeof(hdr), clnt->sb)) != sizeof(hdr))
@@ -615,11 +616,24 @@ static int newsql_flush(struct sqlclntstate *clnt)
 
 static int newsql_heartbeat(struct sqlclntstate *clnt)
 {
+    int file, offset, state;
+
     if (!clnt->heartbeat)
         return 0;
     if (!clnt->ready_for_heartbeats)
         return 0;
-    return newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_HEARTBEAT);
+
+    bdb_get_lsn_node(thedb->bdb_env, gbl_mynode, &file, &offset);
+
+    state = gbl_sqltick > clnt->progress.sqltick ||
+            file > clnt->progress.file ||
+            (file == clnt->progress.file && offset > clnt->progress.offset);
+    clnt->progress.sqltick = gbl_sqltick;
+    clnt->progress.file = file;
+    clnt->progress.offset = offset;
+
+    return newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_HEARTBEAT,
+                           state);
 }
 
 static int newsql_save_postponed_row(struct sqlclntstate *clnt,
@@ -2184,7 +2198,7 @@ retry_read:
         }
 
         if (client_supports_ssl) {
-            newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_SSL);
+            newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_SSL, 0);
             cdb2__query__free_unpacked(query, &pb_alloc);
             query = NULL;
             goto retry_read;

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -208,11 +208,9 @@ static int tranlogNext(sqlite3_vtab_cursor *cur){
       if (pCur->flags & TRANLOG_FLAGS_BLOCK &&
               !(pCur->flags & TRANLOG_FLAGS_DESCENDING)) {
           do {
-
               /* Tick up. Return an error if sql_tick() fails
-                 (peer dropped connection, reached max query time, etc.) */
-              rc = comdb2_sql_tick();
-              if (rc != 0)
+                 (peer dropped connection, max query time reached, etc.) */
+              if ((rc = comdb2_sql_tick()) != 0)
                   return rc;
 
               struct timespec ts;

--- a/tests/smartbeats.test/Makefile
+++ b/tests/smartbeats.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/smartbeats.test/runit
+++ b/tests/smartbeats.test/runit
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+# Create a table
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'create table t (i int)'
+# Insert a record
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'insert into t values(1)'
+# Background updater to push LSN further
+yes "update t set i = 1 where 1" | cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default >/dev/null 2>&1 &
+# Remember the PID
+wpid=$!
+# Test smartbeats
+${TESTSBUILDDIR}/smartbeats $dbnm &
+tpid=$!
+
+# Kill the PID after 15 seconds
+sleep 15
+kill -9 $wpid
+
+set -e
+wait $tpid

--- a/tests/smartbeats.test/runit
+++ b/tests/smartbeats.test/runit
@@ -1,23 +1,3 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
-
-dbnm=$1
-
-# Create a table
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'create table t (i int)'
-# Insert a record
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'insert into t values(1)'
-# Background updater to push LSN further
-yes "update t set i = 1 where 1" | cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default >/dev/null 2>&1 &
-# Remember the PID
-wpid=$!
-# Test smartbeats
-${TESTSBUILDDIR}/smartbeats $dbnm &
-tpid=$!
-
-# Kill the PID after 15 seconds
-sleep 15
-kill -9 $wpid
-
-set -e
-wait $tpid
+${TESTSBUILDDIR}/smartbeats $1

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -60,6 +60,7 @@ add_exe(selectv_rcode selectv_rcode.c)
 add_exe(api_libs api_libs.c)
 add_exe(test_threadpool test_threadpool.c)
 add_exe(updater updater.c testutil.c)
+add_exe(smartbeats smartbeats.c)
 
 target_link_libraries(stepper util mem dlmalloc util)
 target_link_libraries(test_threadpool util mem dlmalloc util)

--- a/tests/tools/smartbeats.c
+++ b/tests/tools/smartbeats.c
@@ -1,0 +1,108 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+
+#include <cdb2api.h>
+
+const char *db, *tier;
+int nheartbeats;
+
+static void *processing_heartbeat(cdb2_hndl_tp *hndl, void *user_arg,
+                                  int argc, void **argv)
+{
+    if (argc != 1)
+        return NULL;
+
+    int state = (intptr_t)argv[0];
+
+    if (!state) {
+        puts("neither lsn nor sqltick is advancing!");
+        abort();
+    }
+
+    printf("Received non-zero state in %p.\n", (void *)pthread_self());
+
+    ++nheartbeats;
+
+    return NULL;
+}
+
+void *consumer(void *_)
+{
+    cdb2_hndl_tp *h;
+    cdb2_open(&h, db, tier, 0);
+    cdb2_event *e = cdb2_register_event(h, CDB2_AT_RECEIVE_HEARTBEAT, 0,
+                                        processing_heartbeat, NULL,
+                                        1, CDB2_STATE);
+    cdb2_run_statement(h, "exec procedure w()");
+    cdb2_unregister_event(h, e);
+    cdb2_close(h);
+    return NULL;
+}
+
+static int TEST_heartbeat_events()
+{
+    int rc;
+    cdb2_hndl_tp *h;
+    cdb2_event *e;
+    pthread_t t1, t2;
+
+
+    cdb2_open(&h, db, tier, 0);
+    e = cdb2_register_event(h, CDB2_AT_RECEIVE_HEARTBEAT, 0,
+                            processing_heartbeat, NULL, 1, CDB2_STATE);
+
+    /* Test sql */
+    rc = cdb2_run_statement(h, "SELECT SLEEP(10)");
+    if (rc != 0)
+        return rc;
+    while ((rc = cdb2_next_record(h)) == CDB2_OK);
+
+    /* Test consumer */
+    rc = cdb2_run_statement(h, "create table c (i int)");
+    if (rc != 0)
+        return rc;
+    rc = cdb2_run_statement(h, "create procedure w { local function main (e) local c = db:consumer() local e = c:get() end }");
+    if (rc != 0)
+        return rc;
+    rc = cdb2_run_statement(h, "create lua consumer w on (table c for insert)");
+    if (rc != 0)
+        return rc;
+
+    /* Test comdb2_transaction_logs */
+    cdb2_run_statement(h, "set maxquerytime 10");
+    cdb2_run_statement(h, "select * from comdb2_transaction_logs where flags = 1");
+    while (cdb2_next_record(h) == CDB2_OK);
+
+    cdb2_unregister_event(h, e);
+    cdb2_close(h);
+
+    /* Test dbq_poll */
+    pthread_create(&t1, NULL, consumer, NULL);
+
+    /* Test trigger register */
+    pthread_create(&t2, NULL, consumer, NULL);
+
+    sleep(10);
+
+    return (nheartbeats == 0);
+}
+
+int main(int argc, char **argv)
+{
+    char *conf = getenv("CDB2_CONFIG");
+    tier = "local";
+    db = argv[1];
+
+    if (conf != NULL) {
+        cdb2_set_comdb2db_config(conf);
+        tier = "default";
+    }
+
+    if (argc >= 3)
+        tier = argv[2];
+
+    return TEST_heartbeat_events();
+}


### PR DESCRIPTION
When a query is taking too much time, we don't know whether this is due
to its complex nature or a hung backend. To know this, We enhance our
heartbeats by embedding the node state (e.g., whether the node is progressing)
in a heartbeat packet. The node state can help us tell an expensive query and
a stuck query apart, through a monitoring tool built around our API
event-handling mechanism (e.g., hungserv).