### PR TITLE
Move dbqueudb_admin call to after the commit

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6082,7 +6082,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                                           request */
     }
     case OSQL_USEDB: {
-        osql_usedb_t dt;
+        osql_usedb_t dt = {0};
         p_buf_end = (uint8_t *)p_buf + sizeof(osql_usedb_t);
         const char *tablename;
 
@@ -6111,7 +6111,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         }
 
         if (gbl_enable_osql_logging) {
-            uuidstr_t us;
+            uuidstr_t us = {0};
             logmsg(LOGMSG_DEBUG, "[%llu %s] OSQL_USEDB %*.s\n", rqid,
                    comdb2uuidstr(uuid, us), dt.tablenamelen, tablename);
         }

--- a/db/osqlpfthdpool.c
+++ b/db/osqlpfthdpool.c
@@ -601,7 +601,7 @@ int osql_page_prefault(char *rpl, int rplen, struct dbtable **last_db,
 
     switch (rpl_op.type) {
     case OSQL_USEDB: {
-        osql_usedb_t dt;
+        osql_usedb_t dt = {0};
         p_buf = (uint8_t *)&((osql_usedb_rpl_t *)rpl)->dt;
         const char *tablename;
         struct dbtable *db;

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -648,10 +648,6 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         tran = NULL;
     }
 
-    if (sc->addonly || sc->alteronly) {
-        dbqueuedb_admin(thedb);
-    }
-
     /* log for replicants to do the same */
     if (!same_tran) {
         rc = bdb_llog_scdone(db->handle, scdone_type, 1, &bdberr);
@@ -716,6 +712,10 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         }
         tran = NULL;
         ltran = NULL;
+    }
+
+    if (sc->addonly || sc->alteronly) {
+        dbqueuedb_admin(thedb);
     }
 
 done:


### PR DESCRIPTION
'perform_trigger_update' was recently changed to use a single transaction.  This pr moves the dbqueuedb_admin to later in the function to a point after the transaction has written its commit record.
