### PR TITLE
Tests: check for failexit to correctly identify failed tests

### DIFF
--- a/tests/autoanalyze.test/runit
+++ b/tests/autoanalyze.test/runit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 # Grab my database name.
 dbnm=$1
@@ -54,13 +55,6 @@ dup "B" =  b
 }
 }
 '
-
-failexit() 
-{
-    echo "Failed: $1"
-    exit -1
-}
-
 
 
 

--- a/tests/cldeadlock.test/runit
+++ b/tests/cldeadlock.test/runit
@@ -46,6 +46,7 @@ function failexit
     typeset f=$1
     cleanup
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/constraints.test/runit
+++ b/tests/constraints.test/runit
@@ -201,12 +201,6 @@ done
 
 ### Tests for CREATE UNIQUE INDEX with multiple NULL values
 
-function failexit
-{
-    echo "Failed $1"
-    exit -1
-}
-
 function assertbadexitcode
 {
     rc=$1

--- a/tests/deadlock_load.test/runit
+++ b/tests/deadlock_load.test/runit
@@ -22,6 +22,7 @@ function failexit
     typeset func="failexit"
     typeset f=$1
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/explain.test/runit
+++ b/tests/explain.test/runit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 set -e
 #set -x
@@ -10,12 +11,6 @@ if [ "x$dbnm" == "x" ] ; then
     echo "need a DB name"
     exit 1
 fi
-
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
 
 
 output=run.log

--- a/tests/guid.test/runit
+++ b/tests/guid.test/runit
@@ -18,13 +18,6 @@ fi
 nins=0
 
 
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
-
-
 echo $CDB2_CONFIG
 CNT=10000
 

--- a/tests/ignore_bad_table.test/runit
+++ b/tests/ignore_bad_table.test/runit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 set -x
 

--- a/tests/largecsc2.test/runit
+++ b/tests/largecsc2.test/runit
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 dbnm=$1
 
 if [ "x$dbnm" == "x" ] ; then
-    echo "need a DB name"
-    exit 1
+    failexit "need a DB name"
 fi
-
-function failexit
-{
-    echo "Failed $1"
-    exit -1
-}
 
 echo "create table t2, should succeed"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t2  { `cat t2_1.csc2 ` }" || failexit "create failed"

--- a/tests/limitsortingtbl.test/runit
+++ b/tests/limitsortingtbl.test/runit
@@ -1,15 +1,12 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
 set -x
 
 db=$1
 
 set -e
-
-function failexit {
-    echo "Failed $1"
-    exit 1
-}
 
 cdb2sql ${CDB2_OPTIONS} $db default "create table t1 { `cat t1.csc2` }"
 cdb2sql ${CDB2_OPTIONS} $db default "create table t2 { `cat t2.csc2` }"

--- a/tests/load_cache.test/runit
+++ b/tests/load_cache.test/runit
@@ -38,6 +38,7 @@ function failexit
     typeset f=$1
     write_prompt $func "$f failed: $2"
     cleanup
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/logical_ops.test/runit
+++ b/tests/logical_ops.test/runit
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 dbname=$1
 NRUNS=100
@@ -44,12 +45,6 @@ function makebl
     echo
 
     return 0
-}
-
-function failexit
-{
-    echo "Failed $1"
-    exit -1
 }
 
 function insert

--- a/tests/maxtable.test/runit
+++ b/tests/maxtable.test/runit
@@ -17,6 +17,7 @@ function failexit
     typeset func="failexit"
     typeset f=$1
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/morestripe.test/runit
+++ b/tests/morestripe.test/runit
@@ -29,6 +29,7 @@ function failexit
     typeset f=$1
     kill_background_writer
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/queueing_sql.test/runit
+++ b/tests/queueing_sql.test/runit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 set -e
 set -x
@@ -16,13 +17,6 @@ fi
 
 # Number of insert_records function calls
 nins=0
-
-
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
 
 
 echo "create t1"

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -18,12 +18,6 @@ fi
 nout=0  # file extension counter
 
 
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
-
 assert_vers()
 {
     tbl=$1

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -340,6 +340,9 @@ elif [[ -n "$verify_ret" ]] && [[ ! $rc -eq 0 ]] ; then
     echo "!$TESTCASE: failed" >> ${TEST_LOG}
     echo -e "!$TESTCASE: also ${FAILCOL}failed${NORCOL} verify ($verify_ret)"
     echo "!$TESTCASE: also failed verify ($verify_ret)" >> ${TEST_LOG}
+elif [[ -f "${DBNAME}.failexit" ]] ; then
+    echo -e "!$TESTCASE: ${FAILCOL}failed${NORCOL} (found ${DBNAME}.failexit)"
+    echo "!$TESTCASE: failed (found ${DBNAME}.failexit)" >> ${TEST_LOG}
 elif [[ -n "$verify_ret" ]] ; then
     echo -e "!$TESTCASE: ${FAILCOL}failed${NORCOL} verify ($verify_ret)"
     echo "!$TESTCASE: failed verify ($verify_ret)" >> ${TEST_LOG}

--- a/tests/sc_add_vutf8.test/runit
+++ b/tests/sc_add_vutf8.test/runit
@@ -19,16 +19,9 @@ nrecs=100
 # Max number of schema changes
 max_nusc=100
 
-function failexit
-{
-    echo "Failed $1"
-    touch failexit
-    exit -1
-}
-
 function checkfailexit
 {
-    if [[ -f failexit ]] ; then
+    if [[ -f ${DBNAME}.failexit ]] ; then
         exit 1
     fi
 }

--- a/tests/sc_async_constraints.test/runit
+++ b/tests/sc_async_constraints.test/runit
@@ -27,6 +27,7 @@ function failexit
     typeset f=$1
     write_prompt $func "$f failed: $2"
     cleanup
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/sc_drop.test/runit
+++ b/tests/sc_drop.test/runit
@@ -13,11 +13,6 @@ max_iter=10
 
 # Max number of schema changes
 max_nusc=100
-function failexit
-{
-    echo "Failed $@"
-    exit -1
-}
 
 
 insert_into_t1() {

--- a/tests/sc_repeated_updates.test/runit
+++ b/tests/sc_repeated_updates.test/runit
@@ -30,7 +30,7 @@ upid=0
 function failexit
 {
     echo "Failed: $1"
-    touch failexit
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     if [[ $$ -eq $upid ]] ; then
         kill -9 $t_ppid
     else
@@ -41,8 +41,7 @@ function failexit
 
 function checkfailexit
 {
-    if [[ -f failexit ]] ; then
-        rm failexit
+    if [[ -f ${DBNAME}.failexit ]] ; then
         exit 1
     fi
 }

--- a/tests/sc_versmismatch.test/runit
+++ b/tests/sc_versmismatch.test/runit
@@ -15,13 +15,12 @@ fi
 nins=0
 
 
-function failexit
+function failexit_wrap
 {
     if [[ "$stco" == "1" ]]; then
         echo "quit" >&${COPROC[1]}
     fi
-    echo "Failed $1"
-    exit -1
+    failexit $1
 }
 
 function insert_records_oneshot
@@ -54,10 +53,10 @@ function test1
         j=$((j+1))
         out=$(cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(a,b,c) values ($j,'test1$j',$j)")
         if [ $? -ne 0 ] ; then
-            failexit " timeout reading pipe output, j=$j, rc=$rc, out=$out"
+            failexit_wrap " timeout reading pipe output, j=$j, rc=$rc, out=$out"
         fi
         if [ "$out" != "(rows inserted=1)" ] ; then
-            failexit " error inserting $j, out=$out"
+            failexit_wrap " error inserting $j, out=$out"
         fi
         [ -f alter1.done ] && break
     done
@@ -65,7 +64,7 @@ function test1
     echo assert count $j
     assertcnt t1 $j
     if grep failed alter1.scout ; then
-        failexit "alter1: see alter1.scout"
+        failexit_wrap "alter1: see alter1.scout"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $dbnm default "select a,b,c from t1 order by a" > have.txt
@@ -74,7 +73,7 @@ function test1
     done
 
     if ! diff have.txt shouldhave.txt ; then
-        failexit "have.txt shouldhave.txt differ"
+        failexit_wrap "have.txt shouldhave.txt differ"
     fi
     
     rm alter1.done have.txt shouldhave.txt
@@ -88,7 +87,7 @@ function test1
         j=$((j-1))
         out=$(cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set c=c+100000 where a = $j")
         if [ $? -ne 0 ] || [ "$out" != "(rows updated=1)" ] ; then
-            failexit " error updating $j, out=$out"
+            failexit_wrap " error updating $j, out=$out"
         fi
     done
     if [ ! -f alter2.done ] ; then
@@ -96,7 +95,7 @@ function test1
     fi 
 
     if grep failed alter2.scout ; then
-        failexit "alter2: see alter2.scout"
+        failexit_wrap "alter2: see alter2.scout"
     fi
 
 
@@ -111,7 +110,7 @@ function test1
     done
 
     if ! diff have.txt shouldhave.txt ; then
-        failexit "have.txt shouldhave.txt differ"
+        failexit_wrap "have.txt shouldhave.txt differ"
     fi
  
     rm alter2.done have.txt shouldhave.txt
@@ -120,7 +119,7 @@ function test1
     echo "Insert few more records from $((cnt+1)) up"
     cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(a,b,c) select value, 'test1'||value, value+100000 from generate_series limit 6000 - $cnt offset $cnt + 1"
     if [[ $? -ne 0 ]]; then
-        failexit "error inserting upto 6000"
+        failexit_wrap "error inserting upto 6000"
     fi
     j=6000
     assertcnt t1 $j
@@ -134,7 +133,7 @@ function test1
     while [[ ! -f alter3.done && $j -gt $sequpto ]] ; do
         out=$(cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where c = $((j+100000))")
         if [ $? -ne 0 ] || [ "$out" != "(rows deleted=1)" ] ; then
-            failexit " error deleting $((j+100000)), out=$out"
+            failexit_wrap " error deleting $((j+100000)), out=$out"
         fi
 
         j=$((j-1))
@@ -146,7 +145,7 @@ function test1
     fi
     
     if grep failed alter3.scout ; then
-        failexit "alter3: see alter3.scout"
+        failexit_wrap "alter3: see alter3.scout"
     fi
 
     cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 0')"
@@ -161,16 +160,16 @@ function test1
     done
 
     if ! diff have.txt shouldhave.txt ; then
-        failexit "have.txt shouldhave.txt differ"
+        failexit_wrap "have.txt shouldhave.txt differ"
     fi
 
     rm alter3.done have.txt shouldhave.txt
     echo "Resetting table to t1_1 version"
     #cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('debg 0')"
     do_verify t1
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_1.csc2 ` }" || failexit "alter to t1_1"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_1.csc2 ` }" || failexit_wrap "alter to t1_1"
     do_verify t1
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate t1" || failexit "truncate"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate t1" || failexit_wrap "truncate"
 }
 
 
@@ -216,13 +215,13 @@ function test2
     echo "(a=300002, b='test1300002', c=300002)" >> pre.txt
 
     if ! diff pre.txt post.txt ; then
-        failexit "pre and post differ"
+        failexit_wrap "pre and post differ"
     fi
     rm pre.txt post.txt
     #cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('debg 0')"
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where a > $INITCNT" || failexit "deleting extra"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where a > $INITCNT" || failexit_wrap "deleting extra"
     echo "Resetting table to t1_1 version"
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_1.csc2 ` }" || failexit "alter to t1_1"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_1.csc2 ` }" || failexit_wrap "alter to t1_1"
 }
 
 function test3
@@ -245,7 +244,7 @@ function test3
     cdb2sql ${CDB2_OPTIONS} $dbnm default "select * from t3" > test3.res
 
     if ! diff test3.exp test3.res; then
-        failexit "test3 failed"
+        failexit_wrap "test3 failed"
     fi
 }
 
@@ -274,7 +273,7 @@ for i in 1 2 3 4 5; do
 done
 
 
-cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate t1" || failexit "truncate"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate t1" || failexit_wrap "truncate"
 insert_records_oneshot 1 $INITCNT
 echo "test2 $i sosql"
 test2 0

--- a/tests/select_one.test/runit
+++ b/tests/select_one.test/runit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 set -e
 #set -x
@@ -11,11 +12,6 @@ if [ "x$dbnm" == "x" ] ; then
     exit 1
 fi
 
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
 
 
 echo "create t1"

--- a/tests/selectv_deadlock.test/runit
+++ b/tests/selectv_deadlock.test/runit
@@ -23,6 +23,7 @@ function failexit
     typeset func="failexit"
     typeset f=$1
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -5,7 +5,8 @@
 # exit after displaying error message
 failexit()
 {
-    echo "Failed $1"
+    echo "Failed $@"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/truncatesc.test/runit
+++ b/tests/truncatesc.test/runit
@@ -42,6 +42,7 @@ function failexit
         kill -9 $(cat $repdir/${repname}.pid)
     fi
     [[ "$reader_pid" -gt 0 ]] && kill -9 $reader_pid
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/updater_latency.test/runit
+++ b/tests/updater_latency.test/runit
@@ -16,6 +16,7 @@ function failexit
     write_prompt $func "Running $func"
     typeset f=$1
     write_prompt $func "$f failed: $2"
+    touch ${DBNAME}.failexit # runtestcase script looks for this file
     exit 1
 }
 

--- a/tests/verify_db.test/runit
+++ b/tests/verify_db.test/runit
@@ -18,12 +18,6 @@ if [ "x$dbnm" == "x" ] ; then
     exit 1
 fi
 
-failexit()
-{
-    echo "Failed $1"
-    exit -1
-}
-
 assert_vers()
 {
     local loc_tbl=$1


### PR DESCRIPTION
From failexit() function touch ${DBNAME}.failexit file and
from runtestcase check for such file to always correctly
identify failed tests (which were not being caught because of
subshell).

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
