### PR TITLE
ANALYZE fails for OP user

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -6181,8 +6181,9 @@ int comdb2_next_allowed_table(sqlite3_int64 *tabId)
     while (*tabId < thedb->num_dbs) {
         pDb = thedb->dbs[*tabId];
         tablename = pDb->tablename;
-        rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->clnt->user,
-                                       tablename, ACCESS_READ, &bdberr);
+        rc = bdb_check_user_tbl_access(thedb->bdb_env,
+                                       thd->clnt->current_user.name, tablename,
+                                       ACCESS_READ, &bdberr);
         if (rc == 0)
             return SQLITE_OK;
         (*tabId)++;

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1715,13 +1715,13 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
     if (gbl_uses_password &&
         (thd->clnt->no_transaction == 0)) {
         rc = bdb_check_user_tbl_access(
-            pCur->db->dbenv->bdb_env, thd->clnt->user,
+            pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
             pCur->db->tablename, ACCESS_WRITE, &bdberr);
         if (rc != 0) {
             char msg[1024];
             snprintf(msg, sizeof(msg),
                      "Write access denied to %s for user %s bdberr=%d",
-                     pCur->db->tablename, thd->clnt->user, bdberr);
+                     pCur->db->tablename, thd->clnt->current_user.name, bdberr);
             logmsg(LOGMSG_INFO, "%s\n", msg);
             errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
             errstat_set_str(&thd->clnt->osql.xerr, msg);
@@ -1762,13 +1762,13 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
     /* Check it only if engine is open already. */
     if (gbl_uses_password && thd->clnt->no_transaction == 0) {
         rc = bdb_check_user_tbl_access(
-            pCur->db->dbenv->bdb_env, thd->clnt->user,
+            pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
             pCur->db->tablename, ACCESS_READ, &bdberr);
         if (rc != 0) {
             char msg[1024];
             snprintf(msg, sizeof(msg),
                      "Read access denied to %s for user %s bdberr=%d",
-                     pCur->db->tablename, thd->clnt->user, bdberr);
+                     pCur->db->tablename, thd->clnt->current_user.name, bdberr);
             logmsg(LOGMSG_INFO, "%s\n", msg);
             errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
             errstat_set_str(&thd->clnt->osql.xerr, msg);

--- a/db/sql.h
+++ b/db/sql.h
@@ -576,6 +576,17 @@ struct sql_hist_cost {
     int64_t rows;
 };
 
+struct user {
+    char name[MAX_USERNAME_LEN];
+    char password[MAX_PASSWORD_LEN];
+
+    uint8_t have_name;
+    uint8_t have_password;
+    /* 1 if the user is retrieved from a client certificate */
+    uint8_t is_x509_user;
+};
+
+
 #define in_client_trans(clnt) ((clnt)->in_client_trans)
 
 /* Client specific sql state */
@@ -692,14 +703,7 @@ struct sqlclntstate {
     struct query_effects log_effects;
     int64_t nsteps;
 
-    int have_user;
-    char user[MAX_USERNAME_LEN];
-    int is_x509_user; /* True if the user is retrieved
-                         from a client certificate. */
-
-    int have_password;
-    char password[MAX_PASSWORD_LEN];
-
+    struct user current_user;
     int authgen;
 
     int no_transaction;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12346,14 +12346,14 @@ int comdb2_check_vtab_access(sqlite3 *db, sqlite3_module *module)
                 return SQLITE_OK;
             }
 
-            rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->clnt->user,
-                                           (char *)mod->zName, ACCESS_READ,
-                                           &bdberr);
+            rc = bdb_check_user_tbl_access(
+                thedb->bdb_env, thd->clnt->current_user.name,
+                (char *)mod->zName, ACCESS_READ, &bdberr);
             if (rc != 0) {
                 char msg[1024];
                 snprintf(msg, sizeof(msg),
                          "Read access denied to %s for user %s bdberr=%d",
-                         mod->zName, thd->clnt->user, bdberr);
+                         mod->zName, thd->clnt->current_user.name, bdberr);
                 logmsg(LOGMSG_INFO, "%s\n", msg);
                 errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
                 errstat_set_str(&thd->clnt->osql.xerr, msg);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2910,7 +2910,7 @@ int release_locks_on_emit_row(struct sqlthdstate *thd,
     return 0;
 }
 
-/* if userpassword does not match this function
+/* If user password does not match this function
  * will write error response and return a non 0 rc
  */
 static inline int check_user_password(struct sqlclntstate *clnt)
@@ -2921,18 +2921,18 @@ static inline int check_user_password(struct sqlclntstate *clnt)
     if (!gbl_uses_password)
         return 0;
 
-    if (!clnt->have_user) {
-        clnt->have_user = 1;
-        strcpy(clnt->user, DEFAULT_USER);
+    if (!clnt->current_user.have_name) {
+        clnt->current_user.have_name = 1;
+        strcpy(clnt->current_user.name, DEFAULT_USER);
     }
 
-    if (!clnt->have_password) {
-        clnt->have_password = 1;
-        strcpy(clnt->password, DEFAULT_PASSWORD);
+    if (!clnt->current_user.have_password) {
+        clnt->current_user.have_password = 1;
+        strcpy(clnt->current_user.password, DEFAULT_PASSWORD);
     }
 
-    password_rc =
-        bdb_user_password_check(clnt->user, clnt->password, &valid_user);
+    password_rc = bdb_user_password_check(
+        clnt->current_user.name, clnt->current_user.password, &valid_user);
 
     if (password_rc != 0) {
         write_response(clnt, RESPONSE_ERROR_ACCESS, "access denied", 0);
@@ -2944,10 +2944,18 @@ static inline int check_user_password(struct sqlclntstate *clnt)
 /* Return current authenticated user for the session */
 char *get_current_user(struct sqlclntstate *clnt)
 {
-    if (clnt && !clnt->is_x509_user && clnt->have_user) {
-        return clnt->user;
+    if (clnt && !clnt->current_user.is_x509_user &&
+        clnt->current_user.have_name) {
+        return clnt->current_user.name;
     }
     return NULL;
+}
+
+static void reset_user(struct sqlclntstate *clnt)
+{
+    if (!clnt)
+        return;
+    bzero(&clnt->current_user, sizeof(clnt->current_user));
 }
 
 void thr_set_current_sql(const char *sql)
@@ -4330,16 +4338,17 @@ static int check_sql_access(struct sqlthdstate *thd, struct sqlclntstate *clnt)
 #   if WITH_SSL
     /* If 1) this is an SSL connection, 2) and client sends a certificate,
        3) and client does not override the user, let it through. */
-    if (sslio_has_x509(clnt->sb) && clnt->is_x509_user)
+    if (sslio_has_x509(clnt->sb) && clnt->current_user.is_x509_user)
         rc = 0;
     else
 #   endif
         rc = check_user_password(clnt);
 
     if (rc == 0) {
-        if (thd->lastuser[0] != '\0' && strcmp(thd->lastuser, clnt->user) != 0)
+        if (thd->lastuser[0] != '\0' &&
+            strcmp(thd->lastuser, clnt->current_user.name) != 0)
             delete_prepared_stmts(thd);
-        strcpy(thd->lastuser, clnt->user);
+        strcpy(thd->lastuser, clnt->current_user.name);
         clnt->authgen = bpfunc_auth_gen;
     } else {
         clnt->authgen = 0;
@@ -4890,7 +4899,8 @@ void clnt_to_ruleset_item_criteria(
   if ((clnt == NULL) || (context == NULL)) return;
   context->zOriginHost = clnt->origin_host;
   context->zOriginTask = clnt->conninfo.pename;
-  context->zUser = clnt->have_user ? clnt->user : NULL;
+  context->zUser =
+      clnt->current_user.have_name ? clnt->current_user.name : NULL;
   context->zSql = clnt->sql;
   context->pFingerprint = clnt->work.aFingerprint;
 }
@@ -5675,17 +5685,9 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->limits.tablescans_warn = gbl_querylimits_tablescans_warn;
     clnt->limits.temptables_warn = gbl_querylimits_temptables_warn;
 
-
     reset_query_effects(clnt);
 
-    /* reset the user */
-    clnt->have_user = 0;
-    clnt->is_x509_user = 0;
-    bzero(clnt->user, sizeof(clnt->user));
-
-    /* reset the password */
-    clnt->have_password = 0;
-    bzero(clnt->password, sizeof(clnt->password));
+    reset_user(clnt);
 
     /* reset authentication status */
     clnt->authgen = 0;

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -342,12 +342,12 @@ static const char *ssl_mode_to_string(ssl_mode mode)
 
 void ssl_set_clnt_user(struct sqlclntstate *clnt)
 {
-    int rc =
-        sslio_x509_attr(clnt->sb, gbl_nid_user, clnt->user, sizeof(clnt->user));
+    int rc = sslio_x509_attr(clnt->sb, gbl_nid_user, clnt->current_user.name,
+                             sizeof(clnt->current_user.name));
     if (rc != 0)
         return;
-    clnt->have_user = 1;
-    clnt->is_x509_user = 1;
+    clnt->current_user.have_name = 1;
+    clnt->current_user.is_x509_user = 1;
 }
 
 void ssl_stats(void)

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -453,7 +453,8 @@ static int db_send(Lua L) {
     if (gbl_uses_password) {
       if (sp && sp->clnt) {
           int bdberr;
-          if (bdb_tbl_op_access_get(thedb->bdb_env, NULL, 0, "", sp->clnt->user, &bdberr)) {
+          if (bdb_tbl_op_access_get(thedb->bdb_env, NULL, 0, "",
+                                    sp->clnt->current_user.name, &bdberr)) {
               return luaL_error(L, "User doesn't have access to run this command.");
           }
       }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1642,18 +1642,19 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                     rc = ii + 1;
                 } else {
                     sqlite3Dequote(sqlstr);
-                    if (strlen(sqlstr) >= sizeof(clnt->user)) {
+                    if (strlen(sqlstr) >= sizeof(clnt->current_user.name)) {
                         snprintf(err, sizeof(err),
                                  "set user: '%s' exceeds %zu characters",
-                                 sqlstr, sizeof(clnt->user) - 1);
+                                 sqlstr, sizeof(clnt->current_user.name) - 1);
                         rc = ii + 1;
                     } else {
-                        clnt->have_user = 1;
+                        clnt->current_user.have_name = 1;
                         /* Re-authenticate the new user. */
-                        if (clnt->authgen && strcmp(clnt->user, sqlstr) != 0)
+                        if (clnt->authgen &&
+                            strcmp(clnt->current_user.name, sqlstr) != 0)
                             clnt->authgen = 0;
-                        clnt->is_x509_user = 0;
-                        strcpy(clnt->user, sqlstr);
+                        clnt->current_user.is_x509_user = 0;
+                        strcpy(clnt->current_user.name, sqlstr);
                     }
                 }
             } else if (strncasecmp(sqlstr, "password", 8) == 0) {
@@ -1666,19 +1667,19 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                     rc = ii + 1;
                 } else {
                     sqlite3Dequote(sqlstr);
-                    if (strlen(sqlstr) >= sizeof(clnt->password)) {
+                    if (strlen(sqlstr) >= sizeof(clnt->current_user.password)) {
                         snprintf(err, sizeof(err),
                                  "set password: password length exceeds %zu "
                                  "characters",
-                                 sizeof(clnt->password) - 1);
+                                 sizeof(clnt->current_user.password) - 1);
                         rc = ii + 1;
                     } else {
-                        clnt->have_password = 1;
+                        clnt->current_user.have_password = 1;
                         /* Re-authenticate the new password. */
                         if (clnt->authgen &&
-                            strcmp(clnt->password, sqlstr) != 0)
+                            strcmp(clnt->current_user.password, sqlstr) != 0)
                             clnt->authgen = 0;
-                        strcpy(clnt->password, sqlstr);
+                        strcpy(clnt->current_user.password, sqlstr);
                     }
                 }
             } else if (strncasecmp(sqlstr, "spversion", 9) == 0) {

--- a/sqlite/ext/comdb2/tablepermissions.c
+++ b/sqlite/ext/comdb2/tablepermissions.c
@@ -95,7 +95,7 @@ static int permissionsOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
   memset(pCur, 0, sizeof(*pCur));
 
   struct sql_thread *thd = pthread_getspecific(query_info_key);
-  char *usr = thd->clnt->user;
+  char *usr = thd->clnt->current_user.name;
 
   rdlock_schema_lk();
   pCur->ppTables = sqlite3_malloc(sizeof(char*) * (thedb->num_dbs +

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -115,7 +115,8 @@ static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
       continue;
 
     /* Check user access. */
-    rc = bdb_check_user_tbl_access(thedb->bdb_env, thd->clnt->user,
+    rc = bdb_check_user_tbl_access(thedb->bdb_env,
+                                   thd->clnt->current_user.name,
                                    thedb->qdbs[i]->tablename, ACCESS_READ,
                                    &bdberr);
     if (rc != 0) {

--- a/tests/auth.test/Makefile
+++ b/tests/auth.test/Makefile
@@ -4,7 +4,7 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=5m
 endif
 
 export CHECK_DB_AT_FINISH=0

--- a/tests/auth.test/t16.expected
+++ b/tests/auth.test/t16.expected
@@ -1,0 +1,5 @@
+(user='---------- OP user ----------')
+(rows inserted=3)
+(user='---------- non-OP user ----------')
+[analyze t1] failed with rc -3 User does not have OP credentials
+(user='---------- OP user ----------')

--- a/tests/auth.test/t16.req
+++ b/tests/auth.test/t16.req
@@ -1,0 +1,20 @@
+# OP user
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+create table t1(i int unique)$$
+insert into t1 values(1),(2),(3);
+
+# non-OP user
+set user 'user2'
+set password 'new_password'
+select '---------- non-OP user ----------' as user;
+analyze t1;
+
+# Run analyze (OP user)
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+analyze t1;
+# Cleanup
+drop table t1;


### PR DESCRIPTION
When authentication is enabled, ANALYZE table commands are limited to OP users only. But, since the user credentials are not inherited by the analyze threads, they fail the authorization check.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>

/plugin-branch comdb2-auth-analyze