### PR TITLE
Copy effects to chkboard only when they are available in snapshot

### DIFF
--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -41,6 +41,8 @@
 #define SQLHERR_MASTER_QUEUE_FULL -108
 #define SQLHERR_MASTER_TIMEOUT -109
 
+extern int gbl_master_sends_query_effects;
+
 typedef struct osql_checkboard {
 
     hash_t *
@@ -346,19 +348,9 @@ int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops,
         entry->done = 1; /* mem sync? */
         entry->nops = nops;
 
-        if (entry->type == OSQL_SNAP_UID_REQ && data != NULL) {
-            snap_uid_t *snap_info = (snap_uid_t *)data;
-            if (snap_info->rqtype == OSQL_NET_SNAP_FOUND_UID) {
-                entry->clnt->is_retry = 1;
-                if (effects) {
-                    memcpy(&entry->clnt->effects, effects,
-                           sizeof(struct query_effects));
-                }
-            } else if (snap_info->rqtype == OSQL_NET_SNAP_NOT_FOUND_UID) {
-                entry->clnt->is_retry = 0;
-            } else {
-                entry->clnt->is_retry = -1;
-            }
+        if (gbl_master_sends_query_effects && effects) {
+            memcpy(&entry->clnt->effects, effects,
+                   sizeof(struct query_effects));
         }
 
         Pthread_cond_signal(&entry->cond);

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -336,18 +336,12 @@ int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops,
         rc = -1;
 
     } else {
+        Pthread_mutex_lock(&entry->mtx);
 
         if (errstat)
             entry->err = *errstat;
         else
             bzero(&entry->err, sizeof(entry->err));
-
-        if (effects) {
-            memcpy(&entry->clnt->effects, effects,
-                   sizeof(struct query_effects));
-        }
-
-        Pthread_mutex_lock(&entry->mtx);
 
         entry->done = 1; /* mem sync? */
         entry->nops = nops;
@@ -356,6 +350,10 @@ int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops,
             snap_uid_t *snap_info = (snap_uid_t *)data;
             if (snap_info->rqtype == OSQL_NET_SNAP_FOUND_UID) {
                 entry->clnt->is_retry = 1;
+                if (effects) {
+                    memcpy(&entry->clnt->effects, effects,
+                           sizeof(struct query_effects));
+                }
             } else if (snap_info->rqtype == OSQL_NET_SNAP_NOT_FOUND_UID) {
                 entry->clnt->is_retry = 0;
             } else {


### PR DESCRIPTION
This fixes a bug where all query effects were incorrectly reported 0.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>