### PR TITLE
Print id of sql statement up to the end of string

### DIFF
--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -232,8 +232,8 @@ void bdb_access_tbl_invalidate(bdb_state_type *bdb_state)
           sizeof(bdb_state->access->hosts_cache));
 }
 
-int gbl_allow_user_schema;
-int gbl_uses_password;
+extern int gbl_allow_user_schema;
+extern int gbl_uses_password;
 
 int bdb_check_user_tbl_access_tran(bdb_state_type *bdb_state, tran_type *tran, char *user, char *table, int access_type,
                                    int *bdberr)

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -569,7 +569,7 @@ static int bdb_temp_table_env_close(bdb_state_type *bdb_state,
     return 0;
 }
 
-pthread_key_t current_sql_query_key;
+extern pthread_key_t current_sql_query_key;
 int gbl_debug_temptables = 0;
 
 static struct temp_table *bdb_temp_table_create_main(bdb_state_type *bdb_state,

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -69,9 +69,9 @@ extern int gbl_rowlocks;
 extern int gbl_page_latches;
 extern int gbl_replicant_latches;
 extern int gbl_print_deadlock_cycles;
+extern int gbl_lock_conflict_trace;
 
 int gbl_berkdb_track_locks = 0;
-int gbl_lock_conflict_trace;
 unsigned gbl_ddlk = 0;
 
 void comdb2_dump_blocker(unsigned int);
@@ -1306,26 +1306,6 @@ __get_page_latch(lt, locker, flags, obj, lock_mode, lock)
  * PUBLIC: int __lock_vec __P((DB_ENV *,
  * PUBLIC:     u_int32_t, u_int32_t, DB_LOCKREQ *, int, DB_LOCKREQ **));
  */
-
-static char *
-opstring(int op)
-{
-	switch (op) {
-	case DB_LOCK_PUT_ALL:
-		return "PUT_ALL";
-		break;
-	case DB_LOCK_PUT_READ:
-		return "PUT_READ";
-		break;
-	case DB_LOCK_UPGRADE_WRITE:
-		return "UPGRADE_WRITE";
-		break;
-	default:
-		return "OTHER_LOCKOP";
-		break;
-	}
-}
-
 int
 __lock_vec(dbenv, locker, flags, list, nlist, elistp)
 	DB_ENV *dbenv;

--- a/db/block_internal.h
+++ b/db/block_internal.h
@@ -544,7 +544,7 @@ BB_COMPILE_TIME_ASSERT(packedreq_dbglog_cookie_size,
 struct packed_pragma {
     int type;
     int len;
-} pragma;
+};
 enum { PACKEDREQ_PRAGMA_LEN = 4 + 4 };
 BB_COMPILE_TIME_ASSERT(packed_pragma_size,
                        sizeof(struct packed_pragma) == PACKEDREQ_PRAGMA_LEN);
@@ -576,13 +576,6 @@ enum FSTBLK_CODES {
     FSTBLK_RSPKL = 2,
     FSTBLK_SNAP_INFO = 3
 };
-
-enum GTID_CODES { GTID_PREPARED = 1, GTID_COMMITED = 2 };
-
-struct gtid_record {
-    int type;
-    int dbnum;
-} coord;
 
 struct fstblk_header {
     short type;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1603,6 +1603,7 @@ dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
     tbl->dbtype = isqueuedb ? DBTYPE_QUEUEDB : DBTYPE_QUEUE;
     tbl->avgitemsz = avgsz;
     tbl->queue_pagesize_override = pagesize;
+    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
 
     if (tbl->dbtype == DBTYPE_QUEUEDB) {
         Pthread_rwlock_init(&tbl->consumer_lk, NULL);
@@ -1641,6 +1642,7 @@ void cleanup_newdb(dbtable *tbl)
         free(tbl->check_constraint_query[i]);
         tbl->check_constraint_query[i] = NULL;
     }
+    Pthread_mutex_destroy(&tbl->rev_constraints_lk);
 
     if (tbl->dbtype == DBTYPE_QUEUEDB)
         Pthread_rwlock_destroy(&tbl->consumer_lk);
@@ -1672,6 +1674,7 @@ dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
     tbl->dbnum = dbnum;
     tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
     Pthread_rwlock_init(&tbl->sc_live_lk, NULL);
+    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
     if (dbnum == 0) {
         /* if no dbnumber then no default tag is required ergo lrl can be 0 */
         if (tbl->lrl < 0)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -18,7 +18,6 @@ int __berkdb_write_alarm_ms;
 int __berkdb_read_alarm_ms;
 int __berkdb_fsync_alarm_ms;
 
-extern int gbl_berkdb_track_locks;
 extern int gbl_delay_sql_lock_release_sec;
 
 void __berkdb_set_num_read_ios(long long *n);
@@ -520,6 +519,7 @@ int gbl_newsi_use_timestamp_table = 0;
 int gbl_update_shadows_interval = 0;
 int gbl_lowpri_snapisol_sessions = 0;
 int gbl_support_sock_luxref = 1;
+int gbl_allow_user_schema;
 
 struct quantize *q_min;
 struct quantize *q_hour;
@@ -534,7 +534,6 @@ struct quantize *q_sql_steps_hour;
 struct quantize *q_sql_steps_all;
 
 extern int gbl_net_lmt_upd_incoherent_nodes;
-extern int gbl_allow_user_schema;
 extern int gbl_skip_cget_in_db_put;
 
 int gbl_argc;
@@ -776,6 +775,8 @@ int64_t gbl_temptable_spills;
 int gbl_osql_odh_blob = 1;
 
 int gbl_clean_exit_on_sigterm = 1;
+
+int gbl_is_physical_replicant;
 
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();
@@ -1232,8 +1233,6 @@ static void *purge_old_blkseq_thread(void *arg)
     backend_thread_event(thedb, COMDB2_THR_EVENT_DONE_RDONLY);
     return NULL;
 }
-
-extern int gbl_is_physical_replicant;
 
 static void *purge_old_files_thread(void *arg)
 {

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1588,7 +1588,7 @@ extern int gbl_maxqueue;     /* max number of requests to be queued up */
 extern int gbl_thd_linger;   /* number of seconds for threads to linger */
 extern char *gbl_myhostname; /* my hostname */
 extern char *gbl_machine_class; /* my machine class */
-struct in_addr gbl_myaddr;   /* my IPV4 address */
+extern struct in_addr gbl_myaddr;   /* my IPV4 address */
 extern int gbl_mynodeid;     /* node number, for backwards compatibility */
 extern pid_t gbl_mypid;      /* my pid */
 extern int gbl_create_mode;  /* create files if no exists */
@@ -2865,20 +2865,10 @@ void debug_traverse_data(char *tbl);
 int add_gtid(struct ireq *iq, int source_db, tranid_t id);
 int rem_gtid(struct ireq *iq, tranid_t id);
 
-enum rsptype { RSP_COORDINATOR_PARTIAL_BLOCK = 12 };
-
-struct crsphdr {
-    enum rsptype rsptype;
-};
-
 /* Wrappers around berkeley lock code (gut says bad idea, brain insists) */
 int locks_get_locker(unsigned int *lid);
 int locks_lock_row(unsigned int lid, unsigned long long genid);
 int locks_release_locker(unsigned int lid);
-
-void reload_gtids(void);
-
-int handle_coordinator_master_switch(void);
 
 void berkdb_use_malloc_for_regions(void);
 int get_slotnum_from_buf(struct dbtable *db, char *tagname, void *buf, void *nulls);
@@ -2897,16 +2887,6 @@ int find_record_older_than(struct ireq *iq, void *tran, int timestamp,
                            void *rec, int *reclen, int maxlen,
                            unsigned long long *genid);
 
-int remaining_active_gtid_count(void);
-
-void check_old_transaction_status(void);
-
-/* TODO: move all the twophase stuff into a separate .h file - too much
- * pollution */
-
-void twophase_process_message(char *line, int lline, int st);
-void get_instant_record_lock(unsigned long long genid);
-int genid_exists(struct ireq *iq, unsigned long long genid);
 extern int gbl_exclusive_blockop_qconsume;
 extern pthread_rwlock_t gbl_block_qconsume_lock;
 
@@ -3182,17 +3162,17 @@ extern int gbl_lowpri_snapisol_sessions;
 
 /* stats */
 /* non-sql request service times (last minute, last hour, since start) */
-struct quantize *q_min;
-struct quantize *q_hour;
-struct quantize *q_all;
+extern struct quantize *q_min;
+extern struct quantize *q_hour;
+extern struct quantize *q_all;
 /* sql query times */
-struct quantize *q_sql_min;
-struct quantize *q_sql_hour;
-struct quantize *q_sql_all;
+extern struct quantize *q_sql_min;
+extern struct quantize *q_sql_hour;
+extern struct quantize *q_sql_all;
 /* sql #steps */
-struct quantize *q_sql_steps_min;
-struct quantize *q_sql_steps_hour;
-struct quantize *q_sql_steps_all;
+extern struct quantize *q_sql_steps_min;
+extern struct quantize *q_sql_steps_hour;
+extern struct quantize *q_sql_steps_all;
 
 extern int gbl_stop_thds_time;
 extern int gbl_stop_thds_time_threshold;
@@ -3362,7 +3342,7 @@ int reload_after_bulkimport(dbtable *, tran_type *);
 int reload_db_tran(dbtable *, tran_type *);
 int debug_this_request(int until);
 
-int gbl_disable_stable_for_ipu;
+extern int gbl_disable_stable_for_ipu;
 
 extern int gbl_debug_memp_alloc_size;
 
@@ -3416,7 +3396,7 @@ int setup_net_listen_all(struct dbenv *dbenv);
 
 extern int gbl_no_env;
 
-int gbl_hostname_refresh_time;
+extern int gbl_hostname_refresh_time;
 
 extern int gbl_noenv_messages;
 
@@ -3434,8 +3414,8 @@ void stat4dump(int more, char *table, int istrace);
 int net_allow_node(struct netinfo_struct *netinfo_ptr, const char *host);
 
 extern int gbl_ctrace_dbdir;
-int gbl_private_blkseq;
-int gbl_use_blkseq;
+extern int gbl_private_blkseq;
+extern int gbl_use_blkseq;
 
 extern int gbl_sc_inco_chk;
 extern int gbl_track_queue_time;
@@ -3574,4 +3554,7 @@ void dump_client_sql_data(struct reqlogger *logger, int do_snapshot);
 
 int backout_schema_changes(struct ireq *iq, tran_type *tran);
 int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err);
+
+extern int gbl_abort_invalid_query_info_key;
+extern int gbl_is_physical_replicant;
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -687,6 +687,7 @@ typedef struct dbtable {
     /* Pointers to other table constraints that are directed at this table. */
     constraint_t *rev_constraints[MAXCONSTRAINTS];
     int n_rev_constraints;
+    pthread_mutex_t rev_constraints_lk;
 
     /* CHECK constraints */
     check_constraint_t check_constraints[MAXCONSTRAINTS];

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -60,6 +60,7 @@ static DB_Connection *curr_cnct = NULL;
 static volatile int do_repl;
 
 int gbl_deferred_phys_flag = 0;
+unsigned int gbl_deferred_phys_update;
 
 /* externs here */
 extern struct dbenv *thedb;

--- a/db/phys_rep.h
+++ b/db/phys_rep.h
@@ -3,8 +3,8 @@
 #include <stdlib.h>
 
 // extern variable defn
-int gbl_is_physical_replicant;
-unsigned int gbl_deferred_phys_update;
+extern int gbl_is_physical_replicant;
+extern unsigned int gbl_deferred_phys_update;
 extern int gbl_deferred_phys_flag;
 
 int add_replicant_host(char *hostname, char *dbname, size_t tier);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5574,8 +5574,6 @@ void sqlengine_thd_start(struct thdpool *pool, struct sqlthdstate *thd,
                 bdb_attr_get(thedb->bdb_attr, BDB_ATTR_RCACHE_PGSZ));
 }
 
-int gbl_abort_invalid_query_info_key;
-
 void sqlengine_thd_end(struct thdpool *pool, struct sqlthdstate *thd)
 {
     rcache_destroy();

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -1177,6 +1177,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
         if (!strcasecmp(rdb->tablename, newdb->tablename)) {
             rdb = newdb;
         }
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (int j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1193,6 +1194,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                 }
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
         for (int j = 0; j < newdb->n_constraints; j++) {
             for (int k = 0; k < newdb->constraints[j].nrules; k++) {
                 int ridx = 0;
@@ -1358,6 +1360,7 @@ int remove_constraint_pointers(struct dbtable *db)
     for (int i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
         int j = 0;
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1374,6 +1377,7 @@ int remove_constraint_pointers(struct dbtable *db)
                 }
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
     }
     return 0;
 }
@@ -1383,6 +1387,7 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
     for (int i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
         int j = 0;
+        Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
@@ -1390,6 +1395,7 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
                 strcpy(ct->lcltable->tablename, newname);
             }
         }
+        Pthread_mutex_unlock(&rdb->rev_constraints_lk);
     }
     return 0;
 }
@@ -1407,6 +1413,7 @@ void fix_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
         rdb = thedb->dbs[i];
         /* fix reverse references */
         if (rdb->n_rev_constraints > 0) {
+            Pthread_mutex_lock(&rdb->rev_constraints_lk);
             for (j = 0; j < rdb->n_rev_constraints; j++) {
                 ct = rdb->rev_constraints[j];
                 for (k = 0; k < MAXCONSTRAINTS; k++) {
@@ -1415,6 +1422,7 @@ void fix_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
                     }
                 }
             }
+            Pthread_mutex_unlock(&rdb->rev_constraints_lk);
         }
         /* fix forward references */
         if (rdb->n_constraints) {

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -7,37 +7,37 @@
 extern "C" {
 #endif /* __cplusplus */
 
-const sqlite3_module systblTablesModule;
-const sqlite3_module systblColumnsModule;
-const sqlite3_module systblKeysModule;
-const sqlite3_module systblFieldsModule;
-const sqlite3_module systblConstraintsModule;
-const sqlite3_module systblTblSizeModule;
-const sqlite3_module systblSPsModule;
-const sqlite3_module systblUsersModule;
-const sqlite3_module systblQueuesModule;
-const sqlite3_module systblTablePermissionsModule;
-const sqlite3_module systblTriggersModule;
-const sqlite3_module systblKeywordsModule;
-const sqlite3_module systblLimitsModule;
-const sqlite3_module systblTunablesModule;
-const sqlite3_module systblThreadPoolsModule;
-const sqlite3_module systblPluginsModule;
-const sqlite3_module systblAppsockHandlersModule;
-const sqlite3_module systblOpcodeHandlersModule;
-const sqlite3_module completionModule; // in ext/misc
-const sqlite3_module systblClientStatsModule;
-const sqlite3_module systblTimepartModule;
-const sqlite3_module systblTimepartShardsModule;
-const sqlite3_module systblTimepartEventsModule;
-const sqlite3_module systblCronSchedsModule;
-const sqlite3_module systblCronEventsModule;
-const sqlite3_module systblTransactionLogsModule;
-const sqlite3_module systblMetricsModule;
-const sqlite3_module systblTimeseriesModule;
-const sqlite3_module systblReplStatsModule;
-const sqlite3_module systblLogicalOpsModule;
-const sqlite3_module systblSystabsModule;
+extern const sqlite3_module systblTablesModule;
+extern const sqlite3_module systblColumnsModule;
+extern const sqlite3_module systblKeysModule;
+extern const sqlite3_module systblFieldsModule;
+extern const sqlite3_module systblConstraintsModule;
+extern const sqlite3_module systblTblSizeModule;
+extern const sqlite3_module systblSPsModule;
+extern const sqlite3_module systblUsersModule;
+extern const sqlite3_module systblQueuesModule;
+extern const sqlite3_module systblTablePermissionsModule;
+extern const sqlite3_module systblTriggersModule;
+extern const sqlite3_module systblKeywordsModule;
+extern const sqlite3_module systblLimitsModule;
+extern const sqlite3_module systblTunablesModule;
+extern const sqlite3_module systblThreadPoolsModule;
+extern const sqlite3_module systblPluginsModule;
+extern const sqlite3_module systblAppsockHandlersModule;
+extern const sqlite3_module systblOpcodeHandlersModule;
+extern const sqlite3_module completionModule; // in ext/misc
+extern const sqlite3_module systblClientStatsModule;
+extern const sqlite3_module systblTimepartModule;
+extern const sqlite3_module systblTimepartShardsModule;
+extern const sqlite3_module systblTimepartEventsModule;
+extern const sqlite3_module systblCronSchedsModule;
+extern const sqlite3_module systblCronEventsModule;
+extern const sqlite3_module systblTransactionLogsModule;
+extern const sqlite3_module systblMetricsModule;
+extern const sqlite3_module systblTimeseriesModule;
+extern const sqlite3_module systblReplStatsModule;
+extern const sqlite3_module systblLogicalOpsModule;
+extern const sqlite3_module systblSystabsModule;
 
 int systblTypeSamplesInit(sqlite3 *db);
 int systblRepNetQueueStatInit(sqlite3 *db);

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -159,6 +159,8 @@ cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int)"
 NUM=2000
 for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
 
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
+
 COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
 
 find $TESTDIR/var/log/cdb2/ | grep "/$DBNAME" | grep '.events.' > logfls.txt

--- a/tools/cdb2_printlog/cdb2_printlog.c
+++ b/tools/cdb2_printlog/cdb2_printlog.c
@@ -61,7 +61,7 @@ extern char printlog_endline;
 
 extern pthread_key_t comdb2_open_key;
 
-bdb_state_type *gbl_bdb_state;
+extern bdb_state_type *gbl_bdb_state;
 
 extern int comdb2ma_init(size_t init_sz, size_t max_cap);
 

--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -21,7 +21,7 @@
 
 #ifndef NDEBUG
 
-enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX } CHR_ENUM;
+enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX };
 
 /* NB: this construct is ment to encompass a function call like this:
  * ACCUMULATE_TIMING(CHR_FUNCTOMEASURE


### PR DESCRIPTION
Current cson does not stop at '\0' but prints as much
characters as passed to the function for a given string.
So instead of sizeof() we should use strlen().

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>