### PR TITLE
cdb2api: bind parameter list

### DIFF
--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -232,8 +232,10 @@ int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *name, int type,
 int cdb2_bind_index(cdb2_hndl_tp *hndl, int index, int type,
                     const void *varaddr, int length);
 int cdb2_clearbindings(cdb2_hndl_tp *hndl);
-int cdb2_bind_list(cdb2_hndl_tp *hndl, const char *varname, int count,
+int cdb2_bind_list(cdb2_hndl_tp *hndl, const char *varname, unsigned int count,
                    int type[], const void *varaddr[], int length[]);
+int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *varname, unsigned int count,
+                    int type, const void *varaddr[], int typelen, int length[]);
 
 const char *cdb2_dbname(cdb2_hndl_tp *hndl);
 

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -232,6 +232,8 @@ int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *name, int type,
 int cdb2_bind_index(cdb2_hndl_tp *hndl, int index, int type,
                     const void *varaddr, int length);
 int cdb2_clearbindings(cdb2_hndl_tp *hndl);
+int cdb2_bind_list(cdb2_hndl_tp *hndl, const char *varname, int count,
+                   int type[], const void *varaddr[], int length[]);
 
 const char *cdb2_dbname(cdb2_hndl_tp *hndl);
 

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -235,7 +235,7 @@ int cdb2_clearbindings(cdb2_hndl_tp *hndl);
 int cdb2_bind_list(cdb2_hndl_tp *hndl, const char *varname, unsigned int count,
                    int type[], const void *varaddr[], int length[]);
 int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *varname, unsigned int count,
-                    int type, const void *varaddr[], int typelen, int length[]);
+                    int type, const void **array, int typelen, int length[]);
 
 const char *cdb2_dbname(cdb2_hndl_tp *hndl);
 


### PR DESCRIPTION
Bind parameter list by calling new cdb2api function:
```
int cdb2_bind_list(cdb2_hndl_tp *hndl, const char *varname, int count,
                   int type[], const void *varaddr[], int length[]);
int cdb2_bind_array(cdb2_hndl_tp *hndl, const char *varname, unsigned int count,
                    int type, const void *varaddr[], int typelen, int length[]);
```

Example usage:
```
    int type[2] = {CDB2_INTEGER, CDB2_INTEGER};
    int a = 11, b = 33;
    const void *vals[2] = {&a, &b};
    int lengths[2] = { sizeof(a), sizeof(b)};

    cdb2_bind_list(hndl, "list", 2, type, vals, lengths);
    cdb2_run_statement("select * from t2 where a in (@list[])");
```

Will replace the `@list[]` part with `@list_0,@list_1` and bind each of
of the `count==2` elements passed in.
Please see testcase in pr for more usage examples.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>