### PR TITLE
Fix log-delete stat trace

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3142,7 +3142,7 @@ void backend_sync_stat(struct dbenv *dbenv)
     else
         logmsg(LOGMSG_USER, "LOG DELETE ENABLED only up to and including log.%010d\n",
                dbenv->log_delete_filenum);
-    if (dbenv->log_delete_age > 0) {
+    if (dbenv->log_delete_age > comdb2_time_epoch()) {
         struct tm tm;
         time_t secs;
         char buf[64];


### PR DESCRIPTION
Log deletion policy returned by 'stat' should read "LOG DELETE POLICY: delete all eligible log files" after the log-delete age has expired.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>