### PR TITLE
Change reorder tunables to be settable dynamically

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1650,12 +1650,12 @@ REGISTER_TUNABLE("random_fail_client_write_lock",
 
 REGISTER_TUNABLE("reorder_socksql_no_deadlock",
                  "Reorder sock sql to have no deadlocks ", TUNABLE_BOOLEAN,
-                 &gbl_reorder_socksql_no_deadlock, EXPERIMENTAL | INTERNAL,
+                 &gbl_reorder_socksql_no_deadlock, DYNAMIC | EXPERIMENTAL,
                  NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("reorder_idx_writes", "reorder_idx_writes (Default on)",
-                 TUNABLE_BOOLEAN, &gbl_reorder_idx_writes, DYNAMIC, NULL, NULL,
-                 NULL, NULL);
+                 TUNABLE_BOOLEAN, &gbl_reorder_idx_writes, DYNAMIC | EXPERIMENTAL,
+                 NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("osql_snap_info_hashcheck",
                  "Enable snapinfo to be stored and checked in a hash in "

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -701,6 +701,7 @@
 (name='release_locks_trace', description='Print trace if we release locks', type='BOOLEAN', value='OFF', read_only='N')
 (name='remove_commitdelay_on_coherent_cluster', description='Stop delaying commits when all the nodes in the cluster are coherent.', type='BOOLEAN', value='ON', read_only='N')
 (name='reorder_idx_writes', description='reorder_idx_writes (Default on)', type='BOOLEAN', value='ON', read_only='N')
+(name='reorder_socksql_no_deadlock', description='Reorder sock sql to have no deadlocks ', type='BOOLEAN', value='ON', read_only='N')
 (name='rep_db_pagesize', description='Page size for BerkeleyDB's replication cache db.', type='INTEGER', value='0', read_only='N')
 (name='rep_debug_delay', description='Set an artificial replication delay (used for debugging).', type='INTEGER', value='0', read_only='N')
 (name='rep_delay', description='rep_delay', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Change reorder tunables to be settable dynamically
since they were set only at start time.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>