### PR TITLE
Test: Fix occasional failures of upsert.test

### DIFF
--- a/tests/upsert.test/lrl.options
+++ b/tests/upsert.test/lrl.options
@@ -1,0 +1,1 @@
+osql_verify_retry_max 1000


### PR DESCRIPTION
Bump up 'osql_verify_retry_max' as upsert_stress.sh could cause quite a bit of contention.