### PR TITLE
Tweak sql_tick

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -607,6 +607,9 @@ static int sql_tick(struct sql_thread *thd)
     int rc;
     extern int gbl_epoch_time;
 
+    if (thd == NULL)
+        return 0;
+
     gbl_sqltick++;
 
     clnt = thd->clnt;
@@ -622,7 +625,7 @@ static int sql_tick(struct sql_thread *thd)
 
     /* statement cancelled? done */
     if (clnt->stop_this_statement)
-        return SQLITE_BUSY;
+        return SQLITE_ABORT;
 
     if (clnt->statement_timedout)
         return SQLITE_LIMIT;
@@ -652,7 +655,7 @@ static int sql_tick(struct sql_thread *thd)
         clnt->last_check_time = gbl_epoch_time;
         if (!gbl_notimeouts && peer_dropped_connection(clnt)) {
             logmsg(LOGMSG_INFO, "Peer dropped connection\n");
-            return SQLITE_BUSY;
+            return SQLITE_ABORT;
         }
     }
 


### PR DESCRIPTION
Check for NULL sql thread to address the crash below, and use a more proper SQLite return code for sql-cancel and peer-dropping-connection.

```
0  sql_tick (thd=0x0)
1  0x00000000005e993b in comdb2_sql_tick ()
2  0x00000000008defa4 in luabb_trigger_unregister (L=L@entry=0x0, q=q@entry=0x7f878e656fc0)
3  0x00000000008eb1ff in force_unregister (L=L@entry=0x0, reg=reg@entry=0x7f878e657a70)
4  0x00000000006280e8 in trigger_start_int (name_=<optimized out>)
5  0x00007f87ae153dd5 in start_thread () from /lib64/libpthread.so.0
6  0x00007f87ad1f202d in clone () from /lib64/libc.so.6
```

(DRQS 164062538)