### PR TITLE
tz: Delay freeing tz on exit

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1500,8 +1500,6 @@ void clean_exit(void)
     cleanup_q_vars();
     cleanup_switches();
     free_gbl_tunables();
-    free_tzdir();
-    tz_hash_free();
     destroy_plugins();
     destroy_appsock();
 
@@ -1544,6 +1542,8 @@ void clean_exit(void)
     cleanresources(); // list of lrls
     // TODO: would be nice but other threads need to exit first:
     // comdb2ma_exit();
+    free_tzdir();
+    tz_hash_free();
 
     logmsg(LOGMSG_USER, "goodbye\n");
     exit(0);


### PR DESCRIPTION
`backend_close` correctly waits for threads which have bdb rdlock, so any point after it would be ok to free tz. I've moved it all the way to the end of `clean_exit` just in case something else may call into tz routines (event_log?).

/silent