### PR TITLE
Fix bulk-import in R7

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -7118,6 +7118,8 @@ int reload_after_bulkimport(dbtable *db, tran_type *tran)
     }
     db->tableversion = table_version_select(db, NULL);
     update_dbstore(db);
+    create_sqlmaster_records(tran);
+    create_sqlite_master();
     return 0;
 }
 


### PR DESCRIPTION
Port 185f8bad1e592413839231600c2e4b2ac2000d9a to R7 - the calls to create_sqmaster_records and create_sqlite_master are required to advertise the new table definitions to sqlite.  This passes robomark testing because the sql executes against a replicant, and the reload_sqlite_master is called directly from scdone_callback.