### PR TITLE
Dont create file for in memory repdb 

### DIFF
--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -596,7 +596,8 @@ __rep_client_dbinit(dbenv, startup)
 	sprintf(repdbname, "%s.%ld.%d", REPDBBASE, time(NULL),
 	    db_rep->repdbcnt++);
 
-	if ((ret = __db_open(dbp, NULL,
+    extern int gbl_inmem_repdb;
+	if (!gbl_inmem_repdb && (ret = __db_open(dbp, NULL,
 		    repdbname, NULL, DB_BTREE, flags, 0, PGNO_BASE_MD)) != 0)
 		 goto err;
 

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -74,6 +74,7 @@ extern int gbl_is_physical_replicant;
 extern int gbl_dumptxn_at_commit;
 int gbl_rep_badgen_trace;
 int gbl_decoupled_logputs = 1;
+int gbl_inmem_repdb = 1;
 int gbl_max_apply_dequeue = 100000;
 int gbl_master_req_waitms = 200;
 int gbl_fills_waitms = 1000;
@@ -618,7 +619,7 @@ static void *apply_thread(void *arg)
 
 			if (ret != 0 && ret != DB_REP_ISPERM && ret != DB_REP_NOTPERM)
 				abort();
-			/* If this is null, we've stuck both in inmem_repdb */
+			/* If this is null, we've stuck both in gbl_inmem_repdb */
 			if (rec.data) {
 				free(q->data);
 				free(q->rp);
@@ -2909,7 +2910,6 @@ __rep_apply_int(dbenv, rp, rec, ret_lsnp, commit_gen, decoupled)
 	int cmp, do_req, gap, ret, t_ret, rc;
 	int num_retries;
 	int disabled_minwrite_noread = 0;
-	int inmem_repdb = gbl_decoupled_logputs;
 	char *eid;
 
 	db_rep = dbenv->rep_handle;
@@ -3093,7 +3093,7 @@ gap_check:		max_lsn_dbtp = NULL;
 			ZERO_LSN(lp->max_wait_lsn);
 
 			/* In-memory drop in replacement */
-			if (inmem_repdb) {
+			if (gbl_inmem_repdb) {
 				repdb_dequeue(&control_dbt, &rec_dbt);
 				rp = (REP_CONTROL *)control_dbt.data;
 				assert(!IS_ZERO_LSN(rp->lsn));
@@ -3159,7 +3159,7 @@ gap_check:		max_lsn_dbtp = NULL;
 				rectype = 0;
 			}
 
-			if (!inmem_repdb && (ret = __db_c_del(dbc, 0)) != 0) {
+			if (!gbl_inmem_repdb && (ret = __db_c_del(dbc, 0)) != 0) {
 				abort();
 				goto err;
 			}
@@ -3189,7 +3189,7 @@ gap_check:		max_lsn_dbtp = NULL;
 			 * interested in its contents, just in its LSN.
 			 * Optimize by doing a partial get of the data item.
 			 */
-			if (inmem_repdb) {
+			if (gbl_inmem_repdb) {
 				struct repdb_rec *r = LISTC_TOP(&repdb_queue);
 				ret = 0;
 				if (!r) {
@@ -3397,7 +3397,7 @@ gap_check:		max_lsn_dbtp = NULL;
 		}
 #endif
 		/* Only add less than the oldest */
-		if (inmem_repdb) {
+		if (gbl_inmem_repdb) {
 			repdb_enqueue(rp, rec, decoupled);
 			ret = 0;
 		} else {
@@ -3665,7 +3665,7 @@ gap_check:		max_lsn_dbtp = NULL;
 		goto err;
 	}
 
-	if (inmem_repdb) {
+	if (gbl_inmem_repdb) {
 		if (control_dbt.data) 
 			free(control_dbt.data);
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -147,6 +147,7 @@ extern int gbl_dump_full_net_queue;
 extern int gbl_max_clientstats_cache;
 extern int gbl_decoupled_logputs;
 extern int gbl_apply_queue_memory;
+extern int gbl_inmem_repdb;
 extern int gbl_inmem_repdb_maxlog;
 extern int gbl_inmem_repdb_memory;
 extern int gbl_net_writer_thread_poll_ms;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1456,6 +1456,10 @@ REGISTER_TUNABLE("net_writer_poll_ms",
                  "Poll time for net writer thread.  (Default: 1000)",
                  TUNABLE_INTEGER, &gbl_net_writer_thread_poll_ms,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("inmem_repdb",
+                 "Use in memory structure for repdb (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_inmem_repdb,
+                 EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("inmem_repdb_maxlog",
                  "Maximum records for in-memory replist.  "
                  "(Default: 10000)",

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -2,6 +2,7 @@
 bash -n "$0" | exit 1
 
 set -e
+set -x
 source ${TESTSROOTDIR}/tools/runit_common.sh
 
 if [[ "x${DEBUGGER}" == "xvalgrind" ]] ; then


### PR DESCRIPTION
Introducing a new global to control behavior of inmemory repdb.
Currently we misuse another global for that purpose.
Also, don't open repdb file if this new global is set.