### PR TITLE
Acquire locks against certain comdb2 systables

### DIFF
--- a/bdb/bdb_cursor.h
+++ b/bdb/bdb_cursor.h
@@ -171,7 +171,7 @@ int bdb_put_cursortran(bdb_state_type *bdb_state, cursor_tran_t *curtran,
  * Return lockerid in use by provided curtran
  *
  */
-int bdb_get_lid_from_cursortran(cursor_tran_t *curtran);
+uint32_t bdb_get_lid_from_cursortran(cursor_tran_t *curtran);
 
 /**
  * Parse a string containing an enable/disable feature and

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1606,7 +1606,7 @@ int bdb_get_active_logical_transaction_lsns(bdb_state_type *bdb_state,
 
 unsigned long long get_lowest_genid_for_datafile(int file);
 
-int bdb_get_lid_from_cursortran(cursor_tran_t *curtran);
+uint32_t bdb_get_lid_from_cursortran(cursor_tran_t *curtran);
 
 DBC *get_cursor_for_cursortran_flags(cursor_tran_t *curtran, DB *db,
                                      u_int32_t flags, int *bdberr);

--- a/bdb/locks.h
+++ b/bdb/locks.h
@@ -90,6 +90,7 @@ void bdb_checklock(bdb_state_type *bdb_state);
 int bdb_lock_table_read(bdb_state_type *, tran_type *);
 
 int bdb_lock_table_read_fromlid(bdb_state_type *, int lid);
+int bdb_lock_tablename_read_fromlid(bdb_state_type *, const char *name, int lid);
 int bdb_lock_table_write_fromlid(bdb_state_type *, int lid);
 int berkdb_lock_random_rowlock(bdb_state_type *bdb_state, int lid, int flags,
                                void *lkname, int mode, void *lk);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2664,7 +2664,7 @@ int bdb_get_lsn_lwm(bdb_state_type *bdb_state, DB_LSN *lsnout)
     return rc;
 }
 
-int bdb_get_lid_from_cursortran(cursor_tran_t *curtran)
+uint32_t bdb_get_lid_from_cursortran(cursor_tran_t *curtran)
 {
     return curtran->lockerid;
 }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -336,6 +336,8 @@ extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int eventlog_nkeep;
+extern int gbl_debug_systable_locks;
+extern int gbl_assert_systable_locks;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1983,4 +1983,15 @@ REGISTER_TUNABLE("test_log_file",
                  "(Default: off)", TUNABLE_STRING, &gbl_test_log_file,
                  EXPERIMENTAL | INTERNAL | READEARLY, NULL, NULL,
                  test_log_file_update, NULL);
+
+REGISTER_TUNABLE("debug_systable_locks",
+                 "Grab the comdb2_systables lock in every schema change.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_systable_locks, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("assert_systable_locks",
+                 "Assert that schema change holds the correct locks on replicants.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_assert_systable_locks, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -86,8 +86,11 @@ typedef struct stmt_hash_entry {
 
 struct sql_authorizer_state {
     struct sqlclntstate *clnt;         /* pointer to current client info */
+    sqlite3 *db;
     int flags;                         /* DDL, PRAGMA, CREATE TRIGGER denied? */
     int numDdls;                       /* number of DDLs found */
+    int numVTableLocks;
+    char **vTableLocks;
 };
 
 /* Thread specific sql state */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -708,6 +708,40 @@ void sqlinit(void)
         abort();
 }
 
+static char *vtable_lockname(sqlite3 *db, const char *vtable)
+{
+    if (vtable == NULL || db == NULL || db->aModule.count == 0)
+        return NULL;
+    struct Module *module;
+    char *lockname = NULL;
+    sqlite3_mutex_enter(db->mutex);
+    if ((module = sqlite3HashFind(&db->aModule, vtable)) != NULL) {
+        lockname = module->pModule->systable_lock;
+    }
+    sqlite3_mutex_leave(db->mutex);
+    return lockname;
+}
+
+static int vtable_search(char **vtables, int ntables, const char *table)
+{
+    for (int i = 0; i < ntables; i++) {
+        if (strcmp(vtables[i], table) == 0) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static void record_locked_vtable(struct sql_authorizer_state *pAuthState, const char *table)
+{
+    const char *vtable_lock = vtable_lockname(pAuthState->db, table);
+    if (vtable_lock && !vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_lock)) {
+        pAuthState->vTableLocks =
+            (char **)realloc(pAuthState->vTableLocks, sizeof(char *) * pAuthState->numVTableLocks + 1);
+        pAuthState->vTableLocks[pAuthState->numVTableLocks++] = strdup(vtable_lock);
+    }
+}
+
 static int comdb2_authorizer_for_sqlite(
   void *pArg,        /* IN: NOT USED */
   int code,          /* IN: NOT USED */
@@ -789,9 +823,27 @@ static int comdb2_authorizer_for_sqlite(
     case SQLITE_DROP_TEMP_VIEW:
       pAuthState->numDdls++;
       return allowTempDDL ? SQLITE_OK : SQLITE_DENY;
+    case SQLITE_READ:
+        record_locked_vtable(pAuthState, zArg1);
+        return SQLITE_OK;
     default:
       return SQLITE_OK;
   }
+}
+
+static void comdb2_reset_authstate(struct sqlthdstate *thd)
+{
+    bzero(&thd->authState, sizeof(thd->authState));
+}
+
+static void comdb2_set_authstate(struct sqlthdstate *thd, struct sqlclntstate *clnt, int flags)
+{
+    thd->authState.clnt = clnt;
+    thd->authState.flags = flags;
+    thd->authState.numDdls = 0;
+    thd->authState.numVTableLocks = 0;
+    thd->authState.vTableLocks = NULL;
+    thd->authState.db = thd->sqldb;
 }
 
 static void comdb2_setup_authorizer_for_sqlite(
@@ -3459,9 +3511,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
     int startPrepMs = comdb2_time_epochms(); /* start of prepare phase */
     while (rec->stmt == NULL) {
         clnt->no_transaction = 1;
-        thd->authState.clnt = clnt;
-        thd->authState.flags = flags;
-        thd->authState.numDdls = 0;
+        comdb2_set_authstate(thd, clnt, flags);
         rec->prepFlags = flags;
 
         clnt->prep_rc = rc = sqlite3_prepare_v3(thd->sqldb, rec->sql, -1,
@@ -3543,6 +3593,19 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
 
             if (rec->stmt)
                 stmt_set_cached_columns(rec->stmt, column_names, column_count);
+        }
+
+        if (rec->stmt) {
+            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks);
+            thd->authState.numVTableLocks = 0;
+            thd->authState.vTableLocks = NULL;
+        } else {
+            for (int i = 0; i < thd->authState.numVTableLocks; i++) {
+                free(thd->authState.vTableLocks[i]);
+            }
+            free(thd->authState.vTableLocks);
+            thd->authState.numVTableLocks = 0;
+            thd->authState.vTableLocks = NULL;
         }
 
         thd->authState.flags = 0;
@@ -3813,6 +3876,7 @@ static void handle_expert_query(struct sqlthdstate *thd,
         return;
     }
 
+    comdb2_set_authstate(thd, clnt, PREPARE_RECREATE);
     rc = -1;
     sqlite3expert *p = sqlite3_expert_new(thd->sqldb, &zErr);
 
@@ -4729,6 +4793,7 @@ check_version:
             thd->dbopen_gen = bdb_get_dbopen_gen();
         }
 
+        comdb2_reset_authstate(thd);
         get_copy_rootpages_nolock(thd->sqlthd);
         if (clnt->dbtran.cursor_tran) {
             if (thedb->timepart_views) {

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -276,6 +276,11 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
     int rc, bdberr;
     struct dbtable *db = s->db;
 
+    if ((rc = bdb_lock_tablename_write(db->handle, "comdb2_tables", tran)) != 0) {
+        sc_errf(s, "failed to lock comdb2_tables (%s:%d)\n", __func__, __LINE__);
+        return -1;
+    }
+
     if (iq && iq->tranddl > 1 &&
         verify_constraints_exist(db, NULL, NULL, s) != 0) {
         sc_errf(s, "error verifying constraints\n");

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -708,6 +708,11 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     new_bdb_handle = newdb->handle;
     old_bdb_handle = db->handle;
 
+    if ((rc = bdb_lock_tablename_write(db->handle, "comdb2_tables", transac)) != 0) {
+        sc_errf(s, "Error getting comdb2_tables lock: %d\n", rc);
+        BACKOUT;
+    }
+
     if ((rc = bdb_lock_table_write(db->handle, transac)) != 0) {
         sc_errf(s, "Error getting tablelock: %d\n", rc);
         BACKOUT;

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -77,8 +77,16 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
         return ERR_SC;
     }
 
-    /* Before this handle is closed, lets wait for all the db reads to finish*/
-    bdb_lock_table_write(db->handle, tran);
+    /* Before this handle is closed, lets wait for all the db reads to finish */
+    if ((bdb_lock_tablename_write(db->handle, "comdb2_tables", tran) != 0)) {
+        sc_errf(s, "%s: failed to lock comdb2_tables rc: %d\n", __func__, rc);
+        return rc;
+    }
+
+    if ((bdb_lock_table_write(db->handle, tran) != 0)) {
+        sc_errf(s, "%s: failed to lock table rc: %d\n", __func__, rc);
+        return rc;
+    }
 
     /* at this point if a backup is going on, it will be bad */
     gbl_sc_commit_count++;

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -445,6 +445,13 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         }
     }
 
+    rc = bdb_lock_tablename_write(thedb->bdb_env, "comdb2_queues", tran);
+    if (rc != 0) {
+        sbuf2printf(sb, "!Error %d getting tablelock for comdb2_queues.\n", rc, sc->tablename);
+        sbuf2printf(sb, "FAILED\n");
+        goto done;
+    }
+
     rc = bdb_lock_tablename_write(thedb->bdb_env, sc->tablename, tran);
     if (rc) {
         sbuf2printf(sb, "!Error %d getting tablelock for %s.\n", rc,

--- a/schemachange/sc_view.c
+++ b/schemachange/sc_view.c
@@ -34,6 +34,12 @@ int finalize_add_view(struct ireq *iq, struct schema_change_type *s,
         return -1;
     }
 
+    if ((rc = bdb_lock_tablename_write(thedb->bdb_env, "comdb2_views", tran)) != 0) {
+        sc_errf(s, "Failed to lock comdb2_views (%s:%d)\n", __func__, __LINE__);
+        rc = -1;
+        goto err;
+    }
+
     if ((rc = count_views()) >= MAX_NUM_VIEWS) {
         sc_errf(s, "Failed too many views (%s:%d)\n", __func__, __LINE__);
         rc = -1;
@@ -88,6 +94,11 @@ int finalize_drop_view(struct ireq *iq, struct schema_change_type *s,
                        tran_type *tran)
 {
     int rc = 0;
+
+    if ((rc = bdb_lock_tablename_write(thedb->bdb_env, "comdb2_views", tran)) != 0) {
+        sc_errf(s, "Failed to lock comdb2_views rc=%d\n", rc);
+        return rc;
+    }
 
     if ((rc = bdb_del_view(tran, s->tablename)) != 0) {
         return rc;

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -278,6 +278,7 @@ const sqlite3_module systblColumnsModule = {
   0,                          /* xRollbackTo */
   0,                          /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/constraints.c
+++ b/sqlite/ext/comdb2/constraints.c
@@ -419,6 +419,7 @@ const sqlite3_module systblConstraintsModule = {
   0,                             /* xRollbackTo */
   0,                             /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/indexuse.c
+++ b/sqlite/ext/comdb2/indexuse.c
@@ -30,6 +30,7 @@
 
 static sqlite3_module systblIndexUsageModule = {
     .access_flag = CDB2_ALLOW_USER,
+    .systable_lock = "comdb2_tables"
 };
 
 struct index_usage {

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -285,6 +285,7 @@ const sqlite3_module systblFieldsModule = {
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -281,6 +281,7 @@ const sqlite3_module systblKeysModule = {
   0,                       /* xRollbackTo */
   0,                       /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/queues.c
+++ b/sqlite/ext/comdb2/queues.c
@@ -281,6 +281,7 @@ const sqlite3_module systblQueuesModule = {
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
   .access_flag = CDB2_ALLOW_USER,
+  .systable_lock = "comdb2_queues",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/tablepermissions.c
+++ b/sqlite/ext/comdb2/tablepermissions.c
@@ -254,6 +254,7 @@ const sqlite3_module systblTablePermissionsModule = {
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -189,6 +189,7 @@ const sqlite3_module systblTablesModule = {
   0,                         /* xRelease */
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
+  .systable_lock = "comdb2_tables",
 };
 
 /* This initializes this table but also a bunch of other schema tables

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -203,6 +203,7 @@ const sqlite3_module systblTblSizeModule = {
   0,                       /* xRollbackTo */
   0,                       /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_tables",
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -309,4 +309,5 @@ const sqlite3_module systblTriggersModule = {
   0,                 /* xRollbackTo */
   0,                 /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
+  .systable_lock = "comdb2_queues",
 };

--- a/sqlite/ext/comdb2/views.c
+++ b/sqlite/ext/comdb2/views.c
@@ -28,6 +28,7 @@
 
 sqlite3_module systblViewsModule = {
     .access_flag = CDB2_ALLOW_USER,
+  .systable_lock = "comdb2_views",
 };
 
 typedef struct view_entry {

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4847,6 +4847,7 @@ int stmt_cached_column_count(sqlite3_stmt *);
 char *stmt_cached_column_name(sqlite3_stmt *, int);
 char *stmt_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4847,6 +4847,7 @@ int stmt_cached_column_count(sqlite3_stmt *);
 char *stmt_cached_column_name(sqlite3_stmt *, int);
 char *stmt_column_name(sqlite3_stmt *, int);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
@@ -6504,6 +6505,7 @@ struct sqlite3_module {
   int (*xShadowName)(const char*);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   int access_flag;
+  char *systable_lock;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -576,6 +576,8 @@ struct Vdbe {
   int *updCols;           /* list of columns modified in this update */
   Table **tbls;           /* list of tables to be open. */ 
   u16 numTables;
+  u16 numVTableLocks;
+  char **vTableLocks;
   char tzname[TZNAME_MAX];/* timezone info for datetime support */
   int dtprec;             /* datetime precision - make it u32 to silence compiler */
   struct timespec tspec;  /* time of prepare, used for stable now() */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -141,6 +141,28 @@ static void stmt_free_column_names(sqlite3_stmt *pStmt) {
   vdbe->oldColCount = 0;
 }
 
+static void stmt_free_vtable_locks(sqlite3_stmt *pStmt) {
+  Vdbe *vdbe;
+  int i;
+  vdbe = (Vdbe *)pStmt;
+  if (!vdbe)
+      return;
+  for (i=0; i<vdbe->numVTableLocks; i++) {
+      free(vdbe->vTableLocks[i]);
+  }
+  free(vdbe->vTableLocks);
+  vdbe->vTableLocks = 0;
+  vdbe->numVTableLocks = 0;
+}
+
+void stmt_set_vlock_tables(sqlite3_stmt *pStmt, char **vTableLocks,
+        int numVTableLocks) {
+  Vdbe *vdbe = (Vdbe *)pStmt;
+  stmt_free_vtable_locks(pStmt);
+  vdbe->numVTableLocks = numVTableLocks;
+  vdbe->vTableLocks = vTableLocks;
+}
+
 void stmt_set_cached_columns(sqlite3_stmt *pStmt, char **column_names,
                              int column_count) {
   Vdbe *vdbe = (Vdbe *)pStmt;
@@ -198,6 +220,7 @@ int sqlite3_finalize(sqlite3_stmt *pStmt){
     if (gbl_old_column_names && (stmt_cached_column_count(pStmt)>0)){
       stmt_free_column_names(pStmt);
     }
+    stmt_free_vtable_locks(pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     sqlite3 *db = v->db;
     if( vdbeSafety(v) ) return SQLITE_MISUSE_BKPT;

--- a/tests/systable_locking.test/extralock.testopts
+++ b/tests/systable_locking.test/extralock.testopts
@@ -1,1 +1,2 @@
-debug_systable_locks on
+#disable this for now
+#debug_systable_locks on


### PR DESCRIPTION
This is another chunk of https://github.com/bloomberg/comdb2/pull/2295 - this detects the tables used for this sql statement via the authorizer code as an SQLITE_READ.  If the table is a systable which requires a lock, the name of that lock is added to a list, and stored with the prepared statement.  In addition to the normal table locks, schema change acquires writelocks against systables categories that can be affected.
