### PR TITLE
Smartbeats for trigger deregistration

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -507,11 +507,15 @@ static void luabb_trigger_unregister(Lua L, dbconsumer_t *q)
     while (retry > 0) {
         --retry;
         rc = trigger_unregister_req(&q->info);
+        /* See comments in luabb_trigger_register(). */
+        comdb2_sql_tick();
         if (rc == CDB2_TRIG_REQ_SUCCESS || rc == CDB2_TRIG_ASSIGNED_OTHER)
             return;
         if (L)
             check_retry_conditions(L, &q->info, 1);
         sleep(1);
+        /* See comments in luabb_trigger_register(). */
+        comdb2_sql_tick();
     }
 }
 


### PR DESCRIPTION
Send smartbeats for trigger deregistration. This fixes hungserv false alarms on db exit.
