### PR TITLE
Always grab a table lock in scdone.

### DIFF
--- a/bdb/fetch.c
+++ b/bdb/fetch.c
@@ -2206,7 +2206,7 @@ static int bdb_fetch_prefault_int(
         return -1;
     }
 
-    rc = bdb_lock_table_read_fromlid(bdb_state, lockerid);
+    rc = bdb_lock_table_read_fromlid(bdb_state, bdb_state->name, lockerid);
     if (rc != 0) {
         *bdberr = BDBERR_MISC;
         return -1;

--- a/bdb/locks.c
+++ b/bdb/locks.c
@@ -679,15 +679,15 @@ int bdb_lock_stripe_write(bdb_state_type *bdb_state, int stripe,
     return bdb_lock_stripe_int(bdb_state, tran, stripe, BDB_LOCK_WRITE);
 }
 
-int bdb_lock_table_read_fromlid(bdb_state_type *bdb_state, int lid)
+int bdb_lock_table_read_fromlid(bdb_state_type *bdb_state, const char *name, int lid)
 {
-    return bdb_lock_table_int(bdb_state->dbenv, bdb_state->name, lid,
+    return bdb_lock_table_int(bdb_state->dbenv, name, lid,
                               BDB_LOCK_READ);
 }
 
-int bdb_lock_table_write_fromlid(bdb_state_type *bdb_state, int lid)
+int bdb_lock_table_write_fromlid(bdb_state_type *bdb_state, const char *name, int lid)
 {
-    return bdb_lock_table_int(bdb_state->dbenv, bdb_state->name, lid,
+    return bdb_lock_table_int(bdb_state->dbenv, name, lid,
                               BDB_LOCK_WRITE);
 }
 

--- a/bdb/locks.h
+++ b/bdb/locks.h
@@ -85,8 +85,8 @@ void bdb_checklock(bdb_state_type *bdb_state);
 
 int bdb_lock_table_read(bdb_state_type *, tran_type *);
 
-int bdb_lock_table_read_fromlid(bdb_state_type *, int lid);
-int bdb_lock_table_write_fromlid(bdb_state_type *, int lid);
+int bdb_lock_table_read_fromlid(bdb_state_type *, const char *name,int lid);
+int bdb_lock_table_write_fromlid(bdb_state_type *, const char *name, int lid);
 int berkdb_lock_random_rowlock(bdb_state_type *bdb_state, int lid, int flags,
                                void *lkname, int mode, void *lk);
 int berkdb_lock_rowlock(bdb_state_type *bdb_state, int lid, int flags,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7460,7 +7460,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         }
 
         bdb_lock_table_read_fromlid(
-            db->handle, bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran));
+            db->handle, db->tablename, bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran));
 
         if (clnt->dbtran.shadow_tran &&
             (clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -742,6 +742,10 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
     bdb_get_tran_lockerid(tran, &lid);
     bdb_set_tran_lockerid(tran, gbl_rep_lockid);
 
+    rc = bdb_lock_table_write_fromlid(bdb_state, table, gbl_rep_lockid);
+    if (rc)
+        goto done;
+
     if (olddb) {
         /* protect us from getting rep_handle_dead'ed to death */
         rc = bdb_get_csc2_highest(tran, table, &highest_ver, &bdberr);


### PR DESCRIPTION
Fixes a race between dropping/reading a table in legacy_options mode.