### PR TITLE
Fix for Smartbeats

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -7076,3 +7076,8 @@ int exec_procedure(struct sqlthdstate *thd, struct sqlclntstate *clnt, char **er
     }
     return rc;
 }
+
+int is_pingpong(struct sqlclntstate *clnt)
+{
+    return ((clnt->sp == NULL) ? 0 : clnt->sp->pingpong);
+}

--- a/lua/sp.h
+++ b/lua/sp.h
@@ -32,6 +32,7 @@ int exec_procedure(struct sqlthdstate *, struct sqlclntstate *, char **err);
 void exec_thread(struct sqlthdstate *, struct sqlclntstate *);
 void *exec_trigger(struct trigger_reg *);
 void close_sp(struct sqlclntstate *);
+int is_pingpong(struct sqlclntstate *);
 
 void lua_final(struct sqlite3_context *);
 void lua_step(struct sqlite3_context *, int argc, struct sqlite3_value **argv);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -626,8 +626,13 @@ static int newsql_heartbeat(struct sqlclntstate *clnt)
     if (!clnt->ready_for_heartbeats)
         return 0;
 
-    state = (clnt->sqltick > clnt->sqltick_last_seen);
-    clnt->sqltick_last_seen = clnt->sqltick;
+    /* We're still in a good state if we're just waiting for the client to consume an event. */
+    if (is_pingpong(clnt))
+        state = 1;
+    else {
+        state = (clnt->sqltick > clnt->sqltick_last_seen);
+        clnt->sqltick_last_seen = clnt->sqltick;
+    }
 
     return newsql_send_hdr(clnt, RESPONSE_HEADER__SQL_RESPONSE_HEARTBEAT,
                            state);


### PR DESCRIPTION
Do not send "hung" smartbeats to a LUA consumer if it isn't consuming events in a timely manner.

(DRQS 160019348)
