### PR TITLE
sqlitex: fix column names for stored proc (7.0)

### DIFF
--- a/bbinc/comdb2_query_preparer.h
+++ b/bbinc/comdb2_query_preparer.h
@@ -18,8 +18,8 @@
 #define __INCLUDED_QUERY_PREPARER_H
 
 struct comdb2_query_preparer {
-    int (*do_prepare)(struct sqlthdstate *, struct sqlclntstate *,
-                      const char *);
+    int (*do_prepare)(struct sqlthdstate *, struct sqlclntstate *, const char *,
+                      char ***, int *);
     int (*do_cleanup)(struct sqlclntstate *);
     int (*sqlitex_is_initializing)(void *);
     char *(*sqlitex_table_name)(void *);

--- a/db/db_fingerprint.c
+++ b/db/db_fingerprint.c
@@ -70,23 +70,6 @@ void calc_fingerprint(const char *zNormSql, size_t *pnNormSql,
     MD5Final(fingerprint, &ctx);
 }
 
-static int compare_column_names(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
-{
-    if (gbl_old_column_names == 0 || clnt->old_columns_count == 0 ||
-        (sqlite3_column_count(stmt) == 0)) {
-        // do nothing
-        return 0;
-    }
-
-    assert(clnt->old_columns_count == sqlite3_column_count(stmt));
-
-    for (int i = 0; i < clnt->old_columns_count; i++) {
-        if (strcmp(sqlite3_column_name(stmt, i), clnt->old_columns[i]))
-            return 1; // mismatch!
-    }
-    return 0;
-}
-
 void add_fingerprint(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
                      const char *zSql, const char *zNormSql, int64_t cost,
                      int64_t time, int64_t nrows, struct reqlogger *logger,
@@ -146,7 +129,7 @@ void add_fingerprint(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
                    fp, zSql, t->zNormSql);
         }
 
-        if (gbl_old_column_names && compare_column_names(clnt, stmt)) {
+        if (gbl_old_column_names && !stmt_do_column_names_match(stmt)) {
             logmsg(LOGMSG_USER,
                    "COLUMN NAME MISMATCH DETECTED! Use 'AS' clause to keep "
                    "column names stable, fp:%s "

--- a/db/sql.h
+++ b/db/sql.h
@@ -677,9 +677,6 @@ struct sqlclntstate {
     int hinted_cursors_alloc;
     int hinted_cursors_used;
 
-    int old_columns_count;
-    char **old_columns;
-
     /* remote settings, used in run_sql */
     sqlclntstate_fdb_t fdb_state;
 
@@ -1268,6 +1265,4 @@ struct query_count {
 void add_fingerprint_to_rawstats(struct rawnodestats *stats,
                                  unsigned char *fingerprint, int cost, int rows,
                                  int timems);
-const char *comdb2_column_name(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                               int index);
 #endif /* _SQL_H_ */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2790,6 +2790,7 @@ static void get_cached_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     if (gbl_enable_sql_stmt_caching == STMT_CACHE_PARAM &&
         param_count(clnt) == 0)
         return;
+    /* NC: Do we use this? */
     if (extract_sqlcache_hint(rec->sql, rec->cache_hint, HINT_LEN)) {
         rec->status = CACHE_HAS_HINT;
         if (find_stmt_table(thd, rec->cache_hint, &rec->stmt_entry) == 0) {
@@ -3060,21 +3061,6 @@ static void normalize_stmt_and_store(
   }
 }
 
-const char *comdb2_column_name(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                               int index)
-{
-    if (gbl_old_column_names == 0 || clnt->old_columns_count == 0) {
-        return sqlite3_column_name(stmt, index);
-    }
-
-    if (index > (clnt->old_columns_count - 1)) {
-        logmsg(LOGMSG_ERROR, "%s:%d bad column index %d\n", __func__, __LINE__,
-               index);
-        return 0;
-    }
-    return clnt->old_columns[index];
-}
-
 /**
  * Get a sqlite engine, either from cache or building a new one
  * Locks tables to prevent any schema changes for them
@@ -3112,7 +3098,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
 
     const char *tail = NULL;
 
-    /* if we did not get a cached stmt, need to prepare it in sql engine */
+    /* If we did not get a cached stmt, need to prepare it in sql engine */
     while (rec->stmt == NULL) {
         clnt->no_transaction = 1;
         thd->authState.clnt = clnt;
@@ -3123,14 +3109,18 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         clnt->prep_rc = rc = sqlite3_prepare_v3(thd->sqldb, rec->sql, -1,
                                                 sqlPrepFlags, &rec->stmt, &tail);
 
+        /* Prepare the query with the query_preparer plugin. */
         if (rc == SQLITE_OK && gbl_old_column_names && query_preparer_plugin &&
-            query_preparer_plugin->do_prepare &&
-            sqlite3_stmt_readonly(rec->stmt) &&
-            !sqlite3_stmt_isexplain(rec->stmt) &&
-            (thd->authState.numDdls == 0)) {
-            rc = query_preparer_plugin->do_prepare(thd, clnt, rec->sql);
+            query_preparer_plugin->do_prepare && sqlite3_stmt_readonly(rec->stmt) &&
+            !sqlite3_stmt_isexplain(rec->stmt) && (thd->authState.numDdls == 0)) {
+            char **column_names;
+            int column_count;
+            rc = query_preparer_plugin->do_prepare(thd, clnt, rec->sql,
+                                                   &column_names, &column_count);
             if (rc)
                 return rc;
+            if (rec->stmt)
+                stmt_set_cached_columns(rec->stmt, column_names, column_count);
         }
 
         thd->authState.flags = 0;
@@ -3147,6 +3137,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         sql_remote_schema_changed(clnt, rec->stmt);
         update_schema_remotes(clnt, rec);
     }
+
     if (rec->stmt) {
         normalize_stmt_and_store(clnt, rec);
         sqlite3_resetclock(rec->stmt);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -640,8 +640,7 @@ char *sp_column_name(struct response_data *arg, int col)
     if (parent->clntname[col] == NULL) {
         sqlite3_stmt *stmt = arg->stmt;
         if (stmt) {
-            parent->clntname[col] = strdup(comdb2_column_name(arg->sp->clnt,
-                                                              stmt, col));
+            parent->clntname[col] = strdup(sqlite3_column_name(stmt, col));
         } else {
             size_t n = snprintf(NULL, 0, "$%d", col);
             char *name = malloc(n + 1);
@@ -1329,9 +1328,9 @@ static int lua_sql_step(Lua lua, sqlite3_stmt *stmt)
         }
         default:
             return luaL_error(lua, "unknown field type:%d for col:%s",
-                              type, comdb2_column_name(clnt, stmt, col));
+                              type, sqlite3_column_name(stmt, col));
         }
-        lua_setfield(lua, -2, comdb2_column_name(clnt, stmt, col));
+        lua_setfield(lua, -2, sqlite3_column_name(stmt, col));
     }
     return rc;
 }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -500,7 +500,7 @@ static int newsql_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
     for (int i = 0; i < ncols; ++i) {
         value[i] = &cols[i];
         cdb2__sqlresponse__column__init(&cols[i]);
-        const char *name = comdb2_column_name(clnt, stmt, i);
+        const char *name = sqlite3_column_name(stmt, i);
         size_t len = strlen(name) + 1;
         ADJUST_LONG_COL_NAME(name, len);
         cols[i].value.data = (uint8_t *)name;
@@ -784,7 +784,7 @@ static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
                 char *e =
                     "failed to convert sqlite to client datetime for field";
                 errstat_set_rcstrf(arg->err, ERR_CONVERSION_DT, "%s \"%s\"", e,
-                                   comdb2_column_name(clnt, stmt, i));
+                                   sqlite3_column_name(stmt, i));
                 return -1;
             }
             if (flip) {

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4841,6 +4841,9 @@ int sqlite3_reset(sqlite3_stmt *pStmt);
 int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
+
+void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4841,6 +4841,9 @@ SQLITE_API int sqlite3_reset(sqlite3_stmt *pStmt);
 SQLITE_API int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
+
+void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -581,6 +581,8 @@ struct Vdbe {
   struct timespec tspec;  /* time of prepare, used for stable now() */
   u8 oeFlag;              /* ON CONFLICT action */
   u8 upsertIdx;           /* ON CONFLICT target */
+  char **oldColNames;     /* Column names returned by old-sqlite version */
+  int oldColCount;        /* Column count (refer: sqlitex)*/
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -91,6 +91,81 @@ static SQLITE_NOINLINE void invokeProfileCallback(sqlite3 *db, Vdbe *p){
 # define checkProfileCallback(DB,P)  /*no-op*/
 #endif
 
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+extern int gbl_old_column_names;
+
+static char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
+  char **column_names;
+  Vdbe *vdbe = (Vdbe *)pStmt;
+
+  if (!vdbe) {
+    logmsg(LOGMSG_ERROR, "%s:%d stmt handle not set\n", __func__, __LINE__);
+    return 0;
+  }
+  column_names = vdbe->oldColNames;
+  return column_names[index];
+}
+
+static inline int stmt_cached_column_count(sqlite3_stmt *pStmt) {
+  Vdbe *vdbe = (Vdbe *)pStmt;
+  return (vdbe) ? vdbe->oldColCount : 0;
+}
+
+static void stmt_free_column_names(sqlite3_stmt *pStmt) {
+  Vdbe *vdbe;
+  int column_count;
+  int i;
+  char **column_names;
+
+  vdbe = (Vdbe *)pStmt;
+  if (!vdbe)
+    return;
+
+  column_names = vdbe->oldColNames;
+  column_count = vdbe->oldColCount;
+  for(i=0; i<column_count; i++) {
+    free(column_names[i]);
+  }
+  free(column_names);
+
+  vdbe->oldColNames = 0;
+  vdbe->oldColCount = 0;
+}
+
+void stmt_set_cached_columns(sqlite3_stmt *pStmt, char **column_names,
+                             int column_count) {
+  Vdbe *vdbe = (Vdbe *)pStmt;
+
+  /* Free current cached names (if any) */
+  stmt_free_column_names(pStmt);
+
+  vdbe->oldColNames = column_names;
+  vdbe->oldColCount = column_count;
+}
+
+int stmt_do_column_names_match(sqlite3_stmt *pStmt) {
+  int cached_column_count;
+  int i;
+
+  if( gbl_old_column_names==0 || (stmt_cached_column_count(pStmt)==0) ||
+      (sqlite3_column_count(pStmt)==0) ){
+    return 1;
+  }
+
+  cached_column_count = stmt_cached_column_count(pStmt);
+  assert(cached_column_count == sqlite3_column_count(pStmt));
+
+  for(i=0; i<cached_column_count; i++){
+    if( (strcmp(sqlite3_column_name(pStmt, i),
+                stmt_cached_column_name(pStmt, i)))!=0 ) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+
 /*
 ** The following routine destroys a virtual machine that is created by
 ** the sqlite3_compile() routine. The integer returned is an SQLITE_
@@ -108,6 +183,11 @@ int sqlite3_finalize(sqlite3_stmt *pStmt){
     rc = SQLITE_OK;
   }else{
     Vdbe *v = (Vdbe*)pStmt;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    if (gbl_old_column_names && (stmt_cached_column_count(pStmt)>0)){
+      stmt_free_column_names(pStmt);
+    }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     sqlite3 *db = v->db;
     if( vdbeSafety(v) ) return SQLITE_MISUSE_BKPT;
     sqlite3_mutex_enter(db->mutex);
@@ -1334,6 +1414,13 @@ static const void *columnName(
     N += useType*n;
     sqlite3_mutex_enter(db->mutex);
     assert( db->mallocFailed==0 );
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    if( gbl_old_column_names && useUtf16 == 0 && useType == COLNAME_NAME &&
+        stmt_cached_column_count(pStmt)>0 ){
+      assert(N<=stmt_cached_column_count(pStmt));
+      ret = stmt_cached_column_name(pStmt, N);
+    }else
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifndef SQLITE_OMIT_UTF16
     if( useUtf16 ){
       ret = sqlite3_value_text16((sqlite3_value*)&p->aColName[N]);


### PR DESCRIPTION
* cache old column names in sqlite3_stmt
* remove comdb2_column_name(); logic moved to columName()
* minor change in plugin API
* also fixes a bug with statement caching

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>

/plugin-branch comdb2-sqlitex-sp-fix-7.0