### PR TITLE
Fix macOS build of pmux

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -61,6 +61,10 @@
 #   define debug_log(...)
 #endif
 
+#ifdef __APPLE__
+#define HOST_NAME_MAX 255
+#endif
+
 struct connection;
 static event_base *base;
 static std::map<std::string, int> port_map;


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?

Fix macOS build (bug?)

* What are the current behavior and expected behavior, if this is a bugfix ? 

macOS does not define `HOST_NAME_MAX` (it does define a few other constants similar though, but nothing broadly portable).

* What are the steps required to reproduce the bug, if this is a bugfix ?

build on macOS

* What is the current behavior and new behavior, if this is a feature change or enhancement ?

n/a

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?

n/a
