### PR TITLE
Fix null/empty parameter binding

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4985,20 +4985,21 @@ int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *varname, int type,
     bindval->type = type;
     bindval->varname = (char *)varname;
     bindval->value.data = (void *)varaddr;
-    if (varaddr == NULL) {
-        bindval->value.len = 0;
+    bindval->value.len = length;
+    if (length == 0) {
+        /* protobuf-c discards `data' if `len' is 0. A NULL value and a 0-length
+           value would look the same from the server's perspective. Hence we
+           need an addtional isnull flag to tell them apart. */
         bindval->has_isnull = 1;
-        bindval->isnull = 1;
-    } else if (type == CDB2_CSTRING && length == 0) {
-        bindval->value.data = (unsigned char *)"";
-        bindval->value.len = 1;
-    } else if (type == CDB2_BLOB && length == 0) {
-        bindval->value.data = (unsigned char *)"";
-        bindval->value.len = 0;
-        bindval->has_isnull = 1;
-        bindval->isnull = 0;
-    } else {
-        bindval->value.len = length;
+        bindval->isnull = (varaddr == NULL);
+
+        /* R6 and old R7 ignore isnull for cstring and treat a 0-length string
+           as NULL. So we send 1 dummy byte here to be backward compatible with
+           an old backend. */
+        if (type == CDB2_CSTRING && !bindval->isnull) {
+            bindval->value.data = (unsigned char *)"";
+            bindval->value.len = 1;
+        }
     }
     hndl->bindvars[hndl->n_bindvars - 1] = bindval;
     if (log_calls)
@@ -5028,22 +5029,17 @@ int cdb2_bind_index(cdb2_hndl_tp *hndl, int index, int type,
     bindval->type = type;
     bindval->varname = NULL;
     bindval->value.data = (void *)varaddr;
+    bindval->value.len = length;
     bindval->has_index = 1;
     bindval->index = index;
-    if (varaddr == NULL) {
-        bindval->value.len = 0;
+    if (length == 0) {
+        /* See comments in cdb2_bind_param(). */
         bindval->has_isnull = 1;
-        bindval->isnull = 1;
-    } else if (type == CDB2_CSTRING && length == 0) {
-        bindval->value.data = (unsigned char *)"";
-        bindval->value.len = 1;
-    } else if (type == CDB2_BLOB && length == 0) {
-        bindval->value.data = (unsigned char *)"";
-        bindval->value.len = 0;
-        bindval->has_isnull = 1;
-        bindval->isnull = 0;
-    } else {
-        bindval->value.len = length;
+        bindval->isnull = (varaddr == NULL);
+        if (type == CDB2_CSTRING && !bindval->isnull) {
+            bindval->value.data = (unsigned char *)"";
+            bindval->value.len = 1;
+        }
     }
     hndl->bindvars[hndl->n_bindvars - 1] = bindval;
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Cdb2Query.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Cdb2Query.java
@@ -35,6 +35,7 @@ public class Cdb2Query implements Serializable {
     }
 
     static class Cdb2BindValue {
+        int index;
         String varName;
         int type;
         byte[] value;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2LocalHandle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2LocalHandle.java
@@ -46,10 +46,16 @@ class Comdb2LocalHandle extends AbstractConnection {
     public void clearParameters() {
     }
 
+    public void bindParameter(int index, int type, byte[] data) {
+    }
+
     public void bindParameter(String name, int type, byte[] data) {
     }
 
-    public void bindParameters(Map<String, Cdb2Query.Cdb2BindValue> bindVars) {
+    public void bindNamedParameters(Map<String, Cdb2Query.Cdb2BindValue> bindVars) {
+    }
+
+    public void bindIndexedParameters(Map<Integer, Cdb2Query.Cdb2BindValue> aBindVars) {
     }
 
     public int runStatement(String sql) {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ResultSet.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ResultSet.java
@@ -153,7 +153,7 @@ public class Comdb2ResultSet implements ResultSet {
 
             byte[] bytes = hndl.columnValue(columnIndex);
 
-            if (bytes == null || bytes.length == 0) {
+            if (bytes == null) {
                 wasNull = true;
                 return null;
             }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DbHandle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DbHandle.java
@@ -43,7 +43,12 @@ public interface DbHandle extends Closeable {
     void clearParameters();
 
     /**
-     * Bind a parameter.
+     * Bind a parameter to a position.
+     */
+    void bindParameter(int index, int type, byte[] data);
+
+    /**
+     * Bind a parameter to a name.
      * 
      * @param name
      * @param type
@@ -52,9 +57,14 @@ public interface DbHandle extends Closeable {
     void bindParameter(String name, int type, byte[] data);
 
     /**
-     * Bind parameters.
+     * Bind a list of named parameters.
      */
-    void bindParameters(Map<String, Cdb2Query.Cdb2BindValue> bindVars);
+    void bindNamedParameters(Map<String, Cdb2Query.Cdb2BindValue> bindVars);
+
+    /**
+     * Bind a list of indexed parameters.
+     */
+    void bindIndexedParameters(Map<Integer, Cdb2Query.Cdb2BindValue> bindVars);
 
     /**
      * Run @sql.

--- a/db/types.c
+++ b/db/types.c
@@ -14596,6 +14596,9 @@ int get_type(struct param_data *param, void *p, int len, int type,
 #   endif
         flip = 1;
     param->null = 0;
+    /* Make sure the parameter is not NULL if we're binding a 0-length value. */
+    if (p == NULL)
+        p = "";
     switch (type) {
     case CLIENT_INT:
         param->len = sizeof(param->u.i);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1225,23 +1225,21 @@ static int newsql_param_value(struct sqlclntstate *clnt,
     param->name = val->varname;
     param->pos = val->has_index ? val->index : 0;
     param->type = newsql_to_client_type(val->type);
-
+    int len = val->value.len;
     void *p = val->value.data;
 
-    if (val->has_isnull && val->isnull) {
+    /* The bound parameter is from an old client which does not send isnull,
+       and its length is 0. Treat it as a NULL to keep backward-compatible. */
+    if (len == 0 && !val->has_isnull) {
         param->null = 1;
         return 0;
     }
 
-    if (val->value.data == NULL) {
-        if (param->type != CLIENT_BLOB) {
-            param->null = 1;
-            return 0;
-        }
-        p = (void *)"";
+    if (val->isnull) {
+        param->null = 1;
+        return 0;
     }
 
-    int len = val->value.len;
     int little = appdata->sqlquery->little_endian;
 
     return get_type(param, p, len, param->type, clnt->tzname, little);


### PR DESCRIPTION
Honor `isnull` if present. Otherwise treat a 0-length parameter as NULL. Also simplify parameter binding in cdb2jdbc.

(DRQS 162977752)
