### PR TITLE
fix crashes due to reorg of the osql_sqlthr struct

### DIFF
--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -34,16 +34,15 @@ struct errstat;
 struct sqlclntstate;
 
 struct osql_sqlthr {
-    struct errstat err; /* valid if done = 1 */
-    pthread_cond_t cond;
     unsigned long long rqid; /* osql rq id */
     uuid_t uuid;             /* request id, take 2 */
     char *master;            /* who was the master I was talking to */
-    struct sqlclntstate *clnt; /* cache clnt */
-    pthread_mutex_t mtx;       /* mutex and cond for commitrc sync */
     int done;            /* result of socksql, recom, snapisol and serial master
                             transactions*/
+    struct errstat err;  /* valid if done = 1 */
     int type;            /* type of the request, enum OSQL_REQ_TYPE */
+    pthread_mutex_t mtx; /* mutex and cond for commitrc sync */
+    pthread_cond_t cond;
     int master_changed; /* set if we detect that node we were waiting for was
                            disconnected */
     int nops;
@@ -55,6 +54,7 @@ struct osql_sqlthr {
     int last_updated; /* poking support: when was the last time I got info, 0 is
                          never */
     int last_checked; /* poking support: when was the loast poke sent */
+    struct sqlclntstate *clnt; /* cache clnt */
 };
 typedef struct osql_sqlthr osql_sqlthr_t;
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -24,7 +24,8 @@
 #include "sql.h"
 #include "comdb2_appsock.h"
 #include "comdb2_atomic.h"
-#include <str0.h>
+#include "str0.h"
+#include "sqloffload.h"
 
 #include <sqlquery.pb-c.h>
 #include <sqlresponse.pb-c.h>
@@ -45,7 +46,6 @@ void ssl_set_clnt_user(struct sqlclntstate *clnt);
 int disable_server_sql_timeouts(void);
 int tdef_to_tranlevel(int tdef);
 int check_active_appsock_connections(struct sqlclntstate *clnt);
-int osql_clean_sqlclntstate(struct sqlclntstate *clnt);
 int watcher_warning_function(void *arg, int timeout, int gap);
 void handle_sql_intrans_unrecoverable_error(struct sqlclntstate *clnt);
 int fdb_access_control_create(struct sqlclntstate *clnt, char *str);


### PR DESCRIPTION
fix crashes due to reorg of the osql_sqlthr struct