### PR TITLE
always trylock for sql within an sp

### DIFF
--- a/bbinc/cheapstack.h
+++ b/bbinc/cheapstack.h
@@ -31,12 +31,12 @@ extern "C" {
  */
 
 void comdb2_linux_cheap_stack_trace(void);
-#define cheap_stack_trace()                                                    \
-    do {                                                                       \
-        pthread_t pid = pthread_self();                                        \
-        logmsg(LOGMSG_USER, "Comdb2's Linux Cheap Stack Trace :: pthread_self:%p @ %s:%d\n",  \
-            (void *)pid, __FILE__, __LINE__);                                          \
-        comdb2_linux_cheap_stack_trace();                                      \
+#define cheap_stack_trace()                                                                                            \
+    do {                                                                                                               \
+        pthread_t pid = pthread_self();                                                                                \
+        logmsg(LOGMSG_USER, "Comdb2's Linux Cheap Stack Trace :: pthread_self:%p @ %s:%d\n", (void *)pid, __FILE__,    \
+               __LINE__);                                                                                              \
+        comdb2_linux_cheap_stack_trace();                                                                              \
     } while (0)
 
 #if defined __cplusplus

--- a/bdb/bdblock.c
+++ b/bdb/bdblock.c
@@ -94,8 +94,7 @@ static void get_read_lock_log(bdb_state_type *bdb_state)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "GOT THE READ LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "GOT THE READ LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
             (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -112,8 +111,7 @@ static void get_read_lock_ref_log(bdb_state_type *bdb_state, int ref)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "INCREMENTING READ LOCK TO %d AT BDB_STATE=%p THREAD=%p: ", ref,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "INCREMENTING READ LOCK TO %d AT BDB_STATE=%p THREAD=%p: ", ref,
             bdb_state, (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -130,8 +128,7 @@ static void get_write_lock_log(bdb_state_type *bdb_state)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "GOT THE WRITE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "GOT THE WRITE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
             (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -148,8 +145,7 @@ static void get_write_lock_try_log(bdb_state_type *bdb_state)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "TRY GET THE WRITE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "TRY GET THE WRITE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
             (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -166,8 +162,7 @@ static void rel_lock_log(bdb_state_type *bdb_state)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "RELEASED THE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "RELEASED THE LOCK AT BDB_STATE=%p THREAD=%p: ", bdb_state,
             (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -184,8 +179,7 @@ static void rel_lock_ref_log(bdb_state_type *bdb_state, int ref)
 
     Pthread_mutex_lock(&(bdb_state->bdblock_debug_lock));
 
-    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp,
-            "DECREMENTING LOCK TO %d AT BDB_STATE=%p THREAD=%p: ", ref,
+    logmsgf(LOGMSG_USER, bdb_state->bdblock_debug_fp, "DECREMENTING LOCK TO %d AT BDB_STATE=%p THREAD=%p: ", ref,
             bdb_state, (void *)pthread_self());
     comdb2_cheap_stack_trace_file(bdb_state->bdblock_debug_fp);
 
@@ -311,15 +305,13 @@ static int lower_thd_priority(void)
 
     rc = pthread_getschedparam(pthread_self(), &policy, &sparam);
     if (0 != rc) {
-        logmsg(LOGMSG_ERROR, "%s:pthread_getschedparam returns %d for thd %p\n",
-                __func__, rc, (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "%s:pthread_getschedparam returns %d for thd %p\n", __func__, rc, (void *)pthread_self());
         return rc;
     }
     prio = (sparam.sched_priority - 1);
     rc = pthread_setschedprio(pthread_self(), prio);
     if (0 != rc) {
-        logmsg(LOGMSG_ERROR, "%s:pthread_setschedprio returns %d for thd %p\n",
-                __func__, rc, (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "%s:pthread_setschedprio returns %d for thd %p\n", __func__, rc, (void *)pthread_self());
         return rc;
     }
     return 0;
@@ -332,15 +324,13 @@ static int raise_thd_priority(void)
 
     rc = pthread_getschedparam(pthread_self(), &policy, &sparam);
     if (0 != rc) {
-        logmsg(LOGMSG_ERROR, "%s:pthread_getschedparam returns %d for thd %p\n",
-                __func__, rc, (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "%s:pthread_getschedparam returns %d for thd %p\n", __func__, rc, (void *)pthread_self());
         return rc;
     }
     prio = (sparam.sched_priority + 1);
     rc = pthread_setschedprio(pthread_self(), prio);
     if (0 != rc) {
-        logmsg(LOGMSG_ERROR, "%s:pthread_setschedprio returns %d for thd %p\n",
-                __func__, rc, (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "%s:pthread_setschedprio returns %d for thd %p\n", __func__, rc, (void *)pthread_self());
         return rc;
     }
     return 0;
@@ -417,10 +407,8 @@ static inline void bdb_get_writelock_int(bdb_state_type *bdb_state,
 
         rc = pthread_rwlock_trywrlock(lock_handle->bdb_lock);
         if (rc == EBUSY) {
-            logmsg(LOGMSG_INFO,
-                   "trying writelock (%s %p), last writelock is %s %p\n",
-                   idstr, (void *)pthread_self(), lock_handle->bdb_lock_write_idstr,
-                   (void *)lock_handle->bdb_lock_write_holder);
+            logmsg(LOGMSG_INFO, "trying writelock (%s %p), last writelock is %s %p\n", idstr, (void *)pthread_self(),
+                   lock_handle->bdb_lock_write_idstr, (void *)lock_handle->bdb_lock_write_holder);
 
             /*
              * Abort threads waiting on logical locks.
@@ -525,10 +513,8 @@ void bdb_get_readlock(bdb_state_type *bdb_state, const char *idstr,
 
         rc = pthread_rwlock_tryrdlock(lock_handle->bdb_lock);
         if (rc == EBUSY) {
-            logmsg(LOGMSG_INFO,
-                   "trying readlock (%s %p), last writelock is %s %p\n",
-                   idstr, (void *)pthread_self(), lock_handle->bdb_lock_write_idstr,
-                   (void *)lock_handle->bdb_lock_write_holder);
+            logmsg(LOGMSG_INFO, "trying readlock (%s %p), last writelock is %s %p\n", idstr, (void *)pthread_self(),
+                   lock_handle->bdb_lock_write_idstr, (void *)lock_handle->bdb_lock_write_holder);
 
             Pthread_rwlock_rdlock(lock_handle->bdb_lock);
         } else if (rc != 0) {
@@ -676,12 +662,10 @@ void bdb_checklock(bdb_state_type *bdb_state)
     if (lk == NULL || lk->lockref == 0)
         return; /* all good */
 
-    logmsg(LOGMSG_FATAL,
-           "%p %s: request terminated but thread is holding bdb lock!\n",
-           (void *)pthread_self(), __func__);
-    logmsg(LOGMSG_FATAL, "%p %s: %s %s lockref=%u\n", (void *)pthread_self(), __func__,
-           locktype2str(lk->locktype), lk->ident ? lk->ident : "?",
-           lk->lockref);
+    logmsg(LOGMSG_FATAL, "%p %s: request terminated but thread is holding bdb lock!\n", (void *)pthread_self(),
+           __func__);
+    logmsg(LOGMSG_FATAL, "%p %s: %s %s lockref=%u\n", (void *)pthread_self(), __func__, locktype2str(lk->locktype),
+           lk->ident ? lk->ident : "?", lk->lockref);
     abort_lk(lk);
 }
 
@@ -903,8 +887,7 @@ static void dump_int(thread_lock_info_type *lk, FILE *out)
 {
 
 #ifdef _LINUX_SOURCE
-    logmsgf(LOGMSG_USER, out, "thr 0x%p  lk %9s %u", (void *)lk->threadid,
-            locktype2str(lk->locktype), lk->lockref);
+    logmsgf(LOGMSG_USER, out, "thr 0x%p  lk %9s %u", (void *)lk->threadid, locktype2str(lk->locktype), lk->lockref);
 #else
     logmsgf(LOGMSG_USER, out, "thr %u (0x%x)  lk %9s %u", (int)lk->threadid,
             (int)lk->threadid, locktype2str(lk->locktype), lk->lockref);

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -5086,11 +5086,9 @@ step1:
         if (rc == 1) {
             if (cur->used_rl == 0) {
                 if (cur->trak) {
-                    logmsg(LOGMSG_USER, 
-                        "%p %s:%d tran %p skipping %llx, startgenid=%llx\n",
-                        (void *)pthread_self(), __FILE__, __LINE__, cur->shadow_tran,
-                        bdb_genid_to_host_order(genid_rl),
-                        bdb_genid_to_host_order(cur->shadow_tran->startgenid));
+                    logmsg(LOGMSG_USER, "%p %s:%d tran %p skipping %llx, startgenid=%llx\n", (void *)pthread_self(),
+                           __FILE__, __LINE__, cur->shadow_tran, bdb_genid_to_host_order(genid_rl),
+                           bdb_genid_to_host_order(cur->shadow_tran->startgenid));
                 }
             }
 

--- a/bdb/cursor_rowlocks.c
+++ b/bdb/cursor_rowlocks.c
@@ -1975,8 +1975,8 @@ static inline int lockcount_trace(bdb_berkdb_t *berkdb, const char *func,
         logmsg(LOGMSG_USER,
                "thd %p function %s %s %d lock-count incremented from "
                "%d to %d\n",
-               (void *)pthread_self(), func, cur->type == BDBC_IX ? "index" : "stripe",
-               cur->idx, enter_lkcount, exit_lkcount);
+               (void *)pthread_self(), func, cur->type == BDBC_IX ? "index" : "stripe", cur->idx, enter_lkcount,
+               exit_lkcount);
 
         /* Grab the number of cursors */
         cursor_count = cur->ifn->count(cur->ifn->countarg);
@@ -1986,18 +1986,18 @@ static inline int lockcount_trace(bdb_berkdb_t *berkdb, const char *func,
             bdb_state->dbenv, cur->curtran->lockerid, &page_lock_count);
 
         if (page_lock_count > cursor_count) {
-            logmsg(LOGMSG_USER, "thd %p function %s %s %d pagelock-count is "
-                                "%d cursor count is  %d\n",
-                   (void *)pthread_self(), func,
-                   cur->type == BDBC_IX ? "index" : "stripe", cur->idx,
-                   page_lock_count, cursor_count);
+            logmsg(LOGMSG_USER,
+                   "thd %p function %s %s %d pagelock-count is "
+                   "%d cursor count is  %d\n",
+                   (void *)pthread_self(), func, cur->type == BDBC_IX ? "index" : "stripe", cur->idx, page_lock_count,
+                   cursor_count);
         }
 
         if (cur->max_page_locks < page_lock_count) {
-            logmsg(LOGMSG_USER, "thd %p function %s %s %d incrementing max "
-                                "pagelock count from %d to %d\n",
-                   (void *)pthread_self(), func,
-                   cur->type == BDBC_IX ? "index" : "stripe", cur->idx,
+            logmsg(LOGMSG_USER,
+                   "thd %p function %s %s %d incrementing max "
+                   "pagelock count from %d to %d\n",
+                   (void *)pthread_self(), func, cur->type == BDBC_IX ? "index" : "stripe", cur->idx,
                    cur->max_page_locks, page_lock_count);
 
             cur->max_page_locks = page_lock_count;
@@ -2039,15 +2039,12 @@ static inline int bdb_berkdb_rowlocks_enter(bdb_berkdb_t *berkdb,
             }
 
             /* Print */
-            logmsg(LOGMSG_USER,
-                   "Cur %p thd %p %s tbl %s %s how=%d srch='%s'\n", berkdb,
-                   (void *)pthread_self(), func, bdb_state->name,
-                   curtypetostr(cur->type), how, srckeyp);
+            logmsg(LOGMSG_USER, "Cur %p thd %p %s tbl %s %s how=%d srch='%s'\n", berkdb, (void *)pthread_self(), func,
+                   bdb_state->name, curtypetostr(cur->type), how, srckeyp);
         } else {
             /* Print */
-            logmsg(LOGMSG_USER, "Cur %p thd %p %s tbl %s %s how=%d\n", berkdb,
-                   (void *)pthread_self(), func, bdb_state->name,
-                   curtypetostr(cur->type), how);
+            logmsg(LOGMSG_USER, "Cur %p thd %p %s tbl %s %s how=%d\n", berkdb, (void *)pthread_self(), func,
+                   bdb_state->name, curtypetostr(cur->type), how);
         }
 
         /* Grab the lock count if debugging */

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -4474,7 +4474,7 @@ deadlock_again:
         case BDBTYPE_LITE:
             snprintf(tmpname, sizeof(tmpname), "XXX.%s.dta", bdb_state->name);
             break;
-	default:
+        default:
             break;
         }
 

--- a/bdb/locktest.c
+++ b/bdb/locktest.c
@@ -821,17 +821,17 @@ static void stripe(void)
     get_locks_wrapper(arraylen(arg), arg);
 }
 
-#define shuffle(x)                                                             \
-    do {                                                                       \
-        int i;                                                                 \
-        unsigned int seed = (int)pthread_self();                               \
-        for (i = 0; i < arraylen(x) - 1; ++i) {                                \
-            int j = i + (rand_r(&seed) % (arraylen(x) - i));                   \
-            uint8_t tmp[sizeof(x[0])];                                         \
-            memcpy(tmp, &x[i], sizeof(tmp));                                   \
-            memcpy(&x[i], &x[j], sizeof(tmp));                                 \
-            memcpy(&x[j], tmp, sizeof(tmp));                                   \
-        }                                                                      \
+#define shuffle(x)                                                                                                     \
+    do {                                                                                                               \
+        int i;                                                                                                         \
+        unsigned int seed = (int)pthread_self();                                                                       \
+        for (i = 0; i < arraylen(x) - 1; ++i) {                                                                        \
+            int j = i + (rand_r(&seed) % (arraylen(x) - i));                                                           \
+            uint8_t tmp[sizeof(x[0])];                                                                                 \
+            memcpy(tmp, &x[i], sizeof(tmp));                                                                           \
+            memcpy(&x[i], &x[j], sizeof(tmp));                                                                         \
+            memcpy(&x[j], tmp, sizeof(tmp));                                                                           \
+        }                                                                                                              \
     } while (0)
 #define NUMLOCKS 5
 static uint8_t p_lockdesc[NUMLOCKS][28];

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -1269,12 +1269,10 @@ elect_again:
         strcat(hoststring, " ");
     }
 
-    logmsg(
-        LOGMSG_INFO,
-        "0x%p: calling for election with cluster"
-        " of %d nodes (%d connected) : %s,  %f secs timeout and priority %d\n",
-        (void *)pthread_self(), elect_count, num_connected, hoststring,
-        ((double)elect_time) / 1000000.00, rep_pri);
+    logmsg(LOGMSG_INFO,
+           "0x%p: calling for election with cluster"
+           " of %d nodes (%d connected) : %s,  %f secs timeout and priority %d\n",
+           (void *)pthread_self(), elect_count, num_connected, hoststring, ((double)elect_time) / 1000000.00, rep_pri);
 
     free(hoststring);
 
@@ -3710,8 +3708,7 @@ void send_myseqnum_to_all(bdb_state_type *bdb_state, int nodelay)
     int flag[] = {nodelay};
     int rc = net_send_all(bdb_state->repinfo->netinfo, 1, data, sz, type, flag);
     if (rc) {
-        logmsg(LOGMSG_ERROR, "0x%p %s:%d net_send rc=%d\n", (void *)pthread_self(),
-               __func__, __LINE__, rc);
+        logmsg(LOGMSG_ERROR, "0x%p %s:%d net_send rc=%d\n", (void *)pthread_self(), __func__, __LINE__, rc);
     }
 }
 
@@ -5664,8 +5661,8 @@ void *watcher_thread(void *arg)
             }
             if (!bdb_state->repinfo->in_election) {
                 print(bdb_state, "watcher_thread: calling for election\n");
-                logmsg(LOGMSG_DEBUG, "0x%p %s:%d %s: calling for election\n",
-                       (void *)pthread_self(), __FILE__, __LINE__, __func__);
+                logmsg(LOGMSG_DEBUG, "0x%p %s:%d %s: calling for election\n", (void *)pthread_self(), __FILE__,
+                       __LINE__, __func__);
 
                 call_for_election(bdb_state, __func__, __LINE__);
             }

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1614,9 +1614,8 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
             if (iirc) {
                 tran->tid->abort(tran->tid);
                 bdb_osql_trn_repo_unlock();
-                logmsg(LOGMSG_ERROR,
-                       "%s:%d td %p failed to log logical commit, rc %d\n",
-                       __func__, __LINE__, (void *)pthread_self(), iirc);
+                logmsg(LOGMSG_ERROR, "%s:%d td %p failed to log logical commit, rc %d\n", __func__, __LINE__,
+                       (void *)pthread_self(), iirc);
                 *bdberr = BDBERR_MISC;
                 outrc = -1;
                 goto cleanup;

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -284,8 +284,7 @@ ast_t *ast_init(Parse *pParse, const char *caller)
         return pParse->ast->unsupported ? NULL : pParse->ast;
 
     if (gbl_dohast_verbose)
-        logmsg(LOGMSG_USER, "TTT: %p %s from %s\n", (void *)pthread_self(), __func__,
-               caller);
+        logmsg(LOGMSG_USER, "TTT: %p %s from %s\n", (void *)pthread_self(), __func__, caller);
 
     if (!sqlite3IsToplevel(pParse)) {
         ast = ast_init(sqlite3ParseToplevel(pParse), __func__);
@@ -713,8 +712,7 @@ int comdb2_check_parallel(Parse *pParse)
 
     if (node->type == AST_TYPE_SELECT) {
         if (gbl_dohast_verbose)
-            logmsg(LOGMSG_USER, "%p Single query \"%s\"\n", (void *)pthread_self(),
-                   node->sql);
+            logmsg(LOGMSG_USER, "%p Single query \"%s\"\n", (void *)pthread_self(), node->sql);
         return 0;
     }
 
@@ -722,8 +720,7 @@ int comdb2_check_parallel(Parse *pParse)
         _save_params(pParse, node);
 
         if (gbl_dohast_verbose) {
-            logmsg(LOGMSG_USER, "%p Parallelizable union %d threads:\n",
-                   (void *)pthread_self(), node->nnodes);
+            logmsg(LOGMSG_USER, "%p Parallelizable union %d threads:\n", (void *)pthread_self(), node->nnodes);
             for (i = 0; i < node->nnodes; i++) {
                 logmsg(LOGMSG_USER, "\t Thread %d: \"%s\"\n", i + 1,
                        node->nodes[i]->sql);
@@ -813,8 +810,7 @@ static void _save_params(Parse *pParse, dohsql_node_t *node)
         return;
 
     if (gbl_dohast_verbose) {
-        logmsg(LOGMSG_USER, "%p Caching bound parameters length %p\n",
-                (void *)pthread_self(), v->pVList);
+        logmsg(LOGMSG_USER, "%p Caching bound parameters length %p\n", (void *)pthread_self(), v->pVList);
         sqlite3VListPrint(LOGMSG_USER, v->pVList);
     }
 

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -395,9 +395,8 @@ static int inner_row(struct sqlclntstate *clnt, struct response_data *resp,
 
     if (conn->status == DOH_MASTER_DONE) {
         if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG, "%p %s master done q %d qf %d\n",
-                   (void *)pthread_self(), __func__, queue_count(conn->que),
-                   queue_count(conn->que_free));
+            logmsg(LOGMSG_DEBUG, "%p %s master done q %d qf %d\n", (void *)pthread_self(), __func__,
+                   queue_count(conn->que), queue_count(conn->que_free));
         /* work is done, need to clean-up */
         _track_que_free(conn);
         trimQue(conn, stmt, conn->que, 0);
@@ -414,8 +413,7 @@ static int inner_row(struct sqlclntstate *clnt, struct response_data *resp,
     /* try to steal an old row */
     oldrow = queue_next(conn->que_free);
     if (oldrow && gbl_dohsql_verbose)
-        logmsg(LOGMSG_DEBUG, "%p %s retrieved older row\n", (void *)pthread_self(),
-               __func__);
+        logmsg(LOGMSG_DEBUG, "%p %s retrieved older row\n", (void *)pthread_self(), __func__);
     Pthread_mutex_unlock(&conn->mtx);
 
     if (oldrow)
@@ -433,8 +431,7 @@ static int inner_row(struct sqlclntstate *clnt, struct response_data *resp,
         abort();
 
     if (gbl_dohsql_verbose)
-        logmsg(LOGMSG_DEBUG, "%p XXX: %p added new row\n", (void *)pthread_self(),
-               conn);
+        logmsg(LOGMSG_DEBUG, "%p XXX: %p added new row\n", (void *)pthread_self(), conn);
 
     _que_limiter(conn, stmt, row_size);
 
@@ -653,16 +650,13 @@ static int init_next_row(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
     rc = sqlite3_maybe_step(clnt, stmt);
 
     if (gbl_dohsql_verbose) {
-        logmsg(LOGMSG_DEBUG, "%p %s: sqlite3_maybe_step rc %d\n", (void *)pthread_self(),
-               __func__, rc);
+        logmsg(LOGMSG_DEBUG, "%p %s: sqlite3_maybe_step rc %d\n", (void *)pthread_self(), __func__, rc);
         if (conns->limitRegs[ILIMIT_SAVED_MEM_IDX] > 0)
             logmsg(LOGMSG_DEBUG,
                    "%p clnt %p conns %p limitMem %d:%d limit %d "
                    "offsetMem %d:%d offset %d\n",
-                   (void *)pthread_self(), clnt, conns,
-                   conns->limitRegs[ILIMIT_MEM_IDX],
-                   conns->limitRegs[ILIMIT_SAVED_MEM_IDX], conns->limit,
-                   conns->limitRegs[IOFFSET_MEM_IDX],
+                   (void *)pthread_self(), clnt, conns, conns->limitRegs[ILIMIT_MEM_IDX],
+                   conns->limitRegs[ILIMIT_SAVED_MEM_IDX], conns->limit, conns->limitRegs[IOFFSET_MEM_IDX],
                    conns->limitRegs[IOFFSET_SAVED_MEM_IDX], conns->offset);
     }
 
@@ -683,8 +677,7 @@ static int _check_limit(sqlite3_stmt *stmt, dohsql_t *conns)
     if (conns->limitRegs[ILIMIT_SAVED_MEM_IDX] > 0 && conns->limit >= 0 &&
         conns->nrows >= conns->limit) {
         if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG, "%p REACHED LIMIT rc =%d!\n", (void *)pthread_self(),
-                   conns->conns[0].rc);
+            logmsg(LOGMSG_DEBUG, "%p REACHED LIMIT rc =%d!\n", (void *)pthread_self(), conns->conns[0].rc);
         if (conns->conns[0].rc != SQLITE_DONE) {
             if (gbl_dohsql_verbose)
                 logmsg(LOGMSG_DEBUG, "RESET STMT!\n");
@@ -818,8 +811,7 @@ got_row:
 static int dohsql_write_response(struct sqlclntstate *c, int t, void *a, int i)
 {
     if (gbl_plugin_api_debug)
-        logmsg(LOGMSG_WARN, "%p %s type %d code %d\n", (void *)pthread_self(),
-               __func__, t, i);
+        logmsg(LOGMSG_WARN, "%p %s type %d code %d\n", (void *)pthread_self(), __func__, t, i);
     switch (t) {
     case RESPONSE_COLUMNS:
         return inner_columns(c, a);
@@ -1127,12 +1119,10 @@ static int _shard_connect(struct sqlclntstate *clnt, dohsql_connector_t *conn,
     conn->thr_where = strdup(where ? where : "");
     conn->nparams = nparams;
     conn->params = params;
-    logmsg(LOGMSG_DEBUG, "%p %p saved nparams %d\n", (void *)pthread_self(), __func__,
-           conn->nparams);
+    logmsg(LOGMSG_DEBUG, "%p %p saved nparams %d\n", (void *)pthread_self(), __func__, conn->nparams);
     for (int i = 0; i < conn->nparams; i++) {
-        logmsg(LOGMSG_DEBUG, "%p %p saved params %d name \"%s\" pos %d\n",
-               (void *)pthread_self(), __func__, i, conn->params[i].name,
-               conn->params[i].pos);
+        logmsg(LOGMSG_DEBUG, "%p %p saved params %d name \"%s\" pos %d\n", (void *)pthread_self(), __func__, i,
+               conn->params[i].name, conn->params[i].pos);
     }
 
     conn->rc = SQLITE_ROW;
@@ -1444,8 +1434,8 @@ int comdb2_register_limit(int iLimit, int iSavedLimit)
         clnt->conns->limitRegs[ILIMIT_SAVED_MEM_IDX] = iSavedLimit;
         clnt->conns->limitRegs[ILIMIT_MEM_IDX] = iLimit;
         if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG, "%p setting saved limit to %d limit is %d\n",
-                   (void *)pthread_self(), iSavedLimit, iLimit);
+            logmsg(LOGMSG_DEBUG, "%p setting saved limit to %d limit is %d\n", (void *)pthread_self(), iSavedLimit,
+                   iLimit);
         return 1;
     }
     return 0;
@@ -1459,9 +1449,8 @@ void comdb2_register_offset(int iOffset, int iLimitOffset, int iSavedOffset)
         clnt->conns->limitRegs[IOFFSETLIMIT_MEM_IDX] = iLimitOffset;
         clnt->conns->limitRegs[IOFFSET_MEM_IDX] = iOffset;
         if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG,
-                   "%p setting saved offset to %d offset is %d\n",
-                   (void *)pthread_self(), iSavedOffset, iOffset);
+            logmsg(LOGMSG_DEBUG, "%p setting saved offset to %d offset is %d\n", (void *)pthread_self(), iSavedOffset,
+                   iOffset);
     }
 }
 
@@ -1484,8 +1473,8 @@ void comdb2_handle_limit(Vdbe *v, Mem *m)
         /* limit */
         conns->limit = sqlite3_value_int64(reg);
         if (gbl_dohsql_verbose)
-            logmsg(LOGMSG_DEBUG, "%p found limit %d from register %d\n",
-                   (void *)pthread_self(), conns->limit, conns->limitRegs[0]);
+            logmsg(LOGMSG_DEBUG, "%p found limit %d from register %d\n", (void *)pthread_self(), conns->limit,
+                   conns->limitRegs[0]);
     } else {
         if (m == &v->aMem[conns->limitRegs[IOFFSET_MEM_IDX]]) {
             reg = &v->aMem[conns->limitRegs[IOFFSET_SAVED_MEM_IDX]];
@@ -1499,12 +1488,10 @@ void comdb2_handle_limit(Vdbe *v, Mem *m)
                        " updating internal offset mems to %lld->0 and "
                        "%lld->%lld\n",
                        (void *)pthread_self(), conns->offset, conns->limitRegs[1],
-                       (conns->limit < 0) ? conns->limit
-                                          : (conns->limit - conns->offset),
+                       (conns->limit < 0) ? conns->limit : (conns->limit - conns->offset),
                        v->aMem[conns->limitRegs[IOFFSET_MEM_IDX]].u.i,
                        v->aMem[conns->limitRegs[IOFFSETLIMIT_MEM_IDX]].u.i,
-                       v->aMem[conns->limitRegs[IOFFSETLIMIT_MEM_IDX]].u.i -
-                           conns->offset);
+                       v->aMem[conns->limitRegs[IOFFSETLIMIT_MEM_IDX]].u.i - conns->offset);
             if (conns->limit >= 0 && conns->offset > 0)
                 conns->limit = conns->limit - conns->offset;
             /* nuke the offset, maybe do this only for order?*/
@@ -1552,8 +1539,8 @@ static int _cmp(dohsql_t *conns, int idx_a, int idx_b)
             assert(orderby_idx > 0);
             orderby_idx--;
             if (gbl_dohsql_verbose) {
-                logmsg(LOGMSG_USER, "%p COMPARE %s <> %s\n", (void *)pthread_self(),
-                       print_mem(&a[orderby_idx]), print_mem(&b[orderby_idx]));
+                logmsg(LOGMSG_USER, "%p COMPARE %s <> %s\n", (void *)pthread_self(), print_mem(&a[orderby_idx]),
+                       print_mem(&b[orderby_idx]));
             }
 
             ret = sqlite3MemCompare(&a[orderby_idx], &b[orderby_idx], NULL);
@@ -1610,10 +1597,8 @@ static void _print_order_info(dohsql_t *conns, const char *label)
     if (!gbl_dohsql_verbose)
         return;
 
-    logmsg(LOGMSG_DEBUG,
-           "%p Order %s: top_idx=%d filling=%d active=%d nconns=%d\n[",
-           (void *)pthread_self(), label, conns->top_idx, conns->filling, conns->active,
-           conns->nconns);
+    logmsg(LOGMSG_DEBUG, "%p Order %s: top_idx=%d filling=%d active=%d nconns=%d\n[", (void *)pthread_self(), label,
+           conns->top_idx, conns->filling, conns->active, conns->nconns);
     for (i = 0; i < conns->nconns; i++) {
         logmsg(LOGMSG_DEBUG, "(%d, %d, %d) ", order[i],
                (order[i] >= 0) ? conns->conns[order[i]].rc : -1,
@@ -1675,8 +1660,7 @@ static void _move_client_done(dohsql_t *conns, int idx)
 
     last = (conns->top_idx + conns->active - 1) % conns->nconns;
     if (gbl_dohsql_verbose)
-        logmsg(LOGMSG_DEBUG, "%p %s: client %d done\n", (void *)pthread_self(),
-               __func__, order[idx]);
+        logmsg(LOGMSG_DEBUG, "%p %s: client %d done\n", (void *)pthread_self(), __func__, order[idx]);
     if (last != idx)
         order[idx] = order[last];
     order[last] = -1;

--- a/db/fdb_bend.c
+++ b/db/fdb_bend.c
@@ -341,9 +341,8 @@ int fdb_svc_cursor_close(char *cid, int isuuid, struct sqlclntstate **pclnt)
     }
 
     if (gbl_fdb_track)
-        logmsg(LOGMSG_USER, "%p: CLosing rem cursor cid=%llx autocommit=%d\n",
-               (void *)pthread_self(), *(unsigned long long *)cur->cid,
-               cur->autocommit);
+        logmsg(LOGMSG_USER, "%p: CLosing rem cursor cid=%llx autocommit=%d\n", (void *)pthread_self(),
+               *(unsigned long long *)cur->cid, cur->autocommit);
 
     Pthread_rwlock_unlock(&center->cursors_rwlock);
 
@@ -515,8 +514,7 @@ again:
 
             if (recover_deadlock(thedb->bdb_env, thd, NULL, 0)) {
                 if (!gbl_rowlocks)
-                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n",
-                           __func__, (void *)pthread_self());
+                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n", __func__, (void *)pthread_self());
                 return SQLITE_DEADLOCK;
             }
 

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -440,11 +440,9 @@ int fdb_svc_trans_commit(char *tid, enum transaction_level lvl,
     if (gbl_fdb_track) {
         if (clnt->osql.rqid == OSQL_RQID_USE_UUID) {
             uuidstr_t us;
-            logmsg(LOGMSG_USER, "%p commiting tid=%s\n", (void *)pthread_self(),
-                   comdb2uuidstr(clnt->osql.uuid, us));
+            logmsg(LOGMSG_USER, "%p commiting tid=%s\n", (void *)pthread_self(), comdb2uuidstr(clnt->osql.uuid, us));
         } else
-            logmsg(LOGMSG_USER, "%p commiting tid=%llx\n", (void *)pthread_self(),
-                   clnt->osql.rqid);
+            logmsg(LOGMSG_USER, "%p commiting tid=%llx\n", (void *)pthread_self(), clnt->osql.rqid);
     }
 
     if (clnt->dbtran.mode == TRANLEVEL_RECOM ||
@@ -520,11 +518,9 @@ int fdb_svc_trans_rollback(char *tid, enum transaction_level lvl,
     if (gbl_fdb_track) {
         if (clnt->osql.rqid == OSQL_RQID_USE_UUID) {
             uuidstr_t us;
-            logmsg(LOGMSG_USER, "%p commiting tid=%s\n", (void *)pthread_self(),
-                   comdb2uuidstr(clnt->osql.uuid, us));
+            logmsg(LOGMSG_USER, "%p commiting tid=%s\n", (void *)pthread_self(), comdb2uuidstr(clnt->osql.uuid, us));
         } else
-            logmsg(LOGMSG_USER, "%p commiting tid=%llx\n", (void *)pthread_self(),
-                   clnt->osql.rqid);
+            logmsg(LOGMSG_USER, "%p commiting tid=%llx\n", (void *)pthread_self(), clnt->osql.rqid);
     }
 
     if (osql_unregister_sqlthr(clnt)) {
@@ -579,14 +575,12 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
     }
 
     if (gbl_fdb_track)
-        logmsg(LOGMSG_ERROR, "XYXYXY: thread %p getting a curtran\n",
-               (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "XYXYXY: thread %p getting a curtran\n", (void *)pthread_self());
 
     /* we need a curtran for this one */
     if (!clnt->dbtran.cursor_tran) {
         if (gbl_fdb_track)
-            logmsg(LOGMSG_ERROR, "XYXYXY: thread %p getting a curtran\n",
-                   (void *)pthread_self());
+            logmsg(LOGMSG_ERROR, "XYXYXY: thread %p getting a curtran\n", (void *)pthread_self());
 
         clnt->dbtran.cursor_tran =
             bdb_get_cursortran(thedb->bdb_env, 0, &bdberr);
@@ -598,9 +592,8 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
         *standalone = 1;
     } else {
         if (gbl_fdb_track)
-            logmsg(LOGMSG_ERROR,
-                   "XYXYXY: thread %p part of transaction %llu\n",
-                   (void *)pthread_self(), clnt->osql.rqid);
+            logmsg(LOGMSG_ERROR, "XYXYXY: thread %p part of transaction %llu\n", (void *)pthread_self(),
+                   clnt->osql.rqid);
 
         *standalone = 0;
     }
@@ -692,8 +685,7 @@ static int _fdb_svc_cursor_end(BtCursor *pCur, struct sqlclntstate *clnt,
     if (standalone) {
         if (clnt->dbtran.cursor_tran) {
             if (gbl_fdb_track)
-                logmsg(LOGMSG_ERROR, "XYXYXY: thread %p releasing curtran\n",
-                       (void *)pthread_self());
+                logmsg(LOGMSG_ERROR, "XYXYXY: thread %p releasing curtran\n", (void *)pthread_self());
 
             rc = bdb_put_cursortran(thedb->bdb_env, clnt->dbtran.cursor_tran, 0,
                                     &bdberr);
@@ -711,9 +703,7 @@ static int _fdb_svc_cursor_end(BtCursor *pCur, struct sqlclntstate *clnt,
         }
     } else {
         if (gbl_fdb_track)
-            logmsg(LOGMSG_USER,
-                   "XYXYXY: thread %p in transaction, keeping curtran\n",
-                   (void *)pthread_self());
+            logmsg(LOGMSG_USER, "XYXYXY: thread %p in transaction, keeping curtran\n", (void *)pthread_self());
     }
 
     if (pCur->ondisk_buf) {

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -412,8 +412,7 @@ static void __fdb_add_user(fdb_t *fdb, int noTrace)
     fdb->users++;
 
     if (!noTrace && gbl_fdb_track)
-        logmsg(LOGMSG_USER, "%p %s %s users %d\n", (void *)pthread_self(), __func__,
-               fdb->dbname, fdb->users);
+        logmsg(LOGMSG_USER, "%p %s %s users %d\n", (void *)pthread_self(), __func__, fdb->dbname, fdb->users);
 
     assert(fdb->users > 0);
     Pthread_mutex_unlock(&fdb->users_mtx);
@@ -429,8 +428,7 @@ static void __fdb_rem_user(fdb_t *fdb, int noTrace)
     fdb->users--;
 
     if (!noTrace && gbl_fdb_track)
-        logmsg(LOGMSG_USER, "%p %s %s users %d\n", (void *)pthread_self(), __func__,
-               fdb->dbname, fdb->users);
+        logmsg(LOGMSG_USER, "%p %s %s users %d\n", (void *)pthread_self(), __func__, fdb->dbname, fdb->users);
 
     assert(fdb->users >= 0);
     Pthread_mutex_unlock(&fdb->users_mtx);

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -279,10 +279,11 @@ static void thd_dump_nolock(void)
         for (thd = busy.top; thd; thd = thd->lnk.next) {
             cnt++;
             opc = thd->iq->opcode;
-            logmsg(LOGMSG_USER, "busy  tid %p  time %5d ms  %-6s (%-3d) "
-                                "%-20s where %s %s\n",
-                   (void *)thd->tid, U2M(nowus - thd->iq->nowus), req2a(opc), opc,
-                   getorigin(thd->iq), thd->iq->where, thd->iq->gluewhere);
+            logmsg(LOGMSG_USER,
+                   "busy  tid %p  time %5d ms  %-6s (%-3d) "
+                   "%-20s where %s %s\n",
+                   (void *)thd->tid, U2M(nowus - thd->iq->nowus), req2a(opc), opc, getorigin(thd->iq), thd->iq->where,
+                   thd->iq->gluewhere);
         }
 
         for (thd = idle.top; thd; thd = thd->lnk.next) {
@@ -355,9 +356,8 @@ void thd_dump(void)
             logmsg(LOGMSG_USER,
                    "busy  tid %p  time %5d ms  %-6s (%-3d) %-20s where %s "
                    "%s\n",
-                   (void *)thd->tid, U2M(nowus - thd->iq->nowus),
-                   req2a(thd->iq->opcode), thd->iq->opcode, getorigin(thd->iq),
-                   thd->iq->where, thd->iq->gluewhere);
+                   (void *)thd->tid, U2M(nowus - thd->iq->nowus), req2a(thd->iq->opcode), thd->iq->opcode,
+                   getorigin(thd->iq), thd->iq->where, thd->iq->gluewhere);
         }
 
         for (thd = idle.top; thd; thd = thd->lnk.next) {
@@ -429,8 +429,7 @@ static void *thd_req(void *vthd)
      * will automatically free it when the thread exits. */
     thdinfo = malloc(sizeof(struct thread_info));
     if (thdinfo == NULL) {
-        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n",
-               (void *)pthread_self());
+        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n", (void *)pthread_self());
         abort();
     }
     thdinfo->uniquetag = 0;
@@ -467,8 +466,8 @@ static void *thd_req(void *vthd)
     do {
         if (thd->tid != pthread_self()) /*sanity check*/
         {
-            logmsg(LOGMSG_FATAL, "**aborting due thd_req mismatch thd id %p (my thd %p)\n",
-                    (void *)thd->tid, (void *)pthread_self());
+            logmsg(LOGMSG_FATAL, "**aborting due thd_req mismatch thd id %p (my thd %p)\n", (void *)thd->tid,
+                   (void *)pthread_self());
             abort();
         }
         thd->iq->startus = comdb2_time_epochus();
@@ -609,7 +608,7 @@ static void *thd_req(void *vthd)
                     nretire++;
                     listc_rfl(&idle, thd);
                     Pthread_cond_destroy(&thd->wakeup);
-                    thd->tid = (pthread_t) -2; /*returned. this is just for info & debugging*/
+                    thd->tid = (pthread_t)-2;  /*returned. this is just for info & debugging*/
                     pool_relablk(p_thds, thd); /*release this struct*/
                     /**/
                     retUNLOCK(&lock);
@@ -653,7 +652,7 @@ static int reterr(intptr_t curswap, struct thd *thd, struct ireq *iq, int rc)
                     }
                 }
                 thd->iq = 0;
-                thd->tid = (pthread_t) -1;
+                thd->tid = (pthread_t)-1;
                 pool_relablk(p_thds, thd);
             }
             if (iq) {

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -960,8 +960,8 @@ static int process_this_session(
         DEBUG_PRINT_TMPBL_READ();
 
         if (bdb_lock_desired(thedb->bdb_env)) {
-            logmsg(LOGMSG_ERROR, "%p %s:%d blocksql session closing early\n",
-                   (void *)pthread_self(), __FILE__, __LINE__);
+            logmsg(LOGMSG_ERROR, "%p %s:%d blocksql session closing early\n", (void *)pthread_self(), __FILE__,
+                   __LINE__);
             err->blockop_num = 0;
             err->errcode = ERR_NOMASTER;
             err->ixnum = 0;

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -693,8 +693,8 @@ static int osql_sock_start_int(struct sqlclntstate *clnt, int type, int start_fl
 #ifdef DEBUG
     if (gbl_debug_sql_opcodes) {
         uuidstr_t us;
-        logmsg(LOGMSG_USER, "%p gets rqid %llx %s tid=0x%x\n", clnt, osql->rqid,
-                comdb2uuidstr(osql->uuid, us), (void *)pthread_self());
+        logmsg(LOGMSG_USER, "%p gets rqid %llx %s tid=0x%x\n", clnt, osql->rqid, comdb2uuidstr(osql->uuid, us),
+               (void *)pthread_self());
     }
 #endif
 
@@ -850,10 +850,8 @@ int osql_sock_restart(struct sqlclntstate *clnt, int maxretries,
         if (!keep_session) {
             uuidstr_t us;
             if (gbl_master_swing_osql_verbose)
-                logmsg(LOGMSG_USER,
-                       "0x%p Starting new session rqid=%llx, uuid=%s\n",
-                       (void *)pthread_self(), clnt->osql.rqid,
-                       comdb2uuidstr(clnt->osql.uuid, us));
+                logmsg(LOGMSG_USER, "0x%p Starting new session rqid=%llx, uuid=%s\n", (void *)pthread_self(),
+                       clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us));
             /* unregister this osql thread from checkboard */
             rc = osql_unregister_sqlthr(clnt);
             if (rc)
@@ -861,10 +859,8 @@ int osql_sock_restart(struct sqlclntstate *clnt, int maxretries,
         } else {
             uuidstr_t us;
             if (gbl_master_swing_osql_verbose)
-                logmsg(LOGMSG_USER,
-                       "0x%p Restarting rqid=%llx uuid=%s against %s\n",
-                       (void *)pthread_self(), clnt->osql.rqid,
-                       comdb2uuidstr(clnt->osql.uuid, us), thedb->master);
+                logmsg(LOGMSG_USER, "0x%p Restarting rqid=%llx uuid=%s against %s\n", (void *)pthread_self(),
+                       clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us), thedb->master);
             /* TODO: osql_sock_start will also call osql_reuse_sqlthr() */
             rc = osql_reuse_sqlthr(clnt, thedb->master);
             if (rc)
@@ -1019,8 +1015,7 @@ retry:
 
         /* trap */
         if (!osql->rqid) {
-            logmsg(LOGMSG_ERROR, "%s: !rqid %p %p???\n", __func__, clnt,
-                   (void *)pthread_self());
+            logmsg(LOGMSG_ERROR, "%s: !rqid %p %p???\n", __func__, clnt, (void *)pthread_self());
             /*cheap_stack_trace();*/
             abort();
         }

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -457,8 +457,7 @@ static void *prefault_io_thread(void *arg)
      * will automatically free it when the thread exits. */
     thdinfo = malloc(sizeof(struct thread_info));
     if (thdinfo == NULL) {
-        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n",
-               (void *)pthread_self());
+        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n", (void *)pthread_self());
         abort();
     }
     thdinfo->uniquetag = 0;

--- a/db/prefault_helper.c
+++ b/db/prefault_helper.c
@@ -81,9 +81,7 @@ static void *prefault_helper_thread(void *arg)
     dbenv = prefault_helper_thread_arg.dbenv;
     i = prefault_helper_thread_arg.instance;
 
-    logmsg(LOGMSG_INFO,
-           "prefault_helper_thread instance %d started as tid %p\n", i,
-           (void *)pthread_self());
+    logmsg(LOGMSG_INFO, "prefault_helper_thread instance %d started as tid %p\n", i, (void *)pthread_self());
 
     backend_thread_event(dbenv, COMDB2_THR_EVENT_START_RDWR);
 
@@ -91,8 +89,7 @@ static void *prefault_helper_thread(void *arg)
      * will automatically free it when the thread exits. */
     thdinfo = malloc(sizeof(struct thread_info));
     if (thdinfo == NULL) {
-        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n",
-               (void *)pthread_self());
+        logmsg(LOGMSG_FATAL, "**aborting due malloc failure thd %p\n", (void *)pthread_self());
         abort();
     }
     thdinfo->uniquetag = 0;
@@ -173,8 +170,7 @@ static void *prefault_helper_thread(void *arg)
             */
 
             if (dbenv->prefault_helper.threads[i].working_for == gbl_invalid_tid) {
-                fprintf(stderr, "PREFAULT ERROR!  working_for was %p\n",
-                        (void *)working_for);
+                fprintf(stderr, "PREFAULT ERROR!  working_for was %p\n", (void *)working_for);
                 break;
             }
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2164,9 +2164,8 @@ int sql_syntax_check(struct ireq *iq, struct dbtable *db)
 
     rc = get_curtran(thedb->bdb_env, &clnt);
     if (rc) {
-        logmsg(LOGMSG_ERROR,
-               "%s: td %p unable to get a CURSOR transaction, rc = %d!\n",
-               __func__, (void *)pthread_self(), rc);
+        logmsg(LOGMSG_ERROR, "%s: td %p unable to get a CURSOR transaction, rc = %d!\n", __func__,
+               (void *)pthread_self(), rc);
         goto done;
     }
     got_curtran = 1;
@@ -9232,9 +9231,8 @@ int get_curtran_flags(bdb_state_type *bdb_state, struct sqlclntstate *clnt,
     }
 
     if (clnt->gen_changed) {
-        logmsg(LOGMSG_DEBUG,
-               "td %p %s line %d calling get_curtran on gen_changed\n",
-               (void *)pthread_self(), __func__, __LINE__);
+        logmsg(LOGMSG_DEBUG, "td %p %s line %d calling get_curtran on gen_changed\n", (void *)pthread_self(), __func__,
+               __LINE__);
     }
 
 retry:
@@ -9341,8 +9339,7 @@ int put_curtran_flags(bdb_state_type *bdb_state, struct sqlclntstate *clnt,
     rc = bdb_put_cursortran(bdb_state, clnt->dbtran.cursor_tran, curtran_flags,
                             &bdberr);
     if (rc) {
-        logmsg(LOGMSG_DEBUG, "%s: %p rc %d bdberror %d\n", __func__,
-               (void *)pthread_self(), rc, bdberr);
+        logmsg(LOGMSG_DEBUG, "%s: %p rc %d bdberror %d\n", __func__, (void *)pthread_self(), rc, bdberr);
         ctrace("%s: rc %d bdberror %d\n", __func__, rc, bdberr);
         if (bdberr == BDBERR_BUG_KILLME) {
             /* should I panic? */
@@ -9497,8 +9494,7 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
         if (!sleepms)
             sleepms = 2000;
 
-        logmsg(LOGMSG_ERROR, "THD %p:recover_deadlock, and lock desired\n",
-               (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "THD %p:recover_deadlock, and lock desired\n", (void *)pthread_self());
     } else if (ptrace)
         logmsg(LOGMSG_INFO, "THD %p:recover_deadlock\n", (void *)pthread_self());
 
@@ -9795,8 +9791,7 @@ static int ddguard_bdb_cursor_find(struct sql_thread *thd, BtCursor *pCur,
                 if (rc == SQLITE_CLIENT_CHANGENODE)
                     *bdberr = BDBERR_NOT_DURABLE;
                 else if (!gbl_rowlocks)
-                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n",
-                           __func__, (void *)pthread_self());
+                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n", __func__, (void *)pthread_self());
                 return -1;
             }
         }
@@ -9991,8 +9986,7 @@ static int ddguard_bdb_cursor_find_last_dup(struct sql_thread *thd,
                 if (rc == SQLITE_CLIENT_CHANGENODE)
                     *bdberr = BDBERR_NOT_DURABLE;
                 else if (!gbl_rowlocks)
-                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n",
-                           __func__, (void *)pthread_self());
+                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n", __func__, (void *)pthread_self());
                 return -1;
             }
         }
@@ -10201,8 +10195,7 @@ static int ddguard_bdb_cursor_move(struct sql_thread *thd, BtCursor *pCur,
                 if (rc == SQLITE_CLIENT_CHANGENODE)
                     *bdberr = BDBERR_NOT_DURABLE;
                 else
-                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n",
-                           __func__, (void *)pthread_self());
+                    logmsg(LOGMSG_ERROR, "%s: %p failed dd recovery\n", __func__, (void *)pthread_self());
                 return -1;
             }
         }
@@ -10861,8 +10854,7 @@ static int _sockpool_get(const char *protocol, const char *dbname, const char *s
         socket_pool_get_ext(socket_type, 0, SOCKET_POOL_GET_GLOBAL, NULL, NULL);
 
     if (gbl_fdb_track)
-        logmsg(LOGMSG_ERROR, "%p: Asked socket for %s got %d\n",
-               (void *)pthread_self(), socket_type, fd);
+        logmsg(LOGMSG_ERROR, "%p: Asked socket for %s got %d\n", (void *)pthread_self(), socket_type, fd);
 
     return fd;
 }
@@ -10888,8 +10880,7 @@ void disconnect_remote_db(const char *protocol, const char *dbname, const char *
                           sizeof(socket_type));
 
     if (gbl_fdb_track)
-        logmsg(LOGMSG_ERROR, "%p: Donating socket for %s\n", (void *)pthread_self(),
-               socket_type);
+        logmsg(LOGMSG_ERROR, "%p: Donating socket for %s\n", (void *)pthread_self(), socket_type);
 
     /* this is used by fdb sql for now */
     socket_pool_donate_ext(socket_type, fd, IOTIMEOUTMS / 1000, 0,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1349,8 +1349,8 @@ void sql_set_sqlengine_state(struct sqlclntstate *clnt, char *file, int line,
                              int newstate)
 {
     if (gbl_track_sqlengine_states)
-        logmsg(LOGMSG_USER, "%p: %p %s:%d %d->%d\n", (void *)pthread_self(), clnt,
-               file, line, clnt->ctrl_sqlengine, newstate);
+        logmsg(LOGMSG_USER, "%p: %p %s:%d %d->%d\n", (void *)pthread_self(), clnt, file, line, clnt->ctrl_sqlengine,
+               newstate);
 
     if (newstate == SQLENG_WRONG_STATE) {
         logmsg(LOGMSG_ERROR, "sqlengine entering wrong state from state %d file %s line %d.\n",
@@ -1988,18 +1988,14 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                     if (rc == SQLITE_ABORT) {
                         rc = blockproc2sql_error(clnt->osql.xerr.errval,
                                                  __func__, __LINE__);
-                        logmsg(
-                            LOGMSG_ERROR,
-                            "td=%p no-shadow-tran %s line %d, returning %d\n",
-                            (void *)pthread_self(), __func__, __LINE__, rc);
+                        logmsg(LOGMSG_ERROR, "td=%p no-shadow-tran %s line %d, returning %d\n", (void *)pthread_self(),
+                               __func__, __LINE__, rc);
                     } else if (rc == SQLITE_CLIENT_CHANGENODE) {
                         rc = has_high_availability(clnt)
                                  ? CDB2ERR_CHANGENODE
                                  : SQLHERR_MASTER_TIMEOUT;
-                        logmsg(
-                            LOGMSG_ERROR,
-                            "td=%p no-shadow-tran %s line %d, returning %d\n",
-                            (void *)pthread_self(), __func__, __LINE__, rc);
+                        logmsg(LOGMSG_ERROR, "td=%p no-shadow-tran %s line %d, returning %d\n", (void *)pthread_self(),
+                               __func__, __LINE__, rc);
                     }
                 }
             } else {
@@ -2224,8 +2220,8 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
 
 #ifdef DEBUG
     if (gbl_debug_sql_opcodes) {
-        logmsg(LOGMSG_USER, "%p (U) commits transaction %d %d intran=%d\n",
-               clnt, (void *)pthread_self(), clnt->dbtran.mode, clnt->intrans);
+        logmsg(LOGMSG_USER, "%p (U) commits transaction %d %d intran=%d\n", clnt, (void *)pthread_self(),
+               clnt->dbtran.mode, clnt->intrans);
     }
 #endif
 
@@ -3736,8 +3732,7 @@ int get_prepared_stmt_try_lock(struct sqlthdstate *thd,
                        "Returning SQLITE_PERM on tryrdlock failure\n");
         return SQLITE_PERM;
     }
-    int rc = get_prepared_stmt_int(thd, clnt, rec, err,
-                                   flags & ~PREPARE_RECREATE);
+    int rc = get_prepared_stmt_int(thd, clnt, rec, err, flags);
     unlock_schema_lk();
     return rc;
 }
@@ -4816,9 +4811,8 @@ check_version:
             if (!clnt->dbtran.cursor_tran) {
                 int ctrc = get_curtran(thedb->bdb_env, clnt);
                 if (ctrc) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s td %p: unable to get a CURSOR transaction, rc = %d!\n",
-                           __func__, (void *)pthread_self(), ctrc);
+                    logmsg(LOGMSG_ERROR, "%s td %p: unable to get a CURSOR transaction, rc = %d!\n", __func__,
+                           (void *)pthread_self(), ctrc);
                     if (thd->sqldb) {
                         delete_prepared_stmts(thd);
                         sqlite3_close_serial(&thd->sqldb);
@@ -5220,9 +5214,8 @@ void sqlengine_work_appsock(void *thddata, void *work)
     /* everything going in is cursor based */
     int rc = get_curtran(thedb->bdb_env, clnt);
     if (rc) {
-        logmsg(LOGMSG_ERROR,
-               "%s td %p: unable to get a CURSOR transaction, rc=%d!\n",
-               __func__, (void *)pthread_self(), rc);
+        logmsg(LOGMSG_ERROR, "%s td %p: unable to get a CURSOR transaction, rc=%d!\n", __func__, (void *)pthread_self(),
+               rc);
         send_run_error(clnt, "Client api should change nodes",
                        CDB2ERR_CHANGENODE);
         clnt->query_rc = -1;

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -587,8 +587,8 @@ int osql_clean_sqlclntstate(struct sqlclntstate *clnt)
      * clnt->sql will be pointing at free memory after that.
      */
     if (clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS && clnt->ctrl_sqlengine != SQLENG_STRT_STATE) {
-        logmsg(LOGMSG_ERROR, "%p ctrl engine has wrong state %d %llx %p\n", clnt, clnt->ctrl_sqlengine,
-               clnt->osql.rqid, (void *)pthread_self());
+        logmsg(LOGMSG_ERROR, "%p ctrl engine has wrong state %d %llx %p\n", clnt, clnt->ctrl_sqlengine, clnt->osql.rqid,
+               (void *)pthread_self());
         if (clnt->sql)
             logmsg(LOGMSG_ERROR, "%p sql is \"%s\"\n", clnt, clnt->sql);
     }
@@ -625,8 +625,7 @@ int osql_clean_sqlclntstate(struct sqlclntstate *clnt)
 
     if (osql_chkboard_sqlsession_exists(clnt->osql.rqid, clnt->osql.uuid)) {
         uuidstr_t us;
-        logmsg(LOGMSG_ERROR, "%p [%llx %s] in USE! %p\n", clnt,
-               clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
+        logmsg(LOGMSG_ERROR, "%p [%llx %s] in USE! %p\n", clnt, clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
                (void *)pthread_self());
         /* XXX temporary debug code. */
         if (gbl_abort_on_clear_inuse_rqid)

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2025,9 +2025,8 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
             iq->sc_logical_tran = NULL; // use trans in rowlocks
             if (sc_parent == NULL) {
                 irc = -1;
-                logmsg(LOGMSG_ERROR,
-                       "%s:%d/%d td %p failed to get physical tran\n",
-                       __func__, __LINE__, line, (void *)pthread_self());
+                logmsg(LOGMSG_ERROR, "%s:%d/%d td %p failed to get physical tran\n", __func__, __LINE__, line,
+                       (void *)pthread_self());
             } else {
                 irc = trans_start_sc(iq, sc_parent, &(iq->sc_tran));
                 if (irc == 0 && gbl_sc_close_txn)
@@ -2441,8 +2440,8 @@ static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent,
         rc = trans_commit_logical(iq, iq->sc_logical_tran, gbl_myhostname, 0, 1,
                                   NULL, 0, NULL, 0);
         if (rc != 0) {
-            logmsg(LOGMSG_ERROR, "%s:%d TD %p TRANS_ABORT FAILED RC %d\n",
-                   __func__, __LINE__, (void *)pthread_self(), rc);
+            logmsg(LOGMSG_ERROR, "%s:%d TD %p TRANS_ABORT FAILED RC %d\n", __func__, __LINE__, (void *)pthread_self(),
+                   rc);
         }
     } else if (parent && !rowlocks) {
         /*
@@ -2882,9 +2881,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             }
 
             if (verbose_deadlocks)
-                logmsg(LOGMSG_USER, "%p %s:%d Using iq %p priority %d\n",
-                       (void *)pthread_self(), __FILE__, __LINE__, iq,
-                       iq->priority);
+                logmsg(LOGMSG_USER, "%p %s:%d Using iq %p priority %d\n", (void *)pthread_self(), __FILE__, __LINE__,
+                       iq, iq->priority);
 
             irc =
                 trans_start_set_retries(iq, parent_trans, &trans, iq->priority);

--- a/db/views_systable.c
+++ b/db/views_systable.c
@@ -169,8 +169,7 @@ int timepart_systable_timepartpermissions_collect(void **data, int *nrecords)
     Pthread_rwlock_rdlock(&views_lk);
     arr = calloc(views->nviews, sizeof(char *));
     if (!arr) {
-        logmsg(LOGMSG_ERROR, "%s OOM %zu!\n", __func__,
-               sizeof(char *) * views->nviews);
+        logmsg(LOGMSG_ERROR, "%s OOM %zu!\n", __func__, sizeof(char *) * views->nviews);
         rc = -1;
         goto done;
     }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2253,14 +2253,13 @@ static int lua_prepare_sql_int(SP sp, const char *sql, sqlite3_stmt **stmt,
 retry:
     memset(&err, 0, sizeof(struct errstat));
     if (sp->initial) {
-        sp->rc = get_prepared_stmt(sp->thd, sp->clnt, rec_ptr, &err, flags);
-        assert(sp->rc != SQLITE_PERM);
+        sp->rc = get_prepared_stmt_try_lock(sp->thd, sp->clnt, rec_ptr, &err, flags | PREPARE_RECREATE);
     } else if (flags & PREPARE_ALLOW_TEMP_DDL) {
         sp->rc = get_prepared_stmt_no_lock(sp->thd, sp->clnt, rec_ptr, &err, flags);
         assert(sp->rc != SQLITE_PERM);
     } else {
         /* NOTE: Only this call can return SQLITE_PERM. */
-        sp->rc = get_prepared_stmt_try_lock(sp->thd, sp->clnt, rec_ptr, &err, flags);
+        sp->rc = get_prepared_stmt_try_lock(sp->thd, sp->clnt, rec_ptr, &err, flags & ~PREPARE_RECREATE);
     }
     sp->initial = 0;
     if ((sp->rc == SQLITE_PERM) && (maxRetries != 0) &&

--- a/net/net.c
+++ b/net/net.c
@@ -1495,8 +1495,7 @@ static void net_throttle_wait_loop(netinfo_type *netinfo_ptr,
             logmsg(LOGMSG_ERROR,
                    "%s thread %p waiting for net count to drop"
                    " to %u enqueued buffers or %" PRIu64 " bytes (%d loops)\n",
-                   __func__, (void *)pthread_self(), queue_threshold, byte_threshold,
-                   loops);
+                   __func__, (void *)pthread_self(), queue_threshold, byte_threshold, loops);
         }
 
         host_ptr->stats.throttle_waits++;

--- a/net/trace.c
+++ b/net/trace.c
@@ -48,8 +48,8 @@ static void host_node_vprintf(loglvl lvl, host_node_type *host_node_ptr,
     */
 
     Pthread_mutex_lock(&trace_lock);
-    logmsg(lvl, "%p [%s %s%s fd %d] ", (void *)pthread_self(), netinfo_ptr->service,
-           host_node_ptr->host, host_node_ptr->subnet, host_node_ptr->fd);
+    logmsg(lvl, "%p [%s %s%s fd %d] ", (void *)pthread_self(), netinfo_ptr->service, host_node_ptr->host,
+           host_node_ptr->subnet, host_node_ptr->fd);
     logmsgv(lvl, fmt, ap);
     Pthread_mutex_unlock(&trace_lock);
 }

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -1753,9 +1753,8 @@ void fdb_msg_print_message(SBUF2 *sb, fdb_msg_t *msg, char *prefix)
     int isuuid;
     char prf[512];
 
-    snprintf(prf, sizeof(prf), "%p: %llu%s%s", (void *)pthread_self(),
-             (unsigned long long)gettimeofday_ms(), (prefix) ? " " : "",
-             (prefix) ? prefix : "");
+    snprintf(prf, sizeof(prf), "%p: %llu%s%s", (void *)pthread_self(), (unsigned long long)gettimeofday_ms(),
+             (prefix) ? " " : "", (prefix) ? prefix : "");
     prefix = prf;
 
     isuuid = msg->hd.type & FD_MSG_FLAGS_ISUUID;
@@ -3507,8 +3506,7 @@ int handle_remsql_request(comdb2_appsock_arg_t *arg)
 
         rc = handle_remsql_session(sb, dbenv);
         if (gbl_fdb_track)
-            logmsg(LOGMSG_USER, "%p: %s: executed session rc=%d\n",
-                   (void *)pthread_self(), __func__, rc);
+            logmsg(LOGMSG_USER, "%p: %s: executed session rc=%d\n", (void *)pthread_self(), __func__, rc);
 
         if (gbl_fdb_track_times) {
             then = gettimeofday_ms();
@@ -3545,8 +3543,7 @@ int handle_remsql_request(comdb2_appsock_arg_t *arg)
         }
     }
     if (gbl_fdb_track)
-        logmsg(LOGMSG_USER, "%p: %s: done processing\n", (void *)pthread_self(),
-               __func__);
+        logmsg(LOGMSG_USER, "%p: %s: done processing\n", (void *)pthread_self(), __func__);
 
     return rc;
 }

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -704,8 +704,8 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
         case alter:
             bdb_assert_tablename_locked(bdb_state, "comdb2_tables", gbl_rep_lockid, ASSERT_TABLENAME_LOCKED_WRITE);
             break;
-	default:
-	    break;
+        default:
+            break;
         }
     }
     switch (type) {

--- a/util/logmsg.c
+++ b/util/logmsg.c
@@ -162,10 +162,8 @@ int logmsgv(loglvl lvl, const char *fmt, va_list args)
         struct tm tm;
         localtime_r(&t, &tm);
         if (do_thread) {
-            snprintf(timestamp, sizeof(timestamp),
-                     "%04d/%02d/%02d %02d:%02d:%02d 0x%p ", tm.tm_year + 1900,
-                     tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min,
-                     tm.tm_sec, (void *)pthread_self());
+            snprintf(timestamp, sizeof(timestamp), "%04d/%02d/%02d %02d:%02d:%02d 0x%p ", tm.tm_year + 1900,
+                     tm.tm_mon + 1, tm.tm_mday, tm.tm_hour, tm.tm_min, tm.tm_sec, (void *)pthread_self());
         } else {
             snprintf(timestamp, sizeof(timestamp),
                      "%04d/%02d/%02d %02d:%02d:%02d ", tm.tm_year + 1900,

--- a/util/thread_util.c
+++ b/util/thread_util.c
@@ -252,9 +252,12 @@ arch_tid getarchtid(void) { return syscall(__NR_gettid); }
 
 arch_tid getarchtid(void) { return thread_self(); }
 
-#elif defined (__APPLE__)
+#elif defined(__APPLE__)
 
-arch_tid getarchtid(void) { return (int)pthread_self(); }
+arch_tid getarchtid(void)
+{
+    return (int)pthread_self();
+}
 
 #else
 


### PR DESCRIPTION
A recent change to get_prepared_stmt asserts that the calling thread is holding no database level locks.  The assert makes sense, as our lock-ordering protocol requires that we hold the schemalk prior to gathering any table locks- doing otherwise can cause lock-inversion deadlocks against a schema-change thread.

This assert triggered, however, for Lua SP customers, which will sometimes hold a Berkley lock against a queue.  The simplest solution (actually designed by Akshat and sanctioned by Joe, our SP specialists) is to do a 'try lock' against the schemalk when running sql in a stored procedure.  Prior to this PR, we would 'try lock' in a stored procedure only on the second and subsequent prepares.  This PR extends this convention to the first prepare as well.