### PR TITLE
Supporting multiple constraints sections in csc2 (7.0)

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -3215,15 +3215,13 @@ int dyns_get_table_field_count(char *tabletag)
 
 int dyns_get_constraint_count(void)
 {
-    if (nconstraints < 0)
-        return 0;
-    return nconstraints;
+    return (nconstraints + 1);
 }
 
 int dyns_get_constraint_at(int idx, char **consname, char **keyname,
                            int *rulecnt, int *flags)
 {
-    if (idx < 0 || idx >= nconstraints)
+    if (idx < 0 || idx > nconstraints)
         return -1;
     *consname = constraints[idx].consname;
     *keyname = constraints[idx].lclkey;
@@ -3235,7 +3233,7 @@ int dyns_get_constraint_at(int idx, char **consname, char **keyname,
 int dyns_get_constraint_rule(int cidx, int ridx, char **tblname, char **keynm)
 {
     int rcnt = 0;
-    if (cidx < 0 || cidx >= nconstraints)
+    if (cidx < 0 || cidx > nconstraints)
         return -1;
     rcnt = constraints[cidx].ncnstrts;
     if (ridx < 0 || ridx >= rcnt)

--- a/csc2/maccparse.y
+++ b/csc2/maccparse.y
@@ -125,7 +125,7 @@ validstruct:	recstruct
 
 
 /* constraintstruct: defines cross-table constraints */
-constraintstruct: T_CONSTRAINTS comment '{' cnstrtdef '}' { end_constraint_list(); }
+constraintstruct: T_CONSTRAINTS comment '{' cnstrtdef '}' { }
                 ;
 
 ctmodifiers:    T_CON_ON T_CON_UPDATE T_CASCADE ctmodifiers           { set_constraint_mod(0,0,1); }

--- a/tests/constraints.test/t14.req
+++ b/tests/constraints.test/t14.req
@@ -1,0 +1,5 @@
+drop table if exists c
+drop table if exists p
+
+create table p {schema{int i int j} keys{"pki" = i "pkj" = j}} $$
+create table c {schema{int i} keys{"cki" = i} constraints{"cki" -> <"p" : "pki">} constraints{"cki" -> <"p" : "pkj">}} $$

--- a/tests/constraints.test/t14.req.exp
+++ b/tests/constraints.test/t14.req.exp
@@ -1,0 +1,4 @@
+[drop table if exists c] rc 0
+[drop table if exists p] rc 0
+[create table p {schema{int i int j} keys{"pki" = i "pkj" = j}}] rc 0
+[create table c {schema{int i} keys{"cki" = i} constraints{"cki" -> <"p" : "pki">} constraints{"cki" -> <"p" : "pkj">}}] rc 0


### PR DESCRIPTION
The bug is 7.0 only: the server crashes if a csc2 schema contains multiple `constraints` sections.

(DRQS 159823090)