### PR TITLE
Tests: Speedup get_tests_inorder.sh used also for tab completion

### DIFF
--- a/tests/tools/get_tests_inorder.sh
+++ b/tests/tools/get_tests_inorder.sh
@@ -11,11 +11,10 @@ default_times=`grep -c "TEST_TIMEOUT=" *.test/Makefile  | grep ":0" | sed "s#/Ma
 IFS=$'\n'; 
 
 #get the generated tests
-generated=$(for j in `ls */*.testopts` ; do 
-    gen=`echo $j | sed 's#\.testopts#_generated#g; s#/#_#g; s#\.test##g; s#$#.test#'`
-    name=`dirname $j`
-    time=`echo -e "${custom_times[*]} \n${default_times[*]}" | grep $name | awk '{print $2}'`
-    echo $gen $time
-done )
+generated=$(for j in */*.testopts ; do 
+    basedir=${j%%/*}
+    time=`echo -e "${custom_times} \n${default_times}" | grep $basedir | awk '{print $2}'`
+    echo $j $time
+done | sed 's#.test/#_#g; s#\.testopts#_generated.test#g;' )
 
-echo -e "${custom_times[*]} \n${default_times[*]} \n${generated[*]}" | awk '{print $2,$1}'| sort -nr | awk '{print $2}'
+echo -e "${custom_times} \n${default_times} \n${generated}" | sort -k2 -t' ' -nr | cut -f1 -d' '


### PR DESCRIPTION
Tests: Speedup get_tests_inorder.sh used also for tab completion when running tests manually