### PR TITLE
Workaround for MacOS + CMake + TINFO

### DIFF
--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -7,6 +7,7 @@ find_package_handle_standard_args(Readline DEFAULT_MSG READLINE_INCLUDE_DIR)
 find_package_handle_standard_args(libreadline DEFAULT_MSG READLINE_LIBRARY)
 find_package_handle_standard_args(libncurses  DEFAULT_MSG NCURSES_LIBRARY)
 
+set (TINFO_LIBRARY "")
 if (NOT APPLE)
   find_library(TINFO_LIBRARY NAMES tinfo HINTS ${TINFO_ROOT_DIR})
   find_package_handle_standard_args(libtinfo DEFAULT_MSG TINFO_LIBRARY)


### PR DESCRIPTION
My version of CMake doesn't like that TINFO_LIBRARY being used unset:

CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
TINFO_LIBRARY