### PR TITLE
cdb2jdbc: turn on verify-retry and return per-statement effects

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -58,6 +58,7 @@ public class Comdb2Connection implements Connection {
     private String password;
 
     private boolean usemicrodt = true;
+    private boolean statement_effects = true;
 
     /**
      * -1 indicates the default txn mode.
@@ -78,6 +79,7 @@ public class Comdb2Connection implements Connection {
         ret.user = user;
         ret.password = password;
         ret.usemicrodt = usemicrodt;
+        ret.statement_effects = statement_effects;
         ret.hndl = hndl.duplicate();
         return ret;
     }
@@ -260,7 +262,7 @@ public class Comdb2Connection implements Connection {
     }
 
     public void setStatementQueryEffects(boolean stmtEffects) {
-        hndl.setStatementQueryEffects(stmtEffects);
+        statement_effects = stmtEffects;
     }
 
     public void setVerifyRetry(boolean vrfyRetry) {
@@ -325,6 +327,7 @@ public class Comdb2Connection implements Connection {
             stmt.setQueryTimeout(querytimeout);
 
         stmt.setUseMicroDt(usemicrodt);
+        stmt.setStatementEffects(statement_effects);
         stmts.add(stmt);
         return stmt;
     }
@@ -343,6 +346,7 @@ public class Comdb2Connection implements Connection {
             stmt.setQueryTimeout(querytimeout);
 
         stmt.setUseMicroDt(usemicrodt);
+        stmt.setStatementEffects(statement_effects);
         stmts.add(stmt);
         return stmt;
     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Statement.java
@@ -45,6 +45,7 @@ public class Comdb2Statement implements Statement {
     protected String user;
     protected String password;
     protected boolean usemicrodt = true;
+    protected boolean statement_effects;
 
     public Comdb2Statement(DbHandle hndl, Comdb2Connection conn) {
         this(hndl, conn, -1, -1);
@@ -162,7 +163,13 @@ public class Comdb2Statement implements Statement {
                     Constants.Errors.CDB2ERR_PREPARE_ERROR, sql, hndl.getLastThrowable());
 
         ResultSet rs = executeQuery(sql);
-        int count = ((Comdb2Handle)hndl).rowsAffected();
+        int count = 0;
+        if (statement_effects) {
+            while (rs.next())
+                count = rs.getInt(1);
+        } else {
+            count = hndl.rowsAffected();
+        }
         return count;
     }
 
@@ -410,6 +417,10 @@ public class Comdb2Statement implements Statement {
 
     public void setUseMicroDt(boolean use) {
         usemicrodt = use;
+    }
+
+    public void setStatementEffects(boolean stmteffects) {
+        statement_effects = stmteffects;
     }
 }
 /* vim: set sw=4 ts=4 et: */

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
@@ -62,6 +62,56 @@ public class StatementQueryEffectsTest {
         conn.close();
     }
 
+    /* Under statement query effects,
+       executeBatch() returns the query effects made by each statement. */
+    @Test public void statementQueryEffectsBatch() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?statement_query_effects=1", cluster, db));
+        conn.setAutoCommit(false);
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO t_stmteffects values (?)");
+        ps.setInt(1, 100);
+        ps.addBatch();
+        ps.setInt(1, 200);
+        ps.addBatch();
+        ps.setInt(1, 300);
+        ps.addBatch();
+        int[] counts = ps.executeBatch();
+
+        Assert.assertEquals("Inserted 3 rows", 3, counts.length);
+        Assert.assertEquals("1", 1, counts[0]);
+        Assert.assertEquals("2", 1, counts[1]);
+        Assert.assertEquals("3", 1, counts[2]);
+
+        conn.rollback();
+        ps.close();
+        conn.close();
+    }
+
+    /* Under transaction query effects,
+       executeBatch() returns the cumulative query effects. */
+    @Test public void transactionQueryEffectsBatch() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s?statement_query_effects=0", cluster, db));
+        conn.setAutoCommit(false);
+        PreparedStatement ps = conn.prepareStatement("INSERT INTO t_stmteffects values (?)");
+        ps.setInt(1, 100);
+        ps.addBatch();
+        ps.setInt(1, 200);
+        ps.addBatch();
+        ps.setInt(1, 300);
+        ps.addBatch();
+        int[] counts = ps.executeBatch();
+
+        Assert.assertEquals("Inserted 3 rows", 3, counts.length);
+        Assert.assertEquals("1", 1, counts[0]);
+        Assert.assertEquals("2", 2, counts[1]);
+        Assert.assertEquals("3", 3, counts[2]);
+
+        conn.rollback();
+        ps.close();
+        conn.close();
+    }
+
     @After public void unsetup() throws SQLException {
         conn = DriverManager.getConnection(String.format(
                     "jdbc:comdb2://%s/%s", cluster, db));

--- a/tests/jepsen_a6.test/runit
+++ b/tests/jepsen_a6.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_a6_nemesis.test/runit
+++ b/tests/jepsen_a6_nemesis.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_atomic_writes.test/runit
+++ b/tests/jepsen_atomic_writes.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_bank.test/runit
+++ b/tests/jepsen_bank.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_bank_nemesis.test/runit
+++ b/tests/jepsen_bank_nemesis.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=1

--- a/tests/jepsen_dirty_reads.test/runit
+++ b/tests/jepsen_dirty_reads.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_g2.test/runit
+++ b/tests/jepsen_g2.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_register.test/runit
+++ b/tests/jepsen_register.test/runit
@@ -5,6 +5,7 @@
 #debug_trace="-D"
 export COMDB2_DEBUG=1
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0

--- a/tests/jepsen_register_nemesis.test/runit
+++ b/tests/jepsen_register_nemesis.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=1

--- a/tests/jepsen_sets.test/runit
+++ b/tests/jepsen_sets.test/runit
@@ -4,6 +4,7 @@
 #debug=1
 #debug_trace="-D"
 export CDB2JDBC_STATEMENT_QUERYEFFECTS=1
+export CDB2JDBC_VERIFY_RETRY=0
 
 [[ "$debug" == 1 ]] && set -x
 needcluster=0


### PR DESCRIPTION
This is a compromise between Comdb2's OCC model and what JDBC users normally expect. With the verify-retry mechanism, one can't rely on per-statement query effects in a transaction. So we lose a bit of accuracy (harmlessly, I hope) to be more in line with the JDBC land.