### PR TITLE
toblock_int: gettimeofday once, and other cleanup

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -237,14 +237,14 @@ static inline int print_verify_progress(verify_common_t *par, int now)
     int rc;
     if (par->verify_mode == VERIFY_DEFAULT) {
         rc = locprint(par->sb, par->lua_callback, par->lua_params,
-                      "!%s, did %lld records, %d per second\n", par->header,
+                      "!%s, did %d records, %d per second\n", par->header,
                       par->nrecs_progress,
                       par->nrecs_progress / par->progress_report_seconds);
         par->nrecs_progress = 0;
     } else {
         unsigned long long delta = par->items_processed - par->saved_progress;
         rc = locprint(par->sb, par->lua_callback, par->lua_params,
-                      "!verify: processed %lld items, %d per second\n",
+                      "!verify: processed %lld items, %lld per second\n",
                       par->items_processed,
                       delta / par->progress_report_seconds);
         par->saved_progress = par->items_processed;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1325,7 +1325,7 @@ struct ireq {
     /************/
     uint8_t region3; /* used for offsetof */
 
-    uint64_t startus;           /* thread handling; start time stamp */
+    uint64_t startus; /* thread handling; start time stamp */
     /* for waking up socket thread. */
     void *request_data;
     char *tag;

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -328,7 +328,8 @@ void eventlog_perfdata(cson_object *obj, const struct reqlogger *logger)
     cson_object *perfobj = cson_value_get_object(perfval);
 
     cson_object_set(perfobj, "tottime", cson_new_int(logger->durationus));
-    cson_object_set(perfobj, "processingtime", cson_new_int(logger->durationus - logger->queuetimeus));
+    cson_object_set(perfobj, "processingtime",
+                    cson_new_int(logger->durationus - logger->queuetimeus));
     if (logger->queuetimeus)
         cson_object_set(perfobj, "qtime", cson_new_int(logger->queuetimeus));
 

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2763,12 +2763,14 @@ inline int reqlog_get_error_code(const struct reqlogger *logger)
     return logger->error_code;
 }
 
-inline void reqlog_set_path(struct reqlogger *logger, struct client_query_stats *path)
+inline void reqlog_set_path(struct reqlogger *logger,
+                            struct client_query_stats *path)
 {
     logger->path = path;
 }
 
-inline void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context)
+inline void reqlog_set_context(struct reqlogger *logger, int ncontext,
+                               char **context)
 {
     logger->ncontext = ncontext;
     logger->context = context;

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -103,7 +103,7 @@ struct reqlogger {
     int sqlrows;
     double sqlcost;
 
-    uint64_t startus; /* logger start timestamp */
+    uint64_t startus;     /* logger start timestamp */
     uint64_t startprcsus; /* processing start timestamp */
     uint64_t durationus;
     uint64_t queuetimeus;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6573,22 +6573,23 @@ int gather_connection_info(struct connection_info **info, int *num_connections) 
    c = malloc(*num_connections * sizeof(struct connection_info));
    struct sqlclntstate *clnt;
    LISTC_FOR_EACH(&clntlist, clnt, lnk) {
-      c[cid].connection_id = clnt->connid;
-      c[cid].pid = clnt->last_pid;
-      c[cid].total_sql = clnt->total_sql;
-      c[cid].sql_since_reset = clnt->sql_since_reset;
-      c[cid].num_resets = clnt->num_resets;
-      c[cid].connect_time_int = clnt->connect_time;
-      c[cid].last_reset_time_int = clnt->last_reset_time;
-      c[cid].num_resets = clnt->num_resets;
-      c[cid].host = clnt->origin;
-      c[cid].state_int = clnt->state;
-      c[cid].time_in_state_int = clnt->state_start_time;
-      Pthread_mutex_lock(&clnt->state_lk);
-      if (clnt->state == CONNECTION_RUNNING || clnt->state == CONNECTION_QUEUED) {
-         c[cid].sql = strdup(clnt->sql);
+       c[cid].connection_id = clnt->connid;
+       c[cid].pid = clnt->last_pid;
+       c[cid].total_sql = clnt->total_sql;
+       c[cid].sql_since_reset = clnt->sql_since_reset;
+       c[cid].num_resets = clnt->num_resets;
+       c[cid].connect_time_int = clnt->connect_time;
+       c[cid].last_reset_time_int = clnt->last_reset_time;
+       c[cid].num_resets = clnt->num_resets;
+       c[cid].host = clnt->origin;
+       c[cid].state_int = clnt->state;
+       c[cid].time_in_state_int = clnt->state_start_time;
+       Pthread_mutex_lock(&clnt->state_lk);
+       if (clnt->state == CONNECTION_RUNNING ||
+           clnt->state == CONNECTION_QUEUED) {
+           c[cid].sql = strdup(clnt->sql);
       } else {
-         c[cid].sql = NULL;
+          c[cid].sql = NULL;
       }
       Pthread_mutex_unlock(&clnt->state_lk);
       cid++;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6566,32 +6566,32 @@ void clnt_unregister(struct sqlclntstate *clnt) {
 
 int gather_connection_info(struct connection_info **info, int *num_connections) {
    struct connection_info *c;
-   int connid = 0;
+   int cid = 0;
 
    Pthread_mutex_lock(&clnt_lk);
    *num_connections = listc_size(&clntlist);
    c = malloc(*num_connections * sizeof(struct connection_info));
    struct sqlclntstate *clnt;
    LISTC_FOR_EACH(&clntlist, clnt, lnk) {
-      c[connid].connection_id = clnt->connid;
-      c[connid].pid = clnt->last_pid;
-      c[connid].total_sql = clnt->total_sql;
-      c[connid].sql_since_reset = clnt->sql_since_reset;
-      c[connid].num_resets = clnt->num_resets;
-      c[connid].connect_time_int = clnt->connect_time;
-      c[connid].last_reset_time_int = clnt->last_reset_time;
-      c[connid].num_resets = clnt->num_resets;
-      c[connid].host = clnt->origin;
-      c[connid].state_int = clnt->state;
-      c[connid].time_in_state_int = clnt->state_start_time;
+      c[cid].connection_id = clnt->connid;
+      c[cid].pid = clnt->last_pid;
+      c[cid].total_sql = clnt->total_sql;
+      c[cid].sql_since_reset = clnt->sql_since_reset;
+      c[cid].num_resets = clnt->num_resets;
+      c[cid].connect_time_int = clnt->connect_time;
+      c[cid].last_reset_time_int = clnt->last_reset_time;
+      c[cid].num_resets = clnt->num_resets;
+      c[cid].host = clnt->origin;
+      c[cid].state_int = clnt->state;
+      c[cid].time_in_state_int = clnt->state_start_time;
       Pthread_mutex_lock(&clnt->state_lk);
       if (clnt->state == CONNECTION_RUNNING || clnt->state == CONNECTION_QUEUED) {
-         c[connid].sql = strdup(clnt->sql);
+         c[cid].sql = strdup(clnt->sql);
       } else {
-         c[connid].sql = NULL;
+         c[cid].sql = NULL;
       }
       Pthread_mutex_unlock(&clnt->state_lk);
-      connid++;
+      cid++;
    }
    Pthread_mutex_unlock(&clnt_lk);
    *info = c;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -99,7 +99,6 @@ extern __thread int send_prefault_udp;
 extern void delay_if_sc_resuming(struct ireq *iq);
 extern unsigned int gbl_delayed_skip;
 
-
 int gbl_osql_snap_info_hashcheck = 1;
 
 #if 0
@@ -5912,8 +5911,9 @@ static int toblock_main(struct javasp_trans_state *javasp_trans_handle,
     Pthread_mutex_unlock(&blklk);
 
     if (prcnt && gbl_print_blockp_stats) {
-        logmsg(LOGMSG_USER, "%d threads are in the block processor, max is %d\n",
-               prcnt, prmax);
+        logmsg(LOGMSG_USER,
+               "%d threads are in the block processor, max is %d\n", prcnt,
+               prmax);
     }
 
     rc = toblock_main_int(javasp_trans_handle, iq, p_blkstate);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -82,7 +82,6 @@
 int (*comdb2_ipc_swapnpasdb_sinfo)(struct ireq *) = 0;
 
 extern int is_buffer_from_remote(const void *buf);
-
 extern pthread_t gbl_invalid_tid;
 extern int gbl_enable_berkdb_retry_deadlock_bias;
 extern int gbl_osql_verify_retries_max;
@@ -94,6 +93,12 @@ extern pthread_mutex_t commit_stat_lk;
 extern pthread_mutex_t osqlpf_mutex;
 extern int gbl_prefault_udp;
 extern int gbl_reorder_socksql_no_deadlock;
+extern int gbl_print_blockp_stats;
+extern int gbl_dump_blkseq;
+extern __thread int send_prefault_udp;
+extern void delay_if_sc_resuming(struct ireq *iq);
+extern unsigned int gbl_delayed_skip;
+
 
 int gbl_osql_snap_info_hashcheck = 1;
 
@@ -759,8 +764,6 @@ static void block_state_free(block_state_t *p_blkstate)
     free(p_blkstate->p_buf_saved_start);
     p_blkstate->p_buf_saved_start = NULL;
 }
-
-extern int gbl_dump_blkseq;
 
 unsigned long long blkseq_replay_count = 0;
 unsigned long long blkseq_replay_error_count = 0;
@@ -2346,8 +2349,6 @@ static int extract_blkseq2(struct ireq *iq, block_state_t *p_blkstate,
 
 static pthread_rwlock_t commit_lock = PTHREAD_RWLOCK_INITIALIZER;
 
-extern __thread int send_prefault_udp;
-extern void delay_if_sc_resuming(struct ireq *iq);
 
 void handle_postcommit_bpfunc(struct ireq *iq)
 {
@@ -4836,7 +4837,6 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
     } /* end delayed */
     else {
-        extern unsigned int gbl_delayed_skip;
         ++gbl_delayed_skip;
     }
 
@@ -5890,18 +5890,18 @@ static uint64_t block_processor_ms = 0;
 static int toblock_main(struct javasp_trans_state *javasp_trans_handle,
                         struct ireq *iq, block_state_t *p_blkstate)
 {
-    int now, rc, prcnt = 0, prmax = 0;
-    uint64_t start, end;
-    extern int gbl_print_blockp_stats;
+    int rc, prcnt = 0, prmax = 0;
     static pthread_mutex_t blklk = PTHREAD_MUTEX_INITIALIZER;
-    static int blkcnt = 0, lastpr = 0;
+    static int blkcnt = 0;
+    static uint64_t lastpr = 0;
+
+    uint64_t start = gettimeofday_ms();
 
     Pthread_mutex_lock(&blklk);
     blkcnt++;
-
-    if (((now = comdb2_time_epoch()) - lastpr) > 1) {
+    if (start - lastpr > 1000) {
         prcnt = blkcnt;
-        lastpr = now;
+        lastpr = start;
     }
 
     if (blkcnt > blkmax)
@@ -5913,12 +5913,11 @@ static int toblock_main(struct javasp_trans_state *javasp_trans_handle,
 
     if (prcnt && gbl_print_blockp_stats) {
         logmsg(LOGMSG_USER, "%d threads are in the block processor, max is %d\n",
-                prcnt, prmax);
+               prcnt, prmax);
     }
 
-    start = gettimeofday_ms();
     rc = toblock_main_int(javasp_trans_handle, iq, p_blkstate);
-    end = gettimeofday_ms();
+    uint64_t end = gettimeofday_ms();
 
     if (rc == 0) {
         osql_postcommit_handle(iq);

--- a/tests/README.md
+++ b/tests/README.md
@@ -263,7 +263,7 @@ of comdb2 servers in those containers.
             bridge_maxwait 5
             bridge_fd 0
             pre-up /sbin/modprobe dummy
-            iptables -t nat -A POSTROUTING -o wlp1s0 -j MASQUERADE
+            iptables -t nat -A POSTROUTING -o eth0 -j MASQUERADE
     ```
 
     and then bring `br0` up:
@@ -276,10 +276,12 @@ of comdb2 servers in those containers.
       /etc/init.d/apparmor start
     ```
 
-2.  Create a container with a recent distribution release for instance debian stretch:
+2.  Create a container with a recent distribution release, for instance debian stretch:
     ```sh
       lxc-create -n node1 -t debian -- -r stretch
     ```
+
+    Note that if you are going to compile and link on the host machine, then you should install the same distribution that you have in the host machine otherwise glibc version and other libraries might not be available.
 
 3.  Change the config for `node1` to have `br0` (or `lxcbr0`) as interface for networking. In debian the config file resides for node1 we just created resides in `/var/lib/lxc/node1/config` and you should have it contain the following
     ```
@@ -343,6 +345,11 @@ of comdb2 servers in those containers.
     hostname node1
     ```
 
+    You will also want to install inside the containers the required packages for comdb2 to run:
+    ```sh
+      apt-get install libprotobuf-c1 libunwind8 libsqlite3-0
+    ```
+
 4.  At this time you will want to make copies of this container:
     ```sh
       lxc-copy -n node1 -N node2
@@ -371,14 +378,16 @@ of comdb2 servers in those containers.
       done
     ```
 
+    You should be able to login without typing password given that you created ssh keys above.
+
 6.  To run tests in clusters residing in the above containers, launch the tests from the host machine: 
     ```sh
-      export CLUSTER="node1 node2 node"
+      export CLUSTER="node1 node2 node3"
       make test1
     ```
     or
     ```sh
-      make -k -j 16 CLUSTER="node1 node2 node"
+      make -k -j 16 CLUSTER="node1 node2 node3"
     ```
 
 ## Running tests on AWS EC2 clusters

--- a/tests/tools/copy_files_to_cluster.sh
+++ b/tests/tools/copy_files_to_cluster.sh
@@ -59,7 +59,6 @@ copy_files_to_node() {
     if [[ "$SKIP_COPY_EXE" != "1" ]] ; then
         scp $SSH_OPT $SSH_MSTR $COMDB2AR_EXE $node:$COMDB2AR_EXE
         scp $SSH_OPT $SSH_MSTR $COMDB2_EXE $node:$COMDB2_EXE
-        scp $SSH_OPT $SSH_MSTR $CDB2SQL_EXE $node:$CDB2SQL_EXE
         if [ -n "$RESTARTPMUX" ] ; then
             echo stop pmux on $node first before copying and starting it
             ssh $SSH_OPT $SSH_MSTR $node "$stop_pmux" < /dev/null


### PR DESCRIPTION
* get time only once and outside of lock
* move extern definitions to the top
* cluster nodes dont need cdb2sql for tests
* update readme in tests dir