### PR TITLE
Fix temp cursor leak

### DIFF
--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -481,6 +481,8 @@ static void bdb_temp_table_reset(struct temp_table *tbl)
     tbl->num_mem_entries = 0;
 }
 
+static int bdb_temp_table_reset_cursor(bdb_state_type *bdb_state, struct temp_cursor *cur, int *bdberr);
+
 static int bdb_temp_table_init_temp_db(bdb_state_type *bdb_state,
                                        struct temp_table *tbl, int *bdberr)
 {
@@ -492,11 +494,10 @@ static int bdb_temp_table_init_temp_db(bdb_state_type *bdb_state,
         struct temp_cursor *cur;
         LISTC_FOR_EACH(&tbl->cursors, cur, lnk)
         {
-            if ((rc = bdb_temp_table_close_cursor(bdb_state, cur, bdberr)) !=
-                0) {
-                logmsg(LOGMSG_ERROR,
-                       "%s: bdb_temp_table_close_cursor(%p, %p) rc %d\n",
-                       __func__, tbl, cur, rc);
+            /* Do not destory the temp cursor. Only reset it. The cursor may still
+               be referenced by others (e.g., SQLite's BtCursor). */
+            if ((rc = bdb_temp_table_reset_cursor(bdb_state, cur, bdberr)) != 0) {
+                logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_reset_cursor(%p, %p) rc %d\n", __func__, tbl, cur, rc);
                 return rc;
             }
         }
@@ -1490,10 +1491,6 @@ int bdb_temp_table_close(bdb_state_type *bdb_state, struct temp_table *tbl,
                    __func__, tbl, cur, rc);
             return rc;
         }
-
-        /* We're closing the temptable so discard its cursors. */
-        listc_rfl(&tbl->cursors, cur);
-        free(cur);
     }
 
     rc = bdb_temp_table_truncate(bdb_state, tbl, bdberr);
@@ -2127,8 +2124,7 @@ static int key_memcmp(void *_, int key1len, const void *key1, int key2len,
     return rc;
 }
 
-int bdb_temp_table_close_cursor(bdb_state_type *bdb_state,
-                                struct temp_cursor *cur, int *bdberr)
+static int bdb_temp_table_reset_cursor(bdb_state_type *bdb_state, struct temp_cursor *cur, int *bdberr)
 {
     int rc = 0;
     struct temp_table *tbl;
@@ -2155,13 +2151,20 @@ int bdb_temp_table_close_cursor(bdb_state_type *bdb_state,
             }
             cur->cur = NULL;
         }
-
-        /* Note: we can't do this until the cursor is closed.
-           Closing a cursor may invoke a search if we deleted items through that
-           cursor.  The search (custom search routine)
-           will need access to thread-specific data. */
-        /*Pthread_setspecific(cur->tbl->curkey, NULL);*/
     }
+
+    return rc;
+}
+
+/* The function closes the underlying berkdb cursor, removes the temp cursor from the temp table and frees it. */
+int bdb_temp_table_close_cursor(bdb_state_type *bdb_state, struct temp_cursor *cur, int *bdberr)
+{
+    int rc;
+    struct temp_table *tbl = cur->tbl;
+
+    listc_rfl(&tbl->cursors, cur);
+    rc = bdb_temp_table_reset_cursor(bdb_state, cur, bdberr);
+    free(cur);
 
     return rc;
 }

--- a/tests/temp_table_cursor_leak.test/Makefile
+++ b/tests/temp_table_cursor_leak.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/temp_table_cursor_leak.test/lrl.options
+++ b/tests/temp_table_cursor_leak.test/lrl.options
@@ -1,0 +1,2 @@
+sqlenginepool linger 4
+sqlenginepool mint 0

--- a/tests/temp_table_cursor_leak.test/runit
+++ b/tests/temp_table_cursor_leak.test/runit
@@ -1,0 +1,39 @@
+# TODO consolidate all leak regression tests into one
+
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Make sure we talk to the same host
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+
+
+cdb2sql $dbnm --host $host 'create table p {schema{int i} keys{"pki" = i}}'
+cdb2sql $dbnm --host $host 'create table c {schema{int i} keys{dup "cki" = i} constraints{"cki" -> <"p" : "pki">} }'
+
+sleep 1
+
+cdb2sql $dbnm --host $host 'insert into p values(1)' >/dev/null 2>&1
+cdb2sql $dbnm --host $host 'insert into c values(1)' >/dev/null 2>&1
+
+cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat bdb')"
+before=`cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat bdb')" | grep total | tail -1 | awk '{print $6}'`
+
+yes "insert into c values(1)" | cdb2sql $dbnm --host $host - >/dev/null 2>&1 &
+pid=$!
+sleep 120
+kill $pid
+
+cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat bdb')"
+after=`cdb2sql --tabs $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('memstat bdb')" | grep total | tail -1 | awk '{print $6}'`
+
+# Should be almost identical
+ratio=`echo "$after/$before" | bc`
+echo "$after/$before=$ratio"
+if [ $ratio -gt 1 ]; then
+  echo "ratio is too high: $ratio" >&2
+  exit 1
+fi


### PR DESCRIPTION
Make sure a temp cursor is freed in bdb_temp_table_close_cursor().

(DRQS 161214587)