### PR TITLE
Use random() instead of rand() for all occurences

### DIFF
--- a/berkdb/mutex/tm.c
+++ b/berkdb/mutex/tm.c
@@ -255,7 +255,7 @@ run_locker(id)
 
 	(void)__os_sleep(&dbenv, 3, 0);		/* Let everyone catch up. */
 
-	srand((u_int)time(NULL) % getpid());	/* Initialize random numbers. */
+	srandom((u_int)time(NULL) % getpid());	/* Initialize random numbers. */
 
 #if defined(MUTEX_THREAD_TEST)
 	/*
@@ -320,11 +320,11 @@ run_lthread(arg)
 				printf(
 				    "%03lu: map threads @ %#lx; locks @ %#lx\n",
 				    id, (u_long)tm_addr, (u_long)lm_addr);
-			remap = (rand() % 100) + 35;
+			remap = (random() % 100) + 35;
 		}
 
 		/* Select and acquire a data lock. */
-		lock = rand() % maxlocks;
+		lock = random() % maxlocks;
 		mp = (TM *)(lm_addr + lock * align);
 		if (verbose)
 			printf("%03lu: lock %d @ %#lx\n",
@@ -348,7 +348,7 @@ run_lthread(arg)
 		 * we still hold the mutex.
 		 */
 		for (i = 0; i < 3; ++i) {
-			(void)__os_sleep(&dbenv, 0, rand() % 3);
+			(void)__os_sleep(&dbenv, 0, random() % 3);
 			if (mp->id != id) {
 				fprintf(stderr,
 				    "RACE! (%03lu stole lock %d from %03lu)\n",
@@ -427,7 +427,7 @@ run_lthread(arg)
 			if (nl == 0)
 				break;
 
-			(void)__os_sleep(&dbenv, 0, rand() % 500);
+			(void)__os_sleep(&dbenv, 0, random() % 500);
 		}
 	}
 
@@ -445,7 +445,7 @@ run_wakeup(id)
 #endif
 	(void)__os_sleep(&dbenv, 3, 0);		/* Let everyone catch up. */
 
-	srand((u_int)time(NULL) % getpid());	/* Initialize random numbers. */
+	srandom((u_int)time(NULL) % getpid());	/* Initialize random numbers. */
 
 #if defined(MUTEX_THREAD_TEST)
 	/*
@@ -543,7 +543,7 @@ run_wthread(arg)
 			return ((void *)EXIT_FAILURE);
 		}
 
-		(void)__os_sleep(&dbenv, 0, rand() % 3);
+		(void)__os_sleep(&dbenv, 0,random() % 3);
 	}
 	return (NULL);
 }

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5418,7 +5418,7 @@ int main(int argc, char **argv)
 
     init_q_vars();
 
-    srand(time(NULL) ^ (((unsigned int)getpid()) << 16));
+    srandom(time(NULL) ^ (((unsigned int)getpid()) << 16));
     srandom(comdb2_time_epochus());
 
     if (debug_switch_verbose_deadlocks())

--- a/lua/lmathlib.c
+++ b/lua/lmathlib.c
@@ -180,8 +180,8 @@ static int math_max (lua_State *L) {
 
 static int math_random (lua_State *L) {
   /* the `%' avoids the (rare) case of r==1, and is needed also because on
-     some systems (SunOS!) `rand()' may return a value larger than RAND_MAX */
-  lua_Number r = (lua_Number)(rand()%RAND_MAX) / (lua_Number)RAND_MAX;
+     some systems (SunOS!) `random()' may return a value larger than RAND_MAX */
+  lua_Number r = (lua_Number)(random()%RAND_MAX) / (lua_Number)RAND_MAX;
   switch (lua_gettop(L)) {  /* check number of arguments */
     case 0: {  /* no arguments */
       lua_pushnumber(L, r);  /* Number between 0 and 1 */
@@ -207,7 +207,7 @@ static int math_random (lua_State *L) {
 
 
 static int math_randomseed (lua_State *L) {
-  srand(luaL_checkint(L, 1));
+  srandom(luaL_checkint(L, 1));
   return 0;
 }
 

--- a/tests/tools/breakloop.c
+++ b/tests/tools/breakloop.c
@@ -248,7 +248,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "NO NEMESIS SPECIFIED .. THIS SHOULD BE AN EASY RUN..\n");
     }
 
-    srand(time(NULL) ^ getpid());
+    srandom(time(NULL) ^ getpid());
 
     if (partition_master) flags |= NEMESIS_PARTITION_MASTER;
     if (partition_whole_network) flags |= NEMESIS_PARTITION_WHOLE_NETWORK;

--- a/tests/tools/cldeadlock.c
+++ b/tests/tools/cldeadlock.c
@@ -79,7 +79,7 @@ int select_and_update_orphan(const char *dbname, const char *type,
         int idx, int snapshot, int64_t count, int range, int pint)
 {
     int sel_rc, upd_rc;
-    int64_t target = (rand() % count) / 10, iter = 0;
+    int64_t target = (random() % count) / 10, iter = 0;
     int64_t *sel_val, upd_val, cnt=0;
     char *host;
     char upd_sql[80];
@@ -144,7 +144,7 @@ sel_again:
         if ((sel_val = (int64_t *)cdb2_column_value(sel_hndl, 0)) != NULL) {
             cnt++;
             if (range > 0)
-                upd_val = *sel_val + (rand() % range);
+                upd_val = *sel_val + (random() % range);
             else
                 upd_val = *sel_val;
 
@@ -242,7 +242,7 @@ int main(int argc,char *argv[])
 
     setvbuf(stdout, NULL, _IOLBF, 0);
     setvbuf(stderr, NULL, _IOLBF, 0);
-    srand(time(NULL) ^ getpid());
+    srandom(time(NULL) ^ getpid());
 
     while ((c = getopt(argc,argv,"hd:r:p:t:c:f:sT"))!=EOF) {
         switch(c) {

--- a/tests/tools/deadlock_load.c
+++ b/tests/tools/deadlock_load.c
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
         exit(1);
     }
 
-    srand(time(NULL));
+    srandom(time(NULL));
     drop_table();
     create_table();
 

--- a/tests/tools/insert.c
+++ b/tests/tools/insert.c
@@ -973,7 +973,7 @@ int main(int argc, char *argv[])
         printf("master is %s\n", master_node);
     else
         printf("could not find master\n");
-    srand(time(NULL) ^ getpid());
+    srandom(time(NULL) ^ getpid());
     setbuf(stdout, NULL);
     state = calloc(1, sizeof(int) * allocated);
     clear();

--- a/tests/tools/multithd.c
+++ b/tests/tools/multithd.c
@@ -138,7 +138,7 @@ int main(int argc, char *argv[])
     pthread_t *tids;
 
     argv0=argv[0];
-    srand(time(NULL)*getpid());
+    srandom(time(NULL)*getpid());
 
     while ((opt = getopt(argc,argv,"d:t:i:x:s:f:h"))!=EOF)
     {

--- a/tests/tools/overflow_blobtest.c
+++ b/tests/tools/overflow_blobtest.c
@@ -91,7 +91,7 @@ int main(int argc,char *argv[])
     }
 
     if(err) usage(stderr);
-    srand( time(NULL) * getpid() );
+    srandom( time(NULL) * getpid() );
 
     char *conf = getenv("CDB2_CONFIG");
     if (conf)

--- a/tests/tools/register.c
+++ b/tests/tools/register.c
@@ -255,13 +255,13 @@ out:
 void update(cdb2_hndl_tp **indb, char *readnode, int threadnum)
 {
     cdb2_hndl_tp *db = (*indb);
-    int rc, op, newval = (rand() % 5), curval = (rand() % 5),
-                newuid = (rand() % 100000);
+    int rc, op, newval = (random() % 5), curval = (random() % 5),
+                newuid = (random() % 100000);
     int foundval, founduid;
     unsigned long long begintm, endtm;
     static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
 
-    op = (rand() % 3);
+    op = (random() % 3);
 
     if (is_hasql) {
         rc = cdb2_run_statement(db, "set hasql on");
@@ -542,7 +542,7 @@ int main(int argc, char *argv[])
         fprintf(stderr, "NO TESTS SPECIFIED .. THIS SHOULD BE AN EASY RUN..\n");
     }
 
-    srand(time(NULL) ^ getpid());
+    srandom(time(NULL) ^ getpid());
 
     uint32_t flags = 0;
     if (partition_master) flags |= NEMESIS_PARTITION_MASTER;

--- a/tests/tools/selectv_deadlock.c
+++ b/tests/tools/selectv_deadlock.c
@@ -413,7 +413,7 @@ int main(int argc, char *argv[])
 
     errlog = fopen("err.log", "w");
     assert(errlog);
-    srand(time(NULL));
+    srandom(time(NULL));
 
     if (do_create) {
         drop_tables();

--- a/tests/tools/selectv_rcode.c
+++ b/tests/tools/selectv_rcode.c
@@ -763,7 +763,7 @@ int main(int argc, char *argv[]) {
 
     signal(SIGPIPE, SIG_IGN);
     setvbuf(stdout, NULL, _IOLBF, 0);
-    srand(time(NULL) * getpid());
+    srandom(time(NULL) * getpid());
 
     while((opt = getopt(argc, argv, "d:s:c:v:u:V:U:S:p:e:i:t:faARDh")) != EOF) {
         switch (opt) {

--- a/tests/tools/updater.c
+++ b/tests/tools/updater.c
@@ -131,7 +131,7 @@ void update(int iterations, int thresholdms)
     }
 
     for (int64_t i = 0; (iterations <= 0) || (i < iterations); i++) {
-        int ix = (rand() % rec_index);
+        int ix = (random() % rec_index);
         struct index_rec *rec = &rec_array[ix];
         cdb2_effects_tp effects;
         cdb2_clearbindings(hndl);
@@ -178,7 +178,7 @@ int main(int argc,char *argv[])
     argv0=argv[0];
     setvbuf(stdout, NULL, _IOLBF, 0);
     setvbuf(stderr, NULL, _IOLBF, 0);
-    srand(time(NULL) ^ getpid());
+    srandom(time(NULL) ^ getpid());
 
     while ((c = getopt(argc, argv, "hd:c:i:p:s:t:P:"))!=EOF) {
         switch(c) {

--- a/util/object_pool.c
+++ b/util/object_pool.c
@@ -248,7 +248,7 @@ int comdb2_objpool_create_rand(comdb2_objpool_t *opp, const char *name,
                                void *del_arg, obj_not_fn not_fn,
                                void *not_arg)
 {
-    srand(time(NULL));
+    srandom(time(NULL));
     return comdb2_objpool_create_int(opp, name, cap, new_fn, new_arg, del_fn,
                                      del_arg, not_fn, not_arg, OP_RAND);
 }
@@ -1057,7 +1057,7 @@ static void objpool_fifo_clear(comdb2_objpool_t op)
 
 static void objpool_rand_get(comdb2_objpool_t op, void **objp)
 {
-    int out = rand() % nidles(op);
+    int out = random() % nidles(op);
     *objp = op->objs[out];
     --op->in;
     op->objs[out] = op->objs[op->in];


### PR DESCRIPTION
random() does not suffer from the issues that rand() has,
and it is thread safe. There is no reason to use rand() in the DB.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>