### PR TITLE
Fix rollat zero size to actually not roll

### DIFF
--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -50,6 +50,7 @@ extern void cson_snap_info_key(cson_object *obj, snap_uid_t *snap_info);
 static char *gbl_eventlog_fname = NULL;
 static char *eventlog_fname(const char *dbname);
 int eventlog_nkeep = 2; // keep only last 2 event log files
+#define EVENTLOG_ROLLAT_MINSIZE 1024 * 2        // need minsize to avoid cleanup flood
 static int eventlog_rollat = 100 * 1024 * 1024; // 100MB to begin
 static int eventlog_enabled = 1;
 static int eventlog_detailed = 0;
@@ -536,7 +537,7 @@ void eventlog_add(const struct reqlogger *logger)
     Pthread_mutex_lock(&eventlog_lk);
 
     if (eventlog != NULL && eventlog_enabled) {
-        if (bytes_written > eventlog_rollat) {
+        if (eventlog_rollat > 0 && bytes_written > eventlog_rollat) {
             eventlog_roll();
         }
         add_to_fingerprints(logger);
@@ -675,12 +676,13 @@ static void eventlog_process_message_locked(char *line, int lline, int *toff)
         }
         rollat = strtol(s, NULL, 10);
         free(s);
-        if (rollat < 0) {
-            return;
-        }
         if (rollat == 0)
             logmsg(LOGMSG_USER, "Turned off rolling\n");
-        else {
+        else if (rollat < 0 || rollat < EVENTLOG_ROLLAT_MINSIZE) {
+            logmsg(LOGMSG_USER, "Invalid size to roll (Must be greater than %d or 0 to stop rolling)\n",
+                   EVENTLOG_ROLLAT_MINSIZE);
+            return;
+        } else {
             logmsg(LOGMSG_USER, "Rolling logs after %d bytes\n", (int)rollat);
         }
         eventlog_rollat = rollat;

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -177,8 +177,18 @@ res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
 done | wc -l)
 assertres $res 1
 
+echo "Test having no limit for logfiles (turning off rolling)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"
+NUM=2000
+for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
 
-# test setting custom file for event logging
+find $TESTDIR/var/log/cdb2/ | grep "/$DBNAME" | grep '.events.' > logfls2.txt
+if ! diff logfls.txt logfls2.txt ; then
+    failexit "Should not have rolled: logfls.txt vs. logfls2.txt"
+fi
+
+
+echo "test setting custom file for event logging"
 myevfl=$TESTDIR/var/log/cdb2/$DBNAME.myfile.events
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events file $myevfl')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select 2"


### PR DESCRIPTION
Currently we now roll after every sql statement that was run because we fail
to account for zero as special case to not perform check to roll or not.

Also adding a testcase that without this fix makes masterbranch to fail with:

11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979280117
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979272857
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979265584
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979258290
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979251082
11:06:21> ---
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981895265
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981891032
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981887340
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981883182
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981879600
11:06:21> + failexit 'Should not have rolled: logfls.txt vs. logfls2.txt'

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
