### PR TITLE
Emit an error message if generation is not set in the logstream

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -212,6 +212,7 @@ extern int gbl_instrument_dblist;
 extern int gbl_replicated_truncate_timeout;
 extern int gbl_match_on_ckp;
 extern int gbl_verbose_physrep;
+extern int gbl_physrep_exit_on_invalid_logstream;
 extern int gbl_blocking_physrep;
 extern int gbl_verbose_set_sc_in_progress;
 extern int gbl_send_failed_dispatch_message;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1846,4 +1846,8 @@ REGISTER_TUNABLE("json_escape_control_characters",
 REGISTER_TUNABLE("test_fdb_io", "Testing fail mode remote sql.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_test_io_errors, INTERNAL, NULL, NULL,
                  NULL, NULL);
+
+REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid logstream.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_physrep_exit_on_invalid_logstream, 0, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -613,6 +613,7 @@
 (name='pgcompactpool.stacksz', description='Thread stack size.', type='INTEGER', value='1048576', read_only='N')
 (name='physical_ack_interval', description='For logical transactions, have the slave send an 'ack' after this many physical operations.', type='INTEGER', value='0', read_only='N')
 (name='physical_commit_interval', description='Force a physical commit after this many physical operations.', type='INTEGER', value='512', read_only='N')
+(name='physrep_exit_on_invalid_logstream', description='Exit physreps on invalid logstream.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='physrep_reconnect_penalty', description='Physrep wait seconds before retry to the same node.  (Default: 5)', type='INTEGER', value='5', read_only='N')
 (name='physrep_register_interval', description='Interval for physical replicant re-registration.  (Default: 3600)', type='INTEGER', value='3600', read_only='N')
 (name='plannedsc', description='Use planned schema change by default', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Physical replicants require that elect_highest_committed_gen is enabled on the source cluster.  Print a message if we detect that it is not enabled there.