### PR TITLE
Fix for cdb2jdbc database metadata

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2DatabaseMetaData.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2DatabaseMetaData.java
@@ -1133,7 +1133,7 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
 
         ps = conn.prepareStatement(q.toString());
         ps.setString(1, conn.getDatabase());
-        ps.setString(2, conn.getCluster());
+        ps.setObject(2, null);
         ps.setInt(3, DatabaseMetaData.procedureResultUnknown);
         if (procedureNamePattern != null)
             ps.setString(4, procedureNamePattern);
@@ -1189,7 +1189,7 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
             ps.close();
         ps = conn.prepareStatement(sql.toString());
         ps.setString(1, conn.getDatabase());
-        ps.setString(2, conn.getCluster());
+        ps.setObject(2, null);
         ps.setString(3, tableNamePattern);
 
         return ps.executeQuery();
@@ -1199,7 +1199,7 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
         if (ps != null)
             ps.close();
         ps = conn.prepareStatement("select ? as TABLE_SCHEM, ? as TABLE_CATALOG");
-        ps.setString(1, conn.getCluster());
+        ps.setObject(1, null);
         ps.setString(2, conn.getDatabase());
 
         return ps.executeQuery();
@@ -1490,6 +1490,12 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
             .append("    ? as TABLE_SCHEM,")
             .append("    tablename as TABLE_NAME,")
             .append("    columnname as COLUMN_NAME,")
+            .append("    0 as DATA_TYPE,")
+            .append("    type as TYPE_NAME,")
+            .append("    (size - 1) as COLUMN_SIZE,")
+            .append("    0 as BUFFER_LENGTH,")
+            .append("    0 as DECIMAL_DIGITS,")
+            .append("    10 as NUM_PREC_RADIX,")
             .append("    (upper(isnullable) == 'Y') as NULLABLE,")
             .append("    null as REMARKS,")
             .append("    trim(defaultvalue) as COLUMN_DEF,")
@@ -1509,17 +1515,17 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
             .append("where 1=1 AND ")
             .append("tablename LIKE ? AND ")
             .append("columnname LIKE ? ")
-            .append("order by TABLE_CAT,TABLE_SCHEM, TABLE_NAME, ORDINAL_POSITION");
+            .append("order by TABLE_CAT,TABLE_SCHEM, TABLE_NAME");
 
         if (ps != null)
             ps.close();
         ps = conn.prepareStatement(q.toString());
         ps.setString(1, conn.getDatabase());
-        ps.setString(2, conn.getCluster());
+        ps.setObject(2, null);
         ps.setString(3, tableNamePattern != null ? tableNamePattern : "%");
         ps.setString(4, columnNamePattern != null ? columnNamePattern : "%");
 
-        return ps.executeQuery();
+        return new Comdb2DatabaseMetaDataResultSet(ps.executeQuery());
     }
 
     public ResultSet getColumnPrivileges(String catalog, String schema,
@@ -2028,7 +2034,7 @@ public class Comdb2DatabaseMetaData implements DatabaseMetaData {
     }
 
     public ResultSet getSchemas(String catalog, String schemaPattern) throws SQLException {
-        return stmt.executeQuery("select null as TABLE_SCHEM, null as TABLE_CATALOG limit 0");
+        return getSchemas();
     }
 
     public boolean supportsStoredFunctionsUsingCallSyntax() throws SQLException {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -188,7 +188,7 @@ public class Comdb2Statement implements Statement {
 
     @Override
     public void setMaxFieldSize(int max) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return;
     }
 
     @Override
@@ -198,7 +198,7 @@ public class Comdb2Statement implements Statement {
 
     @Override
     public void setMaxRows(int max) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return;
     }
 
     @Override
@@ -334,7 +334,7 @@ public class Comdb2Statement implements Statement {
 
     @Override
     public ResultSet getGeneratedKeys() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return null;
     }
 
     @Override
@@ -384,7 +384,7 @@ public class Comdb2Statement implements Statement {
 
     @Override
     public void setPoolable(boolean poolable) throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return;
     }
 
     @Override
@@ -393,7 +393,7 @@ public class Comdb2Statement implements Statement {
     }
 
     public void closeOnCompletion() throws SQLException {
-        throw new SQLFeatureNotSupportedException();
+        return;
     }
 
     public boolean isCloseOnCompletion() throws SQLException {

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseMetaDataTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseMetaDataTest.java
@@ -40,7 +40,7 @@ public class DatabaseMetaDataTest {
         String nm = rs.getString(3);
 
         assertEquals(cat, db);
-        assertEquals(sche, cluster);
+        assertEquals(sche, null);
         assertEquals(nm, "sp1");
         rs.close();
 
@@ -66,7 +66,7 @@ public class DatabaseMetaDataTest {
         String nm = rs.getString(3);
 
         assertEquals(cat, db);
-        assertEquals(sche, cluster);
+        assertEquals(sche, null);
         assertEquals(nm, "t1");
         assertFalse(rs.next());
         rs.close();
@@ -93,8 +93,14 @@ public class DatabaseMetaDataTest {
         assertTrue(rs.next());
         String tbl = rs.getString("TABLE_NAME");
         String col = rs.getString("COLUMN_NAME");
+        /* The 5th column is the SQL type. */
+        int sqltype = rs.getInt(5);
+        /* The 7th column is size. */
+        int len = rs.getInt(7);
         assertEquals(tbl, "t1");
         assertEquals(col, "i");
+        assertEquals(sqltype, java.sql.Types.INTEGER);
+        assertEquals(len, 4); /* 4-byte integer */
         assertFalse(rs.next());
         rs.close();
 
@@ -197,7 +203,7 @@ public class DatabaseMetaDataTest {
         String sche = rs.getString(1);
         String cat = rs.getString(2);
         assertEquals(cat, db);
-        assertEquals(sche, cluster);
+        assertEquals(sche, null);
         assertFalse(rs.next());
         rs.close();
     }


### PR DESCRIPTION
Cdb2jdbc's implementation of `DatabaseMetaData.getColumns` does not comply
with the JDBC specification. The patch fixes it.

Co-authored-by: Oleg Kosenkov <okosenkov@bloomberg.net>
Signed-off-by: Rivers Zhang <hzhang320@bloomberg.net>