### PR TITLE
Bthash fix

### DIFF
--- a/berkdb/btree/bt_rec.c
+++ b/berkdb/btree/bt_rec.c
@@ -371,10 +371,18 @@ lrundo:		if ((rootsplit && lp != NULL) || rp != NULL) {
 done:	*lsnp = argp->prev_lsn;
 	ret = 0;
 
+	if (dbp && dbp->is_free) {
+		logmsg(LOGMSG_FATAL, "%s line %d file_dbp=%p freed-dbp=%p AM_RECOVER=%d"
+				" AM_HASH=%d HASH=%p rootsplit=%d\n", __func__, __LINE__,
+				file_dbp, dbp, dbp ? F_ISSET(dbp, DB_AM_RECOVER) : 0, dbp ?
+				F_ISSET(dbp, DB_AM_HASH) : 0, dbp ? dbp->pg_hash : NULL,
+				rootsplit);
+		abort();
+	}
 	if (file_dbp && dbp &&
-	    !F_ISSET(dbp, DB_AM_RECOVER) &&
-	    F_ISSET(dbp, DB_AM_HASH) &&
-	    (hash = dbp->pg_hash) != NULL &&!rootsplit) {
+		!F_ISSET(dbp, DB_AM_RECOVER) &&
+		F_ISSET(dbp, DB_AM_HASH) &&
+		(hash = dbp->pg_hash) != NULL &&!rootsplit) {
 		argp_lp = argp->pg.data;
 		// Update the page numbers in the genid-pg hash
 		for (off = argp->indx; off < NUM_ENT(argp_lp); off += P_INDX) {
@@ -384,21 +392,21 @@ done:	*lsnp = argp->prev_lsn;
 				memset(&split_key, 0, sizeof(split_key));
 				split_key.data = tmp_bk->data;
 				ASSIGN_ALIGN_DIFF(u_int32_t, split_key.size,
-				    db_indx_t, tmp_bk->len);
+					db_indx_t, tmp_bk->len);
 				hashtbl = hash->tbl;
 				hh = hash_fixedwidth((unsigned char
 					*)(split_key.data)) % (hash->ntbl);
 				if (split_key.size == GENID_SIZE &&
-				    genidcmp(hashtbl[hh].genid,
+					genidcmp(hashtbl[hh].genid,
 					split_key.data) == 0) {
 					// This key (genid) exists in hash
-                    Pthread_mutex_lock(&(hash->mutex));
+					Pthread_mutex_lock(&(hash->mutex));
 					// update new page
 					genidsetzero(hashtbl[hh].genid);
 					hashtbl[hh].pgno = argp->right;
 					genidcpy(hashtbl[hh].genid,
-					    split_key.data);
-                    Pthread_mutex_unlock(&(hash->mutex));
+						split_key.data);
+					Pthread_mutex_unlock(&(hash->mutex));
 				}
 			}
 		}

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1664,6 +1664,15 @@ struct __db {
 	 */
 	DB *peer;
 
+	/* DB **revpeer points back to the recovery dbp.  It allows us
+	 * to set it's peer pointer to NULL if the table is closed.
+	 */
+
+	DB **revpeer;
+	int revpeer_count;
+
+	int is_free;
+
 	genid_hash *pg_hash;
 
 	dbp_bthash_stat pg_hash_stat;

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -537,6 +537,9 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 						sizeof(DB *));
 				dbp->revpeer[dbp->revpeer_count-1] = lldbp;
 			} else {
+#if defined BTHASH_REPRODUCE_BUG
+				dbp->peer = lldbp->peer;
+#else
 				if (lldbp->peer && F_ISSET(lldbp->peer, DB_AM_HASH)) {
 					dbp->peer = lldbp->peer;
 					lldbp->peer->revpeer_count++;
@@ -544,6 +547,7 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 							lldbp->peer->revpeer_count * sizeof(DB *));
 					lldbp->peer->revpeer[lldbp->peer->revpeer_count-1] = dbp;
 				}
+#endif
 				break;
 			}
 		}

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -786,6 +786,7 @@ __db_close(dbp, txn, flags)
 	MUTEX_THREAD_LOCK(dbenv, dbenv->dblist_mutexp);
 	db_ref = --dbenv->db_ref;
 
+    /* Nullify references to this dbp */
 	if (dbp->peer) {
 		for (int i = 0; i < dbp->peer->revpeer_count; i++) {
 			if (dbp->peer->revpeer[i] == dbp)

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -453,6 +453,12 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 
 	dbenv = dbp->dbenv;
 
+	/* Set up peer pointers */
+	dbp->peer = NULL;
+	dbp->revpeer = NULL;
+	dbp->revpeer_count = 0;
+	dbp->is_free = 0;
+
 	/* If we don't yet have an environment, it's time to create it. */
 	if (!F_ISSET(dbenv, DB_ENV_OPEN_CALLED)) {
 		/* Make sure we have at least DB_MINCACHE pages in our cache. */
@@ -517,18 +523,27 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 	 */
 	MUTEX_THREAD_LOCK(dbenv, dbenv->dblist_mutexp);
 
-	/* set up peer pointer */
-	dbp->peer = NULL;
-
-	if (F_ISSET(dbp, DB_AM_HASH))
+	if (F_ISSET(dbp, DB_AM_HASH)) {
 		dbp->peer = dbp;
+	}
+
 	for (lldbp = LIST_FIRST(&dbenv->dblist);
 		lldbp != NULL; lldbp = LIST_NEXT(lldbp, dblistlinks)) {
 		if (memcmp(lldbp->fileid, dbp->fileid, DB_FILE_ID_LEN) == 0) {
 			if (F_ISSET(dbp, DB_AM_HASH)) {
 				lldbp->peer = dbp;
+				dbp->revpeer_count++;
+				dbp->revpeer = realloc(dbp->revpeer, dbp->revpeer_count *
+						sizeof(DB *));
+				dbp->revpeer[dbp->revpeer_count-1] = lldbp;
 			} else {
-				dbp->peer = lldbp->peer;
+				if (lldbp->peer && F_ISSET(lldbp->peer, DB_AM_HASH)) {
+					dbp->peer = lldbp->peer;
+					lldbp->peer->revpeer_count++;
+					lldbp->peer->revpeer = realloc(lldbp->peer->revpeer,
+							lldbp->peer->revpeer_count * sizeof(DB *));
+					lldbp->peer->revpeer[lldbp->peer->revpeer_count-1] = dbp;
+				}
 				break;
 			}
 		}
@@ -581,16 +596,16 @@ __db_dbenv_setup(dbp, txn, fname, id, flags)
 		aft = get_dblist_count(dbenv, dbp, "after-insert", __func__, __LINE__);
 		if (gbl_instrument_dblist && aft != (bef+1))
 			abort();
-        if (gbl_instrument_dblist)
-            logmsg(LOGMSG_DEBUG, "%s found match for dbp at adj_fileid %u\n",
-                    __func__, ldbp->adj_fileid);
+		if (gbl_instrument_dblist)
+			logmsg(LOGMSG_DEBUG, "%s found match for dbp at adj_fileid %u\n",
+					__func__, ldbp->adj_fileid);
 	}
 	dbp->inadjlist = 1;
 	listc_abl(&dbenv->dbs[dbp->adj_fileid], dbp);
-    if (gbl_instrument_dblist)
-        logmsg(LOGMSG_DEBUG, "%s putting dbp %p adj_fileid %u into %p list "
-                "%p\n", __func__, dbp, dbp->adj_fileid, dbenv, &dbenv->dbs[
-                dbp->adj_fileid]);
+	if (gbl_instrument_dblist)
+		logmsg(LOGMSG_DEBUG, "%s putting dbp %p adj_fileid %u into %p list "
+				"%p\n", __func__, dbp, dbp->adj_fileid, dbenv, &dbenv->dbs[
+				dbp->adj_fileid]);
 
 	MUTEX_THREAD_UNLOCK(dbenv, dbenv->dblist_mutexp);
 
@@ -770,17 +785,46 @@ __db_close(dbp, txn, flags)
 	 */
 	MUTEX_THREAD_LOCK(dbenv, dbenv->dblist_mutexp);
 	db_ref = --dbenv->db_ref;
+
+#if !defined BTHASH_REPRODUCE_BUG
+	if (dbp->peer) {
+		for (int i = 0; i < dbp->peer->revpeer_count; i++) {
+			if (dbp->peer->revpeer[i] == dbp)
+				dbp->peer->revpeer[i] = NULL;
+		}
+	}
+
+	for (int i = 0; i < dbp->revpeer_count; i++) {
+		DB *lldbp = dbp->revpeer[i];
+		if (lldbp != NULL)
+			lldbp->peer = NULL;
+	}
+#endif
 	MUTEX_THREAD_UNLOCK(dbenv, dbenv->dblist_mutexp);
 	if (F_ISSET(dbenv, DB_ENV_DBLOCAL) && db_ref == 0 &&
-	    (t_ret = __dbenv_close(dbenv, 0)) != 0 && ret == 0)
+		(t_ret = __dbenv_close(dbenv, 0)) != 0 && ret == 0)
 		ret = t_ret;
 
 	/* Free bthash. */
-	if (F_ISSET(dbp, DB_AM_HASH) && dbp->pg_hash)
+	if (F_ISSET(dbp, DB_AM_HASH) && dbp->pg_hash) {
 		genid_hash_free(dbenv, dbp->pg_hash);
+#if !defined BTHASH_REPRODUCE_BUG
+		if (dbp->revpeer) {
+			free(dbp->revpeer);
+			dbp->revpeer = NULL;
+		}
+		dbp->pg_hash = NULL;
+#endif
+	}
 
 	/* Free the database handle. */
 	memset(dbp, CLEAR_BYTE, sizeof(*dbp));
+	dbp->is_free = 1;
+
+#if defined BTHASH_REPRODUCE_BUG
+	F_SET(dbp, DB_AM_HASH);
+	F_CLR(dbp, DB_AM_RECOVER);
+#endif
 	__os_free(dbenv, dbp);
 
 	return (ret);

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2126,6 +2126,9 @@ int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp);
 /* Configure txn_checkpoint() to sleep this much time before memp_sync() */
 int gbl_ckp_sleep_before_sync = 0;
 
+/* Don't actually write a checkpoint */
+int gbl_disable_ckp = 0;
+
 /*
  * __txn_checkpoint --
  *	DB_ENV->txn_checkpoint.
@@ -2168,6 +2171,9 @@ __txn_checkpoint(dbenv, kbytes, minutes, flags)
 
 	mgr = dbenv->tx_handle;
 	region = mgr->reginfo.primary;
+
+	if (gbl_disable_ckp)
+		return 0;
 
 	/*
 	 * The checkpoint LSN is an LSN such that all transactions begun before

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -238,6 +238,7 @@ extern int gbl_load_cache_max_pages;
 extern int gbl_dump_cache_max_pages;
 extern int gbl_max_pages_per_cache_thread;
 extern int gbl_memp_dump_cache_threshold;
+extern int gbl_disable_ckp;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1860,4 +1860,9 @@ REGISTER_TUNABLE("waitalive_iterations",
                  TUNABLE_INTEGER, &gbl_waitalive_iterations,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("disable_ckp",
+                 "Disable checkpoints to debug.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_disable_ckp,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1860,9 +1860,8 @@ REGISTER_TUNABLE("waitalive_iterations",
                  TUNABLE_INTEGER, &gbl_waitalive_iterations,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("disable_ckp",
-                 "Disable checkpoints to debug.  (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_disable_ckp,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1785,6 +1785,7 @@ void *osql_commit_timepart_resuming_sc(void *p)
                __LINE__);
         abort();
     }
+    iq.sc_logical_tran = NULL;
 
     osql_postcommit_handle(&iq);
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1804,8 +1804,10 @@ abort_sc:
     }
     if (parent_trans)
         trans_abort(&iq, parent_trans);
-    if (iq.sc_logical_tran)
+    if (iq.sc_logical_tran) {
         trans_abort_logical(&iq, iq.sc_logical_tran, NULL, 0, NULL, 0);
+        iq.sc_logical_tran = NULL;
+    }
     osql_postabort_handle(&iq);
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE_RDWR);
     return NULL;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2051,6 +2051,10 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
                 *trans = bdb_get_physical_tran(iq->sc_logical_tran);
                 irc = create_child_transaction(iq, *trans, &(iq->sc_tran));
             }
+        } else {
+            logmsg(LOGMSG_ERROR, "%s:%d trans_start failed rc %d\n", __func__,
+                    __LINE__, irc);
+            return irc;
         }
     } else if (!gbl_rowlocks) {
         /* start parent transaction */

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2051,10 +2051,6 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
                 *trans = bdb_get_physical_tran(iq->sc_logical_tran);
                 irc = create_child_transaction(iq, *trans, &(iq->sc_tran));
             }
-        } else {
-            logmsg(LOGMSG_ERROR, "%s:%d trans_start failed rc %d\n", __func__,
-                   __LINE__, irc);
-            return irc;
         }
     } else if (!gbl_rowlocks) {
         /* start parent transaction */

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5564,7 +5564,8 @@ add_blkseq:
                 if (iq->tranddl) {
                     if (backed_out) {
                         assert(trans == NULL);
-                        bdb_ltran_put_schema_lock(iq->sc_logical_tran);
+                        if (iq->sc_logical_tran)
+                            bdb_ltran_put_schema_lock(iq->sc_logical_tran);
                     } else {
                         assert(iq->sc_tran);
                         assert(trans != NULL);
@@ -5583,9 +5584,10 @@ add_blkseq:
                         unlock_schema_lk();
                         iq->sc_locked = 0;
                     }
-                    irc = trans_commit_logical(iq, iq->sc_logical_tran,
-                                               gbl_mynode, 0, 1, NULL, 0, NULL,
-                                               0);
+                    if (iq->sc_logical_tran)
+                        irc = trans_commit_logical(iq, iq->sc_logical_tran,
+                                gbl_mynode, 0, 1, NULL, 0, NULL,
+                                0);
                     iq->sc_logical_tran = NULL;
                 } else {
                     irc = trans_commit_adaptive(iq, parent_trans, source_host);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2053,7 +2053,7 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
             }
         } else {
             logmsg(LOGMSG_ERROR, "%s:%d trans_start failed rc %d\n", __func__,
-                    __LINE__, irc);
+                   __LINE__, irc);
             return irc;
         }
     } else if (!gbl_rowlocks) {
@@ -5586,8 +5586,8 @@ add_blkseq:
                     }
                     if (iq->sc_logical_tran)
                         irc = trans_commit_logical(iq, iq->sc_logical_tran,
-                                gbl_mynode, 0, 1, NULL, 0, NULL,
-                                0);
+                                                   gbl_mynode, 0, 1, NULL, 0,
+                                                   NULL, 0);
                     iq->sc_logical_tran = NULL;
                 } else {
                     irc = trans_commit_adaptive(iq, parent_trans, source_host);

--- a/tests/sc_truncate.test/Makefile
+++ b/tests/sc_truncate.test/Makefile
@@ -3,7 +3,7 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
-export CHECK_DB_AT_FINISH=0
+
 ifeq ($(TEST_TIMEOUT),)
 	export TEST_TIMEOUT=10m
 endif

--- a/tests/sc_truncate.test/Makefile
+++ b/tests/sc_truncate.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_truncate.test/lrl.options
+++ b/tests/sc_truncate.test/lrl.options
@@ -1,0 +1,15 @@
+nowatch
+logmsg level info
+enable_new_snapshot
+enable_snapshot_isolation
+berkattr abort_on_replicant_log_write 1
+init_with_genid48
+logdelete_lock_trace
+verbose_set_sc_in_progress on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+on logical_live_sc
+#Do this in the test
+#sc_logical_pause_seconds 20
+dtastripe   1

--- a/tests/sc_truncate.test/lrl.options
+++ b/tests/sc_truncate.test/lrl.options
@@ -4,7 +4,7 @@ enable_new_snapshot
 enable_snapshot_isolation
 berkattr abort_on_replicant_log_write 1
 init_with_genid48
-logdelete_lock_trace
+#logdelete_lock_trace
 verbose_set_sc_in_progress on
 setattr REP_PROCESSORS 0
 setattr REP_WORKERS 0

--- a/tests/sc_truncate.test/runit
+++ b/tests/sc_truncate.test/runit
@@ -96,7 +96,6 @@ function run_test
     typeset inserters=${4}
     typeset insertrecs=${5}
     typeset nocheckpoint=${6}
-    typeset bthashtest=${7}
 
     # Locals
     typeset maxtime=300
@@ -148,18 +147,16 @@ if [[ $DBNAME == *"lockordergenerated"* ]]; then
     export inserters=10
     export insertrecs=10
     export nocheckpoint=0
-    export bthashtest=0
 else
-    export inserters=1
     export tablecount=100
     export truncaters=1
     export truncate_sleep=30
     export downgrade_sleep=30
+    export inserters=1
     export insertrecs=10000
     export nocheckpoint=1
-    export bthashtest=1
 fi
 
-run_test $truncaters $truncate_sleep $downgrade_sleep $inserters $insertrecs $nocheckpoint $bthashtest
+run_test $truncaters $truncate_sleep $downgrade_sleep $inserters $insertrecs $nocheckpoint
 
 echo "Success"

--- a/tests/sc_truncate.test/runit
+++ b/tests/sc_truncate.test/runit
@@ -135,6 +135,7 @@ function run_test
         fi
     done
     touch $stopfile
+    wait
 }
 
 # Globals

--- a/tests/sc_truncate.test/runit
+++ b/tests/sc_truncate.test/runit
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+function cleanup
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="cleanup"
+    write_prompt $func "Running $func"
+    touch $stopfile
+    wait
+}
+
+function randomtable
+{
+    [[ $debug == "1" ]] && set -x
+    typeset table=$(( RANDOM % tablecount ))
+    echo "t$table"
+}
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="failexit"
+    write_prompt $func "Running $func"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    cleanup
+    exit -1
+}
+
+function create_database_tables
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="create_tables"
+    write_prompt $func "Running $func"
+
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        drop_table t$i
+        let i=i+1
+    done
+
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        create_table t$i
+        let i=i+1
+    done
+}
+
+function truncate_thread
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="truncate_thread"
+    typeset tdno=$1
+    typeset sleep_sec=${2:-0.10}
+    write_prompt $func "Running $func $tdno"
+    while [[ ! -f $stopfile ]]; do
+        table=$(randomtable)
+        truncate_table $table
+        [[ $sleep_sec ]] && sleep $sleep_sec
+    done
+}
+
+function insert_thread
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="insert_thread"
+    typeset tdno=$1
+    typeset sleep_sec=${2:-0}
+    typeset maxrec=${3:-10000}
+    write_prompt $func "Running $func $tdno"
+    while [[ ! -f $stopfile ]]; do
+        table=$(randomtable)
+        $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "INSERT INTO $table SELECT * FROM generate_series(1, $maxrec)" >/dev/null 2>&1
+        [[ $sleep_sec ]] && sleep $sleep_sec
+    done
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    write_prompt $func "Running $func"
+
+    # Arguments
+    typeset truncaters=${1}
+    typeset truncate_sleep=${2}
+    typeset downgrade_sleep=${3}
+    typeset inserters=${4}
+    typeset insertrecs=${5}
+    typeset nocheckpoint=${6}
+    typeset bthashtest=${7}
+
+    # Locals
+    typeset maxtime=300
+    typeset downgrade=1
+    typeset i=0
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+
+    create_database_tables
+    rm -f $stopfile
+
+    # Tell nodes to not change the checkpoint-lsn
+    if [[ $nocheckpoint != 0 ]]; then
+        for node in $CLUSTER ; do
+            $CDB2SQL_EXE --admin -tabs $CDB2_OPTIONS --host $node $DBNAME "PUT TUNABLE 'disable_ckp' 1"
+        done
+    fi
+
+    i=0
+    while [[ $i -lt $truncaters ]]; do
+        truncate_thread $i $truncate_sleep &
+        let i=i+1
+    done
+
+    i=0
+    while [[ $i -lt $inserters ]]; do
+        insert_thread $i 0 $insertrecs &
+        let i=i+1
+    done
+
+    while [[ "$(date +%s)" -lt $endtime ]]; do
+        sleep $downgrade_sleep
+        if [[ $downgrade != 0 ]]; then
+            for node in $CLUSTER ; do
+                $CDB2SQL_EXE -tabs $CDB2_OPTIONS --host $node $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+            done
+        fi
+    done
+    touch $stopfile
+}
+
+# Globals
+export stopfile=./stop.test
+if [[ $DBNAME == *"lockordergenerated"* ]]; then
+    export tablecount=3
+    export truncaters=5
+    export truncate_sleep=0
+    export downgrade_sleep=20
+    export inserters=10
+    export insertrecs=10
+    export nocheckpoint=0
+    export bthashtest=0
+else
+    export inserters=1
+    export tablecount=100
+    export truncaters=1
+    export truncate_sleep=30
+    export downgrade_sleep=30
+    export insertrecs=10000
+    export nocheckpoint=1
+    export bthashtest=1
+fi
+
+run_test $truncaters $truncate_sleep $downgrade_sleep $inserters $insertrecs $nocheckpoint $bthashtest
+
+echo "Success"

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/waitmach.sh
+
+if [[ -z "$sleeptime" ]]; then 
+    sleeptime=5
+fi
+
+function get_master
+{
+    [[ "$debug" == 1 ]] && set -x
+    typeset func="get_master"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]')
+    echo "$x"
+}
+
+function bounce_cluster
+{
+    [[ "$debug" == 1 ]] && set -x
+    typeset func="bounce_cluster"
+    typeset sleeptime=${1:-5}
+    write_prompt $func "Running $func"
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $n "exec procedure sys.cmd.send(\"exit\")"
+    done
+    sleep $sleeptime
+
+    for node in $CLUSTER ; do
+        PARAMS="$DBNAME --no-global-lrl"
+        CMD="sleep $sleeptime ; source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        if [ $node == $(hostname) ] ; then
+            (
+                kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+                sleep $sleeptime
+                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
+            ) &
+        else
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+            ssh -o StrictHostKeyChecking=no -tt $node ${DEBUG_PREFIX} ${CMD} 2>&1 </dev/null > >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >> $TESTDIR/logs/${DBNAME}.${node}.db) &
+            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+        fi
+    done
+}
+
+function bounce_local
+{
+    [[ "$debug" == 1 ]] && set -x
+    typeset func="bounce_local"
+    typeset sleeptime=${1:-5}
+    write_prompt $func "Running $func"
+    $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "exec procedure sys.cmd.send(\"exit\")"
+    sleep $sleeptime
+    (
+        PARAMS="$DBNAME --no-global-lrl"
+        kill -9 $(cat ${TMPDIR}/${DBNAME}.pid)
+        sleep $sleeptime
+        ${DEBUG_PREFIX} ${COMDB2_EXE} $PARAMS --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >>$TESTDIR/logs/${DBNAME}.db &
+    ) &
+}
+
+function bounce_database
+{
+    [[ "$debug" == 1 ]] && set -x
+    typeset func="bounce_database"
+    typeset sleeptime=${1:-5}
+    write_prompt $func "Running $func"
+
+    if [[ -n "$CLUSTER" ]]; then
+        bounce_cluster $sleeptime
+    else
+        bounce_local $sleeptime
+    fi
+
+    wait_up
+}

--- a/tests/tools/ddl.sh
+++ b/tests/tools/ddl.sh
@@ -11,6 +11,15 @@ function drop_table
     $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "drop table $table"
 }
 
+function truncate_table
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="truncate_table"
+    write_prompt $func "Running $func"
+    typeset table=${1:-t1}
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "truncate table $table"
+}
+
 function create_table
 {
     [[ $debug == "1" ]] && set -x


### PR DESCRIPTION
Fix bug in bam_split_recover handle where the dbp peer handle references free memory.  This bug is reproducible by checking out 2638790f47fa06a6e1f50d706fd266bc22680967, compiling with -DBTHASH_REPRODUCE_BUG, and running the sc_truncate test in clustered mode.  The fix is to fill "backpointer" references to peers, and to zero these when the reference is no longer valid (because it is closed).


