### PR TITLE
Show running SC seed when sending stat to the db

### DIFF
--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -78,6 +78,8 @@ int replicant_reload_analyze_stats();
 void sc_set_logical_redo_lwm(char *table, unsigned int file);
 unsigned int sc_get_logical_redo_lwm();
 unsigned int sc_get_logical_redo_lwm_table(char *table);
+/* get sc seed for table for a running schema change */
+uint64_t sc_get_seed_table(char *table);
 
 void add_ongoing_alter(struct schema_change_type *sc);
 void remove_ongoing_alter(struct schema_change_type *sc);

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -257,6 +257,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     }
     uuidstr_t us;
     comdb2uuidstr(s->uuid, us);
+    s->seed = seed;
     rc = sc_set_running(iq, s, s->tablename, s->preempted ? 2 : 1, node,
                         time(NULL), 0, __func__, __LINE__);
     if (rc != 0) {

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -216,6 +216,7 @@ struct schema_change_type {
     bool views_locked : 1;
     bool is_osql : 1;
     bool set_running : 1;
+    uint64_t seed;
 };
 
 struct ireq;

--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -10,6 +10,7 @@
 #include "cdb2api.h"
 #include "schemachange.h"
 #include "sc_schema.h"
+#include "sc_global.h"
 
 struct sc_status_ent {
     char *name;
@@ -104,13 +105,10 @@ int get_status(void **data, int *npoints)
         if (status[i].status == BDB_SC_RUNNING || 
             status[i].status == BDB_SC_PAUSED || 
             status[i].status == BDB_SC_COMMIT_PENDING) {
-            unsigned long long seed = 0;
-            unsigned int host = 0;
-            if ((rc = fetch_sc_seed(sc.tablename, thedb, &seed, &host)) == SC_OK) {
-                char str[22];
-                sprintf(str, "0x%llx", seed);
-                sc_status_ents[i].seed = strdup(str);
-            }
+            uint64_t seed = sc_get_seed_table(sc.tablename);
+            char str[22];
+            sprintf(str, "%0#16" PRIx64, flibc_htonll(seed));
+            sc_status_ents[i].seed = strdup(str);
         }
     }
 

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -52,6 +52,15 @@ function assert_schema
     fi
 }
 
+function check_systable_sc_status
+{
+    seed1=$1
+    seed2=`cdb2sql --tabs --host $master ${CDB2_OPTIONS} $dbnm "select seed from comdb2_sc_status where name='t1'"`
+    if [ "$seed1" != "$seed2" ] ; then
+        failexit "sc_status does not contain the correct seed for t1 schemachange $seed1 vs $seed2"
+    fi
+}
+
 
 function assert_sc_status
 {
@@ -293,6 +302,10 @@ echo "sleep 10 to let alter1 process some rows"
 sleep 10
 
 seed1=`get_sc_seed`
+
+# check that comdb2_sc_status table has the same seed
+check_systable_sc_status $seed1
+
 #if it is a cluster we can downgrade, if it is single node we can restart
 #we can add feature to send('restart') where it will cleanup then exec self
 echo "sending downgrade"


### PR DESCRIPTION
While there is a schema change running, `@send stat` no longer
displays a seed (accidentally removed). This patch will enable
to show running SC seed when sending stat to the db, and also adds
a check in testcase that comdb2_sc_status table has the same seed.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>