### PR TITLE
Enable release-locks-on-emit-row, check for lock-desired in that code

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -342,6 +342,7 @@ extern int gbl_debug_systable_locks;
 extern int gbl_assert_systable_locks;
 extern int gbl_track_curtran_gettran_locks;
 extern int gbl_permit_small_sequences;
+extern int gbl_debug_sleep_in_sql_tick;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2020,4 +2020,7 @@ REGISTER_TUNABLE("test_fdb_io", "Testing fail mode remote sql.  (Default: off)",
 REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid logstream.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_physrep_exit_on_invalid_logstream, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_sleep_in_sql_tick", "Sleep for a second in sql tick.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_sleep_in_sql_tick, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -600,6 +600,7 @@ static int is_sqlite_db_init(BtCursor *pCur)
    This is called every time the db does something (find/next/etc. on a cursor).
    The query is aborted if this returns non-zero.
  */
+int gbl_debug_sleep_in_sql_tick;
 static int sql_tick(struct sql_thread *thd)
 {
     struct sqlclntstate *clnt;
@@ -615,6 +616,9 @@ static int sql_tick(struct sql_thread *thd)
 
     /* Increment per-clnt sqltick */
     ++clnt->sqltick;
+
+    if (gbl_debug_sleep_in_sql_tick)
+        sleep(1);
 
     /* statement cancelled? done */
     if (clnt->stop_this_statement)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3008,7 +3008,11 @@ int release_locks_on_emit_row(struct sqlthdstate *thd,
     extern int gbl_sql_random_release_interval;
     int rep_lock_time_ms = gbl_rep_lock_time_ms;
 
-    /* Short circuit if check-waiters is disabled */
+    /* Always release if we're emitting during a master change */
+    if (bdb_lock_desired(thedb->bdb_env))
+        return release_locks("release locks on emit-row for lock-desired");
+
+    /* Short circuit if check-waiters or tunable is disabled */
     if (!gbl_locks_check_waiters)
         return 0;
 

--- a/tests/nophyswrite.test/runit
+++ b/tests/nophyswrite.test/runit
@@ -10,9 +10,6 @@ export repdir=${DBDIR}/$repname
 export replog=$repdir/log.txt
 export COPYCOMDB2_EXE=${BUILDDIR}/db/copycomdb2
 
-export total_tries=60
-export begin_lsn=""
-
 function write_prompt
 {
     typeset func=$1

--- a/tests/permitdowngrade.test/Makefile
+++ b/tests/permitdowngrade.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/permitdowngrade.test/runit
+++ b/tests/permitdowngrade.test/runit
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+selectpid=0
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+[[ $debug == "1" ]] && set -x
+
+function failexit
+{
+    [[ "$selectpid" != 0 ]] && kill -9 $selectpid
+    exit -1
+}
+
+function setup
+{
+    typeset func="setup"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "CREATE TABLE t1 (a INT)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "INSERT INTO t1 SELECT * FROM GENERATE_SERIES(1, 300)"
+    for n in ${CLUSTER} ; do 
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "PUT TUNABLE debug_sleep_in_sql_tick = '1'"
+    done
+}
+
+function run_tests
+{
+    set -x
+    master=$(get_master)
+    echo "MASTER IS $master"
+    newmaster=0
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "SELECT * FROM t1" &
+    selectpid=$!
+    sleep 2
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "EXEC PROCEDURE sys.cmd.send('downgrade')"
+    sleep 2
+    for ((i=0;i<60;++i)); do
+        m=$(get_master)
+        if [[ "$m" == "$master" ]] ; then
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        else
+            newmaster=1
+            break 2
+        fi
+        sleep 1
+    done
+
+    kill -9 $selectpid
+    selectpid=0
+
+    echo "OLD MASTER WAS $master NEW MASTER IS $(get_master)"
+    [[ "$newmaster" == "0" ]] && failexit "master never downgraded"
+}
+
+# Eventually master is watchdogged - this "succeeds" but produces a core
+setup
+run_tests
+
+echo "Success!"


### PR DESCRIPTION
Rivers tracked this one down: gbl_delay_sql_lock_release_seconds will prevent that function from releasing the bdb-lock so long as a client is actively reading from an sql cursor.  The fix is to call recover-deadlock if the bob-lock is desired in 'release_locks_on_emit_row'.  