### PR TITLE
Eventlog: Do not record fingerprint for SP

### DIFF
--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -306,8 +306,7 @@ int srs_tran_replay(struct sqlclntstate *clnt, struct thr_handle *thr_self)
         if (rc < 0) {
             if (clnt->osql.replay != OSQL_RETRY_NONE) {
                 logmsg(LOGMSG_ERROR,
-                       "%p Replaying failed abnormally, calling "
-                       "abort, nq=%d tnq=%d\n",
+                       "%p Replaying failed abnormally, calling abort, nq=%d tnq=%d\n",
                        clnt, nq, tnq);
                 if (debug_switch_osql_verbose_history_replay()) {
                     if (osql->history) {

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2858,6 +2858,11 @@ inline void reqlog_set_event(struct reqlogger *logger, evtype_t ev)
     logger->event_type = ev;
 }
 
+inline evtype_t reqlog_get_event(struct reqlogger *logger)
+{
+    return logger->event_type;
+}
+
 void reqlog_add_table(struct reqlogger *logger, const char *table)
 {
     if (logger->ntables == logger->alloctables) {

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -81,6 +81,7 @@ void reqlog_reset_fingerprint(struct reqlogger *logger, size_t n);
 void reqlog_set_fingerprint(struct reqlogger *logger, const char *fp, size_t n);
 void reqlog_set_rqid(struct reqlogger *logger, void *id, int idlen);
 void reqlog_set_event(struct reqlogger *logger, evtype_t evtype);
+evtype_t reqlog_get_event(struct reqlogger *logger);
 void reqlog_add_table(struct reqlogger *logger, const char *table);
 void reqlog_set_error(struct reqlogger *logger, const char *error,
                       int error_code);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -448,14 +448,13 @@ static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col)
     return type;
 }
 
-static struct newsql_appdata *get_newsql_appdata(struct sqlclntstate *clnt,
-                                                 int ncols)
+#define APPDATA_MINCOLS 32
+static struct newsql_appdata *get_newsql_appdata(struct sqlclntstate *clnt, int ncols)
 {
     struct newsql_appdata *appdata = clnt->appdata;
     size_t alloc_sz;
     if (appdata == NULL) {
-        alloc_sz =
-            sizeof(struct newsql_appdata) + ncols * sizeof(appdata->type[0]);
+        alloc_sz = sizeof(struct newsql_appdata) + ncols * sizeof(appdata->type[0]);
         appdata = calloc(1, alloc_sz);
         clnt->appdata = appdata;
         if (!appdata)
@@ -463,7 +462,7 @@ static struct newsql_appdata *get_newsql_appdata(struct sqlclntstate *clnt,
         appdata->capacity = ncols;
         appdata->send_intrans_response = 1;
     } else if (appdata->capacity < ncols) {
-        size_t n = ncols + 32;
+        size_t n = ncols + APPDATA_MINCOLS;
         alloc_sz = sizeof(struct newsql_appdata) + n * sizeof(appdata->type[0]);
         appdata = realloc(appdata, alloc_sz);
         clnt->appdata = appdata;
@@ -2295,7 +2294,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     reset_clnt(&clnt, sb, 1);
     clnt_register(&clnt);
 
-    get_newsql_appdata(&clnt, 32);
+    get_newsql_appdata(&clnt, APPDATA_MINCOLS);
     plugin_set_callbacks(&clnt, newsql);
     clnt.tzname[0] = '\0';
     clnt.admin = arg->admin;
@@ -2389,8 +2388,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         sql_query = query->sqlquery;
 #ifdef EXTENDED_DEBUG
 #define MAXTOPRINT 200
-        int num = logmsg(LOGMSG_DEBUG, "Query is '%.*s", MAXTOPRINT,
-                         sql_query->sql_query);
+        int num = logmsg(LOGMSG_DEBUG, "Query is '%.*s", MAXTOPRINT, sql_query->sql_query);
         if (num >= MAXTOPRINT)
             logmsg(LOGMSG_DEBUG, "...'\n");
         else
@@ -2413,11 +2411,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         clnt.osql.sent_column_data = 0;
         clnt.stop_this_statement = 0;
 
-        if ((clnt.tzname[0] == '\0') && sql_query->tzname)
+        if (clnt.tzname[0] == '\0' && sql_query->tzname)
             strncpy0(clnt.tzname, sql_query->tzname, sizeof(clnt.tzname));
 
-        if (sql_query->dbname && dbenv->envname &&
-            strcasecmp(sql_query->dbname, dbenv->envname)) {
+        if (sql_query->dbname && dbenv->envname && strcasecmp(sql_query->dbname, dbenv->envname)) {
             char errstr[64 + (2 * MAX_DBNAME_LENGTH)];
             snprintf(errstr, sizeof(errstr),
                      "DB name mismatch query:%s actual:%s", sql_query->dbname,
@@ -2473,8 +2470,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         if (incoh_reject(clnt.admin, thedb->bdb_env) &&
             (clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS)) {
             logmsg(LOGMSG_ERROR,
-                   "%s line %d td %u new query on incoherent node, "
-                   "dropping socket\n",
+                   "%s line %d td %u new query on incoherent node, dropping socket\n",
                    __func__, __LINE__, (uint32_t)pthread_self());
             goto done;
         }
@@ -2514,8 +2510,7 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
             /* if this transaction is done (marked by SQLENG_NORMAL_PROCESS),
                clean transaction sql history
             */
-            if (clnt.osql.history &&
-                clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS) {
+            if (clnt.osql.history && clnt.ctrl_sqlengine == SQLENG_NORMAL_PROCESS) {
                 srs_tran_destroy(&clnt);
                 query = APPDATA->query = NULL;
             }


### PR DESCRIPTION
Previous checkin allowed for fingerprint to be computed for begin/commit
however Stored Procedures also call into the same code resulting in
unintended behavior.
So we now compute fingerprint only for sql event types.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>