### PR TITLE
R7: cdb2_sqlreplay to process correctly parameters from bindindex

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3391,9 +3391,18 @@ static int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt,
             rc = SQLITE_ERROR;
             goto out;
         }
+
+        char *name;
+        if (strlen(p.name) <= 0) { // name is blank because this was from cdb2_bind_index()
+            name = alloca(12);     // enough space to fit string representation of integer
+            sprintf(name, "?%d", p.pos);
+        }
+        else 
+            name = p.name;
+
         if (p.null || p.type == COMDB2_NULL_TYPE) {
             rc = sqlite3_bind_null(stmt, p.pos);
-            eventlog_bind_null(arr, p.name);
+            eventlog_bind_null(arr, name);
             if (rc) { /* position out-of-bounds, etc? */
                 goto out;
             }
@@ -3403,11 +3412,11 @@ static int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt,
         case CLIENT_INT:
         case CLIENT_UINT:
             rc = sqlite3_bind_int64(stmt, p.pos, p.u.i);
-            eventlog_bind_int64(arr, p.name, p.u.i, p.len);
+            eventlog_bind_int64(arr, name, p.u.i, p.len);
             break;
         case CLIENT_REAL:
             rc = sqlite3_bind_double(stmt, p.pos, p.u.r);
-            eventlog_bind_double(arr, p.name, p.u.r, p.len);
+            eventlog_bind_double(arr, name, p.u.r, p.len);
             break;
         case CLIENT_CSTR:
         case CLIENT_PSTR:
@@ -3417,27 +3426,27 @@ static int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt,
              */
             p.len = strnlen((char *)p.u.p, p.len);
             rc = sqlite3_bind_text(stmt, p.pos, p.u.p, p.len, NULL);
-            eventlog_bind_text(arr, p.name, p.u.p, p.len);
+            eventlog_bind_text(arr, name, p.u.p, p.len);
             break;
         case CLIENT_VUTF8:
             rc = sqlite3_bind_text(stmt, p.pos, p.u.p, p.len, NULL);
-            eventlog_bind_varchar(arr, p.name, p.u.p, p.len);
+            eventlog_bind_varchar(arr, name, p.u.p, p.len);
             break;
         case CLIENT_BLOB:
         case CLIENT_BYTEARRAY:
             rc = sqlite3_bind_blob(stmt, p.pos, p.u.p, p.len, NULL);
-            eventlog_bind_blob(arr, p.name, p.u.p, p.len);
+            eventlog_bind_blob(arr, name, p.u.p, p.len);
             break;
         case CLIENT_DATETIME:
         case CLIENT_DATETIMEUS:
             rc = sqlite3_bind_datetime(stmt, p.pos, &p.u.dt, clnt->tzname);
-            eventlog_bind_datetime(arr, p.name, &p.u.dt, clnt->tzname);
+            eventlog_bind_datetime(arr, name, &p.u.dt, clnt->tzname);
             break;
         case CLIENT_INTVYM:
         case CLIENT_INTVDS:
         case CLIENT_INTVDSUS:
             rc = sqlite3_bind_interval(stmt, p.pos, &p.u.tv);
-            eventlog_bind_interval(arr, p.name, &p.u.tv);
+            eventlog_bind_interval(arr, name, &p.u.tv);
             break;
         default:
             rc = SQLITE_ERROR;

--- a/tests/replay_eventlog.test/Makefile
+++ b/tests/replay_eventlog.test/Makefile
@@ -5,7 +5,7 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=4m
+	export TEST_TIMEOUT=1m
 endif
 
 

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -45,6 +45,18 @@ assertcnt()
     fi
 }
 
+assertres ()
+{
+    if [ $# != 2 ] ; then 
+        failexit "number of parameters passed is $# but expecting 2"
+    fi
+    res=$1
+    target=$2
+    if [ "$res" != "$target" ] ; then
+        failexit "res is $res but should be $target"
+    fi
+}
+
 
 assert_vers()
 {
@@ -74,6 +86,7 @@ assert_schema()
 
 insert_records()
 {
+    echo "Entering insert_records()"
     j=$1
     nstop=$2
     let nout=nout+1
@@ -83,19 +96,16 @@ insert_records()
 
     while [[ $j -le $nstop ]]; do 
         cdb2sql --host $node $dbnm "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        assertres $? 0
         # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
         let j=j+1
-        sleep 0.01
     done
     echo "done inserting round $nout"
 }
 
 insert_records_with_bind()
 {
+    echo "Entering insert_records_with_bind()"
     j=$1
     nstop=$2
     let nout=nout+1
@@ -124,18 +134,15 @@ insert_records_with_bind()
 @bind CDB2_CSTRING v_alltypes_decimal64 $((1-2*(j%2)))0000000$j
 @bind CDB2_CSTRING v_alltypes_decimal128 $((1-2*(j%2)))000000000000000$j
 insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_cstring, alltypes_pstring, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values (@v_alltypes_short, @v_alltypes_u_short, @v_alltypes_int, @v_alltypes_u_int, @v_alltypes_longlong, @v_alltypes_float, @v_alltypes_double, @v_alltypes_cstring, @v_alltypes_pstring, @v_alltypes_datetime, @v_alltypes_datetimeus, @v_alltypes_vutf8, @v_alltypes_intervalym, @v_alltypes_intervalds, @v_alltypes_decimal32, @v_alltypes_decimal64, @v_alltypes_decimal128)" | cdb2sql --host $node $dbnm - &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        assertres $? 0
         let j=j+1
-        sleep 0.01
     done
     echo "done inserting round $nout"
 }
 
 update_records()
 {
+    echo "Entering update_records()"
     j=$1
     nstop=$2
     let nout=nout+1
@@ -145,18 +152,15 @@ update_records()
 
     while [[ $j -le $nstop ]]; do 
         cdb2sql --host $node $dbnm "update t1 set alltypes_short=alltypes_short+1, alltypes_int=alltypes_int+1,alltypes_u_int=alltypes_u_int+1,alltypes_longlong=alltypes_longlong+1,alltypes_float=alltypes_float=1,alltypes_double=alltypes_double+1,alltypes_decimal32=alltypes_decimal32+1,alltypes_decimal64=alltypes_decimal64+1,alltypes_decimal128=alltypes_decimal128+1 where alltypes_u_short=$j"  &>> $updfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        assertres $? 0
         let j=j+1
-        sleep 0.01
     done
     echo "done updating round $nout"
 }
 
 update_records_with_bind()
 {
+    echo "Entering update_records_with_bind()"
     j=$1
     nstop=$2
     let nout=nout+1
@@ -165,21 +169,41 @@ update_records_with_bind()
     echo "" > $updfl
 
     while [[ $j -le $nstop ]]; do 
-        jpone=$j+1
-        echo "
+       let jpone=$j+1
+       # update will effectively make col v_alltypes_int+2
+       echo "
 @bind CDB2_INTEGER v_alltypes_u_short $j
 @bind CDB2_INTEGER v_alltypes_int $jpone
-update t1 set alltypes_u_int=1+@v_alltypes_u_int where alltypes_u_short=@v_alltypes_u_short" | cdb2sql --host $node $dbnm - &>> $updfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+update t1 set alltypes_u_int=1+@v_alltypes_int where alltypes_u_short=@v_alltypes_u_short" | cdb2sql --host $node $dbnm - &>> $updfl
+        assertres $? 0
         let j=j+1
-        sleep 0.01
     done
     echo "done updating round $nout"
 }
 
+update_records_with_bind_index()
+{
+    j=$1
+    nstop=$2
+    let nout=nout+1
+    updfl=update${nout}.out
+    echo "Updating $((nstop-j+1)) records ($j to $nstop)."
+    echo "" > $updfl
+    let k=0
+
+    while [[ $j -le $nstop ]]; do 
+       let jpone=$j+1
+       let k=$k+1
+       # update will increase alltypes_u_int by 1,2,3...N
+       echo "
+@bind CDB2_INTEGER 1 $k
+@bind CDB2_INTEGER 2 $j
+update t1 set alltypes_u_int=alltypes_u_int+? where alltypes_u_short=?" | cdb2sql --host $node $dbnm - &>> $updfl
+        assertres $? 0
+        let j=j+1
+    done
+    echo "done updating round $nout"
+}
 
 delete_records()
 {
@@ -230,8 +254,11 @@ let NEWSTRT=$((INITNUMREC+1))
 insert_records_with_bind $NEWSTRT $NEWNUMREC
 assertcnt $NEWNUMREC
 
-#update_records_with_bind $NEWSTRT $NEWNUMREC
-#assertcnt $NEWNUMREC
+update_records_with_bind $NEWSTRT $((NEWSTRT+9))
+assertcnt $NEWNUMREC
+
+update_records_with_bind_index $((NEWSTRT+10)) $((NEWSTRT+19))
+assertcnt $NEWNUMREC
 
 set -e
 #echo "Now call task that uses cdb2api to ins/upd/del"
@@ -267,7 +294,7 @@ else
 fi
 
 count=`wc -l $logflunziped | cut -f 1 -d' '`
-CSHOULDBE=8244 # number of lines that should be in the log when single node
+CSHOULDBE=8286 # number of lines that should be in the log when single node
 if [[ -z "$CLUSTER" ]] && [[ $count -ne $CSHOULDBE ]] ; then 
     failexit "$logflunziped contains $count rather than $CSHOULDBE entries"
 elif [ $count -lt 4142 ] ; then
@@ -288,7 +315,7 @@ if ! diff orig.txt replayed.txt ; then
 fi
 
 if [ $success != 1 ] ; then
-    failexit "replayed.txt content is not the same as original.txt"
+    failexit "replayed.txt content is not the same as orig.txt"
 fi
 
 if [ "$CLEANUPDBDIR" != "0" ] ; then


### PR DESCRIPTION
- Modify generation of events for bound_parameters from cdb2_bind_index()
  to encode position in the name field: "?1", "?2", etc.
- Add ability to cdb2_sqlreplay to process such bound_parameters from cdb2_bind_index()
- Verify in replay_eventlog.test that cdb2_bind_index() calls are successfully replayed.

Change in master branch in https://github.com/bloomberg/comdb2/pull/2445.
Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>