### PR TITLE
fix regression do not try to run bplogs ending with an osql_xerr

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -852,7 +852,7 @@ int osql_bplog_saveop(osql_sess_t *sess, char *rpl, int rplen,
         if (!osql_sess_dispatched(sess) && !osql_sess_is_terminated(sess)) {
             osql_session_set_ireq(sess, NULL);
             osql_sess_set_dispatched(sess, 1);
-            tran->iscomplete = true;
+            tran->iscomplete = (type != OSQL_XERR);
             rc = handle_buf_sorese(thedb, iq, debug);
         }
         osql_sess_unlock_complete(sess);


### PR DESCRIPTION
Regression introduced in https://github.com/bloomberg/comdb2/pull/1960.
Normally, if a bplog ends with an OSQL_XERR packet (because replicant decided to abort the sql transaction), the bplog is not processed and we simply discard it.  After the PR, the log is processed, aborted, db spews (since it is not expected to process an OSQL_XERR), but albeit the extra-work, things are normal (therefore the regression tests did not capture the issue).