### PR TITLE
Do not allow writes against physical replicants

### DIFF
--- a/berkdb/db/db_iface.c
+++ b/berkdb/db/db_iface.c
@@ -65,6 +65,12 @@ static int __dbt_ferr __P((const DB *, const char *, const DBT *, int));
  * specified as such or if we're a client in a replicated environment and
  * we don't have the special "client-writer" designation.
  */
+
+extern int gbl_is_physical_replicant;
+
+#define IS_PHYSREP(dbenv) \
+    (gbl_is_physical_replicant && LOGGING_ON(dbenv))
+
 #define	IS_READONLY(dbp)						\
     (F_ISSET(dbp, DB_AM_RDONLY) ||					\
     (IS_REP_CLIENT((dbp)->dbenv) &&					\
@@ -782,13 +788,13 @@ __db_cursor_arg(dbp, flags)
 	case 0:
 		break;
 	case DB_WRITECURSOR:
-		if (IS_READONLY(dbp))
+		if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 			return (__db_rdonly(dbenv, "DB->cursor"));
 		if (!CDB_LOCKING(dbenv))
 			return (__db_ferr(dbenv, "DB->cursor", 0));
 		break;
 	case DB_WRITELOCK:
-		if (IS_READONLY(dbp))
+		if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 			return (__db_rdonly(dbenv, "DB->cursor"));
 		if (pgorder || discardp || pausible)
 			return (__db_invwrite(dbenv, "DB->cursor"));
@@ -865,7 +871,7 @@ __db_del_arg(dbp, flags)
 	dbenv = dbp->dbenv;
 
 	/* Check for changes to a read-only tree. */
-	if (IS_READONLY(dbp))
+	if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 		return (__db_rdonly(dbenv, "DB->del"));
 
 	/* Check for invalid function flags. */
@@ -1851,7 +1857,7 @@ __db_put_arg(dbp, key, data, flags)
 	returnkey = 0;
 
 	/* Check for changes to a read-only tree. */
-	if (IS_READONLY(dbp))
+	if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 		return (__db_rdonly(dbenv, "put"));
 
 	/* Check for puts on a secondary. */
@@ -2210,7 +2216,7 @@ __db_c_del_arg(dbc, flags)
 	dbenv = dbp->dbenv;
 
 	/* Check for changes to a read-only tree. */
-	if (IS_READONLY(dbp))
+	if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 		return (__db_rdonly(dbenv, "DBcursor->del"));
 
 	/* Check for invalid function flags. */
@@ -2679,7 +2685,7 @@ __db_c_put_arg(dbc, key, data, flags)
 	key_flags = 0;
 
 	/* Check for changes to a read-only tree. */
-	if (IS_READONLY(dbp))
+	if (IS_READONLY(dbp) || IS_PHYSREP(dbenv))
 		return (__db_rdonly(dbenv, "c_put"));
 
 	/* Check for puts on a secondary. */

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -946,6 +946,7 @@ static inline int sock_restart_retryable_rcode(int restart_rc)
  * Returns the result of block processor commit
  *
  */
+extern int gbl_is_physical_replicant;
 int osql_sock_commit(struct sqlclntstate *clnt, int type)
 {
     osqlstate_t *osql = &clnt->osql;
@@ -954,6 +955,12 @@ int osql_sock_commit(struct sqlclntstate *clnt, int type)
     int retries = 0;
     int bdberr = 0;
     int timeout = 0;
+
+    if (gbl_is_physical_replicant) {
+        logmsg(LOGMSG_ERROR, "%s attempted write against physical replicant\n", __func__);
+        osql_sock_abort(clnt, type);
+        return SQLITE_READONLY;
+    }
 
     /* temp hook for sql transactions */
     /* is it distributed? */

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2571,6 +2571,8 @@ static inline int check_for_node_up(struct ireq *iq, block_state_t *p_blkstate)
     return 0;
 }
 
+extern int gbl_is_physical_replicant;
+
 static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                             struct ireq *iq, block_state_t *p_blkstate)
 {
@@ -2632,6 +2634,12 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
     iq->oplog_numops = 0;
 
     num_reqs = p_blkstate->numreq;
+
+    if (gbl_is_physical_replicant) {
+        logmsg(LOGMSG_ERROR, "%s client attempting write against physical replicant\n", __func__);
+        rc = ERR_NOMASTER;
+        return rc;
+    }
 
     /* reset queue hits stats so we don't accumulate them over several
      * retries */

--- a/tests/nophyswrite.test/Makefile
+++ b/tests/nophyswrite.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/nophyswrite.test/runit
+++ b/tests/nophyswrite.test/runit
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+[[ $debug == "1" ]] && set -x
+
+# Grab my database name.
+export repsleep=5
+export repname=rep${DBNAME}
+export repdir=${DBDIR}/$repname
+export replog=$repdir/log.txt
+export COPYCOMDB2_EXE=${BUILDDIR}/db/copycomdb2
+
+export total_tries=60
+export begin_lsn=""
+
+function write_prompt
+{
+    typeset func=$1
+    echo "[$func] $2"
+}
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="failexit"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    kill -9 $(cat $repdir/${repname}.pid)
+    exit -1
+}
+
+function make_phys_rep
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="make_phys_rep"
+    myhost=$(hostname)
+
+    mkdir -p $repdir
+
+    if [[ -z "$CLUSTER" ]]; then
+        cl="-y @localhost"
+    else
+        cl="-y @$(echo $CLUSTER | tr ' ' ',')"
+    fi
+
+    if [[ -n "$CLUSTER" ]]; then
+        if [[ "$CLUSTER" =~ .*$myhost.* ]]; then
+            rmt=""
+        else
+            clarray=($CLUSTER)
+            rmt="${clarray[0]}:"
+        fi
+    fi
+
+    write_prompt $func "Creating physical rep $repname"
+    ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H $repname $cl $rmt${DBDIR}/${DBNAME}.lrl $repdir $repdir
+    if [ ! $? -eq 0 ]; then
+        write_prompt $func "Copycomdb2 failed"
+        exit 1
+    fi
+
+    write_prompt $func "Starting replicant database, replog is $replog"
+    ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1) &
+}
+
+function setup
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="setup"
+
+    make_phys_rep
+    sleep $repsleep
+}
+
+function tear_down
+{
+    kill -9 $(cat $repdir/${repname}.pid)
+}
+
+function run_tests
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "CREATE TABLE t1 (a INT)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "INSERT INTO t1(a) values(1)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "INSERT INTO t1(a) values(1)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "INSERT INTO t1(a) values(1)"
+
+    cnt=0
+    # Wait for 3 values to propogate to physical replicant
+    while [[ "$cnt" != "3" ]]; do
+        cnt=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "select count(*) from t1")
+        sleep 1
+    done
+
+    # Try to insert against physical replicant 
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "insert into t1(a) values(4)"
+    [[ $? == 0 ]] && failexit "Database allowed inserts against physical replicant"
+
+    # Make sure there are still only 3 values
+    cnt=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "select count(*) from t1 where a = 1")
+    [[ "$cnt" != "3" ]] && failexit "Database insert against physical replicant changed count"
+
+    # Try to delete against physical replicant 
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "delete from t1 where 1"
+    [[ $? == 0 ]] && failexit "Database allowed deletes against physical replicant"
+
+    # Make sure there are still only 3 values
+    cnt=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "select count(*) from t1 where a = 1")
+    [[ "$cnt" != "3" ]] && failexit "Database deletes against physical replicant changed count"
+
+    # Try to update a physical replicant
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "update t1 set a = 4 where 1"
+    [[ $? == 0 ]] && failexit "Database allowed updates against physical replicant"
+
+    # Make sure there are still only 3 values
+    cnt=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $repname --host localhost "select count(*) from t1 where a = 1")
+    [[ "$cnt" != "3" ]] && failexit "Database updates against physical replicant changed count"
+}
+
+setup
+run_tests
+tear_down
+
+echo "Success!"


### PR DESCRIPTION
Physical replicants don't explicitly block writes.  This PR blocks writes at the Berkley-layer, in toblock, and at osql_commit, and includes a simple test to verify that writes are blocked.
