### PR TITLE
Guard checkerboard hash with a mutex rather than a rwlock

### DIFF
--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -43,8 +43,8 @@
 
 typedef struct osql_checkboard {
 
-    hash_t * rqs; /* sql threads processing a blocksql are registered here */
-    hash_t *rqsuuid;                /* like above, but register by uuid */
+    hash_t *rqs;     /* sql threads processing a blocksql are registered here */
+    hash_t *rqsuuid; /* like above, but register by uuid */
     pthread_mutex_t mtx; /* protect all the requests */
 
 } osql_checkboard_t;
@@ -125,9 +125,11 @@ static inline int insert_into_checkerboard(osql_checkboard_t *checkboard,
 }
 
 /* delete entry from checkerboard -- called with checkerboard->mtx held */
-static inline osql_sqlthr_t * delete_from_checkerboard(osql_checkboard_t *checkboard, osqlstate_t *osql)
-{    
-    osql_sqlthr_t *entry = osql_chkboard_fetch_entry(osql->rqid, osql->uuid, false);
+static inline osql_sqlthr_t *
+delete_from_checkerboard(osql_checkboard_t *checkboard, osqlstate_t *osql)
+{
+    osql_sqlthr_t *entry =
+        osql_chkboard_fetch_entry(osql->rqid, osql->uuid, false);
     if (!entry) {
         goto done;
     }
@@ -141,8 +143,7 @@ static inline osql_sqlthr_t * delete_from_checkerboard(osql_checkboard_t *checkb
         if (rc) {
             uuidstr_t us;
             logmsg(LOGMSG_ERROR, "%s: unable to delete record %llx %s, rc=%d\n",
-                   __func__, entry->rqid, comdb2uuidstr(osql->uuid, us),
-                   rc);
+                   __func__, entry->rqid, comdb2uuidstr(osql->uuid, us), rc);
         }
     }
 done:

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -2,7 +2,6 @@
 bash -n "$0" | exit 1
 
 set -e
-set -x
 source ${TESTSROOTDIR}/tools/runit_common.sh
 
 if [[ "x${DEBUGGER}" == "xvalgrind" ]] ; then
@@ -446,9 +445,19 @@ test_bulk() {
         cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from mytable6 where 1"
     done
 }
+test_generate_series() {
+    CNT=5000
+    for j in `seq 1 2` ; do
+        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "insert into mytable6 select value, value, value from generate_series limit $CNT"
+        assertcnt mytable6 $CNT
+        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from mytable6 where 1"
+    done
+}
+
 
 test_t1
 test_bulk
+test_generate_series
 
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("sql hist")'
 
@@ -463,3 +472,4 @@ res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select i from trowid where co
 assertres $res 12345
 
 echo "Success"
+


### PR DESCRIPTION
Guard checkerboard hash with a mutex rather than a rwlock