### PR TITLE
Max blob field size

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -19,7 +19,7 @@
 
 #define COMDB2_MAX_RECORD_SIZE 16384
 #define LONG_REQMS 2000
-#define MAXBLOBLENGTH 255 * 1024 * 1024 /* TODO: set a good maximum here */
+#define MAXBLOBLENGTH ((1 << 28) - 1)   /* (1 << ODH_LENGTH_BITS) - 1 */
 #define MAXBLOBS 15                     /* Should be bdb's MAXDTAFILES - 1 */
 #define MAXCOLNAME 99                   /* not incl. \0 */
 #define MAXCOLUMNS 1024

--- a/tests/blob_size_limit.test/expected.txt
+++ b/tests/blob_size_limit.test/expected.txt
@@ -11,6 +11,6 @@ run b 113 blob size exceeds max for table 't'
 (a=7, length(b)=1000000)
 (a=8, length(b)=10000000)
 (a=9, length(b)=100000000)
-(a=10, length(b)=267386880)
+(a=10, length(b)=268435455)
 (a=11, length(b)=0)
 (a=12, length(b)=0)

--- a/tests/blob_size_limit.test/runit
+++ b/tests/blob_size_limit.test/runit
@@ -19,8 +19,8 @@ ${TESTSBUILDDIR}/comdb2_blobtest $dbname 6 100000
 ${TESTSBUILDDIR}/comdb2_blobtest $dbname 7 1000000
 ${TESTSBUILDDIR}/comdb2_blobtest $dbname 8 10000000
 ${TESTSBUILDDIR}/comdb2_blobtest $dbname 9  100000000
-${TESTSBUILDDIR}/comdb2_blobtest $dbname 10 267386880
-${TESTSBUILDDIR}/comdb2_blobtest $dbname 11 267386881
+${TESTSBUILDDIR}/comdb2_blobtest $dbname 10 268435455
+${TESTSBUILDDIR}/comdb2_blobtest $dbname 11 268435456
 ${TESTSBUILDDIR}/comdb2_blobtest $dbname 12 300000000
 ) > out.txt 2>&1
 cdb2sql -s $testreq ${CDB2_OPTIONS} $dbname default "select a, length(b) from t order by a" >> out.txt

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -302,7 +302,7 @@
 (name='ZLIB', reserved='N')
 [SELECT * FROM comdb2_keywords WHERE reserved = 'N' ORDER BY name] rc 0
 (name='max_blob_fields', description='Maximum number of blob/vutf8 fields per table', value=15)
-(name='max_blob_length', description='Maximum blob length', value=267386880)
+(name='max_blob_length', description='Maximum blob length', value=268435455)
 (name='max_bounded_parameters', description='Maximum number of bounded parameters per prepared statement', value=2048)
 (name='max_column_name_length', description='Maximum column name length', value=99)
 (name='max_columns', description='Maximum columns per table', value=1024)


### PR DESCRIPTION
Max blob field size should be 268435455 (2^28 - 1).

(DRQS 153686908)

Signed-off-by: Rivers Zhang <hzhang320@bloomberg.net>