### PR TITLE
Fix analyze crash on database exit

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -67,6 +67,7 @@ int debug_switch_fake_sc_replication_timeout(void);      /* 0 */
 int debug_switch_test_ddl_backout_nomaster(void);        /* 0 */
 int debug_switch_test_ddl_backout_deadlock(void);        /* 0 */
 int debug_switch_test_ddl_backout_blkseq(void);          /* 0 */
+int debug_switch_test_delay_analyze_commit(void);        /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -7076,10 +7076,10 @@ void run_internal_sql(char *sql)
     start_internal_sql_clnt(&clnt);
     clnt.sql = skipws(sql);
 
-    dispatch_sql_query(&clnt, PRIORITY_T_DEFAULT);
-    if (clnt.query_rc || clnt.saved_errstr) {
-        logmsg(LOGMSG_ERROR, "%s: Error from query: '%s' (rc = %d) \n", __func__, sql,
-               clnt.query_rc);
+    int rc = dispatch_sql_query(&clnt, PRIORITY_T_DEFAULT);
+    if (rc || clnt.query_rc || clnt.saved_errstr) {
+        if (clnt.query_rc)
+            logmsg(LOGMSG_ERROR, "%s: Error from query: '%s' (rc = %d) \n", __func__, sql, clnt.query_rc);
         if (clnt.saved_errstr)
             logmsg(LOGMSG_ERROR, "%s: Error: '%s' \n", __func__, clnt.saved_errstr);
     }
@@ -7298,12 +7298,10 @@ int run_internal_sql_clnt(struct sqlclntstate *clnt, char *sql)
     printf("run_internal_sql_clnt() sql '%s'\n", sql);
 #endif
     clnt->sql = skipws(sql);
-    dispatch_sql_query(clnt, PRIORITY_T_DEFAULT);
-    int rc = 0;
-
-    if (clnt->query_rc || clnt->saved_errstr) {
-        logmsg(LOGMSG_ERROR, "%s: Error from query: '%s' (rc = %d) \n", __func__, sql,
-               clnt->query_rc);
+    int rc = dispatch_sql_query(clnt, PRIORITY_T_DEFAULT);
+    if (rc || clnt->query_rc || clnt->saved_errstr) {
+        if (clnt->query_rc)
+            logmsg(LOGMSG_ERROR, "%s: Error from query: '%s' (rc = %d) \n", __func__, sql, clnt->query_rc);
         if (clnt->saved_errstr)
             logmsg(LOGMSG_ERROR, "%s: Error: '%s' \n", __func__, clnt->saved_errstr);
         rc = 1;

--- a/tests/analyze_exit.test/Makefile
+++ b/tests/analyze_exit.test/Makefile
@@ -1,0 +1,6 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/analyze_exit.test/lrl.options
+++ b/tests/analyze_exit.test/lrl.options
@@ -1,0 +1,1 @@
+analyze_comp_threshold 1

--- a/tests/analyze_exit.test/output.expected
+++ b/tests/analyze_exit.test/output.expected
@@ -1,0 +1,1 @@
+[analyze t 100] failed with rc -5 Analyze could not run because of internal problems

--- a/tests/analyze_exit.test/runit
+++ b/tests/analyze_exit.test/runit
@@ -1,0 +1,26 @@
+# Verify that analyze commit correctly bails out on exit,
+# and the database does not crash.
+
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t (i INT)'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE INDEX t_i ON t(i)'
+
+sleep 1
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'INSERT INTO t VALUES (1), (2), (3)'
+
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+cdb2sql $dbnm --host $host "exec procedure sys.cmd.send('test_delay_analyze_commit 1')"
+cdb2sql $dbnm --host $host 'analyze t 100' >output.actual 2>&1 &
+sleep 5
+
+cdb2sql $dbnm --host $host 'exec procedure sys.cmd.send("exit")'
+
+wait
+
+diff output.actual output.expected

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -873,6 +873,7 @@
 (name='test_ddl_backout_blkseq', description='Force a blkseq error in toblock.', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_ddl_backout_deadlock', description='Force a deadlock in toblock.', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_ddl_backout_nomaster', description='Force a NOMASTER error in toblock.', type='BOOLEAN', value='OFF', read_only='N')
+(name='test_delay_analyze_commit', description='Delay analyze commit', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_io_time', description='Check I/O in watchdog this often', type='INTEGER', value='10', read_only='N')
 (name='test_sc_resume_race', description='Test race between schemachange resume and blockprocessor', type='BOOLEAN', value='OFF', read_only='Y')
 (name='test_scindex_deadlock', description='Test index on expressions schema change deadlock', type='BOOLEAN', value='OFF', read_only='Y')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -74,6 +74,7 @@ static struct debug_switches {
     int test_ddl_backout_nomaster;
     int test_ddl_backout_deadlock;
     int test_ddl_backout_blkseq;
+    int test_delay_analyze_commit;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -127,6 +128,7 @@ int init_debug_switches(void)
     debug_switches.test_ddl_backout_nomaster = 0;
     debug_switches.test_ddl_backout_deadlock = 0;
     debug_switches.test_ddl_backout_blkseq = 0;
+    debug_switches.test_delay_analyze_commit = 0;
 
     register_int_switch("alternate_verify_fail", "alternate_verify_fail",
                         &debug_switches.alternate_verify_fail);
@@ -232,6 +234,7 @@ int init_debug_switches(void)
                         &debug_switches.test_ddl_backout_deadlock);
     register_int_switch("test_ddl_backout_blkseq", "Force a blkseq error in toblock.",
                         &debug_switches.test_ddl_backout_blkseq);
+    register_int_switch("test_delay_analyze_commit", "Delay analyze commit", &debug_switches.test_delay_analyze_commit);
     return 0;
 }
 
@@ -430,4 +433,8 @@ int debug_switch_test_ddl_backout_deadlock(void)
 int debug_switch_test_ddl_backout_blkseq(void)
 {
     return debug_switches.test_ddl_backout_blkseq;
+}
+int debug_switch_test_delay_analyze_commit(void)
+{
+    return debug_switches.test_delay_analyze_commit;
 }


### PR DESCRIPTION
If an analyze's commit or rollback fails to dispatch (which happens quite often during clean-exit), the database will trigger the in-use-rqid assertion when cleaning up the analyze's OSQL structures.

The fix is unregister the analyze thread from the OSQL checkboard if commit/rollback fails.
