### PR TITLE
Create transactional versions of several llmeta functions

### DIFF
--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -235,8 +235,8 @@ void bdb_access_tbl_invalidate(bdb_state_type *bdb_state)
 int gbl_allow_user_schema;
 int gbl_uses_password;
 
-int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user,
-                              char *table, int access_type, int *bdberr)
+int bdb_check_user_tbl_access_tran(bdb_state_type *bdb_state, tran_type *tran, char *user, char *table, int access_type,
+                                   int *bdberr)
 {
     int rc = 0;
     if (gbl_uses_password) {
@@ -248,20 +248,25 @@ int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user,
             }
         }
         if (access_type == ACCESS_READ) {
-            rc = bdb_tbl_access_read_get(bdb_state, NULL, table, user, bdberr);
+            rc = bdb_tbl_access_read_get(bdb_state, tran, table, user, bdberr);
         }
         if (rc != 0 &&
             (access_type == ACCESS_WRITE || access_type == ACCESS_READ)) {
-            rc = bdb_tbl_access_write_get(bdb_state, NULL, table, user, bdberr);
+            rc = bdb_tbl_access_write_get(bdb_state, tran, table, user, bdberr);
         }
         if (rc != 0 &&
             (access_type == ACCESS_DDL || access_type == ACCESS_WRITE ||
              access_type == ACCESS_READ)) {
-            rc = bdb_tbl_op_access_get(bdb_state, NULL, 0, table, user, bdberr);
+            rc = bdb_tbl_op_access_get(bdb_state, tran, 0, table, user, bdberr);
         }
         if (rc != 0) {
-            rc = bdb_tbl_op_access_get(bdb_state, NULL, 0, "", user, bdberr);
+            rc = bdb_tbl_op_access_get(bdb_state, tran, 0, "", user, bdberr);
         }
     }
     return rc;
+}
+
+int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user, char *table, int access_type, int *bdberr)
+{
+    return bdb_check_user_tbl_access_tran(bdb_state, NULL, user, table, access_type, bdberr);
 }

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -545,9 +545,11 @@ int bdb_handle_dbp_hash_stat_reset(bdb_state_type *bdb_state);
 int bdb_close_temp_state(bdb_state_type *bdb_state, int *bdberr);
 
 /* get file sizes for indexes and data files */
-uint64_t bdb_index_size(bdb_state_type *bdb_state, int ixnum);
+uint64_t bdb_index_size_tran(bdb_state_type *bdb_state, tran_type *tran, int ixnum);
+uint64_t bdb_data_size_tran(bdb_state_type *bdb_state, tran_type *tran, int dtanum);
 uint64_t bdb_data_size(bdb_state_type *bdb_state, int dtanum);
 uint64_t bdb_queue_size(bdb_state_type *bdb_state, unsigned *num_extents);
+uint64_t bdb_queue_size_tran(bdb_state_type *bdb_state, tran_type *tran, unsigned *num_extents);
 uint64_t bdb_logs_size(bdb_state_type *bdb_state, unsigned *num_logs);
 
 /*
@@ -1557,8 +1559,8 @@ int bdb_set_schema_change_status(tran_type *input_trans, const char *db_name,
                                  size_t schema_change_data_len, int status,
                                  const char *errstr, int *bdberr);
 
-int bdb_llmeta_get_all_sc_status(llmeta_sc_status_data **status_out,
-                                 void ***sc_data_out, int *num, int *bdberr);
+int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status_out, void ***sc_data_out, int *num,
+                                 int *bdberr);
 
 typedef struct {
     uint64_t start;
@@ -1679,6 +1681,7 @@ int bdb_rowlocks_check_commit_physical(bdb_state_type *bdb_state,
 int bdb_is_rowlocks_transaction(tran_type *tran);
 
 int bdb_get_sp_get_default_version(const char *sp_name, int *bdberr);
+int bdb_get_sp_get_default_version_tran(tran_type *tran, const char *sp_name, int *bdberr);
 int bdb_set_sp_lua_source(bdb_state_type *bdb_state, tran_type *tran,
                           const char *sp_name, char *lua_file, int size,
                           int version, int *bdberr);
@@ -1754,9 +1757,10 @@ int bdb_accesscontrol_tableXnode_get(bdb_state_type *bdb_state, tran_type *tran,
                                      int *bdberr);
 
 int bdb_user_password_set(tran_type *, char *user, char *passwd);
-int bdb_user_password_check(char *user, char *passwd, int *valid_user);
+int bdb_user_password_check(tran_type *, char *user, char *passwd, int *valid_user);
 int bdb_user_password_delete(tran_type *tran, char *user);
 int bdb_user_get_all(char ***users, int *num);
+int bdb_user_get_all_tran(tran_type *tran, char ***users, int *num);
 
 void bdb_set_instant_schema_change(bdb_state_type *bdb_state, int isc);
 void bdb_set_inplace_updates(bdb_state_type *bdb_state, int ipu);
@@ -2011,6 +2015,7 @@ int bdb_osql_serial_check(bdb_state_type *bdb_state, void *ranges,
 int llmeta_set_tablename_alias(void *ptran, const char *tablename_alias,
                                const char *url, char **errstr);
 char *llmeta_get_tablename_alias(const char *tablename_alias, char **errstr);
+char *llmeta_get_tablename_alias_tran(tran_type *tran, const char *tablename_alias, char **errstr);
 int llmeta_rem_tablename_alias(const char *tablename_alias, char **errstr);
 void llmeta_list_tablename_alias(void);
 
@@ -2128,18 +2133,24 @@ int bdb_watchdog_test_io(bdb_state_type *bdb_state);
 
 int bdb_add_versioned_sp(tran_type *, char *name, char *version, char *src);
 int bdb_get_versioned_sp(char *name, char *version, char **src);
+int bdb_get_versioned_sp_tran(tran_type *, char *name, char *version, char **src);
 int bdb_del_versioned_sp(char *name, char *version);
 
 int bdb_set_default_versioned_sp(tran_type *, char *name, char *version);
 int bdb_get_default_versioned_sp(char *name, char **version);
+int bdb_get_default_versioned_sp_tran(tran_type *, char *name, char **version);
 int bdb_del_default_versioned_sp(tran_type *tran, char *name);
 
 int bdb_get_all_for_versioned_sp(char *name, char ***versions, int *num);
+int bdb_get_all_for_versioned_sp_tran(tran_type *tran, char *name, char ***versions, int *num);
 int bdb_get_default_versioned_sps(char ***names, int *num);
 int bdb_get_versioned_sps(char ***names, int *num);
+int bdb_get_versioned_sps_tran(tran_type *tran, char ***names, int *num);
 
 int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user,
                               char *table, int access_type, int *bdberr);
+int bdb_check_user_tbl_access_tran(bdb_state_type *bdb_state, tran_type *tran, char *user, char *table, int access_type,
+                                   int *bdberr);
 int bdb_first_user_get(bdb_state_type *bdb_state, tran_type *tran,
                        char *key_out, char *user_out, int *isop, int *bdberr);
 int bdb_next_user_get(bdb_state_type *bdb_state, tran_type *tran, char *key,

--- a/db/bpfunc.c
+++ b/db/bpfunc.c
@@ -353,7 +353,7 @@ static int exec_authentication(void *tran, bpfunc_t *func, struct errstat *err)
     int valid_user;
 
     if (auth->enabled)
-        bdb_user_password_check(DEFAULT_USER, DEFAULT_PASSWORD, &valid_user);
+        bdb_user_password_check(tran, DEFAULT_USER, DEFAULT_PASSWORD, &valid_user);
 
     /* Check if there is already op password. */
     int rc = bdb_authentication_set(thedb->bdb_env, tran, auth->enabled, &bdberr);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2613,6 +2613,7 @@ void upgrade_record_by_genid(struct dbtable *db, unsigned long long genid);
 void backend_thread_event(struct dbenv *dbenv, int event);
 void backend_cmd(struct dbenv *dbenv, char *line, int lline, int st);
 uint64_t calc_table_size(struct dbtable *db, int skip_blobs);
+uint64_t calc_table_size_tran(tran_type *tran, struct dbtable *db, int skip_blobs);
 
 enum { WHOLE_BUFFER = -1 };
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2999,8 +2999,7 @@ static inline int check_user_password(struct sqlclntstate *clnt)
         strcpy(clnt->current_user.password, DEFAULT_PASSWORD);
     }
 
-    password_rc = bdb_user_password_check(
-        clnt->current_user.name, clnt->current_user.password, &valid_user);
+    password_rc = bdb_user_password_check(NULL, clnt->current_user.name, clnt->current_user.password, &valid_user);
 
     if (password_rc != 0) {
         write_response(clnt, RESPONSE_ERROR_ACCESS, "access denied", 0);

--- a/sqlite/ext/comdb2/scstatus.c
+++ b/sqlite/ext/comdb2/scstatus.c
@@ -50,7 +50,7 @@ static int get_status(void **data, int *npoints)
     void **sc_data = NULL;
     struct sc_status_ent *sc_status_ents = NULL;
 
-    rc = bdb_llmeta_get_all_sc_status(&status, &sc_data, &nkeys, &bdberr);
+    rc = bdb_llmeta_get_all_sc_status(NULL, &status, &sc_data, &nkeys, &bdberr);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s: failed to get all schema change status\n",
                __func__);

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -441,7 +441,7 @@ static int comdb2AuthenticateOpPassword(Parse* pParse)
      if (clnt)
      {
          /* Authenticate the password first, as we haven't been doing it so far. */
-         if (bdb_user_password_check(clnt->current_user.name,
+         if (bdb_user_password_check(NULL, clnt->current_user.name,
                                      clnt->current_user.password, NULL))
          {
             return SQLITE_AUTH;


### PR DESCRIPTION
This is another piece of https://github.com/bloomberg/comdb2/pull/2295.  This pr provides transactional versions of several llmeta accessors.  The next pr will utilize these accessors from within systable code.