### PR TITLE
Allow us to assert that a lockid holds a tablelock

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1798,6 +1798,13 @@ int bdb_lock_table_write(bdb_state_type *bdb_state, tran_type *tran);
 int bdb_lock_tablename_write(bdb_state_type *bdb_state, const char *tblname,
                              tran_type *tran);
 int bdb_lock_tablename_read(bdb_state_type *, const char *name, tran_type *);
+
+enum assert_lock_type {
+    ASSERT_TABLENAME_LOCKED_WRITE = 1,
+    ASSERT_TABLENAME_LOCKED_READ = 2,
+    ASSERT_TABLENAME_LOCKED_EITHER = 3
+};
+int bdb_assert_tablename_locked(bdb_state_type *, const char *name, uint32_t lid, enum assert_lock_type type);
 int bdb_lock_row_write(bdb_state_type *bdb_state, tran_type *tran,
                        unsigned long long genid);
 int bdb_trylock_row_write(bdb_state_type *bdb_state, tran_type *tran,
@@ -2221,6 +2228,7 @@ void allow_sc_to_run(void);
 int bdb_lock_stats(bdb_state_type *bdb_state, int64_t *nlocks);
 
 int bdb_rep_stats(bdb_state_type *bdb_state, int64_t *nrep_deadlocks);
+int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks);
 
 int bdb_run_logical_recovery(bdb_state_type *bdb_state, int locks_only);
 

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -2289,6 +2289,12 @@ int bdb_fill_cluster_info(void **data, int *num_nodes) {
     *data = info;
     return 0;
 }
+int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks)
+{
+    *nrep_deadlocks = 0;
+    bdb_state->dbenv->rep_deadlocks(bdb_state->dbenv, (uint64_t *)nrep_deadlocks);
+    return 0;
+}
 
 int bdb_rep_stats(bdb_state_type *bdb_state, int64_t *nrep_deadlocks) {
     DB_REP_STAT *stats;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2325,6 +2325,7 @@ struct __db_env {
 	int  (*lock_abort_logical_waiters)__P((DB_ENV *, u_int32_t, u_int32_t));
 	int  (*lock_get) __P((DB_ENV *,
 		u_int32_t, u_int32_t, const DBT *, db_lockmode_t, DB_LOCK *));
+    int  (*lock_query) __P((DB_ENV *, u_int32_t, const DBT *, db_lockmode_t));
 	int  (*lock_put) __P((DB_ENV *, DB_LOCK *));
 	int  (*lock_id) __P((DB_ENV *, u_int32_t *));
 	int  (*lock_id_flags) __P((DB_ENV *, u_int32_t *, u_int32_t));
@@ -2378,6 +2379,7 @@ struct __db_env {
 	int  (*rep_truncate_repdb) __P((DB_ENV *));
 	int  (*rep_start) __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
 	int  (*rep_stat) __P((DB_ENV *, DB_REP_STAT **, u_int32_t));
+	int  (*rep_deadlocks) __P((DB_ENV *, u_int64_t *));
 	int  (*set_logical_start) __P((DB_ENV *, int (*) (DB_ENV *, void *,
 		u_int64_t, DB_LSN *)));
 	int  (*set_logical_commit) __P((DB_ENV *, int (*) (DB_ENV *, void *,

--- a/berkdb/lock/lock_method.c
+++ b/berkdb/lock/lock_method.c
@@ -101,6 +101,7 @@ __lock_dbenv_create(dbenv)
 		dbenv->lock_detect = __lock_detect_pp;
 		dbenv->lock_dump_region = __lock_dump_region;
 		dbenv->lock_get = __lock_get_pp;
+		dbenv->lock_query = __lock_query_pp;
 
 		dbenv->lock_abort_logical_waiters =
 		    __lock_abort_logical_waiters_pp;

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -28,6 +28,7 @@ static const char revid[] = "$Id: rep_method.c,v 1.134 2003/11/13 15:41:51 sue E
 #include "dbinc/btree.h"
 #include "dbinc/log.h"
 #include "dbinc/txn.h"
+#include <comdb2_atomic.h>
 
 #ifdef HAVE_RPC
 #include "dbinc_auto/db_server.h"
@@ -64,6 +65,7 @@ static int __rep_set_rep_db_pagesize __P((DB_ENV *, int));
 static int __rep_get_rep_db_pagesize __P((DB_ENV *, int *));
 static int __rep_start __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
 static int __rep_stat __P((DB_ENV *, DB_REP_STAT **, u_int32_t));
+static int __rep_deadlocks __P((DB_ENV *, u_int64_t *));
 static int __rep_wait __P((DB_ENV *, u_int32_t, char **, u_int32_t *, u_int32_t, u_int32_t));
 
 extern int gbl_is_physical_replicant;
@@ -116,6 +118,7 @@ __rep_dbenv_create(dbenv)
 		dbenv->rep_verify_will_recover = __rep_verify_will_recover;
 		dbenv->rep_start = __rep_start;
 		dbenv->rep_stat = __rep_stat;
+		dbenv->rep_deadlocks = __rep_deadlocks;
 		dbenv->get_rep_gen = __rep_get_gen;
 		dbenv->get_last_locked = __rep_get_last_locked;
 		dbenv->get_rep_limit = __rep_get_limit;
@@ -1663,6 +1666,17 @@ __rep_get_master(dbenv, master_out, gen, egen)
 }
 
 extern pthread_mutex_t gbl_durable_lsn_lk;
+
+static int
+__rep_deadlocks(dbenv, deadlocks)
+    DB_ENV *dbenv;
+    u_int64_t *deadlocks;
+{
+	DB_REP *db_rep = dbenv->rep_handle;
+	REP *rep = db_rep->region;
+    *deadlocks = ATOMIC_LOAD64(rep->stat.retry);
+    return 0;
+}
 
 /*
  * __rep_stat --

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -17,12 +17,14 @@
 #include <assert.h>
 #include <stdint.h>
 #include <unistd.h>
-#include "comdb2.h"
-#include "comdb2_atomic.h"
-#include "metrics.h"
-#include "bdb_api.h"
-#include "net.h"
-#include "thread_stats.h"
+#include <sql.h>
+#include <bdb_int.h>
+#include <comdb2.h>
+#include <comdb2_atomic.h>
+#include <metrics.h>
+#include <bdb_api.h>
+#include <net.h>
+#include <thread_stats.h>
 
 #include <sys/time.h>
 #include <sys/resource.h>
@@ -459,7 +461,7 @@ int refresh_metrics(void)
 
     refresh_queue_size(thedb);
 
-    bdb_rep_stats(thedb->bdb_env, &stats.rep_deadlocks);
+    bdb_rep_deadlocks(thedb->bdb_env, &stats.rep_deadlocks);
 
     stats.standing_queue_time = metrics_standing_queue_time();
 


### PR DESCRIPTION
This is another bite-sized chunk of https://github.com/bloomberg/comdb2/pull/2295.  This PR gives us the ability to assert on holding a tablelock from a specific lockid.  It additionally replaces a rep_stat call in db_metrics with a call which doesn't use the rep-mutex, but retrieves the number of deadlocks atomically.