### PR TITLE
Honor 'sqlsortermult' tunable even with a LIMIT clause.

### DIFF
--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -4024,6 +4024,9 @@ static LogEst whereSortingCost(
   ** Use the LIMIT for M if it is smaller */
   if( (pWInfo->wctrlFlags & WHERE_USE_LIMIT)!=0 && pWInfo->iLimit<nRow ){
     nRow = pWInfo->iLimit;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    nRow *= gbl_sqlite_sortermult;
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   }
   rSortCost += estLog(nRow);
   return rSortCost;


### PR DESCRIPTION

While investigating a performance regression, I discovered that the 'sqlsortermult' tunable will not be properly honored if there is a LIMIT clause present in the SQL query.  These changes fix this oversight.

Signed-off-by: mistachkin <joe@mistachkin.com>