### PR TITLE
ltrim: Fix the allowed number of arguments

### DIFF
--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -2488,12 +2488,7 @@ void sqlite3RegisterBuiltinFunctions(void){
                                                      SQLITE_FUNC_TYPEOF),
 #endif
     FUNCTION(ltrim,              1, 1, 0, trimFunc         ),
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-    /* TODO: Why is a 3 argument version of ltrim needed? */
-    FUNCTION(ltrim,              3, 1, 0, trimFunc         ),
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     FUNCTION(ltrim,              2, 1, 0, trimFunc         ),
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     FUNCTION(rtrim,              1, 2, 0, trimFunc         ),
     FUNCTION(rtrim,              2, 2, 0, trimFunc         ),
     FUNCTION(trim,               1, 3, 0, trimFunc         ),

--- a/tests/sql.test/t9_01.req
+++ b/tests/sql.test/t9_01.req
@@ -1,0 +1,4 @@
+SELECT ltrim("abcdef");
+SELECT ltrim(" abcdef");
+SELECT ltrim("abcdef", "abc");
+SELECT ltrim("abcdef", "abc", "abc");

--- a/tests/sql.test/t9_01.req.exp
+++ b/tests/sql.test/t9_01.req.exp
@@ -1,0 +1,4 @@
+(ltrim("abcdef")='abcdef')
+(ltrim(" abcdef")='abcdef')
+(ltrim("abcdef", "abc")='def')
+[SELECT ltrim("abcdef", "abc", "abc")] failed with rc -3 wrong number of arguments to function ltrim()


### PR DESCRIPTION
Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>