### PR TITLE
R7:  Process message: dump remote policy structures

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -154,6 +154,7 @@ extern void bdb_dumptrans(bdb_state_type *bdb_state);
 void bdb_locker_summary(void *_bdb_state);
 extern int printlog(bdb_state_type *bdb_state, int startfile, int startoff,
                     int endfile, int endoff);
+extern void dump_remote_policy();
 
 static const char *HELP_MAIN[] = {
     "stat           - status report",
@@ -1634,14 +1635,17 @@ clipper_usage:
             }
             free(dbname);
         } else if (tokcmp(tok, ltok, "rmtpol") == 0) {
-            char *host;
             logmsg(LOGMSG_USER, "I am running on a %s machine\n",
                    get_mach_class_str(gbl_mynode));
             tok = segtok(line, lline, &st, &ltok);
             if (ltok != 0) {
                 char *m = tokdup(tok, ltok);
-                host = intern(m);
+                char *host = intern(m);
                 free(m);
+                if (host == intern("dump")) {
+                    dump_remote_policy();
+                    return 0;
+                }
                 logmsg(LOGMSG_USER, "Machine %s is a %s machine\n", host,
                        get_mach_class_str(host));
                 logmsg(LOGMSG_USER, "Allow writes from %s        ? %s\n", host,

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1642,10 +1642,6 @@ clipper_usage:
                 char *m = tokdup(tok, ltok);
                 char *host = intern(m);
                 free(m);
-                if (host == intern("dump")) {
-                    dump_remote_policy();
-                    return 0;
-                }
                 logmsg(LOGMSG_USER, "Machine %s is a %s machine\n", host,
                        get_mach_class_str(host));
                 logmsg(LOGMSG_USER, "Allow writes from %s        ? %s\n", host,
@@ -1655,6 +1651,8 @@ clipper_usage:
                 logmsg(LOGMSG_USER, "Allow queue broadcast to %s ? %s\n", host,
                        allow_broadcast_to_remote(host) ? "YES" : "NO");
             }
+            else
+                dump_remote_policy();
         } else if (tokcmp(tok, ltok, "size") == 0) {
             dump_table_sizes(thedb);
         } else if (tokcmp(tok, ltok, "reql") == 0) {

--- a/db/rmtpolicy.c
+++ b/db/rmtpolicy.c
@@ -276,9 +276,7 @@ int process_allow_command(char *line, int lline)
         }
     } else if (cls != CLASS_UNKNOWN) {
         if (allow == 1) {
-            //logmsg(LOGMSG_USER, "az bset %s pol->explicit_allow_classes %d machines %d\n", pol->descr, pol->explicit_allow_classes, cls);
             bset(&pol->explicit_allow_classes, cls);
-            //logmsg(LOGMSG_USER, "az after bset %s pol->explicit_allow_classes %d test %d machines %d\n", pol->descr, pol->explicit_allow_classes, btst(&pol->explicit_allow_classes, cls), cls);
             bclr(&pol->explicit_disallow_classes, cls);
             logmsg(LOGMSG_USER, "allowing %s %s machines\n", pol->descr,
                    mach_class_class2name(cls));
@@ -308,20 +306,20 @@ bad:
     return -1;
 }
 
-void dump_policy_structure(const struct rmtpol *pol) 
+void dump_policy_structure(const struct rmtpol *pol)
 {
     logmsg(LOGMSG_USER, "Policy '%s'\n", pol->descr);
     for (int i = 0; i < sizeof(pol->explicit_disallow_machs); i++) {
         if (btst(pol->explicit_disallow_machs, i))
             logmsg(LOGMSG_USER, "  explicit_disallow mach %d\n", i);
     }
-    for (int i = 0; i < sizeof(pol->explicit_allow_machs); i++){
+    for (int i = 0; i < sizeof(pol->explicit_allow_machs); i++) {
         if (btst(pol->explicit_allow_machs, i))
             logmsg(LOGMSG_USER, "  explicit_allow mach %d\n", i);
     }
 
     int c = 0;
-    while (++c <= 6) { //start from dev
+    while (++c <= 6) { // start from dev
         if (btst(&pol->explicit_disallow_classes, c))
             logmsg(LOGMSG_USER, "  explicit_disallow class %s\n",
                    mach_class_class2name(c));
@@ -331,7 +329,7 @@ void dump_policy_structure(const struct rmtpol *pol)
     }
 }
 
-void dump_remote_policy() 
+void dump_remote_policy()
 {
     dump_policy_structure(&write_pol);
     dump_policy_structure(&brd_pol);

--- a/util/rtcpu.c
+++ b/util/rtcpu.c
@@ -182,8 +182,10 @@ static int machine_class_default(const char *host)
         }
     done:
         /* Error if can't find class? */
-        if (my_class == CLASS_UNKNOWN)
+        if (my_class == CLASS_UNKNOWN) {
+            logmsg(LOGMSG_DEBUG, "Can't find class -- assigning PROD\n");
             my_class = CLASS_PROD;
+        }
         if (db)
             cdb2_close(db);
     }


### PR DESCRIPTION
Process message: dump remote policy structures when no host given:
```
> cdb2sql --tabs basic75753  'exec procedure sys.cmd.send("stat rmtpol")'
I am running on a prod machine
Policy 'write from'
  explicit_allow class beta
Policy 'broadcast to'
Policy 'cluster with'
```