### PR TITLE
Fix unportable usage of realpath

### DIFF
--- a/bbinc/bb_oscompat.h
+++ b/bbinc/bb_oscompat.h
@@ -33,6 +33,7 @@ void set_hostbyname(hostbyname *);
 hostbyname comdb2_gethostbyname;
 void comdb2_getservbyname(const char *, const char *, short *);
 int bb_readdir(DIR *d, void *buf, struct dirent **dent);
+char *comdb2_realpath(const char *path, char *resolved_path);
 
 #ifdef __cplusplus
 }

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3328,27 +3328,28 @@ static int init_sqlite_tables(struct dbenv *dbenv)
 
 static int create_db(char *dbname, char *dir) {
    int rc;
-   char path[PATH_MAX + 1];
 
-   char *fulldir = realpath(dir, path);
+   char *fulldir;
+   fulldir = comdb2_realpath(dir, NULL);
    if (fulldir == NULL) {
       rc = mkdir(dir, 0755);
       if (rc) {
-          logmsg(LOGMSG_FATAL, "%s doesn't exist, and couldn't create: %s\n",
-                 dir, strerror(errno));
-          return -1;
+         logmsg(LOGMSG_FATAL, 
+               "%s doesn't exist, and couldn't create: %s\n", dir,
+               strerror(errno));
+         return -1;
       }
-      fulldir = realpath(dir, path);
+      fulldir = comdb2_realpath(dir, NULL);
       if (fulldir == NULL) {
-          logmsg(LOGMSG_FATAL, "Can't figure out full path for %s\n", dir);
-          return -1;
+         logmsg(LOGMSG_FATAL, "Can't figure out full path for %s\n", dir);
+         return -1;
       }
    }
    dir = fulldir;
    logmsg(LOGMSG_INFO, "Creating db in %s\n", dir);
-   setenv("COMDB2_DB_DIR", strdup(dir), 1);
+   setenv("COMDB2_DB_DIR", fulldir, 1);
 
-   if (init_db_dir(dbname, fulldir)) return -1;
+   if (init_db_dir(dbname, dir)) return -1;
 
    /* set up as a create run */
    gbl_local_mode = 1;
@@ -3506,9 +3507,7 @@ static int init(int argc, char **argv)
         }
 
         if (rc == 0 && (st.st_mode & S_IFDIR)) {
-            char path[PATH_MAX + 1];
-            if ((gbl_dbdir = realpath(".", path)) != NULL)
-                gbl_dbdir = strdup(gbl_dbdir);
+            gbl_dbdir = comdb2_realpath(".", NULL);
         } else {
             /* can't access or can't find logs in current directory, assume db
              * isn't here */

--- a/db/resource.c
+++ b/db/resource.c
@@ -72,19 +72,11 @@ void initresourceman(const char *newlrlname)
     if (lrlname) // free before assigning new one
         free(lrlname);
 
-    char *mem = NULL;
-#   if defined(_IBM_SOURCE)
-    mem = malloc(PATH_MAX);
-#   endif
-    lrlname = realpath(newlrlname, mem);
+    lrlname = realpath(newlrlname, NULL);
 
     /* lrl file is always known as "lrl" */
     if (lrlname)
         addresource("lrl", lrlname);
-#   if defined(_IBM_SOURCE)
-    else
-        free(mem);
-#   endif
 }
 
 /* Gets the path of the child file (usually a .lrl or .csc2 relative to a

--- a/db/resource.c
+++ b/db/resource.c
@@ -33,6 +33,7 @@
 #include <stdlib.h>
 #include <stddef.h>
 
+#include <bb_oscompat.h>
 #include <list.h>
 
 #include "comdb2.h"

--- a/db/resource.c
+++ b/db/resource.c
@@ -72,7 +72,7 @@ void initresourceman(const char *newlrlname)
     if (lrlname) // free before assigning new one
         free(lrlname);
 
-    lrlname = realpath(newlrlname, NULL);
+    lrlname = comdb2_realpath(newlrlname, NULL);
 
     /* lrl file is always known as "lrl" */
     if (lrlname)

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -63,6 +63,7 @@
 #include <logmsg.h>
 #include <tohex.h>
 #include <ctrace.h>
+#include <bb_oscompat.h>
 
 #ifdef WITH_RDKAFKA    
 

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3462,7 +3462,7 @@ int db_csvcopy(Lua lua)
     strbuf *columns, *params, *sql;
 
     char path[PATH_MAX + 1];
-    char *fname = realpath(fname_orig, path);
+    char *fname = comdb2_realpath(fname_orig, path);
 
     int basedir_len = strlen(thedb->basedir);
 

--- a/util/bb_oscompat.c
+++ b/util/bb_oscompat.c
@@ -21,8 +21,13 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netdb.h>
+#include <limits.h>
+#include <stdlib.h>
 
 #include <bb_oscompat.h>
+#include <logmsg.h>
+#include <mem_util.h>
+#include <mem_override.h>
 
 static int os_gethostbyname(char **name_ptr, struct in_addr *addr)
 {
@@ -101,4 +106,21 @@ int bb_readdir(DIR *d, void *buf, struct dirent **dent) {
     int rc;
     return readdir_r(d, buf, dent);
 #endif
+}
+
+char *comdb2_realpath(const char *path, char *resolved_path)
+{
+    char *rv, *rpath;
+    rpath = resolved_path;
+    if (rpath == NULL) {
+        rpath = malloc(PATH_MAX + 1);
+        if (rpath == NULL) {
+            logmsgperror("malloc");
+            return NULL;
+        }
+    }
+    rv = realpath(path, rpath);
+    if (rv == NULL && resolved_path == NULL)
+        free(rpath);
+    return rv;
 }


### PR DESCRIPTION
Some systems (e.g., AIX) do not like resolved_path being NULL: POSIX.1-2001 states that if resolved_name is a null pointer, the behavior of realpath is implementation-defined. So use realpath in a portable way.