### PR TITLE
Tweak systbl_proc_leak test

### DIFF
--- a/tests/systbl_proc_leak.test/lrl.options
+++ b/tests/systbl_proc_leak.test/lrl.options
@@ -1,0 +1,3 @@
+sqlenginepool linger 4
+sqlenginepool mint 0
+sqlenginepool maxt 1

--- a/tests/systbl_proc_leak.test/runit
+++ b/tests/systbl_proc_leak.test/runit
@@ -14,14 +14,23 @@ for i in `seq 1 100`; do
   cdb2sql -s ${CDB2_OPTIONS} --host $mach $dbnm "create procedure sp$i { local function main (e) end }" >/dev/null
 done
 
+# Sleep more than the lingering time to ensure we start with 0 SQL thread in the database below.
+sleep 5
+
 # Warm up
 yes 'select name, version from comdb2sys_procedures' | head -100 | cdb2sql -s ${CDB2_OPTIONS} --host $mach $dbnm ->/dev/null
+
+# allow a bit of time for the SQL thread to clean up itself.
+sleep 2
 
 # Get memory snapshot
 cdb2sql --tabs -s ${CDB2_OPTIONS} --host $mach $dbnm 'exec procedure sys.cmd.send("memstat bdb")' >expected
 
 # Run the leak reproducer
 yes 'select name, version from comdb2sys_procedures' | head -100 | cdb2sql -s ${CDB2_OPTIONS} --host $mach $dbnm ->/dev/null
+
+# allow a bit of time for the SQL thread to clean up itself.
+sleep 2
 
 # Get memory snapshot again
 cdb2sql --tabs -s ${CDB2_OPTIONS} --host $mach $dbnm 'exec procedure sys.cmd.send("memstat bdb")' >actual


### PR DESCRIPTION
The test works only when there is one single SQL thread in the database. However, because of the extra cleanup work after a statement is finished, an SQL thread isn't always immediately available for the next statement and hence a new SQL thread is spawned. It causes the test to fail intermittently.

The change makes sure that the test database can have 1 SQL thread at most.