### PR TITLE
Don't hold usedb between appsock calls

### DIFF
--- a/bbinc/comdb2_appsock.h
+++ b/bbinc/comdb2_appsock.h
@@ -32,7 +32,8 @@ enum {
 struct comdb2_appsock_arg {
     struct thr_handle *thr_self;
     struct dbenv *dbenv;
-    struct dbtable *tab; /* Changed on the execution of 'use' */
+    char *table_name;       /* Changed on the execution of 'use' */ 
+    int table_num;          /* Also for 'use' */
     int conv_flags;      /* Changed on the execution of 'lendian' */
     SBUF2 *sb;
     char *cmdline;

--- a/db/appsock_handler.c
+++ b/db/appsock_handler.c
@@ -185,7 +185,7 @@ static void *thd_appsock_int(appsock_work_args_t *w, int *keepsocket,
         return 0;
     }
 
-    arg.tab = &thedb->static_table;
+    arg.table_name = strdup(COMDB2_STATIC_TABLE);
     arg.conv_flags = 0;
 
     while (1) {
@@ -239,6 +239,7 @@ static void *thd_appsock_int(appsock_work_args_t *w, int *keepsocket,
         if (rc != APPSOCK_RETURN_CONT)
             break;
     }
+    free(arg.table_name);
 
     thrman_where(thr_self, NULL);
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -782,8 +782,6 @@ int init_gbl_tunables();
 int free_gbl_tunables();
 int register_db_tunables(struct dbenv *tbl);
 
-#define COMDB2_STATIC_TABLE "_comdb2_static_table"
-
 int destroy_plugins(void);
 void register_plugin_tunables(void);
 int install_static_plugins(void);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -32,6 +32,8 @@
 #define DEFAULT_USER "default"
 #define DEFAULT_PASSWORD ""
 
+#define COMDB2_STATIC_TABLE "_comdb2_static_table"
+
 enum { IOTIMEOUTMS = 10000 };
 
 struct dbtable;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2225,24 +2225,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     struct thr_handle *thr_self;
     struct sbuf2 *sb;
     struct dbenv *dbenv;
-    struct dbtable *tab;
 
     thr_self = arg->thr_self;
     dbenv = arg->dbenv;
-    tab = arg->tab;
     sb = arg->sb;
-
-    if (tab->dbtype != DBTYPE_TAGGED_TABLE) {
-        /*
-          Don't change this message. The sql api recognises the first four
-          characters (Erro) and can respond gracefully.
-        */
-        sbuf2printf(sb, "Error: newsql is only supported for tagged DBs\n");
-        logmsg(LOGMSG_ERROR,
-               "Error: newsql is only supported for tagged DBs\n");
-        sbuf2flush(sb);
-        return APPSOCK_RETURN_ERR;
-    }
 
     if (incoh_reject(arg->admin, dbenv->bdb_env)) {
         logmsg(LOGMSG_DEBUG,


### PR DESCRIPTION
This just removes usedb from the shared appsock struct, and replaces it with name.  There's further plugin changes that address locking usedb while it's being used.