### PR TITLE
Backwards compatibility - decltype similar to column names

### DIFF
--- a/bbinc/comdb2_query_preparer.h
+++ b/bbinc/comdb2_query_preparer.h
@@ -19,7 +19,7 @@
 
 struct comdb2_query_preparer {
     int (*do_prepare)(struct sqlthdstate *, struct sqlclntstate *, const char *,
-                      char ***, int *);
+                      char ***, char ***, int *);
     int (*do_cleanup)(struct sqlclntstate *);
     int (*sqlitex_is_initializing)(void *);
     char *(*sqlitex_table_name)(void *);

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1114,6 +1114,11 @@ static int dohsql_send_intrans_response(struct sqlclntstate *a)
         logmsg(LOGMSG_WARN, "%lx %s\n", pthread_self(), __func__);
     return 0;
 }
+static int dohsql_needs_decltypes(struct sqlclntstate *a) {
+    if (gbl_plugin_api_debug)
+        logmsg(LOGMSG_WARN, "%lx %s\n", pthread_self(), __func__);
+    return 0;
+}
 
 static int _shard_connect(struct sqlclntstate *clnt, dohsql_connector_t *conn,
                           const char *sql, int nparams,

--- a/db/sql.h
+++ b/db/sql.h
@@ -71,6 +71,7 @@ struct fingerprint_track {
     char *zNormSql;   /* The normalized SQL query */
     size_t nNormSql;  /* Length of normalized SQL query */
     char ** cachedColNames; /* Cached column names from sqlitex */
+    char ** cachedColDeclTypes; /* Cached column types from sqlitex */
     int cachedColCount;     /* Cached column count from sqlitex */
 };
 
@@ -442,6 +443,8 @@ struct plugin_callbacks {
     plugin_func *get_high_availability; /* newsql_get_high_availability*/
     plugin_func *has_parallel_sql;      /* newsql_has_parallel_sql */
 
+
+
     add_steps_func *add_steps; /* newsql_add_steps */
     setup_client_info_func *setup_client_info; /* newsql_setup_client_info */
     skip_row_func *skip_row; /* newsql_skip_row */
@@ -453,6 +456,7 @@ struct plugin_callbacks {
     void *state;
     int (*column_count)(struct sqlclntstate *,
                         sqlite3_stmt *); /* sqlite3_column_count */
+    plugin_func *needs_decltypes;
     int (*next_row)(struct sqlclntstate *, sqlite3_stmt *); /* sqlite3_step */
     SQLITE_CALLBACK_API(int, type);                   /* sqlite3_column_type */
     SQLITE_CALLBACK_API(sqlite_int64, int64);         /* sqlite3_column_int64*/
@@ -504,6 +508,7 @@ struct plugin_callbacks {
         make_plugin_callback(clnt, name, get_client_starttime);                \
         make_plugin_callback(clnt, name, get_client_retries);                  \
         make_plugin_callback(clnt, name, send_intrans_response);               \
+        make_plugin_callback(clnt, name, needs_decltypes);                     \
         make_plugin_optional_null(clnt, count);                                \
         make_plugin_optional_null(clnt, type);                                 \
         make_plugin_optional_null(clnt, int64);                                \
@@ -1266,7 +1271,7 @@ void clnt_query_cost(struct sqlthdstate *thd, double *pCost, int64_t *pPrepMs);
 int clear_fingerprints(void);
 void calc_fingerprint(const char *zNormSql, size_t *pnNormSql,
                       unsigned char fingerprint[FINGERPRINTSZ]);
-void add_fingerprint(sqlite3_stmt *, const char *, const char *, int64_t,
+void add_fingerprint(struct sqlclntstate *clnt, sqlite3_stmt *, const char *, const char *, int64_t,
                      int64_t, int64_t, int64_t, struct reqlogger *logger,
                      unsigned char *fingerprint_out);
 

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2163,7 +2163,7 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
 
             unsigned char fingerprint[FINGERPRINTSZ];
             add_fingerprint(
-                pStmt, sqlite3_sql(pStmt), zNormSql, cost,
+                clnt, pStmt, sqlite3_sql(pStmt), zNormSql, cost,
                 timeMs, prepMs, pVdbe->luaRows, NULL,
                 fingerprint
             );

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2201,6 +2201,10 @@ retry_read:
     return query;
 }
 
+static int newsql_needs_decltypes(struct sqlclntstate *clnt) {
+    return 0;
+}
+
 extern int gbl_allow_incoherent_sql;
 static inline int incoh_reject(int admin, bdb_state_type *bdb_state)
 {

--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -1890,9 +1890,6 @@ static void generateColumnNames(
   sqlite3 *db = pParse->db;
   int fullName;    /* TABLE.COLUMN if no AS clause and is a direct table ref */
   int srcName;     /* COLUMN or TABLE.COLUMN if no AS clause and is direct */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  int isCompound = 0; /* Will be >0 for compound SELECT statements */
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifndef SQLITE_OMIT_EXPLAIN
   /* If this is an EXPLAIN, skip this step */
@@ -1903,18 +1900,9 @@ static void generateColumnNames(
 
   if( pParse->colNamesSet ) return;
   /* Column names are determined by the left-most term of a compound select */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  /* COMPAT: column types of compound SELECTs are assumed to be 'text'. */
-  while( pSelect->pPrior ){ isCompound++; pSelect = pSelect->pPrior; }
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   while( pSelect->pPrior ) pSelect = pSelect->pPrior;
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   SELECTTRACE(1,pParse,pSelect,("generating column names\n"));
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  pTabList = isCompound>0 ? 0 : pSelect->pSrc;
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pTabList = pSelect->pSrc;
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pEList = pSelect->pEList;
   assert( v!=0 );
 #if !defined(SQLITE_BUILDING_FOR_COMDB2)

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4845,8 +4845,11 @@ void stmt_set_dtprec(sqlite3_stmt *, int);
 int stmt_cached_column_count(sqlite3_stmt *);
 char *stmt_cached_column_name(sqlite3_stmt *, int);
 char *stmt_column_name(sqlite3_stmt *, int);
-void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
+char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
+void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
+int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4846,8 +4846,11 @@ void stmt_set_dtprec(sqlite3_stmt *, int);
 int stmt_cached_column_count(sqlite3_stmt *);
 char *stmt_cached_column_name(sqlite3_stmt *, int);
 char *stmt_column_name(sqlite3_stmt *, int);
-void stmt_set_cached_columns(sqlite3_stmt *, char **, int);
+char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
+char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
+void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
+int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -585,6 +585,7 @@ struct Vdbe {
   i64 luaRows;            /* number of rows processed by Lua */
   double luaSavedCost;    /* saved cost for this Lua thread */
   char **oldColNames;     /* Column names returned by old-sqlite version */
+  char **oldColDeclTypes; /* Column decltypes returned by old-sqlite version */
   int oldColCount;        /* Column count (refer: sqlitex)*/
   u8 fingerprint_added;   /* Whether fingerprint was added? Only used in SP code */
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -115,6 +115,32 @@ char *stmt_cached_column_name(sqlite3_stmt *pStmt, int index) {
   return column_names[index];
 }
 
+char *stmt_column_decltype(sqlite3_stmt *pStmt, int index) {
+  Vdbe *vdbe = (Vdbe *)pStmt;
+  if (!vdbe) {
+    logmsg(LOGMSG_ERROR, "%s:%d stmt handle not set\n", __func__, __LINE__);
+    return 0;
+  }
+  index += COLNAME_DECLTYPE * sqlite3_column_count(pStmt);
+  char *ret = (char *) sqlite3_value_text((sqlite3_value*)&vdbe->aColName[index]);
+  if (ret == NULL)
+      return "text";
+  return ret;
+}
+
+char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index) {
+  char **column_decltypes;
+  Vdbe *vdbe = (Vdbe *)pStmt;
+
+  if (!vdbe) {
+    logmsg(LOGMSG_ERROR, "%s:%d stmt handle not set\n", __func__, __LINE__);
+    return 0;
+  }
+  column_decltypes = vdbe->oldColDeclTypes;
+  return column_decltypes[index];
+}
+
+
 int stmt_cached_column_count(sqlite3_stmt *pStmt) {
   Vdbe *vdbe = (Vdbe *)pStmt;
   return (vdbe) ? vdbe->oldColCount : 0;
@@ -125,6 +151,7 @@ static void stmt_free_column_names(sqlite3_stmt *pStmt) {
   int column_count;
   int i;
   char **column_names;
+  char **column_decltypes;
 
   vdbe = (Vdbe *)pStmt;
   if (!vdbe)
@@ -132,16 +159,21 @@ static void stmt_free_column_names(sqlite3_stmt *pStmt) {
 
   column_names = vdbe->oldColNames;
   column_count = vdbe->oldColCount;
+  column_decltypes = vdbe->oldColDeclTypes;
   for(i=0; i<column_count; i++) {
     free(column_names[i]);
+    free(column_decltypes[i]);
   }
   free(column_names);
+  free(column_decltypes);
 
   vdbe->oldColNames = 0;
+  vdbe->oldColDeclTypes = 0;
   vdbe->oldColCount = 0;
 }
 
 void stmt_set_cached_columns(sqlite3_stmt *pStmt, char **column_names,
+                             char **column_decltypes, 
                              int column_count) {
   Vdbe *vdbe = (Vdbe *)pStmt;
 
@@ -149,26 +181,37 @@ void stmt_set_cached_columns(sqlite3_stmt *pStmt, char **column_names,
   stmt_free_column_names(pStmt);
 
   vdbe->oldColNames = column_names;
+  vdbe->oldColDeclTypes = column_decltypes;
   vdbe->oldColCount = column_count;
 }
 
-int stmt_do_column_names_match(sqlite3_stmt *pStmt) {
-  Vdbe *p;
-  int cached_column_count;
-  int i;
-
-  if( gbl_old_column_names==0 || (stmt_cached_column_count(pStmt)==0) ||
-      (sqlite3_column_count(pStmt)==0) ){
-    return 1;
-  }
-
-  cached_column_count = stmt_cached_column_count(pStmt);
+#define COLUMN_MATCH_COMMON(pStmt) \
+  int cached_column_count;        \
+  int i;                          \
+  if( gbl_old_column_names==0 || (stmt_cached_column_count(pStmt)==0) ||  \
+      (sqlite3_column_count(pStmt)==0) ){                                 \
+    return 1;                     \
+  }                               \
+  cached_column_count = stmt_cached_column_count(pStmt);        \
   assert(cached_column_count == sqlite3_column_count(pStmt));
 
+int stmt_do_column_names_match(sqlite3_stmt *pStmt) {
+  COLUMN_MATCH_COMMON(pStmt);
+  Vdbe *p;
   p = (Vdbe *)pStmt;
   for(i=0; i<cached_column_count; i++){
     if( (strcmp((const char *)sqlite3_value_text((sqlite3_value*)&p->aColName[i]),
                 stmt_cached_column_name(pStmt, i)))!=0 ) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt) {
+  COLUMN_MATCH_COMMON(pStmt);
+  for(i=0; i<cached_column_count; i++){
+    if((strcmp(stmt_column_decltype(pStmt, i), stmt_cached_column_decltype(pStmt, i)))!=0) {
       return 0;
     }
   }
@@ -1426,10 +1469,14 @@ static const void *columnName(
     sqlite3_mutex_enter(db->mutex);
     assert( db->mallocFailed==0 );
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( gbl_old_column_names && useUtf16 == 0 && useType == COLNAME_NAME &&
-        stmt_cached_column_count(pStmt)>0 ){
+    if( gbl_old_column_names && useUtf16 == 0 && 
+            (useType == COLNAME_NAME || useType == COLNAME_DECLTYPE) &&
+            stmt_cached_column_count(pStmt)>0 ){
       assert(N<=stmt_cached_column_count(pStmt));
-      ret = stmt_cached_column_name(pStmt, N);
+      if (useType == COLNAME_NAME)
+          ret = stmt_cached_column_name(pStmt, N);
+      else if (useType == COLNAME_DECLTYPE)
+          ret = stmt_cached_column_decltype(pStmt, N-n);
     }else
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #ifndef SQLITE_OMIT_UTF16

--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -165,6 +165,7 @@ void sqlite3VdbeSwap(Vdbe *pA, Vdbe *pB){
     SWAP(int *, pA->updCols, pB->updCols);
     SWAP(int, pA->oldColCount, pB->oldColCount);
     SWAP(char **, pA->oldColNames, pB->oldColNames);
+    SWAP(char **, pA->oldColDeclTypes, pB->oldColDeclTypes);
   }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pB->expmask = pA->expmask;


### PR DESCRIPTION
Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>

This adds SQLite's decltype to a preparer plugin interface, so we can keep consistent types when SQLite engine changes theirs.
