### PR TITLE
Properly reset 'sqlthdstate->query_preparer_running' to prevent asserts in the debug build.

### DIFF
--- a/db/sqlpool.c
+++ b/db/sqlpool.c
@@ -50,6 +50,7 @@ void sqlengine_thd_start(struct thdpool *pool, struct sqlthdstate *thd,
     thd->sqldb = NULL;
     thd->stmt_caching_table = NULL;
     thd->have_lastuser = 0;
+    thd->query_preparer_running = 0;
 
     start_sql_thread();
 


### PR DESCRIPTION

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>
