### PR TITLE
have comdb2_sc_status table to show seed of running SC

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1511,7 +1511,7 @@ int bdb_set_schema_change_status(tran_type *input_trans, const char *db_name,
                                  size_t schema_change_data_len, int status,
                                  const char *errstr, int *bdberr);
 
-int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data ***status_out,
+int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data **status_out,
                                  void ***sc_data_out, int *num, int *bdberr);
 
 int bdb_set_high_genid(tran_type *input_trans, const char *db_name,
@@ -1625,7 +1625,7 @@ int bdb_set_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
                     const char *table, unsigned long long genid,
                     unsigned int host, int *bdberr);
 int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
-                    const char *table, unsigned long long *genid,
+                    const char *tablename, unsigned long long *genid,
                     unsigned int *host, int *bdberr);
 int bdb_delete_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
                        const char *table, int *bdberr);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -3885,13 +3885,13 @@ backout:
 static int kv_get(tran_type *t, void *k, size_t klen, void ***ret, int *num,
                   int *bdberr);
 
-int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data ***status_out,
+int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data **status_out,
                                  void ***sc_data_out, int *num, int *bdberr)
 {
     void **data = NULL;
     int nkey = 0, rc = 1;
     llmetakey_t k = htonl(LLMETA_SCHEMACHANGE_STATUS);
-    llmeta_sc_status_data **status = NULL;
+    llmeta_sc_status_data *status = NULL;
     void **sc_data = NULL;
 
     *num = 0;
@@ -3905,7 +3905,7 @@ int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data ***status_out,
     }
     if (nkey == 0)
         return 0;
-    status = calloc(nkey, sizeof(llmeta_sc_status_data *));
+    status = calloc(nkey, sizeof(llmeta_sc_status_data) * nkey);
     if (status == NULL) {
         logmsg(LOGMSG_ERROR, "%s: failed malloc\n", __func__);
         *bdberr = BDBERR_MALLOC;
@@ -3922,23 +3922,17 @@ int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data ***status_out,
 
     for (int i = 0; i < nkey; i++) {
         const uint8_t *p_buf;
-        status[i] = malloc(sizeof(llmeta_sc_status_data));
-        if (status[i] == NULL) {
-            logmsg(LOGMSG_ERROR, "%s: failed malloc\n", __func__);
-            *bdberr = BDBERR_MALLOC;
-            goto err;
-        }
-        p_buf = llmeta_sc_status_data_get(status[i], data[i],
+        p_buf = llmeta_sc_status_data_get(&status[i], data[i],
                                           (uint8_t *)(data[i]) +
                                               sizeof(llmeta_sc_status_data));
-        sc_data[i] = malloc(status[i]->sc_data_len);
+        sc_data[i] = malloc(status[i].sc_data_len);
         if (sc_data[i] == NULL) {
             logmsg(LOGMSG_ERROR, "%s: failed malloc\n", __func__);
             *bdberr = BDBERR_MALLOC;
             goto err;
         }
 
-        memcpy(sc_data[i], p_buf, status[i]->sc_data_len);
+        memcpy(sc_data[i], p_buf, status[i].sc_data_len);
     }
 
     for (int i = 0; i < nkey; i++) {
@@ -3956,8 +3950,6 @@ err:
     for (int i = 0; i < nkey; i++) {
         if (data[i])
             free(data[i]);
-        if (status[i])
-            free(status[i]);
         if (sc_data[i])
             free(sc_data[i]);
     }
@@ -5003,7 +4995,7 @@ done:
 }
 
 int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
-                    const char *table, unsigned long long *genid,
+                    const char *tablename, unsigned long long *genid,
                     unsigned int *host, int *bdberr)
 {
     int rc;
@@ -5018,14 +5010,14 @@ int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, tablename, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
         logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
                __func__);
         logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
-               table);
+               tablename);
         *bdberr = BDBERR_BADARGS;
         return -1;
     }
@@ -5040,7 +5032,7 @@ int bdb_get_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 int bdb_set_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
-                    const char *table, unsigned long long genid,
+                    const char *tablename, unsigned long long genid,
                     unsigned int host, int *bdberr)
 {
     int rc;
@@ -5067,20 +5059,20 @@ int bdb_set_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, tablename, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
         logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
                __func__);
         logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
-               table);
+               tablename);
         *bdberr = BDBERR_BADARGS;
         rc = -1;
         goto done;
     }
 
-    rc = bdb_get_sc_seed(bdb_state, tran, table, &genid, &host, bdberr);
+    rc = bdb_get_sc_seed(bdb_state, tran, tablename, &genid, &host, bdberr);
     if (rc) { //not found, just add -- should refactor
         if (*bdberr == BDBERR_FETCH_DTA) {
             rc = bdb_lite_add(llmeta_bdb_state, tran, data_buf, data_sz, key,
@@ -5110,7 +5102,7 @@ done:
 }
 
 int bdb_delete_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
-                       const char *table, int *bdberr)
+                       const char *tablename, int *bdberr)
 {
     int rc;
     int started_our_own_transaction = 0;
@@ -5129,14 +5121,14 @@ int bdb_delete_sc_seed(bdb_state_type *bdb_state, tran_type *tran,
 
     schema_change.file_type = LLMETA_SC_SEEDS;
     /*copy the table name and check its length so that we have a clean key*/
-    strncpy0(schema_change.dbname, table, sizeof(schema_change.dbname));
+    strncpy0(schema_change.dbname, tablename, sizeof(schema_change.dbname));
     schema_change.dbname_len = strlen(schema_change.dbname) + 1;
 
     if (!(llmeta_schema_change_type_put(&(schema_change), p_buf, p_buf_end))) {
         logmsg(LOGMSG_ERROR, "%s: llmeta_schema_change_type_put returns NULL\n",
                __func__);
         logmsg(LOGMSG_ERROR, "%s: check the length of table: %s\n", __func__,
-               table);
+               tablename);
         *bdberr = BDBERR_BADARGS;
         rc = -1;
         goto done;
@@ -6418,9 +6410,24 @@ int bdb_llmeta_print_record(bdb_state_type *bdb_state, void *key, int keylen,
     case LLMETA_LOGICAL_LSN_LWM:
         logmsg(LOGMSG_USER, "LLMETA_LOGICAL_LSN_LWM\n");
         break;
-    case LLMETA_SC_SEEDS:
-        logmsg(LOGMSG_USER, "LLMETA_SC_SEEDS\n");
-        break;
+    case LLMETA_SC_SEEDS: {
+        struct llmeta_schema_change_type akey;
+
+        if (keylen < sizeof(akey) || datalen < sizeof(unsigned long long)) {
+            logmsg(LOGMSG_USER, "%s:%d: wrong LLMETA_IN_SCHEMA_CHANGE entry\n",
+                    __FILE__, __LINE__);
+            *bdberr = BDBERR_MISC;
+            return -1;
+        }
+
+        p_buf_key =
+            llmeta_schema_change_type_get(&akey, p_buf_key, p_buf_end_key);
+
+       logmsg(LOGMSG_USER, "LLMETA_SC_SEEDS: table=\"%s\" seed=\"0x%llx\" %s\n",
+              akey.dbname, *(unsigned long long *)p_buf_data,
+               (datalen == 0) ? "done" : "in progress");
+
+    } break;
     case LLMETA_SC_START_LSN: {
         struct llmeta_schema_change_type akey;
         struct llmeta_db_lsn_data_type adata = {{0}};

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -569,7 +569,7 @@ Table of users for the database that do or do not have operator access.
 
 Information about recent schema changes.
 
-    comdb2_sc_status(name, type, newcsc2, start, status, last_updated,
+    comdb2_sc_status(name, type, newcsc2, start, status, seed, last_updated,
                      converted, error)
 
 * `name` - Name of the table.
@@ -577,6 +577,7 @@ Information about recent schema changes.
 * `newcsc2` - New schema in csc2 format.
 * `start` - Start time of the schema change.
 * `status` - Current status of the schema change.
+* `seed` - Seed (ID) of schema change running for this table (NULL if not currently running).
 * `last_updated` - Time of the last status change.
 * `converted` - Number of records converted.
 * `error` - Error message of the schema change.

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -291,7 +291,7 @@ void sc_status(struct dbenv *dbenv)
 
         if (db && db->doing_conversion)
             logmsg(LOGMSG_USER,
-                   "Conversion phase running %" PRId64 "converted\n",
+                   "Conversion phase running %" PRId64 " converted\n",
                    db->sc_nrecs);
         else if (db && db->doing_upgrade)
             logmsg(LOGMSG_USER, "Upgrade phase running %" PRId64 " upgraded\n",

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -472,27 +472,22 @@ struct dbtable *create_db_from_schema(struct dbenv *thedb,
     return newdb;
 }
 
-int fetch_schema_change_seed(struct schema_change_type *s, struct dbenv *thedb,
+int fetch_sc_seed(const char *tablename, struct dbenv *thedb,
                              unsigned long long *stored_sc_genid,
                              unsigned int *stored_sc_host)
 {
     int bdberr;
-    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, s->tablename,
+    int rc = bdb_get_sc_seed(thedb->bdb_env, NULL, tablename,
                              stored_sc_genid, stored_sc_host, &bdberr);
     if (rc == -1 && bdberr == BDBERR_FETCH_DTA) {
         /* No seed exists, proceed. */
     } else if (rc) {
         logmsg(LOGMSG_ERROR,
-               "Can't retrieve schema change seed, aborting rc %d bdberr %d\n",
+               "Can't retrieve schema change seed, rc %d bdberr %d\n",
                rc, bdberr);
         return SC_INTERNAL_ERROR;
     } else {
         /* found some seed */
-        logmsg(LOGMSG_INFO, "stored seed %016llx, stored host %u\n",
-               *stored_sc_genid, *stored_sc_host);
-        logmsg(
-            LOGMSG_WARN,
-            "Resuming previously restarted schema change, disabling plan.\n");
     }
 
     return SC_OK;

--- a/schemachange/sc_schema.h
+++ b/schemachange/sc_schema.h
@@ -26,7 +26,7 @@ int mark_schemachange_over_tran(const char *table, tran_type *);
 int prepare_table_version_one(tran_type *, struct dbtable *db,
                               struct schema **version);
 
-int fetch_schema_change_seed(struct schema_change_type *s, struct dbenv *thedb,
+int fetch_sc_seed(const char *tablename, struct dbenv *thedb,
                              unsigned long long *stored_sc_genid,
                              unsigned int *stored_sc_host);
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -205,7 +205,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     }
 
     strcpy(s->original_master_node, gbl_mynode);
-    unsigned long long seed;
+    unsigned long long seed = 0;
     const char *node = gbl_mynode;
     if (s->tran == trans && iq->sc_seed) {
         seed = iq->sc_seed;
@@ -215,11 +215,19 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     } else if (s->resume) {
         unsigned int host = 0;
         logmsg(LOGMSG_INFO, "Resuming schema change: fetching seed\n");
-        if ((rc = fetch_schema_change_seed(s, thedb, &seed, &host))) {
+        if ((rc = fetch_sc_seed(s->tablename, thedb, &seed, &host))) {
             logmsg(LOGMSG_ERROR, "FAILED to fetch schema change seed\n");
             free_schema_change_type(s);
             return rc;
         }
+        if (seed == 0 && host == 0)
+            return SC_INTERNAL_ERROR; // SC_INVALID_OPTIONS?
+        logmsg(LOGMSG_INFO, "stored seed %016llx, stored host %u\n",
+               seed, host);
+        logmsg(
+            LOGMSG_WARN,
+            "Resuming previously restarted schema change, disabling plan.\n");
+
         node = get_hostname_with_crc32(thedb->bdb_env, host);
         logmsg(
             LOGMSG_INFO,

--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -9,11 +9,13 @@
 #include "ezsystables.h"
 #include "cdb2api.h"
 #include "schemachange.h"
+#include "sc_schema.h"
 
 struct sc_status_ent {
     char *name;
     char *type;
     char *newcsc2;
+    char *seed;
     cdb2_client_datetime_t start;
     char *status;
     cdb2_client_datetime_t lastupdated;
@@ -43,10 +45,9 @@ static char *status_num2str(int s)
 int get_status(void **data, int *npoints)
 {
     int rc, bdberr, nkeys;
-    llmeta_sc_status_data **status = NULL;
+    llmeta_sc_status_data *status = NULL;
     void **sc_data = NULL;
     struct sc_status_ent *sc_status_ents = NULL;
-    struct schema_change_type sc = {0};
 
     rc = bdb_llmeta_get_all_sc_status(&status, &sc_data, &nkeys, &bdberr);
     if (rc || bdberr) {
@@ -58,38 +59,40 @@ int get_status(void **data, int *npoints)
     sc_status_ents = calloc(nkeys, sizeof(struct sc_status_ent));
     if (sc_status_ents == NULL) {
         logmsg(LOGMSG_ERROR, "%s: failed to malloc\n", __func__);
-        return SQLITE_NOMEM;
+        rc = SQLITE_NOMEM;
+        goto cleanup;
     }
 
     for (int i = 0; i < nkeys; i++) {
         dttz_t d;
+        struct schema_change_type sc = {0}; // used for upacking
 
-        init_schemachange_type(&sc);
-        rc = unpack_schema_change_type(&sc, sc_data[i], status[i]->sc_data_len);
+        rc = unpack_schema_change_type(&sc, sc_data[i], status[i].sc_data_len);
         if (rc) {
             free(sc_status_ents);
             logmsg(LOGMSG_ERROR, "%s: failed to unpack schema change\n",
                    __func__);
-            return SQLITE_INTERNAL;
+            rc = SQLITE_INTERNAL;
+            goto cleanup;
         }
         sc_status_ents[i].name = strdup(sc.tablename);
         sc_status_ents[i].type = strdup(get_ddl_type_str(&sc));
         sc_status_ents[i].newcsc2 = strdup(get_ddl_csc2(&sc));
 
-        d = (dttz_t){.dttz_sec = status[i]->start / 1000,
+        d = (dttz_t){.dttz_sec = status[i].start / 1000,
                      .dttz_frac =
-                         status[i]->start - (status[i]->start / 1000 * 1000),
+                         status[i].start - (status[i].start / 1000 * 1000),
                      .dttz_prec = DTTZ_PREC_MSEC};
         dttz_to_client_datetime(
             &d, "UTC", (cdb2_client_datetime_t *)&(sc_status_ents[i].start));
-        d = (dttz_t){.dttz_sec = status[i]->last / 1000,
+        d = (dttz_t){.dttz_sec = status[i].last / 1000,
                      .dttz_frac =
-                         status[i]->last - (status[i]->last / 1000 * 1000),
+                         status[i].last - (status[i].last / 1000 * 1000),
                      .dttz_prec = DTTZ_PREC_MSEC};
         dttz_to_client_datetime(
             &d, "UTC",
             (cdb2_client_datetime_t *)&(sc_status_ents[i].lastupdated));
-        sc_status_ents[i].status = strdup(status_num2str(status[i]->status));
+        sc_status_ents[i].status = strdup(status_num2str(status[i].status));
 
         struct dbtable *db = get_dbtable_by_name(sc.tablename);
         if (db && db->doing_conversion)
@@ -97,20 +100,31 @@ int get_status(void **data, int *npoints)
         else
             sc_status_ents[i].converted = -1;
 
-        sc_status_ents[i].error = strdup(status[i]->errstr);
-
-        sc.onstack = 1;
-        free_schema_change_type(&sc);
-        free(status[i]);
-        free(sc_data[i]);
+        sc_status_ents[i].error = strdup(status[i].errstr);
+        if (status[i].status == BDB_SC_RUNNING || 
+            status[i].status == BDB_SC_PAUSED || 
+            status[i].status == BDB_SC_COMMIT_PENDING) {
+            unsigned long long seed = 0;
+            unsigned int host = 0;
+            if ((rc = fetch_sc_seed(sc.tablename, thedb, &seed, &host)) == SC_OK) {
+                char str[22];
+                sprintf(str, "0x%llx", seed);
+                sc_status_ents[i].seed = strdup(str);
+            }
+        }
     }
-
-    free(status);
-    free(sc_data);
 
     *npoints = nkeys;
     *data = sc_status_ents;
-    return 0;
+
+cleanup:
+    for (int i = 0; i < nkeys; i++) {
+        free(sc_data[i]);
+    }
+    free(status);
+    free(sc_data);
+
+    return rc;
 }
 
 void free_status(void *p, int n)
@@ -145,6 +159,7 @@ int systblScStatusInit(sqlite3 *db)
         CDB2_CSTRING, "newcsc2", -1, offsetof(struct sc_status_ent, newcsc2),
         CDB2_DATETIME, "start", -1, offsetof(struct sc_status_ent, start),
         CDB2_CSTRING, "status", -1, offsetof(struct sc_status_ent, status),
+        CDB2_CSTRING, "seed", -1, offsetof(struct sc_status_ent, seed),
         CDB2_DATETIME, "last_updated", -1, offsetof(struct sc_status_ent,
                                                     lastupdated),
         CDB2_INTEGER, "converted", -1, offsetof(struct sc_status_ent,


### PR DESCRIPTION
Have comdb2_sc_status table to show seed of running SC and few smaller changes:
* status_out does not need to be an array of pointers, we can simply have it be an array 
  (however sc_data is still an array of pointers)
* sc var does not need to be inited because we only use it to read in a few of the members from buf
* for `@send llmeta list` print all content of type LLMETA_SC_SEED
* refactor fetch_sc_seed() to make it reusable
* select * from comdb2_sc_status will call fetch_sc_seed() if status is running, ex:
`select name,seed from comdb2_sc_status
(name='t2', seed='0xf53400000000')
`

Unfortunately LLMETA_SC_SEED content gets removed once SC is done, so comdb2_sc_status  will not have a seed for non-running SC.