### PR TITLE
Fix for live vutf8 schema change (7.0)

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -62,6 +62,7 @@ int debug_switch_fix_pinref(void);                       /* 1 - not debug */
 int debug_switch_verbose_cursor_deadlocks(void);         /* 0 */
 int debug_switch_check_multiple_lockers(void);           /* 1 */
 int debug_switch_dump_pool_on_full(void);                /* 1 */
+int debug_switch_scconvert_finish_delay(void);           /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1826,5 +1826,4 @@ REGISTER_TUNABLE("debug_queuedb",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_debug_queuedb, EXPERIMENTAL, NULL, NULL,
                  NULL, NULL);
-
 #endif /* _DB_TUNABLES_H */

--- a/db/types.c
+++ b/db/types.c
@@ -3827,8 +3827,7 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
             memcpy(out, inblob->data, len);
             *outdtsz += len;
 
-            free(inblob->data);
-            bzero(inblob, sizeof(blob_buffer_t));
+            free_blob_buffers(inblob, 1);
 
             if (outblob) {
                 outblob->collected = 1;
@@ -6526,8 +6525,7 @@ static TYPES_INLINE int blob2_convert(int len, const void *in, int in_len,
             memcpy(out, inblob->data, len);
             *outdtsz += len;
 
-            free(inblob->data);
-            bzero(inblob, sizeof(blob_buffer_t));
+            free_blob_buffers(inblob, 1);
 
             if (outblob) {
                 outblob->collected = 1;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -32,6 +32,7 @@
 #include "bdb_osql_log_rec.h"
 
 #include "comdb2_atomic.h"
+#include "debug_switches.h"
 #include "logmsg.h"
 
 int gbl_logical_live_sc = 0;
@@ -686,6 +687,11 @@ static int convert_record(struct convert_record_data *data)
             // AZ: determine what locks we hold at this time
             // bdb_dump_active_locks(data->to->handle, stdout);
             data->sc_genids[data->stripe] = -1ULL;
+
+            if (debug_switch_scconvert_finish_delay()) {
+                logmsg(LOGMSG_WARN, "scgenid reset. sleeping 10 sec.\n");
+                sleep(10);
+            }
 
             int usellmeta = 0;
             if (!data->to->plan) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -671,25 +671,55 @@ int live_sc_post_delete(struct ireq *iq, void *trans, unsigned long long genid,
     return rc;
 }
 
+/* If the schema change is to 1) remove ODH, 2) change the compression
+   algorithm, 3) or alter a field from or to vutf8, unpack the blobs. */
 static int unodhfy_if_necessary(struct ireq *iq, blob_buffer_t *blobs,
                                 int maxblobs)
 {
-    int i, rc, oldodh, newodh, reccompr, oldcompr, newcompr;
+    int i, rc, oldodh, newodh, reccompr, oldcompr, newcompr, fromidx, blobidx;
+    struct schema *from, *to;
 
-    for (i = 0, rc = 0; i != maxblobs; ++i) {
-        bdb_get_compr_flags(iq->usedb->sc_from->handle, &oldodh, &reccompr,
-                            &oldcompr);
-        bdb_get_compr_flags(iq->usedb->sc_to->handle, &newodh, &reccompr,
-                            &newcompr);
-        (void)reccompr;
+    bdb_get_compr_flags(iq->usedb->sc_from->handle, &oldodh, &reccompr,
+                        &oldcompr);
+    bdb_get_compr_flags(iq->usedb->sc_to->handle, &newodh, &reccompr,
+                        &newcompr);
+    (void)reccompr;
 
-        /* If we're removing the ODH, or changing the compression algorithm,
-           unpack the blobs. */
-        if ((oldodh && !newodh) || oldcompr != newcompr) {
+    /* If we're removing the ODH, or changing the compression algorithm,
+       unpack the blobs. */
+    if ((oldodh && !newodh) || oldcompr != newcompr) {
+        for (i = 0, rc = 0; i != maxblobs; ++i) {
             rc = unodhfy_blob_buffer(iq->usedb->sc_to, blobs + i, i);
             if (rc != 0)
-                break;
+                return rc;
         }
+    }
+
+    /* Check if we need to unpack vutf8. */
+    assert(iq->usedb->sc_from != NULL && iq->usedb->sc_to != NULL);
+
+    from = find_tag_schema(iq->usedb->sc_from->tablename, ".ONDISK");
+    to = find_tag_schema(iq->usedb->sc_to->tablename, ".NEW..ONDISK");
+
+    for (rc = 0, i = 0; i != to->nmembers; ++i) {
+        /* If the field in the new schema is new, do nothing. */
+        fromidx = find_field_idx_in_tag(from, to->member[i].name);
+        if (fromidx < 0)
+            continue;
+        /* We only care about vutf8. So if neither the old
+           nor new type is vutf8, continue. */
+        if (to->member[i].type != SERVER_VUTF8 &&
+            from->member[fromidx].type != SERVER_VUTF8)
+            continue;
+        /* Inline vutf8 data isn't preprocessed. Continue. */
+        blobidx = from->member[fromidx].blob_index;
+        if (blobidx < 0)
+            continue;
+        /* We have a preprocessed blob which is vutf8 or to be converted to
+           vutf8, unpack it as we need to validate the utf8 content. */
+        rc = unodhfy_blob_buffer(iq->usedb->sc_to, blobs + blobidx, blobidx);
+        if (rc)
+            break;
     }
 
     return rc;

--- a/tests/sc_vutf8_validate.test/Makefile
+++ b/tests/sc_vutf8_validate.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sc_vutf8_validate.test/off_osql_odh_blob.testopts
+++ b/tests/sc_vutf8_validate.test/off_osql_odh_blob.testopts
@@ -1,0 +1,1 @@
+off osql_odh_blob

--- a/tests/sc_vutf8_validate.test/runit
+++ b/tests/sc_vutf8_validate.test/runit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# Test live schema change of preprocessed (ODH prefixed) vutf8 data.
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+set -e
+
+dbnm=$1
+
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select host from comdb2_cluster where is_master="Y"'`
+
+cat << EOF | cdb2sql ${CDB2_OPTIONS} $dbnm --host $master - >/dev/null 2>&1 &
+drop table if exists t
+create table t {
+    tag ondisk {
+        int i
+        vutf8 txt1[8]
+        vutf8 txt2[8]
+        int j
+        blob binary[4]
+    }
+}\$\$
+insert into t values(1, 'charlie', 'sally', 2, x'00112233')
+exec procedure sys.cmd.send('scconvert_finish_delay 1')
+alter table t {
+    tag ondisk {
+        vutf8 txt1[16]
+        int j
+        cstring txt2[16]
+        double p null = yes
+        double q null = yes
+        blob binary[8]
+    }
+}\$\$
+EOF
+
+pid=$!
+
+sleep 5
+cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t values(1, 'charlie brown', 'sally brown', 2, x'00112233445566')"
+wait $pid

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=923)
+(TUNABLES_COUNT=924)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -744,6 +744,7 @@
 (name='sc_use_num_threads', description='Start up to this many threads for parallel rebuilding during schema change. 0 means use one per dtastripe. Setting is capped at dtastripe.', type='INTEGER', value='0', read_only='N')
 (name='sc_via_ddl_only', description='If set, we don't do checks needed for comdb2sc.', type='BOOLEAN', value='OFF', read_only='N')
 (name='scatterkeys', description='', type='BOOLEAN', value='OFF', read_only='N')
+(name='scconvert_finish_delay', description='Delay returning from convert_record when a stripe finishes. This would create a scenario where scgenids are on the right of any new genids to reproduce a vutf8 schema change bug. ', type='BOOLEAN', value='OFF', read_only='N')
 (name='schemachange_perms', description='Check if schema change allowed from source machines', type='BOOLEAN', value='ON', read_only='N')
 (name='scpushlogs', description='Push to next log after a schema changes', type='BOOLEAN', value='ON', read_only='N')
 (name='seqnum_wait_interval', description='Wake up to check the state of the world this often while waiting for replication ACKs.', type='INTEGER', value='500', read_only='N')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -69,6 +69,7 @@ static struct debug_switches {
     int check_multiple_lockers;
     int dump_pool_on_full;
     int net_delay;
+    int scconvert_finish_delay;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -117,6 +118,7 @@ int init_debug_switches(void)
     debug_switches.check_multiple_lockers = 1;
     debug_switches.dump_pool_on_full = 1;
     debug_switches.net_delay = 0;
+    debug_switches.scconvert_finish_delay = 0;
 
     register_int_switch("alternate_verify_fail", "alternate_verify_fail",
                         &debug_switches.alternate_verify_fail);
@@ -207,6 +209,11 @@ int init_debug_switches(void)
                         &debug_switches.check_multiple_lockers);
     register_int_switch("dump_pool_on_full", "dump_pool_on_full",
                         &debug_switches.dump_pool_on_full);
+    register_int_switch("scconvert_finish_delay",
+                        "Delay returning from convert_record when a stripe finishes. "
+                        "This would create a scenario where scgenids are on the right "
+                        "of any new genids to reproduce a vutf8 schema change bug. ",
+                        &debug_switches.scconvert_finish_delay);
 
     return 0;
 }
@@ -386,4 +393,8 @@ int debug_switch_dump_pool_on_full(void)
 int debug_switch_net_delay(void)
 {
     return debug_switches.net_delay;
+}
+int debug_switch_scconvert_finish_delay(void)
+{
+    return debug_switches.scconvert_finish_delay;
 }


### PR DESCRIPTION
This is an edge case when extending inline size of a vutf8 field:

Let P and Q denote the inline size in the old and new schemas, respectively. Stripe S finishes converting. A new record now lands on stripe S. It must be written to both old and new tables as the schema change hasn't completed yet. Let X denote the length of the vutf8 field in the new record.

If `P < X <= Q`, when `osql_odh_blob` is on, the insert would fail because `utf8_validate()` would be examining wrong data and the schema change would subsequently abort; when it is off, the database would crash in an invalid `free`.

The bug was introduced by blob preprocessing (#1399). The fix is simple: If the old or new type of a field is vutf8, we unodhfy the payload of any new records during the schema change.

(DRQS 155195897)