### PR TITLE
Check a sequence's committed gen only if elect_highest_committed_gen …

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -865,6 +865,14 @@ void bdb_berkdb_iomap_set(bdb_state_type *bdb_state, int onoff)
     bdb_state->dbenv->setattr(bdb_state->dbenv, "iomap", NULL, onoff);
 }
 
+int bdb_berkdb_get_attr(bdb_state_type *bdb_state, char *attr, char **value,
+                        int *ivalue)
+{
+    int rc;
+    rc = bdb_state->dbenv->getattr(bdb_state->dbenv, attr, value, ivalue);
+    return rc;
+}
+
 int bdb_berkdb_set_attr(bdb_state_type *bdb_state, char *attr, char *value,
                         int ivalue)
 {

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1823,6 +1823,9 @@ int bdb_master_should_reject(bdb_state_type *bdb_state);
 
 void bdb_berkdb_iomap_set(bdb_state_type *bdb_state, int onoff);
 
+int bdb_berkdb_get_attr(bdb_state_type *bdb_state, char *attr, char **value,
+                        int *ivalue);
+
 int bdb_berkdb_set_attr(bdb_state_type *bdb_state, char *attr, char *value,
                         int ivalue);
 int bdb_berkdb_set_attr_after_open(bdb_attr_type *bdb_attr, char *attr,

--- a/bdb/bdb_net.c
+++ b/bdb/bdb_net.c
@@ -875,8 +875,10 @@ void send_coherency_leases(bdb_state_type *bdb_state, int lease_time,
             time_t now;
             if (gbl_verbose_send_coherency_lease &&
                 (now = time(NULL)) - lastpr) {
-                logmsg(LOGMSG_ERROR, "%s: not sending to %s\n", __func__,
-                       hostlist[i]);
+                logmsg(LOGMSG_ERROR,
+                       "%s: not sending to %s: "
+                       "master_is_coherent=%d\n",
+                       __func__, hostlist[i], master_is_coherent);
                 lastpr = now;
             }
         }


### PR DESCRIPTION
This PR fixes an issue with the enable_seqnum_generations tunable: got_new_seqnum_from_node refuses to change a node's coherency if the most recent committed generation is not equal to the master's current generation.  The bug is that the most recent committed generation is set only if the berkdb attribute, "elect_highest_committed_gen" is enabled.  Straightforward fix: check a sequence number's committed_gen only if elect_highest_committed_gen is enabled.
