### PR TITLE
adapted R6 patch

### DIFF
--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -56,6 +56,7 @@ int fdb_appsock_work(const char *cid, struct sqlclntstate *clnt, int version,
     clnt->fdb_state.version = version;
     clnt->fdb_state.flags = flags;
     clnt->osql.timings.query_received = osql_log_time();
+    clnt->queue_me = 1;
 
     /*
        dispatch the sql

--- a/tests/load_remsql.test/Makefile
+++ b/tests/load_remsql.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=srcdb
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/load_remsql.test/README
+++ b/tests/load_remsql.test/README
@@ -1,0 +1,1 @@
+This test make sure we don't fail remote sql when remote node is overloaded.

--- a/tests/load_remsql.test/lrl.options
+++ b/tests/load_remsql.test/lrl.options
@@ -1,0 +1,5 @@
+table t t.csc2
+table select t.csc2
+round_robin_stripes
+ssl_allow_remsql 1
+sqlenginepool maxt 1

--- a/tests/load_remsql.test/output.expected
+++ b/tests/load_remsql.test/output.expected
@@ -1,0 +1,4 @@
+(rows inserted=1)
+(rows inserted=1)
+(id=1, order=99)
+(id=2, order=98)

--- a/tests/load_remsql.test/runit
+++ b/tests/load_remsql.test/runit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# args
+# <dbname> <dbdir> <testdir> <autodbname> <autodbnum> <cluster> <task>
+echo "main db vars"
+vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG SECONDARY_DBNAME SECONDARY_DBDIR SECONDARY_CDB2_OPTIONS"
+for required in $vars; do
+    q=${!required}
+    echo "$required=$q" 
+    if [[ -z "$q" ]]; then
+        echo "$required not set" >&2
+        exit 1
+    fi
+done
+
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "INSERT INTO LOCAL_${SECONDARY_DBNAME}.t VALUES(1, 99)" >> output.actual 2>&1
+cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "INSERT INTO LOCAL_${SECONDARY_DBNAME}.t VALUES(2, 98)" >> output.actual 2>&1
+
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default 'select comdb2_host()'`
+echo "target machine is $mach"
+if [[ -z "$mach" ]] ; then
+    echo "Failed to get machine name"
+    exit 1
+fi
+
+cdb2sql ${SECONDARY_CDB2_OPTIONS} --host $mach ${SECONDARY_DBNAME} "SELECT sleep(10)" &
+
+cdb2sql ${CDB2_OPTIONS} --host $mach ${DBNAME} "SELECT * FROM LOCAL_${SECONDARY_DBNAME}.t" >> output.actual 2>&1
+
+# validate results
+testcase_output=$(cat output.actual)
+expected_output=$(cat output.expected)
+if [[ "$testcase_output" != "$expected_output" ]]; then
+
+   # print message
+   echo "  ^^^^^^^^^^^^"
+   echo "The above testcase (${testcase}) has failed!!!"
+   echo " "
+   echo "Use 'diff <expected-output> <my-output>' to see why:"
+   echo "> diff ${PWD}/{output.actual,output.expected}"
+   echo " "
+   diff output.actual output.expected
+   echo " "
+
+   successful=0
+else
+   successful=1
+fi
+
+if (( $successful != 1 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/load_remsql.test/t.csc2
+++ b/tests/load_remsql.test/t.csc2
@@ -1,0 +1,9 @@
+schema
+{
+   int  id
+   int order
+}
+keys
+{
+   "ID"  = id
+}


### PR DESCRIPTION
Ported from R6.
Internally generated remote sql queries are running on target host in the overloaded quota, if node has no available sqlite_engines.
