### PR TITLE
Fix remsql when the network/remote node fails.

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -123,6 +123,8 @@ static const char NEW_PREFIX[] = "new.";
 
 static pthread_once_t ONCE_LOCK = PTHREAD_ONCE_INIT;
 
+static int notclosingdta_trace = 0;
+
 int rep_caught_up(bdb_state_type *bdb_state);
 static int bdb_del_file(bdb_state_type *bdb_state, DB_TXN *tid, char *filename,
                         int *bdberr);
@@ -1379,7 +1381,7 @@ static int close_dbs_int(bdb_state_type *bdb_state, DB_TXN *tid, int flags)
                            bdb_state->name, dtanum, strnum, rc,
                            db_strerror(rc));
                 }
-            } else {
+            } else if (notclosingdta_trace) {
                 logmsg(LOGMSG_DEBUG,
                        "%s:%d not closing dtafile %d stripe %d "
                        "(NULL ptr)\n",

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1760,6 +1760,8 @@ extern int gbl_dohsql_max_threads;
 
 extern int gbl_logical_live_sc;
 
+extern int gbl_test_io_errors;
+
 /* init routines */
 int appsock_init(void);
 int thd_init(void);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2005,4 +2005,7 @@ REGISTER_TUNABLE("track_curtran_gettran_locks", "Stack-trace curtran_gettran thr
 REGISTER_TUNABLE("permit_small_sequences", "Allow int32 and int16 length sequences.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_permit_small_sequences, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("test_fdb_io", "Testing fail mode remote sql.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_test_io_errors, INTERNAL, NULL, NULL,
+                 NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/fdb_bend.c
+++ b/db/fdb_bend.c
@@ -246,9 +246,16 @@ svc_cursor_t *fdb_svc_cursor_open(char *tid, char *cid, int code_release,
     if (cur->autocommit == 0) {
         /* surprise, if tran_clnt != NULL, it is LOCKED, PINNED, FROZED */
         tran_clnt = fdb_svc_trans_get(tid, isuuid);
-        if (!tran_clnt) {
-            logmsg(LOGMSG_ERROR, "%s: missing client transaction %llx!\n", __func__,
-                    *(unsigned long long *)tid);
+        /* check of out-of-order rollbacks */
+        if (!tran_clnt || tran_clnt->dbtran.rollbacked) {
+            if (!tran_clnt)
+                logmsg(LOGMSG_ERROR, "%s: missing client transaction %llx!\n",
+                       __func__, *(unsigned long long *)tid);
+            else {
+                logmsg(LOGMSG_ERROR, "%s: out of order rollback %llx!\n",
+                       __func__, *(unsigned long long *)tid);
+                Pthread_mutex_unlock(&tran_clnt->dtran_mtx);
+            }
             free(cur);
             free(*pclnt);
             return NULL;

--- a/db/sql.h
+++ b/db/sql.h
@@ -247,6 +247,7 @@ typedef struct {
 
     fdb_distributed_tran_t *
         dtran; /* remote transactions, contain each remote cluster tran */
+    bool rollbacked; /* mark this to catch out-of-order errors */
 
     sqlite3_stmt *pStmt; /* if sql is in progress, points at the engine */
     fdb_tbl_ent_t **lockedRemTables; /* list of fdb_tbl_ent_t* for read-locked

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11216,6 +11216,10 @@ void fdb_packedsqlite_process_sqlitemaster_row(char *row, int rowlen,
         }
         fld++;
     }
+    if (fld < 7) {
+        /* we received an non-version answer */
+        *version = 0;
+    }
 }
 
 int fdb_add_remote_time(BtCursor *pCur, unsigned long long start,

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -36,6 +36,7 @@ extern int gbl_time_fdb;
 extern int gbl_notimeouts;
 extern int gbl_expressions_indexes;
 extern int gbl_fdb_track_times;
+extern int gbl_test_io_errors;
 extern char *gbl_myuri;
 
 /* matches fdb_svc_callback_t callbacks */
@@ -874,6 +875,15 @@ int fdb_msg_read_message(SBUF2 *sb, fdb_msg_t *msg, enum recv_flags flags)
 
     /* clean previous message */
     fdb_msg_clean_message(msg);
+
+    if (gbl_test_io_errors) {
+        static int counter = 0;
+        if (random() % 5 == 0) {
+            logmsg(LOGMSG_ERROR, "%s: triggered i/o error %d\n", __func__,
+                   counter++);
+            return -1;
+        }
+    }
 
     rc = sbuf2fread((char *)&msg->hd.type, 1, sizeof(msg->hd.type), sb);
 
@@ -3517,11 +3527,14 @@ int handle_remsql_request(comdb2_appsock_arg_t *arg)
         if (rc == FDB_NOERR) {
             /* we need to read the header again, waiting here */
             rc = sbuf2gets(line, sizeof(line), sb);
+            if (rc < 0) {
+                /* I/O error */
+                rc = FDB_NOERR;
+                break;
+            }
             if (rc != strlen("remsql\n")) {
-                if (rc != -1)
-                    logmsg(LOGMSG_ERROR,
-                           "%s: received wrong request! rc=%d: %s\n", __func__,
-                           rc, line);
+                logmsg(LOGMSG_ERROR, "%s: received wrong request! rc=%d: %s\n",
+                       __func__, rc, line);
                 rc = FDB_NOERR;
                 break;
             }


### PR DESCRIPTION
Fix broken sequence in transaction that rollback early
    (crash in fdb_cursor_open, or otherwise access a freed dbtran->dtran)

Fixes for the retry in the first remote access (creation of fdb, populating stats):
    preserve rootpage/sql_hint while reopening the remote connection
    fix the sqlite stats retry.

Fix case when sqlite3LockStmtTables failed (for example, old table versions)
    sql cached engines were removed from hash but kept in the [no]param_stmt_list

Fix crashes when I/O happens in between remsql sessions (printing random memory area)

Add io error generator and testcase to eliminate side-effects of failing networks

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
