### PR TITLE
Track close

### DIFF
--- a/bbinc/sbuf2.h
+++ b/bbinc/sbuf2.h
@@ -73,8 +73,10 @@ SBUF2 *SBUF2_FUNC(sbuf2open)(int fd, int flags);
 #define sbuf2open SBUF2_FUNC(sbuf2open)
 
 /* flush output, close fd, and free SBUF2. 0==success */
-int SBUF2_FUNC(sbuf2close)(SBUF2 *sb);
-#define sbuf2close SBUF2_FUNC(sbuf2close)
+int SBUF2_FUNC(sbuf2close_impl)(SBUF2 *sb, const char *func, int line);
+#define sbuf2close_impl SBUF2_FUNC(sbuf2close_impl)
+
+#define sbuf2close(sb) sbuf2close_impl(sb, __func__, __LINE__)
 
 /* flush output, close fd, and free SBUF2.*/
 int SBUF2_FUNC(sbuf2free)(SBUF2 *sb);

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -35,6 +35,7 @@
 #include "util.h"
 #include "locks_wrap.h"
 #include "tohex.h"
+#include "openclose.h"
 
 extern int blkseq_get_rcode(void *data, int datalen);
 static int bdb_blkseq_update_lsn_locked(bdb_state_type *bdb_state,
@@ -66,7 +67,7 @@ static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
     }
     rc = fchmod(fd, 0666);
     if (rc) {
-        close(fd);
+        comdb2_close(fd);
         logmsg(LOGMSG_ERROR, "fchmod rc %d %s\n", errno, strerror(errno));
         return NULL;
     }
@@ -74,7 +75,7 @@ static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
     rc = db->open(db, NULL, fname, NULL, DB_BTREE, DB_CREATE | DB_TRUNCATE,
                   0666);
     /* we don't need the descriptor mkstemp creates, just need a unique name */
-    close(fd);
+    comdb2_close(fd);
     if (rc) {
         logmsg(LOGMSG_ERROR, "blkseq->open rc %d\n", rc);
         return NULL;

--- a/bdb/bdb_net.c
+++ b/bdb/bdb_net.c
@@ -358,6 +358,11 @@ static void udp_bind(repinfo_type *repinfo)
         exit(1);
     }
 
+    extern int gbl_track_open;
+    if (gbl_track_open) {
+        logmsg(LOGMSG_USER, "%s socket returned fd %d\n", __func__, repinfo->udp_fd);
+    }
+
     repinfo->udp_addr = addr = calloc(1, socklen);
     addr->sin_addr.s_addr = htonl(INADDR_ANY);
     addr->sin_port = htons(get_host_port(repinfo->netinfo));

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -43,6 +43,7 @@
 #include "logmsg.h"
 #include "thread_stats.h"
 #include <compat.h>
+#include "openclose.h"
 
 extern char *lsn_to_str(char lsn_str[], DB_LSN *lsn);
 extern void bdb_dump_table_dbregs(bdb_state_type *bdb_state);
@@ -1148,7 +1149,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
                 if (bdb_get_data_filename(bdb_state, stripe, blobno, tmpname,
                                           sizeof(tmpname), &bdberr) == 0) {
                     bdb_trans(tmpname, fname);
-                    fd = open(fname, O_RDONLY);
+                    fd = comdb2_open(fname, O_RDONLY, 0);
                     if (fd == -1) {
                         logmsg(LOGMSG_ERROR, "open(\"%s\") => %d %s\n", fname, errno,
                                strerror(errno));
@@ -1157,7 +1158,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
 
                     npages = __berkdb_count_freepages(fd);
                     total_npages += npages;
-                    close(fd);
+                    comdb2_close(fd);
                     if (count_freepages_abort)
                         return 0;
                     if (blobno == 0)
@@ -1174,7 +1175,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
         if (bdb_get_index_filename(bdb_state, ix, tmpname, sizeof(tmpname),
                                    &bdberr) == 0) {
             bdb_trans(tmpname, fname);
-            fd = open(fname, O_RDONLY);
+            fd = comdb2_open(fname, O_RDONLY, 0);
             if (fd == -1) {
                 logmsg(LOGMSG_ERROR, "open(\"%s\") => %d %s\n", fname, errno,
                        strerror(errno));
@@ -1183,7 +1184,7 @@ uint64_t bdb_dump_freepage_info_table(bdb_state_type *bdb_state, FILE *out)
 
             npages = __berkdb_count_freepages(fd);
             total_npages += npages;
-            close(fd);
+            comdb2_close(fd);
             if (count_freepages_abort)
                 return 0;
             logmsg(LOGMSG_USER, "  %s ix %d   => %u\n", bdb_state->name, ix, npages);

--- a/bdb/summarize.c
+++ b/bdb/summarize.c
@@ -72,6 +72,7 @@
 #include "flibc.h"
 #include "logmsg.h"
 #include "analyze.h"
+#include "openclose.h"
 
 extern volatile int gbl_schema_change_in_progress;
 static double analyze_headroom = 6;
@@ -332,7 +333,7 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
     bdb_trans(tmpname, tran_tmpname);
     logmsg(LOGMSG_DEBUG, "open %s\n", tran_tmpname);
 
-    fd = open(tran_tmpname, O_RDONLY);
+    fd = comdb2_open(tran_tmpname, O_RDONLY, 0);
     if (fd == -1) {
         logmsg(LOGMSG_ERROR, "can't open input db???: %d %s\n", errno,
                 strerror(errno));

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -32,6 +32,7 @@ static const char revid[] = "$Id: mp_sync.c,v 11.80 2003/09/13 19:20:41 bostic E
 #include <pool.h>
 #include <logmsg.h>
 #include <locks_wrap.h>
+#include "openclose.h"
 
 typedef struct {
 	DB_MPOOL_HASH *track_hp;	/* Hash bucket. */
@@ -2332,7 +2333,7 @@ __memp_load_default(dbenv)
 	logmsg(LOGMSG_USER, "%s line %d opening %s\n", __func__, __LINE__,
 			rpath);
 #endif
-	if ((fd = open(rpath, O_RDONLY, 0666)) < 0 ||
+	if ((fd = comdb2_open(rpath, O_RDONLY, 0666)) < 0 ||
 			(s = sbuf2open(fd, 0)) == NULL) {
 #if PAGELIST_DEBUG
 		logmsg(LOGMSG_ERROR, "%s line %d error opening %s, %d\n", __func__,
@@ -2409,7 +2410,7 @@ __memp_dump_default(dbenv, force)
 	snprintf(tmppath, sizeof(tmppath), "%s/%s", dbenv->db_home,
 			PAGELISTTEMP);
 	rtmppath = bdb_trans(tmppath, tmppathbuf);
-	if ((fd = open(rtmppath, O_WRONLY | O_TRUNC | O_CREAT, 0666)) < 0 ||
+	if ((fd = comdb2_open(rtmppath, O_WRONLY | O_TRUNC | O_CREAT, 0666)) < 0 ||
 			(s = sbuf2open(fd, 0)) == NULL) {
 #if PAGELIST_DEBUG
 		logmsg(LOGMSG_ERROR, "%s line %d error opening %s, %d\n", __func__,

--- a/berkdb/mutex/tm.c
+++ b/berkdb/mutex/tm.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <openclose.h>
 
 #if defined(MUTEX_THREAD_TEST)
 #include <pthread.h>
@@ -189,7 +190,7 @@ main(argc, argv)
 		}
 
 	/* Signal wakeup thread to exit. */
-	if ((fd = open(MT_FILE_QUIT, O_WRONLY | O_CREAT, 0664)) == -1) {
+	if ((fd = comdb2_open(MT_FILE_QUIT, O_WRONLY | O_CREAT, 0664)) == -1) {
 		fprintf(stderr, "tm: %s\n", strerror(errno));
 		status = EXIT_FAILURE;
 	}

--- a/berkdb/os/os_handle.c
+++ b/berkdb/os/os_handle.c
@@ -18,6 +18,7 @@ static const char revid[] = "$Id: os_handle.c,v 11.32 2003/02/16 15:54:03 bostic
 #include <string.h>
 #include <unistd.h>
 #endif
+#include <openclose.h>
 
 #include "db_int.h"
 
@@ -134,7 +135,7 @@ ___os_openhandle(dbenv, name, flags, mode, fhpp)
 		if (LF_ISSET(O_CREAT)) {
 			DB_BEGIN_SINGLE_THREAD;
 			newflags = flags & ~(O_CREAT | O_EXCL);
-			if ((fhp->fd = open(name, newflags, mode)) != -1) {
+			if ((fhp->fd = comdb2_open(name, newflags, mode)) != -1) {
 				if (LF_ISSET(O_EXCL)) {
 					/*
 					 * If we get here, want O_EXCL create,
@@ -172,9 +173,9 @@ ___os_openhandle(dbenv, name, flags, mode, fhpp)
 			 * existing DB regions.
 			 */
 			fhp->fd =
-			    open(name, flags, mode, "shr=get,put,upd,del,upi");
+			    comdb2_open(name, flags, mode, "shr=get,put,upd,del,upi");
 #else
-			fhp->fd = open(name, flags, mode);
+			fhp->fd = comdb2_open(name, flags, mode);
 #if 0
 		{
 			char o_flags[512];

--- a/berkdb/os/os_region.c
+++ b/berkdb/os/os_region.c
@@ -24,6 +24,7 @@ static const char revid[] = "$Id: os_region.c,v 11.17 2003/07/13 17:45:23 bostic
 #include "db_int.h"
 #include <cdb2_constants.h>
 #include "logmsg.h"
+#include "openclose.h"
 
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern int gbl_largepages;
@@ -126,7 +127,7 @@ __os_r_attach(dbenv, infop, rp)
 		char name[MAXPATHLEN];
 		snprintf(name, sizeof(name) - 1, "/mnt/hugetlbfs/%s.%u",
 			 gbl_dbname, infop->id);
-		infop->fd = open(name, O_CREAT | O_RDWR | O_TRUNC, 0755);
+		infop->fd = comdb2_open(name, O_CREAT | O_RDWR | O_TRUNC, 0755);
 		if (infop->fd < 0) {
 			logmsgperror("open hugepage");
 			exit(1);

--- a/cdb2api/CMakeLists.txt
+++ b/cdb2api/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(src
   cdb2api.c
+  ${PROJECT_SOURCE_DIR}/util/openclose.c
   ${PROJECT_SOURCE_DIR}/util/sbuf2.c
   ${PROJECT_BINARY_DIR}/protobuf/sqlquery.pb-c.c
   ${PROJECT_BINARY_DIR}/protobuf/sqlresponse.pb-c.c
@@ -21,6 +22,7 @@ set_source_files_properties(
 include_directories(
   ${PROJECT_SOURCE_DIR}/bbinc
   ${PROJECT_BINARY_DIR}/protobuf
+  ${PROJECT_SOURCE_DIR}/util
   ${PROTOBUF-C_INCLUDE_DIR}
   ${OPENSSL_INCLUDE_DIR}
 )

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -132,6 +132,7 @@ void berk_memp_sync_alarm_ms(int);
 #include "time_accounting.h"
 #include <build/db.h>
 #include "comdb2_ruleset.h"
+#include "openclose.h"
 
 #define QUOTE_(x) #x
 #define QUOTE(x) QUOTE_(x)
@@ -929,7 +930,7 @@ int get_max_reclen(struct dbenv *dbenv)
     }
 
     /* open file */
-    file = open(fname, O_RDONLY);
+    file = comdb2_open(fname, O_RDONLY, 0);
     if (file == -1) {
         logmsg(LOGMSG_ERROR, "get_max_reclen: failed to open %s for writing\n",
                 fname);
@@ -941,7 +942,7 @@ int get_max_reclen(struct dbenv *dbenv)
     sbfile = sbuf2open(file, 0);
     if (!sbfile) {
         logmsg(LOGMSG_ERROR, "get_max_reclen: failed to open sbuf2\n");
-        close(file);
+        comdb2_close(file);
         return -1;
     }
 
@@ -2406,7 +2407,7 @@ int llmeta_dump_mapping_tran(void *tran, struct dbenv *dbenv)
     }
 
     /* open file */
-    file = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    file = comdb2_open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     free(fname);
     if (file == -1) {
         logmsg(LOGMSG_ERROR, "llmeta_dump_mapping: failed to open %s for writing\n",
@@ -2416,7 +2417,7 @@ int llmeta_dump_mapping_tran(void *tran, struct dbenv *dbenv)
     sbfile = sbuf2open(file, 0);
     if (!sbfile) {
         logmsg(LOGMSG_ERROR, "llmeta_dump_mapping: failed to open sbuf2\n");
-        close(file);
+        comdb2_close(file);
         return -1;
     }
 
@@ -5300,13 +5301,13 @@ void create_marker_file()
                 comdb2_location("marker", "%s.trap", thedb->dbs[ii]->tablename);
             tmpfd = creat(marker_file, 0666);
             free(marker_file);
-            if (tmpfd != -1) close(tmpfd);
+            if (tmpfd != -1) comdb2_close(tmpfd);
         }
     }
     marker_file = comdb2_location("marker", "%s.trap", thedb->envname);
     tmpfd = creat(marker_file, 0666);
     free(marker_file);
-    if (tmpfd != -1) close(tmpfd);
+    if (tmpfd != -1) comdb2_close(tmpfd);
 }
 
 static void handle_resume_sc()

--- a/db/comdb2_ruleset.c
+++ b/db/comdb2_ruleset.c
@@ -25,6 +25,7 @@
 #include "logmsg.h"
 #include "sbuf2.h"
 #include "tohex.h"
+#include "openclose.h"
 
 #define RULESET_MIN_BUF   (100)
 #define RULESET_MAX_BUF   (8192)
@@ -1042,7 +1043,7 @@ int comdb2_load_ruleset(
              zFileName, lineNo, sizeof(struct ruleset));
     goto failure;
   }
-  fd = open(zFileName, O_RDONLY);
+  fd = comdb2_open(zFileName, O_RDONLY, 0);
   if( fd==-1 ){
     snprintf(zError, sizeof(zError), "%s:%d, open (read) failed errno=%d",
              zFileName, lineNo, errno);
@@ -1344,7 +1345,6 @@ failure:
 
 done:
   if( sb!=NULL ) sbuf2close(sb);
-  if( fd!=-1 ) close(fd);
   return rc;
 }
 
@@ -1364,7 +1364,7 @@ int comdb2_save_ruleset(
              zFileName);
     goto failure;
   }
-  fd = open(zFileName, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+  fd = comdb2_open(zFileName, O_WRONLY | O_CREAT | O_TRUNC, 0666);
   if( fd==-1 ){
     snprintf(zError, sizeof(zError), "%s, open (write) failed errno=%d",
              zFileName, errno);
@@ -1446,6 +1446,5 @@ failure:
 
 done:
   if( sb!=NULL ) sbuf2close(sb);
-  if( fd!=-1 ) close(fd);
   return rc;
 }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -37,6 +37,8 @@
 /* Separator for composite tunable components. */
 #define COMPOSITE_TUNABLE_SEP '.'
 
+extern int gbl_track_close;
+extern int gbl_track_open;
 extern int gbl_allow_lua_print;
 extern int gbl_allow_lua_dynamic_libs;
 extern int gbl_allow_pragma;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -37,6 +37,7 @@
 /* Separator for composite tunable components. */
 #define COMPOSITE_TUNABLE_SEP '.'
 
+extern int gbl_waitalive_iterations;
 extern int gbl_track_close;
 extern int gbl_track_open;
 extern int gbl_allow_lua_print;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1856,4 +1856,10 @@ REGISTER_TUNABLE("track_close", "Print information every time a file is closed."
                  "  (Default: off)", TUNABLE_BOOLEAN, &gbl_track_close, 0, NULL,
                  NULL, NULL, NULL);
 
+REGISTER_TUNABLE("waitalive_iterations", "Wait this many iterations for a "
+                 "socket to be usable.  (Default: 10)", TUNABLE_INTEGER, 
+                 &gbl_waitalive_iterations, EXPERIMENTAL | INTERNAL, NULL,
+                 NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1848,4 +1848,12 @@ REGISTER_TUNABLE("strict_double_quotes",
 REGISTER_TUNABLE("eventlog_nkeep", "Keep this many eventlog files (Default: 2)",
                  TUNABLE_INTEGER, &eventlog_nkeep, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("track_open", "Print information every time a file is opened."
+                 "  (Default: off)", TUNABLE_BOOLEAN, &gbl_track_open, 0, NULL,
+                 NULL, NULL, NULL);
+
+REGISTER_TUNABLE("track_close", "Print information every time a file is closed."
+                 "  (Default: off)", TUNABLE_BOOLEAN, &gbl_track_close, 0, NULL,
+                 NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -47,6 +47,7 @@
 #include "intern_strings.h"
 #include "logmsg.h"
 #include <poll.h>
+#include "openclose.h"
 
 #ifdef MONITOR_STACK
 #include "comdb2_pthread_create.h"
@@ -1241,13 +1242,13 @@ struct ireq *create_sorese_ireq(struct dbenv *dbenv, SBUF2 *sb, uint8_t *p_buf,
 
         snprintf(filename, sizeof(filename), "osql_%llu.log", fcounter++);
 
-        ffile = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        ffile = comdb2_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
         if (ffile == -1) {
             logmsg(LOGMSG_ERROR, "Failed to open osql log file %s\n", filename);
         } else {
             iq->sorese.osqllog = sbuf2open(ffile, 0);
             if (!iq->sorese.osqllog) {
-                close(ffile);
+                comdb2_close(ffile);
             }
         }
     }

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -35,6 +35,7 @@
 #include "bdb_api.h"
 #include "comdb2uuid.h"
 #include <net_types.h>
+#include "openclose.h"
 #include <logmsg.h>
 
 /* delete this after comdb2_api.h changes makes it through */
@@ -191,7 +192,7 @@ retry:
         snprintf(filename, sizeof(filename), "m_%s_%u_%llu_%s.log",
                  clnt->osql.host, type, clnt->osql.rqid,
                  comdb2uuidstr(clnt->osql.uuid, us));
-        fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+        fd = comdb2_open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
         if (!fd) {
             logmsg(LOGMSG_ERROR, "Error opening log file %s\n", filename);
         } else {
@@ -199,7 +200,7 @@ retry:
             if (!clnt->osql.logsb) {
                 logmsg(LOGMSG_ERROR, "Error opening sbuf2 for file %s, fd %d\n",
                         filename, fd);
-                close(fd);
+                comdb2_close(fd);
             }
         }
     }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -98,6 +98,7 @@
 #include "logmsg.h"
 #include "locks.h"
 #include "eventlog.h"
+#include "openclose.h"
 
 #include "str0.h"
 #include "comdb2_atomic.h"
@@ -10831,7 +10832,7 @@ sbuf:
     sb = sbuf2open(sockfd, 0);
     if (!sb) {
         logmsg(LOGMSG_ERROR, "%s: failed to open sbuf\n", __func__);
-        close(sockfd);
+        comdb2_close(sockfd);
         return NULL;
     }
 

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -40,6 +40,8 @@
 #include <logmsg.h>
 #include "str0.h"
 
+#include "openclose.h"
+
 struct javasp_trans_state {
     /* Which events we are subscribed for. */
     int events;
@@ -1197,7 +1199,7 @@ int javasp_load_procedure_int(const char *name, const char *param,
             goto done;
         }
 
-        fd = open(resource, O_RDONLY);
+        fd = comdb2_open(resource, O_RDONLY, 0);
         if (fd == -1) {
             logmsg(LOGMSG_ERROR, "Can't load comdb2translisten configuration from "
                             "\"%s\" for stored procedure \"%s\" %d %s\n",

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -81,6 +81,7 @@
 #include "bdb_access.h"
 #include "views.h"
 #include <logmsg.h>
+#include "openclose.h"
 
 extern int gbl_watcher_thread_ran;
 
@@ -190,13 +191,13 @@ static void *watchdog_thread(void *arg)
             free(ptr);
 
             /* try to get a file descriptor */
-            fd = open("/", O_RDONLY);
+            fd = comdb2_open("/", O_RDONLY, 0);
             if (fd == -1) {
                 logmsg(LOGMSG_WARN, "watchdog: Can't open file\n");
                 its_bad = 1;
             }
 
-            rc = close(fd);
+            rc = comdb2_close(fd);
             if (rc) {
                 logmsg(LOGMSG_WARN, "watchdog: Can't close file\n");
                 its_bad = 1;

--- a/dlmalloc/dlmalloc.c
+++ b/dlmalloc/dlmalloc.c
@@ -583,6 +583,7 @@ DEFAULT_MMAP_THRESHOLD       default: 256K
 #endif
 
 #include "dlmalloc_config.h"
+#include "openclose.h"
 
 /*
   mallopt tuning options.  SVID/XPG defines four standard parameter
@@ -1331,7 +1332,7 @@ extern void*     sbrk(ptrdiff_t);
 #define MMAP_FLAGS           (MAP_PRIVATE)
 static int dev_zero_fd = -1; /* Cached file descriptor for /dev/zero. */
 #define CALL_MMAP(s) ((dev_zero_fd < 0) ? \
-           (dev_zero_fd = open("/dev/zero", O_RDWR), \
+           (dev_zero_fd = comdb2_open("/dev/zero", O_RDWR), \
             mmap(0, (s), MMAP_PROT, MMAP_FLAGS, dev_zero_fd, 0)) : \
             mmap(0, (s), MMAP_PROT, MMAP_FLAGS, dev_zero_fd, 0))
 #endif /* MAP_ANONYMOUS */
@@ -2512,10 +2513,10 @@ static int init_mparams(void) {
       int fd;
       unsigned char buf[sizeof(size_t)];
       /* Try to use /dev/urandom, else fall back on using time */
-      if ((fd = open("/dev/urandom", O_RDONLY)) >= 0 &&
+      if ((fd = comdb2_open("/dev/urandom", O_RDONLY)) >= 0 &&
           read(fd, buf, sizeof(buf)) == sizeof(buf)) {
         s = *((size_t *) buf);
-        close(fd);
+        comdb2_close(fd);
       }
       else
 #endif /* USE_DEV_RANDOM */

--- a/lua/luaconf.h
+++ b/lua/luaconf.h
@@ -645,11 +645,12 @@ union luai_Cast { double l_d; long l_l; };
 
 #if defined(LUA_USE_MKSTEMP)
 #include <unistd.h>
+#include "openclose.h"
 #define LUA_TMPNAMBUFSIZE	32
 #define lua_tmpnam(b,e)	{ \
 	strcpy(b, "/tmp/lua_XXXXXX"); \
 	e = mkstemp(b); \
-	if (e != -1) close(e); \
+	if (e != -1) comdb2_close(e); \
 	e = (e == -1); }
 
 #else

--- a/net/net.c
+++ b/net/net.c
@@ -3108,7 +3108,7 @@ netinfo_type *create_netinfo_int(char myhostname[], int myportnum, int myfd,
 #ifdef DEBUG
     Pthread_attr_setstacksize(&(netinfo_ptr->pthread_attr_detach), 1024 * 1024);
 #else
-    Pthread_attr_setstacksize(&(netinfo_ptr->pthread_attr_detach), 1024 * 512);
+    Pthread_attr_setstacksize(&(netinfo_ptr->pthread_attr_detach), 1024 * 256);
 #endif
 
     Pthread_mutex_init(&(netinfo_ptr->connlk), NULL);
@@ -4709,7 +4709,7 @@ int net_get_port_by_service(const char *dbname)
     return ntohs(port);
 }
 
-int gbl_waitalive_iterations = 10;
+int gbl_waitalive_iterations = 3;
 
 void wait_alive(int fd)
 {
@@ -5181,7 +5181,7 @@ static void accept_handle_new_host(netinfo_type *netinfo_ptr,
         return;
     }
 
-    /* see if we already have an entry.  if we do, comdb2_CLOSE the socket.
+    /* see if we already have an entry.  if we do, CLOSE the socket.
        if we dont, create a reader_thread */
     Pthread_rwlock_rdlock(&(netinfo_ptr->lock));
 

--- a/net/net.c
+++ b/net/net.c
@@ -5601,8 +5601,6 @@ static void *accept_thread(void *arg)
         if (rc != 0) {
             logmsg(LOGMSG_FATAL, "%s: couldnt turn on keep alive on new fd %d: %d %s\n",
                     __func__, new_fd, errno, strerror(errno));
-            logmsg(LOGMSG_ERROR, "%s: sizeof socklen_t is %d\n", __func__,
-                    sizeof(socklen_t));
             exit(1);
         }
 

--- a/net/net.c
+++ b/net/net.c
@@ -5583,15 +5583,11 @@ static void *accept_thread(void *arg)
         }
 
 #ifdef NODELAY
-        /* We've seen unexplained EINVAL errors here.  Be extremely defensive
-         * and always reset flag to 1 before calling this function. */
         flag = 1;
         len = sizeof(flag);
         rc = setsockopt(new_fd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag,
                         len);
-        /* Note: don't complain on EINVAL.  There's a legitimate condition where
-           the requester drops the socket according to manpages. */
-        if (rc != 0 && errno != EINVAL) {
+        if (rc != 0) {
             logmsg(LOGMSG_ERROR, 
                     "%s: couldnt turn off nagel on new_fd %d, flag=%d: %d "
                     "%s\n",

--- a/net/net.c
+++ b/net/net.c
@@ -4866,7 +4866,7 @@ static void *connect_thread(void *arg)
         rc = setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, (char *)&on,
                         len);
         if (rc != 0) {
-            logmsg(LOGMSG_FATAL, 
+            logmsg(LOGMSG_ERROR, 
                     "%s: couldnt turn on keep alive on new fd %d: %d %s\n",
                     __func__, fd, errno, strerror(errno));
 

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -21,6 +21,7 @@
 #include "schemachange.h"
 #include "sc_csc2.h"
 #include "debug_switches.h"
+#include "openclose.h"
 #include "logmsg.h"
 
 int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
@@ -240,7 +241,7 @@ int write_csc2_file_fname(const char *fname, const char *csc2text)
     }
 
     /* Dump new csc2 text into file. */
-    fd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+    fd = comdb2_open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
     if (fd == -1) {
         logmsg(LOGMSG_ERROR,
                "write_csc2_file_fname: error opening %s for writing: %d %s\n",

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -7,6 +7,7 @@
 #include "translistener.h"
 
 #include "logmsg.h"
+#include "openclose.h"
 
 struct sp_file_t {
     char name[128]; // MAX_SPNAME
@@ -40,7 +41,7 @@ int dump_spfile(char *path, const char *dbname, char *file_name)
             /* Open the file to store stored procedures. */
             has_sp = 1;
             logmsg(LOGMSG_USER, "FILE : %s\n", file);
-            fd_out = open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+            fd_out = comdb2_open(file, O_WRONLY | O_CREAT | O_TRUNC, 0666);
             if (fd_out == -1) {
                 logmsg(LOGMSG_USER, "%s: cannot open '%s' for writing %d %s\n",
                        __func__, file, errno, strerror(errno));
@@ -49,7 +50,7 @@ int dump_spfile(char *path, const char *dbname, char *file_name)
 
             sb_out = sbuf2open(fd_out, 0);
             if (!sb_out) {
-                close(fd_out);
+                comdb2_close(fd_out);
                 return 0;
             }
         }
@@ -92,14 +93,14 @@ int dump_spfile(char *path, const char *dbname, char *file_name)
 int read_spfile(char *file)
 {
     int bdberr;
-    int fd_in = open(file, O_RDONLY);
+    int fd_in = comdb2_open(file, O_RDONLY, 0);
     if (fd_in == -1) {
         return -1;
     }
 
     SBUF2 *sb_in = sbuf2open(fd_in, 0);
     if (!sb_in) {
-        close(fd_in);
+        comdb2_close(fd_in);
         return -1;
     }
 

--- a/sqlite/src/os_unix.c
+++ b/sqlite/src/os_unix.c
@@ -50,6 +50,7 @@
 #ifdef SQLITE_UNIX_THREADS
 #include <pthread.h>
 #endif
+#include "openclose.h"
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*
@@ -360,7 +361,7 @@ static pid_t randomnessPid = 0;
 ** which always has the same well-defined interface.
 */
 static int posixOpen(const char *zFile, int flags, int mode){
-  return open(zFile, flags, mode);
+  return comdb2_open(zFile, flags, mode);
 }
 
 /* Forward reference */

--- a/tools/comdb2ar/CMakeLists.txt
+++ b/tools/comdb2ar/CMakeLists.txt
@@ -19,6 +19,7 @@ add_executable(comdb2ar
   tar_header.cpp
   util.cpp
   ${PROJECT_SOURCE_DIR}/util/sbuf2.c
+  ${PROJECT_SOURCE_DIR}/util/openclose.c
 )
 include_directories(
   ${PROJECT_SOURCE_DIR}/util

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -9,6 +9,7 @@ set(src
   bb_oscompat.c
   bbhrtime.c
   cheapstub.c
+  openclose.c
   comdb2_pthread_create.c
   comdb2file.c
   compat.c

--- a/util/openclose.c
+++ b/util/openclose.c
@@ -1,0 +1,43 @@
+/*
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <unistd.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+int gbl_track_close = 0;
+int gbl_track_open = 0;
+
+int comdb2_open_impl(const char *pathname, int flags, mode_t mode, const char *func, int line)
+{
+    int fd = -1;
+    fd = open(pathname, flags, mode);
+    if (gbl_track_open) {
+        fprintf(stderr, "Opening %s flags 0x%x mode 0x%x fd %d from %s line "
+                "%d\n", pathname, flags, mode, fd, func, line);
+    }
+    return fd;
+}
+
+int comdb2_close_impl(int fd, const char *func, int line)
+{
+    if (gbl_track_close) {
+        fprintf(stderr, "Closing fd %d from %s line %d\n", fd, func, line);
+    }
+    return close(fd);
+}

--- a/util/openclose.h
+++ b/util/openclose.h
@@ -1,0 +1,26 @@
+/*
+   Copyright 2015 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef __COMDB2_CLOSE_H_INCLUDED__
+#define __COMDB2_CLOSE_H_INCLUDED__
+
+int comdb2_close_impl(int fd, const char *func, int line);
+#define comdb2_close(fd) comdb2_close_impl(fd, __func__, __LINE__)
+
+int comdb2_open_impl(const char *pathname, int flags, mode_t mode, const char *func, int line);
+#define comdb2_open(pathname, flags, mode) comdb2_open_impl(pathname, flags, mode, __func__, __LINE__)
+
+#endif

--- a/util/sbuf2.c
+++ b/util/sbuf2.c
@@ -31,6 +31,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include "locks_wrap.h"
+#include "openclose.h"
 
 #if SBUF2_SERVER
 #  ifndef SBUF2_DFL_SIZE
@@ -152,7 +153,7 @@ int SBUF2_FUNC(sbuf2close)(SBUF2 *sb)
 #endif
 
     if (!(sb->flags & SBUF2_NO_CLOSE_FD))
-        close(sb->fd);
+        comdb2_close(sb->fd);
 
     return sbuf2free(sb);
 }


### PR DESCRIPTION
Open and close file tracking, and more permissive setsockopt behavior.  We should assume that a setsockopt failure can occur legitimately if the other side has closed the socket.
