### PR TITLE
DDL-style no-csc2 schema change commands do not work on time partitions

### DIFF
--- a/tests/ddl_no_csc2.test/runit
+++ b/tests/ddl_no_csc2.test/runit
@@ -1,11 +1,12 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
-test_file="t10_view_timepart.sql"
-TIMEPART_STARTTIME=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC";\
-                    print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+2)'`
-cat ${test_file} | sed "s/{{STARTTIME}}/${TIMEPART_STARTTIME}/" > ${test_file}.new
-mv ${test_file}.new ${test_file}
+for test_file in `ls *timepart*.sql`; do
+    TIMEPART_STARTTIME=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC";\
+                        print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+2)'`
+    cat ${test_file} | sed "s/{{STARTTIME}}/${TIMEPART_STARTTIME}/" > ${test_file}.new
+    mv ${test_file}.new ${test_file}
+done
 
 ${TESTSROOTDIR}/tools/compare_results.sh -s -d $1
 [ $? -eq 0 ] || exit 1

--- a/tests/ddl_no_csc2.test/t10_view_timepart.expected
+++ b/tests/ddl_no_csc2.test/t10_view_timepart.expected
@@ -27,3 +27,13 @@
 		int i null = yes 
 	}
 ')
+(type='table', name='$1_383D642F', tbl_name='$1_383D642F', rootpage=5, sql='create table "$1_383D642F"("i" int);', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(type='table', name='time_part_t', tbl_name='time_part_t', rootpage=4, sql='create table "time_part_t"("i" int);', csc2='schema
+	{
+		int i null = yes 
+	}
+')

--- a/tests/ddl_no_csc2.test/t10_view_timepart.sql
+++ b/tests/ddl_no_csc2.test/t10_view_timepart.sql
@@ -28,5 +28,5 @@ select * from sqlite_master where name not like 'sqlite%' order by name;
 # cleanup
 drop table t2;
 drop view t2_v;
-# Can't schema change time partition
-#drop table time_part_t;
+drop time partition time_part_v;
+select * from sqlite_master where name not like 'sqlite%' order by name;

--- a/tests/ddl_no_csc2.test/t11_timepart.expected
+++ b/tests/ddl_no_csc2.test/t11_timepart.expected
@@ -1,0 +1,85 @@
+(rows inserted=3)
+(sleep(5)=5)
+(i=1)
+(i=2)
+(i=3)
+(name='$1_383D642F', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(name='$1_7FC6B09', csc2='schema
+	{
+		int i null = yes 
+		int j null = yes 
+	}
+')
+(name='t1', csc2='schema
+	{
+		int i null = yes 
+		int j null = yes 
+	}
+')
+(name='time_part_t', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(i=1, j=NULL)
+(i=2, j=NULL)
+(i=3, j=NULL)
+(name='$1_383D642F', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(name='$1_7FC6B09', csc2='schema
+	{
+		int i null = yes 
+		int j null = yes 
+	}
+keys
+	{
+		uniqnulls "IDX1" = i 
+		dup "idx2" = i 
+	}
+')
+(name='t1', csc2='schema
+	{
+		int i null = yes 
+		int j null = yes 
+	}
+keys
+	{
+		uniqnulls "IDX1" = i 
+		dup "idx2" = i 
+	}
+')
+(name='time_part_t', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(name='$1_383D642F', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(name='$1_7FC6B09', csc2='schema
+	{
+		int j null = yes 
+	}
+')
+(name='t1', csc2='schema
+	{
+		int j null = yes 
+	}
+')
+(name='time_part_t', csc2='schema
+	{
+		int i null = yes 
+	}
+')
+(j=NULL)
+(j=NULL)
+(j=NULL)

--- a/tests/ddl_no_csc2.test/t11_timepart.sql
+++ b/tests/ddl_no_csc2.test/t11_timepart.sql
@@ -1,0 +1,33 @@
+drop table if exists t1;
+
+create table t1(i int)$$
+insert into t1 values(1),(2),(3);
+
+# create a time partition
+create time partition on t1 as t1_tp period 'daily' retention 2 start '{{STARTTIME}}';
+
+select sleep(5);
+
+select * from t1_tp;
+
+# Schema change the time partition
+alter table t1_tp add column j int null$$
+select name, csc2 from sqlite_master where name not like 'sqlite%' and type = 'table' order by name;
+
+# We should now see the newly added column
+select * from t1_tp;
+
+# Try creating indices
+create unique index idx1 on t1_tp(i);
+create index idx2 on t1_tp(i);
+select name, csc2 from sqlite_master where name not like 'sqlite%' and type = 'table' order by name;
+
+# Schema change the time partition, again
+alter table t1_tp drop column i$$
+select name, csc2 from sqlite_master where name not like 'sqlite%' and type = 'table' order by name;
+
+# We should NOT see the dropped column anymore
+select * from t1_tp;
+
+# cleanup
+drop time partition t1_tp;


### PR DESCRIPTION
Fixed by retrieving the schema for the time partition from its latest shard.