### PR TITLE
Use string_ref for logger sql stmt instead of strdup copy

### DIFF
--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -24,6 +24,7 @@ struct reqlogger;
 struct ireq;
 struct sqlclntstate;
 struct client_query_stats;
+struct string_ref;
 
 enum {
     REQL_INFO = 1,    /* info on the request being processed */
@@ -62,8 +63,8 @@ void reqlog_usetable(struct reqlogger *logger, const char *tablename);
 void reqlog_setflag(struct reqlogger *logger, unsigned flag);
 int reqlog_logl(struct reqlogger *logger, unsigned event_flag, const char *s);
 void reqlog_new_request(struct ireq *iq);
-void reqlog_new_sql_request(struct reqlogger *logger, char *sqlstmt);
-void reqlog_set_sql(struct reqlogger *logger, const char *sqlstmt);
+void reqlog_new_sql_request(struct reqlogger *logger, struct string_ref *sr);
+void reqlog_set_sql(struct reqlogger *logger, struct string_ref *sr);
 void reqlog_set_startprcs(struct reqlogger *logger, uint64_t start);
 uint64_t reqlog_current_us(struct reqlogger *logger);
 void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc, int line);

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -60,6 +60,7 @@ struct tablelist {
     char name[1];
 };
 
+
 struct reqlogger {
     char origin[128];
 
@@ -94,7 +95,7 @@ struct reqlogger {
     struct logevent *last_event;
 
     /* the sql statement */
-    char *stmt;
+    struct string_ref *sql_ref;
 
     /* the bound parameters */
     cson_value *bound_param_cson;

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -1225,7 +1225,7 @@ void get_one_explain_line(sqlite3 *hndl, strbuf *out, Vdbe *v, int indent,
 
 int newsql_dump_query_plan(struct sqlclntstate *clnt, sqlite3 *hndl)
 {
-    char *sql = clnt->sql;
+    const char *sql = clnt->sql;
     FILE *f = NULL;
 
     //if verbose explain get costs dumped to tmpfile by setting wheretrace

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -513,10 +513,56 @@ test_generate_series() {
     done
 }
 
+test_sp() {
+    cdb2sql --tabs -s ${CDB2_OPTIONS} $dbnm default > test_sp.out << 'EOF'
+create procedure test version 'sptest' {
+local function main(test_no, t)
+    db:exec(t)
+    db:column_type("string", 1);
+    db:emit("123")
+    return 0
+end}$$
+put default procedure test 'sptest'
+exec procedure test('select 1, 2')
+EOF
+
+    echo "sptest
+123" > test_sp.exp
+    if ! diff test_sp.out test_sp.exp ; then
+        failexit "unexpected testsp.out"
+    fi
+}
+
+test_trigger() {
+cdb2sql --tabs -s ${CDB2_OPTIONS} $dbnm default > test_trigger.out << 'EOF'
+create table t_orig (i int)$$
+create table t_trig (i int)$$
+create procedure ins_trig version 'instrig' {
+local function main(event)
+	local tt = db:table("t_trig")	
+	local tp = event.type
+	local inew, iold
+	if tp == 'add' then
+		inew = event.new.i
+	elseif tp == 'del' then
+		iold = event.old.i
+	end
+	return tt:insert({i=inew})
+end}$$
+create lua trigger ins_trig on (table t_orig for insert and update and delete)
+insert into t_orig values (1)
+EOF
+    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select * from t_orig"`
+    assertres $res 1
+    res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select * from t_trig"`
+    assertres $res 1
+}
 
 test_t1
 test_bulk
 test_generate_series
+test_sp
+test_trigger
 
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("sql hist")'
 


### PR DESCRIPTION
Convert strdup of sql string with a string reference in logger structure.
Add test cases to basic.test for stored procedure and trigger, the latter
calling into reflog without having created sql_ref yet.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>