### PR TITLE
Move freeing of the array in FreeAllBuiltinFunctions

### DIFF
--- a/sqlite/ext/comdb2/functions.c
+++ b/sqlite/ext/comdb2/functions.c
@@ -34,11 +34,7 @@ static int get_functions(void **data, int *npoints)
 
 static void free_functions(void *p, int n)
 {
-    char **arr = p;
-    for (int i = 0; i < n; i++) {
-        sqlite3_free(arr[i]); /* sqlite3_mprintf() */
-    }
-    free(arr);
+    sqlite3FreeAllBuiltinFunctions(p, n);
 }
 
 sqlite3_module systblFunctionsModule = {

--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -2825,4 +2825,13 @@ void sqlite3GetAllBuiltinFunctions(void **data, int *tot)
     *tot = num;
     *data = arr;
 }
+
+void sqlite3FreeAllBuiltinFunctions(void **data, int tot)
+{
+    char **arr = (char **)data;
+    for (int i = 0; i < tot; i++) {
+        sqlite3_free(arr[i]);
+    }
+    free(arr);
+}
 #endif

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -4440,6 +4440,7 @@ int sqlite3VListNameToNum(VList*,const char*,int);
 VList *sqlite3VListClone(const VList*, void* (*)(size_t));
 void sqlite3VListPrint(loglvl lvl, const VList *pIn);
 void sqlite3GetAllBuiltinFunctions(void **data, int *tot);
+void sqlite3FreeAllBuiltinFunctions(void **data, int tot);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*


### PR DESCRIPTION
For a cleaner cleanup of arr, move the freeing in same file as it was allocated.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>