### PR TITLE
For a single-node cluster, always attempt to enter the SQL queue.  Also, fixes to terminology in comments, docs, and status output.

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -783,7 +783,7 @@ DEF_ATTR(TEST_IO_TIME, test_io_time, SECS, 10,
      one again to the master
 
   BDB_ATTR_SQL_QUEUEING_DISABLE_TRACE
-     disables the Queuing sql trace, which detects sql overload cases
+     disables the Queuing sql trace, which detects sql override cases
 
   BDB_ATTR_SQL_QUEUEING_CRITICAL_TRACE
      maximum number of sql queries we can queue without alerting when

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -394,6 +394,7 @@ void replication_stats(struct dbenv *dbenv)
 {
     logmsg(LOGMSG_USER, "Replication statistics:-\n");
     logmsg(LOGMSG_USER, "   Num commits      %d\n", dbenv->num_txns);
+    logmsg(LOGMSG_USER, "   Num siblings     %d\n", dbenv->nsiblings);
     if (dbenv->num_txns > 0) {
         logmsg(LOGMSG_USER, "   Avg txn sz           %" PRIu64 "\n",
                dbenv->total_txn_sz / dbenv->num_txns);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5392,6 +5392,14 @@ static int enqueue_sql_query(struct sqlclntstate *clnt, priority_t priority)
     if (gbl_thdpool_queue_only) {
         flags |= THDPOOL_QUEUE_ONLY;
     }
+    if ((thedb->nsiblings <= 1) && (clnt->queue_me == 0)) {
+        /*
+        ** NOTE: For a single-node cluster, always attempt to enter the queue
+        **       if needed, because we know there are no other nodes available
+        **       that can service requests immediately (i.e. without queueing).
+        */
+        clnt->queue_me = 1;
+    }
     if ((rc = thdpool_enqueue(gbl_sqlengine_thdpool, sqlengine_work_appsock_pp,
                               clnt, clnt->queue_me, sqlcpy, flags,
                               clnt->priority)) != 0) {

--- a/docs/pages/operating/op.md
+++ b/docs/pages/operating/op.md
@@ -79,7 +79,7 @@ Thread pool [memptrickle] stats
   Long wait alarm threshold : 30000 ms
   Thread linger time        : 10 seconds
   Thread stack size         : 1048576 bytes
-  Maximum queue overload    : 0
+  Maximum queue override    : 0
   Maximum queue age         : 0 ms
   Exit on thread errors     : yes
   Dump on queue full        : no

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -468,7 +468,7 @@ Information about thread pools in the database.
 * `long_wait_ms` - Long wait alarm threshold
 * `linger_secs` - Thread linger time
 * `stack_size` - Thread stack size
-* `max_queue_override` - Maximum queue overload
+* `max_queue_override` - Maximum queue override
 * `max_queue_age_ms` - Maximum queue age
 * `exit_on_create_fail` - If 'Y', exit on failure to create thread
 * `dump_on_full` - If 'Y', dump on queue full

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -430,7 +430,7 @@ void thdpool_print_stats(FILE *fh, struct thdpool *pool)
                 pool->lingersecs);
         logmsgf(LOGMSG_USER, fh, "  Thread stack size         : %zu bytes\n",
                 pool->stack_sz);
-        logmsgf(LOGMSG_USER, fh, "  Maximum queue overload    : %u\n",
+        logmsgf(LOGMSG_USER, fh, "  Maximum queue override    : %u\n",
                 pool->maxqueueoverride);
         logmsgf(LOGMSG_USER, fh, "  Maximum queue age         : %u ms\n",
                 pool->maxqueueagems);


### PR DESCRIPTION

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>
