### PR TITLE
Use bplog to send to master operation to delete from sc_history

### DIFF
--- a/db/bpfunc.c
+++ b/db/bpfunc.c
@@ -33,6 +33,7 @@ static int exec_rowlocks_enable(void *tran, bpfunc_t *func,
                                 struct errstat *err);
 static int exec_genid48_enable(void *tran, bpfunc_t *func, struct errstat *err);
 static int exec_set_skipscan(void *tran, bpfunc_t *func, struct errstat *err);
+static int exec_delete_from_sc_history(void *tran, bpfunc_t *func, struct errstat *err);
 /********************      UTILITIES     ***********************/
 
 static int empty(void *tran, bpfunc_t *func, struct errstat *err)
@@ -114,6 +115,11 @@ static int prepare_methods(bpfunc_t *func, bpfunc_info *info)
     case BPFUNC_SET_SKIPSCAN:
         func->exec = exec_set_skipscan;
         break;
+
+    case BPFUNC_DELETE_FROM_SC_HISTORY:
+        func->exec = exec_delete_from_sc_history;
+        break;
+
 
     default:
         logmsg(LOGMSG_ERROR, "Unknown function_id in bplog function\n");
@@ -520,3 +526,12 @@ static int exec_rowlocks_enable(void *tran, bpfunc_t *func, struct errstat *err)
     return rc;
 }
 
+static int exec_delete_from_sc_history(void *tran, bpfunc_t *func,
+                                       struct errstat *err)
+{
+    BpfuncDeleteFromScHistory *tblseed = func->arg->tblseed;
+    int rc = bdb_del_schema_change_history(tran, tblseed->tablename, tblseed->seed);
+    if (rc)
+        errstat_set_rcstrf(err, rc, "%s failed delete", __func__);
+    return rc;
+}

--- a/db/bpfunc.h
+++ b/db/bpfunc.h
@@ -22,6 +22,7 @@ enum {
     BPFUNC_ROWLOCKS_ENABLE = 10,
     BPFUNC_GENID48_ENABLE = 11,
     BPFUNC_SET_SKIPSCAN = 12,
+    BPFUNC_DELETE_FROM_SC_HISTORY = 13,
 };
 
 typedef int (*bpfunc_prot)(void *tran, bpfunc_t *arg, struct errstat *err);

--- a/db/config.c
+++ b/db/config.c
@@ -349,7 +349,6 @@ static char *legacy_options[] = {
     "on accept_on_child_nets",
     "on disable_etc_services_lookup",
     "online_recovery off",
-    "osql_check_replicant_numops off",
     "osql_send_startgen off",
     "queuedb_genid_filename off",
     "reorder_socksql_no_deadlock off",

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -968,7 +968,6 @@ configurations:
     on accept_on_child_nets
     on disable_etc_services_lookup
     online_recovery off
-    osql_check_replicant_numops off
     osql_send_startgen off
     queuedb_genid_filename off
     reorder_socksql_no_deadlock off

--- a/protobuf/bpfunc.proto
+++ b/protobuf/bpfunc.proto
@@ -65,6 +65,12 @@ message bpfunc_genid48_enable
     required int32 enable = 1;
 }
 
+message bpfunc_delete_from_sc_history
+{
+    required string tablename = 1;
+    required uint64 seed = 2;
+}
+
 message bpfunc_arg {
     required  int32 type = 1;
     optional  bpfunc_create_timepart crt_tp = 2;
@@ -78,5 +84,6 @@ message bpfunc_arg {
     optional  bpfunc_timepart_retention tp_ret = 10;
     optional  bpfunc_rowlocks_enable rl_enable = 11;
     optional  bpfunc_genid48_enable gn_enable = 12;
+    optional  bpfunc_delete_from_sc_history tblseed = 13;
 }
 

--- a/sqlite/src/comdb2vdbe.c
+++ b/sqlite/src/comdb2vdbe.c
@@ -2,9 +2,6 @@
 #include "vdbeInt.h"
 #include "vdbe.h"
 
-/* Unfortunately needed for now */
-extern pthread_key_t query_info_key;
-
 
 inline int initOpFunc(OpFunc* o, size_t len)
 {

--- a/tests/sc_rebuilds.test/runit
+++ b/tests/sc_rebuilds.test/runit
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
+set -x
+
 source ${TESTSROOTDIR}/tools/runit_common.sh
 # Grab my database name.
 dbnm=$1
@@ -353,21 +355,20 @@ function check_comdb2_sc_hist
         master=`getmaster`
         ssh -o StrictHostKeyChecking=no $master "cat $COMDB2_ROOT/var/log/cdb2/$DBNAME.trc.c" | grep "starting schema" | cut -f10 -d' ' > seeds_trc.txt
     else
-        master=localhost
         grep "starting schema" $COMDB2_ROOT/var/log/cdb2/$DBNAME.trc.c | cut -f10 -d' ' > seeds_trc.txt
     fi
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select * from comdb2_sc_history order by seed"  > all_seeds_sql.txt
 
-    # use tail +3 to skip first two entries which are creating t1 and t2 and dont show up in trc.c
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select seed from comdb2_sc_history order by seed" | tail +3 > seeds_sql.txt
+    # use tail -n +3 to skip first two entries which are creating t1 and t2 and dont show up in trc.c
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select seed from comdb2_sc_history order by seed" | tail -n +3 > seeds_sql.txt
     if ! diff seeds_trc.txt seeds_sql.txt ; then
         failexit "Seed captured in sc_history is not the same as trc.c"
     fi
     # delete the aforementioned first two entries by truncating, and check again
-    d1=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t1",0)'`
+    d1=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'EXEC PROCEDURE sys.cmd.trim_sc_history("t1",0)'`
     assertres "$d1" "Deleted 1 rows from sc_history for tablename t1"
 
-    d2=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'EXEC PROCEDURE sys.cmd.trim_sc_history("t2",15)'`
+    d2=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'EXEC PROCEDURE sys.cmd.trim_sc_history("t2",15)'`
     assertres "$d2" "Deleted 1 rows from sc_history for tablename t2"
 
     cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select seed from comdb2_sc_history order by seed" > seeds_sql2.txt


### PR DESCRIPTION
   - Use bplog commands to delete from sc_history
   - Remove remnants of stale osql_check_replicant_numops tunable
   - sc_rebuilds.test can send send trim command to any node, fix tail -n +3
