### PR TITLE
Add tunable which prevents mixed ddl and dml write schedules

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1914,6 +1914,8 @@ void bdb_locker_assert_nolocks(bdb_state_type *bdb_state, int lid);
 
 void bdb_thread_assert_nolocks(bdb_state_type *bdb_state);
 
+void bdb_tran_assert_nolocks(bdb_state_type *bdb_state, tran_type *tran);
+
 int bdb_llmeta_list_records(bdb_state_type *bdb_state, int *bdberr);
 
 int bdb_have_ipu(bdb_state_type *bdb_state);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -4260,7 +4260,7 @@ retry:
             goto backout;
 
         /* it's ok if no data was found, fail on all other errors*/
-        if (*bdberr != BDBERR_FETCH_DTA)
+        if (*bdberr != BDBERR_FETCH_DTA || status == BDB_SC_ABORTED)
             goto backout;
 
         new_sc = 1;

--- a/bdb/locks.c
+++ b/bdb/locks.c
@@ -852,6 +852,12 @@ void bdb_locker_assert_nolocks(bdb_state_type *bdb_state, int lid)
     assert(nlocks == 0);
 }
 
+void bdb_tran_assert_nolocks(bdb_state_type *bdb_state, tran_type *tran)
+{
+    u_int32_t lid = resolve_locker_id(tran);
+    bdb_locker_assert_nolocks(bdb_state, lid);
+}
+
 void bdb_thread_assert_nolocks(bdb_state_type *bdb_state)
 {
     int nlocks;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -340,6 +340,7 @@ extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_instrument_consumer_lock;
+extern int gbl_reject_mixed_ddl_dml;
 extern int eventlog_nkeep;
 extern int gbl_debug_systable_locks;
 extern int gbl_assert_systable_locks;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2047,6 +2047,9 @@ REGISTER_TUNABLE("debug_consumer_lock",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_instrument_consumer_lock, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("reject_mixed_ddl_dml", "Reject write schedules which mix DDL and DML.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_reject_mixed_ddl_dml, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("protobuf_prealloc_buffer_size", "Size of protobuf preallocated buffer.  (Default: 8192)", TUNABLE_INTEGER,
                  &gbl_protobuf_prealloc_buffer_size, INTERNAL, NULL, NULL, NULL, NULL);
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1283,6 +1283,11 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
         iq->sc_pending = NULL;
     }
     logmsg(LOGMSG_INFO, ">>> DDL SCHEMA CHANGE RC %d <<<\n", rc);
+
+    assert(!iq->sc_locked);
+    iq->sc_locked = 1;
+    wrlock_schema_lk();
+
     return rc;
 }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6015,6 +6015,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                 /* Lock schema from now on before we finalize any schema changes
                  * and hold on to the lock until the transaction commits/aborts.
                  */
+                bdb_tran_assert_nolocks(thedb->bdb_env, trans);
                 wrlock_schema_lk();
                 iq->sc_locked = 1;
             }

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1294,6 +1294,7 @@ int osql_sock_abort(struct sqlclntstate *clnt, int type)
 
 /********************** INTERNALS
  * ***********************************************/
+int gbl_reject_mixed_ddl_dml = 1;
 
 static int osql_send_usedb_logic_int(char *tablename, struct sqlclntstate *clnt,
                                      int nettype)
@@ -1301,6 +1302,10 @@ static int osql_send_usedb_logic_int(char *tablename, struct sqlclntstate *clnt,
     osqlstate_t *osql = &clnt->osql;
     int rc = 0;
     int restarted;
+
+    if (gbl_reject_mixed_ddl_dml && osql->running_ddl) {
+        return SQLITE_DDL_MISUSE;
+    }
 
     if (clnt->ddl_tables && hash_find_readonly(clnt->ddl_tables, tablename)) {
         return SQLITE_DDL_MISUSE;
@@ -1836,8 +1841,16 @@ int osql_schemachange_logic(struct schema_change_type *sc,
     osqlstate_t *osql = &clnt->osql;
     int restarted;
     int rc = 0;
+    int count = 0;
 
     osql->running_ddl = 1;
+
+    if (gbl_reject_mixed_ddl_dml && clnt->dml_tables) {
+        hash_info(clnt->dml_tables, NULL, NULL, NULL, NULL, &count, NULL, NULL);
+        if (count > 0) {
+            return SQLITE_DDL_MISUSE;
+        }
+    }
 
     if (clnt->dml_tables &&
         hash_find_readonly(clnt->dml_tables, sc->tablename)) {

--- a/tests/sc_lock_inversion.test/Makefile
+++ b/tests/sc_lock_inversion.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=7m
+endif

--- a/tests/sc_lock_inversion.test/README.txt
+++ b/tests/sc_lock_inversion.test/README.txt
@@ -1,0 +1,5 @@
+This test verifies that writing to comdb2_oplog will not results in a schema-lk
+lock-inversion bug.  The customer who was affected was a local replicant.  The
+logic relies on the bb-plugins fastseed implementation.  While this test will 
+pass in the open-source branch, a copy of this test under the RM testsuite more
+accurately represents what the customer was seeing.

--- a/tests/sc_lock_inversion.test/comdb2_oplog.csc2
+++ b/tests/sc_lock_inversion.test/comdb2_oplog.csc2
@@ -1,0 +1,23 @@
+tag ondisk {
+longlong seqno
+int blkpos
+int optype
+blob ops null=yes
+}
+
+tag "log" {
+longlong seqno
+int optype
+int blkpos
+blob ops
+}
+
+tag "justseq" {
+longlong seqno
+int blkpos
+int optype
+}
+
+keys {
+"seqno" = seqno + blkpos
+}

--- a/tests/sc_lock_inversion.test/lrl.options
+++ b/tests/sc_lock_inversion.test/lrl.options
@@ -1,0 +1,10 @@
+# To see "inverted" behavior, set 'debug_mixed_ddl_dml on' ..  (will core on debug builds)
+# debug_mixed_ddl_dml on
+
+reject_mixed_ddl_dml off
+table comdb2_oplog comdb2_oplog.csc2
+table t1 t1.csc2
+table t2 t1.csc2
+replicate_local on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0

--- a/tests/sc_lock_inversion.test/runit
+++ b/tests/sc_lock_inversion.test/runit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+
+[[ $debug == "1" ]] && set -x
+
+function failexit
+{
+    typeset func="failexit"
+    typeset f=$1
+    write_prompt $func "$f failed: $2"
+    exit -1
+}
+
+function insertandrebuild
+{
+    typeset insert=$1
+    typeset rebuild=$2
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+BEGIN
+INSERT INTO $insert (a) SELECT * FROM GENERATE_SERIES(1, 10000)
+REBUILD $rebuild
+COMMIT
+EOF
+}
+
+function insertandrebuildthread
+{
+    typeset iterations=$1
+
+    for (( x = 0; x < iterations; ++x )) ; do
+        if [[ $(( x % 2 )) == 1 ]]; then
+            insertandrebuild t1 t2
+        else
+            insertandrebuild t2 t1
+        fi
+    done
+}
+
+function run_test
+{
+    typeset threads=8
+    typeset iterations=20
+
+    for (( tds = 0; tds < threads; ++tds )) ; do
+        insertandrebuildthread $iterations &
+    done
+    wait
+}
+
+run_test
+echo "Success"

--- a/tests/sc_lock_inversion.test/t1.csc2
+++ b/tests/sc_lock_inversion.test/t1.csc2
@@ -1,0 +1,15 @@
+
+tag ondisk {
+int a
+longlong comdb2_seqno
+}
+tag "comdb2_seqno_tag" {
+longlong comdb2_seqno
+}
+
+keys
+{
+dup "ix" = a
+"comdb2_seqno" = comdb2_seqno
+}
+

--- a/tests/sc_transactional.test/lrl.options
+++ b/tests/sc_transactional.test/lrl.options
@@ -1,0 +1,1 @@
+reject_mixed_ddl_dml off

--- a/tests/verify_error.test/lrl.options
+++ b/tests/verify_error.test/lrl.options
@@ -1,3 +1,4 @@
 table t1 t1.csc2
 round_robin_stripes
 reorder_socksql_no_deadlock off
+reject_mixed_ddl_dml off


### PR DESCRIPTION
We have to prevent "mixed" ddl and dml schedules for now.  The fundamental issue is the handling of the schema-lock on the master: currently we acquire the schema-lk when handling OSQL_DONE before finalizing any outstanding schema-changes.  If we've executed DML as part of the same transaction, we'll be holding locks on those tables and pages while blocking on schema-lock (lock-inversion).

There might be other approaches that would allow us to bring this back.  The simplest is to have the master acquire the schemalk in osql_process_schemachange after all of the outstanding schema-changes have completed.  We'd avoid lock-inversion by maintaining the schema writelock while executing the transaction's dml.  This would only be feasible if we limit the size of mixed dml / ddl transactions, and if we prevent it outright for writes which would cause cascades (which could carry an unknown number of additional writes).

This is being actively worked on (and discussed).  Not yet ready for review.