### PR TITLE
Fix invalid transaction state transition

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -5797,9 +5797,17 @@ static int run_sp_int(struct sqlclntstate *clnt, int argcnt, char **err)
         int tmp;
         /* Don't make new parent transaction on this rollback. */
         sp->make_parent_trans = 0;
+
         db_rollback_int(lua, &tmp);
-        sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
-                                SQLENG_FNSH_ABORTED_STATE);
+
+        if (clnt->in_client_trans) {
+            /* We have rolled back the transaction before having seen a commit
+             * or rollback from the client. Let's fix the transaction state.
+             */
+            assert(clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS);
+            sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
+                                    SQLENG_FNSH_ABORTED_STATE);
+        }
     }
 
     if (gbl_break_lua && (gbl_break_lua == pthread_self())) {

--- a/tests/sp.test/t06.req
+++ b/tests/sp.test/t06.req
@@ -1,0 +1,6 @@
+create procedure foo version 'bar' {
+    local function main()
+    db:rollback()
+    end
+}$$
+exec procedure foo()

--- a/tests/sp.test/t06.req.out
+++ b/tests/sp.test/t06.req.out
@@ -1,0 +1,2 @@
+(version='bar')
+[exec procedure foo()] failed with rc -3 [db:rollback()...]:3: No transaction to COMMIT/ROLLBACK

--- a/tests/sp.test/test.sh
+++ b/tests/sp.test/test.sh
@@ -161,6 +161,12 @@ for testcase in $files ; do
 
 done
 
+egrep -i "ctrl engine has wrong state" $TESTDIR/logs/*db
+if [[ $? == 0 ]]; then
+    echo "error: corrupted transaction state detected"
+    exit 1
+fi
+
 echo "Testcase passed."
 
 exit 0


### PR DESCRIPTION
On preemptive abort, do not set clnt's transaction state to SQLENG_FNSH_ABORTED_STATE, if we are not in a client transaction.
