### PR TITLE
Fix newsql protobuf allocator pointer after realloc

### DIFF
--- a/protobuf/pb_alloc.h
+++ b/protobuf/pb_alloc.h
@@ -6,6 +6,7 @@
 
 extern comdb2bma blobmem;
 extern unsigned gbl_blob_sz_thresh_bytes;
+extern int gbl_protobuf_prealloc_buffer_size;
 
 static inline void* malloc_wrap(void *allocator_data, size_t n)
 {
@@ -30,10 +31,10 @@ struct NewsqlProtobufCAllocator {
     void (*free_func)(void *ptr);
     int protobuf_offset;
     int protobuf_size;
-
+    int alloced_outside_buffer;
 };
 
-static inline void reset_protobuf_offset(struct NewsqlProtobufCAllocator *npa)
+static inline void newsql_protobuf_reset_offset(struct NewsqlProtobufCAllocator *npa)
 {
     npa->protobuf_offset = 0;
 }
@@ -47,6 +48,7 @@ static inline void *newsql_protobuf_alloc(void *allocator_data, size_t size)
         npa->protobuf_offset += size;
     } else {
         p = npa->malloc_func(size);
+        npa->alloced_outside_buffer++;
     }
     return p;
 }
@@ -56,12 +58,13 @@ static inline void newsql_protobuf_free(void *allocator_data, void *p)
     struct NewsqlProtobufCAllocator *npa = allocator_data;
     if (p < npa->protobuf_data || p > (npa->protobuf_data + npa->protobuf_size)) {
         npa->free_func(p);
+        npa->alloced_outside_buffer--;
     }
 }
 
-static inline void newsql_protobuf_init(struct NewsqlProtobufCAllocator *npa, void *(*malloc_func)(size_t size), void (*free_func)(void *ptr))
+static inline void newsql_protobuf_init(struct NewsqlProtobufCAllocator *npa, void *(*malloc_func)(size_t size),
+                                        void (*free_func)(void *ptr))
 {
-    extern int gbl_protobuf_prealloc_buffer_size;
     npa->protobuf_size = gbl_protobuf_prealloc_buffer_size;
     npa->protobuf_offset = 0;
     npa->protobuf_data = malloc_func(npa->protobuf_size);
@@ -70,10 +73,17 @@ static inline void newsql_protobuf_init(struct NewsqlProtobufCAllocator *npa, vo
     npa->protobuf_allocator.alloc = &newsql_protobuf_alloc;
     npa->protobuf_allocator.free = &newsql_protobuf_free;
     npa->protobuf_allocator.allocator_data = npa;
+    npa->alloced_outside_buffer = 0;
+}
+
+static inline void newsql_protobuf_set_allocator_data(struct NewsqlProtobufCAllocator *npa)
+{
+    npa->protobuf_allocator.allocator_data = npa;
 }
 
 static inline void newsql_protobuf_destroy(struct NewsqlProtobufCAllocator *npa)
 {
+    assert(npa->alloced_outside_buffer == 0);
     npa->free_func(npa->protobuf_data);
 }
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,7 @@ This is the comdb2 test suite.
 Some of the tests require non standard tools to be installed, so here is a 
 list of packages needed to run all the tests:
 
-`apt-get install bash coreutils jq`
+`apt-get install bash coreutils jq tcl-dev`
 
 Clustered tests also need ssh-client and ssh-server setup.
 


### PR DESCRIPTION
Currently we realloc appdata when number of columns is greater
than our buffer, and in that case the protobuf allocator pointer
is stale resulting in a crash. This checkin fixes that by updating
the allocator pointer.
Also reset the offset at the end of processing each query.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>