### PR TITLE
Eventlog: cleanup old log files outside of lock

### DIFF
--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -142,10 +142,10 @@ fi
 
 mv $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
 
-NKEEP=4
+NKEEP=5
 IFS=$SAVIFS
 
-echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size 1 MB"
+echo "start db again, make sure that we keep only $NKEEP event log files of size 1 MB"
 $DEBUGGER ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
 
 waitfordb $DBNAME
@@ -172,8 +172,8 @@ cat logfls.txt
 
 logflcnt=$(wc -l logfls.txt | cut -f1 -d' ')
 
-echo make sure we have $((NKEEP+1)) as per the lrl option
-assertres $logflcnt $((NKEEP+1))
+echo make sure we have $NKEEP as per the lrl option
+assertres $logflcnt $NKEEP
 
 echo "make sure string 'insert into t1 values(10001, 'abc')' is in the last 2 eventlog files:"
 res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do


### PR DESCRIPTION
Move calling eventlog_roll_cleanup() (which keeps only the last n most recent
eventlog files) outside of lock in order to not hold up other sql engines which
want the lock to write to the eventlog file.
Cleanup now occurs after creating the new file as opposed to before, so updating
the testcase to account for one less logfile after the cleanup.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>