### PR TITLE
Configure row-buffering

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -866,6 +866,7 @@ struct sqlclntstate {
     LINKC_T(struct sqlclntstate) lnk;
     int last_sent_row_sec; /* used to delay releasing locks when bdb_lock is
                               desired */
+    int8_t rowbuffer;
 };
 
 /* Query stats. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5895,6 +5895,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     set_sent_data_to_client(clnt, 0, __func__, __LINE__);
     set_asof_snapshot(clnt, 0, __func__, __LINE__);
     clnt->sqltick = 0;
+    clnt->rowbuffer = 1;
 }
 
 void reset_clnt_flags(struct sqlclntstate *clnt)

--- a/docs/pages/programming/sql.md
+++ b/docs/pages/programming/sql.md
@@ -769,6 +769,11 @@ Sets a tunable that determines how hard the query planner will work to estimate 
 setting is a number from 1 (least effort, quickly formed plans) to 10 (most effort, possibly better plans).  The 
 default setting is 1.
 
+### SET ROWBUFFER
+
+Configures row-buffering. The default is `ON`, where a server writes a row into a buffer and does not flush the buffer
+immediately. When off, a server flushes on every single row and hence it may reduce latency.
+
 ### SET SSL_MODE
 
 Sets client-side SSL mode. See [SSL Mode Summary](ssl.html#ssl-mode-summary) for details.

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -855,7 +855,7 @@ static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
         return newsql_response_int(clnt, &r, RESPONSE_HEADER__SQL_RESPONSE_PING,
                                    1);
     }
-    return newsql_response(clnt, &r, 0);
+    return newsql_response(clnt, &r, !clnt->rowbuffer);
 }
 
 static int newsql_row_last(struct sqlclntstate *clnt)
@@ -1896,6 +1896,10 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                 }
             } else if (strncasecmp(sqlstr, "querylimit", 10) == 0) {
                 rc = handle_set_querylimits(sqlstr, clnt);
+            } else if (strncasecmp(sqlstr, "rowbuffer", 9) == 0) {
+                sqlstr += 9;
+                sqlstr = skipws(sqlstr);
+                clnt->rowbuffer = (strncasecmp(sqlstr, "on", 2) == 0);
             } else {
                 rc = ii + 1;
             }


### PR DESCRIPTION
Add `SET ROWBUFFER` which allows an application to configure whether rows are sent over time or immediately.