### PR TITLE
switch osqllog instrumentation  from files to output

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5005,10 +5005,9 @@ static void register_all_int_switches()
     register_int_switch("repverifyrecs",
                         "Verify every berkeley log record received",
                         &gbl_verify_rep_log_records);
-    register_int_switch(
-        "enable_osql_logging",
-        "Log every osql packet received in a special file, per iq",
-        &gbl_enable_osql_logging);
+    register_int_switch("enable_osql_logging",
+                        "Log every osql packet and operation",
+                        &gbl_enable_osql_logging);
     register_int_switch("enable_osql_longreq_logging",
                         "Log untruncated osql strings",
                         &gbl_enable_osql_longreq_logging);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1260,7 +1260,6 @@ struct osql_sess {
 
     /* from sorese */
     const char *host; /* sql machine, 0 is local */
-    SBUF2 *osqllog;   /* used to track sorese requests */
     int nops;         /* if no error, how many updated rows were performed */
     int rcout;        /* store here the block proc main error */
 

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -534,10 +534,6 @@ static void *thd_req(void *vthd)
                 pool_free(thd->iq->vfy_genid_pool);
                 thd->iq->vfy_genid_pool = NULL;
             }
-            if (thd->iq->sorese && thd->iq->sorese->osqllog) {
-                sbuf2close(thd->iq->sorese->osqllog);
-                thd->iq->sorese->osqllog = NULL;
-            }
             thd->iq->vfy_genid_track = 0;
 #if 0
             fprintf(stderr, "%s:%d: THD=%d relablk iq=%p\n", __func__, __LINE__, pthread_self(), thd->iq);
@@ -669,11 +665,6 @@ static int reterr(intptr_t curswap, struct thd *thd, struct ireq *iq, int rc)
                     } else {
                         sndbak_socket(iq->sb, NULL, 0, ERR_INTERNAL);
                         iq->sb = NULL;
-                    }
-                } else if (iq->sorese) {
-                    if (iq->sorese->osqllog) {
-                        sbuf2close(iq->sorese->osqllog);
-                        iq->sorese->osqllog = NULL;
                     }
                 }
                 pool_relablk(p_reqs, iq);
@@ -1204,25 +1195,6 @@ struct ireq *create_sorese_ireq(struct dbenv *dbenv, uint8_t *p_buf,
     snprintf(iq->corigin, sizeof(iq->corigin), "SORESE# %15s %s RQST %llx",
              iq->sorese->host, osql_sorese_type_to_str(iq->sorese->type),
              iq->sorese->rqid);
-
-    /* enable logging, if any */
-    if (gbl_enable_osql_logging) {
-        int ffile = 0;
-        char filename[128];
-        static unsigned long long fcounter = 0;
-
-        snprintf(filename, sizeof(filename), "osql_%llu.log", fcounter++);
-
-        ffile = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
-        if (ffile == -1) {
-            logmsg(LOGMSG_ERROR, "Failed to open osql log file %s\n", filename);
-        } else {
-            iq->sorese->osqllog = sbuf2open(ffile, 0);
-            if (!iq->sorese->osqllog) {
-                close(ffile);
-            }
-        }
-    }
 
     iq->timings.req_received = osql_log_time();
     iq->tranddl = 0;

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -234,26 +234,6 @@ int _osql_register_sqlthr(struct sqlclntstate *clnt, int type, int is_remote)
         cleanup_entry(entry);
     }
 
-    if (gbl_enable_osql_logging && !clnt->osql.logsb) {
-        int fd = 0;
-        char filename[256];
-
-        snprintf(filename, sizeof(filename), "m_%s_%u_%llu_%s.log",
-                 clnt->osql.host, type, clnt->osql.rqid,
-                 comdb2uuidstr(clnt->osql.uuid, us));
-        fd = open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
-        if (!fd) {
-            logmsg(LOGMSG_ERROR, "Error opening log file %s\n", filename);
-        } else {
-            clnt->osql.logsb = sbuf2open(fd, 0);
-            if (!clnt->osql.logsb) {
-                logmsg(LOGMSG_ERROR, "Error opening sbuf2 for file %s, fd %d\n",
-                        filename, fd);
-                close(fd);
-            }
-        }
-    }
-
     return rc;
 }
 
@@ -308,11 +288,6 @@ int osql_unregister_sqlthr(struct sqlclntstate *clnt)
 
     /*reset rqid */
     clnt->osql.rqid = 0;
-
-    if (clnt->osql.logsb) {
-        sbuf2close(clnt->osql.logsb);
-        clnt->osql.logsb = NULL;
-    }
 
     cleanup_entry(entry);
     return rc;

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -93,8 +93,7 @@ int osql_comm_send_poke(char *tonode, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
-                    char *tablename, int type, SBUF2 *logsb,
-                    unsigned long long version);
+                    char *tablename, int type, unsigned long long version);
 
 /**
  * Send INDEX op
@@ -102,8 +101,8 @@ int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_index(char *tohost, unsigned long long rqid, uuid_t uuid,
-        unsigned long long genid, int isDelete, int ixnum,
-        char *pData, int nData, int type, SBUF2 *logsb);
+                    unsigned long long genid, int isDelete, int ixnum,
+                    char *pData, int nData, int type);
 
 /**
  * Send QBLOB op
@@ -112,7 +111,7 @@ int osql_send_index(char *tohost, unsigned long long rqid, uuid_t uuid,
  */
 int osql_send_qblob(char *tohost, unsigned long long rqid, uuid_t uuid,
                     int blobid, unsigned long long seq, int type, char *data,
-                    int datalen, SBUF2 *logsb);
+                    int datalen);
 
 /**
  * Send UPDCOLS op
@@ -120,8 +119,8 @@ int osql_send_qblob(char *tohost, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_updcols(char *tohost, unsigned long long rqid, uuid_t uuid,
-                      unsigned long long seq, int type, int *colList, int ncols,
-                      SBUF2 *logsb);
+                      unsigned long long seq, int type, int *colList,
+                      int ncols);
 
 /**
  * Send UPDREC op
@@ -131,7 +130,7 @@ int osql_send_updcols(char *tohost, unsigned long long rqid, uuid_t uuid,
 int osql_send_updrec(char *tonode, unsigned long long rqid, uuid_t uuid,
                      unsigned long long genid, unsigned long long ins_keys,
                      unsigned long long del_keys, char *pData, int nData,
-                     int type, SBUF2 *logsb);
+                     int type);
 
 /**
  * Send INSREC op
@@ -140,8 +139,7 @@ int osql_send_updrec(char *tonode, unsigned long long rqid, uuid_t uuid,
  */
 int osql_send_insrec(char *tohost, unsigned long long rqid, uuid_t uuid,
                      unsigned long long genid, unsigned long long dirty_keys,
-                     char *pData, int nData, int type, SBUF2 *logsb,
-                     int upsert_flags);
+                     char *pData, int nData, int type, int upsert_flags);
 
 /**
  * Send DELREC op
@@ -150,7 +148,7 @@ int osql_send_insrec(char *tohost, unsigned long long rqid, uuid_t uuid,
  */
 int osql_send_delrec(char *tohost, unsigned long long rqid, uuid_t uuid,
                      unsigned long long genid, unsigned long long dirty_keys,
-                     int type, SBUF2 *logsb);
+                     int type);
 
 /**
  * Send SCHEMACHANGE op
@@ -158,8 +156,7 @@ int osql_send_delrec(char *tohost, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_schemachange(char *tonode, unsigned long long rqid, uuid_t uuid,
-                           struct schema_change_type *sc, int type,
-                           SBUF2 *logsb);
+                           struct schema_change_type *sc, int type);
 
 /**
  * Send BPFUNC op
@@ -167,7 +164,7 @@ int osql_send_schemachange(char *tonode, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_bpfunc(char *tonode, unsigned long long rqid, uuid_t uuid,
-                     BpfuncArg *msg, int type, SBUF2 *logsb);
+                     BpfuncArg *msg, int type);
 
 /**
  * Send SERIAL op
@@ -175,7 +172,7 @@ int osql_send_bpfunc(char *tonode, unsigned long long rqid, uuid_t uuid,
  */
 int osql_send_serial(char *tohost, unsigned long long rqid, uuid_t uuid,
                      CurRangeArr *arr, unsigned int file, unsigned int offset,
-                     int type, SBUF2 *logsb);
+                     int type);
 
 /**
  * Send DONE or DONE_XERR op
@@ -183,16 +180,16 @@ int osql_send_serial(char *tohost, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_commit(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     int nops, struct errstat *xerr, int type, SBUF2 *logsb,
+                     int nops, struct errstat *xerr, int type,
                      struct client_query_stats *query_stats,
                      snap_uid_t *snap_info);
 
 int osql_send_commit_by_uuid(char *tohost, uuid_t uuid, int nops,
-                             struct errstat *xerr, int type, SBUF2 *logsb,
+                             struct errstat *xerr, int type,
                              struct client_query_stats *query_stats,
                              snap_uid_t *snap_info);
 int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
-                       uint32_t start_gen, int type, SBUF2 *logsb);
+                       uint32_t start_gen, int type);
 
 /**
  * Send decomission for osql net
@@ -201,7 +198,7 @@ int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
 int osql_process_message_decom(char *host);
 
 int osql_send_dbq_consume(char *tohost, unsigned long long rqid, uuid_t,
-                          genid_t, int type, SBUF2 *);
+                          genid_t, int type);
 
 /**
  * Constructs a reusable osql request
@@ -221,7 +218,7 @@ void *osql_create_request(const char *sql, int sqlen, int type,
 int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                         void *trans, char **pmsg, int msglen, int *flags,
                         int **updCols, blob_buffer_t blobs[MAXBLOBS], int step,
-                        struct block_err *err, int *receivedrows, SBUF2 *logsb);
+                        struct block_err *err, int *receivedrows);
 
 /**
  * Handles each packet and start schema change
@@ -231,8 +228,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
                               uuid_t uuid, void *trans, char **pmsg, int msglen,
                               int *flags, int **updCols,
                               blob_buffer_t blobs[MAXBLOBS], int step,
-                              struct block_err *err, int *receivedrows,
-                              SBUF2 *logsb);
+                              struct block_err *err, int *receivedrows);
 /**
  * Sends a user command to offload net (used by "osqlnet")
  *
@@ -334,7 +330,7 @@ int osql_send_dbglog(char *tohost, unsigned long long rqid, uuid_t uuid,
  *
  */
 int osql_send_recordgenid(char *tohost, unsigned long long rqid, uuid_t uuid,
-                          unsigned long long genid, int type, SBUF2 *logsb);
+                          unsigned long long genid, int type);
 
 /**
  * Enable a netinfo-test for the osqlcomm netinfo_ptr
@@ -356,7 +352,7 @@ int osql_comm_check_bdb_lock(const char *func, int line);
 
 int osql_send_updstat(char *tohost, unsigned long long rqid, uuid_t uuid,
                       unsigned long long seq, char *pData, int nData, int nStat,
-                      int type, SBUF2 *logsb);
+                      int type);
 
 netinfo_type *osql_get_netinfo(void);
 

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -1615,7 +1615,7 @@ static int process_local_shadtbl_usedb(struct sqlclntstate *clnt,
     int osql_nettype = tran2netrpl(clnt->dbtran.mode);
 
     rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, tablename,
-                         osql_nettype, osql->logsb, tableversion);
+                         osql_nettype, tableversion);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: osql_send_usedb rc=%d\n", __func__, rc);
     }
@@ -1663,7 +1663,7 @@ static int process_local_shadtbl_skp(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                       (gbl_partial_indexes && tbl->ix_partial)
                                           ? get_del_keys(clnt, tbl, genid)
                                           : -1ULL,
-                                      osql_nettype, osql->logsb);
+                                      osql_nettype);
                 if (rc) {
                     logmsg(LOGMSG_ERROR,
                            "%s: error writting record to master in offload "
@@ -1687,7 +1687,7 @@ static int process_local_shadtbl_skp(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                       (gbl_partial_indexes && tbl->ix_partial)
                                           ? get_del_keys(clnt, tbl, genid)
                                           : -1ULL,
-                                      osql_nettype, osql->logsb);
+                                      osql_nettype);
                 if (rc) {
                     logmsg(LOGMSG_ERROR,
                            "%s: error writting record to master in offload "
@@ -1764,7 +1764,7 @@ static int process_local_shadtbl_updcols(struct sqlclntstate *clnt,
     }
 
     rc = osql_send_updcols(osql->host, osql->rqid, osql->uuid, savkey,
-                           osql_nettype, &cdata[1], cdata[0], osql->logsb);
+                           osql_nettype, &cdata[1], cdata[0]);
 
     if (rc) {
         logmsg(LOGMSG_ERROR, 
@@ -1802,7 +1802,7 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
             ncols = updCols[0];
             if (idx >= 0 && idx < ncols && -1 == updCols[idx + 1]) {
                 rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid, i, seq,
-                                     osql_nettype, NULL, -2, osql->logsb);
+                                     osql_nettype, NULL, -2);
                 osql->replicant_numops++;
                 DEBUG_PRINT_NUMOPS();
                 continue;
@@ -1833,7 +1833,7 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
         }
 
         rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid, idx, seq,
-                             osql_nettype, data, ldata, osql->logsb);
+                             osql_nettype, data, ldata);
 
         if (rc) {
             logmsg(LOGMSG_ERROR, 
@@ -1890,7 +1890,7 @@ static int process_local_shadtbl_index(struct sqlclntstate *clnt,
         index = bdb_temp_table_data(tmp_cur);
         lindex = bdb_temp_table_datasize(tmp_cur);
         rc = osql_send_index(osql->host, osql->rqid, osql->uuid, seq, is_delete,
-                             i, index, lindex, osql_nettype, osql->logsb);
+                             i, index, lindex, osql_nettype);
 
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: error writting record to master in offload mode %d!\n",
@@ -1947,7 +1947,7 @@ static int process_local_shadtbl_add(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, key)
                                       : -1ULL,
-                                  data, ldata, osql_nettype, osql->logsb,
+                                  data, ldata, osql_nettype,
                                   get_rec_flags(clnt, tbl, key, 1));
 
             if (rc) {
@@ -1983,7 +1983,7 @@ static int process_local_shadtbl_add(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, key)
                                       : -1ULL,
-                                  data, ldata, osql_nettype, osql->logsb,
+                                  data, ldata, osql_nettype,
                                   get_rec_flags(clnt, tbl, key, 1));
 
             if (rc) {
@@ -2065,7 +2065,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_del_keys(clnt, tbl, genid)
                                       : -1ULL,
-                                  data, ldata, osql_nettype, osql->logsb);
+                                  data, ldata, osql_nettype);
 
             if (rc) {
                 rc = SQLITE_INTERNAL;
@@ -2106,7 +2106,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_del_keys(clnt, tbl, genid)
                                       : -1ULL,
-                                  data, ldata, osql_nettype, osql->logsb);
+                                  data, ldata, osql_nettype);
 
             if (rc) {
                 rc = SQLITE_INTERNAL;
@@ -2836,7 +2836,7 @@ static int process_local_shadtbl_recgenids(struct sqlclntstate *clnt,
       printf("RECGENID SENDING %s[%d] : %llx %s\n", key.tablename, key.tableversion, key.genid, us);
 #endif
         rc = osql_send_recordgenid(osql->host, osql->rqid, osql->uuid,
-                                   key.genid, osql_nettype, osql->logsb);
+                                   key.genid, osql_nettype);
         if (rc) {
             logmsg(LOGMSG_ERROR, 
                     "%s: error writting record to master in offload mode!\n",
@@ -2971,7 +2971,7 @@ static int process_local_shadtbl_sc(struct sqlclntstate *clnt, int *bdberr)
         }
 
         rc = osql_send_schemachange(osql->host, osql->rqid, osql->uuid, sc,
-                                    NET_OSQL_SOCK_RPL, osql->logsb);
+                                    NET_OSQL_SOCK_RPL);
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s: error writting record to master in offload mode!\n",
@@ -3080,7 +3080,7 @@ static int process_local_shadtbl_bpfunc(struct sqlclntstate *clnt, int *bdberr)
         }
 
         rc = osql_send_bpfunc(osql->host, osql->rqid, osql->uuid, func->arg,
-                              NET_OSQL_SOCK_RPL, osql->logsb);
+                              NET_OSQL_SOCK_RPL);
         free_bpfunc(func);
 
         if (rc) {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -229,7 +229,7 @@ static int osql_send_del_logic(struct BtCursor *pCur, struct sql_thread *thd)
                               (gbl_partial_indexes && pCur->db->ix_partial)
                                   ? clnt->del_keys
                                   : -1ULL,
-                              NET_OSQL_SOCK_RPL, osql->logsb);
+                              NET_OSQL_SOCK_RPL);
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s:%d %s - failed to send socksql row rc=%d\n", __FILE__,
@@ -253,7 +253,7 @@ static int osql_send_del_logic(struct BtCursor *pCur, struct sql_thread *thd)
                               (gbl_partial_indexes && pCur->db->ix_partial)
                                   ? clnt->del_keys
                                   : -1ULL,
-                              NET_OSQL_SOCK_RPL, osql->logsb);
+                              NET_OSQL_SOCK_RPL);
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s:%d %s - failed to send socksql row rc=%d\n", __FILE__,
@@ -337,11 +337,11 @@ static int osql_send_ins_logic(struct BtCursor *pCur, struct sql_thread *thd,
         return rc;
 
     if (osql->is_reorder_on) {
-        rc = osql_send_insrec(
-            osql->host, osql->rqid, osql->uuid, pCur->genid,
-            (gbl_partial_indexes && pCur->db->ix_partial) ? thd->clnt->ins_keys
-                                                          : -1ULL,
-            pData, nData, NET_OSQL_SOCK_RPL, osql->logsb, flags);
+        rc = osql_send_insrec(osql->host, osql->rqid, osql->uuid, pCur->genid,
+                              (gbl_partial_indexes && pCur->db->ix_partial)
+                                  ? thd->clnt->ins_keys
+                                  : -1ULL,
+                              pData, nData, NET_OSQL_SOCK_RPL, flags);
 
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -369,11 +369,11 @@ static int osql_send_ins_logic(struct BtCursor *pCur, struct sql_thread *thd,
     }
 
     if (!osql->is_reorder_on) {
-        rc = osql_send_insrec(
-            osql->host, osql->rqid, osql->uuid, pCur->genid,
-            (gbl_partial_indexes && pCur->db->ix_partial) ? thd->clnt->ins_keys
-                                                          : -1ULL,
-            pData, nData, NET_OSQL_SOCK_RPL, osql->logsb, flags);
+        rc = osql_send_insrec(osql->host, osql->rqid, osql->uuid, pCur->genid,
+                              (gbl_partial_indexes && pCur->db->ix_partial)
+                                  ? thd->clnt->ins_keys
+                                  : -1ULL,
+                              pData, nData, NET_OSQL_SOCK_RPL, flags);
 
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -456,7 +456,7 @@ static int osql_send_upd_logic(struct BtCursor *pCur, struct sql_thread *thd,
                                                           : -1ULL,
             (gbl_partial_indexes && pCur->db->ix_partial) ? thd->clnt->del_keys
                                                           : -1ULL,
-            pData, nData, NET_OSQL_SOCK_RPL, osql->logsb);
+            pData, nData, NET_OSQL_SOCK_RPL);
 
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -493,8 +493,7 @@ static int osql_send_upd_logic(struct BtCursor *pCur, struct sql_thread *thd,
 
     if (updCols) {
         rc = osql_send_updcols(osql->host, osql->rqid, osql->uuid, pCur->genid,
-                               NET_OSQL_SOCK_RPL, &updCols[1], updCols[0],
-                               osql->logsb);
+                               NET_OSQL_SOCK_RPL, &updCols[1], updCols[0]);
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s:%d %s - failed to send socksql row rc=%d\n", __FILE__,
@@ -512,7 +511,7 @@ static int osql_send_upd_logic(struct BtCursor *pCur, struct sql_thread *thd,
                                                           : -1ULL,
             (gbl_partial_indexes && pCur->db->ix_partial) ? thd->clnt->del_keys
                                                           : -1ULL,
-            pData, nData, NET_OSQL_SOCK_RPL, osql->logsb);
+            pData, nData, NET_OSQL_SOCK_RPL);
 
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -635,7 +634,7 @@ int osql_serial_send_readset(struct sqlclntstate *clnt, int nettype)
         arr_ptr = clnt->selectv_arr;
 
     rc = osql_send_serial(osql->host, osql->rqid, osql->uuid, arr_ptr,
-                          arr_ptr->file, arr_ptr->offset, nettype, osql->logsb);
+                          arr_ptr->file, arr_ptr->offset, nettype);
     osql->replicant_numops++;
     DEBUG_PRINT_NUMOPS();
     return rc;
@@ -1311,8 +1310,7 @@ static int osql_send_usedb_logic_int(char *tablename, struct sqlclntstate *clnt,
 
     do {
         rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, tablename,
-                             nettype, osql->logsb,
-                             comdb2_table_version(tablename));
+                             nettype, comdb2_table_version(tablename));
         RESTART_SOCKSQL;
     } while (restarted);
 
@@ -1347,7 +1345,7 @@ inline int osql_send_updstat_logic(struct BtCursor *pCur,
     START_SOCKSQL;
     do {
         rc = osql_send_updstat(osql->host, osql->rqid, osql->uuid, pCur->genid,
-                               pData, nData, nStat, nettype, osql->logsb);
+                               pData, nData, nStat, nettype);
         RESTART_SOCKSQL;
     } while (restarted);
     osql->replicant_numops++;
@@ -1376,7 +1374,7 @@ static int osql_send_insidx_logic(struct BtCursor *pCur,
             continue;
         rc = osql_send_index(osql->host, osql->rqid, osql->uuid, pCur->genid, 0,
                              i, (char *)clnt->idxInsert[i],
-                             getkeysize(pCur->db, i), nettype, osql->logsb);
+                             getkeysize(pCur->db, i), nettype);
         if (rc)
             break;
         osql->replicant_numops++;
@@ -1406,7 +1404,7 @@ static int osql_send_delidx_logic(struct BtCursor *pCur,
 
         rc = osql_send_index(osql->host, osql->rqid, osql->uuid, pCur->genid, 1,
                              i, (char *)clnt->idxDelete[i],
-                             getkeysize(pCur->db, i), nettype, osql->logsb);
+                             getkeysize(pCur->db, i), nettype);
         if (rc)
             break;
         osql->replicant_numops++;
@@ -1441,8 +1439,7 @@ static int osql_send_qblobs_logic(struct BtCursor *pCur, osqlstate_t *osql,
             if (idx >= 0 && idx < ncols && -1 == updCols[idx + 1]) {
                 /* Put a token on the network if this isn't going to be used */
                 rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid, i,
-                                     pCur->genid, nettype, NULL, -2,
-                                     osql->logsb);
+                                     pCur->genid, nettype, NULL, -2);
                 if (rc)
                     break; /* break out from while loop so we can return rc */
                 osql->replicant_numops++;
@@ -1456,7 +1453,7 @@ static int osql_send_qblobs_logic(struct BtCursor *pCur, osqlstate_t *osql,
 
         rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid,
                              blobs[i].odhind, pCur->genid, nettype,
-                             blobs[i].data, blobs[i].length, osql->logsb);
+                             blobs[i].data, blobs[i].length);
         if (rc)
             break;
         osql->replicant_numops++;
@@ -1504,7 +1501,7 @@ static int osql_send_commit_logic(struct sqlclntstate *clnt, int is_retry,
         if (gbl_osql_send_startgen && clnt->start_gen > 0) {
             osql->replicant_numops++;
             rc = osql_send_startgen(osql->host, osql->rqid, osql->uuid,
-                                    clnt->start_gen, nettype, osql->logsb);
+                                    clnt->start_gen, nettype);
         }
 
         if (rc == 0) {
@@ -1512,11 +1509,11 @@ static int osql_send_commit_logic(struct sqlclntstate *clnt, int is_retry,
             if (osql->rqid == OSQL_RQID_USE_UUID) {
                 rc = osql_send_commit_by_uuid(
                     osql->host, osql->uuid, osql->replicant_numops, &osql->xerr,
-                    nettype, osql->logsb, clnt->query_stats, snap_info_p);
+                    nettype, clnt->query_stats, snap_info_p);
             } else {
-                rc = osql_send_commit(
-                    osql->host, osql->rqid, osql->uuid, osql->replicant_numops,
-                    &osql->xerr, nettype, osql->logsb, clnt->query_stats, NULL);
+                rc = osql_send_commit(osql->host, osql->rqid, osql->uuid,
+                                      osql->replicant_numops, &osql->xerr,
+                                      nettype, clnt->query_stats, NULL);
             }
         }
         RESTART_SOCKSQL_KEEP_RQID(is_retry);
@@ -1548,11 +1545,11 @@ static int osql_send_abort_logic(struct sqlclntstate *clnt, int nettype)
     if (osql->rqid == OSQL_RQID_USE_UUID)
         rc = osql_send_commit_by_uuid(osql->host, osql->uuid,
                                       osql->replicant_numops, &xerr, nettype,
-                                      osql->logsb, clnt->query_stats, NULL);
+                                      clnt->query_stats, NULL);
     else
         rc = osql_send_commit(osql->host, osql->rqid, osql->uuid,
                               osql->replicant_numops, &xerr, nettype,
-                              osql->logsb, clnt->query_stats, NULL);
+                              clnt->query_stats, NULL);
     /* no need to restart an abort, master will drop the transaction anyway
     RESTART_SOCKSQL; */
     osql->replicant_numops = 0;
@@ -1661,7 +1658,7 @@ static int osql_send_recordgenid_logic(struct BtCursor *pCur,
                 nettype = NET_OSQL_SOCK_RPL_UUID;
 
             rc = osql_send_recordgenid(osql->host, osql->rqid, osql->uuid,
-                                       genid, nettype, osql->logsb);
+                                       genid, nettype);
             if (gbl_master_swing_sock_restart_sleep) {
                 usleep(gbl_master_swing_sock_restart_sleep * 1000);
             }
@@ -1681,7 +1678,7 @@ int osql_dbq_consume(struct sqlclntstate *clnt, const char *spname,
     if (rc != SQLITE_OK)
         return rc;
     return osql_send_dbq_consume(osql->host, osql->rqid, osql->uuid, genid,
-                                 NET_OSQL_SOCK_RPL, osql->logsb);
+                                 NET_OSQL_SOCK_RPL);
 }
 
 int osql_dbq_consume_logic(struct sqlclntstate *clnt, const char *spname,
@@ -1846,7 +1843,7 @@ int osql_schemachange_logic(struct schema_change_type *sc,
         do {
             rc = osql_send_schemachange(osql->host, osql->rqid,
                                         thd->clnt->osql.uuid, sc,
-                                        NET_OSQL_SOCK_RPL, osql->logsb);
+                                        NET_OSQL_SOCK_RPL);
             RESTART_SOCKSQL;
         } while (restarted);
         if (rc) {
@@ -1887,7 +1884,7 @@ int osql_bpfunc_logic(struct sql_thread *thd, BpfuncArg *arg)
         START_SOCKSQL;
         do {
             rc = osql_send_bpfunc(osql->host, osql->rqid, thd->clnt->osql.uuid,
-                                  arg, NET_OSQL_SOCK_RPL, osql->logsb);
+                                  arg, NET_OSQL_SOCK_RPL);
             RESTART_SOCKSQL;
         } while (restarted);
         if (rc) {

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -142,7 +142,7 @@ void commit_bench(void *, int, int);
 void bdb_detect(void *);
 void enable_ack_trace(void);
 void disable_ack_trace(void);
-void osql_send_test(SBUF2 *sb);
+void osql_send_test(void);
 extern unsigned long long get_genid(bdb_state_type *bdb_state,
                                     unsigned int dtafile);
 int bdb_dump_logical_tranlist(void *state, FILE *f);
@@ -4897,8 +4897,7 @@ clipper_usage:
             bdb_locktest(thedb->bdb_env);
             Pthread_mutex_unlock(&testguard);
         } else if (tokcmp(tok, ltok, "bad_osql") == 0) {
-            SBUF2 *sb = sbuf2open(fileno(stdout), 0);
-            osql_send_test(sb);
+            osql_send_test();
         } else if (tokcmp(tok, ltok, "rep") == 0) { // was testrep
             int nitems;
             int size;

--- a/db/sql.h
+++ b/db/sql.h
@@ -144,8 +144,6 @@ typedef struct osqlstate {
     int replicant_numops; /* total num of ops sent by replicant to master which
                              includes USEDB, BLOB, etc. */
 
-    SBUF2 *logsb; /* help debugging */
-
     /* == sqlclntstate == */
 
     int count_changes;   /* enable pragma count_changes=1, for rr, sosql, recom,

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -230,7 +230,7 @@ support_datetime_in_triggers|  on |Enable support for datetime/interval types in
 prefix_foreign_keys|  on |Allow foreign key to be a prefix of your key
 superset_foreign_keys|  on |Allow foreign key to be a superset of your key
 repverifyrecs|  off |Verify every berkeley log record received
-enable_osql_logging|  off |Log every osql packet received in a special file, per iq
+enable_osql_logging|  off |Log every osql packet and operation
 enable_osql_longreq_logging|  off |Log untruncated osql strings
 check_sparse_files|  off |When allocating a page, check that we aren't creating a sparse file
 core_on_sparse_file|  off |Generate a core if we catch berkeley creating a sparse file

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -273,7 +273,7 @@
 (name='enable_inplace_blobs', description='Do not update the rowid of a blob entry on an update. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='enable_lowpri_snapisol', description='Give lower priority to locks acquired when updating snapshot state. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='enable_osql_blob_optimization', description='Replicant tracks which columns are modified in a transaction to allow blob updates to be ommitted if possible. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
-(name='enable_osql_logging', description='Log every osql packet received in a special file, per iq', type='BOOLEAN', value='OFF', read_only='N')
+(name='enable_osql_logging', description='Log every osql packet and operation', type='BOOLEAN', value='OFF', read_only='N')
 (name='enable_osql_longreq_logging', description='Log untruncated osql strings', type='BOOLEAN', value='OFF', read_only='N')
 (name='enable_overflow_page_trace', description='If set, warn when a page order table scan encounters an overflow page. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='enable_page_compact_backward_scan', description='', type='INTEGER', value='1', read_only='Y')


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

I used this feature in the early days of writing osql.  It hasn't seen usage in a decade to my knowledge.   This PR changes the code  to save instrumentation lines to output instead of files.