### PR TITLE
seriously dumb bug: i left stop_threads in 7.0

### DIFF
--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -120,12 +120,6 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize)
         return SC_INTERNAL_ERROR;
     }
 
-    /* why?  er... not sure.  this is copied off the pattern below, but we
-     * don't have much to do.   think this is still good as we'll get a
-     * memory sync in there. */
-    stop_threads(thedb);
-    resume_threads(thedb);
-
     if (newdb->dbenv->master == gbl_mynode) {
         /* I am master: create new db */
         newdb->handle =


### PR DESCRIPTION
The RM queue clustered test was getting watchdogged because 7.0 was still stopping the watcher thread.