### PR TITLE
Fix incorrect check for backup_logfiles_dir when not set

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3370,14 +3370,16 @@ static int create_db(char *dbname, char *dir) {
 static void setup_backup_logfiles_dir()
 {
     char *backupdir = comdb2_location("backup_logfiles_dir", NULL);
-    if (!backupdir || strcmp(backupdir, "backup_logfiles_dir") == 0)
+    if (!backupdir)
         goto cleanup;
 
-    /* if path like "..../%dbname" then substitute %dbname with thedb->envname
-     * char *newname = comdb2_location("backup_logfiles_dir", "%s/%s", thedb->envname);
-     * and update_location("backup_logfiles_dir", newname);
-     */
+    /* cant have the db called 'backup_logfiles_dir' */
+    char *loc = strstr(backupdir, "backup_logfiles_dir");
+    if (loc != 0 && *(loc + sizeof("backup_logfiles_dir") + 1) == '\0' && *(loc - 1) == '/')
+        goto cleanup;
+
     {
+        /* if path like "..../%dbname" then substitute %dbname with thedb->envname */
         char *loc = strstr(backupdir, "%dbname");
         if (loc) {
             int dbnamelen = strlen(thedb->envname);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5266,7 +5266,6 @@ void sqlengine_work_appsock(void *thddata, void *work)
     }
 
     if (clnt->sql_ref) {
-        logmsg(LOGMSG_USER, "calling put_ref to rid clnt->ref %p\n", clnt->sql_ref);
         put_ref(&clnt->sql_ref);
     }
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -18,7 +18,6 @@ set(src
   fsnapf.c
   hashfuncs.c
   hostname_support.c
-  hashfuncs.c
   int_overflow.c
   intern_strings.c
   list.c


### PR DESCRIPTION
Bug is that the backup_logfiles_dir directory is returned as full path
including the db root and as such check for whether backup_logfiles_dir was
incorrect. This patch fixes that check.
