### PR TITLE
Chunky deletes (#1858)

### DIFF
--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -1013,3 +1013,27 @@ int bdb_osql_destroy(int *bdberr)
 
     return rc;
 }
+
+int bdb_osql_cursor_reset(bdb_state_type *bdb_state, bdb_cursor_ifn_t *pcur_ifn)
+{
+    bdb_cursor_impl_t *cur = pcur_ifn->impl;
+    int rc = 0;
+    int bdberr = 0;
+
+    if (cur->skip) {
+        rc = bdb_temp_table_close_cursor(bdb_state, cur->skip, &bdberr);
+        if (rc)
+            logmsg(LOGMSG_ERROR, "%s: close cursor %d %d\n", __func__, rc,
+                   bdberr);
+        cur->skip = NULL;
+    }
+
+    return rc;
+}
+
+void bdb_osql_cursor_set(bdb_cursor_ifn_t *pcur_ifn, tran_type *shadow_tran)
+{
+    bdb_cursor_impl_t *cur = pcur_ifn->impl;
+
+    cur->shadow_tran = shadow_tran;
+}

--- a/bdb/bdb_osqlcur.h
+++ b/bdb/bdb_osqlcur.h
@@ -124,4 +124,14 @@ struct bdb_osql_log *bdb_osql_shadow_get_lastlog(bdb_cursor_ifn_t *cur,
  */
 int bdb_osql_shadow_set_lastlog(bdb_cursor_ifn_t *cur, struct bdb_osql_log *log,
                                 int *bdberr);
+
+/**
+ * Clear any cached pointers to existing transactions
+ * Set the shadow transaction to a reset cursor
+ *
+ */
+int bdb_osql_cursor_reset(bdb_state_type *bdb_state,
+                          bdb_cursor_ifn_t *pcur_ifn);
+void bdb_osql_cursor_set(bdb_cursor_ifn_t *pcur_ifn, tran_type *shadow_tran);
+
 #endif

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -168,6 +168,9 @@ static int queryOverlapsCursors(struct sqlclntstate *clnt, BtCursor *pCur);
 
 enum { AUTHENTICATE_READ = 1, AUTHENTICATE_WRITE = 2 };
 
+static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
+                             struct sql_thread *thd);
+
 CurRange *currange_new()
 {
     CurRange *rc = (CurRange *)malloc(sizeof(CurRange));
@@ -3637,6 +3640,14 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
 #endif
         }
         if (pCur->bt == NULL || pCur->bt->is_remote == 0) {
+
+            if (clnt->dbtran.maxchunksize > 0 &&
+                clnt->dbtran.mode == TRANLEVEL_SOSQL &&
+                clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                if ((rc = chunk_transaction(pCur, clnt, thd)) != SQLITE_OK)
+                    goto done;
+            }
+
             if (is_sqlite_stat(pCur->db->tablename)) {
                 clnt->ins_keys = -1ULL;
                 clnt->del_keys = -1ULL;
@@ -8239,6 +8250,90 @@ int sqlite3BtreeBeginStmt(Btree *pBt, int iStatement)
     sqlite3VdbeError(vdbe, "%s", errstr);                                      \
     sqlite3_mutex_leave(sqlite3_db_mutex(vdbe->db));
 
+static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
+                             struct sql_thread *thd)
+{
+    BtCursor *cur = NULL;
+    int rc = SQLITE_OK;
+    int commit_rc = SQLITE_OK;
+    int bdberr = 0;
+
+    if (clnt->dbtran.crtchunksize >= clnt->dbtran.maxchunksize) {
+
+        /* commit current transaction and reopen another one */
+
+        /* disconnect berkeley db cursors */
+        unlock_bdb_cursors(thd, NULL, &bdberr);
+        if (bdberr) {
+            comdb2_sqlite3VdbeError(pCur->vdbe,
+                                    "Failed to disconnect berkeleydb cursors");
+            rc = SQLITE_ERROR;
+            goto done;
+        }
+
+        /* need to reset shadow table fast point in cursors */
+        if (thd->bt) {
+            LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
+            {
+                cur->shadtbl = NULL;
+                if (cur->bdbcur)
+                    bdb_osql_cursor_reset(thedb->bdb_env, cur->bdbcur);
+            }
+        }
+
+        /* commit current transaction */
+        sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_FNSH_STATE);
+        rc = handle_sql_commitrollback(clnt->thd, clnt, TRANS_CLNTCOMM_CHUNK);
+        if (rc) {
+            comdb2_sqlite3VdbeError(pCur->vdbe,
+                                    errstat_get_str(&clnt->osql.xerr));
+            logmsg(LOGMSG_ERROR, "Failed to commit chunk\n");
+            commit_rc = SQLITE_ABORT;
+            /* we need to recreate the transaction in any case
+               goto done;
+             */
+        }
+
+        /* restart a new transaction */
+        sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
+                                SQLENG_PRE_STRT_STATE);
+        rc = handle_sql_begin(clnt->thd, clnt, TRANS_CLNTCOMM_CHUNK);
+        if (rc && !commit_rc) {
+            comdb2_sqlite3VdbeError(pCur->vdbe, "Failed to start a new chunk");
+            rc = SQLITE_ERROR;
+            goto done;
+        }
+
+        rc = _start_new_transaction(clnt, thd);
+
+        if (thd->bt) {
+            LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
+            {
+                if (cur->bdbcur)
+                    bdb_osql_cursor_set(cur->bdbcur, clnt->dbtran.shadow_tran);
+            }
+        }
+
+        if (rc && !commit_rc) {
+            comdb2_sqlite3VdbeError(pCur->vdbe,
+                                    "Failed to initialize new transaction");
+
+            rc = SQLITE_ERROR;
+            goto done;
+        }
+        rc = commit_rc;
+
+        clnt->dbtran.crtchunksize = 1;
+        if (rc != SQLITE_OK)
+            goto done;
+
+    } else {
+        clnt->dbtran.crtchunksize++;
+    }
+done:
+    return rc;
+}
+
 /*
  ** Insert a new record into the BTree.  The key is given by (pKey,nKey)
  ** and the data is given by (pData,nData).  The cursor is used only to
@@ -8269,7 +8364,6 @@ int sqlite3BtreeInsert(
     blob_buffer_t blobs[MAXBLOBS];
     struct sql_thread *thd = pCur->thd;
     struct sqlclntstate *clnt = pCur->clnt;
-    int commit_rc = 0;
 
     if (thd && pCur->db == NULL) {
         thd->nwrite++;
@@ -8404,73 +8498,10 @@ int sqlite3BtreeInsert(
         }
 
         if (clnt->dbtran.maxchunksize > 0 &&
+            clnt->dbtran.mode == TRANLEVEL_SOSQL &&
             clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
-            if (clnt->dbtran.crtchunksize >= clnt->dbtran.maxchunksize) {
-
-                /* commit current transaction and reopen another one */
-
-                /* disconnect berkeley db cursors */
-                bdberr = 0;
-                unlock_bdb_cursors(thd, NULL, &bdberr);
-                if (bdberr) {
-                    comdb2_sqlite3VdbeError(
-                        pCur->vdbe, "Failed to disconnect berkeleydb cursors");
-                    rc = SQLITE_ERROR;
-                    goto done;
-                }
-
-                /* commit current transaction */
-                sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
-                                        SQLENG_FNSH_STATE);
-                rc = handle_sql_commitrollback(clnt->thd, clnt,
-                                               TRANS_CLNTCOMM_CHUNK);
-                if (rc) {
-                    comdb2_sqlite3VdbeError(pCur->vdbe,
-                                            errstat_get_str(&clnt->osql.xerr));
-                    logmsg(LOGMSG_ERROR, "Failed to commit chunk\n");
-                    commit_rc = SQLITE_ABORT;
-                    /* we need to recreate the transaction in any case
-                    goto done;
-                    */
-                }
-
-                /* need to reset shadow table fast point in cursors */
-                if (thd->bt) {
-                    BtCursor *cur = NULL;
-                    LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
-                    {
-                        cur->shadtbl = NULL;
-                    }
-                }
-
-                /* restart a new transaction */
-                sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
-                                        SQLENG_PRE_STRT_STATE);
-                rc = handle_sql_begin(clnt->thd, clnt, TRANS_CLNTCOMM_CHUNK);
-                if (rc && !commit_rc) {
-                    comdb2_sqlite3VdbeError(pCur->vdbe,
-                                            "Failed to start a new chunk");
-                    rc = SQLITE_ERROR;
-                    goto done;
-                }
-
-                rc = _start_new_transaction(clnt, thd);
-                if (rc && !commit_rc) {
-                    comdb2_sqlite3VdbeError(
-                        pCur->vdbe, "Failed to initialize new transaction");
-
-                    rc = SQLITE_ERROR;
-                    goto done;
-                }
-                rc = commit_rc;
-
-                clnt->dbtran.crtchunksize = 1;
-                if (rc != SQLITE_OK)
-                    goto done;
-
-            } else {
-                clnt->dbtran.crtchunksize++;
-            }
+            if ((rc = chunk_transaction(pCur, clnt, thd)) != SQLITE_OK)
+                goto done;
         }
 
         /* We ignore keys on insert but save dirty keys.

--- a/docs/pages/programming/sql.md
+++ b/docs/pages/programming/sql.md
@@ -676,8 +676,8 @@ This sets the current connection's transaction level.  See
 
 This allows bulk data processing to be automatically split into smaller size chunks, freeing the client from 
 the responsibility of spliting up the data.  Jobs like ```INSERT INTO 't' SELECT * FROM 't2'``` are trivially handled
-as a sequence of small lock-footprint transactions.  Currently only supported for bulk inserts in a client specified 
-```BEGIN ... COMMIT``` transaction.
+as a sequence of small lock-footprint transactions.  Another common use-case is periodic data-set clean-up, replacing 
+the legacy comdb2del tool.  Currently requires a client specified ```BEGIN ... COMMIT``` transaction.
 
 ### SET TIMEZONE
 

--- a/tests/transchunk.test/log.expected
+++ b/tests/transchunk.test/log.expected
@@ -35,3 +35,8 @@ Failure tests
 (a=123456789)
 (count(*)=7)
 (out='    OSQL_DONE            5060')
+(rows inserted=994)
+(out='    OSQL_DONE            5560')
+(count(*)=502)
+(out='    OSQL_DONE            5611')
+(count(*)=0)

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -174,6 +174,29 @@ $rt "select count(*) from t" >> $outlog
 
 check_done
 
+$r >> $outlog 2>&1 << "EOF"
+insert into t select value from generate_series(7, 1000)
+set transaction chunk 1
+begin
+delete from t where a <500
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 10
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
 # get testcase output
 testcase_output=$(cat $outlog)
 


### PR DESCRIPTION
This completes porting transaction chunk mode to 7.0 (adding support for deletes).
Based on https://github.com/bloomberg/comdb2/pull/1858

* interrupted work

* delete in chunks

* format

* chunk deletes testcase

* fix dangling pointers

* format

* docs updated

