### PR TITLE
R7: Fix crashes from acces to sqlquery, and other eventlog fixes

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2897,6 +2897,7 @@ void reqlog_reset_fingerprint(struct reqlogger *logger, size_t n);
 void reqlog_set_fingerprint(struct reqlogger *logger, const char *fp, size_t n);
 void reqlog_set_rqid(struct reqlogger *logger, void *id, int idlen);
 void reqlog_set_event(struct reqlogger *logger, const char *evtype);
+const char *reqlog_get_event(struct reqlogger *logger);
 void reqlog_add_table(struct reqlogger *logger, const char *table);
 void reqlog_set_error(struct reqlogger *logger, const char *error,
                       int error_code);

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -572,15 +572,6 @@ static void eventlog_add_int(cson_object *obj, const struct reqlogger *logger)
     eventlog_path(obj, logger);
 }
 
-static inline void add_to_fingerprints(const struct reqlogger *logger)
-{
-    bool isSqlErr = logger->error && logger->stmt;
-
-    if ((EV_SQL == logger->event_type || isSqlErr) && !hash_find(seen_sql, logger->fingerprint)) {
-        eventlog_add_newsql(logger);
-    }
-}
-
 void eventlog_add(const struct reqlogger *logger)
 {
     int call_roll_cleanup = 0;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7887,8 +7887,7 @@ static void net_sorese_signal(void *hndl, void *uptr, char *fromhost,
     if (osql_nettype_is_uuid(usertype)) {
         osql_uuid_rpl_t uuid_hdr;
         /* unpack */
-        p_buf =
-            (uint8_t *)osqlcomm_uuid_rpl_type_get(&uuid_hdr, p_buf, p_buf_end);
+        p_buf = (uint8_t *)osqlcomm_uuid_rpl_type_get(&uuid_hdr, p_buf, p_buf_end);
         comdb2uuidcpy(uuid, uuid_hdr.uuid);
         rqid = OSQL_RQID_USE_UUID;
         type = uuid_hdr.type;
@@ -7920,8 +7919,7 @@ static void net_sorese_signal(void *hndl, void *uptr, char *fromhost,
 
             osql_chkboard_sqlsession_rc(rqid, uuid, 0, NULL, &errstat, NULL);
         } else {
-            osql_chkboard_sqlsession_rc(rqid, uuid, done.nops, NULL, NULL,
-                                        p_effects);
+            osql_chkboard_sqlsession_rc(rqid, uuid, done.nops, NULL, NULL, p_effects);
         }
 
     } else {

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2860,6 +2860,11 @@ inline void reqlog_set_event(struct reqlogger *logger, const char *evtype)
     logger->event_type = evtype;
 }
 
+inline const char *reqlog_get_event(struct reqlogger *logger)
+{
+    return logger->event_type;
+}
+
 void reqlog_add_table(struct reqlogger *logger, const char *table)
 {
     if (logger->ntables == logger->alloctables) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1656,7 +1656,7 @@ static void create_sqlite_stat_sqlmaster_record(struct dbtable *tbl)
 
 int create_datacopy_arrays()
 {
-    int rc;
+    int rc = 0;
     for (int table = 0; table < thedb->num_dbs && rc == 0; table++) {
         rc = create_datacopy_array(thedb->dbs[table]);
         if (rc)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1412,6 +1412,24 @@ static void log_cost(struct reqlogger *logger, int64_t cost, int64_t rows) {
     reqlog_set_rows(logger, rows);
 }
 
+static void reqlog_setup_begin_commit_rollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
+{
+    query_stats_setup(thd, clnt);
+    reqlog_set_event(thd->logger, EV_SQL);
+    reqlog_new_sql_request(thd->logger, clnt->sql);
+    size_t len;
+    unsigned char fp[FINGERPRINTSZ];
+
+    char stmt[7];
+    int i = 0;
+    for (const char *s = clnt->sql; *s != '\0' && *s != ' ' && i < sizeof(stmt) - 1; s++, i++) {
+        stmt[i] = (char) tolower(*s);
+    }
+    calc_fingerprint(stmt, &len, fp);
+    reqlog_set_fingerprint(thd->logger, (const char *)fp, FINGERPRINTSZ);
+    log_queue_time(thd->logger, clnt);
+}
+
 /* begin; send return code */
 int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                      enum trans_clntcomm sideeffects)
@@ -1421,8 +1439,7 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     if (sideeffects != TRANS_CLNTCOMM_CHUNK)
         clnt->ready_for_heartbeats = 0;
 
-    reqlog_new_sql_request(thd->logger, clnt->sql);
-    log_queue_time(thd->logger, clnt);
+    reqlog_setup_begin_commit_rollback(thd, clnt);
 
     /* this is a good "begin", just say "ok" */
     sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_STRT_STATE);
@@ -1907,8 +1924,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     int rc = 0;
     int outrc = 0;
 
-    reqlog_new_sql_request(thd->logger, clnt->sql);
-    log_queue_time(thd->logger, clnt);
+    reqlog_setup_begin_commit_rollback(thd, clnt);
 
     int64_t rows = clnt->log_effects.num_updated +
                    clnt->log_effects.num_deleted +
@@ -1958,7 +1974,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
        if this is a user rollback or an sqlite engine error */
     sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_NORMAL_PROCESS);
 
-/* we are out of transaction, mark this here */
 #ifdef DEBUG
     if (gbl_debug_sql_opcodes) {
         logmsg(LOGMSG_USER, "%p (U) commits transaction %d %d intran=%d\n",
@@ -1966,6 +1981,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     }
 #endif
 
+    /* we are out of transaction, mark this here */
     clnt->intrans = 0;
     clnt->dbtran.shadow_tran = NULL;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1416,12 +1416,12 @@ static void reqlog_setup_begin_commit_rollback(struct sqlthdstate *thd, struct s
 {
     query_stats_setup(thd, clnt);
     reqlog_new_sql_request(thd->logger, clnt->sql);
-    size_t len;
-    unsigned char fp[FINGERPRINTSZ];
 
     const char * ev = reqlog_get_event(thd->logger);
     if (ev && strcmp(ev, "sql") == 0) {
-        char stmt[7];
+        unsigned char fp[FINGERPRINTSZ];
+        size_t len;
+        char stmt[9] = {0}; // begin, commit, or rollback
         int i = 0;
         for (const char *s = clnt->sql; *s != '\0' && *s != ' ' && i < sizeof(stmt) - 1; s++, i++) {
             stmt[i] = (char) tolower(*s);
@@ -1484,13 +1484,13 @@ static int handle_sql_wrongstate(struct sqlthdstate *thd,
     write_response(clnt, RESPONSE_ERROR_BAD_STATE,
                    "sqlinterfaces: wrong sql handle state\n", 0);
 
-    if (srs_tran_destroy(clnt))
-        logmsg(LOGMSG_ERROR, "Fail to destroy transaction replay session\n");
-
     clnt->intrans = 0;
     reset_clnt_flags(clnt);
 
     reqlog_end_request(thd->logger, -1, __func__, __LINE__);
+
+    if (srs_tran_destroy(clnt))
+        logmsg(LOGMSG_ERROR, "Fail to destroy transaction replay session\n");
 
     return SQLITE_INTERNAL;
 }
@@ -2076,6 +2076,10 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     if (sideeffects == TRANS_CLNTCOMM_CHUNK)
         return outrc;
 
+done:
+    reset_clnt_flags(clnt);
+    reqlog_end_request(thd->logger, -1, __func__, __LINE__);
+
     /* if this is a retry, let the upper layer free the structure */
     if (clnt->osql.replay == OSQL_RETRY_NONE) {
         if (srs_tran_destroy(clnt))
@@ -2083,10 +2087,6 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
                    "Fail to destroy transaction replay session\n");
     }
 
-done:
-    reset_clnt_flags(clnt);
-
-    reqlog_end_request(thd->logger, -1, __func__, __LINE__);
     return outrc;
 }
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2395,12 +2395,10 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
                 release_node_stats(clnt.argv0, clnt.stack, clnt.origin);
                 clnt.rawnodestats = NULL;
             }
-            if (clnt.conninfo.pid &&
-                clnt.conninfo.pid != sql_query->client_info->pid) {
+            if (clnt.conninfo.pid && clnt.conninfo.pid != sql_query->client_info->pid) {
                 /* Different pid is coming without reset. */
                 logmsg(LOGMSG_WARN,
-                       "Multiple processes using same socket PID 1 %d "
-                       "PID 2 %d Host %.8x\n",
+                       "Multiple processes using same socket PID 1 %d PID 2 %d Host %.8x\n",
                        clnt.conninfo.pid, sql_query->client_info->pid,
                        sql_query->client_info->host_id);
             }

--- a/tests/replay_eventlog.test/Makefile
+++ b/tests/replay_eventlog.test/Makefile
@@ -5,7 +5,7 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=2m
 endif
 
 

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -226,6 +226,48 @@ delete_records()
     echo "done updating round $nout"
 }
 
+insert_rollback_tran()
+{
+    echo "Entering insert_records()"
+    j=$1
+    nstop=$2
+    let nout=nout+1
+    insfl=insert${nout}.out
+    echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
+    echo "" > $insfl
+
+    echo "begin" > in.sql
+    while [[ $j -le $nstop ]]; do 
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  >> in.sql
+        let j=j+1
+    done
+    echo "rollback" >> in.sql
+    cdb2sql --host $node $dbnm -f in.sql &>> $insfl
+    assertres $? 0
+    echo "done inserting round $nout"
+}
+
+insert_commit_tran()
+{
+    echo "Entering insert_records()"
+    j=$1
+    nstop=$2
+    let nout=nout+1
+    insfl=insert${nout}.out
+    echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
+    echo "" > $insfl
+
+    echo "begin" > in.sql
+    while [[ $j -le $nstop ]]; do 
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  >> in.sql
+        let j=j+1
+    done
+    echo "commit" >> in.sql
+    cdb2sql --host $node $dbnm -f in.sql &>> $insfl
+    assertres $? 0
+    echo "done inserting round $nout"
+}
+
 # Make sure we talk to the same host
 node=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT comdb2_host()"`
 export CDB2_HOST="$node"
@@ -259,6 +301,13 @@ assertcnt $NEWNUMREC
 
 update_records_with_bind_index $((NEWSTRT+10)) $((NEWSTRT+19))
 assertcnt $NEWNUMREC
+
+insert_rollback_tran $((NEWNUMREC+1)) $((NEWNUMREC+10))
+assertcnt t1 $NEWNUMREC
+
+insert_commit_tran $((NEWNUMREC+1)) $((NEWNUMREC+10))
+assertcnt t1 $((NEWNUMREC+10))
+
 
 set -e
 #echo "Now call task that uses cdb2api to ins/upd/del"

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -303,10 +303,10 @@ update_records_with_bind_index $((NEWSTRT+10)) $((NEWSTRT+19))
 assertcnt $NEWNUMREC
 
 insert_rollback_tran $((NEWNUMREC+1)) $((NEWNUMREC+10))
-assertcnt t1 $NEWNUMREC
+assertcnt $NEWNUMREC
 
 insert_commit_tran $((NEWNUMREC+1)) $((NEWNUMREC+10))
-assertcnt t1 $((NEWNUMREC+10))
+assertcnt $((NEWNUMREC+10))
 
 
 set -e
@@ -342,11 +342,11 @@ else
     zcat $logfl > $logflunziped
 fi
 
-count=`wc -l $logflunziped | cut -f 1 -d' '`
-CSHOULDBE=8286 # number of lines that should be in the log when single node
+count=`grep '"sql": ' $logflunziped | wc -l | cut -f 1 -d' '`
+CSHOULDBE=4192 # number of "sql" lines that should be in the log when single node
 if [[ -z "$CLUSTER" ]] && [[ $count -ne $CSHOULDBE ]] ; then 
     failexit "$logflunziped contains $count rather than $CSHOULDBE entries"
-elif [ $count -lt 4142 ] ; then
+elif [ $count -lt 4197 ] ; then
     failexit "$logflunziped contains $count which is too few entries"
 fi
 

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -346,8 +346,8 @@ count=`grep '"sql": ' $logflunziped | wc -l | cut -f 1 -d' '`
 CSHOULDBE=4192 # number of "sql" lines that should be in the log when single node
 if [[ -z "$CLUSTER" ]] && [[ $count -ne $CSHOULDBE ]] ; then 
     failexit "$logflunziped contains $count rather than $CSHOULDBE entries"
-elif [ $count -lt 4197 ] ; then
-    failexit "$logflunziped contains $count which is too few entries"
+elif [ $count -ne 4197 ] ; then
+    failexit "$logflunziped contains $count rather than 4197"
 fi
 
 set -e

--- a/tests/setup
+++ b/tests/setup
@@ -302,11 +302,11 @@ setup_db() {
         echo "!$TESTCASE: starting"
         for node in $CLUSTER; do
             if [ $node == $HOSTNAME ] ; then # dont ssh to ourself -- just start db locally
-                CL_PARAMS=--no-global-lrl --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+                CL_PARAMS="--no-global-lrl --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
                 if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
                     echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${CL_PARAMS} ${NOCOLOR}"
                 else
-                    ${DEBUG_PREFIX} $COMDB2_EXE ${CL_PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
+                    ${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${CL_PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
                 fi
                 continue
             fi

--- a/tests/setup
+++ b/tests/setup
@@ -47,7 +47,7 @@ if [[ -n ${DEBUGGER} ]]; then
         fi
         ;;
     valgrind)
-        DEBUG_PREFIX="valgrind"
+        DEBUG_PREFIX="valgrind --track-origins=yes"
         if [[ -z ${INTERACTIVE_DEBUG} ]]; then
             INTERACTIVE_DEBUG=0
         fi

--- a/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
+++ b/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
@@ -153,48 +153,47 @@ bool event_is_sql(cson_value *val) {
     return get_strprop(val, "type") == std::string("sql");
 }
 
-void replay_transaction(cdb2_hndl_tp *db, std::list<cson_value*> &list) {
-    cson_value *statement;
-
-    std::cout << "replay" << std::endl;
+void replay_transaction(cdb2_hndl_tp *db, cson_value *val)
+{
+    const char *cnonce = get_strprop(val, "cnonce");
+    assert(cnonce != nullptr);
+    auto jt = transactions.find(cnonce);
+    assert(jt != transactions.end());
+    auto &list = (*jt).second;
+    std::cout << "replay transaction " << cnonce << std::endl;
 
     auto it = list.begin();
     while (it != list.end()) {
-        std::cout << "replaying txn" << std::endl;
-        if (event_is_sql(*it))
-            replay(db, *it);
-        
+        assert(event_is_sql(*it));
+        replay(db, *it);
         cson_free_value(*it);
         it = list.erase(it);
     }
+    transactions.erase(jt);
+    replay(db, val); // finally 'commit' or 'rollback'
 }
 
-void add_to_transaction(cdb2_hndl_tp *db, cson_value *val) {
-    const char *s = get_strprop(val, "id");
+bool is_part_of_transaction(const char *cnonce)
+{
+    auto it = transactions.find(cnonce);
+    return (it != transactions.end());
+}
+
+void add_to_transaction(cson_value *val)
+{
+    const char *cnonce = get_strprop(val, "cnonce");
     const char *type = get_strprop(val, "type");
 
-    auto i = transactions.find(s);
-    if (i == transactions.end()) {
-        std::cout << "new transaction " << s << std::endl;
+    auto it = transactions.find(cnonce);
+    if (it == transactions.end()) {
+        std::cout << "new transaction " << cnonce << std::endl;
         std::list<cson_value*> statements;
         statements.push_back(val);
-        transactions.insert(std::pair<std::string, std::list<cson_value*>>(s, statements));
-    }
-    else {
-        auto &list = (*i).second;
-        std::cout << "add to existing transaction " << list.size() << " (" << event_is_txn(list.front()) <<  ") " << s << std::endl;
-        if (list.size() == 1 && event_is_txn(list.front())) {
-            /* This is a single statement, and we just saw it's transaction.  We can 
-               now replay the whole list. */
-            list.push_back(list.front());
-            list.pop_front();
-            replay_transaction(db, list);
-        }
-        else {
-            list.push_back(val);
-            if (event_is_txn(val))
-                replay_transaction(db, list);
-        }
+        transactions.insert(std::pair<std::string, std::list<cson_value*>>(cnonce, statements));
+    } else {
+        auto &list = (*it).second;
+        std::cout << "add to existing transaction " << cnonce << " size=" << list.size() << std::endl;
+        list.push_back(val);
     }
 }
 
@@ -239,7 +238,7 @@ bool do_bindings(cdb2_hndl_tp *db, cson_value *event_val,
             int64_t *iv = new int64_t;
             bool succ = get_intprop(bp, "value", iv);
             if (!succ) {
-                std::cerr << "error getting " << type << " value of bound parameter " << name << std::endl;
+                std::cerr << "Error getting " << type << " value of bound parameter " << name << std::endl;
                 return false;
             }
             cdb2_type = CDB2_INTEGER;
@@ -251,7 +250,7 @@ bool do_bindings(cdb2_hndl_tp *db, cson_value *event_val,
             double *dv = new double;
             bool succ = get_doubleprop(bp, "value", dv);
             if (!succ) {
-                std::cerr << "error getting " << type << " value of bound parameter " << name << std::endl;
+                std::cerr << "Error getting " << type << " value of bound parameter " << name << std::endl;
                 return false;
             }
             cdb2_type = CDB2_REAL;
@@ -265,7 +264,7 @@ bool do_bindings(cdb2_hndl_tp *db, cson_value *event_val,
                  ) {
             const char *strp = get_strprop(bp, "value");
             if (strp == nullptr) {
-                std::cerr << "error getting " << type << " value of bound parameter " << name << std::endl;
+                std::cerr << "Error getting " << type << " value of bound parameter " << name << std::endl;
                 return false;
             }
             cdb2_type = CDB2_CSTRING;
@@ -276,7 +275,7 @@ bool do_bindings(cdb2_hndl_tp *db, cson_value *event_val,
         else if( strcmp(type, "byte") == 0 || strcmp(type, "blob") == 0) {
             const char *strp = get_strprop(bp, "value");
             if (strp == nullptr) {
-                std::cerr << "error getting " << type << " value of bound parameter " << name << std::endl;
+                std::cerr << "Error getting " << type << " value of bound parameter " << name << std::endl;
                 return false;
             }
             assert(strp[0] == 'x' && strp[1] == '\'' && "Blob field needs to be in x'123abc' format");
@@ -304,13 +303,13 @@ bool do_bindings(cdb2_hndl_tp *db, cson_value *event_val,
         if (name[0] == '?') {
             int idx = atoi(name + 1);
             if ((ret = cdb2_bind_index(cdb2h, idx, cdb2_type, varaddr, length)) != 0) {
-                std::cerr << "error from cdb2_bind_index() column " << name << ", ret=" << ret << std::endl;
+                std::cerr << "Error from cdb2_bind_index() column " << name << ", ret=" << ret << std::endl;
                 return false;
             }
         }
         else {
             if ((ret = cdb2_bind_param(cdb2h, name, cdb2_type, varaddr, length)) != 0) {
-                std::cerr << "error from cdb2_bind_param column " << name << ", ret=" << ret << std::endl;
+                std::cerr << "Error from cdb2_bind_param column " << name << ", ret=" << ret << std::endl;
                 return false;
             }
         }
@@ -463,12 +462,12 @@ void replay(cdb2_hndl_tp *db, cson_value *event_val) {
     if(sql == nullptr) {
 	    const char *fp = get_strprop(event_val, "fingerprint");
 	    if (fp == nullptr) {
-		    std::cerr << "No fingerprint logged?" << std::endl;
+		    std::cerr << "Error: No fingerprint logged?" << std::endl;
 		    return;
 	    }
 	    auto s = sqltrack.find(fp);
 	    if (s == sqltrack.end()) {
-		    std::cerr << "Unknown fingerprint? " << fp << std::endl;
+		    std::cerr << "Error: Unknown fingerprint? " << fp << std::endl;
 		    return;
 	    }
 	    sql = (*s).second.c_str();
@@ -487,7 +486,7 @@ void replay(cdb2_hndl_tp *db, cson_value *event_val) {
     free_blobs(blobs_vect);
 
     if (rc != CDB2_OK) {
-        std::cerr << "run rc " << rc << ": " << cdb2_errstr(db) << std::endl;
+        std::cerr << "Error: run rc " << rc << ": " << cdb2_errstr(db) << std::endl;
         return;
     }
 
@@ -508,7 +507,7 @@ void replay(cdb2_hndl_tp *db, cson_value *event_val) {
         std::cout << std::endl;
     }
     if (rc != CDB2_OK_DONE) {
-        std::cerr << "next rc " << rc << ": " << cdb2_errstr(db) << std::endl;
+        std::cerr << "Error: next rc " << rc << ": " << cdb2_errstr(db) << std::endl;
         return;
     }
 }
@@ -525,38 +524,51 @@ void replay(cdb2_hndl_tp *db, cson_value *event_val) {
      eliminate it.
   */
 
+
+/* We can only replay if we have the full SQL, including parameters.
+   That means
+   1) event logged a bindings array
+   2) event logged a nbindings integer, and it's 0
+
+   If there's non-zero bindings and we don't have them, we can't replay.
+
+   Another complication is transactions - we don't want to play one back
+   until we have all the statements collected, and see a commit event.
+   Anything with a cnonce logged is part of a transaction - a commit
+   event will have the same cnonce.  SQL writes that are not part of
+   a transaction get logged before txn log entry.  SQL in BEGIN/COMMIT
+   blocks gets logged before the txn log entry as well.
+   */ 
 void handle_sql(cdb2_hndl_tp *db, cson_value *event_val) {
     int rc;
-    /* We can only replay if we have the full SQL, including parameters.
-       That means
-       1) event logged a bindings array
-       2) event logged a nbindings integer, and it's 0
-
-       If there's non-zero bindings and we don't have them, we can't replay.
-
-       Another complication is transactions - we don't want to play one back
-       until we have all the statements collected, and see a commit event.
-       Anything with an id logged is part of a transaction - a commit
-       event will have the same id.  SQL writes that are not part of
-       a transaction get logged after transaction.  SQL in BEGIN/COMMIT
-       blocks gets logged before the transaction.
-
-       */ 
-
     if (!is_replayable(event_val)) {
         cson_free_value(event_val);
         return;
     }
 
-#if 0
-    if (is_transactional(event_val)) {
-        add_to_transaction(db, event_val);
+    const char *cnonce = get_strprop(event_val, "cnonce");
+    if (cnonce == nullptr) { // no cnonce if comdb2api -- just replay it
+        replay(db, event_val);
+        cson_free_value(event_val);
         return;
     }
-#endif
-    
-    replay(db, event_val);
-    cson_free_value(event_val);
+
+    const char *sql = get_strprop(event_val, "sql");
+    assert(sql != nullptr);
+    if (strcmp(sql, "commit") == 0 || strcmp(sql, "rollback") == 0) {
+        if (!is_part_of_transaction(cnonce)) {
+            std::cerr << "Error: Commit/rollback record without cnonce in txn list (possibly already commited)"
+                      << std::endl;
+        } else {
+            replay_transaction(db, event_val);
+        }
+        cson_free_value(event_val);
+    } else if (strcmp(sql, "begin") == 0 || is_part_of_transaction(cnonce)) {
+        add_to_transaction(event_val); // new entry in list, or append
+    } else { // normal 'sql' statement entry which are not part of a transaction
+        replay(db, event_val); // replay immediately
+        cson_free_value(event_val);
+    }
 }
 
 /* TODO: error messages? */
@@ -583,7 +595,34 @@ void handle_newsql(cdb2_hndl_tp *db, cson_value *val) {
 
 
 void handle_txn(cdb2_hndl_tp *db, cson_value *val) {
-    add_to_transaction(db, val);
+    /* TODO: To achieve closer output to the original db,
+     * we should commit when we encounter 'txn' record, not upon 'commit'
+     * However, to have the sql within a txn replayed correctly we
+     * should run it immediately (instead of at commit time).
+     *
+     * Otherwise the results are different from the original db:
+     * create table t1 (i int);
+     * create table t2 (i int);
+     * txn1 begin
+     * txn2 begin
+     * txn1 insert into t1 select * from t2
+     * txn2 insert into t2 select * from t3
+     * txn1 commit
+     * txn2 commit
+     * 
+     * if we run the entire transaction txn1 and commit, then run txn2 
+     * then commit, the result will be different from the original
+     * run which read (when t2 was empty). 
+     *
+     * We could run different transactions in separate threads, 
+     * and issue sql at the correct time for the reads to be consistent
+     * with original db. tools/serial.c does something like this and
+     * could be an improvement in future.
+     *
+    const char *cnonce = get_strprop(val, "cnonce");
+    if (cnonce != nullptr && is_part_of_transaction(cnonce))
+        replay_transaction(db, val);
+    */
 }
 
 typedef void (*event_handler)(cdb2_hndl_tp *db, cson_value *val);
@@ -618,11 +657,11 @@ void process_events(cdb2_hndl_tp *db, std::istream &in) {
 
         rc = cson_parse_string(&event_val, line.c_str(), line.length(), &cson_parse_opt_empty, &pinfo);
         if (rc) {
-            std::cerr << "Malformed input on line " << linenum << std::endl;
+            std::cerr << "Error: Malformed input on line " << linenum << std::endl;
             continue;
         }
         if (!cson_value_is_object(event_val)) {
-            std::cerr << "Not an object  on line " << linenum << std::endl;
+            std::cerr << "Error: Not an object  on line " << linenum << std::endl;
             continue;
         }
         const char *type = get_strprop(event_val, "type");
@@ -655,24 +694,22 @@ int main(int argc, char **argv) {
     if (conf) {
         cdb2_set_comdb2db_config(conf);
         rc = cdb2_open(&cdb2h, dbname, "default", 0);
-    }
-    else { 
+    } else { 
         rc = cdb2_open(&cdb2h, dbname, "local", 0);
     }
 
     if (rc) {
-        std::cerr << "cdb2_open() failed: " << cdb2_errstr(cdb2h) << std::endl;
+        std::cerr << "Error: cdb2_open() failed: " << cdb2_errstr(cdb2h) << std::endl;
         exit(EXIT_FAILURE);
     }
 
     if (filename == nullptr) {
         process_events(cdb2h, std::cin);
-    }
-    else {
+    } else {
         std::ifstream f;
         f.open(filename);
         if (!f.good()) {
-            std::cerr << "Can't open " << filename << ": " << strerror(errno) << std::endl;
+            std::cerr << "Error: Can't open " << filename << ": " << strerror(errno) << std::endl;
             return 1;
         }
 


### PR DESCRIPTION
* Fix crashes from acces to sqlquery after calling srs_tran_destroy - see #2492
* Eventlog: Do not record fingerprint for SP - see #2480
* Eventlog: fingerprint and cnonce for begin/commit/rollback - see #2462

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>