### PR TITLE
Remove stop-threads

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1605,7 +1605,7 @@ dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
     tbl->queue_pagesize_override = pagesize;
     Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
 
-    if (tbl->dbtype == DBTYPE_QUEUEDB) {
+    if (tbl->dbtype == DBTYPE_QUEUEDB || tbl->dbtype == DBTYPE_QUEUE) {
         Pthread_rwlock_init(&tbl->consumer_lk, NULL);
     }
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -581,6 +581,16 @@ struct dbstore {
 };
 
 typedef struct timepart_views timepart_views_t;
+
+#define consumer_lock_read(x) consumer_lock_read_int(x, __func__, __LINE__);
+void consumer_lock_read_int(struct dbtable *db, const char *func, int line);
+
+#define consumer_lock_write(x) consumer_lock_write_int(x, __func__, __LINE__);
+void consumer_lock_write_int(struct dbtable *db, const char *func, int line);
+
+#define consumer_unlock(x) consumer_unlock_int(x, __func__, __LINE__);
+void consumer_unlock_int(struct dbtable *db, const char *func, int line);
+
 /*
  * We now have different types of db (I overloaded this structure rather than
  * create a new structure because the ireq usedb concept is endemic anyway).
@@ -2427,8 +2437,6 @@ int broadcast_add_new_queue(char *table, int avgitemsz);
 int broadcast_add_consumer(const char *queuename, int consumern,
                            const char *method);
 int broadcast_procedure_op(int op, const char *name, const char *param);
-int broadcast_quiesce_threads(void);
-int broadcast_resume_threads(void);
 int broadcast_close_db(char *table);
 int broadcast_close_only_db(char *table);
 int broadcast_close_all_dbs(void);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -337,6 +337,7 @@ extern int gbl_debug_omit_dta_write;
 extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
+extern int gbl_instrument_consumer_lock;
 extern int eventlog_nkeep;
 extern int gbl_debug_systable_locks;
 extern int gbl_assert_systable_locks;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1981,12 +1981,14 @@ REGISTER_TUNABLE("client_queued_slow_seconds",
                  "which may trigger an action by the watchdog.  (Default: off)",
                  TUNABLE_INTEGER, &gbl_client_queued_slow_seconds,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("client_running_slow_seconds",
                  "If a client connection remains \"running\" longer than this "
                  "period of time (in seconds), it is considered to be \"slow\", "
                  "which may trigger an action by the watchdog.  (Default: off)",
                  TUNABLE_INTEGER, &gbl_client_running_slow_seconds,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("client_abort_on_slow",
                  "Enable watchdog to abort if a \"slow\" client is detected."
                  "  (Default: off)", TUNABLE_BOOLEAN, &gbl_client_abort_on_slow,
@@ -2026,5 +2028,10 @@ REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid 
 
 REGISTER_TUNABLE("debug_sleep_in_sql_tick", "Sleep for a second in sql tick.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_in_sql_tick, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("debug_consumer_lock",
+                 "Enable debug-trace for consumer lock.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_instrument_consumer_lock, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Extremely simple changes to remove the stop-threads code that still persists for old-style-queues. This branch passed roborivers yesterday, but as old-style queues are deprecated, most of the work and testing for this project will be done under robomark. I'm submitting a PR to submit this to RM, but this is a work-in-progress.