### PR TITLE
Compatibility mode for fdb requests

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -660,6 +660,7 @@ char *gbl_recovery_options = NULL;
 bool gbl_rcache = true;
 
 int gbl_noenv_messages = 1;
+int gbl_fdb_use_rqid = 0;
 
 int gbl_check_sql_source = 0;
 int skip_clear_queue_extents = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3499,6 +3499,7 @@ extern int gbl_no_env;
 int gbl_hostname_refresh_time;
 
 extern int gbl_noenv_messages;
+extern int gbl_fdb_use_rqid;
 
 extern int gbl_bbenv;
 

--- a/db/config.c
+++ b/db/config.c
@@ -333,6 +333,7 @@ static char *legacy_options[] = {
     "enable_sql_stmt_caching none",
     "enable_tagged_api",
     "env_messages",
+    "fdb_use_rqid on",
     "init_with_time_based_genids",
     "legacy_schema on",
     "logmsg level info",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1838,4 +1838,10 @@ REGISTER_TUNABLE("json_escape_control_characters",
                  TUNABLE_BOOLEAN, &gbl_json_escape_control_chars, 0, NULL, NULL,
                  NULL, NULL);
 
+REGISTER_TUNABLE("fdb_use_rqid", "Use rqid-based messages for foreign db access"
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_fdb_use_rqid, INTERNAL, NULL, NULL,
+                 NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -683,6 +683,10 @@ int osql_sock_start(struct sqlclntstate *clnt, int type, int keep_rqid)
             assert(osql->rqid);
         }
     }
+    if (gbl_fdb_use_rqid)
+        osql->rmtqid = comdb2fastseed();
+    else
+        osql->rmtqid = OSQL_RQID_USE_UUID;
 
     osql->is_reorder_on = gbl_reorder_socksql_no_deadlock;
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -141,6 +141,7 @@ typedef struct osqlstate {
     /* == sql_thread == */
     char *host;              /* matching remote node */
     unsigned long long rqid; /* per node offload request session */
+    unsigned long long rmtqid; /* per node offload request session */
     uuid_t uuid;             /* session id, take 2 */
     char *tablename;         /* malloc-ed cache of send tablename for usedb */
     int tablenamelen;        /* tablename length */


### PR DESCRIPTION
Compatibility mode for running fdb queries against older databases - generate an old request type (rqid instead of uuid-based) even if noenv-messages is enabled.