### PR TITLE
Keep all of a transactions queue operations in a temptable

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1389,6 +1389,8 @@ struct ireq {
      * we'll have to wake up all queues on commit - oh well. */
     unsigned num_queues_hit;
 
+    struct temp_table *dbq_adds;
+
     /* Number of oplog operations logged as part of this transaction */
     int oplog_numops;
     int seqlen;
@@ -1416,6 +1418,9 @@ struct ireq {
     bool sc_should_abort : 1;
     bool sc_closed_files : 1;
 
+    bool deferred_dbq_adds : 1;
+
+    int dbq_deferred_add_count;
     int written_row_count;
     int sc_running;
     /* REVIEW COMMENTS AT BEGINING OF STRUCT BEFORE ADDING NEW VARIABLES */
@@ -2496,6 +2501,9 @@ int lite_get_keys_auxdb(int auxdb, struct ireq *iq, void *firstkey,
 /* queue databases */
 struct bdb_queue_found;
 struct bdb_queue_cursor;
+int dbq_deferred_adds(struct ireq *iq, void *trans);
+int dbq_deferred_truncate(struct ireq *iq);
+int dbq_deferred_close(struct ireq *iq);
 int dbq_add(struct ireq *iq, void *trans, const void *dta, size_t dtalen);
 int dbq_consume(struct ireq *iq, void *trans, int consumer,
                 const struct bdb_queue_found *fnd);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -324,6 +324,7 @@ extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int eventlog_nkeep;
+extern int gbl_deferred_dbq_adds;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1931,4 +1931,10 @@ REGISTER_TUNABLE("debug_queuedb",
                  TUNABLE_BOOLEAN, &gbl_debug_queuedb, EXPERIMENTAL, NULL, NULL,
                  NULL, NULL);
 
+REGISTER_TUNABLE("deferred_queuedb_adds",
+                 "Defer dbqueue operations until after osql processing.  "
+                 "(Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_deferred_dbq_adds, EXPERIMENTAL, NULL,
+                 NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/glue.c
+++ b/db/glue.c
@@ -5115,20 +5115,186 @@ int lite_del_auxdb(int auxdb, struct ireq *iq, void *trans, void *key)
 /*         QUEUE DATABASES           */
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
+struct deferred_queue_add_key {
+    int ix;
+    char name[1];
+};
+
+static int dbq_queue_key_cmp(void *usermem, int key1len, const void *key1,
+        int key2len, const void *key2)
+{
+    int cmp;
+    struct deferred_queue_add_key *k1 = (struct deferred_queue_add_key *)key1;
+    struct deferred_queue_add_key *k2 = (struct deferred_queue_add_key *)key2;
+    char *n1 = (char *)k1->name;
+    char *n2 = (char *)k2->name;
+    if ((cmp = strcmp(n1, n2)))
+        return cmp;
+    return (k2->ix - k1->ix);
+}
+
+static int dbq_save_add(struct ireq *iq, void *tran, const void *dta,
+        size_t dtalen)
+{
+    int rc = 0, bdberr = 0;
+    struct dbtable *qdb = iq->usedb;
+    void *bdb_handle = get_bdb_handle_ireq(iq, AUXDB_NONE);
+    struct deferred_queue_add_key *k;
+
+
+    if (!bdb_handle)
+        return ERR_NO_AUXDB;
+
+    rc = bdb_lock_table_read(bdb_handle, tran);
+    if (rc == BDBERR_DEADLOCK)  {
+        logmsg(LOGMSG_ERROR, "%s deadlock locking %s\n", __func__,
+                qdb->tablename);
+        return RC_INTERNAL_RETRY;
+    }
+    else if (rc)
+        return map_unhandled_bdb_wr_rcode("dbq_save_add", rc);
+
+    if (iq->dbq_adds == NULL) {
+        iq->dbq_adds = bdb_temp_table_create(thedb->bdb_env, &bdberr);
+        if (!iq->dbq_adds) {
+            logmsg(LOGMSG_ERROR, "*ERROR* failed create dbq_adds table, %d\n",
+                    bdberr);
+            return map_unhandled_bdb_wr_rcode("dbq_save_add", bdberr);
+        }
+        bdb_temp_table_set_cmp_func(iq->dbq_adds, dbq_queue_key_cmp);
+    }
+
+    int klen = offsetof(struct deferred_queue_add_key, name) +
+        strlen(qdb->tablename) + 1;
+    k = alloca(klen);
+    k->ix = iq->dbq_deferred_add_count++;
+    strcpy(k->name, qdb->tablename);
+
+    rc = bdb_temp_table_put(thedb->bdb_env, iq->dbq_adds, k, klen, (void *)dta,
+            dtalen, NULL, &bdberr);
+
+    if (bdberr == 0)
+        return 0;
+
+    return map_unhandled_bdb_wr_rcode("dbq_save_add", bdberr);
+}
+
+int dbq_deferred_truncate(struct ireq *iq)
+{
+    int bdberr = 0, rc = 0;
+    if (!iq->deferred_dbq_adds || !iq->dbq_adds)
+        return 0;
+    rc = bdb_temp_table_truncate(thedb->bdb_env, iq->dbq_adds, &bdberr);
+    iq->dbq_deferred_add_count = 0;
+    if (bdberr || rc)
+        return (bdberr || rc);
+    return 0;
+}
+
+int dbq_deferred_close(struct ireq *iq)
+{
+    int bdberr = 0, rc = 0;
+    if (!iq->deferred_dbq_adds || !iq->dbq_adds)
+        return 0;
+    rc = bdb_temp_table_close(thedb->bdb_env, iq->dbq_adds, &bdberr);
+    iq->dbq_adds = NULL;
+    iq->dbq_deferred_add_count = 0;
+    if (bdberr || rc)
+        return (bdberr || rc);
+    return 0;
+}
+
+int dbq_deferred_adds(struct ireq *iq, void *trans)
+{
+    struct temp_cursor *cur;
+    struct dbtable *qdb = NULL;
+    void *bdb_handle;
+    int bdberr = 0, close_err = 0, rc;
+    unsigned long long unused;
+
+    if (!iq->deferred_dbq_adds || !iq->dbq_adds)
+        return 0;
+
+    cur = bdb_temp_table_cursor(thedb->bdb_env, iq->dbq_adds, NULL,
+            &bdberr);
+    if (cur == NULL) {
+        logmsg(LOGMSG_ERROR, "%s failed create temptable cursor, %d\n",
+                __func__, bdberr);
+        return map_unhandled_bdb_wr_rcode("dbq_deferred_adds", bdberr);
+    }
+
+    rc = bdb_temp_table_first(thedb->bdb_env, cur, &bdberr);
+    while (rc == 0) {
+        struct deferred_queue_add_key *k = bdb_temp_table_key(cur);
+        char *name = k->name;
+        void *dta = bdb_temp_table_data(cur);
+        size_t dtalen = bdb_temp_table_datasize(cur);
+
+        if (!qdb || strcmp(qdb->tablename, name))
+            qdb = getqueuebyname(name);
+
+        if (!qdb) {
+            logmsg(LOGMSG_ERROR, "%s failed to locate queuedb %s\n", __func__,
+                    name);
+            rc = bdb_temp_table_next(thedb->bdb_env, cur, &bdberr);
+            continue;
+        }
+
+        iq->usedb = qdb;
+        bdb_handle = get_bdb_handle_ireq(iq, AUXDB_NONE);
+
+        if (!bdb_handle) {
+            logmsg(LOGMSG_ERROR, "%s failed acquire handle for %s\n", __func__,
+                    name);
+            rc = bdb_temp_table_next(thedb->bdb_env, cur, &bdberr);
+            continue;
+        }
+
+        iq->gluewhere = "bdb_queue_add";
+        bdb_queue_add(bdb_handle, trans, dta, dtalen, &bdberr, &unused);
+        iq->gluewhere = "bdb_queue_add done";
+
+        if (bdberr != 0) {
+            logmsg(LOGMSG_ERROR, "%s bdb_queue_add returns %d\n",
+                    __func__, bdberr);
+            break;
+        }
+
+        rc = bdb_temp_table_next(thedb->bdb_env, cur, &bdberr);
+    }
+
+    rc = bdb_temp_table_close_cursor(thedb->bdb_env, cur, &close_err);
+
+    if (!bdberr && (close_err || rc))
+        bdberr = (close_err || rc);
+    if (bdberr == 0)
+        return 0;
+    if (bdberr == BDBERR_DEADLOCK)
+        return RC_INTERNAL_RETRY;
+    if (bdberr == BDBERR_READONLY)
+        return ERR_NOMASTER;
+    if (bdberr == BDBERR_ADD_DUPE)
+        return IX_DUP;
+    return map_unhandled_bdb_wr_rcode("bdb_queue_add", bdberr);
+}
+
 int dbq_add(struct ireq *iq, void *trans, const void *dta, size_t dtalen)
 {
     int bdberr;
     void *bdb_handle;
     unsigned long long genid;
+    struct dbtable *qdb = iq->usedb;
     bdb_handle = get_bdb_handle_ireq(iq, AUXDB_NONE);
     if (!bdb_handle)
         return ERR_NO_AUXDB;
+    if (iq->deferred_dbq_adds && qdb->dbtype == DBTYPE_QUEUEDB) {
+        return dbq_save_add(iq, trans, dta, dtalen);
+    }
     iq->gluewhere = "bdb_queue_add";
     bdb_queue_add(bdb_handle, trans, dta, dtalen, &bdberr, &genid);
     iq->gluewhere = "bdb_queue_add done";
 
     if (bdberr == 0) {
-        struct dbtable *qdb = iq->usedb;
         if (qdb->dbtype == DBTYPE_QUEUEDB) {
             return 0;
         }

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -774,6 +774,7 @@ int handle_buf(struct dbenv *dbenv, uint8_t *p_buf, const uint8_t *p_buf_end,
 int handled_queue;
 
 int q_reqs_len(void) { return q_reqs.count; }
+int gbl_deferred_dbq_adds = 1;
 
 static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
                             uint8_t *p_buf, const uint8_t *p_buf_end, int debug,
@@ -803,6 +804,7 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     iq->debug_now = iq->nowus = nowus;
     iq->dbenv = dbenv;
     iq->fwd_tag_rqid = rqid;
+    iq->deferred_dbq_adds = gbl_deferred_dbq_adds;
 
     iq->p_buf_orig =
         p_buf; /* need this for optimized fast fail (skip blkstate) */

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -430,6 +430,9 @@ int handle_ireq(struct ireq *iq)
         }
     }
 
+    /* Close deferred-queue temptable */
+    dbq_deferred_close(iq);
+
     /* Finish off logging. */
     if (iq->sorese) {
         osql_sess_reqlogquery(iq->sorese, iq->reqlogger);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2688,6 +2688,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     if (lrc)
         return lrc;
 
+    dbq_deferred_truncate(iq);
+
     uint64_t strt = comdb2_time_epochus();
     reqlog_set_queue_time(iq->reqlogger, strt - iq->startus);
     reqlog_set_startprcs(iq->reqlogger, strt);
@@ -4895,6 +4897,18 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     } /* end delayed */
     else {
         ++gbl_delayed_skip;
+    }
+
+    if (iq->deferred_dbq_adds && iq->dbq_adds) {
+        rc = dbq_deferred_adds(iq, trans);
+        if (rc != 0) {
+            err.blockop_num = 0;
+            err.errcode = rc;
+            err.ixnum = -1;
+            numerrs = 1;
+            reqlog_set_error(iq->reqlogger, "Deferred queue add error", rc);
+            GOTOBACKOUT;
+        }
     }
 
     if (gbl_replicate_local && iq->oplog_numops > 0) {


### PR DESCRIPTION
Enqueuing an item to a queuedb type queue will block all other transactions attempting to add to the same queue.  This pull requests attempts to minimize the amount of time that a transaction will maintain a lock on the queue by deferring all of the queue processing to the end of the transaction.
