### PR TITLE
Fix smoke test for CentOS 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ On every machine in the cluster:
        flex \
        protobuf-c-compiler \
        liblz4-dev \
-       libncurses5-dev \
+       ncurses-dev  \
        libprotobuf-c-dev \
        libreadline-dev \
        libssl-dev \
@@ -51,10 +51,43 @@ On every machine in the cluster:
        zlib1g-dev
    ```
 
-   **CentOS 7**
+   **CentOS 7/8**
+
+   On CentOS 8, enable the PowerTools repository first:
 
    ```
-   sudo yum install -y gcc gcc-c++ cmake3 protobuf-c libunwind libunwind-devel protobuf-c-devel byacc flex openssl openssl-devel openssl-libs readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel zlib lz4-devel gawk tcl epel-release lz4 rpm-build which
+   dnf config-manager --set-enabled PowerTools
+   ```
+
+   ```
+   yum install -y       \
+       gcc              \
+       gcc-c++          \
+       cmake3           \
+       make             \
+       protobuf-c       \
+       libunwind        \
+       libunwind-devel  \
+       protobuf-c-devel \
+       byacc            \
+       flex             \
+       openssl          \
+       openssl-devel    \
+       openssl-libs     \
+       readline-devel   \
+       sqlite           \
+       sqlite-devel     \
+       libuuid          \
+       libuuid-devel    \
+       zlib-devel       \
+       zlib             \
+       lz4-devel        \
+       gawk             \
+       tcl              \
+       epel-release     \
+       lz4              \
+       rpm-build        \
+       which
    ```
 
    **macOS High Sierra (experimental)**

--- a/tests/smoketest/Dockerfile.inst.build
+++ b/tests/smoketest/Dockerfile.inst.build
@@ -1,8 +1,10 @@
 FROM centos:latest
 
 RUN \
+   dnf install 'dnf-command(config-manager)' -y && \
+   dnf config-manager --set-enabled PowerTools && \
    yum install -y epel-release && \
-   yum install -y cmake3 gcc gcc-c++ protobuf-c libunwind libunwind-devel \
+   yum install -y cmake3 make gcc gcc-c++ protobuf-c libunwind libunwind-devel \
    protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
    readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
    zlib lz4-devel gawk tcl lz4 rpm-build which java-sdk

--- a/tests/smoketest/Dockerfile.nossl.build
+++ b/tests/smoketest/Dockerfile.nossl.build
@@ -2,8 +2,10 @@ FROM centos:latest
 
 # Comdb2 uses libcrypto. Therefore OpenSSL is still needed.
 RUN \
+   dnf install 'dnf-command(config-manager)' -y && \
+   dnf config-manager --set-enabled PowerTools && \
    yum install -y epel-release && \
-   yum install -y cmake3 gcc gcc-c++ protobuf-c libunwind libunwind-devel   \
+   yum install -y cmake3 make gcc gcc-c++ protobuf-c libunwind libunwind-devel \
    protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
    readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
    zlib lz4-devel gawk tcl lz4 rpm-build which

--- a/tests/smoketest/Dockerfile.rpm.build
+++ b/tests/smoketest/Dockerfile.rpm.build
@@ -1,8 +1,10 @@
 FROM centos:latest
 
 RUN \
+   dnf install 'dnf-command(config-manager)' -y && \
+   dnf config-manager --set-enabled PowerTools && \
    yum install -y epel-release && \
-   yum install -y cmake3 gcc gcc-c++ protobuf-c libunwind libunwind-devel   \
+   yum install -y cmake3 make gcc gcc-c++ protobuf-c libunwind libunwind-devel \
    protobuf-c-devel byacc flex openssl openssl-devel openssl-libs         \
    readline-devel sqlite sqlite-devel libuuid libuuid-devel zlib-devel    \
    zlib lz4-devel gawk tcl lz4 rpm-build which


### PR DESCRIPTION
`protobuf-c-devel` is moved to the PowerTools repository on CentOS 8. Update the docker file accordingly.