### PR TITLE
Ported r7, eventlog: change the set command to be in MB instead of bytes

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -652,7 +652,7 @@ static const char *help_text[] = {
     "       roll             - roll over log file",
     "       keep N           - keep N log files",
     "       detailed on/off  - turn on/off detailed mode (ex. sql bound param)",
-    "       rollat N         - roll when log file size larger than N bytes",
+    "       rollat N         - roll when log file size larger than N MB",
     "       every N          - log only every Nth event, 0 logs all",
     "       verbose on/off   - turn on/off verbose mode",
     "       dir <dir>        - set custom directory for event log files\n",

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -166,19 +166,23 @@ mv $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
 NKEEP=4
 IFS=$SAVIFS
 
-echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size ~2000 bytes"
+echo "start db again, make sure that we keep only $((NKEEP+1)) event log files of size 1 MB"
 $DEBUGGER ${COMDB2_EXE} $DBNAME --no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid &> $TESTDIR/logs/${DBNAME}.db &
 
 waitfordb $DBNAME
 
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events detailed on')"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events keep $NKEEP')"
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 4000')"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 1')" # in MB
 
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t1(i int, s cstring(4001))"
+blb=`cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "select hex(randomblob(2000))"`
 
 NUM=2000
-for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
+for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i, '$blb')"; done > in.sql 
+cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
+
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values(10001, 'abc')"
 
 sleep 3
 # need to flush to get correct stmts in logfile
@@ -193,18 +197,17 @@ logflcnt=$(wc -l logfls.txt | cut -f1 -d' ')
 echo make sure we have $((NKEEP+1)) as per the lrl option
 assertres $logflcnt $((NKEEP+1))
 
-echo "make sure string 'insert into t1 values(2000)' is in the last 2 eventlog files:"
+echo "make sure string 'insert into t1 values(10001, 'abc')' is in the last 2 eventlog files:"
 cat logfls.txt | xargs ls -1t | head -2 > lastfls.txt
 echo lastfls 
 cat lastfls.txt
 
-res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(2000)' | grep -c '"type": "sql"')
+res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(10001, '"'abc'"')' | grep -c '"type": "sql"')
 assertres $res 1
 
 echo "Test having no limit for logfiles (turning off rolling)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"
-NUM=2000
-for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i)"; done | cdb2sql ${CDB2_OPTIONS} $DBNAME default -
+cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
 
 find $TESTDIR/var/log/cdb2/ | grep "/$DBNAME" | grep '.events.' > logfls2.txt
 if ! diff logfls.txt logfls2.txt ; then


### PR DESCRIPTION
Instead of 'reql events rollat N' to be in bytes, we should have
this in MB so it does not risk rolling every few sql stmts.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
