### PR TITLE
Eventlog: change reql events rollat to take MB instead of bytes

### DIFF
--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -50,8 +50,7 @@ extern void cson_snap_info_key(cson_object *obj, snap_uid_t *snap_info);
 static char *gbl_eventlog_fname = NULL;
 static char *eventlog_fname(const char *dbname);
 int eventlog_nkeep = 2; // keep only last 2 event log files
-#define EVENTLOG_ROLLAT_MINSIZE 1024 * 2        // need minsize to avoid cleanup flood
-static int eventlog_rollat = 100 * 1024 * 1024; // 100MB to begin
+static uint64_t eventlog_rollat = 100 * 1024 * 1024; // 100MB to begin
 static int eventlog_enabled = 1;
 static int eventlog_detailed = 0;
 static int64_t bytes_written = 0;
@@ -606,6 +605,11 @@ void eventlog_stop(void)
     eventlog_disable();
 }
 
+static inline void eventlog_set_rollat(uint64_t rollat_bytes) 
+{
+    eventlog_rollat = rollat_bytes;
+}
+
 static void eventlog_help(void)
 {
     logmsg(LOGMSG_USER, "Event logging framework commands:\n"
@@ -614,7 +618,7 @@ static void eventlog_help(void)
                         "events roll              - roll the event log file\n"
                         "events keep N            - keep N files\n"
                         "events detailed <on|off> - turn on/off detailed mode (ex. sql bound param)\n"
-                        "events rollat N          - roll when log file size larger than N bytes\n"
+                        "events rollat N          - roll when log file size larger than N MB\n"
                         "events every N           - log only every Nth event, 0 logs all\n"
                         "events verbose on/off    - turn on/off verbose mode\n"
                         "events dir <dir>         - set custom directory for event log files\n"
@@ -662,7 +666,7 @@ static void eventlog_process_message_locked(char *line, int lline, int *toff)
         else if (tokcmp(tok, ltok, "off") == 0)
             eventlog_detailed = 0;
     } else if (tokcmp(tok, ltok, "rollat") == 0) {
-        off_t rollat;
+        int rollat;
         char *s;
         tok = segtok(line, lline, toff, &ltok);
         if (ltok == 0) {
@@ -676,16 +680,18 @@ static void eventlog_process_message_locked(char *line, int lline, int *toff)
         }
         rollat = strtol(s, NULL, 10);
         free(s);
-        if (rollat == 0)
-            logmsg(LOGMSG_USER, "Turned off rolling\n");
-        else if (rollat < 0 || rollat < EVENTLOG_ROLLAT_MINSIZE) {
-            logmsg(LOGMSG_USER, "Invalid size to roll (Must be greater than %d or 0 to stop rolling)\n",
-                   EVENTLOG_ROLLAT_MINSIZE);
+
+        if (rollat < 0) {
+            logmsg(LOGMSG_USER, "Invalid size to roll (%d); set to 0 to stop rolling)\n", rollat);
             return;
-        } else {
-            logmsg(LOGMSG_USER, "Rolling logs after %d bytes\n", (int)rollat);
         }
-        eventlog_rollat = rollat;
+
+        if (rollat == 0) {
+            logmsg(LOGMSG_USER, "Turned off rolling\n");
+        } else {
+            logmsg(LOGMSG_USER, "Rolling logs after %d MB\n", rollat);
+        }
+        eventlog_set_rollat(rollat * 1024 * 1024);  // we perform check in bytes
     } else if (tokcmp(tok, ltok, "every") == 0) {
         int every;
         tok = segtok(line, lline, toff, &ltok);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -653,7 +653,7 @@ static const char *help_text[] = {
     "       roll             - roll over log file",
     "       keep N           - keep N log files",
     "       detailed on/off  - turn on/off detailed mode (ex. sql bound param)",
-    "       rollat N         - roll when log file size larger than N bytes",
+    "       rollat N         - roll when log file size larger than N MB",
     "       every N          - log only every Nth event, 0 logs all",
     "       verbose on/off   - turn on/off verbose mode",
     "       dir <dir>        - set custom directory for event log files\n",

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -145,19 +145,23 @@ mv $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
 NKEEP=4
 IFS=$SAVIFS
 
-echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size ~2000 bytes"
+echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size 1 MB"
 $DEBUGGER ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
 
 waitfordb $DBNAME
 
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events detailed on')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events keep $NKEEP')"
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 4000')"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 1')" # in MB
 
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int, s cstring(4001))"
+blb=`cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "select hex(randomblob(2000))"`
 
 NUM=2000
-for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
+for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i, '$blb')"; done > in.sql 
+cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
+
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values(10001, 'abc')"
 
 # need to flush to get correct stmts in logfile
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
@@ -171,16 +175,15 @@ logflcnt=$(wc -l logfls.txt | cut -f1 -d' ')
 echo make sure we have $((NKEEP+1)) as per the lrl option
 assertres $logflcnt $((NKEEP+1))
 
-echo "make sure string 'insert into t1 values($NUM)' is in the last 2 eventlog files:"
+echo "make sure string 'insert into t1 values(10001, 'abc')' is in the last 2 eventlog files:"
 res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
-    zcat $f | jq -c 'if (.type == "sql") and (.sql == "insert into t1 values('"$NUM"')") then . else empty end'
+    zcat $f | jq -c 'if (.type == "sql") and (.sql == "insert into t1 values(10001, '"'abc'"')") then . else empty end'
 done | wc -l)
 assertres $res 1
 
 echo "Test having no limit for logfiles (turning off rolling)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"
-NUM=2000
-for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
+cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
 
 find $TESTDIR/var/log/cdb2/ | grep "/$DBNAME" | grep '.events.' > logfls2.txt
 if ! diff logfls.txt logfls2.txt ; then
@@ -216,6 +219,8 @@ assertres $d $TESTDIR/var/log
 #zcat $f | jq -c 'if (.type == "sql") and (.sql | startswith("insert into t1 values")) then . else empty end'
 #done | wc -l)
 #assertres $res $NUM
+
+COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
 
 valgrind --error-exitcode=1 --leak-check=full --trace-children=yes --quiet ${TESTSBUILDDIR}/cson_test
 res=$?


### PR DESCRIPTION
Instead of 'reql events rollat N' to be in bytes, we should have
this in MB so it does not risk rolling every few sql stmts.

Added a debug tunable to set rollat in bytes for testing purposes.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>