### PR TITLE
Ref sync tunables

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -255,6 +255,8 @@ extern char *gbl_timepart_file_name;
 extern char *gbl_exec_sql_on_new_connect;
 extern char *gbl_portmux_unix_socket;
 extern char *gbl_machine_class;
+extern int gbl_ref_sync_pollms;
+extern int gbl_ref_sync_iterations;
 
 extern char *gbl_kafka_topic;
 extern char *gbl_kafka_brokers;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1864,17 +1864,12 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("ref_sync_pollms", "Set pollms for ref_sync thread.  "
-        "(Default: 250)",
-                 TUNABLE_INTEGER, &gbl_ref_sync_pollms, EXPERIMENTAL | INTERNAL,
-                 NULL, NULL, NULL, NULL);
+                 "(Default: 250)", TUNABLE_INTEGER, &gbl_ref_sync_pollms,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("ref_sync_iterations", "Set iterations for ref_sync thread.  "
-                "(Default: 4)",
-                 TUNABLE_INTEGER, &gbl_ref_sync_iterations, EXPERIMENTAL | INTERNAL,
-                 NULL, NULL, NULL, NULL);
-
-
-
+                 "(Default: 4)", TUNABLE_INTEGER, &gbl_ref_sync_iterations,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",
                  "Maximum size in bytes of the output buffer of an appsock "

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1863,6 +1863,19 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("ref_sync_pollms", "Set pollms for ref_sync thread.  "
+        "(Default: 250)",
+                 TUNABLE_INTEGER, &gbl_ref_sync_pollms, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("ref_sync_iterations", "Set iterations for ref_sync thread.  "
+                "(Default: 4)",
+                 TUNABLE_INTEGER, &gbl_ref_sync_iterations, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
+
+
+
+
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",
                  "Maximum size in bytes of the output buffer of an appsock "
                  "thread.  (Default: 8 MiB)",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1863,12 +1863,16 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("ref_sync_pollms", "Set pollms for ref_sync thread.  "
-                 "(Default: 250)", TUNABLE_INTEGER, &gbl_ref_sync_pollms,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("ref_sync_pollms",
+                 "Set pollms for ref_sync thread.  "
+                 "(Default: 250)",
+                 TUNABLE_INTEGER, &gbl_ref_sync_pollms, EXPERIMENTAL | INTERNAL,
+                 NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("ref_sync_iterations", "Set iterations for ref_sync thread.  "
-                 "(Default: 4)", TUNABLE_INTEGER, &gbl_ref_sync_iterations,
+REGISTER_TUNABLE("ref_sync_iterations",
+                 "Set iterations for ref_sync thread.  "
+                 "(Default: 4)",
+                 TUNABLE_INTEGER, &gbl_ref_sync_iterations,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",


### PR DESCRIPTION
A "better" quick-fix for the checkpoint-latency issue: introduce two new tunables which control the amount of time that a trickle-thread waits for a buffer's ref_sync to drop to 0.  While this doesn't directly address the lock-order issue, it should reduce the bug's impact.