### PR TITLE
Ported from master https://github.com/bloomberg/comdb2/pull/2434:

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -121,6 +121,8 @@ static const char NEW_PREFIX[] = "new.";
 
 static pthread_once_t ONCE_LOCK = PTHREAD_ONCE_INIT;
 
+static int notclosingdta_trace = 0;
+
 int rep_caught_up(bdb_state_type *bdb_state);
 static int bdb_del_file(bdb_state_type *bdb_state, DB_TXN *tid, char *filename,
                         int *bdberr);
@@ -1328,7 +1330,7 @@ static int close_dbs_int(bdb_state_type *bdb_state, DB_TXN *tid, int flags)
                            bdb_state->name, dtanum, strnum, rc,
                            db_strerror(rc));
                 }
-            } else {
+            } else if (notclosingdta_trace) {
                 logmsg(LOGMSG_DEBUG,
                        "%s:%d not closing dtafile %d stripe %d "
                        "(NULL ptr)\n",

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1808,6 +1808,8 @@ extern int gbl_dohsql_max_threads;
 
 extern int gbl_logical_live_sc;
 
+extern int gbl_test_io_errors;
+
 /* init routines */
 int appsock_init(void);
 int thd_init(void);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1838,4 +1838,7 @@ REGISTER_TUNABLE("json_escape_control_characters",
                  TUNABLE_BOOLEAN, &gbl_json_escape_control_chars, 0, NULL, NULL,
                  NULL, NULL);
 
+REGISTER_TUNABLE("test_fdb_io", "Testing fail mode remote sql.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_test_io_errors, INTERNAL, NULL, NULL,
+                 NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/fdb_bend.c
+++ b/db/fdb_bend.c
@@ -246,9 +246,16 @@ svc_cursor_t *fdb_svc_cursor_open(char *tid, char *cid, int code_release,
     if (cur->autocommit == 0) {
         /* surprise, if tran_clnt != NULL, it is LOCKED, PINNED, FROZED */
         tran_clnt = fdb_svc_trans_get(tid, isuuid);
-        if (!tran_clnt) {
-            logmsg(LOGMSG_ERROR, "%s: missing client transaction %llx!\n", __func__,
-                    *(unsigned long long *)tid);
+        /* check of out-of-order rollbacks */
+        if (!tran_clnt || tran_clnt->dbtran.rollbacked) {
+            if (!tran_clnt)
+                logmsg(LOGMSG_ERROR, "%s: missing client transaction %llx!\n",
+                       __func__, *(unsigned long long *)tid);
+            else {
+                logmsg(LOGMSG_ERROR, "%s: out of order rollback %llx!\n",
+                       __func__, *(unsigned long long *)tid);
+                Pthread_mutex_unlock(&tran_clnt->dtran_mtx);
+            }
             free(cur);
             free(*pclnt);
             return NULL;

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -494,7 +494,12 @@ int fdb_svc_trans_rollback(char *tid, enum transaction_level lvl,
 
     /* we need to wait for not yet arrived cursors, before we wait for them
        to finish!!!
+       NOTE: this can get called also for out-of-order rollbacks, for example
+       when I/O errors happen.  The sequencing is always inline in this case,
+       but new cursors can arrive afterwards.  Mark the session rollbacked,
+       so that new cursors can detect and fail gracefully
      */
+    clnt->dbtran.rollbacked = true;
     fdb_sequence_request(clnt, clnt->dbtran.dtran->fdb_trans.top, seq);
 
     while (clnt->dbtran.dtran->fdb_trans.top->cursors.top != NULL) {
@@ -502,6 +507,7 @@ int fdb_svc_trans_rollback(char *tid, enum transaction_level lvl,
         poll(NULL, 0, 10);
         Pthread_mutex_lock(&clnt->dtran_mtx);
     }
+
     Pthread_mutex_unlock(&clnt->dtran_mtx);
 
     switch (clnt->dbtran.mode) {

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -62,6 +62,7 @@ extern int gbl_expressions_indexes;
 
 int gbl_fdb_track = 0;
 int gbl_fdb_track_times = 0;
+int gbl_test_io_errors = 0;
 
 struct fdb_tbl;
 struct fdb;
@@ -940,6 +941,7 @@ static int check_table_fdb(fdb_t *fdb, fdb_tbl_t *tbl, int initial,
     cur->bt->fdb = fdb;
     cur->bt->is_remote = 1;
     struct sqlclntstate *clnt = cur->clnt;
+    cur->rootpage = 1;
 
 run:
     /* if we have already learnt that fdb is older, do not try newer versioned
@@ -949,7 +951,7 @@ run:
     else
         versioned = 1;
 
-    fdbc_if = fdb_cursor_open(clnt, cur, 1, NULL, NULL, need_ssl);
+    fdbc_if = fdb_cursor_open(clnt, cur, cur->rootpage, NULL, NULL, need_ssl);
     if (!fdbc_if) {
         rc = clnt->fdb_state.xerr.errval;
         logmsg(LOGMSG_ERROR, 
@@ -2928,6 +2930,7 @@ static int fdb_cursor_reopen(BtCursor *pCur)
     int rc;
     fdb_tran_t *tran;
     int need_ssl = 0;
+    char *sql_hint;
 
     thd = pthread_getspecific(query_info_key);
 
@@ -2942,6 +2945,9 @@ static int fdb_cursor_reopen(BtCursor *pCur)
     if (tran)
         Pthread_mutex_lock(&clnt->dtran_mtx);
 
+    /* preserve the hint */
+    sql_hint = pCur->fdbc->impl->sql_hint;
+
     rc = pCur->fdbc->close(pCur);
     if (rc) {
         /*rc = -1;*/
@@ -2954,6 +2960,8 @@ static int fdb_cursor_reopen(BtCursor *pCur)
         rc = clnt->fdb_state.xerr.errval;
         goto done;
     }
+
+    pCur->fdbc->impl->sql_hint = sql_hint;
 
 done:
     if (tran)
@@ -3003,6 +3011,7 @@ retry:
                     flags = FDB_RUN_SQL_SCHEMA;
                 }
             } else {
+                assert(!fdbc->is_schema);
                 sql = _build_run_sql_from_hint(
                     pCur, NULL, 0, (how == CLAST) ? OP_Prev : OP_Next, &sqllen,
                     &error);

--- a/db/sql.h
+++ b/db/sql.h
@@ -244,6 +244,7 @@ typedef struct {
 
     fdb_distributed_tran_t *
         dtran; /* remote transactions, contain each remote cluster tran */
+    bool rollbacked; /* mark this to catch out-of-order errors */
 
     sqlite3_stmt *pStmt; /* if sql is in progress, points at the engine */
     fdb_tbl_ent_t **lockedRemTables; /* list of fdb_tbl_ent_t* for read-locked

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11191,6 +11191,10 @@ void fdb_packedsqlite_process_sqlitemaster_row(char *row, int rowlen,
         }
         fld++;
     }
+    if (fld < 7) {
+        /* we received an non-version answer */
+        *version = 0;
+    }
 }
 
 int fdb_add_remote_time(BtCursor *pCur, unsigned long long start,


### PR DESCRIPTION
Ported from https://github.com/bloomberg/comdb2/pull/2434:
Fix broken sequence in transaction that rollback early
(crash in fdb_cursor_open, or otherwise access a freed dbtran->dtran)

Fixes for the retry in the first remote access (creation of fdb, populating stats):
preserve rootpage/sql_hint while reopening the remote connection
fix the sqlite stats retry.

Fix case when sqlite3LockStmtTables failed (for example, old table versions)
sql cached engines were removed from hash but kept in the [no]param_stmt_list

Fix crashes when I/O happens in between remsql sessions (printing random memory area)

Add io error generator and testcase to eliminate side-effects of failing networks

Signed-off-by: Dorin Hogea dhogea@bloomberg.net

