### PR TITLE
Always perform extended verify checking for tran_rows > 1

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -438,10 +438,8 @@ int gbl_enable_cache_internal_nodes = 1;
 int gbl_use_appsock_as_sqlthread = 0;
 int gbl_rep_process_txn_time = 0;
 
-int gbl_osql_verify_retries_max =
-    499; /* how many times we retry osql for verify */
-int gbl_osql_verify_ext_chk =
-    1; /* extended verify-checking after this many failures */
+int gbl_osql_verify_retries_max = 499; /* # of times we retry osql for verify */
+int gbl_osql_verify_ext_chk = 1; /* extended verify-checking after # failures */
 int gbl_test_badwrite_intvl = 0;
 int gbl_test_blob_race = 0;
 int gbl_skip_ratio_trace = 0;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1501,10 +1501,13 @@ static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
     Pthread_mutex_lock(&tran->store_mtx);
 
     *nops = 0;
+    int verify_ext_chk = gbl_osql_verify_ext_chk;
+    if (tran->sess->tran_rows > 1 && !iq->is_sorese)
+        verify_ext_chk = 0; // trigger extended checking the first time
+
 
     /* if we've already had a few verify-failures, add extended checking now */
-    if (!iq->vfy_genid_track &&
-        iq->sorese.verify_retries >= gbl_osql_verify_ext_chk) {
+    if (!iq->vfy_genid_track && iq->sorese.verify_retries >= verify_ext_chk) {
         iq->vfy_genid_track = 1;
         iq->vfy_genid_hash = hash_init(sizeof(unsigned long long));
         iq->vfy_genid_pool =


### PR DESCRIPTION
Always perform extended verify checking for tran_rows > 1 and transaction level below read committed.