### PR TITLE
fdb/sqlitex: leaking connection (7.0)

### DIFF
--- a/bbinc/comdb2_query_preparer.h
+++ b/bbinc/comdb2_query_preparer.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Bloomberg Finance L.P.
+   Copyright 2019, 2020 Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -21,8 +21,11 @@ struct comdb2_query_preparer {
     int (*do_prepare)(struct sqlthdstate *, struct sqlclntstate *,
                       const char *);
     int (*do_cleanup)(struct sqlclntstate *);
+    int (*sqlitex_is_initializing)(void *);
+    char *(*sqlitex_table_name)(void *);
 };
 typedef struct comdb2_query_preparer comdb2_query_preparer_t;
 
 extern comdb2_query_preparer_t *query_preparer_plugin;
+extern int gbl_old_column_names;
 #endif /* !__INCLUDED_QUERY_PREPARER_H */

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -53,10 +53,10 @@
 #include "ssl_support.h"
 #include "ssl_io.h"
 #include "ssl_bend.h"
+#include "comdb2_query_preparer.h"
 
 extern int gbl_fdb_resolve_local;
 extern int gbl_fdb_allow_cross_classes;
-
 extern int gbl_partial_indexes;
 extern int gbl_expressions_indexes;
 
@@ -999,7 +999,7 @@ run:
         switch (rc) {
         case FDB_ERR_SSL:
 #if WITH_SSL
-            /* remote needs sql */
+            /* remote needs ssl */
             fdb_cursor_close_on_open(cur, 0);
             if (gbl_client_ssl_mode >= SSL_ALLOW) {
                 logmsg(LOGMSG_ERROR, "remote required SSl, switching to SSL\n");
@@ -1900,8 +1900,20 @@ void *fdb_get_sqlite_master_entry(fdb_t *fdb, fdb_tbl_ent_t *ent)
 
 int fdb_cursor_move_master(BtCursor *pCur, int *pRes, int how)
 {
-    sqlite3 *sqlite = pCur->sqlite;
-    const char *zTblName = sqlite->init.zTblName;
+    const char *zTblName;
+
+    if (gbl_old_column_names && pCur->clnt->thd &&
+        pCur->clnt->thd->query_preparer_running) {
+        /* We must have a query_preparer_plugin installed. */
+        assert(pCur->query_preparer_data != 0);
+        assert(query_preparer_plugin &&
+               query_preparer_plugin->sqlitex_table_name);
+        zTblName = query_preparer_plugin->sqlitex_table_name(
+            pCur->query_preparer_data);
+    } else {
+        sqlite3 *sqlite = pCur->sqlite;
+        zTblName = sqlite->init.zTblName;
+    }
     fdb_t *fdb = pCur->bt->fdb;
     fdb_tbl_t *tbl = NULL;
     int step = 0;
@@ -4175,6 +4187,18 @@ int fdb_master_is_local(BtCursor *pCur)
         return 1;
     /* this is looking at a remote pBt; check if this is schema initializing
        or a remote lookup */
+    if (gbl_old_column_names && pCur->clnt->thd &&
+        pCur->clnt->thd->query_preparer_running) {
+        /* We must have a query_preparer_plugin installed. */
+        assert(pCur->query_preparer_data != 0);
+        /* Since query_preparer plugin only prepares the query, the 'init.busy'
+         * flag must be set at this point. */
+        assert(query_preparer_plugin &&
+               query_preparer_plugin->sqlitex_is_initializing &&
+               query_preparer_plugin->sqlitex_is_initializing(
+                   pCur->query_preparer_data));
+        return 1;
+    }
     return pCur->sqlite && pCur->sqlite->init.busy == 1;
 }
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -102,6 +102,11 @@ struct sqlthdstate {
     int dbopen_gen;
     int analyze_gen;
     int views_gen;
+
+    /* A flag to tell us whether we are inside the query preparer plugin. This
+     * is especially needed to differentiate between fdb cursors opened by core
+     * versus query preparer plugin. */
+    bool query_preparer_running;
 };
 
 typedef struct osqltimings {
@@ -974,6 +979,8 @@ struct BtCursor {
     int open_flags; /* flags used to open it */
 
     int tableversion;
+
+    void *query_preparer_data;
 };
 
 struct sql_hist {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -102,6 +102,7 @@
 
 #include "str0.h"
 #include "comdb2_atomic.h"
+#include "comdb2_query_preparer.h"
 
 int gbl_delay_sql_lock_release_sec = 5;
 
@@ -8023,11 +8024,18 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
 void init_cursor(BtCursor *cur, Vdbe *vdbe, Btree *bt)
 {
     cur->thd = pthread_getspecific(query_info_key);
+    assert(cur->thd);
     cur->clnt = cur->thd->clnt;
     cur->vdbe = vdbe;
-    cur->sqlite = vdbe ? vdbe->db : NULL;
+    if (gbl_old_column_names && cur->clnt->thd &&
+        cur->clnt->thd->query_preparer_running) {
+        assert(query_preparer_plugin);
+        /* sqlitex */
+        cur->query_preparer_data = vdbe ? vdbe->db : NULL;
+    } else {
+        cur->sqlite = vdbe ? vdbe->db : NULL;
+    }
     cur->bt = bt;
-    assert(cur->thd);
     assert(cur->clnt);
 }
 


### PR DESCRIPTION
Due to struct mismatch (sqlite3 vs sqlitex) fdb_master_is_local was returning incorrect result after reading invalid memory. Fixed by caching sqlitex struct in BtCursor (alongside sqlite3)
and adding accessor methods to query_preparer plugin to return correct values out of the cached object.

/plugin-branch comdb2-sqlitex-conn-leak-7.0
Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>