### PR TITLE
Copy blobs only once

### DIFF
--- a/bdb/bdb_fetch.h
+++ b/bdb/bdb_fetch.h
@@ -70,6 +70,8 @@ typedef struct {
     uint8_t ignore_incoherent;
     uint8_t page_order;
     uint8_t for_write;
+    void *(*fn_malloc)(int); /* user-specified malloc function */
+    void (*fn_free)(void *); /* user-specified free function */
 } bdb_fetch_args_t;
 
 int bdb_fetch(bdb_state_type *bdb_handle, void *ix, int ixnum, int ixlen,

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1197,10 +1197,10 @@ void bdb_maybe_uncompress_data(bdb_state_type *bdb_state, DBT *data,
 
 int bdb_cget_unpack(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data,
                     uint8_t *ver, u_int32_t flags);
-int bdb_cget_unpack_blob(bdb_state_type *bdb_state, DBC *dbcp, DBT *key,
-                         DBT *data, uint8_t *ver, u_int32_t flags);
-int bdb_get_unpack_blob(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
-                        DBT *key, DBT *data, uint8_t *ver, u_int32_t flags);
+int bdb_cget_unpack_blob(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data, uint8_t *ver, u_int32_t flags,
+                         void *(*fn_malloc)(int), void (*fn_free)(void *));
+int bdb_get_unpack_blob(bdb_state_type *bdb_state, DB *db, DB_TXN *tid, DBT *key, DBT *data, uint8_t *ver,
+                        u_int32_t flags, void *(*fn_malloc)(int), void (*fn_free)(void *));
 int bdb_get_unpack(bdb_state_type *bdb_state, DB *db, DB_TXN *tid, DBT *key,
                    DBT *data, uint8_t *ver, u_int32_t flags);
 int bdb_put_pack(bdb_state_type *bdb_state, int is_blob, DB *db, DB_TXN *tid,
@@ -1231,7 +1231,6 @@ int bdb_pack(bdb_state_type *bdb_state, const struct odh *odh, void *to,
 int bdb_unpack(bdb_state_type *bdb_state, const void *from, size_t fromlen,
                void *to, size_t tolen, struct odh *odh, void **freeptr);
 
-/* This is used by */
 int bdb_unpack_force_odh(bdb_state_type *bdb_state, const void *from,
                          size_t fromlen, void *to, size_t tolen,
                          struct odh *odh, void **freeptr);

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -389,8 +389,7 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
 
                 DBT dbt_blob_data = {.flags = DB_DBT_MALLOC, .data = NULL};
 
-                rc = bdb_cget_unpack_blob(bdb_state, cblob, &dbt_blob_key,
-                                          &dbt_blob_data, &ver, DB_SET);
+                rc = bdb_cget_unpack_blob(bdb_state, cblob, &dbt_blob_key, &dbt_blob_data, &ver, DB_SET, NULL, NULL);
                 if (rc == DB_NOTFOUND) {
                     realblobsz[blobno] = -1;
                     if (blobsizes[blobno] != -1 && blobsizes[blobno] != -2) {
@@ -796,8 +795,8 @@ static int bdb_verify_key(verify_common_t *par, int ix, unsigned int lid)
                     dbt_blob_data.flags = DB_DBT_MALLOC;
                     dbt_blob_data.data = NULL;
 
-                    rc = bdb_cget_unpack_blob(bdb_state, cblob, &dbt_blob_key,
-                                              &dbt_blob_data, &ver, DB_SET);
+                    rc =
+                        bdb_cget_unpack_blob(bdb_state, cblob, &dbt_blob_key, &dbt_blob_data, &ver, DB_SET, NULL, NULL);
                     if (rc == DB_NOTFOUND) {
                         realblobsz[blobno] = -1;
                         if (blobsizes[blobno] != -1 &&

--- a/bdb/fetch.c
+++ b/bdb/fetch.c
@@ -195,8 +195,8 @@ static int bdb_fetch_blobs_by_rrn_and_genid_int_int(
             /* for transactional mode, preserve the path;
                tid will have the needed lockid
                */
-            rc = bdb_get_unpack_blob(bdb_state, dbp, tid, &dbt_key, &dbt_data,
-                                     &args->ver, 0);
+            rc = bdb_get_unpack_blob(bdb_state, dbp, tid, &dbt_key, &dbt_data, &args->ver, 0, args->fn_malloc,
+                                     args->fn_free);
 
         } else {
 
@@ -363,8 +363,8 @@ static int bdb_fetch_blobs_by_rrn_and_genid_int_int(
                     }
                 }
 
-                rc = bdb_cget_unpack_blob(bdb_state, dbcp, &dbt_key, &dbt_data,
-                                          &args->ver, DB_SET);
+                rc = bdb_cget_unpack_blob(bdb_state, dbcp, &dbt_key, &dbt_data, &args->ver, DB_SET, args->fn_malloc,
+                                          args->fn_free);
 
                 if ((rc2 = dbcp->c_close(dbcp)) != 0) {
                     logmsg(LOGMSG_ERROR, "bdb_fetch_blobs_by_rrn_and_genid_int_int:"

--- a/bdb/odh.c
+++ b/bdb/odh.c
@@ -475,10 +475,9 @@ int bdb_pack(bdb_state_type *bdb_state, const struct odh *odh, void *to,
  *
  *    *freeptr!=NULL => *freeptr==odh->recptr
  */
-static int bdb_unpack_updateid(bdb_state_type *bdb_state, const void *from,
-                               size_t fromlen, void *to, size_t tolen,
-                               struct odh *odh, int updateid, void **freeptr,
-                               int verify_updateid, int force_odh)
+static int bdb_unpack_updateid(bdb_state_type *bdb_state, const void *from, size_t fromlen, void *to, size_t tolen,
+                               struct odh *odh, int updateid, void **freeptr, int verify_updateid, int force_odh,
+                               void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
     void *mallocmem = NULL;
     const int ver_bytes = 2;
@@ -488,7 +487,7 @@ static int bdb_unpack_updateid(bdb_state_type *bdb_state, const void *from,
         *freeptr = NULL;
     }
 
-    if (bdb_state->ondisk_header) {
+    if (bdb_state->ondisk_header || force_odh) {
 
         int alg;
 
@@ -534,9 +533,10 @@ static int bdb_unpack_updateid(bdb_state_type *bdb_state, const void *from,
                 if (freeptr == NULL) {
                     do_uncompress = 0;
                 } else {
-                    if ((odh->length + ver_bytes) > bdb_state->bmaszthresh)
-                        to = comdb2_bmalloc(bdb_state->bma,
-                                            odh->length + ver_bytes);
+                    if (fn_malloc != NULL)
+                        to = fn_malloc((int)(odh->length + ver_bytes));
+                    else if ((odh->length + ver_bytes) > bdb_state->bmaszthresh)
+                        to = comdb2_bmalloc(bdb_state->bma, odh->length + ver_bytes);
                     else
                         to = malloc(odh->length + ver_bytes);
 
@@ -633,24 +633,23 @@ static int bdb_unpack_updateid(bdb_state_type *bdb_state, const void *from,
     return 0;
 
 err:
-    if (mallocmem)
-        free(mallocmem);
+    if (mallocmem) {
+        (fn_free != NULL) ? fn_free(mallocmem) : free(mallocmem);
+    }
     return DB_UNCOMPRESS_ERR;
 }
 
 int bdb_unpack(bdb_state_type *bdb_state, const void *from, size_t fromlen,
                void *to, size_t tolen, struct odh *odh, void **freeptr)
 {
-    return bdb_unpack_updateid(bdb_state, from, fromlen, to, tolen, odh, -1,
-                               freeptr, 1, 0);
+    return bdb_unpack_updateid(bdb_state, from, fromlen, to, tolen, odh, -1, freeptr, 1, 0, NULL, NULL);
 }
 
 int bdb_unpack_force_odh(bdb_state_type *bdb_state, const void *from,
                          size_t fromlen, void *to, size_t tolen,
                          struct odh *odh, void **freeptr)
 {
-    return bdb_unpack_updateid(bdb_state, from, fromlen, to, tolen, odh, -1,
-                               freeptr, 1, 1);
+    return bdb_unpack_updateid(bdb_state, from, fromlen, to, tolen, odh, -1, freeptr, 1, 1, NULL, NULL);
 }
 
 static int bdb_write_updateid(bdb_state_type *bdb_state, void *buf,
@@ -719,9 +718,8 @@ int bdb_retrieve_updateid(bdb_state_type *bdb_state, const void *from,
  *
  */
 
-static int bdb_unpack_dbt_verify_updateid(bdb_state_type *bdb_state, DBT *data,
-                                          int *updateid, uint8_t *ver,
-                                          int flags, int verify_updateid)
+static int bdb_unpack_dbt_verify_updateid(bdb_state_type *bdb_state, DBT *data, int *updateid, uint8_t *ver, int flags,
+                                          int verify_updateid, void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
     int rc;
     struct odh odh = {0};
@@ -759,8 +757,8 @@ static int bdb_unpack_dbt_verify_updateid(bdb_state_type *bdb_state, DBT *data,
     printf("Unpack %u bytes:\n", data->size);
     fsnapf(stdout, data->data, data->size);
     */
-    rc = bdb_unpack_updateid(bdb_state, data->data, data->size, NULL, 0, &odh,
-                             *updateid, &buf, verify_updateid, 0);
+    rc = bdb_unpack_updateid(bdb_state, data->data, data->size, NULL, 0, &odh, *updateid, &buf, verify_updateid, 0,
+                             fn_malloc, fn_free);
 
     if (rc == 0) {
         /*
@@ -982,9 +980,8 @@ int bdb_cget(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data,
     return rc;
 }
 
-static int bdb_cget_unpack_int(bdb_state_type *bdb_state, DBC *dbcp, DBT *key,
-                               DBT *data, uint8_t *ver, u_int32_t flags,
-                               int verify_updateid)
+static int bdb_cget_unpack_int(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data, uint8_t *ver, u_int32_t flags,
+                               int verify_updateid, void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
     int rc, updateid = -1, ipu = ip_updates_enabled(bdb_state);
     unsigned long long *genptr = NULL;
@@ -997,19 +994,37 @@ static int bdb_cget_unpack_int(bdb_state_type *bdb_state, DBC *dbcp, DBT *key,
         *genptr = get_search_genid(bdb_state, *genptr);
     }
 
-    rc = dbcp->c_get(dbcp, key, data, flags);
+    /* Allocate memory using caller-specified malloc function */
+    if ((data->flags == DB_DBT_MALLOC) && fn_malloc != NULL) {
+        /* Firstly, use USERMEM to get the length of the record. */
+        data->flags = DB_DBT_USERMEM;
+        rc = dbcp->c_get(dbcp, key, data, flags);
+        if (rc == ENOMEM) {
+            /* Secondly, allocate the needed size and get from the current cursor position. */
+            if ((data->data = fn_malloc((int)data->size)) == NULL)
+                rc = BDBERR_MALLOC;
+            else {
+                data->ulen = data->size;
+                rc = dbcp->c_get(dbcp, key, data, DB_CURRENT);
+            }
+        }
+        /* Lastly, restore the DBT flags. */
+        data->flags = DB_DBT_MALLOC;
+    } else {
+        rc = dbcp->c_get(dbcp, key, data, flags);
+    }
 
     if (rc == 0) {
         /* This uses the verify_update argument to determine whether it should
          * fail for mismatched updateids if updateid >= 0.  It will always
          * return
          * the ondisk-header updateid on success */
-        rc = bdb_unpack_dbt_verify_updateid(bdb_state, data, &updateid, ver,
-                                            flags, verify_updateid);
+        rc =
+            bdb_unpack_dbt_verify_updateid(bdb_state, data, &updateid, ver, flags, verify_updateid, fn_malloc, fn_free);
 
         /* bad rcode: free any memory the c_get allocated */
         if (rc != 0 && data->flags & DB_DBT_MALLOC) {
-            free(data->data);
+            (fn_free != NULL) ? fn_free(data->data) : free(data->data);
         }
     }
 
@@ -1034,20 +1049,19 @@ static int bdb_cget_unpack_int(bdb_state_type *bdb_state, DBC *dbcp, DBT *key,
 int bdb_cget_unpack(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data,
                     uint8_t *ver, u_int32_t flags)
 {
-    return bdb_cget_unpack_int(bdb_state, dbcp, key, data, ver, flags, 1);
+    return bdb_cget_unpack_int(bdb_state, dbcp, key, data, ver, flags, 1, NULL, NULL);
 }
 
 /* The updateid-agnostic version of this code. */
-int bdb_cget_unpack_blob(bdb_state_type *bdb_state, DBC *dbcp, DBT *key,
-                         DBT *data, uint8_t *ver, u_int32_t flags)
+int bdb_cget_unpack_blob(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, DBT *data, uint8_t *ver, u_int32_t flags,
+                         void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
-    return bdb_cget_unpack_int(bdb_state, dbcp, key, data, ver, flags, 0);
+    return bdb_cget_unpack_int(bdb_state, dbcp, key, data, ver, flags, 0, fn_malloc, fn_free);
 }
 
 /* as above, but for DB->get instead of DBC->c_get. */
-static int bdb_get_unpack_int(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
-                              DBT *key, DBT *data, uint8_t *ver,
-                              u_int32_t flags, int verify_updateid)
+static int bdb_get_unpack_int(bdb_state_type *bdb_state, DB *db, DB_TXN *tid, DBT *key, DBT *data, uint8_t *ver,
+                              u_int32_t flags, int verify_updateid, void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
     int rc, updateid = -1, ipu = ip_updates_enabled(bdb_state);
     unsigned long long *genptr = NULL;
@@ -1063,8 +1077,8 @@ static int bdb_get_unpack_int(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
     if (rc == 0) {
         /* This will fail for mismatched updateids if updateid >= 0.
          * It will always return the correct updateid on success */
-        rc = bdb_unpack_dbt_verify_updateid(bdb_state, data, &updateid, ver,
-                                            flags, verify_updateid);
+        rc =
+            bdb_unpack_dbt_verify_updateid(bdb_state, data, &updateid, ver, flags, verify_updateid, fn_malloc, fn_free);
 
         /* bad rcode: free any memory the c_get allocated */
         if (rc != 0 && data->flags & DB_DBT_MALLOC) {
@@ -1093,13 +1107,13 @@ static int bdb_get_unpack_int(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
 int bdb_get_unpack(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
                    DBT *key, DBT *data, uint8_t *ver, u_int32_t flags)
 {
-    return bdb_get_unpack_int(bdb_state, db, tid, key, data, ver, flags, 1);
+    return bdb_get_unpack_int(bdb_state, db, tid, key, data, ver, flags, 1, NULL, NULL);
 }
 
-int bdb_get_unpack_blob(bdb_state_type *bdb_state, DB *db, DB_TXN *tid,
-                        DBT *key, DBT *data, uint8_t *ver, u_int32_t flags)
+int bdb_get_unpack_blob(bdb_state_type *bdb_state, DB *db, DB_TXN *tid, DBT *key, DBT *data, uint8_t *ver,
+                        u_int32_t flags, void *(*fn_malloc)(int), void (*fn_free)(void *))
 {
-    return bdb_get_unpack_int(bdb_state, db, tid, key, data, ver, flags, 0);
+    return bdb_get_unpack_int(bdb_state, db, tid, key, data, ver, flags, 0, fn_malloc, fn_free);
 }
 
 int bdb_prepare_put_pack_updateid(bdb_state_type *bdb_state, int is_blob,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -6534,6 +6534,9 @@ again:
         rc = osql_fetch_shadblobs_by_genid(pCur, &blobnum, &blobs, &bdberr);
     } else {
         bdb_fetch_args_t args = {0};
+        /* Tell bdb to use sqlite's malloc routines. */
+        args.fn_malloc = sqlite3GlobalConfig.m.xMalloc;
+        args.fn_free = sqlite3GlobalConfig.m.xFree;
         rc = bdb_fetch_blobs_by_rrn_and_genid_cursor(
             pCur->db->handle, pCur->rrn, pCur->genid, 1, &blobnum,
             blobs.bloblens, blobs.bloboffs, (void **)blobs.blobptrs,
@@ -6592,17 +6595,16 @@ again:
         m->z = NULL;
         m->flags = MEM_Null;
     } else {
-        m->z = blobs.blobptrs[0];
-        m->n = blobs.bloblens[0];
-        m->flags = MEM_Dyn;
-        m->xDel = free;
+        m->zMalloc = m->z = blobs.blobptrs[0];
+        m->szMalloc = m->n = blobs.bloblens[0];
 
         if (f->type == SERVER_VUTF8) {
-            m->flags |= MEM_Str;
+            /* Already nul-terminated. */
+            m->flags = (MEM_Term | MEM_Str);
             if (m->n > 0)
                 --m->n; /* sqlite string lengths do not include NULL */
         } else
-            m->flags |= MEM_Blob;
+            m->flags = MEM_Blob;
     }
 
     return 0;

--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -3034,9 +3034,7 @@ case OP_Column: {
   if( pC->eCurType == CURTYPE_BTREE && cur_is_raw(pCrsr) && !pC->nullRow ) {
     /* We may reuse a Mem structure.
        So delete any previously allocated memory in pDest. */
-    if( VdbeMemDynamic(pDest) ){
-      sqlite3VdbeMemSetNull(pDest);
-    }
+    sqlite3VdbeMemRelease(pDest); /* takes care of both z and zMalloc */
     if(cur_is_remote(pCrsr)) {
       goto cooked_access;
     }


### PR DESCRIPTION
When retrieving a blob, we copy it from berkdb (if uncompressed) or bdb (if compressed) to sqlite, so that the memory is owned by sqlite. However, we can get rid of the extra copy by passing sqlite's allocator to berkdb and bdb and allocate memory directly from it. This way it'll be faster and require less memory.

(DRQS 163035031)
