### PR TITLE
Test successful canceling of running sql

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -12,14 +12,22 @@ include $(TESTSROOTDIR)/Makefile.common
 # List of disabled tests
 DISABLED_TESTS:=$(shell awk '/^DISABLED/{f=1;next};/<END>/{f=0}f' TODO | cut -d' ' -f1)
 
+# When SKIPSSL is on, skip running tests which rely on SSL
 ifeq ($(SKIPSSL), 1)
 SKIPS:=$(shell grep ssl *.test/lrl*  | grep 'ssl_client_mode VERIFY' | cut -f1 -d'/' | sort -u)
 DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
 endif
 
+# Skip tests that need tcl
 ifeq ($(wildcard $(BUILDDIR)/tcl/libtclcdb2.so),)
 #if we have not compiled with tcl, skip tests that require tclcdb2
 SKIPS:=$(shell ls *.test/*.tcl | xargs grep 'package require tclcdb2' | cut -f1 -d'/' | sort -u)
+DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
+endif
+
+# Skip any tests that we specifically want by reading 'tests/excluded.txt'
+ifeq ($(wildcard excluded.txt),excluded.txt)
+SKIPS:=$(shell cat excluded.txt | sort -u)
 DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
 endif
 

--- a/tests/cancel_sql.test/Makefile
+++ b/tests/cancel_sql.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/cancel_sql.test/README
+++ b/tests/cancel_sql.test/README
@@ -1,0 +1,5 @@
+Testing ability to cancel running sql. 
+We already have a way of testing manually from within cdb2sql by sending
+`sql cancelcnonce xxx` when in the middle of an ongoing stmt such as
+`select 1, sleep(30)`.
+This test exercises `sql cancel id` of a similarly running stmt.

--- a/tests/cancel_sql.test/lrl.options
+++ b/tests/cancel_sql.test/lrl.options
@@ -1,0 +1,3 @@
+dtastripe 1
+appsockslimit 10
+maxappsockslimit 10

--- a/tests/cancel_sql.test/runit
+++ b/tests/cancel_sql.test/runit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+set -x
+
+node=`$CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $DBNAME default 'select comdb2_node()'`
+q="$CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $DBNAME --host $node"
+
+signature="abcdefg123"
+
+get_sql_id()
+{
+    $q "EXEC PROCEDURE sys.cmd.send('sql dump')" | grep $signature | cut -f2 -d' '
+}
+
+# first test that query stops when client goes away
+$q "select '$signature', sleep(30)" &
+pid=$!
+kill -9 $pid
+
+sleep 4 # apparently takes about 3 seconds to go away from sql dump
+
+id=`get_sql_id`
+if [ "$id" != "" ] ; then
+    failexit "id '$id' should be blank -- client disconnected"
+fi
+
+wait
+
+
+$q "select '$signature', sleep(30)" &
+pid=$!
+sleep 1
+
+id=`get_sql_id`
+if [ "$id" == "" ] ; then
+    failexit "id '$id' should not be blank -- client is connected"
+fi
+
+res=`$q "EXEC PROCEDURE sys.cmd.send('sql cancel $id')"`
+assertres "$res" "Query $id was told to stop"
+
+sleep 4
+
+id=`get_sql_id`
+if [ "$id" != "" ] ; then
+    failexit "id '$id' should be blank -- client disconnected"
+fi
+
+# also check pid
+kill -0 $pid && failexit "Pid $pid should have exited but is running"
+
+echo "Testcase passed."


### PR DESCRIPTION
When client disconnects running sql should stop running.
Also 'send sql cancel id' should stop running sql.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>