### PR TITLE
Disallow out of range longlong values.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -778,6 +778,8 @@ int gbl_clean_exit_on_sigterm = 1;
 
 int gbl_is_physical_replicant;
 
+int gbl_disallow_sql_ull_values = 0;
+
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();
 int free_gbl_tunables();

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -778,7 +778,7 @@ int gbl_clean_exit_on_sigterm = 1;
 
 int gbl_is_physical_replicant;
 
-int gbl_disallow_sql_ull_values = 0;
+int gbl_disallow_sql_ull_values = 1;
 
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3567,4 +3567,6 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err);
 
 extern int gbl_abort_invalid_query_info_key;
 extern int gbl_is_physical_replicant;
+extern int gbl_disallow_sql_ull_values;
+
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/config.c
+++ b/db/config.c
@@ -362,6 +362,7 @@ static char *legacy_options[] = {
     "init_with_queue_compr off",
     "init_with_queue_persistent_sequence off",
     "usenames",
+    "disallow_sql_ull_values off"
 };
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2005,7 +2005,7 @@ REGISTER_TUNABLE("track_curtran_gettran_locks", "Stack-trace curtran_gettran thr
 REGISTER_TUNABLE("permit_small_sequences", "Allow int32 and int16 length sequences.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_permit_small_sequences, 0, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("disallow_sql_ull_values", "Disallow out of range longlong values on SQL insert to u_longlong fields.  (Default: off)",
+REGISTER_TUNABLE("disallow_sql_ull_values", "Disallow out of range longlong values on SQL insert to u_longlong fields.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_disallow_sql_ull_values, 0, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2005,4 +2005,7 @@ REGISTER_TUNABLE("track_curtran_gettran_locks", "Stack-trace curtran_gettran thr
 REGISTER_TUNABLE("permit_small_sequences", "Allow int32 and int16 length sequences.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_permit_small_sequences, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("disallow_sql_ull_values", "Disallow out of range longlong values on SQL insert to u_longlong fields.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_disallow_sql_ull_values, 0, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/sql.test/Makefile
+++ b/tests/sql.test/Makefile
@@ -6,3 +6,6 @@ endif
 ifeq ($(TEST_TIMEOUT),)
 	export TEST_TIMEOUT=3m
 endif
+
+clean::
+	rm -f *.out

--- a/tests/sql.test/t11.req
+++ b/tests/sql.test/t11.req
@@ -1,0 +1,12 @@
+create table ulltest(a u_longlong)$$
+put tunable disallow_sql_ull_values 'ON'
+insert into ulltest(a) values(9223372036854775807)
+insert into ulltest(a) values('9223372036854775807')
+insert into ulltest(a) values(9223372036854775808)
+insert into ulltest(a) values('9223372036854775808')
+insert into ulltest(a) values(1)
+insert into ulltest(a) values(0)
+select a from ulltest order by a
+put tunable disallow_sql_ull_values 'OFF'
+insert into ulltest(a) values(9223372036854775808)
+select a from ulltest order by a

--- a/tests/sql.test/t11.req.exp
+++ b/tests/sql.test/t11.req.exp
@@ -1,0 +1,12 @@
+(rows inserted=1)
+(rows inserted=1)
+[insert into ulltest(a) values(9223372036854775808)] failed with rc 113 incompatible values for table 'ulltest'
+[insert into ulltest(a) values('9223372036854775808')] failed with rc 113 incompatible values for table 'ulltest'
+(rows inserted=1)
+(rows inserted=1)
+(a=0)
+(a=1)
+(a=9223372036854775807)
+(a=9223372036854775807)
+(rows inserted=1)
+[select a from ulltest order by a] failed with rc -5 unknown error

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -221,6 +221,7 @@
 (name='disable_upgrade_ahead', description='Sets 'enable_upgrade_ahead' to 0.', type='BOOLEAN', value='ON', read_only='Y')
 (name='disable_writer_penalty_deadlock', description='If set, won't shrink max #writers on deadlock.', type='BOOLEAN', value='OFF', read_only='N')
 (name='disallow_portmux_route', description='Disables 'allow_portmux_route'', type='BOOLEAN', value='OFF', read_only='Y')
+(name='disallow_sql_ull_values', description='Disallow out of range longlong values on SQL insert to u_longlong fields.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='dohast_disable', description='Disable generating AST for queries. This disables distributed mode as well.', type='BOOLEAN', value='OFF', read_only='N')
 (name='dohast_verbose', description='Print debug information when creating AST for statements', type='BOOLEAN', value='OFF', read_only='N')
 (name='dohsql_disable', description='Disable running queries in distributed mode', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
It's possible to use SQL to get u_longlong values that are perfectly valid, in range u_longlong values but are not valid longlong values and therefore cannot be read back with SQL.  Provide an option to disallow that.