### PR TITLE
Port from r6 1079, 1092

### DIFF
--- a/db/fdb_boots.c
+++ b/db/fdb_boots.c
@@ -141,7 +141,7 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
         } else if (loc && refresh) {
             /* free location */
             if (loc->nodes) {
-                bzero(loc->nodes, sizeof(loc->nnodes));
+                bzero(loc->nodes, loc->nnodes*sizeof(loc->nodes[0]));
                 int i;
                 for (i = 0; i < loc->nnodes; i++)
                     loc->lcl[i] = false;

--- a/db/fdb_boots.c
+++ b/db/fdb_boots.c
@@ -141,7 +141,7 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
         } else if (loc && refresh) {
             /* free location */
             if (loc->nodes) {
-                bzero(loc->nodes, loc->nnodes*sizeof(loc->nodes[0]));
+                bzero(loc->nodes, loc->nnodes * sizeof(loc->nodes[0]));
                 int i;
                 for (i = 0; i < loc->nnodes; i++)
                     loc->lcl[i] = false;

--- a/db/fdb_boots.c
+++ b/db/fdb_boots.c
@@ -26,6 +26,9 @@
 #include "sql.h"
 #include "fdb_fend.h"
 #include "logmsg.h"
+#include "locks_wrap.h"
+
+#define MY_CLUSTER_MAX 32
 
 extern int gbl_myroom;
 
@@ -35,9 +38,7 @@ struct fdb_location {
 
     int nnodes;
     char **nodes; /* bb node numbers */
-    char *lcl;    /* set for same datacenter nodes */
-
-    int need_refresh; /* if a previous run returned error, refresh the nodes */
+    bool *lcl;    /* set for same datacenter nodes */
 };
 
 struct fdb_affinity_elem {
@@ -93,11 +94,11 @@ static int _fdb_refresh_location(const char *dbname, fdb_location_t *loc)
 
     /* cache the nodes locally */
     if (loc->nnodes != nnodes) {
-        loc->nodes = (char **)realloc(loc->nodes, sizeof(char **) * nnodes);
+        loc->nodes = (char **)realloc(loc->nodes, sizeof(char*) * nnodes);
         if (!loc->nodes) {
             return FDB_ERR_MALLOC;
         }
-        loc->lcl = (char *)realloc(loc->lcl, sizeof(char *) * nnodes);
+        loc->lcl = (bool *)realloc(loc->lcl, sizeof(bool) * nnodes);
         if (!loc->lcl) {
             return FDB_ERR_MALLOC;
         }
@@ -120,16 +121,18 @@ static int _fdb_refresh_location(const char *dbname, fdb_location_t *loc)
  * Retrieve the nodes from codmb2db
  */
 int fdb_locate(const char *dbname, enum mach_class class, int refresh,
-               fdb_location_t **ploc)
+               fdb_location_t **ploc, pthread_mutex_t *mtx)
 {
     fdb_location_t *loc = *ploc;
     int rc = 0;
-
+   
+    Pthread_mutex_lock(mtx);
     if (!loc || refresh) {
         if (!loc) {
             loc = (fdb_location_t *)calloc(1, sizeof(fdb_location_t) +
                                                   strlen(dbname) + 1);
             if (!loc) {
+                Pthread_mutex_unlock(mtx);
                 return FDB_ERR_MALLOC;
             }
             loc->dbname = ((char *)loc) + sizeof(fdb_location_t);
@@ -139,10 +142,11 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
             /* free location */
             if (loc->nodes) {
                 bzero(loc->nodes, sizeof(loc->nnodes));
-                bzero(loc->lcl, sizeof(loc->nodes));
+                int i;
+                for(i=0;i<loc->nnodes;i++)
+                    loc->lcl[i] = false;
             }
             loc->nnodes = 0;
-            loc->need_refresh = 0;
         }
 
         /* get the nodes */
@@ -154,9 +158,154 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
 
         *ploc = loc;
     }
+    Pthread_mutex_unlock(mtx);
 
     return rc;
 }
+
+static char* _get_node_initial(int nnodes, char **nodes, bool *lcl, enum fdb_location_op op,
+        int *lcl_nnodes, int *rescpu_nnodes)
+{
+    char* lcl_nodes[MY_CLUSTER_MAX];
+    char* rescpu_nodes[MY_CLUSTER_MAX];
+    char* node = NULL;
+    int i;
+
+    /* routing; ignoring down nodes */
+    *lcl_nnodes = 0;
+    *rescpu_nnodes = 0;
+    for (i=0; i<nnodes; i++)
+    {
+        if (!machine_is_up(nodes[i]))
+        {
+            continue;
+        }
+
+        /* prefer local node if available */
+        if (nodes[i] == gbl_mynode)
+        {
+            node = nodes[i];  
+        }
+
+        /* prefer same datacenter if available */
+        if (!(op&FDB_LOCATION_IGNORE_LCL) && lcl[i])
+        {
+            lcl_nodes[(*lcl_nnodes)++] = nodes[i];
+        }
+
+        /* all the rescpu pool */
+        rescpu_nodes[(*rescpu_nnodes)++] = nodes[i];
+    }
+
+    if (!node)
+    {
+        /* if local node is not part of remote cluster, randomly picked a
+           node, prefering the local dc */
+        if (*rescpu_nnodes <=0)
+            return NULL;
+
+        /* random selection out of same datacenter */
+        if (*lcl_nnodes>0)
+        {
+            node = lcl_nodes[random() % *lcl_nnodes];
+        }
+        /* no same datacenter, get a random one */
+        else
+        {
+            node = rescpu_nodes[random() % *rescpu_nnodes];
+        }
+    }
+
+    /* we got a good node */
+    return node;
+}
+
+static char* _get_node_next(int nnodes, char **nodes, bool *lcl, char* arg,
+        enum fdb_location_op op, int *lcl_nnodes, int *rescpu_nnodes)
+{
+    int arg_idx;
+    int prefer_local;
+    int i;
+    char *node = NULL;
+
+    *lcl_nnodes = 0;
+    *rescpu_nnodes = 0;
+
+    /* if we are single node, return error */
+    if (nnodes == 1 && (nodes[0] == arg))
+        return NULL;
+
+    /* look for current node */
+    arg_idx = 0; /* if node dissapear, stick with first node */
+    for (i=0; i<nnodes; i++)
+    {
+        if(nodes[i] == arg)
+        {
+            arg_idx = i;
+            break;
+        }
+    } 
+
+
+    /* try to find a local node following the one I am trying and
+       grab any rescpu one that is local, if any */
+    prefer_local = !(op & FDB_LOCATION_IGNORE_LCL);
+    do
+    {
+        i = arg_idx;
+        *rescpu_nnodes = 0;
+        *lcl_nnodes = 0;
+        do
+        {
+            i = (i+1)%nnodes;
+
+            if (i == arg_idx)
+                break;
+
+            /* ignore rtcpu */
+            if (!machine_is_up(nodes[i]))
+            {
+                continue;
+            }
+
+            (*rescpu_nnodes)++;
+            if(lcl[i])
+                (*lcl_nnodes)++;
+
+            if(node == NULL)
+            {
+                /* ignore non locals first run */
+                if (prefer_local && lcl[i])
+                {
+                    node = nodes[i];
+                }
+                else if(!prefer_local)
+                {
+                    /* we want ANY node */
+                    node = nodes[i];
+                }
+            }
+        } while(i != arg_idx);
+
+        /* found our rescpu local? */
+        if(node)
+        {
+            break;
+        }
+
+        /* if tried all nodes, or none rescpu, error out */
+        if (!prefer_local || !(*rescpu_nnodes)) {
+            return NULL;
+        }
+
+        /* try to look into other datacenters */
+        prefer_local = 0;
+    }
+    while(1);
+
+    return node;
+}
+
 
 /**
  * Routing algo
@@ -172,19 +321,17 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
  *
  */
 char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
-                      int *avail_nodes, int *p_lcl_nodes)
+                      int *avail_nodes, int *p_lcl_nodes, pthread_mutex_t *mtx)
 {
     fdb_location_t *loc = *ploc;
     int rc = 0;
-    char *lcl_nodes[REPMAX];
     int lcl_nnodes;
-    char *rescpu_nodes[REPMAX];
     int rescpu_nnodes = 0;
     char *host = NULL;
-    int arg_idx;
-    int i;
     int masked_op;
-    int prefer_local;
+    int my_nnodes = 0;
+    char **my_nodes = NULL;
+    bool *my_lcl = NULL;
 
     /* if we are here, and we don't have a location already, it means this was
        local */
@@ -202,8 +349,9 @@ char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
 
     assert(loc != NULL);
 
-    if ((op & FDB_LOCATION_REFRESH) || loc->need_refresh) {
-        rc = fdb_locate(loc->dbname, loc->class, loc->need_refresh, ploc);
+    if (op & FDB_LOCATION_REFRESH) {
+retry:
+        rc = fdb_locate(loc->dbname, loc->class, 1, ploc, mtx);
         if (rc) {
             goto done;
         }
@@ -211,120 +359,31 @@ char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
 
     masked_op = op & (FDB_LOCATION_INITIAL | FDB_LOCATION_NEXT);
 
+    Pthread_mutex_lock(mtx);
+    /* cache information locally, in case the remote is all down
+       and multiple threads might try to refresh the information;
+       this is optimistic and better and a lock */
+    my_nnodes = loc->nnodes;
+    my_nodes = realloc(my_nodes, loc->nnodes * sizeof(loc->nodes[0]));
+    my_lcl = realloc(my_lcl, loc->nnodes * sizeof(loc->lcl[0]));
+    memcpy(my_nodes, loc->nodes, my_nnodes * sizeof(loc->nodes[0]));
+    memcpy(my_lcl, loc->lcl, my_nnodes *sizeof(loc->lcl[0]));
+    if (my_nnodes == 0) {
+        Pthread_mutex_unlock(mtx);
+        goto retry;
+    }
+    Pthread_mutex_unlock(mtx);
+
     switch (masked_op) {
-    case FDB_LOCATION_INITIAL:
+        case FDB_LOCATION_INITIAL:
+            host = _get_node_initial(my_nnodes, my_nodes, my_lcl, op, &lcl_nnodes, 
+                    &rescpu_nnodes);
+            break;
 
-        /* routing; ignoring down nodes */
-        lcl_nnodes = 0;
-        rescpu_nnodes = 0;
-        for (i = 0; i < loc->nnodes; i++) {
-            if (!machine_is_up(loc->nodes[i])) {
-                continue;
-            }
-
-            /* prefer local node if available */
-            if (loc->nodes[i] == gbl_mynode) {
-                host = loc->nodes[i];
-            }
-
-            /* prefer same datacenter if available */
-            if (!(op & FDB_LOCATION_IGNORE_LCL) && loc->lcl[i]) {
-                lcl_nodes[lcl_nnodes++] = loc->nodes[i];
-            }
-
-            /* all the rescpu pool */
-            rescpu_nodes[rescpu_nnodes++] = loc->nodes[i];
-        }
-
-        if (host == NULL) {
-            if (rescpu_nnodes <= 0) {
-                rc = FDB_ERR_REGISTER_NORESCPU;
-                goto done;
-            }
-
-            /* random selection out of same datacenter */
-            if (lcl_nnodes > 0) {
-                host = lcl_nodes[random() % lcl_nnodes];
-            }
-            /* no same datacenter, get a random one */
-            else {
-                host = rescpu_nodes[random() % rescpu_nnodes];
-            }
-        }
-        break;
-
-    case FDB_LOCATION_NEXT:
-
-        lcl_nnodes = 0;
-        rescpu_nnodes = 0;
-        arg_idx = -1;
-
-        /* if we are single node, return error */
-        if (loc->nnodes == 1 && (loc->nodes[0] == arg)) {
-            rc = FDB_ERR_REGISTER_NONODES;
-            goto done;
-        }
-
-        /* look for current node */
-        for (i = 0; i < loc->nnodes; i++) {
-            if (loc->nodes[i] == arg) {
-                arg_idx = i;
-                break;
-            }
-        }
-
-        /* our current dissapear? hm, start with the first known node */
-        if (arg_idx == -1)
-            arg_idx = 0;
-
-        /* try to find a local node following the one I am trying and grab any
-         * rescpu one that is local, if any */
-        prefer_local = !(op & FDB_LOCATION_IGNORE_LCL);
-        do {
-            i = arg_idx;
-            rescpu_nnodes = 0;
-            lcl_nnodes = 0;
-            do {
-                i = (i + 1) % loc->nnodes;
-
-                if (i == arg_idx)
-                    break;
-
-                /* ignore rtcpu */
-                if (!machine_is_up(loc->nodes[i])) {
-                    continue;
-                }
-
-                rescpu_nnodes++;
-                if (loc->lcl[i])
-                    lcl_nnodes++;
-
-                if (host == NULL) {
-                    /* ignore non locals first run */
-                    if (prefer_local && loc->lcl[i]) {
-                        host = loc->nodes[i];
-                    } else if (!prefer_local) {
-                        /* we want ANY node */
-                        host = loc->nodes[i];
-                    }
-                }
-            } while (i != arg_idx);
-
-            /* found our rescpu local? */
-            if (host) {
-                break;
-            }
-
-            /* we did not find a node */
-            if (prefer_local) {
-                /* try to look into other datacenters */
-                prefer_local = 0;
-            } else {
-                break; /* done */
-            }
-        } while (1);
-
-        break;
+        case FDB_LOCATION_NEXT:
+            host = _get_node_next(my_nnodes, my_nodes, my_lcl, arg, op, &lcl_nnodes,
+                    &rescpu_nnodes);
+            break;
     }
 
     if (host == NULL) {
@@ -343,6 +402,11 @@ char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
     }
 
 done:
+    if (my_lcl)
+        free(my_lcl);
+    if (my_nodes)
+        free(my_nodes);
+
     return host;
 }
 
@@ -421,10 +485,14 @@ static int _discover_remote_db_nodes(const char *dbname, const char *class,
                 nodes[*nnodes] = node;
 
                 assert(cdb2_column_type(db, 1) == CDB2_CSTRING);
-                if (strncasecmp(cdb2_column_value(db, 1), "NY", 2) == 0) {
-                    room[*nnodes] = 1;
+                if (strncasecmp(cdb2_column_value(db, 1), "ORG", 3) == 0) {
+                    room[*nnodes] = 6;
+                } 
+                else if (strncasecmp(cdb2_column_value(db, 1), "NJ", 2) == 0)
+                {
+                    room [*nnodes] = 2;
                 } else {
-                    room[*nnodes] = 2;
+                    room[*nnodes] = 1;
                 }
 
                 (*nnodes)++;

--- a/db/fdb_boots.h
+++ b/db/fdb_boots.h
@@ -35,7 +35,7 @@ typedef struct fdb_affinity fdb_affitnity_t;
  * NOTE: fdb is dbcon_mtx locked here
  */
 int fdb_locate(const char *dbname, enum mach_class class, int refresh,
-               fdb_location_t **ploc);
+               fdb_location_t **ploc, pthread_mutex_t *mtx);
 
 /**
  * Routing algo
@@ -51,7 +51,7 @@ int fdb_locate(const char *dbname, enum mach_class class, int refresh,
  *
  */
 char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
-                      int *avail_nodes, int *p_lcl_nodes);
+                      int *avail_nodes, int *p_lcl_nodes, pthread_mutex_t *mtx);
 
 /**
  * Get the number of available/rescpu nodes

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1302,9 +1302,7 @@ retry_fdb_creation:
     }
 
     if (!local) {
-        Pthread_mutex_lock(&fdb->dbcon_mtx);
-        rc = fdb_locate(fdb->dbname, fdb->class, 0, &fdb->loc);
-        Pthread_mutex_unlock(&fdb->dbcon_mtx);
+        rc = fdb_locate(fdb->dbname, fdb->class, 0, &fdb->loc, &fdb->dbcon_mtx);
         if (rc != FDB_NOERR) {
             switch (rc) {
             case FDB_ERR_CLASS_UNKNOWN:
@@ -2168,7 +2166,7 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
         op = FDB_LOCATION_INITIAL;
 
     refresh:
-        host = fdb_select_node(&fdb->loc, op, 0, &avail_nodes, &lcl_nodes);
+        host = fdb_select_node(&fdb->loc, op, 0, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
 
         if (avail_nodes <= 0) {
             clnt->fdb_state.preserve_err = 1;
@@ -2182,7 +2180,7 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
     } else if (was_bad) {
         /* we failed earlier on this one, we need the next node */
         op = FDB_LOCATION_NEXT;
-        host = fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes);
+        host = fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
     }
     if (host == NULL) {
         clnt->fdb_state.preserve_err = 1;
@@ -2270,20 +2268,9 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
         if (!tried_nodes && op == FDB_LOCATION_REFRESH) {
             op = FDB_LOCATION_INITIAL;
             host =
-                fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes);
+                fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
             continue; /* try again with the selected node, can be the same */
         }
-#if 0
-
-      host = fdb_select_node(&fdb->loc, op, host, NULL, NULL);
-      if (host == NULL)
-      {
-         /* we need to retrieve the location information if
-            the first try was using the cached node */
-         host = fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes);
-         continue;   /* try again with the selected node, can be the same */
-      }
-#endif
         else {
             /* either this is the first node, and
                   have location info (avail_nodes, lcl_nodes),
@@ -2306,7 +2293,7 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
                 op |= FDB_LOCATION_IGNORE_LCL;
             }
 
-            host = fdb_select_node(&fdb->loc, op, host, NULL, NULL);
+            host = fdb_select_node(&fdb->loc, op, host, NULL, NULL, &fdb->dbcon_mtx);
             if (host == NULL) {
                 break;
             }

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -2166,7 +2166,8 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
         op = FDB_LOCATION_INITIAL;
 
     refresh:
-        host = fdb_select_node(&fdb->loc, op, 0, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
+        host = fdb_select_node(&fdb->loc, op, 0, &avail_nodes, &lcl_nodes,
+                               &fdb->dbcon_mtx);
 
         if (avail_nodes <= 0) {
             clnt->fdb_state.preserve_err = 1;
@@ -2180,7 +2181,8 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
     } else if (was_bad) {
         /* we failed earlier on this one, we need the next node */
         op = FDB_LOCATION_NEXT;
-        host = fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
+        host = fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes,
+                               &fdb->dbcon_mtx);
     }
     if (host == NULL) {
         clnt->fdb_state.preserve_err = 1;
@@ -2267,8 +2269,8 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
         /* FAIL on current node, NEED to get the next node */
         if (!tried_nodes && op == FDB_LOCATION_REFRESH) {
             op = FDB_LOCATION_INITIAL;
-            host =
-                fdb_select_node(&fdb->loc, op, host, &avail_nodes, &lcl_nodes, &fdb->dbcon_mtx);
+            host = fdb_select_node(&fdb->loc, op, host, &avail_nodes,
+                                   &lcl_nodes, &fdb->dbcon_mtx);
             continue; /* try again with the selected node, can be the same */
         }
         else {
@@ -2293,7 +2295,8 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
                 op |= FDB_LOCATION_IGNORE_LCL;
             }
 
-            host = fdb_select_node(&fdb->loc, op, host, NULL, NULL, &fdb->dbcon_mtx);
+            host = fdb_select_node(&fdb->loc, op, host, NULL, NULL,
+                                   &fdb->dbcon_mtx);
             if (host == NULL) {
                 break;
             }


### PR DESCRIPTION
When multiple cross-db requests hit a server for the first time, there is a race populating remote db location.  This patch adds a lock around it.