### PR TITLE
Return head and tail ages for queues, limit scans

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -951,7 +951,8 @@ enum {
 };
 
 typedef int (*bdb_queue_stats_callback_t)(int consumern, size_t item_length,
-                                          unsigned int epoch,
+                                          unsigned int newest_epoch,
+                                          unsigned int oldest_epoch,
                                           unsigned int depth, void *userptr);
 
 int bdb_queuedb_stats(bdb_state_type *bdb_state,
@@ -962,8 +963,9 @@ typedef int (*bdb_queue_walk_callback_t)(int consumern, size_t item_length,
                                          unsigned int epoch, void *userptr);
 
 int bdb_queue_walk(bdb_state_type *bdb_state, int flags, bbuint32_t *lastitem,
-                   bdb_queue_walk_callback_t callback, tran_type *tran,
+                   bdb_queue_walk_callback_t callback, tran_type *tran, int limit,
                    void *userptr, int *bdberr);
+int bdb_queue_oldest_epoch(bdb_state_type *bdb_state, tran_type *tran, time_t *epoch, int *bdberr);
 
 /* debug aid - dump the entire queue */
 int bdb_queue_dump(bdb_state_type *bdb_state, FILE *out, int *bdberr);

--- a/bdb/bdb_queuedb.h
+++ b/bdb/bdb_queuedb.h
@@ -32,7 +32,7 @@ int bdb_queuedb_consume_goose(bdb_state_type *bdb_state, tran_type *tran,
 
 int bdb_queuedb_walk(bdb_state_type *bdb_state, int flags, void *lastitem,
                      bdb_queue_walk_callback_t callback, tran_type *tran,
-                     void *userptr, int *bdberr);
+                     int limit, void *userptr, int *bdberr);
 
 int bdb_queuedb_dump(bdb_state_type *bdb_state, FILE *out, int *bdberr);
 
@@ -56,5 +56,7 @@ int bdb_trigger_close(bdb_state_type *);
 int bdb_trigger_ispaused(bdb_state_type *);
 int bdb_trigger_pause(bdb_state_type *);
 int bdb_trigger_unpause(bdb_state_type *);
+
+int bdb_queuedb_oldest_epoch(bdb_state_type *bdb_state, tran_type *tran, time_t *epoch, int *bdberr);
 
 #endif

--- a/bdb/queue.c
+++ b/bdb/queue.c
@@ -1087,7 +1087,7 @@ static int bdb_queue_walk_int(bdb_state_type *bdb_state, int flags,
 }
 
 int bdb_queue_walk(bdb_state_type *bdb_state, int flags, bbuint32_t *lastitem,
-                   bdb_queue_walk_callback_t callback, tran_type *tran,
+                   bdb_queue_walk_callback_t callback, tran_type *tran, int limit,
                    void *userptr, int *bdberr)
 {
     int rc;
@@ -1097,7 +1097,7 @@ int bdb_queue_walk(bdb_state_type *bdb_state, int flags, bbuint32_t *lastitem,
      * worth of state,
      * caller needs to call it correctly. */
     if (bdb_state->bdbtype == BDBTYPE_QUEUEDB) {
-        rc = bdb_queuedb_walk(bdb_state, flags, lastitem, callback, tran,
+        rc = bdb_queuedb_walk(bdb_state, flags, lastitem, callback, tran, limit,
                               userptr, bdberr);
     } else {
         /* TODO: The "tran" parameter is not passed here.  Maybe it should be? */
@@ -2138,4 +2138,12 @@ const struct bdb_queue_stats *bdb_queue_get_stats(bdb_state_type *bdb_state)
         return bdb_queuedb_get_stats(bdb_state);
 
     return &bdb_state->qpriv->stats;
+}
+
+int bdb_queue_oldest_epoch(bdb_state_type *bdb_state, tran_type *tran, time_t *epoch, int *bdberr) {
+    if (bdb_state->bdbtype != BDBTYPE_QUEUEDB) {
+        *bdberr = BDBERR_BADARGS;
+        return -1;
+    }
+    return bdb_queuedb_oldest_epoch(bdb_state, tran, epoch, bdberr);
 }

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -809,6 +809,8 @@ int reload_lua_sfuncs();
 int reload_lua_afuncs();
 void oldfile_clear(void);
 
+int gbl_queue_walk_limit = 10000;
+
 inline int getkeyrecnums(const dbtable *tbl, int ixnum)
 {
     if (ixnum < 0 || ixnum >= tbl->nix)

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2524,11 +2524,14 @@ unsigned long long dbq_item_genid(const struct bdb_queue_found *dta);
 typedef int (*dbq_walk_callback_t)(int consumern, size_t item_length,
                                    unsigned int epoch, void *userptr);
 typedef int (*dbq_stats_callback_t)(int consumern, size_t item_length,
-                                    unsigned int epoch, unsigned int depth,
+                                    unsigned int newest_epoch, 
+                                    unsigned int oldest_epoch, 
+                                    unsigned int depth,
                                     void *userptr);
 
-int dbq_walk(struct ireq *iq, int flags, dbq_walk_callback_t callback,
+int dbq_walk(struct ireq *iq, int flags, dbq_walk_callback_t callback, int limit, 
              tran_type *tran, void *userptr);
+int dbq_oldest_epoch(struct ireq *iq, tran_type *tran, time_t *epoch);
 int dbq_odh_stats(struct ireq *iq, dbq_stats_callback_t callback,
                   tran_type *tran, void *userptr);
 int dbq_dump(struct dbtable *db, FILE *out);
@@ -3589,4 +3592,6 @@ void destroy_password_cache();
 
 extern int gbl_rcache;
 
+
+extern int gbl_queue_walk_limit;
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2076,6 +2076,12 @@ REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid 
 REGISTER_TUNABLE("debug_sleep_in_sql_tick", "Sleep for a second in sql tick.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_in_sql_tick, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("queue_walk_limit",
+                 "When walking queues for metrics, stop after this many elements.  "
+                 "(Default: 10000)",
+                 TUNABLE_INTEGER, &gbl_queue_walk_limit, EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
+
 REGISTER_TUNABLE("debug_consumer_lock",
                  "Enable debug-trace for consumer lock.  "
                  "(Default: off)",
@@ -2116,5 +2122,6 @@ REGISTER_TUNABLE("sc_logbytes_per_second",
 REGISTER_TUNABLE("net_somaxconn",
                  "listen() backlog setting.  (Default: 0, implies system default)",
                  TUNABLE_INTEGER, &gbl_net_maxconn, READONLY, NULL, NULL, NULL, NULL);
+
 
 #endif /* _DB_TUNABLES_H */

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -14,7 +14,8 @@ struct consumer_base {
 struct consumer_stat {
     int has_stuff;
     size_t first_item_length;
-    time_t epoch;
+    time_t newest_epoch;
+    time_t oldest_epoch;
     int depth;
 };
 

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -513,20 +513,20 @@ static void admin(struct dbenv *dbenv, int type)
     Pthread_mutex_unlock(&dbqueuedb_admin_lk);
 }
 
-static int stat_odh_callback(int consumern, size_t length, unsigned int epoch,
-                             unsigned int depth, void *userptr)
+static int stat_odh_callback(int consumern, size_t length, unsigned int newest_epoch,
+        unsigned int oldest_epoch, unsigned int depth, void *userptr)
 {
     struct consumer_stat *stats = userptr;
 
     if (consumern < 0 || consumern >= MAXCONSUMERS) {
         logmsg(LOGMSG_USER, "%s: consumern=%d length=%u epoch=%u\n", __func__,
-               consumern, (unsigned)length, epoch);
+               consumern, (unsigned)length, newest_epoch);
     } else {
         assert(!stats[consumern].has_stuff);
         stats[consumern].has_stuff = 1;
         stats[consumern].first_item_length = length;
-        stats[consumern].epoch = epoch;
-        stats[consumern].has_stuff = 1;
+        stats[consumern].newest_epoch = newest_epoch;
+        stats[consumern].oldest_epoch = oldest_epoch;
         stats[consumern].depth = depth;
     }
     return BDB_QUEUE_WALK_CONTINUE;
@@ -543,7 +543,7 @@ static int stat_callback(int consumern, size_t length,
     } else {
         if (!stats[consumern].has_stuff) {
             stats[consumern].first_item_length = length;
-            stats[consumern].epoch = epoch;
+            stats[consumern].newest_epoch = epoch;
         }
         stats[consumern].has_stuff = 1;
         stats[consumern].depth++;
@@ -613,9 +613,9 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
 
             if (stats[ii].has_stuff) {
                 unsigned int now = comdb2_time_epoch();
-                unsigned int age = now - stats[ii].epoch;
+                unsigned int age = now - stats[ii].newest_epoch;
                 struct tm ctime;
-                time_t cepoch = (time_t)stats[ii].epoch;
+                time_t cepoch = (time_t)stats[ii].newest_epoch;
                 char buf[32]; /* must be at least 26 chars */
                 unsigned int hr, mn, sc;
 
@@ -630,7 +630,7 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
                     LOGMSG_USER,
                     "    head item length %u age %u:%02u:%02u created %ld %s",
                     (unsigned)stats[ii].first_item_length, hr, mn, sc,
-                    stats[ii].epoch, buf);
+                    stats[ii].newest_epoch, buf);
             } else if (consumer)
                 logmsg(LOGMSG_USER, "    empty\n");
         }
@@ -929,8 +929,12 @@ static int get_stats(struct dbtable *db, int flags, void *tran,
     if (db->odh) {
         rc = dbq_odh_stats(&iq, stat_odh_callback, (tran_type *)tran, st);
     } else {
-        rc = dbq_walk(&iq, flags, stat_callback, (tran_type *)tran, st);
+        rc = dbq_walk(&iq, flags, stat_callback, gbl_queue_walk_limit, (tran_type *)tran, st);
     }
+    time_t epoch;
+    rc = dbq_oldest_epoch(&iq, (tran_type*)tran, &epoch);
+    if (rc == 0)
+        st->oldest_epoch = epoch;
     if (made_tran) {
         bdberr = 0;
         int rc2 = bdb_tran_abort(db->handle, tran, &bdberr);
@@ -956,7 +960,7 @@ comdb2_queue_consumer_t dbqueuedb_plugin_lua = {
     .wake_all_consumers_all_queues = wake_all_consumers_all_queues,
     .handles_method = handles_method,
     .get_name = get_name,
-    .get_stats = get_stats
+    .get_stats = get_stats,
 };
 
 comdb2_queue_consumer_t dbqueuedb_plugin_dynlua = {
@@ -972,7 +976,7 @@ comdb2_queue_consumer_t dbqueuedb_plugin_dynlua = {
     .wake_all_consumers_all_queues = wake_all_consumers_all_queues,
     .handles_method = handles_method,
     .get_name = get_name,
-    .get_stats = get_stats
+    .get_stats = get_stats,
 };
 
 

--- a/tests/trigger.test/lrl.options
+++ b/tests/trigger.test/lrl.options
@@ -1,0 +1,3 @@
+init_with_queue_ondisk_header off
+init_with_queue_compr off
+init_with_queue_persistent_sequence off

--- a/tests/trigger.test/runit
+++ b/tests/trigger.test/runit
@@ -3,4 +3,40 @@ bash -n "$0" | exit 1
 
 ${TESTSROOTDIR}/tools/compare_results.sh -s -d $1 -r req
 [ $? -eq 0 ] || exit 1
+
+dbname=$1
+default=default
+
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create procedure test {
+local function main()
+    return 1
+end
+}"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create table qlentest(a int)"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create lua trigger test on (table qlentest for insert)"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "insert into qlentest values(1)"
+sleep 5
+cdb2sql ${CDB2_OPTIONS} $dbname $default "insert into qlentest select value from generate_series(1, 11999)"
+
+count=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "select depth from comdb2_queues where queuename='__qtest'")
+agediff=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "select head_age - tail_age from comdb2_queues where queuename='__qtest'")
+
+if [[ $count -ne 10000 ]]; then
+    echo "Expected count of 10000 got $count"
+    exit 1
+fi
+
+if [[ $agediff -lt 5 ]]; then
+    echo "Expected agediff of at least 5 got $agediff"
+    exit 1
+fi
+
+host=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "select host from comdb2_cluster where is_master='Y'")
+cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "put tunable queue_walk_limit 0"
+count=$(cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "select depth from comdb2_queues where queuename='__qtest'")
+if [[ $count -ne 12000 ]]; then
+    echo "Expected count of 12000 got $count"
+    exit 1
+fi
+
 exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -672,6 +672,7 @@
 (name='private_blkseq_maxtraverse', description='', type='INTEGER', value='4', read_only='N')
 (name='private_blkseq_stripes', description='Number of stripes for the blkseq table.', type='INTEGER', value='8', read_only='N')
 (name='qscanmode', description='Enables queue scan mode optimisation.', type='BOOLEAN', value='OFF', read_only='N')
+(name='queue_walk_limit', description='When walking queues for metrics, stop after this many elements.  (Default: 10000)', type='INTEGER', value='10000', read_only='N')
 (name='queuedb_file_interval', description='Check on this interval each queuedb against its configured maximum file size. (Default: 60000ms)', type='INTEGER', value='60000', read_only='Y')
 (name='queuedb_file_threshold', description='Maximum queuedb file size (in MB) before enqueueing to the alternate file.  (Default: 0)', type='INTEGER', value='0', read_only='Y')
 (name='queuedb_genid_filename', description='Use genid in queuedb filenames.  (Default: on)', type='BOOLEAN', value='ON', read_only='Y')


### PR DESCRIPTION
Cap the scan depth for comdb2_queues.  Stop after a configurable number of records, and report that as the queue depth.  Prevents long running scans when there are very deep queues.  Also reports the ages of the newest and oldest item on the queue.  For queues that have odh we still report the full queue depth, since that's available without a scan.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>
