### PR TITLE
Use sqlite3_free in free_functions

### DIFF
--- a/sqlite/ext/comdb2/functions.c
+++ b/sqlite/ext/comdb2/functions.c
@@ -36,7 +36,7 @@ static void free_functions(void *p, int n)
 {
     char **arr = p;
     for (int i = 0; i < n; i++) {
-        free(arr[i]);
+        sqlite3_free(arr[i]); /* sqlite3_mprintf() */
     }
     free(arr);
 }


### PR DESCRIPTION
Since the arr[i] string is allocated via sqlite3_mprintf(), it must be sqlite3_free().

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>
