### PR TITLE
Discard locks at cursor close for readonly lockids which are wrapped in a transaction

### DIFF
--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -944,10 +944,14 @@ static int bdb_queuedb_get_int(bdb_state_type *bdb_state, tran_type *tran, DB *d
 
     dbt_key.flags = dbt_data.flags = DB_DBT_REALLOC;
 
-    rc = db->cursor(db, tran ? tran->tid : NULL, &dbcp, 0);
+    rc = db->cursor(db, NULL, &dbcp, 0);
     if (rc) {
         *bdberr = BDBERR_MISC;
         goto done;
+    }
+
+    if (tran) {
+        dbcp->c_replace_lockid(dbcp, tran->tid->txnid);
     }
 
     k.consumer = consumer;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1811,6 +1811,7 @@ struct __dbc {
 
 	u_int32_t lid;			/* Default process' locker id. */
 	u_int32_t locker;		/* Locker for this operation. */
+	u_int32_t origlocker;
 	DBT	  lock_dbt;		/* DBT referencing lock. */
 	DB_LOCK_ILOCK lock;		/* Object to be locked. */
 	DB_LOCK	  mylock;		/* CDB lock held on this cursor. */
@@ -1848,6 +1849,7 @@ struct __dbc {
 	int (*c_pget) __P((DBC *, DBT *, DBT *, DBT *, u_int32_t));
 	int (*c_put) __P((DBC *, DBT *, DBT *, u_int32_t));
 	int (*c_skip_stat) __P((DBC *, u_int64_t *nxtcnt, u_int64_t *skpcnt));
+	int (*c_replace_lockid) __P((DBC *, u_int32_t));
 
 					/* Methods: private. */
 	int (*c_am_bulk) __P((DBC *, DBT *, u_int32_t));

--- a/tests/qget_curtran.test/Makefile
+++ b/tests/qget_curtran.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/qget_curtran.test/runit
+++ b/tests/qget_curtran.test/runit
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+
+[[ $debug == "1" ]] && set -x
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="failexit"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    exit -1
+}
+
+function setup
+{
+    [[ $debug == "1" ]] && set -x
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table t(i int)\$\$
+create procedure foo version 'bar' {
+local function main(event)
+    return 0
+end
+}\$\$
+create lua trigger foo on (table t for insert and delete)
+insert into t select value from generate_series(1,5)
+EOF
+}
+
+setup
+echo "Success"


### PR DESCRIPTION
I've ported Akshat's demonstration as a new test ("qget_curtran") to our testsuite.  This test demonstrates that simple queue operations can cause the database to deadlock when they are performed in single-node mode.  The issue is that Berkley leaves locks on the queue intact so long as the cursor is associated with a transaction.  In our queue code, we maintained api compatibility between the bdb-layer and the sql layer by creating a transaction, and substituting the sql's curtran (which is a readonly lockid) for the original transaction id.  This pull request changes cursor-close: it forces the release of the lock held by the cursor if the lockid is marked as READONLY.