### PR TITLE
cdb2api: Renaming (un)install_static_libs

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1388,10 +1388,12 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, SBUF2 *s,
                         cdb2_allow_pmux_route = 0;
                     }
                 }
-            } else if (strcasecmp("install_static_libs", tok) == 0) {
+            } else if (strcasecmp("install_static_libs_v2", tok) == 0 ||
+                       strcasecmp("enable_static_libs", tok) == 0) {
                 if (cdb2_install != NULL)
                     (*cdb2_install)();
-            } else if (strcasecmp("uninstall_static_libs", tok) == 0) {
+            } else if (strcasecmp("uninstall_static_libs_v2", tok) == 0 ||
+                       strcasecmp("disable_static_libs", tok) == 0) {
                 /* Provide a way to disable statically installed (via
                  * CDB2_INSTALL_LIBS) libraries. */
                 if (cdb2_uninstall != NULL)

--- a/tests/api_dl_libs.test/runit
+++ b/tests/api_dl_libs.test/runit
@@ -3,7 +3,7 @@
 bash -n "$0" | exit 1
 dbnm=$1
 echo "
-comdb2_config:install_static_libs
+comdb2_config:enable_static_libs
 comdb2_config:lib=${TESTSBUILDDIR}/libapi_hello_world_lib.so
 " >>$DBDIR/comdb2db.cfg
 ${TESTSBUILDDIR}/api_libs $dbnm 2>&1 | diff expected -

--- a/tests/api_events.test/runit
+++ b/tests/api_events.test/runit
@@ -3,7 +3,7 @@
 bash -n "$0" | exit 1
 dbnm=$1
 echo '
-comdb2_config:install_static_libs
+comdb2_config:enable_static_libs
 comdb2_config:allow_pmux_route:false
 ' >>$DBDIR/comdb2db.cfg
 ${TESTSBUILDDIR}/api_events $dbnm 2>&1 | diff expected -

--- a/tests/tools/api_libs.c
+++ b/tests/tools/api_libs.c
@@ -55,15 +55,15 @@ int main(int argc, char **argv)
     cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
     cdb2_close(hndl);
     /* Uninstall */
-    cdb2_set_comdb2db_info("comdb2_config:uninstall_static_libs");
+    cdb2_set_comdb2db_info("comdb2_config:disable_static_libs");
     cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
     cdb2_close(hndl);
     /* Install again */
-    cdb2_set_comdb2db_info("comdb2_config:install_static_libs");
+    cdb2_set_comdb2db_info("comdb2_config:enable_static_libs");
     cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
     cdb2_close(hndl);
     /* Uninstall again */
-    cdb2_set_comdb2db_info("comdb2_config:uninstall_static_libs");
+    cdb2_set_comdb2db_info("comdb2_config:disable_static_libs");
     cdb2_open(&hndl, "dummy", "localhost", CDB2_DIRECT_CPU);
     cdb2_close(hndl);
     return 0;


### PR DESCRIPTION
Rename `install_static_libs` and `uninstall_static_libs` to `enable_static_libs` and `disable_static_libs` respectively. We've discovered a bug in the hungserv plugin. Therefore we need a way to disable the feature in buggy versions but still enable it in later versions. Renaming the configuration names is the simplest solution.