### PR TITLE
csc2: Simplify the GC logic

### DIFF
--- a/csc2/CMakeLists.txt
+++ b/csc2/CMakeLists.txt
@@ -6,12 +6,8 @@ add_library(csc2
   maccparse.h
   maccprocarr.c
   maccwrite2.c
-  mem_csc2.h
 )
 add_definitions(-DYYMAXDEPTH=1100)
-set(module csc2)
-set(MODULE CSC2)
-configure_file(${PROJECT_SOURCE_DIR}/mem/mem.h.in mem_csc2.h @ONLY)
 find_program(yacc NAMES bison yacc)
 if(NOT yacc)
   message(FATAL_ERROR "yacc not found!")

--- a/csc2/macc.h
+++ b/csc2/macc.h
@@ -9,8 +9,7 @@
 #include "dynschemaload.h"
 #include <cdb2_constants.h>
 
-#include "mem_csc2.h"
-#include "mem_override.h"
+#include "mem.h"
 
 extern char *revision;
 

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -3319,8 +3319,10 @@ char *csc2_strdup(char *s)
 
 void csc2_free_all(void)
 {
-    comdb2ma_destroy(csc2a);
-    csc2a = NULL;
+    if (csc2a != NULL) {
+        comdb2ma_destroy(csc2a);
+        csc2a = NULL;
+    }
 
     if (errors) {
         strbuf_free(errors);

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -3374,7 +3374,7 @@ void csc2_error(const char *fmt, ...)
     va_end(args);
     strbuf_append(errors, out);
     logmsg(LOGMSG_ERROR, "%s", out);
-    free(out);
+    comdb2_free(out);
 }
 
 void csc2_syntax_error(const char *fmt, ...)
@@ -3402,5 +3402,5 @@ void csc2_syntax_error(const char *fmt, ...)
     vsnprintf(out, len, fmt, args);
     va_end(args);
     strbuf_append(syntax_errors, out);
-    free(out);
+    comdb2_free(out);
 }

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -3291,55 +3291,37 @@ int dyns_get_check_constraint_at(int idx, char **consname, char **expr)
     return 0;
 }
 
-static pthread_once_t once = PTHREAD_ONCE_INIT;
-struct csc2_mem_block {
-    int sz;
-    LINKC_T(struct csc2_mem_block) lnk;
-    double mem[1];
-};
-
-static LISTC_T(struct csc2_mem_block) csc2_allocated_blocks;
+/* CSC2 one-time allocator */
+static comdb2ma csc2a;
 
 static void init_csc2_malloc(void)
 {
-    listc_init(&csc2_allocated_blocks, offsetof(struct csc2_mem_block, lnk));
+    if (csc2a == NULL) {
+        csc2a = comdb2ma_create(0, 0, "CSC2", 0);
+        if (csc2a == NULL) {
+            logmsg(LOGMSG_FATAL, "Failed to create CSC2 allocator.\n");
+            abort();
+        }
+    }
 }
 
 void *csc2_malloc(size_t sz)
 {
-    struct csc2_mem_block *blk;
-
-    pthread_once(&once, init_csc2_malloc);
-
-    blk = malloc(offsetof(struct csc2_mem_block, mem) + sz);
-    blk->sz = sz;
-    listc_abl(&csc2_allocated_blocks, blk);
-    return &blk->mem[0];
+    init_csc2_malloc();
+    return comdb2_malloc(csc2a, sz);
 }
 
 char *csc2_strdup(char *s)
 {
-    struct csc2_mem_block *blk;
-    int len;
-
-    pthread_once(&once, init_csc2_malloc);
-
-    len = strlen(s);
-    blk = malloc(offsetof(struct csc2_mem_block, mem) + len + 1);
-    blk->sz = len;
-    strcpy((char *)&blk->mem[0], s);
-    listc_abl(&csc2_allocated_blocks, blk);
-    return (char *)&blk->mem[0];
+    init_csc2_malloc();
+    return comdb2_strdup(csc2a, s);
 }
 
 void csc2_free_all(void)
 {
-    struct csc2_mem_block *blk;
-    blk = listc_rtl(&csc2_allocated_blocks);
-    while (blk) {
-        free(blk);
-        blk = listc_rtl(&csc2_allocated_blocks);
-    }
+    comdb2ma_destroy(csc2a);
+    csc2a = NULL;
+
     if (errors) {
         strbuf_free(errors);
         errors = NULL;
@@ -3384,7 +3366,7 @@ void csc2_error(const char *fmt, ...)
         return;
     }
     len++;
-    out = malloc(len);
+    out = csc2_malloc(len);
     va_start(args, fmt);
     vsnprintf(out, len, fmt, args);
     va_end(args);
@@ -3413,7 +3395,7 @@ void csc2_syntax_error(const char *fmt, ...)
         return;
     }
     len++;
-    out = malloc(len);
+    out = csc2_malloc(len);
     va_start(args, fmt);
     vsnprintf(out, len, fmt, args);
     va_end(args);

--- a/csc2/macclex.l
+++ b/csc2/macclex.l
@@ -23,8 +23,6 @@
 #include <ctype.h>
 #include <string.h>
 #include "maccparse.h"
-#include "mem_csc2.h"
-#include "mem_override.h"
 #include "logmsg.h"
 extern int current_line;
 extern YYSTYPE yylval;

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -36,7 +36,6 @@ XMACRO_COMDB2MA(COMDB2MA_STATIC_BERKDB,         "berkdb",           0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_NET,            "net",              0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_SQLITE,         "sqlite",           0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_UTIL,           "util",             0, 0) \
-XMACRO_COMDB2MA(COMDB2MA_STATIC_CSC2,           "csc2",             0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_DATETIME,       "datetime",         0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_DFP_DECNUMBER,  "dfp_decNumber",    0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_PROTOBUF,       "protobuf",         0, 0) \


### PR DESCRIPTION
We keep track of malloc chunks using a linkedlist and free them all when done, in the csc2 subsystem. The logic can be implemented by simply using a dlmalloc allocator. Also get rid of the per-thread CSC2 allocator as it's needless now.