### PR TITLE
Use DEBUG level for rqid/uuid trace.

### DIFF
--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -877,7 +877,7 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
 
         {
             uuidstr_t us;
-            logmsg(LOGMSG_ERROR, "%lu %s rqid %llu uuid %s got_cnonce %d\n",
+            logmsg(LOGMSG_DEBUG, "%lu %s rqid %llu uuid %s got_cnonce %d\n",
                    pthread_self(), __func__, iq->sorese->rqid,
                    comdb2uuidstr(iq->sorese->uuid, us), IQ_HAS_SNAPINFO(iq));
         }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -8677,7 +8677,7 @@ static void osql_extract_snap_info(osql_sess_t *sess, void *rpl, int rpllen,
 
     {
         uuidstr_t us;
-        logmsg(LOGMSG_ERROR, "%lu %s rqid %llu uuid %s got_cnonce %d\n",
+        logmsg(LOGMSG_DEBUG, "%lu %s rqid %llu uuid %s got_cnonce %d\n",
                pthread_self(), __func__, sess->rqid,
                comdb2uuidstr(sess->uuid, us), sess->snap_info != 0);
     }


### PR DESCRIPTION
The write slowdown we've seen with last commit is probably caused by the incorrect log level. Let's see whether sysbench agrees.

Signed-off-by: Rivers Zhang <hzhang320@bloomberg.net>
