### PR TITLE
timeout remote writes if we lose some connectivit

### DIFF
--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -388,6 +388,17 @@ int fdb_svc_trans_commit(char *tid, enum transaction_level lvl,
     }
     Pthread_mutex_unlock(&clnt->dtran_mtx);
 
+    if (clnt->dbtran.dtran->fdb_trans.top->timeout) {
+        errstat_set_rcstrf(&clnt->osql.xerr, CDB2ERR_IO_ERROR,
+                           "timeout commit sequence");
+        rc = fdb_svc_trans_rollback(tid, lvl, clnt, seq);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "Transaction timeout, also rollback rc %d\n",
+                   rc);
+        }
+        return CDB2ERR_IO_ERROR;
+    }
+
     if (clnt->dbtran.mode == TRANLEVEL_RECOM ||
         clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
         clnt->dbtran.mode == TRANLEVEL_SERIAL ||

--- a/db/fdb_fend.h
+++ b/db/fdb_fend.h
@@ -176,6 +176,7 @@ struct fdb_tran {
 
     int seq; /* sequencing tran begin/commit/rollback, writes, cursor open/close
                 */
+    int timeout; /* timeout a sequence */
 };
 typedef struct fdb_tran fdb_tran_t;
 


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

This is the simplified timeout for remote writes from R6.   The plan going forward is to replace the fdb custom wire protocol with cdb2api.