### PR TITLE
Experimental changes to detect 'stuck' clients...

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -243,6 +243,9 @@ extern int gbl_abort_on_illegal_log_put;
 extern int gbl_sc_close_txn;
 extern int gbl_master_sends_query_effects;
 extern int gbl_dump_sql_on_repwait_sec;
+extern int gbl_client_queued_slow_seconds;
+extern int gbl_client_running_slow_seconds;
+extern int gbl_client_abort_on_slow;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1960,4 +1960,21 @@ REGISTER_TUNABLE("dump_sql_on_repwait_sec",
                  "Dump sql queries that are blocking the replication thread "
                  "for more than this duration (Default: 10secs)",
                  TUNABLE_INTEGER, &gbl_dump_sql_on_repwait_sec, EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("client_queued_slow_seconds",
+                 "If a client connection remains \"queued\" longer than this "
+                 "period of time (in seconds), it is considered to be \"slow\", "
+                 "which may trigger an action by the watchdog.  (Default: off)",
+                 TUNABLE_INTEGER, &gbl_client_queued_slow_seconds,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("client_running_slow_seconds",
+                 "If a client connection remains \"running\" longer than this "
+                 "period of time (in seconds), it is considered to be \"slow\", "
+                 "which may trigger an action by the watchdog.  (Default: off)",
+                 TUNABLE_INTEGER, &gbl_client_running_slow_seconds,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("client_abort_on_slow",
+                 "Enable watchdog to abort if a \"slow\" client is detected."
+                 "  (Default: off)", TUNABLE_BOOLEAN, &gbl_client_abort_on_slow,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -1280,6 +1280,7 @@ long long run_sql_thd_return_ll(const char *query, struct sql_thread *thd,
 
 /* Connection tracking */
 int gather_connection_info(struct connection_info **info, int *num_connections);
+void free_connection_info(struct connection_info *info, int num_connections);
 void clnt_change_state(struct sqlclntstate *clnt, enum connection_state state);
 void clnt_register(struct sqlclntstate *clnt);
 void clnt_unregister(struct sqlclntstate *clnt);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -7027,6 +7027,10 @@ int gather_connection_info(struct connection_info **info, int *num_connections) 
    Pthread_mutex_lock(&clnt_lk);
    *num_connections = listc_size(&clntlist);
    c = malloc(*num_connections * sizeof(struct connection_info));
+   if (c == NULL) {
+       Pthread_mutex_unlock(&clnt_lk);
+       return -1;
+   }
    struct sqlclntstate *clnt;
    LISTC_FOR_EACH(&clntlist, clnt, lnk) {
        c[cid].connection_id = clnt->connid;
@@ -7053,6 +7057,16 @@ int gather_connection_info(struct connection_info **info, int *num_connections) 
    Pthread_mutex_unlock(&clnt_lk);
    *info = c;
    return 0;
+}
+
+void free_connection_info(struct connection_info *info, int num_connections)
+{
+    if (info == NULL) return;
+    for (int i = 0; i < num_connections; i++) {
+        if (info[i].sql) free(info[i].sql);
+        /* state is static, don't free */
+    }
+    free(info);
 }
 
 static int internal_write_response(struct sqlclntstate *a, int b, void *c, int d)

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -82,6 +82,10 @@
 #include "views.h"
 #include <logmsg.h>
 
+int gbl_client_queued_slow_seconds = 0;
+int gbl_client_running_slow_seconds = 0;
+int gbl_client_abort_on_slow = 0;
+
 extern int gbl_watcher_thread_ran;
 
 static void *watchdog_thread(void *arg);
@@ -352,6 +356,58 @@ static void *watchdog_thread(void *arg)
                     logmsg(LOGMSG_WARN, "Failed to restart timepartitions rc=%d!\n",
                             rc);
                 }
+            }
+        }
+
+        if ((gbl_client_queued_slow_seconds > 0) ||
+            (gbl_client_running_slow_seconds > 0)) {
+            struct connection_info *conn_infos = NULL;
+            int conn_count = 0;
+            if ((rc = gather_connection_info(&conn_infos, &conn_count)) == 0) {
+                int slow_count = 0;
+                int conn_time_now = comdb2_time_epochms();
+                for (int cid = 0; cid < conn_count; cid++) {
+                    struct connection_info *conn_info = &conn_infos[cid];
+                    const char *zState = NULL;
+                    int slow_seconds = 0;
+                    switch (conn_info->state_int) {
+                        case CONNECTION_QUEUED:
+                            zState = "QUEUED";
+                            slow_seconds = gbl_client_queued_slow_seconds;
+                            break;
+                        case CONNECTION_RUNNING:
+                            zState = "RUNNING";
+                            slow_seconds = gbl_client_running_slow_seconds;
+                            break;
+                    }
+                    if ((zState != NULL) && (slow_seconds > 0)) {
+                        int state_time = conn_info->time_in_state_int;
+                        int diff_seconds = (conn_time_now - state_time) / 1000;
+                        if ((diff_seconds < 0) || (diff_seconds > slow_seconds)) {
+                            logmsg((diff_seconds > 0) && gbl_client_abort_on_slow ?
+                                           LOGMSG_FATAL : LOGMSG_ERROR,
+                                   "%s: client #%lld has been in state %s for "
+                                   "%d seconds (>%d): connect_time %0.2f "
+                                   "seconds, raw_time_in_state %d, host {%s}, "
+                                   "pid %lld, sql {%s}\n", __func__,
+                                   (long long int)conn_info->connection_id,
+                                   zState, diff_seconds, slow_seconds,
+                                   difftime(conn_info->connect_time_int, (time_t)0),
+                                   conn_info->time_in_state_int, conn_info->host,
+                                   (long long int)conn_info->pid, conn_info->sql);
+                             /* NOTE: Do not count negative seconds here... */
+                             if (diff_seconds > 0) slow_count++;
+                        }
+                    }
+                }
+                free_connection_info(conn_infos, conn_count);
+                if (slow_count > 0) {
+                    bdb_dump_threads_and_maybe_abort(
+                        thedb->bdb_env, gbl_client_abort_on_slow);
+                }
+            } else {
+                logmsg(LOGMSG_ERROR, "%s: gather_connection_info rc=%d\n",
+                       __func__, rc);
             }
         }
 

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -25,6 +25,9 @@ int get_connections(void **data, int *num_points) {
         dttz_t d = {.dttz_sec = info[i].connect_time_int, .dttz_frac = 0, .dttz_prec = DTTZ_PREC_MSEC};
         dttz_to_client_datetime(&d, "UTC", (cdb2_client_datetime_t*) &info[i].connect_time);
 
+        d = (dttz_t) { .dttz_sec = info[i].last_reset_time_int, .dttz_frac = 0, .dttz_frac = DTTZ_PREC_MSEC };
+        dttz_to_client_datetime(&d, "UTC", (cdb2_client_datetime_t*) &info[i].last_reset_time);
+
         info[i].time_in_state.sign = 1;
         int ms = now - info[i].time_in_state_int;
         info[i].time_in_state.days = ms / 86400000; ms %= 86400000;
@@ -55,13 +58,7 @@ int get_connections(void **data, int *num_points) {
 }
 
 void free_connections(void *data, int num_points) {
-    struct connection_info *info = (struct connection_info*) data;
-    for (int i = 0; i < num_points; i++) {
-        if (info[i].sql)
-            free(info[i].sql);
-        /* state is static, don't free */
-    }
-    free(data);
+    free_connection_info((struct connection_info *)data, num_points);
 }
 
 int systblConnectionsInit(sqlite3 *db) {
@@ -70,7 +67,7 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_CSTRING, "host", -1, offsetof(struct connection_info, host),
             CDB2_INTEGER, "connection_id", -1, offsetof(struct connection_info, connection_id),
             CDB2_DATETIME, "connect_time", -1, offsetof(struct connection_info, connect_time),
-            CDB2_DATETIME, "last_reset_time", -1, offsetof(struct connection_info, connect_time),
+            CDB2_DATETIME, "last_reset_time", -1, offsetof(struct connection_info, last_reset_time),
             CDB2_INTEGER, "pid", -1, offsetof(struct connection_info, pid),
             CDB2_INTEGER, "total_sql", -1, offsetof(struct connection_info, total_sql),
             CDB2_INTEGER, "sql_since_reset", -1, offsetof(struct connection_info, sql_since_reset),


### PR DESCRIPTION
These changes introduce several tunable parameters.  When enabled, they allow the watchdog thread to detect client connections that appear to be stuck in the 'queued' or 'running' states, using configurable time values, in seconds.  Optionally, if a stuck client is detected, the watchdog thread will abort the process, after dumping all key state information.