### PR TITLE
Parallel verify to work on indices first then data

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -1304,18 +1304,6 @@ int bdb_verify_enqueue(td_processing_info_t *info, thdpool *verify_thdpool)
         return 0;
     }
 
-    if (v_mode == VERIFY_PARALLEL || v_mode == VERIFY_DATA) {
-        /* scan 1 - run through data, verify all the keys and blobs */
-        for (int dtastripe = 0; dtastripe < par->bdb_state->attr->dtastripe;
-             dtastripe++) {
-            td_processing_info_t *work = malloc(sizeof(*work));
-            memcpy(work, info, sizeof(*work));
-            work->type = PROCESS_DATA;
-            work->dtastripe = dtastripe;
-            enqueue_work(work, desc, verify_thdpool);
-        }
-    }
-
     if (v_mode == VERIFY_PARALLEL || v_mode == VERIFY_INDICES) {
         /* scan 2: scan each key, verify data exists */
         for (int ix = 0; ix < par->bdb_state->numix; ix++) {
@@ -1340,6 +1328,18 @@ int bdb_verify_enqueue(td_processing_info_t *info, thdpool *verify_thdpool)
                 work->dtastripe = dtastripe;
                 enqueue_work(work, desc, verify_thdpool);
             }
+        }
+    }
+
+    if (v_mode == VERIFY_PARALLEL || v_mode == VERIFY_DATA) {
+        /* scan 1 - run through data, verify all the keys and blobs */
+        for (int dtastripe = 0; dtastripe < par->bdb_state->attr->dtastripe;
+             dtastripe++) {
+            td_processing_info_t *work = malloc(sizeof(*work));
+            memcpy(work, info, sizeof(*work));
+            work->type = PROCESS_DATA;
+            work->dtastripe = dtastripe;
+            enqueue_work(work, desc, verify_thdpool);
         }
     }
 

--- a/db/verify.c
+++ b/db/verify.c
@@ -347,6 +347,7 @@ int verify_table_mode(const char *table, SBUF2 *sb, int progress_report_seconds,
         .sb = sb,
         .bdb_state = db->handle,
         .db_table = db,
+        .tablename = table,
         .formkey_callback = verify_formkey_callback,
         .get_blob_sizes_callback = verify_blobsizes_callback,
         .vtag_callback =


### PR DESCRIPTION
To minimize total runtime, verify should work first on indices,
which can take longer to process since they contain NUMSTRIPES
times more records, and then on data stripes and blobs.