### PR TITLE
cdb2jdbc: Fix Connection.setTransactionIsolation() when autoCommit is on

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -951,11 +951,10 @@ public class Comdb2Handle extends AbstractConnection {
         tdlog(Level.FINE, "[running sql] %s", sql);
 
         if (lowerSql.startsWith("set")) {
-            Iterator<String> iter = sets.iterator();
-            while(iter.hasNext()) {
-                if (iter.next().toLowerCase().equals(lowerSql)) {
-                    return 0;
-                }
+            int ii = nSetsSent, len = sets.size();
+            for (; ii < len; ++ii) {
+                if (sets.get(ii).toLowerCase().equals(lowerSql))
+                    break;
             }
 
             if (isClientOnlySetCommand(lowerSql)) {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -106,27 +106,26 @@ public class Comdb2Statement implements Statement {
             }
         }
 
-        if (!conn.getAutoCommit() && !conn.isInTxn()) {
+        if (!conn.isInTxn()) {
             if (conn.isTxnModeChanged()) {
                 String txnMode = conn.getComdb2TxnMode();
                 if (txnMode != null) {
-                    /**
-                     * set transaction mode implicitly
-                     */
+                    /* set transaction mode implicitly */
                     if ( (rc = hndl.runStatement("set transaction " + txnMode)) != 0 )
                         throw Comdb2Connection.createSQLException(
                                 hndl.errorString(), rc, sql, hndl.getLastThrowable());
                 }
+                conn.setTxnModeChanged(false);
             }
-            /**
-             * send `begin' implicitly
-             */
-            if (!locase.startsWith("set ")) { /* just a set. don't begin yet. */
-                if ( (rc = hndl.runStatement("begin")) != 0)
-                    throw Comdb2Connection.createSQLException(
-                            hndl.errorString(), rc, sql, hndl.getLastThrowable());
-                /* mark connection in trans */
-                conn.setInTxn(true);
+            if (!conn.getAutoCommit()) {
+                /* send `begin' implicitly */
+                if (!locase.startsWith("set ")) { /* just a set. don't begin yet. */
+                    if ( (rc = hndl.runStatement("begin")) != 0)
+                        throw Comdb2Connection.createSQLException(
+                                hndl.errorString(), rc, sql, hndl.getLastThrowable());
+                    /* mark connection in trans */
+                    conn.setInTxn(true);
+                }
             }
         }
 

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ConnectionTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ConnectionTest.java
@@ -1,0 +1,72 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class ConnectionTest {
+
+    String db, cluster;
+    Connection conn;
+
+    @Before public void setup() throws SQLException {
+        db = System.getProperty("cdb2jdbc.test.database");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+        Statement stmt = conn.createStatement();
+        stmt.execute("DROP TABLE IF EXISTS t_connection_test");
+        stmt.execute("CREATE TABLE t_connection_test (i INTEGER)");
+
+        stmt.close();
+        conn.close();
+    }
+
+    @Test public void setTransactionIsolationTest() throws SQLException {
+        int cnt = -1;
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+
+        conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+
+        stmt.executeUpdate("INSERT INTO t_connection_test VALUES (1)");
+        ResultSet rs = stmt.executeQuery("SELECT COUNT(*) AS CNT FROM t_connection_test");
+        while (rs.next()) {
+            cnt = rs.getInt(1);
+        }
+        conn.rollback();
+        Assert.assertEquals("Should see 1 row", 1, cnt);
+
+        conn.setTransactionIsolation(Comdb2Connection.TRANSACTION_BLOCK);
+        stmt.executeUpdate("INSERT INTO t_connection_test VALUES (1)");
+        rs = stmt.executeQuery("SELECT COUNT(*) AS CNT FROM t_connection_test");
+        while (rs.next()) {
+            cnt = rs.getInt(1);
+        }
+        conn.rollback();
+        Assert.assertEquals("Should see 0 row", 0, cnt);
+
+        conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+        conn.setAutoCommit(true);
+        stmt.executeQuery("begin");
+        stmt.executeUpdate("INSERT INTO t_connection_test VALUES (1)");
+        rs = stmt.executeQuery("SELECT COUNT(*) AS CNT FROM t_connection_test");
+        while (rs.next()) {
+            cnt = rs.getInt(1);
+        }
+        stmt.executeQuery("rollback");
+        Assert.assertEquals("Should see 1 row", 1, cnt);
+
+        stmt.close();
+        conn.close();
+    }
+
+    @After public void unsetup() throws SQLException {
+        DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db))
+            .createStatement().execute("DROP TABLE t_connection_test");
+    }
+}


### PR DESCRIPTION
`Connection.setTransactionIsolation()` has no effect when autoCommit is on. The patch fixes it.