### PR TITLE
Test and fix locking for comdb2_queues

### DIFF
--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -163,12 +163,11 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
         bdb_get_tran_lockerid(trans, &savedlid);
         bdb_set_tran_lockerid(trans, lockid);
 
-        // TODO: re-enable when systable fixes are checked in
-        if (0 && gbl_debug_systable_locks) {
+        if (gbl_debug_systable_locks) {
             bdb_assert_tablename_locked(bdb_state, "_comdb2_systables", lockid, ASSERT_TABLENAME_LOCKED_READ);
         }
 
-        if (0 && gbl_assert_systable_locks) {
+        if (gbl_assert_systable_locks) {
             bdb_assert_tablename_locked(bdb_state, "comdb2_queues", lockid, ASSERT_TABLENAME_LOCKED_READ);
         }
     }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7360,8 +7360,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         return 0;
     }
 
-    // TODO: re-enable when systables are fixed
-    for (int i = 0; 0 && (i < p->numVTableLocks); i++) {
+    for (int i = 0; i < p->numVTableLocks; i++) {
         if ((rc = bdb_lock_tablename_read_fromlid(thedb->bdb_env, p->vTableLocks[i],
                                                   bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran))) != 0) {
             logmsg(LOGMSG_ERROR, "%s lock %s returns %d\n", __func__, p->vTableLocks[i], rc);
@@ -7369,8 +7368,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         }
     }
 
-    // TODO: re-enable when systables are fixed
-    if (0 && gbl_debug_systable_locks && p->numVTableLocks > 0) {
+    if (gbl_debug_systable_locks && p->numVTableLocks > 0) {
         if ((rc = bdb_lock_tablename_read_fromlid(thedb->bdb_env, "_comdb2_systables",
                                                   bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran))) != 0) {
             logmsg(LOGMSG_ERROR, "%s lock _comdb2_systables returns %d\n", __func__, rc);

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -873,6 +873,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     rc = bdb_close_only_sc(old_bdb_handle, NULL, &bdberr);
     if (rc) {
         sc_errf(s, "Failed closing old db, bdberr %d\n", bdberr);
+        abort();
         goto failed;
     }
     sc_printf(s, "Close old db ok\n");
@@ -892,6 +893,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
             rc = table_version_upsert(db, transac, &bdberr);
         if (rc) {
             sc_errf(s, "Failed updating table version bdberr %d\n", bdberr);
+            abort();
             goto failed;
         }
     } else {
@@ -916,6 +918,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     rc = bdb_free_and_replace(old_bdb_handle, new_bdb_handle, &bdberr);
     if (rc) {
         sc_errf(s, "Failed freeing old db, bdberr %d\n", bdberr);
+        abort();
         goto failed;
     } else
         sc_printf(s, "bdb free ok\n");

--- a/sqlite/ext/comdb2/indexuse.c
+++ b/sqlite/ext/comdb2/indexuse.c
@@ -26,7 +26,6 @@
 #include "sql.h"
 #include "ezsystables.h"
 #include "cdb2api.h"
-#include "schema_lk.h"
 
 static sqlite3_module systblIndexUsageModule = {
     .access_flag = CDB2_ALLOW_USER,
@@ -60,7 +59,6 @@ static int get_index_usage(void **recsp, int *nrecs) {
     int allocated = 0;
     int nix = 0;
 
-    rdlock_schema_lk();
 
     for (int dbn = 0; dbn < thedb->num_dbs; dbn++) {
         db = thedb->dbs[dbn];
@@ -73,7 +71,6 @@ static int get_index_usage(void **recsp, int *nrecs) {
                 struct index_usage *n = realloc(ixs, allocated * sizeof(struct index_usage));
                 if (n == NULL) {
                     free_index_usage(ixs, nix);
-                    unlock_schema_lk();
                     return -1;
                 }
                 ixs = n;
@@ -91,7 +88,6 @@ static int get_index_usage(void **recsp, int *nrecs) {
     }
     *nrecs = nix;
     *recsp = ixs;
-    unlock_schema_lk();
     return 0;
 }
 

--- a/sqlite/ext/comdb2/procedures.c
+++ b/sqlite/ext/comdb2/procedures.c
@@ -19,10 +19,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "comdb2.h"
-#include "bdb_api.h"
-#include "comdb2systbl.h"
-#include "comdb2systblInt.h"
+#include <comdb2.h>
+#include <bdb_api.h>
+#include <bdb_int.h>
+#include <sql.h>
+#include <comdb2systbl.h>
+#include <comdb2systblInt.h>
 
 /*
 ** Functions to load server & client versioned SPs
@@ -61,9 +63,14 @@ static void get_sp_versions(systbl_sps_cursor *c) {
   free_sp_versions(c);
   char *sp = c->ppProc[c->iProc];
   char **cvers;
-  int scnt, ccnt, bdberr;
-  bdb_get_lua_highest(NULL, sp, &scnt, INT_MAX, &bdberr);
-  bdb_get_all_for_versioned_sp(sp, &cvers, &ccnt);
+  int scnt = 0, ccnt = 0, bdberr;
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return;
+  }
+  bdb_get_lua_highest(trans, sp, &scnt, INT_MAX, &bdberr);
+  bdb_get_all_for_versioned_sp_tran(trans, sp, &cvers, &ccnt);
   c->pVer = sqlite3_malloc(sizeof(spversion) * (scnt + ccnt));
   int i;
   for(i = 0; i < scnt; ++i) {
@@ -83,14 +90,15 @@ static void get_sp_versions(systbl_sps_cursor *c) {
   c->defaultVer.sVer = 0;
   c->defaultVer.cVer = NULL;
   int rc;
-  if((rc = bdb_get_sp_get_default_version(sp, &bdberr)) > 0) {
+  if((rc = bdb_get_sp_get_default_version_tran(trans, sp, &bdberr)) > 0) {
     c->defaultVer.sVer = rc;
   } else {
-    bdb_get_default_versioned_sp(sp, &c->defaultVer.cVer);
+    bdb_get_default_versioned_sp_tran(trans, sp, &c->defaultVer.cVer);
   }
+  curtran_puttran(trans);
 }
 
-static void get_server_versioned_sps(char ***a, int *x) {
+static void get_server_versioned_sps(tran_type *tran, char ***a, int *x) {
   char old_sp[MAX_SPNAME] = {0};
   char new_sp[MAX_SPNAME] = {0};
   old_sp[0] = 127;
@@ -100,7 +108,7 @@ static void get_server_versioned_sps(char ***a, int *x) {
   int alloc = 0;
   while(1) {
     int bdberr;
-    int rc = bdb_get_sp_name(NULL, old_sp, new_sp, &bdberr);
+    int rc = bdb_get_sp_name(tran, old_sp, new_sp, &bdberr);
     if(rc || (strcmp(old_sp, new_sp) <= 0)) {
       break;
     }
@@ -185,8 +193,10 @@ static int systblSPsOpen(
   char **sname, **cname; // server name, client name
   int scnt, ccnt;        // server count, client count
 
-  get_server_versioned_sps(&sname, &scnt);
-  bdb_get_versioned_sps(&cname, &ccnt);
+  tran_type *trans = curtran_gettran();
+
+  get_server_versioned_sps(trans, &sname, &scnt);
+  bdb_get_versioned_sps_tran(trans, &cname, &ccnt);
 
   // SP can have both clnt and server versioned names.
   // Merge the two lists to de-dup
@@ -210,6 +220,7 @@ static int systblSPsOpen(
   for(i = 0; i < ccnt; ++i)
     free(cname[i]);
   free(cname);
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 
@@ -271,6 +282,11 @@ static int systblSPsColumn(
   char *sp = NULL;
   int def = 0, size;
   spversion *v;
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return -1;
+  }
 
   /* Check to see if c->pVer is already allocated. If not, allocate. */
   if (c->iVer == 0 && c->pVer == NULL) {
@@ -319,9 +335,9 @@ static int systblSPsColumn(
         sqlite3_result_null( ctx );
       else if( v->sVer ) {
         int bdberr;
-        bdb_get_sp_lua_source( NULL, NULL, sp, &src, v->sVer, &size, &bdberr );
+        bdb_get_sp_lua_source( thedb->bdb_env, trans, sp, &src, v->sVer, &size, &bdberr );
       } else {
-        bdb_get_versioned_sp( sp, v->cVer, &src );
+        bdb_get_versioned_sp_tran( trans, sp, v->cVer, &src );
         size = strlen(src);
       }
       if( src == NULL )
@@ -330,6 +346,7 @@ static int systblSPsColumn(
         sqlite3_result_text( ctx, src, size, free );
       break;
   }
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 

--- a/sqlite/ext/comdb2/schistory.c
+++ b/sqlite/ext/comdb2/schistory.c
@@ -48,8 +48,9 @@ static int get_status(void **data, int *npoints)
     int rc, bdberr, nkeys;
     sc_hist_row *hist = NULL;
     struct sc_hist_ent *sc_hist_ents = NULL;
+    tran_type *trans = curtran_gettran();
 
-    rc = bdb_llmeta_get_sc_history(NULL, &hist, &nkeys, &bdberr, NULL);
+    rc = bdb_llmeta_get_sc_history(trans, &hist, &nkeys, &bdberr, NULL);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s: failed to get all schema change hist\n",
                __func__);
@@ -87,6 +88,7 @@ static int get_status(void **data, int *npoints)
     *data = sc_hist_ents;
 
 cleanup:
+    curtran_puttran(trans);
     free(hist);
 
     return rc;

--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -49,8 +49,9 @@ static int get_status(void **data, int *npoints)
     llmeta_sc_status_data *status = NULL;
     void **sc_data = NULL;
     struct sc_status_ent *sc_status_ents = NULL;
-
-    rc = bdb_llmeta_get_all_sc_status(NULL, &status, &sc_data, &nkeys, &bdberr);
+    tran_type *tran = curtran_gettran();
+    rc = bdb_llmeta_get_all_sc_status(tran, &status, &sc_data, &nkeys, &bdberr);
+    curtran_puttran(tran);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s: failed to get all schema change status\n",
                __func__);

--- a/sqlite/ext/comdb2/tablepermissions.c
+++ b/sqlite/ext/comdb2/tablepermissions.c
@@ -23,10 +23,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "comdb2.h"
-#include "sql.h"
-#include "comdb2systbl.h"
-#include "comdb2systblInt.h"
+#include <comdb2.h>
+#include <sql.h>
+#include <comdb2systbl.h>
+#include <comdb2systblInt.h>
+#include <bdb_int.h>
+#include <sql.h>
 
 /* permissions_cursor is a subclass of sqlite3_vtab_cursor which serves
 ** as the underlying cursor to enumerate the rows in this vtable.
@@ -92,25 +94,28 @@ static int permissionsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
 
   permissions_cursor *pCur = sqlite3_malloc(sizeof(*pCur));
   if( pCur==0 ) return SQLITE_NOMEM;
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return -1;
+  }
+
   memset(pCur, 0, sizeof(*pCur));
 
   struct sql_thread *thd = pthread_getspecific(query_info_key);
   char *usr = thd->clnt->current_user.name;
-
-  rdlock_schema_lk();
   pCur->ppTables = sqlite3_malloc(sizeof(char*) * (thedb->num_dbs +
                                                    vtab->db->aModule.count));
   for(int i=0;i<thedb->num_dbs;++i) {
     // skip sqlite_stat* ?
     char *tbl = thedb->dbs[i]->tablename;
     int err;
-    if( bdb_check_user_tbl_access(NULL, usr, tbl, ACCESS_READ, &err)!=0 ){
+    if( bdb_check_user_tbl_access_tran(thedb->bdb_env, trans, usr, tbl, ACCESS_READ, &err)!=0 ){
       continue;
     }
     pCur->ppTables[pCur->nTables++] = strdup(tbl);
   }
-  bdb_user_get_all(&pCur->ppUsers, &pCur->nUsers);
-  unlock_schema_lk();
+  bdb_user_get_all_tran(trans, &pCur->ppUsers, &pCur->nUsers);
 
   HashElem *systbl;
   for(systbl = sqliteHashFirst(&vtab->db->aModule);
@@ -120,6 +125,7 @@ static int permissionsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
   }
 
   *ppCursor = &pCur->base;
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 
@@ -156,6 +162,12 @@ static int permissionsColumn(
   int i
 ){
   permissions_cursor *pCur = (permissions_cursor*)cur;
+
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return 1;
+  }
   char *tbl = pCur->ppTables[pCur->iTable];
   char *usr = pCur->ppUsers[pCur->iUser];
   switch( i ){
@@ -179,11 +191,12 @@ static int permissionsColumn(
         access = ACCESS_DDL;
       }
       sqlite3_result_text(ctx,
-        YESNO(!bdb_check_user_tbl_access(NULL, usr, tbl, access, &err)),
+        YESNO(!bdb_check_user_tbl_access_tran(thedb->bdb_env, trans, usr, tbl, access, &err)),
         -1, SQLITE_STATIC);
       break;
     }
   }
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -23,9 +23,12 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "comdb2.h"
-#include "comdb2systbl.h"
-#include "comdb2systblInt.h"
+#include <bdb_api.h>
+#include <bdb_int.h>
+#include <sql.h>
+#include <comdb2.h>
+#include <comdb2systbl.h>
+#include <comdb2systblInt.h>
 
 /* systbl_tblsize_cursor is a subclass of sqlite3_vtab_cursor which
 ** serves as the underlying cursor to enumerate the rows in this
@@ -117,16 +120,22 @@ static int systblTblSizeColumn(
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
   char *x = pDb->tablename;
 
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return -1;
+  }
   switch( i ){
     case STTS_TABLE: {
       sqlite3_result_text(ctx, x, -1, NULL);
       break;
     }
     case STTS_SIZE: {
-      calc_table_size(pDb, 0);
+      calc_table_size_tran(trans, pDb, 0);
       sqlite3_result_int64(ctx, (sqlite3_int64)pDb->totalsize);
     }
   }
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -16,14 +16,13 @@
 
 /* Implement comdb2_triggers to introspect triggers and consumers */
 
-#include "comdb2systbl.h"
-#include "comdb2systblInt.h"
-#include <schema_lk.h>
+#include <comdb2systbl.h>
+#include <comdb2systblInt.h>
 #include <comdb2.h>
 #include <bdb/bdb_int.h>
-
 #include <translistener.h>
-#include "sql.h"
+#include <bdb_int.h>
+#include <sql.h>
 
 typedef struct trigger trigger;
 struct trigger {

--- a/sqlite/ext/comdb2/views.c
+++ b/sqlite/ext/comdb2/views.c
@@ -53,7 +53,6 @@ static int get_views(void **data, int *npoints)
     int rc = SQLITE_OK;
     *npoints = 0;
     *data = NULL;
-    rdlock_schema_lk();
     if (thedb->view_hash != NULL) {
         int count;
         hash_info(thedb->view_hash, NULL, NULL, NULL, NULL, &count, NULL, NULL);
@@ -79,7 +78,6 @@ static int get_views(void **data, int *npoints)
             }
         }
     }
-    unlock_schema_lk();
     return rc;
 }
 

--- a/tests/sc_rebuilds.test/extralock.testopts
+++ b/tests/sc_rebuilds.test/extralock.testopts
@@ -1,0 +1,1 @@
+debug_systable_locks on

--- a/tests/schemalk.test/extralock.testopts
+++ b/tests/schemalk.test/extralock.testopts
@@ -1,0 +1,1 @@
+debug_systable_locks on

--- a/tests/systable_locking.test/runit
+++ b/tests/systable_locking.test/runit
@@ -24,10 +24,10 @@ function failexit
 }
 
 # The test will pass this after all the "chunked" changes are checked in
-function stat_all_tables_complete
+function stat_all_tables
 {
     [[ $debug == "1" ]] && set -x
-    t=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "SELECT * FROM COMDB2_SYSTABLES" 2>&1 | egrep -v comdb2_sc_history)
+    t=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "SELECT * FROM COMDB2_SYSTABLES")
     for x in $t; do
         $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM $x LIMIT 10" >/dev/null 2>&1
     done
@@ -84,12 +84,6 @@ function stat_all_tables_complete
 # comdb2_tablepermissions
 # comdb2_net_userfuncs
 # comdb2_active_osqls
-
-function stat_all_tables
-{
-    #$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2_queues LIMIT 10" >/dev/null 2>&1
-    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2_triggers LIMIT 10" >/dev/null 2>&1
-}
 
 function write_tables
 {


### PR DESCRIPTION
Protect the comdb2_queues system table with a lock on that table.  All schema-changes on queues must acquire this lock in write-mode.  I've written the queue_locking test which demonstrates the issue- current master fails this test.
