### PR TITLE
Fix a race between time partition rollout and regular schema change

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -22,6 +22,7 @@
 #include <list.h>
 #include <stddef.h>
 #include <cdb2_constants.h>
+#include <locks_wrap.h>
 
 #include "dynschemaload.h"
 
@@ -3319,6 +3320,8 @@ char *csc2_strdup(char *s)
 
 void csc2_free_all(void)
 {
+    extern pthread_mutex_t csc2_subsystem_mtx;
+    Pthread_mutex_lock(&csc2_subsystem_mtx);
     if (csc2a != NULL) {
         comdb2ma_destroy(csc2a);
         csc2a = NULL;
@@ -3332,6 +3335,7 @@ void csc2_free_all(void)
         strbuf_free(syntax_errors);
         syntax_errors = NULL;
     }
+    Pthread_mutex_unlock(&csc2_subsystem_mtx);
 }
 
 char *csc2_get_errors(void)

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -383,12 +383,8 @@ int osql_bplog_schemachange(struct ireq *iq)
         }
         sc = iq->sc;
     }
-    if (rc) {
-        extern pthread_mutex_t csc2_subsystem_mtx;
-        Pthread_mutex_lock(&csc2_subsystem_mtx);
+    if (rc)
         csc2_free_all();
-        Pthread_mutex_unlock(&csc2_subsystem_mtx);
-    }
     if (rc == ERR_NOMASTER) {
         /* free schema changes that have finished without marking schema change
          * over in llmeta so new master can resume properly */

--- a/db/views.c
+++ b/db/views.c
@@ -983,6 +983,7 @@ done:
     if (run) {
         Pthread_rwlock_unlock(&views_lk);
         unlock_schema_lk();
+        csc2_free_all();
         BDB_RELLOCK();
         bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE_RDWR);
 
@@ -1161,6 +1162,7 @@ done:
     if (run) {
         Pthread_rwlock_unlock(&views_lk);
         unlock_schema_lk();
+        csc2_free_all();
         bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE_RDWR);
 
         /*  schedule next */
@@ -1220,6 +1222,7 @@ void *_view_cron_phase3(struct cron_event *event, struct errstat *err)
 
         Pthread_rwlock_unlock(&views_lk);
         unlock_schema_lk();
+        csc2_free_all();
         BDB_RELLOCK();
         bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE_RDWR);
     }

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -198,9 +198,14 @@ static void free_sc(struct schema_change_type *s)
 {
     free_schema_change_type(s);
     /* free any memory csc2 allocated when parsing schema */
-    Pthread_mutex_lock(&csc2_subsystem_mtx);
+
+    /* Bail out if we're in a time partition rollout otherwise
+       we may deadlock with a regular schema change. The time partition
+       rollout will invoke this function again without holding views_lk. */
+    if (s->views_locked)
+        return;
+
     csc2_free_all();
-    Pthread_mutex_unlock(&csc2_subsystem_mtx);
 }
 
 static void stop_and_free_sc(int rc, struct schema_change_type *s, int do_free)
@@ -371,7 +376,9 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         goto end;
     broadcast_sc_start(s->tablename, iq->sc_seed, iq->sc_host,
                        time(NULL));                   // dont care rcode
+
     rc = pre(iq, s, NULL);                            // non-tran ??
+
     if (type == alter && master_downgrading(s)) {
         s->sc_rc = SC_MASTER_DOWNGRADE;
         errstat_set_strf(

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -201,7 +201,7 @@ static void free_sc(struct schema_change_type *s)
 
     /* Bail out if we're in a time partition rollout otherwise
        we may deadlock with a regular schema change. The time partition
-       rollout will invoke this function again without holding views_lk. */
+       rollout will invoke csc2_free_all() without holding views_lk. */
     if (s->views_locked)
         return;
 
@@ -376,9 +376,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         goto end;
     broadcast_sc_start(s->tablename, iq->sc_seed, iq->sc_host,
                        time(NULL));                   // dont care rcode
-
     rc = pre(iq, s, NULL);                            // non-tran ??
-
     if (type == alter && master_downgrading(s)) {
         s->sc_rc = SC_MASTER_DOWNGRADE;
         errstat_set_strf(


### PR DESCRIPTION
Time partition rollout locks `views_lk` first and `csc2_subsystem_mtx` (in `csc2_free_all()`) second.
A regular schema change locks `csc2_subsystem_mtx` first and `views_lk` (in `timepart_is_shard()`) second.

To fix this, in time partition rollout, we invoke `csc2_free_all()` after `views_lk` is released.

(DRQS 147345691)
