### PR TITLE
logmsg: Introduce 'logmsg.skiplevel' to skip attaching level to the log message

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -333,6 +333,7 @@ static char *legacy_options[] = {
     "legacy_schema on",
     "logmsg level info",
     "logmsg notimestamp",
+    "logmsg skiplevel",
     "logput window 1",
     "noblobstripe",
     "nochecksums",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1247,6 +1247,12 @@ REGISTER_TUNABLE("logmsg.level",
                  "All messages below this level will not be logged.",
                  TUNABLE_ENUM, NULL, READEARLY, logmsg_level_value, NULL,
                  logmsg_level_update, NULL);
+REGISTER_TUNABLE(
+    "logmsg.skiplevel",
+    "Skip appending level information to the log message. This was added to "
+    "keep up with the historical behavior (Default: on)",
+    TUNABLE_BOOLEAN, NULL, NOARG | READEARLY | INVERSE_VALUE | INTERNAL,
+    logmsg_prefix_level_value, NULL, logmsg_prefix_level_update, NULL);
 REGISTER_TUNABLE("logmsg.syslog", "Log messages to syslog.", TUNABLE_BOOLEAN,
                  NULL, NOARG | READEARLY, logmsg_syslog_value, NULL,
                  logmsg_syslog_update, NULL);

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -942,6 +942,7 @@ configurations:
     legacy_schema on
     logmsg level info
     logmsg notimestamp
+    logmsg skiplevel
     logput window 1
     noblobstripe
     nochecksums

--- a/util/logmsg.c
+++ b/util/logmsg.c
@@ -18,6 +18,7 @@ static loglvl level = LOGMSG_WARN;
 static int do_syslog = 0;
 static int do_time = 1;
 static int do_thread = 0;
+static int do_prefix_level = 1;
 static int ended_with_newline = 1;
 
 /* from io_override.c */
@@ -148,7 +149,8 @@ static int logmsgv_lk(loglvl lvl, const char *fmt, va_list args)
             *s = 0;
             ended_with_newline = 1;
             /* Add a prefix for ERROR/FATAL messages. */
-            if (lvl == LOGMSG_ERROR || lvl == LOGMSG_FATAL) {
+            if (do_prefix_level &&
+                (lvl == LOGMSG_ERROR || lvl == LOGMSG_FATAL)) {
                 ret += fprintf(f, "[%s] ", logmsg_level_str(lvl));
             }
             ret += fprintf(f, "%s\n", msg);
@@ -161,7 +163,7 @@ static int logmsgv_lk(loglvl lvl, const char *fmt, va_list args)
     }
     if (*msg != 0) {
         /* Add a prefix for ERROR/FATAL messages. */
-        if (lvl == LOGMSG_ERROR || lvl == LOGMSG_FATAL) {
+        if (do_prefix_level && (lvl == LOGMSG_ERROR || lvl == LOGMSG_FATAL)) {
             ret += fprintf(f, "[%s] ", logmsg_level_str(lvl));
         }
         ret += fprintf(f, "%s", msg);
@@ -339,4 +341,15 @@ int logmsg_timestamp_update(void *unused, void *value)
 {
     logmsg_set_time(*(int *)value);
     return 0;
+}
+
+int logmsg_prefix_level_update(void *unused, void *value)
+{
+    do_prefix_level = *(int *)value;
+    return 0;
+}
+
+void *logmsg_prefix_level_value(void *unused)
+{
+    return &do_prefix_level;
 }

--- a/util/logmsg.h
+++ b/util/logmsg.h
@@ -45,9 +45,11 @@ int logmsg_process_message(char *line, int llen);
 int logmsg_level_update(void *unused, void *value);
 int logmsg_syslog_update(void *unused, void *value);
 int logmsg_timestamp_update(void *unused, void *value);
+int logmsg_prefix_level_update(void *unused, void *value);
 void *logmsg_level_value(void *unused);
 void *logmsg_syslog_value(void *unused);
 void *logmsg_timestamp_value(void *unused);
+void *logmsg_prefix_level_value(void *unused);
 
 int io_override_set_std(FILE *);
 FILE *io_override_get_std(void);


### PR DESCRIPTION
* Disabled by default (i.e. always log levels)
* Enabled in legacy_defaults (to match legacy behavior)