### PR TITLE
Hostname support

### DIFF
--- a/bbinc/hostname_support.h
+++ b/bbinc/hostname_support.h
@@ -1,0 +1,28 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef INCLUDED_HOSTNAME_SUPPORT_H
+#define INCLUDED_HOSTNAME_SUPPORT_H
+
+char *get_hostname_by_fileno(int);
+int get_hostname_by_fileno_v2(int, char *, size_t);
+
+#ifndef DISABLE_HOSTADDR_CACHE
+void init_peer_hash(void);
+void cleanup_peer_hash(void);
+#endif
+
+#endif /* INCLUDED_HOSTNAME_SUPPORT_H */

--- a/bbinc/sbuf2.h
+++ b/bbinc/sbuf2.h
@@ -211,9 +211,6 @@ int SBUF2_FUNC(sbuf2unbufferedwrite)(SBUF2 *sb, const char *cc, int len);
 char *SBUF2_FUNC(get_origin_mach_by_buf)(SBUF2 *);
 #define get_origin_mach_by_buf SBUF2_FUNC(get_origin_mach_by_buf)
 
-void SBUF2_FUNC(cleanup_peer_hash)();
-#define cleanup_peer_hash SBUF2_FUNC(cleanup_peer_hash)
-
 /* Returns the error of a preceding call to sbuf2flush(), sbuf2putc(),
    sbuf2puts(), sbuf2write(), sbuf2fwrite(), sbuf2getc(), sbuf2gets(),
    sbuf2fread(), sbuf2unbufferedread() or sbuf2unbufferedwrite().

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -60,6 +60,7 @@ as long as there was a successful move in the past
 #include <util.h>
 #endif
 
+#include <errno.h>
 #include <pthread.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/cdb2api/CMakeLists.txt
+++ b/cdb2api/CMakeLists.txt
@@ -1,8 +1,9 @@
 set(src
   cdb2api.c
-  ${PROJECT_SOURCE_DIR}/util/sbuf2.c
   ${PROJECT_BINARY_DIR}/protobuf/sqlquery.pb-c.c
   ${PROJECT_BINARY_DIR}/protobuf/sqlresponse.pb-c.c
+  ${PROJECT_SOURCE_DIR}/util/hostname_support.c
+  ${PROJECT_SOURCE_DIR}/util/sbuf2.c
 )
 
 list(APPEND src ${PROJECT_SOURCE_DIR}/util/walkback.c)
@@ -30,6 +31,7 @@ if (COMDB2_EXTRA_PLUGINS)
 endif()
 
 # common obj files for .so/.dylib and .a
+add_definitions(-DDISABLE_HOSTADDR_CACHE)
 add_definitions(-DSBUF2_SERVER=0)
 add_library(objlib OBJECT ${src})
 set_property(TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -132,6 +132,7 @@ void berk_memp_sync_alarm_ms(int);
 #include "time_accounting.h"
 #include <build/db.h>
 #include "comdb2_ruleset.h"
+#include <hostname_support.h>
 
 #define tokdup strndup
 
@@ -5359,6 +5360,8 @@ int main(int argc, char **argv)
        char *arg = strdup(argv[0]);
        exe = basename(arg);
     }
+
+    init_peer_hash();
 
     for (int i = 0; tool_callbacks[i].tool; i++) {
        if (strcmp(tool_callbacks[i].tool, exe) == 0)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5812,8 +5812,10 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     /* clear dbtran after aborting unfinished shadow transactions. */
     bzero(&clnt->dbtran, sizeof(dbtran_type));
 
-    if (initial)
-        clnt->origin = intern(get_origin_mach_by_buf(sb));
+    if (initial) {
+        char *origin = get_origin_mach_by_buf(sb);
+        clnt->origin = origin ? origin : "???";
+    }
 
     clnt->dbtran.crtchunksize = clnt->dbtran.maxchunksize = 0;
     clnt->in_client_trans = 0;
@@ -7007,7 +7009,7 @@ static void sql_thread_describe(void *obj, FILE *out)
         logmsg(LOGMSG_USER, "%s \"%s\"\n", clnt->origin, clnt->sql);
     } else {
         host = get_origin_mach_by_buf(clnt->sb);
-        logmsg(LOGMSG_USER, "(old client) %s \"%s\"\n", host, clnt->sql);
+        logmsg(LOGMSG_USER, "(old client) %s \"%s\"\n", host ? host : "???", clnt->sql);
     }
 }
 

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -556,13 +556,13 @@ inline int check_option_queue_coherency(struct schema_change_type *s,
 
 int sc_request_disallowed(SBUF2 *sb)
 {
-    char *from = intern(get_origin_mach_by_buf(sb));
+    char *from = get_origin_mach_by_buf(sb);
     /* Allow if we can't figure out where it came from - don't want this
        to break in production. */
     if (from == NULL) return 0;
     if (strcmp(from, "localhost") == 0) return 0;
-    if (!allow_write_from_remote(from)) return 1;
-    return 0;
+    if (allow_write_from_remote(from)) return 0;
+    return 1;
 }
 
 int sc_cmp_fileids(unsigned long long a, unsigned long long b)

--- a/tools/comdb2ar/CMakeLists.txt
+++ b/tools/comdb2ar/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(comdb2ar
   serialiseerror.cpp
   tar_header.cpp
   util.cpp
+  ${PROJECT_SOURCE_DIR}/util/hostname_support.c
   ${PROJECT_SOURCE_DIR}/util/sbuf2.c
 )
 include_directories(
@@ -36,7 +37,8 @@ if(COMDB2_BUILD_STATIC)
   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libgcc -static-libstdc++")
 endif()
 add_definitions(
-  -DSBUF2_SERVER=0
   -DBUILDING_TOOLS
+  -DDISABLE_HOSTADDR_CACHE
+  -DSBUF2_SERVER=0
 )
 install(TARGETS comdb2ar RUNTIME DESTINATION bin)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -16,6 +16,7 @@ set(src
   debug_switches.c
   flibc.c
   fsnapf.c
+  hostname_support.c
   int_overflow.c
   intern_strings.c
   list.c
@@ -36,8 +37,8 @@ set(src
   queuetest.c
   roll_file.c
   rtcpu.c
-  schema_lk.c
   sbuf2.c
+  schema_lk.c
   segstring.c
   sltpck.c
   str0.c

--- a/util/hostname_support.c
+++ b/util/hostname_support.c
@@ -1,0 +1,129 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <hostname_support.h>
+
+static int get_hostname_by_addr(struct sockaddr_in *addr, char *host, socklen_t hostlen)
+{
+    socklen_t addrlen = sizeof(*addr);
+    if (getnameinfo((struct sockaddr *)addr, addrlen, host, hostlen, NULL, 0, 0)) {
+        if (!inet_ntop(addr->sin_family, &addr->sin_addr, host, hostlen)) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+#ifndef DISABLE_HOSTADDR_CACHE
+#include <pthread.h>
+#include <intern_strings.h>
+#include <locks_wrap.h>
+#include <plhash.h>
+
+static hash_t *hs;
+static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+
+struct peer_entry {
+    struct in_addr addr;
+    char *name;
+};
+
+static struct peer_entry *new_peer_entry(struct in_addr addr, char *name)
+{
+    struct peer_entry *entry = malloc(sizeof(struct peer_entry));
+    entry->addr = addr;
+    entry->name = intern(name);
+    return entry;
+}
+
+static int free_peer_entry(void *obj, void *arg)
+{
+    free(obj);
+    return 0;
+}
+
+static char *find_peer_hash(struct in_addr addr)
+{
+    Pthread_mutex_lock(&lk);
+    struct peer_entry *entry = hash_find(hs, &addr);
+    Pthread_mutex_unlock(&lk);
+    return entry ? entry->name : NULL;
+}
+
+static char *add_peer_hash(struct in_addr addr, char *name)
+{
+    struct peer_entry *entry = new_peer_entry(addr, name);
+    Pthread_mutex_lock(&lk);
+    hash_add(hs, entry);
+    Pthread_mutex_unlock(&lk);
+    return entry->name;
+}
+
+void init_peer_hash(void)
+{
+    hs = hash_init_o(offsetof(struct peer_entry, addr), sizeof(struct in_addr));
+}
+
+void cleanup_peer_hash(void)
+{
+    Pthread_mutex_lock(&lk);
+    hash_for(hs, free_peer_entry, NULL);
+    hash_free(hs);
+    Pthread_mutex_unlock(&lk);
+}
+
+#endif /* ifndef DISABLE_HOSTADDR_CACHE */
+
+char *get_hostname_by_fileno(int fd)
+{
+    struct sockaddr_in saddr;
+    socklen_t len = sizeof(saddr);
+    if (getpeername(fd, (struct sockaddr *)&saddr, &len)) return NULL;
+    char host[NI_MAXHOST];
+# ifdef DISABLE_HOSTADDR_CACHE
+    if (get_hostname_by_addr(&saddr, host, NI_MAXHOST)) return NULL;
+    return strdup(host);
+# else
+    char *name = find_peer_hash(saddr.sin_addr);
+    if (name) return name;
+    if (get_hostname_by_addr(&saddr, host, NI_MAXHOST)) return NULL;
+    return add_peer_hash(saddr.sin_addr, host);
+# endif
+}
+
+int get_hostname_by_fileno_v2(int fd, char *out, size_t sz)
+{
+    struct sockaddr_in saddr;
+    socklen_t len = sizeof(saddr);
+    if (getpeername(fd, (struct sockaddr *)&saddr, &len)) return -1;
+# ifdef DISABLE_HOSTADDR_CACHE
+    return get_hostname_by_addr(&saddr, out, sz);
+# else
+    char *name = find_peer_hash(saddr.sin_addr);
+    if (name) return snprintf(out, sz, "%s", name) >= sz;
+    if (get_hostname_by_addr(&saddr, out, sz)) return -1;
+    add_peer_hash(saddr.sin_addr, out);
+    return 0;
+# endif
+}

--- a/util/sbuf2.c
+++ b/util/sbuf2.c
@@ -16,9 +16,10 @@
 
 /* simple buffering for stream */
 
-#include <sbuf2.h>
-
+#include <arpa/inet.h>
 #include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
 #include <poll.h>
 #include <stdarg.h>
 #include <stdio.h>
@@ -27,10 +28,9 @@
 #include <strings.h>
 #include <sys/uio.h>
 #include <unistd.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include "locks_wrap.h"
+
+#include <hostname_support.h>
+#include <sbuf2.h>
 
 #if SBUF2_SERVER
 #  ifndef SBUF2_DFL_SIZE
@@ -910,188 +910,12 @@ void SBUF2_FUNC(sbuf2nextline)(SBUF2 *sb)
         ;
 }
 
-#if SBUF2_SERVER
-#include <lockmacros.h> /* LOCK & UNLOCK */
-#include <plhash.h>    /* hash_t */
-#include <logmsg.h>    /* logmsg */
-#define logi(...) logmsg(LOGMSG_INFO, ##__VA_ARGS__)
-#define loge(...) logmsg(LOGMSG_ERROR, ##__VA_ARGS__)
-static pthread_mutex_t peer_lk = PTHREAD_MUTEX_INITIALIZER;
-static hash_t *peer_hash = NULL;
-struct peer_info {
-    /* Key (must come first in struct) */
-    struct in_addr addr;
-    short family;
-    /* (don't forget to bzero the key area as the member fields may not
-     * be aligned) */
-
-    /* Data */
-    char *host;
-};
-#else
-/* Keep quiet in client mode. */
-#define logi(...)
-#define loge(...)
-/* Don't cache host info in client mode. */
-#ifdef LOCK
-#undef LOCK
-#endif /* LOCK */
-#define LOCK(arg)
-#ifdef UNLOCK
-#undef UNLOCK
-#endif /* UNLOCK */
-#define UNLOCK(arg)
-#endif /* SBUF2_SERVER */
-
 char *SBUF2_FUNC(get_origin_mach_by_buf)(SBUF2 *sb)
 {
-    int fd;
-    char *host = NULL;
-#if SBUF2_SERVER
-    struct peer_info *info;
-    char *funcname;
-#else
-    void *info = NULL;
-#endif
-
-    if (sb == NULL)
-        return "???";
-
-    fd = sb->fd;
-
-    if (fd == -1)
-        return "???";
-
-    struct sockaddr_in peeraddr = {0};
-    socklen_t len = sizeof(peeraddr);
-    if (getpeername(fd, (struct sockaddr *)&peeraddr, &len) < 0) {
-        loge("%s:getpeername failed fd %d: %d %s\n", __func__, fd, errno,
-             strerror(errno));
-        return "???";
+    if (sb == NULL || sb->fd == -1) {
+        return NULL;
     }
-
-#if SBUF2_SERVER
-    struct peer_info key = {.family = peeraddr.sin_family};
-    memcpy(&key.addr, &peeraddr.sin_addr, sizeof(key.addr));
-#endif
-
-    LOCK(&peer_lk)
-    {
-#if SBUF2_SERVER
-        if (!peer_hash) {
-            peer_hash = hash_init(offsetof(struct peer_info, host));
-            if (!peer_hash) {
-                loge("%s:hash_init failed\n", __func__);
-                errUNLOCK(&peer_lk);
-                return "???";
-            }
-        }
-
-        info = hash_find(peer_hash, &key);
-#endif
-        if (!info) {
-            /* Do a slow lookup of this internet address in the host database
-             * to get a hostname, and then search the bigsnd node list to
-             * map this to a node number. */
-            char hnm[256] = {0};
-            char *h_name = NULL;
-            int rc;
-            int error_num = 0;
-            int goodrc = 0;
-
-#ifdef _LINUX_SOURCE
-#if SBUF2_SERVER
-            funcname = "getnameinfo";
-#endif
-            rc = getnameinfo((struct sockaddr *)&peeraddr, sizeof(peeraddr),
-                             hnm, sizeof(hnm), NULL, 0, 0);
-
-            if (0 == rc) {
-                goodrc = 1;
-                h_name = hnm;
-            } else {
-                error_num = errno;
-            }
-#else
-#if SBUF2_SERVER
-            funcname = "getipnodebyaddr";
-#endif
-            struct hostent *hp = NULL;
-            hp = getipnodebyaddr(&peeraddr.sin_addr, sizeof(peeraddr.sin_addr),
-                                 peeraddr.sin_family, &error_num);
-            if (hp) {
-                goodrc = 1;
-                h_name = hp->h_name;
-            }
-#endif
-
-            if (0 == goodrc) {
-                char addrstr[64] = "";
-                inet_ntop(peeraddr.sin_family, &peeraddr.sin_addr, addrstr,
-                          sizeof(addrstr));
-                loge("%s:%s failed fd %d (%s): error_num %d", __func__,
-                     funcname, fd, addrstr, error_num);
-                switch (error_num) {
-                case HOST_NOT_FOUND:
-                    loge(" HOST_NOT_FOUND\n");
-                    break;
-                case NO_DATA:
-                    loge(" NO_DATA\n");
-                    break;
-                case NO_RECOVERY:
-                    loge(" NO_RECOVERY\n");
-                    break;
-                case TRY_AGAIN:
-                    loge(" TRY_AGAIN\n");
-                    break;
-                default:
-                    loge(" ???\n");
-                    break;
-                }
-                host = strdup(addrstr);
-            } else {
-                host = strdup(h_name);
-            }
-
-#if SBUF2_SERVER
-            info = calloc(1, sizeof(struct peer_info));
-            if (!info) {
-                errUNLOCK(&peer_lk);
-                loge("%s: out of memory\n", __func__);
-                free(host);
-                host = NULL;
-                return "???";
-            }
-
-            memcpy(info, &key, sizeof(key));
-            info->host = host;
-            if (hash_add(peer_hash, info) != 0) {
-                errUNLOCK(&peer_lk);
-                loge("%s: hash_add failed\n", __func__);
-                free(info);
-                return host;
-            }
-#endif
-        }
-    }
-    UNLOCK(&peer_lk);
-
-#if SBUF2_SERVER
-    return (info != NULL) ? info->host : "???";
-#else
-    return (host != NULL) ? host : "???";
-#endif
-}
-
-void SBUF2_FUNC(cleanup_peer_hash)()
-{
-#if SBUF2_SERVER
-    if (peer_hash) {
-        hash_clear(peer_hash);
-        hash_free(peer_hash);
-        peer_hash = NULL;
-    }
-#endif
+    return get_hostname_by_fileno(sb->fd);
 }
 
 int SBUF2_FUNC(sbuf2lasterror)(SBUF2 *sb, char *err, size_t n)

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -238,7 +238,6 @@ static int ssl_verify_ca(SBUF2 *sb)
     ** The forward DNS lookup is necessary in case an attacker is
     ** in control of reverse DNS for the source IP.
     */
-    const char *peerhost;
     struct sockaddr_in peeraddr;
     struct in_addr *peer_in_addr, **p_fwd_in_addr;
     socklen_t len = sizeof(struct sockaddr_in);
@@ -246,9 +245,8 @@ static int ssl_verify_ca(SBUF2 *sb)
     struct hostent *hp = NULL;
 
     /* Reverse lookup the hostname */
-    peerhost = get_origin_mach_by_buf(sb);
-
-    if (strcmp(peerhost, "???") == 0) {
+    char peerhost[NI_MAXHOST];
+    if (get_hostname_by_fileno_v2(sbuf2fileno(sb), peerhost, sizeof(peerhost))) {
         ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr), my_ssl_eprintln,
                      "Could not obtain peer host name.");
         return 1;


### PR DESCRIPTION
This makes mapping `fd` -> `hostname`, independent of whether `fd` is obtained from `sbuf`, `socket` or `libevent`. It wan't appropriate to have that facility burried in `sbuf` library.

Also fixes memory leak in `ssl_verify_ca` when run in `cdb2api`.

This is needed for another ongoing project, but I wanted to keep semi-related changes in separate PR. At the very least, this is cleaner than existing `get_origin_mach_by_buf`