### PR TITLE
fixed bug in test incrementalcopy

### DIFF
--- a/tests/incrementalcopy.test/runit
+++ b/tests/incrementalcopy.test/runit
@@ -32,7 +32,7 @@ idx=$RANDOM
 function getmaster {
     r=1
     while [[ $r != 0 ]]; do 
-        x=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]')
+        x=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $DBNAME default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]')
         r=$?
     done
     echo $x


### PR DESCRIPTION
This pull request is for a bug fix in the test incrementalcopy
$dbnm is not defined in the script, and as a result getmaster() function returns "" for master. This subsequently fails(silently, does not stop the test from proceeding) cdb2sql queries against master. 
Changed $dbnm to $DBNAME