### PR TITLE
Trigger epoch

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -908,7 +908,7 @@ int bdb_queue_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
                   const struct bdb_queue_cursor *prevcursor,
                   struct bdb_queue_found **fnd, size_t *fnddtalen,
                   size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
-                  long long *seq, unsigned int *epoch, int *bdberr);
+                  long long *seq, int *bdberr);
 
 /* Get the genid of a queue item that was retrieved by bdb_queue_get() */
 unsigned long long bdb_queue_item_genid(const struct bdb_queue_found *dta);

--- a/bdb/bdb_queuedb.h
+++ b/bdb/bdb_queuedb.h
@@ -40,7 +40,7 @@ int bdb_queuedb_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
                     const struct bdb_queue_cursor *prevcursor,
                     struct bdb_queue_found **fnd, size_t *fnddtalen,
                     size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
-                    long long *seq, unsigned int *epoch, int *bdberr);
+                    long long *seq, int *bdberr);
 
 int bdb_queuedb_consume(bdb_state_type *bdb_state, tran_type *tran,
                         int consumer, const struct bdb_queue_found *prevfnd,

--- a/bdb/queue.c
+++ b/bdb/queue.c
@@ -1287,7 +1287,7 @@ static int bdb_queue_get_int(bdb_state_type *bdb_state, int consumer,
                              const struct bdb_queue_cursor *prevcursor,
                              void **fnd, size_t *fnddtalen, size_t *fnddtaoff,
                              struct bdb_queue_cursor *fndcursor,
-                             unsigned int *epoch, int *bdberr)
+                             int *bdberr)
 {
     DBT dbt_key, dbt_data;
     DBC *dbcp;
@@ -1709,8 +1709,6 @@ lookagain:
         fndcursor->recno = ntohl(recnos[0]);
         fndcursor->reserved = 0;
     }
-    if (epoch)
-        *epoch = item.epoch;
     if (fnddtalen)
         *fnddtalen = item.data_len;
     if (fnddtaoff)
@@ -1730,18 +1728,17 @@ int bdb_queue_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
                   const struct bdb_queue_cursor *prevcursor,
                   struct bdb_queue_found **fnd, size_t *fnddtalen,
                   size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
-                  long long *seq, unsigned int *epoch, int *bdberr)
+                  long long *seq, int *bdberr)
 {
     int rc;
 
     BDB_READLOCK("bdb_queue_get");
     if (bdb_state->bdbtype == BDBTYPE_QUEUEDB)
         rc = bdb_queuedb_get(bdb_state, tran, consumer, prevcursor, fnd,
-                             fnddtalen, fnddtaoff, fndcursor, seq, epoch,
-                             bdberr);
+                             fnddtalen, fnddtaoff, fndcursor, seq, bdberr);
     else
         rc = bdb_queue_get_int(bdb_state, consumer, prevcursor, (void **)fnd, fnddtalen,
-                               fnddtaoff, fndcursor, epoch, bdberr);
+                               fnddtaoff, fndcursor, bdberr);
     BDB_RELLOCK();
 
     return rc;

--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -914,14 +914,10 @@ int bdb_queuedb_dump(bdb_state_type *bdb_state, FILE *out, int *bdberr)
     return 0;
 }
 
-static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran,
-                               DB *db, int consumer,
-                               const struct bdb_queue_cursor *prevcursor,
-                               struct bdb_queue_found **fnd, size_t *fnddtalen,
-                               size_t *fnddtaoff,
-                               struct bdb_queue_cursor *fndcursor,
-                               long long *seq, unsigned int *epoch,
-                               int *bdberr)
+static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran, DB *db, int consumer,
+                               const struct bdb_queue_cursor *prevcursor, struct bdb_queue_found **fnd,
+                               size_t *fnddtalen, size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
+                               long long *seq, int *bdberr)
 {
     if (db == NULL) { // trigger dropped?
         *bdberr = BDBERR_BADARGS;
@@ -935,7 +931,6 @@ static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran,
     size_t data_offset;
     int rc;
     long long sequence = 0;
-    unsigned int found_epoch = 0;
     struct bdb_queue_found qfnd;
     struct bdb_queue_found_seq qfnd_odh;
     uint8_t *p_buf, *p_buf_end;
@@ -1101,11 +1096,9 @@ static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran,
     if (bdb_state->ondisk_header) {
         p_buf = (uint8_t *)queue_found_seq_get(&qfnd_odh, p_buf, p_buf_end);
         sequence = qfnd_odh.seq;
-        found_epoch = qfnd_odh.epoch;
         data_offset = qfnd_odh.data_offset;
     } else {
         p_buf = (uint8_t *)queue_found_get(&qfnd, p_buf, p_buf_end);
-        found_epoch = qfnd.epoch;
         data_offset = qfnd.data_offset;
     }
     if (p_buf == NULL) {
@@ -1125,8 +1118,6 @@ static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran,
             data_offset; /* This length will be used to check version. */
     if (seq)
         *seq = sequence;
-    if (epoch)
-        *epoch = found_epoch;
     if (fndcursor) {
         memcpy(&fndcursor->genid, &fndk.genid, sizeof(fndk.genid));
         fndcursor->recno = 0;
@@ -1164,7 +1155,7 @@ int bdb_queuedb_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
                     const struct bdb_queue_cursor *prevcursor,
                     struct bdb_queue_found **fnd, size_t *fnddtalen,
                     size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
-                    long long *seq, unsigned int *epoch, int *bdberr)
+                    long long *seq, int *bdberr)
 {
     int rc = bdb_lock_table_read(bdb_state, tran);
     if (rc == DB_LOCK_DEADLOCK) {
@@ -1185,7 +1176,7 @@ int bdb_queuedb_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
 
     rc = bdb_queuedb_get_int(bdb_state, tran, db, consumer, prevcursor,
                              fnd, fnddtalen, fnddtaoff, fndcursor,
-                             seq, epoch, bdberr);
+                             seq, bdberr);
     if ((rc == -1) && (*bdberr == BDBERR_FETCH_DTA)) { /* EMPTY FILE #0? */
         db = BDB_QUEUEDB_GET_DBP_ONE(bdb_state);
 
@@ -1194,7 +1185,7 @@ int bdb_queuedb_get(bdb_state_type *bdb_state, tran_type *tran, int consumer,
 
             rc = bdb_queuedb_get_int(bdb_state, tran, db, consumer, prevcursor,
                                      fnd, fnddtalen, fnddtaoff, fndcursor,
-                                     seq, epoch, bdberr);
+                                     seq, bdberr);
         }
     }
     return rc;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2500,8 +2500,7 @@ int dbq_consume(struct ireq *iq, void *trans, int consumer,
 int dbq_consume_genid(struct ireq *, void *trans, int consumer, const genid_t);
 int dbq_get(struct ireq *iq, int consumer, const struct bdb_queue_cursor *prev,
             struct bdb_queue_found **fnddta, size_t *fnddtalen,
-            size_t *fnddtaoff, struct bdb_queue_cursor *fnd, long long *seq,
-            unsigned int *epoch);
+            size_t *fnddtaoff, struct bdb_queue_cursor *fnd, long long *seq);
 void dbq_get_item_info(const struct bdb_queue_found *fnd, size_t *dtaoff, size_t *dtalen);
 unsigned long long dbq_item_genid(const struct bdb_queue_found *dta);
 typedef int (*dbq_walk_callback_t)(int consumern, size_t item_length,

--- a/db/glue.c
+++ b/db/glue.c
@@ -5278,7 +5278,7 @@ int dbq_get(struct ireq *iq, int consumer,
             const struct bdb_queue_cursor *prevcursor,
             struct bdb_queue_found **fnddta, size_t *fnddtalen,
             size_t *fnddtaoff, struct bdb_queue_cursor *fndcursor,
-            long long *seq, unsigned int *epoch)
+            long long *seq)
 {
     int bdberr;
     void *bdb_handle;
@@ -5298,7 +5298,7 @@ int dbq_get(struct ireq *iq, int consumer,
 retry:
     iq->gluewhere = "bdb_queue_get";
     rc = bdb_queue_get(bdb_handle, tran, consumer, prevcursor, fnddta,
-                       fnddtalen, fnddtaoff, fndcursor, seq, epoch, &bdberr);
+                       fnddtalen, fnddtaoff, fndcursor, seq, &bdberr);
     iq->gluewhere = "bdb_queue_get done";
     if (rc != 0) {
         if (bdberr == BDBERR_DEADLOCK) {

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -174,7 +174,6 @@ struct dbconsumer_t {
 struct qfound {
     struct bdb_queue_found *item;
     long long seq;
-    unsigned int epoch;
     size_t len;
     size_t dtaoff;
 };
@@ -750,7 +749,7 @@ static int dbq_poll_int(Lua L, dbconsumer_t *q)
         return rc == -2 ? 0 : -1;
     }
     rc = dbq_get(&q->iq, 0, &q->last, &f.item, &f.len, &f.dtaoff, &q->fnd,
-                 &f.seq, &f.epoch);
+                 &f.seq);
     Pthread_mutex_unlock(q->lock);
     comdb2_sql_tick();
     sp->num_instructions = 0;
@@ -6381,7 +6380,7 @@ static int push_trigger_args_int(Lua L, dbconsumer_t *q, struct qfound *f, char 
         lua_setfield (L, -2, "sequence");
     }
     if (q->push_epoch) {
-        luabb_pushinteger(L, f->epoch);
+        luabb_pushinteger(L, f->item->epoch);
         lua_setfield (L, -2, "epoch");
     }
     if (flags & TYPE_TAGGED_ADD) {
@@ -6417,7 +6416,7 @@ static int push_trigger_args_int(Lua L, dbconsumer_t *q, struct qfound *f, char 
     luabb_pushinteger(L, f->item->trans.tid);
     lua_setfield(L, -2, "tid");
 
-    luabb_pushinteger(L, f->epoch);
+    luabb_pushinteger(L, f->item->epoch);
     lua_setfield(L, -2, "epoch");
 
     lua_setmetatable(L, -2);

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -386,8 +386,7 @@ static unsigned long long dbqueue_get_front_genid(struct dbtable *table,
         goto skip;
     }
 
-    rc = dbq_get(&iq, consumer, NULL, &fnddta, &fnddtalen, &fnddtaoff, NULL,
-                 NULL, NULL);
+    rc = dbq_get(&iq, consumer, NULL, &fnddta, &fnddtalen, &fnddtaoff, NULL, NULL);
     if (rc == 0) {
         genid = dbq_item_genid(fnddta);
     } else if (rc != IX_NOTFND) {
@@ -720,7 +719,7 @@ static void queue_flush(struct dbtable *db, int consumern)
             return;
         }
 
-        rc = dbq_get(&iq, consumern, NULL, &item, NULL, NULL, NULL, NULL, NULL);
+        rc = dbq_get(&iq, consumern, NULL, &item, NULL, NULL, NULL, NULL);
 
         if (rc != 0) {
             if (rc != IX_NOTFND)


### PR DESCRIPTION
Allow trigger clients to obtain event epoch. Also includes `dbq_get` cleanup. `epoch` argument is redundant.