### PR TITLE
Option to run SC in detached mode and return seed

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -480,6 +480,8 @@ DEF_ATTR(SC_RESUME_WATCHDOG_TIMER, sc_resume_watchdog_timer, QUANTITY, 60,
 DEF_ATTR(SC_DELAY_VERIFY_ERROR, sc_delay_verify_error, MSECS, 100, NULL)
 DEF_ATTR(SC_ASYNC, sc_async, BOOLEAN, 1,
          "Run transactional schema changes asynchronously.")
+DEF_ATTR(SC_DETACHED, sc_detached, BOOLEAN, 0,
+         "Run schema changes in detached mode--just return seed to client.")
 DEF_ATTR(SC_ASYNC_MAXTHREADS, sc_async_maxthreads, QUANTITY, 5,
          "Max number of threads for asynchronous schema changes.")
 DEF_ATTR(SC_DONE_SAME_TRAN, sc_done_same_tran, BOOLEAN, 1,

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1255,6 +1255,7 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
     /* wait for all schema changes to finish */
     iq->sc = sc = iq->sc_pending;
     iq->sc_pending = NULL;
+
     while (sc != NULL) {
         Pthread_mutex_lock(&sc->mtx);
         sc->nothrevent = 1;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -386,6 +386,15 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
     }
     if ((rc = mark_sc_in_llmeta_tran(s, NULL))) // non-tran ??
         goto end;
+
+    if (!s->resume && type == alter &&
+        bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_DETACHED)) {
+        sc_printf(s, "Starting Schema Change with seed 0x%llx\n",
+                  flibc_htonll(iq->sc_seed));
+        sbuf2printf(s->sb, "SUCCESS\n");
+        s->sc_rc = SC_DETACHED;
+    }
+
     broadcast_sc_start(s->tablename, iq->sc_seed, iq->sc_host,
                        time(NULL));                   // dont care rcode
     rc = pre(iq, s, NULL);                            // non-tran ??


### PR DESCRIPTION
Add option to run schemachange in detached mode for rebuilds and alters.
Immediately return the seed to the [comdb2sc] client and perform the SC
in detached mode.
Client can monitor schema change progress and status via the
comdb2_sc_history table.

Example usage:
```
$ comdb2sc -m -v aditdb send bdb setattr sc_detached 1
Connected to master node 2091
Attribute set

$ comdb2sc -v aditdb rebuild t1
Connected to master node 2091
Info> Starting Schema Change with seed 0x5ebb1d9a00010000

$ comdb2sc -m -v aditdb send bdb setattr sc_detached 0
Connected to master node 2091
Attribute set

$ comdb2sql aditdb 'select * from comdb2_sc_history'
(name='t1', start='2020-05-12T180514.418 America/New_York', status='COMMITTED', seed='0x5ebb1d9a00010000', last_updated='2020-05-12T180514.624 America/New_York', converted=500, error='')
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>