### PR TITLE
Increase timeout of insert_lots to 20m

### DIFF
--- a/tests/insert_lots.test/Makefile
+++ b/tests/insert_lots.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=15m
+	export TEST_TIMEOUT=20m
 endif


### PR DESCRIPTION
Adi reverted the cget optimization in R7, which accounts for a 20% slowdown in this test.  This isn't a performance test- the solution is to simply increase the timeout.
