### PR TITLE
Fix crash while casting datetime 

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -4356,6 +4356,7 @@ u32 sqlite3VdbeSerialGet(
 
       pMem->flags = MEM_Datetime;
       pMem->tz = NULL;  /* make sure it's not garbage */
+      pMem->z = NULL; // make sure this ain't garbage either 
       return sizeof(dttz_t);
     }
     case SQLITE_MAX_U32: {  /* datetime blob */


### PR DESCRIPTION
The following causes the database to crash reliably: 

CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1(a datetime)"
CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index idx1 on t1(a)"

for (( x = 0 ; x < 20 ; ++x )) ; do
   $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(now())"
done

x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select cast(a as long) from t1 order by a")
echo "$x"

When fetching from an index, pMem->z remains unintialized and points to garbage. 
This causes a crash while casting, where we check this field for NULLNESS (for correct behavior).

This PR sets pMem->z to NULL in sqlite3VdbeSerialGet while copying values into register in OP_Column 