### PR TITLE
cdb2jdbc: Fix mishandling of driver defaults

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -263,6 +263,7 @@ public class Comdb2Connection implements Connection {
 
     public void setStatementQueryEffects(boolean stmtEffects) {
         statement_effects = stmtEffects;
+        hndl.setStatementQueryEffects(stmtEffects);
     }
 
     public void setVerifyRetry(boolean vrfyRetry) {

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/StatementQueryEffectsTest.java
@@ -24,6 +24,25 @@ public class StatementQueryEffectsTest {
         conn.close();
     }
 
+    /* by default,
+       executeUpdate() returns the query effects made by the statement. */
+    @Test public void defaultQueryEffects() throws SQLException {
+        conn = DriverManager.getConnection(String.format(
+                    "jdbc:comdb2://%s/%s", cluster, db));
+        conn.setAutoCommit(false);
+        Statement stmt = conn.createStatement();
+
+        int nupd;
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 2 WHERE i = 1");
+        Assert.assertEquals("Updated 1 record.", 1, nupd);
+        nupd = stmt.executeUpdate("UPDATE t_stmteffects SET i = 4 WHERE i = 3");
+        Assert.assertEquals("Updated 0 record.", 0, nupd);
+
+        conn.rollback();
+        stmt.close();
+        conn.close();
+    }
+
     /* Under statement query effects,
        executeUpdate() returns the query effects made by the statement. */
     @Test public void statementQueryEffects() throws SQLException {


### PR DESCRIPTION
Per-statement query effects and verify-retry are not turned on by default. The patch fixes it.
