### PR TITLE
Fix repopulating a queuedb

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -567,19 +567,6 @@ static int file_update(void *context, void *value)
     return 0;
 }
 
-extern char **qdbs;
-
-static int num_qdbs_update(void *context, void *value)
-{
-    comdb2_tunable *tunable = (comdb2_tunable *)context;
-    int val = *(int *)value;
-
-    *(int *)tunable->var = val;
-    thedb->qdbs = calloc(val, sizeof(struct dbtable *));
-    qdbs = calloc(val + 1, sizeof(char *));
-    return 0;
-}
-
 static int lk_verify(void *context, void *value)
 {
     comdb2_tunable *tunable = (comdb2_tunable *)context;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -813,8 +813,6 @@ REGISTER_TUNABLE("nullsort", NULL, TUNABLE_ENUM,
 */
 REGISTER_TUNABLE("num_contexts", NULL, TUNABLE_INTEGER, &gbl_num_contexts,
                  READONLY | NOZERO, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("num_qdbs", NULL, TUNABLE_INTEGER, &db->num_qdbs, READONLY,
-                 NULL, NULL, num_qdbs_update, NULL);
 REGISTER_TUNABLE("num_record_converts",
                  "During schema changes, pack this many records into a "
                  "transaction. (Default: 100)",

--- a/tests/repopulate_queues.test/Makefile
+++ b/tests/repopulate_queues.test/Makefile
@@ -1,0 +1,6 @@
+COMDB2_UNITTEST=1
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/repopulate_queues.test/runit
+++ b/tests/repopulate_queues.test/runit
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -ex
+
+db=repopulatequeues
+
+rm -rf $DBDIR
+mkdir -p $DBDIR
+
+$COMDB2_EXE $db --create --dir $DBDIR/$db >/dev/null 2>&1
+$COMDB2_EXE $db -lrl $DBDIR/$db/$db.lrl >/dev/null 2>&1 &
+sleep 10
+
+# Create a table
+cdb2sql $db "create table t (i int)" >/dev/null
+# Create 2 consumers
+cdb2sql $db "create procedure p { local function main (e) local c = db:consumer() local e = c:get() end }" >/dev/null
+cdb2sql $db "create lua consumer p on (table t for insert)" >/dev/null
+cdb2sql $db "create procedure q { local function main (e) local c = db:consumer() local e = c:get() end }" >/dev/null
+cdb2sql $db "create lua consumer q on (table t for insert)" >/dev/null
+
+cdb2sql $db 'exec procedure sys.cmd.send("exit")' >/dev/null
+sleep 5
+
+for i in `seq 1 5`; do
+    rm -rf $DBDIR/$db.repop
+    mkdir -p $DBDIR/$db.repop
+    $COMDB2_EXE $db --repopnewlrl $DBDIR/$db.repop/$db.lrl --lrl $DBDIR/$db/$db.lrl
+    $COMDB2_EXE $db --create --lrl $DBDIR/$db.repop/$db.lrl
+    $COMDB2_EXE $db -lrl $DBDIR/$db.repop/$db.lrl &
+    sleep 10
+    cdb2sql $db 'exec procedure sys.cmd.send("exit")'
+    sleep 5
+done
+
+echo "Passed."
+exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=936)
+(TUNABLES_COUNT=935)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -543,7 +543,6 @@
 (name='null_blob_fix', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='nullfkey', description='Do not enforce foreign key constraints for null keys. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='num_contexts', description='', type='INTEGER', value='16', read_only='Y')
-(name='num_qdbs', description='', type='INTEGER', value='0', read_only='Y')
 (name='num_record_converts', description='During schema changes, pack this many records into a transaction. (Default: 100)', type='INTEGER', value='100', read_only='Y')
 (name='num_write_retries', description='number of times to retry writes on ENOSPC', type='INTEGER', value='128', read_only='N')
 (name='numberkdbcaches', description='Split the cache into this many segments.', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
This PR fixes handling of the `queuedb` directive. `qdbs` is referenced
but is never initialized. The PR properly allocates and resizes `qdbs`
on each `queuedb` configuration.

The last character of a queuedb config is dropped every time it's created
from a repopulated LRL file. The PR fixes this bug too.

(DRQS 152088323)