### PR TITLE
Only malloc necessary amount of memory in sorese_rcvreq

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7282,6 +7282,7 @@ static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
     int debug = 0;
     uuid_t uuid;
     int replaced = 0;
+    uint8_t *malcd = NULL;
 
     /* grab the request */
     if (osql_nettype_is_uuid(nettype)) {
@@ -7326,7 +7327,7 @@ static int sorese_rcvreq(char *fromhost, void *dtap, int dtalen, int type,
     }
 
     size_t sz = p_buf_end - p_buf;
-    uint8_t *malcd = malloc(sz);
+    malcd = malloc(sz);
     if (!malcd) {
         logmsg(LOGMSG_ERROR, "%s:unable to allocate %ld bytes\n", __func__, sz);
         rc = -1;

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -537,12 +537,9 @@ int gbl_selectv_writelock_on_update = 1;
  * Returns created object if success, NULL otherwise
  *
  */
-osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
-                              int type, unsigned long long rqid, uuid_t uuid,
-                              const char *host, bool is_reorder_on)
+osql_sess_t *osql_sess_create(char *tzname, int type, unsigned long long rqid,
+                              uuid_t uuid, const char *host, bool is_reorder_on)
 {
-    osql_sess_t *sess = NULL;
-
 #ifdef TEST_QSQL_REQ
     uuidstr_t us;
     logmsg(LOGMSG_INFO, "%s: Opening request %llu %s\n", __func__, rqid,
@@ -550,7 +547,7 @@ osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
 #endif
 
     /* alloc object */
-    sess = (osql_sess_t *)calloc(sizeof(*sess), 1);
+    osql_sess_t *sess = (osql_sess_t *)calloc(sizeof(*sess), 1);
     if (!sess) {
         logmsg(LOGMSG_ERROR, "%s:unable to allocate %zu bytes\n", __func__,
                sizeof(*sess));
@@ -559,8 +556,7 @@ osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
 #if DEBUG_REORDER
     uuidstr_t us;
     comdb2uuidstr(uuid, us);
-    logmsg(LOGMSG_DEBUG, "%s:processing sql=%s sess=%p, uuid=%s\n", __func__,
-           sql, sess, us);
+    logmsg(LOGMSG_DEBUG, "%s:process sess=%p, uuid=%s\n", __func__, sess, us);
 #endif
 
     /* init sync fields */
@@ -570,7 +566,6 @@ osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
 
     sess->rqid = rqid;
     comdb2uuidcpy(sess->uuid, uuid);
-    /*save_sql(iq, sess, sql, sqlen);*/
     sess->type = type;
     sess->host = host ? intern(host) : NULL;
     sess->startus = comdb2_time_epochus();

--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -106,9 +106,9 @@ int osql_session_testterminate(void *obj, void *arg);
  * Returns created object if success, NULL otherwise
  *
  */
-osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
-                              int type, unsigned long long rqid, uuid_t uuid,
-                              const char *host, bool is_reorder_on);
+osql_sess_t *osql_sess_create(char *tzname, int type, unsigned long long rqid,
+                              uuid_t uuid, const char *host,
+                              bool is_reorder_on);
 
 /**
  * Returns


### PR DESCRIPTION
We blindly allocate 32kb always, but most of the requests are
much smaller than that, so we should only malloc as much memory
 as is needed for the request.