### PR TITLE
Honor seqnum_generations tunable from should_copy_seqnum

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2372,7 +2372,8 @@ static inline int should_copy_seqnum(bdb_state_type *bdb_state,
         return 1;
     }
 
-    if (seqnum->generation < last_seqnum->generation) {
+    if (bdb_state->attr->enable_seqnum_generations && seqnum->generation <
+            last_seqnum->generation) {
         if (trace && (now = time(NULL)) > lastpr) {
             logmsg(LOGMSG_USER,
                    "seqnum-generation %d < last_generation %d, not"


### PR DESCRIPTION
Only discard a seqnum based on it's generation if enable_seqnum_generations is enabled.
