### PR TITLE
Fix a race condition between net accept and clean exit

### DIFF
--- a/bbinc/portmuxapi.h
+++ b/bbinc/portmuxapi.h
@@ -265,7 +265,6 @@ const char *portmux_fds_get_instance(portmux_fd_t *fds);
 void set_portmux_port(int port);
 int set_portmux_bind_path(const char *path);
 char *get_portmux_bind_path(void);
-void clear_portmux_bind_path();
 
 /**
  * @brief  Connects to remote_host using portmux registered

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1520,7 +1520,6 @@ void clean_exit(void)
     free(gbl_myhostname);
 
     cleanresources(); // list of lrls
-    clear_portmux_bind_path();
     // TODO: would be nice but other threads need to exit first:
     // comdb2ma_exit();
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -863,6 +863,16 @@ static int page_order_table_scan_update(void *context, void *value)
     return 0;
 }
 
+static void *portmux_bind_path_get(void *dum)
+{
+    return get_portmux_bind_path();
+}
+
+static int portmux_bind_path_set(void *dum, void *path)
+{
+    return set_portmux_bind_path(path);
+}
+
 /* Routines for the tunable system itself - tunable-specific
  * routines belong above */
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -913,8 +913,8 @@ REGISTER_TUNABLE("penaltyincpercent", NULL, TUNABLE_INTEGER,
 REGISTER_TUNABLE("perfect_ckp", NULL, TUNABLE_INTEGER, &gbl_use_perfect_ckp,
                  READONLY | NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("portmux_bind_path", NULL, TUNABLE_STRING,
-                 &gbl_portmux_unix_socket, READONLY | READEARLY, NULL, NULL,
-                 NULL, NULL);
+                 NULL, READONLY | READEARLY, portmux_bind_path_get, NULL,
+                 portmux_bind_path_set, NULL);
 REGISTER_TUNABLE("portmux_port", NULL, TUNABLE_INTEGER, &portmux_port,
                  READONLY | READEARLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("prefaulthelper_blockops", NULL, TUNABLE_INTEGER,

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <poll.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -46,6 +47,7 @@
 #include <cdb2_constants.h>
 #include <logmsg.h>
 #include <mem.h>
+#include <str0.h>
 
 #ifndef PORTMUXUSR_TESTSUITE
 #include "mem_util.h"
@@ -83,8 +85,8 @@ enum {
 static int portmux_default_timeout = TIMEOUTMS;
 static int max_wait_timeoutms = MAX_WAIT_TIMEOUTMS;
 
-static const char *gbl_portmux_unix_socket_default = "/tmp/portmux.socket";
-char *gbl_portmux_unix_socket;
+#define PORTMUX_UNIX_SOCKET_DEFAULT_PATH "/tmp/portmux.socket"
+static char portmux_unix_socket[PATH_MAX] = PORTMUX_UNIX_SOCKET_DEFAULT_PATH;
 
 static int (*reconnect_callback)(void *) = NULL;
 static void *reconnect_callback_arg;
@@ -538,14 +540,14 @@ static int portmux_get_unix_socket(const char *unix_bind_path)
     /*connect to portmux unix socket*/
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
-    int uslen = strlen(gbl_portmux_unix_socket);
+    int uslen = strlen(portmux_unix_socket);
 
     if (uslen >= sizeof(addr.sun_path)) {
         logmsg(LOGMSG_ERROR, "%s:%d Portmux unix socket path too long.",
                __func__, __LINE__);
         return -1;
     } else {
-        strncpy(addr.sun_path, gbl_portmux_unix_socket, sizeof(addr.sun_path));
+        strncpy(addr.sun_path, portmux_unix_socket, sizeof(addr.sun_path));
     }
 
     len = offsetof(struct sockaddr_un, sun_path) + uslen;
@@ -554,7 +556,7 @@ static int portmux_get_unix_socket(const char *unix_bind_path)
         if ((errno != ENOENT) && (errno != ECONNREFUSED)) {
             logmsg(LOGMSG_ERROR, "%s:%d error connecting to portmux "
                                  "on %s errno[%d]=%s\n",
-                   __func__, __LINE__, gbl_portmux_unix_socket, errno,
+                   __func__, __LINE__, portmux_unix_socket, errno,
                    strerror(errno));
         }
         close(listenfd);
@@ -745,7 +747,7 @@ static int portmux_handle_recover(portmux_fd_t *fds, int timeoutms)
         /*recovered unix socket connection*/
         logmsg(LOGMSG_ERROR,
                "%s:%d reconnected to %s on fd# %d for <%s/%s/%s>\n", __func__,
-               __LINE__, gbl_portmux_unix_socket, fds->listenfd, fds->app,
+               __LINE__, portmux_unix_socket, fds->listenfd, fds->app,
                fds->service, fds->instance);
         fds->nretries = 0;
     } else {
@@ -757,7 +759,7 @@ static int portmux_handle_recover(portmux_fd_t *fds, int timeoutms)
              *connectivity drop it and only use tcp port*/
             logmsg(LOGMSG_ERROR, "%s:%d dropping recovery on %s for <%s/%s/%s> "
                                  "too many retries %d will only use port# %d\n",
-                   __func__, __LINE__, gbl_portmux_unix_socket, fds->app,
+                   __func__, __LINE__, portmux_unix_socket, fds->app,
                    fds->service, fds->instance, fds->nretries, fds->port);
             fds->recov_conn = 0 /*FALSE*/;
         }
@@ -1233,7 +1235,7 @@ static int portmux_handle_recover_v(portmux_fd_t *fds)
         /*recovered unix socket connection*/
         logmsg(LOGMSG_WARN,
                "%s:%d reconnected to %s on fd# %d for <%s/%s/%s>\n", __func__,
-               __LINE__, gbl_portmux_unix_socket, fds->listenfd, fds->app,
+               __LINE__, portmux_unix_socket, fds->listenfd, fds->app,
                fds->service, fds->instance);
         fds->nretries = 0;
     } else {
@@ -1245,7 +1247,7 @@ static int portmux_handle_recover_v(portmux_fd_t *fds)
              *connectivity drop it and only use tcp port*/
             logmsg(LOGMSG_ERROR, "%s:%d dropping recovery on %s for <%s/%s/%s> "
                                  "too many retries %d will only use port# %d\n",
-                   __func__, __LINE__, gbl_portmux_unix_socket, fds->app,
+                   __func__, __LINE__, portmux_unix_socket, fds->app,
                    fds->service, fds->instance, fds->nretries, fds->port);
             fds->recov_conn = 0 /*FALSE*/;
             return 2;
@@ -1776,25 +1778,18 @@ void set_portmux_port(int port)
     portmux_port = port;
 }
 
-void clear_portmux_bind_path()
-{
-    free(gbl_portmux_unix_socket);
-    gbl_portmux_unix_socket = NULL;
-}
-
 char *get_portmux_bind_path(void)
 {
-    return gbl_portmux_unix_socket;
+    return portmux_unix_socket;
 }
 
 int set_portmux_bind_path(const char *path)
 {
-    path = (path) ? path : gbl_portmux_unix_socket_default;
+    path = (path) ? path : PORTMUX_UNIX_SOCKET_DEFAULT_PATH;
 
     if (strlen(path) < sizeof(((struct sockaddr_un *)0)->sun_path)) {
-        free(gbl_portmux_unix_socket);
-        gbl_portmux_unix_socket = strdup(path);
-        return (gbl_portmux_unix_socket) ? 0 : -1;
+        strncpy0(portmux_unix_socket, path, sizeof(portmux_unix_socket));
+        return 0;
     }
     logmsg(LOGMSG_ERROR, "%s:%d Portmux unix socket path too long.", __func__,
            __LINE__);


### PR DESCRIPTION
Clean exit sets portmux's unix socket path to NULL. It races with portmux accept where it connects to portmux via an AF_UNIX socket.

(DRQS 163806375)