### PR TITLE
Address deadlocks for tests running in standalone mode

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -291,6 +291,7 @@ struct tran_tag {
     DB_TXN *tid;
     u_int32_t logical_lid;
     u_int32_t original_lid;
+    int is_curtran;
 
     void *usrptr;
     DB_LSN savelsn;

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2179,6 +2179,12 @@ __lock_get_internal_int(lt, locker, in_locker, flags, obj, lock_mode, timeout,
 	}
 	lpartition = sh_locker->partition;
 
+    extern __thread int track_thread_locks;
+    if (track_thread_locks) {
+        extern void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+        comdb2_cheapstack_sym(stderr, "lockid %u", locker);
+    }
+
 #ifdef DEBUG_LOCKS
 	DB_LOCKER *mlockerp = R_ADDR(&lt->reginfo, sh_locker->master_locker);
 	logmsg(LOGMSG_ERROR, "%p Get (%c) locker lock %x (m %x)\n",

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -338,6 +338,7 @@ extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int eventlog_nkeep;
 extern int gbl_debug_systable_locks;
 extern int gbl_assert_systable_locks;
+extern int gbl_track_curtran_gettran_locks;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1999,4 +1999,7 @@ REGISTER_TUNABLE("assert_systable_locks",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_assert_systable_locks, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("track_curtran_gettran_locks", "Stack-trace curtran_gettran threads at lock-get.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_track_curtran_gettran_locks, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Berkley will leave locks on a B-tree after a cursor is closed if there is a transaction associated with the cursor.  This is true even for curtran readonly transactions.  We can get around this by creating a cursor using a NULL transaction, and then replacing the lockid in that cursor with the c_replace_lockid function (as there is no berkley transaction, the close-cursor function discards it's pagelocks).  This PR modifies the Berkley access routines in bdb/lite.c such that curtran_gettran transactions (used only from an SQL thread) will not leave pages locked when the cursor is closed.