### PR TITLE
Add rollback test, correctly return rc

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -385,21 +385,20 @@ enum RCODES {
     ERR_NO_SUCH_TABLE = 310,  /* operation tried to use non-existant table */
     ERR_CALLBACK = 311,       /* operation failed due to errors in callback */
     ERR_TRAN_FAILED = 312,    /* could not start of finish transaction */
-    ERR_CONSTR =
-        313, /* could not complete the operation becouse of constraints in the
-                table */
-    ERR_SC_COMMIT =
-        314, /* schema change in its final stages; proxy should retry */
+    ERR_CONSTR = 313,         /* could not complete the operation because of
+                                 constraints in the table */
+    ERR_SC_COMMIT = 314,      /* schema change in its final stages;
+                                 proxy should retry */
     ERR_CONFIG_FAILED = 316,
     ERR_NO_RECORDS_FOUND = 317,
     ERR_NULL_CONSTRAINT = 318,
     ERR_VERIFY_PI = 319,
     ERR_CHECK_CONSTRAINT = 320,
-    ERR_UNCOMMITABLE_TXN =
-        404, /* txn is uncommitable, returns ERR_VERIFY rather than retry */
+    ERR_UNCOMMITABLE_TXN = 404, /* txn is uncommitable, returns ERR_VERIFY
+                                   rather than retry */
     ERR_QUERY_REJECTED = 451,
-    ERR_INCOHERENT =
-        996, /* prox2 understands it should retry another node for 996 */
+    ERR_INCOHERENT = 996, /* prox2 understands it should retry another
+                             node for 996 */
     ERR_SQL_PREPARE = 1003,
     ERR_NO_AUXDB = 2000,    /* requested auxiliary database not available */
     ERR_SQL_PREP = 2001,    /* block sql error in sqlite3_prepare */
@@ -439,15 +438,14 @@ enum DB_METADATA {
                                when a schema was loaded.  key is a schema
                                version number. */
 
-    META_BLOBSTRIPE_GENID_RRN =
-        -3, /* in this rrn we store the genid of the table
-               when it was converted to blobstripe */
+    META_BLOBSTRIPE_GENID_RRN = -3, /* in this rrn store the genid of table
+                                       when it was converted to blobstripe */
 
     META_STUFF_RRN = -4, /* used by pushlogs.c to do "stuff" to the database
                            until we get past a given lsn. */
-    META_ONDISK_HEADER_RRN = -5, /* do we have the new ondisk header? */
-    META_COMPRESS_RRN =
-        -6, /* which compression algorithm to use for new records (if any) */
+    META_ONDISK_HEADER_RRN = -5,  /* do we have the new ondisk header? */
+    META_COMPRESS_RRN = -6,       /* which compression algorithm to use for new
+                                     records (if any) */
     META_COMPRESS_BLOBS_RRN = -7, /* and which to use for blobs. */
     META_FILEVERS = -8,           /* 64 bit id for filenames */
     META_FILE_LWM = -9,           /* int - lower deleteable log file */

--- a/tests/basic.test/Makefile
+++ b/tests/basic.test/Makefile
@@ -4,7 +4,16 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+  export TEST_TIMEOUT=1m
+endif
+
+ifneq (,$(findstring singlenode_generated,$(TESTCASE)))
+  # var TESTCASE contains substring singlenode_generated
+  # note that could have put this as a rule in the parent directory's Makefile:
+  #%singlenode_generated: basicops
+  #	@$(MAKE) CLUSTER=$(word 1,$(CLUSTER)) -skC $(TESTDIR)/$@.test
+  CLUSTER_SV := $(word 1,$(CLUSTER))
+  override CLUSTER := $(CLUSTER_SV)
 endif
 
 tool:

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -264,14 +264,37 @@ select count(*) from t1
 select count(*) from t2
 select count(*) from t2 where i = 1
 commit" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans1.txt
+echo "[begin] rc 0
+(count(*)=0)
+[select count(*) from t1] rc 0
+(count(*)=2)
+[select count(*) from t2] rc 0
+(count(*)=1)
+[select count(*) from t2 where i = 1] rc 0
+[commit] rc 0" > trans1.exp 
+if ! diff trans1.txt trans1.exp ; then
+    failexit "trans1.txt does not match expected"
+fi
 
 # test transaction of diff sizes
 echo "begin
 commit" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans0.txt
+echo "[begin] rc 0
+[commit] rc 0" > trans0.exp
+if ! diff trans0.txt trans0.exp ; then
+    failexit "trans0.txt does not match expected"
+fi
+
 
 echo "begin
 insert into t2 values(3)
 commit" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans2.txt
+echo "[begin] rc 0
+[insert into t2 values(3)] rc 0
+[commit] rc 0" > trans2.exp
+if ! diff trans2.txt trans2.exp ; then
+    failexit "trans2 does not match expected"
+fi
 
 assertcnt t2 3
 
@@ -279,6 +302,13 @@ echo "begin
 insert into t2 values(4)
 insert into t2 values(5)
 commit" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans3.txt
+echo "[begin] rc 0
+[insert into t2 values(4)] rc 0
+[insert into t2 values(5)] rc 0
+[commit] rc 0" > trans3.exp
+if ! diff trans3.txt trans3.exp ; then
+    failexit "trans3 does not match expected"
+fi
 
 assertcnt t2 5
 
@@ -287,6 +317,14 @@ insert into t2 values(6)
 insert into t2 values(7)
 insert into t2 values(8)
 commit" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans4.txt
+echo "[begin] rc 0
+[insert into t2 values(6)] rc 0
+[insert into t2 values(7)] rc 0
+[insert into t2 values(8)] rc 0
+[commit] rc 0" > trans4.exp
+if ! diff trans4.txt trans4.exp ; then
+    failexit "trans4 does not match expected"
+fi
 
 assertcnt t2 8
 
@@ -294,13 +332,26 @@ assertcnt t2 8
 echo "begin
 insert into t2 values(9)
 rollback" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans5.txt
+echo "[begin] rc 0
+[insert into t2 values(9)] rc 0
+[rollback] rc 0" > trans5.exp
+if ! diff trans5.txt trans5.exp ; then
+    failexit "trans5 does not match expected"
+fi
 
 assertcnt t2 8
 
 echo "begin
 insert into t2 values(9)
 insert into t2 values(10)
-rollback" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans5.txt
+rollback" | cdb2sql ${CDB2_OPTIONS} $dbnm default &> trans6.txt
+echo "[begin] rc 0
+[insert into t2 values(9)] rc 0
+[insert into t2 values(10)] rc 0
+[rollback] rc 0" > trans6.exp
+if ! diff trans6.txt trans6.exp ; then
+    failexit "trans6 does not match expected"
+fi
 
 assertcnt t2 8
 


### PR DESCRIPTION
    - Add rollback checking output to basic.test
    - in osql_sess_rcvop() perr can be uninitialized so we should not derefetence
      it if is_msg_done is false, thus on failure only return rc
    - add ability to run test in single node even when CLUSTER is specified
      by just having a file singlenode.testopts in test directory.
