### PR TITLE
Use buffer to unpack protobuf query messages

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -346,6 +346,7 @@ extern int gbl_assert_systable_locks;
 extern int gbl_track_curtran_gettran_locks;
 extern int gbl_permit_small_sequences;
 extern int gbl_debug_sleep_in_sql_tick;
+extern int gbl_protobuf_prealloc_buffer_size;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2047,4 +2047,7 @@ REGISTER_TUNABLE("debug_consumer_lock",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_instrument_consumer_lock, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("protobuf_prealloc_buffer_size", "Size of protobuf preallocated buffer.  (Default: 8192)", TUNABLE_INTEGER,
+                 &gbl_protobuf_prealloc_buffer_size, INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/protobuf/pb_alloc.h
+++ b/protobuf/pb_alloc.h
@@ -22,4 +22,59 @@ static ProtobufCAllocator pb_alloc = {
     .free  = free_wrap
 };
 
+
+struct NewsqlProtobufCAllocator {
+    ProtobufCAllocator protobuf_allocator;
+    void *protobuf_data;
+    void *(*malloc_func)(size_t size);
+    void (*free_func)(void *ptr);
+    int protobuf_offset;
+    int protobuf_size;
+
+};
+
+static inline void reset_protobuf_offset(struct NewsqlProtobufCAllocator *npa)
+{
+    npa->protobuf_offset = 0;
+}
+
+static inline void *newsql_protobuf_alloc(void *allocator_data, size_t size)
+{
+    struct NewsqlProtobufCAllocator *npa = allocator_data;
+    void *p = NULL;
+    if (size <= npa->protobuf_size - npa->protobuf_offset) {
+        p = npa->protobuf_data + npa->protobuf_offset;
+        npa->protobuf_offset += size;
+    } else {
+        p = npa->malloc_func(size);
+    }
+    return p;
+}
+
+static inline void newsql_protobuf_free(void *allocator_data, void *p)
+{
+    struct NewsqlProtobufCAllocator *npa = allocator_data;
+    if (p < npa->protobuf_data || p > (npa->protobuf_data + npa->protobuf_size)) {
+        npa->free_func(p);
+    }
+}
+
+static inline void newsql_protobuf_init(struct NewsqlProtobufCAllocator *npa, void *(*malloc_func)(size_t size), void (*free_func)(void *ptr))
+{
+    extern int gbl_protobuf_prealloc_buffer_size;
+    npa->protobuf_size = gbl_protobuf_prealloc_buffer_size;
+    npa->protobuf_offset = 0;
+    npa->protobuf_data = malloc_func(npa->protobuf_size);
+    npa->malloc_func = malloc_func;
+    npa->free_func = free_func;
+    npa->protobuf_allocator.alloc = &newsql_protobuf_alloc;
+    npa->protobuf_allocator.free = &newsql_protobuf_free;
+    npa->protobuf_allocator.allocator_data = npa;
+}
+
+static inline void newsql_protobuf_destroy(struct NewsqlProtobufCAllocator *npa)
+{
+    npa->free_func(npa->protobuf_data);
+}
+
 #endif

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -175,8 +175,8 @@ if [ $OSTYPE -eq "linux-gnu" ] ; then
     cat  /proc/sys/kernel/core_pattern
 fi
 
-cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("debg 100")'
-cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("ndebg 100")'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("debg 2")'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("ndebg 2")'
 
 echo "create, alter, drop table t2"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t2  { `cat alltypes.csc2 ` }"


### PR DESCRIPTION
Use a small buffer as part of clnt structure to unpack protobuf query.
This is similar to 63c9364ed5 (#1645) which  added buffer to cdb2api clients.

As a measure of savings, running basic.test under valgrind with and without
this patch shows a reduction of 136K calls to comdb2_malloc_static()  
(via the protobuf_message_unpack() callpath) for the test's 5146 sql queries
(out of 1316K total mallocs, so almost 10% less mallocs).

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>