### PR TITLE
Ported 7.0: Check that cur->db is not NULL before accessing its members.

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9402,21 +9402,24 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
                     return -700;
                 }
             }
-            if (!cur->bt->is_remote &&
-                cur->tableversion != cur->db->tableversion) {
-                Pthread_mutex_unlock(&thd->lk);
-                logmsg(LOGMSG_ERROR,
-                       "%s: table version for %s changed from %d to %lld\n",
-                       __func__, cur->db->tablename, cur->tableversion,
-                       cur->db->tableversion);
-                sqlite3_mutex_enter(sqlite3_db_mutex(cur->vdbe->db));
-                sqlite3VdbeError(cur->vdbe, "table \"%s\" was schema changed",
-                                 cur->db->tablename);
-                sqlite3VdbeTransferError(cur->vdbe);
-                sqlite3MakeSureDbHasErr(cur->vdbe->db, SQLITE_OK);
-                sqlite3_mutex_leave(sqlite3_db_mutex(cur->vdbe->db));
-                return SQLITE_COMDB2SCHEMA;
-            } else if (!cur->bt->is_remote && cur->db) {
+
+            if (!cur->bt->is_remote && cur->db) {
+                if (cur->tableversion != cur->db->tableversion) {
+                    Pthread_mutex_unlock(&thd->lk);
+                    logmsg(LOGMSG_ERROR,
+                           "%s: table version for %s changed from %d to %lld\n",
+                           __func__, cur->db->tablename, cur->tableversion,
+                           cur->db->tableversion);
+                    sqlite3_mutex_enter(sqlite3_db_mutex(cur->vdbe->db));
+                    sqlite3VdbeError(cur->vdbe,
+                                     "table \"%s\" was schema changed",
+                                     cur->db->tablename);
+                    sqlite3VdbeTransferError(cur->vdbe);
+                    sqlite3MakeSureDbHasErr(cur->vdbe->db, SQLITE_OK);
+                    sqlite3_mutex_leave(sqlite3_db_mutex(cur->vdbe->db));
+                    return SQLITE_COMDB2SCHEMA;
+                }
+
                 if (cur->ixnum == -1)
                     cur->sc = cur->db->schema;
                 else


### PR DESCRIPTION
Check that cur->db is not NULL before accessing its members.
Ported from #1878 