### PR TITLE
7.0 Eventlog: fix rollat zero size to actually not roll

### DIFF
--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -201,8 +201,18 @@ cat lastfls.txt
 res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(2000)' | grep -c '"type": "sql"')
 assertres $res 1
 
+echo "Test having no limit for logfiles (turning off rolling)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"
+NUM=2000
+for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
 
-# test setting custom file for event logging
+find $TESTDIR/var/log/cdb2/ | grep "/$DBNAME" | grep '.events.' > logfls2.txt
+if ! diff logfls.txt logfls2.txt ; then
+    failexit "Should not have rolled: logfls.txt vs. logfls2.txt"
+fi
+
+
+echo "test setting custom file for event logging"
 myevfl=$TESTDIR/var/log/cdb2/$DBNAME.myfile.events
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events file $myevfl')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select 2"


### PR DESCRIPTION
BUG: Currently we now roll after every sql statement that was run because of
not accounting for zero as special case and avoid check to perform rolling.

Also adding a testcase which without this fix makes masterbranch to fail with:

```
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979280117
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979272857
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979265584
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979258290
11:06:21> < /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367979251082
11:06:21> ---
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981895265
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981891032
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981887340
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981883182
11:06:21> > /dev/shm/test1/var/log/cdb2/eventlog82288.events.1598367981879600
11:06:21> + failexit 'Should not have rolled: logfls.txt vs. logfls2.txt'
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>