### PR TITLE
Fix pmux copying to replicant nodes correctly

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -372,7 +372,7 @@ of comdb2 servers in those containers.
 
     You will also want to install inside the containers the required packages for comdb2 to run:
     ```sh
-      apt-get install libprotobuf-c1 libunwind8 libsqlite3-0
+      apt-get install libprotobuf-c1 libunwind8 libsqlite3-0 libevent-core-2.1 libevent-pthreads-2.1
     ```
 
 4.  At this time you will want to make copies of this container:

--- a/tests/tools/copy_files_to_cluster.sh
+++ b/tests/tools/copy_files_to_cluster.sh
@@ -54,7 +54,7 @@ copy_files_to_node() {
     trap "close_master_ssh_session \"closing\"" INT EXIT
       
     ssh $SSH_OPT $SSH_MSTR -MNf $node   #start master ssh session for node
-    ssh $SSH_OPT $SSH_MSTR $node "mkdir -p $d1 $d2 $d3 $TESTDIR/logs/ $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2" < /dev/null
+    ssh $SSH_OPT $SSH_MSTR $node "mkdir -p $d1 $d2 $d3 $d4 $TESTDIR/logs/ $TESTDIR/var/log/cdb2 $TESTDIR/tmp/cdb2" < /dev/null
 
     if [[ "$SKIP_COPY_EXE" != "1" ]] ; then
         scp $SSH_OPT $SSH_MSTR $COMDB2AR_EXE $node:$COMDB2AR_EXE


### PR DESCRIPTION
Fix pmux copying to replicant nodes correctly.
Directory was not created so in my containers pmux would not copy at all resulting in failed cluntered tests.