### PR TITLE
db:emit type-conv failure

### DIFF
--- a/lua/sp_int.h
+++ b/lua/sp_int.h
@@ -91,6 +91,13 @@ void luabb_tointervalym(Lua, int index, intv_t *);
 void luabb_toreal(Lua, int index, double *);
 void luabb_todecimal(Lua, int index, decQuad *);
 
+int luabb_tointeger_noerr(Lua, int index, long long *);
+int luabb_toreal_noerr(Lua, int index, double *);
+int luabb_todatetime_noerr(Lua, int index, datetime_t *);
+int luabb_tointervalym_noerr(Lua, int index, intv_t *);
+int luabb_tointervalds_noerr(Lua, int index, intv_t *);
+int luabb_toblob_noerr(Lua, int index, blob_t *);
+
 void luabb_pushblob(Lua, const blob_t *);
 void luabb_pushblob_dl(Lua, const blob_t *); //dl -> dup-less
 void luabb_pushcstring(Lua, const char *);

--- a/tests/sp.test/t11.req
+++ b/tests/sp.test/t11.req
@@ -1,0 +1,44 @@
+create procedure bad_emit version 'sptest' {
+local function main()
+    db:column_name("bad", 1)
+    db:column_type("int", 1)
+    db:emit({bad = "hi"})
+end
+}$$
+exec procedure bad_emit()
+
+create procedure bad_emit version 'sptest' {
+local function main()
+    db:column_name("bad", 1)
+    db:column_type("real", 1)
+    db:emit({bad = "hi"})
+end
+}$$
+exec procedure bad_emit()
+
+create procedure bad_emit version 'sptest' {
+local function main()
+    db:column_name("bad", 1)
+    db:column_type("blob", 1)
+    db:emit({bad = 1})
+end
+}$$
+exec procedure bad_emit()
+
+create procedure bad_emit version 'sptest' {
+local function main()
+    db:column_name("bad", 1)
+    db:column_type("datetime", 1)
+    db:emit({bad = "hi"})
+end
+}$$
+exec procedure bad_emit()
+
+create procedure bad_emit version 'sptest' {
+local function main()
+    db:column_name("bad", 1)
+    db:column_type("datetime", 1)
+    db:emit({bad = {}})
+end
+}$$
+exec procedure bad_emit()

--- a/tests/sp.test/t11.req.out
+++ b/tests/sp.test/t11.req.out
@@ -1,0 +1,10 @@
+(version='sptest')
+[exec procedure bad_emit()] failed with rc -3 [db:emit({bad = "hi"})...]:5: conversion to:int failed from:string
+(version='sptest')
+[exec procedure bad_emit()] failed with rc -3 [db:emit({bad = "hi"})...]:5: conversion to:real failed from:string
+(version='sptest')
+[exec procedure bad_emit()] failed with rc -3 [db:emit({bad = 1})...]:5: conversion to:blob failed from:number
+(version='sptest')
+[exec procedure bad_emit()] failed with rc -3 [db:emit({bad = "hi"})...]:5: conversion to:datetime failed from:string
+(version='sptest')
+[exec procedure bad_emit()] failed with rc -3 [db:emit({bad = {}})...]:5: conversion to:datetime failed from:table


### PR DESCRIPTION
Delay throwing runtime-error when type conversion fails during `emit`. Instead, we wait for a failed `write_response`, release `emit_mutex`, then throw error.