### PR TITLE
Port from r6 1097

### DIFF
--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -462,7 +462,9 @@ int bdb_osql_update_shadows(bdb_cursor_ifn_t *pcur_ifn, bdb_osql_trn_t *trn,
         if (gbl_sql_release_locks_in_update_shadows && !released_locks) {
             extern int gbl_sql_random_release_interval;
             if (bdb_curtran_has_waiters(cur->state, cur->curtran)) {
-                logmsg(LOGMSG_WARN, "%s: releasing locks while updating shadows\n", __func__);
+                logmsg(LOGMSG_WARN,
+                       "%s: releasing locks while updating shadows\n",
+                       __func__);
                 rc = release_locks_int("update shadows", __func__, __LINE__);
                 released_locks = 1;
             } else if (gbl_sql_random_release_interval &&

--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -462,6 +462,7 @@ int bdb_osql_update_shadows(bdb_cursor_ifn_t *pcur_ifn, bdb_osql_trn_t *trn,
         if (gbl_sql_release_locks_in_update_shadows && !released_locks) {
             extern int gbl_sql_random_release_interval;
             if (bdb_curtran_has_waiters(cur->state, cur->curtran)) {
+                logmsg(LOGMSG_WARN, "%s: releasing locks while updating shadows\n", __func__);
                 rc = release_locks_int("update shadows", __func__, __LINE__);
                 released_locks = 1;
             } else if (gbl_sql_random_release_interval &&

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5276,7 +5276,9 @@ static void register_all_int_switches()
                         "Send ODH'd blobs to master. (Default: ON)",
                         &gbl_osql_odh_blob);
     register_int_switch("delay_sql_lock_release",
-                        "Delay release locks in cursor move if bdb lock desired but client sends rows back", &gbl_delay_sql_lock_release_sec);
+                        "Delay release locks in cursor move if bdb lock "
+                        "desired but client sends rows back",
+                        &gbl_delay_sql_lock_release_sec);
 }
 
 static void getmyid(void)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -19,6 +19,7 @@ int __berkdb_read_alarm_ms;
 int __berkdb_fsync_alarm_ms;
 
 extern int gbl_berkdb_track_locks;
+extern int gbl_delay_sql_lock_release_sec;
 
 void __berkdb_set_num_read_ios(long long *n);
 void __berkdb_set_num_write_ios(long long *n);
@@ -5274,6 +5275,8 @@ static void register_all_int_switches()
     register_int_switch("osql_odh_blob",
                         "Send ODH'd blobs to master. (Default: ON)",
                         &gbl_osql_odh_blob);
+    register_int_switch("delay_sql_lock_release",
+                        "Delay release locks in cursor move if bdb lock desired but client sends rows back", &gbl_delay_sql_lock_release_sec);
 }
 
 static void getmyid(void)

--- a/db/sql.h
+++ b/db/sql.h
@@ -848,6 +848,7 @@ struct sqlclntstate {
     int8_t sent_data_to_client;
     int8_t is_asof_snapshot;
     LINKC_T(struct sqlclntstate) lnk;
+    int last_sent_row_sec;   /* used to delay releasing locks when bdb_lock is desired */
 };
 
 /* Query stats. */

--- a/db/sql.h
+++ b/db/sql.h
@@ -848,7 +848,8 @@ struct sqlclntstate {
     int8_t sent_data_to_client;
     int8_t is_asof_snapshot;
     LINKC_T(struct sqlclntstate) lnk;
-    int last_sent_row_sec;   /* used to delay releasing locks when bdb_lock is desired */
+    int last_sent_row_sec; /* used to delay releasing locks when bdb_lock is
+                              desired */
 };
 
 /* Query stats. */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -101,6 +101,9 @@
 #include "str0.h"
 #include "comdb2_atomic.h"
 
+int gbl_delay_sql_lock_release_sec = 5;
+
+
 unsigned long long get_id(bdb_state_type *);
 static void unlock_bdb_cursors(struct sql_thread *thd, bdb_cursor_ifn_t *bdbcur,
                                int *bdberr);
@@ -619,7 +622,8 @@ static int sql_tick(struct sql_thread *thd)
     if ((rc = check_recover_deadlock(clnt)))
         return rc;
 
-    if (bdb_lock_desired(thedb->bdb_env)) {
+    if (((gbl_epoch_time - clnt->last_sent_row_sec) >= gbl_delay_sql_lock_release_sec) &&
+        bdb_lock_desired(thedb->bdb_env)) {
         int sleepms;
 
         logmsg(LOGMSG_WARN, "bdb_lock_desired so calling recover_deadlock\n");

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -103,7 +103,6 @@
 
 int gbl_delay_sql_lock_release_sec = 5;
 
-
 unsigned long long get_id(bdb_state_type *);
 static void unlock_bdb_cursors(struct sql_thread *thd, bdb_cursor_ifn_t *bdbcur,
                                int *bdberr);
@@ -622,7 +621,8 @@ static int sql_tick(struct sql_thread *thd)
     if ((rc = check_recover_deadlock(clnt)))
         return rc;
 
-    if (((gbl_epoch_time - clnt->last_sent_row_sec) >= gbl_delay_sql_lock_release_sec) &&
+    if (((gbl_epoch_time - clnt->last_sent_row_sec) >=
+         gbl_delay_sql_lock_release_sec) &&
         bdb_lock_desired(thedb->bdb_env)) {
         int sleepms;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3935,6 +3935,7 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                "Fail to add query to transaction replay session\n");
 
     /* Get first row to figure out column structure */
+    clnt->last_sent_row_sec = time(NULL);
     int steprc = next_row(clnt, stmt);
     if (steprc == SQLITE_SCHEMA_REMOTE) {
         /* remote schema changed;
@@ -3969,6 +3970,8 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     }
 
     do {
+        clnt->last_sent_row_sec = time(NULL);
+
         /* replication contention reduction */
         rc = release_locks_on_emit_row(thd, clnt);
         if (rc) {

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -903,6 +903,7 @@ These options are toggle-able at runtime.
 |logmsg   |  | Controls the database logging level - accepts [logging commands](op.html#logging-commands).
 | pbkdf2_iterations | 4096 | Number of PBKDF2 iterations. PBKDF2 is used for password hashing. The higher the value, the more secure and the more computationally expensive. The mininum number of iterations is 4096.
 |clean_exit_on_sigterm | 1 | When enabled, SIGTERM will cause database to do an orderly shutdown.  When disabled follows system SIGTERM default (terminate, no core) 
+|delay_sql_lock_release| 1 | Delay release locks in cursor move if bdb lock desired but client sends rows back
 
 <!-- TODO
 |enable_datetime_truncation | |

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=934)
+(TUNABLES_COUNT=935)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -170,6 +170,7 @@
 (name='delay_after_saveop_done', description='', type='INTEGER', value='0', read_only='N')
 (name='delay_after_saveop_usedb', description='', type='INTEGER', value='0', read_only='N')
 (name='delay_file_open', description='', type='INTEGER', value='0', read_only='N')
+(name='delay_sql_lock_release', description='Delay release locks in cursor move if bdb lock desired but client sends rows back', type='BOOLEAN', value='ON', read_only='N')
 (name='delay_writes_in_record_c', description='', type='INTEGER', value='0', read_only='N')
 (name='delayed_oldfile_cleanup', description='If set, don't delete unused data/index files in the critical path of schema change; schedule them for deletion later.', type='BOOLEAN', value='ON', read_only='N')
 (name='dflt_livesc', description='Use live schema change by default', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Currently releasing locks during cursor moves can leave sqlite engine in a non-recoverable state.  Since it is safe to release the lock during row emitting phase, we can postpone lock release until the engine sends a row to the client.
The only case when this is a problem is when a join runs a heavy inner loop, taking a long time to send a row back.  We provide a configurable time delay default to 5 seconds to prevent this from becoming a problem.
In the targeted non-recoverable state, sqlite engine prints "Dta lookup failed" error, and client gets a 203 error code.  
