### PR TITLE
comdb2ar: handle certificates in the data directory

### DIFF
--- a/tools/comdb2ar/serialise.cpp
+++ b/tools/comdb2ar/serialise.cpp
@@ -640,6 +640,8 @@ void parse_lrl_file(const std::string& lrlpath,
 
     if (!certdir.empty())
         certdir += "/";
+    else
+        certdir = *p_dbdir + "/";
 
     if (!cert.empty())
         p_support_files->push_back(cert);


### PR DESCRIPTION
Look up SSL certificates in the data directory, if no `ssl_cert_path` is specified.

(DRQS 158608511)
