### PR TITLE
Don't truncate reql output by default.

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -111,7 +111,7 @@ static struct list master_opcode_inv_list = {0};
 static int master_table_rules = 0;
 static char master_stmts[NUMSTMTS][MAXSTMT + 1];
 static int master_num_stmts = 0;
-int reqltruncate = 1;
+int reqltruncate = 0;
 
 /* sometimes you have to debug the debugger */
 static int verbose = 0;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -715,7 +715,7 @@
 (name='reptimeout_minms', description='Wait at least this many ms for replication to complete on other nodes, before marking them incoherent.', type='INTEGER', value='10000', read_only='N')
 (name='repverifyrecs', description='Verify every berkeley log record received', type='BOOLEAN', value='OFF', read_only='N')
 (name='reqldiffstat', description='', type='INTEGER', value='60', read_only='Y')
-(name='reqltruncate', description='', type='INTEGER', value='1', read_only='Y')
+(name='reqltruncate', description='', type='INTEGER', value='0', read_only='Y')
 (name='request_durable_lsn_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='requeue_on_tran_dispatch', description='Requeue transactional statement if not enough threads', type='BOOLEAN', value='ON', read_only='N')
 (name='reset_deadlock_race', description='reset_deadlock_race', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Change default reqlog output to not truncate.

Signed-off-by: Michael Ponomarenko <mponomarenko@bloomberg.net>
