### PR TITLE
block tpt creation that violates constraints limits

### DIFF
--- a/tests/fkey_timepart.test/Makefile
+++ b/tests/fkey_timepart.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/fkey_timepart.test/README
+++ b/tests/fkey_timepart.test/README
@@ -1,0 +1,1 @@
+This tests test failure due to too many reverse constraints in time partitions

--- a/tests/fkey_timepart.test/lrl.options
+++ b/tests/fkey_timepart.test/lrl.options
@@ -1,0 +1,4 @@
+table t t.csc2
+table tconadd tconadd.csc2
+table tcon1 tcon1.csc2
+table tcon2 tcon2.csc2

--- a/tests/fkey_timepart.test/run.log.alpha
+++ b/tests/fkey_timepart.test/run.log.alpha
@@ -1,0 +1,2 @@
+(name='testview1', period='daily', retention=30, nshards=1, version=0, shard0name='tcon1')
+(name='testview1', period='daily', retention=30, nshards=1, version=0, shard0name='tcon1')

--- a/tests/fkey_timepart.test/runit
+++ b/tests/fkey_timepart.test/runit
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+# Time partition testcase for comdb2
+################################################################################
+
+
+# args
+# <dbname>
+dbname=$1
+
+VIEW="testview1"
+OUT="run.log"
+
+rm $OUT 2>/dev/null
+touch $OUT
+
+function show_timepart() 
+{
+    echo cdb2sql ${CDB2_OPTIONS} $dbname default "select name, period, retention, nshards, version, shard0name from comdb2_timepartitions" 
+    cdb2sql ${CDB2_OPTIONS} $dbname default "select name, period, retention, nshards, version, shard0name from comdb2_timepartitions" >> $OUT
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+}
+
+
+# create the partition at limit number of rev constraints
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+60)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tcon1 as ${VIEW} PERIOD 'daily' RETENTION 30 START '${starttime}'" 
+echo "Creating $VIEW 30 shards table has 1 constraint on t table with 1 existing rev constraints from tconadd" 
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tcon1 as ${VIEW} PERIOD 'daily' RETENTION 30 START '${starttime}'" 2>&1 >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE to create $VIEW"
+   exit 1
+fi
+
+show_timepart
+
+VIEW="testview2"
+
+# create the partition at limit number of rev constraints
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+60)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tcon2 as ${VIEW} PERIOD 'daily' RETENTION 31 START '${starttime}'" 
+echo "FAIL TEST: Creating $VIEW 31 shards table has 1 constraint on t table with 1 existing rev constraints from tconadd" 
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tcon2 as ${VIEW} PERIOD 'daily' RETENTION 31 START '${starttime}'" 2>&1 >> $OUT
+if (( $? == 0 )) ; then
+   echo "FAILURE to stop creating $VIEW"
+   exit 1
+fi
+
+show_timepart
+
+difs=`diff $OUT $OUT.alpha`
+if (( $? != 0 )) ; then
+   echo "FAILURE diff"
+   exit 1
+fi
+if [[ ! -z "${difs}" ]] ; then
+   echo "diff $OUT $OUT.alpha.actual"
+   echo ${difs}
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/fkey_timepart.test/t.csc2
+++ b/tests/fkey_timepart.test/t.csc2
@@ -1,0 +1,14 @@
+schema
+{
+   int a0
+   int a1
+   int a2
+}
+
+keys
+{
+   "a0"  = a0
+   "a1"  = a1
+   "a2"  = a2
+}
+

--- a/tests/fkey_timepart.test/tcon1.csc2
+++ b/tests/fkey_timepart.test/tcon1.csc2
@@ -1,0 +1,17 @@
+schema
+{
+   int a0
+   int a1
+   int a2
+}
+
+keys
+{
+   "a0"  = a0
+   "a1"  = a1
+}
+
+constraints
+{
+    "a0" -> <"t":"a0"> <"t":"a1">
+}

--- a/tests/fkey_timepart.test/tcon2.csc2
+++ b/tests/fkey_timepart.test/tcon2.csc2
@@ -1,0 +1,17 @@
+schema
+{
+   int b0
+   int b1
+   int b2
+}
+
+keys
+{
+   "b0"  = b0
+   "b1"  = b1
+}
+
+constraints
+{
+    "b0" -> <"t":"a0"> <"t":"a1">
+}

--- a/tests/fkey_timepart.test/tconadd.csc2
+++ b/tests/fkey_timepart.test/tconadd.csc2
@@ -1,0 +1,21 @@
+schema
+{
+   int a
+   int b
+   int c
+   int d
+}
+keys
+{
+   "a"  = a
+   "b"  = b
+   "c"  = c
+   "d"  = d
+}
+constraints
+{
+    "a" -> <"t":"a0"> <"t":"a1"> <"t":"a2">
+}
+
+
+


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Creating a time partition on a table Ta that has a foreign key constraint on another table Tb can fail shard creation.  Since each shard registers its own constraint with the Tb, the Tb might run out of reverse constraints space (which is currently hardcoded all over the code base to 32).  This patch check at time partition creation that this simple scenario does not happen.   