### PR TITLE
Fixes in user authentication

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -56,7 +56,7 @@
 /* Primary data file + 15 blobs files */
 #define MAXDTAFILES 16
 #define MAXDTASTRIPE 16
-#define MAX_USERNAME_LEN 17
+#define MAX_USERNAME_LEN 16
 #define MAX_PASSWORD_LEN 19
 
 /*

--- a/docs/pages/programming/auth.md
+++ b/docs/pages/programming/auth.md
@@ -8,7 +8,10 @@ permalink: auth.html
 
 ### Password-based Authentication
 
-A comdb2 session can be authenticated by setting username and password using [set user](sql.html#set-user) and [set password](sql.html#set-password), just after opening the connection.
+A comdb2 session can be authenticated by setting username and password using
+[set user](sql.html#set-user) and [set password](sql.html#set-password), just
+after opening the connection. The allowed limits for username and password are
+`15` and `18` characters respectively.
 
 ```sql
 set user 'foo_user'

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1672,8 +1672,9 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                     sqlite3Dequote(sqlstr);
                     if (strlen(sqlstr) >= sizeof(clnt->password)) {
                         snprintf(err, sizeof(err),
-                                 "set password: '%s' exceeds %zu characters",
-                                 sqlstr, sizeof(clnt->password) - 1);
+                                 "set password: password length exceeds %lu "
+                                 "characters",
+                                 sizeof(clnt->password) - 1);
                         rc = ii + 1;
                     } else {
                         clnt->have_password = 1;

--- a/tests/userschema.test/t09.expected
+++ b/tests/userschema.test/t09.expected
@@ -153,15 +153,29 @@
 (tablename='test@dcba', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 [select * from test] failed with rc -106 access denied
 [select * from comdb2_tablepermissions order by tablename] failed with rc -106 access denied
-[select * from test] failed with rc -3 set user: '12345678901234567' exceeds 16 characters
-[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '12345678901234567' exceeds 16 characters
-[select * from test] failed with rc -3 set password: '1234567890123456789' exceeds 18 characters
-[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set password: '1234567890123456789' exceeds 18 characters
-[select * from test] failed with rc -106 access denied
-[select * from comdb2_tablepermissions order by tablename] failed with rc -106 access denied
-[select * from test] failed with rc -3 set user: '12345678901234567' exceeds 16 characters
-[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '12345678901234567' exceeds 16 characters
-[select * from test] failed with rc -3 set password: '1234567890123456789' exceeds 18 characters
-[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set password: '1234567890123456789' exceeds 18 characters
-[select * from test] failed with rc -106 access denied
-[select * from comdb2_tablepermissions order by tablename] failed with rc -106 access denied
+[select * from test] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from test] failed with rc -3 set password: password length exceeds 18 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set password: password length exceeds 18 characters
+[select * from test] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from test] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from test] failed with rc -3 set password: password length exceeds 18 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set password: password length exceeds 18 characters
+[select * from test] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select * from comdb2_tablepermissions order by tablename] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+(comdb2_user()='mohit')
+[put password '1234567890123456789' for '1234567890123456'] failed with rc -3 Password is too long
+[put password '1234567890123456789' for '123456789012345'] failed with rc -3 Password is too long
+[put password '123456789012345678' for '1234567890123456'] failed with rc -3 User name is too long
+(username='123456789012345', isOP='Y')
+(username='abcd', isOP='N')
+(username='dcba', isOP='N')
+(username='mohit', isOP='Y')
+[select 1] failed with rc -3 set user: '1234567890123456' exceeds 15 characters
+[select 1] failed with rc -3 set password: password length exceeds 18 characters
+(1=1)
+(comdb2_user()='123456789012345')
+(comdb2_user()='mohit')
+(comdb2_user()='mohit')

--- a/tests/userschema.test/t09.req
+++ b/tests/userschema.test/t09.req
@@ -11,12 +11,12 @@ set password garbaj garbanj
 select * from test
 select * from comdb2_tablepermissions order by tablename
 
-set user 12345678901234567
+set user 1234567890123456
 set password 1234567890123456789
 select * from test
 select * from comdb2_tablepermissions order by tablename
 
-set user 1234567890123456
+set user 123456789012345
 set password 1234567890123456789
 select * from test
 select * from comdb2_tablepermissions order by tablename
@@ -26,12 +26,12 @@ set password 123456789012345678
 select * from test
 select * from comdb2_tablepermissions order by tablename
 
-set user "12345678901234567"
+set user "1234567890123456"
 set password "1234567890123456789"
 select * from test
 select * from comdb2_tablepermissions order by tablename
 
-set user "1234567890123456"
+set user "123456789012345"
 set password "1234567890123456789"
 select * from test
 select * from comdb2_tablepermissions order by tablename
@@ -40,3 +40,34 @@ set user "1234567890123456"
 set password "123456789012345678"
 select * from test
 select * from comdb2_tablepermissions order by tablename
+
+set user mohit
+set password mohit
+select comdb2_user();
+
+put password '1234567890123456789' for '1234567890123456'
+put password '1234567890123456789' for '123456789012345'
+put password '123456789012345678' for '1234567890123456'
+put password '123456789012345678' for '123456789012345'
+grant op to '123456789012345'
+select * from comdb2_users;
+
+set user '1234567890123456'
+set password '1234567890123456789'
+select 1;
+
+set user '123456789012345'
+set password '1234567890123456789'
+select 1;
+
+set user '123456789012345'
+set password '123456789012345678'
+select 1;
+select comdb2_user();
+
+set user mohit
+set password mohit
+select comdb2_user();
+put password off for '123456789012345'
+select comdb2_user();
+


### PR DESCRIPTION
* Fix username buffer size to 16 (limits to 15 characters)
* Update error message to not append password string when it exceeds the limit
* Add tests
* Update docs to show username/password limits