### PR TITLE
Use parallel verify at end of the tests

### DIFF
--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -15,6 +15,7 @@ static const char revid[] = "$Id: mp_fget.c,v 11.81 2003/09/25 02:15:16 sue Exp 
 #include <stdint.h>
 #include <stdlib.h>
 #include <alloca.h>
+#include <limits.h>
 #include <sys/types.h>
 #include <limits.h>
 

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -20,6 +20,7 @@ static const char revid[] = "$Id: mp_sync.c,v 11.80 2003/09/13 19:20:41 bostic E
 
 #include <sys/types.h>
 #include <pthread.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -233,8 +233,8 @@ verify_db_at_finish() {
 
     tables=$(timeout 1m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default 'select * from comdb2_tables')
     for t in $tables ; do 
-        timeout 3m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default "exec procedure sys.cmd.verify('$t')" &> verify.out
-        if ! grep "Verify succeeded." verify.out > /dev/null ; then
+        timeout 3m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default "exec procedure sys.cmd.verify('$t', 'parallel')" &> ${t}_verify.out
+        if ! grep "Verify succeeded." ${t}_verify.out > /dev/null ; then
             echo "Table $t"
             return
         fi

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -231,10 +231,12 @@ verify_db_at_finish() {
     local LCLCONFIG="$2"
     local LCLOPTIONS="--cdb2cfg ${LCLCONFIG}"
 
-    tables=$(timeout 1m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default 'select * from comdb2_tables')
+    node=$(timeout 1m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default 'select comdb2_host()' )
+    tables=$(timeout 1m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM --host $node 'select * from comdb2_tables')
     for t in $tables ; do 
-        timeout 3m $CDB2SQL_EXE ${LCLOPTIONS} --tabs $LCLDBNM default "exec procedure sys.cmd.verify('$t', 'parallel')" &> ${t}_verify.out
-        if ! grep "Verify succeeded." ${t}_verify.out > /dev/null ; then
+        outfl=${t}_verify.out
+        timeout 3m $CDB2SQL_EXE ${LCLOPTIONS} --verbose --tabs $LCLDBNM --host $node "exec procedure sys.cmd.verify('$t', 'parallel')" &> $outfl
+        if ! grep "^Verify succeeded.$" $outfl > /dev/null ; then
             echo "Table $t"
             return
         fi
@@ -287,12 +289,15 @@ fi
 if [ $CHECK_DB_AT_FINISH -eq 1 ] ; then
     dbdown=`check_db_at_finish ${DBNAME} $CDB2_CONFIG`
 
+    # if no crashes, check secondary
     if [[ -z "$dbdown" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
         dbdown=`check_db_at_finish ${SECONDARY_DBNAME} $SECONDARY_CDB2_CONFIG`
     fi
 
+    # if no crashes, run verify
     if [[ -z "$dbdown" ]] ; then
         verify_ret=`verify_db_at_finish ${DBNAME} $CDB2_CONFIG`
+        # if no issues with verify, run verify on secondary
         if [[ -z "$verify_ret" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
             verify_ret=`verify_db_at_finish ${SECONDARY_DBNAME} $SECONDARY_CDB2_CONFIG`
         fi

--- a/tests/verify_db.test/runit
+++ b/tests/verify_db.test/runit
@@ -210,4 +210,14 @@ insert_records 1 $NEWNUMREC
 assertcnt t1 $NEWNUMREC
 
 
+tables=$(timeout 1m cdb2sql_exe --tabs $dbnm $master 'select * from comdb2_tables')
+for t in $tables ; do
+    outfl=${t}_verify.out
+    timeout 3m cdb2sql_exe --verbose --tabs dbnm $master "exec procedure sys.cmd.verify('$t', 'parallel')" &> $outfl
+    if ! grep "^Verify succeeded.$" $outfl > /dev/null ; then
+        failexit "Failed verify: Table $t"
+    fi
+done
+
+
 echo "Success"


### PR DESCRIPTION
Run the parallel version of verify at the end of the tests.