### PR TITLE
Fix sc_rebuilds.test when run in singlenode

### DIFF
--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1288,10 +1288,10 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
     data.s = s;
 
     if (data.live && data.scanmode != SCAN_PARALLEL) {
-        sc_errf(data.s, "live schema change can only be done in parallel "
-                        "scan mode\n");
-        logmsg(LOGMSG_ERROR, "live schema change can only be done in parallel "
-                             "scan mode\n");
+        sc_errf(data.s,
+                "live schema change can only be done in parallel scan mode\n");
+        logmsg(LOGMSG_ERROR,
+               "live schema change can only be done in parallel scan mode\n");
         return -1;
     }
 

--- a/tests/sc_rebuilds.test/runit
+++ b/tests/sc_rebuilds.test/runit
@@ -348,10 +348,12 @@ function rebuild_new_field_and_idx
 
 function check_comdb2_sc_hist
 {
+    echo "check_comdb2_sc_hist"
     if [[ -n "$CLUSTER" ]]; then
         master=`getmaster`
         ssh -o StrictHostKeyChecking=no $master "cat $COMDB2_ROOT/var/log/cdb2/$DBNAME.trc.c" | grep "starting schema" | cut -f10 -d' ' > seeds_trc.txt
     else
+        master=localhost
         grep "starting schema" $COMDB2_ROOT/var/log/cdb2/$DBNAME.trc.c | cut -f10 -d' ' > seeds_trc.txt
     fi
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select * from comdb2_sc_history order by seed"  > all_seeds_sql.txt
@@ -362,8 +364,12 @@ function check_comdb2_sc_hist
         failexit "Seed captured in sc_history is not the same as trc.c"
     fi
     # delete the aforementioned first two entries by truncating, and check again
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t1",0)'
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t2",15)'
+    d1=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t1",0)'`
+    assertres "$d1" "Deleted 1 rows from sc_history for tablename t1"
+
+    d2=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t2",15)'`
+    assertres "$d2" "Deleted 1 rows from sc_history for tablename t2"
+
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select seed from comdb2_sc_history order by seed" > seeds_sql2.txt
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select * from comdb2_sc_history order by seed"  > all_seeds_sql2.txt
     if ! diff seeds_trc.txt seeds_sql2.txt ; then

--- a/tests/setup
+++ b/tests/setup
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
 set -e
+if [[ $CLEANUPDBDIR -eq 0 ]]; then
+    set -x
+fi
 
 failexit() {
     echo $1


### PR DESCRIPTION
- missing assigning master for singlenode case
- added check for correct response when trimming sc_history

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
