### PR TITLE
Small cleanup in dyns_get_table_field_option function

### DIFF
--- a/csc2/macc.h
+++ b/csc2/macc.h
@@ -104,8 +104,7 @@ struct check_constraint {
 struct symbol {
     char *nm;   /* symbol name                     */
     int dim[6]; /* # of elements in each dimension */
-    char *
-        dim_cnst[6]; /* if we have any constants in the symbol specs, store it*/
+    char *dim_cnst[6]; /* if we have any constants in the symbol specs, store it */
     int arr;         /* if this is an array, is it C or Fortran */
     int size;        /* base size of variable           */
     int szof;        /* size of whole varaible/array    */

--- a/csc2/macclex.l
+++ b/csc2/macclex.l
@@ -291,7 +291,7 @@ sqlhexstr x{space}*"'"{space}*([a-fA-F0-9])*{space}*"'"
 <CONSTRAINTS>on                 { return T_CON_ON; }
 <CONSTRAINTS>update             { return T_CON_UPDATE; }
 <CONSTRAINTS>delete             { return T_CON_DELETE; }
-<CONSTRAINTS>[\-:]              { return yytext[0];;  }
+<CONSTRAINTS>[\-:]              { return yytext[0];  }
 <CONSTRAINTS>{varname}          { yylval.varname=yytext; return T_VARNAME; }
 <CONSTRAINTS>=                  { return T_EQ; }
 <INITIAL,RECTYPE,CONSTRAINTS>[\{]                   { rectplvl++; return yytext[0]; }


### PR DESCRIPTION
In this cleanup:
- Refactor function to be more readable
- Use pointer instead of repeat structure-member-dereferencing train
- Reuse length of string instead of recomputing it

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
