### PR TITLE
Add sqlite_sorterpenalty as tunable

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -353,6 +353,7 @@ int gbl_old_column_names = 1;
 int gbl_enable_sq_flattening_optimization = 1;
 
 size_t gbl_cached_output_buffer_max_bytes = 8 * 1024 * 1024; /* 8 MiB */
+int gbl_sqlite_sorterpenalty = 5;
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1082,6 +1082,9 @@ REGISTER_TUNABLE("sqlsortermem", "Maximum amount of memory to be "
                  NULL, NULL);
 REGISTER_TUNABLE("sqlsortermult", NULL, TUNABLE_INTEGER, &gbl_sqlite_sortermult,
                  READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("sqlsorterpenalty",
+                 "Sets the sorter penalty for query planner to prefer plans without explicit sort (Default: 5)",
+                 TUNABLE_INTEGER, &gbl_sqlite_sorterpenalty, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sql_time_threshold",
                  "Sets the threshold time in ms after which queries are "
                  "reported as running a long time. (Default: 5000 ms)",

--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -4196,7 +4196,12 @@ static int wherePathSolver(WhereInfo *pWInfo, LogEst nRowEst){
           ** extra encouragment to the query planner to select a plan
           ** where the rows emerge in the correct order without any sorting
           ** required. */
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+          extern int gbl_sqlite_sorterpenalty;
+          rCost = sqlite3LogEstAdd(rUnsorted, aSortCost[isOrdered]) + gbl_sqlite_sorterpenalty;
+#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
           rCost = sqlite3LogEstAdd(rUnsorted, aSortCost[isOrdered]) + 5;
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
           WHERETRACE(0x002,
               ("---- sort cost=%-3d (%d/%d) increases cost %3d to %-3d\n",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -840,6 +840,7 @@
 (name='sqlreadaheadthresh', description='', type='INTEGER', value='0', read_only='Y')
 (name='sqlsortermem', description='Maximum amount of memory to be allocated to the sqlite sorter. (Default: 314572800)', type='INTEGER', value='314572800', read_only='Y')
 (name='sqlsortermult', description='', type='INTEGER', value='1', read_only='Y')
+(name='sqlsorterpenalty', description='Sets the sorter penalty for query planner to prefer plans without explicit sort (Default: 5)', type='INTEGER', value='5', read_only='Y')
 (name='sqlwrtimeout', description='Set timeout for writing to an SQL connection. (Default: 10000ms)', type='INTEGER', value='10000', read_only='Y')
 (name='stable_rootpages_test', description='Delay sql processing to allow a schema change to finish', type='BOOLEAN', value='OFF', read_only='N')
 (name='stack_disable', description='', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Add sqlite_sorterpenalty as tunable to control with lrl cost of sorting.
Sqlite can change this default in future so some DBs benefit by having
this value determined in the lrl.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>