### PR TITLE
Sundry fixes for crashes I was seeing while testing

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -5545,6 +5545,7 @@ static bdb_state_type *bdb_open_int(
     iammaster = 0;
 
     if (numix > MAXINDEX) {
+        logmsg(LOGMSG_INFO, "%s failing with bdberr_misc at line %d\n", __func__, __LINE__);
         *bdberr = BDBERR_MISC;
         return NULL;
     }
@@ -5555,11 +5556,13 @@ static bdb_state_type *bdb_open_int(
         return NULL;
     }
     if (bdbtype == BDBTYPE_LITE && numix != 1) {
+        logmsg(LOGMSG_INFO, "%s failing with bdberr_misc at line %d\n", __func__, __LINE__);
         *bdberr = BDBERR_MISC;
         return NULL;
     }
     if ((bdbtype == BDBTYPE_QUEUE || bdbtype == BDBTYPE_QUEUEDB) &&
         numix != 0) {
+        logmsg(LOGMSG_INFO, "%s failing with bdberr_misc at line %d\n", __func__, __LINE__);
         *bdberr = BDBERR_MISC;
         return NULL;
     }
@@ -5576,6 +5579,7 @@ static bdb_state_type *bdb_open_int(
 
     if ((envonly && numdtafiles != 0) ||
         (!envonly && (numdtafiles > MAXDTAFILES || numdtafiles < 1))) {
+        logmsg(LOGMSG_INFO, "%s failing with bdberr_misc at line %d\n", __func__, __LINE__);
         *bdberr = BDBERR_MISC;
         return NULL;
     }
@@ -6070,6 +6074,7 @@ static bdb_state_type *bdb_open_int(
         if (rc != 0) {
             if (bdb_state->parent) {
                 free(bdb_state);
+                logmsg(LOGMSG_INFO, "%s failing with bdberr_misc at line %d\n", __func__, __LINE__);
                 *bdberr = BDBERR_MISC;
                 return NULL;
             } else {

--- a/db/cron.c
+++ b/db/cron.c
@@ -452,7 +452,7 @@ int cron_systable_schedulers_collect(void **data, int *nrecords)
             arr = temparr;
         }
         cron_lock(sched);
-        arr[narr].name = strdup(sched->impl.name);
+        arr[narr].name = sched->impl.name ? strdup(sched->impl.name) : strdup("");
         arr[narr].type = strdup(cron_type_to_name(sched->impl.type));
         arr[narr].running = sched->running;
         arr[narr].nevents = sched->events.count;
@@ -516,7 +516,7 @@ int cron_systable_sched_events_collect(cron_sched_t *sched,
         arr[narr].name = sched->impl.event_describe
                              ? sched->impl.event_describe(&sched->impl, event)
                              : strdup("");
-        arr[narr].type = strdup(sched->impl.name);
+        arr[narr].type = sched->impl.name ? strdup(sched->impl.name) : strdup("");
         arr[narr].epoch = event->epoch;
         arr[narr].arg1 = event->arg1 ? strdup(event->arg1) : NULL;
         arr[narr].arg2 = event->arg2 ? strdup(event->arg2) : NULL;

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -562,10 +562,11 @@ uint64_t sc_get_seed_table(char *table)
     sc_table_t *sctbl = NULL;
     uint64_t seed = 0;
     Pthread_mutex_lock(&schema_change_in_progress_mutex);
-    assert(sc_tables);
-    sctbl = hash_find_readonly(sc_tables, &table);
-    if (sctbl)
-        seed = sctbl->seed;
+    if (sc_tables) {
+        sctbl = hash_find_readonly(sc_tables, &table);
+        if (sctbl)
+            seed = sctbl->seed;
+    }
     Pthread_mutex_unlock(&schema_change_in_progress_mutex);
     return seed;
 }


### PR DESCRIPTION
This consists of several small fixes and other instrumentation that I came across while working on https://github.com/bloomberg/comdb2/pull/2295.  I added trace to file.c so that we can determine from the logs which line of code which returned a BDBERR_MISC.  In cron_systable_schedulers_collect, handle the possibility that sched->impl.name is NULL.  Finally, isc_get_seed_table can be called just after startup, but before the sc_tables hash has been created.