### PR TITLE
BPLOG over socket

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -43,6 +43,8 @@ set(src
   osqlsession.c
   osqlshadtbl.c
   osqlsqlthr.c
+  osqlsqlnet.c
+  osqlsqlsocket.c
   phys_rep.c
   plugin_handler.c
   prefault.c

--- a/db/block_internal.h
+++ b/db/block_internal.h
@@ -761,10 +761,10 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
                   unsigned long long genid, unsigned long long ins_keys,
                   int blkpos, int flags);
 
-int process_defered_table(struct ireq *iq, block_state_t *blkstate, void *trans,
-                          int *blkpos, int *ixout, int *errout);
-int delayed_key_adds(struct ireq *iq, block_state_t *blkstate, void *trans,
-                     int *blkpos, int *ixout, int *errout);
+int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
+                          int *errout);
+int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
+                     int *errout);
 void *create_constraint_table();
 void *create_constraint_index_table();
 int delete_constraint_table(void *table);
@@ -776,10 +776,8 @@ int close_constraint_table_cursor(void *cursor);
 void delete_defered_index_tbl();
 void truncate_defered_index_tbl();
 
-int verify_add_constraints(struct ireq *iq, block_state_t *blkstate,
-                           void *trans, int *errout);
-int verify_del_constraints(struct ireq *iq, block_state_t *blkstate,
-                           void *trans, blob_buffer_t *blobs, int *errout);
+int verify_add_constraints(struct ireq *iq, void *trans, int *errout);
+int verify_del_constraints(struct ireq *iq, void *trans, int *errout);
 int check_delete_constraints(struct ireq *iq, void *trans,
                              block_state_t *blkstate, int op, void *rec_dta,
                              unsigned long long del_keys, int *errout);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -576,7 +576,6 @@ int gbl_querylimits_tablescans_warn = 0;
 int gbl_querylimits_temptables_warn = 0;
 extern int gbl_empty_strings_dont_convert_to_numbers;
 
-extern int gbl_survive_n_master_swings;
 extern int gbl_master_retry_poll_ms;
 
 int gbl_check_schema_change_permissions = 1;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -613,8 +613,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
 
 /* FOR UPDATES/DELETES, MUST VERIFY AGAINST DELETED RECORD'S TABLE TO SEE IF
  * THERE'RE ANY  KEYS WITH SAME VALUE.  IT IS OK TO DELETE IF THATS THE CASE */
-int verify_del_constraints(struct ireq *iq, block_state_t *blkstate,
-                           void *trans, blob_buffer_t *blobs, int *errout)
+int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
 {
     int rc = 0, fndrrn = 0, err = 0;
     int keylen;
@@ -996,8 +995,8 @@ int verify_del_constraints(struct ireq *iq, block_state_t *blkstate,
                    __func__, __LINE__, lrc, genid);                            \
     } while (0);
 
-int delayed_key_adds(struct ireq *iq, block_state_t *blkstate, void *trans,
-                     int *blkpos, int *ixout, int *errout)
+int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
+                     int *errout)
 {
     int rc = 0, fndlen = 0, err = 0, limit = 0;
     int idx = 0, ixkeylen = -1;
@@ -1319,8 +1318,7 @@ int delayed_key_adds(struct ireq *iq, block_state_t *blkstate, void *trans,
 
 /* go through all entries in ct_add_table and verify that
  * the key exists in the parent table if there are constraints */
-int verify_add_constraints(struct ireq *iq, block_state_t *blkstate,
-                           void *trans, int *errout)
+int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
 {
     if (gbl_debug_skip_constraintscheck_on_insert)
         return 0;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -101,7 +101,7 @@ extern int skip_clear_queue_extents;
 extern int gbl_slow_rep_process_txn_freq;
 extern int gbl_slow_rep_process_txn_maxms;
 extern int gbl_sqlite_sorter_mem;
-extern int gbl_survive_n_master_swings;
+extern int gbl_allow_bplog_restarts;
 extern int gbl_test_blob_race;
 extern int gbl_test_scindex_deadlock;
 extern int gbl_test_sc_resume_race;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1121,7 +1121,7 @@ REGISTER_TUNABLE("surprise", NULL, TUNABLE_BOOLEAN, &gbl_surprise,
 REGISTER_TUNABLE("survive_n_master_swings",
                  "Have a node retry applying a transaction against a new "
                  "master this many times before giving up. (Default: 600)",
-                 TUNABLE_INTEGER, &gbl_survive_n_master_swings, READONLY, NULL,
+                 TUNABLE_INTEGER, &gbl_allow_bplog_restarts, READONLY, NULL,
                  NULL, NULL, NULL);
 REGISTER_TUNABLE("temptable_limit",
                  "Set the maximum number of temporary tables the database can "
@@ -2049,5 +2049,14 @@ REGISTER_TUNABLE("debug_consumer_lock",
 
 REGISTER_TUNABLE("protobuf_prealloc_buffer_size", "Size of protobuf preallocated buffer.  (Default: 8192)", TUNABLE_INTEGER,
                  &gbl_protobuf_prealloc_buffer_size, INTERNAL, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("sockbplog",
+                 "Enable sending transactions over socket instead of net",
+                 TUNABLE_BOOLEAN, &gbl_sockbplog, READONLY | NOARG, NULL, NULL,
+                 NULL, NULL);
+REGISTER_TUNABLE("sockbplog_sockpool",
+                 "Enable sockpool when for sockbplog feature", TUNABLE_BOOLEAN,
+                 &gbl_sockbplog_sockpool, READONLY | NOARG, NULL, NULL, NULL,
+                 NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/glue.c
+++ b/db/glue.c
@@ -89,6 +89,7 @@
 #include "logmsg.h"
 #include "reqlog.h"
 #include "time_accounting.h"
+#include "schemachange.h"
 
 int (*comdb2_ipc_master_set)(char *host) = 0;
 

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -871,8 +871,8 @@ static int init_ireq_legacy(struct dbenv *dbenv, struct ireq *iq, SBUF2 *sb,
     } else if (sorese) {
         iq->sorese = sorese;
         snprintf(iq->corigin, sizeof(iq->corigin), "SORESE# %15s %s RQST %llx",
-                 iq->sorese->host, osql_sorese_type_to_str(iq->sorese->type),
-                 iq->sorese->rqid);
+                 iq->sorese->target.host,
+                 osql_sorese_type_to_str(iq->sorese->type), iq->sorese->rqid);
         iq->timings.req_received = osql_log_time();
         /* cache these things so we don't change too much code */
         iq->tranddl = iq->sorese->is_tranddl;

--- a/db/indices.c
+++ b/db/indices.c
@@ -1299,8 +1299,8 @@ int insert_defered_tbl(struct ireq *iq, void *od_dta, size_t od_len,
 }
 #endif
 
-int process_defered_table(struct ireq *iq, block_state_t *blkstate, void *trans,
-                          int *blkpos, int *ixout, int *errout)
+int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
+                          int *errout)
 {
     void *cur = get_defered_index_tbl_cursor(0);
 

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -53,6 +53,7 @@
 #include "ctrace.h"
 #include "intern_strings.h"
 #include "sc_global.h"
+#include "schemachange.h"
 
 extern int gbl_reorder_idx_writes;
 

--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -38,7 +38,7 @@ struct osql_sqlthr {
     pthread_cond_t cond;
     unsigned long long rqid; /* osql rq id */
     uuid_t uuid;             /* request id, take 2 */
-    char *master;            /* who was the master I was talking to */
+    const char *master;      /* who was the master I was talking to */
     struct sqlclntstate *clnt; /* cache clnt */
     pthread_mutex_t mtx; /* mutex and cond for commitrc sync */
     int done;            /* result of socksql, recom, snapisol and serial master
@@ -127,7 +127,7 @@ int osql_checkboard_update_status(unsigned long long rqid, uuid_t uuid,
  * we're interested in things like master_changed
  *
  */
-int osql_reuse_sqlthr(struct sqlclntstate *clnt, char *master);
+int osql_reuse_sqlthr(struct sqlclntstate *clnt, const char *master);
 
 /**
  * Retrieve the sqlclntstate for a certain rqid

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -23,9 +23,6 @@
 #include "sqloffload.h"
 #include "block_internal.h"
 #include "comdb2uuid.h"
-#include "schemachange.h"
-#include "osqlrpltypes.h"
-
 
 #define OSQL_BLOB_ODH_BIT (1 << 31)
 #define IS_ODH_READY(x) (!!(((x)->odhind) & OSQL_BLOB_ODH_BIT))
@@ -48,15 +45,174 @@ int osql_comm_init(struct dbenv *dbenv);
  */
 void osql_comm_destroy(void);
 
-/* This is used for:
-    - forward-to-master block requests over socket
-    - upgrade records
-   And wait for reply inline. */
-int offload_comm_send_blockreq(char *host, void *rqid, void *buf, int buflen);
+/**
+ * Sends a sosql request to the master
+ * Sql is the first update part of this transaction
+ *
+ */
+int osql_comm_send_socksqlreq(osql_target_t *target, const char *sql, int sqlen,
+                              unsigned long long rqid, uuid_t uuid,
+                              char *tzname, int type, int flags);
 
-/* Reply to offload block request. */
-int offload_comm_send_blockreply(char *host, unsigned long long rqid, void *buf,
-                                 int buflen, int rc);
+/**
+ * Send USEDB op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_usedb(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
+                    char *tablename, int type, unsigned long long version);
+
+/**
+ * Send INDEX op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_index(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
+                    unsigned long long genid, int isDelete, int ixnum,
+                    char *pData, int nData, int type);
+
+/**
+ * Send QBLOB op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_qblob(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
+                    int blobid, unsigned long long seq, int type, char *data,
+                    int datalen);
+
+/**
+ * Send UPDCOLS op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_updcols(osql_target_t *target, unsigned long long rqid,
+                      uuid_t uuid, unsigned long long seq, int type,
+                      int *colList, int ncols);
+
+/**
+ * Send UPDREC op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_updrec(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, unsigned long long genid,
+                     unsigned long long ins_keys, unsigned long long del_keys,
+                     char *pData, int nData, int type);
+
+/**
+ * Send INSREC op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_insrec(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, unsigned long long genid,
+                     unsigned long long dirty_keys, char *pData, int nData,
+                     int type, int upsert_flags);
+
+/**
+ * Send DELREC op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_delrec(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, unsigned long long genid,
+                     unsigned long long dirty_keys, int type);
+
+/**
+ * Send SCHEMACHANGE op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_schemachange(osql_target_t *target, unsigned long long rqid,
+                           uuid_t uuid, struct schema_change_type *sc,
+                           int type);
+
+/**
+ * Send BPFUNC op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_bpfunc(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, BpfuncArg *msg, int type);
+
+/**
+ * Send SERIAL op
+ *
+ */
+int osql_send_serial(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, CurRangeArr *arr, unsigned int file,
+                     unsigned int offset, int type);
+
+/**
+ * Send DONE or DONE_XERR op
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_commit(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, int nops, struct errstat *xerr, int type,
+                     struct client_query_stats *query_stats,
+                     snap_uid_t *snap_info);
+int osql_send_commit_by_uuid(osql_target_t *target, uuid_t uuid, int nops,
+                             struct errstat *xerr, int type,
+                             struct client_query_stats *query_stats,
+                             snap_uid_t *snap_info);
+
+/**
+ * Extra commit info
+ *
+ */
+int osql_send_startgen(osql_target_t *target, unsigned long long rqid,
+                       uuid_t uuid, uint32_t start_gen, int type);
+
+/**
+ * Consume
+ *
+ */
+int osql_send_dbq_consume(osql_target_t *target, unsigned long long rqid,
+                          uuid_t, genid_t, int type);
+
+/**
+ * Request that a remote sql engine start recording it's query stats to a
+ * dbglog file.  This will later be slurped up & returned via an
+ * FSQL_GRAB_DBGLOG request.
+ *
+ */
+int osql_send_dbglog(osql_target_t *target, unsigned long long rqid,
+                     uuid_t uuid, unsigned long long dbglog_cookie, int queryid,
+                     int type);
+
+/**
+ * Send RECGENID
+ * It handles remote/local connectivity
+ *
+ */
+int osql_send_recordgenid(osql_target_t *target, unsigned long long rqid,
+                          uuid_t uuid, unsigned long long genid, int type);
+
+/**
+ * Update stats
+ *
+ */
+int osql_send_updstat(osql_target_t *target, unsigned long long rqid,
+                      uuid_t uuid, unsigned long long seq, char *pData,
+                      int nData, int nStat, int type);
+
+/**
+ * Sends the result of block processor transaction commit
+ * to the sql thread so that it can return the result to the
+ * client
+ *
+ */
+int osql_comm_signal_sqlthr_rc(osql_target_t *target, unsigned long long rqid,
+                               uuid_t uuid, int nops, struct errstat *xerr,
+                               snap_uid_t *snap, int rc);
+/**
+ * if anything goes wrong during master bplog processing,
+ * let replicant know (wrapper around signal_sqlthr_rc)
+ *
+ */
+void signal_replicant_error(osql_target_t *target, unsigned long long rqid,
+                            uuid_t uuid, int rc, const char *msg);
 
 /**
  * If "rpl" is a done packet, set xerr to error if any and return 1
@@ -68,126 +224,6 @@ int offload_comm_send_blockreply(char *host, unsigned long long rqid, void *buf,
 int osql_comm_is_done(osql_sess_t *sess, int type, char *rpl, int rpllen,
                       int hasuuid, struct errstat **xerr,
                       struct query_effects *effects);
-
-/**
- * Send a "POKE" message to "tonode" inquering about session "rqid"
- *
- */
-int osql_comm_send_poke(char *tonode, unsigned long long rqid, uuid_t uuid,
-                        int type);
-
-/**
- * Send USEDB op
- * It handles remote/local connectivity
- *
- */
-int osql_send_usedb(char *tohost, unsigned long long rqid, uuid_t uuid,
-                    char *tablename, int type, unsigned long long version);
-
-/**
- * Send INDEX op
- * It handles remote/local connectivity
- *
- */
-int osql_send_index(char *tohost, unsigned long long rqid, uuid_t uuid,
-                    unsigned long long genid, int isDelete, int ixnum,
-                    char *pData, int nData, int type);
-
-/**
- * Send QBLOB op
- * It handles remote/local connectivity
- *
- */
-int osql_send_qblob(char *tohost, unsigned long long rqid, uuid_t uuid,
-                    int blobid, unsigned long long seq, int type, char *data,
-                    int datalen);
-
-/**
- * Send UPDCOLS op
- * It handles remote/local connectivity
- *
- */
-int osql_send_updcols(char *tohost, unsigned long long rqid, uuid_t uuid,
-                      unsigned long long seq, int type, int *colList,
-                      int ncols);
-
-/**
- * Send UPDREC op
- * It handles remote/local connectivity
- *
- */
-int osql_send_updrec(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     unsigned long long genid, unsigned long long ins_keys,
-                     unsigned long long del_keys, char *pData, int nData,
-                     int type);
-
-/**
- * Send INSREC op
- * It handles remote/local connectivity
- *
- */
-int osql_send_insrec(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     unsigned long long genid, unsigned long long dirty_keys,
-                     char *pData, int nData, int type, int upsert_flags);
-
-/**
- * Send DELREC op
- * It handles remote/local connectivity
- *
- */
-int osql_send_delrec(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     unsigned long long genid, unsigned long long dirty_keys,
-                     int type);
-
-/**
- * Send SCHEMACHANGE op
- * It handles remote/local connectivity
- *
- */
-int osql_send_schemachange(char *tohost, unsigned long long rqid, uuid_t uuid,
-                           struct schema_change_type *sc, int type);
-
-/**
- * Send BPFUNC op
- * It handles remote/local connectivity
- *
- */
-int osql_send_bpfunc(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     BpfuncArg *msg, int type);
-
-/**
- * Send SERIAL op
- *
- */
-int osql_send_serial(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     CurRangeArr *arr, unsigned int file, unsigned int offset,
-                     int type);
-
-/**
- * Send DONE or DONE_XERR op
- * It handles remote/local connectivity
- *
- */
-int osql_send_commit(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     int nops, struct errstat *xerr, int type,
-                     struct client_query_stats *query_stats,
-                     snap_uid_t *snap_info);
-
-int osql_send_commit_by_uuid(char *tohost, uuid_t uuid, int nops,
-                             struct errstat *xerr, int type,
-                             struct client_query_stats *query_stats,
-                             snap_uid_t *snap_info);
-int osql_send_startgen(char *tohost, unsigned long long rqid, uuid_t uuid,
-                       uint32_t start_gen, int type);
-
-/**
- * Send decomission for osql net
- *
- */
-int osql_process_message_decom(char *host);
-
-int osql_send_dbq_consume(char *tohost, unsigned long long rqid, uuid_t,
-                          genid_t, int type);
 
 /**
  * Handles each packet and calls record.c functions
@@ -221,25 +257,6 @@ void osql_net_cmd(char *line, int lline, int st, int op1);
 void osql_set_net_poll(int pval);
 
 /**
- * Sends a sosql request to the master
- * Sql is the first update part of this transaction
- *
- */
-int osql_comm_send_socksqlreq(char *tohost, const char *sql, int sqlen,
-                              unsigned long long rqid, uuid_t uuid,
-                              char *tzname, int type, int flags);
-
-/**
- * Sends the result of block processor transaction commit
- * to the sql thread so that it can return the result to the
- * client
- *
- */
-int osql_comm_signal_sqlthr_rc(const char *tohost, unsigned long long rqid,
-                               uuid_t uuid, int nops, struct errstat *xerr,
-                               snap_uid_t *snap, int rc);
-
-/**
  * Report on the traffic noticed
  *
  */
@@ -259,7 +276,6 @@ void osql_remap_request(osql_req_t *req, unsigned long long rqid);
 const uint8_t *osqlcomm_errstat_type_get(errstat_t *p_errstat_type,
                                          const uint8_t *p_buf,
                                          const uint8_t *p_buf_end);
-
 /**
  * Copy the little-endian errstat_t pointed to by errstat_type into 
  * p_errstat_type.  Exposed for fstblk.
@@ -290,7 +306,7 @@ uint8_t *client_query_stats_put(const struct client_query_stats *p_stats,
  * Displays per packet latencies
  *
  */
-int osql_comm_echo(char *tohost, int stream, unsigned long long *sent,
+int osql_comm_echo(char *host, int stream, unsigned long long *sent,
                    unsigned long long *replied, unsigned long long *received);
 
 /**
@@ -298,23 +314,6 @@ int osql_comm_echo(char *tohost, int stream, unsigned long long *sent,
  *
  */
 void osql_net_exiting(void);
-
-/**
- * Request that a remote sql engine start recording it's query stats to a
- * dbglog file.  This will later be slurped up & returned via an
- * FSQL_GRAB_DBGLOG request.
- *
- */
-int osql_send_dbglog(char *tohost, unsigned long long rqid, uuid_t uuid,
-                     unsigned long long dbglog_cookie, int queryid, int type);
-
-/**
- * Send RECGENID
- * It handles remote/local connectivity
- *
- */
-int osql_send_recordgenid(char *tohost, unsigned long long rqid, uuid_t uuid,
-                          unsigned long long genid, int type);
 
 /**
  * Enable a netinfo-test for the osqlcomm netinfo_ptr
@@ -334,9 +333,6 @@ int osql_disable_net_test(void);
  */
 int osql_comm_check_bdb_lock(const char *func, int line);
 
-int osql_send_updstat(char *tohost, unsigned long long rqid, uuid_t uuid,
-                      unsigned long long seq, char *pData, int nData, int nStat,
-                      int type);
 
 netinfo_type *osql_get_netinfo(void);
 
@@ -383,8 +379,65 @@ int osql_page_prefault(char *rpl, int rplen, struct dbtable **last_db,
 int osql_set_usedb(struct ireq *iq, const char *tablename, int tableversion,
                    int step, struct block_err *err);
 
-void signal_replicant_error(const char *host, unsigned long long rqid,
-                            uuid_t uuid, int rc, const char *msg);
-
 int osql_send_del_qdb_logic(struct sqlclntstate *, char *, genid_t);
+
+/**
+ * Send a "POKE" message to "tonode" inquering about session "rqid"
+ *
+ */
+int osql_comm_send_poke(const char *tonode, unsigned long long rqid,
+                        uuid_t uuid, int type);
+
+/**
+ * Send decomission for osql net
+ *
+ */
+int osql_process_message_decom(char *host);
+
+/**
+ * Simple ping-pong write on the master; used by:
+ *   - forward-to-master block requests over socket
+ *   - upgrade records
+ *  And wait for reply inline.
+ */
+int offload_comm_send_blockreq(char *host, void *rqid, void *buf, int buflen);
+
+/* Reply to offload block request. */
+int offload_comm_send_blockreply(char *host, unsigned long long rqid, void *buf,
+                                 int buflen, int rc);
+
+/* Send a message over net to "host" */
+int offload_net_send(const char *host, int usertype, void *data, int datalen,
+                     int nodelay, void *tail, int tailen);
+
+/**
+ * Copy and pack the host-ordered client_query_stats type into big-endian
+ * format.  This routine only packs up to the path_stats component:  use
+ * client_query_path_commponent_put to pack each of the path_stats
+ *
+ */
+uint8_t *client_query_stats_put(const struct client_query_stats *p_stats,
+                                uint8_t *p_buf, const uint8_t *p_buf_end);
+
+/**
+ * Read a commit (DONE/XERR) from a socket, used in bplog over socket
+ * Timeoutms limits total amount of waiting for a commit
+ *
+ */
+int osql_recv_commit_rc(SBUF2 *sb, int timeoutms, int timeoutdeltams, int *nops,
+                        struct errstat *err);
+
+/**
+ * Read the bplog request, coming from a socket
+ *
+ */
+int osqlcomm_req_socket(SBUF2 *sb, char **sql, char tzname[DB_MAX_TZNAMEDB],
+                        int *type, uuid_t uuid, int *flags);
+
+/**
+ * Read the bplog body, coming from a socket
+ *
+ */
+int osqlcomm_bplog_socket(SBUF2 *sb, osql_sess_t *sess);
+
 #endif

--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -82,6 +82,13 @@ char *osql_sess_info(osql_sess_t *sess);
 int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, int type, void *data,
                     int datalen, int *found);
 
+/**
+ * Same as osql_sess_rcvop, for socket protocol
+ *
+ */
+int osql_sess_rcvop_socket(osql_sess_t *sess, int type, void *data, int datalen,
+                           bool *is_msg_done);
+
 int osql_sess_queryid(osql_sess_t *sess);
 
 /**

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -32,6 +32,7 @@
 #include "comdb2uuid.h"
 #include "logmsg.h"
 #include "str0.h"
+#include "schemachange.h"
 
 #include <dbinc/queue.h>
 
@@ -1624,7 +1625,7 @@ static int process_local_shadtbl_usedb(struct sqlclntstate *clnt,
     int rc = 0;
     int osql_nettype = tran2netrpl(clnt->dbtran.mode);
 
-    rc = osql_send_usedb(osql->host, osql->rqid, osql->uuid, tablename,
+    rc = osql_send_usedb(&osql->target, osql->rqid, osql->uuid, tablename,
                          osql_nettype, tableversion);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: osql_send_usedb rc=%d\n", __func__, rc);
@@ -1669,7 +1670,8 @@ static int process_local_shadtbl_skp(struct sqlclntstate *clnt, shad_tbl_t *tbl,
             }
 
             if (osql->is_reorder_on) {
-                rc = osql_send_delrec(osql->host, osql->rqid, osql->uuid, genid,
+                rc = osql_send_delrec(&osql->target, osql->rqid, osql->uuid,
+                                      genid,
                                       (gbl_partial_indexes && tbl->ix_partial)
                                           ? get_del_keys(clnt, tbl, genid)
                                           : -1ULL,
@@ -1693,7 +1695,8 @@ static int process_local_shadtbl_skp(struct sqlclntstate *clnt, shad_tbl_t *tbl,
             }
 
             if (!osql->is_reorder_on) {
-                rc = osql_send_delrec(osql->host, osql->rqid, osql->uuid, genid,
+                rc = osql_send_delrec(&osql->target, osql->rqid, osql->uuid,
+                                      genid,
                                       (gbl_partial_indexes && tbl->ix_partial)
                                           ? get_del_keys(clnt, tbl, genid)
                                           : -1ULL,
@@ -1773,7 +1776,7 @@ static int process_local_shadtbl_updcols(struct sqlclntstate *clnt,
         memcpy(*updcolsout, cdata, cksz);
     }
 
-    rc = osql_send_updcols(osql->host, osql->rqid, osql->uuid, savkey,
+    rc = osql_send_updcols(&osql->target, osql->rqid, osql->uuid, savkey,
                            osql_nettype, &cdata[1], cdata[0]);
 
     if (rc) {
@@ -1811,8 +1814,8 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
             idx = get_schema_blob_field_idx(tbl->tablename, ".ONDISK", i);
             ncols = updCols[0];
             if (idx >= 0 && idx < ncols && -1 == updCols[idx + 1]) {
-                rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid, i, seq,
-                                     osql_nettype, NULL, -2);
+                rc = osql_send_qblob(&osql->target, osql->rqid, osql->uuid, i,
+                                     seq, osql_nettype, NULL, -2);
                 osql->replicant_numops++;
                 DEBUG_PRINT_NUMOPS();
                 continue;
@@ -1842,7 +1845,7 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
             return SQLITE_INTERNAL;
         }
 
-        rc = osql_send_qblob(osql->host, osql->rqid, osql->uuid, idx, seq,
+        rc = osql_send_qblob(&osql->target, osql->rqid, osql->uuid, idx, seq,
                              osql_nettype, data, ldata);
 
         if (rc) {
@@ -1899,8 +1902,8 @@ static int process_local_shadtbl_index(struct sqlclntstate *clnt,
 
         index = bdb_temp_table_data(tmp_cur);
         lindex = bdb_temp_table_datasize(tmp_cur);
-        rc = osql_send_index(osql->host, osql->rqid, osql->uuid, seq, is_delete,
-                             i, index, lindex, osql_nettype);
+        rc = osql_send_index(&osql->target, osql->rqid, osql->uuid, seq,
+                             is_delete, i, index, lindex, osql_nettype);
 
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: error writting record to master in offload mode %d!\n",
@@ -1953,7 +1956,7 @@ static int process_local_shadtbl_add(struct sqlclntstate *clnt, shad_tbl_t *tbl,
             goto next;
 
         if (osql->is_reorder_on) {
-            rc = osql_send_insrec(osql->host, osql->rqid, osql->uuid, key,
+            rc = osql_send_insrec(&osql->target, osql->rqid, osql->uuid, key,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, key)
                                       : -1ULL,
@@ -1989,7 +1992,7 @@ static int process_local_shadtbl_add(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         }
 
         if (!osql->is_reorder_on) {
-            rc = osql_send_insrec(osql->host, osql->rqid, osql->uuid, key,
+            rc = osql_send_insrec(&osql->target, osql->rqid, osql->uuid, key,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, key)
                                       : -1ULL,
@@ -2068,7 +2071,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
             return SQLITE_TOOBIG;
         }
         if (osql->is_reorder_on) {
-            rc = osql_send_updrec(osql->host, osql->rqid, osql->uuid, genid,
+            rc = osql_send_updrec(&osql->target, osql->rqid, osql->uuid, genid,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, seq)
                                       : -1ULL,
@@ -2109,7 +2112,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         }
 
         if (!osql->is_reorder_on) {
-            rc = osql_send_updrec(osql->host, osql->rqid, osql->uuid, genid,
+            rc = osql_send_updrec(&osql->target, osql->rqid, osql->uuid, genid,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_ins_keys(clnt, tbl, seq)
                                       : -1ULL,
@@ -2849,7 +2852,7 @@ static int process_local_shadtbl_recgenids(struct sqlclntstate *clnt,
       comdb2uuidstr(osql->uuid, us);
       printf("RECGENID SENDING %s[%d] : %llx %s\n", key.tablename, key.tableversion, key.genid, us);
 #endif
-        rc = osql_send_recordgenid(osql->host, osql->rqid, osql->uuid,
+        rc = osql_send_recordgenid(&osql->target, osql->rqid, osql->uuid,
                                    key.genid, osql_nettype);
         if (rc) {
             logmsg(LOGMSG_ERROR, 
@@ -2984,7 +2987,7 @@ static int process_local_shadtbl_sc(struct sqlclntstate *clnt, int *bdberr)
             return ERR_SC;
         }
 
-        rc = osql_send_schemachange(osql->host, osql->rqid, osql->uuid, sc,
+        rc = osql_send_schemachange(&osql->target, osql->rqid, osql->uuid, sc,
                                     NET_OSQL_SOCK_RPL);
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -3093,7 +3096,7 @@ static int process_local_shadtbl_bpfunc(struct sqlclntstate *clnt, int *bdberr)
             return -1;
         }
 
-        rc = osql_send_bpfunc(osql->host, osql->rqid, osql->uuid, func->arg,
+        rc = osql_send_bpfunc(&osql->target, osql->rqid, osql->uuid, func->arg,
                               NET_OSQL_SOCK_RPL);
         free_bpfunc(func);
 

--- a/db/osqlsqlnet.c
+++ b/db/osqlsqlnet.c
@@ -1,0 +1,95 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
+ * Interface between sqlite engine and bplog. It is the legacy mode of
+ * intra-cluster bplog transfer to master.  It multiplexes the transactions over
+ * the existing "net" fully connected mesh. Multiplexing is supported on
+ * replicants by a checkboard hashing the running sessions, and on master by a
+ * repository
+ *
+ */
+
+#include "sql.h"
+#include "osqlcheckboard.h"
+#include "osqlcomm.h"
+
+static int _send(osql_target_t *target, int usertype, void *data, int datalen,
+                 int nodelay, void *tail, int tailen);
+
+/**
+ * Init bplog over net master side
+ *
+ */
+void init_bplog_net(osql_target_t *target)
+{
+    target->type = OSQL_OVER_NET;
+    target->sb = NULL;
+    target->send = _send;
+}
+
+/**
+ * Handle to registration of thread for net multiplex purposes
+ *
+ */ /* loop in caller */
+int osql_begin_net(struct sqlclntstate *clnt, int type, int keep_rqid)
+{
+    osqlstate_t *osql = &clnt->osql;
+    int rc;
+
+    /* register the session */
+    osql->target.type = OSQL_OVER_NET;
+    osql->target.host = thedb->master;
+    osql->target.send = _send;
+    assert(osql->target.sb == NULL);
+
+    /* protect against no master */
+    if (osql->target.host == NULL || osql->target.host == db_eid_invalid)
+        return 0; /* loop in caller */
+
+    if (!keep_rqid) {
+        /* register this new member */
+        rc = osql_register_sqlthr(clnt, type);
+    } else {
+        /* this is a replay with same rqid, already registered */
+        /* sets to the same node */
+        rc = osql_reuse_sqlthr(clnt, osql->target.host);
+    }
+    if (rc) {
+        sql_debug_logf(clnt, __func__, __LINE__, "fail to %s rc %d\n",
+                       keep_rqid ? "reuse" : "register", rc);
+        return -1;
+    }
+
+    return 0;
+}
+
+/**
+ * End the osql transaction
+ * Unregisted the sql thread
+ *
+ */
+int osql_end_net(struct sqlclntstate *clnt)
+{
+    return osql_unregister_sqlthr(clnt);
+}
+
+static int _send(osql_target_t *target, int usertype, void *data, int datalen,
+                 int nodelay, void *tail, int tailen)
+{
+    return offload_net_send(target->host, usertype, data, datalen, nodelay,
+                            tail, tailen);
+}

--- a/db/osqlsqlnet.h
+++ b/db/osqlsqlnet.h
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef INCLUDED_OSQLSQLNET_H
+#define INCLUDED_OSQLSQLNET_H
+
+/**
+ * Interface between sqlite engine and bplog. It is the legacy mode of
+ * intra-cluster bplog transfer to master.  It multiplexes the transactions over
+ * the existing "net" fully connected mesh. Multiplexing is supported on
+ * replicants by a checkboard hashing the running sessions, and on master by a
+ * repository
+ *
+ */
+
+/**
+ * Init bplog over net master side
+ *
+ */
+void init_bplog_net(osql_target_t *target);
+
+/**
+ * Handle to registration of thread for net multiplex purposes
+ *
+ */
+int osql_begin_net(struct sqlclntstate *clnt, int type, int keep_rqid);
+
+/**
+ * End the osql transaction
+ * Unregisted the sql thread
+ *
+ */
+int osql_end_net(struct sqlclntstate *clnt);
+
+/**
+ * Send messages over net
+ *
+ */
+int offload_net_send(const char *host, int usertype, void *data, int datalen,
+                     int nodelay, void *tail, int tailen);
+
+#endif /* !INCLUDED_OSQLSQLNET_H */

--- a/db/osqlsqlsocket.c
+++ b/db/osqlsqlsocket.c
@@ -1,0 +1,393 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/**
+ * Interface between sqlite engine and bplog. It is using a direct socket
+ * connection to a remote node instead of a "net" mesh. The replicant uses an
+ * appsock to communicate with the master; the receiving master stores the
+ * bplog, before dispatching to a block processor writer for execution.
+ * Replicant receives heartbeats to confirm the progress on the master.
+ * Master catches a socket drop to detect cases when replicant fails
+ *
+ */
+#include <sys/socket.h>
+
+#include "comdb2.h"
+#include "sql.h"
+#include "tohex.h"
+#include "endian_core.h"
+#include "osqlsqlsocket.h"
+#include "osqlblockproc.h"
+#include "osqlcomm.h"
+
+#define BPLOG_PROTO "icdb2"
+#define BPLOG_APPSOCK "sockbplog"
+
+int gbl_sockbplog_debug = 0;
+extern int osql_recv_commit_rc(SBUF2 *sb, int timeoutms, int timeoutdeltams,
+                               int *nops, struct errstat *err);
+
+int gbl_sockbplog = 0;
+int gbl_sockbplog_poll = 1000;
+int gbl_sockbplog_timeout = 60000;
+int gbl_sockbplog_sockpool = 0;
+
+static int _socket_send(osql_target_t *target, int usertype, void *data,
+                        int datalen, int nodelay, void *tail, int tailen);
+static int osql_begin_socket(struct sqlclntstate *clnt, int type,
+                             int keep_rqid);
+static int osql_end_socket(struct sqlclntstate *clnt);
+static int osql_wait_socket(struct sqlclntstate *clnt, int timeout,
+                            struct errstat *err);
+
+void init_bplog_socket(struct sqlclntstate *clnt)
+{
+    clnt->begin = osql_begin_socket;
+    clnt->end = osql_end_socket;
+    clnt->wait = osql_wait_socket;
+}
+
+void init_bplog_socket_master(osql_target_t *target, SBUF2 *sb)
+{
+    target->type = OSQL_OVER_SOCKET;
+    target->sb = sb;
+    target->send = _socket_send;
+}
+
+static int osql_begin_socket(struct sqlclntstate *clnt, int type, int keep_rqid)
+{
+    SBUF2 *sb = NULL;
+    int rc;
+
+    if (thedb->master == gbl_myhostname) {
+        /* it is possible here that we are in a master swing,
+        and the replicant became master! Close up any previous connection */
+        if (clnt->osql.target.type == OSQL_OVER_SOCKET &&
+            clnt->osql.target.sb != NULL) {
+            rc = osql_end_socket(clnt);
+            if (rc != 0) {
+                logmsg(LOGMSG_ERROR,
+                       "%s:%d closing previous socket errored rc %d\n",
+                       __func__, __LINE__, rc);
+            }
+        }
+
+        clnt->osql.target.type = OSQL_OVER_NET;
+        return -1;
+    }
+
+    clnt->osql.target.type = OSQL_OVER_SOCKET;
+    clnt->osql.target.host = thedb->master;
+    clnt->osql.target.send = _socket_send;
+
+    /* protect against no master */
+    if (clnt->osql.target.host == NULL ||
+        clnt->osql.target.host == db_eid_invalid)
+        return 0; /* loop in caller */
+
+    /* get a socket to target */
+    clnt->osql.target.sb = sb = connect_remote_db(
+        BPLOG_PROTO, thedb->envname, BPLOG_APPSOCK,
+        (char *)clnt->osql.target.host, gbl_sockbplog_sockpool);
+    if (!sb) {
+        logmsg(LOGMSG_ERROR, "%s Failed to open socket to %s\n", __func__,
+               clnt->osql.target.host);
+        return -1;
+    }
+    /* keep alive */
+    int fd = sbuf2fileno(sb);
+    int flag = 1;
+
+    if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &flag, sizeof(flag)) != 0)
+        logmsg(LOGMSG_ERROR, "%s fd:%d err:%s\n", __func__, fd,
+               strerror(errno));
+
+    /* come for air every gbl_sockbplog_poll msecond */
+    sbuf2settimeout(sb, gbl_sockbplog_poll, gbl_sockbplog_poll);
+
+    /* appsock id */
+    sbuf2printf(sb, BPLOG_APPSOCK);
+    sbuf2printf(sb, "\n");
+    sbuf2flush(sb);
+
+    return 0;
+}
+
+static int osql_end_socket(struct sqlclntstate *clnt)
+{
+    if (clnt->osql.target.type != OSQL_OVER_SOCKET)
+        return -1;
+
+    disconnect_remote_db(BPLOG_PROTO, thedb->envname, BPLOG_APPSOCK,
+                         (char *)clnt->osql.target.host, &clnt->osql.target.sb);
+    return 0;
+}
+
+static int _socket_send(osql_target_t *target, int usertype, void *data,
+                        int datalen, int nodelay, void *tail, int tailen)
+{
+    SBUF2 *sb = target->sb;
+    int totallen = datalen + tailen;
+    int rc;
+
+    if (gbl_sockbplog_debug) {
+        logmsg(LOGMSG_ERROR, "sending %d datalen %d tailen %d nodelay %d\n",
+               usertype, datalen, tailen, nodelay);
+        logmsg(LOGMSG_ERROR, "Data:\n");
+        hexdump(LOGMSG_ERROR, data, datalen);
+        logmsg(LOGMSG_ERROR, "Tail:\n");
+        if (tailen > 0)
+            hexdump(LOGMSG_ERROR, tail, tailen);
+        logmsg(LOGMSG_ERROR, "Done\n");
+    }
+
+    totallen = htonl(totallen);
+    rc = sbuf2fwrite((char *)&totallen, 1, sizeof(totallen), sb);
+    if (rc != sizeof(totallen)) {
+        logmsg(LOGMSG_ERROR, "%s: failed to write header rc=%d\n", __func__,
+               rc);
+        return -1;
+    }
+
+    rc = sbuf2fwrite((char *)data, 1, datalen, sb);
+    if (rc != datalen) {
+        logmsg(LOGMSG_ERROR, "%s: failed to write packet rc=%d\n", __func__,
+               rc);
+        return -1;
+    }
+
+    if (tail && tailen > 0) {
+        rc = sbuf2fwrite((char *)tail, 1, tailen, sb);
+        if (rc != tailen) {
+            logmsg(LOGMSG_ERROR, "%s: failed to write packet tail rc=%d\n",
+                   __func__, rc);
+            return -1;
+        }
+    }
+
+    if (nodelay)
+        sbuf2flush(sb);
+
+    return 0;
+}
+
+static int osql_wait_socket(struct sqlclntstate *clnt, int timeout,
+                            struct errstat *err)
+{
+    if (clnt->osql.target.type != OSQL_OVER_SOCKET)
+        return -1;
+
+    assert(clnt->osql.target.sb);
+
+    int rc;
+    int nops_commit;
+
+    rc = osql_recv_commit_rc(clnt->osql.target.sb, timeout * 1000,
+                             gbl_sockbplog_poll, &nops_commit, err);
+    if (rc) {
+        logmsg(LOGMSG_ERROR,
+               "%s failed to read commit rc from master rc %d timeout %d\n",
+               __func__, rc, timeout);
+    }
+    if (rc == ERR_NOMASTER) {
+        /* communication with the master failed, no err */
+        errstat_set_rcstrf(&clnt->osql.xerr, ERR_NOMASTER,
+                           "timeout receiving rc from master %s",
+                           clnt->osql.target.host);
+        rc = 0;
+    }
+    return rc;
+}
+
+int osql_read_buffer(char *p_buf, size_t p_buf_len, SBUF2 *sb, int *timeoutms,
+                     int deltams)
+{
+    int rc = 0;
+    int start, end;
+    int initial_timeoutms = *timeoutms;
+
+    assert(timeoutms && *timeoutms > 0);
+
+    while (*timeoutms > 0) {
+        start = comdb2_time_epochms();
+        rc = sbuf2fread(p_buf, p_buf_len, 1, sb);
+        end = comdb2_time_epochms();
+        /* sbuf2 does not tell us if it was timeout or socket closed; we do not
+        want to loop here if socket closed; measure the time to discriminate,
+        since we use at least a 1ms timeout */
+        if (rc == 0 && start == end) {
+            *timeoutms = 0;
+            return -1;
+        }
+
+        if (rc == 1)
+            return 0;
+        if (rc < 0) {
+            logmsg(LOGMSG_ERROR, "%s failed to read rc from master rc %d\n",
+                   __func__, rc);
+            return rc;
+        }
+
+        assert(rc == 0);
+
+        if (*timeoutms > deltams) {
+            *timeoutms -= deltams;
+        } else {
+            logmsg(LOGMSG_ERROR, "%s timeout after %d ms\n", __func__,
+                   initial_timeoutms);
+            *timeoutms = 0;
+            return -1;
+        }
+    }
+
+    return -1;
+}
+
+int osql_read_buffer_default(char *buf, int buflen, SBUF2 *sb)
+{
+    int timeout = gbl_sockbplog_timeout;
+    return osql_read_buffer(buf, buflen, sb, &timeout, gbl_sockbplog_poll);
+}
+
+#define GDATA(obj)                                                             \
+    rc = osql_read_buffer_default((char *)&(obj), sizeof(obj), sb);            \
+    if (rc) {                                                                  \
+        logmsg(LOGMSG_ERROR, "Failure to read message %d rc %d\n", __LINE__,   \
+               rc);                                                            \
+    }
+
+#define GDATALEN(obj, objlen)                                                  \
+    rc = osql_read_buffer_default((char *)obj, (objlen), sb);                  \
+    if (rc) {                                                                  \
+        logmsg(LOGMSG_ERROR, "Failure to read message %d rc %d\n", __LINE__,   \
+               rc);                                                            \
+    }
+
+int osqlcomm_req_socket(SBUF2 *sb, char **sql, char tzname[DB_MAX_TZNAMEDB],
+                        int *type, uuid_t uuid, int *flags)
+{
+    int rqlen, sqlqlen;
+    int rc;
+    char pad[2], unused;
+    int totallen;
+
+    *sql = NULL;
+
+    GDATA(totallen);
+    if (rc)
+        goto err;
+    totallen = htonl(totallen);
+
+    GDATA(*type);
+    if (rc)
+        goto err;
+    *type = htonl(*type);
+
+    GDATA(rqlen);
+    if (rc)
+        goto err;
+    rqlen = htonl(rqlen);
+
+    GDATA(sqlqlen);
+    if (rc)
+        goto err;
+    sqlqlen = htonl(sqlqlen);
+
+    *sql = malloc(sqlqlen + 1);
+    if (!*sql)
+        goto err;
+    GDATA(*flags);
+    if (rc)
+        goto err;
+    *flags = htonl(*flags);
+
+    GDATALEN(uuid, sizeof(uuid_t));
+    if (rc)
+        goto err;
+    GDATALEN(tzname, DB_MAX_TZNAMEDB);
+    if (rc)
+        goto err;
+
+    GDATA(unused);
+    if (rc)
+        goto err;
+    GDATA(pad);
+    if (rc)
+        goto err;
+    GDATALEN(*sql, sqlqlen + 1 /* there is an extra byte here */);
+
+    return 0;
+err:
+    if (*sql)
+        free(*sql);
+    return -1;
+}
+
+/**
+ * Read the bplog body, coming from a socket
+ *
+ */
+int osqlcomm_bplog_socket(SBUF2 *sb, osql_sess_t *sess)
+{
+    char *buf = NULL;
+    int buflen = 0, oldbuflen = -1;
+    int type;
+    int rc;
+    bool is_msg_done = false;
+
+    while (!is_msg_done) {
+        GDATA(buflen);
+        if (rc)
+            goto err;
+        buflen = htonl(buflen);
+
+        if (gbl_sockbplog_debug)
+            logmsg(LOGMSG_ERROR, "%lu Received a packet of length %d\n",
+                   pthread_self(), buflen);
+
+        if (oldbuflen < buflen) {
+            buf = realloc(buf, buflen);
+            if (!buf) {
+                logmsg(LOGMSG_ERROR, "%s malloc buflen %d\n", __func__, buflen);
+                goto err;
+            }
+            oldbuflen = buflen;
+        }
+
+        GDATALEN(buf, buflen);
+        if (rc)
+            goto err;
+
+        if (!(buf_get(&type, sizeof(type), buf, buf + buflen))) {
+            logmsg(LOGMSG_ERROR, "%s:%s returns NULL\n", __func__,
+                   "osqlcomm_uuid_rpl_type_get");
+            return -1;
+        }
+
+        rc = osql_sess_rcvop_socket(sess, type, buf, buflen, &is_msg_done);
+        if (rc) {
+            /* failed to save into bplog; discard and be done */
+            goto err;
+        }
+    }
+
+    return rc;
+
+err:
+    if (buf)
+        free(buf);
+    return rc;
+}

--- a/db/osqlsqlsocket.h
+++ b/db/osqlsqlsocket.h
@@ -1,0 +1,37 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef __OSQLSQLSOCKET_H__
+#define __OSQLSQLSOCKET_H__
+
+/**
+ * Initialize a client to use a socket instead of net
+ * for bplog transfer to master
+ * Second prototype is for the master receiver
+ *
+ */
+void init_bplog_socket(struct sqlclntstate *clnt);
+void init_bplog_socket_master(osql_target_t *target, SBUF2 *sb);
+
+/**
+ * Read buffer over the socket with timeout and default timeout
+ *
+ */
+int osql_read_buffer(char *p_buf, size_t p_buf_len, SBUF2 *sb, int *timeoutms,
+                     int deltams);
+int osql_read_buffer_default(char *buf, int buflen, SBUF2 *sb);
+
+#endif

--- a/db/osqlsqlthr.h
+++ b/db/osqlsqlthr.h
@@ -177,16 +177,6 @@ int osql_updstat(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
 
 /**
- * Restart a broken socksql connection by opening
- * a new blockproc on the provided master and
- * sending the cache rows to resume the current.
- * If keep_session is set, the same rqid is used for the replay
- *
- */
-int osql_sock_restart(struct sqlclntstate *clnt, int maxretries,
-                      int keep_session);
-
-/**
 *
 * Process a schema change request
 * Returns SQLITE_OK if successful.

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -85,6 +85,7 @@ extern int __berkdb_read_alarm_ms;
 #include "comdb2_atomic.h"
 #include "comdb2_ruleset.h"
 #include "osqluprec.h"
+#include "schemachange.h"
 
 extern struct ruleset *gbl_ruleset;
 extern int gbl_exit_alarm_sec;
@@ -1643,6 +1644,8 @@ clipper_usage:
         logmsg(LOGMSG_USER, "gbl_thrman_trace = %d\n", gbl_thrman_trace);
     } else if (tokcmp(tok, ltok, "long") == 0) {
         request_stats(dbenv);
+    } else if (tokcmp(tok, ltok, "totalsqltiming") == 0) {
+        global_sql_timings_print();
     } else if (tokcmp(tok, ltok, "dmpl") == 0) {
         thd_dump();
     } else if (tokcmp(tok, ltok, "dmptrn") == 0) {

--- a/db/record.c
+++ b/db/record.c
@@ -50,6 +50,7 @@
 #include "logmsg.h"
 #include "indices.h"
 #include "comdb2_atomic.h"
+#include "schemachange.h"
 
 extern int gbl_partial_indexes;
 extern int gbl_expressions_indexes;

--- a/db/sql.h
+++ b/db/sql.h
@@ -149,7 +149,7 @@ typedef struct {
 typedef struct osqlstate {
 
     /* == sql_thread == */
-    char *host;              /* matching remote node */
+    osql_target_t target;    /* where to send the bplog */
     unsigned long long rqid; /* per node offload request session */
     uuid_t uuid;             /* session id, take 2 */
     char *tablename;         /* malloc-ed cache of send tablename for usedb */
@@ -663,6 +663,11 @@ struct sqlclntstate {
     /* appsock plugin specific data */
     void *appdata;
     struct plugin_callbacks plugin;
+
+    /* bplog write plugin */
+    int (*begin)(struct sqlclntstate *clnt, int retries, int keep_id);
+    int (*end)(struct sqlclntstate *clnt);
+    int (*wait)(struct sqlclntstate *clnt, int timeout, struct errstat *err);
 
     dbtran_type dbtran;
     pthread_mutex_t dtran_mtx; /* protect dbtran.dtran, if any,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8477,6 +8477,7 @@ int sqlite3BtreeInsert(
     sqlite3_int64 nKey = pPayload->nKey;
     const void *pData = pPayload->pData;
     int nData = pPayload->nData;
+
     int rc = UNIMPLEMENTED;
     int bdberr;
     blob_buffer_t blobs[MAXBLOBS];
@@ -10885,6 +10886,9 @@ void disconnect_remote_db(const char *protocol, const char *dbname, const char *
     socket_pool_donate_ext(socket_type, fd, IOTIMEOUTMS / 1000, 0,
                            0, NULL, NULL);
 
+    /*fprintf(stderr, "%s: donated socket %d to sockpool %s\n", __func__, fd,
+     * socket_type);*/
+
     sbuf2free(sb);
     *psb = NULL;
 }
@@ -10904,16 +10908,18 @@ SBUF2 *connect_remote_db(const char *protocol, const char *dbname, const char *s
         /* lets try to use sockpool, if available */
         sockfd = _sockpool_get(protocol, dbname, service, host);
         if (sockfd > 0) {
-            /*fprintf(stderr, "%s: retrieved sockpool socket for %s.%s.%s fd=%d\n",
-              __func__, dbname, service, host);*/
+            /*fprintf(stderr, "%s: retrieved sockpool socket for %s.%s.%s.%s
+              fd=%d\n",
+              __func__, dbname, protocol, service, host, sockfd);*/
             goto sbuf;
         }
     }
-    /*fprintf(stderr, "%s: no sockpool socket for %s.%s.%s\n",
-      __func__, dbname, service, host);*/
+    /*fprintf(stderr, "%s: no sockpool socket for %s.%s.%s.%s\n",
+      __func__, dbname, protocol, service, host);*/
 
     retry = 0;
 retry:
+
     /* this could fail due to load */
     port = portmux_get(host, "comdb2", "replication", dbname);
     if (port == -1) {

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -48,6 +48,7 @@
 #include "osqlsqlthr.h"
 #include "osqlshadtbl.h"
 #include "osqlblkseq.h"
+#include "schemachange.h"
 #include <net_types.h>
 
 #include <logmsg.h>
@@ -195,10 +196,12 @@ void block2_sorese(struct ireq *iq, const char *sql, int sqlen, int block2_type)
     struct thr_handle *thr_self = thrman_self();
 
     if (iq->debug)
-        reqprintf(iq, "%s received from node %s", __func__, iq->sorese->host);
+        reqprintf(iq, "%s received from node %s", __func__,
+                  iq->sorese->target.host);
 
     thrman_wheref(thr_self, "%s [%s %s %llx]", req2a(iq->opcode),
-                  breq2a(block2_type), iq->sorese->host, iq->sorese->rqid);
+                  breq2a(block2_type), iq->sorese->target.host,
+                  iq->sorese->rqid);
 }
 
 extern int gbl_early_verify;
@@ -415,13 +418,6 @@ int recom_abort(struct sqlclntstate *clnt)
     }
 
     return sorese_abort(clnt, OSQL_RECOM_REQ);
-}
-
-inline int block2_serial(struct ireq *iq, const char *sql, int sqlen)
-{
-
-    block2_sorese(iq, sql, sqlen, BLOCK2_SERIAL);
-    return 0;
 }
 
 int snapisol_commit(struct sqlclntstate *clnt, struct sql_thread *thd,

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -903,6 +903,9 @@ These options are toggle-able at runtime.
 | pbkdf2_iterations | 4096 | Number of PBKDF2 iterations. PBKDF2 is used for password hashing. The higher the value, the more secure and the more computationally expensive. The mininum number of iterations is 4096.
 |clean_exit_on_sigterm | 1 | When enabled, SIGTERM will cause database to do an orderly shutdown.  When disabled follows system SIGTERM default (terminate, no core) 
 |delay_sql_lock_release| 1 | Delay release locks in cursor move if bdb lock desired but client sends rows back
+|sockbplog| off | Osql bplog is sent from replicants to master on their own socket
+|sockbplog_sockpool| off | Osql bplog sent over sockets is using local sockpool
+
 
 <!-- TODO
 |enable_datetime_truncation | |

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -19,6 +19,7 @@ add_subdirectory(newsql)
 add_subdirectory(remsql)
 add_subdirectory(repopnewlrl)
 add_subdirectory(dbqueuedb)
+add_subdirectory(sockbplog)
 
 set(COMDB2_EXTRA_PLUGINS ${EXTRA_PLUGINS} CACHE PATH "Path to additional plugins")
 if (COMDB2_EXTRA_PLUGINS)

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -17,14 +17,19 @@
 #include <pthread.h>
 #include <stdlib.h>
 
-#include <newsql.h>
-#include <reqlog.h>
-#include <sp.h>
-#include <sql.h>
-#include <sqloffload.h>
-#include <sqlquery.pb-c.h>
-#include <sqlresponse.pb-c.h>
-#include <str0.h>
+#include "newsql.h"
+#include "comdb2_plugin.h"
+#include "pb_alloc.h"
+#include "sp.h"
+#include "sql.h"
+#include "reqlog.h"
+#include "comdb2_appsock.h"
+#include "comdb2_atomic.h"
+#include "str0.h"
+#include "sqloffload.h"
+#include "osqlsqlsocket.h"
+#include "sqlquery.pb-c.h"
+#include "sqlresponse.pb-c.h"
 
 static int newsql_clr_snapshot(struct sqlclntstate *);
 static int newsql_has_high_availability(struct sqlclntstate *);
@@ -1766,6 +1771,9 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
                 sqlstr += 9;
                 sqlstr = skipws(sqlstr);
                 clnt->rowbuffer = (strncasecmp(sqlstr, "on", 2) == 0);
+            } else if (strncasecmp(sqlstr, "sockbplog", 10) == 0) {
+                init_bplog_socket(clnt);
+                rc = 0;
             } else {
                 rc = ii + 1;
             }

--- a/plugins/sockbplog/CMakeLists.txt
+++ b/plugins/sockbplog/CMakeLists.txt
@@ -1,0 +1,35 @@
+include(${CMAKE_MODULE_PATH}/plugin.cmake)
+
+include(${PROJECT_SOURCE_DIR}/sqlite/definitions.cmake)
+add_definitions(
+  ${SQLITE_FLAGS}
+)
+include_directories(
+  ${PROJECT_SOURCE_DIR}/util
+  ${PROJECT_SOURCE_DIR}/bbinc
+  ${PROJECT_SOURCE_DIR}/bdb
+  ${PROJECT_SOURCE_DIR}/cdb2api
+  ${PROJECT_SOURCE_DIR}/crc32c
+  ${PROJECT_SOURCE_DIR}/csc2
+  ${PROJECT_SOURCE_DIR}/datetime
+  ${PROJECT_SOURCE_DIR}/db
+  ${PROJECT_SOURCE_DIR}/dfp/decNumber
+  ${PROJECT_SOURCE_DIR}/dfp/dfpal
+  ${PROJECT_SOURCE_DIR}/dlmalloc
+  ${PROJECT_SOURCE_DIR}/lua
+  ${PROJECT_SOURCE_DIR}/mem
+  ${PROJECT_SOURCE_DIR}/net
+  ${PROJECT_SOURCE_DIR}/protobuf
+  ${PROJECT_SOURCE_DIR}/sqlite/src
+  ${PROJECT_BINARY_DIR}/db
+  ${PROJECT_BINARY_DIR}/mem
+  ${PROJECT_BINARY_DIR}/protobuf
+  ${PROJECT_BINARY_DIR}/sqlite
+  ${CMAKE_CURRENT_BINARY_DIR}
+  ${OPENSSL_INCLUDE_DIR}
+  ${PROTOBUF-C_INCLUDE_DIR}
+)
+
+set(SOURCES sockbplog.c)
+add_plugin(sockbplog STATIC "${SOURCES}")
+add_dependencies(sockbplog sqlite) # Wait for parse.h

--- a/plugins/sockbplog/plugin.h.in
+++ b/plugins/sockbplog/plugin.h.in
@@ -1,0 +1,13 @@
+struct comdb2_plugin @PLUGIN_SYM@[] = {
+    {
+        "sockbplog",           /* Plugin identifier */
+        "bplog over socket plugin", /* Plugin description */
+        COMDB2_PLUGIN_APPSOCK, /* Plugin type */
+        1,                     /* Plugin version */
+        1,                     /* Plugin interface version */
+        0,                     /* Plugin flags */
+        NULL,                  /* Initialization function */
+        NULL,                  /* Destroy function */
+        &sockbplog_plugin         /* Plugin-specific data */
+    },
+    {0, 0, 0, 0, 0, 0, 0, 0, 0}};

--- a/plugins/sockbplog/sockbplog.c
+++ b/plugins/sockbplog/sockbplog.c
@@ -1,0 +1,137 @@
+/*
+   Copyright 2019 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "comdb2.h"
+#include "comdb2_appsock.h"
+#include "osqlsession.h"
+#include "osqlcomm.h"
+#include "osqlsqlsocket.h"
+
+extern int gbl_sockbplog_debug;
+int handle_sockbplog_request(comdb2_appsock_arg_t *arg);
+
+comdb2_appsock_t sockbplog_plugin = {
+    "sockbplog",             /* Name */
+    "",                      /* Usage info */
+    0,                       /* Execution count */
+    0,                       /* Flags */
+    handle_sockbplog_request /* Handler function */
+};
+
+static int handle_sockbplog_request_session(SBUF2 *sb, char *host)
+{
+    osql_sess_t *sess = NULL;
+    char *sql = NULL;
+    int flags = 0;
+    char tzname[CDB2_MAX_TZNAME] = {0};
+    int type = OSQL_SOCK_REQ;
+    uuid_t uuid;
+    unsigned long long rqid = OSQL_RQID_USE_UUID;
+    int rc;
+
+    /* received the request; */
+    rc = osqlcomm_req_socket(sb, &sql, tzname, &type, uuid, &flags);
+    if (rc) {
+        if (gbl_sockbplog_debug)
+            logmsg(LOGMSG_ERROR, "Failure to receive osql request rc=%d\n", rc);
+        goto err_nomsg;
+    }
+
+    if (gbl_sockbplog_debug)
+        logmsg(LOGMSG_ERROR, "Received req %d sql %s\n", type, sql);
+
+    /* create a session/bplog */
+    sess = osql_sess_create(sql, strlen(sql) + 1, tzname, type, rqid, uuid,
+                            host, flags & OSQL_FLAGS_REORDER_ON);
+    if (!sess) {
+        logmsg(LOGMSG_ERROR, "Malloc failure for new ireq\n");
+        sbuf2printf(sb, "Error: Out of memory");
+        sbuf2flush(sb);
+        rc = APPSOCK_RETURN_ERR;
+        goto err;
+    }
+    /* override the connection */
+    init_bplog_socket_master(&sess->target, sb);
+
+    /* collect the bplog; dispatch if bplog successful */
+    rc = osqlcomm_bplog_socket(sb, sess);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "Failure to receive osql bplog rc=%d\n", rc);
+        goto err;
+    }
+
+    /* NOTE:
+        here, the responsibility for handling the sess is delegated
+        to the writer thread */
+    if (gbl_sockbplog_debug)
+        logmsg(LOGMSG_ERROR, "%lu %s called\n", pthread_self(), __func__);
+    return 0;
+
+err:
+    logmsg(LOGMSG_ERROR, "%lu %s called and failed rc %d\n", pthread_self(),
+           __func__, rc);
+err_nomsg:
+    if (sql)
+        free(sql);
+    if (sess) {
+        osql_sess_remclient(sess);
+        osql_sess_close(&sess, 0);
+    }
+    return rc;
+}
+
+int handle_sockbplog_request(comdb2_appsock_arg_t *arg)
+{
+    struct sbuf2 *sb;
+    char *host = "localhost";
+    char line[128];
+    int rc = 0;
+
+    sb = arg->sb;
+
+    while (!rc) {
+        rc = handle_sockbplog_request_session(sb, host);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s: failed to process session rc %d\n",
+                   __func__, rc);
+            break;
+        }
+
+        /* wait for next request */
+        /* TODO: wait longer than 10 seconds */
+        rc = sbuf2gets(line, sizeof(line), sb);
+        if (rc < 0) {
+            if (gbl_sockbplog_debug)
+                logmsg(LOGMSG_ERROR,
+                       "%s sbufgets returned rc %d, done sockbplog appsock\n",
+                       __func__, rc);
+            break;
+        }
+        if ((rc != strlen("sockbplog\n")) || strncmp(line, "sockbplog\n", 10)) {
+            logmsg(LOGMSG_ERROR, "%s: received wrong request! rc=%d: %s\n",
+                   __func__, rc, line);
+            rc = -1;
+        }
+        if (gbl_sockbplog_debug)
+            logmsg(LOGMSG_ERROR, "%s received another sockbplog string\n",
+                   __func__);
+        rc = 0;
+    }
+
+    return rc;
+}
+
+#include "plugin.h"

--- a/sockpool/sockpool.c
+++ b/sockpool/sockpool.c
@@ -51,6 +51,8 @@
 #include <syslog.h>
 #include <locks_wrap.h>
 
+//#define SOCKET_POOL_DEBUG
+
 #ifdef SOCKET_POOL_DEBUG
 #define DBG(x) printf x
 #else
@@ -126,7 +128,7 @@ static LISTC_T(struct item) lru_list;
 
 static unsigned max_active_fds = 16;
 
-static unsigned max_fds_per_typestr = 1;
+static unsigned max_fds_per_typestr = 10;
 
 /* Default on by now.  Whether or not comdb2 uses this will be controlled
  * at the comdb2 api level. */

--- a/sqlite/ext/comdb2/activeosqls.c
+++ b/sqlite/ext/comdb2/activeosqls.c
@@ -118,7 +118,7 @@ static int collect_bplog_session(void *obj, void *arg)
     memset(o, 0, sizeof(*o));
 
     o->type = bplogtype;
-    o->origin = sess->host? strdup(sess->host) : NULL;
+    o->origin = sess->target.host? strdup(sess->target.host) : NULL;
     o->where = iq && iq->where ? strdup(iq->where) : NULL;
     if (iq && IQ_HAS_SNAPINFO(iq)) {
         o->cnonce = malloc(IQ_SNAPINFO(iq)->keylen + 1);

--- a/tests/curmoves.test/sockbplog.testopts
+++ b/tests/curmoves.test/sockbplog.testopts
@@ -1,0 +1,2 @@
+sockbplog
+sockbplog_sockpool

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -807,6 +807,8 @@
 (name='slowwrite', description='', type='INTEGER', value='0', read_only='Y')
 (name='snapisol', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='snapshot_serial_verify_retry', description='Automatic retries on verify errors for clients that haven't read results.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='sockbplog', description='Enable sending transactions over socket instead of net', type='BOOLEAN', value='OFF', read_only='Y')
+(name='sockbplog_sockpool', description='Enable sockpool when for sockbplog feature', type='BOOLEAN', value='OFF', read_only='Y')
 (name='sort_nulls_with_header', description='Using record headers in key sorting. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='sosql_ddl_max_commit_wait_sec', description='Wait for the master to commit a DDL transaction for up to this long.', type='INTEGER', value='259200', read_only='N')
 (name='sosql_max_commit_wait_sec', description='Wait for the master to commit a transaction for up to this long.', type='INTEGER', value='600', read_only='N')


### PR DESCRIPTION
Use socket to send bplogs to the master, as an alternative to osql net.






bplog over socket squashed

change protocol to skip reset

another set of fixes and instrumentation cleanup

format; working remotely and tested

fix master swing, going from socket to local

add testcase

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

