### PR TITLE
Experimental changes to fix stat4dump heap management

### DIFF
--- a/bbinc/thread_malloc.h
+++ b/bbinc/thread_malloc.h
@@ -21,7 +21,9 @@
 
 #define thread_memcreate(x)
 #define thread_memcreate_notrace(x)
+#define thread_memcreate_with_save(x, y)
 #define thread_memdestroy()
+#define thread_memdestroy_and_restore(x)
 #define thread_malloc(x) malloc(x)
 #define thread_free(x) free(x)
 #define thread_calloc(x, y) calloc(x, y)
@@ -31,7 +33,9 @@
 
 void thread_memcreate(size_t);
 void thread_memcreate_notrace(size_t);
+void thread_memcreate_with_save(size_t, void **);
 void thread_memdestroy(void);
+void thread_memdestroy_and_restore(void **);
 void *thread_malloc(size_t);
 void thread_free(void *);
 void *thread_calloc(size_t n_elem, size_t elem_sz);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -6019,8 +6019,7 @@ retry_tran:
         thd = sqlthd->clnt->thd;
 
         delete_prepared_stmts(thd);
-        sqlite3_close(thd->sqldb);
-        thd->sqldb = NULL;
+        sqlite3_close_serial(&thd->sqldb);
     }
 
     create_sqlmaster_records(tran);

--- a/db/sql.h
+++ b/db/sql.h
@@ -1155,10 +1155,13 @@ int replicant_is_able_to_retry(struct sqlclntstate *clnt);
 void sql_get_query_id(struct sql_thread *thd);
 
 void sql_dlmalloc_init(void);
-int sql_mem_init(void *dummy);
-void sql_mem_shutdown(void *dummy);
+int sql_mem_init(void *);
+int sql_mem_init_with_save(void *, void **);
+void sql_mem_shutdown(void *);
+void sql_mem_shutdown_and_restore(void *, void **);
 
 int sqlite3_open_serial(const char *filename, sqlite3 **, struct sqlthdstate *);
+int sqlite3_close_serial(sqlite3 **);
 
 void reset_clnt(struct sqlclntstate *, SBUF2 *, int initial);
 void cleanup_clnt(struct sqlclntstate *);

--- a/util/thread_malloc.c
+++ b/util/thread_malloc.c
@@ -53,11 +53,24 @@ void thread_memcreate_notrace(size_t sz)
     thread_memcreate_int(sz);
 }
 
+void thread_memcreate_with_save(size_t sz, void **poldm)
+{
+    *poldm = m; m = NULL;
+    thread_memcreate_int(sz);
+}
+
 void thread_memdestroy(void)
 {
     if (m)
         comdb2ma_destroy(m);
     m = NULL;
+}
+
+void thread_memdestroy_and_restore(void **poldm)
+{
+    if (m)
+        comdb2ma_destroy(m);
+    m = *poldm; *poldm = NULL;
 }
 
 void *thread_malloc(size_t n) { return comdb2_malloc(m, n); }


### PR DESCRIPTION
These changes involve modifying the stat4dump function so that it uses save/restore semantics for the global state that it modifies.  Without changes very similar to these, the following sequence of commands may cause the database process to crash:

```
@send stat4dump
SELECT 1
```