### PR TITLE
Make the result of sqlite3_normalized_sql() survive its statement being reprepared.

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -158,7 +158,7 @@ void sqlite3VdbeSwap(Vdbe *pA, Vdbe *pB){
   zTmp = pA->zSql;
   pA->zSql = pB->zSql;
   pB->zSql = zTmp;
-#if 0
+#ifdef SQLITE_ENABLE_NORMALIZE
   zTmp = pA->zNormSql;
   pA->zNormSql = pB->zNormSql;
   pB->zNormSql = zTmp;


### PR DESCRIPTION
Cherrypick of upstream SQLite trunk fix [4330f0795dbc2ab41].