### PR TITLE
Thread local cursor queues and faster deadlock detection

### DIFF
--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -237,11 +237,7 @@ __db_close_cq(db)
 	Pthread_mutex_lock(&gbl_all_cursors.lk);
 	TAILQ_FOREACH(h, &gbl_all_cursors, links) {
 		Pthread_mutex_lock(&h->lk);
-		for (cq = hash_first(h->h, &hashent, &pos); cq != NULL;
-				cq = hash_next(h->h, &hashent, &pos)) {
-			if (db != cq->db)
-				continue;
-
+		if ((cq = hash_find(h->h, &db)) != NULL) {
 			/* Comdb2 shouldn't close dbhandles with active cursors */
 			DB_ASSERT(TAILQ_EMPTY(&cq->aq));
 

--- a/berkdb/db/db_am.c
+++ b/berkdb/db/db_am.c
@@ -127,7 +127,7 @@ __db_cursor_int(dbp, txn, dbtype, root, is_opd, lockerid, dbcp, flags)
 					adbc = TAILQ_FIRST(&dbp->active_queue);
 				else {
 					cq = __db_acquire_cq(dbp);
-					adbc = TAILQ_FIRST(&cq->aq);
+					adbc = (cq == NULL) ? NULL : TAILQ_FIRST(&cq->aq);
 					__db_release_cq(cq);
 				}
 			    if (adbc != NULL)
@@ -504,8 +504,6 @@ __db_count_cursors(DB *dbp)
 	int ncur = 0;
 	DB_CQ *cq;
 	DB_CQ_HASH *h;
-	void *hashent;
-	unsigned int pos;
 
 	if (!dbp->use_tlcq) {
 		MUTEX_THREAD_LOCK(dbp->dbenv, dbp->mutexp);
@@ -517,11 +515,7 @@ __db_count_cursors(DB *dbp)
 		Pthread_mutex_lock(&gbl_all_cursors.lk);
 		TAILQ_FOREACH(h, &gbl_all_cursors, links) {
 			Pthread_mutex_lock(&h->lk);
-			for (cq = hash_first(h->h, &hashent, &pos); cq != NULL;
-					cq = hash_next(h->h, &hashent, &pos)) {
-				if (dbp != cq->db)
-					continue;
-
+			if ((cq = hash_find(h->h, &dbp)) != NULL) {
 				for (dbc = TAILQ_FIRST(&cq->aq); dbc != NULL;
 						dbc = TAILQ_NEXT(dbc, links))
 					ncur++;
@@ -565,8 +559,6 @@ __db_cprint(dbp)
 	int ret, t_ret;
 	DB_CQ *cq;
 	DB_CQ_HASH *h;
-	void *hashent;
-	unsigned int pos;
 
 	ret = 0;
 
@@ -581,11 +573,7 @@ __db_cprint(dbp)
 		Pthread_mutex_lock(&gbl_all_cursors.lk);
 		TAILQ_FOREACH(h, &gbl_all_cursors, links) {
 			Pthread_mutex_lock(&h->lk);
-			for (cq = hash_first(h->h, &hashent, &pos); cq != NULL;
-					cq = hash_next(h->h, &hashent, &pos)) {
-				if (dbp != cq->db)
-					continue;
-
+			if ((cq = hash_find(h->h, &dbp)) != NULL) {
 				for (dbc = TAILQ_FIRST(&cq->aq); dbc != NULL;
 						dbc = TAILQ_NEXT(dbc, links))
 					if ((t_ret = __db_cprint_item(dbc)) != 0 && ret == 0)
@@ -1215,8 +1203,6 @@ __db_check_all_btree_cursors(dbp, pgno)
 	DB_ENV *dbenv = dbp->dbenv;
 	DB_CQ *cq;
 	DB_CQ_HASH *h;
-	void *hashent;
-	unsigned int pos;
 	db_pgno_t tmp_pgno = 0;
 
 	if (!dbp->use_tlcq) {
@@ -1240,9 +1226,7 @@ __db_check_all_btree_cursors(dbp, pgno)
 		Pthread_mutex_lock(&gbl_all_cursors.lk);
 		TAILQ_FOREACH(h, &gbl_all_cursors, links) {
 			Pthread_mutex_lock(&h->lk);
-			for (cq = hash_first(h->h, &hashent, &pos); cq != NULL;
-				cq = hash_next(h->h, &hashent, &pos)) {
-
+			if ((cq = hash_find(h->h, &dbp)) != NULL) {
 				for (dbc = TAILQ_FIRST(&cq->aq); dbc != NULL;
 					dbc = TAILQ_NEXT(dbc, links)) {
 					if (dbc->dbtype != DB_BTREE)

--- a/berkdb/db/db_cam.c
+++ b/berkdb/db/db_cam.c
@@ -76,6 +76,7 @@ __db_c_close_ll(dbc, countmein)
 	DBC *opd;
 	DBC_INTERNAL *cp;
 	DB_ENV *dbenv;
+	DB_CQ *cq;
 	int ret, t_ret;
 
 #ifdef LULU2
@@ -116,16 +117,26 @@ __db_c_close_ll(dbc, countmein)
 	 * access specific cursor close routine, btree depends on having that
 	 * order of operations.
 	 */
-	MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
-
-	if (opd != NULL) {
-		F_CLR(opd, DBC_ACTIVE);
-		TAILQ_REMOVE(&dbp->active_queue, opd, links);
+	if (dbp->use_tlcq) {
+		cq = __db_acquire_cq(dbp);
+		DB_ASSERT(cq != NULL);
+		if (opd != NULL) {
+			F_CLR(opd, DBC_ACTIVE);
+			TAILQ_REMOVE(&cq->aq, opd, links);
+		}
+		F_CLR(dbc, DBC_ACTIVE);
+		TAILQ_REMOVE(&cq->aq, dbc, links);
+		__db_release_cq(cq);
+	} else {
+		MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
+		if (opd != NULL) {
+			F_CLR(opd, DBC_ACTIVE);
+			TAILQ_REMOVE(&dbp->active_queue, opd, links);
+		}
+		F_CLR(dbc, DBC_ACTIVE);
+		TAILQ_REMOVE(&dbp->active_queue, dbc, links);
+		MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
 	}
-	F_CLR(dbc, DBC_ACTIVE);
-	TAILQ_REMOVE(&dbp->active_queue, dbc, links);
-
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
 
 	/* Call the access specific cursor close routine. */
 	if ((t_ret =
@@ -159,15 +170,28 @@ __db_c_close_ll(dbc, countmein)
 		dbc->txn->cursors--;
 
 	/* Move the cursor(s) to the free queue. */
-	MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
-	if (opd != NULL) {
-		if (dbc->txn != NULL)
-			dbc->txn->cursors--;
-		TAILQ_INSERT_TAIL(&dbp->free_queue, opd, links);
-		opd = NULL;
+	if (dbp->use_tlcq) {
+		cq = __db_acquire_cq(dbp);
+		DB_ASSERT(cq != NULL);
+		if (opd != NULL) {
+			if (dbc->txn != NULL)
+				dbc->txn->cursors--;
+			TAILQ_INSERT_TAIL(&cq->fq, opd, links);
+			opd = NULL;
+		}
+		TAILQ_INSERT_TAIL(&cq->fq, dbc, links);
+		__db_release_cq(cq);
+	} else {
+		MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
+		if (opd != NULL) {
+			if (dbc->txn != NULL)
+				dbc->txn->cursors--;
+			TAILQ_INSERT_TAIL(&dbp->free_queue, opd, links);
+			opd = NULL;
+		}
+		TAILQ_INSERT_TAIL(&dbp->free_queue, dbc, links);
+		MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
 	}
-	TAILQ_INSERT_TAIL(&dbp->free_queue, dbc, links);
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
 
 	return (ret);
 }
@@ -524,9 +548,11 @@ __db_c_destroy(dbc)
 	dbenv = dbp->dbenv;
 
 	/* Remove the cursor from the free queue. */
-	MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
-	TAILQ_REMOVE(&dbp->free_queue, dbc, links);
-	MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
+	if (!dbp->use_tlcq) {
+		MUTEX_THREAD_LOCK(dbenv, dbp->free_mutexp);
+		TAILQ_REMOVE(&dbp->free_queue, dbc, links);
+		MUTEX_THREAD_UNLOCK(dbenv, dbp->free_mutexp);
+	}
 
 	/* Free up allocated memory. */
 	if (dbc->my_rskey.data != NULL)

--- a/berkdb/db/db_method.c
+++ b/berkdb/db/db_method.c
@@ -131,6 +131,10 @@ db_create(dbpp, dbenv, flags)
 	if (ret != 0)
 		goto err;
 
+    /* Use thread-local cursor queues for indexes. */
+	if (idxpri)
+		dbp->use_tlcq = 1;
+
 	/* If we don't have an environment yet, allocate a local one. */
 	if (dbenv == NULL) {
 		if ((ret = db_env_create(&dbenv, 0)) != 0)
@@ -174,6 +178,20 @@ err:	if (dbp->mpf != NULL)
 	return (ret);
 }
 
+pthread_key_t tlcq_key;
+DB_CQ_HASH_LIST gbl_all_cursors;
+static pthread_once_t tlcq_once = PTHREAD_ONCE_INIT;
+static void __db_tlcq_init_once(void)
+{
+    /* Create a pthread key for per-thread cursor queues.
+       On exit, destroy all free cursors. */
+    Pthread_key_create(&tlcq_key, __db_delete_cq);
+
+    /* Initialize the big mutex and list. */
+    Pthread_mutex_init(&gbl_all_cursors.lk, NULL);
+    TAILQ_INIT(&gbl_all_cursors);
+}
+
 /*
  * __db_init --
  *	Initialize a DB structure.
@@ -191,6 +209,7 @@ __db_init(dbp, flags)
 	dbp->lid = DB_LOCK_INVALIDID;
 	LOCK_INIT(dbp->handle_lock);
 
+	Pthread_once(&tlcq_once, __db_tlcq_init_once);
 	TAILQ_INIT(&dbp->free_queue);
 	TAILQ_INIT(&dbp->active_queue);
 	TAILQ_INIT(&dbp->join_queue);

--- a/berkdb/db/db_method.c
+++ b/berkdb/db/db_method.c
@@ -131,10 +131,6 @@ db_create(dbpp, dbenv, flags)
 	if (ret != 0)
 		goto err;
 
-    /* Use thread-local cursor queues for indexes. */
-	if (idxpri)
-		dbp->use_tlcq = 1;
-
 	/* If we don't have an environment yet, allocate a local one. */
 	if (dbenv == NULL) {
 		if ((ret = db_env_create(&dbenv, 0)) != 0)

--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -93,6 +93,10 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 	if (F_ISSET(dbenv, DB_ENV_THREAD))
 		LF_SET(DB_THREAD);
 
+	/* Enable thread-local cursor queues for DB_THREAD. */
+	if (LF_ISSET(DB_THREAD))
+		dbp->use_tlcq = 1;
+
 	/* Convert any DB->open flags. */
 	if (LF_ISSET(DB_RDONLY))
 		F_SET(dbp, DB_AM_RDONLY);

--- a/berkdb/db/db_truncate.c
+++ b/berkdb/db/db_truncate.c
@@ -173,6 +173,7 @@ __db_cursor_check(dbp)
 	DBC *dbc;
 	DB_ENV *dbenv;
 	DB_CQ *cq;
+	DB_CQ_HASH *h;
 	int found;
 
 	dbenv = dbp->dbenv;
@@ -181,14 +182,35 @@ __db_cursor_check(dbp)
 	for (found = 0, ldbp = __dblist_get(dbenv, dbp->adj_fileid);
 	    ldbp != NULL && ldbp->adj_fileid == dbp->adj_fileid;
 	    ldbp = LIST_NEXT(ldbp, dblistlinks)) {
-		for (dbc = __db_lock_aq(dbp, ldbp, &cq);
-		    dbc != NULL; dbc = TAILQ_NEXT(dbc, links)) {
-			if (IS_INITIALIZED(dbc)) {
-				found = 1;
-				break;
+
+		if (!dbp->use_tlcq) {
+			MUTEX_THREAD_LOCK(dbenv, dbp->mutexp);
+			for (dbc = TAILQ_FIRST(&ldbp->active_queue);
+				dbc != NULL; dbc = TAILQ_NEXT(dbc, links)) {
+				if (IS_INITIALIZED(dbc)) {
+					found = 1;
+					break;
+				}
 			}
+			MUTEX_THREAD_UNLOCK(dbenv, dbp->mutexp);
+		} else {
+			Pthread_mutex_lock(&gbl_all_cursors.lk);
+			TAILQ_FOREACH(h, &gbl_all_cursors, links) {
+				Pthread_mutex_lock(&h->lk);
+				if ((cq = hash_find(h->h, &dbp)) != NULL) {
+					for (dbc = TAILQ_FIRST(&cq->aq); dbc != NULL;
+							dbc = TAILQ_NEXT(dbc, links)) {
+						if (IS_INITIALIZED(dbc)) {
+							found = 1;
+							break;
+						}
+					}
+				}
+				Pthread_mutex_unlock(&h->lk);
+			}
+			Pthread_mutex_unlock(&gbl_all_cursors.lk);
 		}
-		__db_unlock_aq(dbp, ldbp, cq);
+
 		if (found == 1)
 			break;
 	}

--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -125,9 +125,11 @@ struct __db_lockerid_latch_list;
 typedef struct __db_lockregion {
 	u_int32_t	need_dd;	/* flag for deadlock detector */
 	u_int32_t	detect;		/* run dd on every conflict */
+	u_int32_t	dd_gen;		/* generation of deadlock detector ID (dd_id) */
 	db_timeval_t	next_timeout;	/* next time to expire a lock */
 	SH_TAILQ_HEAD(__dobj, __db_lockobj) dd_objs;	/* objects with waiters */
 	SH_TAILQ_HEAD(__lkrs, __db_locker) lockers;	/* list of lockers */
+	SH_TAILQ_HEAD(__wlkrs, __db_locker) wlockers;	/* list of lockers in waiting status */
 	db_timeout_t	lk_timeout;	/* timeout for locks. */
 	db_timeout_t	tx_timeout;	/* timeout for txns. */
 	roff_t		conf_off;	/* offset of conflicts array */
@@ -264,6 +266,7 @@ typedef struct __db_locker {
 					   list. */
 	SH_TAILQ_ENTRY(__db_locker) links;		/* Links for free and hash list. */
 	SH_TAILQ_ENTRY(__db_locker) ulinks;	/* Links in-use list. */
+	SH_TAILQ_ENTRY(__db_locker) wlinks;	/* Links in-use list. */
 	SH_LIST_HEAD(_held, __db_lock) heldby;	/* Locks held by this locker. */
 	db_timeval_t	lk_expire;	/* When current lock expires. */
 	db_timeval_t	tx_expire;	/* When this txn expires. */
@@ -295,7 +298,8 @@ typedef struct __db_locker {
 	u_int8_t has_waiters;
 	u_int32_t flags;
 	u_int8_t has_pglk_lsn;
-	u_int8_t wstatus;  /* master locker waiting, for deadlock detection */
+	u_int32_t   dd_gen;		/* generation of the locker's deadlock detector ID */
+	u_int32_t   dd_in_wlockers; /* whether the locker is in wlockers list */
 } DB_LOCKER;
 
 /*

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2121,7 +2121,7 @@ __lock_get_internal_int(lt, locker, in_locker, flags, obj, lock_mode, timeout,
 	uint64_t x1 = 0, x2;
 	struct __db_lock *newl, *lp, *firstlp, *wwrite;
 	DB_ENV *dbenv;
-	DB_LOCKER *sh_locker;
+	DB_LOCKER *sh_locker, *master_locker;
 	DB_LOCKOBJ *sh_obj;
 	DB_LOCKREGION *region;
 	u_int32_t holder, obj_ndx, ihold, *holdarr, holdix, holdsz;
@@ -2758,10 +2758,9 @@ upgrade:
 
 		/* set waiting status for master_locker */
 		if (sh_locker->master_locker == INVALID_ROFF)
-			sh_locker->wstatus = 1;
+			master_locker = sh_locker;
 		else
-			((DB_LOCKER *)R_ADDR(&lt->reginfo,
-				sh_locker->master_locker))->wstatus = 1;
+			master_locker = ((DB_LOCKER *)R_ADDR(&lt->reginfo, sh_locker->master_locker));
 
 		unlock_locker_partition(region, lpartition);
 
@@ -2811,6 +2810,16 @@ upgrade:
 			}
 			__os_free(dbenv, holdarr);
 			holdarr = NULL;
+		}
+
+		/* Add the locker to the waiting list before calling the deadlock detector. */
+		if (!master_locker->dd_in_wlockers) {
+			lock_detector(region);
+			if (!master_locker->dd_in_wlockers) {
+				SH_TAILQ_INSERT_HEAD(&region->wlockers, master_locker, wlinks, __db_locker);
+				master_locker->dd_in_wlockers = 1;
+			}
+			unlock_detector(region);
 		}
 
 		/*
@@ -2924,10 +2933,18 @@ expired:			obj_ndx = sh_obj->index;
 
 	/* clear waiting status for master_locker */
 	if (sh_locker->master_locker == INVALID_ROFF)
-		sh_locker->wstatus = 0;
+		master_locker = sh_locker;
 	else
-		((DB_LOCKER *)R_ADDR(&lt->reginfo,
-			sh_locker->master_locker))->wstatus = 0;
+		master_locker = ((DB_LOCKER *)R_ADDR(&lt->reginfo, sh_locker->master_locker));
+
+	if (master_locker->dd_in_wlockers) {
+		lock_detector(region);
+		if (master_locker->dd_in_wlockers) {
+			SH_TAILQ_REMOVE(&region->wlockers, master_locker, wlinks, __db_locker);
+			master_locker->dd_in_wlockers = 0;
+		}
+		unlock_detector(region);
+	}
 
 	if (is_pagelock(sh_obj))
 		sh_locker->npagelocks++;
@@ -3841,6 +3858,16 @@ __lock_freelocker(lt, region, sh_locker, indx)
 	SH_TAILQ_INSERT_HEAD(&region->free_lockers[partition], sh_locker, links,
 	    __db_locker);
 	SH_TAILQ_REMOVE(&region->lockers, sh_locker, ulinks, __db_locker);
+
+	if (sh_locker->dd_in_wlockers) {
+		lock_detector(region);
+		if (sh_locker->dd_in_wlockers) {
+			SH_TAILQ_REMOVE(&region->wlockers, sh_locker, wlinks, __db_locker);
+			sh_locker->dd_in_wlockers = 0;
+		}
+		unlock_detector(region);
+	}
+
 	region->stat.st_nlockers--;
 }
 
@@ -4054,7 +4081,7 @@ __lock_getlocker_int(lt, locker, indx, partition, create, prop, retp,
 		SH_TAILQ_REMOVE(&region->free_lockers[partition],
 		    sh_locker, links, __db_locker);
 		sh_locker->id = locker;
-		sh_locker->dd_id = 0;
+		sh_locker->dd_id = -1;
 		sh_locker->master_locker = INVALID_ROFF;
 		sh_locker->parent_locker = INVALID_ROFF;
 		SH_LIST_INIT(&sh_locker->child_locker);
@@ -4069,6 +4096,8 @@ __lock_getlocker_int(lt, locker, indx, partition, create, prop, retp,
 		sh_locker->num_retries = prop ? prop->retries : 0;
 		if (prop && prop->flags & DB_LOCK_ID_LOWPRI)
 			F_SET(sh_locker, DB_LOCKER_KILLME);
+		sh_locker->dd_gen = 0;
+		sh_locker->dd_in_wlockers = 0;
 #if TEST_DEADLOCKS
 		printf("%p %s:%d lockerid %x setting priority to %d\n",
 		    (void*)pthread_self(), __FILE__, __LINE__, sh_locker->id, sh_locker->priority);

--- a/berkdb/lock/lock_region.c
+++ b/berkdb/lock/lock_region.c
@@ -236,6 +236,7 @@ __lock_init(dbenv, lt)
 	}
 
 	region->need_dd = 0;
+	region->dd_gen = 0;
 
 	LOCK_SET_TIME_INVALID(&region->next_timeout);
 	region->detect = DB_LOCK_NORUN;
@@ -412,6 +413,7 @@ mem_err:		__db_err(dbenv,
 
 	SH_TAILQ_INIT(&region->dd_objs);
 	SH_TAILQ_INIT(&region->lockers);
+	SH_TAILQ_INIT(&region->wlockers);
 
 	Pthread_mutex_init(&region->dd_mtx.mtx, NULL);
 	bzero(region->dd_mtx.fluff, sizeof(region->dd_mtx.fluff));

--- a/berkdb/lock/lock_stat.c
+++ b/berkdb/lock/lock_stat.c
@@ -1297,7 +1297,7 @@ berkdb_dump_lockers_summary(DB_ENV *dbenv)
 		    (l->parent_locker ==
 			INVALID_ROFF ? 0 : ((DB_LOCKER *)R_ADDR(&lt->reginfo,
 				l->parent_locker))->id), (m ? m->id : 0),
-		    (l->wstatus ? 'y' : (m &&m->wstatus ? 'p' : 'n'))
+		    (l->dd_in_wlockers ? 'y' : (m &&m->dd_in_wlockers ? 'p' : 'n'))
 		    );
 		l = SH_TAILQ_NEXT(l, ulinks, __db_locker);
 	}


### PR DESCRIPTION
There are 2 self-contained commits in the pull request.

https://github.com/bloomberg/comdb2/pull/2219/commits/c81d233b2ffe2c84adf1ade0fa30de8f86544ca6: Thread local cursor queues

In the commit, per-thread cursor queues are created to eliminate contention on per-DB cursor queues. However this greatly increases the number of lockers which makes deadlock detection slower.

https://github.com/bloomberg/comdb2/pull/2219/commits/48f0f58dcade9710356cf76a10ea94935efaa7bf: Faster deadlock detection

This commit addresses the problem of the first commit. A list of lockers in waiting status is maintained separately from the active locker list. In `__dd_build()`, we simply loop over the waiting locker list to assign out deadlock detector ID. The waiting locker list is much shorter than the active locker list and we can get rid of the waiting status check (an `if` branch) from the loop.