### PR TITLE
Fix race with verify_status returned from bdb_verify_enqueue

### DIFF
--- a/bdb/bdb_verify.h
+++ b/bdb/bdb_verify.h
@@ -70,6 +70,6 @@ typedef struct td_processing_info {
     int8_t index;
 } td_processing_info_t;
 
-int bdb_verify_enqueue(td_processing_info_t *, thdpool *);
+void bdb_verify_enqueue(td_processing_info_t *, thdpool *);
 
 #endif

--- a/db/verify.c
+++ b/db/verify.c
@@ -359,12 +359,11 @@ int verify_table(const char *table, int progress_report_seconds,
     par.bdb_state = db->handle;
     par.db_table = db;
     td_processing_info_t info = {.common_params = &par};
-    if ((rc = bdb_verify_enqueue(&info, gbl_verify_thdpool)) != 0) {
-        goto done;
-    }
+    bdb_verify_enqueue(&info, gbl_verify_thdpool);
+
     while (par.threads_spawned > par.threads_completed) {
         if (!par.client_dropped_connection && par.peer_check(par.arg)){
-            logmsg(LOGMSG_WARN, "client connection closed, stopped verify\n");
+            logmsg(LOGMSG_WARN, "%s: client connection closed, stopped verify\n", __func__);
             par.client_dropped_connection = 1;
         }
         sleep(1);


### PR DESCRIPTION
Issue manifests itself in a crash because bdb_verify_enqueue returns
par->verify_status which may already be set to 1 (because one of the
threads that was started has found an issue), and returning such value
will cause the processing to bypass check for
`par.threads_spawned > par.threads_completed` and thus resultin in
verify_table() returning and the memory area par will now be invalid
and all the still processing thdpool threads to access such invalid
memory resulting in a crash.

Solution is to not return an rc from bdb_verify_enqueue -- error is
returned back via par->verify_status anyway -- and instead wait until
all thdpool threads are completed.