### PR TITLE
Fix a race condition between net accept and clean exit

### DIFF
--- a/net/event.c
+++ b/net/event.c
@@ -2448,6 +2448,7 @@ static void unix_connect(int dummyfd, short what, void *data)
     struct sockaddr_un addr = {0};
     socklen_t len = sizeof(addr);
     addr.sun_family = AF_UNIX;
+    /* get_portmux_bind_path() doesn't return NULL. */
     strcpy(addr.sun_path, get_portmux_bind_path());
     int rc = connect(fd, (struct sockaddr *)&addr, len);
     if (rc == -1 && errno != EINPROGRESS) {


### PR DESCRIPTION
Clean exit sets portmux's unix socket path to NULL. It races with portmux accept where it connects to portmux via an AF_UNIX socket.

(DRQS 163806375)