### PR TITLE
Execute sql in admin mode from watchdog thread

### DIFF
--- a/tests/eventlog.test/lrl.options
+++ b/tests/eventlog.test/lrl.options
@@ -1,0 +1,1 @@
+nowatch

--- a/tests/watchdog_sql.test/Makefile
+++ b/tests/watchdog_sql.test/Makefile
@@ -1,0 +1,10 @@
+COMDB2_UNITTEST=1
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/watchdog_sql.test/runit
+++ b/tests/watchdog_sql.test/runit
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+#set -ex
+set -x
+db=$DBNAME
+
+rm -rf $DBDIR
+mkdir -p $DBDIR
+
+$COMDB2_EXE $db --create --dir $DBDIR/$db >/dev/null 2>&1
+ulimit -c 0
+echo "watchthreshold 10" >> $DBDIR/$db/$db.lrl
+$COMDB2_EXE $db -lrl $DBDIR/$db/$db.lrl >$DBDIR/$db/out 2>&1 &
+pid=$!
+sleep 10
+
+# Create a table
+cdb2sql $db "create table t (i int)" >/dev/null
+
+# Grab schema-lk
+cdb2sql $db "exec procedure sys.cmd.send('getschemalk')"
+
+sleep 40
+kill -0 $pid
+
+if [[ $? == 0 ]]; then
+    echo "TESTCASE FAILED"
+    kill -9 $pid
+    exit 1
+fi
+
+echo "Success"
+exit 0


### PR DESCRIPTION
Simple change to run a 'select 1' from the watchdog thread.  The 'watchdog_sql' test verifies that the database will watchdog-abort itself if this sql hangs for longer than the threshold.
