### PR TITLE
Add osql cleanup test where client rollback or disconnects

### DIFF
--- a/db/osqlrepository.c
+++ b/db/osqlrepository.c
@@ -256,12 +256,19 @@ int osql_repository_printcrtsessions(void)
 
     Pthread_mutex_lock(&theosql->hshlck);
 
-    logmsg(LOGMSG_USER, "Begin osql session info:\n");
+    logmsg(LOGMSG_USER, "Begin osql session info (rqs):\n");
     if ((rc = hash_for(theosql->rqs, _getcrtinfo, NULL))) {
         logmsg(LOGMSG_USER, "hash_for failed with rc = %d\n", rc);
         rc = -1;
     } else
-        logmsg(LOGMSG_USER, "Done osql info.\n");
+        logmsg(LOGMSG_USER, "Done osql info (rqs).\n");
+    logmsg(LOGMSG_USER, "Begin osql session info (uuids):\n");
+
+    if ((rc = hash_for(theosql->rqsuuid, _getcrtinfo, NULL))) {
+        logmsg(LOGMSG_USER, "hash_for failed with rc = %d\n", rc);
+        rc = -1;
+    } else
+        logmsg(LOGMSG_USER, "Done osql info(uuids).\n");
 
     Pthread_mutex_unlock(&theosql->hshlck);
 

--- a/tests/backup_logfiles.test/runit
+++ b/tests/backup_logfiles.test/runit
@@ -34,7 +34,7 @@ TRANSIZE=0
 gen_series_test
 
 cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default 'create table t1 {schema { short i  int j } keys { "PK"=i+j dup "j"=j } }'
-time ${TESTSBUILDDIR}/insert_lots_mt $DBNAME $THRDS $CNT $ITERATIONS $TRANSIZE> ins.out
+time ${TESTSBUILDDIR}/insert_lots_mt --dbname $DBNAME --numthreads $THRDS --cntperthread $CNT --iterations $ITERATIONS --transize $TRANSIZE> ins.out
 assertcnt t1 $((THRDS * CNT * ITERATIONS))
 
 while [ $SECONDS -lt 120 ] ; do

--- a/tests/insert_lots.test/runit
+++ b/tests/insert_lots.test/runit
@@ -52,7 +52,7 @@ fi
 
 gen_series_test
 
-time ${TESTSBUILDDIR}/insert_lots_mt $dbnm $THRDS $CNT $ITERATIONS $TRANSIZE> ins.out
+time ${TESTSBUILDDIR}/insert_lots_mt --dbname $dbnm --numthreads $THRDS --cntperthread $CNT --iterations $ITERATIONS --transize $TRANSIZE> ins.out
 assertcnt t1 $((THRDS * CNT * ITERATIONS))
 do_verify t1
 

--- a/tests/osql_cleanup.test/Makefile
+++ b/tests/osql_cleanup.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/osql_cleanup.test/README
+++ b/tests/osql_cleanup.test/README
@@ -1,0 +1,22 @@
+Verify correct osql cleanup under rollbacks and clients not closing db connections.
+
+When a client calls rollback (or disconnects), we remove them from the osql hash
+immediately (or after connetion closes), so there should be no items in the hash
+after all clients have disconnected. Note that replicant sends osql schedule immediately
+to masternode without waiting for commit. This test only exercises newsql queries.
+
+NB: due to the high number of threads that dont close, the db will run out of appsock
+connections and client will see error:
+
+12:50:49> Error: cdb2_run_statement failed: -110 Exhausted appsock connections.
+
+server will have these errors:
+
+2020/11/26 12:54:29 [ERROR] 0x7feb4675e770 ctrl engine has wrong state 6 0 0x7feb46760700
+
+and proceed to cleanup:
+
+2020/11/26 12:54:29 osql_sess_rcvop: cancelled transaction
+
+In fact there are exacly as many calls to osql_sess_rcvop() to cleanup as there are calls
+to osql_repository_add() to add osql entry.

--- a/tests/osql_cleanup.test/lrl.options
+++ b/tests/osql_cleanup.test/lrl.options
@@ -1,0 +1,2 @@
+table t1 t1.csc2
+pagesizeix 1024

--- a/tests/osql_cleanup.test/runit
+++ b/tests/osql_cleanup.test/runit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+# Debug variable
+debug=0
+
+dbnm=$1
+
+if [ "x$dbnm" == "x" ] ; then
+    echo "need a DB name"
+    exit 1
+fi
+
+gen_series_test()
+{
+    MAX=9000
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table t2 (i int)"
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "insert into t2 select * from generate_series(1, $MAX) "
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select distinct i from t2" | sort -n > gen.out
+    seq 1 $MAX > gen.exp
+    if ! diff gen.out gen.exp ; then 
+        failexit 'genseries content not what it is expected'
+    fi
+}
+
+echo $CDB2_CONFIG
+THRDS=20
+CNT=10000
+ITERATIONS=5
+TRANSIZE=2
+time ${TESTSBUILDDIR}/insert_lots_mt --dbname $dbnm --numthreads $THRDS --cntperthread $CNT --iterations $ITERATIONS --transize $TRANSIZE --atcommit rollback > ins.out
+assertcnt t1 0
+
+master=`getmaster`
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} --host $master 'exec procedure sys.cmd.send("stat osql")' &> stat_osql.txt
+assertres `cat stat_osql.txt | wc -l` 5
+
+ITERATIONS=100
+
+time ${TESTSBUILDDIR}/insert_lots_mt --dbname $dbnm --numthreads $THRDS --cntperthread $CNT --iterations $ITERATIONS --transize $TRANSIZE --atcommit disconnect > ins.out
+assertcnt t1 0
+
+sleep 10
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} --host $master 'exec procedure sys.cmd.send("stat osql")' &> stat_osql.txt
+assertres `cat stat_osql.txt | wc -l` 5
+
+echo "Success"

--- a/tests/osql_cleanup.test/t1.csc2
+++ b/tests/osql_cleanup.test/t1.csc2
@@ -1,0 +1,11 @@
+schema
+{
+    short       i
+    int         j
+}
+
+keys 
+{
+    "PK"=i+j
+dup "j"=j
+}


### PR DESCRIPTION
Verify correct osql cleanup under rollbacks and clients disconnects
without closing db connections.
When a client calls rollback (or disconnects), we remove them from the osql hash
immediately (or after connetion closes), so there should be no items in the hash
after all clients have disconnected.

* Modified insert_lots to rollback or disconnect instead of commit.
* Fix dumpint of osql entries to include rqsuuid hash too
