### PR TITLE
Fix random -105 in transactions with big blobs

### DIFF
--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2138,10 +2138,8 @@ retry_read:
         Pthread_mutex_unlock(&clnt->wait_mutex);
     }
 
-    if (!query || (errno != 0)) {
+    if (!query) {
         logmsg(LOGMSG_ERROR, "%s:%d Error unpacking query error: %s\n", __func__, __LINE__, strerror(errno));
-        if (query)
-            cdb2__query__free_unpacked(query, &pb_alloc);
         return NULL;
     }
 


### PR DESCRIPTION
As per https://port70.net/~nsz/c/c11/n1570.html#7.5p3 and https://linux.die.net/man/3/malloc, always rely on return value in case of malloc/realloc/calloc