### PR TITLE
Reproduce sc replication error

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -63,6 +63,7 @@ int debug_switch_verbose_cursor_deadlocks(void);         /* 0 */
 int debug_switch_check_multiple_lockers(void);           /* 1 */
 int debug_switch_dump_pool_on_full(void);                /* 1 */
 int debug_switch_scconvert_finish_delay(void);           /* 0 */
+int debug_switch_fake_sc_replication_timeout(void);      /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -1156,8 +1156,8 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 						ltranflags, gen, request.obj,
 						&list_dbt_rl, usr_ptr);
 #if defined DEBUG_STACK_AT_TXN_LOG
-					comdb2_cheapstack_sym(stderr, "COMMIT-RL LSN [%d:%d]",
-							lsn_out->file,lsn_out->offset);
+					comdb2_cheapstack_sym(stderr, "COMMIT-RL TXNID %x LSN [%d:%d]",
+							txnp->txnid, lsn_out->file, lsn_out->offset);
 #endif
 
 					if (elect_highest_committed_gen) {
@@ -1199,8 +1199,8 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 							TXN_COMMIT, gen, timestamp,
 							request.obj, usr_ptr);
 #if defined DEBUG_STACK_AT_TXN_LOG
-						comdb2_cheapstack_sym(stderr, "TXN-COMMIT-GEN LSN [%d:%d]",
-								txnp->last_lsn.file,txnp->last_lsn.offset);
+						comdb2_cheapstack_sym(stderr, "TXN-COMMIT-GEN TXNID %x LSN [%d:%d]",
+								txnp->txnid,txnp->last_lsn.file,txnp->last_lsn.offset);
 #endif
 						MUTEX_LOCK(dbenv,
 							db_rep->rep_mutexp);
@@ -1217,8 +1217,8 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 							timestamp, request.obj,
 							usr_ptr);
 #if defined DEBUG_STACK_AT_TXN_LOG
-						comdb2_cheapstack_sym(stderr, "TXN-COMMIT LSN [%d:%d]",
-							txnp->last_lsn.file,txnp->last_lsn.offset);
+						comdb2_cheapstack_sym(stderr, "TXN-COMMIT TXNID %x LSN [%d:%d]",
+							txnp->txnid,txnp->last_lsn.file,txnp->last_lsn.offset);
 #endif
 					}
 
@@ -1271,8 +1271,8 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 					goto err;
 				}
 #if defined DEBUG_STACK_AT_TXN_LOG
-				comdb2_cheapstack_sym(stderr, "CHILD-COMMIT LSN [%d:%d]",
-						txnp->last_lsn.file,txnp->last_lsn.offset);
+				comdb2_cheapstack_sym(stderr, "CHILD-COMMIT TXNID %x LSN [%d:%d]",
+						txnp->txnid,txnp->last_lsn.file,txnp->last_lsn.offset);
 #endif
 			}
 

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -38,6 +38,7 @@
 #include "sc_view.h"
 #include "logmsg.h"
 #include "comdb2_atomic.h"
+#include <debug_switches.h>
 
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 
@@ -267,6 +268,16 @@ typedef int (*ddl_t)(struct ireq *, struct schema_change_type *, tran_type *);
 **   1. also commit it
 **   2. log scdone here
 */
+static inline int replication_only_error_code(int rc)
+{
+    switch (rc) {
+    case -1:
+    case BDBERR_NOT_DURABLE:
+        return 1;
+    }
+    return 0;
+}
+
 static int do_finalize(ddl_t func, struct ireq *iq,
                        struct schema_change_type *s, tran_type *input_tran,
                        scdone_t type)
@@ -314,12 +325,18 @@ static int do_finalize(ddl_t func, struct ireq *iq,
     if (input_tran == NULL) {
         // void all_locks(void*);
         // all_locks(thedb->bdb_env);
+        if (debug_switch_fake_sc_replication_timeout()) {
+            logmsg(LOGMSG_USER, "Forcing replication error table %s '%s' for tran %p\n", bdb_get_scdone_str(type),
+                   s->tablename, tran);
+        }
         if (s->keep_locked) {
             rc = trans_commit(iq, tran, gbl_myhostname);
         } else {
             rc = trans_commit_adaptive(iq, tran, gbl_myhostname);
         }
-        if (rc) {
+        if (debug_switch_fake_sc_replication_timeout())
+            rc = -1;
+        if (rc && !replication_only_error_code(rc)) {
             sc_errf(s, "Failed to commit finalize transaction\n");
             return rc;
         }

--- a/tests/simple_timepart.test/reptimeout.testopts
+++ b/tests/simple_timepart.test/reptimeout.testopts
@@ -1,0 +1,1 @@
+# The test changes options if it matches 'reptimeout'

--- a/tests/simple_timepart.test/runit
+++ b/tests/simple_timepart.test/runit
@@ -178,6 +178,10 @@ for run in 1 2 3 4 5; do
    echo "Done waiting for ${partition_config[${run}]}"
    echo "Done waiting for ${partition_config[${run}]}" >> $OUT
 
+   if [[ "$run" == "4" && $dbname == *"reptimeout"* ]]; then
+       cdb2sql ${CDB2_OPTIONS} --host ${master} $dbname default  "PUT TUNABLE 'fake_sc_replication_timeout' 1"
+   fi
+
    timepart_stats
 done
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -303,6 +303,7 @@
 (name='exit_on_internal_failure', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='exitalarmsec', description='', type='INTEGER', value='300', read_only='Y')
 (name='extended_sql_debug_trace', description='Print extended trace for durable sql debugging', type='BOOLEAN', value='OFF', read_only='N')
+(name='fake_sc_replication_timeout', description='Fake a replication timeout on finalize schemachange. ', type='BOOLEAN', value='OFF', read_only='N')
 (name='fdb_sqlstats_cache_lock_waittime_nsec', description='', type='INTEGER', value='1000', read_only='N')
 (name='fdbdebg', description='', type='INTEGER', value='0', read_only='N')
 (name='fdbtrackhints', description='', type='INTEGER', value='0', read_only='Y')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -70,6 +70,7 @@ static struct debug_switches {
     int dump_pool_on_full;
     int net_delay;
     int scconvert_finish_delay;
+    int fake_sc_replication_timeout;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -119,6 +120,7 @@ int init_debug_switches(void)
     debug_switches.dump_pool_on_full = 1;
     debug_switches.net_delay = 0;
     debug_switches.scconvert_finish_delay = 0;
+    debug_switches.fake_sc_replication_timeout = 0;
 
     register_int_switch("alternate_verify_fail", "alternate_verify_fail",
                         &debug_switches.alternate_verify_fail);
@@ -215,6 +217,8 @@ int init_debug_switches(void)
         "This would create a scenario where scgenids are on the right "
         "of any new genids to reproduce a vutf8 schema change bug. ",
         &debug_switches.scconvert_finish_delay);
+    register_int_switch("fake_sc_replication_timeout", "Fake a replication timeout on finalize schemachange. ",
+                        &debug_switches.fake_sc_replication_timeout);
 
     return 0;
 }
@@ -398,4 +402,8 @@ int debug_switch_net_delay(void)
 int debug_switch_scconvert_finish_delay(void)
 {
     return debug_switches.scconvert_finish_delay;
+}
+int debug_switch_fake_sc_replication_timeout(void)
+{
+    return debug_switches.fake_sc_replication_timeout;
 }


### PR DESCRIPTION
Simple fixes to paper over schema-change finalize commits which successfully write a commit record, but fail to replicate to all of the replicant nodes.  We should ignore this error code, and write an scdone record in this case.  I've modified the simple_timepart test to reproduce the issue while running the reptimeout.testopt version of this test.