### PR TITLE
cdb2jdbc: Cursor position

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ResultSet.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ResultSet.java
@@ -560,42 +560,42 @@ public class Comdb2ResultSet implements ResultSet {
 
     @Override
     public boolean isBeforeFirst() throws SQLException {
-        return false;
+        return ((Comdb2Handle)hndl).isBeforeFirst;
     }
 
     @Override
     public boolean isAfterLast() throws SQLException {
-        return false;
+        return ((Comdb2Handle)hndl).isAfterLast;
     }
 
     @Override
     public boolean isFirst() throws SQLException {
-        return false;
+        return ((Comdb2Handle)hndl).isFirst;
     }
 
     @Override
     public boolean isLast() throws SQLException {
-        return false;
+        throw new SQLFeatureNotSupportedException();
     }
 
     @Override
     public void beforeFirst() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public void afterLast() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public boolean first() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public boolean last() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
@@ -605,22 +605,23 @@ public class Comdb2ResultSet implements ResultSet {
 
     @Override
     public boolean absolute(int row) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public boolean relative(int rows) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public boolean previous() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override
     public void setFetchDirection(int direction) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        if (direction != ResultSet.FETCH_FORWARD)
+            throw new SQLException("The fetch direction of a TYPE_FORWARD_ONLY resultset can only be set to FETCH_FORWARD");
     }
 
     @Override
@@ -870,7 +871,7 @@ public class Comdb2ResultSet implements ResultSet {
 
     @Override
     public void refreshRow() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        throw new SQLException("The method should not be called on a TYPE_FORWARD_ONLY resultset");
     }
 
     @Override

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/CursorStateTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/CursorStateTest.java
@@ -1,0 +1,46 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import java.util.logging.*;
+import java.util.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class CursorStateTest {
+
+    @Test public void CursorStates() throws SQLException {
+        String db = System.getProperty("cdb2jdbc.test.database");
+        String cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        Connection conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?maxquerytime=1", cluster, db));
+        Statement stmt = conn.createStatement();
+        ResultSet rs = stmt.executeQuery("SELECT 1 UNION SELECT 2");
+
+        Assert.assertEquals(true, rs.isBeforeFirst());
+        Assert.assertEquals(false, rs.isFirst());
+        Assert.assertEquals(false, rs.isAfterLast());
+
+        rs.next();
+
+        Assert.assertEquals(false, rs.isBeforeFirst());
+        Assert.assertEquals(true, rs.isFirst());
+        Assert.assertEquals(false, rs.isAfterLast());
+
+        rs.next();
+
+        Assert.assertEquals(false, rs.isBeforeFirst());
+        Assert.assertEquals(false, rs.isFirst());
+        Assert.assertEquals(false, rs.isAfterLast());
+
+        rs.next();
+
+        Assert.assertEquals(false, rs.isBeforeFirst());
+        Assert.assertEquals(false, rs.isFirst());
+        Assert.assertEquals(true, rs.isAfterLast());
+
+        rs.close();
+        stmt.close();
+        conn.close();
+    }
+}


### PR DESCRIPTION
Implement some of the methods defined in class `ResultSet`. These methods return the position of a cursor which is useful to some data streaming libraries.