### PR TITLE
Send syncmode in dbinfo message.

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -97,6 +97,7 @@ enum {
     BDB_CALLBACK_NODE_IS_DOWN,
     BDB_CALLBACK_SERIALCHECK,
     BDB_CALLBACK_ADMIN_APPSOCK,
+    BDB_CALLBACK_SYNCMODE,
 };
 
 enum { BDB_REPFAIL_NET, BDB_REPFAIL_TIMEOUT, BDB_REPFAIL_RMTBDB };
@@ -404,6 +405,9 @@ typedef int (*BDBSETFILELWMFP)(int *);
    tables to account for committed deletes and hide adds */
 struct bdb_osql_log;
 typedef void (*UNDOSHADOWFP)(struct bdb_osql_log *);
+
+/* Callback to return sync type */
+typedef int (*SYNCMODE)(bdb_state_type *);
 
 typedef int (*BDB_CALLBACK_FP)();
 bdb_callback_type *bdb_callback_create(void);

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -688,9 +688,9 @@ struct bdb_callback_tag {
     BDBSETFILELWMFP set_file_lwm_rtn;
     SCDONEFP scdone_rtn;
     SCABORTFP scabort_rtn;
-    UNDOSHADOWFP undoshadow_rtn;
     NODEDOWNFP nodedown_rtn;
     SERIALCHECK serialcheck_rtn;
+    SYNCMODE syncmode_rtn;
 };
 
 struct waiting_for_lsn {

--- a/bdb/callback.c
+++ b/bdb/callback.c
@@ -102,10 +102,10 @@ void bdb_callback_set(bdb_callback_type *bdb_callback, int callback_type,
     case BDB_CALLBACK_SERIALCHECK:
         bdb_callback->serialcheck_rtn = (SERIALCHECK)callback_rtn;
         break;
-    /*
-        case BDB_CALLBACK_UNDOSHADOW:
-            bdb_callback->undoshadow_rtn = (UNDOSHADOWFP) callback_rtn;
-    */
+
+    case BDB_CALLBACK_SYNCMODE:
+        bdb_callback->syncmode_rtn = (SYNCMODE)callback_rtn;
+        break;
 
     default:
         break;

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -689,6 +689,9 @@ void fill_dbinfo(void *p_response, bdb_state_type *bdb_state)
     cdb2__dbinforesponse__nodeinfo__init(master);
     int our_room = 0;
 
+    dbinfo_response->has_sync_mode = 1;
+    dbinfo_response->sync_mode = bdb_state->callback->syncmode_rtn(bdb_state);
+
     if (bdb_state->callback->getroom_rtn)
         our_room = (bdb_state->callback->getroom_rtn(
             bdb_state, bdb_state->repinfo->myhost));

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -95,6 +95,15 @@ enum ResponseType {
   SP_DEBUG      = 6;
 }
 
+enum CDB2SyncMode {
+    SYNC         = 1;
+    ASYNC        = 2;
+    SYNC_ROOM    = 3;
+    SYNC_N       = 4;
+    SYNC_SOURCE  = 5;
+    SYNC_UNKNOWN = 6;
+}
+
 enum CDB2ServerFeatures {
     SKIP_INTRANS_RESULTS = 1;
 }
@@ -110,6 +119,7 @@ message CDB2_DBINFORESPONSE {
     required nodeinfo master = 1;
     repeated nodeinfo nodes  = 2;     // These are replicants, we need to parse through these only.
     optional bool require_ssl = 3;
+    optional CDB2SyncMode sync_mode = 4;
 }
 
 message CDB2_EFFECTS {


### PR DESCRIPTION
Send back the sync mode in a dbinfo response so the API can route to the master immediately instead of retrying all nodes.