### PR TITLE
Maximum row buffer size

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -327,6 +327,7 @@ extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int eventlog_nkeep;
 
 int gbl_page_order_table_scan = 0;
+size_t gbl_cached_output_buffer_max_bytes = 8 * 1024 * 1024; /* 8 MiB */
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1864,4 +1864,9 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("cached_output_buffer_max_bytes",
+                 "Maximum size in bytes of the output buffer of an appsock "
+                 "thread.  (Default: 8 MiB)",
+                 TUNABLE_INTEGER, &gbl_cached_output_buffer_max_bytes, 0, NULL,
+                 NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2155,6 +2155,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     struct sbuf2 *sb;
     struct dbenv *dbenv;
     struct dbtable *tab;
+    extern size_t gbl_cached_output_buffer_max_bytes;
 
     thr_self = arg->thr_self;
     dbenv = arg->dbenv;
@@ -2454,6 +2455,14 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
             cdb2__query__free_unpacked(APPDATA->query, &pb_alloc);
             APPDATA->query = NULL;
         }
+
+        /* Keep a reasonable amount of memory in the clnt. */
+        if (APPDATA->packed_capacity > gbl_cached_output_buffer_max_bytes) {
+            APPDATA->packed_capacity = 0;
+            free(APPDATA->packed_buf);
+            APPDATA->packed_buf = NULL;
+        }
+
         query = read_newsql_query(dbenv, &clnt, sb);
     }
 

--- a/tests/row_buf_max_sz.test/Makefile
+++ b/tests/row_buf_max_sz.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/row_buf_max_sz.test/lrl.options
+++ b/tests/row_buf_max_sz.test/lrl.options
@@ -1,0 +1,3 @@
+sqlenginepool maxt 1
+appsockpool linger 600
+logmsg level info

--- a/tests/row_buf_max_sz.test/runit
+++ b/tests/row_buf_max_sz.test/runit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Make sure that all queries go to the same node.
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+echo "target machine is $mach"
+
+# Create a table
+cdb2sql --host $mach $dbnm "create table lengthy_blob (b blob)" >/dev/null
+# Insert a lengthy blob
+cdb2sql --host $mach $dbnm "insert into lengthy_blob values(randomblob(104857600))" >/dev/null
+# Reproducer
+for i in `seq 1 10`; do
+cat << EOF | cdb2sql --host $mach $dbnm - >/dev/null 2>&1 &
+select b from lengthy_blob
+select 1
+EOF
+done
+
+total=`cdb2sql --tabs --host $mach $dbnm 'exec procedure sys.cmd.send("memstat")' | grep total | tail -1 | awk '{print $4}'`
+echo "total mem use: $total" >&2
+
+wait
+
+if [ $total -gt 419430400 ]; then
+    echo "total mem use: $total" >&2
+    exit 1
+fi
+
+echo "Passed."
+exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=935)
+(TUNABLES_COUNT=936)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -88,6 +88,7 @@
 (name='cache_lc_memlimit_tran', description='Limit per transaction memory used by LC cache', type='INTEGER', value='1048576', read_only='N')
 (name='cache_lc_trace_evictions', description='Print a message at the point of eviction', type='BOOLEAN', value='OFF', read_only='N')
 (name='cache_lc_trace_misses', description='Print a message on cache miss', type='BOOLEAN', value='OFF', read_only='N')
+(name='cached_output_buffer_max_bytes', description='Maximum size in bytes of the output buffer of an appsock thread.  (Default: 1048576)', type='INTEGER', value='1048576', read_only='N')
 (name='cachekb', description='', type='INTEGER', value='65536', read_only='Y')
 (name='cachekbmax', description='', type='INTEGER', value='0', read_only='Y')
 (name='cachekbmin', description='', type='INTEGER', value='65536', read_only='Y')

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -88,7 +88,7 @@
 (name='cache_lc_memlimit_tran', description='Limit per transaction memory used by LC cache', type='INTEGER', value='1048576', read_only='N')
 (name='cache_lc_trace_evictions', description='Print a message at the point of eviction', type='BOOLEAN', value='OFF', read_only='N')
 (name='cache_lc_trace_misses', description='Print a message on cache miss', type='BOOLEAN', value='OFF', read_only='N')
-(name='cached_output_buffer_max_bytes', description='Maximum size in bytes of the output buffer of an appsock thread.  (Default: 1048576)', type='INTEGER', value='1048576', read_only='N')
+(name='cached_output_buffer_max_bytes', description='Maximum size in bytes of the output buffer of an appsock thread.  (Default: 8 MiB)', type='INTEGER', value='8388608', read_only='N')
 (name='cachekb', description='', type='INTEGER', value='65536', read_only='Y')
 (name='cachekbmax', description='', type='INTEGER', value='0', read_only='Y')
 (name='cachekbmin', description='', type='INTEGER', value='65536', read_only='Y')


### PR DESCRIPTION
Only keep a reasonable amount of memory for the row buffer in a clnt.
If the size of the row buffer exceeds a threshold, don't keep it.

(DRQS 150673741)