### PR TITLE
Use protobuf allocator for newsql unpacking

### DIFF
--- a/tests/mem_protobuf.test/Makefile
+++ b/tests/mem_protobuf.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/mem_protobuf.test/runit
+++ b/tests/mem_protobuf.test/runit
@@ -1,0 +1,9 @@
+# Simple test to verify that protobuf memory is accounted for.
+#!/bin/sh
+
+bash -n "$0" | exit 1
+set -e
+
+dbnm=$1
+host=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT comdb2_host()'`
+cdb2sql $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("memstat")' | grep 'protobuf.*appsockpool'


### PR DESCRIPTION
It may also help reduce heap fragmentation, as protobuf allocation will be done in its own allocator.