### PR TITLE
cdb2jdbc: Fix PreparedStatement.setNull()

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2PreparedStatement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2PreparedStatement.java
@@ -140,7 +140,7 @@ public class Comdb2PreparedStatement extends Comdb2Statement implements Prepared
     public void setNull(int parameterIndex, int sqlType) throws SQLException {
         String pname = getParamNameByIndex(parameterIndex);
         if (pname != null)
-            bindParameter(pname, sqlType, null);
+            bindParameter(pname, Constants.Types.CDB2_INTEGER, null);
     }
 
     @Override

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/PreparedStatementTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/PreparedStatementTest.java
@@ -15,12 +15,7 @@ package com.bloomberg.comdb2.jdbc;
 
 import static org.junit.Assert.*;
 
-import java.sql.Connection;
-import java.sql.Date;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
+import java.sql.*;
 
 import org.junit.After;
 import org.junit.AfterClass;
@@ -227,6 +222,33 @@ public class PreparedStatementTest {
         assertEquals(id, 1);
         
         stmt.clearParameters();
+    }
+
+    /* test PreparedStatement.setNull() and PreparedStatement.setObject(indx, null). */
+    @Test
+    public void testBindNull() throws SQLException{
+        Statement stmt = conn.createStatement();
+        stmt.execute("DROP TABLE IF EXISTS longlong");
+        stmt.execute("CREATE TABLE longlong (f BIGINT NULL)");
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO longlong VALUES(?)");
+
+        ps.setNull(1, Types.INTEGER);
+        ps.executeUpdate();
+
+        ps.setNull(1, Types.DOUBLE);
+        ps.executeUpdate();
+
+        ps.setObject(1, null);
+        ps.executeUpdate();
+
+        ResultSet rs = ps.executeQuery("SELECT COUNT(*) FROM longlong");
+        assertEquals(rs.getInt(1), 3);
+
+        rs = ps.executeQuery("SELECT * FROM longlong");
+        while (rs.next()) {
+            rs.getObject(1);
+            assertEquals(rs.wasNull(), true);
+        }
     }
 }
 /* vim: set sw=4 ts=4 et: */


### PR DESCRIPTION
Don't pass an SQL type. Just pass CDB2_INTEGER as a placeholder type for a NULL value.