### PR TITLE
Views: fix a crash when db has both user views and time partitions

### DIFF
--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -5133,7 +5133,12 @@ restart:
   for( k=sqliteHashFirst(&pDb->pSchema->tblHash);  k; k=sqliteHashNext(k) ){
     pTab = (Table*)sqliteHashData(k);
     if( pTab->pSelect ){  
-      /* this is a view */
+      /* Ignore 'user' views */
+      if ((get_view_by_name(pTab->zName))) {
+        continue;
+      }
+
+      /* This is a time partition view */
       if( (*predicated_delete)(pTab->zName, db, arg) ){
 
         /* NOTE: we need to delete also the trigggers, and that require 

--- a/tests/ddl_no_csc2.test/runit
+++ b/tests/ddl_no_csc2.test/runit
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
+test_file="t10_view_timepart.sql"
+TIMEPART_STARTTIME=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC";\
+                    print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+2)'`
+cat ${test_file} | sed "s/{{STARTTIME}}/${TIMEPART_STARTTIME}/" > ${test_file}.new
+mv ${test_file}.new ${test_file}
+
 ${TESTSROOTDIR}/tools/compare_results.sh -s -d $1
 [ $? -eq 0 ] || exit 1
 exit 0

--- a/tests/ddl_no_csc2.test/t10_view_timepart.expected
+++ b/tests/ddl_no_csc2.test/t10_view_timepart.expected
@@ -1,0 +1,29 @@
+(rows inserted=3)
+(rows inserted=3)
+(sleep(5)=5)
+(i=1)
+(i=2)
+(i=3)
+(i=1)
+(i=2)
+(i=3)
+(i=1)
+(i=2)
+(i=3)
+(name='t2_v', definition='CREATE VIEW t2_v as select * from t2')
+(type='table', name='$1_383D642F', tbl_name='$1_383D642F', rootpage=6, sql='create table "$1_383D642F"("i" int);', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(type='table', name='t2', tbl_name='t2', rootpage=5, sql='create table "t2"("i" int);', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(type='view', name='t2_v', tbl_name=NULL, rootpage=-1, sql='CREATE VIEW t2_v as select * from t2', csc2=NULL)
+(type='table', name='time_part_t', tbl_name='time_part_t', rootpage=4, sql='create table "time_part_t"("i" int);', csc2='schema
+	{
+		int i null = yes 
+	}
+')

--- a/tests/ddl_no_csc2.test/t10_view_timepart.sql
+++ b/tests/ddl_no_csc2.test/t10_view_timepart.sql
@@ -1,0 +1,32 @@
+drop table if exists time_part_t;
+drop table if exists t2;
+
+create table time_part_t(i int)$$
+create table t2(i int)$$
+
+insert into time_part_t values(1),(2),(3);
+insert into t2 values(1),(2),(3);
+
+# create a time partition
+create time partition on time_part_t as time_part_v period 'daily' retention 2 start '{{STARTTIME}}';
+
+select sleep(5);
+
+# create a view
+create view t2_v as select * from t2;
+
+select * from time_part_t;
+select * from t2;
+select * from t2_v;
+
+# this should only list 'user' views
+select * from comdb2_views;
+
+# this should list everything!
+select * from sqlite_master where name not like 'sqlite%' order by name;
+
+# cleanup
+drop table t2;
+drop view t2_v;
+# Can't schema change time partition
+#drop table time_part_t;


### PR DESCRIPTION
Problem: Time partition implementation wrongly tried to delete triggers formed on user defined view names.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>