### PR TITLE
Abort when we cant convert from client to server type

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -303,7 +303,7 @@ int client_type_to_server_type(int type)
     case CLIENT_SEQUENCE:
         return SERVER_SEQUENCE;
     default:
-        return type;
+        abort();
     }
 }
 


### PR DESCRIPTION
All types should have a conversion from client to server. In the case that we add new types, we should add conversion as well. 
So we should abort here to catch those cases.