### PR TITLE
Fix datacopy race in create_sqlmaster_record

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4002,6 +4002,11 @@ static int init(int argc, char **argv)
     unlock_schema_lk();
 
     sqlinit();
+    rc = create_datacopy_arrays();
+    if (rc) {
+        logmsg(LOGMSG_FATAL, "create_datacopy_arrays rc %d\n", rc);
+        return -1;
+    }
     rc = create_sqlmaster_records(NULL);
     if (rc) {
         logmsg(LOGMSG_FATAL, "create_sqlmaster_records rc %d\n", rc);
@@ -6004,6 +6009,7 @@ retry_tran:
         sqlite3_close_serial(&thd->sqldb);
     }
 
+    create_datacopy_arrays();
     create_sqlmaster_records(tran);
     create_sqlite_master();
     oldfile_list_clear();

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2500,6 +2500,8 @@ int get_copy_rootpages_selectfire(struct sql_thread *thd, int nnames,
                                   int *oldnentries, int lock);
 void restore_old_rootpages(struct sql_thread *thd, master_entry_t *ents,
                            int nents);
+int create_datacopy_arrays(void);
+int create_datacopy_array(struct dbtable *db);
 master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
                                           hash_t *view_hash, int *nents);
 void cleanup_sqlite_master();

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1655,6 +1655,75 @@ static void create_sqlite_stat_sqlmaster_record(struct dbtable *tbl)
     tbl->ix_blob = 0;
 }
 
+int create_datacopy_arrays()
+{
+    int rc;
+    for (int table = 0; table < thedb->num_dbs && rc == 0; table++) {
+        rc = create_datacopy_array(thedb->dbs[table]);
+        if (rc)
+            return rc;
+    }
+
+    return 0;
+}
+
+int create_datacopy_array(struct dbtable *tbl)
+{
+    struct schema *schema = tbl->schema;
+
+    if (schema == NULL) {
+        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename);
+        return -1;
+    }
+
+    if (is_sqlite_stat(tbl->tablename)) {
+        return 0;
+    }
+
+    for (int ixnum = 0; ixnum < tbl->nix; ixnum++) {
+
+        schema = tbl->schema->ix[ixnum];
+        struct schema *ondisk = tbl->schema;
+        if (schema == NULL) {
+            logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum, tbl->tablename);
+            return -1;
+        }
+
+        if (!(schema->flags & SCHEMA_DATACOPY)) {
+            continue;
+        }
+
+        int datacopy_pos = 0;
+        for (int ondisk_i = 0; ondisk_i < ondisk->nmembers; ++ondisk_i) {
+            int skip = 0;
+            struct field *ondisk_field = &ondisk->member[ondisk_i];
+
+            for (int schema_i = 0; schema_i < schema->nmembers; ++schema_i) {
+                if (strcmp(ondisk_field->name, schema->member[schema_i].name) == 0) {
+                    skip = 1;
+                    break;
+                }
+            }
+            if (skip)
+                continue;
+
+            if (datacopy_pos == 0) {
+                size_t need = ondisk->nmembers * sizeof(schema->datacopy[0]);
+                if (schema->datacopy)
+                    free(schema->datacopy);
+                schema->datacopy = (int *)malloc(need);
+                if (schema->datacopy == NULL) {
+                    logmsg(LOGMSG_ERROR, "Could not allocate memory for datacopy array\n");
+                    return -1;
+                }
+            }
+            schema->datacopy[datacopy_pos] = ondisk_i;
+            ++datacopy_pos;
+        }
+    }
+    return 0;
+}
+
 /* This creates SQL statements that correspond to a table's schema. These
    statements are used to bootstrap sqlite. */
 static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
@@ -1790,8 +1859,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
 
         if (schema->flags & SCHEMA_DATACOPY) {
             struct schema *ondisk = tbl->schema;
-            int datacopy_pos = 0;
-            size_t need;
+            int first = 1;
             /* Add all fields from ONDISK to index */
             for (int ondisk_i = 0; ondisk_i < ondisk->nmembers; ++ondisk_i) {
                 int skip = 0;
@@ -1811,20 +1879,10 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
 
                 strbuf_appendf(sql, ", \"%s\"", ondisk_field->name);
                 /* stop optimizer by adding dummy collation */
-                if (datacopy_pos == 0) {
+                if (first == 1) {
                     strbuf_append(sql, " collate DATACOPY");
-                    need = ondisk->nmembers * sizeof(schema->datacopy[0]);
-                    schema->datacopy = (int *)malloc(need);
-                    if (schema->datacopy == NULL) {
-                        logmsg(LOGMSG_ERROR, 
-                                "Could not malloc for datacopy lookup array\n");
-                        strbuf_free(sql);
-                        return -1;
-                    }
+                    first = 0;
                 }
-                /* datacopy_pos is i-th ondisk */
-                schema->datacopy[datacopy_pos] = ondisk_i;
-                ++datacopy_pos;
             }
         }
 

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -308,6 +308,12 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
         return -1;
     }
 
+    rc = create_datacopy_array(db);
+    if (rc) {
+        sc_errf(s, "error initializing datacopy array\n");
+        return -1;
+    }
+
     /* Set instant schema-change */
     db->instant_schema_change = db->odh && s->instant_sc;
 

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -787,6 +787,12 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         BACKOUT;
     }
 
+    rc = create_datacopy_array(newdb);
+    if (rc) {
+        sc_errf(s, "error initializing datacopy array\n");
+        return -1;
+    }
+
     if ((rc = prepare_version_for_dbs_without_instant_sc(transac, db, newdb)))
         BACKOUT;
 

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -913,6 +913,13 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
         llmeta_dump_mapping_table_tran(tran, thedb, table, 1);
     }
 
+    if (type == add || type == alter) {
+        if (create_datacopy_array(db)) {
+            logmsg(LOGMSG_FATAL, "create_datacopy_array failed for %s.\n", table);
+            exit(1);
+        }
+    }
+
     /* Fetch the correct dbnum for this table.  We need this step because db
      * numbers aren't stored in the schema, and it's not handed to us during
      * schema change.  But it is committed to the llmeta table, so we can fetch


### PR DESCRIPTION
This is a WIP fix for the datacopy race that was affecting ddisncal: create_sqlmaster_record modifies a schema's datacopy array "in-place", even for schema's that are not being schema-changed (and therefore do not have a writelock on the table). 