### PR TITLE
Traps for the fingerprint subsystem... (backport of #1869)

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -47,6 +47,7 @@ extern int gbl_upgrade_blocksql_2_socksql;
 extern int gbl_rep_node_pri;
 extern int gbl_bad_lrl_fatal;
 extern int gbl_disable_new_snapshot;
+extern int gbl_fingerprint_max_queries;
 
 extern char *gbl_recovery_options;
 extern const char *gbl_repoplrl_fname;
@@ -1345,6 +1346,13 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
                gbl_deferred_phys_update);
         free(wait);
 
+    } else if (tokcmp(tok, ltok, "max_query_fingerprints") == 0) {
+        tok = segtok(line, len, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "Expected max query fingerprints\n");
+            return -1;
+        }
+        gbl_fingerprint_max_queries = toknum(tok, ltok);
     } else {
         // see if any plugins know how to handle this
         struct lrl_handler *h;

--- a/db/db_fingerprint.c
+++ b/db/db_fingerprint.c
@@ -30,7 +30,28 @@ pthread_mutex_t gbl_fingerprint_hash_mu = PTHREAD_MUTEX_INITIALIZER;
 
 extern int gbl_fingerprint_queries;
 extern int gbl_verbose_normalized_queries;
-int gbl_fingerprint_max_queries = 1000; /* TODO: Tunable? */
+int gbl_fingerprint_max_queries = 1000;
+
+static int free_fingerprint(void *obj, void *arg){
+    struct fingerprint_track *t = (struct fingerprint_track *)obj;
+    if (t != NULL) {
+        free(t->zNormSql);
+        free(t);
+    }
+    return 0;
+}
+
+int clear_fingerprints(void) {
+    int count = 0;
+    Pthread_mutex_lock(&gbl_fingerprint_hash_mu);
+    hash_info(gbl_fingerprint_hash, NULL, NULL, NULL, NULL, &count, NULL, NULL);
+    hash_for(gbl_fingerprint_hash, free_fingerprint, NULL);
+    hash_clear(gbl_fingerprint_hash);
+    hash_free(gbl_fingerprint_hash);
+    gbl_fingerprint_hash = NULL;
+    Pthread_mutex_unlock(&gbl_fingerprint_hash_mu);
+    return count;
+}
 
 void add_fingerprint(const char *zSql, const char *zNormSql, int64_t cost,
                      int64_t time, int64_t nrows, struct reqlogger *logger,

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -105,6 +105,7 @@ extern int gbl_reallyearly;
 extern int gbl_udp;
 extern int gbl_prefault_udp;
 extern int gbl_prefault_latency;
+extern int gbl_fingerprint_max_queries;
 extern struct thdpool *gbl_verify_thdpool;
 
 void debug_bulktraverse_data(char *tbl);
@@ -4791,6 +4792,18 @@ clipper_usage:
 
         testrep_usage:
             logmsg(LOGMSG_ERROR, "Usage: testrep num_items item_size\n");
+        }
+    } else if (tokcmp(tok, ltok, "clear_fingerprints") == 0) {
+        int fpcount = clear_fingerprints();
+        logmsg(LOGMSG_USER, "Cleared %d fingerprints\n", fpcount);
+    } else if (tokcmp(tok, ltok, "max_query_fingerprints") == 0) {
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR,
+                   "Expected max query fingerprints, current %d\n",
+                   gbl_fingerprint_max_queries);
+        } else {
+            gbl_fingerprint_max_queries = toknum(tok, ltok);
         }
     } else {
         // see if any plugins know how to handle this

--- a/db/sql.h
+++ b/db/sql.h
@@ -1189,6 +1189,9 @@ struct query_stats {
     int64_t npwrites;
 };
 int get_query_stats(struct query_stats *stats);
+
+int clear_fingerprints(void);
+
 void add_fingerprint(const char *, const char *, int64_t, int64_t, int64_t,
                      struct reqlogger *logger, unsigned char *fingerprint_out);
 


### PR DESCRIPTION
Add 'max_query_fingerprints' trap and LRL option for backward compat.  Also add 'clear_fingerprints' trap.  Backport of PR #1869 from master.