### PR TITLE
Fix reqlog context handling for internal sql threads

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1004,6 +1004,12 @@ void reqlog_stat(void)
     Pthread_mutex_unlock(&rules_mutex);
 }
 
+void reqlog_reset(struct reqlogger *logger)
+{
+    if (logger)
+        logger->ncontext = 0;
+}
+
 struct reqlogger *reqlog_alloc(void)
 {
     struct reqlogger *logger;

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -38,6 +38,7 @@ typedef enum { EV_UNSET, EV_TXN, EV_SQL, EV_SP } evtype_t;
 
 int reqlog_init(const char *dbname);
 struct reqlogger *reqlog_alloc(void);
+void reqlog_reset(struct reqlogger *logger);
 void reqlog_process_message(char *line, int st, int lline);
 void reqlog_stat(void);
 void reqlog_help(void);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5683,6 +5683,7 @@ void cleanup_clnt(struct sqlclntstate *clnt)
         }
         free(clnt->context);
         clnt->context = NULL;
+        clnt->ncontext = 0;
     }
 
     if (clnt->selectv_arr) {
@@ -7265,6 +7266,7 @@ static int internal_skip_row(struct sqlclntstate *a, uint64_t b)
 }
 static int internal_log_context(struct sqlclntstate *a, struct reqlogger *b)
 {
+    reqlog_reset(b);
     return 0;
 }
 static uint64_t internal_get_client_starttime(struct sqlclntstate *a)

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -617,6 +617,7 @@ struct reqlogger *thrman_get_reqlogger(struct thr_handle *thr)
     if (thr) {
         if (!thr->reqlogger)
             thr->reqlogger = reqlog_alloc();
+        reqlog_reset(thr->reqlogger);
         return thr->reqlogger;
     } else {
         return NULL;


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

reqlog context memory management is done inside of reset_clnt.  This PR addresses an issue where an sql thread that previously ran a newsql request is subsequently dispatched to handle an 'internal' request.  The fix is to reset the reqlog structure inside of internal_log_context.

This issue is the root-cause of the RR test case failures seen in https://github.com/bloomberg/comdb2/pull/2540
