### PR TITLE
Correct two instances of undefined behavior

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5418,7 +5418,7 @@ int main(int argc, char **argv)
 
     init_q_vars();
 
-    srand(time(NULL) ^ getpid() << 16);
+    srand(time(NULL) ^ (((unsigned int)getpid()) << 16));
     srandom(comdb2_time_epochus());
 
     if (debug_switch_verbose_deadlocks())

--- a/net/net.c
+++ b/net/net.c
@@ -3020,7 +3020,7 @@ netinfo_type *create_netinfo(char myhostname[], int myportnum, int myfd,
     netinfo_ptr->user_data_buf_size = 256 * 1024;
 
     netinfo_ptr->throttle_percent = 50;
-    netinfo_ptr->seqnum = (getpid() * 65537);
+    netinfo_ptr->seqnum = ((unsigned int)getpid()) * 65537;
     netinfo_ptr->myport = myportnum;
     netinfo_ptr->myhostname = intern(myhostname);
     netinfo_ptr->myhostname_len = strlen(netinfo_ptr->myhostname) + 1;


### PR DESCRIPTION
Casting to unsigned int to avoid undefined behavior
from left shifting a large int.
Addresses #2272

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>