### PR TITLE
Fix length of string created for sql function guid_str

### DIFF
--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -729,7 +729,7 @@ static void guidStrFunc(
   char guid_str[GUID_STR_LENGTH];
   uuid_unparse(guid, guid_str);
 
-  sqlite3_result_text(context, guid_str, GUID_STR_LENGTH, SQLITE_TRANSIENT);
+  sqlite3_result_text(context, guid_str, GUID_STR_LENGTH - 1, SQLITE_TRANSIENT);
 }
 
 static void guidFromStrFunc(
@@ -781,7 +781,7 @@ static void guidFromByteFunc(
   char guid_str[GUID_STR_LENGTH];
   uuid_unparse(guid_blob, guid_str);
 
-  sqlite3_result_text(context, guid_str, GUID_STR_LENGTH, SQLITE_TRANSIENT);
+  sqlite3_result_text(context, guid_str, GUID_STR_LENGTH - 1, SQLITE_TRANSIENT);
 }
 
 static void comdb2TestLogFunc(

--- a/tests/guid.test/runit
+++ b/tests/guid.test/runit
@@ -92,6 +92,20 @@ test_guid_function() {
     echo "found $mult with duplicate key for randomblob()"
 }
 
+test_guid_str_function() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table if exists t2'
+    cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table t2(gs cstring(37))'
+    cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into t2 select guid_str()'
+    cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into t2 select guid_str(guid())'
+    assertcnt t2 2
+    cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table t2'
+
+    res=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'select typeof( guid_str() )'`
+    assertres "$res" "(typeof( guid_str() )='text')"
+    res=`cdb2sql ${CDB2_OPTIONS} $dbnm default 'select typeof( guid() )'`
+    assertres "$res" "(typeof( guid() )='blob')"
+}
+
 
 test_guid_column() {
     echo "Test that having guid as a column works"
@@ -283,6 +297,8 @@ test_guid_errors() {
 
     
 }
+
+test_guid_str_function
 
 test_guid_function
 


### PR DESCRIPTION
For guid_str sql function(s) the length of sqlite_result_text
which we create is one greater than it should be, thus masterbranch
currently fails to insert such string into appropriately sized column.
Added testcase to insert guit_str into a cstring(37) field to show
issue and verify fix.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>