### PR TITLE
sp: Enable h/b incase push-args take time [DRQS  161737935]

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -6753,6 +6753,7 @@ void exec_thread(struct sqlthdstate *thd, struct sqlclntstate *clnt)
 
 int exec_procedure(struct sqlthdstate *thd, struct sqlclntstate *clnt, char **err)
 {
+    clnt->ready_for_heartbeats = 1;
     int rc = exec_procedure_int(thd, clnt, err);
     if (clnt->sp) {
         reset_sp(clnt->sp);


### PR DESCRIPTION
Sometimes `clnt->ready_for_heartbeat` is cleared on entry into `exec_procedure`. It may take a while before we run implicit begin (which does set that flag) due to combination of large blobs to process, Lua running gc, machine load, etc. During this time client may timeout.