### PR TITLE
Introduce curtran_gettran, and utilize for a few db-layer functions

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -290,6 +290,7 @@ struct tran_tag {
     tranclass_type tranclass;
     DB_TXN *tid;
     u_int32_t logical_lid;
+    u_int32_t original_lid;
 
     void *usrptr;
     DB_LSN savelsn;
@@ -1693,7 +1694,7 @@ int bdb_lock_row_fromlid_int(bdb_state_type *bdb_state, int lid, int idx,
 /* we use this structure to create a dummy cursor to be used for all
  * non-transactional cursors. it is defined below */
 struct cursor_tran {
-    unsigned int lockerid;
+    uint32_t lockerid;
     int id; /* debugging */
 };
 

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -266,8 +266,7 @@ int gbl_metrics_count = sizeof(gbl_metrics) / sizeof(comdb2_metric);
 extern int n_commits;
 extern long n_fstrap;
 
-
-static int64_t refresh_diskspace(struct dbenv *dbenv)
+static int64_t refresh_diskspace(struct dbenv *dbenv, tran_type *tran)
 {
     int64_t total = 0;
     int ndb;
@@ -277,12 +276,12 @@ static int64_t refresh_diskspace(struct dbenv *dbenv)
     for(ndb = 0; ndb < dbenv->num_dbs; ndb++)
     {
         db = dbenv->dbs[ndb];
-        total += calc_table_size(db, 0);
+        total += calc_table_size_tran(tran, db, 0);
     }
     for(ndb = 0; ndb < dbenv->num_qdbs; ndb++)
     {
         db = dbenv->qdbs[ndb];
-        total += calc_table_size(db, 0);
+        total += calc_table_size_tran(tran, db, 0);
     }
     total += bdb_logs_size(dbenv->bdb_env, &num_logs);
     return total;
@@ -406,7 +405,6 @@ int refresh_metrics(void)
     }
     stats.cpu_percent = gbl_cpupercent;
 #endif
-    stats.diskspace = refresh_diskspace(thedb);
     stats.service_time = time_metric_average(thedb->service_time);
     stats.queue_depth = time_metric_average(thedb->queue_depth);
     stats.concurrent_sql = time_metric_average(thedb->concurrent_queries);
@@ -419,13 +417,6 @@ int refresh_metrics(void)
         bdb_whoismaster((bdb_state_type *)thedb->bdb_env) == gbl_myhostname ? 1
                                                                             : 0;
     stats.ismaster = master;
-    rc = bdb_get_num_sc_done(((bdb_state_type *)thedb->bdb_env), NULL,
-                             (unsigned long long *)&stats.num_sc_done, &bdberr);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "failed to refresh statistics (%s:%d)\n", __FILE__,
-               __LINE__);
-        return 1;
-    }
     stats.last_checkpoint_ms = gbl_last_checkpoint_ms;
     stats.total_checkpoint_ms = gbl_total_checkpoint_ms;
     stats.checkpoint_count = gbl_checkpoint_count;
@@ -471,6 +462,17 @@ int refresh_metrics(void)
     stats.minimum_truncation_offset = min_offset;
     stats.minimum_truncation_timestamp = min_timestamp;
 #endif
+
+    tran_type *trans = curtran_gettran();
+    rc = bdb_get_num_sc_done(((bdb_state_type *)thedb->bdb_env), trans, (unsigned long long *)&stats.num_sc_done,
+                             &bdberr);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "failed to refresh statistics (%s:%d)\n", __FILE__, __LINE__);
+        return 1;
+    }
+    stats.diskspace = refresh_diskspace(thedb, trans);
+    curtran_puttran(trans);
+
     return 0;
 }
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -4094,8 +4094,11 @@ char *fdb_get_alias(const char **p_tablename)
     char *errstr = NULL;
     char *alias = NULL;
     const char *tablename = *p_tablename;
+    tran_type *trans;
 
-    alias = llmeta_get_tablename_alias(tablename, &errstr);
+    trans = curtran_gettran();
+    alias = llmeta_get_tablename_alias_tran(trans, tablename, &errstr);
+    curtran_puttran(trans);
     if (!alias) {
         if (errstr) {
             logmsg(LOGMSG_ERROR, "%s: error retrieving fdb alias for %s\n", __func__,

--- a/db/glue.c
+++ b/db/glue.c
@@ -3908,10 +3908,12 @@ void get_disable_skipscan_all()
 #ifdef DEBUGSKIPSCAN
     logmsg(LOGMSG_WARN, "get_disable_skipscan_all() called\n");
 #endif
+    tran_type *tran = curtran_gettran();
     for (int ii = 0; ii < thedb->num_dbs; ii++) {
         struct dbtable *d = thedb->dbs[ii];
-        get_disable_skipscan(d, NULL);
+        get_disable_skipscan(d, tran);
     }
+    curtran_puttran(tran);
 }
  
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -1343,4 +1343,13 @@ void add_fingerprint_to_rawstats(struct rawnodestats *stats,
  */
 int clnt_check_bdb_lock_desired(struct sqlclntstate *clnt);
 
+/**
+ * Bdb transaction objects with curtran lockid
+ */
+tran_type *curtran_gettran(void);
+
+void curtran_assert_nolocks(void);
+
+void curtran_puttran(tran_type *tran);
+
 #endif /* _SQL_H_ */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2999,7 +2999,9 @@ static inline int check_user_password(struct sqlclntstate *clnt)
         strcpy(clnt->current_user.password, DEFAULT_PASSWORD);
     }
 
-    password_rc = bdb_user_password_check(NULL, clnt->current_user.name, clnt->current_user.password, &valid_user);
+    tran_type *tran = curtran_gettran();
+    password_rc = bdb_user_password_check(tran, clnt->current_user.name, clnt->current_user.password, &valid_user);
+    curtran_puttran(tran);
 
     if (password_rc != 0) {
         write_response(clnt, RESPONSE_ERROR_ACCESS, "access denied", 0);

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -798,7 +798,7 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                 if ((rc = trans_start(iq, NULL, &lock_trans)) == 0) {
                     bdb_lock_tablename_read(thedb->bdb_env, iq->sc->tablename,
                                             lock_trans);
-                    sc_del_unused_files(iq->sc->db);
+                    sc_del_unused_files_tran(iq->sc->db, lock_trans);
                     trans_abort(iq, lock_trans);
                 } else {
                     logmsg(LOGMSG_ERROR,

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -96,13 +96,16 @@ again:
 
 static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
   struct sql_thread *thd;
-
+  tran_type *trans = curtran_gettran();
+  if (!trans) {
+      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
+      return -1;
+  }
   trigger_cursor *cur = sqlite3_malloc(sizeof(trigger_cursor));
   if( cur == 0)
     return SQLITE_NOMEM;
   memset(cur, 0, sizeof(*cur));
   listc_init(&cur->trgs, offsetof(trigger, lnk));
-  rdlock_schema_lk(); // protect thedb access
 
   thd = pthread_getspecific(query_info_key);
 
@@ -115,7 +118,7 @@ static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
       continue;
 
     /* Check user access. */
-    rc = bdb_check_user_tbl_access(thedb->bdb_env,
+    rc = bdb_check_user_tbl_access_tran(thedb->bdb_env, trans,
                                    thd->clnt->current_user.name,
                                    thedb->qdbs[i]->tablename, ACCESS_READ,
                                    &bdberr);
@@ -133,13 +136,13 @@ static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
       t->type = dbqueue_consumer_type(thedb->qdbs[i]->consumers[0]);
     listc_abl(&cur->trgs, t);
   }
-  unlock_schema_lk();
   if( (t = LISTC_TOP(&cur->trgs)) != NULL ){
     cur->trg = t;
     get_info(cur);
   }
 
   *ppCursor = &cur->base;
+  curtran_puttran(trans);
   return SQLITE_OK;
 }
 


### PR DESCRIPTION
This is another chunk of https://github.com/bloomberg/comdb2/pull/2295 which introduces a wrapper function, curtran_gettran.  curtran_gettran produces a bdb-level tran_type, but replaces it's lockid with the thread's curtran lockid.  This checkin further utilizes these routines for a few tasks in the db layer.