### PR TITLE
Fix TXN accounting in comdb2_clientstats

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2647,15 +2647,15 @@ struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
 
             case BLOCK2_RECOM:
                 summaries[ii].recom += n;
-		break;
+                break;
 
             case BLOCK2_SNAPISOL:
                 summaries[ii].snapisol += n;
-		break;
+                break;
 
             case BLOCK2_SERIAL:
                 summaries[ii].serial += n;
-		break;
+                break;
             }
         }
         ii++;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2647,12 +2647,15 @@ struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
 
             case BLOCK2_RECOM:
                 summaries[ii].recom += n;
+		break;
 
             case BLOCK2_SNAPISOL:
                 summaries[ii].snapisol += n;
+		break;
 
             case BLOCK2_SERIAL:
                 summaries[ii].serial += n;
+		break;
             }
         }
         ii++;


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
bug fix

* What are the current behavior and expected behavior, if this is a bugfix ?
When you run a read committed txn, the snapiso and serialze counters are incremented by 1 as well. Only recom counter should be incremented

* What are the steps required to reproduce the bug, if this is a bugfix ?
set transaction read committed
begin
insert into t1 values (1)
commit

select * from comdb2_clientstats --> serialize, and snapiso will be incremented by 1 as well as recom.