### PR TITLE
fix assert

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7344,10 +7344,11 @@ done:
            clients to disappear before it will wipe out the session
          */
 
-        rc = osql_repository_put(sess, false /* bplog not complete */);
+        rc = osql_repository_put(sess);
         if (!rc)
             return 0;
         /* if put noticed a termination flag, fall-through */
+        send_rc = 1;
     }
 
     /* notify the sql thread there will be no response! */
@@ -7356,7 +7357,7 @@ done:
     }
     if (sess) {
         /* session start with 1 client, this reader thread */
-        osql_sess_remclient(sess, false);
+        osql_sess_remclient(sess);
         osql_sess_close(&sess, false);
     } else {
         /* free a la carte */

--- a/db/osqlrepository.c
+++ b/db/osqlrepository.c
@@ -214,13 +214,13 @@ osql_sess_t *osql_repository_get(unsigned long long rqid, uuid_t uuid)
  *   0 if success
  *   1 if session is marked terminated
  */
-int osql_repository_put(osql_sess_t *sess, bool bplog_complete)
+int osql_repository_put(osql_sess_t *sess)
 {
     int rc;
 
     Pthread_mutex_lock(&theosql->hshlck);
 
-    rc = osql_sess_remclient(sess, bplog_complete);
+    rc = osql_sess_remclient(sess);
 
     Pthread_mutex_unlock(&theosql->hshlck);
 

--- a/db/osqlrepository.h
+++ b/db/osqlrepository.h
@@ -47,7 +47,7 @@ osql_sess_t *osql_repository_get(unsigned long long rqid, uuid_t uuid);
  * Decrements the number of users
  * Returns 0 if success
  */
-int osql_repository_put(osql_sess_t *sess, bool bplog_complete);
+int osql_repository_put(osql_sess_t *sess);
 
 /**
  * Init repository

--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -57,7 +57,7 @@ int osql_sess_addclient(osql_sess_t *sess);
  * Unregister client
  *
  */
-int osql_sess_remclient(osql_sess_t *sess, bool bplog_complete);
+int osql_sess_remclient(osql_sess_t *sess);
 
 /**
  * Log query to the reqlog


### PR DESCRIPTION
Make sure session is marked dispatched before releasing the clients counter, to prevent termination race.
