### PR TITLE
remove ireq from early osql session structure

### DIFF
--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -472,8 +472,8 @@ static void populate_obj(cson_object *obj, const struct reqlogger *logger)
     }
 
     snap_uid_t snap, *p = NULL;
-    if (logger->iq && logger->iq->have_snap_info) /* for txn type */
-        p = &logger->iq->snap_info;
+    if (logger->iq && IQ_HAS_SNAPINFO(logger->iq)) /* for txn type */
+        p = IQ_SNAPINFO(logger->iq);
     else if (logger->clnt && get_cnonce(logger->clnt, &snap) == 0)
         p = &snap;
     if (p) {

--- a/db/glue.c
+++ b/db/glue.c
@@ -719,10 +719,10 @@ static int trans_commit_int(struct ireq *iq, void *trans, char *source_host,
     rc = trans_commit_seqnum_int(bdb_handle, thedb, iq, trans, &ss, logical,
                                  blkseq, blklen, blkkey, blkkeylen);
 
-    if (gbl_extended_sql_debug_trace && iq->have_snap_info) {
-        cn_len = iq->snap_info.keylen;
+    if (gbl_extended_sql_debug_trace && IQ_HAS_SNAPINFO(iq)) {
+        cn_len = IQ_SNAPINFO(iq)->keylen;
         cnonce = alloca(cn_len + 1);
-        memcpy(cnonce, iq->snap_info.key, cn_len);
+        memcpy(cnonce, IQ_SNAPINFO(iq)->key, cn_len);
         cnonce[cn_len] = '\0';
         logmsg(LOGMSG_USER, "%s %s line %d: trans_commit returns %d\n", cnonce,
                __func__, __LINE__, rc);

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -728,9 +728,9 @@ int handle_buf_block_offload(struct dbenv *dbenv, uint8_t *p_buf,
     int length = p_buf_end - p_buf;
     uint8_t *p_bigbuf = get_bigbuf();
     memcpy(p_bigbuf, p_buf, length);
-    int rc = handle_buf_main(dbenv, NULL, NULL, p_bigbuf, p_bigbuf + length,
-                             debug, frommach, 0, NULL, NULL, REQ_SOCKREQUEST,
-                             NULL, 0, rqid);
+    int rc = handle_buf_main(dbenv, NULL, p_bigbuf, p_bigbuf + length, debug,
+                             frommach, 0, NULL, NULL, REQ_SOCKREQUEST, NULL, 0,
+                             rqid);
 
     return rc;
 }
@@ -740,7 +740,7 @@ int handle_socket_long_transaction(struct dbenv *dbenv, SBUF2 *sb,
                                    int debug, char *frommach, int frompid,
                                    char *fromtask)
 {
-    return handle_buf_main(dbenv, NULL, sb, p_buf, p_buf_end, debug, frommach,
+    return handle_buf_main(dbenv, sb, p_buf, p_buf_end, debug, frommach,
                            frompid, fromtask, NULL, REQ_SOCKET, NULL, 0, 0);
 }
 
@@ -767,8 +767,8 @@ void cleanup_lock_buffer(struct buf_lock_t *lock_buffer)
 int handle_buf(struct dbenv *dbenv, uint8_t *p_buf, const uint8_t *p_buf_end,
                int debug, char *frommach) /* 040307dh: 64bits */
 {
-    return handle_buf_main(dbenv, NULL, NULL, p_buf, p_buf_end, debug, frommach,
-                           0, NULL, NULL, REQ_WAITFT, NULL, 0, 0);
+    return handle_buf_main(dbenv, NULL, p_buf, p_buf_end, debug, frommach, 0,
+                           NULL, NULL, REQ_WAITFT, NULL, 0, 0);
 }
 
 int handled_queue;
@@ -778,8 +778,8 @@ int q_reqs_len(void) { return q_reqs.count; }
 static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
                             uint8_t *p_buf, const uint8_t *p_buf_end, int debug,
                             char *frommach, int frompid, char *fromtask,
-                            int qtype, void *data_hndl, int luxref,
-                            unsigned long long rqid, void *p_sinfo,
+                            osql_sess_t *sorese, int qtype, void *data_hndl,
+                            int luxref, unsigned long long rqid, void *p_sinfo,
                             intptr_t curswap)
 {
     struct req_hdr hdr;
@@ -829,12 +829,12 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
         iq->request_data = data_hndl;
     }
 
-    iq->sb = NULL;
-
     if (qtype == REQ_SOCKET || qtype == REQ_SOCKREQUEST) {
         iq->sb = sb;
         iq->is_fromsocket = 1;
         iq->is_socketrequest = (qtype == REQ_SOCKREQUEST) ? 1 : 0;
+    } else {
+        iq->sb = NULL;
     }
 
     if (iq->is_socketrequest) {
@@ -859,6 +859,28 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
         else
             snprintf(iq->corigin, sizeof(iq->corigin), "SRMT# %s PID %6.6d",
                      iq->frommach, frompid);
+    } else if (sorese) {
+        iq->sorese = sorese;
+        snprintf(iq->corigin, sizeof(iq->corigin), "SORESE# %15s %s RQST %llx",
+                 iq->sorese->host, osql_sorese_type_to_str(iq->sorese->type),
+                 iq->sorese->rqid);
+        iq->timings.req_received = osql_log_time();
+        /* cache these things so we don't change too much code */
+        iq->tranddl = iq->sorese->is_tranddl;
+        iq->sorese->iq = iq;
+        if (!iq->debug) {
+            if (gbl_who > 0) {
+                gbl_who--;
+                iq->debug = 1;
+            }
+        }
+
+        {
+            uuidstr_t us;
+            logmsg(LOGMSG_ERROR, "%lu %s rqid %llu uuid %s got_cnonce %d\n",
+                   pthread_self(), __func__, iq->sorese->rqid,
+                   comdb2uuidstr(iq->sorese->uuid, us), IQ_HAS_SNAPINFO(iq));
+        }
     }
 
     if (luxref < 0 || luxref >= dbenv->num_dbs) {
@@ -880,13 +902,13 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
 
 int gbl_handle_buf_add_latency_ms = 0;
 
-int handle_buf_main2(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
-                     const uint8_t *p_buf, const uint8_t *p_buf_end, int debug,
-                     char *frommach, int frompid, char *fromtask,
-                     osql_sess_t *sorese, int qtype, void *data_hndl,
-                     int luxref, unsigned long long rqid, void *p_sinfo,
-                     intptr_t curswap)
+int handle_buf_main2(struct dbenv *dbenv, SBUF2 *sb, const uint8_t *p_buf,
+                     const uint8_t *p_buf_end, int debug, char *frommach,
+                     int frompid, char *fromtask, osql_sess_t *sorese,
+                     int qtype, void *data_hndl, int luxref,
+                     unsigned long long rqid, void *p_sinfo, intptr_t curswap)
 {
+    struct ireq *iq = NULL;
     int rc, num, ndispatch, iamwriter = 0;
     int add_latency = gbl_handle_buf_add_latency_ms;
     struct thd *thd;
@@ -908,7 +930,6 @@ int handle_buf_main2(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     }
 
 
-    if (iq == NULL) {
 #if 0
         fprintf(stderr, "%s:%d: THD=%d getablk iq=%p\n", __func__, __LINE__, pthread_self(), iq);
 #endif
@@ -925,103 +946,105 @@ int handle_buf_main2(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
         }
 
         rc = init_ireq_legacy(dbenv, iq, sb, (uint8_t *)p_buf, p_buf_end, debug,
-                              frommach, frompid, fromtask, qtype, data_hndl,
-                              luxref, rqid, p_sinfo, curswap);
+                              frommach, frompid, fromtask, sorese, qtype,
+                              data_hndl, luxref, rqid, p_sinfo, curswap);
         if (rc) {
             logmsg(LOGMSG_ERROR, "handle_buf:failed to unpack req header\n");
             return reterr(curswap, /*thd*/ 0, iq, rc);
         }
-    } else {
-#if 0
-       fprintf(stderr, "%s:%d: THD=%d delivered iq=%p\n", __func__, __LINE__, pthread_self(), iq);
-#endif
-    }
+        iq->sorese = sorese;
 
-    Pthread_mutex_lock(&lock);
-    {
-        ++handled_queue;
+        Pthread_mutex_lock(&lock);
+        {
+            ++handled_queue;
 
-        /*count queue*/
-        num = q_reqs.count;
-        if (num >= MAXSTAT)
-            num = MAXSTAT - 1;
-        bkt_queue[num]++;
+            /*count queue*/
+            num = q_reqs.count;
+            if (num >= MAXSTAT)
+                num = MAXSTAT - 1;
+            bkt_queue[num]++;
 
-        /*while ((idle.top || busy.count < gbl_maxthreads)
-         * && (iq = queue_next(q_reqs)))*/
-        newent = (struct dbq_entry_t *)pool_getablk(pq_reqs);
-        if (newent == NULL) {
-            errUNLOCK(&lock);
-            logmsg(LOGMSG_ERROR, "handle_buf:failed to alloc new queue entry, rc %d\n", rc);
-            return reterr(curswap, /*thd*/ 0, iq, ERR_REJECTED);
-        }
-        newent->obj = (void *)iq;
-        iamwriter = is_req_write(iq->opcode) ? 1 : 0;
-        newent->queue_time_ms = comdb2_time_epochms();
-        if (!iamwriter) {
-            (void)listc_abl(&rq_reqs, newent);
-        }
-
-        /*add to global queue*/
-        (void)listc_abl(&q_reqs, newent);
-        /* dispatch work ...*/
-        iq->where = "enqueued";
-
-        while (busy.count - iothreads < gbl_maxthreads) {
-            struct dbq_entry_t *nextrq = NULL;
-            nextrq = (struct dbq_entry_t *)listc_rtl(&q_reqs);
-            if (nextrq == NULL)
-                break;
-            iq = nextrq->obj;
+            /*while ((idle.top || busy.count < gbl_maxthreads)
+             * && (iq = queue_next(q_reqs)))*/
+            newent = (struct dbq_entry_t *)pool_getablk(pq_reqs);
+            if (newent == NULL) {
+                errUNLOCK(&lock);
+                logmsg(LOGMSG_ERROR,
+                       "handle_buf:failed to alloc new queue entry, rc %d\n",
+                       rc);
+                return reterr(curswap, /*thd*/ 0, iq, ERR_REJECTED);
+            }
+            newent->obj = (void *)iq;
             iamwriter = is_req_write(iq->opcode) ? 1 : 0;
+            newent->queue_time_ms = comdb2_time_epochms();
+            if (!iamwriter) {
+                (void)listc_abl(&rq_reqs, newent);
+            }
 
-            numwriterthreads = gbl_maxwthreads - gbl_maxwthreadpenalty;
-            if (numwriterthreads < 1)
-                numwriterthreads = 1;
+            /*add to global queue*/
+            (void)listc_abl(&q_reqs, newent);
+            /* dispatch work ...*/
+            iq->where = "enqueued";
 
-            if (iamwriter &&
-                (write_thd_count - iothreads) >= numwriterthreads) {
-                /* i am invalid writer, check the read queue instead */
-                listc_atl(&q_reqs, nextrq);
-
-                nextrq = (struct dbq_entry_t *)listc_rtl(&rq_reqs);
+            while (busy.count - iothreads < gbl_maxthreads) {
+                struct dbq_entry_t *nextrq = NULL;
+                nextrq = (struct dbq_entry_t *)listc_rtl(&q_reqs);
                 if (nextrq == NULL)
                     break;
                 iq = nextrq->obj;
-                /* remove from global list, and release link block of reader*/
-                listc_rfl(&q_reqs, nextrq);
-                if (add_latency > 0) {
-                    poll(0, 0, rand() % add_latency);
+                iamwriter = is_req_write(iq->opcode) ? 1 : 0;
+
+                numwriterthreads = gbl_maxwthreads - gbl_maxwthreadpenalty;
+                if (numwriterthreads < 1)
+                    numwriterthreads = 1;
+
+                if (iamwriter &&
+                    (write_thd_count - iothreads) >= numwriterthreads) {
+                    /* i am invalid writer, check the read queue instead */
+                    listc_atl(&q_reqs, nextrq);
+
+                    nextrq = (struct dbq_entry_t *)listc_rtl(&rq_reqs);
+                    if (nextrq == NULL)
+                        break;
+                    iq = nextrq->obj;
+                    /* remove from global list, and release link block of
+                     * reader*/
+                    listc_rfl(&q_reqs, nextrq);
+                    if (add_latency > 0) {
+                        poll(0, 0, rand() % add_latency);
+                    }
+                    time_metric_add(thedb->handle_buf_queue_time,
+                                    comdb2_time_epochms() -
+                                        nextrq->queue_time_ms);
+                    pool_relablk(pq_reqs, nextrq);
+                    if (!iq)
+                        /* this should never be hit */
+                        break;
+                    /* make sure to mark the reader request accordingly */
+                    iamwriter = 0;
+                } else {
+                    /* i am reader or valid writer */
+                    if (!iamwriter) {
+                        /* remove reader from read queue */
+                        listc_rfl(&rq_reqs, nextrq);
+                    }
+                    if (add_latency > 0) {
+                        poll(0, 0, rand() % add_latency);
+                    }
+                    time_metric_add(thedb->handle_buf_queue_time,
+                                    comdb2_time_epochms() -
+                                        nextrq->queue_time_ms);
+                    /* release link block */
+                    pool_relablk(pq_reqs, nextrq);
+                    if (!iq) {
+                        /* this should never be hit */
+                        abort();
+                        break;
+                    }
                 }
-                time_metric_add(thedb->handle_buf_queue_time,
-                                comdb2_time_epochms() - nextrq->queue_time_ms);
-                pool_relablk(pq_reqs, nextrq);
-                if (!iq)
-                    /* this should never be hit */
-                    break;
-                /* make sure to mark the reader request accordingly */
-                iamwriter = 0;
-            } else {
-                /* i am reader or valid writer */
-                if (!iamwriter) {
-                    /* remove reader from read queue */
-                    listc_rfl(&rq_reqs, nextrq);
-                }
-                if (add_latency > 0) {
-                    poll(0, 0, rand() % add_latency);
-                }
-                time_metric_add(thedb->handle_buf_queue_time,
-                                comdb2_time_epochms() - nextrq->queue_time_ms);
-                /* release link block */
-                pool_relablk(pq_reqs, nextrq);
-                if (!iq) {
-                    /* this should never be hit */
-                    abort();
-                    break;
-                }
-            }
-            if ((thd = listc_rtl(&idle)) != NULL) /*try to find an idle thread*/
-            {
+                if ((thd = listc_rtl(&idle)) !=
+                    NULL) /*try to find an idle thread*/
+                {
 #if 0
                 printf("%s:%d: thdpool FOUND THD=%d -> newTHD=%d iq=%p\n", __func__, __LINE__, pthread_self(), thd->tid, iq);
 #endif
@@ -1147,59 +1170,14 @@ int handle_buf_main2(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     return 0;
 }
 
-int handle_buf_main(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
-                    const uint8_t *p_buf, const uint8_t *p_buf_end, int debug,
-                    char *frommach, int frompid, char *fromtask,
-                    osql_sess_t *sorese, int qtype, void *data_hndl, int luxref,
-                    unsigned long long rqid)
+int handle_buf_main(struct dbenv *dbenv, SBUF2 *sb, const uint8_t *p_buf,
+                    const uint8_t *p_buf_end, int debug, char *frommach,
+                    int frompid, char *fromtask, osql_sess_t *sorese, int qtype,
+                    void *data_hndl, int luxref, unsigned long long rqid)
 {
-    return handle_buf_main2(dbenv, iq, sb, p_buf, p_buf_end, debug, frommach,
+    return handle_buf_main2(dbenv, sb, p_buf, p_buf_end, debug, frommach,
                             frompid, fromtask, sorese, qtype, data_hndl, luxref,
                             rqid, 0, 0);
-}
-struct ireq *create_sorese_ireq(struct dbenv *dbenv, uint8_t *p_buf,
-                                const uint8_t *p_buf_end, int debug,
-                                char *frommach, osql_sess_t *sorese)
-{
-    int rc;
-    struct ireq *iq;
-
-    LOCK(&lock)
-    {
-        iq = (struct ireq *)pool_getablk(p_reqs);
-    }
-    UNLOCK(&lock);
-#if 0
-    fprintf(stderr, "%s:%d: THD=%d getablk iq=%p\n", __func__, __LINE__, pthread_self(), iq);
-#endif
-
-    if (!iq) {
-        reterr(0, 0, iq, ERR_INTERNAL);
-        logmsg(LOGMSG_ERROR, "can't allocate ireq\n");
-        return NULL;
-    }
-
-    rc = init_ireq_legacy(dbenv, iq, NULL, p_buf, p_buf_end, debug, frommach, 0,
-                          NULL, REQ_OFFLOAD, NULL, 0, 0, 0, 0);
-    if (rc) {
-        reterr(0, /*thd*/ 0, iq, rc);
-        return NULL;
-    }
-
-    iq->sorese = sorese;
-
-#if 0
-    printf("Mapping sorese %llu\n", osql_log_time());
-#endif
-    /* this creates the socksql/recom/serial local log (temp table) */
-    snprintf(iq->corigin, sizeof(iq->corigin), "SORESE# %15s %s RQST %llx",
-             iq->sorese->host, osql_sorese_type_to_str(iq->sorese->type),
-             iq->sorese->rqid);
-
-    iq->timings.req_received = osql_log_time();
-    iq->tranddl = 0;
-
-    return iq;
 }
 
 void destroy_ireq(struct dbenv *dbenv, struct ireq *iq)

--- a/db/osqlblkseq.c
+++ b/db/osqlblkseq.c
@@ -65,27 +65,27 @@ int osql_blkseq_register_cnonce(struct ireq *iq)
     assert(hiqs_cnonce != NULL);
 
     Pthread_mutex_lock(&hmtx);
-    iq_src = hash_find(hiqs_cnonce, &iq->snap_info);
+    iq_src = hash_find(hiqs_cnonce, IQ_SNAPINFO(iq));
     if (!iq_src) { /* not there, we add it */
-        hash_add(hiqs_cnonce, &iq->snap_info);
+        hash_add(hiqs_cnonce, IQ_SNAPINFO(iq));
         rc = OSQL_BLOCKSEQ_FIRST;
     }
     Pthread_mutex_unlock(&hmtx);
 #ifdef DEBUG_BLKSEQ
     if (!iq_src) {
-        logmsg(LOGMSG_DEBUG, "Added to blkseq %*s\n", iq->snap_info.keylen - 3,
-               iq->snap_info.key);
+        logmsg(LOGMSG_DEBUG, "Added to blkseq %*s\n",
+               IQ_SNAPINFO(iq)->keylen - 3, IQ_SNAPINFO(iq)->key);
     }
 #endif
 
     /* rc == 0 means we need to wait for it to go away */
     while (rc == 0) {
         logmsg(LOGMSG_DEBUG, "Already in blkseq %*s, stalling...\n",
-               iq->snap_info.keylen - 3, iq->snap_info.key);
+               IQ_SNAPINFO(iq)->keylen - 3, IQ_SNAPINFO(iq)->key);
         poll(NULL, 0, gbl_block_blkseq_poll);
 
         Pthread_mutex_lock(&hmtx);
-        iq_src = hash_find_readonly(hiqs_cnonce, &iq->snap_info);
+        iq_src = hash_find_readonly(hiqs_cnonce, IQ_SNAPINFO(iq));
         Pthread_mutex_unlock(&hmtx);
 
         if (!iq_src) {
@@ -102,7 +102,8 @@ int osql_blkseq_register_cnonce(struct ireq *iq)
 static inline int osql_blkseq_unregister_cnonce(struct ireq *iq)
 {
     assert(hiqs_cnonce != NULL);
-    return hash_del(hiqs_cnonce, &iq->snap_info);
+
+    return hash_del(hiqs_cnonce, IQ_SNAPINFO(iq));
 }
 
 /*
@@ -190,17 +191,22 @@ int osql_blkseq_unregister(struct ireq *iq)
     Pthread_mutex_lock(&hmtx);
 
     hash_del(hiqs, iq);
+    if (IQ_HAS_SNAPINFO(iq)) {
 #ifdef DEBUG_BLKSEQ
-    int rc = osql_blkseq_unregister_cnonce(iq);
+        int rc = osql_blkseq_unregister_cnonce(iq);
 #else
-    osql_blkseq_unregister_cnonce(iq);
+        osql_blkseq_unregister_cnonce(iq);
 #endif
+    }
 
     Pthread_mutex_unlock(&hmtx);
 #ifdef DEBUG_BLKSEQ
-    if (iq->have_snap_info)
+    if (IQ_HAS_SNAPINFO(iq))
         logmsg(LOGMSG_DEBUG, "Removed from blkseq %*s, rc=%d\n",
-               iq->snap_info.keylen - 3, iq->snap_info.key, rc);
+               IQ_SNAPINFO(iq)->keylen - 3, IQ_SNAPINFO(iq)->key, rc);
+    else
+        logmsg(LOGMSG_DEBUG, "XXXXX NO CNONCE rc=%d\n", rc);
+
 #endif
     return 0;
 }

--- a/db/osqlblockproc.h
+++ b/db/osqlblockproc.h
@@ -101,11 +101,17 @@ int osql_bplog_saveop(osql_sess_t *sess, blocksql_tran_t *tran, char *rpl,
  *       This will allow let us point directly to the buffer
  *
  */
-int osql_bplog_build_sorese_req(uint8_t *p_buf_start,
+int osql_bplog_build_sorese_req(uint8_t **p_buf_start,
                                 const uint8_t **pp_buf_end, const char *sqlq,
                                 int sqlqlen, const char *tzname, int reqtype,
-                                char **sqlqret, int *sqlqlenret,
                                 unsigned long long rqid, uuid_t uuid);
+
+/**
+ * Set proper blkseq from session to iq
+ * NOTE: We don't need to create buffers _SEQ, _SEQV2 for it
+ *
+ */
+void osql_bplog_set_blkseq(osql_sess_t *sess, struct ireq *iq);
 
 /**
  * Debugging support

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -201,16 +201,6 @@ int osql_send_dbq_consume(char *tohost, unsigned long long rqid, uuid_t,
                           genid_t, int type);
 
 /**
- * Constructs a reusable osql request
- *
- */
-void *osql_create_request(const char *sql, int sqlen, int type,
-                          unsigned long long rqid, uuid_t uuid, char *tzname,
-                          int *prqlen, char *tag, void *tagbuf, int tagbuflen,
-                          void *nullbits, int numnullbits, blob_buffer_t *blobs,
-                          int numblobs, int queryid, int flags);
-
-/**
  * Handles each packet and calls record.c functions
  * to apply to received row updates
  *
@@ -402,9 +392,6 @@ int osql_get_replicant_numops(const char *rpl, int has_uuid);
 
 int osql_set_usedb(struct ireq *iq, const char *tablename, int tableversion,
                    int step, struct block_err *err);
-
-void osql_extract_snap_info(struct ireq *iq, void *data, int datalen,
-                            int hasuuid);
 
 void signal_replicant_error(const char *host, unsigned long long rqid,
                             uuid_t uuid, int rc, const char *msg);

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -41,8 +41,6 @@ struct sess_impl {
     bool dispatched : 1; /* Set when session is dispatched to handle_buf */
     bool terminate : 1;  /* Set when this session is about to be terminated */
 
-    uint8_t *buf; /* toblock request buffer */
-
     pthread_mutex_t mtx; /* dispatched/terminate/clients protection */
 };
 
@@ -82,8 +80,6 @@ int osql_sess_close(osql_sess_t **psess, bool is_linked)
     if (sess->tran)
         osql_bplog_close(&sess->tran);
 
-    if ((*psess)->iq)
-        destroy_ireq(thedb, (*psess)->iq);
     _destroy_session(psess);
 
     return 0;
@@ -93,8 +89,9 @@ static void _destroy_session(osql_sess_t **psess)
 {
     osql_sess_t *sess = *psess;
 
-    if (sess->impl->buf)
-        free(sess->impl->buf);
+    if (sess->snap_info)
+        free(sess->snap_info);
+
     Pthread_mutex_destroy(&sess->impl->mtx);
     free(sess);
 
@@ -266,8 +263,7 @@ failed_stream:
  */
 osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
                               int type, unsigned long long rqid, uuid_t uuid,
-                              const char *host, uint8_t *buf,
-                              bool is_reorder_on)
+                              const char *host, bool is_reorder_on)
 {
     osql_sess_t *sess = NULL;
     sess_impl_t *impl;
@@ -279,13 +275,15 @@ osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
 #endif
 
     /* alloc object */
-    sess = (osql_sess_t *)calloc(sizeof(osql_sess_t) + sizeof(sess_impl_t), 1);
+    sess = (osql_sess_t *)calloc(
+        sizeof(osql_sess_t) + sizeof(sess_impl_t) + sqlen + 1, 1);
     if (!sess) {
         logmsg(LOGMSG_ERROR, "%s:unable to allocate %zu bytes\n", __func__,
                sizeof(*sess));
         return NULL;
     }
     sess->impl = impl = (sess_impl_t *)(sess + 1);
+    sess->sql = (char *)(sess->impl + 1);
 #if DEBUG_REORDER
     uuidstr_t us;
     comdb2uuidstr(uuid, us);
@@ -302,11 +300,11 @@ osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
     sess->host = host ? intern(host) : NULL;
     sess->startus = comdb2_time_epochus();
     sess->is_reorder_on = is_reorder_on;
+    strncpy0((char *)sess->sql, sql, sqlen + 1);
     if (tzname)
         strncpy0(sess->tzname, tzname, sizeof(sess->tzname));
 
     sess->impl->clients = 1;
-    sess->impl->buf = buf;
 
     /* create bplog so we can collect ops from sql thread */
     sess->tran = osql_bplog_create(sess->rqid == OSQL_RQID_USE_UUID,
@@ -385,6 +383,8 @@ static int handle_buf_sorese(osql_sess_t *psess)
     sess_impl_t *sess = psess->impl;
     int debug;
     int rc = 0;
+    uint8_t *p_buf = NULL;
+    const uint8_t *p_buf_end = NULL;
 
     debug = debug_this_request(gbl_debug_until);
     if (gbl_who > 0 && gbl_debug) {
@@ -405,8 +405,18 @@ static int handle_buf_sorese(osql_sess_t *psess)
 
     osql_repository_put(psess);
 
-    rc = handle_buf_main(thedb, psess->iq, NULL, NULL, NULL, debug, 0, 0, NULL,
-                         NULL, REQ_OFFLOAD, NULL, 0, 0);
+    /* create the buffer now */
+    /* construct a block transaction */
+    if (osql_bplog_build_sorese_req(&p_buf, &p_buf_end, psess->sql,
+                                    strlen(psess->sql) + 1, psess->tzname,
+                                    psess->type, psess->rqid, psess->uuid)) {
+        logmsg(LOGMSG_ERROR, "bug in code %s:%d", __func__, __LINE__);
+        return rc;
+    }
+
+    rc = handle_buf_main(thedb, NULL, p_buf, p_buf_end, debug,
+                         (char *)psess->host, 0, NULL, psess, REQ_OFFLOAD, NULL,
+                         0, 0);
 
     if (rc) {
         signal_replicant_error(psess->host, psess->rqid, psess->uuid,

--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -32,8 +32,7 @@ typedef struct osql_uuid_req osql_uuid_req_t;
  */
 osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
                               int type, unsigned long long rqid, uuid_t uuid,
-                              const char *host, uint8_t *p_buf,
-                              bool is_reorder_on);
+                              const char *host, bool is_reorder_on);
 
 /**
  * Terminates an in-use osql session (for which we could potentially

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -269,7 +269,7 @@ int handle_ireq(struct ireq *iq)
     if (iq->rawnodestats && iq->opcode >= 0 && iq->opcode < MAXTYPCNT)
         iq->rawnodestats->opcode_counts[iq->opcode]++;
     if (gbl_print_deadlock_cycles)
-        osql_snap_info = &iq->snap_info;
+        osql_snap_info = IQ_SNAPINFO(iq);
 
     comdb2_opcode_t *opcode = hash_find_readonly(gbl_opcode_hash, &iq->opcode);
     if (!opcode) {

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -76,6 +76,7 @@
 #include "logmsg.h"
 #include "reqlog.h"
 #include "comdb2_atomic.h"
+#include "str0.h"
 
 #if 0
 #define TEST_OSQL
@@ -810,7 +811,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
 
     if (!replay_data) {
 
-        if (!iq->have_snap_info) {
+        if (!IQ_HAS_SNAPINFO(iq)) {
             assert( (seqlen == (sizeof(fstblkseq_t))) || 
                     (seqlen == (sizeof(uuid_t))));
         }
@@ -1080,7 +1081,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
 
     /* Snapinfo is ascii text */
     if (snapinfo) {
-        assert(iq->have_snap_info);
+        assert(IQ_HAS_SNAPINFO(iq));
         printkey = (char *)malloc(seqlen + 1);
         memcpy(printkey, fstseqnum, seqlen);
         printkey[seqlen]='\0';
@@ -1092,10 +1093,10 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
     }
 
     char *cnonce = NULL;
-    if (iq->have_snap_info) {
-        cnonce = alloca(iq->snap_info.keylen + 1);
-        memcpy(cnonce, iq->snap_info.key, iq->snap_info.keylen);
-        cnonce[iq->snap_info.keylen] = '\0';
+    if (IQ_HAS_SNAPINFO(iq)) {
+        cnonce = alloca(IQ_SNAPINFO(iq)->keylen + 1);
+        memcpy(cnonce, IQ_SNAPINFO(iq)->key, IQ_SNAPINFO(iq)->keylen);
+        cnonce[IQ_SNAPINFO(iq)->keylen] = '\0';
     }
 
     logmsg(LOGMSG_WARN,
@@ -1108,7 +1109,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
      * the cluster is incoherent */
     if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS) &&
             !bdb_latest_commit_is_durable(thedb->bdb_env)) {
-        if (iq->have_snap_info) {
+        if (IQ_HAS_SNAPINFO(iq)) {
             logmsg(LOGMSG_ERROR,
                    "%u replay rc changed from %d to NOT_DURABLE "
                    "for blkseq '%s'\n",
@@ -1117,7 +1118,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
         outrc = ERR_NOT_DURABLE;
     }
 
-    if (gbl_dump_blkseq && iq->have_snap_info) {
+    if (gbl_dump_blkseq && IQ_HAS_SNAPINFO(iq)) {
         logmsg(LOGMSG_USER,
                "Replay case for '%s' rc=%d, errval=%d errstr='%s' rcout=%d\n",
                cnonce, outrc, iq->errstat.errval, iq->errstat.errstr,
@@ -2348,11 +2349,6 @@ static int extract_blkseq2(struct ireq *iq, block_state_t *p_blkstate,
             return ERR_BADREQ;
         }
 
-        /* The old proxy only sent an 8 byte sequence number.
-         * The new proxy sends 12 bytes, but for compatibility
-         * with older comdb2 builds the first 4 bytes of what
-         * is logically the sequence number are sent last.
-         * Thus we have to reorder the data. */
         memcpy(iq->seq, seq.seq, sizeof(uuid_t));
         iq->seqlen = sizeof(uuid_t);
 
@@ -2676,7 +2672,6 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     if (iq->retries == 0) {
         const uint8_t *p_buf_in_saved;
         int got_blockseq = 0;
-        int got_blockseq2 = 0;
         int got_osql = 0;
 
         /* this is a pre-loop, we want to jump back to the begining after it's
@@ -2728,7 +2723,6 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                         GOTOBACKOUT;
                     }
                     if (have_blkseq) {
-                        got_blockseq2 = 1;
                         /* We don't do the pre-scan again if it's a retry, so
                          * save whether we had a blkseq */
                         iq->have_blkseq =
@@ -2736,15 +2730,21 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                                   blkseq */
                     }
                 }
-
             case BLOCK2_SOCK_SQL:
             case BLOCK2_RECOM:
                 got_osql = 1;
+                /* fall-through */
+            case BLOCK2_SNAPISOL:
+            case BLOCK2_SERIAL:
+                if (gbl_use_blkseq) {
+                    have_blkseq = 1;
+                    osql_bplog_set_blkseq(iq->sorese, iq);
+                }
                 break;
             }
         }
 
-        if (got_osql && iq->have_snap_info) {
+        if (got_osql && IQ_HAS_SNAPINFO(iq)) {
             if (gbl_osql_snap_info_hashcheck) {
                 // the goal here is to stall until the original transaction
                 // has finished that way we can retrieve the outcome from blkseq
@@ -2762,14 +2762,14 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 goto cleanup;
             }
             int found;
-            found = bdb_blkseq_find(thedb->bdb_env, parent_trans,
-                                    iq->snap_info.key, iq->snap_info.keylen,
-                                    &replay_data, &replay_len);
+            found = bdb_blkseq_find(
+                thedb->bdb_env, parent_trans, IQ_SNAPINFO(iq)->key,
+                IQ_SNAPINFO(iq)->keylen, &replay_data, &replay_len);
             if (!found) {
                 logmsg(LOGMSG_WARN,
                        "early snapinfo blocksql replay detected\n");
-                outrc = do_replay_case(iq, iq->snap_info.key,
-                                       iq->snap_info.keylen, num_reqs, 0,
+                outrc = do_replay_case(iq, IQ_SNAPINFO(iq)->key,
+                                       IQ_SNAPINFO(iq)->keylen, num_reqs, 0,
                                        replay_data, replay_len, __LINE__);
                 bdb_rellock(thedb->bdb_env, __func__, __LINE__);
 #if DEBUG_DID_REPLAY
@@ -2781,7 +2781,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             bdb_rellock(thedb->bdb_env, __func__, __LINE__);
         }
 
-        if ((got_blockseq || got_blockseq2) && got_osql && !iq->have_snap_info) {
+        if (got_blockseq && got_osql && !IQ_HAS_SNAPINFO(iq)) {
             /* register this blockseq early to detect expensive replays
                of the same blocksql transactions */
             bdb_get_readlock(thedb->bdb_env, "early_replay", __func__,
@@ -4420,6 +4420,12 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             struct packedreq_sql sql;
             const uint8_t *p_buf_sqlq;
 
+            /* synthetic block2_use */
+            iq->usedb = get_dbtable_by_name(thedb->static_table.tablename);
+
+            /* synthetic block2_tz */
+            strncpy0(iq->tzname, iq->sorese->tzname, sizeof(iq->tzname));
+
             ++delayed;
             is_block2sqlmode = 1;
             have_keyless_requests = 1;
@@ -5447,7 +5453,8 @@ add_blkseq:
             struct fstblk_header fstblk_header;
             struct fstblk_pre_rspkl fstblk_pre_rspkl;
 
-            fstblk_header.type = (short)(iq->have_snap_info ? FSTBLK_SNAP_INFO : FSTBLK_RSPKL);
+            fstblk_header.type =
+                (short)(IQ_HAS_SNAPINFO(iq) ? FSTBLK_SNAP_INFO : FSTBLK_RSPKL);
             fstblk_pre_rspkl.fluff = (short)0;
 
             if (!(p_buf_fstblk = fstblk_header_put(&fstblk_header, p_buf_fstblk,
@@ -5462,7 +5469,7 @@ add_blkseq:
                 return ERR_INTERNAL;
             }
 
-            if (iq->have_snap_info) {
+            if (IQ_HAS_SNAPINFO(iq)) {
                 if (!(p_buf_fstblk = buf_put(&(outrc), sizeof(outrc), p_buf_fstblk, 
                                 p_buf_fstblk_end))) {
                             return ERR_INTERNAL;
@@ -5490,9 +5497,9 @@ add_blkseq:
         void *bskey;
         int bskeylen;
         /* Snap_info is our blkseq key */
-        if (iq->have_snap_info) {
-            bskey = iq->snap_info.key;
-            bskeylen = iq->snap_info.keylen;
+        if (IQ_HAS_SNAPINFO(iq)) {
+            bskey = IQ_SNAPINFO(iq)->key;
+            bskeylen = IQ_SNAPINFO(iq)->keylen;
         } else {
             bskey = iq->seq;
             bskeylen = iq->seqlen;
@@ -5504,8 +5511,8 @@ add_blkseq:
             // if VERIFY-ERROR && replicant_is_able_to_retry don't add to blkseq
             if ((outrc == ERR_NOTSERIAL ||
                  (outrc == ERR_BLOCK_FAILED && err.errcode == ERR_VERIFY)) &&
-                (iq->have_snap_info &&
-                 iq->snap_info.replicant_is_able_to_retry)) {
+                (IQ_HAS_SNAPINFO(iq) &&
+                 IQ_SNAPINFO(iq)->replicant_is_able_to_retry)) {
                 /* do nothing */
             } else {
                 rc = bdb_blkseq_insert(thedb->bdb_env, parent_trans, bskey,
@@ -5566,10 +5573,11 @@ add_blkseq:
                     Pthread_rwlock_unlock(&commit_lock);
                     hascommitlock = 0;
                 }
-                if (gbl_dump_blkseq && iq->have_snap_info) {
-                    char *bskey = alloca(iq->snap_info.keylen + 1);
-                    memcpy(bskey, iq->snap_info.key, iq->snap_info.keylen);
-                    bskey[iq->snap_info.keylen] = '\0';
+                if (gbl_dump_blkseq && IQ_HAS_SNAPINFO(iq)) {
+                    char *bskey = alloca(IQ_SNAPINFO(iq)->keylen + 1);
+                    memcpy(bskey, IQ_SNAPINFO(iq)->key,
+                           IQ_SNAPINFO(iq)->keylen);
+                    bskey[IQ_SNAPINFO(iq)->keylen] = '\0';
                     logmsg(LOGMSG_USER,
                            "blkseq add '%s', outrc=%d errval=%d "
                            "errstr='%s', rcout=%d commit-rc=%d\n",
@@ -5854,8 +5862,8 @@ add_blkseq:
     fromline = __LINE__;
 cleanup:
 #if DEBUG_DID_REPLAY
-    logmsg(LOGMSG_DEBUG, "%s cleanup did_replay:%d fromline:%d\n", __func__,
-           did_replay, fromline);
+    logmsg(LOGMSG_DEBUG, "%s cleanup rc %d did_replay:%d fromline:%d\n",
+           __func__, outrc, did_replay, fromline);
 #endif
     bdb_checklock(thedb->bdb_env);
 

--- a/sqlite/ext/comdb2/activeosqls.c
+++ b/sqlite/ext/comdb2/activeosqls.c
@@ -103,10 +103,10 @@ static int collect_bplog_session(void *obj, void *arg)
     o->type = bplogtype;
     o->origin = sess->host? strdup(sess->host) : NULL;
     o->where = iq && iq->where ? strdup(iq->where) : NULL;
-    if (iq && iq->have_snap_info) {
-        o->cnonce = malloc(iq->snap_info.keylen + 1);
-        memcpy(o->cnonce, iq->snap_info.key, iq->snap_info.keylen);
-        o->cnonce[iq->snap_info.keylen] = '\0';
+    if (iq && IQ_HAS_SNAPINFO(iq)) {
+        o->cnonce = malloc(IQ_SNAPINFO(iq)->keylen + 1);
+        memcpy(o->cnonce, IQ_SNAPINFO(iq)->key, IQ_SNAPINFO(iq)->keylen);
+        o->cnonce[IQ_SNAPINFO(iq)->keylen] = '\0';
     }
     if (sess->rqid == 1) {
         comdb2uuidstr(sess->uuid, us);

--- a/tests/restart_socksql.test/lrl.options
+++ b/tests/restart_socksql.test/lrl.options
@@ -5,3 +5,4 @@ do reql events n
 do reql events detailed on
 debug.osql_random_restart on
 osql_verify_retry_max 0
+enable_osql_logging

--- a/tests/serialstep.test/lrl.options
+++ b/tests/serialstep.test/lrl.options
@@ -13,4 +13,3 @@ setattr WAIT_FOR_SEQNUM_TRACE 1
 logmsg level info
 set_coherent_state_trace on
 #on extended_sql_debug_trace
-#on enable_osql_logging


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Delay postponing allocating a struct ireq until the bplog is complete.  The dispatch and failure is simpler, since we keep less state; the memory footprint per bplog is reduced.