### PR TITLE
Fix SQL mspace race condition in DOHSQL

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -387,7 +387,7 @@ static int inner_row(struct sqlclntstate *clnt, struct response_data *resp,
     oldrow = queue_next(conn->que_free);
     if (oldrow && gbl_dohsql_verbose)
         logmsg(LOGMSG_DEBUG, "%lx %s retrieved older row\n", pthread_self(),
-                __func__);
+               __func__);
     Pthread_mutex_unlock(&conn->mtx);
 
     if (oldrow)

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -126,6 +126,20 @@ pthread_mutex_t dohsql_stats_mtx = PTHREAD_MUTEX_INITIALIZER;
 dohsql_stats_t gbl_dohsql_stats;       /* updated only on request completion */
 dohsql_stats_t gbl_dohsql_stats_dirty; /* updated dynamically, unlocked */
 
+/* An SQlite engine's mspace isn't thread-safe because it's supposed to
+   be accessed by the engine only. DOHSQL breaks the assumption:
+   While the master engine is casting a Mem object which needs to reallocate
+   zMalloc from its mspace, a child engine may decide to reuse or discard a
+   cached Mem object and therefore free zMalloc in the Mem object which is
+   also allocated from the master's mspace. They can race with each other.
+
+   An obvious fix to this is to make an SQL mspace thread-safe. However
+   this would incur unnecessary locking overhead for non-parallelizable
+   queries. Instead we use a mutex to guard the Mem objects. We just need to
+   ensure that we always hold the mutex whenever casting, reusing or discarding
+   a Mem object inside the DOHSQL subsystem. */
+pthread_mutex_t master_mem_mtx = PTHREAD_MUTEX_INITIALIZER;
+
 static int gbl_plugin_api_debug = 0;
 
 static void sqlengine_work_shard_pp(struct thdpool *pool, void *work,
@@ -272,7 +286,10 @@ static void trimQue(dohsql_connector_t *conn, sqlite3_stmt *stmt,
         if (gbl_dohsql_verbose)
             logmsg(LOGMSG_DEBUG, "XXX: %p freed older row limit %d\n", que,
                    limit);
+
+        Pthread_mutex_lock(&master_mem_mtx);
         sqlite3CloneResultFree(stmt, &row, &row_size);
+        Pthread_mutex_unlock(&master_mem_mtx);
 
         if (gbl_dohsql_max_queued_kb_highwm) {
             conn->queue_size -= row_size;
@@ -367,15 +384,18 @@ static int inner_row(struct sqlclntstate *clnt, struct response_data *resp,
     }
 
     /* try to steal an old row */
-    if (queue_count(conn->que_free) > 0) {
-        if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG, "%lx %s retrieved older row\n", pthread_self(),
-                   __func__);
-        oldrow = queue_next(conn->que_free);
-    }
+    oldrow = queue_next(conn->que_free);
+    if (oldrow && gbl_dohsql_verbose)
+        logmsg(LOGMSG_DEBUG, "%lx %s retrieved older row\n", pthread_self(),
+                __func__);
     Pthread_mutex_unlock(&conn->mtx);
 
+    if (oldrow)
+        Pthread_mutex_lock(&master_mem_mtx);
     row = sqlite3CloneResult(stmt, oldrow, &row_size);
+    if (oldrow)
+        Pthread_mutex_unlock(&master_mem_mtx);
+
     if (!row)
         return SHARD_ERR_GENERIC;
 
@@ -412,14 +432,20 @@ static int dohsql_dist_column_count(struct sqlclntstate *clnt, sqlite3_stmt *_)
     return clnt->conns->ncols;
 }
 
+/* Typecasting may reallocate zMalloc. So do it while holding master_mem_mtx. */
 #define FUNC_COLUMN_TYPE(ret, type)                                            \
     static ret dohsql_dist_column_##type(struct sqlclntstate *clnt,            \
                                          sqlite3_stmt *stmt, int iCol)         \
     {                                                                          \
+        ret rv;                                                                \
         dohsql_t *conns = clnt->conns;                                         \
+        Pthread_mutex_lock(&master_mem_mtx);                                   \
         if (conns->row_src == 0)                                               \
-            return sqlite3_column_##type(stmt, iCol);                          \
-        return sqlite3_value_##type(&conns->row[iCol]);                        \
+            rv = sqlite3_column_##type(stmt, iCol);                            \
+        else                                                                   \
+            rv = sqlite3_value_##type(&conns->row[iCol]);                      \
+        Pthread_mutex_unlock(&master_mem_mtx);                                 \
+        return rv;                                                             \
     }
 
 FUNC_COLUMN_TYPE(int, type)
@@ -434,21 +460,29 @@ static const intv_t *dohsql_dist_column_interval(struct sqlclntstate *clnt,
                                                  sqlite3_stmt *stmt, int iCol,
                                                  int type)
 {
+    const intv_t *rv;
     dohsql_t *conns = clnt->conns;
+    Pthread_mutex_lock(&master_mem_mtx);
     if (conns->row_src == 0)
-        return sqlite3_column_interval(stmt, iCol, type);
-    return sqlite3_value_interval(&conns->row[iCol], type);
+        rv = sqlite3_column_interval(stmt, iCol, type);
+    else
+        rv = sqlite3_value_interval(&conns->row[iCol], type);
+    Pthread_mutex_unlock(&master_mem_mtx);
+    return rv;
 }
 
 static sqlite3_value *dohsql_dist_column_value(struct sqlclntstate *clnt,
                                                sqlite3_stmt *stmt, int i)
 {
+    sqlite3_value *rv;
     dohsql_t *conns = clnt->conns;
-
+    Pthread_mutex_lock(&master_mem_mtx);
     if (conns->row_src == 0)
-        return sqlite3_column_value(stmt, i);
-
-    return &conns->row[i];
+        rv = sqlite3_column_value(stmt, i);
+    else
+        rv = &conns->row[i];
+    Pthread_mutex_unlock(&master_mem_mtx);
+    return rv;
 }
 
 #define Q_LOCK(x) Pthread_mutex_lock(&conns->conns[x].mtx)
@@ -566,8 +600,8 @@ static int _get_a_parallel_row(dohsql_t *conns, row_t **prow, int *error_child)
             return rc;
         }
         rc = SQLITE_OK;
-        if (queue_count(conns->conns[child_num].que) > 0) {
-            *prow = queue_next(conns->conns[child_num].que);
+        *prow = queue_next(conns->conns[child_num].que);
+        if (*prow != NULL) {
             if (gbl_dohsql_verbose)
                 logmsg(LOGMSG_DEBUG, "XXX: %p retrieved row\n",
                        &conns->conns[child_num]);

--- a/sqlite/src/main.c
+++ b/sqlite/src/main.c
@@ -3462,22 +3462,8 @@ int sqlite3_open(
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 ){
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  int rc;
-
-#ifdef DEBUG_SQLITE_MEMORY
-  extern void sqlite_init_start(void);
-  sqlite_init_start();
-#endif
-
-  rc = openDatabase(zFilename, ppDb,
+  return openDatabase(zFilename, ppDb,
                     SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, 0, thd);
-
-#ifdef DEBUG_SQLITE_MEMORY
-  extern void sqlite_init_end(void);
-  sqlite_init_end();
-#endif
-
-  return rc;
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   return openDatabase(zFilename, ppDb,
                       SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE, 0);

--- a/sqlite/src/prepare.c
+++ b/sqlite/src/prepare.c
@@ -541,20 +541,7 @@ done_with_init:
 */
 int sqlite3Init(sqlite3 *db, char **pzErrMsg)
 {
-   int rc;
-
-#ifdef DEBUG_SQLITE_MEMORY
-   extern void sqlite_init_start(void);
-   sqlite_init_start();
-#endif
-
-   rc = sqlite3InitTable(db, pzErrMsg, NULL);
-
-#ifdef DEBUG_SQLITE_MEMORY
-   extern void sqlite_init_end(void);
-   sqlite_init_end();
-#endif
-   return rc;
+   return sqlite3InitTable(db, pzErrMsg, NULL);
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 

--- a/tests/dohsql_race.test/Makefile
+++ b/tests/dohsql_race.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=15m
+endif

--- a/tests/dohsql_race.test/lrl.options
+++ b/tests/dohsql_race.test/lrl.options
@@ -1,0 +1,3 @@
+dohsql_disable 0
+dohast_disable 0
+cache 256 mb

--- a/tests/dohsql_race.test/runit
+++ b/tests/dohsql_race.test/runit
@@ -22,4 +22,3 @@ done
 for i in `seq 1 20`; do
   cdb2sql ${CDB2_OPTIONS} $dbnm default "$sql" >/dev/null
 done
-exit 1

--- a/tests/dohsql_race.test/runit
+++ b/tests/dohsql_race.test/runit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t0 (c DATETIME)"
+sleep 1
+yes 'INSERT INTO t0 VALUES (now())' | head -9999 | cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default >/dev/null
+
+sql='SELECT CAST(c AS TEXT) FROM t0 '
+for i in `seq 1 4`; do
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t$i (c DATETIME)"
+    sleep 1
+    for j in `seq 1 10`; do
+        cdb2sql ${CDB2_OPTIONS} $dbnm default "INSERT INTO t$i SELECT * FROM t0" >/dev/null
+    done
+    sql="${sql} UNION ALL SELECT CAST(c AS TEXT) from t$i "
+done
+
+for i in `seq 1 20`; do
+  cdb2sql ${CDB2_OPTIONS} $dbnm default "$sql" >/dev/null
+done
+exit 1


### PR DESCRIPTION
An SQlite engine's mspace isn't thread-safe because it's supposed to be accessed by the engine only. Unfortunately DOHSQL breaks the assumption:
While the master engine is casting a Mem object which needs to reallocate zMalloc from its mspace, a child engine may decide to reuse or discard a cached Mem object and therefore free zMalloc in the Mem object which is also allocated from the master's mspace. They can race with each other, as shown below.

```
                                      +----------------+
                                      | Child Engine 1 |
                                      +----------------+
                                              |
                                       inner_row (dohsql.c)
                                              |
                                       add_row (dohsql.c)
                                        * add Mem M to queue
+-------------------+                         |
| Master SQL engine |                         |
+-------------------+                         |
        |                                     |
next_row (sqlinterfaces.c)                    |
        |                                     |
dohsql_dist_next_row (dohsql.c)               |
        |                                     |
 * grab M from Child Engine 1 ----------------+
        |                                     |
send_row (sqlinterfaces.c)                    |
        |                                     |
column_value(M) (vdbeapi.c)                   |
        |                                     |
apply affinity to M (vdbemem.c)               |
 * e.g., sqlite3VdbeMemStringify              |
        |                                     |
sqlite3Malloc (malloc.c)                      |       +----------------+
        |                                     |       | Child Engine 2 |
mspace_malloc (dlmalloc.c)                    |       +----------------+
        |                                     |               |
        |                                     |        inner_row (dohsql.c)
next_row (sqlinterfaces.c)                    |               |
        |                                     |        add_row (dohsql.c)
dohsql_dist_next_row (dohsql.c)               |         * add Mem N to queue
 * Return M to Child Engine 1 ----------------+               |
 * grab N from Child Engine 2 ----------------)---------------+
        |                                     |
        |                              inner_row (dohsql.c)
        |                                     |
        |                              trimQue (dohsql.c)
send_row (sqlinterfaces.c)                    |
        |                              sqlite3CloneResultFree(M) (vdbeaux.c)
column_value(N) (vdbeapi.c)                   |
        |                                     |
apply affinity to N (vdbemem.c)               |
 * e.g., sqlite3VdbeMemStringify              |
        |                                     |
sqlite3Malloc (malloc.c)               sqlite3_free (malloc.c)
        |                                     |
mspace_malloc (dlmalloc.c)             mspace_free (dlmalloc.c)
                         \            /
! Race condition: Non thread-safe mspace shared between 2 engines
```

An obvious fix to this is to make an SQL mspace thread-safe. However this would incur unnecessary locking overhead for non-parallelizable queries. Instead we use a mutex to guard the Mem objects. We just need to ensure that we always hold the mutex whenever casting, reusing or discarding a Mem object inside the DOHSQL subsystem.

(DRQS 150091313)
