### PR TITLE
sqlitex: cache sqlitex columns names alongside fingerprint (ported from 7.0)

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -72,6 +72,8 @@ struct fingerprint_track {
     int64_t rows;     /* Cumulative number of rows selected */
     char *zNormSql;   /* The normalized SQL query */
     size_t nNormSql;  /* Length of normalized SQL query */
+    char ** cachedColNames; /* Cached column names from sqlitex */
+    int cachedColCount;     /* Cached column count from sqlitex */
 };
 
 typedef struct stmt_hash_entry {

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4843,6 +4843,8 @@ int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
 
+int stmt_cached_column_count(sqlite3_stmt *);
+char *stmt_cached_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4843,6 +4843,8 @@ SQLITE_API int sqlite3_resetclock(sqlite3_stmt *pStmt);
 char *stmt_tzname(sqlite3_stmt *);
 void stmt_set_dtprec(sqlite3_stmt *, int);
 
+int stmt_cached_column_count(sqlite3_stmt *);
+char *stmt_cached_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -94,7 +94,7 @@ static SQLITE_NOINLINE void invokeProfileCallback(sqlite3 *db, Vdbe *p){
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 extern int gbl_old_column_names;
 
-static char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
+char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
   char **column_names;
   Vdbe *vdbe = (Vdbe *)pStmt;
 
@@ -106,7 +106,7 @@ static char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
   return column_names[index];
 }
 
-static inline int stmt_cached_column_count(sqlite3_stmt *pStmt) {
+int stmt_cached_column_count(sqlite3_stmt *pStmt) {
   Vdbe *vdbe = (Vdbe *)pStmt;
   return (vdbe) ? vdbe->oldColCount : 0;
 }


### PR DESCRIPTION
Once the query is prepared by the query preparer plugin (sqlitex), we cache the column names alongside the fingerprint object. Later, we can simply reuse these cached column names when a similar query is executed again. This would help keep the column names consistent across multiple runs and provide performance gains by preventing the sqlitex plugin from re-preparing the same query multiple times.

One point to note here is that for queries having same fingerprints, the column names that get cached would be ones from the very first query that gets executed, subsequent queries would reuse and return same column names. For instance, consider the following 2 queries:

SELECT i FROM t1 UNION SELECT 1; -- S1
SELECT I FROM t1 UNION SELECT 1; -- S2

When executed independently with sqlite version 3.8.9 (sqlitex), column name returned for S1 and S2 would be i and I respectively. But, with this feature enabled, we they both will return same column names when executed in succession. Thus, for the above sequence, both queries will return i.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>