### PR TITLE
fix insertlots.test expected output generation

### DIFF
--- a/bdb/bdb_osqltrn.c
+++ b/bdb/bdb_osqltrn.c
@@ -152,7 +152,7 @@ void bdb_verify_repo_lock() { verify_pthread_mutex(&trn_repo_mtx); }
  * lock the snapshot/serializable transaction repository
  *
  */
-void bdb_osql_trn_repo_lock()
+inline void bdb_osql_trn_repo_lock()
 {
     Pthread_mutex_lock(&trn_repo_mtx);
 }
@@ -161,7 +161,7 @@ void bdb_osql_trn_repo_lock()
  * unlock the snapshot/serializable transaction repository
  *
  */
-void bdb_osql_trn_repo_unlock()
+inline void bdb_osql_trn_repo_unlock()
 {
     Pthread_mutex_unlock(&trn_repo_mtx);
 }
@@ -526,7 +526,6 @@ done:
     return trn;
 }
 
-int free_pglogs_queue_cursors(void *obj, void *arg);
 /**
  *  Unregister a shadow transaction with the repository
  *  Called upon transaction commit/rollback

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -65,11 +65,7 @@ gen_series_test()
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table t2 (i int)"
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "insert into t2 select * from generate_series(1, $MAX) "
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select distinct i from t2" | sort -n > gen.out
-    i=1
-    while [ $i -le $MAX ] ; do 
-        echo $i >> gen.exp
-        let i=i+1
-    done
+    seq 1 $MAX > gen.exp
     if ! diff gen.out gen.exp ; then 
         failexit 'genseries content not what it is expected'
     fi

--- a/tests/setup
+++ b/tests/setup
@@ -84,6 +84,10 @@ if [[ -n ${DEBUGGER} ]]; then
         DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g "
         INTERACTIVE_DEBUG=0
         ;;    
+    mutrace)   # mutex contention detection tool
+        DEBUG_PREFIX="mutrace "
+        INTERACTIVE_DEBUG=0
+        ;;    
     *)
         DEBUG_PREFIX=${DEBUGGER}
         if [[ -z ${INTERACTIVE_DEBUG} ]]; then


### PR DESCRIPTION
- fix insertlots.test expected output generation
- add `DEBUGGER=mutrace` tool support to inspect mutex contention