### PR TITLE
Fix DOHAST double-free

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -99,8 +99,8 @@ static char *describeExprList(Vdbe *v, const ExprList *lst, int *order_size,
         newterm = sqlite3ExprDescribeParams(v, lst->a[i].pExpr, pParamsOut);
         if (!newterm) {
             sqlite3_free(ret);
-            if (*order_dir)
-                free(*order_dir);
+            free(*order_dir);
+            *order_dir = NULL;
             return NULL;
         }
         tmp = sqlite3_mprintf(

--- a/tests/dohsql_leaks.test/runit
+++ b/tests/dohsql_leaks.test/runit
@@ -78,3 +78,9 @@ if [ $ratio -gt 1 ]; then
   echo "ratio is $ratio" >&2
   exit 1
 fi
+
+# We double free dohsql_node_t.order_dir if any column after the first one
+# in the order-by cluase refers to a subquery (Thanks Mike!).
+# For instance, in the query below, the 2nd column in the order-by clause
+# is 'SELECT 1', and it would crash the database.
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT i, (SELECT 1) FROM t0 ORDER BY 1, 2'


### PR DESCRIPTION
We double free dohsql_node_t.order_dir if any column after the first one in the order-by cluase refers to a subquery (Thanks Mike!).