### PR TITLE
Quick-fix for sequences

### DIFF
--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -181,7 +181,7 @@ int bdb_queuedb_add(bdb_state_type *bdb_state, tran_type *tran, const void *dta,
             qfnd_seq.epoch = tran->trigger_epoch = comdb2_time_epoch();
         }
 
-        qfnd_seq.seq = 0;
+        qfnd_fnd.seq = 0;
 
         if (rc == 0) {
             p_buf = dbt_data.data;


### PR DESCRIPTION
Set an initial sequence to 0 rather than whatever happened to be on the stack.  I didn't notice this before because the stat command would always return the correct answer (subsequent sequence numbers just look at the previous and add one).  PR https://github.com/bloomberg/comdb2/pull/2143 providing persistent sequence numbers- contains the same fix.