### PR TITLE
syssp to respect loglevel set globally

### DIFF
--- a/tests/analyze.test/t10_01.sh
+++ b/tests/analyze.test/t10_01.sh
@@ -193,7 +193,7 @@ function writer
 function reader 
 {
     while true; do
-        $CDB2SQL_EXE ${CDB2_OPTIONS} -f t10.sql $dbname default > /dev/null
+        $CDB2SQL_EXE ${CDB2_OPTIONS} -f t10.sql $dbname default &> reader.out
         if [[ $? != 0 ]]; then
             echo "reader failed"
             exit 1
@@ -206,7 +206,7 @@ function reader
 function analyzer 
 {
     while true; do
-        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default "analyze t10 100" > /dev/null
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default "analyze t10 100" &> analyzer.out
         if [[ $? != 0 ]]; then
             echo "analyzer failed"
             exit 1

--- a/util/logmsg.c
+++ b/util/logmsg.c
@@ -37,11 +37,6 @@ void logmsg_set_level(loglvl lvl) {
     level = lvl;
 }
 
-loglvl logmsg_get_level() {
-    return level;
-}
-
-
 void logmsg_set_thd(int onoff)
 {
     do_thread = onoff;

--- a/util/logmsg.c
+++ b/util/logmsg.c
@@ -307,7 +307,7 @@ int logmsg_level_update(void *unused, void *value)
     } else if (tokcmp(tok, ltok, "fatal") == 0) {
         logmsg_set_level(LOGMSG_FATAL);
     } else {
-        logmsg(LOGMSG_DEBUG, "Unknown logging level requested\n");
+        logmsg(LOGMSG_USER, "Unknown logging level requested\n");
         return 1;
     }
     logmsg(LOGMSG_USER, "Set default log level to %s\n",

--- a/util/logmsg.c
+++ b/util/logmsg.c
@@ -37,6 +37,11 @@ void logmsg_set_level(loglvl lvl) {
     level = lvl;
 }
 
+loglvl logmsg_get_level() {
+    return level;
+}
+
+
 void logmsg_set_thd(int onoff)
 {
     do_thread = onoff;
@@ -89,13 +94,12 @@ static int logmsgv_lk(loglvl lvl, const char *fmt, va_list args)
     FILE *f;
     int ret = 0;
 
-    FILE *override = io_override_get_std();
-    if (!override) {
-        if (lvl < level)
-            return 0;
+    if (lvl < level)
+        return 0;
 
+    FILE *override = io_override_get_std();
+    if (!override)
         f = stderr;
-    }
     else
         f = override;
 
@@ -245,7 +249,11 @@ int logmsg_process_message(char *line, int llen) {
         return 1;
     } else if (tokcmp(tok, ltok, "level") == 0) {
         tok = segtok(line, llen, &st, &ltok);
-        logmsg_level_update(0, tok);
+        if (!ltok)
+            logmsg(LOGMSG_USER, "Current log level is %s\n",
+                   logmsg_level_str(level));
+        else
+            logmsg_level_update(0, tok);
     } else if (tokcmp(tok, ltok, "thread") == 0) {
         logmsg_set_thd(1);
         logmsg(LOGMSG_USER, "threadids on\n");


### PR DESCRIPTION
Currently calls from syssp to send() commands to db will print DEBUG msgs even though loglevel is INFO or higher because syssp overrides the output file desc. for stdout. 
This change causes the loglevel set globally to be respected even for overriden stdout.