### PR TITLE
Lock cascading delete or update table

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1603,6 +1603,7 @@ dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
     tbl->dbtype = isqueuedb ? DBTYPE_QUEUEDB : DBTYPE_QUEUE;
     tbl->avgitemsz = avgsz;
     tbl->queue_pagesize_override = pagesize;
+    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
 
     if (tbl->dbtype == DBTYPE_QUEUEDB) {
         Pthread_rwlock_init(&tbl->consumer_lk, NULL);
@@ -1641,6 +1642,7 @@ void cleanup_newdb(dbtable *tbl)
         free(tbl->check_constraint_query[i]);
         tbl->check_constraint_query[i] = NULL;
     }
+    Pthread_mutex_destroy(&tbl->rev_constraints_lk);
 
     if (tbl->dbtype == DBTYPE_QUEUEDB)
         Pthread_rwlock_destroy(&tbl->consumer_lk);
@@ -1672,6 +1674,7 @@ dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
     tbl->dbnum = dbnum;
     tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
     Pthread_rwlock_init(&tbl->sc_live_lk, NULL);
+    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
     if (dbnum == 0) {
         /* if no dbnumber then no default tag is required ergo lrl can be 0 */
         if (tbl->lrl < 0)

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -687,6 +687,7 @@ typedef struct dbtable {
     /* Pointers to other table constraints that are directed at this table. */
     constraint_t *rev_constraints[MAXCONSTRAINTS];
     int n_rev_constraints;
+    pthread_mutex_t rev_constraints_lk;
 
     /* CHECK constraints */
     check_constraint_t check_constraints[MAXCONSTRAINTS];

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -1177,6 +1177,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
         if (!strcasecmp(rdb->tablename, newdb->tablename)) {
             rdb = newdb;
         }
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (int j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1193,6 +1194,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                 }
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
         for (int j = 0; j < newdb->n_constraints; j++) {
             for (int k = 0; k < newdb->constraints[j].nrules; k++) {
                 int ridx = 0;
@@ -1358,6 +1360,7 @@ int remove_constraint_pointers(struct dbtable *db)
     for (int i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
         int j = 0;
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1374,6 +1377,7 @@ int remove_constraint_pointers(struct dbtable *db)
                 }
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
     }
     return 0;
 }
@@ -1383,6 +1387,7 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
     for (int i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
         int j = 0;
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1390,6 +1395,7 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
                 strcpy(ct->lcltable->tablename, newname);
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
     }
     return 0;
 }
@@ -1407,6 +1413,7 @@ void fix_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
         rdb = thedb->dbs[i];
         /* fix reverse references */
         if (rdb->n_rev_constraints > 0) {
+            Pthread_mutex_lock(&rdb->rev_constraints_lk);
             for (j = 0; j < rdb->n_rev_constraints; j++) {
                 ct = rdb->rev_constraints[j];
                 for (k = 0; k < MAXCONSTRAINTS; k++) {
@@ -1415,6 +1422,7 @@ void fix_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
                     }
                 }
             }
+            Pthread_mutex_unlock(&rdb->rev_constraints_lk);
         }
         /* fix forward references */
         if (rdb->n_constraints) {


### PR DESCRIPTION
This pr fixes periodic failures in the sc_blob_update test.  This test does updates against a table, and concurrently does rebuilds against a different table.  The table being rebuilt has a foreign key constraint against the table being updated- because the updating transaction never acquired a table lock on the table which has the constraint, it may reference a bob_state object which is invalid.  The change here simply acquires a table lock on the table which contains the constraint.