### PR TITLE
Remove ptranfail fault injection code

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3234,9 +3234,6 @@ int access_control_check_write(struct ireq *iq, tran_type *tran, int *bdberr);
 /* tcm test case enums */
 enum { TCM_PARENT_DEADLOCK = 1, TCM_MAX = 1 };
 
-/* return non-zero if this test is enabled */
-int tcm_testpoint(int tcmtestid);
-
 /* tagged api big or little endian. */
 enum { TAGGED_API_BIG_ENDIAN = 1, TAGGED_API_LITTLE_ENDIAN = 2 };
 

--- a/db/debug.c
+++ b/db/debug.c
@@ -40,29 +40,9 @@ enum { NETINFO_NONE = 0, NETINFO_OSQL = 1, NETINFO_REP = 2 };
 /* which event */
 enum { NETTEST_NONE = 0, NETTEST_ENABLE = 1, NETTEST_DISABLE = 2 };
 
-/* keep track of any tcm-test state that we need */
-static int tcmtest_flag = 0;
-
-/* check if a tcm test is enabled */
-int tcm_testpoint(int tcmtestid)
-{
-    if (tcmtestid < 0 || tcmtestid > TCM_MAX) {
-        logmsg(LOGMSG_ERROR, "invalid tcm testid %d\n", tcmtestid);
-        return 0;
-    }
-
-    if (tcmtest_flag == tcmtestid) {
-        return 1;
-    }
-
-    return 0;
-}
-
 /* print a description of each tcm test */
 static void tcmtest_printlist()
 {
-    logmsg(LOGMSG_USER, "ptranfail <on|off>         - enable/disable toblock "
-                    "parenttran deadlock test\n");
     logmsg(LOGMSG_USER, "routecpu <node>            - set routecpu test-node to "
                     "<node> (routes off the node)\n");
     logmsg(LOGMSG_USER, "nettest <opts>             - enable net debugging - use "
@@ -202,44 +182,6 @@ void debug_trap(char *line, int lline)
                 }
             }
         }
-
-        /* ptranfail test */
-        else if (tokcmp(tok, ltok, "ptranfail") == 0) {
-            tok = segtok(line, lline, &st, &ltok);
-
-            /* no tail */
-            if (ltok <= 0) {
-                logmsg(LOGMSG_ERROR, "ptranfail command requires 'on' or 'off' argument\n");
-                logmsg(LOGMSG_USER, "ptranfail test is %s\n",
-                       (TCM_PARENT_DEADLOCK == tcmtest_flag) ? "*enabled*"
-                                                             : "*disabled*");
-            }
-
-            /* enable this test */
-            else if (tokcmp(tok, ltok, "on") == 0) {
-                tcmtest_flag = TCM_PARENT_DEADLOCK;
-                logmsg(LOGMSG_USER, "enabled tcm parent-tran deadlock test\n");
-            }
-
-            /* disable this test */
-            else if (tokcmp(tok, ltok, "off") == 0) {
-                if (TCM_PARENT_DEADLOCK == tcmtest_flag) {
-                    tcmtest_flag = 0;
-                    logmsg(LOGMSG_USER, "disabled tcm parent-tran deadlock test\n");
-                } else {
-                    logmsg(LOGMSG_USER, "tcm parent-tran deadlock test is not enabled\n");
-                }
-            }
-
-            /* garbage tail */
-            else {
-                logmsg(LOGMSG_ERROR, "ptranfail command requires 'on' or 'off' argument\n");
-                logmsg(LOGMSG_USER, "ptranfail test is %s\n",
-                       (TCM_PARENT_DEADLOCK == tcmtest_flag) ? "*enabled*"
-                                                             : "*disabled*");
-            }
-        }
-
     } else if (tokcmp(tok, ltok, "nodeix") == 0) {
         const char *hosts[REPMAX];
         int numnodes;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5550,12 +5550,6 @@ add_blkseq:
                                        &replay_data, &replay_len);
             }
 
-            /* force a parent-deadlock for cdb2tcm */
-            if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
-                logmsg(LOGMSG_DEBUG, "tcm forcing parent retry\n");
-                rc = RC_INTERNAL_RETRY;
-            }
-
             if (rc == 0 && have_blkseq) {
                 if (iq->tranddl) {
                     if (backed_out) {
@@ -5690,23 +5684,6 @@ add_blkseq:
             }
         } else /* rowlocks */
         {
-            /* force a parent-deadlock for cdb2tcm */
-            if ((tcm_testpoint(TCM_PARENT_DEADLOCK)) && (0 == (rand() % 20))) {
-                logmsg(LOGMSG_DEBUG, "tcm forcing parent retry in rowlocks\n");
-                if (hascommitlock) {
-                    Pthread_rwlock_unlock(&commit_lock);
-                    hascommitlock = 0;
-                }
-                if (iq->tranddl)
-                    backout_and_abort_tranddl(iq, trans, 1);
-                trans_abort_logical(iq, trans, NULL, 0, NULL, 0);
-                rc = RC_INTERNAL_RETRY;
-                if (block_state_restore(iq, p_blkstate))
-                    return ERR_INTERNAL;
-                outrc = RC_INTERNAL_RETRY;
-                fromline = __LINE__;
-                goto cleanup;
-            }
             /* commit or abort the trasaction as appropriate,
                and write the blkseq */
             if (!backed_out) {


### PR DESCRIPTION
This is a "proof-of-concept" fix for the ptranfail_socksql failures we've been seeing against robomark.
