### PR TITLE
Fix the temptable starve logic for prepares

### DIFF
--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -46,6 +46,7 @@
  * but in case of B-Tree new data is allocated. So far haven't seen any
  * problems. */
 
+#include <schema_lk.h>
 #include "locks.h"
 #include "locks_wrap.h"
 #include "bdb_int.h"
@@ -688,7 +689,15 @@ int bdb_temp_table_notify_pool_wrapper(void **tblp, void *bdb_state_arg)
     if (rc1 == TMPTBL_PRIORITY) { /* Are we going to end up waiting? */
         return OP_FORCE_NOW; /* No, we are forcing object creation. */
     } else {
-        int rc2 = recover_deadlock_simple(bdb_state);
+        int rc2;
+
+        /* This is in the middle of prepare.  We can't call recover deadlock,
+         * as releasing and re-acquiring the bdblock while holding the schema
+         * lock violates lock order.  We also can't prevent upgrades. */
+        if (have_schema_lock()) {
+            return OP_FAIL_NOW;
+        }
+        rc2 = recover_deadlock_simple(bdb_state);
         if (rc2 != 0) {
             logmsg(LOGMSG_WARN, "%s: recover_deadlock rc=%d\n", __func__, rc2);
         }

--- a/util/schema_lk.c
+++ b/util/schema_lk.c
@@ -24,6 +24,11 @@ static pthread_rwlock_t schema_lk = PTHREAD_RWLOCK_INITIALIZER;
 __thread int have_readlock = 0;
 __thread int have_writelock = 0;
 
+inline int have_schema_lock(void)
+{
+    return (have_readlock || have_writelock);
+}
+
 /* We actually acquire the readlock recursively: change these asserts to
  * accommodate */
 inline void rdlock_schema_int(const char *file, const char *func, int line)

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -19,6 +19,8 @@
 
 #include <locks_wrap.h>
 
+int have_schema_lock(void);
+
 #define rdlock_schema_lk() rdlock_schema_int(__FILE__, __func__, __LINE__)
 void rdlock_schema_int(const char *file, const char *func, int line);
 


### PR DESCRIPTION
bdb_temp_table_notify_pool_wrapper is called when the objpool subsystem cannot immediately allocate a temptable.  As we don't want to give up, the code calls recover deadlock, and continues to poll.  We are running across cases where we fail to acquire a temptable during the prepare phase.  Because this holds the schema-lock, calling recover_deadlock would violate lock order (and possibly deadlock the database).  Simple fix: sniff out whether this thread holds the schema-lock, and return an error if it does.
