### PR TITLE
failing retried transaction: send proper request type

### DIFF
--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -313,7 +313,7 @@ int srs_tran_replay(struct sqlclntstate *clnt, struct thr_handle *thr_self)
                     }
                 }
 
-                int type = tran2netreq(clnt->dbtran.mode);
+                int type = tran2req(clnt->dbtran.mode);
                 osql_sock_abort(clnt, type);
             }
             break;


### PR DESCRIPTION
Ported from R6; need to send back proper code; currently -1 is sent and treated as DECOM.