### PR TITLE
Auth: A special commandline option to bypass access checks

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -35,6 +35,7 @@
 #include <str0.h>
 
 extern int gbl_maxretries;
+extern int gbl_disable_access_controls;
 
 static bdb_state_type *llmeta_bdb_state = NULL; /* the low level meta table */
 
@@ -5739,6 +5740,10 @@ static int bdb_feature_get_int(bdb_state_type *bdb_state, tran_type *tran,
 int bdb_authentication_get(bdb_state_type *bdb_state, tran_type *tran,
                            int *bdberr)
 {
+    if (gbl_disable_access_controls) {
+        logmsg(LOGMSG_WARN, "**Bypassing user authentication**\n");
+        return 1;
+    }
     return bdb_feature_get_int(bdb_state, tran, bdberr, LLMETA_AUTHENTICATION);
 }
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -749,9 +749,6 @@ int gbl_pg_compact_latency_ms = 0;
 int gbl_large_str_idx_find = 1;
 int gbl_abort_invalid_query_info_key;
 
-extern int gbl_allow_user_schema;
-extern int gbl_uses_password;
-
 extern int gbl_direct_count;
 extern int gbl_parallel_count;
 extern int gbl_debug_sqlthd_failures;

--- a/db/config.c
+++ b/db/config.c
@@ -48,6 +48,8 @@ extern int gbl_rep_node_pri;
 extern int gbl_bad_lrl_fatal;
 extern int gbl_disable_new_snapshot;
 
+int gbl_disable_access_controls;
+
 extern char *gbl_recovery_options;
 extern const char *gbl_repoplrl_fname;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
@@ -73,6 +75,7 @@ static struct option long_options[] = {
     {"dir", required_argument, NULL, 0},
     {"tunable", required_argument, NULL, 0},
     {"version", no_argument, NULL, 'v'},
+    {"insecure", no_argument, &gbl_disable_access_controls, 1},
     {NULL, 0, NULL, 0}};
 
 static const char *help_text = {
@@ -92,6 +95,7 @@ static const char *help_text = {
     "        --tunable                  override tunable\n"
     "        --help                     displays this help text and exit\n"
     "        --version                  displays version information and exit\n"
+    "        --insecure                 disable access controls\n"
     "\n"
     "        NAME                       database name\n"
     "        LRLFILE                    lrl configuration file\n"


### PR DESCRIPTION
With this change, Comdb2 can be started with an extra argument **--insecure**, in order to temporarily bypass the access controls. This would come in handy when one needs to reset 'op' password.