### PR TITLE
cdb2_verify: Detect inter-page out of order btree key entries in verify

### DIFF
--- a/berkdb/btree/bt_verify.c
+++ b/berkdb/btree/bt_verify.c
@@ -374,9 +374,7 @@ __bam_vrfy(dbp, vdp, h, pgno, flags)
 		EPRINT((dbenv,
 		    "Page %lu: item order check unsafe: skipping",
 		    (u_long)pgno));
-	}
-#if 0
-	else if (!LF_ISSET(DB_NOORDERCHK) && (ret =
+	} else if (!LF_ISSET(DB_NOORDERCHK) && (ret =
 	    __bam_vrfy_itemorder(dbp, vdp, h, pgno, 0, 0, 0, flags)) != 0) {
 		/*
 		 * We know that the elements of inp are reasonable.
@@ -388,7 +386,6 @@ __bam_vrfy(dbp, vdp, h, pgno, flags)
 		else
 			goto err;
 	}
-#endif
 
 err:	if ((t_ret = __db_vrfy_putpageinfo(dbenv, vdp, pip)) != 0 && ret == 0)
 		ret = t_ret;
@@ -955,7 +952,7 @@ __bam_vrfy_itemorder(dbp, vdp, h, pgno, nentries, ovflok, hasdups, flags)
 	p1 = &dbta;
 	p2 = &dbtb;
 
-	if (last_key_from_prev_pg.data && (TYPE(h) == P_LBTREE)) {
+	if (last_key_from_prev_pg.data && (TYPE(h) == P_LBTREE) && LF_ISSET(DB_IN_ORDER_CHECK)) {
 		/*
         long int genid = *(long int*)(last_key_from_prev_pg.data+5);
 		printf("setting pgno=%lu from last_key_from_prev_pg, sz=%d, data=%p *data=%016lx\n", (u_long)pgno, last_key_from_prev_pg.size, last_key_from_prev_pg.data, flibc_ntohll(genid));
@@ -1175,7 +1172,7 @@ overflow:		if (!ovflok) {
 			}
 		}
 	}
-	if ((TYPE(h) == P_LBTREE)) {
+	if ((TYPE(h) == P_LBTREE) && LF_ISSET(DB_IN_ORDER_CHECK)) {
 		if (last_key_from_prev_pg.data && p2->size > last_key_from_prev_pg.size) {
 			last_key_from_prev_pg.data = realloc(last_key_from_prev_pg.data, p2->size);
 		} else 

--- a/berkdb/btree/bt_verify.c
+++ b/berkdb/btree/bt_verify.c
@@ -879,6 +879,9 @@ err:	if (nentriesp != NULL)
  *	and we run into an overflow page, carp and return DB_VERIFY_BAD;
  *	we shouldn't be called if any exist.
  *
+ *  COMDB2_MODIFICATION: if flag DB_IN_ORDER_CHECK is set we will compare
+ *  first record on leaf page with last record from prev pg.
+ *
  * PUBLIC: int __bam_vrfy_itemorder __P((DB *, VRFY_DBINFO *, PAGE *,
  * PUBLIC:     db_pgno_t, u_int32_t, int, int, u_int32_t));
  */

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -351,6 +351,7 @@ struct __db_trigger_subscription;
 #define	DB_PR_RECOVERYTEST    0x0000010	/* Recovery test (-dr). */
 #define	DB_PRINTABLE	      0x0000020	/* Use printable format for salvage. */
 #define	DB_SALVAGE	      0x0000040	/* Salvage what looks like data. */
+#define	DB_IN_ORDER_CHECK 0x0000080	/* We are traversing in order so check intra page for out-of-order keys. */
 /*
  * !!!
  * These must not go over 0x8000, or they will collide with the flags

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -351,7 +351,7 @@ struct __db_trigger_subscription;
 #define	DB_PR_RECOVERYTEST    0x0000010	/* Recovery test (-dr). */
 #define	DB_PRINTABLE	      0x0000020	/* Use printable format for salvage. */
 #define	DB_SALVAGE	      0x0000040	/* Salvage what looks like data. */
-#define	DB_IN_ORDER_CHECK 0x0000080	/* We are traversing in order so check intra page for out-of-order keys. */
+#define	DB_IN_ORDER_CHECK   0x0000080	/* We are traversing in order so check intra page for out-of-order keys. */
 /*
  * !!!
  * These must not go over 0x8000, or they will collide with the flags

--- a/berkdb/db/db_pr.c
+++ b/berkdb/db/db_pr.c
@@ -718,10 +718,10 @@ __db_pr(p, len, fp)
 	lastch = '.';
 	if (len != 0) {
 		logmsgf(LOGMSG_USER, fp, " data: ");
-        char temp[2*len+1];
-        util_tohex(temp, (const char*)p, len);
-        logmsgf(LOGMSG_USER, fp, "%s", temp);
-        /*
+		char temp[2*len+1];
+		util_tohex(temp, (const char*)p, len);
+		logmsgf(LOGMSG_USER, fp, "%s", temp);
+		/* COMDB2_MODIFICATION
 		for (i = len <= 20 ? len : 20; i > 0; --i, ++p) {
 			lastch = *p;
 			if (isprint((int)*p) || *p == '\n')
@@ -733,7 +733,7 @@ __db_pr(p, len, fp)
 			logmsgf(LOGMSG_USER, fp, "...");
 			lastch = '.';
 		}
-        */
+		 */
 	}
 	if (lastch != '\n')
 		logmsgf(LOGMSG_USER, fp, "\n");

--- a/berkdb/db/db_pr.c
+++ b/berkdb/db/db_pr.c
@@ -19,6 +19,7 @@ static const char revid[] = "$Id: db_pr.c,v 11.94 2003/06/30 17:19:46 bostic Exp
 #include <string.h>
 #endif
 
+#include "tohex.h"
 #include "db_int.h"
 #include "dbinc/db_page.h"
 #include "dbinc/db_shash.h"
@@ -717,17 +718,22 @@ __db_pr(p, len, fp)
 	lastch = '.';
 	if (len != 0) {
 		logmsgf(LOGMSG_USER, fp, " data: ");
+        char temp[2*len+1];
+        util_tohex(temp, (const char*)p, len);
+        logmsgf(LOGMSG_USER, fp, "%s", temp);
+        /*
 		for (i = len <= 20 ? len : 20; i > 0; --i, ++p) {
 			lastch = *p;
 			if (isprint((int)*p) || *p == '\n')
 				logmsgf(LOGMSG_USER, fp, "%c", *p);
 			else
-				logmsgf(LOGMSG_USER, fp, "0x%.2x", (u_int)*p);
+				logmsgf(LOGMSG_USER, fp, "%x", (u_int)*p);
 		}
 		if (len > 20) {
 			logmsgf(LOGMSG_USER, fp, "...");
 			lastch = '.';
 		}
+        */
 	}
 	if (lastch != '\n')
 		logmsgf(LOGMSG_USER, fp, "\n");

--- a/berkdb/db/db_pr.c
+++ b/berkdb/db/db_pr.c
@@ -721,13 +721,13 @@ __db_pr(p, len, fp)
 		char temp[2*len+1];
 		util_tohex(temp, (const char*)p, len);
 		logmsgf(LOGMSG_USER, fp, "%s", temp);
-		/* COMDB2_MODIFICATION
+		/* COMDB2_MODIFICATION: better output with util_tohex
 		for (i = len <= 20 ? len : 20; i > 0; --i, ++p) {
 			lastch = *p;
 			if (isprint((int)*p) || *p == '\n')
 				logmsgf(LOGMSG_USER, fp, "%c", *p);
 			else
-				logmsgf(LOGMSG_USER, fp, "%x", (u_int)*p);
+				logmsgf(LOGMSG_USER, fp, "0x%.2x", (u_int)*p);
 		}
 		if (len > 20) {
 			logmsgf(LOGMSG_USER, fp, "...");

--- a/berkdb/db/db_vrfy.c
+++ b/berkdb/db/db_vrfy.c
@@ -616,7 +616,6 @@ __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, pgno)
 	dbenv = dbp->dbenv;
 	mpf = dbp->mpf;
 	ret = isbad = t_ret = 0;
-	// printf("__db_vrfy_depthfirst pg=%d\n", pgno);
 
 	if ((t_ret = __memp_fget(mpf, &pgno, 0, &h)) != 0) {
 		return (t_ret);
@@ -632,7 +631,6 @@ __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, pgno)
 			BINTERNAL *bi;
 			bi = GET_BINTERNAL(dbp, h, i);
 
-			// printf("from pg %d to pg %d\n", pgno, bi->pgno);
 			ret = __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, (u_long)bi->pgno);
 			if (ret) 
 				isbad = 1;

--- a/berkdb/db/db_vrfy.c
+++ b/berkdb/db/db_vrfy.c
@@ -613,6 +613,7 @@ __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, pgno)
 	PAGE *h;
 	db_pgno_t i;
 	int ret, t_ret, isbad;
+    LF_SET(DB_IN_ORDER_CHECK);
 
 	dbenv = dbp->dbenv;
 	mpf = dbp->mpf;

--- a/berkdb/db/db_vrfy.c
+++ b/berkdb/db/db_vrfy.c
@@ -339,7 +339,6 @@ __db_verify(dbp, name, subdb, handle, callback, flags)
 			F_SET(vdp, SALVAGE_PRINTHEADER);
 	}
 
-
 	if ((ret =
 	    __db_vrfy_walkpages(dbp, vdp, handle, callback, flags)) != 0) {
 		if (ret == DB_VERIFY_BAD)
@@ -349,7 +348,7 @@ __db_verify(dbp, name, subdb, handle, callback, flags)
 	}
 
 	if ((ret =
-        __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, 1)) != 0) {
+		__db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, 1)) != 0) {
 		if (ret == DB_VERIFY_BAD)
 			isbad = 1;
 		else if (ret != 0)
@@ -613,40 +612,40 @@ __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, pgno)
 	PAGE *h;
 	db_pgno_t i;
 	int ret, t_ret, isbad;
-    LF_SET(DB_IN_ORDER_CHECK);
 
 	dbenv = dbp->dbenv;
 	mpf = dbp->mpf;
 	ret = isbad = t_ret = 0;
-    // printf("__db_vrfy_depthfirst pg=%d\n", pgno);
+	// printf("__db_vrfy_depthfirst pg=%d\n", pgno);
 
-    if ((t_ret = __memp_fget(mpf, &pgno, 0, &h)) != 0) {
-        return (t_ret);
-    }
-    
-    if (TYPE(h) == P_IBTREE) {
-        VRFY_PAGEINFO *pip;
-        if ((ret = __db_vrfy_getpageinfo(vdp, pgno, &pip)) != 0)
-            return (ret);
-        u_int32_t nentries = pip->entries;
-        db_indx_t i;
-        for (i = 1; i < nentries; i+= O_INDX) {
-            BINTERNAL *bi;
+	if ((t_ret = __memp_fget(mpf, &pgno, 0, &h)) != 0) {
+		return (t_ret);
+	}
+
+	if (TYPE(h) == P_IBTREE) {
+		VRFY_PAGEINFO *pip;
+		if ((ret = __db_vrfy_getpageinfo(vdp, pgno, &pip)) != 0)
+			return (ret);
+		u_int32_t nentries = pip->entries;
+		db_indx_t i;
+		for (i = 1; i < nentries; i+= O_INDX) {
+			BINTERNAL *bi;
 			bi = GET_BINTERNAL(dbp, h, i);
 
-            // printf("from pg %d to pg %d\n", pgno, bi->pgno);
-            ret = __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, (u_long)bi->pgno);
-            if (ret) 
-                isbad = 1;
-        }
-    } else if (TYPE(h) == P_LBTREE) {
-        ret = __bam_vrfy_itemorder(dbp, vdp, h, pgno, 0, 0, 0, flags);
-    }
+			// printf("from pg %d to pg %d\n", pgno, bi->pgno);
+			ret = __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, (u_long)bi->pgno);
+			if (ret) 
+				isbad = 1;
+		}
+	} else if (TYPE(h) == P_LBTREE) {
+		LF_SET(DB_IN_ORDER_CHECK);
+		ret = __bam_vrfy_itemorder(dbp, vdp, h, pgno, 0, 0, 0, flags);
+	}
 
-    if ((t_ret = __memp_fput(mpf, h, 0)) != 0) 
-        return t_ret;
+	if ((t_ret = __memp_fput(mpf, h, 0)) != 0) 
+		return t_ret;
 
-    return (ret || isbad) ? DB_VERIFY_BAD : 0;
+	return (ret || isbad) ? DB_VERIFY_BAD : 0;
 }
 
 /*

--- a/berkdb/db/db_vrfy.c
+++ b/berkdb/db/db_vrfy.c
@@ -64,6 +64,9 @@ static int   __db_vrfy_structure
 static int   __db_vrfy_walkpages __P((DB *, VRFY_DBINFO *,
 		void *, int (*)(void *, const void *), u_int32_t));
 
+static int   __db_vrfy_depthfirst __P((DB *, VRFY_DBINFO *,
+		void *, int (*)(void *, const void *), u_int32_t, u_int32_t));
+
 /*
  * __db_verify_pp --
  *	DB->verify public interface.
@@ -336,8 +339,17 @@ __db_verify(dbp, name, subdb, handle, callback, flags)
 			F_SET(vdp, SALVAGE_PRINTHEADER);
 	}
 
+
 	if ((ret =
 	    __db_vrfy_walkpages(dbp, vdp, handle, callback, flags)) != 0) {
+		if (ret == DB_VERIFY_BAD)
+			isbad = 1;
+		else if (ret != 0)
+			goto err;
+	}
+
+	if ((ret =
+        __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, 1)) != 0) {
 		if (ret == DB_VERIFY_BAD)
 			isbad = 1;
 		else if (ret != 0)
@@ -582,6 +594,58 @@ __db_vrfy_pagezero(dbp, vdp, fhp, flags)
 		F_SET(dbp, DB_AM_SWAP);
 
 	return (isbad ? DB_VERIFY_BAD : 0);
+}
+
+/* depthfirst search, starting at root go to leftmost page and do 
+ * a consistency search.
+ */
+static int
+__db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, pgno)
+	DB *dbp;
+	VRFY_DBINFO *vdp;
+	void *handle;
+	int (*callback) __P((void *, const void *));
+	u_int32_t flags;
+    db_pgno_t pgno;
+{
+	DB_ENV *dbenv;
+	DB_MPOOLFILE *mpf;
+	PAGE *h;
+	db_pgno_t i;
+	int ret, t_ret, isbad;
+
+	dbenv = dbp->dbenv;
+	mpf = dbp->mpf;
+	ret = isbad = t_ret = 0;
+    // printf("__db_vrfy_depthfirst pg=%d\n", pgno);
+
+    if ((t_ret = __memp_fget(mpf, &pgno, 0, &h)) != 0) {
+        return (t_ret);
+    }
+    
+    if (TYPE(h) == P_IBTREE) {
+        VRFY_PAGEINFO *pip;
+        if ((ret = __db_vrfy_getpageinfo(vdp, pgno, &pip)) != 0)
+            return (ret);
+        u_int32_t nentries = pip->entries;
+        db_indx_t i;
+        for (i = 1; i < nentries; i+= O_INDX) {
+            BINTERNAL *bi;
+			bi = GET_BINTERNAL(dbp, h, i);
+
+            // printf("from pg %d to pg %d\n", pgno, bi->pgno);
+            ret = __db_vrfy_depthfirst(dbp, vdp, handle, callback, flags, (u_long)bi->pgno);
+            if (ret) 
+                isbad = 1;
+        }
+    } else if (TYPE(h) == P_LBTREE) {
+        ret = __bam_vrfy_itemorder(dbp, vdp, h, pgno, 0, 0, 0, flags);
+    }
+
+    if ((t_ret = __memp_fput(mpf, h, 0)) != 0) 
+        return t_ret;
+
+    return (ret || isbad) ? DB_VERIFY_BAD : 0;
 }
 
 /*


### PR DESCRIPTION
Start the search at root node (pg 1) and do a depth first search to check for out-of-order keys between pages. We will now detect issues with pages containing an out of order key being inserted at the end of a page:
```/dev/shm/master/build/db/cdb2_verify /dev/shm/test_12546/ixentrymissingreproducer12546/t_*index  
2019/12/30 15:03:00 cdb2_verify: Page 3599: out-of-order key at entry 0 *p1=0000004b3fc90005 *p2=0000004b3d1b0001
2019/12/30 15:03:00 cdb2_verify: DB->verify: /dev/shm/test_12546/ixentrymissingreproducer12546/t_000000493c9b0000.index: DB_VERIFY_BAD: Database verification failed
```