### PR TITLE
Port trickle max-sync logic to 7.0

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -546,6 +546,7 @@ static struct thdpool *trickle_thdpool;
 static pool_t *pgpool;
 pthread_mutex_t pgpool_lk;
 
+int gbl_trickle_sync_counter_max = 20;
 
 static void
 trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
@@ -562,7 +563,7 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 	DB_MUTEX *mutexp;
 	MPOOLFILE *mfp;
 	int ar_cnt, hb_lock, i, j, pass, remaining, ret;
-	int wait_cnt, write_cnt, wrote;
+	int wait_cnt, write_cnt, wrote, sleeps=0;
 	int sgio, gathered, delay_write;
 	db_pgno_t off_gather;
 
@@ -725,11 +726,14 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 		    "... bhp->ref_sync is %d (waiting for it to go to 0)\n",
 			    bhp->ref_sync);
 			(void)__os_sleep(dbenv, 1, 0);
+			sleeps++;
 		}
 #else
 		for (wait_cnt = 1;
-		    bhp->ref_sync != 0 && wait_cnt < 4; ++wait_cnt)
+		    bhp->ref_sync != 0 && wait_cnt < 4; ++wait_cnt) {
 			(void)__os_sleep(dbenv, 1, 0);
+			sleeps++;
+		}
 #endif
 
 		MUTEX_LOCK(dbenv, mutexp);
@@ -740,8 +744,16 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 		 * with this buffer no matter what happens.
 		 */
 		if (bhp->ref_sync == 0) {
+			sleeps = 0;
 			--remaining;
 			bharray[i].track_hp = NULL;
+		} else {
+			if (gbl_trickle_sync_counter_max > 0 && sleeps >=
+					gbl_trickle_sync_counter_max) {
+				logmsg(LOGMSG_FATAL, "%s exceeded max-sync time: aborting\n",
+						__func__);
+				abort();
+			}
 		}
 
 		/*

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -227,6 +227,7 @@ extern int gbl_serialize_reads_like_writes;
 extern int gbl_long_log_truncation_warn_thresh_sec;
 extern int gbl_long_log_truncation_abort_thresh_sec;
 extern int gbl_disable_ckp;
+extern int gbl_trickle_sync_counter_max;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1764,6 +1764,12 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("trickle_max_sync",
+                 "Abort if we can't write a buffer after this many seconds.  "
+                 "(Default: 20)",
+                 TUNABLE_INTEGER, &gbl_trickle_sync_counter_max,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",
                  "Maximum size in bytes of the output buffer of an appsock "
                  "thread.  (Default: 8 MiB)",


### PR DESCRIPTION
This is a quick-fix for a bug that can occur with old-style queues.  This logic assumes that taking longer than 20 seconds to sync a single page to disk is insane on any modern system.  The actual length of time the database is willing to wait for a single page to sync is controlled by the trickle_max_sync tunable.  This is the 7.0 port of https://github.com/bloomberg/comdb2/pull/1953