### PR TITLE
Autoanalyze fails when authentication is enabled

### DIFF
--- a/db/analyze.h
+++ b/db/analyze.h
@@ -64,7 +64,8 @@ int64_t analyze_get_sampled_nrecs(const char *dbname, int ixnum);
 /**
  * Scale and analyze this table.  Write the results to sqlite_stat1.
  */
-int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta);
+int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
+                  int bypass_auth);
 
 /**
  * Scale and analyze all tables in the database.  Write the results to

--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -109,7 +109,7 @@ void *auto_analyze_table(void *arg)
     int percent = bdb_attr_get(thedb->bdb_attr, 
                                BDB_ATTR_DEFAULT_ANALYZE_PERCENT);
 
-    if ((rc = analyze_table(tblname, sb, percent, 0)) == 0) {
+    if ((rc = analyze_table(tblname, sb, percent, 0, 1)) == 0) {
         reset_aa_counter(tblname);
     } else {
         logmsg(LOGMSG_ERROR, "%s: analyze_table %s failed rc:%d\n", __func__,

--- a/db/sql.h
+++ b/db/sql.h
@@ -600,6 +600,10 @@ struct user {
     uint8_t have_password;
     /* 1 if the user is retrieved from a client certificate */
     uint8_t is_x509_user;
+
+    /* Set to allow automatically triggered operations, like autoanalyze, to
+       go through. */
+    uint8_t bypass_auth;
 };
 
 

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -1036,7 +1036,8 @@ int get_analyze_abort_requested()
 
 
 /* analyze 'table' */
-int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta)
+int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
+                  int bypass_auth)
 {
     if (check_stat1(sb))
         return -1;
@@ -1065,6 +1066,7 @@ int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta)
     if (clnt) {
         td.current_user = clnt->current_user;
     }
+    td.current_user.bypass_auth = bypass_auth;
 
     /* dispatch */
     int rc = dispatch_table_thread(&td);
@@ -1416,7 +1418,7 @@ int do_analyze(char *tbl, int percent)
     if (tbl == NULL)
         rc = analyze_database(sb2, percent, overwrite_llmeta);
     else
-        rc = analyze_table(tbl, sb2, percent, overwrite_llmeta);
+        rc = analyze_table(tbl, sb2, percent, overwrite_llmeta, 0);
     sbuf2flush(sb2);
     sbuf2free(sb2);
     return rc;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3014,8 +3014,9 @@ static inline int check_user_password(struct sqlclntstate *clnt)
     int password_rc = 0;
     int valid_user;
 
-    if (!gbl_uses_password)
+    if (!gbl_uses_password || clnt->current_user.bypass_auth) {
         return 0;
+    }
 
     if (!clnt->current_user.have_name) {
         clnt->current_user.have_name = 1;

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -170,7 +170,7 @@ static int db_comdb_analyze(Lua L) {
 
     if(tbl && strlen(tbl) > 0) {
         logmsg(LOGMSG_DEBUG, "db_comdb_analyze: analyze table '%s' at %d percent\n", tbl, percent);
-        analyze_table(tbl, sb, percent, ovr_percent);
+        analyze_table(tbl, sb, percent, ovr_percent, 0);
     }
     else {
         logmsg(LOGMSG_DEBUG, "db_comdb_analyze: analyze database\n");


### PR DESCRIPTION
This is because autoanalyze threads execute analyze operations as anonymous user. Added a mechanism to bypass  authentication for such cases.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>