### PR TITLE
get rid of use_handle

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1274,7 +1274,6 @@ static void *purge_old_files_thread(void *arg)
         }
 
         init_fake_ireq(thedb, &iq);
-        iq.use_handle = thedb->bdb_env;
 
         /* ok, get to work now */
         retries = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1332,7 +1332,6 @@ struct ireq {
     /* for waking up socket thread. */
     void *request_data;
     char *tag;
-    void *use_handle; /* for fake ireqs, so I can start a transaction */
 
     errstat_t errstat;
     struct javasp_trans_state *jsph;

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -1196,7 +1196,6 @@ struct ireq *create_sorese_ireq(struct dbenv *dbenv, uint8_t *p_buf,
     }
 
     iq->sorese = sorese;
-    iq->use_handle = thedb->bdb_env;
 
 #if 0
     printf("Mapping sorese %llu\n", osql_log_time());

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -804,7 +804,6 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
     }
 
     init_fake_ireq(thedb, &iq);
-    iq.use_handle = thedb->bdb_env;
 
     iq.blkstate = &blkstate;
 again:

--- a/db/rowlocks_bench.c
+++ b/db/rowlocks_bench.c
@@ -57,7 +57,6 @@ static void commit_bench_int(bdb_state_type *bdb_state, int op, int tcount,
     assert(count >= 0 && tcount >= 0);
 
     init_fake_ireq(thedb, &iq);
-    iq.use_handle = thedb->bdb_env;
     rep_reset_send_callcount();
     rep_reset_send_bytecount();
     net_reset_num_flushes();
@@ -160,7 +159,6 @@ static void rowlocks_bench_int(bdb_state_type *bdb_state, int op, int count,
     assert(count >= 1 && phys_txns_per_logical >= 1);
 
     init_fake_ireq(thedb, &iq);
-    iq.use_handle = thedb->bdb_env;
 
     rep_reset_send_callcount();
     rep_reset_send_bytecount();

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -537,7 +537,6 @@ static int local_replicate_write_analyze(char *table)
         return 0;
 
     init_fake_ireq(thedb, &iq);
-    iq.use_handle = thedb->bdb_env;
 
     iq.blkstate = &blkstate;
 again:


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Simpler code, remove indirection of iq.use_handle
