### PR TITLE
cdb2api: Fix incorrect rollback behavior

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3684,8 +3684,7 @@ static int retry_query_list(cdb2_hndl_tp *hndl, int num_retry, int run_last)
     if (!(hndl->snapshot_file || hndl->query_no <= 1)) {
         debugprint("in_trans=%d snapshot_file=%d query_no=%d\n", hndl->in_trans,
                    hndl->snapshot_file, hndl->query_no);
-        sprintf(hndl->errstr, "%s: Database disconnected while in transaction.",
-                __func__);
+        sprintf(hndl->errstr, "Database disconnected while in transaction.");
         return CDB2ERR_TRAN_IO_ERROR; /* Fail if disconnect happens in
                                          transaction which doesn't have snapshot
                                          info.*/
@@ -3812,6 +3811,8 @@ static int retry_query_list(cdb2_hndl_tp *hndl, int num_retry, int run_last)
         rc = cdb2_read_record(hndl, &hndl->first_buf, &len, NULL);
         if (rc) {
             debugprint("Can't read response from the db node %s\n", host);
+            free(hndl->first_buf);
+            hndl->first_buf = NULL;
             sbuf2close(hndl->sb);
             hndl->sb = NULL;
             return 1;
@@ -3876,6 +3877,8 @@ static int retry_queries_and_skip(cdb2_hndl_tp *hndl, int num_retry,
     rc = cdb2_read_record(hndl, &hndl->first_buf, &len, NULL);
 
     if (rc) {
+        free(hndl->first_buf);
+        hndl->first_buf = NULL;
         PRINT_AND_RETURN_OK(rc);
     }
 
@@ -4292,7 +4295,8 @@ retry_queries:
                 goto retry_queries;
             }
             else if (rc < 0) {
-                sprintf(hndl->errstr, "Can't retry query to db");
+                if (hndl->in_trans)
+                    hndl->error_in_trans = rc;
                 PRINT_AND_RETURN(rc);
             }
         }
@@ -4393,6 +4397,8 @@ read_record:
 
     if (rc == 0) {
         if (type == RESPONSE_HEADER__SQL_RESPONSE_SSL) {
+            free(hndl->first_buf);
+            hndl->first_buf = NULL;
 #if WITH_SSL
             hndl->s_sslmode = PEER_SSL_REQUIRE;
             /* server wants us to use ssl so turn ssl on in same connection */
@@ -4443,7 +4449,8 @@ read_record:
                 sl->list = NULL;
             }
 #endif
-
+            free(hndl->first_buf);
+            hndl->first_buf = NULL;
             GOTO_RETRY_QUERIES();
         }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -1076,6 +1076,8 @@ public class Comdb2Handle extends AbstractConnection {
                     int retryrc = retryQueries(retry, runLast);
 
                     if (retryrc < 0) {
+                        if (inTxn)
+                            errorInTxn = retryrc;
                         tdlog(Level.FINE, "Can't retry query, retryrc = %d", retryrc);
                         return retryrc;
                     } 

--- a/tests/cdb2api_rollback_rc.test/Makefile
+++ b/tests/cdb2api_rollback_rc.test/Makefile
@@ -1,0 +1,6 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/cdb2api_rollback_rc.test/expected
+++ b/tests/cdb2api_rollback_rc.test/expected
@@ -1,0 +1,2 @@
+[SELECT 1] failed with rc -105 Database disconnected while in transaction.
+[ROLLBACK] rc 0

--- a/tests/cdb2api_rollback_rc.test/runit
+++ b/tests/cdb2api_rollback_rc.test/runit
@@ -1,0 +1,29 @@
+#### Verify that a rollback on node crash yields a good return code.
+
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+
+[ -z "${CLUSTER}" ] && { echo "skipping, it's a cluster test"; exit 0; }
+
+dbnm=$1
+
+# Sleep 15 seconds in the middle of a transaction, kill the node the transaction connects to,
+# and do a rollback.
+
+{ echo -n; echo "BEGIN"; echo "SELECT comdb2_host()"; sleep 15; echo "SELECT 1"; echo "ROLLBACK"; } | \
+    stdbuf -i0 -o0 -e0 cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default - >actual 2>&1 &
+
+sleep 2
+
+host=`tail -2 actual | head -1`
+
+echo host is $host
+
+ssh $host "pgrep -a comdb2 | grep $dbnm | awk '{print \$1}' | xargs kill"
+
+sleep 10
+
+wait
+
+tail -2 actual | diff expected -


### PR DESCRIPTION
If a transaction bails out because a node goes down, the API retries its subsequent ROLLBACK statement which result in a "wrong sqlengine state" error. The ROLLBACK statement should be a no-op and yield a good return code.

(DRQS 159888006)