### PR TITLE
Transaction chunks

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -659,12 +659,9 @@ int bdb_tran_get_start_file_offset(bdb_state_type *bdb_state, tran_type *tran,
 
 /* commit the transaction referenced by the tran handle.  return a
    seqnum that is guaranteed to be greater or equal to the seqnum
-   needed to have this commit reflected in your database */
-int bdb_tran_commit_with_seqnum(bdb_state_type *bdb_state, tran_type *tran,
-                                seqnum_type *seqnum, int *bdberr);
-
-/* same, but also return an estimate of the transaction size in unspecified
- * units */
+   needed to have this commit reflected in your database
+   also return an estimate of the transaction size in unspecified
+   units */
 int bdb_tran_commit_with_seqnum_size(bdb_state_type *bdb_state, tran_type *tran,
                                      seqnum_type *seqnum, uint64_t *out_txnsize,
                                      int *bdberr);

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -183,7 +183,7 @@ done:
     if (t) {
         if (rc == 0) {
             seqnum_type seqnum;
-            rc = bdb_tran_commit_with_seqnum(bdb_state, t, &seqnum, &bdberr);
+            rc = bdb_tran_commit_with_seqnum_size(bdb_state, t, &seqnum, NULL, &bdberr);
             if (rc)
                 goto ret;
             rc = bdb_wait_for_seqnum_from_all(bdb_state, &seqnum);

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -183,7 +183,8 @@ done:
     if (t) {
         if (rc == 0) {
             seqnum_type seqnum;
-            rc = bdb_tran_commit_with_seqnum_size(bdb_state, t, &seqnum, NULL, &bdberr);
+            rc = bdb_tran_commit_with_seqnum_size(bdb_state, t, &seqnum, NULL,
+                                                  &bdberr);
             if (rc)
                 goto ret;
             rc = bdb_wait_for_seqnum_from_all(bdb_state, &seqnum);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1502,10 +1502,11 @@ static int update_logical_redo_lsn(void *obj, void *arg)
     return 0;
 }
 
-static int bdb_tran_commit_with_seqnum_int_int(
-    bdb_state_type *bdb_state, tran_type *tran, seqnum_type *seqnum,
-    int *bdberr, int getseqnum, uint64_t *out_txnsize, void *blkseq, int blklen,
-    void *blkkey, int blkkeylen)
+int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
+                                    seqnum_type *seqnum, int *bdberr,
+                                    int getseqnum, uint64_t *out_txnsize,
+                                    void *blkseq, int blklen, void *blkkey,
+                                    int blkkeylen)
 {
     int rc = 0, outrc = 0;
     unsigned int flags;
@@ -2102,18 +2103,6 @@ cleanup:
     return outrc;
 }
 
-int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
-                                    seqnum_type *seqnum, int *bdberr,
-                                    int getseqnum, uint64_t *out_txnsize,
-                                    void *blkseq, int blklen, void *blkkey,
-                                    int blkkeylen)
-{
-    int rc = bdb_tran_commit_with_seqnum_int_int(
-        bdb_state, tran, seqnum, bdberr, getseqnum, out_txnsize, blkseq, blklen,
-        blkkey, blkkeylen);
-    return rc;
-}
-
 int bdb_tran_rep_handle_dead(bdb_state_type *bdb_state)
 {
     tran_type *tran;
@@ -2210,25 +2199,6 @@ int bdb_tran_commit_with_seqnum_size(bdb_state_type *bdb_state, tran_type *tran,
 
     if (!is_rowlocks_trans)
         BDB_RELLOCK();
-
-    return rc;
-}
-
-int bdb_tran_commit_with_seqnum(bdb_state_type *bdb_state, tran_type *tran,
-                                seqnum_type *seqnum, int *bdberr)
-{
-    int rc;
-
-    /* lock was acquired in bdb_tran_begin */
-    /* BDB_READLOCK(); */
-
-    /* if we were passed a child, find his parent */
-    if (bdb_state->parent)
-        bdb_state = bdb_state->parent;
-
-    rc = bdb_tran_commit_with_seqnum_int(bdb_state, tran, seqnum, bdberr, 1,
-                                         NULL, NULL, 0, NULL, 0);
-    BDB_RELLOCK();
 
     return rc;
 }

--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -168,7 +168,7 @@ int srs_tran_add_query(struct sqlclntstate *clnt)
     osqlstate_t *osql = &clnt->osql;
     srs_tran_query_t *item = NULL;
 
-    if (clnt->verifyretry_off || clnt->isselect || clnt->trans_has_sp ||
+    if (clnt->verifyretry_off || clnt->isselect || clnt->dbtran.trans_has_sp ||
         clnt->has_recording) {
         return 0;
     }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3183,9 +3183,6 @@ int osql_comm_blkout_node(const char *host)
     for (i = 0; i < len; i++) {
         if (host == blk->nds[i]) {
             blk->times[i] = time(NULL); /* refresh blackout */
-#ifdef OFFLOAD_TEST
-            fprintf(stderr, "BO %d %u\n", node, blk->times[i]);
-#endif
             break;
         }
     }

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1082,7 +1082,7 @@ retry:
                     osql->xerr.errval == 999) {
                     if (bdb_attr_get(thedb->bdb_attr,
                                      BDB_ATTR_SC_RESUME_AUTOCOMMIT) &&
-                        !clnt->in_client_trans && osql->running_ddl) {
+                        !in_client_trans(clnt) && osql->running_ddl) {
                         clnt->osql.xerr.errval = ERR_SC;
                         errstat_cat_str(&(clnt->osql.xerr),
                                         "Master node downgrading - new "
@@ -1499,7 +1499,7 @@ static int osql_send_commit_logic(struct sqlclntstate *clnt, int is_retry,
     extern int gbl_always_send_cnonce;
     int send_cnonce = gbl_always_send_cnonce ? 1 : has_high_availability(clnt);
     if (osql->rqid == OSQL_RQID_USE_UUID && send_cnonce &&
-        get_cnonce(clnt, &snap_info) == 0 && !clnt->trans_has_sp) {
+        get_cnonce(clnt, &snap_info) == 0 && !clnt->dbtran.trans_has_sp) {
 
         /* pass to master the state of verify retry.
          * if verify retry is on and error is retryable, don't write to
@@ -1836,7 +1836,7 @@ int osql_schemachange_logic(struct schema_change_type *sc,
     }
 
     if (!bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_AUTOCOMMIT) ||
-        clnt->in_client_trans) {
+        in_client_trans(clnt)) {
         sc->rqid = osql->rqid;
         comdb2uuidcpy(sc->uuid, osql->uuid);
     }

--- a/db/sql.h
+++ b/db/sql.h
@@ -571,8 +571,7 @@ struct sql_hist_cost {
     int64_t rows;
 };
 
-#define in_client_trans(clnt)                                                  \
-    ((clnt)->in_client_trans)
+#define in_client_trans(clnt) ((clnt)->in_client_trans)
 
 /* Client specific sql state */
 struct sqlclntstate {

--- a/db/sql.h
+++ b/db/sql.h
@@ -219,6 +219,12 @@ enum ctrl_sqleng {
     SQLENG_WRONG_STATE,
 };
 
+enum {
+    SENDRESPONSE_NO = 0,
+    SENDRESPONSE_ALL = 1,
+    SENDRESPONSE_ERR = 2
+};
+
 void sql_set_sqlengine_state(struct sqlclntstate *clnt, char *file, int line,
                              int newstate);
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -574,7 +574,8 @@ struct sql_hist_cost {
 #define in_client_trans(clnt)                                                  \
     ((clnt)->ctrl_sqlengine == SQLENG_INTRANS_STATE ||                         \
      (clnt)->ctrl_sqlengine == SQLENG_PRE_STRT_STATE ||                        \
-     (clnt)->ctrl_sqlengine == SQLENG_STRT_STATE)
+     (clnt)->ctrl_sqlengine == SQLENG_STRT_STATE ||                            \
+     (clnt)->ctrl_sqlengine == SQLENG_FNSH_ABORTED_STATE)
 
 /* Client specific sql state */
 struct sqlclntstate {

--- a/db/sql.h
+++ b/db/sql.h
@@ -219,10 +219,10 @@ enum ctrl_sqleng {
     SQLENG_WRONG_STATE,
 };
 
-enum {
-    TRANS_COMMITROLLBK_NOREPLY = 0,
-    TRANS_COMMITROLLBK_NORMAL = 1,
-    TRANS_COMMITROLLBK_CHUNK = 2
+enum trans_clntcomm {
+    TRANS_CLNTCOMM_NOREPLY = 0,
+    TRANS_CLNTCOMM_NORMAL = 1,
+    TRANS_CLNTCOMM_CHUNK = 2
 };
 
 void sql_set_sqlengine_state(struct sqlclntstate *clnt, char *file, int line,
@@ -1135,9 +1135,10 @@ int wait_for_sql_query(struct sqlclntstate *clnt);
 void signal_clnt_as_done(struct sqlclntstate *clnt);
 
 int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                     int sendresponse);
+                     enum trans_clntcomm sideeffects);
 int handle_sql_commitrollback(struct sqlthdstate *thd,
-                              struct sqlclntstate *clnt, int sendresponse);
+                              struct sqlclntstate *clnt,
+                              enum trans_clntcomm sideeffects);
 
 int replicant_is_able_to_retry(struct sqlclntstate *clnt);
 void sql_get_query_id(struct sql_thread *thd);

--- a/db/sql.h
+++ b/db/sql.h
@@ -238,6 +238,8 @@ typedef struct {
     fdb_tbl_ent_t **lockedRemTables; /* list of fdb_tbl_ent_t* for read-locked
                                         remote tables */
     int nLockedRemTables; /* number of pointers in lockedRemTablesRootp */
+    int maxchunksize; /* multi-transaction bulk mode */
+    int crtchunksize; /* how many rows are processed already */
 } dbtran_type;
 typedef dbtran_type trans_t;
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -244,9 +244,9 @@ typedef struct {
     fdb_tbl_ent_t **lockedRemTables; /* list of fdb_tbl_ent_t* for read-locked
                                         remote tables */
     int nLockedRemTables; /* number of pointers in lockedRemTablesRootp */
-    int trans_has_sp; /* running a stored procedure */
-    int maxchunksize; /* multi-transaction bulk mode */
-    int crtchunksize; /* how many rows are processed already */
+    int trans_has_sp;     /* running a stored procedure */
+    int maxchunksize;     /* multi-transaction bulk mode */
+    int crtchunksize;     /* how many rows are processed already */
 } dbtran_type;
 typedef dbtran_type trans_t;
 
@@ -571,10 +571,10 @@ struct sql_hist_cost {
     int64_t rows;
 };
 
-#define in_client_trans(clnt) \
-    ((clnt)->ctrl_sqlengine == SQLENG_INTRANS_STATE || \
-    (clnt)->ctrl_sqlengine == SQLENG_PRE_STRT_STATE || \
-    (clnt)->ctrl_sqlengine == SQLENG_STRT_STATE)
+#define in_client_trans(clnt)                                                  \
+    ((clnt)->ctrl_sqlengine == SQLENG_INTRANS_STATE ||                         \
+     (clnt)->ctrl_sqlengine == SQLENG_PRE_STRT_STATE ||                        \
+     (clnt)->ctrl_sqlengine == SQLENG_STRT_STATE)
 
 /* Client specific sql state */
 struct sqlclntstate {

--- a/db/sql.h
+++ b/db/sql.h
@@ -572,10 +572,7 @@ struct sql_hist_cost {
 };
 
 #define in_client_trans(clnt)                                                  \
-    ((clnt)->ctrl_sqlengine == SQLENG_INTRANS_STATE ||                         \
-     (clnt)->ctrl_sqlengine == SQLENG_PRE_STRT_STATE ||                        \
-     (clnt)->ctrl_sqlengine == SQLENG_STRT_STATE ||                            \
-     (clnt)->ctrl_sqlengine == SQLENG_FNSH_ABORTED_STATE)
+    ((clnt)->in_client_trans)
 
 /* Client specific sql state */
 struct sqlclntstate {
@@ -714,6 +711,8 @@ struct sqlclntstate {
                        need to pend the first error until a commit is issued.
                        any statements
                        past the first error are ignored. */
+    int in_client_trans; /* clnt is in a client transaction (ie. client ran
+                            "begin" but not yet commit or rollback */
     char *saved_errstr;  /* if had_errors, save the error string */
     int saved_rc;        /* if had_errors, save the return code */
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8414,7 +8414,7 @@ int sqlite3BtreeInsert(
                 sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
                                         SQLENG_FNSH_STATE);
                 rc = handle_sql_commitrollback(clnt->thd, clnt,
-                                               TRANS_COMMITROLLBK_CHUNK);
+                                               TRANS_CLNTCOMM_CHUNK);
                 if (rc) {
                     comdb2_sqlite3VdbeError(pCur->vdbe,
                                             errstat_get_str(&clnt->osql.xerr));
@@ -8437,7 +8437,7 @@ int sqlite3BtreeInsert(
                 /* restart a new transaction */
                 sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
                                         SQLENG_PRE_STRT_STATE);
-                rc = handle_sql_begin(clnt->thd, clnt, 0);
+                rc = handle_sql_begin(clnt->thd, clnt, TRANS_CLNTCOMM_CHUNK);
                 if (rc && !commit_rc) {
                     comdb2_sqlite3VdbeError(pCur->vdbe,
                                             "Failed to start a new chunk");

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -103,6 +103,8 @@
 #include "comdb2_atomic.h"
 
 unsigned long long get_id(bdb_state_type *);
+static void unlock_bdb_cursors(struct sql_thread *thd, bdb_cursor_ifn_t *bdbcur,
+        int *bdberr);
 
 struct temp_cursor;
 struct temp_table;
@@ -4465,6 +4467,68 @@ int initialize_shadow_trans(struct sqlclntstate *clnt, struct sql_thread *thd)
     return rc;
 }
 
+
+static int _start_new_transaction(struct sqlclntstate *clnt, struct sql_thread *thd)
+{
+    int rc;
+
+    clnt->ins_keys = 0ULL;
+    clnt->del_keys = 0ULL;
+
+    if (gbl_expressions_indexes) {
+        free_cached_idx(clnt->idxInsert);
+        free_cached_idx(clnt->idxDelete);
+    }
+
+    if (clnt->arr) {
+        currangearr_free(clnt->arr);
+        clnt->arr = NULL;
+    }
+    if (clnt->selectv_arr) {
+        currangearr_free(clnt->selectv_arr);
+        clnt->selectv_arr = NULL;
+    }
+
+    if (clnt->dbtran.mode == TRANLEVEL_SERIAL) {
+        clnt->arr = malloc(sizeof(CurRangeArr));
+        currangearr_init(clnt->arr);
+    }
+    if (gbl_selectv_rangechk) {
+        clnt->selectv_arr = malloc(sizeof(CurRangeArr));
+        currangearr_init(clnt->selectv_arr);
+    }
+
+    get_current_lsn(clnt);
+
+    if (clnt->ctrl_sqlengine == SQLENG_STRT_STATE)
+        sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_INTRANS_STATE);
+
+    clnt->intrans = 1;
+    bzero(clnt->dirty, sizeof(clnt->dirty));
+
+
+#ifdef DEBUG_TRAN
+    if (gbl_debug_sql_opcodes) {
+        logmsg(LOGMSG_ERROR, "%p starts transaction tid=%d mode=%d intrans=%d\n",
+                clnt, pthread_self(), clnt->dbtran.mode, clnt->intrans);
+    }
+#endif
+    if ((rc = initialize_shadow_trans(clnt, thd)) != 0) {
+        sql_debug_logf(clnt, __func__, __LINE__,
+                       "initialize_shadow_tran returns %d\n", rc);
+        return rc;
+    }
+
+    uuidstr_t us;
+    char rqidinfo[40];
+    snprintf(rqidinfo, sizeof(rqidinfo), "rqid=%016llx %s appsock %u",
+             clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
+             clnt->appsock_id);
+    thrman_setid(thrman_self(), rqidinfo);
+
+    return 0;
+}
+
 /*
  ** Attempt to start a new transaction. A write-transaction
  ** is started if the second argument is nonzero, otherwise a read-
@@ -4548,40 +4612,6 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
         }
     }
 
-    clnt->ins_keys = 0ULL;
-    clnt->del_keys = 0ULL;
-
-    if (gbl_expressions_indexes) {
-        free_cached_idx(clnt->idxInsert);
-        free_cached_idx(clnt->idxDelete);
-    }
-
-    if (clnt->arr) {
-        currangearr_free(clnt->arr);
-        clnt->arr = NULL;
-    }
-    if (clnt->selectv_arr) {
-        currangearr_free(clnt->selectv_arr);
-        clnt->selectv_arr = NULL;
-    }
-
-    if (clnt->dbtran.mode == TRANLEVEL_SERIAL) {
-        clnt->arr = malloc(sizeof(CurRangeArr));
-        currangearr_init(clnt->arr);
-    }
-    if (gbl_selectv_rangechk) {
-        clnt->selectv_arr = malloc(sizeof(CurRangeArr));
-        currangearr_init(clnt->selectv_arr);
-    }
-
-    get_current_lsn(clnt);
-
-    if (clnt->ctrl_sqlengine == SQLENG_STRT_STATE)
-        sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_INTRANS_STATE);
-
-    clnt->intrans = 1;
-    bzero(clnt->dirty, sizeof(clnt->dirty));
-
     /* UPSERT: If we were asked to perform some action on conflict
      * (ON CONFLICT DO UPDATE/REPLACE and not DO NOTHING), then its a good
      * idea to switch at least to READ COMMITTED if we are running in some
@@ -4597,24 +4627,7 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
         clnt->dbtran.mode = TRANLEVEL_RECOM;
     }
 
-#ifdef DEBUG_TRAN
-    if (gbl_debug_sql_opcodes) {
-        logmsg(LOGMSG_ERROR, "%p starts transaction tid=%d mode=%d intrans=%d\n",
-                clnt, pthread_self(), clnt->dbtran.mode, clnt->intrans);
-    }
-#endif
-    if ((rc = initialize_shadow_trans(clnt, thd)) != 0) {
-        sql_debug_logf(clnt, __func__, __LINE__,
-                       "initialize_shadow_tran returns %d\n", rc);
-        goto done;
-    }
-
-    uuidstr_t us;
-    char rqidinfo[40];
-    snprintf(rqidinfo, sizeof(rqidinfo), "rqid=%016llx %s appsock %u",
-             clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
-             clnt->appsock_id);
-    thrman_setid(thrman_self(), rqidinfo);
+    rc = _start_new_transaction(clnt, thd);
 
 done:
     if (rc == SQLITE_OK && pSchemaVersion) {
@@ -7939,9 +7952,6 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
         rowlocks ? pause_pagelock_cursors : NULL, rowlocks ? (void *)thd : NULL,
         rowlocks ? count_pagelock_cursors : NULL, rowlocks ? (void *)thd : NULL,
         clnt->bdb_osql_trak, &bdberr);
-#ifdef OFFLOAD_TEST
-    fprintf(stderr, "OPEN %p\n", cur->bdbcur);
-#endif
     if (cur->bdbcur == NULL) {
         logmsg(LOGMSG_ERROR, "%s: bdb_cursor_open rc %d\n", __func__, bdberr);
         if (bdberr == BDBERR_DEADLOCK)
@@ -8387,14 +8397,15 @@ int sqlite3BtreeInsert(
         }
 
 
-        if (clnt->dbtran.maxchunksize > 0) {
+        if (clnt->dbtran.maxchunksize > 0 && clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
             if (clnt->dbtran.crtchunksize >= clnt->dbtran.maxchunksize) {
 
                 /* commit current transaction and reopen another one */
 
                 /* disconnect berkeley db cursors */
-                rc = recover_deadlock(thedb->bdb_env, thd, NULL, 0);
-                if (rc) {
+                bdberr = 0;
+                unlock_bdb_cursors(thd, NULL, &bdberr);
+                if (bdberr) {
                     sqlite3_mutex_enter(sqlite3_db_mutex(pCur->vdbe->db));
                     sqlite3VdbeError(pCur->vdbe,
                             "Failed to disconnect berkeleydb cursors");
@@ -8406,7 +8417,7 @@ int sqlite3BtreeInsert(
 
                 /* commit current transaction */
                 sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_FNSH_STATE);
-                rc = handle_sql_commitrollback(clnt->thd, clnt, 0);
+                rc = handle_sql_commitrollback(clnt->thd, clnt, SENDRESPONSE_ERR);
                 if (rc) {
                     sqlite3_mutex_enter(sqlite3_db_mutex(pCur->vdbe->db));
                     sqlite3VdbeError(pCur->vdbe,
@@ -8433,6 +8444,17 @@ int sqlite3BtreeInsert(
                     sqlite3_mutex_enter(sqlite3_db_mutex(pCur->vdbe->db));
                     sqlite3VdbeError(pCur->vdbe,
                             "Failed to start a new chunk");
+                    sqlite3_mutex_leave(sqlite3_db_mutex(pCur->vdbe->db));
+
+                    rc = SQLITE_ERROR;
+                    goto done;
+                }
+
+                rc = _start_new_transaction(clnt, thd);
+                if (rc) {
+                    sqlite3_mutex_enter(sqlite3_db_mutex(pCur->vdbe->db));
+                    sqlite3VdbeError(pCur->vdbe,
+                            "Failed to initialize new transaction");
                     sqlite3_mutex_leave(sqlite3_db_mutex(pCur->vdbe->db));
 
                     rc = SQLITE_ERROR;
@@ -9252,6 +9274,35 @@ static void recover_deadlock_sc_cleanup(struct sql_thread *thd)
     Pthread_mutex_unlock(&thd->lk);
 }
 
+
+static void unlock_bdb_cursors(struct sql_thread *thd, bdb_cursor_ifn_t *bdbcur,
+        int *bdberr)
+{
+    BtCursor *cur = NULL;
+
+    /* unlock cursors */
+    Pthread_mutex_lock(&thd->lk);
+
+    if (thd->bt) {
+        LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
+        {
+            if (cur->bdbcur) {
+                if (cur->bdbcur->unlock(cur->bdbcur, bdberr))
+                    ctrace("%s: cur ixnum=%d bdberr = %d [1]\n", __func__,
+                           cur->ixnum, *bdberr);
+            }
+        }
+    }
+
+    if (bdbcur) {
+        if (bdbcur->unlock(bdbcur, bdberr))
+            ctrace("%s: cur ixnum=%d bdberr = %d [2]\n", __func__, cur->ixnum,
+                   *bdberr);
+    }
+
+    Pthread_mutex_unlock(&thd->lk);
+}
+
 /**
  * This open a new curtran and walk the list of BtCursors,
  * repositioning any cursor that has a bdbcursor (by closing, reopening
@@ -9306,33 +9357,7 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
     /* increment global counter */
     gbl_sql_deadlock_reconstructions++;
 
-    /* unlock cursors */
-    Pthread_mutex_lock(&thd->lk);
-
-    if (thd->bt) {
-        LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
-        {
-            if (cur->bdbcur) {
-                if (cur->bdbcur->unlock(cur->bdbcur, &bdberr))
-                    ctrace("%s: cur ixnum=%d bdberr = %d [1]\n", __func__,
-                           cur->ixnum, bdberr);
-#ifdef OFFLOAD_TEST
-                fprintf(stderr, "UNLOCK %p\n", cur->bdbcur);
-#endif
-            }
-        }
-    }
-
-    if (bdbcur) {
-        if (bdbcur->unlock(bdbcur, &bdberr))
-            ctrace("%s: cur ixnum=%d bdberr = %d [2]\n", __func__, cur->ixnum,
-                   bdberr);
-#ifdef OFFLOAD_TEST
-        fprintf(stderr, "UNLOCK %p\n", bdbcur);
-#endif
-    }
-
-    Pthread_mutex_unlock(&thd->lk);
+    unlock_bdb_cursors(thd, bdbcur, &bdberr);
 
     curtran_flags = CURTRAN_RECOVERY;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5680,8 +5680,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
         clnt->origin = intern(get_origin_mach_by_buf(sb));
 
     clnt->dbtran.crtchunksize = clnt->dbtran.maxchunksize = 0;
-    logmsg(LOGMSG_ERROR, "%s:%d %lu clnt %p resetting in_trans\n",
-            __func__, __LINE__, pthread_self(), clnt);
+    clnt->in_client_trans = 0;
     clnt->had_errors = 0;
     clnt->statement_timedout = 0;
     clnt->query_timeout = 0;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1732,7 +1732,7 @@ int gbl_snapshot_serial_verify_retry = 1;
 
 inline int replicant_is_able_to_retry(struct sqlclntstate *clnt)
 {
-    if (clnt->verifyretry_off || clnt->trans_has_sp)
+    if (clnt->verifyretry_off || clnt->dbtran.trans_has_sp)
         return 0;
 
     if ((clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
@@ -1746,7 +1746,7 @@ inline int replicant_is_able_to_retry(struct sqlclntstate *clnt)
 
 static inline int replicant_can_retry_rc(struct sqlclntstate *clnt, int rc)
 {
-    if (clnt->verifyretry_off || clnt->trans_has_sp)
+    if (clnt->verifyretry_off || clnt->dbtran.trans_has_sp)
         return 0;
 
     /* Any isolation level can retry if nothing has been read */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3800,8 +3800,7 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
 
     case SQLENG_FNSH_STATE:
     case SQLENG_FNSH_RBK_STATE:
-        *outrc =
-            handle_sql_commitrollback(thd, clnt, TRANS_CLNTCOMM_NORMAL);
+        *outrc = handle_sql_commitrollback(thd, clnt, TRANS_CLNTCOMM_NORMAL);
         return 1;
 
     case SQLENG_NORMAL_PROCESS:

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2131,7 +2131,7 @@ static int do_send_commitrollback_response(struct sqlclntstate *clnt,
                                            int sideeffects)
 {
     if (sideeffects == TRANS_COMMITROLLBK_NORMAL &&
-            (send_intrans_response(clnt) || !clnt->had_errors))
+        (send_intrans_response(clnt) || !clnt->had_errors))
         return 1;
     return 0;
 }
@@ -2261,9 +2261,10 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         }
         /* if this is still an error, but not verify, pass it back to client */
         else if (!can_retry) {
-            reqlog_logf(thd->logger, REQL_QUERY, "\"%s\" SOCKSL retried done "
-                                                 "(non verify error rc=%d) "
-                                                 "sendresp=%d\n",
+            reqlog_logf(thd->logger, REQL_QUERY,
+                        "\"%s\" SOCKSL retried done "
+                        "(non verify error rc=%d) "
+                        "sendresp=%d\n",
                         (clnt->sql) ? clnt->sql : "(???.)", rc, sideeffects);
             osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_NONE);
         } else {
@@ -3270,8 +3271,9 @@ static void _prepare_error(struct sqlthdstate *thd,
     if (rc == SQLITE_SCHEMA_DOHSQL)
         return;
 
-    if (in_client_trans(clnt) && (rec->status & CACHE_HAS_HINT ||
-                                  has_sqlcache_hint(clnt->sql, NULL, NULL)) &&
+    if (in_client_trans(clnt) &&
+        (rec->status & CACHE_HAS_HINT ||
+         has_sqlcache_hint(clnt->sql, NULL, NULL)) &&
         !(rec->status & CACHE_FOUND_STR) &&
         (clnt->osql.replay == OSQL_RETRY_NONE)) {
 
@@ -3793,7 +3795,8 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
 
     case SQLENG_FNSH_STATE:
     case SQLENG_FNSH_RBK_STATE:
-        *outrc = handle_sql_commitrollback(thd, clnt, TRANS_COMMITROLLBK_NORMAL);
+        *outrc =
+            handle_sql_commitrollback(thd, clnt, TRANS_COMMITROLLBK_NORMAL);
         return 1;
 
     case SQLENG_NORMAL_PROCESS:

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1833,52 +1833,9 @@ void handle_sql_intrans_unrecoverable_error(struct sqlclntstate *clnt)
         abort_dbtran(clnt);
 }
 
-/* In a transaction, whenever a non-COMMIT/ROLLBACK command fails, we set
- * clnt->had_errors and report error to the client. Once set, we must not
- * send anything to the client (per the wire protocol?) unless intransresults
- * is set.
- */
-static int do_send_commitrollback_response(struct sqlclntstate *clnt,
-                                           int sendresponse)
+static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
 {
-    if (sendresponse && (send_intrans_response(clnt) || !clnt->had_errors))
-        return 1;
-    return 0;
-}
-
-int handle_sql_commitrollback(struct sqlthdstate *thd,
-                              struct sqlclntstate *clnt, int sendresponse)
-{
-    int bdberr = 0;
-    int rc = 0;
-    int irc = 0;
-    int outrc = 0;
-
-    reqlog_new_sql_request(thd->logger, clnt->sql);
-    log_queue_time(thd->logger, clnt);
-
-    int64_t rows = clnt->log_effects.num_updated +
-                   clnt->log_effects.num_deleted +
-                   clnt->log_effects.num_inserted;
-
-    reqlog_set_cost(thd->logger, 0);
-    reqlog_set_rows(thd->logger, rows);
-
-    if (rows > 0 && gbl_forbid_incoherent_writes && !clnt->had_lease_at_begin) {
-        abort_dbtran(clnt);
-        errstat_cat_str(&clnt->osql.xerr, "failed write from incoherent node");
-        clnt->osql.xerr.errval = ERR_BLOCK_FAILED + ERR_VERIFY;
-        sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
-                                SQLENG_NORMAL_PROCESS);
-        outrc = CDB2ERR_VERIFY_ERROR;
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
-        if (do_send_commitrollback_response(clnt, sendresponse)) {
-            write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, outrc);
-        }
-        goto done;
-    }
+    int irc = 0, rc = 0, bdberr = 0;
 
     if (!clnt->intrans) {
         reqlog_logf(thd->logger, REQL_QUERY, "\"%s\" ignore (no transaction)\n",
@@ -2164,6 +2121,58 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         }
     }
 
+    return rc;
+}
+
+/* In a transaction, whenever a non-COMMIT/ROLLBACK command fails, we set
+ * clnt->had_errors and report error to the client. Once set, we must not
+ * send anything to the client (per the wire protocol?) unless intransresults
+ * is set.
+ */
+static int do_send_commitrollback_response(struct sqlclntstate *clnt,
+                                           int sendresponse, int rc)
+{
+    if (((sendresponse == SENDRESPONSE_ALL) ||
+                (sendresponse == SENDRESPONSE_ERR && rc != SQLITE_OK)) &&
+            (send_intrans_response(clnt) || !clnt->had_errors))
+        return 1;
+    return 0;
+}
+
+int handle_sql_commitrollback(struct sqlthdstate *thd,
+                              struct sqlclntstate *clnt, int sendresponse)
+{
+    int rc = 0;
+    int outrc = 0;
+
+    reqlog_new_sql_request(thd->logger, clnt->sql);
+    log_queue_time(thd->logger, clnt);
+
+    int64_t rows = clnt->log_effects.num_updated +
+                   clnt->log_effects.num_deleted +
+                   clnt->log_effects.num_inserted;
+
+    reqlog_set_cost(thd->logger, 0);
+    reqlog_set_rows(thd->logger, rows);
+
+    if (rows > 0 && gbl_forbid_incoherent_writes && !clnt->had_lease_at_begin) {
+        abort_dbtran(clnt);
+        errstat_cat_str(&clnt->osql.xerr, "failed write from incoherent node");
+        clnt->osql.xerr.errval = ERR_BLOCK_FAILED + ERR_VERIFY;
+        sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
+                                SQLENG_NORMAL_PROCESS);
+        outrc = CDB2ERR_VERIFY_ERROR;
+        Pthread_mutex_lock(&clnt->wait_mutex);
+        clnt->ready_for_heartbeats = 0;
+        Pthread_mutex_unlock(&clnt->wait_mutex);
+        if (do_send_commitrollback_response(clnt, sendresponse, outrc)) {
+            write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, outrc);
+        }
+        goto done;
+    }
+
+    rc = do_commitrollback(thd, clnt);
+
     clnt->ins_keys = 0ULL;
     clnt->del_keys = 0ULL;
 
@@ -2206,7 +2215,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         Pthread_mutex_lock(&clnt->wait_mutex);
         clnt->ready_for_heartbeats = 0;
 
-        if (do_send_commitrollback_response(clnt, sendresponse)) {
+        if (do_send_commitrollback_response(clnt, sendresponse, rc)) {
             /* This is a commit, so we'll have something to send here even on a
              * retry.  Don't trigger code in fsql_write_response that's there
              * to catch bugs when we send back responses on a retry.
@@ -2282,10 +2291,13 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
 
         outrc = rc;
 
-        if (do_send_commitrollback_response(clnt, sendresponse)) {
-            write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, rc);
+        if (do_send_commitrollback_response(clnt, sendresponse, outrc)) {
+            write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, outrc);
         }
     }
+
+    if (sendresponse == SENDRESPONSE_ERR)
+        return outrc;
 
     /* if this is a retry, let the upper layer free the structure */
     if (clnt->osql.replay == OSQL_RETRY_NONE) {
@@ -2295,7 +2307,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     }
 
 done:
-
     reset_clnt_flags(clnt);
 
     reqlog_end_request(thd->logger, -1, __func__, __LINE__);
@@ -3785,7 +3796,7 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
 
     case SQLENG_FNSH_STATE:
     case SQLENG_FNSH_RBK_STATE:
-        *outrc = handle_sql_commitrollback(thd, clnt, 1);
+        *outrc = handle_sql_commitrollback(thd, clnt, SENDRESPONSE_ALL);
         return 1;
 
     case SQLENG_NORMAL_PROCESS:

--- a/docs/pages/programming/sql.md
+++ b/docs/pages/programming/sql.md
@@ -682,6 +682,13 @@ do not need to be quoted. For example, ```SET USER mike``` is correct.  ```SET U
 This sets the current connection's transaction level.  See 
 [transaction levels](transaction_model.html#isolation-levels-and-artifacts) for more details
 
+### SET TRANSACTION CHUNK
+
+This allows bulk data processing to be automatically split into smaller size chunks, freeing the client from 
+the responsibility of spliting up the data.  Jobs like ```INSERT INTO 't' SELECT * FROM 't2'``` are trivially handled
+as a sequence of small lock-footprint transactions.  Currently only supported for bulk inserts in a client specified 
+```BEGIN ... COMMIT``` transaction.
+
 ### SET TIMEZONE
 
 Sets the timezone for the current connection.  All datetime values are returned in this timezone.  All timezone

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2612,7 +2612,7 @@ static const char *db_commit_int(Lua L, int *rc)
     }
     reset_stmts(sp);
     sql_set_sqlengine_state(sp->clnt, __FILE__, __LINE__, SQLENG_FNSH_STATE);
-    if ((*rc = handle_sql_commitrollback(sp->thd, sp->clnt, 0)) == 0) {
+    if ((*rc = handle_sql_commitrollback(sp->thd, sp->clnt, SENDRESPONSE_NO)) == 0) {
         free(sp->error);
         sp->error = NULL;
     } else {
@@ -2640,7 +2640,7 @@ static const char *db_rollback_int(Lua L, int *rc)
     sql_set_sqlengine_state(sp->clnt, __FILE__, __LINE__,
                             SQLENG_FNSH_RBK_STATE);
     reqlog_set_event(sp->thd->logger, "sp");
-    *rc = handle_sql_commitrollback(sp->thd, sp->clnt, 0);
+    *rc = handle_sql_commitrollback(sp->thd, sp->clnt, SENDRESPONSE_NO);
     sp->clnt->ready_for_heartbeats = 1;
     if ((sp->in_parent_trans == 0) && sp->make_parent_trans) {
         int tmp;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2596,7 +2596,7 @@ static const char *db_begin_int(Lua L, int *rc)
     }
     sql_set_sqlengine_state(sp->clnt, __FILE__, __LINE__,
                             SQLENG_PRE_STRT_STATE);
-    *rc = handle_sql_begin(sp->thd, sp->clnt, 0);
+    *rc = handle_sql_begin(sp->thd, sp->clnt, TRANS_CLNTCOMM_NOREPLY);
     sp->clnt->ready_for_heartbeats = 1;
     return NULL;
 }
@@ -2612,7 +2612,7 @@ static const char *db_commit_int(Lua L, int *rc)
     }
     reset_stmts(sp);
     sql_set_sqlengine_state(sp->clnt, __FILE__, __LINE__, SQLENG_FNSH_STATE);
-    if ((*rc = handle_sql_commitrollback(sp->thd, sp->clnt, TRANS_COMMITROLLBK_NOREPLY)) == 0) {
+    if ((*rc = handle_sql_commitrollback(sp->thd, sp->clnt, TRANS_CLNTCOMM_NOREPLY)) == 0) {
         free(sp->error);
         sp->error = NULL;
     } else {
@@ -2640,7 +2640,7 @@ static const char *db_rollback_int(Lua L, int *rc)
     sql_set_sqlengine_state(sp->clnt, __FILE__, __LINE__,
                             SQLENG_FNSH_RBK_STATE);
     reqlog_set_event(sp->thd->logger, "sp");
-    *rc = handle_sql_commitrollback(sp->thd, sp->clnt, TRANS_COMMITROLLBK_NOREPLY);
+    *rc = handle_sql_commitrollback(sp->thd, sp->clnt, TRANS_CLNTCOMM_NOREPLY);
     sp->clnt->ready_for_heartbeats = 1;
     if ((sp->in_parent_trans == 0) && sp->make_parent_trans) {
         int tmp;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3007,10 +3007,10 @@ static void remove_emit(Lua L)
     lua_setfield(L, -2, "emit");
 }
 
-static void update_tran_funcs(Lua L, int in_tran)
+static void update_tran_funcs(Lua L, struct sqlclntstate *clnt)
 {
     int have = have_tran_funcs(L);
-    if (in_tran) {
+    if (in_client_trans(clnt)) {
         if (have) remove_tran_funcs(L);
         return;
     }
@@ -3117,7 +3117,7 @@ static int db_create_thread_int(Lua lua, const char *funcname)
         goto bad;
     }
     Lua newlua = newsp->lua;
-    update_tran_funcs(newlua, in_client_trans(sp->clnt));
+    update_tran_funcs(newlua, sp->clnt);
     remove_create_thread(newlua);
 
     lua_sethook(newlua, InstructionCountHook, 0, 1); /*This means no hook.*/
@@ -6431,7 +6431,7 @@ static int exec_procedure_int(struct sqlthdstate *thd,
 
     if ((rc = get_func_by_name(L, "main", err)) != 0) return rc;
 
-    update_tran_funcs(L, in_client_trans(clnt));
+    update_tran_funcs(L, clnt);
 
     if (IS_SYS(spname)) init_sys_funcs(L);
 

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -5801,7 +5801,7 @@ static int run_sp_int(struct sqlclntstate *clnt, int argcnt, char **err)
 
         db_rollback_int(lua, &tmp);
 
-        if (clnt->in_client_trans) {
+        if (in_client_trans(clnt)) {
             /* We have rolled back the transaction before having seen a commit
              * or rollback from the client. Let's fix the transaction state.
              */

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1468,19 +1468,19 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
             if (strncasecmp(sqlstr, "transaction", 11) == 0) {
                 sqlstr += 11;
                 sqlstr = skipws(sqlstr);
- 
+
                 if (strncasecmp(sqlstr, "chunk", 5) == 0) {
                     int tmp;
                     sqlstr += 5;
                     sqlstr = skipws(sqlstr);
 
-                    if (!sqlstr || ( (tmp = atoi(sqlstr)) <= 0)) {
+                    if (!sqlstr || ((tmp = atoi(sqlstr)) <= 0)) {
                         snprintf(err, sizeof(err),
-                                "set transaction chunk N: missing chunk size N \"%s\"",
-                                sqlstr);
+                                 "set transaction chunk N: missing chunk size "
+                                 "N \"%s\"",
+                                 sqlstr);
                         rc = ii + 1;
-                    }
-                    else {
+                    } else {
                         clnt->dbtran.maxchunksize = tmp;
                         /* in chunked mode, we disable verify retries */
                         clnt->verifyretry_off = 1;
@@ -1507,9 +1507,8 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                         clnt->verify_retries = 0;
                         if (clnt->hasql_on == 1) {
                             newsql_set_high_availability(clnt);
-                            logmsg(
-                                    LOGMSG_ERROR,
-                                    "Enabling snapshot isolation high availability\n");
+                            logmsg(LOGMSG_ERROR, "Enabling snapshot isolation "
+                                                 "high availability\n");
                         }
                     }
                     if (clnt->dbtran.mode == TRANLEVEL_INVALID)

--- a/tests/read_committed.test/q01_2.sql
+++ b/tests/read_committed.test/q01_2.sql
@@ -1,5 +1,5 @@
 delete from t1 where 1
-set transaction read commited
+set transaction read committed
 begin
 insert into t1 (a,b) values (2,1)
 insert into t1 (a,b) values (1,2)

--- a/tests/read_committed.test/q01_2.sql.exp
+++ b/tests/read_committed.test/q01_2.sql.exp
@@ -1,6 +1,6 @@
 (rows deleted=0)
 [delete from t1 where 1] rc 0
-[set transaction read commited] rc 0
+[set transaction read committed] rc 0
 [begin] rc 0
 [insert into t1 (a,b) values (2,1)] rc 0
 [insert into t1 (a,b) values (1,2)] rc 0

--- a/tests/read_committed.test/q02_1.sql
+++ b/tests/read_committed.test/q02_1.sql
@@ -1,6 +1,6 @@
 delete from t1 where 1
 insert into t1 (a,b) values (2,1)
-set transaction read commited
+set transaction read committed
 begin
 insert into t1 (a,b) values (1,2)
 insert into t1 (a,b) values (0,4)

--- a/tests/read_committed.test/q02_1.sql.exp
+++ b/tests/read_committed.test/q02_1.sql.exp
@@ -2,7 +2,7 @@
 [delete from t1 where 1] rc 0
 (rows inserted=1)
 [insert into t1 (a,b) values (2,1)] rc 0
-[set transaction read commited] rc 0
+[set transaction read committed] rc 0
 [begin] rc 0
 [insert into t1 (a,b) values (1,2)] rc 0
 [insert into t1 (a,b) values (0,4)] rc 0

--- a/tests/read_committed.test/q03_1.sql
+++ b/tests/read_committed.test/q03_1.sql
@@ -1,6 +1,6 @@
 delete from t1 where 1
 insert into t1 (a,b) values (2,1)
-set transaction read commited
+set transaction read committed
 begin
 insert into t1 (a,b) values (1,2)
 insert into t1 (a,b) values (0,4)

--- a/tests/read_committed.test/q03_1.sql.exp
+++ b/tests/read_committed.test/q03_1.sql.exp
@@ -2,7 +2,7 @@
 [delete from t1 where 1] rc 0
 (rows inserted=1)
 [insert into t1 (a,b) values (2,1)] rc 0
-[set transaction read commited] rc 0
+[set transaction read committed] rc 0
 [begin] rc 0
 [insert into t1 (a,b) values (1,2)] rc 0
 [insert into t1 (a,b) values (0,4)] rc 0

--- a/tests/read_committed.test/q04_1.sql
+++ b/tests/read_committed.test/q04_1.sql
@@ -1,7 +1,7 @@
 delete from t1 where 1
 insert into t1 (a,b) values (1,2)
 insert into t1 (a,b) values (0,4)
-set transaction read commited
+set transaction read committed
 begin
 insert into t1 (a,b) values (2,1)
 select a,b from t1 where b = 4

--- a/tests/read_committed.test/q04_1.sql.exp
+++ b/tests/read_committed.test/q04_1.sql.exp
@@ -4,7 +4,7 @@
 [insert into t1 (a,b) values (1,2)] rc 0
 (rows inserted=1)
 [insert into t1 (a,b) values (0,4)] rc 0
-[set transaction read commited] rc 0
+[set transaction read committed] rc 0
 [begin] rc 0
 [insert into t1 (a,b) values (2,1)] rc 0
 (a=0, b=4)

--- a/tests/transchunk.test/Makefile
+++ b/tests/transchunk.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/transchunk.test/README
+++ b/tests/transchunk.test/README
@@ -1,0 +1,1 @@
+This test checks the "SET TRANSACTION CHUNK N" effect on bulk insert loads.

--- a/tests/transchunk.test/log.expected
+++ b/tests/transchunk.test/log.expected
@@ -1,0 +1,37 @@
+Starting
+Inserting rows
+Inserting chunks of 99 rows
+(out='    OSQL_DONE            51')
+(count(*)=5000)
+Deleting the existing rows
+(out='    OSQL_DONE            52')
+Inserting chunks of 1 row
+(out='    OSQL_DONE            5052')
+(count(*)=5000)
+Deleting the existing rows
+(out='    OSQL_DONE            5053')
+Multiple inserts in a transaction chunks of 1
+(out='    OSQL_DONE            5059')
+Failure tests
+[commit] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+(out='    OSQL_DONE            5059')
+[commit] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+(out='    OSQL_DONE            5059')
+(a=1)
+(a=2)
+(a=3)
+[select * from t order by a limit 3] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+[commit] failed with rc 299 
+(out='    OSQL_DONE            5059')
+(a=1)
+(a=2)
+(a=3)
+[commit] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+(out='    OSQL_DONE            5059')
+[commit] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+(count(*)=6)
+(out='    OSQL_DONE            5059')
+[commit] failed with rc 299 add key constraint duplicate key 'A' on table 't' index 0
+(a=123456789)
+(count(*)=7)
+(out='    OSQL_DONE            5060')

--- a/tests/transchunk.test/lrl.options
+++ b/tests/transchunk.test/lrl.options
@@ -1,0 +1,3 @@
+table t t.csc2
+table t2 t2.csc2
+always_send_cnonce off

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+TMPDIR=${TMPDIR:-/tmp}
+
+#set -e 
+set -x
+
+# args
+a_dbn=$1
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $a_dbn default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
+r="cdb2sql -s ${CDB2_OPTIONS} $a_dbn default -"
+rt="cdb2sql -s ${CDB2_OPTIONS} $a_dbn default "
+rtm="cdb2sql -s -n ${master} ${CDB2_OPTIONS} $a_dbn default "
+
+outlog='log.run'
+
+#>>$outlog
+
+function check_done
+{ 
+    $rtm "exec procedure sys.cmd.send('long')" | grep -A 3 "'t'" | grep DONE >> $outlog
+}
+
+echo "Starting"
+echo "Starting" > $outlog
+
+echo "Inserting rows"
+echo "Inserting rows" >> $outlog
+$r >> $outlog << "EOF" 
+begin
+insert into t2 select value from generate_series(1, 5000)
+commit
+EOF
+
+echo "Inserting chunks of 99 rows"
+echo "Inserting chunks of 99 rows" >> $outlog
+$r >> $outlog << "EOF" 
+set transaction chunk 99 
+begin 
+insert into t select * from t2
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
+echo "Deleting the existing rows"
+echo "Deleting the existing rows" >> $outlog
+$r >> $outlog << "EOF" 
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+echo "Inserting chunks of 1 row"
+echo "Inserting chunks of 1 row" >> $outlog
+$r >> $outlog << "EOF" 
+set transaction chunk 1 
+begin
+insert into t select * from t2
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
+echo "Deleting the existing rows"
+echo "Deleting the existing rows" >> $outlog
+$r >> $outlog << "EOF" 
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+echo "Multiple inserts in a transaction chunks of 1"
+echo "Multiple inserts in a transaction chunks of 1" >> $outlog
+$r >> $outlog << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+insert into t values (2)
+insert into t values (3)
+insert into t values (4)
+insert into t values (5)
+insert into t values (6)
+commit
+EOF
+
+check_done
+
+echo "Failure tests"
+echo "Failure tests" >> $outlog
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+commit
+EOF
+
+check_done
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+insert into t values (2)
+commit
+EOF
+
+check_done
+
+$rt "select * from t order by a limit 3" >> $outlog
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+insert into t values (2)
+select * from t order by a limit 3
+commit
+EOF
+
+check_done
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+select * from t order by a limit 3
+insert into t values (123456789)
+commit
+EOF
+
+$rt "select * from t where a>1000" >> $outlog
+
+check_done
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (1)
+insert into t values (2)
+insert into t values (3)
+insert into t values (4)
+insert into t values (5)
+insert into t values (123456789)
+commit
+EOF
+
+$rt "select * from t where a>1000" >> $outlog
+
+$rt "select count(*) from t" >> $outlog
+
+check_done
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+begin
+insert into t values (123456789)
+insert into t values (1)
+commit
+EOF
+
+$rt "select * from t where a>1000" >> $outlog
+
+$rt "select count(*) from t" >> $outlog
+
+check_done
+
+# get testcase output
+testcase_output=$(cat $outlog)
+
+# get expected output
+expected_output=$(cat log.expected)
+
+# verify 
+if [[ "$testcase_output" != "$expected_output" ]]; then
+
+    echo "  ^^^^^^^^^^^^"
+    echo "The above testcase (${testcase}) has failed!!!"
+    echo " "
+    echo "Use 'diff <expected-output> <my-output>' to see why:"
+    echo "> diff ${PWD}/{log.expected,$outlog}"
+    echo " "
+    diff log.expected $outlog
+    echo " "
+    exit 1
+
+fi
+
+echo "Testcase passed."
+

--- a/tests/transchunk.test/t.csc2
+++ b/tests/transchunk.test/t.csc2
@@ -1,0 +1,8 @@
+schema
+	{
+		int a
+	}
+keys
+    {
+        "a" = a
+    }

--- a/tests/transchunk.test/t2.csc2
+++ b/tests/transchunk.test/t2.csc2
@@ -1,0 +1,8 @@
+schema
+	{
+		int a
+	}
+keys
+    {
+        "a" = a
+    }


### PR DESCRIPTION
Inserting large data-sets can now be automatically split into multiple transactions for a smaller impact on live databases.
Example:
SET TRANSACTION CHUNK 100
BEGIN
INSERT INTO T SELECT * FROM T2
COMMIT
The above will only commit a maximum of 100 rows at a time.

/plugin-branch transaction_chunks