### PR TITLE
Grab table locks on queue operations

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -8600,6 +8600,8 @@ int bdb_llmeta_drop_queue(bdb_state_type *bdb_state, tran_type *tran,
 
     *bdberr = BDBERR_NOERROR;
 
+    bdb_lock_table_write(bdb_state, tran);
+
     p_buf = (uint8_t *)key;
     p_buf_end = p_buf + LLMETA_IXLEN;
     qk.file_type = LLMETA_TRIGGER;

--- a/bdb/queue.c
+++ b/bdb/queue.c
@@ -527,6 +527,7 @@ int bdb_queue_add(bdb_state_type *bdb_state, tran_type *tran, const void *dta,
     int rc = 0;
 
     BDB_READLOCK("bdb_queue_add");
+    bdb_lock_table_read(bdb_state, tran);
     if (bdb_state->bdbtype == BDBTYPE_QUEUEDB) {
         rc = bdb_queuedb_add(bdb_state, tran, dta, dtalen, bdberr, out_genid);
     } else {


### PR DESCRIPTION
Fixes race between dropping a consumer and writing to a consumer's queue.