### PR TITLE
make sure not to race shard rollout with testing

### DIFF
--- a/tests/simple_timepart.test/lrl.options
+++ b/tests/simple_timepart.test/lrl.options
@@ -1,1 +1,2 @@
 table t t.csc2
+setattr DEBUG_TIMEPART_CRON 1

--- a/tests/simple_timepart.test/runit
+++ b/tests/simple_timepart.test/runit
@@ -217,28 +217,28 @@ assertcnt tbl2 $CNT
 assertcnt tbl3 $CNT
 assertcnt tbl4 $CNT
 
-adayago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(24*3600 + 60))'`
+adayago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(24*3600 + 3600))'`
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl1 as tbl1v1 PERIOD 'DAILY' RETENTION 3 START '${adayago}'" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE"
    exit 1
 fi
 
-aweekago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(7*24*3600 + 60))'`
+aweekago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(7*24*3600 + 3600))'`
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl2 as tbl2v1 PERIOD 'WEEKLY' RETENTION 3 START '${aweekago}'" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE"
    exit 1
 fi
 
-amonthago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(30*24*3600 + 60))'`
+amonthago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(27*24*3600))'`
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl3 as tbl3v1 PERIOD 'MONTHLY' RETENTION 3 START '${amonthago}'" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE"
    exit 1
 fi
 
-ayearago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(365*24*3600 + 60))'`
+ayearago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(365*24*3600 +3600))'`
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl4 as tbl4v1 PERIOD 'YEARLY' RETENTION 3 START '${ayearago}'" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE"
@@ -246,7 +246,7 @@ if (( $? != 0 )) ; then
 fi
 
 
-sleep 20
+sleep 60
 timepart_stats
 
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl1v1 select value from generate_series($CNT+1,2*$CNT)"


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Testing various rollout periods in "simple_timepart" races against the testing itself.  60 seconds preamble was enough for test2min rollout, but not for daily/weekly/etc (changed it to one hour).  Also, a month is not 30 days all the time, so in some months we get one extra rollout, and one extra shard, which breaks the test.