### PR TITLE
Fix copycomdb2 for cases when lz4 is not available

### DIFF
--- a/db/copycomdb2
+++ b/db/copycomdb2
@@ -146,14 +146,6 @@ do_recovery=yes
 [ -z "$comdb2ar" ] && comdb2ar="${PREFIX}/bin/comdb2ar"
 [ -z "$lz4" ] && lz4="${PREFIX}/bin/lz4"
 
-function nolz4 {
-    while [[ $# -gt 0 && $1 = '-*' ]]; do
-        shift
-    done
-    shift 2
-    cat
-}
-
 if [[ ! -x $comdb2ar ]]; then
    comdb2ar=$(which comdb2ar 2>/dev/null)
 fi
@@ -161,7 +153,11 @@ fi
 if [[ ! -x $lz4 ]]; then
    lz4=$(which lz4 2>/dev/null)
    if [[ -z "$lz4" ]]; then
-       lz4=nolz4
+       ar_compress="cat"
+       ar_decompress="cat"
+   else
+       ar_compress="$lz4 stdin stdout"
+       ar_decompress="$lz4 -d stdin stdout"
    fi
 fi
 
@@ -275,6 +271,14 @@ done
 # allow comdb2ar_rmt to be changed
 [ -z "$comdb2ar_rmt" ] && comdb2ar_rmt="${comdb2ar}"
 [ -z "$lz4_rmt" ] && lz4_rmt="${lz4}"
+
+if [[ -z "$lz4_rmt" ]]; then
+    ar_compress_rmt="cat"
+    ar_decompress_rmt="cat"
+else
+    ar_compress_rmt="$lz4_rmt stdin stdout"
+    ar_decompress_rmt="$lz4_rmt -d stdin stdout"
+fi
 
 [ $copy_data = no -a $copy_lrls = no ] && die "cannot use -s and -d together"
 
@@ -468,9 +472,9 @@ exopts="-C $cluster_info -u $max_du_percent $recovery_opts"
 [ $do_recovery = no ]           && exopts="$exopts -R"
 
 if [ $restoremode = yes ]; then
-    $IONICE $lz4 -d stdin stdout | $comdb2ar $COMDB2AR_AROPTS $exopts x $destlrldir $destdbdir 2>$arstatus 
+    $IONICE $ar_decompress | $comdb2ar $COMDB2AR_AROPTS $exopts x $destlrldir $destdbdir 2>$arstatus 
 elif [ $backupmode = yes ]; then
-    $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $lz4 stdin stdout
+    $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $ar_compress
 else
     printf "\n\nSetting up pipe\n_______________________________________\n\n" >>$logfile
     (
@@ -515,12 +519,12 @@ else
         # Pull mode.  Serialise the db at the destination and pipe this in to
         # a local deserialise.
         if [[ $partial = yes ]] ; then
-            $rsh $srcmach "$IONICE_RMT $comdb2ar_rmt $COMDB2AR_AROPTS $aropts c $partialopts $srclrl 2>$arstatus | $lz4_rmt stdin stdout " </dev/null | \ 
-                $lz4 -d stdin stdout | $IONICE $comdb2ar $COMDB2AR_EXOPTS $exopts $outmode $destlrldir/$partiallrl >$exstatus 2>&1
+            $rsh $srcmach "$IONICE_RMT $comdb2ar_rmt $COMDB2AR_AROPTS $aropts c $partialopts $srclrl 2>$arstatus | $ar_compress_rmt " </dev/null | \ 
+                $ar_decompress | $IONICE $comdb2ar $COMDB2AR_EXOPTS $exopts $outmode $destlrldir/$partiallrl >$exstatus 2>&1
             rc=$?
         else
-            $rsh $srcmach "$IONICE_RMT $comdb2ar_rmt $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $lz4_rmt stdin stdout " </dev/null | \
-                $lz4 -d stdin stdout | $IONICE $comdb2ar $COMDB2AR_EXOPTS $exopts $outmode $destlrldir $destdbdir >$exstatus 2>&1
+            $rsh $srcmach "$IONICE_RMT $comdb2ar_rmt $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $ar_compress_rmt " </dev/null | \
+                $ar_decompress | $IONICE $comdb2ar $COMDB2AR_EXOPTS $exopts $outmode $destlrldir $destdbdir >$exstatus 2>&1
             rc=$?
         fi
 
@@ -528,12 +532,12 @@ else
         # Push mode.  Serialise db locally, pipe through o rshd deserialise
         # process on remote machine.
         if [[ $partial = yes ]] ; then
-            $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $partialopts $srclrl 2>$arstatus | $lz4 stdin stdout | \
-                $rsh $destmach "$lz4_rmt -d stdin stdout | $IONICE_RMT $comdb2ar_rmt $COMDB2AR_EXOPTS $exopts $outmode $destlrldir/$partiallrl " >$exstatus 2>&1
+            $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $partialopts $srclrl 2>$arstatus | $ar_compress | \
+                $rsh $destmach "$ar_decompress_rmt | $IONICE_RMT $comdb2ar_rmt $COMDB2AR_EXOPTS $exopts $outmode $destlrldir/$partiallrl " >$exstatus 2>&1
             rc=$?
         else
-            $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $lz4 stdin stdout | \
-                $rsh $destmach "$lz4_rmt -d stdin stdout | $IONICE_RMT $comdb2ar_rmt $COMDB2AR_EXOPTS $exopts $outmode $destlrldir $destdbdir " >$exstatus 2>&1
+            $IONICE $comdb2ar $COMDB2AR_AROPTS $aropts c $srclrl 2>$arstatus | $ar_compress | \
+                $rsh $destmach "$ar_decompress_rmt | $IONICE_RMT $comdb2ar_rmt $COMDB2AR_EXOPTS $exopts $outmode $destlrldir $destdbdir " >$exstatus 2>&1
             rc=$?
         fi
 


### PR DESCRIPTION
For cases when lz4 is not available, copycomdb2 fails with 
`bash: line 7: nolz4: command not found` example from test truncatesc.
This is because indeed the $lz4_rmt is set to `nolz4` which is an undefined function in the remote ssh session. This checkin sets the ar_compress and ar_compress_rmt variables to `cat` explicitly rather than use a `nolz4` as a bash function. 

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>