### PR TITLE
Turn off check for numops because of incorrect accounting

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -355,6 +355,7 @@ static char *legacy_options[] = {
     "on accept_on_child_nets",
     "on disable_etc_services_lookup",
     "online_recovery off",
+    "osql_check_replicant_numops off",
     "osql_send_startgen off",
     "queuedb_genid_filename off",
     "reorder_socksql_no_deadlock off",

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -954,6 +954,7 @@ configurations:
     on accept_on_child_nets
     on disable_etc_services_lookup
     online_recovery off
+    osql_check_replicant_numops off
     osql_send_startgen off
     queuedb_genid_filename off
     reorder_socksql_no_deadlock off


### PR DESCRIPTION
Turn off check for numops because of incorrect accounting.