### PR TITLE
Adjust format of 'sql dump' - no newline, no cnonce, display origin

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9012,17 +9012,6 @@ void cancel_sql_statement_with_cnonce(const char *cnonce)
         logmsg(LOGMSG_USER, "Query with cnonce %s not found (finished?)\n", cnonce);
 }
 
-/* log binary cnonce in hex format 
- * ex. 1234 will become x'31323334' 
- */
-static void log_cnonce(const char * cnonce, int len)
-{
-    logmsg(LOGMSG_USER, " [");
-    for(int i = 0; i < len; i++) 
-        logmsg(LOGMSG_USER, "%2x", cnonce[i]);
-    logmsg(LOGMSG_USER, "] ");
-}
-
 void sql_dump_running_statements(void)
 {
     struct sql_thread *thd;
@@ -9046,12 +9035,9 @@ void sql_dump_running_statements(void)
             } else
                 rqid[0] = 0;
 
-            logmsg(LOGMSG_USER, "id %d %02d/%02d/%02d %02d:%02d:%02d %s%s\n", thd->id,
+            logmsg(LOGMSG_USER, "id %d %02d/%02d/%02d %02d:%02d:%02d %s%s pid %d task %s ", thd->id,
                    tm.tm_mon + 1, tm.tm_mday, 1900 + tm.tm_year, tm.tm_hour,
-                   tm.tm_min, tm.tm_sec, rqid, thd->clnt->origin);
-            snap_uid_t snap;
-            get_cnonce(thd->clnt, &snap);
-            log_cnonce(snap.key, snap.keylen);
+                   tm.tm_min, tm.tm_sec, rqid, thd->clnt->origin, thd->clnt->conninfo.pid, thd->clnt->argv0 ? thd->clnt->argv0 : "???");
             logmsg(LOGMSG_USER, "%s\n", thd->clnt->sql);
 
             if (thd->bt) {


### PR DESCRIPTION
Removes some things added earlier (cnonce, accidental newline).  Cnonce doesn't seem useful to display here (anyone who feels differently, please tell me).  Newline was breaking expected output for people.  Rivers also discovered (thanks Rivers) that we somehow lost pid/argv0 of the requester in the output - that's now added back.