### PR TITLE
Get the schema-lk in net_new_queue, restart the watcher in resume_threads

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3185,7 +3185,9 @@ void net_new_queue(void *hndl, void *uptr, char *fromnode, int usertype,
     }
 
     msg->name[sizeof(msg->name) - 1] = '\0';
+    wrlock_schema_lk();
     rc = add_queue_to_environment(msg->name, msg->avgitemsz, 0);
+    unlock_schema_lk();
     net_ack_message(hndl, rc);
 }
 

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -573,6 +573,7 @@ void stop_threads(struct dbenv *dbenv)
                          * bc sql thds are stopped */
 }
 
+void create_watcher_thread(bdb_state_type *bdb_state);
 void resume_threads(struct dbenv *dbenv)
 {
     if (gbl_appsock_thdpool)
@@ -587,6 +588,7 @@ void resume_threads(struct dbenv *dbenv)
     if (!dbenv->purge_old_blkseq_is_running ||
         !dbenv->purge_old_files_is_running)
         create_old_blkseq_thread(dbenv);
+    create_watcher_thread(dbenv->bdb_env);
     /*watchdog_enable();*/
 }
 


### PR DESCRIPTION
I recently added an assert on having the schema-lk in open_dbs.  Turns out the legacy method of adding a queue via message-trap does not acquire the schema-lock.  Additionally after a queue is added via message-trap, the resume_threads does not restart the watcher, causing the watchdog thread to abort the database.
