### PR TITLE
Fix null/empty parameter binding (7.0)

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -14529,6 +14529,9 @@ int get_type(struct param_data *param, void *p, int len, int type,
 #   endif
         flip = 1;
     param->null = 0;
+    /* Make sure the parameter is not NULL if we're binding a 0-length value. */
+    if (p == NULL)
+        p = "";
     switch (type) {
     case CLIENT_INT:
         param->len = sizeof(param->u.i);


### PR DESCRIPTION
Honor `isnull` if present. Otherwise treat a 0-length parameter as NULL.

(DRQS 162977752)