### PR TITLE
Fix error with expert mode and datacopy index

### DIFF
--- a/sqlite/ext/expert/sqlite3expert.c
+++ b/sqlite/ext/expert/sqlite3expert.c
@@ -1836,6 +1836,21 @@ sqlite3expert *sqlite3_expert_new(sqlite3 *db, char **pzErrmsg){
     while( rc==SQLITE_OK && SQLITE_ROW==sqlite3_step(pSql) ){
       const char *zSql = (const char*)sqlite3_column_text(pSql, 0);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
+      char *coll = NULL;
+      // transform all the "collate DATACOPY" instances from:
+      // create index "$I1_792AC8AF" on "t1" ("i", "b" collate DATACOPY, "c");
+      // to 
+      // create index "$I1_792AC8AF" on "t1" ("i", "b" , "c") OPTION DATACOPY;
+      // note that there is enough space because 'collate' is 1 char longer than 'OPTION'
+      if ((coll=strcasestr(zSql, " collate DATACOPY"))) {
+        char *end = coll + sizeof(" collate DATACOPY") - 1;
+        while(*end != ';') {
+            *coll = *end;
+            ++coll;
+            ++end;
+        }
+        strcpy(coll, " OPTION DATACOPY;");
+      }
       int newLen = strlen(zSql) + 6;
       char *newSql = sqlite3_malloc(newLen);
       snprintf(newSql,newLen, "create temp %s", zSql+7);

--- a/tests/comdb2expert.test/t02.expected
+++ b/tests/comdb2expert.test/t02.expected
@@ -1,0 +1,7 @@
+(rows inserted=1)
+---------- Recommended Indexes --------------
+
+CREATE INDEX t3_idx_00000062 ON t3(b); -- stat1: 1 1
+
+---------------------------------------------
+

--- a/tests/comdb2expert.test/t02.req
+++ b/tests/comdb2expert.test/t02.req
@@ -1,0 +1,5 @@
+create table t3(a int, b int, c int);$$
+create index i3 on t3(a) option datacopy;
+insert into t3 values (1,2,3);
+set expert on
+select * from t3 where b > 0;


### PR DESCRIPTION
If there is a datacopy index we have issue parsing
the sql string from sqlite_master and throw error
`Support for 'COLLATE DATACOPY' syntax has been removed; use OPTION DATACOPY.`
This patch changes the sqlite_master sql for index creation
from `create index "I1" on "t1" ("i", "b" collate DATACOPY, "c");`
to `create index "I1" on "t1" ("i", "b" , "c") OPTION DATACOPY;`
thus allowing the expert mode to be able to parse the index creation sql.