### PR TITLE
PORTED R7 verify: detect out of order keys in any of the btrees

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -202,15 +202,6 @@ ret:
     return rc;
 }
 
-static void printhex(SBUF2 *sb, int (*lua_callback)(void *, const char *),
-        void *lua_params, uint8_t *hex, int sz)
-{
-    const char hexbytes[] = "0123456789abcdef";
-    for (int i = 0; i < sz; i++)
-        locprint(sb, lua_callback, lua_params, "%c%c", 
-                hexbytes[(hex[i] & 0xf0) >> 4], hexbytes[hex[i] & 0xf]);
-}
-
 static inline int print_verify_progress(verify_common_t *par, int now)
 {
     if (!par->progress_report_seconds)
@@ -258,13 +249,32 @@ out:
     return par->client_dropped_connection;
 }
 
+extern int __bam_defcmp(DB *dbp, const DBT *a, const DBT *b);
+
+// compare with previous key, ensure order
+static inline void check_order(DBT *old, DBT *curr,
+                               verify_common_t *par)
+{
+    if (old->size == 0)
+        return;
+    int cmp = __bam_defcmp(NULL, old, curr);
+    if (cmp >= 0) {
+        par->verify_status = 1;
+        char hexstr1[old->size * 2 + 1];
+        char hexstr2[curr->size * 2 + 1];
+        util_tohex(hexstr1, old->data, old->size);
+        util_tohex(hexstr2, curr->data, curr->size);
+        locprint(par->sb, par->lua_callback, par->lua_params,
+                 "!%s out-of-order key, prev %s", hexstr2, hexstr1);
+    }
+}
+
 /* TODO: handle deadlock, get rowlocks if db in rowlocks mode */
 static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                                   unsigned int lid)
 {
     DBC *cdata = NULL;
     DBC *ckey = NULL;
-    DB *db;
     DBC *cblob = NULL;
     unsigned char databuf[17 * 1024];
     unsigned char keybuf[18 * 1024];
@@ -287,7 +297,11 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
     dbt_key.ulen = sizeof(keybuf);
     dbt_key.data = keybuf;
 
-    db = bdb_state->dbp_data[0][dtastripe];
+    unsigned long long oldgenid;
+    DBT dbt_old_key = {
+        .flags = DB_DBT_USERMEM, .ulen = sizeof(oldgenid), .data = &oldgenid};
+
+    DB *db = bdb_state->dbp_data[0][dtastripe];
     rc = db->paired_cursor_from_lid(db, lid, &cdata, 0);
     if (rc) {
         logmsg(LOGMSG_ERROR, "dtastripe %d cursor rc %d\n", dtastripe, rc);
@@ -311,6 +325,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
             break;
 
         unsigned long long genid;
+        memcpy(&genid, dbt_key.data, sizeof(genid));
         /* is it the right size? */
         if (dbt_key.size != sizeof(genid)) {
             par->verify_status = 1;
@@ -318,7 +333,6 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                      "!bad genid sz %d", dbt_key.size);
             goto next_record;
         }
-        memcpy(&genid, dbt_key.data, sizeof(genid));
 
         /* why do we open a cursor for each record/blob?
         1) cursors are cheap - berkeley opens one for every cursor
@@ -334,6 +348,9 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
 #else
         genid_flipped = genid;
 #endif
+
+        check_order(&dbt_old_key, &dbt_key, par);
+
         par->vtag_callback(par->db_table, dbt_data.data, (int *)&dbt_data.size,
                            ver);
         rc = par->get_blob_sizes_callback(par->db_table, dbt_data.data,
@@ -546,7 +563,9 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
         }
         par->free_blob_buffer_callback(blob_buf);
         sbuf2flush(par->sb);
-    next_record:
+next_record:
+        dbt_old_key.size = sizeof(genid);
+        memcpy(dbt_old_key.data, &genid, dbt_old_key.size);
 
         dbt_data.flags = DB_DBT_USERMEM;
         dbt_data.ulen = sizeof(databuf);
@@ -580,7 +599,6 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
 {
     DBC *cdata = NULL;
     DBC *ckey = NULL;
-    DB *db;
     unsigned char databuf[17 * 1024];
     unsigned char keybuf[18 * 1024];
     unsigned char expected_keybuf[18 * 1024];
@@ -597,6 +615,10 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
     dbt_key.data = keybuf;
     dbt_key.ulen = sizeof(keybuf);
     dbt_key.flags = DB_DBT_USERMEM;
+
+    unsigned char oldkeybuf[18 * 1024];
+    DBT dbt_old_key = {
+        .flags = DB_DBT_USERMEM, .ulen = sizeof(oldkeybuf), .data = oldkeybuf};
 
     DBT dbt_data = {0};
     dbt_data.data = databuf;
@@ -620,8 +642,8 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
     logmsg(LOGMSG_DEBUG, "%p:%s Entering ix=%d\n", (void *)pthread_self(),
            __func__, ix);
 
-    rc = bdb_state->dbp_ix[ix]->paired_cursor_from_lid(bdb_state->dbp_ix[ix],
-                                                       lid, &ckey, 0);
+    DB *db = bdb_state->dbp_ix[ix];
+    rc = db->paired_cursor_from_lid(db, lid, &ckey, 0);
     if (rc) {
         par->verify_status = 1;
         locprint(par->sb, par->lua_callback, par->lua_params,
@@ -650,6 +672,7 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                      "!ix %d unexpected length %d", ix, dbt_data.size);
             goto next_key;
         }
+
         memcpy(&genid, dbt_data.data, sizeof(unsigned long long));
         unsigned long long genid_flipped;
 
@@ -660,9 +683,11 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
         genid_flipped = genid;
 #endif
 
+        check_order(&dbt_old_key, &dbt_key, par);
+
         /* make sure the data entry exists: */
-        db = get_dbp_from_genid(bdb_state, 0, genid, NULL);
-        rc = db->paired_cursor_from_lid(db, lid, &cdata, 0);
+        DB *db_d = get_dbp_from_genid(bdb_state, 0, genid, NULL);
+        rc = db_d->paired_cursor_from_lid(db_d, lid, &cdata, 0);
         if (rc) {
             par->verify_status = 1;
             locprint(par->sb, par->lua_callback, par->lua_params,
@@ -912,6 +937,9 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
         }
 
     next_key:
+        dbt_old_key.size = dbt_key.size;
+        memcpy(dbt_old_key.data, dbt_key.data, dbt_key.size);
+
         rc = ckey->c_get(ckey, &dbt_key, &dbt_data, DB_NEXT);
     }
     if (rc && rc != DB_NOTFOUND) {
@@ -985,6 +1013,11 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
     dbt_dta_check_data.dlen = 0;
     dbt_dta_check_data.flags = DB_DBT_USERMEM | DB_DBT_PARTIAL;
 
+    unsigned long long oldgenid;
+    DBT dbt_old_key = {
+        .flags = DB_DBT_USERMEM, .ulen = sizeof(oldgenid), .data = &oldgenid};
+
+
     int atstart = comdb2_time_epochms();
     int now = atstart;
     logmsg(LOGMSG_DEBUG, "%p:%s Entering blobno=%d, stripe=%d\n",
@@ -1009,6 +1042,8 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
         genid_flipped = genid;
 #endif
 
+        check_order(&dbt_old_key, &dbt_key, par);
+
         int stripe = get_dtafile_from_genid(genid);
 
         if (!bdb_state->blobstripe_convert_genid ||
@@ -1026,8 +1061,7 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
         if (rc) {
             logmsg(LOGMSG_ERROR, "dtastripe %d genid %016llx cursor rc %d\n",
                    stripe, genid_flipped, rc);
-            rc = cblob->c_get(cblob, &dbt_key, &dbt_data, DB_NEXT);
-            return;
+            goto next_key;
         }
         rc = cdata->c_get(cdata, &dbt_dta_check_key, &dbt_dta_check_data,
                           DB_SET);
@@ -1044,6 +1078,10 @@ static void bdb_verify_blob(verify_common_t *par, int blobno, int dtastripe,
         rc = cdata->c_close(cdata);
         if (rc)
             logmsg(LOGMSG_ERROR, "close rc %d\n", rc);
+
+next_key:
+        dbt_old_key.size = dbt_key.size;
+        memcpy(dbt_old_key.data, dbt_key.data, dbt_key.size);
 
         rc = cblob->c_get(cblob, &dbt_key, &dbt_data, DB_NEXT);
     }


### PR DESCRIPTION
verify: detect out of order keys in any of the btrees
Out of order errors will now be reported like this:

(out='0000000fcd1f0003 ix 0 missing key')
(out='08800000000000000fca550000 out-of-order key, prev 08800000000000000fcd1f0003')
[exec procedure sys.cmd.verify('t')] failed with rc -3 [sys.comdb_verify(tbl, mode, ver...]:2: Verify failed.

Master branch PR for same https://github.com/bloomberg/comdb2/pull/2005