### PR TITLE
Tests: Try to catch more failures when writing to db

### DIFF
--- a/tests/autoanalyze.test/runit
+++ b/tests/autoanalyze.test/runit
@@ -63,15 +63,11 @@ delete_records()
     nrecs=$1
     j=0
     echo "deleting $nrecs records."
-    echo "" > deleted.out
 
     while [[ $j -lt $nrecs ]]; do 
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "delete from t1 where a == $j" >> deleted.out
-        if [ $? -ne 0 ] ; then
-            continue
-        fi
+        echo "delete from t1 where a == $j"
         let j=j+1
-    done
+    done | cdb2sql -s ${CDB2_OPTIONS} $dbnm default &> deleted.out || failexit 'failure to delete'
 }
 
 update_records()
@@ -79,15 +75,11 @@ update_records()
     nrecs=$1
     j=0
     echo "Updating $nrecs records."
-    echo "" > updated.out
 
     while [[ $j -lt $nrecs ]]; do 
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a == $j" >> updated.out
-        if [ $? -ne 0 ] ; then
-            continue
-        fi
+        echo "update t1 set d=d+1 where a == $j"
         let j=j+1
-    done
+    done | cdb2sql -s ${CDB2_OPTIONS} $dbnm default &> updated.out || failexit 'failure to update'
 }
 
 
@@ -96,15 +88,11 @@ insert_records()
     j=0
     nrecs=$1
     echo "Inserting $nrecs records."
-    echo "" > inserted.out
 
     while [[ $j -lt $nrecs ]]; do 
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "insert into t1(a,b,c,d) values ($j,'test1',x'1234',$j)"  >> inserted.out
-        if [ $? -ne 0 ] ; then
-            continue
-        fi
+        echo "insert into t1(a,b,c,d) values ($j,'test1',x'1234',$j)"
         let j=j+1
-    done
+    done | cdb2sql -s ${CDB2_OPTIONS} $dbnm default &> inserted.out || failexit 'failure to insuert'
 }
 
 
@@ -120,15 +108,9 @@ insert_records_tran()
         let j=j+1
     done >> inserts.in
     echo "commit" >> inserts.in
-    let count=0
-    rc=1
-    while [ $rc -ne 0 ] && [ $count -lt 10 ] ; do
-        count=$((count+1))
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default - < inserts.in >> inserted2.out 2>&1
-        rc=$?
-    done
-    if [ $rc -ne 0 ] ; then
-        failexit "couild not insert the records in a transaction"
+    cdb2sql -s ${CDB2_OPTIONS} $dbnm default - < inserts.in >> inserted2.out 2>&1
+    if [ $? -ne 0 ] ; then
+        failexit "could not insert the records in a transaction"
     fi
 }
 

--- a/tests/logarchive.test/Makefile
+++ b/tests/logarchive.test/Makefile
@@ -3,6 +3,3 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
-ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
-endif

--- a/tests/logarchive.test/runit
+++ b/tests/logarchive.test/runit
@@ -124,7 +124,7 @@ done
 if [[ $reproduced -ne 1 ]]; then
     let runs=$runs-1
     echo Number of retries remaining: $runs
-    continue
+    continue # we are in a loop here
 fi
 
 for onenode in `cdb2sql $CDB2_OPTIONS $TABS $dbnm $DEFAULT 'exec procedure sys.info.cluster()' | cut -d$'\t' -f1`; do

--- a/tests/long_db_name.test/runit
+++ b/tests/long_db_name.test/runit
@@ -46,41 +46,6 @@ assert_schema()
     fi
 }
 
-# Update all records in the table
-update_all_records()
-{
-    typeset prmsg=$1
-    typeset iter=0
-
-    [[ "$debug" == 1 ]] && set -x
-
-    while :; do 
-
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set c=x'1234' where b='test1'" &>/dev/null
-        let iter=iter+1
-
-        if [[ -n "$prmsg" && $(( iter % prmsg )) == 0 ]]; then
-
-            echo "Updated all of table t1 $iter times."
-
-        fi
-
-    done
-}
-
-update_records()
-{
-    j=0
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
-
-
 insert_records()
 {
     j=$1
@@ -88,17 +53,12 @@ insert_records()
     let nout=nout+1
     insfl=insert${nout}.out
     echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"
         # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> $insfl || failexit "insert_records error"
     echo "done inserting round $nout"
 }
 
@@ -109,16 +69,11 @@ update_records()
     let nout=nout+1
     updfl=update${nout}.out
     echo "Updating $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $updfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set alltypes_short=alltypes_short+1, alltypes_int=alltypes_int+1,alltypes_u_int=alltypes_u_int+1,alltypes_longlong=alltypes_longlong+1,alltypes_float=alltypes_float=1,alltypes_double=alltypes_double+1,alltypes_decimal32=alltypes_decimal32+1,alltypes_decimal64=alltypes_decimal64+1,alltypes_decimal128=alltypes_decimal128+1 where alltypes_u_short=$j"  &>> $updfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        echo "update t1 set alltypes_short=alltypes_short+1, alltypes_int=alltypes_int+1,alltypes_u_int=alltypes_u_int+1,alltypes_longlong=alltypes_longlong+1,alltypes_float=alltypes_float=1,alltypes_double=alltypes_double+1,alltypes_decimal32=alltypes_decimal32+1,alltypes_decimal64=alltypes_decimal64+1,alltypes_decimal128=alltypes_decimal128+1 where alltypes_u_short=$j"
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default  &> $updfl || failexit "update_records error"
     echo "done updating round $nout"
 }
 
@@ -129,16 +84,11 @@ delete_records()
     let nout=nout+1
     delfl=delete${nout}.out
     echo "Deleting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $delfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where alltypes_u_short=$j"  &>> $delfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        echo "delete from t1 where alltypes_u_short=$j"
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> $delfl || failexit "delete_reconds error"
     echo "done updating round $nout"
 }
 

--- a/tests/reorder_deletes.test/runit
+++ b/tests/reorder_deletes.test/runit
@@ -49,41 +49,6 @@ assert_schema()
 }
 
 
-# Update all records in the table
-update_all_records()
-{
-    typeset prmsg=$1
-    typeset iter=0
-
-    [[ "$debug" == 1 ]] && set -x
-
-    while :; do 
-
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set c=x'1234' where b='test1'" &>/dev/null
-        let iter=iter+1
-
-        if [[ -n "$prmsg" && $(( iter % prmsg )) == 0 ]]; then
-
-            echo "Updated all of table t1 $iter times."
-
-        fi
-
-    done
-}
-
-update_records()
-{
-    j=0
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
-
-
 insert_records()
 {
     j=$1
@@ -91,41 +56,16 @@ insert_records()
     let nout=nout+1
     insfl=insert${nout}.out
     echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"
         # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> $insfl || failexit "insert_records error"
     echo "done inserting round $nout"
 }
 
 
-
-delete_records()
-{
-    j=$1
-    nstop=$2
-    let nout=nout+1
-    delfl=delete${nout}.out
-    echo "Deleting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $delfl
-
-    while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where alltypes_u_short=$j"  &>> $delfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        let j=j+1
-    done
-    echo "done updating round $nout"
-}
 
 do_deletes()
 {
@@ -138,24 +78,23 @@ do_deletes()
     echo "" > $updfl
 
     while [[ $j -le $count ]]; do 
-#cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set b=random()%500000+500000,c=random()%500000+500000,d=random()%500000+500000 where a=$j"  &>> $updfl
         echo "begin" > $sqlfl
         i=0
 
         while [[ $i -lt $TRANSZ ]] ; do 
           echo "delete from t1 where a=$((RANDOM%NUM))"  >> $sqlfl
-          if [ $? -ne 0 ]; then 
-              exit 1
-          fi
           let j=j+1
           let i=i+1
         done
         echo "commit" >> $sqlfl
 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default -f $sqlfl  &>> $updfl
-#if [ $? -ne 0 ]; then
-#            failexit "failed to update"
-#        fi
+        # the following may fail with "[commit] failed with rc 2 uncommitable txn on del genid=5270003 rc=404"
+        cdb2sql ${CDB2_OPTIONS} $dbnm default -f $sqlfl  &> $updfl
+        res=`grep '\[commit\]' $updfl`
+        if [[ $res != "[commit] rc 0" && $res != "[commit] failed with rc 2 uncommitable"* ]] ; then
+            failexit "update failed with unexpected error"
+        fi
+
     done
     echo "done updater $updater"
 }

--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -47,85 +47,6 @@ assert_schema()
     fi
 }
 
-
-# Update all records in the table
-update_all_records()
-{
-    typeset prmsg=$1
-    typeset iter=0
-
-    [[ "$debug" == 1 ]] && set -x
-
-    while :; do 
-
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set c=x'1234' where b='test1'" &>/dev/null
-        let iter=iter+1
-
-        if [[ -n "$prmsg" && $(( iter % prmsg )) == 0 ]]; then
-
-            echo "Updated all of table t1 $iter times."
-
-        fi
-
-    done
-}
-
-update_records()
-{
-    j=0
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
-
-
-insert_records()
-{
-    j=$1
-    nstop=$2
-    let nout=nout+1
-    insfl=insert${nout}.out
-    echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
-
-    while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
-        let j=j+1
-    done
-    echo "done inserting round $nout"
-}
-
-
-
-delete_records()
-{
-    j=$1
-    nstop=$2
-    let nout=nout+1
-    delfl=delete${nout}.out
-    echo "Deleting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $delfl
-
-    while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where alltypes_u_short=$j"  &>> $delfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        let j=j+1
-    done
-    echo "done updating round $nout"
-}
-
 COUNT=5000
 TRANSZ=50
 INSERTERS=20
@@ -150,7 +71,7 @@ do_inserts()
       done
       echo "commit"
 
-    done | cdb2sql ${CDB2_OPTIONS} $dbnm default - &> $outfl
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> $outfl  || failexit "delete_reconds error"
 
     echo "done inserter $item"
 }

--- a/tests/reorder_updates.test/runit
+++ b/tests/reorder_updates.test/runit
@@ -48,83 +48,6 @@ assert_schema()
     fi
 }
 
-# Update all records in the table
-update_all_records()
-{
-    typeset prmsg=$1
-    typeset iter=0
-
-    [[ "$debug" == 1 ]] && set -x
-
-    while :; do 
-
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set c=x'1234' where b='test1'" &>/dev/null
-        let iter=iter+1
-
-        if [[ -n "$prmsg" && $(( iter % prmsg )) == 0 ]]; then
-
-            echo "Updated all of table t1 $iter times."
-
-        fi
-
-    done
-}
-
-update_records()
-{
-    j=0
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set d=d+1 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
-
-
-insert_records()
-{
-    j=$1
-    nstop=$2
-    let nout=nout+1
-    insfl=insert${nout}.out
-    echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
-
-    while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
-        let j=j+1
-    done
-    echo "done inserting round $nout"
-}
-
-
-
-delete_records()
-{
-    j=$1
-    nstop=$2
-    let nout=nout+1
-    delfl=delete${nout}.out
-    echo "Deleting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $delfl
-
-    while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from t1 where alltypes_u_short=$j"  &>> $delfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        let j=j+1
-    done
-    echo "done updating round $nout"
-}
 
 do_updates()
 {
@@ -134,10 +57,7 @@ do_updates()
     j=0
     updfl=update${updater}.out
     sqlfl=update${updater}.sql
-    echo "" > $updfl
-
     while [[ $j -le $count ]]; do 
-#cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set b=random()%500000+500000,c=random()%500000+500000,d=random()%500000+500000 where a=$j"  &>> $updfl
         echo "begin" > $sqlfl
         i=0
 
@@ -151,7 +71,7 @@ do_updates()
         done
         echo "commit" >> $sqlfl
 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default -f $sqlfl  &>> $updfl
+        cdb2sql ${CDB2_OPTIONS} $dbnm default -f $sqlfl  &> $updfl
 #if [ $? -ne 0 ]; then
 #            failexit "failed to update"
 #        fi

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -51,14 +51,12 @@ insert_records()
     let nout=nout+1
     insfl=insert${nout}.out
     echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        assertres $? 0
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"
         # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} ${DBNAME} default &> $insfl || failexit "insert_records error"
     echo "done inserting round $nout"
 }
 
@@ -107,13 +105,11 @@ update_records()
     let nout=nout+1
     updfl=update${nout}.out
     echo "Updating $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $updfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "update t1 set alltypes_short=alltypes_short+1, alltypes_int=alltypes_int+1,alltypes_u_int=alltypes_u_int+1,alltypes_longlong=alltypes_longlong+1,alltypes_float=alltypes_float=1,alltypes_double=alltypes_double+1,alltypes_decimal32=alltypes_decimal32+1,alltypes_decimal64=alltypes_decimal64+1,alltypes_decimal128=alltypes_decimal128+1 where alltypes_u_short=$j"  &>> $updfl
-        assertres $? 0
+        echo "update t1 set alltypes_short=alltypes_short+1, alltypes_int=alltypes_int+1,alltypes_u_int=alltypes_u_int+1,alltypes_longlong=alltypes_longlong+1,alltypes_float=alltypes_float=1,alltypes_double=alltypes_double+1,alltypes_decimal32=alltypes_decimal32+1,alltypes_decimal64=alltypes_decimal64+1,alltypes_decimal128=alltypes_decimal128+1 where alltypes_u_short=$j"
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} ${DBNAME} default &> $updfl || failexit "update_records error"
     echo "done updating round $nout"
 }
 
@@ -171,24 +167,19 @@ delete_records()
     let nout=nout+1
     delfl=delete${nout}.out
     echo "Updating $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $delfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "delete from t1 where alltypes_u_short=$j"  &>> $delfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
+        echo "delete from t1 where alltypes_u_short=$j"
         let j=j+1
         sleep 0.01
-    done
+    done | cdb2sql ${CDB2_OPTIONS} ${DBNAME} default   &> $delfl || failexit "delete_records error"
     echo "done updating round $nout"
 }
 
 
 insert_rollback_tran()
 {
-    echo "Entering insert_records()"
+    echo "Entering insert_rollback_tran()"
     j=$1
     nstop=$2
     let nout=nout+1
@@ -209,7 +200,7 @@ insert_rollback_tran()
 
 insert_commit_tran()
 {
-    echo "Entering insert_records()"
+    echo "Entering insert_commit_tran()"
     j=$1
     nstop=$2
     let nout=nout+1

--- a/tests/sc_add_vutf8.test/runit
+++ b/tests/sc_add_vutf8.test/runit
@@ -33,20 +33,13 @@ function insert_records
     echo "Inserting $nrecs records."
 
     while [[ $j -lt $nrecs ]]; do 
-        #insert next, if error continue to try again
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"  >> insert.out 2>&1
-        if [ $? -ne 0 ] ; then
-            failexit "Inserting record $j "
-        fi
+        echo "insert into t1(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"
         let j=j+1
-        assertcnt t1 $j
         if [ $1 -gt 0 ] ; then
             sleep 0.1
         fi
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> insert.out || failexit "insert_records error"
 }
-
-
 
 
 #insert all records, alter aftewards, check content
@@ -105,6 +98,7 @@ function run_test_three
 
     while [ $i -lt 16 ]; do 
         $CDB2SQL_EXE $CDB2_OPTIONS $dbnm default "alter table t2 add v$i vutf8" &>> add_vutf8.out
+        assertres $? 0
         echo "v$i" >> add_vutf8.expected
         let i=i+1
     done

--- a/tests/sc_inserts.test/runit
+++ b/tests/sc_inserts.test/runit
@@ -55,20 +55,14 @@ function insert_records
     echo "Inserting $nrecs records."
 
     while [[ $j -lt $nrecs ]]; do 
-        #insert next, if error continue to try again
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into $tbl(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"  >> insert.out 2>&1
-        if [ $? -ne 0 ] ; then
-            continue
-        fi
+        echo "insert into $tbl(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"
         let j=j+1
-        assertcnt $tbl $j
         if [ $1 -gt 0 ] ; then
             sleep 0.1
         fi
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> insert.out || failexit "insert_records error"
     echo "Done inserting $nrecs records."
 }
-
 
 
 

--- a/tests/sc_inserts_deletes.test/runit
+++ b/tests/sc_inserts_deletes.test/runit
@@ -85,19 +85,13 @@ function delete_records
     remaining=$nrecs
     echo
     echo "Deleting $nrecs records."
-    echo "" > delete.out
     strt=$(date +%s)
 
     while [[ $j -le $nrecs ]]; do 
-         cdb2sql ${CDB2_OPTIONS} $dbnm default "delete from $tbl where a = $j" >> delete.out 
-         if [ $? -ne 0 ] ; then
-            continue
-         fi
+         echo "delete from $tbl where a = $j"
          let j=j+1
 	     let remaining=remaining-1
-         #assertcnt $tbl $remaining
-         #sleep 0.1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> delete.out || failexit "delete_records error"
     end=$(date +%s)
     echo "delete_records took $((end - strt)) sec."
 }
@@ -110,22 +104,15 @@ function insert_records
     strt=$(date +%s)
 
     while [[ $j -le $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into $tbl(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"  >> insert.out 
-        if [ $? -ne 0 ] ; then
-            continue
-        fi
-
-        #assertcnt $tbl $j
+        echo "insert into $tbl(a,b,c,d,e,f) values ($j,'test1',x'1234',$((j*2)),$j,$j)"
         let j=j+1
         if [ $1 -gt 0 ] ; then
             sleep 0.1
         fi
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> insert.out || failexit "insert_records"
     end=$(date +%s)
     echo "insert_records took $((end - strt)) sec."
 }
-
-
 
 
 function run_test

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -5,8 +5,7 @@
 # exit after displaying error message
 failexit()
 {
-    echo "Failed $@"
-    touch ${DBNAME}.failexit # runtestcase script looks for this file
+    echo "Failed $@" | tee ${DBNAME}.failexit # runtestcase script looks for this file
     exit -1
 }
 

--- a/tests/verify_db.test/runit
+++ b/tests/verify_db.test/runit
@@ -51,17 +51,11 @@ insert_records()
     let nout=nout+1
     insfl=insert${nout}.out
     echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
 
     while [[ $j -le $nstop ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8whichiwillmakealongstringsothatitgetswrittentothebloboverflowdatafiles$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"  &>> $insfl
-        if [ $? -ne 0 ]; then 
-            sleep 1
-            continue
-        fi
-        # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
+        echo "insert into t1(alltypes_short, alltypes_u_short, alltypes_int, alltypes_u_int, alltypes_longlong, alltypes_float, alltypes_double, alltypes_byte, alltypes_cstring, alltypes_pstring, alltypes_blob, alltypes_datetime, alltypes_datetimeus, alltypes_vutf8, alltypes_intervalym, alltypes_intervalds, alltypes_intervaldsus, alltypes_decimal32, alltypes_decimal64, alltypes_decimal128) values ( $((1-2*(j%2)))$j ,$j ,$((1-2*(j%2)))0000$j ,10000$j ,$((1-2*(j%2)))000000000$j ,$((1-2*(j%2)))00.00$j ,$((1-2*(j%2)))0000$j.0000$j ,x'aabbccddeeffaabb$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))$((j%2))$((j%3))$((j%4))$((j%5))' ,'mycstring$j' ,'mypstring$j' ,x'aabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeffaabbccddeeff$((j%2))$((j%3))$((j%4))$((j%5))' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'$(date +'%Y-%m-%dT%H:%M:%S')' ,'myvutf8whichiwillmakealongstringsothatitgetswrittentothebloboverflowdatafiles$j' ,$((1-2*(j%2)))$j ,$((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))0000$j , $((1-2*(j%2)))00000000$j , $((1-2*(j%2)))000000000000000$j )"
         let j=j+1
-    done
+    done | cdb2sql ${CDB2_OPTIONS} $dbnm default &> $insfl || failexit "insert_records error"
     echo "done inserting round $nout"
 }
 


### PR DESCRIPTION
Currently we retry when simple writes to the db were failing because of a bug
when reading protobuf msg for sqlquery (resulting in -105 error) recently
fixed. This change tries to now detect failures to write to db--there should
be no such failures under normal db operation.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>