### PR TITLE
Fix bdb_get_first_logfile

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -7433,7 +7433,7 @@ int bdb_get_first_logfile(bdb_state_type *bdb_state, int *bdberr)
     }
     bzero(&logent, sizeof(DBT));
     logent.flags = DB_DBT_MALLOC;
-    rc = logc->get(logc, &current_lsn, &logent, DB_LAST);
+    rc = logc->get(logc, &current_lsn, &logent, DB_FIRST);
     if (rc) {
         logc->close(logc, 0);
         logmsg(LOGMSG_ERROR, "%s: logc->get last LSN rc %d\n", __func__, rc);


### PR DESCRIPTION
Fix "day-1" bug in bdb_get_first_logfile.  The current code allows a btree file to be "cleaned" by the purge old files thread even though it's still referenced in the transaction log.
