### PR TITLE
Read committed master

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -319,7 +319,11 @@ DEF_ATTR(REP_PROCESSORS, rep_processors, QUANTITY, 4,
          "stream.")
 DEF_ATTR(REP_PROCESSORS_ROWLOCKS, rep_processors_rowlocks, QUANTITY, 0,
          "Rowlocks touches 1 file/txn; it's handled by the processor thread.")
+#ifdef _SUN_SOURCE
+DEF_ATTR(REP_LSN_CHAINING, rep_lsn_chaining, BOOLEAN, 1,
+#else
 DEF_ATTR(REP_LSN_CHAINING, rep_lsn_chaining, BOOLEAN, 0,
+#endif
          "If set, will force trasnactions on replicant to always release locks "
          "in LSN order.")
 DEF_ATTR(REP_MEMSIZE, rep_memsize, QUANTITY, 524288,

--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -319,11 +319,7 @@ DEF_ATTR(REP_PROCESSORS, rep_processors, QUANTITY, 4,
          "stream.")
 DEF_ATTR(REP_PROCESSORS_ROWLOCKS, rep_processors_rowlocks, QUANTITY, 0,
          "Rowlocks touches 1 file/txn; it's handled by the processor thread.")
-#ifdef _SUN_SOURCE
-DEF_ATTR(REP_LSN_CHAINING, rep_lsn_chaining, BOOLEAN, 1,
-#else
 DEF_ATTR(REP_LSN_CHAINING, rep_lsn_chaining, BOOLEAN, 0,
-#endif
          "If set, will force trasnactions on replicant to always release locks "
          "in LSN order.")
 DEF_ATTR(REP_MEMSIZE, rep_memsize, QUANTITY, 524288,

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2482,7 +2482,9 @@ struct __db_env {
 	pthread_mutex_t recover_lk;
 	pthread_cond_t recover_cond;
 	int recovery_memsize;  /* Use up to this much memory for log records */
-	pthread_rwlock_t ser_lk;
+	pthread_mutex_t ser_lk;
+	pthread_cond_t ser_cond;
+    int ser_count;
 	int lsn_chain;
 
 	/* overrides for minwrite deadlock */

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2484,7 +2484,7 @@ struct __db_env {
 	int recovery_memsize;  /* Use up to this much memory for log records */
 	pthread_mutex_t ser_lk;
 	pthread_cond_t ser_cond;
-    int ser_count;
+	int ser_count;
 	int lsn_chain;
 
 	/* overrides for minwrite deadlock */

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -608,8 +608,8 @@ foundlsn:
 		Pthread_mutex_init(&dbenv->recover_lk, NULL);
 		Pthread_cond_init(&dbenv->recover_cond, NULL);
 		Pthread_mutex_init(&dbenv->ser_lk, NULL);
-        Pthread_cond_init(&dbenv->ser_cond, NULL);
-        dbenv->ser_count = 0;
+		Pthread_cond_init(&dbenv->ser_cond, NULL);
+		dbenv->ser_count = 0;
 		listc_init(&dbenv->inflight_transactions,
 		    offsetof(struct __recovery_processor, lnk));
 		listc_init(&dbenv->inactive_transactions,

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -607,7 +607,9 @@ foundlsn:
 		thdpool_set_maxqueue(dbenv->recovery_workers, 8000);
 		Pthread_mutex_init(&dbenv->recover_lk, NULL);
 		Pthread_cond_init(&dbenv->recover_cond, NULL);
-		Pthread_rwlock_init(&dbenv->ser_lk, NULL);
+		Pthread_mutex_init(&dbenv->ser_lk, NULL);
+        Pthread_cond_init(&dbenv->ser_cond, NULL);
+        dbenv->ser_count = 0;
 		listc_init(&dbenv->inflight_transactions,
 		    offsetof(struct __recovery_processor, lnk));
 		listc_init(&dbenv->inactive_transactions,

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4337,12 +4337,12 @@ err:
 	Pthread_mutex_unlock(&dbenv->recover_lk);
 
 	if (!dbenv->lsn_chain) {
-        Pthread_mutex_lock(&dbenv->ser_lk);
-        dbenv->ser_count--;
-        assert(dbenv->ser_count >= 0);
-        if (dbenv->ser_count == 0) {
-            Pthread_cond_broadcast(&dbenv->ser_cond);
-        }
+		Pthread_mutex_lock(&dbenv->ser_lk);
+		dbenv->ser_count--;
+		assert(dbenv->ser_count >= 0);
+		if (dbenv->ser_count == 0) {
+			Pthread_cond_broadcast(&dbenv->ser_cond);
+		}
 		Pthread_mutex_unlock(&dbenv->ser_lk);
 	}
 
@@ -5021,20 +5021,20 @@ wait_for_running_transactions(dbenv)
 	if (dbenv->lsn_chain) {
 		return wait_for_lsn_chain_lk(dbenv);
 	} else {
-        int count = 0;
+		int count = 0;
 		/* Grab the writelock */
-        Pthread_mutex_lock(&dbenv->ser_lk);
-        while(dbenv->ser_count > 0) {
-            struct timespec ts;
-            clock_gettime(CLOCK_REALTIME, &ts);
-            ts.tv_sec++;
-            pthread_cond_timedwait(&dbenv->ser_cond, &dbenv->ser_lk, &ts);
-            count++;
-            if (count > 5) {
-                logmsg(LOGMSG_ERROR, "%s: waiting for processor threads to "
-                        "complete\n", __func__);
-            }
-        }
+		Pthread_mutex_lock(&dbenv->ser_lk);
+		while(dbenv->ser_count > 0) {
+			struct timespec ts;
+			clock_gettime(CLOCK_REALTIME, &ts);
+			ts.tv_sec++;
+			pthread_cond_timedwait(&dbenv->ser_cond, &dbenv->ser_lk, &ts);
+			count++;
+			if (count > 5) {
+				logmsg(LOGMSG_ERROR, "%s: waiting for processor threads to "
+						"complete\n", __func__);
+			}
+		}
 		Pthread_mutex_unlock(&dbenv->ser_lk);
 		return 0;
 	}
@@ -5581,9 +5581,9 @@ bad_resize:	;
 		if (ret)
 			goto err;
 	} else {
-        Pthread_mutex_lock(&dbenv->ser_lk);
-        dbenv->ser_count++;
-        Pthread_mutex_unlock(&dbenv->ser_lk);
+		Pthread_mutex_lock(&dbenv->ser_lk);
+		dbenv->ser_count++;
+		Pthread_mutex_unlock(&dbenv->ser_lk);
 	}
 
 	/* Dispatch to a processor thread. */

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4337,7 +4337,13 @@ err:
 	Pthread_mutex_unlock(&dbenv->recover_lk);
 
 	if (!dbenv->lsn_chain) {
-		Pthread_rwlock_unlock(&dbenv->ser_lk);
+        Pthread_mutex_lock(&dbenv->ser_lk);
+        dbenv->ser_count--;
+        assert(dbenv->ser_count >= 0);
+        if (dbenv->ser_count == 0) {
+            Pthread_cond_broadcast(&dbenv->ser_cond);
+        }
+		Pthread_mutex_unlock(&dbenv->ser_lk);
 	}
 
 	bdb_thread_done_rw();
@@ -5015,12 +5021,21 @@ wait_for_running_transactions(dbenv)
 	if (dbenv->lsn_chain) {
 		return wait_for_lsn_chain_lk(dbenv);
 	} else {
+        int count = 0;
 		/* Grab the writelock */
-		Pthread_rwlock_wrlock(&dbenv->ser_lk);
-
-		/* Release immediately: no one else is running */
-		Pthread_rwlock_unlock(&dbenv->ser_lk);
-
+        Pthread_mutex_lock(&dbenv->ser_lk);
+        while(dbenv->ser_count > 0) {
+            struct timespec ts;
+            clock_gettime(CLOCK_REALTIME, &ts);
+            ts.tv_sec++;
+            pthread_cond_timedwait(&dbenv->ser_cond, &dbenv->ser_lk, &ts);
+            count++;
+            if (count > 5) {
+                logmsg(LOGMSG_ERROR, "%s: waiting for processor threads to "
+                        "complete\n", __func__);
+            }
+        }
+		Pthread_mutex_unlock(&dbenv->ser_lk);
 		return 0;
 	}
 }
@@ -5566,7 +5581,9 @@ bad_resize:	;
 		if (ret)
 			goto err;
 	} else {
-		Pthread_rwlock_rdlock(&dbenv->ser_lk);
+        Pthread_mutex_lock(&dbenv->ser_lk);
+        dbenv->ser_count++;
+        Pthread_mutex_unlock(&dbenv->ser_lk);
 	}
 
 	/* Dispatch to a processor thread. */


### PR DESCRIPTION
Replace rwlock (dbenv->ser_lk) with a mutex, condition variable, and a counter.  The original design assumed incorrectly that it was okay to release a read-lock from a thread which did not originally acquire it.
