### PR TITLE
Make sure ECDHE ciphers are enabled

### DIFF
--- a/util/ssl_support.c
+++ b/util/ssl_support.c
@@ -391,6 +391,11 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
     if (protocols != 0)
         SSL_CTX_set_options(myctx, protocols);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+    /* Make sure ECDHE ciphers are enabled */
+    SSL_CTX_set_ecdh_auto(myctx, 1);
+#endif
+
     /* We need the flag to be able to write as fast as possible.
        We let sbuf2/comdb2buf take care of uncomplete writes. */
     SSL_CTX_set_mode(myctx, SSL_MODE_ENABLE_PARTIAL_WRITE |


### PR DESCRIPTION
Without calling SSL_CTX_set_ecdh_auto when the server uses
an ecdsa certificate only the ECDH_* ecdsa ciphers will be
allowed, even though the ECDHE ciphers are in the list of
acceptable ciphers.

This fixes an issue with connecting to comdb2 from runtimes
that only support ECDHE, not ECDH.

The faction call is only required for openssl versions prior to
1.1.

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?

bug fix, but could also be seen as a feature to support ECDHE ciphers.

* What are the current behavior and expected behavior, if this is a bugfix ?

When connecting to comdb2 with a TLS library that does not support ECDH_* ciphers, a handshake failure would occur.
One such way is through go's `crypto/tls` package.

* What are the steps required to reproduce the bug, if this is a bugfix ?
I think the easiest way to reproduce this is to generate an ecdsa certificate for comdb2 and set:
```
ssl_cipher_suites ECDHE
```
in its config. This forces the server to only accept ECDHE ciphers, but since they are not enabled all connections will fail.

* What is the current behavior and new behavior, if this is a feature change or enhancement ?

comdb2 would only accept ECDH_* ciphers, now it acceps both ECDH_* and ECDHE_*.

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
