### PR TITLE
Log in statreq write count for every table 

### DIFF
--- a/db/record.c
+++ b/db/record.c
@@ -49,6 +49,7 @@
 #include "debug_switches.h"
 #include "logmsg.h"
 #include "indices.h"
+#include "comdb2_atomic.h"
 
 extern int gbl_partial_indexes;
 extern int gbl_expressions_indexes;
@@ -600,7 +601,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (!is_event_from_sc(flags)) {
-        iq->usedb->write_count[RECORD_WRITE_INS]++;
+        ATOMIC_ADD32(iq->usedb->write_count[RECORD_WRITE_INS], 1);
         gbl_sc_last_writer_time = comdb2_time_epoch();
 
         /* For live schema change */
@@ -1505,7 +1506,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         goto err;
     }
 
-    iq->usedb->write_count[RECORD_WRITE_UPD]++;
+    ATOMIC_ADD32(iq->usedb->write_count[RECORD_WRITE_UPD], 1);
     gbl_sc_last_writer_time = comdb2_time_epoch();
 
     dbglog_record_db_write(iq, "update");
@@ -1799,7 +1800,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         goto err;
     }
 
-    iq->usedb->write_count[RECORD_WRITE_DEL]++;
+    ATOMIC_ADD32(iq->usedb->write_count[RECORD_WRITE_DEL], 1);
     gbl_sc_last_writer_time = comdb2_time_epoch();
 
 err:

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -189,63 +189,43 @@ void osql_cleanup(void)
     bdb_osql_destroy(&bdberr);
 }
 
-char *osql_breq2a(int op)
-{
+const char *osql_tp_str[] = {
+    "OSQL_RPLINV",
+    "OSQL_DONE",
+    "OSQL_USEDB",
+    "OSQL_DELREC",
+    "OSQL_INSREC",
+    "OSQL_CLRTBL",
+    "OSQL_QBLOB",
+    "OSQL_UPDREC",
+    "OSQL_XERR",
+    "OSQL_UPDCOLS",
+    "OSQL_DONE_STATS",
+    "OSQL_DBGLOG",
+    "OSQL_RECGENID",
+    "OSQL_UPDSTAT",
+    "OSQL_EXISTS",
+    "OSQL_SERIAL",
+    "OSQL_SELECTV",
+    "OSQL_DONE_SNAP",
+    "OSQL_SCHEMACHANGE",
+    "OSQL_BPFUNC",
+    "OSQL_DBQ_CONSUME",
+    "OSQL_DELETE",
+    "OSQL_INSERT",
+    "OSQL_UPDATE",
+    "OSQL_DELIDX",
+    "OSQL_INSIDX",
+    "OSQL_STARTGEN",
+    "OSQL_DONE_WITH_EFFECTS",
+};
 
-    switch (op) {
-    case OSQL_RPLINV:
-        return "INVALID";
-    case OSQL_DONE:
-        return "OSQL_DONE";
-    case OSQL_DONE_STATS:
-        return "OSQL_DONE_STATS";
-    case OSQL_DONE_SNAP:
-        return "OSQL_DONE_SNAP";
-    case OSQL_USEDB:
-        return "OSQL_USEDB";
-    case OSQL_DELREC:
-        return "OSQL_DELREC";
-    case OSQL_INSREC:
-        return "OSQL_INSREC";
-    case OSQL_QBLOB:
-        return "OSQL_QBLOB";
-    case OSQL_UPDREC:
-        return "OSQL_UPDREC";
-    case OSQL_XERR:
-        return "OSQL_XERR";
-    case OSQL_UPDCOLS:
-        return "OSQL_UPDCOLS";
-    case OSQL_SERIAL:
-        return "OSQL_SERIAL";
-    case OSQL_SELECTV:
-        return "OSQL_SELECTV";
-    case OSQL_DBGLOG:
-        return "OSQL_DBGLOG";
-    case OSQL_RECGENID:
-        return "OSQL_RECGENID";
-    case OSQL_UPDSTAT:
-        return "OSQL_UPDSTAT";
-    case OSQL_EXISTS:
-        return "OSQL_EXISTS";
-    case OSQL_DBQ_CONSUME:
-        return "OSQL_DBQ_CONSUME";
-    case OSQL_INSERT:
-        return "OSQL_INSERT";
-    case OSQL_DELETE:
-        return "OSQL_DELETE";
-    case OSQL_UPDATE:
-        return "OSQL_UPDATE";
-    case OSQL_SCHEMACHANGE:
-        return "OSQL_SCHEMACHANGE";
-    case OSQL_BPFUNC:
-        return "OSQL_BPFUNC";
-    case OSQL_DELIDX:
-        return "OSQL_DELIDX";
-    case OSQL_INSIDX:
-        return "OSQL_INSIDX";
-    default:
+const char *osql_breq2a(int op)
+{
+    if (0 < op && op < MAX_OSQL_TYPES)
+        return osql_tp_str[op];
+    else
         return "UNKNOWN";
-    }
 }
 
 void block2_sorese(struct ireq *iq, const char *sql, int sqlen, int block2_type)

--- a/db/sqloffload.h
+++ b/db/sqloffload.h
@@ -57,7 +57,7 @@ void osql_cleanup(void);
 void set_osql_maxtransfer(int limit);
 int get_osql_maxtransfer(void);
 
-char *osql_breq2a(int op);
+const char *osql_breq2a(int op);
 
 void block2_sorese(struct ireq *iq, const char *sql, int sqlen,
                    int block2_type);

--- a/tests/autoanalyze.test/lrl.options
+++ b/tests/autoanalyze.test/lrl.options
@@ -8,6 +8,7 @@ setattr aa_count_upd  0
 setattr chk_aa_time  6
 setattr min_aa_time  20
 setattr aa_llmeta_save_freq  2
+do reql diffstat 19
 
 noudp
 ssl_client_mode OPTIONAL

--- a/tests/autoanalyze.test/runit
+++ b/tests/autoanalyze.test/runit
@@ -263,7 +263,7 @@ get_autoanalyze_stat $master
 echo ""; cat stat.out | grep "Table t1" 
 stats_should_be $savedCnt $lastRun 10 $prevDate
 
-sleep 5 
+sleep $T_TO_SLEEP
 
 echo "Testing that manually running analyze zeros out counters"
 date


### PR DESCRIPTION
* Use statthd thread to update saved_write_count and aa_new_count 
* Show count diffs in statreq file
* Cleanup that logic from autoanalyze thread, update test
* Use atomic ops to update write_count for more accurate accounting
* Refactor function to print diff to statreq and update prev value, dont print DB number
* Get schema_lk in statthd when walking table list
* Refactor printing of OSQL type via array of strings instead of case stmt

The new write counts will appear as such:
```
04/30 13:20:57:   DIFF REQUEST STATS FOR TABLE 't1'
04/30 13:20:57:       inserted rows          32
04/30 13:20:57:       updated rows           32
04/30 13:20:57:       deleted rows           32
```