### PR TITLE
Consistent thread pool handling of free lists by work threads.

### DIFF
--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -750,8 +750,10 @@ static void *thdpool_thd(void *voidarg)
                 if (pool->stopped || thr_exit) {
                     /* Thread exiting - remove from pools lists */
                     listc_rfl(&pool->thdlist, thd);
-                    if (thd->on_freelist)
+                    if (thd->on_freelist) {
                         listc_rfl(&pool->freelist, thd);
+                        thd->on_freelist = 0;
+                    }
                     pool->num_exits++;
                     errUNLOCK(&pool->mutex);
 
@@ -830,8 +832,10 @@ static void *thdpool_thd(void *voidarg)
                 if (pool->maxnthd > 0 && listc_size(&pool->thdlist) >
                                              (pool->maxnthd + pool->nwaitthd)) {
                     listc_rfl(&pool->thdlist, thd);
-                    if (thd->on_freelist)
-                        abort();
+                    if (thd->on_freelist) {
+                        listc_rfl(&pool->freelist, thd);
+                        thd->on_freelist = 0;
+                    }
                     pool->num_exits++;
                     errUNLOCK(&pool->mutex);
                     goto thread_exit;


### PR DESCRIPTION
Work threads within a thread pool are setup to (possibly) remove themselves from their associated thread pool (and its associated free thread list) after completion of each work item if the current number of threads exceeds its predefined limit.  This can occur if one or more threads are forced into existence via the "admin" flag or similar thread limit overrides.

The changes in this pull request make handling of free thread lists consistent with thread limit override semantics and avoid an abort() being triggered under some circumstances.

Signed-off-by: mistachkin <joe@mistachkin.com>
