### PR TITLE
Use reference counted pointer to string to have fewer copies of sql string

### DIFF
--- a/bbinc/thdpool.h
+++ b/bbinc/thdpool.h
@@ -32,6 +32,7 @@ extern "C" {
 #include <priority_queue.h>
 
 struct thdpool;
+typedef struct string_ref_t string_ref_t;
 
 enum thdpool_ioctl_op { THD_RUN, THD_FREE };
 
@@ -58,13 +59,14 @@ enum {
 
 typedef void (*thdpool_work_fn)(struct thdpool *pool, void *work, void *thddata,
                                 int op);
+
 struct workitem {
     void *work;
     thdpool_work_fn work_fn;
     int queue_time_ms;
     LINKC_T(struct workitem) linkv;
     int available;
-    char *persistent_info;
+    string_ref_t *ref_persistent_info;
     priority_t priority;
 };
 
@@ -104,7 +106,7 @@ enum {
     THDPOOL_QUEUE_ONLY = 0x8
 };
 int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
-                    int queue_override, char *persistent_info, uint32_t flags,
+                    int queue_override, string_ref_t *persistent_info, uint32_t flags,
                     priority_t priority);
 void thdpool_stop(struct thdpool *pool);
 void thdpool_resume(struct thdpool *pool);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2966,8 +2966,9 @@ int __recover_logfile_pglogs(DB_ENV *, void *);
 
 //#################################### THREAD POOL FOR LOADING PAGES ASYNCHRNOUSLY (WELL NO CALLBACK YET.....) 
 
+typedef struct string_ref_t string_ref_t;
 int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn,
-	void *work, int queue_override, char *persistent_info, uint32_t flags,
+	void *work, int queue_override, struct string_ref_t *persistent_info, uint32_t flags,
         priority_t priority);
 
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -133,6 +133,7 @@ void berk_memp_sync_alarm_ms(int);
 #include <build/db.h>
 #include "comdb2_ruleset.h"
 #include <hostname_support.h>
+#include "string_ref.h"
 
 #define tokdup strndup
 
@@ -790,6 +791,7 @@ int destroy_plugins(void);
 void register_plugin_tunables(void);
 int install_static_plugins(void);
 int run_init_plugins(int phase);
+extern void clear_sqlhist();
 
 inline int getkeyrecnums(const dbtable *tbl, int ixnum)
 {
@@ -1548,6 +1550,9 @@ void clean_exit(void)
     // comdb2ma_exit();
     free_tzdir();
     tz_hash_free();
+    clear_sqlhist();
+    if(!all_string_references_cleared())
+        abort();
 
     logmsg(LOGMSG_USER, "goodbye\n");
     exit(0);

--- a/db/sql.h
+++ b/db/sql.h
@@ -628,6 +628,7 @@ struct user {
 
 
 #define in_client_trans(clnt) ((clnt)->in_client_trans)
+typedef struct string_ref_t string_ref_t;
 
 /* Client specific sql state */
 struct sqlclntstate {
@@ -677,6 +678,7 @@ struct sqlclntstate {
     /* These are only valid while a query is in progress and will point into
      * the i/o thread's buf */
     char *sql;
+    string_ref_t *sql_ref;
     int recno;
     int client_understands_query_stats;
     char tzname[CDB2_MAX_TZNAME];
@@ -1107,7 +1109,7 @@ struct BtCursor {
 
 struct sql_hist {
     LINKC_T(struct sql_hist) lnk;
-    char *sql;
+    string_ref_t *sql_ref;
     struct sql_hist_cost cost;
     int when;
     int64_t txnid;

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -847,7 +847,7 @@ static int analyze_table_int(table_descriptor_t *td,
     if (debug_switch_test_delay_analyze_commit())
         sleep(10);
 
-    rc = run_internal_sql_clnt(&clnt, "COMMIT");
+    rc = run_internal_sql_clnt(&clnt, "COMMIT /* from analyzesqlite main.... */");
     if (rc) {
         /*
         ** Manually unregister the client from the checkboard,
@@ -874,7 +874,7 @@ cleanup:
     return rc;
 
 error:
-    if (run_internal_sql_clnt(&clnt, "ROLLBACK") != 0)
+    if (run_internal_sql_clnt(&clnt, "ROLLBACK /* from analyzesqlite main.... */") != 0)
         osql_unregister_sqlthr(&clnt);
     goto cleanup;
 }
@@ -1317,12 +1317,12 @@ static inline int analyze_backout_table(struct sqlclntstate *clnt, char *table)
         if (rc)
             goto error;
     }
-    rc = run_internal_sql_clnt(clnt, "COMMIT");
+    rc = run_internal_sql_clnt(clnt, "COMMIT /* from analyze backout stats */");
     return rc;
 
 error:
     logmsg(LOGMSG_ERROR, "backout error, rolling back transaction\n");
-    run_internal_sql_clnt(clnt, "ROLLBACK");
+    run_internal_sql_clnt(clnt, "ROLLBACK /* from analyze backout stats */");
     return rc;
 }
 

--- a/sqlite/ext/comdb2/sqlpoolqueue.c
+++ b/sqlite/ext/comdb2/sqlpoolqueue.c
@@ -24,6 +24,7 @@
 #include "ezsystables.h"
 #include "thdpool.h"
 #include "cdb2api.h"
+#include "string_ref.h"
 
 typedef struct systable_sqlpoolqueue {
     int64_t                 time_in_queue_ms;
@@ -51,8 +52,8 @@ static void collect(struct thdpool *pool, struct workitem *item, void *user)
 
     i = &q->records[q->count - 1];
     i->time_in_queue_ms = comdb2_time_epochms() - item->queue_time_ms;
-    if (item->persistent_info) {
-        i->info = strdup(item->persistent_info);
+    if (item->ref_persistent_info) {
+        i->info = strdup(get_string(item->ref_persistent_info));
         i->info_is_null = 0;
     } else {
         i->info = NULL;

--- a/tests/select_one.test/runit
+++ b/tests/select_one.test/runit
@@ -17,6 +17,7 @@ fi
 echo "create t1"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t1 (a int) "
 MAX=100000
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('scon')"
 
 if [ "${DEBUGGER}" == "callgrind" ] || [ "${DEBUGGER}" == "memcheck" ]; then 
    DEBUG_PREFIX="valgrind --tool=callgrind --instr-atstart=yes --dump-instr=yes --collect-jumps=yes --callgrind-out-file=$TESTDIR/$TESTCASE.cdb2sql.callgrind"

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -18,6 +18,7 @@ set(src
   fsnapf.c
   hashfuncs.c
   hostname_support.c
+  hashfuncs.c
   int_overflow.c
   intern_strings.c
   list.c
@@ -45,6 +46,7 @@ set(src
   sltpck.c
   str0.c
   strbuf.c
+  string_ref.c
   switches.c
   tcputil.c
   thdpool.c

--- a/util/string_ref.h
+++ b/util/string_ref.h
@@ -1,0 +1,54 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef _STRING_REF_H
+#define _STRING_REF_H
+
+/* String reference class:
+ *
+ * Allows for multiple pointers to point to the same 'str' object
+ * by means of counting references to 'this' object.
+ *
+ * NOTE: avoid assigning an object of this class to another explicitly,
+ * as that can result in violating the correct counting! 
+ * Instead, use transfer_ref(), or use get_ref() which increments the counter
+ * and returns a reference to 'this'.
+ *
+ * NOTE: One use case of this class is to ref count object passed to another thread, in
+ * which case: when passing a pointer to this class to a function or to another thread,
+ * it has to be clear that only one of the copies should ultimately call put_ref().
+ * For instance, in the case of passing to a thread, the thread takes over ownership
+ * of the pointer (and needs to put_ref() accordingly).
+ *
+ * Releasing the reference should be only done via put_ref() which will free the object
+ * if reference has reached count of 0. Notice that no other pointer to 'this' should
+ * exist when correctly used because this is the last put_ref() and no other pointer
+ * points to this object.
+ *
+ */
+
+
+
+typedef struct string_ref_t string_ref_t;
+
+string_ref_t * create_string_ref(const char *str);
+string_ref_t * get_ref(string_ref_t *ref);
+void put_ref(string_ref_t **ref);
+void transfer_ref(string_ref_t **from, string_ref_t **to);
+const char *get_string(string_ref_t *ref);
+int all_string_references_cleared();
+
+#endif

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -46,6 +46,7 @@
 #include "logmsg.h"
 #include "priority_queue.h"
 #include "comdb2_atomic.h"
+#include "string_ref.h"
 
 #ifdef MONITOR_STACK
 #include "comdb2_pthread_create.h"
@@ -57,6 +58,7 @@ extern int gbl_throttle_sql_overload_dump_sec;
 extern int thdpool_alarm_on_queing(int len);
 extern int gbl_disable_exit_on_thread_error;
 extern comdb2bma blobmem;
+
 
 struct thd {
     pthread_t tid;
@@ -654,9 +656,8 @@ static int get_work_ll(struct thd *thd, struct workitem *work)
                     pool->maxqueueagems)) {
                 if (pool->dque_fn)
                     pool->dque_fn(thd->pool, next, 1);
-                if (next->persistent_info) {
-                    free(next->persistent_info);
-                    next->persistent_info = NULL;
+                if (next->ref_persistent_info) {
+                    put_ref(&next->ref_persistent_info);
                 }
                 next->work_fn(pool, next->work, NULL, THD_FREE);
                 pool_relablk(pool->pool, next);
@@ -795,7 +796,10 @@ static void *thdpool_thd(void *voidarg)
              * current work in progress, obtained from get_work_ll, while
              * still holding the pool lock. */
 
-            thd->persistent_info = work.persistent_info;
+            if (work.ref_persistent_info)
+                thd->persistent_info = get_string(work.ref_persistent_info); // will reset this before put_ref() below
+            else
+                thd->persistent_info = "working on unknown";
         }
         UNLOCK(&pool->mutex);
 
@@ -817,9 +821,8 @@ static void *thdpool_thd(void *voidarg)
          * to examine it. */
         LOCK(&pool->mutex) {
             thd->persistent_info = "work completed.";
-            if (work.persistent_info != NULL) {
-                free(work.persistent_info);
-                work.persistent_info = NULL;
+            if (work.ref_persistent_info) {
+                put_ref(&work.ref_persistent_info);
             }
         }
         UNLOCK(&pool->mutex);
@@ -874,8 +877,8 @@ thread_exit:
 }
 
 int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
-                    int queue_override, char *persistent_info, uint32_t flags,
-                    priority_t priority)
+                    int queue_override, string_ref_t *ref_persistent_info,
+                    uint32_t flags, priority_t priority)
 {
     static time_t last_dump = 0;
     int enqueue_front = (flags & THDPOOL_ENQUEUE_FRONT);
@@ -1064,6 +1067,7 @@ int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
                             ctrace(" === Dumping current pool \"%s\" users:\n",
                                    pool->name);
 
+
                             LISTC_FOR_EACH(&pool->thdlist, thd, thdlist_linkv)
                             {
                                 crt++;
@@ -1119,7 +1123,7 @@ int thdpool_enqueue(struct thdpool *pool, thdpool_work_fn work_fn, void *work,
 
         item->work = work;
         item->work_fn = work_fn;
-        item->persistent_info = persistent_info;
+        transfer_ref(&ref_persistent_info, &item->ref_persistent_info); // item gets ownership of reference
         item->queue_time_ms = comdb2_time_epochms();
         item->available = 1;
         item->priority = priority;


### PR DESCRIPTION
- string_ref structure and functions
- used by dispatch_sql_query
- used for sql history list
- we might be able to use this to make fewer sql copies with eventlogging in future
- memory savings will be more apparent with larger sql queries

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>