### PR TITLE
Remove mpreg

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1191,7 +1191,8 @@ typedef enum {
 	DB_HASH=2,
 	DB_RECNO=3,
 	DB_QUEUE=4,
-	DB_UNKNOWN=5			/* Figure it out on open. */
+	DB_UNKNOWN=5,			/* Figure it out on open. */
+	DB_TYPE_MAX=6
 } DBTYPE;
 
 #define	DB_RENAMEMAGIC	0x030800	/* File has been renamed. */
@@ -2576,8 +2577,8 @@ struct __db_env {
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
 
-    int (*pgin[DB_UNKNOWN]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
-    int (*pgout[DB_UNKNOWN]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
+    int (*pgin[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
+    int (*pgout[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 };
 
 #ifndef DB_DBM_HSEARCH

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2575,6 +2575,9 @@ struct __db_env {
 	int(*trigger_unsubscribe) __P((DB_ENV *, const char *));
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
+
+    int (*pgin[DB_UNKNOWN]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
+    int (*pgout[DB_UNKNOWN]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 };
 
 #ifndef DB_DBM_HSEARCH

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -757,11 +757,11 @@ struct __db_mpoolfile {
 	DB_FH	  *fhp;		/* Underlying file handle. */
 	DB_FH     *recp;        /* Recovery page file handle. */
 
-    /* Protected by mpoolfile mutex */
-    struct {								\
-        DB_MPOOLFILE *le_next;	/* next element */			\
-        DB_MPOOLFILE **le_prev;	/* address of previous next element */	\
-    } mpfq;
+/* Protected by mpoolfile mutex */
+	struct {								\
+		DB_MPOOLFILE *le_next;	/* next element */			\
+		DB_MPOOLFILE **le_prev;	/* address of previous next element */	\
+	} mpfq;
 
 	/* Lock-array for recovery pages. */
 	pthread_mutex_t *recp_lk_array;
@@ -2583,8 +2583,8 @@ struct __db_env {
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
 
-    int (*pgin[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
-    int (*pgout[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
+	int (*pgin[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
+	int (*pgout[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 };
 
 #ifndef DB_DBM_HSEARCH

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -757,6 +757,12 @@ struct __db_mpoolfile {
 	DB_FH	  *fhp;		/* Underlying file handle. */
 	DB_FH     *recp;        /* Recovery page file handle. */
 
+    /* Protected by mpoolfile mutex */
+    struct {								\
+        DB_MPOOLFILE *le_next;	/* next element */			\
+        DB_MPOOLFILE **le_prev;	/* address of previous next element */	\
+    } mpfq;
+
 	/* Lock-array for recovery pages. */
 	pthread_mutex_t *recp_lk_array;
 	int       rec_idx;      /* Current index for recover pages. */

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -141,7 +141,7 @@ struct __db_ltran; typedef struct __db_ltran DB_LTRAN;
 struct __db_mpool;	typedef struct __db_mpool DB_MPOOL;
 struct __db_mpool_fstat;typedef struct __db_mpool_fstat DB_MPOOL_FSTAT;
 struct __db_mpool_stat;	typedef struct __db_mpool_stat DB_MPOOL_STAT;
-struct __db_mpoolfile;	typedef struct __db_mpoolfile DB_MPOOLFILE;
+//struct __db_mpoolfile;	typedef struct __db_mpoolfile DB_MPOOLFILE;
 struct __db_preplist;	typedef struct __db_preplist DB_PREPLIST;
 struct __db_qam_stat;	typedef struct __db_qam_stat DB_QUEUE_STAT;
 struct __db_rep;	typedef struct __db_rep DB_REP;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -141,7 +141,7 @@ struct __db_ltran; typedef struct __db_ltran DB_LTRAN;
 struct __db_mpool;	typedef struct __db_mpool DB_MPOOL;
 struct __db_mpool_fstat;typedef struct __db_mpool_fstat DB_MPOOL_FSTAT;
 struct __db_mpool_stat;	typedef struct __db_mpool_stat DB_MPOOL_STAT;
-//struct __db_mpoolfile;	typedef struct __db_mpoolfile DB_MPOOLFILE;
+struct __db_mpoolfile;	typedef struct __db_mpoolfile DB_MPOOLFILE;
 struct __db_preplist;	typedef struct __db_preplist DB_PREPLIST;
 struct __db_qam_stat;	typedef struct __db_qam_stat DB_QUEUE_STAT;
 struct __db_rep;	typedef struct __db_rep DB_REP;

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -70,19 +70,6 @@ struct __db_mpool {
 };
 
 /*
- * DB_MPREG --
- *	DB_MPOOL registry of pgin/pgout functions.
- */
-struct __db_mpreg {
-	LIST_ENTRY(__db_mpreg) q;	/* Linked list. */
-
-	int32_t ftype;			/* File type. */
-					/* Pgin, pgout routines. */
-	int (*pgin) __P((DB_ENV *, db_pgno_t, void *, DBT *));
-	int (*pgout) __P((DB_ENV *, db_pgno_t, void *, DBT *));
-};
-
-/*
  * NCACHE --
  *	Select a cache based on the file and the page number.  Assumes accesses
  *	are uniform across pages, which is probably OK.  What we really want to

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -204,6 +204,8 @@ struct __mpoolfile {
 	/* Protected by MPOOLFILE mutex. */
 	u_int32_t mpf_cnt;		/* Ref count: DB_MPOOLFILEs. */
 	u_int32_t block_cnt;		/* Ref count: blocks in cache. */
+	LIST_HEAD(, __db_mpoolfile) dbmpf_list;
+
 
 	roff_t	  path_off;		/* File name location. */
 
@@ -220,8 +222,6 @@ struct __mpoolfile {
 	db_pgno_t orig_last_pgno;	/* Original last page in the file. */
 	db_pgno_t alloc_pgno;           /* Last page alloced on disk. */
 	db_pgno_t maxpgno;		/* Maximum page number. */
-
-    LIST_HEAD(, __db_mpoolfile) dbmpf_list;
 
 	/*
 	 * None of the following fields are thread protected.
@@ -320,7 +320,7 @@ struct __bh {
 	SH_TAILQ_ENTRY(__bh) hq;	/* MPOOL hash bucket queue. */
 
 	db_pgno_t pgno;			/* Underlying MPOOLFILE page number. */
-    MPOOLFILE *mpf;
+	MPOOLFILE *mpf;
 
 	/* The begin LSN of the transaction that
 	   marked the page from clean to dirty. */

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -75,7 +75,7 @@ struct __db_mpool {
  *	more frequent than a random data page.
  */
 #define	NCACHE(mp, mf_offset, pgno)					\
-	(((pgno) ^ ((mf_offset) >> 3)) % ((MPOOL *)mp)->nreg)
+	(((pgno) ^ (((uintptr_t) mf_offset) >> 3)) % ((MPOOL *)mp)->nreg)
 
 /*
  * NBUCKET --
@@ -90,7 +90,7 @@ struct __db_mpool {
  *	 good hashing.
  */
 #define	NBUCKET(mc, mf_offset, pgno)					\
-	(((pgno) ^ ((mf_offset) << 9)) % (mc)->htab_buckets)
+	(((pgno) ^ (((intptr_t)mf_offset) << 9)) % (mc)->htab_buckets)
 
 /*
  * MPOOL --
@@ -318,7 +318,7 @@ struct __bh {
 	SH_TAILQ_ENTRY(__bh) hq;	/* MPOOL hash bucket queue. */
 
 	db_pgno_t pgno;			/* Underlying MPOOLFILE page number. */
-	roff_t	  mf_offset;		/* Associated MPOOLFILE offset. */
+    MPOOLFILE *mpf;
 
 	/* The begin LSN of the transaction that
 	   marked the page from clean to dirty. */

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -221,6 +221,8 @@ struct __mpoolfile {
 	db_pgno_t alloc_pgno;           /* Last page alloced on disk. */
 	db_pgno_t maxpgno;		/* Maximum page number. */
 
+    LIST_HEAD(, __db_mpoolfile) dbmpf_list;
+
 	/*
 	 * None of the following fields are thread protected.
 	 *

--- a/berkdb/dbinc/mp.h
+++ b/berkdb/dbinc/mp.h
@@ -15,8 +15,6 @@ struct __bh;
 typedef struct __bh BH;
 struct __db_mpool_hash;
 typedef struct __db_mpool_hash DB_MPOOL_HASH;
-struct __db_mpreg;
-typedef struct __db_mpreg DB_MPREG;
 struct __mpool;
 typedef struct __mpool MPOOL;
 
@@ -51,9 +49,6 @@ typedef enum {
 struct __db_mpool {
 	/* These fields need to be protected for multi-threaded support. */
 	DB_MUTEX   *mutexp;		/* Structure thread lock. */
-
-					/* List of pgin/pgout routines. */
-	LIST_HEAD(__db_mpregh, __db_mpreg) dbregq;
 
 					/* List of DB_MPOOLFILE's. */
 	TAILQ_HEAD(__db_mpoolfileh, __db_mpoolfile) dbmfq;

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -109,6 +109,11 @@ __dbenv_open(dbenv, db_home, flags, mode)
 	u_int32_t init_flags, orig_flags;
 	int rep_check, ret;
 
+	for (int i = 0; i < DB_UNKNOWN; i++) {
+		dbenv->pgin[i] = NULL;
+		dbenv->pgout[i] = NULL;
+	}
+
 	orig_flags = dbenv->flags;
 	rep_check = 0;
 
@@ -661,7 +666,6 @@ foundlsn:
 		goto err;
 
 	dbenv->verbose |= DB_VERB_REPLICATION;
-
 	return (0);
 
 err:				/* If we fail after creating the regions, remove them. */

--- a/berkdb/mp/mp_alloc.c
+++ b/berkdb/mp/mp_alloc.c
@@ -90,7 +90,7 @@ __memp_dump_bufferpool_info(dbenv, f)
 
 			do {
 				bufcnt++;
-				logmsgf(LOGMSG_USER, f, " (%d:%d:%d)", (int)bhp->mf_offset,
+				logmsgf(LOGMSG_USER, f, " (%p:%d:%d)", bhp->mpf,
 				    bhp->pgno, bhp->priority);
 				bhp = SH_TAILQ_NEXT(bhp, hq, __bh);
 			}
@@ -498,7 +498,7 @@ found:		if (offsetp != NULL)
 		buffers++;
 
 		/* Find the associated MPOOLFILE. */
-		bh_mfp = R_ADDR(dbmp->reginfo, bhp->mf_offset);
+		bh_mfp = bhp->mpf;
 
 		if (F_ISSET(bhp, BH_PREFAULT)) {
 			++c_mp->stat.st_pf_evict;

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -1164,7 +1164,7 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
 		bb_memp_pg_hit(start_time_us);
 	return (0);
 
-err:	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
+err:
 	__db_err(dbenv, "%s: %s failed for page %lu",
 	    __memp_fn(dbmfp), is_pgin ? "pgin" : "pgout", (u_long) pgno);
 	if (gbl_bb_berkdb_enable_memp_pg_timing)

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -1143,6 +1143,9 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
 		start_time_us = bb_berkdb_fasttime();
 
 	ftype = mfp->ftype;
+    if (ftype == DB_FTYPE_SET)
+        ftype =  DB_UNKNOWN;
+
     if (mfp->pgcookie_len == 0)
         dbtp = NULL;
     else {
@@ -1151,12 +1154,12 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
         dbtp = &dbt;
     }
     if (is_pgin) {
-        if (dbmp->dbenv->pgin[mfp->ftype] != NULL &&
-                (ret = dbmp->dbenv->pgin[mfp->ftype](dbenv, pgno, buf, dbtp)) != 0)
+        if (dbmp->dbenv->pgin[ftype] != NULL &&
+                (ret = dbmp->dbenv->pgin[ftype](dbenv, pgno, buf, dbtp)) != 0)
             goto err;
     } else {
-        if (dbmp->dbenv->pgout[mfp->ftype] != NULL &&
-                (ret = dbmp->dbenv->pgout[mfp->ftype](dbenv, pgno, buf, dbtp)) != 0)
+        if (dbmp->dbenv->pgout[ftype] != NULL &&
+                (ret = dbmp->dbenv->pgout[ftype](dbenv, pgno, buf, dbtp)) != 0)
             goto err;
     }
 

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -112,7 +112,7 @@ __memp_bhwrite_multi(dbmp, hps, mfp, bhps, numpages, open_extents)
 			++dbmfp->ref;
 			break;
 		}
-    }
+	}
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
 	if (dbmfp != NULL) {
@@ -1144,25 +1144,25 @@ __dir_pg(dbmfp, pgno, buf, is_pgin)
 		start_time_us = bb_berkdb_fasttime();
 
 	ftype = mfp->ftype;
-    if (ftype == DB_FTYPE_SET)
-        ftype =  DB_UNKNOWN;
+	if (ftype == DB_FTYPE_SET)
+		ftype =  DB_UNKNOWN;
 
-    if (mfp->pgcookie_len == 0)
-        dbtp = NULL;
-    else {
-        dbt.size = mfp->pgcookie_len;
-        dbt.data = R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
-        dbtp = &dbt;
-    }
-    if (is_pgin) {
-        if (dbmp->dbenv->pgin[ftype] != NULL &&
-                (ret = dbmp->dbenv->pgin[ftype](dbenv, pgno, buf, dbtp)) != 0)
-            goto err;
-    } else {
-        if (dbmp->dbenv->pgout[ftype] != NULL &&
-                (ret = dbmp->dbenv->pgout[ftype](dbenv, pgno, buf, dbtp)) != 0)
-            goto err;
-    }
+	if (mfp->pgcookie_len == 0)
+		dbtp = NULL;
+	else {
+		dbt.size = mfp->pgcookie_len;
+		dbt.data = R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
+		dbtp = &dbt;
+	}
+	if (is_pgin) {
+		if (dbmp->dbenv->pgin[ftype] != NULL &&
+			(ret = dbmp->dbenv->pgin[ftype](dbenv, pgno, buf, dbtp)) != 0)
+			goto err;
+	} else {
+		if (dbmp->dbenv->pgout[ftype] != NULL &&
+			(ret = dbmp->dbenv->pgout[ftype](dbenv, pgno, buf, dbtp)) != 0)
+			goto err;
+	}
 
 	if (gbl_bb_berkdb_enable_memp_pg_timing)
 		bb_memp_pg_hit(start_time_us);

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -303,7 +303,7 @@ __memp_recover_page(dbmfp, hp, bhp, pgno)
 	mfp = dbmfp->mfp;
 	pagesize = mfp->stat.st_pagesize;
 	dbmp = dbenv->mp_handle;
-	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mf_offset, bhp->pgno);
+	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mpf, bhp->pgno);
 	c_mp = dbmp->reginfo[n_cache].primary;
 
 	pgidx = -1;
@@ -1064,7 +1064,7 @@ file_dead:
 
 			/* Best to do this in lock step with hash_page_dirty */
 			n_cache = NCACHE(dbmp->reginfo[0].primary,
-			    bhp->mf_offset, bhp->pgno);
+			    bhp->mpf, bhp->pgno);
 			c_mp = dbmp->reginfo[n_cache].primary;
 			ATOMIC_ADD32(hp->hash_page_dirty, -1);
 			ATOMIC_ADD32(c_mp->stat.st_page_dirty, -1);
@@ -1216,7 +1216,7 @@ __memp_bhfree(dbmp, hp, bhp, free_mem)
 	 */
 	dbenv = dbmp->dbenv;
 	mp = dbmp->reginfo[0].primary;
-	n_cache = NCACHE(mp, bhp->mf_offset, bhp->pgno);
+	n_cache = NCACHE(mp, bhp->mpf, bhp->pgno);
 
 	/*
 	 * Delete the buffer header from the hash bucket queue and reset
@@ -1238,7 +1238,7 @@ __memp_bhfree(dbmp, hp, bhp, free_mem)
 	 * Find the underlying MPOOLFILE and decrement its reference count.
 	 * If this is its last reference, remove it.
 	 */
-	mfp = R_ADDR(dbmp->reginfo, bhp->mf_offset);
+	mfp = bhp->mpf;
 	MUTEX_LOCK(dbenv, &mfp->mutex);
 	if (--mfp->block_cnt == 0 && mfp->mpf_cnt == 0)
 		(void)__memp_mf_discard(dbmp, mfp);

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -102,16 +102,17 @@ __memp_bhwrite_multi(dbmp, hps, mfp, bhps, numpages, open_extents)
 					     bhps, numpages, 1));
 
 	/*
-	 * Walk the process' DB_MPOOLFILE list and find a file descriptor for
+	 * Walk the MPOOLFILE's list and find a file descriptor for
 	 * the file.  We also check that the descriptor is open for writing.
 	 */
 	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
-	for (dbmfp = TAILQ_FIRST(&dbmp->dbmfq);
-	    dbmfp != NULL; dbmfp = TAILQ_NEXT(dbmfp, q))
+	for (dbmfp = LIST_FIRST(&mfp->dbmpf_list);
+	    dbmfp != NULL; dbmfp = LIST_NEXT(dbmfp, mpfq)) {
 		if (dbmfp->mfp == mfp && !F_ISSET(dbmfp, MP_READONLY)) {
 			++dbmfp->ref;
 			break;
 		}
+    }
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
 	if (dbmfp != NULL) {

--- a/berkdb/mp/mp_bh.c
+++ b/berkdb/mp/mp_bh.c
@@ -318,14 +318,10 @@ __memp_recover_page(dbmfp, hp, bhp, pgno)
 	pginfo = &duminfo;
 	ftype = mfp->ftype;
 
-	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
-
     if (mfp->pgcookie_len > 0) {
         pginfo = (DB_PGINFO *)R_ADDR(dbmp->reginfo,
                 mfp->pgcookie_off);
     }
-
-	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
 	/* Create a temporary pagecache. */
 	if (pagesize <= 4096) {

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -887,7 +887,6 @@ __memp_read_recovery_pages(dbmfp)
 	DB_ENV *dbenv;
 	MPOOLFILE *mfp;
 	DB_MPOOL *dbmp;
-	DB_MPREG *mpreg;
 	DB_PGINFO duminfo = { 0 }, *pginfo;
 	PAGE *pagep;
 	int ret, free_buf, ftype, i;
@@ -916,19 +915,10 @@ __memp_read_recovery_pages(dbmfp)
 		free_buf = 1;
 	}
 
-	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
-
-	/* Get the page-cookie for data format. */
-	for (mpreg = LIST_FIRST(&dbmp->dbregq);
-	    mpreg != NULL; mpreg = LIST_NEXT(mpreg, q)) {
-		if (ftype != mpreg->ftype)
-			continue;
-		if (mfp->pgcookie_len > 0) {
-			pginfo = (DB_PGINFO *)
-			    R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
-		}
-		break;
-	}
+    if (mfp->pgcookie_len > 0) {
+        pginfo = (DB_PGINFO *)
+            R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
+    }
 
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -912,10 +912,10 @@ __memp_read_recovery_pages(dbmfp)
 		free_buf = 1;
 	}
 
-    if (mfp->pgcookie_len > 0) {
-        pginfo = (DB_PGINFO *)
-            R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
-    }
+	if (mfp->pgcookie_len > 0) {
+		pginfo = (DB_PGINFO *)
+		R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
+	}
 
 	/* Scan in each of the recovery pages. */
 	for (i = 0; i <= dbenv->mp_recovery_pages; i++) {

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -920,9 +920,6 @@ __memp_read_recovery_pages(dbmfp)
             R_ADDR(dbmp->reginfo, mfp->pgcookie_off);
     }
 
-	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
-
-
 	/* Scan in each of the recovery pages. */
 	for (i = 0; i <= dbenv->mp_recovery_pages; i++) {
 		/* Lock out other threads */

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -231,7 +231,6 @@ __memp_fget_internal(dbmfp, pgnoaddr, flags, addrp, did_io)
 	DB_MPOOL_HASH *hp;
 	MPOOL *c_mp, *mp;
 	MPOOLFILE *mfp;
-	roff_t mf_offset;
 	u_int32_t n_cache, st_hsearch, alloc_flags;
 	int b_incr, extending, first, ret, is_recovery_page;
 	db_pgno_t falloc_off, falloc_len;
@@ -253,7 +252,6 @@ __memp_fget_internal(dbmfp, pgnoaddr, flags, addrp, did_io)
 	c_mp = NULL;
 	mp = dbmp->reginfo[0].primary;
 	mfp = dbmfp->mfp;
-	mf_offset = R_OFFSET(dbmp->reginfo, mfp);
 	alloc_bhp = bhp = NULL;
 	hp = NULL;
 	b_incr = extending = ret = is_recovery_page = 0;
@@ -320,10 +318,10 @@ hb_search:
 	 * local pointers to them.  Reset on each pass through this code, the
 	 * page number can change.
 	 */
-	n_cache = NCACHE(mp, mf_offset, *pgnoaddr);
+	n_cache = NCACHE(mp, mfp, *pgnoaddr);
 	c_mp = dbmp->reginfo[n_cache].primary;
 	hp = R_ADDR(&dbmp->reginfo[n_cache], c_mp->htab);
-	hp = &hp[NBUCKET(c_mp, mf_offset, *pgnoaddr)];
+	hp = &hp[NBUCKET(c_mp, mfp, *pgnoaddr)];
 
 	/* Search the hash chain for the page. */
 retry:	st_hsearch = 0;
@@ -331,7 +329,7 @@ retry:	st_hsearch = 0;
 	for (bhp = SH_TAILQ_FIRST(&hp->hash_bucket, __bh);
 	    bhp != NULL; bhp = SH_TAILQ_NEXT(bhp, hq, __bh)) {
 		++st_hsearch;
-		if (bhp->pgno != *pgnoaddr || bhp->mf_offset != mf_offset)
+		if (bhp->pgno != *pgnoaddr || bhp->mpf != mfp)
 			continue;
 
 		/*
@@ -501,11 +499,10 @@ alloc:		/*
 
 		/*
 		 * !!!
-		 * In the DB_MPOOL_NEW code path, mf_offset and n_cache have
+		 * In the DB_MPOOL_NEW code path, mfp and n_cache have
 		 * not yet been initialized.
 		 */
-		mf_offset = R_OFFSET(dbmp->reginfo, mfp);
-		n_cache = NCACHE(mp, mf_offset, *pgnoaddr);
+		n_cache = NCACHE(mp, mfp, *pgnoaddr);
 		c_mp = dbmp->reginfo[n_cache].primary;
 		alloc_flags = flags == DB_MPOOL_NOCACHE ? DB_MPOOL_LOWPRI : 0;
 
@@ -558,7 +555,7 @@ alloc:		/*
 		 */
 		if (flags == DB_MPOOL_NEW && *pgnoaddr != mfp->last_pgno + 1) {
 			*pgnoaddr = mfp->last_pgno + 1;
-			if (n_cache != NCACHE(mp, mf_offset, *pgnoaddr)) {
+			if (n_cache != NCACHE(mp, mfp, *pgnoaddr)) {
 				/*
 				 * flags == DB_MPOOL_NEW, so extending is set
 				 * and we're holding the region locked.
@@ -656,7 +653,7 @@ alloc:		/*
 		bhp->ref = 1;
 		bhp->priority = UINT32_T_MAX;
 		bhp->pgno = *pgnoaddr;
-		bhp->mf_offset = mf_offset;
+		bhp->mpf = mfp;
 		SH_TAILQ_INSERT_TAIL(&hp->hash_bucket, bhp, hq);
 
 		hp->hash_priority =

--- a/berkdb/mp/mp_fopen.c
+++ b/berkdb/mp/mp_fopen.c
@@ -892,6 +892,8 @@ alloc:	/* Allocate and initialize a new MPOOLFILE. */
 	mfp->clear_len = dbmfp->clear_len;
 	mfp->priority = dbmfp->priority;
 	mfp->flushed = 0;
+    LIST_INIT(&mfp->dbmpf_list);
+
 	if (dbmfp->gbytes != 0 || dbmfp->bytes != 0) {
 		mfp->maxpgno =
 		    dbmfp->gbytes * (GIGABYTE / mfp->stat.st_pagesize);
@@ -1120,6 +1122,7 @@ check_map:
 		}
 
 	TAILQ_INSERT_TAIL(&dbmp->dbmfq, dbmfp, q);
+    LIST_INSERT_HEAD(&mfp->dbmpf_list, dbmfp, mpfq);
 
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
@@ -1232,8 +1235,10 @@ __memp_fclose(dbmfp, flags)
 	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
 
 	DB_ASSERT(dbmfp->ref >= 1);
-	if ((ref = --dbmfp->ref) == 0 && F_ISSET(dbmfp, MP_OPEN_CALLED))
+	if ((ref = --dbmfp->ref) == 0 && F_ISSET(dbmfp, MP_OPEN_CALLED)) {
 		TAILQ_REMOVE(&dbmp->dbmfq, dbmfp, q);
+        LIST_REMOVE(dbmfp, mpfq);
+    }
 
 	/*
 	 * Decrement the file descriptor's ref count -- if we're the last ref,

--- a/berkdb/mp/mp_fopen.c
+++ b/berkdb/mp/mp_fopen.c
@@ -892,7 +892,7 @@ alloc:	/* Allocate and initialize a new MPOOLFILE. */
 	mfp->clear_len = dbmfp->clear_len;
 	mfp->priority = dbmfp->priority;
 	mfp->flushed = 0;
-    LIST_INIT(&mfp->dbmpf_list);
+	LIST_INIT(&mfp->dbmpf_list);
 
 	if (dbmfp->gbytes != 0 || dbmfp->bytes != 0) {
 		mfp->maxpgno =
@@ -1122,7 +1122,7 @@ check_map:
 		}
 
 	TAILQ_INSERT_TAIL(&dbmp->dbmfq, dbmfp, q);
-    LIST_INSERT_HEAD(&mfp->dbmpf_list, dbmfp, mpfq);
+	LIST_INSERT_HEAD(&mfp->dbmpf_list, dbmfp, mpfq);
 
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
@@ -1237,8 +1237,8 @@ __memp_fclose(dbmfp, flags)
 	DB_ASSERT(dbmfp->ref >= 1);
 	if ((ref = --dbmfp->ref) == 0 && F_ISSET(dbmfp, MP_OPEN_CALLED)) {
 		TAILQ_REMOVE(&dbmp->dbmfq, dbmfp, q);
-        LIST_REMOVE(dbmfp, mpfq);
-    }
+		LIST_REMOVE(dbmfp, mpfq);
+	}
 
 	/*
 	 * Decrement the file descriptor's ref count -- if we're the last ref,

--- a/berkdb/mp/mp_fput.c
+++ b/berkdb/mp/mp_fput.c
@@ -147,10 +147,10 @@ __memp_fput_internal(dbmfp, pgaddr, flags, pgorder)
 		}
 	}
 
-	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mf_offset, bhp->pgno);
+	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mpf, bhp->pgno);
 	c_mp = dbmp->reginfo[n_cache].primary;
 	hp = R_ADDR(&dbmp->reginfo[n_cache], c_mp->htab);
-	hp = &hp[NBUCKET(c_mp, bhp->mf_offset, bhp->pgno)];
+	hp = &hp[NBUCKET(c_mp, bhp->mpf, bhp->pgno)];
 
 	MUTEX_LOCK(dbenv, &hp->hash_mutex);
 

--- a/berkdb/mp/mp_fset.c
+++ b/berkdb/mp/mp_fset.c
@@ -92,10 +92,10 @@ __memp_fset(dbmfp, pgaddr, flags)
 
 	/* Convert the page address to a buffer header and hash bucket. */
 	bhp = (BH *)((u_int8_t *)pgaddr - SSZA(BH, buf));
-	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mf_offset, bhp->pgno);
+	n_cache = NCACHE(dbmp->reginfo[0].primary, bhp->mpf, bhp->pgno);
 	c_mp = dbmp->reginfo[n_cache].primary;
 	hp = R_ADDR(&dbmp->reginfo[n_cache], c_mp->htab);
-	hp = &hp[NBUCKET(c_mp, bhp->mf_offset, bhp->pgno)];
+	hp = &hp[NBUCKET(c_mp, bhp->mpf, bhp->pgno)];
 
 	MUTEX_LOCK(dbenv, &hp->hash_mutex);
 

--- a/berkdb/mp/mp_region.c
+++ b/berkdb/mp/mp_region.c
@@ -72,7 +72,6 @@ __memp_open(dbenv)
 	/* Create and initialize the DB_MPOOL structure. */
 	if ((ret = __os_calloc(dbenv, 1, sizeof(*dbmp), &dbmp)) != 0)
 		return (ret);
-	LIST_INIT(&dbmp->dbregq);
 	TAILQ_INIT(&dbmp->dbmfq);
 	dbmp->dbenv = dbenv;
 
@@ -299,7 +298,6 @@ __memp_dbenv_refresh(dbenv)
 {
 	DB_MPOOL *dbmp;
 	DB_MPOOLFILE *dbmfp;
-	DB_MPREG *mpreg;
 	u_int32_t i;
 	int ret, t_ret;
 

--- a/berkdb/mp/mp_region.c
+++ b/berkdb/mp/mp_region.c
@@ -306,12 +306,6 @@ __memp_dbenv_refresh(dbenv)
 	ret = 0;
 	dbmp = dbenv->mp_handle;
 
-	/* Discard DB_MPREGs. */
-	while ((mpreg = LIST_FIRST(&dbmp->dbregq)) != NULL) {
-		LIST_REMOVE(mpreg, q);
-		__os_free(dbenv, mpreg);
-	}
-
 	/* Discard DB_MPOOLFILEs. */
 	while ((dbmfp = TAILQ_FIRST(&dbmp->dbmfq)) != NULL)
 		if ((t_ret = __memp_fclose(dbmfp, 0)) != 0 && ret == 0)

--- a/berkdb/mp/mp_register.c
+++ b/berkdb/mp/mp_register.c
@@ -12,6 +12,7 @@ static const char revid[] = "$Id: mp_register.c,v 11.24 2003/09/13 19:20:40 bost
 
 #ifndef NO_SYSTEM_INCLUDES
 #include <sys/types.h>
+#include <assert.h>
 #endif
 
 #include "db_int.h"
@@ -67,6 +68,8 @@ __memp_register(dbenv, ftype, pgin, pgout)
 
 	if (ftype == DB_FTYPE_SET)
 		ftype = DB_UNKNOWN;
+
+    assert(ftype > 0 && ftype <= DB_TYPE_MAX);
 
 	if (dbenv->pgin[ftype] || dbenv->pgout[ftype])
 		return (0);

--- a/berkdb/mp/mp_register.c
+++ b/berkdb/mp/mp_register.c
@@ -64,6 +64,13 @@ __memp_register(dbenv, ftype, pgin, pgout)
 	int (*pgin) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 	int (*pgout) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 {
+
+    if (ftype == DB_FTYPE_SET)
+        ftype = DB_UNKNOWN;
+
+    if (dbenv->pgin[ftype] || dbenv->pgout[ftype])
+        return (0);
+
     dbenv->pgin[ftype] = pgin;
     dbenv->pgout[ftype] = pgout;
 	return (0);

--- a/berkdb/mp/mp_register.c
+++ b/berkdb/mp/mp_register.c
@@ -64,40 +64,7 @@ __memp_register(dbenv, ftype, pgin, pgout)
 	int (*pgin) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 	int (*pgout) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 {
-	DB_MPOOL *dbmp;
-	DB_MPREG *mpreg;
-	int ret;
-
-	dbmp = dbenv->mp_handle;
-
-	/*
-	 * Chances are good that the item has already been registered, as the
-	 * DB access methods are the folks that call this routine.  If already
-	 * registered, just update the entry, although it's probably unchanged.
-	 */
-	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
-	for (mpreg = LIST_FIRST(&dbmp->dbregq);
-	    mpreg != NULL; mpreg = LIST_NEXT(mpreg, q))
-		if (mpreg->ftype == ftype) {
-			mpreg->pgin = pgin;
-			mpreg->pgout = pgout;
-			break;
-		}
-	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
-	if (mpreg != NULL)
-		return (0);
-
-	/* New entry. */
-	if ((ret = __os_malloc(dbenv, sizeof(DB_MPREG), &mpreg)) != 0)
-		return (ret);
-
-	mpreg->ftype = ftype;
-	mpreg->pgin = pgin;
-	mpreg->pgout = pgout;
-
-	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
-	LIST_INSERT_HEAD(&dbmp->dbregq, mpreg, q);
-	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
-
+    dbenv->pgin[ftype] = pgin;
+    dbenv->pgout[ftype] = pgout;
 	return (0);
 }

--- a/berkdb/mp/mp_register.c
+++ b/berkdb/mp/mp_register.c
@@ -65,13 +65,13 @@ __memp_register(dbenv, ftype, pgin, pgout)
 	int (*pgout) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 {
 
-    if (ftype == DB_FTYPE_SET)
-        ftype = DB_UNKNOWN;
+	if (ftype == DB_FTYPE_SET)
+		ftype = DB_UNKNOWN;
 
-    if (dbenv->pgin[ftype] || dbenv->pgout[ftype])
-        return (0);
+	if (dbenv->pgin[ftype] || dbenv->pgout[ftype])
+		return (0);
 
-    dbenv->pgin[ftype] = pgin;
-    dbenv->pgout[ftype] = pgout;
+	dbenv->pgin[ftype] = pgin;
+	dbenv->pgout[ftype] = pgout;
 	return (0);
 }


### PR DESCRIPTION
Trying to get rid of 2 bottlenecks.
1) We scan a list of mpreg routines while holding the buffer pool lock.  This list is small, but lots of things are contending for the lock.
2) We scan a list of all open files while holding the buffer pool lock to find a file descriptor we can use for writing.   Here we can deviate from upstream - we never have a shared buffer pool, so we can just store a list of __db_mpoolfiles per __mpoolfile.