### PR TITLE
Experimental changes to address timing issues between repeatedly dropping/adding a queue

### DIFF
--- a/bdb/bdb_queuedb.h
+++ b/bdb/bdb_queuedb.h
@@ -48,5 +48,6 @@ int bdb_trigger_subscribe(bdb_state_type *, pthread_cond_t **,
 int bdb_trigger_unsubscribe(bdb_state_type *);
 int bdb_trigger_open(bdb_state_type *);
 int bdb_trigger_close(bdb_state_type *);
+int bdb_trigger_version(bdb_state_type *);
 
 #endif

--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -691,3 +691,9 @@ int bdb_trigger_close(bdb_state_type *bdb_state)
     DB_ENV *dbenv = bdb_state->dbenv;
     return dbenv->trigger_close(dbenv, bdb_state->name);
 }
+
+int bdb_trigger_version(bdb_state_type *bdb_state)
+{
+    DB_ENV *dbenv = bdb_state->dbenv;
+    return dbenv->trigger_version(dbenv, bdb_state->name);
+}

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2583,6 +2583,7 @@ struct __db_env {
 	int(*trigger_unsubscribe) __P((DB_ENV *, const char *));
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
+	int(*trigger_version) __P((DB_ENV *, const char *));
 
 	int (*pgin[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 	int (*pgout[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));

--- a/berkdb/dbinc/trigger_subscription.h
+++ b/berkdb/dbinc/trigger_subscription.h
@@ -7,6 +7,7 @@
 struct __db_trigger_subscription {
 	char *name;
 	int active;
+	int version;
 	uint8_t open;
 	pthread_cond_t cond;
 	pthread_mutex_t lock;

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -47,6 +47,7 @@ static const char revid[] =
 
 #include "logmsg.h"
 #include "locks_wrap.h"
+#include "comdb2_atomic.h"
 
 static int __dbenv_init __P((DB_ENV *));
 static void __dbenv_err __P((const DB_ENV *, int, const char *, ...));
@@ -93,6 +94,7 @@ static int __dbenv_trigger_subscribe __P((DB_ENV *, const char *,
 static int __dbenv_trigger_unsubscribe __P((DB_ENV *, const char *));
 static int __dbenv_trigger_open __P((DB_ENV *, const char *));
 static int __dbenv_trigger_close __P((DB_ENV *, const char *));
+static int __dbenv_trigger_version __P((DB_ENV *, const char *));
 int __dbenv_apply_log __P((DB_ENV *, unsigned int, unsigned int, int64_t,
             void*, int));
 size_t __dbenv_get_log_header_size __P((DB_ENV*)); 
@@ -336,6 +338,7 @@ __dbenv_init(dbenv)
 	dbenv->trigger_unsubscribe = __dbenv_trigger_unsubscribe;
 	dbenv->trigger_open = __dbenv_trigger_open;
 	dbenv->trigger_close = __dbenv_trigger_close;
+	dbenv->trigger_version = __dbenv_trigger_version;
 
 	return (0);
 }
@@ -1414,6 +1417,7 @@ __dbenv_trigger_open(dbenv, fname)
 	t = __db_get_trigger_subscription(fname);
 	Pthread_mutex_lock(&t->lock);
 	t->open = 1;
+	ATOMIC_ADD32(t->version, 1);
 	Pthread_cond_signal(&t->cond);
 	Pthread_mutex_unlock(&t->lock);
 	return 0;
@@ -1428,7 +1432,18 @@ __dbenv_trigger_close(dbenv, fname)
 	t = __db_get_trigger_subscription(fname);
 	Pthread_mutex_lock(&t->lock);
 	t->open = 0;
+	ATOMIC_ADD32(t->version, 1);
 	Pthread_cond_signal(&t->cond);
 	Pthread_mutex_unlock(&t->lock);
 	return 0;
+}
+
+static int
+__dbenv_trigger_version(dbenv, fname)
+	DB_ENV *dbenv;
+	const char *fname;
+{
+	struct __db_trigger_subscription *t;
+	t = __db_get_trigger_subscription(fname);
+	return ATOMIC_LOAD32(t->version);
 }

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -823,11 +823,14 @@ static int sp_trigger_run(struct javasp_trans_state *javasp_trans_handle,
     byte_buffer_append_zero(&bytes, 4);
 
     /* post it to queue */
-    usedb = javasp_trans_handle->iq->usedb;
-    javasp_trans_handle->iq->usedb = getqueuebyname(p->qname);
-    rc = dbq_add(javasp_trans_handle->iq, javasp_trans_handle->trans,
-                 bytes.bytes, bytes.used);
-    javasp_trans_handle->iq->usedb = usedb;
+    struct dbtable *qdb = getqueuebyname(p->qname);
+    if (qdb != NULL) {
+        usedb = javasp_trans_handle->iq->usedb;
+        javasp_trans_handle->iq->usedb = qdb;
+        rc = dbq_add(javasp_trans_handle->iq, javasp_trans_handle->trans,
+                     bytes.bytes, bytes.used);
+        javasp_trans_handle->iq->usedb = usedb;
+    }
 
 done:
     byte_buffer_free(&bytes);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -703,7 +703,19 @@ static int dbq_poll_int(Lua L, dbconsumer_t *q)
     return -1;
 }
 
-static int dbq_poll(Lua L, dbconsumer_t *q, int delay)
+static int dbq_can_poll(dbconsumer_t *q, int version)
+{
+    if (!*q->open) return 0;
+    int new_version = bdb_trigger_version(q->iq.usedb->handle);
+    if (new_version != version) {
+        logmsg(LOGMSG_ERROR, "%s: trigger %s version mismatch, %d vs %d\n",
+               __func__, q->info.spname, new_version, version);
+        return 0;
+    }
+    return 1;
+}
+
+static int dbq_poll(Lua L, dbconsumer_t *q, int delay, int version)
 {
     SP sp = getsp(L);
     while (1) {
@@ -712,7 +724,7 @@ static int dbq_poll(Lua L, dbconsumer_t *q, int delay)
         }
         int rc;
         Pthread_mutex_lock(q->lock);
-again:  if (*q->open) {
+again:  if (dbq_can_poll(q, version)) {
             rc = dbq_poll_int(L, q); // call will release q->lock
         } else {
             Pthread_mutex_unlock(q->lock);
@@ -733,19 +745,31 @@ again:  if (*q->open) {
             // was woken up -- try getting from queue
             goto again;
         }
+        int wasOpen = *q->open;
         Pthread_mutex_unlock(q->lock);
         delay -= dbq_delay;
         if (delay < 0) {
+            if (check_retry_conditions(L, 0) != 0)
+                return -1;
+
+            if (!wasOpen) {
+                logmsg(LOGMSG_ERROR, "%s: queue %s no longer open after wait\n",
+                       __func__, q->info.spname);
+                rc = -2;
+                luabb_error(L, sp, "failed to read from:%s rc:%d", q->info.spname, rc);
+                return rc;
+            }
+
             return 0;
         }
     }
 }
 
 // this call will block until queue item available
-static int dbconsumer_get_int(Lua L, dbconsumer_t *q)
+static int dbconsumer_get_int(Lua L, dbconsumer_t *q, int version)
 {
     int rc;
-    while ((rc = dbq_poll(L, q, dbq_delay)) == 0)
+    while ((rc = dbq_poll(L, q, dbq_delay, version)) == 0)
         ;
     return rc;
 }
@@ -781,7 +805,7 @@ static int dbconsumer_get(Lua L)
 {
     dbconsumer_t *q = luaL_checkudata(L, 1, dbtypes.dbconsumer);
     int rc;
-    if ((rc = dbconsumer_get_int(L, q)) > 0) return rc;
+    if ((rc = dbconsumer_get_int(L, q, bdb_trigger_version(q->iq.usedb->handle))) > 0) return rc;
     return luaL_error(L, getsp(L)->error);
 }
 
@@ -792,7 +816,7 @@ static int dbconsumer_poll(Lua L)
     lua_Integer delay; // ms
     lua_number2integer(delay, arg);
     delay += (dbq_delay - delay % dbq_delay); // multiple of dbq_delay
-    int rc = dbq_poll(L, q, delay);
+    int rc = dbq_poll(L, q, delay, bdb_trigger_version(q->iq.usedb->handle));
     if (rc >= 0) {
         return rc;
     }
@@ -6728,7 +6752,7 @@ void *exec_trigger(trigger_reg_t *reg)
         }
         SP sp = clnt.sp;
         L = sp->lua;
-        if ((args = dbconsumer_get_int(L, q)) < 0) {
+        if ((args = dbconsumer_get_int(L, q, bdb_trigger_version(q->iq.usedb->handle))) < 0) {
             err = strdup(sp->error);
             goto bad;
         }

--- a/tests/sp_trig_no_qdb.test/Makefile
+++ b/tests/sp_trig_no_qdb.test/Makefile
@@ -1,0 +1,11 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=60m
+endif
+
+export SP_OPTIONS=-s --cdb2cfg $(CDB2_CONFIG) $(DBNAME) default

--- a/tests/sp_trig_no_qdb.test/const_consumer.lua
+++ b/tests/sp_trig_no_qdb.test/const_consumer.lua
@@ -1,0 +1,15 @@
+local function main(i_must_have_value)
+	local consumer = db:consumer()
+	local event = consumer:get()
+	local newi = "<nil>"
+	if event.new ~= nil then
+		newi = tostring(event.new.i)
+	end
+	if (newi == tostring(i_must_have_value)) then
+		consumer:consume()
+	else
+		local msg = "FAILED: wanted " .. tostring(i_must_have_value) ..
+		            ", got " .. newi
+		db:emit(msg)
+	end
+end

--- a/tests/sp_trig_no_qdb.test/foraudit.csc2
+++ b/tests/sp_trig_no_qdb.test/foraudit.csc2
@@ -1,0 +1,4 @@
+schema
+{
+	int i
+}

--- a/tests/sp_trig_no_qdb.test/lrl.options
+++ b/tests/sp_trig_no_qdb.test/lrl.options
@@ -1,0 +1,3 @@
+setattr PRIVATE_BLKSEQ_MAXAGE 30
+setattr MIN_KEEP_LOGS 1
+logmsg level info

--- a/tests/sp_trig_no_qdb.test/runit
+++ b/tests/sp_trig_no_qdb.test/runit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+dbname=$1
+
+echo "Starting tests"
+echo "Using SP_OPTIONS: $SP_OPTIONS"
+./test.sh $dbname
+rc=$?
+if (( $rc != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/sp_trig_no_qdb.test/spt_qdb.sh
+++ b/tests/sp_trig_no_qdb.test/spt_qdb.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+[[ -n "$3" ]] && exec >$3 2>&1
+cdb2sql $SP_OPTIONS - <<EOF
+create table foraudit3 {$(cat foraudit.csc2)}\$\$
+create procedure const3 version 'const_test' {$(cat const_consumer.lua)}\$\$
+create lua consumer const3 on (table foraudit3 for insert)
+EOF
+
+for ((i=0;i<5;++i)); do
+    ./spt_qdb_dml_adds.sh 1000 $i &
+    ./spt_qdb_dml_cons.sh 1000 $i &
+    ./spt_qdb_ddl_cons.sh 10 &
+    ./spt_qdb_ddl_proc.sh 10 &
+    wait
+done
+wait
+
+cdb2sql $SP_OPTIONS "select count(*) as row_count from foraudit3;"

--- a/tests/sp_trig_no_qdb.test/spt_qdb_ddl_cons.sh
+++ b/tests/sp_trig_no_qdb.test/spt_qdb_ddl_cons.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for ((k=0;k<$1;++k)); do
+    cdb2sql $SP_OPTIONS "drop lua consumer const3" &>/dev/null
+    cdb2sql $SP_OPTIONS "create lua consumer const3 on (table foraudit3 for insert)" &>/dev/null
+done

--- a/tests/sp_trig_no_qdb.test/spt_qdb_ddl_proc.sh
+++ b/tests/sp_trig_no_qdb.test/spt_qdb_ddl_proc.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for ((k=0;k<$1;++k)); do
+    cdb2sql $SP_OPTIONS "drop procedure const3 version 'const_test'" &>/dev/null
+    cdb2sql $SP_OPTIONS "create procedure const3 version 'const_test' {$(cat const_consumer.lua)}" &>/dev/null
+done

--- a/tests/sp_trig_no_qdb.test/spt_qdb_dml_adds.sh
+++ b/tests/sp_trig_no_qdb.test/spt_qdb_dml_adds.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+for ((k=0;k<$1;++k)); do
+    did_insert=$(cdb2sql $SP_OPTIONS "insert into foraudit3 values($2)")
+
+    if [[ "$did_insert" != "(rows inserted=1)" ]]; then
+        echo "failed INSERT for round $2 at iteration $k"
+    fi
+done

--- a/tests/sp_trig_no_qdb.test/spt_qdb_dml_cons.sh
+++ b/tests/sp_trig_no_qdb.test/spt_qdb_dml_cons.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+for ((k=0;k<$1;++k)); do
+    cdb2sql $SP_OPTIONS "exec procedure const3($2)" &>/dev/null
+done

--- a/tests/sp_trig_no_qdb.test/t01.req.out
+++ b/tests/sp_trig_no_qdb.test/t01.req.out
@@ -1,0 +1,2 @@
+(version='const_test')
+(row_count=5000)

--- a/tests/sp_trig_no_qdb.test/t01.req.tool
+++ b/tests/sp_trig_no_qdb.test/t01.req.tool
@@ -1,0 +1,1 @@
+./spt_qdb.sh

--- a/tests/sp_trig_no_qdb.test/test.sh
+++ b/tests/sp_trig_no_qdb.test/test.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+################################################################################
+
+# debug=1
+TMPDIR=${TMPDIR:-/tmp}
+
+# args
+a_dbn=$1
+
+# find input files
+files=$( ls *.req | sort )
+
+# counter
+nfiles=0
+
+# last batch
+last_batch=
+
+# post-process
+pproc=cat
+
+# figure out which host should deal with the tunable
+export SP_HOST=$(cdb2sql --tabs -s ${CDB2_OPTIONS} $a_dbn default "SELECT comdb2_host()")
+
+# Iterate through input files
+for testcase in $files ; do
+
+    # increment counter
+    let nfiles=nfiles+1
+
+    # cleanup testcase
+    testcase=${testcase##*/}
+
+    # see if the prefix has changed
+    new_batch=${testcase%%_*}
+
+    # set output
+    output=$testcase.res
+
+    # full path
+    [[ "$output" == "${output#\/}" ]] && output=${PWD}/$output
+
+    # Check for run-stepper
+    if [[ -f $new_batch.tool ]] ; then
+
+        tool=$( cat $new_batch.tool )
+        args=$( cat $new_batch.args )
+        echo "> $tool $a_dbn $args $testcase $output"
+        $tool $a_dbn $args $testcase $output
+
+    else
+
+        # Be verbose
+        cmd="cdb2sql --host $SP_HOST -s ${CDB2_OPTIONS} $a_dbn default - < $testcase > $output 2>&1"
+        echo $cmd
+
+        # run command
+        eval $cmd
+
+    fi
+
+    # post-process
+    if [[ -f $new_batch.post ]]; then
+
+        # zap file
+        > $output.postprocess
+
+        # collect post-processing tool
+        pproc=$(cat $new_batch.post)
+
+        # post-process output
+        $pproc $output >> $output.postprocess
+
+        # copy post-processed output to original
+        mv $output.postprocess $output
+    fi
+
+    # get testcase output
+    testcase_output=$(cat $output)
+
+    # get expected output
+    expected_output=$(cat $testcase.out)
+
+    # verify
+    if [[ "$testcase_output" != "$expected_output" ]]; then
+        echo "  ^^^^^^^^^^^^"
+        echo "The above testcase (${testcase}) has failed!!!"
+        echo "diff ${PWD}/$testcase.out $output"
+        echo " "
+        diff $testcase.out $output
+        echo " "
+        exit 1
+    fi
+done
+
+echo "Testcase passed."
+
+exit 0


### PR DESCRIPTION
These changes attempt to address a couple timing issues related to repeatedly dropping and then re-adding a queue while another client is attempting to add and/or consumer from it.