### PR TITLE
fix off by one when string for stack or taskname is empty

### DIFF
--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -263,7 +263,7 @@ int _osql_register_sqlthr(struct sqlclntstate *clnt, int type, int is_remote)
  * of its sql peer
  *
  */
-int osql_register_sqlthr(struct sqlclntstate *clnt, int type)
+inline int osql_register_sqlthr(struct sqlclntstate *clnt, int type)
 {
     return _osql_register_sqlthr(clnt, type, 0);
 }
@@ -272,11 +272,11 @@ int osql_register_sqlthr(struct sqlclntstate *clnt, int type)
  * TODO: This is unused? If so cleanup.
  * Register a remote transaction, part of a distributed transaction
  *
- */
 int osql_register_remtran(struct sqlclntstate *clnt, int type, char *tid)
 {
     return _osql_register_sqlthr(clnt, type, 1);
 }
+ */
 
 /**
  * Unregister an osql thread from the checkboard

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2142,7 +2142,7 @@ void init_clientstats_table()
 #define UNKNOWN_NAME "Unknown"
 #define GET_NAME_AND_LEN(s, s_len)                                             \
     do {                                                                       \
-        if (!s || (s_len = strlen(s) + 1) < 1) {                               \
+        if (!s || (s_len = strlen(s) + 1) <= 1) {                              \
             s = UNKNOWN_NAME;                                                  \
             s_len = sizeof(UNKNOWN_NAME);                                      \
         }                                                                      \
@@ -2666,6 +2666,7 @@ done:
     *nodes_cnt = max_clients;
     return summaries;
 }
+
 void nodestats_node_report(FILE *fh, const char *prefix, int disp_rates,
                            char *host)
 {


### PR DESCRIPTION
fix off by one when string for stack or taskname is empty