### PR TITLE
remove osql node blackout mechanism

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -845,11 +845,6 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
 
     osql_sess_set_complete(rqid, uuid, sess, xerr);
 
-    /* if we received a too early, check the coherency and mark blackout node */
-    if (xerr && xerr->errval == OSQL_TOOEARLY) {
-        osql_comm_blkout_node(sess->offhost);
-    }
-
     debug = debug_this_request(gbl_debug_until);
     if (gbl_who > 0 && gbl_debug) {
         debug = 1;

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -48,15 +48,6 @@ int osql_comm_init(struct dbenv *dbenv);
  */
 void osql_comm_destroy(void);
 
-/**
- * Disable temporarily replicant "node"
- * "node" will receive no more offloading requests
- * until a blackout window will expire
- * It is used mainly with blocksql
- *
- */
-int osql_comm_blkout_node(const char *host);
-
 /* Offload upgrade record request. */
 int offload_comm_send_upgrade_record(const char *tbl, unsigned long long genid);
 

--- a/db/osqlrepository.h
+++ b/db/osqlrepository.h
@@ -68,16 +68,6 @@ int osql_repository_init(void);
 void osql_repository_destroy(void);
 
 /**
- * Disable temporarily replicant "node"
- * Lock the repository during update
- * "node" will receive no more offloading requests
- * until a blackout window will expire
- * It is used mainly with blocksql
- *
- */
-int osql_repository_blkout_node(char *node);
-
-/**
  * Returns true if all requests are being
  * cancelled (this is usually done because
  * of a schema change)

--- a/net/net.h
+++ b/net/net.h
@@ -333,10 +333,6 @@ int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
 /* pick a sibling for sql offloading */
 char *net_get_osql_node(netinfo_type *netinfo_ptr);
 
-/* pick a sibling for sql offloading using blackout list */
-char *net_get_osql_node_blkout(netinfo_type *netinfo_ptr, char *nodes[REPMAX],
-                               int lnodes);
-
 /* netinfo getters and setters so that we don't have tomake the entire
  * netinfo struct public. */
 char *net_get_mynode(netinfo_type *netinfo_ptr);


### PR DESCRIPTION
Node blackout was used in blocksql to avoid offloading (i.e. sending) sql statements from master to specific replicants, if we have noticed that those replicants were broken.  This is not needed anymore.
