### PR TITLE
Fix adding old-style-queues by msgtrap, and initcomdb2 with the queue directive

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1866,7 +1866,6 @@ size_t gbl_lkr_parts = 23;
 size_t gbl_lk_hash = 32;
 size_t gbl_lkr_hash = 16;
 
-char **qdbs = NULL;
 char **sfuncs = NULL;
 char **afuncs = NULL;
 
@@ -3218,16 +3217,6 @@ static int init_db_dir(char *dbname, char *dir)
     return 0;
 }
 
-static int llmeta_set_qdbs(void)
-{
-    int rc = 0;
-    for (int i = 0; i != thedb->num_qdbs; ++i) {
-        if ((rc = llmeta_set_qdb(qdbs[i])) != 0)
-            break;
-    }
-    return rc;
-}
-
 static int init_sqlite_table(struct dbenv *dbenv, char *table)
 {
     int rc;
@@ -4065,11 +4054,6 @@ static int init(int argc, char **argv)
                 logmsg(LOGMSG_FATAL, "Failed to create time partitions!\n");
                 return -1;
             }
-        }
-
-        if (llmeta_set_qdbs() != 0) {
-            logmsg(LOGMSG_FATAL, "failed to add queuedbs to llmeta\n");
-            return -1;
         }
 
         llmeta_set_lua_funcs(s);

--- a/db/config.c
+++ b/db/config.c
@@ -54,7 +54,6 @@ int gbl_disable_access_controls;
 extern char *gbl_recovery_options;
 extern const char *gbl_repoplrl_fname;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
-extern char **qdbs;
 extern char **sfuncs;
 extern char **afuncs;
 static int gbl_nogbllrl; /* don't load /bb/bin/comdb2*.lrl */
@@ -914,22 +913,17 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         parse_lua_funcs(a);
     } else if (tokcmp(tok, ltok, "queuedb") == 0) {
         int nqdbs = thedb->num_qdbs;
-        qdbs = realloc(qdbs, (nqdbs + 1) * sizeof(char *));
-        if (qdbs == NULL) {
-            logmsgperror("realloc");
-            return -1;
-        }
         thedb->qdbs = realloc(thedb->qdbs, (nqdbs + 1) * sizeof(dbtable *));
         if (thedb->qdbs == NULL) {
             logmsgperror("realloc");
             return -1;
         }
         tok = segtok(line, len, &st, &ltok);
-        qdbs[nqdbs] = tokdup(tok, ltok);
-        char *name = get_qdb_name(qdbs[nqdbs]);
+        char *qfname = tokdup(tok, ltok);
+        char *name = get_qdb_name(qfname);
         if (name == NULL) {
             logmsg(LOGMSG_ERROR, "Failed to obtain queuedb name from:%s\n",
-                   qdbs[nqdbs]);
+                   qfname);
             return -1;
         }
         dbtable *qdb = newqdb(dbenv, name, 65536, 65536, 1);
@@ -938,6 +932,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
             return -1;
         }
         free(name);
+        free(qfname);
         thedb->qdbs[nqdbs] = qdb;
         ++thedb->num_qdbs;
     } else if (tokcmp(tok, ltok, "table") == 0) {

--- a/db/glue.c
+++ b/db/glue.c
@@ -3185,7 +3185,9 @@ void net_new_queue(void *hndl, void *uptr, char *fromnode, int usertype,
     }
 
     msg->name[sizeof(msg->name) - 1] = '\0';
+    wrlock_schema_lk();
     rc = add_queue_to_environment(msg->name, msg->avgitemsz, 0);
+    unlock_schema_lk();
     net_ack_message(hndl, rc);
 }
 


### PR DESCRIPTION
R7 fails initcomdb2 for lrl files which contain the queue directive.  This also contains fixes for adding queue via a message trap.
