### PR TITLE
Unlock mtxs before calling osql_repository_rem to avoid crash

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -503,7 +503,7 @@ void osql_bplog_free(struct ireq *iq, int are_sessions_linked, const char *func,
        of sess before removing it from the lookup hash
      */
 
-    /* remove the sessions from repository and free them */
+    /* remove the sessions from repository (if linked) and free them */
     osql_close_session(&tran->sess, are_sessions_linked, func, callfunc, line);
     iq->sorese = NULL;
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5096,14 +5096,14 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
     char uuid[37];
     int type;
     union {
-        char a [OSQLCOMM_DONE_XERR_UUID_RPL_LEN];
-        char b [OSQLCOMM_DONE_UUID_RPL_LEN];
-        char c [OSQLCOMM_DONE_XERR_RPL_LEN];
-        char d [OSQLCOMM_DONE_RPL_LEN];
+        char a[OSQLCOMM_DONE_XERR_UUID_RPL_LEN];
+        char b[OSQLCOMM_DONE_UUID_RPL_LEN];
+        char c[OSQLCOMM_DONE_XERR_RPL_LEN];
+        char d[OSQLCOMM_DONE_RPL_LEN];
     } largest_message;
-    uint8_t *buf = (uint8_t *) &largest_message;
+    uint8_t *buf = (uint8_t *)&largest_message;
 
-    /* test if the sql thread was the one closing the request, 
+    /* test if the sql thread was the one closing the request,
      * and if so, don't send anything back, request might be gone already anyway
      */
     if (xerr->errval == SQLITE_ABORT)
@@ -7449,9 +7449,10 @@ done:
     if (rc2) {
         uuidstr_t us;
         comdb2uuidstr(uuid, us);
-        logmsg(LOGMSG_ERROR, "%s: failed to signaled rqid=[%llx %s] host=%s of "
-                        "error to create bplog\n",
-                __func__, req.rqid, us, fromhost);
+        logmsg(LOGMSG_ERROR,
+               "%s: failed to signaled rqid=[%llx %s] host=%s of "
+               "error to create bplog\n",
+               __func__, req.rqid, us, fromhost);
     }
     if (onstack)
         sess = NULL;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5095,21 +5095,16 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
     int msglen = 0;
     char uuid[37];
     int type;
-    /* Constructing one of 4 message types so get a buffer big enough */
-    int max = 0;
-    if (OSQLCOMM_DONE_XERR_UUID_RPL_LEN > max)
-        max = OSQLCOMM_DONE_XERR_UUID_RPL_LEN;
-    if (OSQLCOMM_DONE_UUID_RPL_LEN > max)
-        max = OSQLCOMM_DONE_UUID_RPL_LEN;
-    if (OSQLCOMM_DONE_XERR_RPL_LEN > max)
-        max = OSQLCOMM_DONE_XERR_RPL_LEN;
-    if (OSQLCOMM_DONE_RPL_LEN > max)
-        max = OSQLCOMM_DONE_RPL_LEN;
-    uint8_t *buf = alloca(max);
+    union {
+        char a [OSQLCOMM_DONE_XERR_UUID_RPL_LEN];
+        char b [OSQLCOMM_DONE_UUID_RPL_LEN];
+        char c [OSQLCOMM_DONE_XERR_RPL_LEN];
+        char d [OSQLCOMM_DONE_RPL_LEN];
+    } largest_message;
+    uint8_t *buf = (uint8_t *) &largest_message;
 
-    /* test if the sql thread was the one closing the
-       request, and if so, don't send anything back
-       (request might be gone already anyway)
+    /* test if the sql thread was the one closing the request, 
+     * and if so, don't send anything back, request might be gone already anyway
      */
     if (xerr->errval == SQLITE_ABORT)
         return 0;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5095,7 +5095,17 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
     int msglen = 0;
     char uuid[37];
     int type;
-    uint8_t *buf = NULL;
+    /* Constructing one of 4 message types so get a buffer big enough */
+    int max = 0;
+    if (OSQLCOMM_DONE_XERR_UUID_RPL_LEN > max)
+        max = OSQLCOMM_DONE_XERR_UUID_RPL_LEN;
+    if (OSQLCOMM_DONE_UUID_RPL_LEN > max)
+        max = OSQLCOMM_DONE_UUID_RPL_LEN;
+    if (OSQLCOMM_DONE_XERR_RPL_LEN > max)
+        max = OSQLCOMM_DONE_XERR_RPL_LEN;
+    if (OSQLCOMM_DONE_RPL_LEN > max)
+        max = OSQLCOMM_DONE_RPL_LEN;
+    uint8_t *buf = alloca(max);
 
     /* test if the sql thread was the one closing the
        request, and if so, don't send anything back
@@ -5118,7 +5128,6 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
 
         if (rc) {
             msglen = OSQLCOMM_DONE_XERR_UUID_RPL_LEN;
-            buf = alloca(msglen);
             uint8_t *p_buf = buf;
             uint8_t *p_buf_end = buf + msglen;
             rpl_xerr.hd.type = OSQL_XERR;
@@ -5130,7 +5139,6 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
         } else {
             msglen = OSQLCOMM_DONE_UUID_RPL_LEN;
             uint8_t *p_buf = buf;
-            buf = alloca(msglen);
             uint8_t *p_buf_end = buf + msglen;
 
             rpl_ok.hd.type = OSQL_DONE;
@@ -5152,7 +5160,6 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
 
         if (rc) {
             msglen = OSQLCOMM_DONE_XERR_RPL_LEN;
-            buf = alloca(msglen);
             uint8_t *p_buf = buf;
             uint8_t *p_buf_end = buf + msglen;
             rpl_xerr.hd.type = OSQL_XERR;
@@ -5162,7 +5169,6 @@ int osql_comm_signal_sqlthr_rc(osql_sess_t *sorese, struct errstat *xerr,
             osqlcomm_done_xerr_type_put(&(rpl_xerr), p_buf, p_buf_end);
         } else {
             msglen = OSQLCOMM_DONE_RPL_LEN;
-            buf = alloca(msglen);
             uint8_t *p_buf = buf;
             uint8_t *p_buf_end = buf + msglen;
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7271,17 +7271,17 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
                          int nettype)
 {
+    int rc = 0;
+    struct ireq *iq = NULL;
     uint8_t *malcd = malloc(OSQL_BP_MAXLEN);
     if (!malcd)
         goto done;
 
     osql_sess_t *sess = NULL;
-    struct ireq *iq = NULL;
     osql_req_t req;
     bool is_reorder_on = false;
     uint8_t *p_req_buf = dtap;
     const uint8_t *p_req_buf_end = p_req_buf + dtalen;
-    int rc = 0;
     uint8_t *p_buf = malcd;
     const uint8_t *p_buf_end = p_buf + OSQL_BP_MAXLEN;
     char *sql;

--- a/db/osqlrepository.c
+++ b/db/osqlrepository.c
@@ -183,8 +183,8 @@ int osql_repository_add(osql_sess_t *sess, int *replaced)
         }
         /* old request was terminated successfully, let's add the new one */
         logmsg(LOGMSG_INFO,
-               "%s: cancelled old request for rqid=%llx, uuid=%s\n",
-               __func__, sess->rqid, p);
+               "%s: cancelled old request for rqid=%llx, uuid=%s\n", __func__,
+               sess->rqid, p);
     }
 
     if (sess->rqid == OSQL_RQID_USE_UUID)
@@ -217,7 +217,8 @@ int gbl_abort_on_missing_osql_session = 0;
  * Remove an osql session from the repository
  * return 0 on success
  */
-int osql_repository_rem(osql_sess_t *sess, const int lock, const char *func, const char *callfunc, int line)
+int osql_repository_rem(osql_sess_t *sess, const int lock, const char *func,
+                        const char *callfunc, int line)
 {
     osql_repository_t *theosql = get_theosql();
     if (theosql == NULL) {
@@ -236,7 +237,6 @@ int osql_repository_rem(osql_sess_t *sess, const int lock, const char *func, con
 
     if (lock)
         Pthread_rwlock_unlock(&theosql->hshlck);
-
 
 #ifdef TRACK_OSQL_SESSIONS
     static uuid_t uuid_list[MAX_UUID_LIST];
@@ -274,7 +274,8 @@ int osql_repository_rem(osql_sess_t *sess, const int lock, const char *func, con
             logmsg(LOGMSG_ERROR, "%s unable to find previous uuid %s\n", __func__, p);
         }
         else {
-            logmsg(LOGMSG_ERROR, "%s found %s %d times in tracking array\n", __func__, p, found_uuid);
+            logmsg(LOGMSG_ERROR, "%s found %s %d times in tracking array\n",
+                   __func__, p, found_uuid);
         }
 #endif
 

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -77,11 +77,11 @@ static void save_sql(struct ireq *iq, osql_sess_t *sess, const char *sql,
  * This function will remove from osql_repository_rem() if is_linked is set
  * then wait till there are no more clients using this sess then destroy obj
  *
- * NOTE: 
+ * NOTE:
  * - it is possible to inline clean a request on master bounce,
  *   which starts by unlinking the session first, and freeing bplog afterwards
  *
- * - if caller has already removed sess from osql repository, they should 
+ * - if caller has already removed sess from osql repository, they should
  *   call this function with is_linked = 0
  */
 int osql_close_session(osql_sess_t **psess, int is_linked, const char *func,
@@ -108,7 +108,8 @@ int osql_close_session(osql_sess_t **psess, int is_linked, const char *func,
         return rc;
 
     /* wait for all receivers to go away, in current implem this is only 1--the
-       reader_thread, since we removed the hash entry no new messages are added */
+       reader_thread, since we removed the hash entry no new messages are added
+     */
     while (ATOMIC_LOAD32(sess->clients) > 0) {
         poll(NULL, 0, 10);
     }
@@ -194,8 +195,8 @@ inline int osql_sess_remclient(osql_sess_t *sess)
         abort(); // remove this in future
         uuidstr_t us;
         logmsg(LOGMSG_ERROR,
-                "%s: BUG ALERT, session %llu %s freed one too many times\n",
-                __func__, sess->rqid, comdb2uuidstr(sess->uuid, us));
+               "%s: BUG ALERT, session %llu %s freed one too many times\n",
+               __func__, sess->rqid, comdb2uuidstr(sess->uuid, us));
     }
 
     return 0;


### PR DESCRIPTION
Unlock mtx before calling osql_bplog_free() to avoid crash. Before this PR, we destroy the session with the mutexes held via callstack: osql_bplog_free() -> osql_close_session() -> _destroy_session().
fixes PR #2011 