### PR TITLE
Move logfiles into a backup dir if enabled

### DIFF
--- a/bbinc/util.h
+++ b/bbinc/util.h
@@ -72,5 +72,5 @@ char *comdb2_filev(char *fmt, va_list args);
 char *comdb2_file(char *fmt, ...);
 void init_file_locations(char *);
 void cleanup_file_locations();
-void update_file_location(char *type, const char *dir);
+void update_file_location(const char *type, const char *dir);
 #endif

--- a/tests/backup_logfiles.test/Makefile
+++ b/tests/backup_logfiles.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/backup_logfiles.test/Readme
+++ b/tests/backup_logfiles.test/Readme
@@ -1,0 +1,4 @@
+Test moving log files to backup directory.
+Start a clustered test and insert enough data to have logs roll,
+set a low blkseq holding time, so the log files will be moved to
+the backup directory specified in the lrl file.

--- a/tests/backup_logfiles.test/lrl.options
+++ b/tests/backup_logfiles.test/lrl.options
@@ -1,0 +1,3 @@
+private_blkseq_maxage 20
+debug_log_deletion on
+location backup_logfiles_dir ${TESTDIR}/backup_logs_%dbname

--- a/tests/backup_logfiles.test/runit
+++ b/tests/backup_logfiles.test/runit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+BACKUPDIR=${TESTDIR}/backup_logs_$DBNAME
+
+# comdb2 task will create "${TESTDIR}/backup_logs_%dbname"
+# this part is same as from insert_lots.test
+
+gen_series_test()
+{
+    MAX=9000
+    cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "create table t2 (i int)"
+    cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "insert into t2 select * from generate_series(1, $MAX) "
+    cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "select distinct i from t2" | sort -n > gen.out
+    seq 1 $MAX > gen.exp
+    if ! diff gen.out gen.exp ; then 
+        failexit 'genseries content not what it is expected'
+    fi
+}
+
+
+THRDS=20
+CNT=10000
+ITERATIONS=2
+TRANSIZE=0
+#if [[ $DBNAME == *"largetrangenerated"* ]] ; then
+#    TRANSIZE=2800
+#fi
+
+gen_series_test
+
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default 'create table t1 {schema { short i  int j } keys { "PK"=i+j dup "j"=j } }'
+time ${TESTSBUILDDIR}/insert_lots_mt $DBNAME $THRDS $CNT $ITERATIONS $TRANSIZE> ins.out
+assertcnt t1 $((THRDS * CNT * ITERATIONS))
+
+while [ $SECONDS -lt 120 ] ; do
+    cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default "insert into t2 select * from generate_series(1, 100) "
+    sleep 10
+done
+
+master=`getmaster`
+
+# verify that backup dir has log.0000000001
+if [[ -n "$CLUSTER" ]]; then
+    ssh -o StrictHostKeyChecking=no $master "ls -al $BACKUPDIR" > ls_out.txt
+    if [ "$CLEANUPDBDIR" != "0" ] ; then
+        ssh -o StrictHostKeyChecking=no $master "rm -rf $BACKUPDIR"
+    fi
+else
+    ls -al $BACKUPDIR > ls_out.txt
+    if [ "$CLEANUPDBDIR" != "0" ] ; then
+        rm -rf $BACKUPDIR
+    fi
+fi
+
+cnt=`grep -c log.0000000001 ls_out.txt`
+assertres $cnt 1
+
+echo "Success"

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -5,7 +5,13 @@ set -x
 
 source ${TESTSROOTDIR}/tools/runit_common.sh
 
-function waitfordb() {
+function exiting {
+    COMDB2_UNITTEST=0 CLEANUPDBDIR=0 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAME}.unsetup
+}
+
+trap exiting EXIT
+
+function waitfordb {
     sleep 1
     local count=0
 	sel=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $1 "select 1" 2>&1)
@@ -226,4 +232,7 @@ valgrind --error-exitcode=1 --leak-check=full --trace-children=yes --quiet ${TES
 res=$?
 assertres $res 0
 
-exit 0
+trap - INT EXIT
+exiting
+
+echo "Success"

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -29,31 +29,6 @@ assertthdpoolcntzero()
     fi
 }
 
-assert_vers()
-{
-    tbl=$1
-    target=$2
-    newver=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select table_version('$tbl')")
-    if [[ $newver != $target ]] ; then
-        failexit "newver is now $newver but should be $target"
-    fi
-    tblver=$newver
-}
-
-assert_schema()
-{
-    tbl=$1
-    schema=$2
-
-    echo "make sure that the current schema is $schema"
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select csc2 from sqlite_master where name='$tbl'" | sed 's/ \(schema\)/\1/;s/} /}/' > schema.out
-
-    if ! diff -Bw schema.out $schema ; then 
-        cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select * from sqlite_master' > sqlite_master.out
-        failexit "final schema is not same as $schema: diff schema.out $schema"
-    fi
-}
-
 gen_series_test()
 {
     MAX=9000

--- a/tests/setup
+++ b/tests/setup
@@ -161,7 +161,8 @@ setup_db() {
         cat lrl >> ${LRL}
     fi
     if [[ -f lrl.options ]]; then
-        cat lrl.options >> ${LRL}
+        # use sed to substitute in test specific variables into lrl
+        cat lrl.options | sed "s#\${TESTDIR}#${TESTDIR}#" >> ${LRL}
     fi
 
     echo -e "name    ${DBNAME}\ndir     ${DBDIR}\n\nsetattr MASTER_REJECT_REQUESTS 0" >> ${LRL}

--- a/tests/yast.test/runit
+++ b/tests/yast.test/runit
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
-function echo_color()
+function echo_color
 {
     MSG=$1
     COLOR=$2
@@ -36,7 +36,7 @@ function echo_color()
     fi
 }
 
-function echo_color_bold()
+function echo_color_bold
 {
     echo_color "$1" "$2" "BOLD"
 }

--- a/util/comdb2file.c
+++ b/util/comdb2file.c
@@ -255,7 +255,7 @@ void cleanup_file_locations()
     }
 }
 
-void update_file_location(char *type, const char *dir)
+void update_file_location(const char *type, const char *dir)
 {
     add_location(type, dir);
 }


### PR DESCRIPTION
Move the logfiles instead of deleting them if lrl option is set:
```
   location backup_logfiles_dir /bigstore/backup/%dbname
```
This will allow for ability to restore to any point in time given that
logs will always be available. This can work well with a reasonable
maintenance schedule to backup to tape and cleanup log files
older than a preset value (ex a month).

If directory ends with %dbname, we will substitute the actual dbname
to use as directory where the logfiles will be backed up.

Note that if the backup_logfiles_dir is an nfs mounted directory
which is accessible from all the nodes in a cluster, correctness
of the backedup logfiles is ensured because only the master is able
to move logfiles to the backup directory (amongst other restrictions,
we only delete/move a logfile if there is no reference to a transaction
in blkseq).

Added unit test which exercises this feature.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>