### PR TITLE
Remove WSL from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ On every machine in the cluster:
 
 2. Install prerequisites: 
    
-   **Ubuntu 16.04, 16.10, 17.04, 20.04, Debian 10, Windows Subsystem for Linux (WSL)**
+   **Debian/Ubuntu**
         
    ```
    sudo apt-get install -y  \
@@ -127,7 +127,6 @@ On every machine in the cluster:
    ```
    pmux -n
    ```
-   Note: on WSL this needs to be run elevated, such as: `sudo /opt/bb/bin/pmux -n` 
 
 6. _(optional)_ Comdb2 nodes identify each other by their hostnames.  If the hostname 
    of each node isn't resolvable from other nodes, we should tell Comdb2 the full 


### PR DESCRIPTION
Unix Socket on Windows 10 doesn't support `SO_KEEPALIVE`. `evconnlistener_new_bind()` skips `SO_KEEPALIVE` if `_WIN32` is define. However on WSL the macro isn't predefined.

To work it around, we create a socket on our own, attempt to set `KEEPALIVE` on it but do not bail out if failed, and pass it to `evconnlistener_new()` to listen on.

Fixes #2290.