### PR TITLE
Prevent access to freed memory after trans_commit / trans_abort

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -653,6 +653,7 @@ tran_type *bdb_start_ltran_rep_sc(bdb_state_type *bdb_state,
 void bdb_set_tran_lockerid(tran_type *tran, uint32_t lockerid);
 void bdb_get_tran_lockerid(tran_type *tran, uint32_t *lockerid);
 void *bdb_get_physical_tran(tran_type *ltran);
+void bdb_reset_physical_tran(tran_type *ltran);
 void *bdb_get_sc_parent_tran(tran_type *ltran);
 void bdb_ltran_get_schema_lock(tran_type *ltran);
 void bdb_ltran_put_schema_lock(tran_type *ltran);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -261,6 +261,12 @@ void *bdb_get_physical_tran(tran_type *ltran)
     return ltran->physical_tran;
 }
 
+void bdb_reset_physical_tran(tran_type *ltran)
+{
+    assert(ltran->tranclass == TRANCLASS_LOGICAL);
+    ltran->physical_tran = NULL;
+}
+
 void *bdb_get_sc_parent_tran(tran_type *ltran)
 {
     assert(ltran->tranclass == TRANCLASS_LOGICAL);
@@ -1629,7 +1635,8 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
                         "%s:update_shadows_beforecommit nonblocking rc %d\n",
                         __func__, rc);
                 *bdberr = rc;
-                return -1;
+                outrc = -1;
+                goto cleanup;
             }
 
             if (!isabort && tran->committed_child &&

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -417,6 +417,7 @@ int fdb_svc_trans_commit(char *tid, enum transaction_level lvl,
                 logmsg(LOGMSG_ERROR, "%s: failed %s rc=%d bdberr=%d\n", __func__,
                         (rc == SQLITE_OK) ? "commit" : "abort", irc, bdberr);
             }
+            clnt->dbtran.shadow_tran = NULL;
         }
     }
 

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -854,11 +854,11 @@ again:
         goto done;
     }
     rc = trans_commit(&iq, trans, gbl_myhostname);
+    trans = NULL;
     if (rc) {
         printf("toclear: commit rc %d\n", rc);
         goto done;
     }
-    trans = NULL;
 
 done:
     if (trans) {

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1444,8 +1444,10 @@ void *bplog_commit_timepart_resuming_sc(void *p)
 
 abort_sc:
     logmsg(LOGMSG_ERROR, "%s: aborting schema change\n", __func__);
-    if (iq.sc_tran)
+    if (iq.sc_tran) {
         trans_abort(&iq, iq.sc_tran);
+        iq.sc_tran = NULL;
+    }
     backout_schema_changes(&iq, parent_trans);
     if (iq.sc_locked) {
         unlock_schema_lk();

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -592,11 +592,11 @@ again:
         goto done;
     }
     rc = trans_commit(&iq, trans, gbl_myhostname);
+    trans = NULL;
     if (rc) {
         logmsg(LOGMSG_ERROR, "analyze: commit rc %d\n", rc);
         goto done;
     }
-    trans = NULL;
 
 done:
     if (trans) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4735,7 +4735,6 @@ int sqlite3BtreeCommit(Btree *pBt)
 
             if (!rc) {
                 irc = trans_commit_shadow(clnt->dbtran.shadow_tran, &bdberr);
-                clnt->dbtran.shadow_tran = NULL;
             } else {
                 irc = trans_abort_shadow((void **)&clnt->dbtran.shadow_tran,
                                          &bdberr);
@@ -4744,6 +4743,7 @@ int sqlite3BtreeCommit(Btree *pBt)
                 logmsg(LOGMSG_ERROR, "%s: commit failed rc=%d bdberr=%d\n", __func__,
                         irc, bdberr);
             }
+            clnt->dbtran.shadow_tran = NULL;
         }
 
         /* UPSERT: Restore the isolation level back to what it was. */
@@ -4785,7 +4785,7 @@ int sqlite3BtreeCommit(Btree *pBt)
         if (clnt->dbtran.shadow_tran) {
             rc = serial_commit(clnt, thd, clnt->tzname);
             if (!rc) {
-                if (clnt->dbtran.shadow_tran) {
+                if (clnt->dbtran.shadow_tran) { // TODO: NULL possible here?  Maybe from serial_commit?
                     irc =
                         trans_commit_shadow(clnt->dbtran.shadow_tran, &bdberr);
                 }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1891,6 +1891,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                                __func__, (rc == SQLITE_OK) ? "commit" : "abort",
                                irc, bdberr);
                     }
+                    clnt->dbtran.shadow_tran = NULL;
                 }
             } else {
                 reset_query_effects(clnt);
@@ -1964,6 +1965,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                                __func__, (rc == SQLITE_OK) ? "commit" : "abort",
                                irc, bdberr);
                     }
+                    clnt->dbtran.shadow_tran = NULL;
                 } else {
                     sql_debug_logf(clnt, __func__, __LINE__,
                                    "no-shadow-tran returning %d\n", rc);

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1042,6 +1042,7 @@ int finalize_upgrade_table(struct schema_change_type *s)
         if (rc != 0) continue;
 
         rc = trans_commit(&iq, tran, gbl_myhostname);
+        tran = NULL;
     }
 
     return rc;

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -709,11 +709,11 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
     if (!same_tran) {
         rc = trans_commit(&iq, tran, gbl_myhostname);
+        tran = NULL;
         if (rc) {
             sbuf2printf(sb, "!Failed to commit transaction\n");
             goto done;
         }
-        tran = NULL;
     }
 
     /* log for replicants to do the same */
@@ -766,11 +766,11 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
         if (!same_tran) {
             rc = trans_commit(&iq, tran, gbl_myhostname);
+            tran = NULL;
             if (rc) {
                 sbuf2printf(sb, "!Failed to commit transaction\n");
                 goto done;
             }
-            tran = NULL;
         }
     }
 
@@ -782,12 +782,12 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
             goto done;
         }
         rc = trans_commit(&iq, ltran, gbl_myhostname);
+        tran = NULL;
+        ltran = NULL;
         if (rc || bdberr != BDBERR_NOERROR) {
             sbuf2printf(sb, "!Failed to commit transaction, rc=%d\n", rc);
             goto done;
         }
-        tran = NULL;
-        ltran = NULL;
     }
 
     if (sc->addonly || sc->alteronly) {

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -3052,8 +3052,8 @@ done:
         db_seqnum_type ss;
         if (rc) {
             trans_abort(&data->iq, data->trans);
+            data->trans = NULL;
             if (rc == RC_INTERNAL_RETRY) {
-                data->trans = NULL;
                 data->num_retry_errors++;
                 data->totnretries++;
                 poll(0, 0, (rand() % 500 + 10));
@@ -3063,6 +3063,7 @@ done:
             rc = trans_commit_seqnum(&data->iq, data->trans, &ss);
         else
             rc = trans_commit(&data->iq, data->trans, gbl_myhostname);
+        data->trans = NULL;
     }
 
     reqlog_end_request(data->iq.reqlogger, 0, __func__, __LINE__);
@@ -3070,7 +3071,6 @@ done:
     /* free memory used in this function */
     clear_recs_list(&recs);
     clear_blob_hash(data->blob_hash);
-    data->trans = NULL;
     if (rc && !data->s->sc_thd_failed)
         data->s->sc_thd_failed = -1;
     if (logc)


### PR DESCRIPTION
Since the trans_commit() pipeline (eventually) frees its 'tran' argument, make sure to NULL it out so it will not be passed to trans_abort(), trans_commit(), etc again.