### PR TITLE
Fix omission of 'drop_view' from the 'get_ddl_type_str' schema change function.

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -508,7 +508,7 @@ char *get_ddl_type_str(struct schema_change_type *s)
         return "ALTER QUEUE";
     else if (s->type == DBTYPE_MORESTRIPE)
         return "ALTER STRIPE";
-    else if (s->add_view)
+    else if (s->add_view || s->drop_view)
         return "VIEW";
 
     return "UNKNOWN";


### PR DESCRIPTION
The function modified by this pull request appears to be used only from the schema change status (reporting) virtual table.  When a view is being dropped, it should now be reported with a type column value of "view".