### PR TITLE
Tests: show diff on error, clean trc.c on success

### DIFF
--- a/tests/sockpool_remsql.test/runit
+++ b/tests/sockpool_remsql.test/runit
@@ -76,19 +76,25 @@ if [[ $? != 0 ]] ; then
     exit 1
 fi
 
+successful=1
 #run tests
 echo "Running sequence of selects"
 i=0; while (( $i != 1000 )); do
     $CDB2SQL_EXE $cdb2options $dbname default - < load.req
     result=$?
-    if [[ $? != 0 ]] ; then
+    if [[ $result != 0 ]] ; then
         echo "Select failed"
-        echo "FAILURE"
-        exit 1
+        successful=0
+        break
     fi
     let i=i+1;
 done
 
 $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
+
+if (( $successful != 1 )) ; then
+    echo "FAILURE"
+    exit 1
+fi
 
 echo "SUCCESS"

--- a/tests/tools/compare_results.sh
+++ b/tests/tools/compare_results.sh
@@ -82,6 +82,8 @@ for sqlfile in $sqlfiles; do
         echo "failed $testname"
         echo "see diffs here: $HOSTNAME"
         echo "> diff -u ${PWD}/{$testname.$exp_extn,$testname.output}"
+        echo "first 10 lines of the diff:"
+        $cmd | head -10
         echo
         exit 1
     fi

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -110,9 +110,8 @@ cleanup_cluster() {
             scp -r -o StrictHostKeyChecking=no $node:${TESTDIR}/var/log/cdb2/${DBNAME}* $DBDIR/$node/ < /dev/null &
         elif [ "$CLEANUPDBDIR" != "0" ] ; then 
             ssh -o StrictHostKeyChecking=no $node "rm -rf ${DBDIR} $TMPDIR/${DBNAME}" < /dev/null &
-#ssh -o StrictHostKeyChecking=no $node "rm -f ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
             if [ "$CLEANUPDBDIR" == "2" ] ; then 
-                ssh -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*" < /dev/null &
+                ssh -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.* ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
             fi
         fi
     done
@@ -121,9 +120,9 @@ cleanup_cluster() {
     # the local node always has a copy of DBDIR even if not part of cluster
     if [ "$CLEANUPDBDIR" != "0" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
         rm -rf ${DBDIR} ${TMPDIR}/${DBNAME}
-#rm -f ${DBDIR} ${TESTDIR}/var/log/cdb2/${DBNAME}.* ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
         if [ "$CLEANUPDBDIR" == "2" ] ; then
-            rm -f $TESTDIR/logs/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
+            rm -f $TESTDIR/logs/${DBNAME}.* ${TESTDIR}/var/log/cdb2/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
+            #rm -f ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.*
             rmdir ${TMPDIR}/cdb2 ${TMPDIR} 2> /dev/null
             #if DBCLEANUP is 2 then we cleanup the logs/${DBNAME}.testcase, remark so we know
             echo '$CLEANUPDBDIR == 2 and test was successful so we cleaned up all files related to this test' >> $TESTDIR/logs/${DBNAME}.testcase


### PR DESCRIPTION
Small changes to tests: 
* show diff on error for tests using script tests/tools/compare_results.sh
* clean ${TESTDIR}/var/log/cdb2/${DBNAME}.* files such as trc.c, longreqs, events, on success
* fix sockpool_remsql.test to correctly check result and cleanup after successful completion