### PR TITLE
Chunky deletes

### DIFF
--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -1023,7 +1023,8 @@ int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
     if (cur->skip) {
         rc = bdb_temp_table_close_cursor(bdb_state, cur->skip, &bdberr);
         if (rc)
-            logmsg(LOGMSG_ERROR, "%s: close cursor %d %d\n", __func__, rc, bdberr);
+            logmsg(LOGMSG_ERROR, "%s: close cursor %d %d\n", __func__, rc,
+                   bdberr);
         cur->skip = NULL;
     }
 

--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -1013,3 +1013,19 @@ int bdb_osql_destroy(int *bdberr)
 
     return rc;
 }
+
+int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
+{
+    bdb_cursor_impl_t *cur = pcur_ifn->impl;
+    int rc = 0;
+    int bdberr = 0;
+
+    if (cur->skip) {
+        rc = bdb_temp_table_close_cursor(bdb_state, cur->skip, &bdberr);
+        if (rc)
+            logmsg(LOGMSG_ERROR, "%s: close cursor %d %d\n", __func__, rc, bdberr);
+        cur->skip = NULL;
+    }
+
+    return rc;
+}

--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -1014,7 +1014,7 @@ int bdb_osql_destroy(int *bdberr)
     return rc;
 }
 
-int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
+int bdb_osql_cursor_reset(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
 {
     bdb_cursor_impl_t *cur = pcur_ifn->impl;
     int rc = 0;
@@ -1029,4 +1029,11 @@ int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
     }
 
     return rc;
+}
+
+void bdb_osql_cursor_set(bdb_cursor_ifn_t *pcur_ifn, tran_type *shadow_tran)
+{
+    bdb_cursor_impl_t *cur = pcur_ifn->impl;
+
+    cur->shadow_tran = shadow_tran;
 }

--- a/bdb/bdb_osqlcur.h
+++ b/bdb/bdb_osqlcur.h
@@ -126,12 +126,12 @@ int bdb_osql_shadow_set_lastlog(bdb_cursor_ifn_t *cur, struct bdb_osql_log *log,
                                 int *bdberr);
 
 /**
- * Close the skip cursor 
- * Normally the cursor is closed upon table consumption; 
+ * Close the skip cursor
+ * Normally the cursor is closed upon table consumption;
  * We need to reset it before closing the underlying temp table as well
  * if this is a chunk transaction
  *
  */
- int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
+int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
 
 #endif

--- a/bdb/bdb_osqlcur.h
+++ b/bdb/bdb_osqlcur.h
@@ -130,7 +130,8 @@ int bdb_osql_shadow_set_lastlog(bdb_cursor_ifn_t *cur, struct bdb_osql_log *log,
  * Set the shadow transaction to a reset cursor
  *
  */
-int bdb_osql_cursor_reset(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
+int bdb_osql_cursor_reset(bdb_state_type *bdb_state,
+                          bdb_cursor_ifn_t *pcur_ifn);
 void bdb_osql_cursor_set(bdb_cursor_ifn_t *pcur_ifn, tran_type *shadow_tran);
 
 #endif

--- a/bdb/bdb_osqlcur.h
+++ b/bdb/bdb_osqlcur.h
@@ -124,4 +124,14 @@ struct bdb_osql_log *bdb_osql_shadow_get_lastlog(bdb_cursor_ifn_t *cur,
  */
 int bdb_osql_shadow_set_lastlog(bdb_cursor_ifn_t *cur, struct bdb_osql_log *log,
                                 int *bdberr);
+
+/**
+ * Close the skip cursor 
+ * Normally the cursor is closed upon table consumption; 
+ * We need to reset it before closing the underlying temp table as well
+ * if this is a chunk transaction
+ *
+ */
+ int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
+
 #endif

--- a/bdb/bdb_osqlcur.h
+++ b/bdb/bdb_osqlcur.h
@@ -126,12 +126,11 @@ int bdb_osql_shadow_set_lastlog(bdb_cursor_ifn_t *cur, struct bdb_osql_log *log,
                                 int *bdberr);
 
 /**
- * Close the skip cursor
- * Normally the cursor is closed upon table consumption;
- * We need to reset it before closing the underlying temp table as well
- * if this is a chunk transaction
+ * Clear any cached pointers to existing transactions
+ * Set the shadow transaction to a reset cursor
  *
  */
-int bdb_osql_skip_close(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
+int bdb_osql_cursor_reset(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn);
+void bdb_osql_cursor_set(bdb_cursor_ifn_t *pcur_ifn, tran_type *shadow_tran);
 
 #endif

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8305,7 +8305,6 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
             }
         }
 
-
         if (rc && !commit_rc) {
             comdb2_sqlite3VdbeError(pCur->vdbe,
                                     "Failed to initialize new transaction");

--- a/docs/pages/programming/sql.md
+++ b/docs/pages/programming/sql.md
@@ -686,8 +686,8 @@ This sets the current connection's transaction level.  See
 
 This allows bulk data processing to be automatically split into smaller size chunks, freeing the client from 
 the responsibility of spliting up the data.  Jobs like ```INSERT INTO 't' SELECT * FROM 't2'``` are trivially handled
-as a sequence of small lock-footprint transactions.  Currently only supported for bulk inserts in a client specified 
-```BEGIN ... COMMIT``` transaction.
+as a sequence of small lock-footprint transactions.  Another common use-case is periodic data-set clean-up, replacing 
+the legacy comdb2del tool.  Currently requires a client specified ```BEGIN ... COMMIT``` transaction.
 
 ### SET TIMEZONE
 

--- a/tests/transchunk.test/log.expected
+++ b/tests/transchunk.test/log.expected
@@ -35,3 +35,8 @@ Failure tests
 (a=123456789)
 (count(*)=7)
 (out='    OSQL_DONE            5060')
+(rows inserted=994)
+(out='    OSQL_DONE            5560')
+(count(*)=502)
+(out='    OSQL_DONE            5611')
+(count(*)=0)

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -174,6 +174,29 @@ $rt "select count(*) from t" >> $outlog
 
 check_done
 
+$r >> $outlog 2>&1 << "EOF"
+insert into t select value from generate_series(7, 1000)
+set transaction chunk 1
+begin
+delete from t where a <500
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 10
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
 # get testcase output
 testcase_output=$(cat $outlog)
 


### PR DESCRIPTION
Follow-up for https://github.com/bloomberg/comdb2/pull/1814: 
Extending "SET TRANSACTION CHUNK N" to include deletes and updates.   
Example:
instead of comdb2del.tsk, clients can run:
cdb2sql dbn dev <<EOF
SET TRANSACTION CHUNK 10
BEGIN
DELETE FROM tableA WHERE ...
COMMIT
