### PR TITLE
cdb2api bug fixes: pmux, garbage config and the local tier

### DIFF
--- a/tests/dc.test/Makefile
+++ b/tests/dc.test/Makefile
@@ -1,0 +1,13 @@
+# cdb2api DIRECT CPU tests.
+# We need a database name (which is derived from the test name) short enough
+# so we can fit it in the sockpool type string.
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/dc.test/runit
+++ b/tests/dc.test/runit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+dbnm=$1
+
+# Get a host for DIRECT_CPU mode.
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+echo $host
+
+# Make sure sockpool is running.
+pgrep cdb2sockpool
+if [ $? -ne 0 ]; then
+    echo 'SOCKPOOL IS REQUIRED TO RUN THE TEST BUT IS NOT RUNNING.' >&2
+    echo 'TRYING TO BRING IT UP'
+    ${BUILDDIR}/tools/cdb2sockpool/cdb2sockpool
+    sleep 1
+    pgrep cdb2sockpool
+    if [ $? -ne 0 ]; then
+        echo 'FAILED BRINGING UP SOCKPOOL' >&2
+        exit 1
+    fi
+fi
+
+# Give sockpool a bit time to bootstrap.
+sleep 2
+
+echo 'closeall' >/tmp/msgtrap.sockpool
+
+# Make sure we don't read garbage config file.
+strace cdb2sql $dbnm --host $host 'SELECT 1' 2>&1 | grep 'null.*cfg'
+if [ $? -eq 0 ]; then
+    echo 'SHOULD NOT READ GARBAGE CONFIG FILE.' >&2
+    exit 1
+fi
+
+# Make sure we don't query pmux if using a cached connection.
+strace cdb2sql $dbnm --host $host 'SELECT 1' 2>&1 | grep '\<5105\>'
+if [ $? -eq 0 ]; then
+    echo 'SHOULD NOT QUERY PMUX IF USING A CACHED CONNECTION.' >&2
+    echo "IS THE SOCKPOOL TYPESTR comdb2/$dbnm/$host/cdb2sql/dc TOO LONG?" >&2
+    exit 1
+fi

--- a/tests/tools/cdb2api_unit.c
+++ b/tests/tools/cdb2api_unit.c
@@ -260,7 +260,8 @@ void test_get_config_file()
 
     char filename[PATH_MAX];
     rc = get_config_file(NULL, filename, sizeof(filename));
-    assert(rc == 0);
+    /* NULL dbname is no longer permitted. */
+    assert(rc == -1);
 
     setenv("COMDB2_ROOT", "myroot", 1);
     rc = get_config_file("mydb", filename, sizeof(filename));


### PR DESCRIPTION
The change fixes 3 bugs in cdb2api.

1. Unnecessary pmux lookup in DIRECT-CPU mode
In DIRECT-CPU mode the API always looks up the database port. This costs an unnecessary round trip to pmux when there is already a cached connection in the sockpool. We should do so only when the API needs to make a connection on its own.

2. Garbage configuration file
The API attempts to process "(null).cfg". This is caused by passing a NULL database name to snprintf when formatting the database configuration file path.

3. The "local" tier does not mean localhost
The API performs dbinfo query and pulls all nodes in the cluster regardless of tier. However dbinfo should be skipped when "local" is specified as tier.