### PR TITLE
make sure we don't overcount decimal in indexes

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -7429,7 +7429,8 @@ int extract_decimal_quantum(const dbtable *db, int ix, char *inbuf,
 
     decimals = 0;
     for (i = 0; i < s->nmembers; i++) {
-        decimals++;
+        if (s->member[i].type == SERVER_DECIMAL)
+            decimals++;
     }
 
     if (outbuf && outlen && (outbuf_max < 4 * decimals)) {

--- a/tests/decimal.test/t1.csc2
+++ b/tests/decimal.test/t1.csc2
@@ -6,14 +6,6 @@ schema
    decimal128  d128  null=yes
 }
 
-tag "frecord"
-{
-   int         id
-   decimal32   d32
-   decimal64   d64
-   decimal128  d128
-}
-
 keys
 {
    "ID"         = id

--- a/tests/decimal.test/t5_01.req
+++ b/tests/decimal.test/t5_01.req
@@ -1,0 +1,13 @@
+drop table if exists t5
+create table t5 {
+    schema {
+        int id
+        decimal32 dec
+        double num
+    }
+    keys {
+        "ID" = id + dec
+    }
+}$$
+insert into t5 values(1, 5, 10)
+select * from t5

--- a/tests/decimal.test/t5_01.req.exp
+++ b/tests/decimal.test/t5_01.req.exp
@@ -1,0 +1,15 @@
+[drop table if exists t5] rc 0
+[create table t5 {
+    schema {
+        int id
+        decimal32 dec
+        double num
+    }
+    keys {
+        "ID" = id + dec
+    }
+}] rc 0
+(rows inserted=1)
+[insert into t5 values(1, 5, 10)] rc 0
+(id=1, dec='5', num=10.000000)
+[select * from t5] rc 0


### PR DESCRIPTION
Compound indexes including decimal columns are not working due to a bug introduced early on while porting changes to R7.
