### PR TITLE
Fix ref_sync_wait_txnlist

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -651,8 +651,7 @@ trickle_do_work(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 			i = 0;
 			++pass;
 			sgio = 0;
-			if (!gbl_ref_sync_wait_txnlist)
-				(void)__os_sleep(dbenv, 1, 0);
+			(void)__os_sleep(dbenv, 1, 0);
 		}
 		if ((hp = bharray[i].track_hp) == NULL)
 			continue;


### PR DESCRIPTION
Replicants don't ever have transactions- whether or not ref_sync_wait_txnlist is enabled, always sleep at that point in the code.
