### PR TITLE
Provide a hook for plugins to specify a different fastseed generator.

### DIFF
--- a/db/envstubs.c
+++ b/db/envstubs.c
@@ -56,6 +56,8 @@ static inline void fastseed_set_dup(int dup) { fastseed_dup = dup; }
 
 extern int gbl_mynodeid;
 
+uint64_t (*external_fastseed)(void) = NULL;
+
 /* TODO: fastseed - compatibility mode only - remove */
 uint64_t comdb2fastseed(void)
 {
@@ -64,6 +66,9 @@ uint64_t comdb2fastseed(void)
     int retries;
     int seed[2];
     uint64_t out;
+
+    if (external_fastseed)
+        return external_fastseed();
 
     node = gbl_mynodeid;
     if (node < 1 || node > MAXNODE) {


### PR DESCRIPTION
Add a hook into comdb2fastseed() that plugins can override.