### PR TITLE
do not use client cnonce when transaction is chunked

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1466,9 +1466,10 @@ static int osql_send_commit_logic(struct sqlclntstate *clnt, int is_retry,
     osql->tran_ops = 0; /* reset transaction size counter*/
 
     extern int gbl_always_send_cnonce;
-    int send_cnonce = gbl_always_send_cnonce ? 1 : has_high_availability(clnt);
-    if (osql->rqid == OSQL_RQID_USE_UUID && send_cnonce &&
-        get_cnonce(clnt, &snap_info) == 0 && !clnt->dbtran.trans_has_sp) {
+    if (osql->rqid == OSQL_RQID_USE_UUID && clnt->dbtran.maxchunksize == 0 &&
+        !clnt->dbtran.trans_has_sp &&
+        (gbl_always_send_cnonce || has_high_availability(clnt)) &&
+        get_cnonce(clnt, &snap_info) == 0) {
 
         /* pass to master the state of verify retry.
          * if verify retry is on and error is retryable, don't write to


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

If "SET TRANSACTION CHUNK n" is used, we need to disable using client cnonce as blkseq.  We are generating multiple transactions, and each needs its own blkseq.