### PR TITLE
Soften asserts, be more permissive in distributed commit

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -2758,8 +2758,8 @@ retry:
 
     if (rc == 0 && wait_for_seqnum) {
         int timeoutms;
-        rc = bdb_wait_for_seqnum_from_all_adaptive_newcoh(llmeta_bdb_state, &ss,
-                                                          0, &timeoutms);
+        rc = bdb_wait_for_seqnum_from_all_adaptive_newcoh(
+                llmeta_bdb_state->parent, &ss, 0, &timeoutms);
     }
     // rc = bdb_tran_commit(llmeta_bdb_state, tran, &bdberr);
     if (rc && bdberr != BDBERR_NOERROR) {


### PR DESCRIPTION
Simple changes that soften the schema-lk asserts- there are cases where we acquire the schema lock in read mode recursively.
