### PR TITLE
Send constraint errors to comdb2sc

### DIFF
--- a/db/constraints.c
+++ b/db/constraints.c
@@ -1976,12 +1976,20 @@ static void constraint_err(struct schema_change_type *s, struct dbtable *db,
                   "<\"%s\":\"%s\">: %s",
                   db->tablename, ct->lclkeyname, ct->table[rule],
                   ct->keynm[rule], err);
-    } else
+    } else { 
+        if (s && s->sb)
+          sc_errf(s,
+                  "Constraint error for table \"%s\" key \"%s\" -> "
+                  "<\"%s\":\"%s\">: %s\n",
+                  db->tablename, ct->lclkeyname, ct->table[rule],
+                  ct->keynm[rule], err);
+
         logmsg(LOGMSG_ERROR,
-               "constraint error for table \"%s\" key \"%s\" -> "
+               "Constraint error for table \"%s\" key \"%s\" -> "
                "<\"%s\":\"%s\">: %s\n",
                db->tablename, ct->lclkeyname, ct->table[rule], ct->keynm[rule],
                err);
+    }
 }
 
 static inline int key_has_expressions_members(struct schema *key)

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -565,6 +565,7 @@ int do_dryrun(struct schema_change_type *s)
     struct dbtable *newdb = NULL;
     struct scinfo scinfo = {0};
 
+    // not sure if useful to print: sc_printf(s, "starting dryrun\n");
     db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         if (s->alteronly) {


### PR DESCRIPTION
Currently constraint errors are not being reported by comdb2sc on alters (ex. when foreign table does not exist), and so this patch fixes that by sending the error back if s->sb is set.
Fix will make error look like this:
> ./comdb2sc.linux.tsk adidb alter t2 ~/b.csc2
Constraint error for table "t2" key "$KEY_A44A20B" -> <"nonexistent":"I1">: foreign table not found
Failed to process schema!
Schema change failed