### PR TITLE
Fix memstat debug mode for newly created allocators

### DIFF
--- a/mem/mem.c
+++ b/mem/mem.c
@@ -1219,7 +1219,8 @@ static comdb2ma comdb2ma_create_int(void *base, size_t init_sz, size_t max_cap,
     out->file = file;
     out->func = func;
     out->line = line;
-    out->debug = 0;
+
+    out->debug = (debug_master_switch | debug_switches[find_switch_index(name)]);
 
 #ifdef PER_THREAD_MALLOC
     out->refs = 0;

--- a/tests/mem_tracker.test/lrl.options
+++ b/tests/mem_tracker.test/lrl.options
@@ -1,0 +1,2 @@
+sqlenginepool mint 0
+sqlenginepool linger 0

--- a/tests/mem_tracker.test/runit
+++ b/tests/mem_tracker.test/runit
@@ -1,15 +1,23 @@
 #!/bin/sh
 
 bash -n "$0" | exit 1
+set -e
+
 dbnm=$1
 host=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT comdb2_host()'`
 
 cat << EOF | cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm --host $host - >/dev/null
 EXEC PROCEDURE sys.cmd.send("memstat debug on sqlite")
 EXEC PROCEDURE sys.cmd.send("memstat debug start")
-SELECT 1
-EXEC PROCEDURE sys.cmd.send("memstat debug stop")
 EOF
 
-stacks=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("memstat debug dump sqlite")'`
+
+cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm --host $host 'SELECT sleep(5)' &
+sleep 1
+stacks=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("memstat debug dump sqlite 1")'`
+addr2line -fsp -e $COMDB2_EXE $stacks | grep malloc.c
+
+wait
+
+stacks=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("memstat debug dump sqlite 1")'`
 addr2line -fsp -e $COMDB2_EXE $stacks | grep sql_statement_done


### PR DESCRIPTION
Memstat debug mode has no effect on newly created allocators. The patch fixes it and adds a test for it.