### PR TITLE
Carefully adjust thd->persistent_info at strategic points in the pool thread lifecycle to more closely reflect what it is actually doing.

### DIFF
--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -686,6 +686,8 @@ static void *thdpool_thd(void *voidarg)
 
         LOCK(&pool->mutex)
         {
+            thd->persistent_info = "looking for work...";
+
             struct timespec timeout;
             struct timespec *ts = NULL;
             int thr_exit = 0;
@@ -783,7 +785,7 @@ static void *thdpool_thd(void *voidarg)
          * from the perspective of other threads that may need
          * to examine it. */
         LOCK(&pool->mutex) {
-            thd->persistent_info = NULL;
+            thd->persistent_info = "work completed.";
             if (work.persistent_info != NULL) {
                 free(work.persistent_info);
                 work.persistent_info = NULL;
@@ -811,6 +813,12 @@ static void *thdpool_thd(void *voidarg)
 
         // before acquiring next request, yield
         comdb2bma_yield_all();
+
+        // the yield operation has completed, update thread info again
+        LOCK(&pool->mutex) {
+            thd->persistent_info = "yield done.";
+        }
+        UNLOCK(&pool->mutex);
     }
 thread_exit:
 

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -811,14 +811,14 @@ static void *thdpool_thd(void *voidarg)
             UNLOCK(&pool->mutex);
         }
 
-        // before acquiring next request, yield
-        comdb2bma_yield_all();
-
-        // the yield operation has completed, update thread info again
+        // ready to perform yield operation, update thread info again
         LOCK(&pool->mutex) {
-            thd->persistent_info = "yield done.";
+            thd->persistent_info = "yielding...";
         }
         UNLOCK(&pool->mutex);
+
+        // before acquiring next request, yield
+        comdb2bma_yield_all();
     }
 thread_exit:
 


### PR DESCRIPTION
Carefully adjust thd->persistent_info at strategic points in the pool thread lifecycle to more closely reflect what it is actually doing.