### PR TITLE
Fast recovery

### DIFF
--- a/berkdb/btree/bt_rec.c
+++ b/berkdb/btree/bt_rec.c
@@ -26,6 +26,7 @@ static const char revid[] = "$Id: bt_rec.c,v 11.64 2003/09/13 18:48:58 bostic Ex
 #include "dbinc/mp.h"
 #include "bt_prefix.h"
 
+#include <dbinc/recovery_info.h>
 #include <stdlib.h>
 #include <logmsg.h>
 #include <locks_wrap.h>

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2566,6 +2566,8 @@ struct __db_env {
 	DB_LSN durable_lsn;
 	uint32_t durable_generation;
     uint32_t rep_gen;
+    void **parallel_txnlist;
+    int parallel_txnlist_count;
 
 	void (*set_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t));
 	void (*get_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t *));

--- a/berkdb/dbinc/recovery_info.h
+++ b/berkdb/dbinc/recovery_info.h
@@ -1,0 +1,63 @@
+#ifndef _DB_RECOVERY_INFO_H
+#define _DB_RECOVERY_INFO_H
+
+#include <dbinc/hash.h>
+
+/* Determine if this thread should handle this dbp */
+int __recthd_dispatch(DB_ENV *dbenv, DB *file_dbp);
+int __recthd_fileop_dispatch(DB_ENV *dbenv, const char *f1, const char *f2,
+		u_int8_t *fid);
+int __recthd_dbreg_dispatch(DB_ENV *dbenv, u_int8_t *fid, db_recops op);
+
+/* Map fileid to thread number */
+typedef struct ufid_thd {
+	u_int8_t fileid[DB_FILE_ID_LEN];
+	int thd;
+} ufid_thd_t;
+
+typedef struct fop_thd {
+	char *name;
+	int thd;
+} fop_thd_t;
+
+/* Shared information for threaded recovery */
+typedef struct recthd {
+	
+	/* Decides this threads td-id */
+	int *count;
+
+	/* Total threads */
+	int total_threads;
+
+	/* Completed backwards */
+	int completed_backwards;
+
+	/* Number of requests each thread has serviced */
+	int *hitcounts;
+
+	/* FILE-ID to thread map */
+	pthread_mutex_t lk;
+	pthread_cond_t cd;
+	hash_t *fileid_hash;
+	hash_t *fop_hash;
+
+	/* Used for backward and forward roll */
+	DB_ENV *dbenv;
+	DB_LSN lsn;
+	DB_LSN stop_lsn;
+	DB_LSN outlsn;
+    DB **dbpp;
+
+	/* Txninfo */
+	void *txninfo;
+} recthd_t;
+
+/* Thread local infomation */
+typedef struct recovery_info {
+	int threadnum;
+	recthd_t *r;
+} recovery_info_t;
+
+extern __thread recovery_info_t *__recovery_info;
+
+#endif

--- a/berkdb/dbreg/dbreg_rec.c
+++ b/berkdb/dbreg/dbreg_rec.c
@@ -55,6 +55,7 @@ static const char revid[] = "$Id: dbreg_rec.c,v 11.120 2003/10/27 15:54:31 sue E
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
 #include "dbinc/qam.h"
+#include <dbinc/recovery_info.h>
 
 #include "printformats.h"
 
@@ -97,6 +98,12 @@ __dbreg_register_recover(dbenv, dbtp, lsnp, op, info)
 	do_open = do_close = 0;
 	if ((ret = __dbreg_register_read(dbenv, dbtp->data, &argp)) != 0)
 		goto out;
+
+    
+/*
+	if ((ret = __recthd_dbreg_dispatch(dbenv, argp->uid.data, op)) != 1)
+		goto done;
+*/
 
 	/* we're in a forward recovery pass opening files - */
 	if ((op == DB_TXN_OPENFILES || op == DB_TXN_POPENFILES) &&

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -28,6 +28,8 @@ static const char revid[] = "$Id: dbreg_util.c,v 11.39 2003/11/10 17:42:34 sue E
 #include "printformats.h"
 #include "logmsg.h"
 #include "comdb2_atomic.h"
+#include <dbinc/recovery_info.h>
+
 
 static int __dbreg_check_master __P((DB_ENV *, u_int8_t *, char *));
 
@@ -409,6 +411,12 @@ __dbreg_id_to_db_in_recovery(DB_ENV *dbenv, int ndx, DB_TXN *txn, DB_LSN *lsnp,
 
 				goto err;
 			}
+/*
+            if (__recovery_info != NULL && __recovery_info->r->dbpp != NULL) {
+                __db_close(*__recovery_info->r->dbpp, txn, 0);
+                (*__recovery_info->r->dbpp) = *dbpp;
+            }
+*/
 		}
 		*dbpp = r->dbp;
 		goto err;

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -833,6 +833,7 @@ __dbenv_close(dbenv, rep_check)
 	if (dbenv->db_ref != 0) {
 		__db_err(dbenv,
 		    "Database handles open during environment close");
+		abort();
 		if (ret == 0)
 			ret = EINVAL;
 	}

--- a/tests/docker/Dockerfile.install
+++ b/tests/docker/Dockerfile.install
@@ -38,6 +38,8 @@ RUN apt-get update && \
     tcl-dev \
     time \
     tzdata \
+    valgrind \
+    vim \
     uuid-dev && \
   ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata
@@ -48,12 +50,17 @@ RUN cd /comdb2 &&  \
     rm -rf build && \
     mkdir build && \
     cd build && \
-    cmake -DWITH_TCL=1 .. && \
+    cmake -DWITH_TCL=1 -DCMAKE_BUILD_TYPE="Debug" -DDEBUG_ABORT_ON_RECOVERY_FAILURE=1 -DCOMDB2_PER_THREAD_MALLOC=0 .. && \
     make -j4 && \
     make -j4 test-tools && \
     make install &&  \
+    cd /comdb2/pgdump && \
+    make -j4 && \
+    make install && \
     cp /comdb2/tests/docker/client / && \
     cp /comdb2/tests/docker/server / && \
     apt-get clean
 
 ENV PATH      $PATH:/opt/bb/bin
+ENV CLUSTER   "n1 n2 n3"
+ENV SKIPSSL   1

--- a/tests/docker/runit
+++ b/tests/docker/runit
@@ -140,7 +140,7 @@ EOF
 done
 
 # Make sure that root can access common/ under SELinux
-chmod 777 -R common
+chmod -R 777 common
 
 docker-compose build
 docker-compose up --abort-on-container-exit

--- a/tools/comdb2ar/fdostream.h
+++ b/tools/comdb2ar/fdostream.h
@@ -42,6 +42,7 @@ class fdostream : public std::ostream {
 
 public:
     fdostream(int fd);
+    fdostream(void);
     int skip(unsigned long long size);
 };
 


### PR DESCRIPTION
Extremely simple changes to remove the stop-threads code that still persists for old-style-queues.  This branch passed roborivers yesterday, but as old-style queues are deprecated, most of the work and testing for this project will be done under robomark.  I'm submitting a PR to submit this to RM, but this is a work-in-progress.