### PR TITLE
Adjust the expected number of deadlocks for the reorder test

### DIFF
--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -181,8 +181,8 @@ fi
 ddcount=`grep -c DEADLOCK $mlog`
 
 if [[ $DBNAME == *"noreordergenerated"* ]] ; then
-    if [[ $ddcount -lt 1000 ]] ; then
-        failexit 'no reorder expected to get more than 1000 deadlocks for this test'
+    if [[ $ddcount -lt 800 ]] ; then
+        failexit 'no reorder expected to get more than 800 deadlocks for this test'
     fi
 else
     if [[ $ddcount -gt 1000 ]] ; then


### PR DESCRIPTION
Pull request #2085 reduced changes of deadlocks. As a result the expected number of deadlocks in reorder_inserts_noreorder_generated becomes too high.