### PR TITLE
Use thread local variable in get_area()

### DIFF
--- a/mem/mem.c
+++ b/mem/mem.c
@@ -270,6 +270,7 @@ static int comdb2ma_destroy_int(comdb2ma cm);
 
 #ifdef PER_THREAD_MALLOC
 __thread const char *thread_type_key;
+static __thread comdb2ma *t_zone;
 static comdb2ma get_area(int indx);
 static void destroy_zone(void *);
 #else
@@ -1295,13 +1296,14 @@ static comdb2ma get_area(int indx)
         return COMDB2_STATIC_MAS[indx];
 #endif /* !THREAD_DIAGNOSIS */
 
-    zone = (comdb2ma *)pthread_getspecific(root.zone);
+    zone = t_zone;
     if (zone == NULL) {
         if (COMDB2MA_LOCK(&root) == 0) {
             zone = mspace_calloc(root.m, COMDB2MA_COUNT, sizeof(comdb2ma));
             COMDB2MA_UNLOCK(&root);
         }
         Pthread_setspecific(root.zone, (void *)zone);
+        t_zone = zone;
     }
 
     if (zone[indx] == NULL) {


### PR DESCRIPTION
End result is same underlying behavior but without the penalty
of pthread_getspecific(), which allows some savings of about 1%
in a simple select test case (as reported by valgrind).

The usage here is a bit peculiar in having redundant pointers
to the same zone because there is no way to cleanup __thread
variables in c. We use the pthread_key variable to perform
cleanup on thread exit, and for checking whether zone is null
(which is done hundreds of thousand of times) we use the
__thread variable.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>