### PR TITLE
Abort from the trickle thread if it can't sync a buffer

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -239,6 +239,7 @@ extern int gbl_dump_cache_max_pages;
 extern int gbl_max_pages_per_cache_thread;
 extern int gbl_memp_dump_cache_threshold;
 extern int gbl_disable_ckp;
+extern int gbl_trickle_sync_counter_max;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1863,6 +1863,12 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("trickle_max_sync",
+                 "Abort if we can't write a buffer after this many seconds.  "
+                 "(Default: 20)",
+                 TUNABLE_INTEGER, &gbl_trickle_sync_counter_max,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",
                  "Maximum size in bytes of the output buffer of an appsock "
                  "thread.  (Default: 8 MiB)",


### PR DESCRIPTION
This is a quick-fix for a bug that can occur with old-style queues.  This logic assumes that taking longer than 20 seconds to sync a single page to disk is insane on any modern system.  The actual length of time the database is willing to wait for a single page to sync is controlled by the trickle_max_sync tunable.