### PR TITLE
Disable INDEXED BY and NOT INDEXED syntax for backward compatibility.

### DIFF
--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -986,8 +986,10 @@ on_opt(N) ::= .     [OR]   {N = 0;}
 //
 %type indexed_opt {Token}
 indexed_opt(A) ::= .                 {A.z=0; A.n=0;}
+%ifndef SQLITE_BUILDING_FOR_COMDB2
 indexed_opt(A) ::= INDEXED BY nm(X). {A = X;}
 indexed_opt(A) ::= NOT INDEXED.      {A.z=0; A.n=1;}
+%endif !SQLITE_BUILDING_FOR_COMDB2
 
 %type using_opt {IdList*}
 %destructor using_opt {sqlite3IdListDelete(pParse->db, $$);}

--- a/tests/yast.test/comdb2.test
+++ b/tests/yast.test/comdb2.test
@@ -1,0 +1,49 @@
+###############################################################################
+#
+#   Copyright 2020 Bloomberg Finance L.P.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+###############################################################################
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+set ::testprefix comdb2
+
+do_test comdb2-indexed-by-1.1 {
+  execsql {
+    CREATE TABLE t1(c0 INTEGER);
+    CREATE INDEX ii ON t1(c0);
+    INSERT INTO t1 VALUES(1);
+  }
+} {}
+
+do_test comdb2-indexed-by-1.2 {
+  execsql {
+    SELECT c0 FROM t1 WHERE c0 = 1;
+  }
+} {1}
+
+do_test comdb2-indexed-by-1.3 {
+  execsql {
+    SELECT c0 FROM t1 INDEXED BY ii WHERE c0 = 1;
+  }
+} {1 {near "INDEXED": syntax error}}
+
+do_test comdb2-indexed-by-1.4 {
+  execsql {
+    SELECT c0 FROM t1 NOT INDEXED WHERE c0 = 1;
+  }
+} {1 {near "NOT": syntax error}}
+
+finish_test


### PR DESCRIPTION
These changes disable the INDEXED BY and NOT INDEXED clauses in order to restore backward compatibility.

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>
