### PR TITLE
sqlitex: cache sqlitex columns names alongside fingerprint

### DIFF
--- a/db/db_fingerprint.c
+++ b/db/db_fingerprint.c
@@ -27,17 +27,25 @@
 
 extern int gbl_old_column_names;
 
-hash_t *gbl_fingerprint_hash = NULL;
+hash_t *gbl_fingerprint_hash;
 pthread_mutex_t gbl_fingerprint_hash_mu = PTHREAD_MUTEX_INITIALIZER;
 
 extern int gbl_fingerprint_queries;
 extern int gbl_verbose_normalized_queries;
 int gbl_fingerprint_max_queries = 1000;
 
-static int free_fingerprint(void *obj, void *arg){
+static int free_fingerprint(void *obj, void *arg)
+{
     struct fingerprint_track *t = (struct fingerprint_track *)obj;
     if (t != NULL) {
         free(t->zNormSql);
+        /* Free cached column names */
+        if (t->cachedColCount > 0) {
+            for (int i = 0; i < t->cachedColCount; i++) {
+                free(t->cachedColNames[i]);
+            }
+            free(t->cachedColNames);
+        }
         free(t);
     }
     return 0;
@@ -46,6 +54,10 @@ static int free_fingerprint(void *obj, void *arg){
 int clear_fingerprints(void) {
     int count = 0;
     Pthread_mutex_lock(&gbl_fingerprint_hash_mu);
+    if (!gbl_fingerprint_hash) {
+        Pthread_mutex_unlock(&gbl_fingerprint_hash_mu);
+        return count;
+    }
     hash_info(gbl_fingerprint_hash, NULL, NULL, NULL, NULL, &count, NULL, NULL);
     hash_for(gbl_fingerprint_hash, free_fingerprint, NULL);
     hash_clear(gbl_fingerprint_hash);
@@ -77,13 +89,12 @@ void add_fingerprint(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
 {
     assert(zSql);
     assert(zNormSql);
-    size_t nNormSql = strlen(zNormSql);
+    size_t nNormSql;
     unsigned char fingerprint[FINGERPRINTSZ];
-    MD5Context ctx;
-    MD5Init(&ctx);
-    MD5Update(&ctx, (unsigned char *)zNormSql, nNormSql);
-    memset(fingerprint, 0, sizeof(fingerprint));
-    MD5Final(fingerprint, &ctx);
+
+    /* Calculate fingerprint */
+    calc_fingerprint(zNormSql, &nNormSql, fingerprint);
+
     Pthread_mutex_lock(&gbl_fingerprint_hash_mu);
     if (gbl_fingerprint_hash == NULL) gbl_fingerprint_hash = hash_init(FINGERPRINTSZ);
     struct fingerprint_track *t = hash_find(gbl_fingerprint_hash, fingerprint);
@@ -135,6 +146,24 @@ void add_fingerprint(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
                    "column names stable, fp:%s "
                    "(https://www.sqlite.org/c3ref/column_name.html)\n",
                    fp);
+
+            /* Also cache the old column names, stored in the stmt, alongside
+             * the fingerpint. */
+            t->cachedColCount = stmt_cached_column_count(stmt);
+            t->cachedColNames = calloc(sizeof(char *), t->cachedColCount);
+            if (t->cachedColNames == NULL) {
+                logmsg(LOGMSG_ERROR, "%s:%d out of memory\n", __func__,
+                       __LINE__);
+                t->cachedColCount = 0;
+            } else {
+                for (int i = 0; i < t->cachedColCount; i++) {
+                    t->cachedColNames[i] =
+                        strdup(stmt_cached_column_name(stmt, i));
+                }
+            }
+        } else {
+            t->cachedColNames = NULL;
+            t->cachedColCount = 0;
         }
     } else {
         t->count++;

--- a/db/sql.h
+++ b/db/sql.h
@@ -69,6 +69,8 @@ struct fingerprint_track {
     int64_t rows;    /* Cumulative number of rows selected */
     char *zNormSql;  /* The normalized SQL query */
     size_t nNormSql; /* Length of normalized SQL query */
+    char ** cachedColNames; /* Cached column names from sqlitex */
+    int cachedColCount;     /* Cached column count from sqlitex */
 };
 
 typedef struct stmt_hash_entry {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -126,6 +126,8 @@ extern int gbl_stable_rootpages_test;
 extern int gbl_verbose_normalized_queries;
 extern int gbl_expressions_indexes;
 extern int gbl_old_column_names;
+extern hash_t *gbl_fingerprint_hash;
+extern pthread_mutex_t gbl_fingerprint_hash_mu;
 
 /* Once and for all:
 
@@ -3071,6 +3073,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
                                  struct sql_state *rec, struct errstat *err,
                                  int flags)
 {
+    bool normalize_sql_done = false;
     int recreate = (flags & PREPARE_RECREATE);
     int rc = sqlengine_prepare_engine(thd, clnt, recreate);
     if (thd->sqldb == NULL) {
@@ -3110,7 +3113,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
                                                 sqlPrepFlags, &rec->stmt, &tail);
 
         /* Prepare the query with the query_preparer plugin. */
-        if (rc == SQLITE_OK && gbl_old_column_names &&
+        if (rc == SQLITE_OK && gbl_old_column_names && rec->stmt &&
             !clnt->fdb_state.remote_sql_sb && query_preparer_plugin &&
             query_preparer_plugin->do_prepare &&
             sqlite3_stmt_readonly(rec->stmt) &&
@@ -3118,10 +3121,57 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
             (thd->authState.numDdls == 0)) {
             char **column_names;
             int column_count;
-            rc = query_preparer_plugin->do_prepare(thd, clnt, rec->sql,
-                                                   &column_names, &column_count);
-            if (rc)
-                return rc;
+            struct fingerprint_track *t = NULL;
+
+            if (gbl_fingerprint_queries) {
+                unsigned char fingerprint[FINGERPRINTSZ];
+                size_t unused;
+
+                /* Generate normalized sql */
+                normalize_stmt_and_store(clnt, rec);
+                sqlite3_resetclock(rec->stmt);
+                thr_set_current_sql(rec->sql);
+                normalize_sql_done = true;
+
+                /* Calculate fingerprint */
+                calc_fingerprint(clnt->zNormSql, &unused, fingerprint);
+
+                Pthread_mutex_lock(&gbl_fingerprint_hash_mu);
+                if (gbl_fingerprint_hash) {
+                    t = hash_find(gbl_fingerprint_hash, fingerprint);
+                    if (t) {
+                        /* Create a copy of cached column names and pass it to
+                         * stmt, to be later freed when the stmt finalizes. */
+                        column_count = t->cachedColCount;
+                        column_names =
+                            calloc(sizeof(char *), t->cachedColCount);
+                        if (column_names == NULL) {
+                            logmsg(LOGMSG_ERROR, "%s:%d: out of memory\n",
+                                   __func__, __LINE__);
+                            column_count = 0;
+                        } else {
+                            for (int i = 0; i < t->cachedColCount; i++) {
+                                column_names[i] = strdup(t->cachedColNames[i]);
+                            }
+                        }
+                        logmsg(LOGMSG_DEBUG,
+                               "%s:%d: using cached column names from "
+                               "fingerprint\n",
+                               __func__, __LINE__);
+                    }
+                }
+                Pthread_mutex_unlock(&gbl_fingerprint_hash_mu);
+            }
+
+            /* If there's no fingerprint for this query, let's take the longer
+             * route of repreparing the query. */
+            if (!t) {
+                rc = query_preparer_plugin->do_prepare(
+                    thd, clnt, rec->sql, &column_names, &column_count);
+                if (rc)
+                    return rc;
+            }
+
             if (rec->stmt)
                 stmt_set_cached_columns(rec->stmt, column_names, column_count);
         }
@@ -3142,9 +3192,12 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
     }
 
     if (rec->stmt) {
-        normalize_stmt_and_store(clnt, rec);
-        sqlite3_resetclock(rec->stmt);
-        thr_set_current_sql(rec->sql);
+        if (!normalize_sql_done) {
+            normalize_stmt_and_store(clnt, rec);
+            sqlite3_resetclock(rec->stmt);
+            thr_set_current_sql(rec->sql);
+            normalize_sql_done = true;
+        }
     } else if (rc == 0) {
         // No stmt and no error -> Empty sql string or just comment.
         rc = ERR_SQL_PREPARE;

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4842,6 +4842,8 @@ int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
 
+int stmt_cached_column_count(sqlite3_stmt *);
+char *stmt_cached_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4842,6 +4842,8 @@ SQLITE_API int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
 
+int stmt_cached_column_count(sqlite3_stmt *);
+char *stmt_cached_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -94,7 +94,7 @@ static SQLITE_NOINLINE void invokeProfileCallback(sqlite3 *db, Vdbe *p){
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 extern int gbl_old_column_names;
 
-static char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
+char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
   char **column_names;
   Vdbe *vdbe = (Vdbe *)pStmt;
 
@@ -106,7 +106,7 @@ static char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
   return column_names[index];
 }
 
-static inline int stmt_cached_column_count(sqlite3_stmt *pStmt) {
+int stmt_cached_column_count(sqlite3_stmt *pStmt) {
   Vdbe *vdbe = (Vdbe *)pStmt;
   return (vdbe) ? vdbe->oldColCount : 0;
 }


### PR DESCRIPTION
Once the query is prepared by the query preparer plugin (sqlitex), we cache the column names alongside the fingerprint object. Later, we can simply reuse these cached column names when a similar query is executed again. This would help keep the column names consistent across multiple runs and provide performance gains by preventing the sqlitex plugin from re-preparing the same query multiple times. One point to note here is that for queries having same fingerprints, the column names that get cached would be ones from the very first query that gets executed, subsequent queries would reuse and return same column names.
For instance, consider the following 2 queries:
```
select i from t1 union select 1; -- S1
select I from t1 union select 1; -- S2
```
When executed independently with sqlite version 3.8.9 (sqlitex), column name returned for S1 and S2 would be `i` and `I` respectively. But, with this feature enabled, we they both will return same column names when executed in succession. Thus, for the above sequence, both queries will return `i`.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>