### PR TITLE
Modify "transaction too big" error message

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2037,9 +2037,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         }
 
         if (rc == SQLITE_TOOBIG) {
-            strncpy(clnt->osql.xerr.errstr,
-                    "transaction too big, try increasing the limit using 'SET "
-                    "maxtransize N'",
+            strncpy(clnt->osql.xerr.errstr, "transaction too big",
                     sizeof(clnt->osql.xerr.errstr));
             rc = CDB2__ERROR_CODE__TRAN_TOO_BIG;
         }
@@ -5938,8 +5936,7 @@ int sql_check_errors(struct sqlclntstate *clnt, sqlite3 *sqldb,
         break;
 
     case SQLITE_TOOBIG:
-        *errstr = "transaction too big, try increasing the limit using 'SET "
-                  "maxtransize N'";
+        *errstr = "transaction too big";
         rc = ERR_TRAN_TOO_BIG;
         break;
 

--- a/tests/limitsortingtbl.test/err.expected
+++ b/tests/limitsortingtbl.test/err.expected
@@ -1,1 +1,1 @@
-[SELECT t1.* FROM t1,t2,t2 order by t1.k] failed with rc 202 transaction too big, try increasing the limit using 'SET maxtransize N'
+[SELECT t1.* FROM t1,t2,t2 order by t1.k] failed with rc 202 transaction too big

--- a/tests/trans.test/t00.expected
+++ b/tests/trans.test/t00.expected
@@ -1,4 +1,4 @@
-[COMMIT] failed with rc 202 transaction too big, try increasing the limit using 'SET maxtransize N'
+[COMMIT] failed with rc 202 transaction too big
 (COUNT(*)=2=1)
-[COMMIT] failed with rc 202 transaction too big, try increasing the limit using 'SET maxtransize N'
+[COMMIT] failed with rc 202 transaction too big
 (COUNT(*)=2=1)


### PR DESCRIPTION
It's a partial cherry-pick from master.
(commit: 75ae0e727fcc36c486c52cd8efd7fda86e73ff9e)

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>