### PR TITLE
Some SP statememts may not get fingerprinted

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2145,16 +2145,21 @@ static void lua_another_step(struct sqlclntstate *clnt,
 static void lua_end_step(struct sqlclntstate *clnt, SP sp,
                          sqlite3_stmt *pStmt)
 {
-    int64_t time = comdb2_time_epochms();
     Vdbe *pVdbe = (Vdbe*)pStmt;
 
-    if ((sp != NULL) && (pVdbe != NULL) && (pVdbe->luaStartTime != 0)) {
+    /* Check whether fingerprint has already been computed. */
+    if ((pVdbe == NULL) || (pVdbe->fingerprint_added == 1)) {
+        return;
+    }
+
+    if ((sp != NULL) && (pVdbe->luaStartTime != 0)) {
         const char *zNormSql = sqlite3_normalized_sql(pStmt);
 
         if (zNormSql != NULL) {
             double cost = 0.0;
             int64_t prepMs = 0;
             int64_t timeMs;
+            int64_t time = comdb2_time_epochms();
 
             clnt_query_cost(sp->thd, &cost, &prepMs);
             timeMs = time - pVdbe->luaStartTime + prepMs;
@@ -2172,6 +2177,8 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
             clnt->spcost.time += timeMs;
             clnt->spcost.prepTime += prepMs;
             clnt->spcost.rows += pVdbe->luaRows;
+
+            pVdbe->fingerprint_added = 1;
         }
 
         restore_thd_cost_and_reset(sp->thd, pVdbe);
@@ -2275,6 +2282,8 @@ static int luatable_emit(Lua L)
     } else {
         return luaL_error(L, "attempt to emit row without defining columns");
     }
+    /* NC: Should we iterate over all the rows here and call lua_end_step()
+       (like dbstmt_emit()) ? */
     int rc = l_send_back_row(L, stmt, cols);
     lua_pushinteger(L, rc);
     return 1;
@@ -3238,7 +3247,13 @@ static int join_threads(SP sp)
 static int dbstmt_free(Lua L)
 {
     dbstmt_t *stmt = lua_touserdata(L, -1);
-    donate_stmt(getsp(L), stmt);
+    SP sp = getsp(L);
+
+    /* Compute and add fingerprint for this statement in case it wasn't
+       done already. */
+    lua_end_step(sp->clnt, sp, stmt->stmt);
+
+    donate_stmt(sp, stmt);
     return 0;
 }
 

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -586,6 +586,7 @@ struct Vdbe {
   double luaSavedCost;    /* saved cost for this Lua thread */
   char **oldColNames;     /* Column names returned by old-sqlite version */
   int oldColCount;        /* Column count (refer: sqlitex)*/
+  u8 fingerprint_added;   /* Whether fingerprint was added? Only used in SP code */
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 

--- a/tests/fingerprints.test/t05.req
+++ b/tests/fingerprints.test/t05.req
@@ -1,0 +1,30 @@
+create procedure fp_test_1 version 'sptest' {
+    local function main()
+	local t, rc = db:prepare([[SELECT 1,2,3,4,5]])
+	if rc ~=0 then
+	    return rc
+	end
+	local row = t:fetch()
+	db:emit(row)
+	return 0
+    end}$$
+put default procedure fp_test_1 'sptest'
+exec procedure fp_test_1()
+
+create procedure fp_test_2 version 'sptest' {
+    local function main()
+	local t, rc = db:prepare([[SELECT 6,7,8,9,10]])
+	if rc ~=0 then
+	    return rc
+	end
+	local row = t:fetch()
+	while row do
+	    db:emit(row)
+	    row = t:fetch()
+	end
+	return 0
+    end}$$
+put default procedure fp_test_2 'sptest'
+exec procedure fp_test_2()
+
+select * from comdb2_fingerprints where normalized_sql = 'SELECT?,?,?,?,?;' order by 1;

--- a/tests/fingerprints.test/t05.req.out
+++ b/tests/fingerprints.test/t05.req.out
@@ -1,0 +1,5 @@
+(version='sptest')
+(1=1, 2=2, 3=3, 4=4, 5=5)
+(version='sptest')
+(6=6, 7=7, 8=8, 9=9, 10=10)
+(fingerprint='c868ab16d94b512fb381974224dae18e', count=2, total_cost=0, total_time=0, total_prep_time=0, total_rows=2, normalized_sql='SELECT?,?,?,?,?;')


### PR DESCRIPTION
In a simple case where a SELECT statement is prepared, fetched and emitted only once - its fingerprint is never never logged.

```
local function main()
    local t, rc = db:prepare([[SELECT 1,2]])
    if rc ~=0 then
	return rc
    end
    local row = t:fetch()
    db:emit(row)
    return 0
end
```

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>