### PR TITLE
Free the path returned by realpath in the create_db function.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3348,7 +3348,8 @@ static int create_db(char *dbname, char *dir) {
    logmsg(LOGMSG_INFO, "Creating db in %s\n", dir);
    setenv("COMDB2_DB_DIR", fulldir, 1);
 
-   if (init_db_dir(dbname, dir)) return -1;
+   if (init_db_dir(dbname, dir)) { free(fulldir); return -1; }
+   free(fulldir);
 
    /* set up as a create run */
    gbl_local_mode = 1;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3348,8 +3348,9 @@ static int create_db(char *dbname, char *dir) {
    logmsg(LOGMSG_INFO, "Creating db in %s\n", dir);
    setenv("COMDB2_DB_DIR", fulldir, 1);
 
-   if (init_db_dir(dbname, dir)) { free(fulldir); return -1; }
+   rc = init_db_dir(dbname, dir);
    free(fulldir);
+   if (rc) return -1;
 
    /* set up as a create run */
    gbl_local_mode = 1;


### PR DESCRIPTION
Since realpath() returns a malloced buffer that cannot escape the scope of the create_db() function, it should be freed prior to exiting.