### PR TITLE
fix origname troublemaker change

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1012,8 +1012,8 @@ int bdb_rename_table(bdb_state_type *bdb_state, tran_type *tran, char *newname,
                      int *bdberr)
 {
     DB_TXN *tid = tran ? tran->tid : NULL;
-    char *orig_name;
-    char *origname; /* certain sc set this, preserve */
+    char *saved_name;
+    char *saved_origname; /* certain sc set this, preserve */
     int rc;
 
     rc = close_dbs_flush(bdb_state, tid);
@@ -1022,25 +1022,25 @@ int bdb_rename_table(bdb_state_type *bdb_state, tran_type *tran, char *newname,
         return -1;
     }
 
-    origname = bdb_state->origname;
+    saved_origname = bdb_state->origname;
     bdb_state->origname = NULL;
     rc = bdb_rename_file_versioning_table(bdb_state, tran, newname, bdberr);
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "upgrade: open_dbs as master failed\n");
-        bdb_state->origname = origname;
+        bdb_state->origname = saved_origname;
         return -1;
     }
 
-    orig_name = bdb_state->name;
+    saved_name = bdb_state->name;
     bdb_state->name = newname;
     rc = open_dbs(bdb_state, 1, 1, 0, tid);
     if (rc != 0) {
-        bdb_state->name = orig_name;
-        bdb_state->origname = origname;
+        bdb_state->name = saved_name;
+        bdb_state->origname = saved_origname;
         logmsg(LOGMSG_ERROR, "upgrade: open_dbs as master failed\n");
         return -1;
     }
-    bdb_state->name = orig_name;
+    bdb_state->name = saved_name;
     bdb_state->isopen = 1;
 
     return 0;

--- a/tests/renametable.test/t.csc2
+++ b/tests/renametable.test/t.csc2
@@ -2,3 +2,8 @@ schema
 {
    int  id
 }
+
+keys
+{
+    dup "id" = id
+}


### PR DESCRIPTION
Origname is intended to help hide "new." prefix filename during schema change; the prefix is used to differentiate between the old file and the new file being generated.
When origname is present, even though an in-memory file is identified by "new.tblname", final on-disk version is "tblname", and origname is used to map the in-memory to on-disk filenames.
Unfortunately this breaks file renaming, when table is indexed (schema code changes?), and regression test-case did not cover the scenario.  Origname in this case end up replacing the intended name with the old name (that happens to be saved in origname).
Fix here.