### PR TITLE
Member rqid is moved so use hash init with offset

### DIFF
--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -85,7 +85,8 @@ int osql_checkboard_init(void)
         abort();
     }
 
-    tmp->rqs = hash_init(sizeof(unsigned long long));
+    tmp->rqs = hash_init_o(offsetof(osql_sqlthr_t, rqid),
+                           sizeof(unsigned long long));
     if (!tmp->rqs) {
         free(tmp);
         logmsg(LOGMSG_ERROR, "%s: error init hash\n", __func__);

--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -34,15 +34,16 @@ struct errstat;
 struct sqlclntstate;
 
 struct osql_sqlthr {
+    struct errstat err;  /* valid if done = 1 */
+    pthread_cond_t cond;
     unsigned long long rqid; /* osql rq id */
     uuid_t uuid;             /* request id, take 2 */
     char *master;            /* who was the master I was talking to */
+    struct sqlclntstate *clnt; /* cache clnt */
+    pthread_mutex_t mtx; /* mutex and cond for commitrc sync */
     int done;            /* result of socksql, recom, snapisol and serial master
                             transactions*/
-    struct errstat err;  /* valid if done = 1 */
     int type;            /* type of the request, enum OSQL_REQ_TYPE */
-    pthread_mutex_t mtx; /* mutex and cond for commitrc sync */
-    pthread_cond_t cond;
     int master_changed; /* set if we detect that node we were waiting for was
                            disconnected */
     int nops;
@@ -54,7 +55,6 @@ struct osql_sqlthr {
     int last_updated; /* poking support: when was the last time I got info, 0 is
                          never */
     int last_checked; /* poking support: when was the loast poke sent */
-    struct sqlclntstate *clnt; /* cache clnt */
 };
 typedef struct osql_sqlthr osql_sqlthr_t;
 


### PR DESCRIPTION
Moving rqid in structure osql_sqlthr so need to use hash init with offset hash_init_o().