### PR TITLE
Use Canonical Name everywhere

### DIFF
--- a/bbinc/bb_oscompat.h
+++ b/bbinc/bb_oscompat.h
@@ -25,12 +25,13 @@ extern "C" {
 
 struct in_addr;
 
-typedef int(hostbyname)(char **, struct in_addr *);
+typedef int(hostbyname)(char **, struct in_addr *, char **);
 
 hostbyname *get_os_hostbyname();
 void set_hostbyname(hostbyname *);
 
-hostbyname comdb2_gethostbyname;
+int comdb2_gethostbyname(char **name, struct in_addr *addr);
+char *comdb2_getcanonicalname(char *name);
 void comdb2_getservbyname(const char *, const char *, short *);
 int bb_readdir(DIR *d, void *buf, struct dirent **dent);
 char *comdb2_realpath(const char *path, char *resolved_path);

--- a/bdb/bdb_net.c
+++ b/bdb/bdb_net.c
@@ -56,7 +56,6 @@
 #define debug_trace(...)
 #endif
 
-extern char *gbl_myhostname;
 extern void fsnapf(FILE *, void *, int);
 extern int get_myseqnum(bdb_state_type *bdb_state, uint8_t *p_net_seqnum);
 extern int verify_master_leases_int(bdb_state_type *bdb_state,

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -109,7 +109,7 @@ extern int gbl_keycompr;
 extern int gbl_early;
 extern int gbl_exit;
 extern int gbl_fullrecovery;
-extern char *gbl_mynode;
+extern char *gbl_myhostname;
 extern size_t gbl_blobmem_cap;
 
 #define FILENAMELEN 100
@@ -1555,8 +1555,8 @@ static int bdb_close_int(bdb_state_type *bdb_state, int envonly)
         if (gbl_libevent) {
             stop_event_net();
         } else {
-            net_send_decom_all(netinfo_ptr, gbl_mynode);
-            osql_process_message_decom(gbl_mynode);
+            net_send_decom_all(netinfo_ptr, gbl_myhostname);
+            osql_process_message_decom(gbl_myhostname);
             sleep(2);
             net_exiting(netinfo_ptr);
             osql_net_exiting();
@@ -3214,7 +3214,7 @@ done2:
 
     /* send our real seqnum to the master now.  */
 
-    if (bdb_state->repinfo->master_host != gbl_mynode &&
+    if (bdb_state->repinfo->master_host != gbl_myhostname &&
         net_count_nodes(bdb_state->repinfo->netinfo) > 1) {
         rc = send_myseqnum_to_master(bdb_state, 1);
         if (rc != 0) {
@@ -5696,7 +5696,7 @@ static bdb_state_type *bdb_open_int(
         bzero(bdb_state->repinfo, sizeof(repinfo_type));
 
         /* record who we are */
-        bdb_state->repinfo->myhost = gbl_mynode;
+        bdb_state->repinfo->myhost = gbl_myhostname;
 
         /* we dont know who the master is yet */
         set_repinfo_master_host(bdb_state, db_eid_invalid, __func__, __LINE__);
@@ -5889,9 +5889,10 @@ static bdb_state_type *bdb_open_int(
             (bdb_state->callback->whoismaster_rtn)(
                 bdb_state, bdb_state->repinfo->master_host, 1);
 
-        logmsg(LOGMSG_INFO, "@LSN %u:%u\n",
-               bdb_state->seqnum_info->seqnums[nodeix(gbl_mynode)].lsn.file,
-               bdb_state->seqnum_info->seqnums[nodeix(gbl_mynode)].lsn.offset);
+        logmsg(
+            LOGMSG_INFO, "@LSN %u:%u\n",
+            bdb_state->seqnum_info->seqnums[nodeix(gbl_myhostname)].lsn.file,
+            bdb_state->seqnum_info->seqnums[nodeix(gbl_myhostname)].lsn.offset);
 
         BDB_RELLOCK();
     } else {

--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -56,7 +56,7 @@ void reset_aa_counter(char *tblname)
     tbl->aa_saved_counter = 0;
     tbl->aa_lastepoch = time(NULL);
 
-    if (save_freq > 0 && thedb->master == gbl_mynode) {
+    if (save_freq > 0 && thedb->master == gbl_myhostname) {
         // save updated counter
         const char *str = "0";
         bdb_set_table_parameter(NULL, tblname, aa_counter_str, str);
@@ -248,7 +248,8 @@ out:
 // print autoanalyze stats
 void stat_auto_analyze(void)
 {
-    if (thedb->master != gbl_mynode) // refresh from saved if we are not master
+    // refresh from saved if we are not master
+    if (thedb->master != gbl_myhostname)
         load_auto_analyze_counters();
 
     logmsg(LOGMSG_USER, "AUTOANALYZE: %s\n",
@@ -350,7 +351,7 @@ void *auto_analyze_main(void *unused)
     rdlock_schema_lk();
     // for each table update the counters
     for (int i = 0; i < thedb->num_dbs; i++) {
-        if (thedb->master != gbl_mynode ||
+        if (thedb->master != gbl_myhostname ||
             get_schema_change_in_progress(__func__, __LINE__))
             break;
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1587,10 +1587,9 @@ extern int gbl_maxwthreads;  /* max write threads */
 extern int gbl_maxthreads;   /* max number of threads allowed */
 extern int gbl_maxqueue;     /* max number of requests to be queued up */
 extern int gbl_thd_linger;   /* number of seconds for threads to linger */
-extern char *gbl_mynode;     /* my hostname */
+extern char *gbl_myhostname; /* my hostname */
 extern char *gbl_machine_class; /* my machine class */
 struct in_addr gbl_myaddr;   /* my IPV4 address */
-extern char *gbl_myhostname; /* my hostname */
 extern int gbl_mynodeid;     /* node number, for backwards compatibility */
 extern pid_t gbl_mypid;      /* my pid */
 extern int gbl_create_mode;  /* create files if no exists */

--- a/db/config.c
+++ b/db/config.c
@@ -410,7 +410,7 @@ static int lrl_if(char **tok_inout, char *line, int line_len, int *st,
 
 void getmyaddr()
 {
-    if (comdb2_gethostbyname(&gbl_mynode, &gbl_myaddr) != 0) {
+    if (comdb2_gethostbyname(&gbl_myhostname, &gbl_myaddr) != 0) {
         gbl_myaddr.s_addr = INADDR_LOOPBACK; /* default to localhost */
         return;
     }
@@ -781,10 +781,10 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
                 if (comdb2_gethostbyname(&name, &addr) == 0 &&
                     addr.s_addr == gbl_myaddr.s_addr) {
                     /* Assume I am better known by this name. */
-                    gbl_mynode = intern(name);
-                    gbl_mynodeid = machine_num(gbl_mynode);
+                    gbl_myhostname = intern(name);
+                    gbl_mynodeid = machine_num(gbl_myhostname);
                 }
-                if (strcmp(gbl_mynode, name) == 0 &&
+                if (strcmp(gbl_myhostname, name) == 0 &&
                     gbl_rep_node_pri == 0) {
                     /* assign the priority of current node according to its
                      * sequence in nodes list. */
@@ -812,7 +812,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
                     dbenv->nsiblings++;
                 }
             }
-            dbenv->sibling_hostname[0] = gbl_mynode;
+            dbenv->sibling_hostname[0] = gbl_myhostname;
         }
     } else if (tokcmp(tok, ltok, "machine_classes") == 0) {
         int classval = 1;

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -414,7 +414,8 @@ int refresh_metrics(void)
         time_metric_average(thedb->handle_buf_queue_time);
     stats.concurrent_connections = time_metric_average(thedb->connections);
     int master =
-        bdb_whoismaster((bdb_state_type *)thedb->bdb_env) == gbl_mynode ? 1 : 0;
+        bdb_whoismaster((bdb_state_type *)thedb->bdb_env) == gbl_myhostname ? 1
+                                                                            : 0;
     stats.ismaster = master;
     rc = bdb_get_num_sc_done(((bdb_state_type *)thedb->bdb_env), NULL,
                              (unsigned long long *)&stats.num_sc_done, &bdberr);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -489,7 +489,7 @@ REGISTER_TUNABLE("heartbeat_send_time",
                  "Send heartbeats this often. (Default: 5secs)",
                  TUNABLE_INTEGER, &gbl_heartbeat_send, READONLY | NOZERO, NULL,
                  NULL, NULL, NULL);
-REGISTER_TUNABLE("hostname", NULL, TUNABLE_STRING, &gbl_mynode,
+REGISTER_TUNABLE("hostname", NULL, TUNABLE_STRING, &gbl_myhostname,
                  READONLY | READEARLY, NULL, NULL, hostname_update, NULL);
 REGISTER_TUNABLE("incoherent_alarm_time", NULL, TUNABLE_INTEGER,
                  &gbl_incoherent_alarm_time, READONLY, NULL, NULL, NULL, NULL);

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -205,7 +205,7 @@ queue_consume(struct ireq *iq, const void *fnd, int consumern)
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
                 iq->usedb->tablename, consumern);
-        if (db_is_stopped() || thedb->master != gbl_mynode)
+        if (db_is_stopped() || thedb->master != gbl_myhostname)
             return -1;
         sleep(sleeptime);
     }

--- a/db/debug.c
+++ b/db/debug.c
@@ -246,7 +246,7 @@ void debug_trap(char *line, int lline)
 
         numnodes = net_get_all_nodes_connected(thedb->handle_sibling, hosts);
 
-        hosts[numnodes] = gbl_mynode;
+        hosts[numnodes] = gbl_myhostname;
         numnodes++;
 
         logmsg(LOGMSG_USER, "nodes:\n");

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -740,9 +740,10 @@ void log_deadlock_cycle(locker_info *idmap, u_int32_t *deadmap,
     cson_value *dd_list = cson_value_new_array();
     uint64_t startus = comdb2_time_epochus();
     cson_object_set(obj, "time", cson_new_int(startus));
-    extern char *gbl_mynode;
-    cson_object_set(obj, "host",
-                    cson_value_new_string(gbl_mynode, strlen(gbl_mynode)));
+    extern char *gbl_myhostname;
+    cson_object_set(
+        obj, "host",
+        cson_value_new_string(gbl_myhostname, strlen(gbl_myhostname)));
     cson_object_set(obj, "deadlock_cycle", dd_list);
     cson_array *arr = cson_value_get_array(dd_list);
     cson_array_reserve(arr, nlockers);

--- a/db/fdb_boots.c
+++ b/db/fdb_boots.c
@@ -181,7 +181,7 @@ static char *_get_node_initial(int nnodes, char **nodes, bool *lcl,
         }
 
         /* prefer local node if available */
-        if (nodes[i] == gbl_mynode) {
+        if (nodes[i] == gbl_myhostname) {
             node = nodes[i];
         }
 
@@ -326,7 +326,7 @@ char *fdb_select_node(fdb_location_t **ploc, enum fdb_location_op op, char *arg,
             *p_lcl_nodes = 1;
         }
 
-        return gbl_mynode; /* local node */
+        return gbl_myhostname; /* local node */
     }
 
     assert(loc != NULL);

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -853,7 +853,7 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     iq->luxref = luxref;
 
     if (iq->is_fromsocket) {
-        if (iq->frommach == gbl_mynode)
+        if (iq->frommach == gbl_myhostname)
             snprintf(iq->corigin, sizeof(iq->corigin), "SLCL  %.8s PID %6.6d",
                      fromtask ? fromtask : "null", frompid);
         else
@@ -888,7 +888,7 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     iq->usedb = iq->origdb;
 
     if (iq->frommach == NULL)
-        iq->frommach = intern(gbl_mynode);
+        iq->frommach = intern(gbl_myhostname);
 
     return 0;
 }

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -853,7 +853,7 @@ again:
         printf("toclear: add_oplog_entry(commit) rc %d\n", rc);
         goto done;
     }
-    rc = trans_commit(&iq, trans, gbl_mynode);
+    rc = trans_commit(&iq, trans, gbl_myhostname);
     if (rc) {
         printf("toclear: commit rc %d\n", rc);
         goto done;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1419,7 +1419,7 @@ void *bplog_commit_timepart_resuming_sc(void *p)
         create_sqlite_master();
     }
 
-    if (trans_commit(&iq, iq.sc_tran, gbl_mynode)) {
+    if (trans_commit(&iq, iq.sc_tran, gbl_myhostname)) {
         logmsg(LOGMSG_FATAL, "%s:%d failed to commit schema change\n", __func__,
                __LINE__);
         abort();
@@ -1427,8 +1427,8 @@ void *bplog_commit_timepart_resuming_sc(void *p)
 
     unlock_schema_lk();
 
-    if (trans_commit_logical(&iq, iq.sc_logical_tran, gbl_mynode, 0, 1, NULL, 0,
-                             NULL, 0)) {
+    if (trans_commit_logical(&iq, iq.sc_logical_tran, gbl_myhostname, 0, 1,
+                             NULL, 0, NULL, 0)) {
         logmsg(LOGMSG_FATAL, "%s:%d failed to commit schema change\n", __func__,
                __LINE__);
         abort();

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -199,12 +199,12 @@ static osql_sqlthr_t *get_new_entry(struct sqlclntstate *clnt, int type)
         }
     }
 
-    if (clnt->osql.host == gbl_mynode) {
+    if (clnt->osql.host == gbl_myhostname) {
         clnt->osql.host = 0;
     }
 
     if (entry->master == 0)
-        entry->master = gbl_mynode;
+        entry->master = gbl_myhostname;
 
     Pthread_mutex_init(&entry->mtx, NULL);
     Pthread_cond_init(&entry->cond, NULL);
@@ -373,7 +373,7 @@ int osql_checkboard_master_changed(void *obj, void *arg)
 {
     osql_sqlthr_t *rq = obj;
     Pthread_mutex_lock(&rq->mtx);
-    if (rq->master != arg && !(rq->master == 0 && gbl_mynode == arg)) {
+    if (rq->master != arg && !(rq->master == 0 && gbl_myhostname == arg)) {
         signal_master_change(rq, arg, __func__);
     }
     Pthread_mutex_unlock(&rq->mtx);
@@ -492,7 +492,7 @@ static int wait_till_max_wait_or_timeout(osql_sqlthr_t *entry, int max_wait,
             entry->last_checked = now;
 
             /* try poke again */
-            if (entry->master == 0 || entry->master == gbl_mynode) {
+            if (entry->master == 0 || entry->master == gbl_myhostname) {
                 /* local checkup */
                 bool found =
                     osql_repository_session_exists(entry->rqid, entry->uuid);
@@ -668,7 +668,7 @@ int osql_reuse_sqlthr(struct sqlclntstate *clnt, char *master)
     entry->done = 0;
     entry->master_changed = 0;
     entry->master =
-        master ? master : gbl_mynode; /* master changed, store it here */
+        master ? master : gbl_myhostname; /* master changed, store it here */
     bzero(&entry->err, sizeof(entry->err));
     Pthread_mutex_unlock(&entry->mtx);
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5109,7 +5109,7 @@ static void net_osql_master_check(void *hndl, void *uptr, char *fromhost,
         uuidstr_t us;
         logmsg(LOGMSG_ERROR,
                "Missing SORESE sql session %llx %s on %s from %d\n", poke.rqid,
-               comdb2uuidstr(uuid, us), gbl_mynode, poke.from);
+               comdb2uuidstr(uuid, us), gbl_myhostname, poke.from);
     }
 }
 
@@ -5187,7 +5187,7 @@ static int net_osql_nodedwn(netinfo_type *netinfo_ptr, char *host)
 static void signal_rtoff(void)
 {
 
-    if (g_osql_ready && thedb->master == gbl_mynode) {
+    if (g_osql_ready && thedb->master == gbl_myhostname) {
         logmsg(LOGMSG_INFO, "%s: canceling pending blocksql transactions\n",
                 __func__);
         osql_repository_cancelall();
@@ -5291,7 +5291,7 @@ static int offload_net_send(const char *host, int usertype, void *data,
         }
     }
 
-    if (host == gbl_mynode)
+    if (host == gbl_myhostname)
         host = NULL;
 
     if (!host) {
@@ -5316,7 +5316,7 @@ static int offload_net_send(const char *host, int usertype, void *data,
                 logmsg(
                     LOGMSG_ERROR,
                     "%s:%d giving up sending to %s, rc = %d, total wait = %d\n",
-                    __FILE__, __LINE__, host ? host : gbl_mynode, rc,
+                    __FILE__, __LINE__, host ? host : gbl_myhostname, rc,
                     total_wait);
                 return rc;
             }
@@ -5325,7 +5325,7 @@ static int offload_net_send(const char *host, int usertype, void *data,
                 logmsg(LOGMSG_ERROR,
                        "%s:%d failed to check bdb lock, giving up sending to "
                        "%s, rc = %d\n",
-                       __FILE__, __LINE__, host ? host : gbl_mynode, rc);
+                       __FILE__, __LINE__, host ? host : gbl_myhostname, rc);
                 return rc;
             }
 
@@ -5337,7 +5337,7 @@ static int offload_net_send(const char *host, int usertype, void *data,
                will trigger on the other side signalling we've
                lost the comm party */
             logmsg(LOGMSG_ERROR, "%s:%d giving up sending to %s\n", __FILE__,
-                   __LINE__, host ? host : gbl_mynode);
+                   __LINE__, host ? host : gbl_myhostname);
             logmsg(LOGMSG_ERROR,
                    "%s:%d socket is closed, return wrong master\n", __FILE__,
                    __LINE__);
@@ -5346,7 +5346,7 @@ static int offload_net_send(const char *host, int usertype, void *data,
             unknownerror_retry++;
             if (unknownerror_retry >= UNK_ERR_SEND_RETRY) {
                 logmsg(LOGMSG_ERROR, "%s:%d giving up sending to %s\n",
-                       __FILE__, __LINE__, host ? host : gbl_mynode);
+                       __FILE__, __LINE__, host ? host : gbl_myhostname);
                 comdb2_linux_cheap_stack_trace();
                 return -1;
             }
@@ -5420,7 +5420,7 @@ static void net_osql_rpl(void *hndl, void *uptr, char *fromnode, int usertype,
 static int check_master(const char *tohost)
 {
 
-    const char *destnode = (tohost == NULL) ? gbl_mynode : tohost;
+    const char *destnode = (tohost == NULL) ? gbl_myhostname : tohost;
     char *master = thedb->master;
 
     if (destnode != master) {
@@ -5826,7 +5826,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         sc->nothrevent = 1;
     sc->finalize = 0;
     if (sc->original_master_node[0] != 0 &&
-        strcmp(sc->original_master_node, gbl_mynode))
+        strcmp(sc->original_master_node, gbl_myhostname))
         sc->resume = 1;
 
     iq->sc = sc;
@@ -6019,7 +6019,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         // TODO (NC): Check why iq->sc_pending is not getting set for views
         iq->sc = iq->sc_pending;
         while (iq->sc != NULL) {
-            if (strcmp(iq->sc->original_master_node, gbl_mynode) != 0) {
+            if (strcmp(iq->sc->original_master_node, gbl_myhostname) != 0) {
                 return -1;
             }
             if (!iq->sc_locked) {
@@ -7280,7 +7280,7 @@ int osql_send_schemachange(char *tonode, unsigned long long rqid, uuid_t uuid,
     if (tonode)
         strcpy(sc->original_master_node, tonode);
     else
-        strcpy(sc->original_master_node, gbl_mynode);
+        strcpy(sc->original_master_node, gbl_myhostname);
 
     if (rqid == OSQL_RQID_USE_UUID) {
         osql_uuid_rpl_t hd_uuid = {0};

--- a/db/osqluprec.c
+++ b/db/osqluprec.c
@@ -175,7 +175,7 @@ static void *uprec_cron_event(struct cron_event *_, struct errstat *err)
         /* send and then wait */
         p_slock = &uprec->slock;
         rc = offload_comm_send_blockreq(
-            thedb->master == gbl_mynode ? 0 : thedb->master, p_slock,
+            thedb->master == gbl_myhostname ? 0 : thedb->master, p_slock,
             uprec->buffer, (buf_end - uprec->buffer));
         if (rc != 0)
             goto done;
@@ -247,7 +247,7 @@ int offload_comm_send_upgrade_record(const char *tbl, unsigned long long genid)
     else
         // send block request and free buffer
         rc = offload_comm_send_sync_blockreq(
-            thedb->master == gbl_mynode ? 0 : thedb->master, buffer,
+            thedb->master == gbl_myhostname ? 0 : thedb->master, buffer,
             buffer_end - buffer);
 
     return rc;
@@ -311,7 +311,8 @@ int offload_comm_send_upgrade_records(const dbtable *db,
         return EINVAL;
 
     /* if i am master of a cluster, return. */
-    if (thedb->master == gbl_mynode && net_count_nodes(osql_get_netinfo()) > 1)
+    if (thedb->master == gbl_myhostname &&
+        net_count_nodes(osql_get_netinfo()) > 1)
         return 0;
 
     (void)pthread_once(&uprec_sender_array_once, uprec_sender_array_init);

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -353,11 +353,11 @@ static int register_self()
     /* do a cleanup to get new list of tiered replicants */
     cleanup_hosts();
 
-    /* TODO: Change this from local host to gbl_mynode */
+    /* TODO: Change this from local host to gbl_myhostname */
     rc = snprintf(get_tier, sql_len,
                   "exec procedure "
                   "sys.cmd.register_replicant('%s', '%s', '%u', '%u')",
-                  gbl_dbname, gbl_mynode, info.file, info.offset);
+                  gbl_dbname, gbl_myhostname, info.file, info.offset);
 
     if (rc < 0 || rc >= sql_len) {
         logmsg(LOGMSG_ERROR, "lua call buffer is not long enough!\n");

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -842,7 +842,7 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "synccluster") == 0) {
 
         int outrc = -1;
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_USER, "Not the master node. \n");
         } else {
             tok = segtok(line, lline, &st, &ltok);
@@ -1123,7 +1123,7 @@ clipper_usage:
             return -1;
         }
 
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "Can't delete files: I am not master\n");
             return -1;
         }
@@ -2116,7 +2116,7 @@ clipper_usage:
         char fname[128];
         char table[MAXTABLELEN];
         int odh = -1, compress = -1, compress_blobs = -1;
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2176,7 +2176,7 @@ clipper_usage:
                 logmsg(LOGMSG_ERROR, "error with schema change thread\n");
         }
     } else if (tokcmp(tok, ltok, "morestripe") == 0) {
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2222,7 +2222,7 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "init_with_bthash") == 0) {
         int szkb;
 
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2238,7 +2238,7 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "bthash") == 0) {
         char table[MAXTABLELEN];
         int szkb;
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2270,7 +2270,7 @@ clipper_usage:
         int idb;
         struct dbtable *db;
 
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2290,7 +2290,7 @@ clipper_usage:
 
     } else if (tokcmp(tok, ltok, "delbthash") == 0) {
         char table[MAXTABLELEN];
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2314,7 +2314,7 @@ clipper_usage:
         struct dbtable *db;
         int idb;
 
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -2361,7 +2361,7 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "fastinit") == 0 ||
                tokcmp(tok, ltok, "reinit") == 0) {
         char table[MAXTABLELEN];
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not master\n");
             return -1;
         }
@@ -4432,7 +4432,7 @@ clipper_usage:
             if (ltok > 0)
                 cnt = toknum(tok, ltok);
         }
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not the master node\n");
         } else if (tcnt <= 0 || cnt <= 0) {
             logmsg(LOGMSG_ERROR,
@@ -4452,7 +4452,7 @@ clipper_usage:
             if (ltok > 0)
                 pcnt = toknum(tok, ltok);
         }
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not the master node\n");
         } else if (!gbl_rowlocks) {
             logmsg(LOGMSG_ERROR, "I am not in rowlocks mode\n");
@@ -4475,7 +4475,7 @@ clipper_usage:
                 pcnt = toknum(tok, ltok);
             }
         }
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not the master node\n");
         } else if (!gbl_rowlocks) {
             logmsg(LOGMSG_ERROR, "I am not in rowlocks mode\n");
@@ -4500,7 +4500,7 @@ clipper_usage:
                 pcnt = toknum(tok, ltok);
             }
         }
-        if (thedb->master != gbl_mynode) {
+        if (thedb->master != gbl_myhostname) {
             logmsg(LOGMSG_ERROR, "I am not the master node\n");
         } else if (!gbl_rowlocks) {
             logmsg(LOGMSG_ERROR, "I am not in rowlocks mode\n");

--- a/db/pushlogs.c
+++ b/db/pushlogs.c
@@ -130,7 +130,7 @@ static void *pushlogs_thread(void *voidarg)
             break;
         }
         Pthread_mutex_unlock(&schema_change_in_progress_mutex);
-        rc = trans_commit(&iq, trans, gbl_mynode);
+        rc = trans_commit(&iq, trans, gbl_myhostname);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "pushlogs_thread: cannot commit txn %d\n", rc);
             Pthread_mutex_lock(&mutex);

--- a/db/record.c
+++ b/db/record.c
@@ -2764,7 +2764,7 @@ void testrep(int niter, int recsz)
             logmsg(LOGMSG_ERROR, "bdb_add_rep_blob rc %d bdberr %d\n", rc, bdberr);
             goto done;
         }
-        rc = trans_commit(&iq, tran, gbl_mynode);
+        rc = trans_commit(&iq, tran, gbl_myhostname);
         if (rc) {
             logmsg(LOGMSG_ERROR, "commit rc %d\n", rc);
             goto done;

--- a/db/rmtpolicy.c
+++ b/db/rmtpolicy.c
@@ -108,7 +108,7 @@ int allow_write_from_remote(const char *host)
     rc = allow_action_from_remote(host, &write_pol);
     if (rc == -1) {
         /* default logic: allow writes from same or higher classes. */
-        if (get_mach_class(host) >= get_mach_class(gbl_mynode))
+        if (get_mach_class(host) >= get_mach_class(gbl_myhostname))
             rc = 1;
         else
             rc = 0;
@@ -123,7 +123,7 @@ int allow_cluster_from_remote(const char *host)
     if (rc == -1) {
         /* default logic: only cluster with like machines i.e. alpha with alpha,
          * beta with beta etc. */
-        if (get_mach_class(host) == get_mach_class(gbl_mynode))
+        if (get_mach_class(host) == get_mach_class(gbl_myhostname))
             rc = 1;
         else
             rc = 0;
@@ -137,7 +137,7 @@ int allow_broadcast_to_remote(const char *host)
     if (rc == -1) {
         /* default logic: only broadcast to machines of the same or a lower
          * class.  we don't want alpha to broadcast to prod! */
-        if (get_mach_class(host) <= get_mach_class(gbl_mynode))
+        if (get_mach_class(host) <= get_mach_class(gbl_myhostname))
             rc = 1;
         else
             rc = 0;
@@ -257,7 +257,7 @@ int process_allow_command(char *line, int lline)
         if (parse_mach_or_group(tok, ltok, &if_mach, &if_cls) != 0)
             goto bad;
 
-        if (if_mach > 0 && if_mach != gbl_mynode)
+        if (if_mach > 0 && if_mach != gbl_myhostname)
             goto ignore;
         if (if_cls != CLASS_UNKNOWN && if_cls != get_my_mach_class())
             goto ignore;

--- a/db/rowlocks_bench.c
+++ b/db/rowlocks_bench.c
@@ -82,7 +82,7 @@ static void commit_bench_int(bdb_state_type *bdb_state, int op, int tcount,
             }
         }
 
-        if ((rc = trans_commit_adaptive(&iq, trans, gbl_mynode)) != 0) {
+        if ((rc = trans_commit_adaptive(&iq, trans, gbl_myhostname)) != 0) {
             fprintf(stderr, "%s: trans_commit returns %d\n", __func__, rc);
             return;
         }
@@ -193,8 +193,8 @@ static void rowlocks_bench_int(bdb_state_type *bdb_state, int op, int count,
         }
 
         /* This will wait for all nodes to respond */
-        if ((rc = trans_commit_logical(&iq, trans, gbl_mynode, 0, 1, NULL, 0,
-                                       iq.seq, iq.seqlen)) != 0) {
+        if ((rc = trans_commit_logical(&iq, trans, gbl_myhostname, 0, 1, NULL,
+                                       0, iq.seq, iq.seqlen)) != 0) {
             fprintf(stderr, "%s: trans_commit_logical returns %d\n", 
                     __func__, rc);
             return;

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -590,7 +590,7 @@ again:
         logmsg(LOGMSG_ERROR, "analyze: add_oplog_entry(commit) rc %d\n", rc);
         goto done;
     }
-    rc = trans_commit(&iq, trans, gbl_mynode);
+    rc = trans_commit(&iq, trans, gbl_myhostname);
     if (rc) {
         logmsg(LOGMSG_ERROR, "analyze: commit rc %d\n", rc);
         goto done;
@@ -901,7 +901,7 @@ static void *table_thread(void *arg)
     /* mark the return */
     if (0 == rc) {
         td->table_state = TABLE_COMPLETE;
-        if (thedb->master == gbl_mynode) { // reset directly
+        if (thedb->master == gbl_myhostname) { // reset directly
             ctrace("analyze: Analyzed Table %s, reseting counter to 0\n", td->table);
             reset_aa_counter(td->table);
         } else {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11323,14 +11323,14 @@ int bt_hash_table(char *table, int szkb)
         fprintf(stderr, "Failed to write bthash to meta table\n");
         return -1;
     }
-    trans_commit(&iq, metatran, gbl_mynode);
+    trans_commit(&iq, metatran, gbl_myhostname);
 
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
     logmsg(LOGMSG_WARN, "Building bthash for table %s, size %dkb per stripe\n",
            db->tablename, szkb);
     bdb_handle_dbp_add_hash(bdb_state, szkb);
-    trans_commit(&iq, tran, gbl_mynode);
+    trans_commit(&iq, tran, gbl_myhostname);
 
     // scdone log
     rc = bdb_llog_scdone(bdb_state, bthash, 1, &bdberr);
@@ -11377,13 +11377,13 @@ int del_bt_hash_table(char *table)
         logmsg(LOGMSG_ERROR, "Failed to write bthash to meta table\n");
         return -1;
     }
-    trans_commit(&iq, metatran, gbl_mynode);
+    trans_commit(&iq, metatran, gbl_myhostname);
 
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
     logmsg(LOGMSG_WARN, "Deleting bthash for table %s\n", db->tablename);
     bdb_handle_dbp_drop_hash(bdb_state);
-    trans_commit(&iq, tran, gbl_mynode);
+    trans_commit(&iq, tran, gbl_myhostname);
 
     // scdone log
     rc = bdb_llog_scdone(bdb_state, bthash, 1, &bdberr);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2888,7 +2888,7 @@ int release_locks_on_emit_row(struct sqlthdstate *thd,
         return 0;
 
     /* We're emitting a row & have waiters */
-    if (!gbl_rep_wait_release_ms || thedb->master == gbl_mynode)
+    if (!gbl_rep_wait_release_ms || thedb->master == gbl_myhostname)
         return release_locks("release locks on emit-row");
 
     /* We're emitting a row and are blocking replication */
@@ -4990,13 +4990,14 @@ void sqlengine_work_appsock(void *thddata, void *work)
         (clnt->dbtran.mode == TRANLEVEL_SOSQL &&
          (clnt->ctrl_sqlengine == SQLENG_STRT_STATE ||
           clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS))) {
-        clnt->osql.host = (thedb->master == gbl_mynode) ? 0 : thedb->master;
+        clnt->osql.host = (thedb->master == gbl_myhostname) ? 0 : thedb->master;
     }
 
     if (clnt->ctrl_sqlengine == SQLENG_STRT_STATE ||
         clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS) {
-        clnt->had_lease_at_begin =
-            (thedb->master == gbl_mynode) ? 1 : bdb_valid_lease(thedb->bdb_env);
+        clnt->had_lease_at_begin = (thedb->master == gbl_myhostname)
+                                       ? 1
+                                       : bdb_valid_lease(thedb->bdb_env);
     }
 
     /* assign this query a unique id */

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -82,7 +82,7 @@ void trigger_reg_to_cpu(trigger_reg_t *);
 #define trigger_hostname(t) ((t)->spname + (t)->spname_len + 1)
 
 #define trigger_reg_sz(sp_name)                                                \
-    sizeof(trigger_reg_t) + strlen(sp_name) + 1 + strlen(gbl_mynode) + 1
+    sizeof(trigger_reg_t) + strlen(sp_name) + 1 + strlen(gbl_myhostname) + 1
 
 #define trigger_reg_init(dest, sp_name)                                        \
     do {                                                                       \
@@ -92,7 +92,7 @@ void trigger_reg_to_cpu(trigger_reg_t *);
         dest->trigger_cookie = get_id(thedb->bdb_env);                         \
         dest->spname_len = strlen(sp_name);                                    \
         strcpy(dest->spname, sp_name);                                         \
-        strcpy(trigger_hostname(dest), gbl_mynode);                            \
+        strcpy(trigger_hostname(dest), gbl_myhostname);                        \
     } while (0)
 
 #define Q4SP(var, spname)                                                      \

--- a/db/views.c
+++ b/db/views.c
@@ -937,7 +937,7 @@ void *_view_cron_phase1(struct cron_event *event, struct errstat *err)
     assert(arg3 == NULL);
 
     run = (!gbl_exit);
-    if (run && (thedb->master != gbl_mynode || gbl_is_physical_replicant))
+    if (run && (thedb->master != gbl_myhostname || gbl_is_physical_replicant))
         run = 0;
 
     if (run) {
@@ -1094,7 +1094,7 @@ void *_view_cron_phase2(struct cron_event *event, struct errstat *err)
     assert(arg3 == NULL);
 
     run = (!gbl_exit);
-    if (run && (thedb->master != gbl_mynode || gbl_is_physical_replicant))
+    if (run && (thedb->master != gbl_myhostname || gbl_is_physical_replicant))
         run = 0;
 
     if (run) {
@@ -1208,7 +1208,7 @@ void *_view_cron_phase3(struct cron_event *event, struct errstat *err)
     }
 
     run = (!gbl_exit);
-    if (run && (thedb->master != gbl_mynode || gbl_is_physical_replicant))
+    if (run && (thedb->master != gbl_myhostname || gbl_is_physical_replicant))
         run = 0;
 
     if (run) {
@@ -1935,7 +1935,7 @@ int views_cron_restart(timepart_views_t *views)
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START_RDWR);
     BDB_READLOCK(__func__);
 
-    if (thedb->master == gbl_mynode && !gbl_is_physical_replicant) {
+    if (thedb->master == gbl_myhostname && !gbl_is_physical_replicant) {
         /* queue all the events required for this */
         for(i=0;i<views->nviews; i++)
         {

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -236,7 +236,7 @@ static void *watchdog_thread(void *arg)
    disabling for now. */
 #if 0             
              if ((thedb->rep_sync != REP_SYNC_NONE
-                         || thedb->master == gbl_mynode)
+                         || thedb->master == gbl_myhostname)
                      && coherent)
              {
                  rc = sqltest(thedb->envname);
@@ -273,7 +273,7 @@ static void *watchdog_thread(void *arg)
                         }
                     }
 
-                    if (!coherent && master > 0 && master != gbl_mynode) {
+                    if (!coherent && master > 0 && master != gbl_myhostname) {
                         bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes,
                                             curlsn, sizeof(curlsn));
                         bdb_get_cur_lsn_str_node(
@@ -346,7 +346,7 @@ static void *watchdog_thread(void *arg)
         
         if (gbl_trigger_timepart) {
             gbl_trigger_timepart = 0;
-            if(thedb->master == gbl_mynode) {
+            if (thedb->master == gbl_myhostname) {
                 rc = views_cron_restart(thedb->timepart_views);
                 if (rc) {
                     logmsg(LOGMSG_WARN, "Failed to restart timepartitions rc=%d!\n",

--- a/net/testnet.c
+++ b/net/testnet.c
@@ -363,7 +363,7 @@ int main(int argc, char *argv[])
                     netnodes[ii].node);
             exit(1);
         }
-        if (netnodes[ii].node == gbl_mynode) {
+        if (netnodes[ii].node == gbl_myhostname) {
             if (mynetnode) {
                 fprintf(stderr, "I appear twice in node list!\n");
                 exit(1);

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -445,7 +445,7 @@ static int dbqueuedb_admin_running = 0;
  * for each consumer. */
 static void admin(struct dbenv *dbenv, int type)
 {
-    int iammaster = (dbenv->master == gbl_mynode) ? 1 : 0;
+    int iammaster = (dbenv->master == gbl_myhostname) ? 1 : 0;
 
     Pthread_mutex_lock(&dbqueuedb_admin_lk);
     if (dbqueuedb_admin_running) {
@@ -711,7 +711,7 @@ static void queue_flush(struct dbtable *db, int consumern)
     logmsg(LOGMSG_INFO, "Beginning flush for queue '%s' consumer %d\n",
            db->tablename, consumern);
 
-    if (db->dbenv->master != gbl_mynode) {
+    if (db->dbenv->master != gbl_myhostname) {
         logmsg(LOGMSG_WARN, "... but I am not the master node, so I do nothing.\n");
         return;
     }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2271,7 +2271,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
       incoherent data.
     */
     if (!arg->admin && dbenv->rep_sync == REP_SYNC_NONE &&
-        dbenv->master != gbl_mynode) {
+        dbenv->master != gbl_myhostname) {
         logmsg(LOGMSG_DEBUG,
                "%s:%d td %u new query on replicant with sync none, dropping\n",
                __func__, __LINE__, (uint32_t)pthread_self());

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -3686,7 +3686,7 @@ int handle_alias_request(comdb2_appsock_arg_t *arg)
     line = arg->cmdline;
     llen = strlen(line);
 
-    if (dbenv->master != gbl_mynode) {
+    if (dbenv->master != gbl_myhostname) {
         sbuf2printf(sb, "!master swinged, now on %s, please rerun\n",
                     thedb->master);
         sbuf2printf(sb, "FAILED\n");

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -41,7 +41,7 @@ static inline int adjust_master_tables(struct dbtable *newdb, const char *csc2,
         newdb->csc2_schema_len = strlen(newdb->csc2_schema);
     }
 
-    if (newdb->dbenv->master == gbl_mynode) {
+    if (newdb->dbenv->master == gbl_myhostname) {
         if ((rc = sql_syntax_check(iq, newdb)))
             return SC_CSC2_ERROR;
     }
@@ -52,7 +52,7 @@ static inline int adjust_master_tables(struct dbtable *newdb, const char *csc2,
 static inline int get_db_handle(struct dbtable *newdb, void *trans)
 {
     int bdberr;
-    if (newdb->dbenv->master == gbl_mynode && !gbl_is_physical_replicant) {
+    if (newdb->dbenv->master == gbl_myhostname && !gbl_is_physical_replicant) {
         /* I am master: create new db */
         newdb->handle = bdb_create_tran(
             newdb->tablename, thedb->basedir, newdb->lrl, newdb->nix,
@@ -171,7 +171,7 @@ int add_table_to_environment(char *table, const char *csc2,
         goto err;
 
     /* must re add the dbs if you're a physical replicant */
-    if (newdb->dbenv->master != gbl_mynode || gbl_is_physical_replicant) {
+    if (newdb->dbenv->master != gbl_myhostname || gbl_is_physical_replicant) {
         /* This is a replicant calling scdone_callback */
         add_db(newdb);
     }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1029,7 +1029,7 @@ int finalize_upgrade_table(struct schema_change_type *s)
         rc = mark_schemachange_over_tran(s->db->tablename, tran);
         if (rc != 0) continue;
 
-        rc = trans_commit(&iq, tran, gbl_mynode);
+        rc = trans_commit(&iq, tran, gbl_myhostname);
     }
 
     return rc;

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -105,7 +105,7 @@ int check_table_schema(struct dbenv *dbenv, const char *table,
             logmsg(LOGMSG_ERROR, "%s\n", meta_csc2);
             rc = -1;
         }
-    } else if (dbenv->master == gbl_mynode) {
+    } else if (dbenv->master == gbl_myhostname) {
         /* on master node, store schema if we don't have one already. */
         file_csc2 = load_text_file(csc2file);
         if (!file_csc2) {

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -310,7 +310,7 @@ static int do_finalize(ddl_t func, struct ireq *iq,
     if (input_tran == NULL) {
         // void all_locks(void*);
         // all_locks(thedb->bdb_env);
-        rc = trans_commit_adaptive(iq, tran, gbl_mynode);
+        rc = trans_commit_adaptive(iq, tran, gbl_myhostname);
         if (rc) {
             sc_errf(s, "Failed to commit finalize transaction\n");
             return rc;
@@ -551,7 +551,7 @@ static int do_schema_change_tran_int(sc_arg_t *arg, int no_reset)
     if (!no_reset)
         oldtype = prepare_sc_thread(s);
 
-    if (!bdb_iam_master(thedb->bdb_env) || thedb->master != gbl_mynode) {
+    if (!bdb_iam_master(thedb->bdb_env) || thedb->master != gbl_myhostname) {
         logmsg(LOGMSG_INFO, "%s downgraded master\n", __func__);
         rc = SC_MASTER_DOWNGRADE;
         goto downgraded;
@@ -904,7 +904,7 @@ int resume_schema_change(void)
     if (gbl_is_physical_replicant) {
         return 0;
     }
-    if (thedb->master != gbl_mynode) {
+    if (thedb->master != gbl_myhostname) {
         logmsg(LOGMSG_WARN,
                "resume_schema_change: not the master, cannot resume a"
                " schema change\n");
@@ -1334,7 +1334,7 @@ int delete_temp_table(struct ireq *iq, struct dbtable *newdb)
         return -1;
     }
 
-    rc = trans_commit(iq, tran, gbl_mynode);
+    rc = trans_commit(iq, tran, gbl_myhostname);
     if (rc) {
         sc_errf(s, "%d: trans_commit rc %d\n", __LINE__, rc);
         iq->usedb = usedb_sav;
@@ -1365,7 +1365,7 @@ int do_setcompr(struct ireq *iq, const char *rec, const char *blob)
     bdb_set_odh_options(db->handle, db->odh, ra, ba);
     if ((rc = put_db_compress(db, tran, ra)) != 0) goto out;
     if ((rc = put_db_compress_blobs(db, tran, ba)) != 0) goto out;
-    if ((rc = trans_commit(iq, tran, gbl_mynode)) == 0) {
+    if ((rc = trans_commit(iq, tran, gbl_myhostname)) == 0) {
         logmsg(LOGMSG_USER, "%s -- TABLE:%s  REC COMP:%s  BLOB COMP:%s\n",
                __func__, db->tablename, bdb_algo2compr(ra), bdb_algo2compr(ba));
     } else {
@@ -1520,7 +1520,7 @@ int scdone_abort_cleanup(struct ireq *iq)
     struct schema_change_type *s = iq->sc;
     mark_schemachange_over(s->tablename);
     if (s->set_running)
-        sc_set_running(iq, s, s->tablename, 0, gbl_mynode, time(NULL), 0,
+        sc_set_running(iq, s, s->tablename, 0, gbl_myhostname, time(NULL), 0,
                        __func__, __LINE__);
     if (s->db && s->db->handle) {
         if (s->addonly) {

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -134,7 +134,7 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize)
     stop_threads(thedb);
     resume_threads(thedb);
 
-    if (newdb->dbenv->master == gbl_mynode) {
+    if (newdb->dbenv->master == gbl_myhostname) {
         /* I am master: create new db */
         newdb->handle =
             bdb_create_queue(newdb->tablename, thedb->basedir, avgitemsz,
@@ -673,7 +673,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
     }
 
     if (!same_tran) {
-        rc = trans_commit(&iq, tran, gbl_mynode);
+        rc = trans_commit(&iq, tran, gbl_myhostname);
         if (rc) {
             sbuf2printf(sb, "!Failed to commit transaction\n");
             goto done;
@@ -722,7 +722,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         }
 
         if (!same_tran) {
-            rc = trans_commit(&iq, tran, gbl_mynode);
+            rc = trans_commit(&iq, tran, gbl_myhostname);
             if (rc) {
                 sbuf2printf(sb, "!Failed to commit transaction\n");
                 goto done;
@@ -738,7 +738,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
             sbuf2printf(sb, "!Failed write scdone , rc=%d\n", rc);
             goto done;
         }
-        rc = trans_commit(&iq, ltran, gbl_mynode);
+        rc = trans_commit(&iq, ltran, gbl_myhostname);
         if (rc || bdberr != BDBERR_NOERROR) {
             sbuf2printf(sb, "!Failed to commit transaction, rc=%d\n", rc);
             goto done;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -372,7 +372,7 @@ static void delay_sc_if_needed(struct convert_record_data *data,
 
     /* wait for replication on what we just committed */
     if ((data->nrecs % data->num_records_per_trans) == 0) {
-        if ((rc = trans_wait_for_seqnum(&data->iq, gbl_mynode, ss)) != 0) {
+        if ((rc = trans_wait_for_seqnum(&data->iq, gbl_myhostname, ss)) != 0) {
             sc_errf(data->s, "delay_sc_if_needed: error waiting for "
                              "replication rcode %d\n",
                     rc);
@@ -1080,7 +1080,7 @@ err:
     if (data->live) {
         rc = trans_commit_seqnum(&data->iq, data->trans, &ss);
     } else {
-        rc = trans_commit(&data->iq, data->trans, gbl_mynode);
+        rc = trans_commit(&data->iq, data->trans, gbl_myhostname);
     }
 
     data->trans = NULL;
@@ -1202,7 +1202,7 @@ void *convert_records_thd(struct convert_record_data *data)
         /* can only get here for non-live schema change, shouldn't ever get here
          * now since bulk transactions have been disabled in all schema changes
          */
-        rc = trans_commit(&data->iq, data->trans, gbl_mynode);
+        rc = trans_commit(&data->iq, data->trans, gbl_myhostname);
         data->trans = NULL;
         if (rc) {
             sc_errf(data->s, "convert_records_thd: trans_commit failed due "
@@ -1730,7 +1730,8 @@ static int upgrade_records(struct convert_record_data *data)
 
         // txn contains enough records, wait for replicants
         if ((data->nrecs % data->num_records_per_trans) == 0) {
-            if ((rc = trans_wait_for_seqnum(&data->iq, gbl_mynode, &ss)) != 0) {
+            if ((rc = trans_wait_for_seqnum(&data->iq, gbl_myhostname, &ss)) !=
+                0) {
                 sc_errf(data->s, "%s: error waiting for "
                                  "replication rcode %d\n",
                         __func__, rc);
@@ -3055,7 +3056,7 @@ done:
         } else if (data->live)
             rc = trans_commit_seqnum(&data->iq, data->trans, &ss);
         else
-            rc = trans_commit(&data->iq, data->trans, gbl_mynode);
+            rc = trans_commit(&data->iq, data->trans, gbl_myhostname);
     }
 
     reqlog_end_request(data->iq.reqlogger, 0, __func__, __LINE__);

--- a/schemachange/sc_stripes.c
+++ b/schemachange/sc_stripes.c
@@ -159,7 +159,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
         return SC_INTERNAL_ERROR;
     }
 
-    rc = trans_commit(&iq, sc_logical_tran, gbl_mynode);
+    rc = trans_commit(&iq, sc_logical_tran, gbl_myhostname);
     if (rc) {
         logmsg(LOGMSG_ERROR, "morestripe: couldn't commit rename trans\n");
         return SC_FAILED_TRANSACTION;

--- a/schemachange/sc_util.c
+++ b/schemachange/sc_util.c
@@ -70,7 +70,7 @@ int open_all_dbs(void)
 int check_sc_ok(struct schema_change_type *s)
 {
     /* I must be rtcpu up */
-    if (!is_node_up(gbl_mynode)) {
+    if (!is_node_up(gbl_myhostname)) {
         sc_errf(s, "cannot perform schema change; I am rtcpu'd down\n");
         return -1;
     }

--- a/util/rtcpu.c
+++ b/util/rtcpu.c
@@ -121,7 +121,7 @@ static int machine_status_init(void)
     return 0;
 }
 
-extern char *gbl_mynode;
+extern char *gbl_myhostname;
 
 /* pthread_once? */
 static int machine_class_default(const char *host)
@@ -155,8 +155,8 @@ static int machine_class_default(const char *host)
                        rc, cdb2_errstr(db));
                 goto done;
             }
-            rc = cdb2_bind_param(db, "name", CDB2_CSTRING, gbl_mynode,
-                                 strlen(gbl_mynode));
+            rc = cdb2_bind_param(db, "name", CDB2_CSTRING, gbl_myhostname,
+                                 strlen(gbl_myhostname));
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s(%s) bind rc %d %s!\n", __func__, host,
                        rc, cdb2_errstr(db));
@@ -205,7 +205,7 @@ static int machine_class_default(const char *host)
 
 static int machine_my_class_default(void)
 {
-    return machine_class_default(gbl_mynode);
+    return machine_class_default(gbl_myhostname);
 }
 static int machine_dcs[MAXNODES];
 


### PR DESCRIPTION
If the master node has a Canonical Name different from its local hostname, and its Canonical Name is written in `hostname.lrl`, it'll think that the master is down and then call for an election, repeatedly.

This is because `gbl_myhostname`, which is the local hostname, is used in the `net/event` layer to check for localhost, whereas `gbl_node`, which is the host's Canonical Name, is used to create a `net`. Hence if `gbl_myhostname` and `gbl_node` are different, the `net/event` layer will fail to filter out net messages from localhost to localhost.

The patch gets rid of `gbl_myhostname`, and uses `gbl_mynode` everywhere.