### PR TITLE
Can't read from comdb2_sc_status system table

### DIFF
--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -64,6 +64,7 @@ int get_status(void **data, int *npoints)
     for (int i = 0; i < nkeys; i++) {
         dttz_t d;
 
+        init_schemachange_type(&sc);
         rc = unpack_schema_change_type(&sc, sc_data[i], status[i]->sc_data_len);
         if (rc) {
             free(sc_status_ents);

--- a/tests/ddl_no_csc2.test/t00_create_table.expected
+++ b/tests/ddl_no_csc2.test/t00_create_table.expected
@@ -1,3 +1,5 @@
+(part='---------------------------------- PART #00 ----------------------------------')
+(COUNT(*) > 0=1)
 (part='---------------------------------- PART #01 ----------------------------------')
 [CREATE TABLE t1(i INT)] failed with rc -3 Table already exists
 [CREATE TABLE T1(i INT)] failed with rc -3 Table already exists

--- a/tests/ddl_no_csc2.test/t00_create_table.sql
+++ b/tests/ddl_no_csc2.test/t00_create_table.sql
@@ -1,3 +1,9 @@
+SELECT '---------------------------------- PART #00 ----------------------------------' AS part;
+CREATE TABLE t1(i INT) $$
+DROP TABLE t1;
+# a quick test to check selecting from comdb2_sc_status does not hang
+SELECT COUNT(*) > 0 FROM comdb2_sc_status;
+
 SELECT '---------------------------------- PART #01 ----------------------------------' AS part;
 CREATE TABLE t1(i INT) $$
 CREATE TABLE t1(i INT) $$


### PR DESCRIPTION
Problem: The system table implementation was getting stuck while trying to destroy an uninitialized condition variable.