### PR TITLE
Fix timer trap deadlock

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4190,11 +4190,12 @@ static char *strtoupper(char instr[])
 
 static void ttrap(struct timer_parm *parm)
 {
-    char *msg;
     switch (parm->parm) {
     case TMEV_ENABLE_LOG_DELETE:
-        msg = "sync log-delete on";
-        process_command(thedb, msg, strlen(msg), 0);
+        /* We already hold timerlk. process_sync_command("sync log-delete on")
+           will attempt to grab timerlk one more time. So call the routine
+           directly without faking a message trap. */
+        log_delete_counter_change(thedb, LOG_DEL_ABS_ON);
         break;
     case TMEV_PURGE_OLD_LONGTRN:
         (void)purge_expired_long_transactions(thedb);

--- a/tests/sync_log_delete_off_reenable.test/Makefile
+++ b/tests/sync_log_delete_off_reenable.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/sync_log_delete_off_reenable.test/runit
+++ b/tests/sync_log_delete_off_reenable.test/runit
@@ -1,0 +1,21 @@
+# TODO consolidate all leak regression tests into one
+
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+# Make sure we talk to the same host
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+
+
+# Turn off log deletion and enable it back in 1 minute.
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("sync log-delete off 1")'
+
+# Give it 5 extra seconds here to paper over slow machines.
+sleep 65
+
+# Do it again.
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("sync log-delete off 1")'


### PR DESCRIPTION
"sync log-delete off \<N\>" deadlocks itself when re-enabling log deletion.

(DRQS 161450311)