### PR TITLE
Fix DOHSQL memory leak

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -5759,7 +5759,7 @@ Mem *sqlite3CloneResult(
   }else{
     *pSize -= memRowSize(pMem, nCols);
     for(i=0; i<nCols; ++i){
-      sqlite3_value_free_inplace(pMem + i);
+      sqlite3_value_free_inplace(&pMem[i]);
     }
   }
   memset(pMem, 0, sizeof(Mem) * nCols);

--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -5758,7 +5758,7 @@ Mem *sqlite3CloneResult(
     if( !pMem ) return 0;
   }else{
     *pSize -= memRowSize(pMem, nCols);
-    for(i=0; i<nCols; ++i){
+    for(i=0; i<nCols; i++){
       sqlite3_value_free_inplace(&pMem[i]);
     }
   }

--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -5758,6 +5758,9 @@ Mem *sqlite3CloneResult(
     if( !pMem ) return 0;
   }else{
     *pSize -= memRowSize(pMem, nCols);
+    for(i=0; i<nCols; ++i){
+      sqlite3_value_free_inplace(pMem + i);
+    }
   }
   memset(pMem, 0, sizeof(Mem) * nCols);
   for(i=0; i<nCols; i++){

--- a/tests/dohsql_leaks.test/Makefile
+++ b/tests/dohsql_leaks.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=15m
+endif

--- a/tests/dohsql_leaks.test/lrl.options
+++ b/tests/dohsql_leaks.test/lrl.options
@@ -1,0 +1,3 @@
+dohsql_disable 0
+dohast_disable 0
+cache 256 mb

--- a/tests/dohsql_leaks.test/runit
+++ b/tests/dohsql_leaks.test/runit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Populate data
+cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t0 (i TEXT)"
+sleep 1
+yes 'INSERT INTO t0 VALUES ("It is only with the heart that one can see rightly; what is essential is invisible to the eye.")' | head -9999 | cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default >/dev/null
+
+for i in `seq 1 4`; do
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t$i (i TEXT)"
+    sleep 1
+    for j in `seq 1 10`; do
+        cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "INSERT INTO t$i SELECT * FROM t0" >/dev/null
+    done
+done
+
+# Make sure we talk to the same host
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+
+# Warm up
+for i in `seq 1 10`; do
+  cdb2sql $dbnm --host $host 'SELECT * FROM t0 UNION ALL SELECT * FROM t1 UNION ALL SELECT * FROM t2 UNION ALL SELECT * FROM t3 UNION ALL SELECT * FROM t4' >/dev/null
+done
+
+# Get a steady memory snapshot
+before=`cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat sqlite')" | grep total | tail -1 | awk '{print $4}'`
+
+# Run the reproducer another 100 times
+for i in `seq 1 100`; do
+  cdb2sql $dbnm --host $host 'SELECT * FROM t0 UNION ALL SELECT * FROM t1 UNION ALL SELECT * FROM t2 UNION ALL SELECT * FROM t3 UNION ALL SELECT * FROM t4' >/dev/null
+done
+
+# Get a memory snapshot again
+after=`cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat sqlite')" | grep total | tail -1 | awk '{print $4}'`
+
+# Should almost be identical
+ratio=`echo "$after/$before" | bc`
+echo "$after/$before=$ratio"
+if [ $ratio -gt 1 ]; then
+  echo "ratio is $ratio" >&2
+  exit 1
+fi


### PR DESCRIPTION
DOHSQL may decide to reuse a cached row, which is essentially an SQLite Mem object. DOHSQL should free malloc'd memory in the Mem object before reusing it.

(DRQS 141973376)
