### PR TITLE
handle new OP_IfNoHope opcode, and more redundant bug protections

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6321,6 +6321,10 @@ static int execute_sql_query_offload(struct sqlthdstate *poolthd,
     rec.sql = clnt->sql;
     if (get_prepared_bound_stmt(poolthd, clnt, &rec, &clnt->osql.xerr,
                                 PREPARE_NONE)) {
+        /* if prepare failed, and this is not a versioning issue,
+           report error */
+        if (clnt->fdb_state.xerr.errval != SQLITE_SCHEMA)
+            ret = ERR_SQL_PREP;
         goto done;
     }
     thrman_wheref(poolthd->thr_self, "%s", rec.sql);

--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -5458,6 +5458,7 @@ char *sqlite3DescribeIndexOrder(
   }
 
   switch( op ){
+    case OP_IfNoHope:
     case OP_Found:
     case OP_NotFound: {
       isMovingLeft = 0; 
@@ -5518,6 +5519,9 @@ char *sqlite3DescribeIndexOrder(
         :">";
       break;
     }
+    default:
+        logmsg(LOGMSG_ERROR, "Unknown opcode, upgraded sqlite? op %d\n", op);
+        abort();
   }
 
   pTbl = pIdx->pTable;


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Interesting enough, this sqlite tidbit was blocking replication when a schema change occurred!
New opcode, OP_IfNoHope, not handled, error ignored, both remote and source end up waiting for each other, hogging the bdb write lock.  Simple fix, added redundant checks for future sqlite upgrades (send error when we break sqlite generation, also stop fast when new opcodes show up).
