### PR TITLE
Stop just request threads for old-style queue changes.

### DIFF
--- a/bdb/fstdump.c
+++ b/bdb/fstdump.c
@@ -392,12 +392,12 @@ static void *fstdump_thread_inner(fstdump_per_thread_t *fstdump, void *sendrec,
 
         if (db_is_stopped()) {
             logmsg(LOGMSG_ERROR, "fstdump_thread: "
-                            "aborting due to stop_threads\n");
+                            "aborting due to stop_all_threads\n");
             Pthread_mutex_lock(&common->lock);
             {
                 common->bdberr = BDBERR_DEADLOCK;
                 snprintf0(common->errmsg, sizeof(common->errmsg),
-                          "aborted because database stop_threads");
+                          "aborted because database stop_all_threads");
             }
             Pthread_mutex_unlock(&common->lock);
             dbcp->c_close(dbcp);
@@ -534,12 +534,12 @@ static int write_records(fstdump_per_thread_t *fstdump, DBT *data,
 
         if (db_is_stopped()) {
             logmsg(LOGMSG_ERROR, "fstdump_thread: "
-                            "aborting due to stop_threads\n");
+                            "aborting due to stop_all_threads\n");
             Pthread_mutex_lock(&common->lock);
             {
                 common->bdberr = BDBERR_DEADLOCK;
                 snprintf0(common->errmsg, sizeof(common->errmsg),
-                          "aborted because database stop_threads");
+                          "aborted because database stop_all_threads");
             }
             Pthread_mutex_unlock(&common->lock);
             return -1;

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -5302,7 +5302,6 @@ extern int gbl_lock_get_list_start;
 int bdb_clean_pglogs_queues(bdb_state_type *bdb_state, DB_LSN lsn,
                             int truncate);
 extern int db_is_stopped();
-extern int db_is_exiting();
 
 int request_delaymore(void *bdb_state_in)
 {

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1005,6 +1005,11 @@ int db_is_stopped(void)
     return thedb->stopped;
 }
 
+int db_requests_are_stopped(void)
+{
+    return thedb->requests_stopped;
+}
+
 void print_dbsize(void);
 
 static void init_q_vars()
@@ -1102,8 +1107,7 @@ static void *purge_old_blkseq_thread(void *arg)
     loop = 0;
     sleep(1);
 
-    while (!db_is_stopped()) {
-
+    while (!db_is_stopped() && !db_requests_are_stopped()) {
         /* Check del unused files progress about twice per threshold  */
         if (!(loop % (gbl_sc_del_unused_files_threshold_ms /
                       (2 * 1000 /*ms per sec*/))))
@@ -1482,7 +1486,7 @@ void clean_exit(void)
        node. */
     bdb_exiting(thedb->static_table.handle);
 
-    stop_threads(thedb);
+    stop_all_threads(thedb);
     flush_db();
 
 #   if 0

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -931,6 +931,7 @@ struct dbenv {
     int purge_old_blkseq_is_running;
     int purge_old_files_is_running;
     int stopped; /* set when exiting -- if set, drop requests */
+    int requests_stopped;  /* set when we want to stop/block requests, but will resume them later */
     int no_more_sql_connections;
 
     LISTC_T(struct sql_thread) sql_threads;
@@ -2364,7 +2365,8 @@ struct dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pages
                   int isqueuedb);
 int init_check_constraints(struct dbtable *tbl);
 int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
-void stop_threads(struct dbenv *env);
+void stop_all_threads(struct dbenv *env);
+void stop_request_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
 void replace_db_idx(struct dbtable *p_db, int idx);
 int add_db(struct dbtable *db);
@@ -3559,6 +3561,7 @@ comdb2_tunable_err handle_lrl_tunable(char *name, int name_len, char *value,
                                       int value_len, int flags);
 
 int db_is_stopped(void);
+int db_requests_are_stopped(void);
 
 /**
  * check if a tablename is a queue

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -205,7 +205,7 @@ queue_consume(struct ireq *iq, const void *fnd, int consumern)
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
                 iq->usedb->tablename, consumern);
-        if (db_is_stopped() || thedb->master != gbl_mynode)
+        if (db_requests_are_stopped() || thedb->master != gbl_mynode)
             return -1;
         sleep(sleeptime);
     }

--- a/db/glue.c
+++ b/db/glue.c
@@ -3081,7 +3081,7 @@ void backend_update_sync(struct dbenv *dbenv)
 void net_quiesce_threads(void *hndl, void *uptr, char *fromnode, int usertype,
                          void *dta, int dtalen, uint8_t is_tcp)
 {
-    stop_threads(thedb);
+    stop_request_threads(thedb);
     net_ack_message(hndl, 0);
 }
 

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -915,7 +915,7 @@ int handle_buf_main2(struct dbenv *dbenv, SBUF2 *sb, const uint8_t *p_buf,
     int numwriterthreads;
     struct dbq_entry_t *newent = NULL;
 
-    if (db_is_stopped()) {
+    if (db_is_stopped() || db_requests_are_stopped()) {
         return ERR_REJECTED;
     }
 

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -1045,7 +1045,7 @@ int javasp_unload_procedure(const char *name)
     if (rc)
         goto done;
     /* Stop everything */
-    stop_threads(thedb);
+    stop_request_threads(thedb);
     broadcast_quiesce_threads();
 
     if (rc == 0) {
@@ -1072,7 +1072,7 @@ int javasp_reload_procedure(const char *name, const char *jarfile,
 
     rc = javasp_load_procedure_int(name, param, NULL);
 
-    stop_threads(thedb);
+    stop_request_threads(thedb);
     broadcast_quiesce_threads();
 
     if (rc == 0) {

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -34,7 +34,7 @@ int consumer_change(const char *queuename, int consumern, const char *method)
     }
 
     /* Stop everything */
-    stop_threads(thedb);
+    stop_request_threads(thedb);
     broadcast_quiesce_threads();
 
     /* Do the change.  If it works locally then assume that it will work
@@ -130,7 +130,7 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize)
     /* why?  er... not sure.  this is copied off the pattern below, but we
      * don't have much to do.   think this is still good as we'll get a
      * memory sync in there. */
-    stop_threads(thedb);
+    stop_request_threads(thedb);
     resume_threads(thedb);
 
     if (newdb->dbenv->master == gbl_mynode) {

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -1447,7 +1447,7 @@ void change_schemas_recover(char *table)
     backout_schemas(table);
     live_sc_off(db);
 
-    if (db_is_stopped()) {
+    if (db_is_stopped() || db_requests_are_stopped()) {
         resume_threads(thedb);
     }
 }

--- a/sqlite/ext/comdb2/repl_stats.c
+++ b/sqlite/ext/comdb2/repl_stats.c
@@ -95,7 +95,7 @@ static int systblReplStatsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor)
     }
     memset(cur, 0, sizeof(*cur));
 
-    if (db_is_stopped())
+    if (db_is_stopped() || db_requests_are_stopped())
         return SQLITE_INTERNAL;
 
     cur->stats = bdb_get_repl_wait_and_net_stats(thedb->bdb_env, &cur->cluster_size);


### PR DESCRIPTION
This adds a less severe stop_threads that only stops request threads, not all database threads. 