### PR TITLE
Limit queue scans, backport to 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,8 @@ contrib/docker/volumes
 # editor files
 *.swp
 /tags
+.idea
+cmake-build-*
 
 #cscope files
 cscope.*

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -907,19 +907,22 @@ enum {
 };
 
 typedef int (*bdb_queue_stats_callback_t)(int consumern, size_t item_length,
-                                          unsigned int epoch,
+                                          unsigned int newest_epoch,
+                                          unsigned int oldest_epoch,
                                           unsigned int depth, void *userptr);
 
 int bdb_queuedb_stats(bdb_state_type *bdb_state,
-                      bdb_queue_stats_callback_t callback, void *userptr,
+                      bdb_queue_stats_callback_t callback, tran_type *tran, void *userptr,
                       int *bdberr);
 
 typedef int (*bdb_queue_walk_callback_t)(int consumern, size_t item_length,
                                          unsigned int epoch, void *userptr);
 
 int bdb_queue_walk(bdb_state_type *bdb_state, int flags, bbuint32_t *lastitem,
-                   bdb_queue_walk_callback_t callback, void *userptr,
-                   int *bdberr);
+                   bdb_queue_walk_callback_t callback, tran_type *tran, int limit,
+                   void *userptr, int *bdberr);
+
+int bdb_queue_oldest_epoch(bdb_state_type *bdb_state, tran_type *tran, time_t *epoch, int *bdberr);
 
 /* debug aid - dump the entire queue */
 int bdb_queue_dump(bdb_state_type *bdb_state, FILE *out, int *bdberr);

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -290,6 +290,7 @@ struct tran_tag {
     tranclass_type tranclass;
     DB_TXN *tid;
     u_int32_t logical_lid;
+    u_int32_t original_lid;
 
     void *usrptr;
     DB_LSN savelsn;

--- a/bdb/bdb_queuedb.h
+++ b/bdb/bdb_queuedb.h
@@ -27,8 +27,8 @@ int bdb_queuedb_consume_goose(bdb_state_type *bdb_state, tran_type *tran,
                               int *bdberr);
 
 int bdb_queuedb_walk(bdb_state_type *bdb_state, int flags, void *lastitem,
-                     bdb_queue_walk_callback_t callback, void *userptr,
-                     int *bdberr);
+                     bdb_queue_walk_callback_t callback, tran_type *tran,
+                     int limit, void *userptr, int *bdberr);
 
 int bdb_queuedb_dump(bdb_state_type *bdb_state, FILE *out, int *bdberr);
 
@@ -48,5 +48,7 @@ int bdb_trigger_subscribe(bdb_state_type *, pthread_cond_t **,
 int bdb_trigger_unsubscribe(bdb_state_type *);
 int bdb_trigger_open(bdb_state_type *);
 int bdb_trigger_close(bdb_state_type *);
+
+int bdb_queuedb_oldest_epoch(bdb_state_type *bdb_state, tran_type *tran, time_t *epoch, int *bdberr);
 
 #endif

--- a/bdb/locks.c
+++ b/bdb/locks.c
@@ -685,6 +685,12 @@ int bdb_lock_table_read_fromlid(bdb_state_type *bdb_state, int lid)
                               BDB_LOCK_READ);
 }
 
+int bdb_lock_table_read_by_name_fromlid(bdb_state_type *bdb_state, char *name, int lid)
+{
+    return bdb_lock_table_int(bdb_state->dbenv, name, lid,
+                              BDB_LOCK_READ);
+}
+
 int bdb_lock_table_read(bdb_state_type *bdb_state, tran_type *tran)
 {
     int rc;

--- a/bdb/locks.h
+++ b/bdb/locks.h
@@ -90,6 +90,7 @@ void bdb_checklock(bdb_state_type *bdb_state);
 int bdb_lock_table_read(bdb_state_type *, tran_type *);
 
 int bdb_lock_table_read_fromlid(bdb_state_type *, int lid);
+int bdb_lock_table_read_by_name_fromlid(bdb_state_type *bdb_state, char *name, int lid);
 int berkdb_lock_random_rowlock(bdb_state_type *bdb_state, int lid, int flags,
                                void *lkname, int mode, void *lk);
 int berkdb_lock_rowlock(bdb_state_type *bdb_state, int lid, int flags,

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -783,6 +783,8 @@ void register_plugin_tunables(void);
 int install_static_plugins(void);
 int run_init_plugins(int phase);
 
+int gbl_queue_walk_limit = 10000;
+
 inline int getkeyrecnums(const dbtable *tbl, int ixnum)
 {
     if (ixnum < 0 || ixnum >= tbl->nix)
@@ -1199,7 +1201,7 @@ static void *purge_old_blkseq_thread(void *arg)
 
         /* queue consumer thread admin */
         thrman_where(thr_self, "dbqueue_admin");
-        dbqueuedb_admin(dbenv);
+        dbqueuedb_admin(dbenv, NULL);
         thrman_where(thr_self, NULL);
 
         /* purge old blobs.  i didn't want to make a whole new thread just

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2497,12 +2497,16 @@ unsigned long long dbq_item_genid(const void *dta);
 typedef int (*dbq_walk_callback_t)(int consumern, size_t item_length,
                                    unsigned int epoch, void *userptr);
 typedef int (*dbq_stats_callback_t)(int consumern, size_t item_length,
-                                    unsigned int epoch, unsigned int depth,
+                                    unsigned int newest_epoch, 
+                                    unsigned int oldest_epoch, 
+                                    unsigned int depth,
                                     void *userptr);
 
-int dbq_walk(struct ireq *iq, int flags, dbq_walk_callback_t callback,
-             void *userptr);
-int dbq_odh_stats(struct ireq *iq, dbq_stats_callback_t callback,
+
+int dbq_walk(struct ireq *iq, int flags, dbq_walk_callback_t callback, int limit, 
+             tran_type *tran, void *userptr);
+int dbq_oldest_epoch(struct ireq *iq, tran_type *tran, time_t *epoch);
+int dbq_odh_stats(struct ireq *iq, dbq_stats_callback_t callback, tran_type *tran,
                   void *userptr);
 int dbq_dump(struct dbtable *db, FILE *out);
 int fix_consumers_with_bdblib(struct dbenv *dbenv);
@@ -2615,7 +2619,7 @@ void diagnostics_dump_dta(struct dbtable *db, int dtanum);
 
 /* queue stuff */
 void dbqueuedb_coalesce(struct dbenv *dbenv);
-void dbqueuedb_admin(struct dbenv *dbenv);
+void dbqueuedb_admin(struct dbenv *dbenv, tran_type *tran);
 int dbqueuedb_add_consumer(struct dbtable *db, int consumer, const char *method,
                          int noremove);
 int consumer_change(const char *queuename, int consumern, const char *method);
@@ -2625,7 +2629,7 @@ int dbqueuedb_stop_consumers(struct dbtable *db);
 int dbqueuedb_restart_consumers(struct dbtable *db);
 int dbqueuedb_check_consumer(const char *method);
 int dbqueuedb_get_name(struct dbtable *db, char **spname);
-int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats);
+int dbqueuedb_get_stats(struct dbtable *db, tran_type *tran, struct consumer_stat *stats);
 
 /* Resource manager */
 void initresourceman(const char *newlrlname);
@@ -3646,4 +3650,6 @@ extern int gbl_pbkdf2_iterations;
 extern int gbl_bpfunc_auth_gen;
 
 void dump_client_sql_data(struct reqlogger *logger, int do_snapshot);
+
+extern int gbl_queue_walk_limit;
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1856,4 +1856,9 @@ REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid 
 REGISTER_TUNABLE("debug_sleep_in_sql_tick", "Sleep for a second in sql tick.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_in_sql_tick, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("queue_walk_limit",
+                 "When walking queues for metrics, stop after this many elements.  "
+                 "(Default: 10000)",
+                 TUNABLE_INTEGER, &gbl_queue_walk_limit, EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -23,12 +23,12 @@ int dbqueuedb_add_consumer(struct dbtable *db, int consumern, const char *method
 }
 
 /* This gets called for all plugins, not just the first */
-void dbqueuedb_admin(struct dbenv *dbenv) {
+void dbqueuedb_admin(struct dbenv *dbenv, tran_type *tran) {
     comdb2_queue_consumer_t *handler; 
     for (int i = 0; i < CONSUMER_TYPE_LAST; i++) {
         handler = thedb->queue_consumer_handlers[i];
         if (handler)
-            handler->admin(dbenv, i);
+            handler->admin(dbenv, tran, i);
     }
 }
 
@@ -130,14 +130,14 @@ int dbqueuedb_get_name(struct dbtable *db, char **spname) {
     return -1;
 }
 
-static int dbqueuedb_get_stats_int(struct dbtable *db,
+static int dbqueuedb_get_stats_int(struct dbtable *db, tran_type *tran,
                                    struct consumer_stat *stats)
 {
     comdb2_queue_consumer_t *handler;
     for (int i = 0; i < CONSUMER_TYPE_LAST; i++) {
         handler = thedb->queue_consumer_handlers[i];
         if (handler) {
-            int rc = handler->get_stats(db, stats);
+            int rc = handler->get_stats(db, tran, stats);
             if (rc == 0)
                 return 0;
         }
@@ -145,7 +145,7 @@ static int dbqueuedb_get_stats_int(struct dbtable *db,
     return -1;
 }
 
-int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats)
+int dbqueuedb_get_stats(struct dbtable *db, tran_type *tran, struct consumer_stat *stats)
 {
     int rc;
     int bdberr;
@@ -157,7 +157,7 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats)
         return -1;
     }
     if ((rc = bdb_lock_table_read(bdb_state, trans)) == 0) {
-        rc = dbqueuedb_get_stats_int(db, stats);
+        rc = dbqueuedb_get_stats_int(db, tran, stats);
     } else {
         logmsg(LOGMSG_ERROR, "%s bdb_lock_table_read:%s rc:%d\n", __func__,
                db->tablename, rc);

--- a/db/sql.h
+++ b/db/sql.h
@@ -1313,4 +1313,8 @@ struct query_count {
 void add_fingerprint_to_rawstats(struct rawnodestats *stats,
                                  unsigned char *fingerprint, int cost, int rows,
                                  int timems);
+
+tran_type *curtran_gettran(void);
+void curtran_puttran(tran_type *tran);
+
 #endif /* _SQL_H_ */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6587,3 +6587,4 @@ int64_t comdb2_last_stmt_cost(void) {
 
    return thd->clnt ? thd->clnt->last_cost : -1;
 }
+

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -2,6 +2,7 @@
 #define TRIGGER_H
 
 #include "genid.h"
+#include "bdb_api.h"
 
 struct dbtable;
 struct dbenv;
@@ -14,14 +15,15 @@ struct consumer_base {
 struct consumer_stat {
     int has_stuff;
     size_t first_item_length;
-    time_t epoch;
+    time_t newest_epoch;
+    time_t oldest_epoch;
     int depth;
 };
 
 struct comdb2_queue_consumer {
     int type;
     int (*add_consumer)(struct dbtable *db, int consumern, const char *method, int noremove);
-    void (*admin)(struct dbenv *dbenv, int type);
+    void (*admin)(struct dbenv *dbenv, tran_type *tran, int type);
     int (*check_consumer)(const char *method);
     enum consumer_t (*consumer_type)(struct consumer *c);
     void (*coalesce)(struct dbenv *dbenv);
@@ -31,7 +33,7 @@ struct comdb2_queue_consumer {
     int (*wake_all_consumers_all_queues)(struct dbenv *dbenv, int force);
     int (*handles_method)(const char *method);
     int (*get_name)(struct dbtable *db, char **spname);
-    int (*get_stats)(struct dbtable *db, struct consumer_stat *stat);
+    int (*get_stats)(struct dbtable *db, tran_type *tran, struct consumer_stat *stat);
 };
 typedef struct comdb2_queue_consumer comdb2_queue_consumer_t;
 

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -445,7 +445,7 @@ static int dbqueuedb_admin_running = 0;
 /* This gets called once a second from purge_old_blkseq_thread().
  * If we have become master we make sure that we have threads in place
  * for each consumer. */
-static void admin(struct dbenv *dbenv, int type)
+static void admin(struct dbenv *dbenv, tran_type *tran, int type)
 {
     int iammaster = (dbenv->master == gbl_mynode) ? 1 : 0;
 
@@ -503,20 +503,20 @@ static void admin(struct dbenv *dbenv, int type)
     Pthread_mutex_unlock(&dbqueuedb_admin_lk);
 }
 
-static int stat_odh_callback(int consumern, size_t length, unsigned int epoch,
-                             unsigned int depth, void *userptr)
+static int stat_odh_callback(int consumern, size_t length, unsigned int newest_epoch,
+        unsigned int oldest_epoch, unsigned int depth, void *userptr)
 {
     struct consumer_stat *stats = userptr;
 
     if (consumern < 0 || consumern >= MAXCONSUMERS) {
         logmsg(LOGMSG_USER, "%s: consumern=%d length=%u epoch=%u\n", __func__,
-               consumern, (unsigned)length, epoch);
+               consumern, (unsigned)length, newest_epoch);
     } else {
         assert(!stats[consumern].has_stuff);
         stats[consumern].has_stuff = 1;
         stats[consumern].first_item_length = length;
-        stats[consumern].epoch = epoch;
-        stats[consumern].has_stuff = 1;
+        stats[consumern].newest_epoch = newest_epoch;
+        stats[consumern].oldest_epoch = oldest_epoch;
         stats[consumern].depth = depth;
     }
     return BDB_QUEUE_WALK_CONTINUE;
@@ -533,7 +533,7 @@ static int stat_callback(int consumern, size_t length,
     } else {
         if (!stats[consumern].has_stuff) {
             stats[consumern].first_item_length = length;
-            stats[consumern].epoch = epoch;
+            stats[consumern].newest_epoch = epoch;
         }
         stats[consumern].has_stuff = 1;
         stats[consumern].depth++;
@@ -565,9 +565,9 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
         if (fullstat)
             flags |= BDB_QUEUE_WALK_KNOWN_CONSUMERS_ONLY;
         if (db->odh)
-            dbq_odh_stats(&iq, stat_odh_callback, stats);
+            dbq_odh_stats(&iq, stat_odh_callback, NULL, stats);
         else
-            dbq_walk(&iq, flags, stat_callback, stats);
+            dbq_walk(&iq, flags, stat_callback, 0, NULL, stats);
 
         logmsg(LOGMSG_USER, "queue '%s':-\n", db->tablename);
         logmsg(LOGMSG_USER, "  geese added     %u\n", db->num_goose_adds);
@@ -607,9 +607,9 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
 
             if (stats[ii].has_stuff) {
                 unsigned int now = comdb2_time_epoch();
-                unsigned int age = now - stats[ii].epoch;
+                unsigned int age = now - stats[ii].newest_epoch;
                 struct tm ctime;
-                time_t cepoch = (time_t)stats[ii].epoch;
+                time_t cepoch = (time_t)stats[ii].newest_epoch;
                 char buf[32]; /* must be at least 26 chars */
                 unsigned int hr, mn, sc;
 
@@ -624,7 +624,7 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
                     LOGMSG_USER,
                     "    head item length %u age %u:%02u:%02u created %ld %s",
                     (unsigned)stats[ii].first_item_length, hr, mn, sc,
-                    stats[ii].epoch, buf);
+                    stats[ii].newest_epoch, buf);
             } else if (consumer)
                 logmsg(LOGMSG_USER, "    empty\n");
         }
@@ -901,17 +901,42 @@ static int get_name(struct dbtable *db, char **spname) {
     return 0;
 }
 
-static int get_stats(struct dbtable *db, struct consumer_stat *st) {
+static int get_stats(struct dbtable *db, tran_type *tran, struct consumer_stat *st) {
     struct ireq iq;
     int rc;
     if (db->dbtype != DBTYPE_QUEUEDB)
         return -1;
+    int made_tran = 0;
+    int bdberr;
+    if (tran == NULL) {
+        bdberr = 0;
+        tran = bdb_tran_begin(db->handle, NULL, &bdberr);
+        if (tran == NULL) {
+            logmsg(LOGMSG_ERROR, "%s:%d failed to begin transaction (%d)\n",
+                   __FILE__, __LINE__, bdberr);
+            return -1;
+        }
+        made_tran = 1;
+    }
     init_fake_ireq(db->dbenv, &iq);
     iq.usedb = db;
     if (db->odh) {
-        rc = dbq_odh_stats(&iq, stat_odh_callback, st);
+        rc = dbq_odh_stats(&iq, stat_odh_callback, (tran_type *)tran, st);
     } else {
-        rc = dbq_walk(&iq, 0, stat_callback, st);
+        rc = dbq_walk(&iq, 0, stat_callback, gbl_queue_walk_limit, (tran_type *)tran, st);
+    }
+    time_t epoch;
+    rc = dbq_oldest_epoch(&iq, (tran_type*)tran, &epoch);
+    if (rc == 0)
+        st->oldest_epoch = epoch;
+    if (made_tran) {
+        bdberr = 0;
+        int rc2 = bdb_tran_abort(db->handle, tran, &bdberr);
+        if (rc2) {
+            logmsg(LOGMSG_FATAL, "%s:%d failed to abort transaction (%d)\n",
+                   __FILE__, __LINE__, bdberr);
+            abort();
+        }
     }
     if (rc)
         return rc;
@@ -931,7 +956,7 @@ comdb2_queue_consumer_t dbqueuedb_plugin_lua = {
     .wake_all_consumers_all_queues = wake_all_consumers_all_queues,
     .handles_method = handles_method,
     .get_name = get_name,
-    .get_stats = get_stats
+    .get_stats = get_stats,
 };
 
 comdb2_queue_consumer_t dbqueuedb_plugin_dynlua = {
@@ -947,7 +972,7 @@ comdb2_queue_consumer_t dbqueuedb_plugin_dynlua = {
     .wake_all_consumers_all_queues = wake_all_consumers_all_queues,
     .handles_method = handles_method,
     .get_name = get_name,
-    .get_stats = get_stats
+    .get_stats = get_stats,
 };
 
 

--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -3653,6 +3653,7 @@ static int whereLoopAddAll(WhereLoopBuilder *pBuilder){
         }
       }
       rc = whereLoopAddVirtual(pBuilder, mPrereq, mUnusable);
+      sqlite3VdbeAddTable(pWInfo->pParse->pVdbe, pItem->pTab);
     }else
 #endif /* SQLITE_OMIT_VIRTUALTABLE */
     {
@@ -5102,6 +5103,7 @@ WhereInfo *sqlite3WhereBegin(
     pTab = pTabItem->pTab;
     iDb = sqlite3SchemaToIndex(db, pTab->pSchema);
     pLoop = pLevel->pWLoop;
+
     if( (pTab->tabFlags & TF_Ephemeral)!=0 || pTab->pSelect ){
       /* Do nothing */
     }else

--- a/tests/sp.test/t02.req.out
+++ b/tests/sp.test/t02.req.out
@@ -1,3 +1,3 @@
-(queuename='__qa', spname='a', head_age=0, depth=0)
-(queuename='__qb', spname='b', head_age=0, depth=0)
-(queuename='__qno_ddl_proc1', spname='no_ddl_proc1', head_age=0, depth=0)
+(queuename='__qa', spname='a', head_age=0, depth=0, tail_age=0)
+(queuename='__qb', spname='b', head_age=0, depth=0, tail_age=0)
+(queuename='__qno_ddl_proc1', spname='no_ddl_proc1', head_age=0, depth=0, tail_age=0)

--- a/tests/trigger.test/lrl.options
+++ b/tests/trigger.test/lrl.options
@@ -1,0 +1,3 @@
+init_with_queue_ondisk_header off
+init_with_queue_compr off
+init_with_queue_persistent_sequence off

--- a/tests/trigger.test/runit
+++ b/tests/trigger.test/runit
@@ -24,4 +24,41 @@ for testreq in `ls t*.req` ; do
   fi
 done
 
+dbname=$1
+default=default
+
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create procedure test {
+local function main()
+    return 1
+end
+}"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create table qlentest(a int)"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "create lua trigger test on (table qlentest for insert)"
+cdb2sql ${CDB2_OPTIONS} $dbname $default "insert into qlentest values(1)"
+sleep 5
+cdb2sql ${CDB2_OPTIONS} $dbname $default "insert into qlentest select value from generate_series(1, 11999)"
+
+host=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "select host from comdb2_cluster where is_master='Y'")
+cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "put tunable queue_walk_limit 10000"
+count=$(cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "select depth from comdb2_queues where queuename='__qtest'")
+agediff=$(cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "select head_age - tail_age from comdb2_queues where queuename='__qtest'")
+
+if [[ $count -ne 10000 ]]; then
+    echo "Expected count of 10000 got $count"
+    exit 1
+fi
+
+if [[ $agediff -lt 5 ]]; then
+    echo "Expected agediff of at least 5 got $agediff"
+    exit 1
+fi
+
+host=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname $default "select host from comdb2_cluster where is_master='Y'")
+cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "put tunable queue_walk_limit 0"
+count=$(cdb2sql --host $host -tabs ${CDB2_OPTIONS} $dbname $default "select depth from comdb2_queues where queuename='__qtest'")
+if [[ $count -ne 12000 ]]; then
+    echo "Expected count of 12000 got $count"
+    exit 1
+fi
+
 exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=929)
+(TUNABLES_COUNT=930)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -643,6 +643,7 @@
 (name='private_blkseq_maxtraverse', description='', type='INTEGER', value='4', read_only='N')
 (name='private_blkseq_stripes', description='Number of stripes for the blkseq table.', type='INTEGER', value='8', read_only='N')
 (name='qscanmode', description='Enables queue scan mode optimisation.', type='BOOLEAN', value='OFF', read_only='N')
+(name='queue_walk_limit', description='When walking queues for metrics, stop after this many elements.  (Default: 10000)', type='INTEGER', value='10000', read_only='N')
 (name='queuedb_genid_filename', description='Use genid in queuedb filenames.  (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='queuedb_timeout_sec', description='Unassign Lua consumer/trigger if no heartbeat received for this time', type='INTEGER', value='10', read_only='N')
 (name='rand_udp_fails', description='Rate of drop of UDP packets (for testing).', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
Cap the scan depth for comdb2_queues. Stop after a configurable number of records, and report that as the queue depth. Prevents long running scans when there are very deep queues. Also reports the ages of the newest and oldest item on the queue. For queues that have odh we still report the full queue depth, since that's available without a scan.

Backports #2372 to 7.0 branch.  Adds some missing synchronization between trigger changes and walking comdb2_queues.

Signed-off-by: Michael Ponomarenko <mponomarenko@bloomberg.net>