### PR TITLE
Port ref_sync_wait_txn logic to master

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -974,7 +974,8 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 
 		if (txncnt) {
 			int c = 0, cnt;
-			while((cnt = still_running(dbenv, txnarray, txncnt)) > 0) {
+			while(gbl_ref_sync_wait_txnlist &&
+                    (cnt = still_running(dbenv, txnarray, txncnt)) > 0) {
 				c++;
 				if (c > 2) {
 					fprintf(stderr, "%s: waiting for %d txns to complete, cnt %d\n",

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -549,7 +549,7 @@ static pool_t *pgpool;
 pthread_mutex_t pgpool_lk;
 int gbl_ref_sync_pollms = 250;
 int gbl_ref_sync_iterations = 4;
-int gbl_ref_sync_wait_txnlist = 1;
+int gbl_ref_sync_wait_txnlist = 0;
 
 #define MAX_TXNARRAY 64
 void collect_txnids(DB_ENV *dbenv, u_int32_t *txnarray, int max, int *count);

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -549,6 +549,11 @@ static pool_t *pgpool;
 pthread_mutex_t pgpool_lk;
 int gbl_ref_sync_pollms = 250;
 int gbl_ref_sync_iterations = 4;
+int gbl_ref_sync_wait_txnlist = 1;
+
+#define MAX_TXNARRAY 64
+void collect_txnids(DB_ENV *dbenv, u_int32_t *txnarray, int max, int *count);
+int still_running(DB_ENV *dbenv, u_int32_t *txnarray, int count);
 
 static void
 trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
@@ -564,9 +569,11 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 	DB_MPOOL_HASH **hparray;
 	DB_MUTEX *mutexp;
 	MPOOLFILE *mfp;
+	u_int32_t txnarray[MAX_TXNARRAY];
+	int txncnt = 0;
 	int ar_cnt, hb_lock, i, j, pass, remaining, ret;
 	int wait_cnt, write_cnt, wrote;
-	int sgio, gathered, delay_write;
+	int sgio, gathered, delay_write, total_txns = 0;
 	db_pgno_t off_gather;
 
 	ret = 0;
@@ -646,7 +653,8 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 			i = 0;
 			++pass;
 			sgio = 0;
-			(void)__os_sleep(dbenv, 1, 0);
+			if (!gbl_ref_sync_wait_txnlist)
+				(void)__os_sleep(dbenv, 1, 0);
 		}
 		if ((hp = bharray[i].track_hp) == NULL)
 			continue;
@@ -743,6 +751,9 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 		if (bhp->ref_sync == 0) {
 			--remaining;
 			bharray[i].track_hp = NULL;
+		} else if (gbl_ref_sync_wait_txnlist){
+			collect_txnids(dbenv, txnarray, MAX_TXNARRAY, &txncnt);
+			total_txns += txncnt;
 		}
 
 		/*
@@ -960,6 +971,23 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 
 		if (ret != 0)
 			break;
+
+		if (txncnt) {
+			int c = 0, cnt;
+			while((cnt = still_running(dbenv, txnarray, txncnt)) > 0) {
+				c++;
+				if (c > 2) {
+					fprintf(stderr, "%s: waiting for %d txns to complete, cnt %d\n",
+							__func__, cnt, c);
+				}
+				__os_sleep(dbenv, 1, 0);
+			}
+			txncnt = 0;
+			if (total_txns > 20) {
+				fprintf(stderr, "%s: waited on %d total txns so far\n",
+						__func__, total_txns);
+			}
+		}
 	}
 
 	/* 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -255,6 +255,7 @@ extern char *gbl_exec_sql_on_new_connect;
 extern char *gbl_portmux_unix_socket;
 extern char *gbl_machine_class;
 extern int gbl_ref_sync_pollms;
+extern int gbl_ref_sync_wait_txnlist;
 extern int gbl_ref_sync_iterations;
 
 extern char *gbl_kafka_topic;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1872,6 +1872,12 @@ REGISTER_TUNABLE("ref_sync_iterations",
                  TUNABLE_INTEGER, &gbl_ref_sync_iterations,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("ref_sync_wait_txnlist",
+                 "Wait for running txns to complete on sync failure.  "
+                 "(Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_ref_sync_wait_txnlist,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("cached_output_buffer_max_bytes",
                  "Maximum size in bytes of the output buffer of an appsock "
                  "thread.  (Default: 8 MiB)",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1874,7 +1874,7 @@ REGISTER_TUNABLE("ref_sync_iterations",
 
 REGISTER_TUNABLE("ref_sync_wait_txnlist",
                  "Wait for running txns to complete on sync failure.  "
-                 "(Default: on)",
+                 "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_ref_sync_wait_txnlist,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 


### PR DESCRIPTION
Porting the R6 hotfix logic to master.  If ref-sync fails to clear the ref-sync counter, mp_sync thread grabs a list of active transactions and polls at the end of the loop waiting for them to complete.  This prevents a single transaction from being blocked more than a single time by the sync-thread.