### PR TITLE
One line change to initialize Mem before usage

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -831,6 +831,7 @@ static int ondisk_to_sqlite_tz(struct dbtable *db, struct schema *s, void *inp,
         genid = rrn;
 
     if (genid) {
+        memset(&m[fnum], 0, sizeof(Mem));
         m[fnum].u.i = genid;
         m[fnum].flags = MEM_Int;
 


### PR DESCRIPTION
Just a one line addition to Init a Mem structure before using it. 
In the loop before the line of change, we initialize Mem before using it. We seem to have missed it for the genid case 
