### PR TITLE
Use macro to expand enum and representation of osql types

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4590,7 +4590,7 @@ void *statthd(void *p)
                     }
                     for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
                         log_tbl_item(tbl->blockosqltypcnt[jj], &tbl->prev_blockosqltypcnt[jj],
-                                     osql_breq2a, jj, NULL, &hdr, statlogger, tbl, 0);
+                                     osql_reqtype_str, jj, NULL, &hdr, statlogger, tbl, 0);
                     }
 
                     log_tbl_item(dbenv->txns_committed, &dbenv->prev_txns_committed,

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -100,6 +100,7 @@ typedef long long tranid_t;
 #include <schema_lk.h>
 #include "perf.h"
 #include "constraints.h"
+#include "osqlrpltypes.h"
 
 /* buffer offset, given base ptr & right ptr */
 #define BUFOFF(base, right) ((int)(((char *)right) - ((char *)base)))
@@ -309,44 +310,6 @@ enum BLOCK_OPS {
      * opcodes that there actually really are. */
     ,
     NUM_BLOCKOP_OPCODES = 45
-};
-
-const char *osql_reqtype_str(int type); // used for printing string of type
-
-/*
-   type will identify if there is a new record and type the new record is *
-   PLEASE update osql_reqtype_str() when adding to this structure
-*/
-enum OSQL_RPL_TYPE {
-    OSQL_RPLINV = 0,
-    OSQL_DONE = 1,
-    OSQL_USEDB = 2,
-    OSQL_DELREC = 3,
-    OSQL_INSREC = 4, /* R7 uses OSQL_INSERT */
-    OSQL_CLRTBL = 5,
-    OSQL_QBLOB = 6,
-    OSQL_UPDREC = 7,
-    OSQL_XERR = 8,
-    OSQL_UPDCOLS = 9,
-    OSQL_DONE_STATS = 10, /* just like OSQL_DONE, but have additional stats */
-    OSQL_DBGLOG = 11,
-    OSQL_RECGENID = 12,
-    OSQL_UPDSTAT = 13,
-    OSQL_EXISTS = 14,
-    OSQL_SERIAL = 15,
-    OSQL_SELECTV = 16,
-    OSQL_DONE_SNAP = 17,
-    OSQL_SCHEMACHANGE = 18,
-    OSQL_BPFUNC = 19,
-    OSQL_DBQ_CONSUME = 20,
-    OSQL_DELETE = 21, /* new osql type to support partial indexes */
-    OSQL_INSERT = 22, /* new osql type to support partial indexes */
-    OSQL_UPDATE = 23, /* new osql type to support partial indexes */
-    OSQL_DELIDX = 24, /* new osql type to support indexes on expressions */
-    OSQL_INSIDX = 25, /* new osql type to support indexes on expressions */
-    OSQL_STARTGEN = 27,
-    OSQL_DONE_WITH_EFFECTS = 28,
-    MAX_OSQL_TYPES = 29,
 };
 
 enum DEBUGREQ { DEBUG_METADB_PUT = 1 };

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -417,44 +417,6 @@ void osql_bplog_close(blocksql_tran_t **ptran)
     free(tran);
 }
 
-
-const char *osql_reqtype_str(int type)
-{   
-    assert(0 < type && type < MAX_OSQL_TYPES);
-    // copied from enum OSQL_RPL_TYPE
-    static const char *typestr[] = {
-        "RPLINV",
-        "DONE",
-        "USEDB",
-        "DELREC",
-        "INSREC",
-        "CLRTBL",
-        "QBLOB",
-        "UPDREC",
-        "XERR",
-        "UPDCOLS",
-        "DONE_STATS",
-        "DBGLOG",
-        "RECGENID",
-        "UPDSTAT",
-        "EXISTS",
-        "SERIAL",
-        "SELECTV",
-        "DONE_SNAP",
-        "SCHEMACHANGE",
-        "BPFUNC",
-        "DBQ_CONSUME",
-        "DELETE",
-        "INSERT",
-        "UPDATE",
-        "DELIDX",
-        "INSIDX",
-        "DBQ_CONSUME_UUID",
-        "STARTGEN",
-    };
-    return typestr[type];
-}
-
 static void setup_reorder_key(blocksql_tran_t *tran, int type,
                               osql_sess_t *sess, unsigned long long rqid,
                               char *rpl, oplog_key_t *key)
@@ -608,8 +570,7 @@ int osql_bplog_saveop(osql_sess_t *sess, blocksql_tran_t *tran, char *rpl,
     logmsg(LOGMSG_DEBUG, "REORDER: saving for sess %p\n", sess);
     uuidstr_t us;
     comdb2uuidstr(sess->uuid, us);
-    DEBUGMSG("uuid=%s type=%d (%s) seq=%lld\n", us, type,
-             osql_reqtype_str(type), tran->seq);
+    DEBUGMSG("uuid=%s type=%d (%s) seq=%lld\n", us, type, osql_reqtype_str(type), tran->seq);
 #endif
 
     _pre_process_saveop(sess, tran, rpl, rplen, type);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -74,6 +74,28 @@ int db_is_stopped();
 static int osql_net_type_to_net_uuid_type(int type);
 static void osql_extract_snap_info(osql_sess_t *sess, void *rpl, int rpllen,
                                    int is_uuid);
+
+
+#ifdef XMACRO_OSQL_RPL_TYPES
+#   undef XMACRO_OSQL_RPL_TYPES
+#endif
+#define XMACRO_OSQL_RPL_TYPES(a, b, c) case a: osql_rpl_type_to_str = c; break;
+#define OSQL_RPL_TYPE_TO_STR(type)                                             \
+({                                                                             \
+    char *osql_rpl_type_to_str  = "UNKNOWN";                                   \
+    switch (type) {                                                            \
+    OSQL_RPL_TYPES                                                             \
+    }                                                                          \
+    osql_rpl_type_to_str;                                                      \
+})
+
+
+const char *osql_reqtype_str(int type)
+{   
+    assert(0 <= type && type < MAX_OSQL_TYPES);
+    return OSQL_RPL_TYPE_TO_STR(type);
+}
+
 typedef struct osql_blknds {
     char *nds[MAX_CLUSTER];        /* list of nodes to blackout in offloading */
     time_t times[MAX_CLUSTER];     /* time of blacking out */

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -24,14 +24,14 @@
 #include "block_internal.h"
 #include "comdb2uuid.h"
 #include "schemachange.h"
+#include "osqlrpltypes.h"
+
 
 #define OSQL_BLOB_ODH_BIT (1 << 31)
 #define IS_ODH_READY(x) (!!(((x)->odhind) & OSQL_BLOB_ODH_BIT))
 #define OSQL_SEND_ERROR_WRONGMASTER (-1234)
 
-enum {
-    OSQL_PROCESS_FLAGS_BLOB_OPTIMIZATION = 0x00000001,
-};
+enum { OSQL_PROCESS_FLAGS_BLOB_OPTIMIZATION = 0x00000001, };
 
 /**
  * Initializes this node for osql communication

--- a/db/osqlrpltypes.h
+++ b/db/osqlrpltypes.h
@@ -1,0 +1,65 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef _OSQL_RPL_TYPES_H_
+#define _OSQL_RPL_TYPES_H_
+
+const char *osql_reqtype_str(int type); // used for printing string of type
+
+// clang-format off
+
+#define OSQL_RPL_TYPES \
+XMACRO_OSQL_RPL_TYPES( OSQL_RPLINV,             0, "OSQL_RPLINV" ) /* no longer in use */                                    \
+XMACRO_OSQL_RPL_TYPES( OSQL_DONE,               1, "OSQL_DONE" )                                                             \
+XMACRO_OSQL_RPL_TYPES( OSQL_USEDB,              2, "OSQL_USEDB" )                                                            \
+XMACRO_OSQL_RPL_TYPES( OSQL_DELREC,             3, "OSQL_DELREC" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_INSREC,             4, "OSQL_INSREC" ) /* R7 uses OSQL_INSERT */                                 \
+XMACRO_OSQL_RPL_TYPES( OSQL_CLRTBL,             5, "OSQL_CLRTBL" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_QBLOB,              6, "OSQL_QBLOB" )                                                            \
+XMACRO_OSQL_RPL_TYPES( OSQL_UPDREC,             7, "OSQL_UPDREC" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_XERR,               8, "OSQL_XERR" )                                                             \
+XMACRO_OSQL_RPL_TYPES( OSQL_UPDCOLS,            9, "OSQL_UPDCOLS" )                                                          \
+XMACRO_OSQL_RPL_TYPES( OSQL_DONE_STATS,        10, "OSQL_DONE_STATS" ) /* just like OSQL_DONE, but have additional stats */  \
+XMACRO_OSQL_RPL_TYPES( OSQL_DBGLOG,            11, "OSQL_DBGLOG" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_RECGENID,          12, "OSQL_RECGENID" )                                                         \
+XMACRO_OSQL_RPL_TYPES( OSQL_UPDSTAT,           13, "OSQL_UPDSTAT" )                                                          \
+XMACRO_OSQL_RPL_TYPES( OSQL_EXISTS,            14, "OSQL_EXISTS" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_SERIAL,            15, "OSQL_SERIAL" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_SELECTV,           16, "OSQL_SELECTV" )                                                          \
+XMACRO_OSQL_RPL_TYPES( OSQL_DONE_SNAP,         17, "OSQL_DONE_SNAP" )                                                        \
+XMACRO_OSQL_RPL_TYPES( OSQL_SCHEMACHANGE,      18, "OSQL_SCHEMACHANGE" )                                                     \
+XMACRO_OSQL_RPL_TYPES( OSQL_BPFUNC,            19, "OSQL_BPFUNC" )                                                           \
+XMACRO_OSQL_RPL_TYPES( OSQL_DBQ_CONSUME,       20, "OSQL_DBQ_CONSUME" )                                                      \
+XMACRO_OSQL_RPL_TYPES( OSQL_DELETE,            21, "OSQL_DELETE" ) /* for partial indexes */                                 \
+XMACRO_OSQL_RPL_TYPES( OSQL_INSERT,            22, "OSQL_INSERT" ) /* for partial indexes */                                 \
+XMACRO_OSQL_RPL_TYPES( OSQL_UPDATE,            23, "OSQL_UPDATE" ) /* for partial indexes */                                 \
+XMACRO_OSQL_RPL_TYPES( OSQL_DELIDX,            24, "OSQL_DELIDX" ) /* for indexes on expressions */                          \
+XMACRO_OSQL_RPL_TYPES( OSQL_INSIDX,            25, "OSQL_INSIDX" ) /* for indexes on expressions */                          \
+XMACRO_OSQL_RPL_TYPES( OSQL_STARTGEN,          27, "OSQL_STARTGEN" )                                                         \
+XMACRO_OSQL_RPL_TYPES( OSQL_DONE_WITH_EFFECTS, 28, "OSQL_DONE_WITH_EFFECTS" )                                                \
+XMACRO_OSQL_RPL_TYPES( MAX_OSQL_TYPES,         29, "OSQL_MAX")
+
+// clang-format on
+
+#ifdef XMACRO_OSQL_RPL_TYPES
+#   undef XMACRO_OSQL_RPL_TYPES
+#endif
+#define XMACRO_OSQL_RPL_TYPES(a, b, c) a,
+enum OSQL_RPL_TYPE { OSQL_RPL_TYPES };
+#undef XMACRO_OSQL_RPL_TYPES
+
+
+#endif

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -75,8 +75,7 @@ void req_stats(struct dbtable *db)
     for (ii = 0; ii <= MAXTYPCNT; ii++) {
         if (db->typcnt[ii]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum,
-                       db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "%-20s %u\n", req2a(ii), db->typcnt[ii]);
@@ -85,23 +84,19 @@ void req_stats(struct dbtable *db)
     for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
         if (db->blocktypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum,
-                       db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
                 hdr = 1;
             }
-            logmsg(LOGMSG_USER, "    %-20s %u\n", breq2a(jj),
-                   db->blocktypcnt[jj]);
+            logmsg(LOGMSG_USER, "    %-20s %u\n", breq2a(jj), db->blocktypcnt[jj]);
         }
     }
     for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
         if (db->blockosqltypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum,
-                       db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
                 hdr = 1;
             }
-            logmsg(LOGMSG_USER, "    %-20s %u\n", osql_breq2a(jj),
-                   db->blockosqltypcnt[jj]);
+            logmsg(LOGMSG_USER, "    %-20s %u\n", osql_reqtype_str(jj), db->blockosqltypcnt[jj]);
         }
     }
 }

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -189,45 +189,6 @@ void osql_cleanup(void)
     bdb_osql_destroy(&bdberr);
 }
 
-const char *osql_tp_str[] = {
-    "OSQL_RPLINV",
-    "OSQL_DONE",
-    "OSQL_USEDB",
-    "OSQL_DELREC",
-    "OSQL_INSREC",
-    "OSQL_CLRTBL",
-    "OSQL_QBLOB",
-    "OSQL_UPDREC",
-    "OSQL_XERR",
-    "OSQL_UPDCOLS",
-    "OSQL_DONE_STATS",
-    "OSQL_DBGLOG",
-    "OSQL_RECGENID",
-    "OSQL_UPDSTAT",
-    "OSQL_EXISTS",
-    "OSQL_SERIAL",
-    "OSQL_SELECTV",
-    "OSQL_DONE_SNAP",
-    "OSQL_SCHEMACHANGE",
-    "OSQL_BPFUNC",
-    "OSQL_DBQ_CONSUME",
-    "OSQL_DELETE",
-    "OSQL_INSERT",
-    "OSQL_UPDATE",
-    "OSQL_DELIDX",
-    "OSQL_INSIDX",
-    "OSQL_STARTGEN",
-    "OSQL_DONE_WITH_EFFECTS",
-};
-
-const char *osql_breq2a(int op)
-{
-    if (0 < op && op < MAX_OSQL_TYPES)
-        return osql_tp_str[op];
-    else
-        return "UNKNOWN";
-}
-
 void block2_sorese(struct ireq *iq, const char *sql, int sqlen, int block2_type)
 {
 

--- a/db/sqloffload.h
+++ b/db/sqloffload.h
@@ -57,8 +57,6 @@ void osql_cleanup(void);
 void set_osql_maxtransfer(int limit);
 int get_osql_maxtransfer(void);
 
-const char *osql_breq2a(int op);
-
 void block2_sorese(struct ireq *iq, const char *sql, int sqlen,
                    int block2_type);
 


### PR DESCRIPTION
This was left as a todo from PR #2224 (edfeafe9): use macros to expand osql types.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
