### PR TITLE
Cleanup a few semle warnings

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -352,8 +352,8 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                 rc = blobdb->paired_cursor_from_lid(blobdb, lid, &cblob, 0);
                 if (rc) {
                     par->verify_status = 1;
-                    locprint(par, "!%016llx cursor on blob %d rc %d", genid_flipped,
-                             blobno, rc);
+                    locprint(par, "!%016llx cursor on blob %d rc %d",
+                             genid_flipped, blobno, rc);
                     rc = 0;
                     goto next_record;
                 }
@@ -376,14 +376,15 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                     if (blobsizes[blobno] != -1 && blobsizes[blobno] != -2) {
                         had_errors = 1;
                         par->verify_status = 1;
-                        locprint(par, "!%016llx no blob %d found expected sz %d",
+                        locprint(par,
+                                 "!%016llx no blob %d found expected sz %d",
                                  genid_flipped, blobno, blobsizes[blobno]);
                     }
                 } else if (rc) {
                     had_irrecoverable_errors = 1;
                     par->verify_status = 1;
-                    locprint(par, "!%016llx blob %d rc %d", genid_flipped, blobno,
-                             rc);
+                    locprint(par, "!%016llx blob %d rc %d", genid_flipped,
+                             blobno, rc);
                     had_errors = 1;
                 }
 
@@ -396,15 +397,19 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                         had_errors = 1;
                     } else if (blobsizes[blobno] == -2) {
                         par->verify_status = 1;
-                        locprint(par, "!%016llx blob %d size %d expected none (inline vutf8)",
+                        locprint(par,
+                                 "!%016llx blob %d size %d expected none "
+                                 "(inline vutf8)",
                                  genid_flipped, blobno, realblobsz[blobno]);
                         had_errors = 1;
                     } else if (blobsizes[blobno] != -1 &&
                                dbt_blob_data.size != blobsizes[blobno]) {
                         par->verify_status = 1;
-                        locprint(par, "!%016llx blob %d size mismatch got %d expected %d",
-                                 genid_flipped, blobno, dbt_blob_data.size,
-                                 blobsizes[blobno]);
+                        locprint(
+                            par,
+                            "!%016llx blob %d size mismatch got %d expected %d",
+                            genid_flipped, blobno, dbt_blob_data.size,
+                            blobsizes[blobno]);
                         had_errors = 1;
                     }
 
@@ -452,7 +457,8 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                                        expected_keybuf, &keylen);
             if (rc) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d formkey rc %d", genid_flipped, ix, rc);
+                locprint(par, "!%016llx ix %d formkey rc %d", genid_flipped, ix,
+                         rc);
                 ckey->c_close(ckey);
                 ckey = NULL;
                 rc = 0;
@@ -492,7 +498,8 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
             if (!(has_keys & (1ULL << ix))) {
                 if (!rc && (bdb_state->ixdups[ix] || genid == verify_genid)) {
                     par->verify_status = 1;
-                    locprint(par, "!%016llx ix %d expect notfound but got an index",
+                    locprint(par,
+                             "!%016llx ix %d expect notfound but got an index",
                              genid_flipped, ix);
                 }
             } else if (rc == DB_NOTFOUND) {
@@ -500,11 +507,12 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                 locprint(par, "!%016llx ix %d missing key", genid_flipped, ix);
             } else if (rc) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d fetch rc %d", genid_flipped, ix, rc);
+                locprint(par, "!%016llx ix %d fetch rc %d", genid_flipped, ix,
+                         rc);
             } else if (genid != verify_genid) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d genid mismatch %016llx", genid_flipped,
-                         ix, verify_genid);
+                locprint(par, "!%016llx ix %d genid mismatch %016llx",
+                         genid_flipped, ix, verify_genid);
             }
 
             ckey->c_close(ckey);
@@ -694,7 +702,8 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             par->verify_status = 1;
             char hexstr[dbt_key.size * 2 + 1];
             util_tohex(hexstr, dbt_key.data, dbt_key.size);
-            locprint(par, "!%016llx ix %d orphaned %s", genid_flipped, ix, hexstr);
+            locprint(par, "!%016llx ix %d orphaned %s", genid_flipped, ix,
+                     hexstr);
             goto next_key;
         } else if (rc) {
             par->verify_status = 1;
@@ -863,7 +872,9 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 
             if (expected_size != bdb_state->lrl) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d dtacpy payload wrong size expected %d got %d",
+                locprint(par,
+                         "!%016llx ix %d dtacpy payload wrong size expected %d "
+                         "got %d",
                          genid_flipped, ix, bdb_state->lrl, expected_size);
                 goto next_key;
             }
@@ -871,8 +882,8 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             if (memcmp(expected_data, dbt_dta_check_data.data,
                        bdb_state->lrl)) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d dtacpy data mismatch", genid_flipped,
-                         ix);
+                locprint(par, "!%016llx ix %d dtacpy data mismatch",
+                         genid_flipped, ix);
                 goto next_key;
             }
 
@@ -880,7 +891,9 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             if (dbt_data.size !=
                 (sizeof(unsigned long long) + 4 * bdb_state->ixcollattr[ix])) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d decimal payload wrong size expected %zu got %d",
+                locprint(par,
+                         "!%016llx ix %d decimal payload wrong size expected "
+                         "%zu got %d",
                          genid_flipped, ix,
                          sizeof(unsigned long long) +
                              4 * bdb_state->ixcollattr[ix],
@@ -891,7 +904,8 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
         } else {
             if (dbt_data.size != sizeof(unsigned long long)) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d payload wrong size expected 8 got %d",
+                locprint(par,
+                         "!%016llx ix %d payload wrong size expected 8 got %d",
                          genid_flipped, ix, dbt_data.size);
                 goto next_key;
             }
@@ -904,7 +918,9 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             masked_genid = get_search_genid(bdb_state, genid);
             if (memcmp(&genid_left, &masked_genid, sizeof(genid))) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix %d dupe key genid != dta genid %016llx (%016llx)",
+                locprint(par,
+                         "!%016llx ix %d dupe key genid != dta genid %016llx "
+                         "(%016llx)",
                          genid_left, ix, masked_genid, genid);
             }
         }
@@ -922,13 +938,17 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                                                lid, &ridx);
             if (rc == DB_NOTFOUND) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix '%d' key '%s': foreign key table '%s' key '%s' not found\n",
+                locprint(par,
+                         "!%016llx ix '%d' key '%s': foreign key table '%s' "
+                         "key '%s' not found\n",
                          genid, ix, ix_constraint->lclkeyname,
                          ix_constraint->table[ridx],
                          ix_constraint->keynm[ridx]);
             } else if (rc) {
                 par->verify_status = 1;
-                locprint(par, "!%016llx ix '%d' key '%s' foreign key table '%s' key '%s' error loading rc = %d\n",
+                locprint(par,
+                         "!%016llx ix '%d' key '%s' foreign key table '%s' key "
+                         "'%s' error loading rc = %d\n",
                          genid, ix, ix_constraint->lclkeyname,
                          ix_constraint->table[ridx], ix_constraint->keynm[ridx],
                          rc);
@@ -966,7 +986,8 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
 
     if (!db) {
         par->verify_status = 1;
-        locprint(par, "incorrect number of blobs? blob index %d stripe %d has no DB",
+        locprint(par,
+                 "incorrect number of blobs? blob index %d stripe %d has no DB",
                  blobno, dtastripe);
         return;
     }

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -48,21 +48,19 @@ extern void fsnapf(FILE *, void *, int);
 
 
 /* print to sb if available lua callback otherwise */
-static int locprint(SBUF2 *sb, int (*lua_callback)(void *, const char *), 
-        void *lua_params, char *fmt, ...)
+static int locprint(verify_common_t *par, char *fmt, ...)
 {
     char lbuf[1024];
     va_list ap;
     va_start(ap, fmt);
     int wrote = vsnprintf(lbuf, sizeof(lbuf), fmt, ap);
     va_end(ap);
-
-    if (sb) {
+    if (par->sb) {
         if (wrote < sizeof(lbuf) - 1)
             strcat(lbuf, "\n");
-        return sbuf2printf(sb, lbuf) >= 0 ? 0 : -1;
-    } else if (lua_callback)
-        return lua_callback(lua_params, lbuf);
+        return sbuf2printf(par->sb, lbuf) >= 0 ? 0 : -1;
+    } else if (par->lua_callback)
+        return par->lua_callback(par->lua_params, lbuf);
     return -1;
 }
 
@@ -204,15 +202,6 @@ ret:
     return rc;
 }
 
-static void printhex(SBUF2 *sb, int (*lua_callback)(void *, const char *),
-        void *lua_params, uint8_t *hex, int sz)
-{
-    const char hexbytes[] = "0123456789abcdef";
-    for (int i = 0; i < sz; i++)
-        locprint(sb, lua_callback, lua_params, "%c%c", 
-                hexbytes[(hex[i] & 0xf0) >> 4], hexbytes[hex[i] & 0xf]);
-}
-
 static inline int print_verify_progress(verify_common_t *par, int now)
 {
     if (!par->progress_report_seconds)
@@ -237,15 +226,13 @@ static inline int print_verify_progress(verify_common_t *par, int now)
 
     int rc;
     if (par->verify_mode == VERIFY_SERIAL) {
-        rc = locprint(par->sb, par->lua_callback, par->lua_params,
-                      "!%s, did %d records, %d per second", par->header,
+        rc = locprint(par, "!%s, did %d records, %d per second", par->header,
                       par->nrecs_progress,
                       par->nrecs_progress / par->progress_report_seconds);
         par->nrecs_progress = 0;
     } else {
         unsigned long long delta = par->items_processed - par->saved_progress;
-        rc = locprint(par->sb, par->lua_callback, par->lua_params,
-                      "!verify: processed %lld items, %lld per second",
+        rc = locprint(par, "!verify: processed %lld items, %lld per second",
                       par->items_processed,
                       delta / par->progress_report_seconds);
         par->saved_progress = par->items_processed;
@@ -312,8 +299,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
         /* is it the right size? */
         if (dbt_key.size != sizeof(genid)) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!bad genid sz %d", dbt_key.size);
+            locprint(par, "!bad genid sz %d", dbt_key.size);
             goto next_record;
         }
         memcpy(&genid, dbt_key.data, sizeof(genid));
@@ -337,8 +323,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                                           blobsizes, bloboffs, &nblobs);
         if (rc) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx blob size rc %d", genid, rc);
+            locprint(par, "!%016llx blob size rc %d", genid, rc);
         } else {
             /* verify blobs */
             int realblobsz[16];
@@ -358,8 +343,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                 dtafile = get_dtafile_from_genid(genid);
                 if (dtafile < 0) {
                     par->verify_status = 1;
-                    locprint(par->sb, par->lua_callback, par->lua_params,
-                             "!%016llx unknown dtafile", genid_flipped);
+                    locprint(par, "!%016llx unknown dtafile", genid_flipped);
                     rc = 0;
                     goto next_record;
                 }
@@ -368,8 +352,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                 rc = blobdb->paired_cursor_from_lid(blobdb, lid, &cblob, 0);
                 if (rc) {
                     par->verify_status = 1;
-                    locprint(par->sb, par->lua_callback, par->lua_params,
-                             "!%016llx cursor on blob %d rc %d", genid_flipped,
+                    locprint(par, "!%016llx cursor on blob %d rc %d", genid_flipped,
                              blobno, rc);
                     rc = 0;
                     goto next_record;
@@ -393,15 +376,13 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                     if (blobsizes[blobno] != -1 && blobsizes[blobno] != -2) {
                         had_errors = 1;
                         par->verify_status = 1;
-                        locprint(par->sb, par->lua_callback, par->lua_params,
-                                 "!%016llx no blob %d found expected sz %d",
+                        locprint(par, "!%016llx no blob %d found expected sz %d",
                                  genid_flipped, blobno, blobsizes[blobno]);
                     }
                 } else if (rc) {
                     had_irrecoverable_errors = 1;
                     par->verify_status = 1;
-                    locprint(par->sb, par->lua_callback, par->lua_params,
-                             "!%016llx blob %d rc %d", genid_flipped, blobno,
+                    locprint(par, "!%016llx blob %d rc %d", genid_flipped, blobno,
                              rc);
                     had_errors = 1;
                 }
@@ -410,23 +391,18 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                     realblobsz[blobno] = dbt_blob_data.size;
                     if (blobsizes[blobno] == -1) {
                         par->verify_status = 1;
-                        locprint(par->sb, par->lua_callback, par->lua_params,
-                                 "!%016llx blob %d null but found blob",
+                        locprint(par, "!%016llx blob %d null but found blob",
                                  genid_flipped, blobno);
                         had_errors = 1;
                     } else if (blobsizes[blobno] == -2) {
                         par->verify_status = 1;
-                        locprint(par->sb, par->lua_callback, par->lua_params,
-                                 "!%016llx blob %d size %d expected "
-                                 "none (inline vutf8)",
+                        locprint(par, "!%016llx blob %d size %d expected none (inline vutf8)",
                                  genid_flipped, blobno, realblobsz[blobno]);
                         had_errors = 1;
                     } else if (blobsizes[blobno] != -1 &&
                                dbt_blob_data.size != blobsizes[blobno]) {
                         par->verify_status = 1;
-                        locprint(par->sb, par->lua_callback, par->lua_params,
-                                 "!%016llx blob %d size mismatch "
-                                 "got %d expected %d",
+                        locprint(par, "!%016llx blob %d size mismatch got %d expected %d",
                                  genid_flipped, blobno, dbt_blob_data.size,
                                  blobsizes[blobno]);
                         had_errors = 1;
@@ -476,8 +452,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                                        expected_keybuf, &keylen);
             if (rc) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d formkey rc %d", genid_flipped, ix, rc);
+                locprint(par, "!%016llx ix %d formkey rc %d", genid_flipped, ix, rc);
                 ckey->c_close(ckey);
                 ckey = NULL;
                 rc = 0;
@@ -517,22 +492,18 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
             if (!(has_keys & (1ULL << ix))) {
                 if (!rc && (bdb_state->ixdups[ix] || genid == verify_genid)) {
                     par->verify_status = 1;
-                    locprint(par->sb, par->lua_callback, par->lua_params,
-                             "!%016llx ix %d expect notfound but got an index",
+                    locprint(par, "!%016llx ix %d expect notfound but got an index",
                              genid_flipped, ix);
                 }
             } else if (rc == DB_NOTFOUND) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d missing key", genid_flipped, ix);
+                locprint(par, "!%016llx ix %d missing key", genid_flipped, ix);
             } else if (rc) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d fetch rc %d", genid_flipped, ix, rc);
+                locprint(par, "!%016llx ix %d fetch rc %d", genid_flipped, ix, rc);
             } else if (genid != verify_genid) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d genid mismatch %016llx", genid_flipped,
+                locprint(par, "!%016llx ix %d genid mismatch %016llx", genid_flipped,
                          ix, verify_genid);
             }
 
@@ -555,8 +526,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
     }
     if (rc != DB_NOTFOUND) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "!dtastripe %d c_get unexpected rc %d", dtastripe, rc);
+        locprint(par, "!dtastripe %d c_get unexpected rc %d", dtastripe, rc);
     } else
         rc = 0;
 err:
@@ -669,8 +639,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                                                        lid, &ckey, 0);
     if (rc) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "!ix %d cursor rc %d", ix, rc);
+        locprint(par, "!ix %d cursor rc %d", ix, rc);
         return 0;
     }
 
@@ -683,8 +652,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
     rc = ckey->c_get(ckey, &dbt_key, &dbt_data, DB_FIRST);
     if (rc && rc != DB_NOTFOUND) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "!ix %d first rc %d", ix, rc);
+        locprint(par, "!ix %d first rc %d", ix, rc);
     }
     while (rc == 0 && !par->client_dropped_connection) {
         ATOMIC_ADD64(par->items_processed, 1);
@@ -698,8 +666,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 
         if (dbt_data.size < sizeof(unsigned long long)) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!ix %d unexpected length %d", ix, dbt_data.size);
+            locprint(par, "!ix %d unexpected length %d", ix, dbt_data.size);
             goto next_key;
         }
         memcpy(&genid, dbt_data.data, sizeof(unsigned long long));
@@ -717,8 +684,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
         rc = db->paired_cursor_from_lid(db, lid, &cdata, 0);
         if (rc) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d rc %d", genid_flipped, ix, rc);
+            locprint(par, "!%016llx ix %d rc %d", genid_flipped, ix, rc);
             goto next_key;
         }
         uint8_t ver;
@@ -726,15 +692,13 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                              &dbt_dta_check_data, &ver, DB_SET);
         if (rc == DB_NOTFOUND) {
             par->verify_status = 1;
-            char *hexstr = alloca(dbt_key.size * 2 + 1);
+            char hexstr[dbt_key.size * 2 + 1];
             util_tohex(hexstr, dbt_key.data, dbt_key.size);
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d orphaned %s", genid_flipped, ix, hexstr);
+            locprint(par, "!%016llx ix %d orphaned %s", genid_flipped, ix, hexstr);
             goto next_key;
         } else if (rc) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d dta rc %d", genid_flipped, ix, rc);
+            locprint(par, "!%016llx ix %d dta rc %d", genid_flipped, ix, rc);
             goto next_key;
         }
         cdata->c_close(cdata);
@@ -853,16 +817,14 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 
         if (dbt_key.size < keylen) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d key size %d < formed key %d",
+            locprint(par, "!%016llx ix %d key size %d < formed key %d",
                      genid_flipped, ix, dbt_key.size, keylen);
             goto next_key;
         }
 
         if (memcmp(expected_keybuf, dbt_key.data, keylen)) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d key mismatch", genid_flipped, ix);
+            locprint(par, "!%016llx ix %d key mismatch", genid_flipped, ix);
             goto next_key;
         }
 
@@ -871,8 +833,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 
         if (keylen != dbt_key.size) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d key size mismatch expected %d got %d",
+            locprint(par, "!%016llx ix %d key size mismatch expected %d got %d",
                      genid_flipped, ix, keylen, dbt_key.size);
             goto next_key;
         }
@@ -902,9 +863,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 
             if (expected_size != bdb_state->lrl) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d dtacpy payload wrong size "
-                         "expected %d got %d",
+                locprint(par, "!%016llx ix %d dtacpy payload wrong size expected %d got %d",
                          genid_flipped, ix, bdb_state->lrl, expected_size);
                 goto next_key;
             }
@@ -912,8 +871,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             if (memcmp(expected_data, dbt_dta_check_data.data,
                        bdb_state->lrl)) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d dtacpy data mismatch", genid_flipped,
+                locprint(par, "!%016llx ix %d dtacpy data mismatch", genid_flipped,
                          ix);
                 goto next_key;
             }
@@ -922,9 +880,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             if (dbt_data.size !=
                 (sizeof(unsigned long long) + 4 * bdb_state->ixcollattr[ix])) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d decimal payload wrong size "
-                         "expected %zu got %d",
+                locprint(par, "!%016llx ix %d decimal payload wrong size expected %zu got %d",
                          genid_flipped, ix,
                          sizeof(unsigned long long) +
                              4 * bdb_state->ixcollattr[ix],
@@ -935,8 +891,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
         } else {
             if (dbt_data.size != sizeof(unsigned long long)) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d payload wrong size expected 8 got %d",
+                locprint(par, "!%016llx ix %d payload wrong size expected 8 got %d",
                          genid_flipped, ix, dbt_data.size);
                 goto next_key;
             }
@@ -949,17 +904,14 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
             masked_genid = get_search_genid(bdb_state, genid);
             if (memcmp(&genid_left, &masked_genid, sizeof(genid))) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix %d dupe key genid != dta "
-                         "genid %016llx (%016llx)",
+                locprint(par, "!%016llx ix %d dupe key genid != dta genid %016llx (%016llx)",
                          genid_left, ix, masked_genid, genid);
             }
         }
 
         if (memcmp(&genid_right, &genid, sizeof(genid))) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx ix %d dupe key genid != dta genid %016llx",
+            locprint(par, "!%016llx ix %d dupe key genid != dta genid %016llx",
                      genid_right, ix, genid);
         }
 
@@ -970,17 +922,13 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                                                lid, &ridx);
             if (rc == DB_NOTFOUND) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix '%d' key '%s': foreign key table '%s' "
-                         "key '%s' not found\n",
+                locprint(par, "!%016llx ix '%d' key '%s': foreign key table '%s' key '%s' not found\n",
                          genid, ix, ix_constraint->lclkeyname,
                          ix_constraint->table[ridx],
                          ix_constraint->keynm[ridx]);
             } else if (rc) {
                 par->verify_status = 1;
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx ix '%d' key '%s' foreign key table '%s' key "
-                         "'%s' error loading rc = %d\n",
+                locprint(par, "!%016llx ix '%d' key '%s' foreign key table '%s' key '%s' error loading rc = %d\n",
                          genid, ix, ix_constraint->lclkeyname,
                          ix_constraint->table[ridx], ix_constraint->keynm[ridx],
                          rc);
@@ -992,14 +940,12 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
     }
     if (rc && rc != DB_NOTFOUND) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "!ix %d first rc %d", ix, rc);
+        locprint(par, "!ix %d first rc %d", ix, rc);
     }
     rc = ckey->c_close(ckey);
     if (rc) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "!%016llx ix %d close cursor rc %d", genid, ix, rc);
+        locprint(par, "!%016llx ix %d close cursor rc %d", genid, ix, rc);
     }
 
     logmsg(LOGMSG_DEBUG, "%p:%s Exiting ix=%d, delta=%dms\n",
@@ -1020,9 +966,7 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
 
     if (!db) {
         par->verify_status = 1;
-        locprint(par->sb, par->lua_callback, par->lua_params,
-                 "incorrect number of blobs? blob index %d "
-                 "stripe %d has no DB",
+        locprint(par, "incorrect number of blobs? blob index %d stripe %d has no DB",
                  blobno, dtastripe);
         return;
     }
@@ -1085,8 +1029,7 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
                                      bdb_state->blobstripe_convert_genid)) {
             /* verify blobstripe and datastripe is the same */
             if (dtastripe != stripe)
-                locprint(par->sb, par->lua_callback, par->lua_params,
-                         "!%016llx blobstripe %d != datastripe %d",
+                locprint(par, "!%016llx blobstripe %d != datastripe %d",
                          genid_flipped, dtastripe, stripe);
         }
 
@@ -1104,12 +1047,10 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
                           DB_SET);
         if (rc == DB_NOTFOUND) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx orphaned blob %d", genid_flipped, blobno);
+            locprint(par, "!%016llx orphaned blob %d", genid_flipped, blobno);
         } else if (rc) {
             par->verify_status = 1;
-            locprint(par->sb, par->lua_callback, par->lua_params,
-                     "!%016llx get rc %d", genid_flipped, rc);
+            locprint(par, "!%016llx get rc %d", genid_flipped, rc);
         }
 
         rc = cdata->c_close(cdata);

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -24,7 +24,7 @@
 #include "sqlinterfaces.h"
 #include "memcompare.c"
 
-extern char *print_mem(Mem * m);
+extern char *print_mem(Mem *m);
 
 int gbl_dohsql_disable = 0;
 int gbl_dohsql_verbose = 0;

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -24,6 +24,8 @@
 #include "sqlinterfaces.h"
 #include "memcompare.c"
 
+extern char *print_mem(Mem * m);
+
 int gbl_dohsql_disable = 0;
 int gbl_dohsql_verbose = 0;
 int gbl_dohsql_max_queued_kb_highwm = 10000000; /* 10 GB */
@@ -1487,7 +1489,6 @@ static int _cmp(dohsql_t *conns, int idx_a, int idx_b)
             assert(orderby_idx > 0);
             orderby_idx--;
             if (gbl_dohsql_verbose) {
-                extern char *print_mem(Mem * m);
                 logmsg(LOGMSG_USER, "%lu COMPARE %s <> %s\n", pthread_self(),
                        print_mem(&a[orderby_idx]), print_mem(&b[orderby_idx]));
             }

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -452,7 +452,7 @@ void osql_sess_reqlogquery(osql_sess_t *sess, struct reqlogger *reqlog)
         "rqid %s node %s sec %ld rtrs %d queuetime=%" PRId64 "ms \"%s\"\n",
         sess->rqid == OSQL_RQID_USE_UUID ? us : rqid,
         (sess->offhost ? sess->offhost : ""),
-        (int)(sess->end - sess->initstart), reqlog_get_retries(reqlog),
+        (sess->end - sess->initstart), reqlog_get_retries(reqlog),
         reqlog_get_queue_time(reqlog) / 1000, sess->sql ? sess->sql : "()");
 }
 

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -451,9 +451,9 @@ void osql_sess_reqlogquery(osql_sess_t *sess, struct reqlogger *reqlog)
         reqlog, REQL_INFO,
         "rqid %s node %s sec %ld rtrs %d queuetime=%" PRId64 "ms \"%s\"\n",
         sess->rqid == OSQL_RQID_USE_UUID ? us : rqid,
-        (sess->offhost ? sess->offhost : ""),
-        (sess->end - sess->initstart), reqlog_get_retries(reqlog),
-        reqlog_get_queue_time(reqlog) / 1000, sess->sql ? sess->sql : "()");
+        (sess->offhost ? sess->offhost : ""), (sess->end - sess->initstart),
+        reqlog_get_retries(reqlog), reqlog_get_queue_time(reqlog) / 1000,
+        sess->sql ? sess->sql : "()");
 }
 
 /**

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -612,6 +612,10 @@ static void on_off_trap(char *line, int lline, int *st, int *ltok, char *msg,
     }
 }
 
+extern int gbl_fdb_track;
+extern int gbl_fdb_track_hints;
+extern unsigned long long release_locks_on_si_lockwait_cnt;
+extern int reset_blkmax(void);
 extern int gbl_new_snapisol;
 #ifdef NEWSI_STAT
 void bdb_print_logfile_pglogs_stat();
@@ -735,7 +739,6 @@ clipper_usage:
         free(subnet);
     }
     else if (tokcmp(tok, ltok, "fdbdebg") == 0) {
-        extern int gbl_fdb_track;
 
         int dbgflag;
         tok = segtok(line, lline, &st, &ltok);
@@ -746,7 +749,6 @@ clipper_usage:
         dbgflag = toknum(tok, ltok);
         gbl_fdb_track = dbgflag;
     } else if (tokcmp(tok, ltok, "fdbtrackhints") == 0) {
-        extern int gbl_fdb_track_hints;
 
         int dbgflag;
         tok = segtok(line, lline, &st, &ltok);
@@ -898,8 +900,6 @@ clipper_usage:
 #if defined SET_GBLCONTEXT_TEST_TRAPS
     else if (tokcmp(tok, ltok, "setcontext") == 0) {
         unsigned long long ctxt;
-        extern void set_gblcontext(void *bdb_state,
-                                   unsigned long long gblcontext);
         tok = segtok(line, lline, &st, &ltok);
         ctxt = strtoull(tok, NULL, 0);
         set_gblcontext(thedb->bdb_env, ctxt);
@@ -937,7 +937,6 @@ clipper_usage:
         logmsg(LOGMSG_USER, "Enabled pageorder records per page check\n");
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_DISABLE_PAGEORDER_RECSZ_CHK, 0);
     } else if (tokcmp(tok, ltok, "get_newsi_status") == 0) {
-        extern unsigned long long release_locks_on_si_lockwait_cnt;
         logmsg(LOGMSG_USER,
                "new snapshot is %s; new snapshot logging is %s; new snapshot "
                "as-of is %s\n",
@@ -1359,7 +1358,6 @@ clipper_usage:
             logmsg(LOGMSG_ERROR, "unknown diag command <%.*s>\n", ltok, tok);
         }
     } else if (tokcmp(tok, ltok, "reset_blkmax") == 0) {
-        extern int reset_blkmax(void);
         reset_blkmax();
         logmsg(LOGMSG_USER, "Reset blkmax\n");
     }

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1704,11 +1704,11 @@ static void log_params(struct reqlogger *logger)
         }
         if (p.pos)
             reqlog_logf(logger, REQL_INFO,
-                        "param%-3d type=%-12s len=%-3zu indx=%-16d value=%s", i,
+                        "param%-3d type=%-12s len=%-3d indx=%-16d value=%s", i,
                         type, p.len, p.pos, value);
         else
             reqlog_logf(logger, REQL_INFO,
-                        "param%-3d type=%-12s len=%-3zu name=%-16s value=%s", i,
+                        "param%-3d type=%-12s len=%-3d name=%-16s value=%s", i,
                         type, p.len, p.name, value);
     }
 }

--- a/net/net.c
+++ b/net/net.c
@@ -4662,8 +4662,9 @@ static int get_dedicated_conhost(host_node_type *host_node_ptr, struct in_addr *
                 continue;
         }
 
-        char *rephostname =
-            alloca(strlen(host_node_ptr->host) + strlen(subnet) + 1);
+        int loc_len = strlen(host_node_ptr->host) + strlen(subnet);
+        char tmp_hostname[loc_len + 1];
+        char *rephostname = tmp_hostname;
         strcpy(rephostname, host_node_ptr->host);
         if (subnet[0]) {
             strcat(rephostname, subnet);

--- a/sqlite/ext/expert/sqlite3expert.h
+++ b/sqlite/ext/expert/sqlite3expert.h
@@ -11,6 +11,9 @@
 *************************************************************************
 */
 
+#ifndef _sqlite3expert_h
+#define _sqlite3expert_h
+
 
 #include "sqlite3.h"
 
@@ -165,4 +168,4 @@ const char *sqlite3_expert_report(sqlite3expert*, int iStmt, int eReport);
 */
 void sqlite3_expert_destroy(sqlite3expert*);
 
-
+#endif

--- a/tests/long_db_name.test/runit
+++ b/tests/long_db_name.test/runit
@@ -73,33 +73,6 @@ do_verify()
     fi
 }
 
-# Do schema changes
-do_schema_changes()
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
-}
-
 # Update all records in the table
 update_all_records()
 {

--- a/tests/reorder_deletes.test/runit
+++ b/tests/reorder_deletes.test/runit
@@ -85,33 +85,6 @@ do_verify()
     fi
 }
 
-# Do schema changes
-do_schema_changes()
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
-}
-
 # Update all records in the table
 update_all_records()
 {

--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -85,33 +85,6 @@ do_verify()
     fi
 }
 
-# Do schema changes
-do_schema_changes()
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
-}
-
 # Update all records in the table
 update_all_records()
 {

--- a/tests/reorder_updates.test/runit
+++ b/tests/reorder_updates.test/runit
@@ -85,33 +85,6 @@ do_verify()
     fi
 }
 
-# Do schema changes
-do_schema_changes()
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
-}
-
 # Update all records in the table
 update_all_records()
 {

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -5,7 +5,7 @@ bash -n "$0" | exit 1
 debug=0
 
 dbnm=$1
-tblcnt=10
+tblcnt=150
 
 if [ "x$dbnm" == "x" ] ; then
     echo "need a DB name"
@@ -163,7 +163,7 @@ for i in `seq 1 $tblcnt`; do
   time cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}$i  { `cat t1_1.csc2 ` }"
   insert_records ${PRFIX}$i $i
   echo truncate ${PRFIX}0
-#time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
+  time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
 
   #flushall
 done

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -5,7 +5,7 @@ bash -n "$0" | exit 1
 debug=0
 
 dbnm=$1
-tblcnt=150
+tblcnt=10
 
 if [ "x$dbnm" == "x" ] ; then
     echo "need a DB name"
@@ -45,33 +45,6 @@ function do_verify
     if ! grep succeeded verify.out > /dev/null ; then
         failexit "Verify"
     fi
-}
-
-# Do schema changes
-function do_schema_changes
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
 }
 
 
@@ -190,7 +163,7 @@ for i in `seq 1 $tblcnt`; do
   time cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}$i  { `cat t1_1.csc2 ` }"
   insert_records ${PRFIX}$i $i
   echo truncate ${PRFIX}0
-  time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
+#time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
 
   #flushall
 done

--- a/tests/sc_swapfields.test/runit
+++ b/tests/sc_swapfields.test/runit
@@ -45,34 +45,6 @@ function do_verify
     fi
 }
 
-# Do schema changes
-function do_schema_changes
-{
-    typeset max=$1
-    typeset iter=0
-    typeset scnt=0
-
-    schema=t2.csc2
-
-    while [[ $scnt -lt $max ]]; do 
-
-        echo "$dbnm alter t1 $schema"
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1 { `cat $schema ` }"
-        if [[ $? != 0 ]]; then
-
-            echo "Error schema-changing on iteration $scnt"
-            return 1
-
-        fi
-
-        let scnt=scnt+1
-
-    done
-
-    return 0
-}
-
-
 function insert_records
 {
     j=$1
@@ -87,8 +59,6 @@ function insert_records
         let j=j+1
     done
 }
-
-
 
 
 echo "Test with insert, SC should not fail"


### PR DESCRIPTION
Cleanup a few semle warnings. 
Pass structure rather than 3 different parameters to locprint().