### PR TITLE
Change default for escaping control characters in table_to_json

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -368,7 +368,6 @@ static char *legacy_options[] = {
     "init_with_queue_ondisk_header off",
     "init_with_queue_compr off",
     "usenames",
-    "json_escape_control_characters off",
 };
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)


### PR DESCRIPTION
This was meant to be enabled by default in 7.0