### PR TITLE
Fix non-single-meta bug in 7.0: disable meta_put for disabled queue odh

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -4277,6 +4277,11 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
     }
 
     if (!dbenv->meta) {
+        gbl_init_with_queue_odh = 0;
+        gbl_init_with_queue_compr = 0;
+    }
+
+    if (!dbenv->meta) {
         for (ii = 0; ii < dbenv->num_dbs; ii++) {
             rc = open_auxdbs(dbenv->dbs[ii], 0);
             /* We still have production comdb2s that don't have meta, so we
@@ -4293,7 +4298,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
     fix_blobstripe_genids(tran);
 
     /* read queue odh and compression information */
-    for (ii = 0; ii < dbenv->num_qdbs; ii++) {
+    for (ii = 0; dbenv->meta && ii < dbenv->num_qdbs; ii++) {
         struct dbtable *queue = dbenv->qdbs[ii];
         int compress;
         if (gbl_create_mode) {

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -530,15 +530,18 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
             goto done;
         }
 
-        if ((rc = put_db_queue_odh(db, tran, sc->headers)) != 0) {
-            logmsg(LOGMSG_ERROR, "failed to set odh for queue, rcode %d\n", rc);
-            goto done;
-        }
+        if (sc->headers == 1) {
+            if ((rc = put_db_queue_odh(db, tran, sc->headers)) != 0) {
+                logmsg(LOGMSG_ERROR, "failed to set odh for queue, rcode %d\n",
+                        rc);
+                goto done;
+            }
 
-        if ((rc = put_db_queue_compress(db, tran, sc->compress)) != 0) {
-            logmsg(LOGMSG_ERROR, "failed to set queue-compression, rcode %d\n",
-                   rc);
-            goto done;
+            if ((rc = put_db_queue_compress(db, tran, sc->compress)) != 0) {
+                logmsg(LOGMSG_ERROR, "failed to set queue-compression, rcode "
+                        "%d\n", rc);
+                goto done;
+            }
         }
 
         db->odh = sc->headers;
@@ -576,15 +579,18 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
             goto done;
         }
 
-        if ((rc = put_db_queue_odh(db, tran, sc->headers)) != 0) {
-            logmsg(LOGMSG_ERROR, "failed to set odh for queue, rcode %d\n", rc);
-            goto done;
-        }
+        if (sc->headers == 1) {
+            if ((rc = put_db_queue_odh(db, tran, sc->headers)) != 0) {
+                logmsg(LOGMSG_ERROR, "failed to set odh for queue, rcode %d\n",
+                        rc);
+                goto done;
+            }
 
-        if ((rc = put_db_queue_compress(db, tran, sc->compress)) != 0) {
-            logmsg(LOGMSG_ERROR, "failed to set queue-compress, rcode %d\n",
-                   rc);
-            goto done;
+            if ((rc = put_db_queue_compress(db, tran, sc->compress)) != 0) {
+                logmsg(LOGMSG_ERROR, "failed to set queue-compress, rcode %d\n",
+                        rc);
+                goto done;
+            }
         }
 
         db->odh = sc->headers;


### PR DESCRIPTION
Discovered yesterday that databases which are not single meta fail in perform_trigger_update_int.  See https://github.com/bloomberg/comdb2/pull/2200 for the *actual* fix, the code mimics the logic in alter_table schema-change and calls open_auxdbs after setting the handle.  This is a less aggressive fix which disables writing to the meta-table if queue-odh is disabled.