### PR TITLE
Fix locking in queues and queue systables

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -847,6 +847,23 @@ bdb_state_type *bdb_get_table_by_name_dbnum(bdb_state_type *bdb_state,
     return NULL;
 }
 
+uint32_t bdb_readonly_lock_id(bdb_state_type *bdb_state)
+{
+    uint32_t lid = 0;
+    DB_ENV *dbenv = bdb_state->dbenv;
+    dbenv->lock_id_flags(dbenv, &lid, DB_LOCK_ID_READONLY);
+    return lid;
+}
+
+void bdb_free_lock_id(bdb_state_type *bdb_state, uint32_t lid)
+{
+    DB_ENV *dbenv = bdb_state->dbenv;
+    DB_LOCKREQ rq = {0};
+    rq.op = DB_LOCK_PUT_ALL;
+    dbenv->lock_vec(dbenv, lid, 0, &rq, 1, NULL);
+    dbenv->lock_id_free(dbenv, lid);
+}
+
 void bdb_lockspeed(bdb_state_type *bdb_state)
 {
     u_int32_t lid;

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1793,6 +1793,8 @@ void berkdb_set_max_rep_retries(int max);
 void bdb_set_recovery(bdb_state_type *);
 tran_type *bdb_tran_begin_set_retries(bdb_state_type *, tran_type *parent,
                                       int retries, int *bdberr);
+uint32_t bdb_readonly_lock_id(bdb_state_type *bdb_state);
+void bdb_free_lock_id(bdb_state_type *bdb_state, uint32_t lid);
 void bdb_lockspeed(bdb_state_type *bdb_state);
 int bdb_lock_table_write(bdb_state_type *bdb_state, tran_type *tran);
 int bdb_lock_tablename_write(bdb_state_type *bdb_state, const char *tblname,

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1202,7 +1202,9 @@ static void *purge_old_blkseq_thread(void *arg)
 
         /* queue consumer thread admin */
         thrman_where(thr_self, "dbqueue_admin");
+        rdlock_schema_lk();
         dbqueuedb_admin(dbenv);
+        unlock_schema_lk();
         thrman_where(thr_self, NULL);
 
         /* purge old blobs.  i didn't want to make a whole new thread just

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2498,9 +2498,8 @@ int dbq_add(struct ireq *iq, void *trans, const void *dta, size_t dtalen);
 int dbq_consume(struct ireq *iq, void *trans, int consumer,
                 const struct bdb_queue_found *fnd);
 int dbq_consume_genid(struct ireq *, void *trans, int consumer, const genid_t);
-int dbq_get(struct ireq *iq, int consumer, const struct bdb_queue_cursor *prev,
-            struct bdb_queue_found **fnddta, size_t *fnddtalen,
-            size_t *fnddtaoff, struct bdb_queue_cursor *fnd, long long *seq);
+int dbq_get(struct ireq *iq, int consumer, const struct bdb_queue_cursor *prev, struct bdb_queue_found **fnddta,
+            size_t *fnddtalen, size_t *fnddtaoff, struct bdb_queue_cursor *fnd, long long *seq, uint32_t lockid);
 void dbq_get_item_info(const struct bdb_queue_found *fnd, size_t *dtaoff, size_t *dtalen);
 unsigned long long dbq_item_genid(const struct bdb_queue_found *dta);
 typedef int (*dbq_walk_callback_t)(int consumern, size_t item_length,
@@ -2632,7 +2631,7 @@ int dbqueuedb_stop_consumers(struct dbtable *db);
 int dbqueuedb_restart_consumers(struct dbtable *db);
 int dbqueuedb_check_consumer(const char *method);
 int dbqueuedb_get_name(struct dbtable *db, char **spname);
-int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats);
+int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_t lockid);
 
 /* Resource manager */
 void initresourceman(const char *newlrlname);

--- a/sqlite/ext/comdb2/queues.c
+++ b/sqlite/ext/comdb2/queues.c
@@ -23,9 +23,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "comdb2.h"
-#include "comdb2systbl.h"
-#include "comdb2systblInt.h"
+#include <comdb2.h>
+#include <comdb2systbl.h>
+#include <comdb2systblInt.h>
+#include <bdb_int.h>
+#include <sql.h>
+
+extern pthread_key_t query_info_key;
 
 /* systbl_queues_cursor is a subclass of sqlite3_vtab_cursor which
 ** serves as the underlying cursor to enumerate the rows in this
@@ -89,6 +93,8 @@ static int get_stats(struct systbl_queues_cursor *pCur) {
   unsigned long long depth = 0;
   char *spname = NULL;
   struct dbtable *qdb = thedb->qdbs[pCur->last_qid];
+  struct sql_thread *thd = pthread_getspecific(query_info_key);
+  uint32_t lockid = bdb_get_lid_from_cursortran(thd->clnt->dbtran.cursor_tran);
 
   dbqueuedb_get_name(qdb, &spname);
   strcpy(pCur->queue_name, qdb->tablename);
@@ -99,7 +105,7 @@ static int get_stats(struct systbl_queues_cursor *pCur) {
   else
       pCur->spname[0] = 0;
 
-  int rc = dbqueuedb_get_stats(qdb, stats);
+  int rc = dbqueuedb_get_stats(qdb, stats, lockid);
   if (rc) {
       /* TODO: signal error? */
   }

--- a/tests/systable_locking.test/Makefile
+++ b/tests/systable_locking.test/Makefile
@@ -4,7 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=40m
+	export TEST_TIMEOUT=30m
 endif
-
-export CHECK_DB_AT_FINISH=0

--- a/tests/systable_locking.test/audit.csc2
+++ b/tests/systable_locking.test/audit.csc2
@@ -1,0 +1,7 @@
+schema
+{
+	int iold null=yes
+	int inew null=yes
+	cstring type[4]
+	cstring added_by[10]
+}

--- a/tests/systable_locking.test/audit.lua
+++ b/tests/systable_locking.test/audit.lua
@@ -1,0 +1,11 @@
+local function main(event)
+	local audit = db:table("audit")	
+	local tp = event.type
+	local inew, iold
+	if tp == 'add' then
+		inew = event.new.i
+	elseif tp == 'del' then
+		iold = event.old.i
+	end
+	return audit:insert({added_by='trigger',iold=iold,inew=inew,type=tp})
+end

--- a/tests/systable_locking.test/extralock.testopts
+++ b/tests/systable_locking.test/extralock.testopts
@@ -1,0 +1,1 @@
+debug_systable_locks on

--- a/tests/systable_locking.test/foraudit.csc2
+++ b/tests/systable_locking.test/foraudit.csc2
@@ -1,0 +1,4 @@
+schema
+{
+	int i
+}

--- a/tests/systable_locking.test/lrl.options
+++ b/tests/systable_locking.test/lrl.options
@@ -1,0 +1,4 @@
+nowatch
+logmsg level info
+#setattr REP_PROCESSORS 0
+#setattr REP_WORKERS 0

--- a/tests/systable_locking.test/runit
+++ b/tests/systable_locking.test/runit
@@ -1,0 +1,231 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+
+[[ $debug == "1" ]] && set -x
+
+export TESTITERS=20
+export MAXTABLES=20
+export MAXVIEWS=20
+export MAXQUEUES=20
+export STOP_TRIGGERS_TEST_TOUCHFILE="stop_triggers_test.txt"
+export STOP_TABLES_TEST_TOUCHFILE="stop_tables_test.txt"
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="failexit"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    exit -1
+}
+
+# The test will pass this after all the "chunked" changes are checked in
+function stat_all_tables_complete
+{
+    [[ $debug == "1" ]] && set -x
+    t=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "SELECT * FROM COMDB2_SYSTABLES" 2>&1 | egrep -v comdb2_sc_history)
+    for x in $t; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM $x LIMIT 10" >/dev/null 2>&1
+    done
+}
+
+# List of systables as of the time this was written
+#
+# json_tree
+# json_each
+# generate_series
+# comdb2_index_usage
+# comdb2_views
+# comdb2_sc_status
+# comdb2_timeseries
+# comdb2_timepartitions
+# comdb2_tablesizes
+# comdb2_cron_events
+# comdb2_type_samples
+# comdb2_keycomponents
+# comdb2_timepartshards
+# comdb2_fingerprints
+# comdb2_sql_client_stats
+# comdb2_procedures
+# comdb2_keys
+# comdb2_queues
+# comdb2_constraints
+# comdb2_keywords
+# comdb2_columns
+# comdb2_threadpools
+# comdb2_triggers
+# comdb2_tables
+# comdb2_timepartevents
+# comdb2_connections
+# comdb2_cron_schedulers
+# comdb2_users
+# comdb2_limits
+# comdb2_plugins
+# comdb2_opcode_handlers
+# comdb2_completion
+# comdb2_transaction_logs
+# comdb2_logical_operations
+# comdb2_clientstats
+# comdb2_sqlpool_queue
+# comdb2_tunables
+# comdb2_appsock_handlers
+# comdb2_repl_stats
+# comdb2_replication_netqueue
+# comdb2_sc_history
+# comdb2_metrics
+# comdb2_systables
+# comdb2_cluster
+# comdb2_blkseq
+# comdb2_locks
+# comdb2_tablepermissions
+# comdb2_net_userfuncs
+# comdb2_active_osqls
+
+function stat_all_tables
+{
+    #$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2_queues LIMIT 10" >/dev/null 2>&1
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2_triggers LIMIT 10" >/dev/null 2>&1
+}
+
+function write_tables
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXTABLES ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "INSERT INTO t$x SELECT * FROM generate_series LIMIT 10" >/dev/null 2>&1
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "UPDATE t$x SET a=1 WHERE a=1 LIMIT 10" >/dev/null 2>&1
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM t$x" >/dev/null 2>&1
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "DELETE FROM t$x LIMIT 9" >/dev/null 2>&1
+    done
+}
+
+function write_tables_loop
+{
+    [[ $debug == "1" ]] && set -x
+    let count=0
+    while [[ ! -f $STOP_TABLES_TEST_TOUCHFILE ]];  do
+        let count=count+1
+        write_tables
+        [[ $(( count % 10 )) == 0 ]] && echo "Completed $count write_tables"
+    done
+}
+
+function drop_tables
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXTABLES ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table t$x"
+    done
+}
+
+function drop_views
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXVIEWS ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop view v$x"
+    done
+}
+
+function create_views
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXVIEWS ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create view v$x as select a from t$x"
+    done
+}
+
+function create_tables
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXTABLES ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t$x (a int)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index ix$x on t$x(a)"
+    done
+}
+
+function drop_triggers
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXQUEUES ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop lua trigger audit$x"
+    done
+}
+
+function create_triggers
+{
+    [[ $debug == "1" ]] && set -x
+    for (( x = 0 ; x < MAXQUEUES ; ++x )) ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create lua trigger audit$x on (table foraudit for insert and update and delete)"
+    done
+}
+
+function setup
+{
+    [[ $debug == "1" ]] && set -x
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table foraudit {$(cat foraudit.csc2)}\$\$
+create table audit {$(cat audit.csc2)}\$\$
+EOF
+
+    for (( x = 0 ; x < MAXQUEUES ; ++x )) ; do
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create procedure audit$x {$(cat audit.lua)}\$\$
+EOF
+    done
+
+}
+
+function stat_tables_loop
+{
+    [[ $debug == "1" ]] && set -x
+    let count=0
+    while [[ ! -f $STOP_TABLES_TEST_TOUCHFILE ]];  do
+        stat_all_tables
+        let count=count+1
+        [[ $(( count % 10 )) == 0 ]] && echo "Completed $count stat_all_tables"
+    done
+}
+
+function check_all_nodes
+{
+    if [[ -z "$CLUSTER" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('stat')" >/dev/null 2>&1
+        [[ $? != 0 ]] && failexit check_all_nodes
+    else
+        for m in $CLUSTER ; do 
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $m "exec procedure sys.cmd.send('stat')" >/dev/null 2>&1
+            [[ $? != 0 ]] && failexit check_all_nodes
+        done
+    fi
+    return 0
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    rm -Rf $STOP_TABLES_TEST_TOUCHFILE
+
+    stat_tables_loop &
+    pid=$!
+    write_tables_loop &
+    writepid=$!
+    for (( i = 0; i < TESTITERS; ++i )); do
+        create_triggers
+        create_tables
+        create_views
+        drop_views
+        drop_tables
+        drop_triggers
+        [[ $(( i % 10 )) == 0 ]] && echo "Completed $i create and drop tables and views"
+    done
+    touch $STOP_TABLES_TEST_TOUCHFILE
+    wait
+    check_all_nodes
+}
+
+setup
+run_test
+echo "Success"


### PR DESCRIPTION
This is a bite-sized chunk of https://github.com/bloomberg/comdb2/pull/2295.  This fixes locking in queues and in queue-admin.  dbq_get has been changed to accept a lockid arguement.  The code will use this lockid in the transaction it creates to query the queue.  Additionally, this revises sp.c to always getqueuebyname while holding the schema-lk to accommodate the possibility that the queue was dropped during a recover_deadlock.

The systable_locking test has been de-fanged and only queries systables relating to queues: comdb2_queues and comdb2_triggers.
