### PR TITLE
Backport the comdb2_user() SQL function from master.

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1224,6 +1224,8 @@ void clnt_change_state(struct sqlclntstate *clnt, enum connection_state state);
 void clnt_register(struct sqlclntstate *clnt);
 void clnt_unregister(struct sqlclntstate *clnt);
 
+struct sqlclntstate *get_sql_clnt(void);
+
 /* Returns the current user for the session */
 char *get_current_user(struct sqlclntstate *clnt);
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -283,6 +283,12 @@ int write_response(struct sqlclntstate *clnt, int R, void *D, int I);
 int gbl_client_heartbeat_ms = 100;
 int gbl_fail_client_write_lock = 0;
 
+struct sqlclntstate *get_sql_clnt(void){
+  struct sql_thread *thd = pthread_getspecific(query_info_key);
+  if (thd == NULL) return NULL;
+  return thd->clnt;
+}
+
 static inline int lock_client_write_lock_int(struct sqlclntstate *clnt, int try)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
@@ -2677,6 +2683,15 @@ static inline int check_user_password(struct sqlclntstate *clnt)
         return 1;
     }
     return 0;
+}
+
+/* Return current authenticated user for the session */
+char *get_current_user(struct sqlclntstate *clnt)
+{
+    if (clnt && !clnt->is_x509_user && clnt->have_user) {
+        return clnt->user;
+    }
+    return NULL;
 }
 
 void thr_set_current_sql(const char *sql)

--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -926,6 +926,17 @@ static void comdb2StartTimeFunc(
   dttz_t dt = {gbl_starttime, 0};
   sqlite3_result_datetime(context, &dt, NULL);
 }
+
+static void comdb2UserFunc(
+  sqlite3_context *context,
+  int NotUsed,
+  sqlite3_value **NotUsed2
+){
+  UNUSED_PARAMETER2(NotUsed, NotUsed2);
+
+  sqlite3_result_text(context, get_current_user(get_sql_clnt()), -1,
+                      SQLITE_STATIC);
+}
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*
@@ -2555,6 +2566,7 @@ void sqlite3RegisterBuiltinFunctions(void){
     FUNCTION(comdb2_dbname,         0, 0, 0, comdb2DbnameFunc),
     FUNCTION(comdb2_prevquerycost,  0, 0, 0, comdb2PrevquerycostFunc),
     FUNCTION(comdb2_starttime,      0, 0, 0, comdb2StartTimeFunc),
+    FUNCTION(comdb2_user,           0, 0, 0, comdb2UserFunc),
 #if defined(SQLITE_BUILDING_FOR_COMDB2_DBGLOG)
     FUNCTION(dbglog_cookie,         0, 0, 0, dbglogCookieFunc),
     FUNCTION(dbglog_begin,          1, 0, 0, dbglogBeginFunc),

--- a/tests/auth.test/t00.expected
+++ b/tests/auth.test/t00.expected
@@ -1,1 +1,4 @@
+(comdb2_user()=NULL)
+(comdb2_user()=NULL)
 [put authentication on] failed with rc -3 User does not have OP credentials
+(comdb2_user()=NULL)

--- a/tests/auth.test/t00.req
+++ b/tests/auth.test/t00.req
@@ -1,5 +1,8 @@
+select comdb2_user();
 put password 'password1' for 'user1'
 put password 'password2' for 'user2'
 grant op to user1
+select comdb2_user();
 #only op can turn on authentication
 put authentication on
+select comdb2_user();

--- a/tests/auth.test/t01.expected
+++ b/tests/auth.test/t01.expected
@@ -1,2 +1,5 @@
 ('user1'='user1')
+(comdb2_user()='user1')
+(comdb2_user()='user1')
 ('authentication turned on'='authentication turned on')
+(comdb2_user()='user1')

--- a/tests/auth.test/t01.req
+++ b/tests/auth.test/t01.req
@@ -1,5 +1,8 @@
 select 'user1'
 set user user1
+select comdb2_user();
 set password password1
+select comdb2_user();
 put authentication on
 select 'authentication turned on'
+select comdb2_user();

--- a/tests/auth.test/t02.expected
+++ b/tests/auth.test/t02.expected
@@ -1,1 +1,4 @@
+[select comdb2_user()] failed with rc -106 access denied
+[select comdb2_user()] failed with rc -106 access denied
+[select comdb2_user()] failed with rc -106 access denied
 [select 'user3'] failed with rc -106 access denied

--- a/tests/auth.test/t02.req
+++ b/tests/auth.test/t02.req
@@ -1,4 +1,7 @@
 #Queries from unknown users will fail
+select comdb2_user();
 set user user2
+select comdb2_user();
 set password password3
+select comdb2_user();
 select 'user3'

--- a/tests/auth.test/t03.expected
+++ b/tests/auth.test/t03.expected
@@ -1,2 +1,5 @@
+[select comdb2_user()] failed with rc -106 access denied
+(comdb2_user()='user2')
 ('user2'='user2')
+(comdb2_user()='user2')
 [put authentication off] failed with rc -3 User does not have OP credentials

--- a/tests/auth.test/t03.req
+++ b/tests/auth.test/t03.req
@@ -1,5 +1,8 @@
 set user user2
+select comdb2_user();
 set password password2
+select comdb2_user();
 select 'user2'
+select comdb2_user();
 #only op can turn off authentication
 put authentication off


### PR DESCRIPTION
Signed-off-by: Joe Mistachkin <joe@mistachkin.com>

This function is needed by the checked-in version of the 'userschema' test on this branch.