### PR TITLE
two rqid in struct ireq, label the dup properly

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1272,7 +1272,7 @@ struct ireq {
     uint8_t *p_buf_out;           /* pointer to current pos in output buf */
     uint8_t *p_buf_out_start;     /* pointer to start of output buf */
     const uint8_t *p_buf_out_end; /* pointer to just past end of output buf */
-    unsigned long long rqid;
+    unsigned long long fwd_tag_rqid;
     int frompid;
     int debug;
     int opcode;

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -835,7 +835,7 @@ static int init_ireq(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     iq->debug = debug_this_request(gbl_debug_until) || (debug && gbl_debug);
     iq->debug_now = iq->nowus = nowus;
     iq->dbenv = dbenv;
-    iq->rqid = rqid;
+    iq->fwd_tag_rqid = rqid;
 
     iq->p_buf_orig =
         p_buf; /* need this for optimized fast fail (skip blkstate) */

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -367,7 +367,7 @@ int handle_ireq(struct ireq *iq)
             if (iq->is_socketrequest) {
                 if (iq->sb == NULL) {
                     rc = offload_comm_send_blockreply(
-                        iq->frommach, iq->rqid, iq->p_buf_out_start,
+                        iq->frommach, iq->fwd_tag_rqid, iq->p_buf_out_start,
                         iq->p_buf_out - iq->p_buf_out_start, rc);
                     free_bigbuf_nosignal(iq->p_buf_out_start);
                 } else {


### PR DESCRIPTION
trivial struct field name change, it was confusing to use two rqid-s in same ireq structure (one is in sorese for regular osql writes, the second is used for forwarded tag writes that piggyback in same osql net). 