### PR TITLE
check bdb lock desired in dohsql master

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3440,6 +3440,7 @@ int read_spfile(char *file);
 
 struct bdb_cursor_ifn;
 
+int recover_deadlock_simple(bdb_state_type *bdb_state);
 int recover_deadlock_flags(bdb_state_type *, struct sql_thread *,
                            struct bdb_cursor_ifn *, int sleepms,
                            const char *func, int line, uint32_t flags);

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1753,6 +1753,17 @@ retry_row:
     }
     if (rc != SQLITE_OK)
         return rc;
+    /* we look at all contributing children, and need to wait;
+       since we have the bdb read lock here, check if we need
+       to run recovery_deadlock */
+    if (bdb_lock_desired(thedb->bdb_env)) {
+        rc = recover_deadlock_simple(thedb->bdb_env);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n", __func__, rc);
+            return rc;
+        }
+    }
+
     goto retry_row;
 }
 

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -762,8 +762,9 @@ wait_for_others:
         if (bdb_lock_desired(thedb->bdb_env)) {
             rc = recover_deadlock_simple(thedb->bdb_env);
             if (rc) {
-                logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n", __func__, rc);
-            return rc;
+                logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n",
+                       __func__, rc);
+                return rc;
             }
         }
         goto wait_for_others;
@@ -1765,7 +1766,8 @@ retry_row:
     if (bdb_lock_desired(thedb->bdb_env)) {
         rc = recover_deadlock_simple(thedb->bdb_env);
         if (rc) {
-            logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n", __func__, rc);
+            logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n",
+                   __func__, rc);
             return rc;
         }
     }

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -759,7 +759,13 @@ wait_for_others:
         }
     }
     if (!empty) {
-        poll(NULL, 0, 10);
+        if (bdb_lock_desired(thedb->bdb_env)) {
+            rc = recover_deadlock_simple(thedb->bdb_env);
+            if (rc) {
+                logmsg(LOGMSG_ERROR, "%s: failed recover_deadlock rc=%d\n", __func__, rc);
+            return rc;
+            }
+        }
         goto wait_for_others;
     }
 


### PR DESCRIPTION
Master thread waits for children sql thread to provides additional rows; the children sql threads can be blocked waiting on a bdb_lock_desired() flag.  Make sure master releases the bdb read lock similarly,