### PR TITLE
Since the trans_commit() pipeline (eventually) frees its 'tran' argument, make sure to NULL it out so it will not be passed to trans_abort().

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -629,6 +629,7 @@ tran_type *bdb_start_ltran_rep_sc(bdb_state_type *bdb_state,
 void bdb_set_tran_lockerid(tran_type *tran, uint32_t lockerid);
 void bdb_get_tran_lockerid(tran_type *tran, uint32_t *lockerid);
 void *bdb_get_physical_tran(tran_type *ltran);
+void bdb_reset_physical_tran(tran_type *ltran);
 void *bdb_get_sc_parent_tran(tran_type *ltran);
 void bdb_ltran_get_schema_lock(tran_type *ltran);
 void bdb_ltran_put_schema_lock(tran_type *ltran);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -261,6 +261,12 @@ void *bdb_get_physical_tran(tran_type *ltran)
     return ltran->physical_tran;
 }
 
+void bdb_reset_physical_tran(tran_type *ltran)
+{
+    assert(ltran->tranclass == TRANCLASS_LOGICAL);
+    ltran->physical_tran = NULL;
+}
+
 void *bdb_get_sc_parent_tran(tran_type *ltran)
 {
     assert(ltran->tranclass == TRANCLASS_LOGICAL);
@@ -1629,7 +1635,8 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
                         "%s:update_shadows_beforecommit nonblocking rc %d\n",
                         __func__, rc);
                 *bdberr = rc;
-                return -1;
+                outrc = -1;
+                goto cleanup;
             }
 
             if (!isabort && tran->committed_child &&

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -428,6 +428,7 @@ int fdb_svc_trans_commit(char *tid, enum transaction_level lvl,
                 logmsg(LOGMSG_ERROR, "%s: failed %s rc=%d bdberr=%d\n", __func__,
                         (rc == SQLITE_OK) ? "commit" : "abort", irc, bdberr);
             }
+            clnt->dbtran.shadow_tran = NULL;
         }
     }
 

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -855,11 +855,11 @@ again:
         goto done;
     }
     rc = trans_commit(&iq, trans, gbl_mynode);
+    trans = NULL;
     if (rc) {
         printf("toclear: commit rc %d\n", rc);
         goto done;
     }
-    trans = NULL;
 
 done:
     if (trans) {

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1808,8 +1808,10 @@ void *osql_commit_timepart_resuming_sc(void *p)
 
 abort_sc:
     logmsg(LOGMSG_ERROR, "%s: aborting schema change\n", __func__);
-    if (iq.sc_tran)
+    if (iq.sc_tran) {
         trans_abort(&iq, iq.sc_tran);
+        iq.sc_tran = NULL;
+    }
     backout_schema_changes(&iq, parent_trans);
     if (iq.sc_locked) {
         unlock_schema_lk();

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -602,11 +602,11 @@ again:
         goto done;
     }
     rc = trans_commit(&iq, trans, gbl_mynode);
+    trans = NULL;
     if (rc) {
         logmsg(LOGMSG_ERROR, "analyze: commit rc %d\n", rc);
         goto done;
     }
-    trans = NULL;
 
 done:
     if (trans) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4781,7 +4781,6 @@ int sqlite3BtreeCommit(Btree *pBt)
 
             if (!rc) {
                 irc = trans_commit_shadow(clnt->dbtran.shadow_tran, &bdberr);
-                clnt->dbtran.shadow_tran = NULL;
             } else {
                 irc = trans_abort_shadow((void **)&clnt->dbtran.shadow_tran,
                                          &bdberr);
@@ -4790,6 +4789,7 @@ int sqlite3BtreeCommit(Btree *pBt)
                 logmsg(LOGMSG_ERROR, "%s: commit failed rc=%d bdberr=%d\n", __func__,
                         irc, bdberr);
             }
+            clnt->dbtran.shadow_tran = NULL;
         }
 
         /* UPSERT: Restore the isolation level back to what it was. */
@@ -4831,7 +4831,7 @@ int sqlite3BtreeCommit(Btree *pBt)
         if (clnt->dbtran.shadow_tran) {
             rc = serial_commit(clnt, thd, clnt->tzname);
             if (!rc) {
-                if (clnt->dbtran.shadow_tran) {
+                if (clnt->dbtran.shadow_tran) { // TODO: NULL possible here?  Maybe from serial_commit?
                     irc =
                         trans_commit_shadow(clnt->dbtran.shadow_tran, &bdberr);
                 }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1642,6 +1642,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                                __func__, (rc == SQLITE_OK) ? "commit" : "abort",
                                irc, bdberr);
                     }
+                    clnt->dbtran.shadow_tran = NULL;
                 }
             } else {
                 reset_query_effects(clnt);
@@ -1715,6 +1716,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                                __func__, (rc == SQLITE_OK) ? "commit" : "abort",
                                irc, bdberr);
                     }
+                    clnt->dbtran.shadow_tran = NULL;
                 } else {
                     sql_debug_logf(clnt, __func__, __LINE__,
                                    "no-shadow-tran returning %d\n", rc);

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2094,12 +2094,14 @@ static int osql_destroy_transaction(struct ireq *iq, tran_type **parent_trans,
     int rc = 0;
 
     rc = trans_abort(iq, *trans);
+    *trans = NULL;
     if (rc) {
         logmsg(LOGMSG_ERROR, "aborting transaction failed\n");
         error = 1;
     }
     if (parent_trans && *parent_trans) {
         rc = trans_abort(iq, *parent_trans);
+        *parent_trans = NULL;
         if (rc) {
             logmsg(LOGMSG_ERROR, "aborting parent transaction failed\n");
             error = 1;
@@ -2107,9 +2109,6 @@ static int osql_destroy_transaction(struct ireq *iq, tran_type **parent_trans,
     }
 
     *osql_needtransaction = OSQL_BPLOG_NOTRANS;
-    if (parent_trans)
-        *parent_trans = NULL;
-    *trans = NULL;
 
     return error;
 }
@@ -2406,6 +2405,7 @@ static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent,
         /* Check if we started a physical transaction. */
         if (bdb_get_physical_tran(parent) != NULL) {
             rc = trans_abort(iq, bdb_get_physical_tran(parent));
+            bdb_reset_physical_tran(parent);
             if (rc != 0) {
                 logmsg(LOGMSG_FATAL, "%s:%d TRANS_ABORT FAILED RC %d", __func__, __LINE__, rc);
                 comdb2_die(1);
@@ -5637,6 +5637,7 @@ add_blkseq:
                     iq->sc_logical_tran = NULL;
                 } else {
                     irc = trans_commit_adaptive(iq, parent_trans, source_host);
+                    parent_trans = NULL;
                 }
                 if (irc) {
                     /* We've committed to the btree, but we are not replicated:

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1035,6 +1035,7 @@ int finalize_upgrade_table(struct schema_change_type *s)
         if (rc != 0) continue;
 
         rc = trans_commit(&iq, tran, gbl_mynode);
+        tran = NULL;
     }
 
     return rc;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -3027,8 +3027,8 @@ done:
         db_seqnum_type ss;
         if (rc) {
             trans_abort(&data->iq, data->trans);
+            data->trans = NULL;
             if (rc == RC_INTERNAL_RETRY) {
-                data->trans = NULL;
                 data->num_retry_errors++;
                 data->totnretries++;
                 poll(0, 0, (rand() % 500 + 10));
@@ -3038,6 +3038,7 @@ done:
             rc = trans_commit_seqnum(&data->iq, data->trans, &ss);
         else
             rc = trans_commit(&data->iq, data->trans, gbl_mynode);
+        data->trans = NULL;
     }
 
     reqlog_end_request(data->iq.reqlogger, 0, __func__, __LINE__);
@@ -3045,7 +3046,6 @@ done:
     /* free memory used in this function */
     clear_recs_list(&recs);
     clear_blob_hash(data->blob_hash);
-    data->trans = NULL;
     if (rc && !data->s->sc_thd_failed)
         data->s->sc_thd_failed = -1;
     if (logc)


### PR DESCRIPTION

See also #2012 and #2515.

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>