### PR TITLE
simple fix for deadlock recovery for remote write backend

### DIFF
--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -332,6 +332,7 @@ int fdb_svc_trans_begin(char *tid, enum transaction_level lvl, int flags,
     if (!clnt) {
         return -1;
     }
+    thd->clnt = clnt;
 
     init_sqlclntstate(clnt, tid, isuuid);
 


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Recover deadlock uses sql thread thd to recover clnt state.  It is not set for remote writes backend, simple fix for it.
