### PR TITLE
Stop the ongoing verify if db is exiting

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -27,6 +27,7 @@
 #include "string_ref.h"
 
 /* NOTE: This is from "comdb2.h". */
+extern int gbl_exit;
 extern int gbl_expressions_indexes;
 extern int get_numblobs(const struct dbtable *tbl);
 extern int ix_isnullk(const struct dbtable *db_table, void *key, int ixnum);
@@ -193,6 +194,13 @@ static inline int check_connection_and_progress(verify_common_t *par, int t_ms)
 
     if (par->peer_check(par->arg)) {
         logmsg(LOGMSG_WARN, "client connection closed, stopped verify\n");
+        par->client_dropped_connection = 1;
+        goto out;
+    }
+
+    if (gbl_exit) {
+        locprint(par, "!DB exiting, stopping verify");
+        logmsg(LOGMSG_WARN, "DB exiting, stopping verify\n");
         par->client_dropped_connection = 1;
         goto out;
     }


### PR DESCRIPTION
When db is sent exit and if there are verify threads working, currently the db will alarm every 10s and wait till timeout (5 min):
```
Waiting for threads to stop
12 registered threads running:-
   0) tid 83914:req
   1) tid 83915:req
....
id 5 11/30/2020 16:59:50 localhost pid 17474 task cdb2sql EXEC PROCEDURE sys.cmd.verify("updlog","parallel","verbose")
Alarm clock
```

Where client currently shows a timeout error:
```
[EXEC PROCEDURE sys.cmd.verify("updlog","parallel","verbose")] failed with rc -1 cdb2_next_record_int: Timeout while reading response from server
```
 

This patch will make the verify threads exit if db is exiting, and will send that info back to the client:
* server will display`DB exiting, stopping verify` in the logs
* client will print same message as server if running verify in verbose mode, otherwise will simply show verify error:
```
(out='DB exiting, stopping verify')
[EXEC PROCEDURE sys.cmd.verify("updlog","parallel","verbose")] failed with rc -3 [sys.comdb_verify(tbl, mode, ver...]:2: Verify failed.
```