### PR TITLE
Intern tablename and dont strdup it unnecessarily

### DIFF
--- a/bbinc/util.h
+++ b/bbinc/util.h
@@ -48,7 +48,7 @@ int rewrite_lrl_table(const char *lrlname, const char *tablename,
                       const char *csc2path);
 /* Create an external lrl file with the db's table defs */
 int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
-                          const char *p_lrl_fname_out, char *p_table_names[],
+                          const char *p_lrl_fname_out, const char *p_table_names[],
                           char *p_csc2_paths[], int table_nums[],
                           size_t num_tables, char *out_lrl_dir, int has_sp,
                           int has_timepartitions);

--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -348,7 +348,7 @@ int bdb_del_all_user_access(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user,
-                              char *table, int access_type, int *bdberr)
+                              const char *table, int access_type, int *bdberr)
 {
     return bdb_check_user_tbl_access_tran(bdb_state, NULL, user, table,
                                           access_type, bdberr);

--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -51,10 +51,10 @@ struct bdb_access_tag {
 };
 
 static int bdb_access_table_by_mach_get_disk(bdb_state_type *bdb_state,
-                                             tran_type *tran, char *table,
+                                             tran_type *tran, const char *table,
                                              int hostnum, int *bdberr);
 static int bdb_access_table_by_mach_put_disk(bdb_state_type *bdb_state,
-                                             tran_type *tran, char *table,
+                                             tran_type *tran, const char *table,
                                              int hostnum, int allow,
                                              int *bdberr);
 
@@ -88,7 +88,7 @@ void bdb_access_destroy(bdb_state_type *bdb_state)
 }
 
 static int bdb_access_tbl_by_mach_get_int(bdb_state_type *bdb_state,
-                                          tran_type *tran, char *table,
+                                          tran_type *tran, const char *table,
                                           int hostnum, int *bdberr)
 {
     bdb_access_t *access = bdb_state->access;
@@ -123,7 +123,7 @@ static int bdb_access_tbl_by_mach_get_int(bdb_state_type *bdb_state,
 }
 
 int bdb_access_tbl_read_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                    char *table, int hostnum, int *bdberr)
+                                    const char *table, int hostnum, int *bdberr)
 {
     int bits =
         bdb_access_tbl_by_mach_get_int(bdb_state, tran, table, hostnum, bdberr);
@@ -135,7 +135,7 @@ int bdb_access_tbl_read_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 int bdb_access_tbl_write_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                     char *table, int hostnum, int *bdberr)
+                                     const char *table, int hostnum, int *bdberr)
 {
     int bits =
         bdb_access_tbl_by_mach_get_int(bdb_state, tran, table, hostnum, bdberr);
@@ -147,7 +147,7 @@ int bdb_access_tbl_write_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 static int bdb_access_table_by_mach_get_disk(bdb_state_type *bdb_state,
-                                             tran_type *tran, char *table,
+                                             tran_type *tran, const char *table,
                                              int hostnum, int *bdberr)
 {
     char machname[MACHNAMELEN];
@@ -168,7 +168,7 @@ static int bdb_access_table_by_mach_get_disk(bdb_state_type *bdb_state,
 }
 
 static int bdb_access_table_by_mach_put_disk(bdb_state_type *bdb_state,
-                                             tran_type *tran, char *table,
+                                             tran_type *tran, const char *table,
                                              int hostnum, int allow,
                                              int *bdberr)
 {
@@ -237,7 +237,7 @@ extern int gbl_allow_user_schema;
 extern int gbl_uses_password;
 
 int bdb_check_user_tbl_access_tran(bdb_state_type *bdb_state, tran_type *tran,
-                                   char *user, char *table, int access_type,
+                                   char *user, const char *table, int access_type,
                                    int *bdberr)
 {
     int rc = 0;

--- a/bdb/bdb_access.h
+++ b/bdb/bdb_access.h
@@ -27,7 +27,7 @@ typedef struct bdb_access_tag bdb_access_t;
  *
  */
 int bdb_access_tbl_write_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                     char *table, int hostnum, int *bdberr);
+                                     const char *table, int hostnum, int *bdberr);
 
 /**
  * Returns 1 if the node "hostnum" is allowed to READ into table "table"
@@ -36,7 +36,7 @@ int bdb_access_tbl_write_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
  *
  */
 int bdb_access_tbl_read_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                    char *table, int hostnum, int *bdberr);
+                                    const char *table, int hostnum, int *bdberr);
 
 /**
  * Sets the right to write for (table, hostname)

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1416,7 +1416,7 @@ int bdb_get_checkpoint_time(bdb_state_type *bdb_state);
 int bdb_have_llmeta();
 int bdb_llmeta_open(char name[], char dir[], bdb_state_type *parent_bdb_handle,
                     int create_override, int *bdberr);
-int bdb_llmeta_set_tables(tran_type *input_trans, char **tblnames,
+int bdb_llmeta_set_tables(tran_type *input_trans, const char **tblnames,
                           const int *dbnums, int numdbs, int *bdberr);
 int bdb_llmeta_get_tables(tran_type *input_trans, char **tblnames, int *dbnums,
                           size_t maxnumtbls, int *fndnumtbls, int *bdberr);
@@ -1739,14 +1739,14 @@ enum {
 };
 
 int bdb_tbl_access_write_set(bdb_state_type *bdb_state, tran_type *input_trans,
-                             char *tblname, char *username, int *bdberr);
+                             const char *tblname, char *username, int *bdberr);
 int bdb_tbl_access_write_get(bdb_state_type *bdb_state, tran_type *input_trans,
-                             char *tblname, char *username, int *bdberr);
+                             const char *tblname, char *username, int *bdberr);
 
 int bdb_tbl_access_read_set(bdb_state_type *bdb_state, tran_type *input_trans,
-                            char *tblname, char *username, int *bdberr);
+                            const char *tblname, char *username, int *bdberr);
 int bdb_tbl_access_read_get(bdb_state_type *bdb_state, tran_type *input_trans,
-                            char *tblname, char *username, int *bdberr);
+                            const char *tblname, char *username, int *bdberr);
 
 int bdb_tbl_access_userschema_set(bdb_state_type *bdb_state,
                                   tran_type *input_trans, const char *schema,
@@ -1843,9 +1843,9 @@ int bdb_reset_csc2_version(tran_type *trans, const char *dbname, int ver);
 void bdb_set_skip(bdb_state_type *bdb_state, int node);
 unsigned long long get_id(bdb_state_type *bdb_state);
 int bdb_access_tbl_write_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                     char *table, int hostnum, int *bdberr);
+                                     const char *table, int hostnum, int *bdberr);
 int bdb_access_tbl_read_by_mach_get(bdb_state_type *bdb_state, tran_type *tran,
-                                    char *table, int hostnum, int *bdberr);
+                                    const char *table, int hostnum, int *bdberr);
 int bdb_flush_up_to_lsn(bdb_state_type *bdb_state, unsigned file,
                         unsigned offset);
 int bdb_set_parallel_recovery_threads(bdb_state_type *bdb_state, int nthreads);
@@ -2122,7 +2122,7 @@ void bdb_send_analysed_table_to_master(bdb_state_type *bdb_state, char *table);
 int bdb_llmeta_get_queues(char **queue_names, size_t max_queues,
                           int *fnd_queues, int *bdberr);
 /* get info for a queue */
-int bdb_llmeta_get_queue(tran_type *tran, char *qname, char **config,
+int bdb_llmeta_get_queue(tran_type *tran, const char *qname, char **config,
                          int *ndests, char ***dests, int *bdberr);
 
 /* manipulate queues */
@@ -2133,7 +2133,7 @@ int bdb_llmeta_alter_queue(bdb_state_type *bdb_state, tran_type *tran,
                            char *queue, char *config, int ndests, char **dests,
                            int *bdberr);
 int bdb_llmeta_drop_queue(bdb_state_type *bdb_state, tran_type *tran,
-                          char *queue, int *bdberr);
+                          const char *queue, int *bdberr);
 
 #include "bdb_queuedb.h"
 
@@ -2184,9 +2184,9 @@ int bdb_user_exists(tran_type *tran, char *user);
 int bdb_create_dba_user(bdb_state_type *bdb_state);
 
 int bdb_check_user_tbl_access(bdb_state_type *bdb_state, char *user,
-                              char *table, int access_type, int *bdberr);
+                              const char *table, int access_type, int *bdberr);
 int bdb_check_user_tbl_access_tran(bdb_state_type *bdb_state, tran_type *tran,
-                                   char *user, char *table, int access_type,
+                                   char *user, const char *table, int access_type,
                                    int *bdberr);
 int bdb_first_user_get(bdb_state_type *bdb_state, tran_type *tran,
                        char *key_out, char *user_out, int *isop, int *bdberr);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -1290,7 +1290,7 @@ int bdb_llmeta_set_tables(
                              * transaction for all actions, if it is NULL a
                              * new transaction will be
                              * created internally */
-    char **tblnames,        /* the table names to add */
+    const char **tblnames,  /* the table names to add */
     const int *dbnums,      /* the table's dbnums to add (or 0 if the table
                              * does not have a dbnum */
     int numdbs,             /* number of tables passed in */
@@ -5827,14 +5827,14 @@ backout:
 }
 
 int bdb_tbl_access_write_set(bdb_state_type *bdb_state, tran_type *input_trans,
-                             char *tblname, char *username, int *bdberr)
+                             const char *tblname, char *username, int *bdberr)
 {
     return bdb_tbl_access_set(bdb_state, input_trans, tblname, username,
                               ACCESS_WRITE, bdberr);
 }
 
 int bdb_tbl_access_read_set(bdb_state_type *bdb_state, tran_type *input_trans,
-                            char *tblname, char *username, int *bdberr)
+                            const char *tblname, char *username, int *bdberr)
 {
     return bdb_tbl_access_set(bdb_state, input_trans, tblname, username,
                               ACCESS_READ, bdberr);
@@ -6234,7 +6234,7 @@ int bdb_accesscontrol_tableXnode_get(bdb_state_type *bdb_state, tran_type *tran,
 }
 
 static int bdb_tbl_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
-                              char *tblname, char *username, int access_mode,
+                              const char *tblname, char *username, int access_mode,
                               int *bdberr)
 {
     uint8_t key[LLMETA_IXLEN] = {0};
@@ -6275,14 +6275,14 @@ static int bdb_tbl_access_get(bdb_state_type *bdb_state, tran_type *input_trans,
 }
 
 int bdb_tbl_access_write_get(bdb_state_type *bdb_state, tran_type *input_trans,
-                             char *tblname, char *username, int *bdberr)
+                             const char *tblname, char *username, int *bdberr)
 {
     return bdb_tbl_access_get(bdb_state, input_trans, tblname, username,
                               ACCESS_WRITE, bdberr);
 }
 
 int bdb_tbl_access_read_get(bdb_state_type *bdb_state, tran_type *input_trans,
-                            char *tblname, char *username, int *bdberr)
+                            const char *tblname, char *username, int *bdberr)
 {
     return bdb_tbl_access_get(bdb_state, input_trans, tblname, username,
                               ACCESS_READ, bdberr);
@@ -9105,7 +9105,7 @@ done:
 }
 
 int bdb_llmeta_drop_queue(bdb_state_type *bdb_state, tran_type *tran,
-                          char *queue, int *bdberr)
+                          const char *queue, int *bdberr)
 {
     char key[LLMETA_IXLEN] = {0};
     uint8_t *p_buf, *p_buf_end;
@@ -9177,7 +9177,7 @@ int bdb_llmeta_get_queues(char **queue_names, size_t max_queues,
     return rc;
 }
 
-int bdb_llmeta_get_queue(tran_type *trans, char *qname, char **config,
+int bdb_llmeta_get_queue(tran_type *trans, const char *qname, char **config,
                          int *ndests, char ***dests, int *bdberr)
 {
     struct queue_key qk = {0};

--- a/csc2/dynschemaload.h
+++ b/csc2/dynschemaload.h
@@ -34,8 +34,8 @@ enum dyns_cnst {
 char *dyns_field_option_text(int option);
 void dyns_init_globals();
 void dyns_cleanup_globals();
-int dyns_load_schema_string(char *schematxt, char *dbname, char *tablename);
-int dyns_load_schema(char *filename, char *dbname, char *tblname);
+int dyns_load_schema_string(char *schematxt, const char *dbname, const char *tablename);
+int dyns_load_schema(const char *filename, const char *dbname, const char *tblname);
 int dyns_form_key(int index, char *record, int recsz, char *key, int keysize);
 int dyns_is_idx_dup(int index);
 int dyns_is_idx_recnum(int index);

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -2410,8 +2410,7 @@ static int dyns_load_schema_int(const char *filename, char *schematxt, const cha
         ipos = 0;
         iusestr = 1;
     } else if (filename) {
-        const char *ifn = NULL;
-        ifn = filename;
+        const char *ifn = filename;
         if (ifn) {
             yyin = fopen(ifn, "r");
             if (yyin == NULL) {

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -2377,18 +2377,18 @@ int macc_ferror(FILE *fh)
  *  in order to initialize the global structure on which this and other dyns_
  *  functions rely.
  */
-static int dyns_load_schema_int(char *filename, char *schematxt, char *dbname,
-                                char *tablename)
+static int dyns_load_schema_int(const char *filename, char *schematxt, const char *dbname,
+                                const char *tablename)
 {
-    char *ifn = NULL;
     int fhopen = 0;
     extern FILE *yyin; /* lexer's input file           */
 
     char VER[16];
     strcpy(VER, revision + 10); /* get my version               */
-    ifn = strchr(VER, '$');     /* clean up version text        */
-    if (ifn)
-        *ifn = 0;
+    char *verp = NULL;
+    verp = strchr(VER, '$');     /* clean up version text        */
+    if (verp)
+        *verp = 0;
 
     macc_globals->flag_anyname = 1;
     if (strlen(dbname) >= MAX_DBNAME_LENGTH || strlen(dbname) < 3) {
@@ -2406,11 +2406,11 @@ static int dyns_load_schema_int(char *filename, char *schematxt, char *dbname,
 
     /* check args for an input filename or any options */
     if (schematxt) {
-        ifn = dbname;
         ischematext = schematxt;
         ipos = 0;
         iusestr = 1;
     } else if (filename) {
+        const char *ifn = NULL;
         ifn = filename;
         if (ifn) {
             yyin = fopen(ifn, "r");
@@ -2445,12 +2445,12 @@ static int dyns_load_schema_int(char *filename, char *schematxt, char *dbname,
     return 0;
 }
 
-int dyns_load_schema_string(char *schematxt, char *dbname, char *tablename)
+int dyns_load_schema_string(char *schematxt, const char *dbname, const char *tablename)
 {
     return dyns_load_schema_int(NULL, schematxt, dbname, tablename);
 }
 
-int dyns_load_schema(char *filename, char *dbname, char *tablename)
+int dyns_load_schema(const char *filename, const char *dbname, const char *tablename)
 {
     return dyns_load_schema_int(filename, NULL, dbname, tablename);
 }

--- a/db/analyze.h
+++ b/db/analyze.h
@@ -22,7 +22,7 @@
  * for the
  * table passed in as an argument.  Returns a 0 otherwise.
  */
-int analyze_is_sampled(struct sqlclntstate *client, char *table, int idx);
+int analyze_is_sampled(struct sqlclntstate *client, const char *table, int idx);
 
 /**
  * Allows the user to set the sampling (compression)-threshold for the analyze
@@ -43,7 +43,7 @@ long long analyze_get_sampling_threshold(void);
  * it
  * exists, or a NULL otherwise.
  */
-sampler_t *analyze_get_sampler(struct sqlclntstate *client, char *table,
+sampler_t *analyze_get_sampler(struct sqlclntstate *client, const char *table,
                                int idx);
 
 /**

--- a/db/analyze.h
+++ b/db/analyze.h
@@ -64,7 +64,7 @@ int64_t analyze_get_sampled_nrecs(const char *dbname, int ixnum);
 /**
  * Scale and analyze this table.  Write the results to sqlite_stat1.
  */
-int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
+int analyze_table(const char *table, SBUF2 *sb, int scale, int override_llmeta,
                   int bypass_auth);
 
 /**

--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -41,7 +41,7 @@ int gbl_debug_aa;
 
 /* reset autoanalyze counters to zero
  */
-void reset_aa_counter(char *tblname)
+void reset_aa_counter(const char *tblname)
 {
     int save_freq = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_AA_LLMETA_SAVE_FREQ);
     bdb_state_type *bdb_state = thedb->bdb_env;
@@ -90,9 +90,8 @@ static inline void loc_print_date(const time_t *timep)
  */
 void *auto_analyze_table(void *arg)
 {
-    char *tblname = (char *)arg;
+    const char *tblname = (const char *)arg;
     if (is_sqlite_stat(tblname)) {
-        free(tblname);
         return NULL;
     }
     int rc;
@@ -118,7 +117,6 @@ void *auto_analyze_table(void *arg)
 
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE_RDWR);
     sbuf2free(sb);
-    free(tblname);
     if (gbl_debug_aa) {
         ctrace("AUTOANALYZE: sleep for testing for %d seconds\n",
                bdb_attr_get(thedb->bdb_attr, BDB_ATTR_CHK_AA_TIME) + 1);
@@ -404,9 +402,8 @@ void *auto_analyze_main(void *unused)
                 auto_analyze_running = true; // will be reset by
                                              // auto_analyze_table()
                 pthread_t analyze;
-                // will be freed in auto_analyze_table()
-                char *tblname = strdup(tbl->tablename_ip);
-                pthread_create(&analyze, &gbl_pthread_attr_detached, auto_analyze_table, tblname);
+                pthread_create(&analyze, &gbl_pthread_attr_detached,
+                               auto_analyze_table, (void*) tbl->tablename_ip);
             }
         } else if (save_freq > 0 && (call_counter % save_freq) == 0) {
             // save updated autoanalyze counter if there is a delta

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5665,7 +5665,7 @@ int rename_db(dbtable *db, const char *newname)
 
     /* db */
     hash_del(thedb->db_hash, db);
-    db->tablename_ip = intern((char *)newname);
+    db->tablename_ip = intern(newname);
     hash_add(thedb->db_hash, db);
 
     Pthread_rwlock_unlock(&thedb_lock);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -971,7 +971,7 @@ void showdbenv(struct dbenv *dbenv)
         logmsg(LOGMSG_USER,
                "table '%s' comdbg compat dbnum %d\ndir '%s' lrlfile '%s' "
                "nconns %d  nrevconns %d\n",
-               usedb->tablename_ip, usedb->dbnum, dbenv->basedir,
+               usedb->tablename_interned, usedb->dbnum, dbenv->basedir,
                (usedb->lrlfname) ? usedb->lrlfname : "NULL",
                usedb->n_constraints, usedb->n_rev_constraints);
         logmsg(LOGMSG_ERROR, "   data reclen %-3d bytes\n", usedb->lrl);
@@ -1444,8 +1444,8 @@ static void free_sqlite_table(struct dbenv *dbenv)
 {
     for (int i = dbenv->num_dbs - 1; i >= 0; i--) {
         dbtable *p_tbl = dbenv->dbs[i];
-        delete_schema(p_tbl->tablename_ip); // tags hash
-        delete_db(p_tbl->tablename_ip);     // will free db
+        delete_schema(p_tbl->tablename_interned); // tags hash
+        delete_db(p_tbl->tablename_interned);     // will free db
         bdb_cleanup_fld_hints(p_tbl->handle);
         freedb(p_tbl);
     }
@@ -1606,7 +1606,7 @@ dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
     dbtable *tbl;
 
     tbl = calloc(1, sizeof(dbtable));
-    tbl->tablename_ip = intern(name);
+    tbl->tablename_interned = intern(name);
     tbl->dbenv = env;
     tbl->dbtype = isqueuedb ? DBTYPE_QUEUEDB : DBTYPE_QUEUE;
     tbl->avgitemsz = avgsz;
@@ -1625,8 +1625,8 @@ void cleanup_newdb(dbtable *tbl)
     if (!tbl)
         return;
 
-    if (tbl->tablename_ip) {
-        tbl->tablename_ip = NULL;
+    if (tbl->tablename_interned) {
+        tbl->tablename_interned = NULL;
     }
 
     if (tbl->lrlfname) {
@@ -1676,7 +1676,7 @@ dbtable *newdb_from_schema(struct dbenv *env, const char *tblname, char *fname,
     tbl->dbtype = DBTYPE_TAGGED_TABLE;
     if (fname)
         tbl->lrlfname = strdup(fname);
-    tbl->tablename_ip = intern(tblname);
+    tbl->tablename_interned = intern(tblname);
     tbl->dbenv = env;
     tbl->dbnum = dbnum;
     tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
@@ -1844,7 +1844,7 @@ int init_check_constraints(dbtable *tbl)
 
         strbuf_clear(sql);
 
-        strbuf_appendf(sql, "WITH \"%s\" (\"%s\"", tbl->tablename_ip,
+        strbuf_appendf(sql, "WITH \"%s\" (\"%s\"", tbl->tablename_interned,
                        tbl->schema->member[0].name);
         for (int j = 1; j < tbl->schema->nmembers; ++j) {
             strbuf_appendf(sql, ", %s", tbl->schema->member[j].name);
@@ -1854,7 +1854,7 @@ int init_check_constraints(dbtable *tbl)
             strbuf_appendf(sql, ", @%s", tbl->schema->member[j].name);
         }
         strbuf_appendf(sql, ") SELECT (%s) FROM \"%s\"",
-                       tbl->check_constraints[i].expr, tbl->tablename_ip);
+                       tbl->check_constraints[i].expr, tbl->tablename_interned);
         tbl->check_constraint_query[i] = strdup(strbuf_buf(sql));
         if (tbl->check_constraint_query[i] == NULL) {
             logmsg(LOGMSG_ERROR, "%s:%d failed to allocate memory\n", __func__,
@@ -2032,7 +2032,7 @@ int llmeta_load_tables_older_versions(struct dbenv *dbenv, void *tran)
             /* load schema for older versions */
             for (int v = 1; v <= ver; ++v) {
                 char *csc2text;
-                if (get_csc2_file_tran(tbl->tablename_ip, v, &csc2text, NULL,
+                if (get_csc2_file_tran(tbl->tablename_interned, v, &csc2text, NULL,
                                        tran)) {
                     logmsg(LOGMSG_ERROR, "get_csc2_file failed %s:%d\n", __FILE__,
                             __LINE__);
@@ -2048,7 +2048,7 @@ int llmeta_load_tables_older_versions(struct dbenv *dbenv, void *tran)
                     goto cleanup;
                 }
 
-                add_tag_schema(tbl->tablename_ip, s);
+                add_tag_schema(tbl->tablename_interned, s);
                 free(csc2text);
             }
         }
@@ -2214,7 +2214,7 @@ static int llmeta_load_tables(struct dbenv *dbenv, char *dbname, void *tran)
         logmsg(LOGMSG_INFO, "%s initializing static table '%s'\n", __func__,
                COMDB2_STATIC_TABLE);
         dbenv->static_table.dbs_idx = -1;
-        dbenv->static_table.tablename_ip = COMDB2_STATIC_TABLE;
+        dbenv->static_table.tablename_interned = COMDB2_STATIC_TABLE;
         dbenv->static_table.dbenv = dbenv;
         dbenv->static_table.dbtype = DBTYPE_TAGGED_TABLE;
         dbenv->static_table.handle = dbenv->bdb_env;
@@ -2297,7 +2297,7 @@ static int llmeta_load_tables(struct dbenv *dbenv, char *dbname, void *tran)
             logmsg(LOGMSG_ERROR,
                    "Failed to load schema: can't process schema file "
                    "%s\n",
-                   tbl->tablename_ip);
+                   tbl->tablename_interned);
             ++i; /* this tblname has already been marshalled so we dont want to
                   * free it below */
             rc = 1;
@@ -2308,7 +2308,7 @@ static int llmeta_load_tables(struct dbenv *dbenv, char *dbname, void *tran)
         rc = init_check_constraints(tbl);
         if (rc) {
             logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-                   tbl->tablename_ip);
+                   tbl->tablename_interned);
             ++i;
             rc = 1;
             break;
@@ -2351,7 +2351,7 @@ int llmeta_set_tables(tran_type *tran, struct dbenv *dbenv)
 
     /* gather all the table names and tbl numbers */
     for (i = 0; i < dbenv->num_dbs; ++i) {
-        tblnames[i] = dbenv->dbs[i]->tablename_ip;
+        tblnames[i] = dbenv->dbs[i]->tablename_interned;
         dbnums[i] = dbenv->dbs[i]->dbnum;
     }
 
@@ -2441,14 +2441,14 @@ int llmeta_dump_mapping_tran(void *tran, struct dbenv *dbenv)
             bdberr != BDBERR_NOERROR) {
             logmsg(LOGMSG_ERROR, "llmeta_dump_mapping: failed to fetch version "
                                  "number for %s's main data files\n",
-                   dbenv->dbs[i]->tablename_ip);
+                   dbenv->dbs[i]->tablename_interned);
             rc = -1;
             goto done;
         }
 
         sbuf2printf(sbfile,
                     "table %s %d\n\tdata files: %016" PRIx64 "\n\tblob files\n",
-                    dbenv->dbs[i]->tablename_ip, dbenv->dbs[i]->lrl,
+                    dbenv->dbs[i]->tablename_interned, dbenv->dbs[i]->lrl,
                     flibc_htonll(version_num));
 
         /* print the indicies' version numbers */
@@ -2460,7 +2460,7 @@ int llmeta_dump_mapping_tran(void *tran, struct dbenv *dbenv)
                 logmsg(LOGMSG_ERROR,
                        "llmeta_dump_mapping: failed to fetch version "
                        "number for %s's blob num %d's files\n",
-                       dbenv->dbs[i]->tablename_ip, j);
+                       dbenv->dbs[i]->tablename_interned, j);
                 rc = -1;
                 goto done;
             }
@@ -2479,7 +2479,7 @@ int llmeta_dump_mapping_tran(void *tran, struct dbenv *dbenv)
                 logmsg(LOGMSG_ERROR,
                        "llmeta_dump_mapping: failed to fetch version "
                        "number for %s's index num %d\n",
-                       dbenv->dbs[i]->tablename_ip, j);
+                       dbenv->dbs[i]->tablename_interned, j);
                 rc = -1;
                 goto done;
             }
@@ -2519,21 +2519,21 @@ int llmeta_dump_mapping_table_tran(void *tran, struct dbenv *dbenv,
         if (err)
             logmsg(LOGMSG_ERROR, "llmeta_dump_mapping: failed to fetch version "
                                  "number for %s's main data files\n",
-                   p_tbl->tablename_ip);
+                   p_tbl->tablename_interned);
         else
             ctrace("llmeta_dump_mapping: failed to fetch version number for "
                    "%s's main data files\n",
-                   p_tbl->tablename_ip);
+                   p_tbl->tablename_interned);
         return -1;
     }
 
     if (err)
         logmsg(LOGMSG_INFO,
                "table %s\n\tdata files: %016" PRIx64 "\n\tblob files\n",
-               p_tbl->tablename_ip, flibc_htonll(version_num));
+               p_tbl->tablename_interned, flibc_htonll(version_num));
     else
         ctrace("table %s\n\tdata files: %016" PRIx64 "\n\tblob files\n",
-               p_tbl->tablename_ip, flibc_htonll(version_num));
+               p_tbl->tablename_interned, flibc_htonll(version_num));
 
     /* print the blobs' version numbers */
     for (i = 1; i <= p_tbl->numblobs; ++i) {
@@ -2544,11 +2544,11 @@ int llmeta_dump_mapping_table_tran(void *tran, struct dbenv *dbenv,
                 logmsg(LOGMSG_ERROR,
                        "llmeta_dump_mapping: failed to fetch version "
                        "number for %s's blob num %d's files\n",
-                       p_tbl->tablename_ip, i);
+                       p_tbl->tablename_interned, i);
             else
                 ctrace("llmeta_dump_mapping: failed to fetch version number "
                        "for %s's blob num %d's files\n",
-                       p_tbl->tablename_ip, i);
+                       p_tbl->tablename_interned, i);
             return -1;
         }
         if (err)
@@ -2569,11 +2569,11 @@ int llmeta_dump_mapping_table_tran(void *tran, struct dbenv *dbenv,
                 logmsg(LOGMSG_ERROR,
                        "llmeta_dump_mapping: failed to fetch version "
                        "number for %s's index num %d\n",
-                       p_tbl->tablename_ip, i);
+                       p_tbl->tablename_interned, i);
             else
                 ctrace("llmeta_dump_mapping: failed to fetch version number "
                        "for %s's index num %d\n",
-                       p_tbl->tablename_ip, i);
+                       p_tbl->tablename_interned, i);
             return -1;
         }
 
@@ -2630,10 +2630,10 @@ struct dbenv *newdbenv(char *dbname, char *lrlname)
     /* Initialize the table/queue hashes. */
     dbenv->db_hash =
         hash_init_user((hashfunc_t *)strhashfunc, (cmpfunc_t *)strcmpfunc,
-                       offsetof(dbtable, tablename_ip), 0);
+                       offsetof(dbtable, tablename_interned), 0);
     dbenv->qdb_hash =
         hash_init_user((hashfunc_t *)strhashfunc, (cmpfunc_t *)strcmpfunc,
-                       offsetof(dbtable, tablename_ip), 0);
+                       offsetof(dbtable, tablename_interned), 0);
 
     dbenv->view_hash =
         hash_init_user((hashfunc_t *)strhashfunc, (cmpfunc_t *)strcmpfunc,
@@ -2734,18 +2734,18 @@ static int db_finalize_and_sanity_checks(struct dbenv *dbenv)
 
         for (jj = 0; jj < dbenv->num_dbs; jj++) {
             if (jj != ii) {
-                if (strcasecmp(dbenv->dbs[ii]->tablename_ip,
-                               dbenv->dbs[jj]->tablename_ip) == 0) {
+                if (strcasecmp(dbenv->dbs[ii]->tablename_interned,
+                               dbenv->dbs[jj]->tablename_interned) == 0) {
                     have_bad_schema = 1;
                     logmsg(LOGMSG_FATAL,
                            "Two tables have identical names (%s) tblnums %d "
                            "%d\n",
-                           dbenv->dbs[ii]->tablename_ip, ii, jj);
+                           dbenv->dbs[ii]->tablename_interned, ii, jj);
                 }
             }
         }
 
-        if ((strcasecmp(dbenv->dbs[ii]->tablename_ip, dbenv->envname) == 0) &&
+        if ((strcasecmp(dbenv->dbs[ii]->tablename_interned, dbenv->envname) == 0) &&
             (dbenv->dbs[ii]->dbnum != 0) &&
             (dbenv->dbnum != dbenv->dbs[ii]->dbnum)) {
 
@@ -2757,7 +2757,7 @@ static int db_finalize_and_sanity_checks(struct dbenv *dbenv)
         if (dbenv->dbs[ii]->nix > MAXINDEX) {
             have_bad_schema = 1;
             logmsg(LOGMSG_FATAL, "Database %s has too many indexes (%d)\n",
-                   dbenv->dbs[ii]->tablename_ip, dbenv->dbs[ii]->nix);
+                   dbenv->dbs[ii]->tablename_interned, dbenv->dbs[ii]->nix);
         }
 
         /* last ditch effort to stop invalid schemas getting through */
@@ -2765,7 +2765,7 @@ static int db_finalize_and_sanity_checks(struct dbenv *dbenv)
             if (dbenv->dbs[ii]->ix_keylen[jj] > MAXKEYLEN) {
                 have_bad_schema = 1;
                 logmsg(LOGMSG_FATAL, "Database %s index %d too large (%d)\n",
-                       dbenv->dbs[ii]->tablename_ip, jj,
+                       dbenv->dbs[ii]->tablename_interned, jj,
                        dbenv->dbs[ii]->ix_keylen[jj]);
             }
 
@@ -2785,13 +2785,13 @@ static int dump_queuedbs(char *dir)
         int ndests;
         char **dests;
         int bdberr;
-        const char *name = thedb->qdbs[i]->tablename_ip;
+        const char *name = thedb->qdbs[i]->tablename_interned;
         int rc;
         rc =
             bdb_llmeta_get_queue(NULL, name, &config, &ndests, &dests, &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "Can't get data for %s: bdberr %d\n",
-                   thedb->qdbs[i]->tablename_ip, bdberr);
+                   thedb->qdbs[i]->tablename_interned, bdberr);
             return -1;
         }
         char path[PATH_MAX];
@@ -2802,14 +2802,14 @@ static int dump_queuedbs(char *dir)
                     strerror(errno));
             return -1;
         }
-        fprintf(f, "%s\n%d\n", thedb->qdbs[i]->tablename_ip, ndests);
+        fprintf(f, "%s\n%d\n", thedb->qdbs[i]->tablename_interned, ndests);
         for (int j = 0; j < ndests; ++j) {
             fprintf(f, "%s\n", dests[j]);
         }
         fprintf(f, "%s", config);
         fclose(f);
         logmsg(LOGMSG_INFO, "%s wrote file:%s for queuedb:%s\n", __func__, path,
-               thedb->qdbs[i]->tablename_ip);
+               thedb->qdbs[i]->tablename_interned);
         free(config);
         for (int j = 0; j < ndests; ++j)
             free(dests[j]);
@@ -2891,7 +2891,7 @@ int repopulate_lrl(const char *p_lrl_fname_out)
                            p_data->csc2_paths[i],
                            sizeof(p_data->csc2_paths[i]))) {
             logmsg(LOGMSG_ERROR, "%s: get_csc2_fname failed for: %s\n",
-                   __func__, thedb->dbs[i]->tablename_ip);
+                   __func__, thedb->dbs[i]->tablename_interned);
 
             free(p_data);
             return -1;
@@ -2903,13 +2903,13 @@ int repopulate_lrl(const char *p_lrl_fname_out)
             logmsg(LOGMSG_ERROR,
                    "%s: dump_table_csc2_to_disk_fname failed for: "
                    "%s\n",
-                   __func__, thedb->dbs[i]->tablename_ip);
+                   __func__, thedb->dbs[i]->tablename_interned);
 
             free(p_data);
             return -1;
         }
 
-        p_data->p_table_names[i] = thedb->dbs[i]->tablename_ip;
+        p_data->p_table_names[i] = thedb->dbs[i]->tablename_interned;
         p_data->p_csc2_paths[i] = p_data->csc2_paths[i];
         p_data->table_nums[i] = thedb->dbs[i]->dbnum;
     }
@@ -4357,7 +4357,7 @@ static inline void log_tbl_item(int curr, unsigned int *prev, const char *(*type
     if (diff > 0) {
         if (*hdr_p == 0) {
             const char hdr_fmt[] = "DIFF REQUEST STATS FOR TABLE '%s'\n";
-            reqlog_logf(statlogger, REQL_INFO, hdr_fmt, tbl->tablename_ip);
+            reqlog_logf(statlogger, REQL_INFO, hdr_fmt, tbl->tablename_interned);
             *hdr_p = 1;
         }
         reqlog_logf(statlogger, REQL_INFO, "%s%-22s %u\n", (first ? "" : "    "),
@@ -5336,7 +5336,7 @@ void create_marker_file()
     for (int ii = 0; ii < thedb->num_dbs; ii++) {
         if (thedb->dbs[ii]->dbnum) {
             marker_file =
-                comdb2_location("marker", "%s.trap", thedb->dbs[ii]->tablename_ip);
+                comdb2_location("marker", "%s.trap", thedb->dbs[ii]->tablename_interned);
             tmpfd = creat(marker_file, 0666);
             free(marker_file);
             if (tmpfd != -1) close(tmpfd);
@@ -5658,14 +5658,14 @@ int rename_db(dbtable *db, const char *newname)
     Pthread_rwlock_wrlock(&thedb_lock);
 
     /* tags */
-    rename_schema(db->tablename_ip, tag_name);
+    rename_schema(db->tablename_interned, tag_name);
 
     /* bdb_state */
     bdb_state_rename(db->handle, bdb_name);
 
     /* db */
     hash_del(thedb->db_hash, db);
-    db->tablename_ip = intern(newname);
+    db->tablename_interned = intern(newname);
     hash_add(thedb->db_hash, db);
 
     Pthread_rwlock_unlock(&thedb_lock);
@@ -5678,7 +5678,7 @@ void replace_db_idx(dbtable *p_tbl, int idx)
     Pthread_rwlock_wrlock(&thedb_lock);
 
     if (idx < 0 || idx >= thedb->num_dbs ||
-        strcasecmp(thedb->dbs[idx]->tablename_ip, p_tbl->tablename_ip) != 0) {
+        strcasecmp(thedb->dbs[idx]->tablename_interned, p_tbl->tablename_interned) != 0) {
         thedb->dbs =
             realloc(thedb->dbs, (thedb->num_dbs + 1) * sizeof(dbtable *));
         if (idx < 0 || idx >= thedb->num_dbs) idx = thedb->num_dbs;
@@ -5783,14 +5783,14 @@ static int put_all_csc2()
             
             if (thedb->dbs[ii]->lrlfname)
                 rc = load_new_table_schema_file(
-                    thedb, thedb->dbs[ii]->tablename_ip, thedb->dbs[ii]->lrlfname);
+                    thedb, thedb->dbs[ii]->tablename_interned, thedb->dbs[ii]->lrlfname);
             else
                 rc = load_new_table_schema_tran(thedb, NULL,
-                                                thedb->dbs[ii]->tablename_ip,
+                                                thedb->dbs[ii]->tablename_interned,
                                                 thedb->dbs[ii]->csc2_schema);
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR, "error storing schema for table '%s'\n",
-                       thedb->dbs[ii]->tablename_ip);
+                       thedb->dbs[ii]->tablename_interned);
                 return -1;
             }
         }
@@ -5813,7 +5813,7 @@ int check_current_schemas(void)
         for (ii = 0; ii < thedb->num_dbs; ii++) {
             if (thedb->dbs[ii]->dbtype == DBTYPE_TAGGED_TABLE) {
                 int rc;
-                rc = check_table_schema(thedb, thedb->dbs[ii]->tablename_ip,
+                rc = check_table_schema(thedb, thedb->dbs[ii]->tablename_interned,
                                         thedb->dbs[ii]->lrlfname);
                 if (rc != 0)
                     schema_errors++;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2336,9 +2336,9 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
 void stop_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
 void replace_db_idx(struct dbtable *p_db, int idx);
-int add_db(dbtable *db);
+int add_db(struct dbtable *db);
 void delete_db(const char *db_name);
-int rename_db(dbtable *db, const char *newname);
+int rename_db(struct dbtable *db, const char *newname);
 int ix_find_rnum_by_recnum(struct ireq *iq, int recnum_in, int ixnum,
                            void *fndkey, int *fndrrn, unsigned long long *genid,
                            void *fnddta, int *fndlen, int *recnum, int maxlen);
@@ -2382,7 +2382,7 @@ int get_db_instant_schema_change_tran(struct dbtable *, int *isc, tran_type *tra
 
 int set_meta_odh_flags(struct dbtable *db, int odh, int compress, int compress_blobs,
                        int ipupates);
-int set_meta_odh_flags_tran(dbtable *db, tran_type *tran, int odh,
+int set_meta_odh_flags_tran(struct dbtable *db, tran_type *tran, int odh,
                             int compress, int compress_blobs, int ipupdates);
 
 int get_csc2_version(const char *table);
@@ -2391,10 +2391,10 @@ int get_csc2_file(const char *table, int version, char **text, int *len);
 int get_csc2_file_tran(const char *table, int version, char **text, int *len,
                        tran_type *);
 int put_csc2_file(const char *table, void *tran, int version, const char *text);
-int put_csc2_stuff(dbtable *db, void *trans, void *stuff, size_t lenstuff);
-int put_blobstripe_genid(dbtable *db, void *tran, unsigned long long genid);
-int get_blobstripe_genid(dbtable *db, unsigned long long *genid);
-int get_blobstripe_genid_tran(dbtable *db, unsigned long long *genid,
+int put_csc2_stuff(struct dbtable *db, void *trans, void *stuff, size_t lenstuff);
+int put_blobstripe_genid(struct dbtable *db, void *tran, unsigned long long genid);
+int get_blobstripe_genid(struct dbtable *db, unsigned long long *genid);
+int get_blobstripe_genid_tran(struct dbtable *db, unsigned long long *genid,
                               tran_type *tran);
 
 int load_new_table_schema_file(struct dbenv *dbenv, const char *table,
@@ -2407,11 +2407,11 @@ int load_new_table_schema(struct dbenv *dbenv, const char *table,
                           const char *csc2_text);
 void fix_blobstripe_genids(tran_type *tran);
 int dump_all_csc2_to_disk();
-int dump_table_csc2_to_disk_fname(dbtable *db, const char *csc2_fname);
+int dump_table_csc2_to_disk_fname(struct dbtable *db, const char *csc2_fname);
 int dump_table_csc2_to_disk(const char *table);
-int get_csc2_fname(const dbtable *db, const char *dir, char *fname,
+int get_csc2_fname(const struct dbtable *db, const char *dir, char *fname,
                    size_t fname_len);
-int get_generic_csc2_fname(const dbtable *db, char *fname, size_t fname_len);
+int get_generic_csc2_fname(const struct dbtable *db, char *fname, size_t fname_len);
 
 void flush_db(void);
 void dump_cache(const char *file, int max_pages);
@@ -2419,16 +2419,16 @@ void load_cache(const char *file);
 void load_cache_default(void);
 void dump_cache_default(void);
 int compare_all_tags(const char *table, FILE *out);
-int restore_constraint_pointers(dbtable *db, dbtable *newdb);
-int backout_constraint_pointers(dbtable *db, dbtable *newdb);
-int populate_reverse_constraints(dbtable *db);
-int has_index_changed(dbtable *db, char *keynm, int ct_check, int newkey,
+int restore_constraint_pointers(struct dbtable *db, struct dbtable *newdb);
+int backout_constraint_pointers(struct dbtable *db, struct dbtable *newdb);
+int populate_reverse_constraints(struct dbtable *db);
+int has_index_changed(struct dbtable *db, char *keynm, int ct_check, int newkey,
                       FILE *out, int accept_type_change);
 int resume_schema_change(void);
 
 void debug_trap(char *line, int lline);
-int count_db(dbtable *db);
-int compact_db(dbtable *db, int timeout, int freefs);
+int count_db(struct dbtable *db);
+int compact_db(struct dbtable *db, int timeout, int freefs);
 int ix_find_last_dup_rnum_kl(struct ireq *iq, int ixnum, void *key, int keylen,
                              void *fndkey, int *fndrrn,
                              unsigned long long *genid, void *fnddta,
@@ -2447,7 +2447,7 @@ int ix_next_rnum_kl(struct ireq *iq, int ixnum, void *key, int keylen,
 int ix_find_rnum(struct ireq *iq, int ixnum, void *key, int keylen,
                  void *fndkey, int *fndrrn, unsigned long long *genid,
                  void *fnddta, int *fndlen, int *recnum, int maxlen);
-void purgerrns(dbtable *db);
+void purgerrns(struct dbtable *db);
 
 /* broadcast messages to other nodes */
 int send_to_all_nodes(void *dta, int len, int type, int waittime);
@@ -2534,14 +2534,14 @@ master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
 void cleanup_sqlite_master();
 void create_sqlite_master();
 int destroy_sqlite_master(master_entry_t *, int);
-int sql_syntax_check(struct ireq *iq, dbtable *db);
+int sql_syntax_check(struct ireq *iq, struct dbtable *db);
 void sql_dump_running_statements(void);
 char *stradd(char **s1, char *s2, int freeit);
 void dbgtrace(int, char *, ...);
 
 int get_sqlite_entry_size(struct sql_thread *thd, int n);
 void *get_sqlite_entry(struct sql_thread *thd, int n);
-dbtable *get_sqlite_db(struct sql_thread *thd, int iTable, int *ixnum);
+struct dbtable *get_sqlite_db(struct sql_thread *thd, int iTable, int *ixnum);
 
 int schema_var_size(struct schema *sc);
 int handle_ireq(struct ireq *iq);
@@ -2590,8 +2590,8 @@ void purge_old_cached_blobs(void);
 void commit_schemas(const char *tblname);
 struct schema *new_dynamic_schema(const char *s, int len, int trace);
 void free_dynamic_schema(const char *table, struct schema *dsc);
-int getdefaultkeysize(const dbtable *tbl, int ixnum);
-int getdefaultdatsize(const dbtable *tbl);
+int getdefaultkeysize(const struct dbtable *tbl, int ixnum);
+int getdefaultdatsize(const struct dbtable *tbl);
 int update_sqlite_stats(struct ireq *iq, void *trans, void *dta);
 void *do_verify(void *);
 void dump_tagged_buf(const char *table, const char *tag,
@@ -2604,8 +2604,8 @@ int ix_find_by_rrn_and_genid_get_curgenid(struct ireq *iq, int rrn,
 int ix_find_last_dup_rnum(struct ireq *iq, int ixnum, void *key, int keylen,
                           void *fndkey, int *fndrrn, unsigned long long *genid,
                           void *fnddta, int *fndlen, int *recnum, int maxlen);
-void dump_record_by_rrn_genid(dbtable *db, int rrn, unsigned long long genid);
-void upgrade_record_by_genid(dbtable *db, unsigned long long genid);
+void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long genid);
+void upgrade_record_by_genid(struct dbtable *db, unsigned long long genid);
 void backend_thread_event(struct dbenv *dbenv, int event);
 void backend_cmd(struct dbenv *dbenv, char *line, int lline, int st);
 uint64_t calc_table_size(struct dbtable *db, int skip_blobs);
@@ -2613,8 +2613,8 @@ uint64_t calc_table_size_tran(tran_type *tran, struct dbtable *db, int skip_blob
 
 enum { WHOLE_BUFFER = -1 };
 
-void diagnostics_dump_rrn(dbtable *tbl, int rrn);
-void diagnostics_dump_dta(dbtable *db, int dtanum);
+void diagnostics_dump_rrn(struct dbtable *tbl, int rrn);
+void diagnostics_dump_dta(struct dbtable *db, int dtanum);
 
 /* queue stuff */
 void dbqueuedb_coalesce(struct dbenv *dbenv);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -601,7 +601,7 @@ void consumer_unlock_int(struct dbtable *db, const char *func, int line);
 typedef struct dbtable {
     struct dbenv *dbenv; /*chain back to my environment*/
     char *lrlfname;
-    char *tablename;
+    const char *tablename_ip; /* intern pointer to tablename */
     struct ireq *iq; /* iq used at sc time */
 
     int dbnum; /* zero unless setup as comdbg table */
@@ -2318,8 +2318,8 @@ int check_table_schema(struct dbenv *dbenv, const char *table,
                        const char *csc2file);
 
 struct dbtable *find_table(const char *table);
-int bt_hash_table(char *table, int szkb);
-int del_bt_hash_table(char *table);
+int bt_hash_table(const char *table, int szkb);
+int del_bt_hash_table(const char *table);
 int stat_bt_hash_table(char *table);
 int stat_bt_hash_table_reset(char *table);
 int fastinit_table(struct dbenv *dbenvin, char *table);
@@ -2327,7 +2327,7 @@ int add_cmacc_stmt(struct dbtable *db, int alt);
 int add_cmacc_stmt_no_side_effects(struct dbtable *db, int alt);
 
 void cleanup_newdb(struct dbtable *);
-struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
+struct dbtable *newdb_from_schema(struct dbenv *env, const char *tblname, char *fname,
                              int dbnum, int dbix, int is_foreign);
 struct dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
                   int isqueuedb);
@@ -2337,7 +2337,7 @@ void stop_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
 void replace_db_idx(struct dbtable *p_db, int idx);
 int add_db(struct dbtable *db);
-void delete_db(char *db_name);
+void delete_db(const char *db_name);
 int rename_db(struct dbtable *db, const char *newname);
 int ix_find_rnum_by_recnum(struct ireq *iq, int recnum_in, int ixnum,
                            void *fndkey, int *fndrrn, unsigned long long *genid,

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -601,7 +601,7 @@ void consumer_unlock_int(struct dbtable *db, const char *func, int line);
 typedef struct dbtable {
     struct dbenv *dbenv; /*chain back to my environment*/
     char *lrlfname;
-    const char *tablename_ip; /* intern pointer to tablename */
+    const char *tablename_interned; /* intern pointer to tablename */
     struct ireq *iq; /* iq used at sc time */
 
     int dbnum; /* zero unless setup as comdbg table */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2336,9 +2336,9 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
 void stop_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
 void replace_db_idx(struct dbtable *p_db, int idx);
-int add_db(struct dbtable *db);
+int add_db(dbtable *db);
 void delete_db(const char *db_name);
-int rename_db(struct dbtable *db, const char *newname);
+int rename_db(dbtable *db, const char *newname);
 int ix_find_rnum_by_recnum(struct ireq *iq, int recnum_in, int ixnum,
                            void *fndkey, int *fndrrn, unsigned long long *genid,
                            void *fnddta, int *fndlen, int *recnum, int maxlen);
@@ -2382,7 +2382,7 @@ int get_db_instant_schema_change_tran(struct dbtable *, int *isc, tran_type *tra
 
 int set_meta_odh_flags(struct dbtable *db, int odh, int compress, int compress_blobs,
                        int ipupates);
-int set_meta_odh_flags_tran(struct dbtable *db, tran_type *tran, int odh,
+int set_meta_odh_flags_tran(dbtable *db, tran_type *tran, int odh,
                             int compress, int compress_blobs, int ipupdates);
 
 int get_csc2_version(const char *table);
@@ -2391,10 +2391,10 @@ int get_csc2_file(const char *table, int version, char **text, int *len);
 int get_csc2_file_tran(const char *table, int version, char **text, int *len,
                        tran_type *);
 int put_csc2_file(const char *table, void *tran, int version, const char *text);
-int put_csc2_stuff(struct dbtable *db, void *trans, void *stuff, size_t lenstuff);
-int put_blobstripe_genid(struct dbtable *db, void *tran, unsigned long long genid);
-int get_blobstripe_genid(struct dbtable *db, unsigned long long *genid);
-int get_blobstripe_genid_tran(struct dbtable *db, unsigned long long *genid,
+int put_csc2_stuff(dbtable *db, void *trans, void *stuff, size_t lenstuff);
+int put_blobstripe_genid(dbtable *db, void *tran, unsigned long long genid);
+int get_blobstripe_genid(dbtable *db, unsigned long long *genid);
+int get_blobstripe_genid_tran(dbtable *db, unsigned long long *genid,
                               tran_type *tran);
 
 int load_new_table_schema_file(struct dbenv *dbenv, const char *table,
@@ -2407,11 +2407,11 @@ int load_new_table_schema(struct dbenv *dbenv, const char *table,
                           const char *csc2_text);
 void fix_blobstripe_genids(tran_type *tran);
 int dump_all_csc2_to_disk();
-int dump_table_csc2_to_disk_fname(struct dbtable *db, const char *csc2_fname);
+int dump_table_csc2_to_disk_fname(dbtable *db, const char *csc2_fname);
 int dump_table_csc2_to_disk(const char *table);
-int get_csc2_fname(const struct dbtable *db, const char *dir, char *fname,
+int get_csc2_fname(const dbtable *db, const char *dir, char *fname,
                    size_t fname_len);
-int get_generic_csc2_fname(const struct dbtable *db, char *fname, size_t fname_len);
+int get_generic_csc2_fname(const dbtable *db, char *fname, size_t fname_len);
 
 void flush_db(void);
 void dump_cache(const char *file, int max_pages);
@@ -2419,16 +2419,16 @@ void load_cache(const char *file);
 void load_cache_default(void);
 void dump_cache_default(void);
 int compare_all_tags(const char *table, FILE *out);
-int restore_constraint_pointers(struct dbtable *db, struct dbtable *newdb);
-int backout_constraint_pointers(struct dbtable *db, struct dbtable *newdb);
-int populate_reverse_constraints(struct dbtable *db);
-int has_index_changed(struct dbtable *db, char *keynm, int ct_check, int newkey,
+int restore_constraint_pointers(dbtable *db, dbtable *newdb);
+int backout_constraint_pointers(dbtable *db, dbtable *newdb);
+int populate_reverse_constraints(dbtable *db);
+int has_index_changed(dbtable *db, char *keynm, int ct_check, int newkey,
                       FILE *out, int accept_type_change);
 int resume_schema_change(void);
 
 void debug_trap(char *line, int lline);
-int count_db(struct dbtable *db);
-int compact_db(struct dbtable *db, int timeout, int freefs);
+int count_db(dbtable *db);
+int compact_db(dbtable *db, int timeout, int freefs);
 int ix_find_last_dup_rnum_kl(struct ireq *iq, int ixnum, void *key, int keylen,
                              void *fndkey, int *fndrrn,
                              unsigned long long *genid, void *fnddta,
@@ -2447,7 +2447,7 @@ int ix_next_rnum_kl(struct ireq *iq, int ixnum, void *key, int keylen,
 int ix_find_rnum(struct ireq *iq, int ixnum, void *key, int keylen,
                  void *fndkey, int *fndrrn, unsigned long long *genid,
                  void *fnddta, int *fndlen, int *recnum, int maxlen);
-void purgerrns(struct dbtable *db);
+void purgerrns(dbtable *db);
 
 /* broadcast messages to other nodes */
 int send_to_all_nodes(void *dta, int len, int type, int waittime);
@@ -2534,14 +2534,14 @@ master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
 void cleanup_sqlite_master();
 void create_sqlite_master();
 int destroy_sqlite_master(master_entry_t *, int);
-int sql_syntax_check(struct ireq *iq, struct dbtable *db);
+int sql_syntax_check(struct ireq *iq, dbtable *db);
 void sql_dump_running_statements(void);
 char *stradd(char **s1, char *s2, int freeit);
 void dbgtrace(int, char *, ...);
 
 int get_sqlite_entry_size(struct sql_thread *thd, int n);
 void *get_sqlite_entry(struct sql_thread *thd, int n);
-struct dbtable *get_sqlite_db(struct sql_thread *thd, int iTable, int *ixnum);
+dbtable *get_sqlite_db(struct sql_thread *thd, int iTable, int *ixnum);
 
 int schema_var_size(struct schema *sc);
 int handle_ireq(struct ireq *iq);
@@ -2590,8 +2590,8 @@ void purge_old_cached_blobs(void);
 void commit_schemas(const char *tblname);
 struct schema *new_dynamic_schema(const char *s, int len, int trace);
 void free_dynamic_schema(const char *table, struct schema *dsc);
-int getdefaultkeysize(const struct dbtable *tbl, int ixnum);
-int getdefaultdatsize(const struct dbtable *tbl);
+int getdefaultkeysize(const dbtable *tbl, int ixnum);
+int getdefaultdatsize(const dbtable *tbl);
 int update_sqlite_stats(struct ireq *iq, void *trans, void *dta);
 void *do_verify(void *);
 void dump_tagged_buf(const char *table, const char *tag,
@@ -2604,8 +2604,8 @@ int ix_find_by_rrn_and_genid_get_curgenid(struct ireq *iq, int rrn,
 int ix_find_last_dup_rnum(struct ireq *iq, int ixnum, void *key, int keylen,
                           void *fndkey, int *fndrrn, unsigned long long *genid,
                           void *fnddta, int *fndlen, int *recnum, int maxlen);
-void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long genid);
-void upgrade_record_by_genid(struct dbtable *db, unsigned long long genid);
+void dump_record_by_rrn_genid(dbtable *db, int rrn, unsigned long long genid);
+void upgrade_record_by_genid(dbtable *db, unsigned long long genid);
 void backend_thread_event(struct dbenv *dbenv, int event);
 void backend_cmd(struct dbenv *dbenv, char *line, int lline, int st);
 uint64_t calc_table_size(struct dbtable *db, int skip_blobs);
@@ -2613,8 +2613,8 @@ uint64_t calc_table_size_tran(tran_type *tran, struct dbtable *db, int skip_blob
 
 enum { WHOLE_BUFFER = -1 };
 
-void diagnostics_dump_rrn(struct dbtable *tbl, int rrn);
-void diagnostics_dump_dta(struct dbtable *db, int dtanum);
+void diagnostics_dump_rrn(dbtable *tbl, int rrn);
+void diagnostics_dump_dta(dbtable *db, int dtanum);
 
 /* queue stuff */
 void dbqueuedb_coalesce(struct dbenv *dbenv);

--- a/db/config.c
+++ b/db/config.c
@@ -595,7 +595,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
     /* Initialize table's check constraint members. */
     if (init_check_constraints(db)) {
         logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-               db->tablename_ip);
+               db->tablename_interned);
         return -1;
     }
     return 0;

--- a/db/config.c
+++ b/db/config.c
@@ -595,7 +595,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
     /* Initialize table's check constraint members. */
     if (init_check_constraints(db)) {
         logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-               db->tablename);
+               db->tablename_ip);
         return -1;
     }
     return 0;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -397,7 +397,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
             char rnkey[MAXKEYLEN];
             int nornrefs = 0;
 
-            if (strcasecmp(cnstrt->table[j], iq->usedb->tablename)) {
+            if (strcasecmp(cnstrt->table[j], iq->usedb->tablename_ip)) {
                 continue;
             }
             rc = getidxnumbyname(cnstrt->table[j], cnstrt->keynm[j], &ixnum);
@@ -433,11 +433,11 @@ int check_update_constraints(struct ireq *iq, void *trans,
                 if (iq->debug)
                     reqprintf(iq,
                               "RTNKYCNSTRT CANT FORM DST TBL %s INDEX %d (%s)",
-                              iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
+                              iq->usedb->tablename_ip, ixnum, cnstrt->keynm[j]);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
                           "key constraint cannot form destination table '%s' "
                           "index %d (%s)",
-                          iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
+                          iq->usedb->tablename_ip, ixnum, cnstrt->keynm[j]);
                 *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                 Pthread_mutex_unlock(&iq->usedb->rev_constraints_lk);
                 return ERR_CONVERT_IX;
@@ -463,11 +463,11 @@ int check_update_constraints(struct ireq *iq, void *trans,
                         reqprintf(
                             iq,
                             "RTNKYCNSTRT NEWDTA CANT FORM TBL %s INDEX %d (%s)",
-                            iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
+                            iq->usedb->tablename_ip, ixnum, cnstrt->keynm[j]);
                     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
                               "key constraint: new data cannot form table '%s' "
                               "index %d (%s)",
-                              iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
+                              iq->usedb->tablename_ip, ixnum, cnstrt->keynm[j]);
                     *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                     Pthread_mutex_unlock(&iq->usedb->rev_constraints_lk);
                     return ERR_CONVERT_IX;
@@ -481,21 +481,21 @@ int check_update_constraints(struct ireq *iq, void *trans,
                     if (iq->debug)
                         reqprintf(iq, "RTNKYCNSTRT SKIP CNSTRT CHECK DUE TO "
                                       "SAME KEY DATA. TBL %s INDEX %d (%s)",
-                                  iq->usedb->tablename, ixnum,
+                                  iq->usedb->tablename_ip, ixnum,
                                   cnstrt->keynm[j]);
                     continue;
                 }
             }
             /* here we convert the key into return db format */
-            rc = getidxnumbyname(cnstrt->lcltable->tablename,
+            rc = getidxnumbyname(cnstrt->lcltable->tablename_ip,
                                  cnstrt->lclkeyname, &rixnum);
             if (rc) {
                 if (iq->debug)
                     reqprintf(iq, "RTNKYCNSTRT: UNKNOWN TABLE %s KEYTAG %s",
-                              cnstrt->lcltable->tablename, cnstrt->lclkeyname);
+                              cnstrt->lcltable->tablename_ip, cnstrt->lclkeyname);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_KEY,
                           "key constraint: unknown table '%s' keytag '%s'",
-                          cnstrt->lcltable->tablename, cnstrt->lclkeyname);
+                          cnstrt->lcltable->tablename_ip, cnstrt->lclkeyname);
                 *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                 Pthread_mutex_unlock(&iq->usedb->rev_constraints_lk);
                 return ERR_CONVERT_IX;
@@ -506,8 +506,8 @@ int check_update_constraints(struct ireq *iq, void *trans,
             int nulls = 0;
 
             rixlen = rc = stag_to_stag_buf_ckey(
-                iq->usedb->tablename, ondisk_tag, lkey,
-                cnstrt->lcltable->tablename, rondisk_tag, rkey, &nulls, PK2FK);
+                iq->usedb->tablename_ip, ondisk_tag, lkey,
+                cnstrt->lcltable->tablename_ip, rondisk_tag, rkey, &nulls, PK2FK);
             if (rc == -1) {
 
 #if 0
@@ -525,7 +525,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                 if (iq->debug)
                     reqprintf(iq, "RTNKYCNSTRT SRC TBL %s INDEX %d (%s). "
                                   "SKIPPING RULE CHECK.",
-                              cnstrt->lcltable->tablename, rixnum,
+                              cnstrt->lcltable->tablename_ip, rixnum,
                               cnstrt->lclkeyname);
                 continue; /* just move on, there should be nothing to check */
             }
@@ -534,7 +534,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                 if (iq->debug)
                     reqprintf(iq, "RTNKYCNSTRT NULL COLUMN PREVENTS FOREIGN "
                                   "REF %s INDEX %d (%s). SKIPPING RULE CHECK.",
-                              cnstrt->lcltable->tablename, rixnum,
+                              cnstrt->lcltable->tablename_ip, rixnum,
                               cnstrt->lclkeyname);
                 continue; /* just move on, there should be nothing to check */
             }
@@ -557,8 +557,8 @@ int check_update_constraints(struct ireq *iq, void *trans,
                    new data for everyone else.
                 */
                 rixlen = rc =
-                    stag_to_stag_buf_ckey(iq->usedb->tablename, ondisk_tag,
-                                          nkey, cnstrt->lcltable->tablename,
+                    stag_to_stag_buf_ckey(iq->usedb->tablename_ip, ondisk_tag,
+                                          nkey, cnstrt->lcltable->tablename_ip,
                                           rondisk_tag, rnkey, NULL, PK2FK);
                 if (rc == -1) {
 /* same thing as for delete.  If the key cannot be formed,
@@ -572,7 +572,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                     if (iq->debug)
                         reqprintf(iq, "RTNKYCNSTRT CANT FORM NEW SRC TBL %s "
                                       "INDEX %d (%s). PENDING RULE CHECK.",
-                                  cnstrt->lcltable->tablename, rixnum,
+                                  cnstrt->lcltable->tablename_ip, rixnum,
                                   cnstrt->lclkeyname);
                     memcpy(rnkey, nkey, ixlen);
                     rixlen = ixlen;
@@ -705,8 +705,8 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
         if (rc != IX_FND && rc != IX_FNDMORE) {
             // key was not found on source table, so nothing to do
             if (iq->debug) {
-                reqprintf(iq, "VERBKYCNSTRT VERIFIED TBL %s IX %d AGAINST TBL %s IX %d ", bct->dstdb->tablename,
-                          bct->dixnum, bct->tablename, bct->sixnum);
+                reqprintf(iq, "VERBKYCNSTRT VERIFIED TBL %s IX %d AGAINST TBL %s IX %d ", bct->dstdb->tablename_ip,
+                          bct->dixnum, bct->tablename_ip, bct->sixnum);
                 reqdumphex(iq, bct->key, bct->sixlen);
                 reqmoref(iq, " RC %d", rc);
             }
@@ -725,12 +725,12 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                 reqprintf(iq,
                           "VERBKYCNSTRT CANT FORM NEW DATA TBL %s "
                           "INDEX %d FROM %s INDEX %d ",
-                          bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+                          bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum);
             reqmoref(iq, " RC %d", rc);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                       "verify key constraint cannot form new data table "
                       "'%s' index %d from %s index %d ",
-                      bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+                      bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum);
             *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
             close_constraint_table_cursor(cur);
             return ERR_CONVERT_IX;
@@ -742,18 +742,18 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
 
         int nullck = 0;
 
-        keylen = rc = stag_to_stag_buf_ckey(bct->tablename, ondisk_tag, skey, bct->dstdb->tablename, dondisk_tag, dkey,
+        keylen = rc = stag_to_stag_buf_ckey(bct->tablename_ip, ondisk_tag, skey, bct->dstdb->tablename_ip, dondisk_tag, dkey,
                                             &nullck, FK2PK);
         if (rc == -1) {
             if (iq->debug)
                 reqprintf(iq,
                           "VERBKYCNSTRT CANT FORM TBL %s INDEX %d FROM "
                           "%s INDEX %d KEY ",
-                          bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+                          bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                       "verify key constraint cannot form table '%s' index "
                       "%d from %s index %d key '%s",
-                      bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum,
+                      bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum,
                       get_keynm_from_db_idx(iq->usedb, bct->sixnum));
             reqdumphex(iq, skey, bct->sixlen);
             reqmoref(iq, " RC %d", rc);
@@ -767,7 +767,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             if (iq->debug) {
                 reqprintf(iq,
                           "VERBKYCNSTRT NULL COLUMN PREVENTS FOREIGN REF %s INDEX %d.",
-                          bct->tablename, bct->sixnum);
+                          bct->tablename_ip, bct->sixnum);
             }
             continue; /* TODO: why do we not get next? */
         }
@@ -797,7 +797,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                 reqprintf(iq,
                           "VERBKYCNSTRT VERIFIED TBL %s IX %d AGAINST "
                           "TBL %s IX %d ",
-                          bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+                          bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum);
                 reqdumphex(iq, bct->key, bct->sixlen);
                 reqmoref(iq, " RC %d", rc);
             }
@@ -810,7 +810,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             /* do cascade logic here */
             int err = 0, idx = 0;
             if (iq->debug) {
-                reqprintf(iq, "VERBKYCNSTRT CASCADE DELETE TBL %s RRN %d ", bct->tablename, rrn);
+                reqprintf(iq, "VERBKYCNSTRT CASCADE DELETE TBL %s RRN %d ", bct->tablename_ip, rrn);
             }
 
             /* verify against source table...must be not found */
@@ -844,7 +844,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     reqprintf(iq,
                               "VERBKYCNSTRT CANT CASCADE DELETE "
                               "TBL %s RRN %d RC %d ",
-                              bct->tablename, rrn, rc);
+                              bct->tablename_ip, rrn, rc);
                 }
                 if (rc == ERR_TRAN_TOO_BIG) {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
@@ -854,7 +854,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
                               "verify key constraint cannot cascade delete "
                               "table '%s' rc %d",
-                              bct->tablename, rc);
+                              bct->tablename_ip, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                 }
                 close_constraint_table_cursor(cur);
@@ -917,7 +917,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     reqprintf(iq,
                               "VERBKYCNSTRT CANT CASCADE UPDATE "
                               "TBL %s RRN %d RC %d ",
-                              bct->tablename, rrn, rc);
+                              bct->tablename_ip, rrn, rc);
                 }
                 if (rc == ERR_TRAN_TOO_BIG) {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
@@ -927,7 +927,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
                               "verify key constraint cannot cascade update "
                               "table '%s' rc %d",
-                              bct->tablename, rc);
+                              bct->tablename_ip, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                 }
                 close_constraint_table_cursor(cur);
@@ -940,7 +940,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                 reqprintf(iq,
                           "VERBKYCNSTRT CANT RESOLVE CONSTRAINT TBL %s "
                           "IDX '%d' KEY -> TBL %s IDX '%d' ",
-                          bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+                          bct->dstdb->tablename_ip, bct->dixnum, bct->tablename_ip, bct->sixnum);
                 reqdumphex(iq, bct->key, bct->sixlen);
                 reqmoref(iq, " RC %d", rc);
             }
@@ -948,8 +948,8 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                       "verify key constraint cannot resolve constraint "
                       "table '%s' index '%d' key '%s' -> table '%s' index "
                       "'%d' ",
-                      bct->dstdb->tablename, bct->dixnum, get_keynm_from_db_idx(bct->dstdb, bct->dixnum),
-                      bct->tablename, bct->sixnum);
+                      bct->dstdb->tablename_ip, bct->dixnum, get_keynm_from_db_idx(bct->dstdb, bct->dixnum),
+                      bct->tablename_ip, bct->sixnum);
             *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
             close_constraint_table_cursor(cur);
             return ERR_BADREQ;
@@ -1127,10 +1127,10 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         if (ondisk_size == -1) {
             if (iq->debug)
                 reqprintf(iq, "%p:ADDKYCNSTRT BAD TABLE %s\n", trans,
-                          iq->usedb->tablename);
+                          iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                       "add key constraint bad table '%s'",
-                      iq->usedb->tablename);
+                      iq->usedb->tablename_ip);
             *blkpos = curop->blkpos;
             close_constraint_table_cursor(cur);
             free_cached_delayed_indexes(iq);
@@ -1152,7 +1152,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                           trans, fndlen, ondisk_size, rc);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                       "add key constraint: record not found in table %s",
-                      iq->usedb->tablename);
+                      iq->usedb->tablename_ip);
             *errout = OP_FAILED_INTERNAL;
             *blkpos = curop->blkpos;
             close_constraint_table_cursor(cur);
@@ -1239,7 +1239,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
 
             if (iq->debug) {
                 reqprintf(iq, "%p:ADDKYCNSTRT  TBL %s IX %d RRN %d KEY ", trans,
-                          iq->usedb->tablename, doidx, addrrn);
+                          iq->usedb->tablename_ip, doidx, addrrn);
                 reqdumphex(iq, key, ixkeylen);
                 reqmoref(iq, " RC %d", rc);
             }
@@ -1253,7 +1253,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                               "add key constraint duplicate key '%s' on table "
                               "'%s' index %d",
                               get_keynm_from_db_idx(iq->usedb, doidx),
-                              iq->usedb->tablename, doidx);
+                              iq->usedb->tablename_ip, doidx);
                     *errout = OP_FAILED_UNIQ;
                 }
 
@@ -1428,10 +1428,10 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
             if (ondisk_size == -1) {
                 if (iq->debug)
                     reqprintf(iq, "VERKYCNSTRT BAD TABLE %s\n",
-                              iq->usedb->tablename);
+                              iq->usedb->tablename_ip);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                           "verify key constraint bad table '%s'",
-                          iq->usedb->tablename);
+                          iq->usedb->tablename_ip);
                 *errout = OP_FAILED_BAD_REQUEST;
                 rc = ERR_BADREQ;
                 close_constraint_table_cursor(cur);
@@ -1470,7 +1470,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                           "verify key constraint: record not found in table %s "
                           "(cascaded)",
-                          iq->usedb->tablename);
+                          iq->usedb->tablename_ip);
                 return ERR_INTERNAL;
             }
 
@@ -1479,7 +1479,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                 int ridx = 0, lixnum = -1;
                 char lkey[MAXKEYLEN];
 
-                rc = getidxnumbyname(iq->usedb->tablename, ct->lclkeyname,
+                rc = getidxnumbyname(iq->usedb->tablename_ip, ct->lclkeyname,
                                      &lixnum);
                 if (rc) {
                     if (iq->debug)
@@ -1517,11 +1517,11 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                     if (iq->debug)
                         reqprintf(iq,
                                   "VERKYCNSTRT CANT FORM TBL %s INDEX %d (%s)",
-                                  iq->usedb->tablename, lixnum, ct->lclkeyname);
+                                  iq->usedb->tablename_ip, lixnum, ct->lclkeyname);
                     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                               "verify key constraint cannot form table '%s' "
                               "index %d ('%s')",
-                              iq->usedb->tablename, lixnum, ct->lclkeyname);
+                              iq->usedb->tablename_ip, lixnum, ct->lclkeyname);
                     *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                     free_cached_delayed_indexes(iq);
                     close_constraint_table_cursor(cur);
@@ -1539,16 +1539,16 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                     if (ftable == NULL) {
                         if (iq->debug)
                             reqprintf(iq, "VERKYCNSTRT BAD TABLE %s\n",
-                                      ftable->tablename);
+                                      ftable->tablename_ip);
                         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                                   "verify key constraint bad table '%s'",
-                                  ftable->tablename);
+                                  ftable->tablename_ip);
                         *errout = OP_FAILED_BAD_REQUEST;
                         free_cached_delayed_indexes(iq);
                         close_constraint_table_cursor(cur);
                         return ERR_BADREQ;
                     }
-                    rc = getidxnumbyname(ftable->tablename, ct->keynm[ridx], &fixnum);
+                    rc = getidxnumbyname(ftable->tablename_ip, ct->keynm[ridx], &fixnum);
                     if (rc) {
                         if (iq->debug)
                             reqprintf(iq, "VERKYCNSTRT: UNKNOWN KEYTAG %s",
@@ -1570,18 +1570,18 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
 
                     snprintf(fondisk_tag, MAXTAGLEN, ".ONDISK_IX_%d", fixnum);
                     fixlen = rc = stag_to_stag_buf_ckey(
-                        iq->usedb->tablename, ondisk_tag, lkey,
-                        ftable->tablename, fondisk_tag, fkey, &nulls, FK2PK);
+                        iq->usedb->tablename_ip, ondisk_tag, lkey,
+                        ftable->tablename_ip, fondisk_tag, fkey, &nulls, FK2PK);
                     if (rc == -1) {
                         if (iq->debug)
                             reqprintf(
                                 iq,
                                 "VERKYCNSTRT CANT FORM TBL %s INDEX %d (%s)",
-                                ftable->tablename, fixnum, ct->keynm[ridx]);
+                                ftable->tablename_ip, fixnum, ct->keynm[ridx]);
                         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                                   "verify key constraint cannot form table "
                                   "'%s' index %d (%s)",
-                                  ftable->tablename, fixnum, ct->keynm[ridx]);
+                                  ftable->tablename_ip, fixnum, ct->keynm[ridx]);
                         *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                         free_cached_delayed_indexes(iq);
                         close_constraint_table_cursor(cur);
@@ -1626,7 +1626,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                         if (iq->debug) {
                             reqprintf(iq, "VERKYCNSTRT CANT RESOLVE CONSTRAINT "
                                           "TBL %s IDX '%s' KEY ",
-                                      ftable->tablename, ct->keynm[ridx]);
+                                      ftable->tablename_ip, ct->keynm[ridx]);
                             reqdumphex(iq, fkey, fixlen);
                             reqmoref(iq, " RC %d", rc);
                         }
@@ -1634,8 +1634,8 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                                   "verify key constraint cannot resolve "
                                   "constraint table '%s' key '%s' -> "
                                   "table '%s' index '%d' key '%s'",
-                                  ct->lcltable->tablename, ct->lclkeyname,
-                                  ftable->tablename, ridx, ct->keynm[ridx]);
+                                  ct->lcltable->tablename_ip, ct->lclkeyname,
+                                  ftable->tablename_ip, ridx, ct->keynm[ridx]);
                         *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                         free_cached_delayed_indexes(iq);
                         close_constraint_table_cursor(cur);
@@ -1645,7 +1645,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                         reqprintf(
                             iq,
                             "VERKYCNSTRT VERIFIED RC=%d %s:%s AGAINST %s:%s",
-                            rc, iq->usedb->tablename, ct->lclkeyname,
+                            rc, iq->usedb->tablename_ip, ct->lclkeyname,
                             ct->table[ridx], ct->keynm[ridx]);
                     }
                 }
@@ -1696,13 +1696,13 @@ void dump_rev_constraints(struct dbtable *table)
 {
     int i = 0;
     logmsg(LOGMSG_USER, "TABLE '%s' HAS %d REVSE CONSTRAINTS\n",
-           table->tablename, table->n_rev_constraints);
+           table->tablename_ip, table->n_rev_constraints);
     for (i = 0; i < table->n_rev_constraints; i++) {
         constraint_t *ct = table->rev_constraints[i];
         int j = 0;
         logmsg(LOGMSG_USER, "(%d)REV CONSTRAINT TBL: '%s' KEY '%s'  CSCUPD: %c "
                             "CSCDEL: %c #RULES %d:\n",
-               i + 1, ct->lcltable->tablename, ct->lclkeyname,
+               i + 1, ct->lcltable->tablename_ip, ct->lclkeyname,
                ((ct->flags & CT_UPD_CASCADE) == CT_UPD_CASCADE) ? 'T' : 'F',
                ((ct->flags & CT_DEL_CASCADE) == CT_DEL_CASCADE) ? 'T' : 'F',
                ct->nrules);
@@ -1717,7 +1717,7 @@ void dump_rev_constraints(struct dbtable *table)
 void dump_constraints(struct dbtable *table)
 {
     int i = 0;
-    logmsg(LOGMSG_USER, "TABLE '%s' HAS %d CONSTRAINTS\n", table->tablename,
+    logmsg(LOGMSG_USER, "TABLE '%s' HAS %d CONSTRAINTS\n", table->tablename_ip,
            table->n_constraints);
     for (i = 0; i < table->n_constraints; i++) {
         constraint_t *ct = &table->constraints[i];
@@ -1978,11 +1978,10 @@ static inline int constraint_key_check(struct schema *fky, struct schema *bky)
 static inline struct dbtable *get_newer_db(struct dbtable *db,
                                            struct dbtable *new_db)
 {
-    if (new_db && strcasecmp(db->tablename, new_db->tablename) == 0) {
+    if (new_db && strcasecmp(db->tablename_ip, new_db->tablename_ip) == 0) {
         return new_db;
-    } else {
-        return db;
     }
+    return db;
 }
 
 static void constraint_err(struct schema_change_type *s, struct dbtable *db,
@@ -1992,7 +1991,7 @@ static void constraint_err(struct schema_change_type *s, struct dbtable *db,
         reqerrstr(s->iq, ERR_SC,
                   "constraint error for table \"%s\" key \"%s\" -> "
                   "<\"%s\":\"%s\">: %s",
-                  db->tablename, ct->lclkeyname, ct->table[rule],
+                  db->tablename_ip, ct->lclkeyname, ct->table[rule],
                   ct->keynm[rule], err);
     } else { 
         if (s && s->sb)
@@ -2005,7 +2004,7 @@ static void constraint_err(struct schema_change_type *s, struct dbtable *db,
         logmsg(LOGMSG_ERROR,
                "Constraint error for table \"%s\" key \"%s\" -> "
                "<\"%s\":\"%s\">: %s\n",
-               db->tablename, ct->lclkeyname, ct->table[rule], ct->keynm[rule],
+               db->tablename_ip, ct->lclkeyname, ct->table[rule], ct->keynm[rule],
                err);
     }
 }
@@ -2049,7 +2048,7 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
         } else {
             snprintf(keytag, sizeof(keytag), "%s", ct->lclkeyname);
         }
-        if (!(fky = find_tag_schema(from_db->tablename, keytag))) {
+        if (!(fky = find_tag_schema(from_db->tablename_ip, keytag))) {
             /* Referencing a nonexistent key */
             constraint_err(s, from_db, ct, 0, "local key not found");
             n_errors++;
@@ -2065,13 +2064,13 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
 
             /* If we have a target table (to_db) only look at rules pointing
              * to that table. */
-            if (to_db && strcasecmp(ct->table[jj], to_db->tablename) != 0)
+            if (to_db && strcasecmp(ct->table[jj], to_db->tablename_ip) != 0)
                 continue;
 
             rdb = get_dbtable_by_name(ct->table[jj]);
             if (rdb)
                 rdb = get_newer_db(rdb, new_db);
-            else if (strcasecmp(ct->table[jj], from_db->tablename) == 0)
+            else if (strcasecmp(ct->table[jj], from_db->tablename_ip) == 0)
                 rdb = from_db;
             if (!rdb) {
                 /* Referencing a non-existent table */
@@ -2079,7 +2078,7 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
                 n_errors++;
                 continue;
             } else {
-                if (timepart_is_shard(rdb->tablename, (!s || !s->views_locked),
+                if (timepart_is_shard(rdb->tablename_ip, (!s || !s->views_locked),
                                       NULL)) {
                     constraint_err(s, from_db, ct, jj,
                                    "foreign table is a shard");
@@ -2123,12 +2122,12 @@ int populate_reverse_constraints(struct dbtable *db)
         constraint_t *cnstrt = &db->constraints[ii];
         struct schema *sc = NULL;
 
-        sc = find_tag_schema(db->tablename, cnstrt->lclkeyname);
+        sc = find_tag_schema(db->tablename_ip, cnstrt->lclkeyname);
         if (sc == NULL) {
             ++n_errors;
             logmsg(LOGMSG_ERROR,
                    "constraint error: key %s is not found in table %s\n",
-                   cnstrt->lclkeyname, db->tablename);
+                   cnstrt->lclkeyname, db->tablename_ip);
         }
 
         for (jj = 0; jj < cnstrt->nrules; jj++) {
@@ -2137,7 +2136,7 @@ int populate_reverse_constraints(struct dbtable *db)
             int rcidx = 0, dupadd = 0;
             cttbl = get_dbtable_by_name(cnstrt->table[jj]);
             if (cttbl == NULL &&
-                strcasecmp(cnstrt->table[jj], db->tablename) == 0)
+                strcasecmp(cnstrt->table[jj], db->tablename_ip) == 0)
                 cttbl = db;
 
             if (cttbl == NULL) {
@@ -2211,7 +2210,7 @@ int check_single_key_constraint(struct ireq *ruleiq, const constraint_t *ct,
             return ERR_BUF_TOO_SMALL;
 
         /* Key -> Key : local table -> referenced table */
-        int rixlen = stag_to_stag_buf_ckey(tblname, lcl_tag, lcl_key, ruledb->tablename,
+        int rixlen = stag_to_stag_buf_ckey(tblname, lcl_tag, lcl_key, ruledb->tablename_ip,
                                            rtag, rkey, &nulls, FK2PK);
 
         if (-1 == rixlen)
@@ -2251,7 +2250,7 @@ constraint_t *get_constraint_for_ix(struct dbtable *db_table, int ix)
     for (int ci = 0; ci < db_table->n_constraints; ci++) {
         constraint_t *ct = &(db_table->constraints[ci]);
         int lcl_idx;
-        int rc = getidxnumbyname(db_table->tablename, ct->lclkeyname, &lcl_idx);
+        int rc = getidxnumbyname(db_table->tablename_ip, ct->lclkeyname, &lcl_idx);
         if (rc) {
             logmsg(LOGMSG_ERROR, "could not get index for key %d\n", ix);
             return NULL;
@@ -2288,7 +2287,7 @@ int convert_key_to_foreign_key(constraint_t *ct, char *lcl_tag, char *lcl_key,
 
     /* convert local Key -> foreign Key : local table -> referenced table */
     *rixlen = rc =
-        stag_to_stag_buf_ckey(tblname, lcl_tag, lcl_key, ruledb->tablename,
+        stag_to_stag_buf_ckey(tblname, lcl_tag, lcl_key, ruledb->tablename_ip,
                               rtag, rkey, &nulls, FK2PK);
 
     if (-1 == rc)

--- a/db/db_util.c
+++ b/db/db_util.c
@@ -322,7 +322,7 @@ int rewrite_lrl_remove_tables(const char *lrlname)
 /* Create a new lrl file with the table defs added back in (the reverse of
  * llmeta'ing an lrl file */
 int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
-                          const char *p_lrl_fname_out, char *p_table_names[],
+                          const char *p_lrl_fname_out, const char *p_table_names[],
                           char *p_csc2_paths[], int table_nums[],
                           size_t num_tables, char *out_lrl_dir, int has_sp,
                           int has_timepartitions)

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -252,7 +252,7 @@ int queue_consume(struct ireq* iq, const void* fnd, int consumern)
         }
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
-                iq->usedb->tablename, consumern);
+                iq->usedb->tablename_ip, consumern);
         if (db_is_stopped() || thedb->master != gbl_myhostname)
             return -1;
         sleep(sleeptime);

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -156,7 +156,7 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
     tran_type *trans = bdb_tran_begin(bdb_state, NULL, &bdberr);
     if (!trans) {
         logmsg(LOGMSG_ERROR, "%s bdb_tran_begin:%s bdberr:%d\n", __func__,
-               db->tablename_ip, bdberr);
+               db->tablename_interned, bdberr);
         return -1;
     }
     if (lockid) {
@@ -175,7 +175,7 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
         rc = dbqueuedb_get_stats_int(db, trans, stats);
     } else {
         logmsg(LOGMSG_ERROR, "%s bdb_lock_table_read:%s rc:%d\n", __func__,
-               db->tablename_ip, rc);
+               db->tablename_interned, rc);
     }
     if (lockid) {
         bdb_set_tran_lockerid(trans, savedlid);
@@ -252,7 +252,7 @@ int queue_consume(struct ireq* iq, const void* fnd, int consumern)
         }
 
         logmsg(LOGMSG_ERROR, "difficulty consuming key from queue '%s' consumer %d\n",
-                iq->usedb->tablename_ip, consumern);
+                iq->usedb->tablename_interned, consumern);
         if (db_is_stopped() || thedb->master != gbl_myhostname)
             return -1;
         sleep(sleeptime);

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -156,7 +156,7 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
     tran_type *trans = bdb_tran_begin(bdb_state, NULL, &bdberr);
     if (!trans) {
         logmsg(LOGMSG_ERROR, "%s bdb_tran_begin:%s bdberr:%d\n", __func__,
-               db->tablename, bdberr);
+               db->tablename_ip, bdberr);
         return -1;
     }
     if (lockid) {
@@ -175,7 +175,7 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
         rc = dbqueuedb_get_stats_int(db, trans, stats);
     } else {
         logmsg(LOGMSG_ERROR, "%s bdb_lock_table_read:%s rc:%d\n", __func__,
-               db->tablename, rc);
+               db->tablename_ip, rc);
     }
     if (lockid) {
         bdb_set_tran_lockerid(trans, savedlid);

--- a/db/fdb_bend.c
+++ b/db/fdb_bend.c
@@ -521,7 +521,7 @@ again:
             if (nretries >= gbl_maxretries) {
                 logmsg(LOGMSG_ERROR, "too much contention fetching "
                                      "tbl %s blob %s tried %d times\n",
-                       thedb->dbs[cur->tblnum]->tablename_ip, f->name, nretries);
+                       thedb->dbs[cur->tblnum]->tablename_interned, f->name, nretries);
                 return SQLITE_DEADLOCK;
             }
             goto again;

--- a/db/fdb_bend.c
+++ b/db/fdb_bend.c
@@ -521,7 +521,7 @@ again:
             if (nretries >= gbl_maxretries) {
                 logmsg(LOGMSG_ERROR, "too much contention fetching "
                                      "tbl %s blob %s tried %d times\n",
-                       thedb->dbs[cur->tblnum]->tablename, f->name, nretries);
+                       thedb->dbs[cur->tblnum]->tablename_ip, f->name, nretries);
                 return SQLITE_DEADLOCK;
             }
             goto again;

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -627,7 +627,7 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
             return NULL;
         }
     }
-    pCur->numblobs = get_schema_blob_count(pCur->db->tablename_ip, ".ONDISK");
+    pCur->numblobs = get_schema_blob_count(pCur->db->tablename_interned, ".ONDISK");
 
     if (need_bdbcursor) {
         pCur->bdbcur = bdb_cursor_open(
@@ -742,7 +742,7 @@ static int _fdb_svc_indexes_to_ondisk(unsigned char **pIndexes, struct dbtable *
                               NULL, 0, fail_reason, pCur);
         if (rc != getkeysize(db, i)) {
             char errs[128];
-            convert_failure_reason_str(fail_reason, db->tablename_ip,
+            convert_failure_reason_str(fail_reason, db->tablename_interned,
                                        "SQLite format", ".ONDISK_ix", errs,
                                        sizeof(errs));
             return -1;
@@ -801,7 +801,7 @@ int fdb_svc_cursor_insert(struct sqlclntstate *clnt, char *tblname,
                           rowblobs, MAXBLOBS, &clnt->fail_reason, &bCur);
     if (rc < 0) {
         char errs[128];
-        convert_failure_reason_str(&clnt->fail_reason, db->tablename_ip,
+        convert_failure_reason_str(&clnt->fail_reason, db->tablename_interned,
                                    "SQLite format", ".ONDISK", errs,
                                    sizeof(errs));
 
@@ -939,7 +939,7 @@ int fdb_svc_cursor_update(struct sqlclntstate *clnt, char *tblname,
                           rowblobs, MAXBLOBS, &clnt->fail_reason, &bCur);
     if (rc < 0) {
         char errs[128];
-        convert_failure_reason_str(&clnt->fail_reason, db->tablename_ip,
+        convert_failure_reason_str(&clnt->fail_reason, db->tablename_interned,
                                    "SQLite format", ".ONDISK", errs,
                                    sizeof(errs));
 

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -627,7 +627,7 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
             return NULL;
         }
     }
-    pCur->numblobs = get_schema_blob_count(pCur->db->tablename, ".ONDISK");
+    pCur->numblobs = get_schema_blob_count(pCur->db->tablename_ip, ".ONDISK");
 
     if (need_bdbcursor) {
         pCur->bdbcur = bdb_cursor_open(
@@ -742,7 +742,7 @@ static int _fdb_svc_indexes_to_ondisk(unsigned char **pIndexes, struct dbtable *
                               NULL, 0, fail_reason, pCur);
         if (rc != getkeysize(db, i)) {
             char errs[128];
-            convert_failure_reason_str(fail_reason, db->tablename,
+            convert_failure_reason_str(fail_reason, db->tablename_ip,
                                        "SQLite format", ".ONDISK_ix", errs,
                                        sizeof(errs));
             return -1;
@@ -801,7 +801,7 @@ int fdb_svc_cursor_insert(struct sqlclntstate *clnt, char *tblname,
                           rowblobs, MAXBLOBS, &clnt->fail_reason, &bCur);
     if (rc < 0) {
         char errs[128];
-        convert_failure_reason_str(&clnt->fail_reason, db->tablename,
+        convert_failure_reason_str(&clnt->fail_reason, db->tablename_ip,
                                    "SQLite format", ".ONDISK", errs,
                                    sizeof(errs));
 
@@ -939,7 +939,7 @@ int fdb_svc_cursor_update(struct sqlclntstate *clnt, char *tblname,
                           rowblobs, MAXBLOBS, &clnt->fail_reason, &bCur);
     if (rc < 0) {
         char errs[128];
-        convert_failure_reason_str(&clnt->fail_reason, db->tablename,
+        convert_failure_reason_str(&clnt->fail_reason, db->tablename_ip,
                                    "SQLite format", ".ONDISK", errs,
                                    sizeof(errs));
 

--- a/db/glue.c
+++ b/db/glue.c
@@ -4160,7 +4160,7 @@ int gbl_instrument_consumer_lock = 0;
 void consumer_lock_read_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d getting consumer readlock for %s\n", func, line, db->tablename);
+        logmsg(LOGMSG_USER, "%s:%d getting consumer readlock for %s\n", func, line, db->tablename_ip);
     }
     Pthread_rwlock_rdlock(&db->consumer_lk);
 }
@@ -4168,7 +4168,7 @@ void consumer_lock_read_int(dbtable *db, const char *func, int line)
 void consumer_lock_write_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d getting consumer writelock for %s\n", func, line, db->tablename);
+        logmsg(LOGMSG_USER, "%s:%d getting consumer writelock for %s\n", func, line, db->tablename_ip);
     }
     Pthread_rwlock_wrlock(&db->consumer_lk);
 }
@@ -4176,7 +4176,7 @@ void consumer_lock_write_int(dbtable *db, const char *func, int line)
 void consumer_unlock_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d unlocking consumer %s\n", func, line, db->tablename);
+        logmsg(LOGMSG_USER, "%s:%d unlocking consumer %s\n", func, line, db->tablename_ip);
     }
     Pthread_rwlock_unlock(&db->consumer_lk);
 }

--- a/db/glue.c
+++ b/db/glue.c
@@ -201,7 +201,7 @@ static void *get_bdb_handle_ireq(struct ireq *iq, int auxdb)
 
     if (iq->usedb) {
         if (auxdb == AUXDB_NONE)
-            reqlog_usetable(iq->reqlogger, iq->usedb->tablename);
+            reqlog_usetable(iq->reqlogger, iq->usedb->tablename_ip);
         return get_bdb_handle(iq->usedb, auxdb);
     }
 
@@ -3501,8 +3501,8 @@ int open_auxdbs(struct dbtable *db, int force_create)
         snprintf(name, sizeof(name), "comdb2_meta");
         snprintf(litename, sizeof(litename), "comdb2_metalite");
     } else {
-        snprintf(name, sizeof(name), "%s.meta", db->tablename);
-        snprintf(litename, sizeof(litename), "%s.metalite", db->tablename);
+        snprintf(name, sizeof(name), "%s.meta", db->tablename_ip);
+        snprintf(litename, sizeof(litename), "%s.metalite", db->tablename_ip);
     }
 
     ctrace("bdb_open_more: opening <%s>\n", name);
@@ -3856,7 +3856,7 @@ static void get_disable_skipscan(struct dbtable *tbl, tran_type *tran)
         return;
 
     char *str = NULL;
-    int rc = bdb_get_table_parameter_tran(tbl->tablename, "disableskipscan",
+    int rc = bdb_get_table_parameter_tran(tbl->tablename_ip, "disableskipscan",
                                           &str, tran);
     if (rc != 0) {
         tbl->disableskipscan = 0;
@@ -3895,13 +3895,13 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         db = dbenv->dbs[ii];
 
         if (db->dbnum)
-            logmsg(LOGMSG_INFO, "open table '%s' (dbnum %d)\n", db->tablename,
+            logmsg(LOGMSG_INFO, "open table '%s' (dbnum %d)\n", db->tablename_ip,
                    db->dbnum);
         else
-            logmsg(LOGMSG_INFO, "open table '%s'\n", db->tablename);
+            logmsg(LOGMSG_INFO, "open table '%s'\n", db->tablename_ip);
 
         db->handle = bdb_open_more_tran(
-            db->tablename, dbenv->basedir, db->lrl, db->nix,
+            db->tablename_ip, dbenv->basedir, db->lrl, db->nix,
             (short *)db->ix_keylen, db->ix_dupes, db->ix_recnums,
             db->ix_datacopy, db->ix_collattr, db->ix_nullsallowed,
             db->numblobs + 1, /* main record + n blobs */
@@ -3912,7 +3912,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                 logmsg(
                     LOGMSG_ERROR,
                     "bdb_open:failed to open table %s/%s, rcode %d, IGNORING\n",
-                    dbenv->basedir, db->tablename, bdberr);
+                    dbenv->basedir, db->tablename_ip, bdberr);
                 /* this is a hack, lets just leak it */
                 if (ii == dbenv->num_dbs - 1) {
                     dbenv->dbs[ii] = NULL;
@@ -3926,7 +3926,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
             }
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open table %s/%s, rcode %d\n",
-                   dbenv->basedir, db->tablename, bdberr);
+                   dbenv->basedir, db->tablename_ip, bdberr);
 
             return -1;
         }
@@ -3935,7 +3935,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
     for (ii = 0; ii < dbenv->num_qdbs; ii++) {
         int pagesize;
         db = dbenv->qdbs[ii];
-        logmsg(LOGMSG_INFO, "open queue '%s'\n", db->tablename);
+        logmsg(LOGMSG_INFO, "open queue '%s'\n", db->tablename_ip);
 
         /* Work out best page size for the expected average item size. */
         if (db->queue_pagesize_override) {
@@ -3950,13 +3950,13 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         }
 
         db->handle = bdb_open_more_queue(
-            db->tablename, dbenv->basedir, db->avgitemsz, pagesize,
+            db->tablename_ip, dbenv->basedir, db->avgitemsz, pagesize,
             dbenv->bdb_env, db->dbtype == DBTYPE_QUEUEDB ? 1 : 0, tran,
             &bdberr);
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open_more_queue:failed to open queue %s/%s, rcode %d\n",
-                   dbenv->basedir, db->tablename, bdberr);
+                   dbenv->basedir, db->tablename_ip, bdberr);
             return -1;
         }
     }
@@ -4053,7 +4053,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         if (bthashsz) {
             logmsg(LOGMSG_INFO,
                    "Building bthash for table %s, size %dkb per stripe\n",
-                   tbl->tablename, bthashsz);
+                   tbl->tablename_ip, bthashsz);
             bdb_handle_dbp_add_hash(tbl->handle, bthashsz);
         }
 
@@ -4069,7 +4069,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                "isc %s  "
                "odh_datacopy %s  "
                "ipu %s",
-               tbl->tablename, tbl->schema_version, tbl->odh ? "yes" : "no",
+               tbl->tablename_ip, tbl->schema_version, tbl->odh ? "yes" : "no",
                tbl->instant_schema_change ? "yes" : "no",
                datacopy_odh ? "yes" : "no",
                tbl->inplace_updates ? "yes" : "no");
@@ -4147,9 +4147,9 @@ void fix_blobstripe_genids(tran_type *tran)
             if (rc == 0) {
                 bdb_set_blobstripe_genid(db->handle, db->blobstripe_genid);
                 ctrace("blobstripe genid 0x%llx for table %s\n",
-                       db->blobstripe_genid, db->tablename);
+                       db->blobstripe_genid, db->tablename_ip);
             } else {
-                ctrace("no blobstripe genid for table %s\n", db->tablename);
+                ctrace("no blobstripe genid for table %s\n", db->tablename_ip);
             }
         }
     }
@@ -4199,7 +4199,7 @@ int fix_consumers_with_bdblib(struct dbenv *dbenv)
                 logmsg(
                     LOGMSG_ERROR,
                     "bdb_queue_consumer error for queue %s/%s/%d, rcode %d\n",
-                    dbenv->basedir, db->tablename, consumern, bdberr);
+                    dbenv->basedir, db->tablename_ip, consumern, bdberr);
                 consumer_unlock(db);
                 return -1;
             }
@@ -4664,7 +4664,7 @@ static int meta_put(struct dbtable *db, void *input_tran, struct metahdr *hdr1,
     if (db->dbenv->meta) {
         bzero(&hdr2, sizeof(struct metahdr2));
         memcpy(&hdr2.hdr1, hdr1, sizeof(struct metahdr));
-        snprintf(hdr2.keystr, sizeof(hdr2.keystr), "/%s", db->tablename);
+        snprintf(hdr2.keystr, sizeof(hdr2.keystr), "/%s", db->tablename_ip);
         keysize = sizeof(struct metahdr2);
         metahdr2_type_put(&hdr2, p_hdr2_buf, p_hdr2_buf_end);
         hdr = &p_metahdr2;
@@ -4793,7 +4793,7 @@ static int meta_get_tran(tran_type *tran, struct dbtable *db, struct metahdr *ke
     if (db->dbenv->meta) {
         bzero(&key2, sizeof(struct metahdr2));
         memcpy(&key2.hdr1, key1, sizeof(struct metahdr));
-        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename);
+        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_ip);
         metahdr2_type_put(&key2, p_hdr2_buf, p_hdr2_buf_end);
         key = &p_metahdr2;
     } else {
@@ -4853,7 +4853,7 @@ static int meta_get_var_tran(tran_type *tran, struct dbtable *db,
     if (db->dbenv->meta) {
         bzero(&key2, sizeof(struct metahdr2));
         memcpy(&key2.hdr1, key1, sizeof(struct metahdr));
-        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename);
+        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_ip);
         metahdr2_type_put(&key2, p_hdr2_buf, p_hdr2_buf_end);
         key = &p_metahdr2;
     } else {
@@ -5487,7 +5487,7 @@ void diagnostics_dump_dta(struct dbtable *db, int dtanum)
 
     char *filename;
     filename =
-        comdb2_location("debug", "%s.dump_dta%d.txt", db->tablename, dtanum);
+        comdb2_location("debug", "%s.dump_dta%d.txt", db->tablename_ip, dtanum);
     fh = fopen(filename, "w");
     if (!fh) {
         logmsg(LOGMSG_ERROR, "diagnostics_dump_dta: cannot open %s: %s\n", filename,
@@ -5566,7 +5566,7 @@ void compr_print_stats()
         struct dbtable *db = thedb->dbs[ii];
         bdb_get_compr_flags(db->handle, &odh, &compr, &blob_compr);
 
-        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename);
+        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_ip);
         logmsg(LOGMSG_USER, "ODH: %3s Compress: %-8s Blob compress: %-8s  in-place updates: "
                "%-3s  instant schema change: %-3s",
                odh ? "yes" : "no", bdb_algo2compr(compr),
@@ -5582,27 +5582,27 @@ void print_tableparams()
     int ii;
     for (ii = 0; ii < thedb->num_dbs; ii++) {
         struct dbtable *db = thedb->dbs[ii];
-        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename);
+        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_ip);
 
         int bdberr = 0;
         int coveragevalue = 0;
         long long thresholdvalue = 0;
         int rc = 0;
 
-        rc = bdb_get_analyzecoverage_table(NULL, db->tablename, &coveragevalue,
+        rc = bdb_get_analyzecoverage_table(NULL, db->tablename_ip, &coveragevalue,
                                            &bdberr);
         if (rc != 0)
             logmsg(LOGMSG_ERROR, "bdb_get_analyzecoverage_table rc = %d, bdberr=%d\n", rc,
                    bdberr);
 
-        rc = bdb_get_analyzethreshold_table(NULL, db->tablename,
+        rc = bdb_get_analyzethreshold_table(NULL, db->tablename_ip,
                                             &thresholdvalue, &bdberr);
         if (rc != 0)
             logmsg(LOGMSG_ERROR, "bdb_get_analyzethreshold_table rc = %d, bdberr=%d\n", rc,
                    bdberr);
 
         char *disableskipscanval = NULL;
-        bdb_get_table_parameter(db->tablename, "disableskipscan",
+        bdb_get_table_parameter(db->tablename_ip, "disableskipscan",
                                 &disableskipscanval);
 
         if (coveragevalue >= 0)
@@ -5623,7 +5623,7 @@ void print_tableparams()
 
         char *tableparams = NULL;
         int tbplen = 0;
-        bdb_get_table_csonparameters(NULL, db->tablename, &tableparams,
+        bdb_get_table_csonparameters(NULL, db->tablename_ip, &tableparams,
                                      &tbplen);
         if (tableparams) {
             logmsg(LOGMSG_USER, " tableparams: %10s", tableparams);
@@ -5807,7 +5807,7 @@ int find_record_older_than(struct ireq *iq, void *tran, int timestamp,
 static int ix_find_check_blob_race(struct ireq *iq, char *inbuf, int numblobs,
                                    int *blobnums, void **blobptrs)
 {
-    char *table = iq->usedb->tablename;
+    const char *table = iq->usedb->tablename_ip;
     struct schema *sch;
     struct field *fld;
     int i;
@@ -6046,7 +6046,7 @@ int table_version_upsert(struct dbtable *db, void *trans, int *bdberr)
     //select needs to be done with the same transaction to avoid 
     //undetectable deadlock for writing and reading from same thread
     unsigned long long version;
-    rc = bdb_table_version_select(db->tablename, trans, &version, bdberr);
+    rc = bdb_table_version_select(db->tablename_ip, trans, &version, bdberr);
     if (rc || *bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, *bdberr);
@@ -6067,7 +6067,7 @@ unsigned long long table_version_select(struct dbtable *db, tran_type *tran)
     unsigned long long version;
     int rc;
 
-    rc = bdb_table_version_select(db->tablename, tran, &version, &bdberr);
+    rc = bdb_table_version_select(db->tablename_ip, tran, &version, &bdberr);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, bdberr);
@@ -6079,7 +6079,6 @@ unsigned long long table_version_select(struct dbtable *db, tran_type *tran)
 
 int rename_table_options(void *tran, struct dbtable *db, const char *newname)
 {
-    char *oldname;
     int rc;
     int odh;
     int compress;
@@ -6113,8 +6112,8 @@ int rename_table_options(void *tran, struct dbtable *db, const char *newname)
             return rc;
     }
 
-    oldname = db->tablename;
-    db->tablename = (char *)newname;
+    const char *oldname = db->tablename_ip;
+    db->tablename_ip = intern(newname);
 
     rc = put_db_odh(db, tran, odh);
     if (rc)
@@ -6135,7 +6134,7 @@ int rename_table_options(void *tran, struct dbtable *db, const char *newname)
         rc = put_db_bthash(db, tran, bthashsz);
 
 done:
-    db->tablename = oldname;
+    db->tablename_ip = oldname;
 
     return rc;
 }
@@ -6185,7 +6184,6 @@ int comdb2_next_allowed_table(sqlite3_int64 *tabId)
 {
     struct dbtable *pDb;
     struct sql_thread *thd;
-    char *tablename;
     int bdberr;
     int rc;
 
@@ -6193,7 +6191,7 @@ int comdb2_next_allowed_table(sqlite3_int64 *tabId)
 
     while (*tabId < thedb->num_dbs) {
         pDb = thedb->dbs[*tabId];
-        tablename = pDb->tablename;
+        const char *tablename = pDb->tablename_ip;
         rc = bdb_check_user_tbl_access(thedb->bdb_env,
                                        thd->clnt->current_user.name, tablename,
                                        ACCESS_READ, &bdberr);

--- a/db/glue.c
+++ b/db/glue.c
@@ -201,7 +201,7 @@ static void *get_bdb_handle_ireq(struct ireq *iq, int auxdb)
 
     if (iq->usedb) {
         if (auxdb == AUXDB_NONE)
-            reqlog_usetable(iq->reqlogger, iq->usedb->tablename_ip);
+            reqlog_usetable(iq->reqlogger, iq->usedb->tablename_interned);
         return get_bdb_handle(iq->usedb, auxdb);
     }
 
@@ -3501,8 +3501,8 @@ int open_auxdbs(struct dbtable *db, int force_create)
         snprintf(name, sizeof(name), "comdb2_meta");
         snprintf(litename, sizeof(litename), "comdb2_metalite");
     } else {
-        snprintf(name, sizeof(name), "%s.meta", db->tablename_ip);
-        snprintf(litename, sizeof(litename), "%s.metalite", db->tablename_ip);
+        snprintf(name, sizeof(name), "%s.meta", db->tablename_interned);
+        snprintf(litename, sizeof(litename), "%s.metalite", db->tablename_interned);
     }
 
     ctrace("bdb_open_more: opening <%s>\n", name);
@@ -3856,7 +3856,7 @@ static void get_disable_skipscan(struct dbtable *tbl, tran_type *tran)
         return;
 
     char *str = NULL;
-    int rc = bdb_get_table_parameter_tran(tbl->tablename_ip, "disableskipscan",
+    int rc = bdb_get_table_parameter_tran(tbl->tablename_interned, "disableskipscan",
                                           &str, tran);
     if (rc != 0) {
         tbl->disableskipscan = 0;
@@ -3895,13 +3895,13 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         db = dbenv->dbs[ii];
 
         if (db->dbnum)
-            logmsg(LOGMSG_INFO, "open table '%s' (dbnum %d)\n", db->tablename_ip,
+            logmsg(LOGMSG_INFO, "open table '%s' (dbnum %d)\n", db->tablename_interned,
                    db->dbnum);
         else
-            logmsg(LOGMSG_INFO, "open table '%s'\n", db->tablename_ip);
+            logmsg(LOGMSG_INFO, "open table '%s'\n", db->tablename_interned);
 
         db->handle = bdb_open_more_tran(
-            db->tablename_ip, dbenv->basedir, db->lrl, db->nix,
+            db->tablename_interned, dbenv->basedir, db->lrl, db->nix,
             (short *)db->ix_keylen, db->ix_dupes, db->ix_recnums,
             db->ix_datacopy, db->ix_collattr, db->ix_nullsallowed,
             db->numblobs + 1, /* main record + n blobs */
@@ -3912,7 +3912,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                 logmsg(
                     LOGMSG_ERROR,
                     "bdb_open:failed to open table %s/%s, rcode %d, IGNORING\n",
-                    dbenv->basedir, db->tablename_ip, bdberr);
+                    dbenv->basedir, db->tablename_interned, bdberr);
                 /* this is a hack, lets just leak it */
                 if (ii == dbenv->num_dbs - 1) {
                     dbenv->dbs[ii] = NULL;
@@ -3926,7 +3926,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
             }
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open table %s/%s, rcode %d\n",
-                   dbenv->basedir, db->tablename_ip, bdberr);
+                   dbenv->basedir, db->tablename_interned, bdberr);
 
             return -1;
         }
@@ -3935,7 +3935,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
     for (ii = 0; ii < dbenv->num_qdbs; ii++) {
         int pagesize;
         db = dbenv->qdbs[ii];
-        logmsg(LOGMSG_INFO, "open queue '%s'\n", db->tablename_ip);
+        logmsg(LOGMSG_INFO, "open queue '%s'\n", db->tablename_interned);
 
         /* Work out best page size for the expected average item size. */
         if (db->queue_pagesize_override) {
@@ -3950,13 +3950,13 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         }
 
         db->handle = bdb_open_more_queue(
-            db->tablename_ip, dbenv->basedir, db->avgitemsz, pagesize,
+            db->tablename_interned, dbenv->basedir, db->avgitemsz, pagesize,
             dbenv->bdb_env, db->dbtype == DBTYPE_QUEUEDB ? 1 : 0, tran,
             &bdberr);
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open_more_queue:failed to open queue %s/%s, rcode %d\n",
-                   dbenv->basedir, db->tablename_ip, bdberr);
+                   dbenv->basedir, db->tablename_interned, bdberr);
             return -1;
         }
     }
@@ -4053,7 +4053,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
         if (bthashsz) {
             logmsg(LOGMSG_INFO,
                    "Building bthash for table %s, size %dkb per stripe\n",
-                   tbl->tablename_ip, bthashsz);
+                   tbl->tablename_interned, bthashsz);
             bdb_handle_dbp_add_hash(tbl->handle, bthashsz);
         }
 
@@ -4069,7 +4069,7 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                "isc %s  "
                "odh_datacopy %s  "
                "ipu %s",
-               tbl->tablename_ip, tbl->schema_version, tbl->odh ? "yes" : "no",
+               tbl->tablename_interned, tbl->schema_version, tbl->odh ? "yes" : "no",
                tbl->instant_schema_change ? "yes" : "no",
                datacopy_odh ? "yes" : "no",
                tbl->inplace_updates ? "yes" : "no");
@@ -4147,9 +4147,9 @@ void fix_blobstripe_genids(tran_type *tran)
             if (rc == 0) {
                 bdb_set_blobstripe_genid(db->handle, db->blobstripe_genid);
                 ctrace("blobstripe genid 0x%llx for table %s\n",
-                       db->blobstripe_genid, db->tablename_ip);
+                       db->blobstripe_genid, db->tablename_interned);
             } else {
-                ctrace("no blobstripe genid for table %s\n", db->tablename_ip);
+                ctrace("no blobstripe genid for table %s\n", db->tablename_interned);
             }
         }
     }
@@ -4160,7 +4160,7 @@ int gbl_instrument_consumer_lock = 0;
 void consumer_lock_read_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d getting consumer readlock for %s\n", func, line, db->tablename_ip);
+        logmsg(LOGMSG_USER, "%s:%d getting consumer readlock for %s\n", func, line, db->tablename_interned);
     }
     Pthread_rwlock_rdlock(&db->consumer_lk);
 }
@@ -4168,7 +4168,7 @@ void consumer_lock_read_int(dbtable *db, const char *func, int line)
 void consumer_lock_write_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d getting consumer writelock for %s\n", func, line, db->tablename_ip);
+        logmsg(LOGMSG_USER, "%s:%d getting consumer writelock for %s\n", func, line, db->tablename_interned);
     }
     Pthread_rwlock_wrlock(&db->consumer_lk);
 }
@@ -4176,7 +4176,7 @@ void consumer_lock_write_int(dbtable *db, const char *func, int line)
 void consumer_unlock_int(dbtable *db, const char *func, int line)
 {
     if (gbl_instrument_consumer_lock) {
-        logmsg(LOGMSG_USER, "%s:%d unlocking consumer %s\n", func, line, db->tablename_ip);
+        logmsg(LOGMSG_USER, "%s:%d unlocking consumer %s\n", func, line, db->tablename_interned);
     }
     Pthread_rwlock_unlock(&db->consumer_lk);
 }
@@ -4199,7 +4199,7 @@ int fix_consumers_with_bdblib(struct dbenv *dbenv)
                 logmsg(
                     LOGMSG_ERROR,
                     "bdb_queue_consumer error for queue %s/%s/%d, rcode %d\n",
-                    dbenv->basedir, db->tablename_ip, consumern, bdberr);
+                    dbenv->basedir, db->tablename_interned, consumern, bdberr);
                 consumer_unlock(db);
                 return -1;
             }
@@ -4664,7 +4664,7 @@ static int meta_put(struct dbtable *db, void *input_tran, struct metahdr *hdr1,
     if (db->dbenv->meta) {
         bzero(&hdr2, sizeof(struct metahdr2));
         memcpy(&hdr2.hdr1, hdr1, sizeof(struct metahdr));
-        snprintf(hdr2.keystr, sizeof(hdr2.keystr), "/%s", db->tablename_ip);
+        snprintf(hdr2.keystr, sizeof(hdr2.keystr), "/%s", db->tablename_interned);
         keysize = sizeof(struct metahdr2);
         metahdr2_type_put(&hdr2, p_hdr2_buf, p_hdr2_buf_end);
         hdr = &p_metahdr2;
@@ -4793,7 +4793,7 @@ static int meta_get_tran(tran_type *tran, struct dbtable *db, struct metahdr *ke
     if (db->dbenv->meta) {
         bzero(&key2, sizeof(struct metahdr2));
         memcpy(&key2.hdr1, key1, sizeof(struct metahdr));
-        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_ip);
+        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_interned);
         metahdr2_type_put(&key2, p_hdr2_buf, p_hdr2_buf_end);
         key = &p_metahdr2;
     } else {
@@ -4853,7 +4853,7 @@ static int meta_get_var_tran(tran_type *tran, struct dbtable *db,
     if (db->dbenv->meta) {
         bzero(&key2, sizeof(struct metahdr2));
         memcpy(&key2.hdr1, key1, sizeof(struct metahdr));
-        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_ip);
+        snprintf(key2.keystr, sizeof(key2.keystr), "/%s", db->tablename_interned);
         metahdr2_type_put(&key2, p_hdr2_buf, p_hdr2_buf_end);
         key = &p_metahdr2;
     } else {
@@ -5487,7 +5487,7 @@ void diagnostics_dump_dta(struct dbtable *db, int dtanum)
 
     char *filename;
     filename =
-        comdb2_location("debug", "%s.dump_dta%d.txt", db->tablename_ip, dtanum);
+        comdb2_location("debug", "%s.dump_dta%d.txt", db->tablename_interned, dtanum);
     fh = fopen(filename, "w");
     if (!fh) {
         logmsg(LOGMSG_ERROR, "diagnostics_dump_dta: cannot open %s: %s\n", filename,
@@ -5566,7 +5566,7 @@ void compr_print_stats()
         struct dbtable *db = thedb->dbs[ii];
         bdb_get_compr_flags(db->handle, &odh, &compr, &blob_compr);
 
-        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_ip);
+        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_interned);
         logmsg(LOGMSG_USER, "ODH: %3s Compress: %-8s Blob compress: %-8s  in-place updates: "
                "%-3s  instant schema change: %-3s",
                odh ? "yes" : "no", bdb_algo2compr(compr),
@@ -5582,27 +5582,27 @@ void print_tableparams()
     int ii;
     for (ii = 0; ii < thedb->num_dbs; ii++) {
         struct dbtable *db = thedb->dbs[ii];
-        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_ip);
+        logmsg(LOGMSG_USER, "[%-16s] ", db->tablename_interned);
 
         int bdberr = 0;
         int coveragevalue = 0;
         long long thresholdvalue = 0;
         int rc = 0;
 
-        rc = bdb_get_analyzecoverage_table(NULL, db->tablename_ip, &coveragevalue,
+        rc = bdb_get_analyzecoverage_table(NULL, db->tablename_interned, &coveragevalue,
                                            &bdberr);
         if (rc != 0)
             logmsg(LOGMSG_ERROR, "bdb_get_analyzecoverage_table rc = %d, bdberr=%d\n", rc,
                    bdberr);
 
-        rc = bdb_get_analyzethreshold_table(NULL, db->tablename_ip,
+        rc = bdb_get_analyzethreshold_table(NULL, db->tablename_interned,
                                             &thresholdvalue, &bdberr);
         if (rc != 0)
             logmsg(LOGMSG_ERROR, "bdb_get_analyzethreshold_table rc = %d, bdberr=%d\n", rc,
                    bdberr);
 
         char *disableskipscanval = NULL;
-        bdb_get_table_parameter(db->tablename_ip, "disableskipscan",
+        bdb_get_table_parameter(db->tablename_interned, "disableskipscan",
                                 &disableskipscanval);
 
         if (coveragevalue >= 0)
@@ -5623,7 +5623,7 @@ void print_tableparams()
 
         char *tableparams = NULL;
         int tbplen = 0;
-        bdb_get_table_csonparameters(NULL, db->tablename_ip, &tableparams,
+        bdb_get_table_csonparameters(NULL, db->tablename_interned, &tableparams,
                                      &tbplen);
         if (tableparams) {
             logmsg(LOGMSG_USER, " tableparams: %10s", tableparams);
@@ -5807,7 +5807,7 @@ int find_record_older_than(struct ireq *iq, void *tran, int timestamp,
 static int ix_find_check_blob_race(struct ireq *iq, char *inbuf, int numblobs,
                                    int *blobnums, void **blobptrs)
 {
-    const char *table = iq->usedb->tablename_ip;
+    const char *table = iq->usedb->tablename_interned;
     struct schema *sch;
     struct field *fld;
     int i;
@@ -6046,7 +6046,7 @@ int table_version_upsert(struct dbtable *db, void *trans, int *bdberr)
     //select needs to be done with the same transaction to avoid 
     //undetectable deadlock for writing and reading from same thread
     unsigned long long version;
-    rc = bdb_table_version_select(db->tablename_ip, trans, &version, bdberr);
+    rc = bdb_table_version_select(db->tablename_interned, trans, &version, bdberr);
     if (rc || *bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, *bdberr);
@@ -6067,7 +6067,7 @@ unsigned long long table_version_select(struct dbtable *db, tran_type *tran)
     unsigned long long version;
     int rc;
 
-    rc = bdb_table_version_select(db->tablename_ip, tran, &version, &bdberr);
+    rc = bdb_table_version_select(db->tablename_interned, tran, &version, &bdberr);
     if (rc || bdberr) {
         logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n", __func__,
                 version, rc, bdberr);
@@ -6112,8 +6112,8 @@ int rename_table_options(void *tran, struct dbtable *db, const char *newname)
             return rc;
     }
 
-    const char *oldname = db->tablename_ip;
-    db->tablename_ip = intern(newname);
+    const char *oldname = db->tablename_interned;
+    db->tablename_interned = intern(newname);
 
     rc = put_db_odh(db, tran, odh);
     if (rc)
@@ -6134,7 +6134,7 @@ int rename_table_options(void *tran, struct dbtable *db, const char *newname)
         rc = put_db_bthash(db, tran, bthashsz);
 
 done:
-    db->tablename_ip = oldname;
+    db->tablename_interned = oldname;
 
     return rc;
 }
@@ -6191,7 +6191,7 @@ int comdb2_next_allowed_table(sqlite3_int64 *tabId)
 
     while (*tabId < thedb->num_dbs) {
         pDb = thedb->dbs[*tabId];
-        const char *tablename = pDb->tablename_ip;
+        const char *tablename = pDb->tablename_interned;
         rc = bdb_check_user_tbl_access(thedb->bdb_env,
                                        thd->clnt->current_user.name, tablename,
                                        ACCESS_READ, &bdberr);

--- a/db/indices.c
+++ b/db/indices.c
@@ -185,7 +185,7 @@ static int check_index(struct ireq *iq, void *trans, int ixnum,
     if (ixkeylen < 0) {
         if (iq->debug)
             reqprintf(iq, "BAD INDEX %d OR KEYLENGTH %d", ixnum, ixkeylen);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_KEY, "bad index %d or keylength %d",
                   ixnum, ixkeylen);
         *ixfailnum = ixnum;
@@ -207,7 +207,7 @@ static int check_index(struct ireq *iq, void *trans, int ixnum,
     if (rc == -1) {
         if (iq->debug)
             reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_IDX, "cannot form index %d", ixnum);
         *ixfailnum = ixnum;
         *opfailcode = OP_FAILED_INTERNAL + ERR_FORM_KEY;
@@ -353,7 +353,7 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
         if (ixkeylen < 0) {
             if (iq->debug)
                 reqprintf(iq, "BAD INDEX %d OR KEYLENGTH %d", ixnum, ixkeylen);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_KEY,
                       "bad index %d or keylength %d", ixnum, ixkeylen);
             *ixfailnum = ixnum;
@@ -376,7 +376,7 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
         if (rc == -1) {
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_IDX, "cannot form index %d",
                       ixnum);
             *ixfailnum = ixnum;
@@ -863,13 +863,13 @@ int del_record_indices(struct ireq *iq, void *trans, int *opfailcode,
         else {
             char keytag[MAXTAGLEN];
             snprintf(keytag, sizeof(keytag), "%s_IX_%d", ondisktag, ixnum);
-            rc = stag_to_stag_buf_blobs(iq->usedb->tablename, ondisktag, od_dta,
+            rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ondisktag, od_dta,
                                         keytag, key, NULL, del_idx_blobs,
                                         del_idx_blobs ? MAXBLOBS : 0, 0);
             if (rc == -1) {
                 if (iq->debug)
                     reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-                reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+                reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
                 reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form index %d",
                           ixnum);
                 *ixfailnum = ixnum;
@@ -923,7 +923,7 @@ int del_record_indices(struct ireq *iq, void *trans, int *opfailcode,
             }
             if (rc != 0) {
                 if (rc == IX_NOTFND) {
-                    reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+                    reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
                     reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
                               "key not found on index %d", ixnum);
                 }
@@ -1126,7 +1126,7 @@ int upd_new_record_indices(
                    oldgenid, ixnum);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM OLD INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form old index %d",
                       ixnum);
             return rc;
@@ -1217,7 +1217,7 @@ int del_new_record_indices(struct ireq *iq, void *trans,
                    ngenid, ixnum);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form index %d",
                       ixnum);
             return rc;
@@ -1349,7 +1349,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
 
             if (iq->debug) {
                 reqprintf(iq, "%p:ADDKYCNSTRT  TBL %s IX %d RRN %d KEY ", trans,
-                          ditk->usedb->tablename, ditk->ixnum, addrrn);
+                          ditk->usedb->tablename_ip, ditk->ixnum, addrrn);
                 int ixkeylen = getkeysize(ditk->usedb, ditk->ixnum);
                 reqdumphex(iq, ditk->ixkey, ixkeylen);
                 reqmoref(iq, " RC %d", rc);
@@ -1361,7 +1361,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                           "duplicate key '%s' on "
                           "table '%s' index %d",
                           get_keynm_from_db_idx(ditk->usedb, ditk->ixnum),
-                          ditk->usedb->tablename, ditk->ixnum);
+                          ditk->usedb->tablename_ip, ditk->ixnum);
 
                 //*blkpos = curop->blkpos;
                 *errout = OP_FAILED_UNIQ;
@@ -1391,7 +1391,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         } else if (ditk->type == DIT_DEL) {
             int delrrn = 0;
 #ifndef NDEBUG
-            char *tblname = iq->usedb->tablename;
+            const char *tblname = iq->usedb->tablename_ip;
             struct dbtable *tbl = get_dbtable_by_name(tblname);
             assert(tbl == iq->usedb);
 #endif
@@ -1406,7 +1406,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
             }
             if (rc != 0) {
                 if (rc == IX_NOTFND) {
-                    reqerrstrhdr(iq, "Table '%s' ", ditk->usedb->tablename);
+                    reqerrstrhdr(iq, "Table '%s' ", ditk->usedb->tablename_ip);
                     reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
                               "key not found on index %d", ditk->ixnum);
                 }

--- a/db/indices.c
+++ b/db/indices.c
@@ -185,7 +185,7 @@ static int check_index(struct ireq *iq, void *trans, int ixnum,
     if (ixkeylen < 0) {
         if (iq->debug)
             reqprintf(iq, "BAD INDEX %d OR KEYLENGTH %d", ixnum, ixkeylen);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_KEY, "bad index %d or keylength %d",
                   ixnum, ixkeylen);
         *ixfailnum = ixnum;
@@ -207,7 +207,7 @@ static int check_index(struct ireq *iq, void *trans, int ixnum,
     if (rc == -1) {
         if (iq->debug)
             reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_IDX, "cannot form index %d", ixnum);
         *ixfailnum = ixnum;
         *opfailcode = OP_FAILED_INTERNAL + ERR_FORM_KEY;
@@ -353,7 +353,7 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
         if (ixkeylen < 0) {
             if (iq->debug)
                 reqprintf(iq, "BAD INDEX %d OR KEYLENGTH %d", ixnum, ixkeylen);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_KEY,
                       "bad index %d or keylength %d", ixnum, ixkeylen);
             *ixfailnum = ixnum;
@@ -376,7 +376,7 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
         if (rc == -1) {
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_IDX, "cannot form index %d",
                       ixnum);
             *ixfailnum = ixnum;
@@ -863,13 +863,13 @@ int del_record_indices(struct ireq *iq, void *trans, int *opfailcode,
         else {
             char keytag[MAXTAGLEN];
             snprintf(keytag, sizeof(keytag), "%s_IX_%d", ondisktag, ixnum);
-            rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ondisktag, od_dta,
+            rc = stag_to_stag_buf_blobs(iq->usedb->tablename_interned, ondisktag, od_dta,
                                         keytag, key, NULL, del_idx_blobs,
                                         del_idx_blobs ? MAXBLOBS : 0, 0);
             if (rc == -1) {
                 if (iq->debug)
                     reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-                reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+                reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
                 reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form index %d",
                           ixnum);
                 *ixfailnum = ixnum;
@@ -923,7 +923,7 @@ int del_record_indices(struct ireq *iq, void *trans, int *opfailcode,
             }
             if (rc != 0) {
                 if (rc == IX_NOTFND) {
-                    reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+                    reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
                     reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
                               "key not found on index %d", ixnum);
                 }
@@ -1126,7 +1126,7 @@ int upd_new_record_indices(
                    oldgenid, ixnum);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM OLD INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form old index %d",
                       ixnum);
             return rc;
@@ -1217,7 +1217,7 @@ int del_new_record_indices(struct ireq *iq, void *trans,
                    ngenid, ixnum);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM INDEX %d", ixnum);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_DEL_RC_INVL_IDX, "cannot form index %d",
                       ixnum);
             return rc;
@@ -1349,7 +1349,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
 
             if (iq->debug) {
                 reqprintf(iq, "%p:ADDKYCNSTRT  TBL %s IX %d RRN %d KEY ", trans,
-                          ditk->usedb->tablename_ip, ditk->ixnum, addrrn);
+                          ditk->usedb->tablename_interned, ditk->ixnum, addrrn);
                 int ixkeylen = getkeysize(ditk->usedb, ditk->ixnum);
                 reqdumphex(iq, ditk->ixkey, ixkeylen);
                 reqmoref(iq, " RC %d", rc);
@@ -1361,7 +1361,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                           "duplicate key '%s' on "
                           "table '%s' index %d",
                           get_keynm_from_db_idx(ditk->usedb, ditk->ixnum),
-                          ditk->usedb->tablename_ip, ditk->ixnum);
+                          ditk->usedb->tablename_interned, ditk->ixnum);
 
                 //*blkpos = curop->blkpos;
                 *errout = OP_FAILED_UNIQ;
@@ -1391,7 +1391,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         } else if (ditk->type == DIT_DEL) {
             int delrrn = 0;
 #ifndef NDEBUG
-            const char *tblname = iq->usedb->tablename_ip;
+            const char *tblname = iq->usedb->tablename_interned;
             struct dbtable *tbl = get_dbtable_by_name(tblname);
             assert(tbl == iq->usedb);
 #endif
@@ -1406,7 +1406,7 @@ int process_defered_table(struct ireq *iq, void *trans, int *blkpos, int *ixout,
             }
             if (rc != 0) {
                 if (rc == IX_NOTFND) {
-                    reqerrstrhdr(iq, "Table '%s' ", ditk->usedb->tablename_ip);
+                    reqerrstrhdr(iq, "Table '%s' ", ditk->usedb->tablename_interned);
                     reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
                               "key not found on index %d", ditk->ixnum);
                 }

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -79,7 +79,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }
@@ -90,7 +90,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename, ".ONDISK", od_dta, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_ip, ".ONDISK", od_dta, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -130,10 +130,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename);
+                               iq->usedb->tablename_ip);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -152,10 +152,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     rc = ERR_BADREQ;
     if ((p = buf_put(&s->nmembers, sizeof(int), p, lim)) == NULL)
         goto err;
-    if ((p = buf_no_net_put(iq->usedb->tablename, strlen(iq->usedb->tablename),
+    if ((p = buf_no_net_put(iq->usedb->tablename_ip, strlen(iq->usedb->tablename_ip),
                             p, lim)) == NULL)
         goto err;
-    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename), p,
+    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_ip), p,
                           lim)) == NULL)
         goto err;
 
@@ -180,10 +180,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename);
+                               iq->usedb->tablename_ip);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -250,7 +250,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                         fprintf(
                             stderr,
                             "table %s field %s: can't determine length rc %d\n",
-                            iq->usedb->tablename, fld->name, rc);
+                            iq->usedb->tablename_ip, fld->name, rc);
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
@@ -329,7 +329,7 @@ int local_replicant_log_delete_for_update(struct ireq *iq, void *trans, int rrn,
     /* printf("genid %016llx rrn %d rc %d\n", vgenid, rrn, rc); */
     if (rc == 0) {
         long long id;
-        strcpy(delop.table, iq->usedb->tablename);
+        strcpy(delop.table, iq->usedb->tablename_ip);
         id = get_record_unique_id(iq->usedb, tmpbuf);
         delop.id = id;
 
@@ -364,7 +364,7 @@ int local_replicant_log_delete(struct ireq *iq, void *trans, void *od_dta,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    strcpy(delop.table, iq->usedb->tablename);
+    strcpy(delop.table, iq->usedb->tablename_ip);
 
     id = get_record_unique_id(iq->usedb, od_dta);
     delop.id = id;
@@ -408,7 +408,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK");
+    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
     if (s == NULL) {
         rc = OP_FAILED_INTERNAL;
         goto done;
@@ -416,7 +416,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     odsz = get_size_of_schema(s);
     server_buf = malloc(odsz);
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK_CLIENT");
     if (s == NULL) {
         free(server_buf);
         server_buf = NULL;
@@ -447,7 +447,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename, ".ONDISK", server_buf, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_ip, ".ONDISK", server_buf, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -482,10 +482,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename);
+                               iq->usedb->tablename_ip);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -505,10 +505,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     rc = ERR_BADREQ;
     if ((p = buf_put(&s->nmembers, sizeof(int), p, lim)) == NULL)
         goto err;
-    if ((p = buf_no_net_put(iq->usedb->tablename, strlen(iq->usedb->tablename),
+    if ((p = buf_no_net_put(iq->usedb->tablename_ip, strlen(iq->usedb->tablename_ip),
                             p, lim)) == NULL)
         goto err;
-    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename), p,
+    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_ip), p,
                           lim)) == NULL)
         goto err;
 
@@ -531,10 +531,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename);
+                               iq->usedb->tablename_ip);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -597,7 +597,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                         fprintf(
                             stderr,
                             "table %s field %s: can't determine length rc %d\n",
-                            iq->usedb->tablename, fld->name, rc);
+                            iq->usedb->tablename_ip, fld->name, rc);
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
@@ -786,7 +786,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
     if (gbl_replicate_local == 0 || get_dbtable_by_name("comdb2_oplog") == NULL)
         return 0;
 
-    s = find_tag_schema(db->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(db->tablename_ip, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }
@@ -796,7 +796,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
         return 0;
     }
 
-    strncpy0(table, db->tablename, sizeof(table));
+    strncpy0(table, db->tablename_ip, sizeof(table));
 
     table[31] = 0;
 

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -79,7 +79,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb->tablename_interned, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }
@@ -90,7 +90,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_ip, ".ONDISK", od_dta, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_interned, ".ONDISK", od_dta, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -130,10 +130,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename_ip);
+                               iq->usedb->tablename_interned);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -152,10 +152,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     rc = ERR_BADREQ;
     if ((p = buf_put(&s->nmembers, sizeof(int), p, lim)) == NULL)
         goto err;
-    if ((p = buf_no_net_put(iq->usedb->tablename_ip, strlen(iq->usedb->tablename_ip),
+    if ((p = buf_no_net_put(iq->usedb->tablename_interned, strlen(iq->usedb->tablename_interned),
                             p, lim)) == NULL)
         goto err;
-    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_ip), p,
+    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_interned), p,
                           lim)) == NULL)
         goto err;
 
@@ -180,10 +180,10 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename_ip);
+                               iq->usedb->tablename_interned);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -250,7 +250,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                         fprintf(
                             stderr,
                             "table %s field %s: can't determine length rc %d\n",
-                            iq->usedb->tablename_ip, fld->name, rc);
+                            iq->usedb->tablename_interned, fld->name, rc);
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
@@ -329,7 +329,7 @@ int local_replicant_log_delete_for_update(struct ireq *iq, void *trans, int rrn,
     /* printf("genid %016llx rrn %d rc %d\n", vgenid, rrn, rc); */
     if (rc == 0) {
         long long id;
-        strcpy(delop.table, iq->usedb->tablename_ip);
+        strcpy(delop.table, iq->usedb->tablename_interned);
         id = get_record_unique_id(iq->usedb, tmpbuf);
         delop.id = id;
 
@@ -364,7 +364,7 @@ int local_replicant_log_delete(struct ireq *iq, void *trans, void *od_dta,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    strcpy(delop.table, iq->usedb->tablename_ip);
+    strcpy(delop.table, iq->usedb->tablename_interned);
 
     id = get_record_unique_id(iq->usedb, od_dta);
     delop.id = id;
@@ -408,7 +408,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+    s = find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
     if (s == NULL) {
         rc = OP_FAILED_INTERNAL;
         goto done;
@@ -416,7 +416,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     odsz = get_size_of_schema(s);
     server_buf = malloc(odsz);
 
-    s = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb->tablename_interned, ".ONDISK_CLIENT");
     if (s == NULL) {
         free(server_buf);
         server_buf = NULL;
@@ -447,7 +447,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_ip, ".ONDISK", server_buf, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb->tablename_interned, ".ONDISK", server_buf, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -482,10 +482,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename_ip);
+                               iq->usedb->tablename_interned);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -505,10 +505,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     rc = ERR_BADREQ;
     if ((p = buf_put(&s->nmembers, sizeof(int), p, lim)) == NULL)
         goto err;
-    if ((p = buf_no_net_put(iq->usedb->tablename_ip, strlen(iq->usedb->tablename_ip),
+    if ((p = buf_no_net_put(iq->usedb->tablename_interned, strlen(iq->usedb->tablename_interned),
                             p, lim)) == NULL)
         goto err;
-    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_ip), p,
+    if ((p = buf_zero_put(MAXTABLELEN - strlen(iq->usedb->tablename_interned), p,
                           lim)) == NULL)
         goto err;
 
@@ -531,10 +531,10 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+                        find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
-                               iq->usedb->tablename_ip);
+                               iq->usedb->tablename_interned);
                         free(client_buf);
                         return OP_FAILED_INTERNAL;
                     }
@@ -597,7 +597,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                         fprintf(
                             stderr,
                             "table %s field %s: can't determine length rc %d\n",
-                            iq->usedb->tablename_ip, fld->name, rc);
+                            iq->usedb->tablename_interned, fld->name, rc);
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
@@ -786,7 +786,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
     if (gbl_replicate_local == 0 || get_dbtable_by_name("comdb2_oplog") == NULL)
         return 0;
 
-    s = find_tag_schema(db->tablename_ip, ".ONDISK_CLIENT");
+    s = find_tag_schema(db->tablename_interned, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }
@@ -796,7 +796,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
         return 0;
     }
 
-    strncpy0(table, db->tablename_ip, sizeof(table));
+    strncpy0(table, db->tablename_interned, sizeof(table));
 
     table[31] = 0;
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3486,7 +3486,7 @@ int osql_send_usedb(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
 
     /* tablename field is not null-terminated -- send rest of tablename */
     rc = target->send(target, type, &buf, msglen, 0,
-                      (tablenamelen > sent) ? tablename + sent : NULL,
+                      (tablenamelen > sent) ? ((char *)tablename) + sent : NULL,
                       (tablenamelen > sent) ? tablenamelen - sent : 0);
 
     if (rc)
@@ -6186,7 +6186,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         int locflags = RECFLAGS_DONT_LOCK_TBL;
 
-        rc = is_tablename_queue(iq->usedb->tablename)
+        rc = is_tablename_queue(iq->usedb->tablename_ip)
             ? dbq_consume_genid(iq, trans, 0, dt.genid)
             : del_record(iq, trans, NULL, 0, dt.genid, dt.dk, &err->errcode, &err->ixnum, BLOCK2_DELKL, locflags);
 
@@ -7344,7 +7344,7 @@ int osql_send_schemachange(osql_target_t *target, unsigned long long rqid,
 
     if (gbl_enable_osql_logging) {
         logmsg(LOGMSG_DEBUG, "[%llu %s] send OSQL_SCHEMACHANGE %s\n", rqid,
-               comdb2uuidstr(uuid, us), sc->tablename_ip);
+               comdb2uuidstr(uuid, us), sc->tablename);
     }
 
     return target->send(target, type, buf, osql_rpl_size, 0, NULL, 0);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6186,7 +6186,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         int locflags = RECFLAGS_DONT_LOCK_TBL;
 
-        rc = is_tablename_queue(iq->usedb->tablename_ip)
+        rc = is_tablename_queue(iq->usedb->tablename_interned)
             ? dbq_consume_genid(iq, trans, 0, dt.genid)
             : del_record(iq, trans, NULL, 0, dt.genid, dt.dk, &err->errcode, &err->ixnum, BLOCK2_DELKL, locflags);
 
@@ -6298,7 +6298,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                                                        "duplicate key '%s' on "
                                                        "table '%s' index %d",
                               get_keynm_from_db_idx(iq->usedb, err->ixnum),
-                              iq->usedb->tablename_ip, err->ixnum);
+                              iq->usedb->tablename_interned, err->ixnum);
                 }
             } else if (rc != RC_INTERNAL_RETRY) {
                 errstat_cat_strf(&iq->errstat, " unable to add record rc = %d",
@@ -6413,7 +6413,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             /* Make sure this is sane before sending to upd_record. */
             for (int ii = 0; ii < MAXBLOBS; ii++) {
                 if (-2 == blobs[ii].length) {
-                    int idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
+                    int idx = get_schema_blob_field_idx(iq->usedb->tablename_interned,
                                                         ".ONDISK", ii);
                     assert(idx < ncols);
                     assert(-1 == (*updCols)[idx + 1]);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -2837,7 +2837,7 @@ static osql_comm_t *get_thecomm(void)
 static void net_osql_rpl(void *hndl, void *uptr, char *fromnode, int usertype,
                          void *dtap, int dtalen, uint8_t is_tcp);
 static int net_osql_rpl_tail(void *hndl, void *uptr, char *fromnode,
-                             int usertype, void *dtap, int dtalen, void *tail,
+                             int usertype, void *dtap, int dtalen, const void *tail,
                              int tailen);
 
 static void net_sosql_req(void *hndl, void *uptr, char *fromnode, int usertype,
@@ -3415,7 +3415,7 @@ int osql_send_startgen(osql_target_t *target, unsigned long long rqid,
  *
  */
 int osql_send_usedb(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
-                    char *tablename, int type, unsigned long long tableversion)
+                    const char *tablename, int type, unsigned long long tableversion)
 {
     unsigned short tablenamelen = strlen(tablename) + 1; /*including trailing 0*/
     int msglen;
@@ -5426,7 +5426,7 @@ static int check_master(const osql_target_t *target)
    this is needed only when routing local packets
    we need to "serialize" the tail as well, therefore the need for duplicate */
 static int net_osql_rpl_tail(void *hndl, void *uptr, char *fromhost,
-                             int usertype, void *dtap, int dtalen, void *tail,
+                             int usertype, void *dtap, int dtalen, const void *tail,
                              int tailen)
 {
     void *dup;
@@ -6298,7 +6298,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
                                                        "duplicate key '%s' on "
                                                        "table '%s' index %d",
                               get_keynm_from_db_idx(iq->usedb, err->ixnum),
-                              iq->usedb->tablename, err->ixnum);
+                              iq->usedb->tablename_ip, err->ixnum);
                 }
             } else if (rc != RC_INTERNAL_RETRY) {
                 errstat_cat_strf(&iq->errstat, " unable to add record rc = %d",
@@ -6413,7 +6413,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             /* Make sure this is sane before sending to upd_record. */
             for (int ii = 0; ii < MAXBLOBS; ii++) {
                 if (-2 == blobs[ii].length) {
-                    int idx = get_schema_blob_field_idx(iq->usedb->tablename,
+                    int idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
                                                         ".ONDISK", ii);
                     assert(idx < ncols);
                     assert(-1 == (*updCols)[idx + 1]);
@@ -7344,7 +7344,7 @@ int osql_send_schemachange(osql_target_t *target, unsigned long long rqid,
 
     if (gbl_enable_osql_logging) {
         logmsg(LOGMSG_DEBUG, "[%llu %s] send OSQL_SCHEMACHANGE %s\n", rqid,
-               comdb2uuidstr(uuid, us), sc->tablename);
+               comdb2uuidstr(uuid, us), sc->tablename_ip);
     }
 
     return target->send(target, type, buf, osql_rpl_size, 0, NULL, 0);

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -60,7 +60,7 @@ int osql_comm_send_socksqlreq(osql_target_t *target, const char *sql, int sqlen,
  *
  */
 int osql_send_usedb(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
-                    char *tablename, int type, unsigned long long version);
+                    const char *tablename, int type, unsigned long long version);
 
 /**
  * Send INDEX op

--- a/db/osqlpfthdpool.c
+++ b/db/osqlpfthdpool.c
@@ -408,17 +408,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename_ip, ixnum);
+                       iq.usedb->tablename_interned, ixnum);
                 break;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                   (char *)fnddta, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename_ip);
+                       ixnum, iq.usedb->tablename_interned);
                 break;
             }
 
@@ -443,17 +443,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename_ip, ixnum);
+                       iq.usedb->tablename_interned, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                   (char *)req->record, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename_ip);
+                       ixnum, iq.usedb->tablename_interned);
                 continue;
             }
 
@@ -506,17 +506,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename_ip, ixnum);
+                       iq.usedb->tablename_interned, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                   (char *)fnddta, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename_ip);
+                       ixnum, iq.usedb->tablename_interned);
                 continue;
             }
 
@@ -536,17 +536,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename_ip, ixnum);
+                       iq.usedb->tablename_interned, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                   (char *)req->record, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename_ip);
+                       ixnum, iq.usedb->tablename_interned);
                 continue;
             }
 

--- a/db/osqlpfthdpool.c
+++ b/db/osqlpfthdpool.c
@@ -408,17 +408,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename, ixnum);
+                       iq.usedb->tablename_ip, ixnum);
                 break;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                   (char *)fnddta, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename);
+                       ixnum, iq.usedb->tablename_ip);
                 break;
             }
 
@@ -443,17 +443,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename, ixnum);
+                       iq.usedb->tablename_ip, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                   (char *)req->record, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename);
+                       ixnum, iq.usedb->tablename_ip);
                 continue;
             }
 
@@ -506,17 +506,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename, ixnum);
+                       iq.usedb->tablename_ip, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                   (char *)fnddta, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename);
+                       ixnum, iq.usedb->tablename_ip);
                 continue;
             }
 
@@ -536,17 +536,17 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot get key size"
                        " tbl %s. idx %d\n",
-                       iq.usedb->tablename, ixnum);
+                       iq.usedb->tablename_ip, ixnum);
                 continue;
             }
             snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+            rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                   (char *)req->record, keytag, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
                        " %d of TBL %s\n",
-                       ixnum, iq.usedb->tablename);
+                       ixnum, iq.usedb->tablename_ip);
                 continue;
             }
 

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -445,7 +445,7 @@ static shad_tbl_t *create_shadtbl(struct BtCursor *pCur,
 
     tbl->seq = 0;
     tbl->env = env;
-    strncpy0(tbl->tablename, db->tablename, sizeof(tbl->tablename));
+    strncpy0(tbl->tablename, db->tablename_ip, sizeof(tbl->tablename));
     tbl->tableversion = db->tableversion;
     tbl->nix = db->nix;
     tbl->ix_expr = db->ix_expr;
@@ -599,7 +599,7 @@ int osql_fetch_shadblobs_by_genid(BtCursor *pCur, int *blobnum,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->blb_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename);
+               pCur->db->tablename_ip);
         return -1;
     }
 
@@ -667,7 +667,7 @@ int osql_get_shadowdata(BtCursor *pCur, unsigned long long genid, void **buf,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->add_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename);
+               pCur->db->tablename_ip);
         return -1;
     }
 
@@ -929,7 +929,7 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->upd_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename);
+               pCur->db->tablename_ip);
         return -1;
     }
 
@@ -1078,7 +1078,7 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->add_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename);
+               pCur->db->tablename_ip);
         return -1;
     }
 
@@ -1445,7 +1445,7 @@ void *osql_get_shadow_bydb(struct sqlclntstate *clnt, struct dbtable *db)
 
     LISTC_FOR_EACH(&clnt->osql.shadtbls, tbl, linkv)
     {
-        if (strcasecmp(tbl->tablename, db->tablename) == 0) {
+        if (strcasecmp(tbl->tablename, db->tablename_ip) == 0) {
             ret = tbl;
             break;
         }
@@ -2192,7 +2192,7 @@ static int insert_record_indexes(BtCursor *pCur, struct sql_thread *thd,
             memcpy(key, thd->clnt->idxInsert[ix],
                    pCur->db->ix_keylen[ix]);
         } else {
-            rc = stag_to_stag_buf(pCur->db->tablename, ".ONDISK",
+            rc = stag_to_stag_buf(pCur->db->tablename_ip, ".ONDISK",
                                   pCur->ondisk_buf, namebuf, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR, "insert_record:stag_to_stag_buf ix %d\n", ix);
@@ -2288,7 +2288,7 @@ static int delete_record_indexes(BtCursor *pCur, char *pdta, int dtasize,
         if (gbl_expressions_indexes && db->ix_expr) {
             memcpy(key, thd->clnt->idxDelete[ix], db->ix_keylen[ix]);
         } else {
-            rc = stag_to_stag_buf(db->tablename, ".ONDISK", dta, namebuf, key,
+            rc = stag_to_stag_buf(db->tablename_ip, ".ONDISK", dta, namebuf, key,
                                   NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR, "%s:stag_to_stag_buf ix %d\n", __func__, ix);
@@ -2719,12 +2719,12 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
 
     if (!osql->verify_tbl || !osql->verify_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting verify table for \'%s\'\n",
-               __func__, pCur->db->tablename);
+               __func__, pCur->db->tablename_ip);
         return -1;
     }
 
-    key.tablename_len = strlen(pCur->db->tablename) + 1;
-    strncpy0(key.tablename, pCur->db->tablename, sizeof(key.tablename));
+    key.tablename_len = strlen(pCur->db->tablename_ip) + 1;
+    strncpy0(key.tablename, pCur->db->tablename_ip, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2734,7 +2734,7 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
     if (packed_key == NULL) {
         logmsg(LOGMSG_ERROR,
                "%s: error packing record genid key for table \'%s\'\n",
-               __func__, pCur->db->tablename);
+               __func__, pCur->db->tablename_ip);
         return -1;
     }
 
@@ -2767,8 +2767,8 @@ int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
         return -1;
     }
 
-    key.tablename_len = strlen(pCur->db->tablename) + 1;
-    strncpy0(key.tablename, pCur->db->tablename, sizeof(key.tablename));
+    key.tablename_len = strlen(pCur->db->tablename_ip) + 1;
+    strncpy0(key.tablename, pCur->db->tablename_ip, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2778,7 +2778,7 @@ int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
     if (packed_key == NULL) {
         logmsg(LOGMSG_ERROR,
                "%s: error packing record genid key for table \'%s\'\n",
-               __func__, pCur->db->tablename);
+               __func__, pCur->db->tablename_ip);
         return -1;
     }
 

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -445,7 +445,7 @@ static shad_tbl_t *create_shadtbl(struct BtCursor *pCur,
 
     tbl->seq = 0;
     tbl->env = env;
-    strncpy0(tbl->tablename, db->tablename_ip, sizeof(tbl->tablename));
+    strncpy0(tbl->tablename, db->tablename_interned, sizeof(tbl->tablename));
     tbl->tableversion = db->tableversion;
     tbl->nix = db->nix;
     tbl->ix_expr = db->ix_expr;
@@ -599,7 +599,7 @@ int osql_fetch_shadblobs_by_genid(BtCursor *pCur, int *blobnum,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->blb_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename_ip);
+               pCur->db->tablename_interned);
         return -1;
     }
 
@@ -667,7 +667,7 @@ int osql_get_shadowdata(BtCursor *pCur, unsigned long long genid, void **buf,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->add_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename_ip);
+               pCur->db->tablename_interned);
         return -1;
     }
 
@@ -929,7 +929,7 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->upd_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename_ip);
+               pCur->db->tablename_interned);
         return -1;
     }
 
@@ -1078,7 +1078,7 @@ int osql_save_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
     if (!(tbl = open_shadtbl(pCur)) || !tbl->add_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting shadtbl for \'%s\'\n", __func__,
-               pCur->db->tablename_ip);
+               pCur->db->tablename_interned);
         return -1;
     }
 
@@ -1445,7 +1445,7 @@ void *osql_get_shadow_bydb(struct sqlclntstate *clnt, struct dbtable *db)
 
     LISTC_FOR_EACH(&clnt->osql.shadtbls, tbl, linkv)
     {
-        if (strcasecmp(tbl->tablename, db->tablename_ip) == 0) {
+        if (strcasecmp(tbl->tablename, db->tablename_interned) == 0) {
             ret = tbl;
             break;
         }
@@ -2192,7 +2192,7 @@ static int insert_record_indexes(BtCursor *pCur, struct sql_thread *thd,
             memcpy(key, thd->clnt->idxInsert[ix],
                    pCur->db->ix_keylen[ix]);
         } else {
-            rc = stag_to_stag_buf(pCur->db->tablename_ip, ".ONDISK",
+            rc = stag_to_stag_buf(pCur->db->tablename_interned, ".ONDISK",
                                   pCur->ondisk_buf, namebuf, key, NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR, "insert_record:stag_to_stag_buf ix %d\n", ix);
@@ -2288,7 +2288,7 @@ static int delete_record_indexes(BtCursor *pCur, char *pdta, int dtasize,
         if (gbl_expressions_indexes && db->ix_expr) {
             memcpy(key, thd->clnt->idxDelete[ix], db->ix_keylen[ix]);
         } else {
-            rc = stag_to_stag_buf(db->tablename_ip, ".ONDISK", dta, namebuf, key,
+            rc = stag_to_stag_buf(db->tablename_interned, ".ONDISK", dta, namebuf, key,
                                   NULL);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR, "%s:stag_to_stag_buf ix %d\n", __func__, ix);
@@ -2719,12 +2719,12 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
 
     if (!osql->verify_tbl || !osql->verify_cur) {
         logmsg(LOGMSG_ERROR, "%s: error getting verify table for \'%s\'\n",
-               __func__, pCur->db->tablename_ip);
+               __func__, pCur->db->tablename_interned);
         return -1;
     }
 
-    key.tablename_len = strlen(pCur->db->tablename_ip) + 1;
-    strncpy0(key.tablename, pCur->db->tablename_ip, sizeof(key.tablename));
+    key.tablename_len = strlen(pCur->db->tablename_interned) + 1;
+    strncpy0(key.tablename, pCur->db->tablename_interned, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2734,7 +2734,7 @@ int osql_save_recordgenid(struct BtCursor *pCur, struct sql_thread *thd,
     if (packed_key == NULL) {
         logmsg(LOGMSG_ERROR,
                "%s: error packing record genid key for table \'%s\'\n",
-               __func__, pCur->db->tablename_ip);
+               __func__, pCur->db->tablename_interned);
         return -1;
     }
 
@@ -2767,8 +2767,8 @@ int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
         return -1;
     }
 
-    key.tablename_len = strlen(pCur->db->tablename_ip) + 1;
-    strncpy0(key.tablename, pCur->db->tablename_ip, sizeof(key.tablename));
+    key.tablename_len = strlen(pCur->db->tablename_interned) + 1;
+    strncpy0(key.tablename, pCur->db->tablename_interned, sizeof(key.tablename));
     key.tableversion = pCur->db->tableversion;
     key.genid = genid;
 
@@ -2778,7 +2778,7 @@ int is_genid_recorded(struct sql_thread *thd, struct BtCursor *pCur,
     if (packed_key == NULL) {
         logmsg(LOGMSG_ERROR,
                "%s: error packing record genid key for table \'%s\'\n",
-               __func__, pCur->db->tablename_ip);
+               __func__, pCur->db->tablename_interned);
         return -1;
     }
 

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1347,7 +1347,7 @@ static int osql_send_usedb_logic_int(const char *tablename, struct sqlclntstate 
 static int osql_send_usedb_logic(struct BtCursor *pCur, struct sql_thread *thd,
                                  int nettype)
 {
-    return osql_send_usedb_logic_int(pCur->db->tablename_ip, thd->clnt,
+    return osql_send_usedb_logic_int(pCur->db->tablename_interned, thd->clnt,
                                      nettype);
 }
 
@@ -1450,7 +1450,7 @@ static int osql_send_qblobs_logic(struct BtCursor *pCur, osqlstate_t *osql,
         /* Send length of -2 if this isn't being used in this update. */
         if (updCols && gbl_osql_blob_optimization && blobs[i].length > 0) {
             int idx =
-                get_schema_blob_field_idx(pCur->db->tablename_ip, ".ONDISK", i);
+                get_schema_blob_field_idx(pCur->db->tablename_interned, ".ONDISK", i);
             /* AZ: is pCur->db->schema not set to ondisk so we can instead call
              * get_schema_blob_field_idx_sc(pCur->db->schema,i); ?? */
             int ncols = updCols[0];
@@ -1737,13 +1737,13 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
 
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_write_by_mach_get(
-            pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename_ip,
+            pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename_interned,
             nodeix(thd->clnt->origin), &bdberr);
         if (rc <= 0) {
             char msg[1024];
             snprintf(
                 msg, sizeof(msg), "Write access denied to %s from %d bdberr=%d",
-                pCur->db->tablename_ip, nodeix(thd->clnt->origin), bdberr);
+                pCur->db->tablename_interned, nodeix(thd->clnt->origin), bdberr);
             logmsg(LOGMSG_INFO, "%s\n", msg);
             errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
             errstat_set_str(&thd->clnt->osql.xerr, msg);
@@ -1758,11 +1758,11 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
         (thd->clnt->no_transaction == 0)) {
         rc = bdb_check_user_tbl_access(
             pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
-            pCur->db->tablename_ip, ACCESS_WRITE, &bdberr);
+            pCur->db->tablename_interned, ACCESS_WRITE, &bdberr);
         if (rc != 0) {
             char msg[1024];
             char buf[MAXTABLELEN];
-            const char *table_name = resolve_table_name(pCur->db->tablename_ip,
+            const char *table_name = resolve_table_name(pCur->db->tablename_interned,
                                                        (char *)buf, sizeof(buf));
             snprintf(msg, sizeof(msg),
                      "Write access denied to %s for user %s bdberr=%d",
@@ -1788,13 +1788,13 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_read_by_mach_get(
-            pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename_ip,
+            pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename_interned,
             nodeix(thd->clnt->origin), &bdberr);
         if (rc <= 0) {
             char msg[1024];
             snprintf(
                 msg, sizeof(msg), "Read access denied to %s from %d bdberr=%d",
-                pCur->db->tablename_ip, nodeix(thd->clnt->origin), bdberr);
+                pCur->db->tablename_interned, nodeix(thd->clnt->origin), bdberr);
             logmsg(LOGMSG_INFO, "%s\n", msg);
             errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
             errstat_set_str(&thd->clnt->osql.xerr, msg);
@@ -1808,11 +1808,11 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
     if (gbl_uses_password && thd->clnt->no_transaction == 0) {
         rc = bdb_check_user_tbl_access(
             pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
-            pCur->db->tablename_ip, ACCESS_READ, &bdberr);
+            pCur->db->tablename_interned, ACCESS_READ, &bdberr);
         if (rc != 0) {
             char msg[1024];
             char buf[MAXTABLELEN];
-            const char *table_name = resolve_table_name(pCur->db->tablename_ip,
+            const char *table_name = resolve_table_name(pCur->db->tablename_interned,
                                                         (char *)buf, sizeof(buf));
             snprintf(msg, sizeof(msg),
                      "Read access denied to %s for user %s bdberr=%d",

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1762,7 +1762,7 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
         if (rc != 0) {
             char msg[1024];
             char buf[MAXTABLELEN];
-            const char *table_name = resolve_table_name(pCur->db->tablename,
+            const char *table_name = resolve_table_name(pCur->db->tablename_ip,
                                                        (char *)buf, sizeof(buf));
             snprintf(msg, sizeof(msg),
                      "Write access denied to %s for user %s bdberr=%d",
@@ -1812,7 +1812,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
         if (rc != 0) {
             char msg[1024];
             char buf[MAXTABLELEN];
-            const char *table_name = resolve_table_name(pCur->db->tablename,
+            const char *table_name = resolve_table_name(pCur->db->tablename_ip,
                                                         (char *)buf, sizeof(buf));
             snprintf(msg, sizeof(msg),
                      "Read access denied to %s for user %s bdberr=%d",

--- a/db/osqlsqlthr.h
+++ b/db/osqlsqlthr.h
@@ -81,7 +81,7 @@ int osql_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
  * issues.
  *
  */
-int osql_cleartable(struct sql_thread *thd, char *dbname);
+int osql_cleartable(struct sql_thread *thd, const char *dbname);
 
 /**
  * Set maximum osql transaction size

--- a/db/osqluprec.c
+++ b/db/osqluprec.c
@@ -88,11 +88,11 @@ static const uint8_t *construct_uptbl_buffer(const struct dbtable *db,
     p_buf_op_hdr_end = p_buf;
 
     usekl.dbnum = db->dbnum;
-    usekl.taglen = strlen(db->tablename_ip) + 1 /*NUL byte*/;
+    usekl.taglen = strlen(db->tablename_interned) + 1 /*NUL byte*/;
     if (!(p_buf = packedreq_usekl_put(&usekl, p_buf, p_buf_end)))
         return NULL;
     if (!(p_buf =
-              buf_no_net_put(db->tablename_ip, usekl.taglen, p_buf, p_buf_end)))
+              buf_no_net_put(db->tablename_interned, usekl.taglen, p_buf, p_buf_end)))
         return NULL;
 
     op_hdr.opcode = BLOCK2_USE;

--- a/db/osqluprec.c
+++ b/db/osqluprec.c
@@ -88,11 +88,11 @@ static const uint8_t *construct_uptbl_buffer(const struct dbtable *db,
     p_buf_op_hdr_end = p_buf;
 
     usekl.dbnum = db->dbnum;
-    usekl.taglen = strlen(db->tablename) + 1 /*NUL byte*/;
+    usekl.taglen = strlen(db->tablename_ip) + 1 /*NUL byte*/;
     if (!(p_buf = packedreq_usekl_put(&usekl, p_buf, p_buf_end)))
         return NULL;
     if (!(p_buf =
-              buf_no_net_put(db->tablename, usekl.taglen, p_buf, p_buf_end)))
+              buf_no_net_put(db->tablename_ip, usekl.taglen, p_buf, p_buf_end)))
         return NULL;
 
     op_hdr.opcode = BLOCK2_USE;

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -746,11 +746,11 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename, ixnum);
+                               iq.usedb->tablename_ip, ixnum);
                         break;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                           (char *)fnddta, keytag, key, NULL);
                     if (rc == -1) {
                         break;
@@ -804,7 +804,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                 if (od_len_int <= 0) {
                     logmsg(LOGMSG_ERROR, "od_len_int = %d\n", od_len_int);
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                     break;
                 }
                 od_len = (size_t)od_len_int;
@@ -818,7 +818,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     i = req->helper_thread;
                     if ((i < 0) || (i >= dbenv->prefault_helper.numthreads)) {
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                         break;
                     }
 
@@ -831,7 +831,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                          dbenv->prefault_helper.threads[i].seqnum)) {
                         dbenv->prefault_stats.skipped_seq++;
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                         break;
                     }
 #endif
@@ -840,7 +840,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (btst(op_bitmap, 63)) {
                         dbenv->prefault_stats.skipped++;
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                         break;
                     }
 #endif
@@ -854,7 +854,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     dbenv->prefault_stats
                         .num_prfq_data_keys_newkeys_no_olddta++;
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
 
                     break;
                 }
@@ -868,17 +868,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename, ixnum);
+                               iq.usedb->tablename_ip, ixnum);
                         continue;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                           (char *)fnddta, keytag, key, NULL);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"
                                " %d of TBL %s\n",
-                               ixnum, iq.usedb->tablename);
+                               ixnum, iq.usedb->tablename_ip);
                         continue;
                     }
 
@@ -892,7 +892,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                  * old record and the changes.
                  */
                 memcpy(od_dta, fnddta, od_len);
-                rc = ctag_to_stag_buf(iq.usedb->tablename, tag, req->record,
+                rc = ctag_to_stag_buf(iq.usedb->tablename_ip, tag, req->record,
                                       WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                       od_dta, CONVERT_UPDATE, &reason);
                 if (rc < 0) {
@@ -900,17 +900,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                      * trace on a turnoffable switch */
                     if (gbl_prefault_verbose) {
                         char str[128];
-                        convert_failure_reason_str(&reason, iq.usedb->tablename,
+                        convert_failure_reason_str(&reason, iq.usedb->tablename_ip,
                                                    tag, ".ONDISK", str,
                                                    sizeof(str));
                         logmsg(LOGMSG_USER,
                                "%s: conv failed for %s:%s->.ONDISK rc %d\n",
-                               __func__, iq.usedb->tablename, tag, rc);
+                               __func__, iq.usedb->tablename_ip, tag, rc);
                         logmsg(LOGMSG_USER, "%s: reason: %s\n", __func__, str);
                     }
 
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                     break;
                 }
 
@@ -923,17 +923,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename, ixnum);
+                               iq.usedb->tablename_ip, ixnum);
                         continue;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
                                           (char *)od_dta, keytag, key, NULL);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"
                                " %d of TBL %s\n",
-                               ixnum, iq.usedb->tablename);
+                               ixnum, iq.usedb->tablename_ip);
                         continue;
                     }
 
@@ -943,7 +943,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                 }
 
                 if (dynschema)
-                    free_dynamic_schema(iq.usedb->tablename, dynschema);
+                    free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
                 break;
             }
 

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -746,11 +746,11 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename_ip, ixnum);
+                               iq.usedb->tablename_interned, ixnum);
                         break;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                           (char *)fnddta, keytag, key, NULL);
                     if (rc == -1) {
                         break;
@@ -804,7 +804,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                 if (od_len_int <= 0) {
                     logmsg(LOGMSG_ERROR, "od_len_int = %d\n", od_len_int);
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                     break;
                 }
                 od_len = (size_t)od_len_int;
@@ -818,7 +818,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     i = req->helper_thread;
                     if ((i < 0) || (i >= dbenv->prefault_helper.numthreads)) {
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                         break;
                     }
 
@@ -831,7 +831,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                          dbenv->prefault_helper.threads[i].seqnum)) {
                         dbenv->prefault_stats.skipped_seq++;
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                         break;
                     }
 #endif
@@ -840,7 +840,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (btst(op_bitmap, 63)) {
                         dbenv->prefault_stats.skipped++;
                         if (dynschema)
-                            free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                            free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                         break;
                     }
 #endif
@@ -854,7 +854,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     dbenv->prefault_stats
                         .num_prfq_data_keys_newkeys_no_olddta++;
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
 
                     break;
                 }
@@ -868,17 +868,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename_ip, ixnum);
+                               iq.usedb->tablename_interned, ixnum);
                         continue;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                           (char *)fnddta, keytag, key, NULL);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"
                                " %d of TBL %s\n",
-                               ixnum, iq.usedb->tablename_ip);
+                               ixnum, iq.usedb->tablename_interned);
                         continue;
                     }
 
@@ -892,7 +892,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                  * old record and the changes.
                  */
                 memcpy(od_dta, fnddta, od_len);
-                rc = ctag_to_stag_buf(iq.usedb->tablename_ip, tag, req->record,
+                rc = ctag_to_stag_buf(iq.usedb->tablename_interned, tag, req->record,
                                       WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                       od_dta, CONVERT_UPDATE, &reason);
                 if (rc < 0) {
@@ -900,17 +900,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                      * trace on a turnoffable switch */
                     if (gbl_prefault_verbose) {
                         char str[128];
-                        convert_failure_reason_str(&reason, iq.usedb->tablename_ip,
+                        convert_failure_reason_str(&reason, iq.usedb->tablename_interned,
                                                    tag, ".ONDISK", str,
                                                    sizeof(str));
                         logmsg(LOGMSG_USER,
                                "%s: conv failed for %s:%s->.ONDISK rc %d\n",
-                               __func__, iq.usedb->tablename_ip, tag, rc);
+                               __func__, iq.usedb->tablename_interned, tag, rc);
                         logmsg(LOGMSG_USER, "%s: reason: %s\n", __func__, str);
                     }
 
                     if (dynschema)
-                        free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                        free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                     break;
                 }
 
@@ -923,17 +923,17 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                     if (keysz < 0) {
                         logmsg(LOGMSG_ERROR, "prefault_thd:cannot get key size"
                                              " tbl %s. idx %d\n",
-                               iq.usedb->tablename_ip, ixnum);
+                               iq.usedb->tablename_interned, ixnum);
                         continue;
                     }
                     snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename_ip, ".ONDISK",
+                    rc = stag_to_stag_buf(iq.usedb->tablename_interned, ".ONDISK",
                                           (char *)od_dta, keytag, key, NULL);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"
                                " %d of TBL %s\n",
-                               ixnum, iq.usedb->tablename_ip);
+                               ixnum, iq.usedb->tablename_interned);
                         continue;
                     }
 
@@ -943,7 +943,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                 }
 
                 if (dynschema)
-                    free_dynamic_schema(iq.usedb->tablename_ip, dynschema);
+                    free_dynamic_schema(iq.usedb->tablename_interned, dynschema);
                 break;
             }
 

--- a/db/prefault_toblock.c
+++ b/db/prefault_toblock.c
@@ -92,7 +92,7 @@ static int add_record_prefault(
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_ip, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,
@@ -112,13 +112,13 @@ static int add_record_prefault(
 
         od_dta = stackbuf;
 
-        rc = ctag_to_stag_buf(iq->usedb->tablename, tag,
+        rc = ctag_to_stag_buf(iq->usedb->tablename_ip, tag,
                               (const char *)p_buf_rec, WHOLE_BUFFER, fldnullmap,
                               ondisktag, od_dta, 0, &reason);
         if (rc == -1) {
             if (iq->debug) {
                 char str[128];
-                convert_failure_reason_str(&reason, iq->usedb->tablename, tag,
+                convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
                                            ".ONDISK", str, sizeof(str));
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
             }
@@ -147,7 +147,7 @@ static int add_record_prefault(
         }
 
         snprintf(ixtag, sizeof(ixtag), "%s_IX_%d", ondisktag, ixnum);
-        rc = stag_to_stag_buf(iq->usedb->tablename, ondisktag, od_dta, ixtag,
+        rc = stag_to_stag_buf(iq->usedb->tablename_ip, ondisktag, od_dta, ixtag,
                               key, NULL);
         if (rc == -1) {
             if (iq->debug)
@@ -184,7 +184,7 @@ err:
         reqpopprefixes(iq, prefixes);
 
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
 
     return retrc;
 }
@@ -235,7 +235,7 @@ upd_record_prefault(struct ireq *iq, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -253,7 +253,7 @@ upd_record_prefault(struct ireq *iq, void *primkey, int rrn,
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_ip, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,
@@ -274,7 +274,7 @@ err:
         reqpopprefixes(iq, prefixes);
 
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
 
     return retrc;
 }
@@ -315,7 +315,7 @@ static int del_record_prefault(struct ireq *iq, void *primkey,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -550,7 +550,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                 iq->usedb = iq->origdb;
                 skipblock = 1;
             } else if (iq->debug)
-                reqprintf(iq, "DB NUM %d '%s'", dbnum, iq->usedb->tablename);
+                reqprintf(iq, "DB NUM %d '%s'", dbnum, iq->usedb->tablename_ip);
             break;
         }
 
@@ -586,7 +586,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                                   dbnum);
                     skipblock = 1;
                 } else if (iq->debug)
-                    reqprintf(iq, "DB '%s'", iq->usedb->tablename);
+                    reqprintf(iq, "DB '%s'", iq->usedb->tablename_ip);
             } else {
                 iq->usedb = getdbbynum(dbnum);
                 if (iq->usedb == 0) {
@@ -598,7 +598,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                     skipblock = 1;
                 } else if (iq->debug)
                     reqprintf(iq, "DB NUM %d '%s'", dbnum,
-                              iq->usedb->tablename);
+                              iq->usedb->tablename_ip);
             }
             break;
         }

--- a/db/prefault_toblock.c
+++ b/db/prefault_toblock.c
@@ -92,7 +92,7 @@ static int add_record_prefault(
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_ip, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_interned, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,
@@ -112,13 +112,13 @@ static int add_record_prefault(
 
         od_dta = stackbuf;
 
-        rc = ctag_to_stag_buf(iq->usedb->tablename_ip, tag,
+        rc = ctag_to_stag_buf(iq->usedb->tablename_interned, tag,
                               (const char *)p_buf_rec, WHOLE_BUFFER, fldnullmap,
                               ondisktag, od_dta, 0, &reason);
         if (rc == -1) {
             if (iq->debug) {
                 char str[128];
-                convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
+                convert_failure_reason_str(&reason, iq->usedb->tablename_interned, tag,
                                            ".ONDISK", str, sizeof(str));
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
             }
@@ -147,7 +147,7 @@ static int add_record_prefault(
         }
 
         snprintf(ixtag, sizeof(ixtag), "%s_IX_%d", ondisktag, ixnum);
-        rc = stag_to_stag_buf(iq->usedb->tablename_ip, ondisktag, od_dta, ixtag,
+        rc = stag_to_stag_buf(iq->usedb->tablename_interned, ondisktag, od_dta, ixtag,
                               key, NULL);
         if (rc == -1) {
             if (iq->debug)
@@ -184,7 +184,7 @@ err:
         reqpopprefixes(iq, prefixes);
 
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_interned, dynschema);
 
     return retrc;
 }
@@ -235,7 +235,7 @@ upd_record_prefault(struct ireq *iq, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -253,7 +253,7 @@ upd_record_prefault(struct ireq *iq, void *primkey, int rrn,
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_ip, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename_interned, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,
@@ -274,7 +274,7 @@ err:
         reqpopprefixes(iq, prefixes);
 
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_interned, dynschema);
 
     return retrc;
 }
@@ -315,7 +315,7 @@ static int del_record_prefault(struct ireq *iq, void *primkey,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -550,7 +550,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                 iq->usedb = iq->origdb;
                 skipblock = 1;
             } else if (iq->debug)
-                reqprintf(iq, "DB NUM %d '%s'", dbnum, iq->usedb->tablename_ip);
+                reqprintf(iq, "DB NUM %d '%s'", dbnum, iq->usedb->tablename_interned);
             break;
         }
 
@@ -586,7 +586,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                                   dbnum);
                     skipblock = 1;
                 } else if (iq->debug)
-                    reqprintf(iq, "DB '%s'", iq->usedb->tablename_ip);
+                    reqprintf(iq, "DB '%s'", iq->usedb->tablename_interned);
             } else {
                 iq->usedb = getdbbynum(dbnum);
                 if (iq->usedb == 0) {
@@ -598,7 +598,7 @@ int prefault_toblock(struct ireq *iq_in, void *ptr_in, int helper_thread,
                     skipblock = 1;
                 } else if (iq->debug)
                     reqprintf(iq, "DB NUM %d '%s'", dbnum,
-                              iq->usedb->tablename_ip);
+                              iq->usedb->tablename_interned);
             }
             break;
         }

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -376,7 +376,7 @@ void print_dbs(struct dbenv *dbenv)
     for (i = 0; i < dbenv->num_dbs; i++) {
         if (dbenv->dbs[i]->dbnum > 0)
             logmsg(LOGMSG_USER, "managing db %-5d '%s'\n", dbenv->dbs[i]->dbnum,
-                   dbenv->dbs[i]->tablename);
+                   dbenv->dbs[i]->tablename_ip);
     }
 }
 
@@ -1741,9 +1741,9 @@ clipper_usage:
             for (ii = 0; ii < thedb->num_dbs; ii++) {
                 if (thedb->dbs[ii]->dbtype == DBTYPE_TAGGED_TABLE) {
                     int version;
-                    version = get_csc2_version(thedb->dbs[ii]->tablename);
+                    version = get_csc2_version(thedb->dbs[ii]->tablename_ip);
                     logmsg(LOGMSG_USER, "table %s is at csc2 version %d\n",
-                           thedb->dbs[ii]->tablename, version);
+                           thedb->dbs[ii]->tablename_ip, version);
                 }
             }
         } else if (tokcmp(tok, ltok, "dumpcsc2") == 0) {
@@ -1774,10 +1774,10 @@ clipper_usage:
             } else {
                 char *csc2 = NULL;
                 int rc, len;
-                rc = get_csc2_file(db->tablename, version, &csc2, &len);
+                rc = get_csc2_file(db->tablename_ip, version, &csc2, &len);
                 logmsg(LOGMSG_ERROR,
                        "Table '%s' get schema returned rcode %d\n",
-                       db->tablename, rc);
+                       db->tablename_ip, rc);
                 if (csc2) {
                     logmsg(LOGMSG_USER, "%s\n", csc2);
                     free(csc2);
@@ -2334,7 +2334,7 @@ clipper_usage:
         /* All tables */
         for (idb = 0; idb < dbenv->num_dbs; idb++) {
             db = dbenv->dbs[idb];
-            if (bt_hash_table(db->tablename, szkb) != 0)
+            if (bt_hash_table(db->tablename_ip, szkb) != 0)
                 return -1;
         }
 
@@ -2372,7 +2372,7 @@ clipper_usage:
         /* All tables */
         for (idb = 0; idb < dbenv->num_dbs; idb++) {
             db = dbenv->dbs[idb];
-            if (del_bt_hash_table(db->tablename) != 0)
+            if (del_bt_hash_table(db->tablename_ip) != 0)
                 return -1;
         }
 
@@ -2440,7 +2440,7 @@ clipper_usage:
     else if (tokcmp(tok, ltok, "dumptags") == 0) {
         int i;
         for (i = 0; i < thedb->num_dbs; i++)
-            debug_dump_tags(thedb->dbs[i]->tablename);
+            debug_dump_tags(thedb->dbs[i]->tablename_ip);
     } else if (tokcmp(tok, ltok, "screportfreq") == 0) {
         tok = segtok(line, lline, &st, &ltok);
         if (ltok != 0) {
@@ -3294,7 +3294,7 @@ clipper_usage:
                 rc = bdb_find_oldest_genid(iq.usedb->handle, NULL, stripe, buf,
                                            &reclen, 64 * 1024, &genid, &ver,
                                            &bdberr);
-                logmsg(LOGMSG_USER, "%s stripe %d ", iq.usedb->tablename,
+                logmsg(LOGMSG_USER, "%s stripe %d ", iq.usedb->tablename_ip,
                        stripe);
                 if (rc == 0)
                    logmsg(LOGMSG_USER, "%016llx %d", genid, bdb_genid_timestamp(genid));
@@ -3799,7 +3799,7 @@ clipper_usage:
             logmsg(LOGMSG_USER,
                    "table:%s  odh:%s  instant_schema_change:%s  "
                    "inplace_updates:%s  version:%d\n",
-                   db->tablename, YESNO(db->instant_schema_change),
+                   db->tablename_ip, YESNO(db->instant_schema_change),
                    YESNO(db->inplace_updates), YESNO(db->odh),
                    db->schema_version);
         } else {
@@ -3999,9 +3999,8 @@ clipper_usage:
             /* All tables */
             for (ii = 0; ii < dbenv->num_dbs; ii++) {
                 db = dbenv->dbs[ii];
-                table = db->tablename;
                 int pgscan = bdb_get_page_scan_for_table(db->handle);
-                logmsg(LOGMSG_USER, "Page-order tablescan for table '%s' is %s\n", table,
+                logmsg(LOGMSG_USER, "Page-order tablescan for table '%s' is %s\n", db->tablename_ip,
                        pgscan ? "enabled" : "disabled");
             }
 
@@ -4378,7 +4377,7 @@ clipper_usage:
         logmsg(LOGMSG_USER, "%-30s %10s\n", "table", "localrep?");
         for (i = 0; i < thedb->num_dbs; i++) {
             db = thedb->dbs[i];
-            logmsg(LOGMSG_USER, "%-30s %10s\n", db->tablename,
+            logmsg(LOGMSG_USER, "%-30s %10s\n", db->tablename_ip,
                    db->do_local_replication ? "YES" : "NO");
         }
     } else if (tokcmp(tok, ltok, "transtat") == 0) {
@@ -5078,14 +5077,14 @@ static void dump_table_sizes(struct dbenv *dbenv)
     for (ndb = 0; ndb < dbenv->num_dbs; ndb++) {
         db = dbenv->dbs[ndb];
         total += calc_table_size(db, 0);
-        len = strlen(db->tablename);
+        len = strlen(db->tablename_ip);
         if (len > maxtblname)
             maxtblname = len;
     }
     for (ndb = 0; ndb < dbenv->num_qdbs; ndb++) {
         db = dbenv->qdbs[ndb];
         total += calc_table_size(db, 0);
-        len = strlen(db->tablename);
+        len = strlen(db->tablename_ip);
         if (len > maxtblname)
             maxtblname = len;
     }
@@ -5103,7 +5102,7 @@ static void dump_table_sizes(struct dbenv *dbenv)
         else
             percent = 0;
         logmsg(LOGMSG_USER, "table %*s sz %12s %3d%% ", maxtblname,
-               db->tablename, fmt_size(b, sizeof(b), db->totalsize),
+               db->tablename_ip, fmt_size(b, sizeof(b), db->totalsize),
                (int)percent);
         logmsg(LOGMSG_USER, "(dta %s", fmt_size(b, sizeof(b), db->dtasize));
         for (ii = 0; ii < db->nix; ii++) {
@@ -5123,7 +5122,7 @@ static void dump_table_sizes(struct dbenv *dbenv)
         else
             percent = 0;
         logmsg(LOGMSG_USER, "queue %*s sz %12s %3d%% (%u extents)\n",
-               maxtblname, db->tablename, fmt_size(b, sizeof(b), db->totalsize),
+               maxtblname, db->tablename_ip, fmt_size(b, sizeof(b), db->totalsize),
                (int)percent, db->numextents);
     }
 
@@ -5169,7 +5168,7 @@ void ixstats(struct dbenv *dbenv)
 
     for (dbn = 0; dbn < dbenv->num_dbs; dbn++) {
         db = dbenv->dbs[dbn];
-        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename);
+        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename_ip);
         for (ix = 0; ix < db->nix; ix++) {
             logmsg(LOGMSG_USER, "  ix %2d:   %lld steps  %lld sql steps\n", ix,
                    db->ixuse[ix], db->sqlixuse[ix]);
@@ -5184,7 +5183,7 @@ void curstats(struct dbenv *dbenv)
 
     for (dbn = 0; dbn < dbenv->num_dbs; dbn++) {
         db = dbenv->dbs[dbn];
-        logmsg(LOGMSG_USER, "table '%s' : ix = %u cur = %u\n", db->tablename,
+        logmsg(LOGMSG_USER, "table '%s' : ix = %u cur = %u\n", db->tablename_ip,
                db->sqlcur_ix, db->sqlcur_cur);
     }
 }

--- a/db/record.c
+++ b/db/record.c
@@ -155,7 +155,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -231,7 +231,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
     if (rc != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TAG,
                   "invalid tag description '%.*s'", (int) taglen, tagdescr);
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -248,7 +248,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
                                    maxblobs);
     }
 
@@ -257,11 +257,11 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         prefixes++;
     }
 
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                      iq->usedb->tablename);
+                      iq->usedb->tablename_ip);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -285,7 +285,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             if (iq->debug)
                 reqprintf(iq, "BAD DTA LEN %zu TAG %s EXPECTS DTALEN %u\n",
                           reclen, tag, expected_dat_len);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                       "bad data length %zu tag '%s' expects data length %u",
                       reclen, tag, expected_dat_len);
@@ -298,9 +298,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        (rc = check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename, tag,
+        (rc = check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
                                  dbname_schema, record, fldnullmap)) != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -333,7 +333,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (od_len_int <= 0) {
             if (iq->debug)
                 reqprintf(iq, "BAD ONDISK SIZE");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA, "bad ondisk size");
             *opfailcode = OP_FAILED_BAD_REQUEST;
             retrc = ERR_BADREQ;
@@ -345,7 +345,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (!allocced_memory) {
             logmsg(LOGMSG_ERROR,
                    "add_record: malloc %u failed! (table %s tag %s)\n",
-                   (unsigned)od_len, iq->usedb->tablename, tag);
+                   (unsigned)od_len, iq->usedb->tablename_ip, tag);
             *opfailcode = OP_FAILED_INTERNAL;
             retrc = ERR_INTERNAL;
             ERR;
@@ -357,18 +357,18 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             conv_flags |= CONVERT_LITTLE_ENDIAN_CLIENT;
         }
 
-        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename, tag, record,
+        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
                                    WHOLE_BUFFER, fldnullmap, ondisktag, od_dta,
                                    conv_flags, &reason /*fail reason*/, blobs,
                                    maxblobs, iq->tzname);
         if (rc == -1) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
                                        ondisktag, str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->%s '%s'", tag, ondisktag, str);
             }
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_CNVT_DTA,
                       "error convert data %s->.ONDISK '%s'", tag, str);
             *opfailcode = OP_FAILED_CONVERSION;
@@ -376,7 +376,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             ERR;
         }
 
-        ondisktagsc = find_tag_schema(iq->usedb->tablename, ondisktag);
+        ondisktagsc = find_tag_schema(iq->usedb->tablename_ip, ondisktag);
     }
 
     rc = set_master_columns(iq, trans, od_dta, od_len);
@@ -505,9 +505,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         bool reorder =
             osql_is_index_reorder_on(iq->osql_flags) && !is_event_from_sc(flags) &&
             rec_flags == 0 && iq->usedb->sc_from != iq->usedb &&
-            strcasecmp(iq->usedb->tablename, "comdb2_oplog") != 0 &&
-            strcasecmp(iq->usedb->tablename, "comdb2_commit_log") != 0 &&
-            strncasecmp(iq->usedb->tablename, "sqlite_stat", 11) != 0;
+            strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
+            strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log") != 0 &&
+            strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0;
 
         if (reorder)
             rec_flags |= OSQL_ITEM_REORDERED;
@@ -557,7 +557,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     if (!(flags & RECFLAGS_NO_TRIGGERS) &&
         javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_ADD)) {
         struct javasp_rec *jrec;
-        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename);
+        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
         if (!jrec) {
             *opfailcode = OP_FAILED_INTERNAL;
             retrc = ERR_INTERNAL;
@@ -580,7 +580,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         }
         retrc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_ADD,
-                                        NULL, jrec, iq->usedb->tablename);
+                                        NULL, jrec, iq->usedb->tablename_ip);
         javasp_dealloc_rec(jrec);
         if (iq->debug)
             reqprintf(iq, "JAVASP_TRANS_LISTEN_AFTER_ADD RC %d", retrc);
@@ -592,9 +592,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
 
     /* Save the op to replay later locally */
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_add(iq, trans, od_dta, blobs, opfailcode);
         if (retrc)
@@ -634,7 +634,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     if (iq->is_block2positionmode) {
@@ -773,7 +773,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -819,15 +819,15 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
                                    maxblobs);
     }
 
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                      iq->usedb->tablename);
+                      iq->usedb->tablename_ip);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -861,7 +861,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename, tag,
+        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
                            dbname_schema, record, fldnullmap) != 0) {
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
@@ -897,7 +897,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (!allocced_memory) {
         logmsg(LOGMSG_ERROR,
                "upd_record: malloc %u failed! (table %s tag %s)\n",
-               (unsigned)mallocced_bytes, iq->usedb->tablename, tag);
+               (unsigned)mallocced_bytes, iq->usedb->tablename_ip, tag);
         *opfailcode = OP_FAILED_INTERNAL;
         retrc = ERR_INTERNAL;
         goto err;
@@ -919,7 +919,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
      */
     if (vrecord && !primkey) {
         static unsigned char nullnulls[32] = {0};
-        rc = ctag_to_stag_buf_tz(iq->usedb->tablename, tag, vrecord, reclen,
+        rc = ctag_to_stag_buf_tz(iq->usedb->tablename_ip, tag, vrecord, reclen,
                                  nullnulls, ".ONDISK_IX_0", lclprimkey,
                                  conv_flags, NULL, iq->tzname);
         if (rc < 0) {
@@ -1026,11 +1026,11 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (strncasecmp(tag, ".ONDISK", 7) == 0) {
             /* the input record is .ONDISK or a .ONDISK_IX_ (which would be the
              * case for a cascaded update) */
-            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename, tag, vrecord,
+            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_ip, tag, vrecord,
                                             ".ONDISK", odv_dta, NULL,
                                             iq->tzname);
         } else {
-            rc = ctag_to_stag_buf_tz(iq->usedb->tablename, tag, vrecord,
+            rc = ctag_to_stag_buf_tz(iq->usedb->tablename_ip, tag, vrecord,
                                      WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                      odv_dta, (conv_flags | CONVERT_UPDATE),
                                      NULL, iq->tzname);
@@ -1074,11 +1074,11 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (strncasecmp(tag, ".ONDISK", 7) == 0) {
             /* the input record is .ONDISK or a .ONDISK_IX_ (which would be the
              * case for a cascaded update) */
-            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename, tag, record,
+            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_ip, tag, record,
                                             ".ONDISK", od_dta, &reason,
                                             iq->tzname);
         } else {
-            rc = ctag_to_stag_blobs_tz(iq->usedb->tablename, tag, record,
+            rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
                                        WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                        od_dta, (conv_flags | CONVERT_UPDATE),
                                        &reason, blobs, maxblobs, iq->tzname);
@@ -1086,7 +1086,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
         /* used for schema-change */
         if (record != NULL && (NULL == updCols) &&
-            (0 == describe_update_columns(iq->usedb->tablename, tag,
+            (0 == describe_update_columns(iq->usedb->tablename_ip, tag,
                                           myupdatecols))) {
             using_myupdatecols = 1;
             updCols = myupdatecols;
@@ -1094,7 +1094,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
         if (rc < 0) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
                                        ".ONDISK", str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
@@ -1112,7 +1112,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                     iq,
                     "Null constraint violation for column '%s' on table '%s'. ",
                     reason.target_schema->member[reason.target_field_idx].name,
-                    iq->usedb->tablename);
+                    iq->usedb->tablename_ip);
             } else {
                 *opfailcode = OP_FAILED_CONVERSION;
                 retrc = ERR_CONVERT_DTA;
@@ -1147,7 +1147,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                 int idx;
                 int ncols;
 
-                idx = get_schema_blob_field_idx((char *)iq->usedb->tablename,
+                idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
                                                 ".ONDISK", blobno);
                 ncols = updCols[0];
 
@@ -1217,9 +1217,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
 
         retrc = local_replicant_log_delete_for_update(iq, trans, rrn, vgenid,
@@ -1315,7 +1315,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
             int idx;
             int ncols;
 
-            idx = get_schema_blob_field_idx((char *)iq->usedb->tablename,
+            idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
                                             ".ONDISK", blobno);
             ncols = updCols[0];
 
@@ -1447,9 +1447,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     /* TODO: largely copy and paste from the add case, with some complexities.
      * functionalize the bastard */
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_add_for_update(iq, trans, rrn, *genid,
                                                    opfailcode);
@@ -1467,12 +1467,12 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         blob_status_t new_rec_blobs = {0};
 
         /* old record no longer exists - don't set trans or rrn */
-        joldrec = javasp_alloc_rec(old_dta, od_len, iq->usedb->tablename);
+        joldrec = javasp_alloc_rec(old_dta, od_len, iq->usedb->tablename_ip);
         javasp_rec_set_blobs(joldrec, &oldblobs);
         javasp_rec_set_trans(joldrec, iq->jsph, rrn, vgenid);
 
         /* new record now exists on disk */
-        jnewrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename);
+        jnewrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
 
         /* we also need to pass down blobs.  not all of them are necessarily
            specified in the 'blobs' variable (eg: static tag that omits a blob)
@@ -1483,7 +1483,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         javasp_rec_set_trans(jnewrec, iq->jsph, rrn, vgenid);
         rc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_UPD,
-                                        joldrec, jnewrec, iq->usedb->tablename);
+                                        joldrec, jnewrec, iq->usedb->tablename_ip);
         javasp_dealloc_rec(joldrec);
         javasp_dealloc_rec(jnewrec);
         free_blob_status_data(&new_rec_blobs);
@@ -1547,7 +1547,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     if (iq->is_block2positionmode) {
@@ -1602,7 +1602,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -1610,7 +1610,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (od_len_int <= 0) {
         if (iq->debug)
             reqprintf(iq, "BAD ONDISK SIZE");
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_DEL_RC_INVL_DTA, "bad ondisk size");
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
@@ -1688,7 +1688,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (iq->debug)
             reqprintf(iq, "FIND OLD RECORD FAILED od_len %zu fndlen %u RC %d",
                       od_len, fndlen, rc);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_DEL_RC_UNKN_REC, "find old record failed");
         *opfailcode = OP_FAILED_VERIFY;
         if (rc == RC_INTERNAL_RETRY)
@@ -1732,7 +1732,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (rc != 0) {
             if (iq->debug)
                 reqprintf(iq, "FAILED TO VERIFY CONSTRAINTS");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_DEL_RC_VFY_CSTRT,
                       "failed to verify constraints");
             retrc = *opfailcode;
@@ -1741,9 +1741,9 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_delete(iq, trans, od_dta, opfailcode);
         if (retrc)
@@ -1792,12 +1792,12 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (!(flags & RECFLAGS_NO_TRIGGERS) &&
         javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_DEL)) {
         struct javasp_rec *jrec;
-        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename);
+        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
         javasp_rec_set_trans(jrec, iq->jsph, rrn, genid);
         javasp_rec_set_blobs(jrec, &oldblobs);
         rc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_DEL,
-                                        jrec, NULL, iq->usedb->tablename);
+                                        jrec, NULL, iq->usedb->tablename_ip);
         javasp_dealloc_rec(jrec);
         if (iq->debug)
             reqprintf(iq, "JAVASP_TRANS_LISTEN_AFTER_DEL %d", rc);
@@ -1899,7 +1899,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -1930,7 +1930,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
     }
 
     /* Remap the incoming updCols to new schema's updCols */
-    rc = remap_update_columns(iq->usedb->tablename, ".ONDISK", updCols,
+    rc = remap_update_columns(iq->usedb->tablename_ip, ".ONDISK", updCols,
                               ".NEW..ONDISK", myupdatecols);
     if (iq->debug) {
         reqprintf(iq, "upd_new_record returns %d", rc);
@@ -1945,7 +1945,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         goto err;
     }
 
-    struct schema *fromsch = find_tag_schema(iq->usedb->tablename, ".ONDISK");
+    struct schema *fromsch = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
 
     if (!gbl_use_plan || !iq->usedb->plan || iq->usedb->plan->dta_plan == -1) {
         if (!verify_retry) {
@@ -1968,7 +1968,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
 
-        rc = stag_to_stag_buf_tz(fromsch, iq->usedb->tablename, ".ONDISK",
+        rc = stag_to_stag_buf_tz(fromsch, iq->usedb->tablename_ip, ".ONDISK",
                                  (char *)new_dta, ".NEW..ONDISK",
                                  (char *)sc_new, NULL, iq->tzname);
 
@@ -1978,7 +1978,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
                     newgenid);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM NEW UPDATE RECORD\n");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_UPD_RC_INVL_DTA, "cannot form new record");
             retrc = rc;
             goto err;
@@ -2034,7 +2034,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
         /* convert old_dta and oldblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename, ".ONDISK", old_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", old_dta,
                                     ".NEW..ONDISK", sc_old, NULL, del_idx_blobs,
                                     del_idx_blobs ? MAXBLOBS : 0, 1);
         if (rc) {
@@ -2050,7 +2050,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
         /* convert new_dta and newblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename, ".ONDISK", new_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", new_dta,
                                     ".NEW..ONDISK", sc_new, NULL, add_idx_blobs,
                                     add_idx_blobs ? MAXBLOBS : 0, 1);
 
@@ -2091,7 +2091,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             blob_buffer_t *blob;
             int oldcol, oldblobidx, idx;
 
-            idx = get_schema_blob_field_idx((char *)iq->usedb->tablename,
+            idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
                                             ".NEW..ONDISK", blobn);
             if (iq->debug) {
                 reqprintf(iq,
@@ -2143,7 +2143,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
 
             /* Use the column of the old blob to map to an old blob index */
             oldcol = myupdatecols[idx + 1];
-            oldblobidx = get_schema_field_blob_idx((char *)iq->usedb->tablename,
+            oldblobidx = get_schema_field_blob_idx(iq->usedb->tablename_ip,
                                                    ".ONDISK", oldcol);
             if (iq->debug) {
                 reqprintf(iq, "get_schema_field_blob_idx returns %d for blobno "
@@ -2232,7 +2232,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
@@ -2277,7 +2277,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
             goto err;
         }
         /* convert old_dta and oldblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename, ".ONDISK", old_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", old_dta,
                                     ".NEW..ONDISK", sc_old, NULL, del_idx_blobs,
                                     del_idx_blobs ? MAXBLOBS : 0, 1);
         if (rc) {
@@ -2515,7 +2515,7 @@ int save_old_blobs(struct ireq *iq, void *trans, const char *tag, const void *re
 
     /* make sure the blobs are consistent with the record; if they're not then
      * we have a database corruption situation. */
-    rc = check_blob_consistency(iq, iq->usedb->tablename, tag, blobs, record);
+    rc = check_blob_consistency(iq, iq->usedb->tablename_ip, tag, blobs, record);
     if (iq->debug)
         reqprintf(iq, "CHECK OLD BLOB CONSISTENCY RRN %d GENID 0x%llx RC %d",
                   rrn, genid, rc);
@@ -2598,13 +2598,13 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
         prefixes++;
     }
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
     if (rc != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TAG,
                   "invalid tag description '%.*s'", (int) taglen, tagdescr);
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2621,7 +2621,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
                                    maxblobs);
     }
 
@@ -2629,12 +2629,12 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         reqpushprefixf(iq, "TAG %s ", tag);
         prefixes++;
     }
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             if (iq->debug)
                 reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                          iq->usedb->tablename);
+                          iq->usedb->tablename_ip);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -2645,7 +2645,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %zu TAG %s EXPECTS DTALEN %u\n", reclen,
                       tag, expected_dat_len);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                   "bad data length %zu tag '%s' expects data length %u\n",
                   reclen, tag, expected_dat_len);
@@ -2657,9 +2657,9 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename, tag,
+        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
                            dbname_schema, record, fldnullmap) != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2667,13 +2667,13 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         ERR;
     }
 
-    rc = getidxnumbyname(iq->usedb->tablename, keyname, &ixnum);
+    rc = getidxnumbyname(iq->usedb->tablename_ip, keyname, &ixnum);
     if (rc != 0) {
         if (iq->debug) {
             reqprintf(iq, "BAD KEY %s", keyname);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2696,23 +2696,23 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (keysz < 0) {
             logmsg(LOGMSG_ERROR, "cannot get key size"
                                  " tbl %s. idx %d\n",
-                   iq->usedb->tablename, ixnum);
+                   iq->usedb->tablename_ip, ixnum);
             /* XXX is this an error? */
         }
         snprintf(keytag, sizeof(keytag), "%s_IX_%d", ondisktag, ixnum);
 
-        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename, tag, record,
+        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
                                    WHOLE_BUFFER, fldnullmap, keytag, key,
                                    conv_flags, &reason /*fail reason*/, blobs,
                                    maxblobs, iq->tzname);
         if (rc == -1) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
                                        ".ONDISK", str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
             }
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_CNVT_DTA,
                       "error convert data %s->.ONDISK '%s'", tag, str);
             *opfailcode = OP_FAILED_CONVERSION;
@@ -2733,7 +2733,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             reqprintf(iq, "IX FIND FAILED ON IDX: %d", ixnum);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB, "failed to find on idx: %d",
                   ixnum);
 
@@ -2756,7 +2756,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             reqprintf(iq, "FAILED TO UPD %s", keyname);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "failed to update record using idx: %d", ixnum);
 
@@ -2774,7 +2774,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     return retrc;

--- a/db/record.c
+++ b/db/record.c
@@ -155,7 +155,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -231,7 +231,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
     if (rc != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TAG,
                   "invalid tag description '%.*s'", (int) taglen, tagdescr);
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -248,7 +248,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_interned, tag, record, blobs,
                                    maxblobs);
     }
 
@@ -257,11 +257,11 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         prefixes++;
     }
 
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_interned, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                      iq->usedb->tablename_ip);
+                      iq->usedb->tablename_interned);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -285,7 +285,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             if (iq->debug)
                 reqprintf(iq, "BAD DTA LEN %zu TAG %s EXPECTS DTALEN %u\n",
                           reclen, tag, expected_dat_len);
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                       "bad data length %zu tag '%s' expects data length %u",
                       reclen, tag, expected_dat_len);
@@ -298,9 +298,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        (rc = check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
+        (rc = check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_interned, tag,
                                  dbname_schema, record, fldnullmap)) != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -333,7 +333,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (od_len_int <= 0) {
             if (iq->debug)
                 reqprintf(iq, "BAD ONDISK SIZE");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA, "bad ondisk size");
             *opfailcode = OP_FAILED_BAD_REQUEST;
             retrc = ERR_BADREQ;
@@ -345,7 +345,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (!allocced_memory) {
             logmsg(LOGMSG_ERROR,
                    "add_record: malloc %u failed! (table %s tag %s)\n",
-                   (unsigned)od_len, iq->usedb->tablename_ip, tag);
+                   (unsigned)od_len, iq->usedb->tablename_interned, tag);
             *opfailcode = OP_FAILED_INTERNAL;
             retrc = ERR_INTERNAL;
             ERR;
@@ -357,18 +357,18 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             conv_flags |= CONVERT_LITTLE_ENDIAN_CLIENT;
         }
 
-        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
+        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_interned, tag, record,
                                    WHOLE_BUFFER, fldnullmap, ondisktag, od_dta,
                                    conv_flags, &reason /*fail reason*/, blobs,
                                    maxblobs, iq->tzname);
         if (rc == -1) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_interned, tag,
                                        ondisktag, str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->%s '%s'", tag, ondisktag, str);
             }
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_CNVT_DTA,
                       "error convert data %s->.ONDISK '%s'", tag, str);
             *opfailcode = OP_FAILED_CONVERSION;
@@ -376,7 +376,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             ERR;
         }
 
-        ondisktagsc = find_tag_schema(iq->usedb->tablename_ip, ondisktag);
+        ondisktagsc = find_tag_schema(iq->usedb->tablename_interned, ondisktag);
     }
 
     rc = set_master_columns(iq, trans, od_dta, od_len);
@@ -505,9 +505,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         bool reorder =
             osql_is_index_reorder_on(iq->osql_flags) && !is_event_from_sc(flags) &&
             rec_flags == 0 && iq->usedb->sc_from != iq->usedb &&
-            strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
-            strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log") != 0 &&
-            strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0;
+            strcasecmp(iq->usedb->tablename_interned, "comdb2_oplog") != 0 &&
+            strcasecmp(iq->usedb->tablename_interned, "comdb2_commit_log") != 0 &&
+            strncasecmp(iq->usedb->tablename_interned, "sqlite_stat", 11) != 0;
 
         if (reorder)
             rec_flags |= OSQL_ITEM_REORDERED;
@@ -557,7 +557,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     if (!(flags & RECFLAGS_NO_TRIGGERS) &&
         javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_ADD)) {
         struct javasp_rec *jrec;
-        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
+        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_interned);
         if (!jrec) {
             *opfailcode = OP_FAILED_INTERNAL;
             retrc = ERR_INTERNAL;
@@ -580,7 +580,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         }
         retrc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_ADD,
-                                        NULL, jrec, iq->usedb->tablename_ip);
+                                        NULL, jrec, iq->usedb->tablename_interned);
         javasp_dealloc_rec(jrec);
         if (iq->debug)
             reqprintf(iq, "JAVASP_TRANS_LISTEN_AFTER_ADD RC %d", retrc);
@@ -592,9 +592,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
 
     /* Save the op to replay later locally */
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_interned, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_interned, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_interned, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_add(iq, trans, od_dta, blobs, opfailcode);
         if (retrc)
@@ -634,7 +634,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_interned, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     if (iq->is_block2positionmode) {
@@ -773,7 +773,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -819,15 +819,15 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_interned, tag, record, blobs,
                                    maxblobs);
     }
 
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_interned, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                      iq->usedb->tablename_ip);
+                      iq->usedb->tablename_interned);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -861,7 +861,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
+        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_interned, tag,
                            dbname_schema, record, fldnullmap) != 0) {
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
@@ -897,7 +897,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (!allocced_memory) {
         logmsg(LOGMSG_ERROR,
                "upd_record: malloc %u failed! (table %s tag %s)\n",
-               (unsigned)mallocced_bytes, iq->usedb->tablename_ip, tag);
+               (unsigned)mallocced_bytes, iq->usedb->tablename_interned, tag);
         *opfailcode = OP_FAILED_INTERNAL;
         retrc = ERR_INTERNAL;
         goto err;
@@ -919,7 +919,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
      */
     if (vrecord && !primkey) {
         static unsigned char nullnulls[32] = {0};
-        rc = ctag_to_stag_buf_tz(iq->usedb->tablename_ip, tag, vrecord, reclen,
+        rc = ctag_to_stag_buf_tz(iq->usedb->tablename_interned, tag, vrecord, reclen,
                                  nullnulls, ".ONDISK_IX_0", lclprimkey,
                                  conv_flags, NULL, iq->tzname);
         if (rc < 0) {
@@ -1026,11 +1026,11 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (strncasecmp(tag, ".ONDISK", 7) == 0) {
             /* the input record is .ONDISK or a .ONDISK_IX_ (which would be the
              * case for a cascaded update) */
-            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_ip, tag, vrecord,
+            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_interned, tag, vrecord,
                                             ".ONDISK", odv_dta, NULL,
                                             iq->tzname);
         } else {
-            rc = ctag_to_stag_buf_tz(iq->usedb->tablename_ip, tag, vrecord,
+            rc = ctag_to_stag_buf_tz(iq->usedb->tablename_interned, tag, vrecord,
                                      WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                      odv_dta, (conv_flags | CONVERT_UPDATE),
                                      NULL, iq->tzname);
@@ -1074,11 +1074,11 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (strncasecmp(tag, ".ONDISK", 7) == 0) {
             /* the input record is .ONDISK or a .ONDISK_IX_ (which would be the
              * case for a cascaded update) */
-            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_ip, tag, record,
+            rc = stag_to_stag_buf_update_tz(iq->usedb->tablename_interned, tag, record,
                                             ".ONDISK", od_dta, &reason,
                                             iq->tzname);
         } else {
-            rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
+            rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_interned, tag, record,
                                        WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                        od_dta, (conv_flags | CONVERT_UPDATE),
                                        &reason, blobs, maxblobs, iq->tzname);
@@ -1086,7 +1086,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
         /* used for schema-change */
         if (record != NULL && (NULL == updCols) &&
-            (0 == describe_update_columns(iq->usedb->tablename_ip, tag,
+            (0 == describe_update_columns(iq->usedb->tablename_interned, tag,
                                           myupdatecols))) {
             using_myupdatecols = 1;
             updCols = myupdatecols;
@@ -1094,7 +1094,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
         if (rc < 0) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_interned, tag,
                                        ".ONDISK", str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
@@ -1112,7 +1112,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                     iq,
                     "Null constraint violation for column '%s' on table '%s'. ",
                     reason.target_schema->member[reason.target_field_idx].name,
-                    iq->usedb->tablename_ip);
+                    iq->usedb->tablename_interned);
             } else {
                 *opfailcode = OP_FAILED_CONVERSION;
                 retrc = ERR_CONVERT_DTA;
@@ -1147,7 +1147,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                 int idx;
                 int ncols;
 
-                idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
+                idx = get_schema_blob_field_idx(iq->usedb->tablename_interned,
                                                 ".ONDISK", blobno);
                 ncols = updCols[0];
 
@@ -1217,9 +1217,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_interned, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_interned, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_interned, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
 
         retrc = local_replicant_log_delete_for_update(iq, trans, rrn, vgenid,
@@ -1315,7 +1315,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
             int idx;
             int ncols;
 
-            idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
+            idx = get_schema_blob_field_idx(iq->usedb->tablename_interned,
                                             ".ONDISK", blobno);
             ncols = updCols[0];
 
@@ -1447,9 +1447,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     /* TODO: largely copy and paste from the add case, with some complexities.
      * functionalize the bastard */
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_interned, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_interned, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_interned, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_add_for_update(iq, trans, rrn, *genid,
                                                    opfailcode);
@@ -1467,12 +1467,12 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         blob_status_t new_rec_blobs = {0};
 
         /* old record no longer exists - don't set trans or rrn */
-        joldrec = javasp_alloc_rec(old_dta, od_len, iq->usedb->tablename_ip);
+        joldrec = javasp_alloc_rec(old_dta, od_len, iq->usedb->tablename_interned);
         javasp_rec_set_blobs(joldrec, &oldblobs);
         javasp_rec_set_trans(joldrec, iq->jsph, rrn, vgenid);
 
         /* new record now exists on disk */
-        jnewrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
+        jnewrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_interned);
 
         /* we also need to pass down blobs.  not all of them are necessarily
            specified in the 'blobs' variable (eg: static tag that omits a blob)
@@ -1483,7 +1483,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         javasp_rec_set_trans(jnewrec, iq->jsph, rrn, vgenid);
         rc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_UPD,
-                                        joldrec, jnewrec, iq->usedb->tablename_ip);
+                                        joldrec, jnewrec, iq->usedb->tablename_interned);
         javasp_dealloc_rec(joldrec);
         javasp_dealloc_rec(jnewrec);
         free_blob_status_data(&new_rec_blobs);
@@ -1547,7 +1547,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_interned, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     if (iq->is_block2positionmode) {
@@ -1602,7 +1602,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -1610,7 +1610,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (od_len_int <= 0) {
         if (iq->debug)
             reqprintf(iq, "BAD ONDISK SIZE");
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_DEL_RC_INVL_DTA, "bad ondisk size");
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
@@ -1688,7 +1688,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (iq->debug)
             reqprintf(iq, "FIND OLD RECORD FAILED od_len %zu fndlen %u RC %d",
                       od_len, fndlen, rc);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_DEL_RC_UNKN_REC, "find old record failed");
         *opfailcode = OP_FAILED_VERIFY;
         if (rc == RC_INTERNAL_RETRY)
@@ -1732,7 +1732,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         if (rc != 0) {
             if (iq->debug)
                 reqprintf(iq, "FAILED TO VERIFY CONSTRAINTS");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_DEL_RC_VFY_CSTRT,
                       "failed to verify constraints");
             retrc = *opfailcode;
@@ -1741,9 +1741,9 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
     if (gbl_replicate_local &&
-        (strcasecmp(iq->usedb->tablename_ip, "comdb2_oplog") != 0 &&
-         (strcasecmp(iq->usedb->tablename_ip, "comdb2_commit_log")) != 0 &&
-         strncasecmp(iq->usedb->tablename_ip, "sqlite_stat", 11) != 0) &&
+        (strcasecmp(iq->usedb->tablename_interned, "comdb2_oplog") != 0 &&
+         (strcasecmp(iq->usedb->tablename_interned, "comdb2_commit_log")) != 0 &&
+         strncasecmp(iq->usedb->tablename_interned, "sqlite_stat", 11) != 0) &&
         !is_event_from_sc(flags)) {
         retrc = local_replicant_log_delete(iq, trans, od_dta, opfailcode);
         if (retrc)
@@ -1792,12 +1792,12 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (!(flags & RECFLAGS_NO_TRIGGERS) &&
         javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_DEL)) {
         struct javasp_rec *jrec;
-        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_ip);
+        jrec = javasp_alloc_rec(od_dta, od_len, iq->usedb->tablename_interned);
         javasp_rec_set_trans(jrec, iq->jsph, rrn, genid);
         javasp_rec_set_blobs(jrec, &oldblobs);
         rc =
             javasp_trans_tagged_trigger(iq->jsph, JAVASP_TRANS_LISTEN_AFTER_DEL,
-                                        jrec, NULL, iq->usedb->tablename_ip);
+                                        jrec, NULL, iq->usedb->tablename_interned);
         javasp_dealloc_rec(jrec);
         if (iq->debug)
             reqprintf(iq, "JAVASP_TRANS_LISTEN_AFTER_DEL %d", rc);
@@ -1899,7 +1899,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -1930,7 +1930,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
     }
 
     /* Remap the incoming updCols to new schema's updCols */
-    rc = remap_update_columns(iq->usedb->tablename_ip, ".ONDISK", updCols,
+    rc = remap_update_columns(iq->usedb->tablename_interned, ".ONDISK", updCols,
                               ".NEW..ONDISK", myupdatecols);
     if (iq->debug) {
         reqprintf(iq, "upd_new_record returns %d", rc);
@@ -1945,7 +1945,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         goto err;
     }
 
-    struct schema *fromsch = find_tag_schema(iq->usedb->tablename_ip, ".ONDISK");
+    struct schema *fromsch = find_tag_schema(iq->usedb->tablename_interned, ".ONDISK");
 
     if (!gbl_use_plan || !iq->usedb->plan || iq->usedb->plan->dta_plan == -1) {
         if (!verify_retry) {
@@ -1968,7 +1968,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
 
-        rc = stag_to_stag_buf_tz(fromsch, iq->usedb->tablename_ip, ".ONDISK",
+        rc = stag_to_stag_buf_tz(fromsch, iq->usedb->tablename_interned, ".ONDISK",
                                  (char *)new_dta, ".NEW..ONDISK",
                                  (char *)sc_new, NULL, iq->tzname);
 
@@ -1978,7 +1978,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
                     newgenid);
             if (iq->debug)
                 reqprintf(iq, "CAN'T FORM NEW UPDATE RECORD\n");
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_UPD_RC_INVL_DTA, "cannot form new record");
             retrc = rc;
             goto err;
@@ -2034,7 +2034,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
         /* convert old_dta and oldblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", old_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_interned, ".ONDISK", old_dta,
                                     ".NEW..ONDISK", sc_old, NULL, del_idx_blobs,
                                     del_idx_blobs ? MAXBLOBS : 0, 1);
         if (rc) {
@@ -2050,7 +2050,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             goto err;
         }
         /* convert new_dta and newblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", new_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_interned, ".ONDISK", new_dta,
                                     ".NEW..ONDISK", sc_new, NULL, add_idx_blobs,
                                     add_idx_blobs ? MAXBLOBS : 0, 1);
 
@@ -2091,7 +2091,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
             blob_buffer_t *blob;
             int oldcol, oldblobidx, idx;
 
-            idx = get_schema_blob_field_idx(iq->usedb->tablename_ip,
+            idx = get_schema_blob_field_idx(iq->usedb->tablename_interned,
                                             ".NEW..ONDISK", blobn);
             if (iq->debug) {
                 reqprintf(iq,
@@ -2143,7 +2143,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
 
             /* Use the column of the old blob to map to an old blob index */
             oldcol = myupdatecols[idx + 1];
-            oldblobidx = get_schema_field_blob_idx(iq->usedb->tablename_ip,
+            oldblobidx = get_schema_field_blob_idx(iq->usedb->tablename_interned,
                                                    ".ONDISK", oldcol);
             if (iq->debug) {
                 reqprintf(iq, "get_schema_field_blob_idx returns %d for blobno "
@@ -2232,7 +2232,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
@@ -2277,7 +2277,7 @@ int del_new_record(struct ireq *iq, void *trans, unsigned long long genid,
             goto err;
         }
         /* convert old_dta and oldblobs to ".NEW..ONDISK" */
-        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_ip, ".ONDISK", old_dta,
+        rc = stag_to_stag_buf_blobs(iq->usedb->tablename_interned, ".ONDISK", old_dta,
                                     ".NEW..ONDISK", sc_old, NULL, del_idx_blobs,
                                     del_idx_blobs ? MAXBLOBS : 0, 1);
         if (rc) {
@@ -2515,7 +2515,7 @@ int save_old_blobs(struct ireq *iq, void *trans, const char *tag, const void *re
 
     /* make sure the blobs are consistent with the record; if they're not then
      * we have a database corruption situation. */
-    rc = check_blob_consistency(iq, iq->usedb->tablename_ip, tag, blobs, record);
+    rc = check_blob_consistency(iq, iq->usedb->tablename_interned, tag, blobs, record);
     if (iq->debug)
         reqprintf(iq, "CHECK OLD BLOB CONSISTENCY RRN %d GENID 0x%llx RC %d",
                   rrn, genid, rc);
@@ -2598,13 +2598,13 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (iq->debug) {
-        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_ip);
+        reqpushprefixf(iq, "TBL %s ", iq->usedb->tablename_interned);
         prefixes++;
     }
 
     rc = resolve_tag_name(iq, tagdescr, taglen, &dynschema, tag, sizeof(tag));
     if (rc != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TAG,
                   "invalid tag description '%.*s'", (int) taglen, tagdescr);
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2621,7 +2621,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     /* Tweak blob-descriptors for static tags. */
     if (gbl_disallow_null_blobs && !dynschema &&
         (flags & RECFLAGS_DYNSCHEMA_NULLS_ONLY)) {
-        static_tag_blob_conversion(iq->usedb->tablename_ip, tag, record, blobs,
+        static_tag_blob_conversion(iq->usedb->tablename_interned, tag, record, blobs,
                                    maxblobs);
     }
 
@@ -2629,12 +2629,12 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         reqpushprefixf(iq, "TAG %s ", tag);
         prefixes++;
     }
-    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_ip, tag);
+    struct schema *dbname_schema = find_tag_schema(iq->usedb->tablename_interned, tag);
     if (dbname_schema == NULL) {
         if (iq->debug)
             if (iq->debug)
                 reqprintf(iq, "UNKNOWN TAG %s TABLE %s\n", tag,
-                          iq->usedb->tablename_ip);
+                          iq->usedb->tablename_interned);
         *opfailcode = OP_FAILED_BAD_REQUEST;
         retrc = ERR_BADREQ;
         ERR;
@@ -2645,7 +2645,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %zu TAG %s EXPECTS DTALEN %u\n", reclen,
                       tag, expected_dat_len);
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                   "bad data length %zu tag '%s' expects data length %u\n",
                   reclen, tag, expected_dat_len);
@@ -2657,9 +2657,9 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     reclen = expected_dat_len;
 
     if (!(flags & RECFLAGS_NO_BLOBS) &&
-        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_ip, tag,
+        check_blob_buffers(iq, blobs, maxblobs, iq->usedb->tablename_interned, tag,
                            dbname_schema, record, fldnullmap) != 0) {
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2667,13 +2667,13 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         ERR;
     }
 
-    rc = getidxnumbyname(iq->usedb->tablename_ip, keyname, &ixnum);
+    rc = getidxnumbyname(iq->usedb->tablename_interned, keyname, &ixnum);
     if (rc != 0) {
         if (iq->debug) {
             reqprintf(iq, "BAD KEY %s", keyname);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_DTA,
                   "no blobs flags with blob buffers");
         *opfailcode = OP_FAILED_BAD_REQUEST;
@@ -2696,23 +2696,23 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         if (keysz < 0) {
             logmsg(LOGMSG_ERROR, "cannot get key size"
                                  " tbl %s. idx %d\n",
-                   iq->usedb->tablename_ip, ixnum);
+                   iq->usedb->tablename_interned, ixnum);
             /* XXX is this an error? */
         }
         snprintf(keytag, sizeof(keytag), "%s_IX_%d", ondisktag, ixnum);
 
-        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_ip, tag, record,
+        rc = ctag_to_stag_blobs_tz(iq->usedb->tablename_interned, tag, record,
                                    WHOLE_BUFFER, fldnullmap, keytag, key,
                                    conv_flags, &reason /*fail reason*/, blobs,
                                    maxblobs, iq->tzname);
         if (rc == -1) {
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_interned, tag,
                                        ".ONDISK", str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR CONVERT DTA %s->.ONDISK '%s'", tag, str);
             }
-            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+            reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
             reqerrstr(iq, COMDB2_ADD_RC_CNVT_DTA,
                       "error convert data %s->.ONDISK '%s'", tag, str);
             *opfailcode = OP_FAILED_CONVERSION;
@@ -2733,7 +2733,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             reqprintf(iq, "IX FIND FAILED ON IDX: %d", ixnum);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB, "failed to find on idx: %d",
                   ixnum);
 
@@ -2756,7 +2756,7 @@ int updbykey_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             reqprintf(iq, "FAILED TO UPD %s", keyname);
         }
 
-        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_ip);
+        reqerrstrhdr(iq, "Table '%s' ", iq->usedb->tablename_interned);
         reqerrstr(iq, COMDB2_ADD_RC_INVL_BLOB,
                   "failed to update record using idx: %d", ixnum);
 
@@ -2774,7 +2774,7 @@ err:
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
-        free_dynamic_schema(iq->usedb->tablename_ip, dynschema);
+        free_dynamic_schema(iq->usedb->tablename_interned, dynschema);
     if (using_myblobs)
         free_blob_buffers(myblobs, MAXBLOBS);
     return retrc;

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1028,7 +1028,6 @@ static void reqlog_free_all(struct reqlogger *logger)
     struct print_event *pevent;
     struct push_prefix_event *pushevent;
     struct tablelist *table;
-    int i, len;
 
     if (logger->error) {
         free(logger->error);
@@ -1058,9 +1057,6 @@ static void reqlog_free_all(struct reqlogger *logger)
     }
     assert(logger->tables == NULL);
 
-    for (i = 0, len = logger->ntables; i != len; ++i) {
-        free(logger->sqltables[i]);
-    }
     free(logger->sqltables);
 }
 
@@ -2873,10 +2869,9 @@ void reqlog_add_table(struct reqlogger *logger, const char *table)
 {
     if (logger->ntables == logger->alloctables) {
         logger->alloctables = logger->alloctables * 2 + 10;
-        logger->sqltables =
-            realloc(logger->sqltables, logger->alloctables * sizeof(char *));
+        logger->sqltables = realloc(logger->sqltables, logger->alloctables * sizeof(char *));
     }
-    logger->sqltables[logger->ntables++] = strdup(table);
+    logger->sqltables[logger->ntables++] = table;
 }
 
 inline void reqlog_set_error(struct reqlogger *logger, const char *error,

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -117,7 +117,7 @@ struct reqlogger {
 
     int ntables;
     int alloctables;
-    char **sqltables;
+    const char **sqltables;
     char *error;
     char error_code;
 

--- a/db/shard_range.c
+++ b/db/shard_range.c
@@ -50,7 +50,7 @@ void shard_range_create(struct Parse *pParser, const char *tblname,
     if (!db)
         return;
 
-    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename, "main");
+    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_ip, "main");
     if (!pTab)
         abort(); /* this should not happen, we are past table lookup */
 
@@ -174,7 +174,7 @@ int comdb2_shard_table_constraints(Parse *pParser, const char *zName,
         return SHARD_NOERR;
 
     /* get the table */
-    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename, "main");
+    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_ip, "main");
 
 #if 0
     /* limits, limits */

--- a/db/shard_range.c
+++ b/db/shard_range.c
@@ -50,7 +50,7 @@ void shard_range_create(struct Parse *pParser, const char *tblname,
     if (!db)
         return;
 
-    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_ip, "main");
+    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_interned, "main");
     if (!pTab)
         abort(); /* this should not happen, we are past table lookup */
 
@@ -174,7 +174,7 @@ int comdb2_shard_table_constraints(Parse *pParser, const char *zName,
         return SHARD_NOERR;
 
     /* get the table */
-    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_ip, "main");
+    pTab = sqlite3FindTableCheckOnly(pParser->db, db->tablename_interned, "main");
 
 #if 0
     /* limits, limits */

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -75,7 +75,7 @@ void req_stats(struct dbtable *db)
     for (ii = 0; ii <= MAXTYPCNT; ii++) {
         if (db->typcnt[ii]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "%-20s %u\n", req2a(ii), db->typcnt[ii]);
@@ -84,7 +84,7 @@ void req_stats(struct dbtable *db)
     for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
         if (db->blocktypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "    %-20s %u\n", breq2a(jj), db->blocktypcnt[jj]);
@@ -93,7 +93,7 @@ void req_stats(struct dbtable *db)
     for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
         if (db->blockosqltypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "    %-20s %u\n", osql_reqtype_str(jj), db->blockosqltypcnt[jj]);
@@ -323,8 +323,8 @@ int handle_ireq(struct ireq *iq)
             rc = opcode->opcode_handler(iq);
 
             /* Record the tablename (aka table) for this op */
-            if (iq->usedb && iq->usedb->tablename) {
-                reqlog_logl(iq->reqlogger, REQL_INFO, iq->usedb->tablename);
+            if (iq->usedb && iq->usedb->tablename_ip) {
+                reqlog_logl(iq->reqlogger, REQL_INFO, iq->usedb->tablename_ip);
             }
         }
     }

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -75,7 +75,7 @@ void req_stats(struct dbtable *db)
     for (ii = 0; ii <= MAXTYPCNT; ii++) {
         if (db->typcnt[ii]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_interned);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "%-20s %u\n", req2a(ii), db->typcnt[ii]);
@@ -84,7 +84,7 @@ void req_stats(struct dbtable *db)
     for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
         if (db->blocktypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_interned);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "    %-20s %u\n", breq2a(jj), db->blocktypcnt[jj]);
@@ -93,7 +93,7 @@ void req_stats(struct dbtable *db)
     for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
         if (db->blockosqltypcnt[jj]) {
             if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_ip);
+                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename_interned);
                 hdr = 1;
             }
             logmsg(LOGMSG_USER, "    %-20s %u\n", osql_reqtype_str(jj), db->blockosqltypcnt[jj]);
@@ -323,8 +323,8 @@ int handle_ireq(struct ireq *iq)
             rc = opcode->opcode_handler(iq);
 
             /* Record the tablename (aka table) for this op */
-            if (iq->usedb && iq->usedb->tablename_ip) {
-                reqlog_logl(iq->reqlogger, REQL_INFO, iq->usedb->tablename_ip);
+            if (iq->usedb && iq->usedb->tablename_interned) {
+                reqlog_logl(iq->reqlogger, REQL_INFO, iq->usedb->tablename_interned);
             }
         }
     }

--- a/db/sql.h
+++ b/db/sql.h
@@ -555,7 +555,7 @@ int get_client_retries(struct sqlclntstate *);
 
 struct clnt_ddl_context {
     /* Name of the table */
-    char *name;
+    const char *name;
     /* Pointer to a comdb2_ddl_context */
     void *ctx;
     /* Memory allocator of the comdb2_ddl_context */

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -265,7 +265,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
     sampler_t *sampler = NULL;
 
     /* cache the tablename for sqlglue */
-    strncpy0(s_ix->name, tbl->tablename_ip, sizeof(s_ix->name));
+    strncpy0(s_ix->name, tbl->tablename_interned, sizeof(s_ix->name));
 
     /* ask bdb to put a summary of this into a temp-table */
     rc = bdb_summarize_table(tbl->handle, ix, sampling_pct, &sampler,
@@ -274,7 +274,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
     /* failed */
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: failed to sample table '%s' idx %d\n",
-               __func__, tbl->tablename_ip, ix);
+               __func__, tbl->tablename_interned, ix);
         return -1;
     }
 
@@ -375,7 +375,7 @@ static int sample_indicies(table_descriptor_t *td, struct sqlclntstate *client,
     index_descriptor_t *ix_des;
 
     /* find table to backout */
-    const char *table = tbl->tablename_ip;
+    const char *table = tbl->tablename_interned;
 
     /* allocate cmp_idx */
     client->sampled_idx_tbl = calloc(tbl->nix, sizeof(sampled_idx_t));
@@ -468,7 +468,7 @@ int64_t analyze_get_nrecs(int iTable)
     assert(db);
 
     /* grab sampled table descriptor */
-    s_ix = find_sampled_index(client, db->tablename_ip, ixnum);
+    s_ix = find_sampled_index(client, db->tablename_interned, ixnum);
 
     /* return -1 if not sampled.  Sqlite will use the value it calculated. */
     if (!s_ix) {
@@ -1115,7 +1115,7 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
     /* start analyzing each table */
     for (i = 0; i < thedb->num_dbs; i++) {
         /* skip sqlite_stat */
-        if (is_sqlite_stat(thedb->dbs[i]->tablename_ip)) {
+        if (is_sqlite_stat(thedb->dbs[i]->tablename_interned)) {
             continue;
         }
 
@@ -1124,7 +1124,7 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
         td[idx].sb = sb;
         td[idx].scale = scale;
         td[idx].override_llmeta = override_llmeta;
-        strncpy0(td[idx].table, thedb->dbs[i]->tablename_ip,
+        strncpy0(td[idx].table, thedb->dbs[i]->tablename_interned,
                  sizeof(td[idx].table));
 
         /* dispatch analyze table thread */
@@ -1341,7 +1341,7 @@ void handle_backout(SBUF2 *sb, char *table)
     } else {
         int i = 0;
         while (i < thedb->num_dbs && rc == 0) {
-            rc = analyze_backout_table(&clnt, thedb->dbs[i]->tablename_ip);
+            rc = analyze_backout_table(&clnt, thedb->dbs[i]->tablename_interned);
             i++;
         }
     }

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -1036,7 +1036,7 @@ int get_analyze_abort_requested()
 
 
 /* analyze 'table' */
-int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
+int analyze_table(const char *table, SBUF2 *sb, int scale, int override_llmeta,
                   int bypass_auth)
 {
     if (check_stat1(sb))

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -232,7 +232,7 @@ void cleanup_stats(SBUF2 *sb)
 
 /* returns the index or NULL */
 static sampled_idx_t *find_sampled_index(struct sqlclntstate *client,
-                                         char *table, int ix)
+                                         const char *table, int ix)
 {
     int i;
 
@@ -265,7 +265,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
     sampler_t *sampler = NULL;
 
     /* cache the tablename for sqlglue */
-    strncpy0(s_ix->name, tbl->tablename, sizeof(s_ix->name));
+    strncpy0(s_ix->name, tbl->tablename_ip, sizeof(s_ix->name));
 
     /* ask bdb to put a summary of this into a temp-table */
     rc = bdb_summarize_table(tbl->handle, ix, sampling_pct, &sampler,
@@ -274,7 +274,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
     /* failed */
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: failed to sample table '%s' idx %d\n",
-               __func__, tbl->tablename, ix);
+               __func__, tbl->tablename_ip, ix);
         return -1;
     }
 
@@ -372,11 +372,10 @@ static int sample_indicies(table_descriptor_t *td, struct sqlclntstate *client,
 {
     int i;
     int err = 0;
-    char *table;
     index_descriptor_t *ix_des;
 
     /* find table to backout */
-    table = tbl->tablename;
+    const char *table = tbl->tablename_ip;
 
     /* allocate cmp_idx */
     client->sampled_idx_tbl = calloc(tbl->nix, sizeof(sampled_idx_t));
@@ -438,7 +437,7 @@ static int cleanup_sampled_indicies(struct sqlclntstate *client, struct dbtable 
 }
 
 /* Return the requested sampler */
-sampler_t *analyze_get_sampler(struct sqlclntstate *client, char *table,
+sampler_t *analyze_get_sampler(struct sqlclntstate *client, const char *table,
                                int idx)
 {
     sampled_idx_t *s_ix;
@@ -469,7 +468,7 @@ int64_t analyze_get_nrecs(int iTable)
     assert(db);
 
     /* grab sampled table descriptor */
-    s_ix = find_sampled_index(client, db->tablename, ixnum);
+    s_ix = find_sampled_index(client, db->tablename_ip, ixnum);
 
     /* return -1 if not sampled.  Sqlite will use the value it calculated. */
     if (!s_ix) {
@@ -517,7 +516,7 @@ int64_t analyze_get_sampled_nrecs(const char *dbname, int ixnum)
 }
 
 /* Return 1 if we have this sampled index, 0 otherwise */
-int analyze_is_sampled(struct sqlclntstate *client, char *table, int idx)
+int analyze_is_sampled(struct sqlclntstate *client, const char *table, int idx)
 {
     sampled_idx_t *s_ix;
 
@@ -1116,7 +1115,7 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
     /* start analyzing each table */
     for (i = 0; i < thedb->num_dbs; i++) {
         /* skip sqlite_stat */
-        if (is_sqlite_stat(thedb->dbs[i]->tablename)) {
+        if (is_sqlite_stat(thedb->dbs[i]->tablename_ip)) {
             continue;
         }
 
@@ -1125,7 +1124,7 @@ int analyze_database(SBUF2 *sb, int scale, int override_llmeta)
         td[idx].sb = sb;
         td[idx].scale = scale;
         td[idx].override_llmeta = override_llmeta;
-        strncpy0(td[idx].table, thedb->dbs[i]->tablename,
+        strncpy0(td[idx].table, thedb->dbs[i]->tablename_ip,
                  sizeof(td[idx].table));
 
         /* dispatch analyze table thread */
@@ -1294,7 +1293,7 @@ void *message_trap_td(void *args)
 }
 
 /* Backout to previous analyze stats */
-static inline int analyze_backout_table(struct sqlclntstate *clnt, char *table)
+static inline int analyze_backout_table(struct sqlclntstate *clnt, const char *table)
 {
     if (is_sqlite_stat(table))
         return 0;
@@ -1342,7 +1341,7 @@ void handle_backout(SBUF2 *sb, char *table)
     } else {
         int i = 0;
         while (i < thedb->num_dbs && rc == 0) {
-            rc = analyze_backout_table(&clnt, thedb->dbs[i]->tablename);
+            rc = analyze_backout_table(&clnt, thedb->dbs[i]->tablename_ip);
             i++;
         }
     }

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -135,7 +135,7 @@ static void print_field(Vdbe *v, struct cursor_info *cinfo, int num, char *buf)
             sc = db->ixschema[cinfo->ix];
         } else {
             snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-            sc = find_tag_schema(db->tablename, scname);
+            sc = find_tag_schema(db->tablename_ip, scname);
         }
     } else {
         sc = db->schema;
@@ -193,7 +193,7 @@ static int print_cursor_description(strbuf *out, struct cursor_info *cinfo)
                 sc = db->ixschema[cinfo->ix];
             } else {
                 snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-                sc = find_tag_schema(db->tablename, scname);
+                sc = find_tag_schema(db->tablename_ip, scname);
             }
             strbuf_appendf(out, "index \"%s\" of ",
                            sc ? (sc->csctag ? sc->csctag : sc->tag) : "???");
@@ -213,7 +213,7 @@ static int print_cursor_description(strbuf *out, struct cursor_info *cinfo)
             }
             */
         }
-        strbuf_appendf(out, "table \"%s\"", db->tablename);
+        strbuf_appendf(out, "table \"%s\"", db->tablename_ip);
     }
     strbuf_appendf(out, " ");
     return is_index;

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -135,7 +135,7 @@ static void print_field(Vdbe *v, struct cursor_info *cinfo, int num, char *buf)
             sc = db->ixschema[cinfo->ix];
         } else {
             snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-            sc = find_tag_schema(db->tablename_ip, scname);
+            sc = find_tag_schema(db->tablename_interned, scname);
         }
     } else {
         sc = db->schema;
@@ -193,7 +193,7 @@ static int print_cursor_description(strbuf *out, struct cursor_info *cinfo)
                 sc = db->ixschema[cinfo->ix];
             } else {
                 snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-                sc = find_tag_schema(db->tablename_ip, scname);
+                sc = find_tag_schema(db->tablename_interned, scname);
             }
             strbuf_appendf(out, "index \"%s\" of ",
                            sc ? (sc->csctag ? sc->csctag : sc->tag) : "???");
@@ -213,7 +213,7 @@ static int print_cursor_description(strbuf *out, struct cursor_info *cinfo)
             }
             */
         }
-        strbuf_appendf(out, "table \"%s\"", db->tablename_ip);
+        strbuf_appendf(out, "table \"%s\"", db->tablename_interned);
     }
     strbuf_appendf(out, " ");
     return is_index;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1400,7 +1400,7 @@ static int stat1_find(char *namebuf, struct schema *schema, struct dbtable *db,
     statschema = iq.usedb->ixschema[stat_ixnum];
 
     f = &statschema->member[0]; /* tbl */
-    set_data(key + f->offset, db->tablename, strlen(db->tablename) + 1);
+    set_data(key + f->offset, db->tablename_ip, strlen(db->tablename_ip) + 1);
     keylen += f->len;
 
     f = &statschema->member[1]; /* idx */
@@ -1421,7 +1421,7 @@ static int stat1_find(char *namebuf, struct schema *schema, struct dbtable *db,
 static int using_old_style_name(char *namebuf, int len, struct schema *schema,
                                 struct dbtable *db, int ixnum, void *trans)
 {
-    snprintf(namebuf, len, "%s_ix_%d", db->tablename, ixnum);
+    snprintf(namebuf, len, "%s_ix_%d", db->tablename_ip, ixnum);
     return stat1_find(namebuf, schema, db, ixnum, trans);
 }
 
@@ -1486,7 +1486,7 @@ int sql_index_name_trans(char *namebuf, int len, struct schema *schema,
         return rc;
     }
 
-    form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename);
+    form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename_ip);
     rc = stat1_find(namebuf, schema, db, ixnum, trans);
     if (rc > 0)
         return 2;
@@ -1640,7 +1640,7 @@ static void create_sqlite_stat_sqlmaster_record(struct dbtable *tbl)
         free(tbl->ixsql[i]);
         tbl->ixsql[i] = NULL;
     }
-    switch (tbl->tablename[11]) {
+    switch (tbl->tablename_ip[11]) {
     case '1':
         tbl->sql = strdup("create table sqlite_stat1(tbl,idx,stat);");
         break;
@@ -1744,18 +1744,18 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
 
     struct schema *schema = tbl->schema;
     if (schema == NULL) {
-        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename);
+        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_ip);
         return -1;
     }
 
-    if (is_sqlite_stat(tbl->tablename)) {
+    if (is_sqlite_stat(tbl->tablename_ip)) {
         create_sqlite_stat_sqlmaster_record(tbl);
         return 0;
     }
 
     strbuf *sql = strbuf_new();
     strbuf_clear(sql);
-    strbuf_appendf(sql, "create table \"%s\"(", tbl->tablename);
+    strbuf_appendf(sql, "create table \"%s\"(", tbl->tablename_ip);
 
     /* Fields */
     for (field = 0; field < schema->nmembers; field++) {
@@ -1763,7 +1763,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         if (type == NULL) {
             logmsg(LOGMSG_ERROR, "Unsupported type in schema: column '%s' [%d] "
                                  "table %s\n",
-                   schema->member[field].name, field, tbl->tablename);
+                   schema->member[field].name, field, tbl->tablename_ip);
             strbuf_free(sql);
             return -1;
         }
@@ -1780,7 +1780,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
                 logmsg(LOGMSG_ERROR,
                        "Failed to convert default value column '%s' table "
                        "%s type %d\n",
-                       schema->member[field].name, tbl->tablename,
+                       schema->member[field].name, tbl->tablename_ip,
                        schema->member[field].type);
                 strbuf_free(sql);
                 return -1;
@@ -1826,7 +1826,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         schema = tbl->schema->ix[ixnum];
         if (schema == NULL) {
             logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum,
-                   tbl->tablename);
+                   tbl->tablename_ip);
             strbuf_free(sql);
             return -1;
         }
@@ -1846,7 +1846,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         /* We lie to sqlite about the uniqueness of the indexes. */
         strbuf_append(sql, "create index ");
 
-        strbuf_appendf(sql, "\"%s\" on \"%s\" (", namebuf, tbl->tablename);
+        strbuf_appendf(sql, "\"%s\" on \"%s\" (", namebuf, tbl->tablename_ip);
         for (field = 0; field < schema->nmembers; field++) {
             if (field > 0)
                 strbuf_append(sql, ", ");
@@ -2336,7 +2336,7 @@ static void extract_stat_record(struct dbtable *db, uint8_t *in, uint8_t *out,
                                 int *outlen)
 {
     struct schema *s = db->schema;
-    int n = is_stat2(db->tablename) ? 3 : 2;
+    int n = is_stat2(db->tablename_ip) ? 3 : 2;
     // for stat4 we have n (samplelen) = 2
 
     /* extract len */
@@ -3596,7 +3596,7 @@ int sqlite3BtreeLast(BtCursor *pCur, int *pRes)
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename);
+            pCur->range->tbname = strdup(pCur->db->tablename_ip);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->rflag = 1;
@@ -3653,7 +3653,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
 
     /* if this is part of an analyze skip the delete - we'll do
      * the entire update part in one shot later when the analyze is done */
-    if (clnt->is_analyze && is_sqlite_stat(pCur->db->tablename)) {
+    if (clnt->is_analyze && is_sqlite_stat(pCur->db->tablename_ip)) {
         rc = SQLITE_OK;
         goto done;
     }
@@ -3727,7 +3727,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
                     goto done;
             }
 
-            if (is_sqlite_stat(pCur->db->tablename)) {
+            if (is_sqlite_stat(pCur->db->tablename_ip)) {
                 clnt->ins_keys = -1ULL;
                 clnt->del_keys = -1ULL;
             }
@@ -3876,7 +3876,7 @@ int sqlite3BtreeFirst(BtCursor *pCur, int *pRes)
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename);
+            pCur->range->tbname = strdup(pCur->db->tablename_ip);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->lflag = 1;
@@ -5820,7 +5820,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
         if (rc < 0) {
             char errs[128];
             convert_failure_reason_str(&thd->clnt->fail_reason,
-                                       pCur->db->tablename, "SQLite format",
+                                       pCur->db->tablename_ip, "SQLite format",
                                        ".ONDISK", errs, sizeof(errs));
             reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                         "Moveto: sqlite_unpacked_to_ondisk failed [%s]\n",
@@ -6269,7 +6269,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
 
     if (thd && thd->query_hash) {
         if (pCur->cursor_class == CURSORCLASS_SQLITEMASTER ||
-            (pCur->db && is_sqlite_stat(pCur->db->tablename))) {
+            (pCur->db && is_sqlite_stat(pCur->db->tablename_ip))) {
             goto skip;
         }
         struct query_path_component fnd = {{0}}, *qc = NULL;
@@ -6280,7 +6280,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
             strncpy0(fnd.lcl_tbl_name, pCur->fdbc->tblname(pCur),
                      sizeof(fnd.lcl_tbl_name));
         } else if (pCur->db) {
-            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename,
+            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename_ip,
                      sizeof(fnd.lcl_tbl_name));
         }
         fnd.ix = pCur->ixnum;
@@ -6293,7 +6293,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
                 strncpy0(qc->lcl_tbl_name, pCur->fdbc->tblname(pCur),
                          sizeof(qc->lcl_tbl_name));
             } else if (pCur->db) {
-                strncpy0(qc->lcl_tbl_name, pCur->db->tablename,
+                strncpy0(qc->lcl_tbl_name, pCur->db->tablename_ip,
                          sizeof(qc->lcl_tbl_name));
             }
             qc->ix = pCur->ixnum;
@@ -6450,11 +6450,11 @@ int sqlite3BtreeClearTable(Btree *pBt, int iTable, int *pnChange)
         }
         /* If we are in analyze, lie.  Otherwise we end up with an empty,
          * and then worse, half-filled stat table during the analyze. */
-        if (clnt->is_analyze && is_sqlite_stat(db->tablename)) {
+        if (clnt->is_analyze && is_sqlite_stat(db->tablename_ip)) {
             rc = SQLITE_OK;
             goto done;
         }
-        rc = db->n_constraints == 0 ? osql_cleartable(thd, db->tablename) : -1;
+        rc = db->n_constraints == 0 ? osql_cleartable(thd, db->tablename_ip) : -1;
         if (rc) {
             logmsg(LOGMSG_ERROR, "sqlite3BtreeClearTable: error rc = %d\n", rc);
             rc = SQLITE_INTERNAL;
@@ -6510,7 +6510,7 @@ static int fetch_blob_into_sqlite_mem(BtCursor *pCur, struct schema *sc,
     struct sql_thread *thd = pCur->thd;
 
     if (!pCur->have_blob_descriptor) {
-        gather_blob_data_byname(pCur->db->tablename, ".ONDISK",
+        gather_blob_data_byname(pCur->db->tablename_ip, ".ONDISK",
                                 &pCur->blob_descriptor);
         pCur->have_blob_descriptor = 1;
     }
@@ -6554,7 +6554,7 @@ again:
             if (nretries >= gbl_maxretries) {
                 logmsg(LOGMSG_ERROR, "too much contention fetching "
                                      "tbl %s blob %s tried %d times\n",
-                       pCur->db->tablename, f->name, nretries);
+                       pCur->db->tablename_ip, f->name, nretries);
                 return SQLITE_DEADLOCK;
             }
             goto again;
@@ -6567,7 +6567,7 @@ again:
     init_fake_ireq(thedb, &iq);
     iq.usedb = pCur->db;
 
-    if (check_one_blob_consistency(&iq, iq.usedb->tablename, ".ONDISK", &blobs,
+    if (check_one_blob_consistency(&iq, iq.usedb->tablename_ip, ".ONDISK", &blobs,
                                    dta, f->blob_index, 0)) {
         free_blob_status_data(&blobs);
         nretries++;
@@ -7095,7 +7095,7 @@ sqlite3BtreeCursor_analyze(Btree *pBt,      /* The btree */
     cur->cursor_class = CURSORCLASS_TEMPTABLE;
     cur->cursor_move = cursor_move_compressed;
 
-    cur->sampler = analyze_get_sampler(clnt, db->tablename, cur->ixnum);
+    cur->sampler = analyze_get_sampler(clnt, db->tablename_ip, cur->ixnum);
 
     cur->db = db;
     cur->tableversion = cur->db->tableversion;
@@ -7404,7 +7404,7 @@ static inline int has_compressed_index(int iTable, BtCursor *cur,
     db = get_sqlite_db(thd, iTable, &ixnum);
     if (!db) return -1;
 
-    rc = analyze_is_sampled(clnt, db->tablename, ixnum);
+    rc = analyze_is_sampled(clnt, db->tablename_ip, ixnum);
     return rc;
 }
 
@@ -7537,7 +7537,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             unsigned long long version;
             int short_version;
 
-            rc = bdb_table_version_select_verbose(db->tablename, NULL, &version,
+            rc = bdb_table_version_select_verbose(db->tablename_ip, NULL, &version,
                                                   &bdberr, 0);
             if (rc || bdberr) {
                 logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n",
@@ -7548,7 +7548,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             if (gbl_fdb_track) {
                 logmsg(LOGMSG_ERROR, "%s: table \"%s\" has version %llu (%u), "
                                      "checking against %u\n",
-                       __func__, db->tablename, version, short_version,
+                       __func__, db->tablename_ip, version, short_version,
                        clnt->fdb_state.version);
             }
 
@@ -7586,7 +7586,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
                    rc, bdberr);*/
                 sqlite3_mutex_enter(sqlite3_db_mutex(p->db));
                 sqlite3VdbeError(p, "table \"%s\" was schema changed",
-                                 db->tablename);
+                                 db->tablename_ip);
                 sqlite3VdbeTransferError(p);
                 sqlite3MakeSureDbHasErr(p->db, SQLITE_OK);
                 sqlite3_mutex_leave(sqlite3_db_mutex(p->db));
@@ -7605,7 +7605,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
                 sqlite3_mutex_enter(sqlite3_db_mutex(p->db));
                 sqlite3VdbeError(
                     p, "table \"%s\" was schema changed during recovery",
-                    db->tablename);
+                    db->tablename_ip);
                 sqlite3VdbeTransferError(p);
                 sqlite3_mutex_leave(sqlite3_db_mutex(p->db));
 
@@ -7616,7 +7616,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             db->nsql++; /* per table nsql stats */
         }
 
-        reqlog_add_table(thrman_get_reqlogger(thrman_self()), db->tablename);
+        reqlog_add_table(thrman_get_reqlogger(thrman_self()), db->tablename_ip);
     }
 
     if (!after_recovery)
@@ -7930,7 +7930,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
     cur->shadtbl = osql_get_shadow_bydb(thd->clnt, cur->db);
 
     if (cur->ixnum == -1) {
-        if (is_stat2(cur->db->tablename) || is_stat4(cur->db->tablename)) {
+        if (is_stat2(cur->db->tablename_ip) || is_stat4(cur->db->tablename_ip)) {
             cur->cursor_class = CURSORCLASS_STAT24;
         } else
             cur->cursor_class = CURSORCLASS_TABLE;
@@ -7943,12 +7943,12 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
         cur->nCookFields = -1;
     }
 
-    reqlog_usetable(pBt->reqlogger, cur->db->tablename);
+    reqlog_usetable(pBt->reqlogger, cur->db->tablename_ip);
 
     /* check one time if we have blobs when we open the cursor,
      * so we dont need to run this code for every row if we dont even
      * have them */
-    rc = gather_blob_data_byname(cur->db->tablename, ".ONDISK", &cur->blobs);
+    rc = gather_blob_data_byname(cur->db->tablename_ip, ".ONDISK", &cur->blobs);
     if (rc) {
        logmsg(LOGMSG_ERROR, "sqlite3BtreeCursor: gather_blob_data error rc=%d\n", rc);
         return SQLITE_INTERNAL;
@@ -8254,7 +8254,7 @@ int sqlite3BtreeCursor(
                                        sqlite3VdbeCompareRecordPacked, pKeyInfo,
                                        cur, thd);
         /* treat sqlite_stat1 as free */
-        if (is_sqlite_stat(cur->db->tablename)) {
+        if (is_sqlite_stat(cur->db->tablename_ip)) {
             cur->find_cost = cur->move_cost = cur->write_cost = CDB2_SQLITE_STAT_COST;
         } else {
             cur->blob_cost = CDB2_BLOB_FETCH_COST;
@@ -8293,7 +8293,7 @@ int sqlite3BtreeCursor(
                 (cur->is_recording && gbl_selectv_rangechk))) {
         cur->range = currange_new();
         if (cur->db) {
-            cur->range->tbname = strdup(cur->db->tablename);
+            cur->range->tbname = strdup(cur->db->tablename_ip);
             cur->range->idxnum = cur->ixnum;
         }
     }
@@ -8308,8 +8308,8 @@ static int make_stat_record(struct sql_thread *thd, BtCursor *pCur,
                             const void *pData, int nData,
                             blob_buffer_t blobs[MAXBLOBS])
 {
-    int n = is_stat2(pCur->db->tablename) ? 3 : 2;
-    struct schema *sc = find_tag_schema(pCur->db->tablename, ".ONDISK_IX_0");
+    int n = is_stat2(pCur->db->tablename_ip) ? 3 : 2;
+    struct schema *sc = find_tag_schema(pCur->db->tablename_ip, ".ONDISK_IX_0");
 
     /* extract first n fields from packed record */
     if (sqlite_to_ondisk(sc, pData, nData, pCur->ondisk_buf, pCur->clnt->tzname,
@@ -8506,7 +8506,7 @@ int sqlite3BtreeInsert(
         if (rc) {
             char errs[128];
             convert_failure_reason_str(&thd->clnt->fail_reason,
-                                       pCur->db->tablename, "SQLite format",
+                                       pCur->db->tablename_ip, "SQLite format",
                                        ".ONDISK_IX_0", errs, sizeof(errs));
             fprintf(stderr, "%s: sqlite -> ondisk conversion failed!\n   %s\n",
                     __func__, errs);
@@ -8515,7 +8515,7 @@ int sqlite3BtreeInsert(
     }
 
     /* send opcode to reload stats at commit */
-    if (clnt->is_analyze && pCur->db && is_stat1(pCur->db->tablename))
+    if (clnt->is_analyze && pCur->db && is_stat1(pCur->db->tablename_ip))
         rc = osql_updstat(pCur, thd, pCur->ondisk_buf, getdatsize(pCur->db), 0);
 
     if (pCur->bt->is_temporary) {
@@ -8639,7 +8639,7 @@ int sqlite3BtreeInsert(
                 if (rc != getkeysize(pCur->db, pCur->ixnum)) {
                     char errs[128];
                     convert_failure_reason_str(
-                        &thd->clnt->fail_reason, pCur->db->tablename,
+                        &thd->clnt->fail_reason, pCur->db->tablename_ip,
                         "SQLite format", ".ONDISK_ix", errs, sizeof(errs));
                     reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                                 "Moveto: sqlite_to_ondisk failed [%s]\n", errs);
@@ -8690,7 +8690,7 @@ int sqlite3BtreeInsert(
             if (rc < 0) {
                 char errs[128];
                 convert_failure_reason_str(&thd->clnt->fail_reason,
-                                           pCur->db->tablename, "SQLite format",
+                                           pCur->db->tablename_ip, "SQLite format",
                                            ".ONDISK", errs, sizeof(errs));
                 reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                             "Moveto: sqlite_to_ondisk failed [%s]\n", errs);
@@ -8721,7 +8721,7 @@ int sqlite3BtreeInsert(
             is_update = 1;
 
         if (pCur->bt == NULL || pCur->bt->is_remote == 0) {
-            if (is_sqlite_stat(pCur->db->tablename)) {
+            if (is_sqlite_stat(pCur->db->tablename_ip)) {
                 clnt->ins_keys = -1ULL;
                 clnt->del_keys = -1ULL;
             }
@@ -9072,14 +9072,14 @@ i64 sqlite3BtreeNewRowid(BtCursor *pCur)
     return bdb_recno_to_genid(++thd->clnt->recno);
 }
 
-char *sqlite3BtreeGetTblName(BtCursor *pCur)
+const char *sqlite3BtreeGetTblName(BtCursor *pCur)
 {
-    return pCur->db->tablename;
+    return pCur->db->tablename_ip;
 }
 
-char *get_dbtable_name(struct dbtable *tbl)
+const char *get_dbtable_name(struct dbtable *tbl)
 {
-    return tbl->tablename;
+    return tbl->tablename_ip;
 }
 
 void cancel_sql_statement(int id)
@@ -9168,10 +9168,10 @@ void sql_dump_running_statements(void)
                     if (cur->db == NULL)
                         logmsg(LOGMSG_USER, " schema table");
                     else if (cur->ixnum == -1)
-                        logmsg(LOGMSG_USER, " table %s", cur->db->tablename);
+                        logmsg(LOGMSG_USER, " table %s", cur->db->tablename_ip);
                     else
                         logmsg(LOGMSG_USER, " table %s index %d",
-                               cur->db->tablename, cur->ixnum);
+                               cur->db->tablename_ip, cur->ixnum);
                     logmsg(LOGMSG_USER, " nmove %d nfind %d nwrite %d\n", cur->nmove,
                            cur->nfind, cur->nwrite);
                 }
@@ -9636,12 +9636,12 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
                     Pthread_mutex_unlock(&thd->lk);
                     logmsg(LOGMSG_ERROR,
                            "%s: table version for %s changed from %d to %lld\n",
-                           __func__, cur->db->tablename, cur->tableversion,
+                           __func__, cur->db->tablename_ip, cur->tableversion,
                            cur->db->tableversion);
                     sqlite3_mutex_enter(sqlite3_db_mutex(cur->vdbe->db));
                     sqlite3VdbeError(cur->vdbe,
                                      "table \"%s\" was schema changed",
-                                     cur->db->tablename);
+                                     cur->db->tablename_ip);
                     sqlite3VdbeTransferError(cur->vdbe);
                     sqlite3MakeSureDbHasErr(cur->vdbe->db, SQLITE_OK);
                     sqlite3_mutex_leave(sqlite3_db_mutex(cur->vdbe->db));
@@ -9769,7 +9769,7 @@ static int ddguard_bdb_cursor_find(struct sql_thread *thd, BtCursor *pCur,
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename);
+            pCur->range->tbname = strdup(pCur->db->tablename_ip);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->lkey = malloc(keylen);
@@ -9969,7 +9969,7 @@ static int ddguard_bdb_cursor_find_last_dup(struct sql_thread *thd,
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename);
+            pCur->range->tbname = strdup(pCur->db->tablename_ip);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->rkey = malloc(keylen);
@@ -10279,7 +10279,7 @@ int sqlite3BtreeSetRecording(BtCursor *pCur, int flag)
         if (gbl_selectv_rangechk) {
             pCur->range = currange_new();
             if (pCur->db) {
-                pCur->range->tbname = strdup(pCur->db->tablename);
+                pCur->range->tbname = strdup(pCur->db->tablename_ip);
                 pCur->range->idxnum = pCur->ixnum;
             }
         }
@@ -10411,7 +10411,7 @@ int sqlite3BtreeCount(BtCursor *pCur, i64 *pnEntry)
     int rc;
     i64 count;
     if (pCur->is_sampled_idx) {
-        count = analyze_get_sampled_nrecs(pCur->db->tablename, pCur->ixnum);
+        count = analyze_get_sampled_nrecs(pCur->db->tablename_ip, pCur->ixnum);
         rc = SQLITE_OK;
     } else if (pCur->cursor_count) {
         rc = pCur->cursor_count(pCur, &count);
@@ -11477,7 +11477,7 @@ void clone_temp_table(sqlite3_stmt *stmt, struct temptable *tbl)
     }
 }
 
-int bt_hash_table(char *table, int szkb)
+int bt_hash_table(const char *table, int szkb)
 {
     struct dbtable *db;
     bdb_state_type *bdb_state;
@@ -11515,7 +11515,7 @@ int bt_hash_table(char *table, int szkb)
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
     logmsg(LOGMSG_WARN, "Building bthash for table %s, size %dkb per stripe\n",
-           db->tablename, szkb);
+           db->tablename_ip, szkb);
     bdb_handle_dbp_add_hash(bdb_state, szkb);
     trans_commit(&iq, tran, gbl_myhostname);
 
@@ -11532,7 +11532,7 @@ int bt_hash_table(char *table, int szkb)
     return 0;
 }
 
-int del_bt_hash_table(char *table)
+int del_bt_hash_table(const char *table)
 {
     struct dbtable *db;
     bdb_state_type *bdb_state;
@@ -11568,7 +11568,7 @@ int del_bt_hash_table(char *table)
 
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
-    logmsg(LOGMSG_WARN, "Deleting bthash for table %s\n", db->tablename);
+    logmsg(LOGMSG_WARN, "Deleting bthash for table %s\n", db->tablename_ip);
     bdb_handle_dbp_drop_hash(bdb_state);
     trans_commit(&iq, tran, gbl_myhostname);
 
@@ -12258,7 +12258,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
     sql = strbuf_new();
 
     if (sc == NULL) {
-        logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n", db->tablename);
+        logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n", db->tablename_ip);
         abort();
     }
 
@@ -12279,8 +12279,8 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
         }
     }
 
-    len = strlen(db->tablename);
-    len = crc32c((uint8_t *)db->tablename, len);
+    len = strlen(db->tablename_ip);
+    len = crc32c((uint8_t *)db->tablename_ip, len);
     snprintf(temp_newdb_name, MAXTABLELEN, "sc_alter_temp_%X", len);
 
     for (ixnum = 0; ixnum < db->nix; ixnum++) {
@@ -12290,7 +12290,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
             int exist = 0;
             strbuf_clear(sql);
             strbuf_appendf(sql, "WITH \"%s\"(\"%s\"",
-                           is_alter ? temp_newdb_name : db->tablename,
+                           is_alter ? temp_newdb_name : db->tablename_ip,
                            sc->member[0].name);
             for (i = 1; i < sc->nmembers; i++) {
                 strbuf_appendf(sql, ", \"%s\"", sc->member[i].name);
@@ -12300,7 +12300,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
                 strbuf_appendf(sql, ", @%s", sc->member[i].name);
             }
             strbuf_appendf(sql, ") SELECT 1 FROM \"%s\" %s",
-                           is_alter ? temp_newdb_name : db->tablename,
+                           is_alter ? temp_newdb_name : db->tablename_ip,
                            db->ixschema[ixnum]->where);
             rc = run_verify_indexes_query((char *)strbuf_buf(sql), sc, m, NULL,
                                           &exist);
@@ -12471,7 +12471,7 @@ uint16_t stmt_num_tbls(sqlite3_stmt *stmt)
     return v->numTables;
 }
 
-int comdb2_save_ddl_context(char *name, void *ctx, comdb2ma mem)
+int comdb2_save_ddl_context(const char *name, void *ctx, comdb2ma mem)
 {
     struct sql_thread *thd = pthread_getspecific(query_info_key);
     struct sqlclntstate *clnt = thd->clnt;
@@ -12660,7 +12660,7 @@ int verify_check_constraints(struct dbtable *table, uint8_t *rec,
     sc = table->schema;
     if (sc == NULL) {
         logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n",
-               table->tablename);
+               table->tablename_ip);
         abort();
     }
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1683,11 +1683,11 @@ int create_datacopy_array(struct dbtable *tbl)
     struct schema *schema = tbl->schema;
 
     if (schema == NULL) {
-        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename);
+        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_ip);
         return -1;
     }
 
-    if (is_sqlite_stat(tbl->tablename)) {
+    if (is_sqlite_stat(tbl->tablename_ip)) {
         return 0;
     }
 
@@ -1696,7 +1696,7 @@ int create_datacopy_array(struct dbtable *tbl)
         schema = tbl->schema->ix[ixnum];
         struct schema *ondisk = tbl->schema;
         if (schema == NULL) {
-            logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum, tbl->tablename);
+            logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum, tbl->tablename_ip);
             return -1;
         }
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1400,7 +1400,7 @@ static int stat1_find(char *namebuf, struct schema *schema, struct dbtable *db,
     statschema = iq.usedb->ixschema[stat_ixnum];
 
     f = &statschema->member[0]; /* tbl */
-    set_data(key + f->offset, db->tablename_ip, strlen(db->tablename_ip) + 1);
+    set_data(key + f->offset, db->tablename_interned, strlen(db->tablename_interned) + 1);
     keylen += f->len;
 
     f = &statschema->member[1]; /* idx */
@@ -1421,7 +1421,7 @@ static int stat1_find(char *namebuf, struct schema *schema, struct dbtable *db,
 static int using_old_style_name(char *namebuf, int len, struct schema *schema,
                                 struct dbtable *db, int ixnum, void *trans)
 {
-    snprintf(namebuf, len, "%s_ix_%d", db->tablename_ip, ixnum);
+    snprintf(namebuf, len, "%s_ix_%d", db->tablename_interned, ixnum);
     return stat1_find(namebuf, schema, db, ixnum, trans);
 }
 
@@ -1486,7 +1486,7 @@ int sql_index_name_trans(char *namebuf, int len, struct schema *schema,
         return rc;
     }
 
-    form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename_ip);
+    form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename_interned);
     rc = stat1_find(namebuf, schema, db, ixnum, trans);
     if (rc > 0)
         return 2;
@@ -1640,7 +1640,7 @@ static void create_sqlite_stat_sqlmaster_record(struct dbtable *tbl)
         free(tbl->ixsql[i]);
         tbl->ixsql[i] = NULL;
     }
-    switch (tbl->tablename_ip[11]) {
+    switch (tbl->tablename_interned[11]) {
     case '1':
         tbl->sql = strdup("create table sqlite_stat1(tbl,idx,stat);");
         break;
@@ -1683,11 +1683,11 @@ int create_datacopy_array(struct dbtable *tbl)
     struct schema *schema = tbl->schema;
 
     if (schema == NULL) {
-        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_ip);
+        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_interned);
         return -1;
     }
 
-    if (is_sqlite_stat(tbl->tablename_ip)) {
+    if (is_sqlite_stat(tbl->tablename_interned)) {
         return 0;
     }
 
@@ -1696,7 +1696,7 @@ int create_datacopy_array(struct dbtable *tbl)
         schema = tbl->schema->ix[ixnum];
         struct schema *ondisk = tbl->schema;
         if (schema == NULL) {
-            logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum, tbl->tablename_ip);
+            logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum, tbl->tablename_interned);
             return -1;
         }
 
@@ -1744,18 +1744,18 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
 
     struct schema *schema = tbl->schema;
     if (schema == NULL) {
-        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_ip);
+        logmsg(LOGMSG_ERROR, "No .ONDISK tag for table %s.\n", tbl->tablename_interned);
         return -1;
     }
 
-    if (is_sqlite_stat(tbl->tablename_ip)) {
+    if (is_sqlite_stat(tbl->tablename_interned)) {
         create_sqlite_stat_sqlmaster_record(tbl);
         return 0;
     }
 
     strbuf *sql = strbuf_new();
     strbuf_clear(sql);
-    strbuf_appendf(sql, "create table \"%s\"(", tbl->tablename_ip);
+    strbuf_appendf(sql, "create table \"%s\"(", tbl->tablename_interned);
 
     /* Fields */
     for (field = 0; field < schema->nmembers; field++) {
@@ -1763,7 +1763,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         if (type == NULL) {
             logmsg(LOGMSG_ERROR, "Unsupported type in schema: column '%s' [%d] "
                                  "table %s\n",
-                   schema->member[field].name, field, tbl->tablename_ip);
+                   schema->member[field].name, field, tbl->tablename_interned);
             strbuf_free(sql);
             return -1;
         }
@@ -1780,7 +1780,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
                 logmsg(LOGMSG_ERROR,
                        "Failed to convert default value column '%s' table "
                        "%s type %d\n",
-                       schema->member[field].name, tbl->tablename_ip,
+                       schema->member[field].name, tbl->tablename_interned,
                        schema->member[field].type);
                 strbuf_free(sql);
                 return -1;
@@ -1826,7 +1826,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         schema = tbl->schema->ix[ixnum];
         if (schema == NULL) {
             logmsg(LOGMSG_ERROR, "No index %d schema for table %s\n", ixnum,
-                   tbl->tablename_ip);
+                   tbl->tablename_interned);
             strbuf_free(sql);
             return -1;
         }
@@ -1846,7 +1846,7 @@ static int create_sqlmaster_record(struct dbtable *tbl, void *tran)
         /* We lie to sqlite about the uniqueness of the indexes. */
         strbuf_append(sql, "create index ");
 
-        strbuf_appendf(sql, "\"%s\" on \"%s\" (", namebuf, tbl->tablename_ip);
+        strbuf_appendf(sql, "\"%s\" on \"%s\" (", namebuf, tbl->tablename_interned);
         for (field = 0; field < schema->nmembers; field++) {
             if (field > 0)
                 strbuf_append(sql, ", ");
@@ -2336,7 +2336,7 @@ static void extract_stat_record(struct dbtable *db, uint8_t *in, uint8_t *out,
                                 int *outlen)
 {
     struct schema *s = db->schema;
-    int n = is_stat2(db->tablename_ip) ? 3 : 2;
+    int n = is_stat2(db->tablename_interned) ? 3 : 2;
     // for stat4 we have n (samplelen) = 2
 
     /* extract len */
@@ -3596,7 +3596,7 @@ int sqlite3BtreeLast(BtCursor *pCur, int *pRes)
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename_ip);
+            pCur->range->tbname = strdup(pCur->db->tablename_interned);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->rflag = 1;
@@ -3653,7 +3653,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
 
     /* if this is part of an analyze skip the delete - we'll do
      * the entire update part in one shot later when the analyze is done */
-    if (clnt->is_analyze && is_sqlite_stat(pCur->db->tablename_ip)) {
+    if (clnt->is_analyze && is_sqlite_stat(pCur->db->tablename_interned)) {
         rc = SQLITE_OK;
         goto done;
     }
@@ -3727,7 +3727,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
                     goto done;
             }
 
-            if (is_sqlite_stat(pCur->db->tablename_ip)) {
+            if (is_sqlite_stat(pCur->db->tablename_interned)) {
                 clnt->ins_keys = -1ULL;
                 clnt->del_keys = -1ULL;
             }
@@ -3876,7 +3876,7 @@ int sqlite3BtreeFirst(BtCursor *pCur, int *pRes)
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename_ip);
+            pCur->range->tbname = strdup(pCur->db->tablename_interned);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->lflag = 1;
@@ -5820,7 +5820,7 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
         if (rc < 0) {
             char errs[128];
             convert_failure_reason_str(&thd->clnt->fail_reason,
-                                       pCur->db->tablename_ip, "SQLite format",
+                                       pCur->db->tablename_interned, "SQLite format",
                                        ".ONDISK", errs, sizeof(errs));
             reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                         "Moveto: sqlite_unpacked_to_ondisk failed [%s]\n",
@@ -6269,7 +6269,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
 
     if (thd && thd->query_hash) {
         if (pCur->cursor_class == CURSORCLASS_SQLITEMASTER ||
-            (pCur->db && is_sqlite_stat(pCur->db->tablename_ip))) {
+            (pCur->db && is_sqlite_stat(pCur->db->tablename_interned))) {
             goto skip;
         }
         struct query_path_component fnd = {{0}}, *qc = NULL;
@@ -6280,7 +6280,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
             strncpy0(fnd.lcl_tbl_name, pCur->fdbc->tblname(pCur),
                      sizeof(fnd.lcl_tbl_name));
         } else if (pCur->db) {
-            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename_ip,
+            strncpy0(fnd.lcl_tbl_name, pCur->db->tablename_interned,
                      sizeof(fnd.lcl_tbl_name));
         }
         fnd.ix = pCur->ixnum;
@@ -6293,7 +6293,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
                 strncpy0(qc->lcl_tbl_name, pCur->fdbc->tblname(pCur),
                          sizeof(qc->lcl_tbl_name));
             } else if (pCur->db) {
-                strncpy0(qc->lcl_tbl_name, pCur->db->tablename_ip,
+                strncpy0(qc->lcl_tbl_name, pCur->db->tablename_interned,
                          sizeof(qc->lcl_tbl_name));
             }
             qc->ix = pCur->ixnum;
@@ -6450,11 +6450,11 @@ int sqlite3BtreeClearTable(Btree *pBt, int iTable, int *pnChange)
         }
         /* If we are in analyze, lie.  Otherwise we end up with an empty,
          * and then worse, half-filled stat table during the analyze. */
-        if (clnt->is_analyze && is_sqlite_stat(db->tablename_ip)) {
+        if (clnt->is_analyze && is_sqlite_stat(db->tablename_interned)) {
             rc = SQLITE_OK;
             goto done;
         }
-        rc = db->n_constraints == 0 ? osql_cleartable(thd, db->tablename_ip) : -1;
+        rc = db->n_constraints == 0 ? osql_cleartable(thd, db->tablename_interned) : -1;
         if (rc) {
             logmsg(LOGMSG_ERROR, "sqlite3BtreeClearTable: error rc = %d\n", rc);
             rc = SQLITE_INTERNAL;
@@ -6510,7 +6510,7 @@ static int fetch_blob_into_sqlite_mem(BtCursor *pCur, struct schema *sc,
     struct sql_thread *thd = pCur->thd;
 
     if (!pCur->have_blob_descriptor) {
-        gather_blob_data_byname(pCur->db->tablename_ip, ".ONDISK",
+        gather_blob_data_byname(pCur->db->tablename_interned, ".ONDISK",
                                 &pCur->blob_descriptor);
         pCur->have_blob_descriptor = 1;
     }
@@ -6554,7 +6554,7 @@ again:
             if (nretries >= gbl_maxretries) {
                 logmsg(LOGMSG_ERROR, "too much contention fetching "
                                      "tbl %s blob %s tried %d times\n",
-                       pCur->db->tablename_ip, f->name, nretries);
+                       pCur->db->tablename_interned, f->name, nretries);
                 return SQLITE_DEADLOCK;
             }
             goto again;
@@ -6567,7 +6567,7 @@ again:
     init_fake_ireq(thedb, &iq);
     iq.usedb = pCur->db;
 
-    if (check_one_blob_consistency(&iq, iq.usedb->tablename_ip, ".ONDISK", &blobs,
+    if (check_one_blob_consistency(&iq, iq.usedb->tablename_interned, ".ONDISK", &blobs,
                                    dta, f->blob_index, 0)) {
         free_blob_status_data(&blobs);
         nretries++;
@@ -7095,7 +7095,7 @@ sqlite3BtreeCursor_analyze(Btree *pBt,      /* The btree */
     cur->cursor_class = CURSORCLASS_TEMPTABLE;
     cur->cursor_move = cursor_move_compressed;
 
-    cur->sampler = analyze_get_sampler(clnt, db->tablename_ip, cur->ixnum);
+    cur->sampler = analyze_get_sampler(clnt, db->tablename_interned, cur->ixnum);
 
     cur->db = db;
     cur->tableversion = cur->db->tableversion;
@@ -7404,7 +7404,7 @@ static inline int has_compressed_index(int iTable, BtCursor *cur,
     db = get_sqlite_db(thd, iTable, &ixnum);
     if (!db) return -1;
 
-    rc = analyze_is_sampled(clnt, db->tablename_ip, ixnum);
+    rc = analyze_is_sampled(clnt, db->tablename_interned, ixnum);
     return rc;
 }
 
@@ -7537,7 +7537,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             unsigned long long version;
             int short_version;
 
-            rc = bdb_table_version_select_verbose(db->tablename_ip, NULL, &version,
+            rc = bdb_table_version_select_verbose(db->tablename_interned, NULL, &version,
                                                   &bdberr, 0);
             if (rc || bdberr) {
                 logmsg(LOGMSG_ERROR, "%s error version=%llu rc=%d bdberr=%d\n",
@@ -7548,7 +7548,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             if (gbl_fdb_track) {
                 logmsg(LOGMSG_ERROR, "%s: table \"%s\" has version %llu (%u), "
                                      "checking against %u\n",
-                       __func__, db->tablename_ip, version, short_version,
+                       __func__, db->tablename_interned, version, short_version,
                        clnt->fdb_state.version);
             }
 
@@ -7586,7 +7586,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
                    rc, bdberr);*/
                 sqlite3_mutex_enter(sqlite3_db_mutex(p->db));
                 sqlite3VdbeError(p, "table \"%s\" was schema changed",
-                                 db->tablename_ip);
+                                 db->tablename_interned);
                 sqlite3VdbeTransferError(p);
                 sqlite3MakeSureDbHasErr(p->db, SQLITE_OK);
                 sqlite3_mutex_leave(sqlite3_db_mutex(p->db));
@@ -7605,7 +7605,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
                 sqlite3_mutex_enter(sqlite3_db_mutex(p->db));
                 sqlite3VdbeError(
                     p, "table \"%s\" was schema changed during recovery",
-                    db->tablename_ip);
+                    db->tablename_interned);
                 sqlite3VdbeTransferError(p);
                 sqlite3_mutex_leave(sqlite3_db_mutex(p->db));
 
@@ -7616,7 +7616,7 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             db->nsql++; /* per table nsql stats */
         }
 
-        reqlog_add_table(thrman_get_reqlogger(thrman_self()), db->tablename_ip);
+        reqlog_add_table(thrman_get_reqlogger(thrman_self()), db->tablename_interned);
     }
 
     if (!after_recovery)
@@ -7930,7 +7930,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
     cur->shadtbl = osql_get_shadow_bydb(thd->clnt, cur->db);
 
     if (cur->ixnum == -1) {
-        if (is_stat2(cur->db->tablename_ip) || is_stat4(cur->db->tablename_ip)) {
+        if (is_stat2(cur->db->tablename_interned) || is_stat4(cur->db->tablename_interned)) {
             cur->cursor_class = CURSORCLASS_STAT24;
         } else
             cur->cursor_class = CURSORCLASS_TABLE;
@@ -7943,12 +7943,12 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
         cur->nCookFields = -1;
     }
 
-    reqlog_usetable(pBt->reqlogger, cur->db->tablename_ip);
+    reqlog_usetable(pBt->reqlogger, cur->db->tablename_interned);
 
     /* check one time if we have blobs when we open the cursor,
      * so we dont need to run this code for every row if we dont even
      * have them */
-    rc = gather_blob_data_byname(cur->db->tablename_ip, ".ONDISK", &cur->blobs);
+    rc = gather_blob_data_byname(cur->db->tablename_interned, ".ONDISK", &cur->blobs);
     if (rc) {
        logmsg(LOGMSG_ERROR, "sqlite3BtreeCursor: gather_blob_data error rc=%d\n", rc);
         return SQLITE_INTERNAL;
@@ -8254,7 +8254,7 @@ int sqlite3BtreeCursor(
                                        sqlite3VdbeCompareRecordPacked, pKeyInfo,
                                        cur, thd);
         /* treat sqlite_stat1 as free */
-        if (is_sqlite_stat(cur->db->tablename_ip)) {
+        if (is_sqlite_stat(cur->db->tablename_interned)) {
             cur->find_cost = cur->move_cost = cur->write_cost = CDB2_SQLITE_STAT_COST;
         } else {
             cur->blob_cost = CDB2_BLOB_FETCH_COST;
@@ -8293,7 +8293,7 @@ int sqlite3BtreeCursor(
                 (cur->is_recording && gbl_selectv_rangechk))) {
         cur->range = currange_new();
         if (cur->db) {
-            cur->range->tbname = strdup(cur->db->tablename_ip);
+            cur->range->tbname = strdup(cur->db->tablename_interned);
             cur->range->idxnum = cur->ixnum;
         }
     }
@@ -8308,8 +8308,8 @@ static int make_stat_record(struct sql_thread *thd, BtCursor *pCur,
                             const void *pData, int nData,
                             blob_buffer_t blobs[MAXBLOBS])
 {
-    int n = is_stat2(pCur->db->tablename_ip) ? 3 : 2;
-    struct schema *sc = find_tag_schema(pCur->db->tablename_ip, ".ONDISK_IX_0");
+    int n = is_stat2(pCur->db->tablename_interned) ? 3 : 2;
+    struct schema *sc = find_tag_schema(pCur->db->tablename_interned, ".ONDISK_IX_0");
 
     /* extract first n fields from packed record */
     if (sqlite_to_ondisk(sc, pData, nData, pCur->ondisk_buf, pCur->clnt->tzname,
@@ -8506,7 +8506,7 @@ int sqlite3BtreeInsert(
         if (rc) {
             char errs[128];
             convert_failure_reason_str(&thd->clnt->fail_reason,
-                                       pCur->db->tablename_ip, "SQLite format",
+                                       pCur->db->tablename_interned, "SQLite format",
                                        ".ONDISK_IX_0", errs, sizeof(errs));
             fprintf(stderr, "%s: sqlite -> ondisk conversion failed!\n   %s\n",
                     __func__, errs);
@@ -8515,7 +8515,7 @@ int sqlite3BtreeInsert(
     }
 
     /* send opcode to reload stats at commit */
-    if (clnt->is_analyze && pCur->db && is_stat1(pCur->db->tablename_ip))
+    if (clnt->is_analyze && pCur->db && is_stat1(pCur->db->tablename_interned))
         rc = osql_updstat(pCur, thd, pCur->ondisk_buf, getdatsize(pCur->db), 0);
 
     if (pCur->bt->is_temporary) {
@@ -8639,7 +8639,7 @@ int sqlite3BtreeInsert(
                 if (rc != getkeysize(pCur->db, pCur->ixnum)) {
                     char errs[128];
                     convert_failure_reason_str(
-                        &thd->clnt->fail_reason, pCur->db->tablename_ip,
+                        &thd->clnt->fail_reason, pCur->db->tablename_interned,
                         "SQLite format", ".ONDISK_ix", errs, sizeof(errs));
                     reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                                 "Moveto: sqlite_to_ondisk failed [%s]\n", errs);
@@ -8690,7 +8690,7 @@ int sqlite3BtreeInsert(
             if (rc < 0) {
                 char errs[128];
                 convert_failure_reason_str(&thd->clnt->fail_reason,
-                                           pCur->db->tablename_ip, "SQLite format",
+                                           pCur->db->tablename_interned, "SQLite format",
                                            ".ONDISK", errs, sizeof(errs));
                 reqlog_logf(pCur->bt->reqlogger, REQL_TRACE,
                             "Moveto: sqlite_to_ondisk failed [%s]\n", errs);
@@ -8721,7 +8721,7 @@ int sqlite3BtreeInsert(
             is_update = 1;
 
         if (pCur->bt == NULL || pCur->bt->is_remote == 0) {
-            if (is_sqlite_stat(pCur->db->tablename_ip)) {
+            if (is_sqlite_stat(pCur->db->tablename_interned)) {
                 clnt->ins_keys = -1ULL;
                 clnt->del_keys = -1ULL;
             }
@@ -9074,12 +9074,12 @@ i64 sqlite3BtreeNewRowid(BtCursor *pCur)
 
 const char *sqlite3BtreeGetTblName(BtCursor *pCur)
 {
-    return pCur->db->tablename_ip;
+    return pCur->db->tablename_interned;
 }
 
 const char *get_dbtable_name(struct dbtable *tbl)
 {
-    return tbl->tablename_ip;
+    return tbl->tablename_interned;
 }
 
 void cancel_sql_statement(int id)
@@ -9168,10 +9168,10 @@ void sql_dump_running_statements(void)
                     if (cur->db == NULL)
                         logmsg(LOGMSG_USER, " schema table");
                     else if (cur->ixnum == -1)
-                        logmsg(LOGMSG_USER, " table %s", cur->db->tablename_ip);
+                        logmsg(LOGMSG_USER, " table %s", cur->db->tablename_interned);
                     else
                         logmsg(LOGMSG_USER, " table %s index %d",
-                               cur->db->tablename_ip, cur->ixnum);
+                               cur->db->tablename_interned, cur->ixnum);
                     logmsg(LOGMSG_USER, " nmove %d nfind %d nwrite %d\n", cur->nmove,
                            cur->nfind, cur->nwrite);
                 }
@@ -9636,12 +9636,12 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
                     Pthread_mutex_unlock(&thd->lk);
                     logmsg(LOGMSG_ERROR,
                            "%s: table version for %s changed from %d to %lld\n",
-                           __func__, cur->db->tablename_ip, cur->tableversion,
+                           __func__, cur->db->tablename_interned, cur->tableversion,
                            cur->db->tableversion);
                     sqlite3_mutex_enter(sqlite3_db_mutex(cur->vdbe->db));
                     sqlite3VdbeError(cur->vdbe,
                                      "table \"%s\" was schema changed",
-                                     cur->db->tablename_ip);
+                                     cur->db->tablename_interned);
                     sqlite3VdbeTransferError(cur->vdbe);
                     sqlite3MakeSureDbHasErr(cur->vdbe->db, SQLITE_OK);
                     sqlite3_mutex_leave(sqlite3_db_mutex(cur->vdbe->db));
@@ -9769,7 +9769,7 @@ static int ddguard_bdb_cursor_find(struct sql_thread *thd, BtCursor *pCur,
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename_ip);
+            pCur->range->tbname = strdup(pCur->db->tablename_interned);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->lkey = malloc(keylen);
@@ -9969,7 +9969,7 @@ static int ddguard_bdb_cursor_find_last_dup(struct sql_thread *thd,
 
     if (pCur->range && pCur->db) {
         if (!pCur->range->tbname) {
-            pCur->range->tbname = strdup(pCur->db->tablename_ip);
+            pCur->range->tbname = strdup(pCur->db->tablename_interned);
         }
         pCur->range->idxnum = pCur->ixnum;
         pCur->range->rkey = malloc(keylen);
@@ -10279,7 +10279,7 @@ int sqlite3BtreeSetRecording(BtCursor *pCur, int flag)
         if (gbl_selectv_rangechk) {
             pCur->range = currange_new();
             if (pCur->db) {
-                pCur->range->tbname = strdup(pCur->db->tablename_ip);
+                pCur->range->tbname = strdup(pCur->db->tablename_interned);
                 pCur->range->idxnum = pCur->ixnum;
             }
         }
@@ -10411,7 +10411,7 @@ int sqlite3BtreeCount(BtCursor *pCur, i64 *pnEntry)
     int rc;
     i64 count;
     if (pCur->is_sampled_idx) {
-        count = analyze_get_sampled_nrecs(pCur->db->tablename_ip, pCur->ixnum);
+        count = analyze_get_sampled_nrecs(pCur->db->tablename_interned, pCur->ixnum);
         rc = SQLITE_OK;
     } else if (pCur->cursor_count) {
         rc = pCur->cursor_count(pCur, &count);
@@ -11515,7 +11515,7 @@ int bt_hash_table(const char *table, int szkb)
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
     logmsg(LOGMSG_WARN, "Building bthash for table %s, size %dkb per stripe\n",
-           db->tablename_ip, szkb);
+           db->tablename_interned, szkb);
     bdb_handle_dbp_add_hash(bdb_state, szkb);
     trans_commit(&iq, tran, gbl_myhostname);
 
@@ -11568,7 +11568,7 @@ int del_bt_hash_table(const char *table)
 
     trans_start(&iq, NULL, &tran);
     bdb_lock_table_write(bdb_state, tran);
-    logmsg(LOGMSG_WARN, "Deleting bthash for table %s\n", db->tablename_ip);
+    logmsg(LOGMSG_WARN, "Deleting bthash for table %s\n", db->tablename_interned);
     bdb_handle_dbp_drop_hash(bdb_state);
     trans_commit(&iq, tran, gbl_myhostname);
 
@@ -12258,7 +12258,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
     sql = strbuf_new();
 
     if (sc == NULL) {
-        logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n", db->tablename_ip);
+        logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n", db->tablename_interned);
         abort();
     }
 
@@ -12279,8 +12279,8 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
         }
     }
 
-    len = strlen(db->tablename_ip);
-    len = crc32c((uint8_t *)db->tablename_ip, len);
+    len = strlen(db->tablename_interned);
+    len = crc32c((uint8_t *)db->tablename_interned, len);
     snprintf(temp_newdb_name, MAXTABLELEN, "sc_alter_temp_%X", len);
 
     for (ixnum = 0; ixnum < db->nix; ixnum++) {
@@ -12290,7 +12290,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
             int exist = 0;
             strbuf_clear(sql);
             strbuf_appendf(sql, "WITH \"%s\"(\"%s\"",
-                           is_alter ? temp_newdb_name : db->tablename_ip,
+                           is_alter ? temp_newdb_name : db->tablename_interned,
                            sc->member[0].name);
             for (i = 1; i < sc->nmembers; i++) {
                 strbuf_appendf(sql, ", \"%s\"", sc->member[i].name);
@@ -12300,7 +12300,7 @@ unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
                 strbuf_appendf(sql, ", @%s", sc->member[i].name);
             }
             strbuf_appendf(sql, ") SELECT 1 FROM \"%s\" %s",
-                           is_alter ? temp_newdb_name : db->tablename_ip,
+                           is_alter ? temp_newdb_name : db->tablename_interned,
                            db->ixschema[ixnum]->where);
             rc = run_verify_indexes_query((char *)strbuf_buf(sql), sc, m, NULL,
                                           &exist);
@@ -12660,7 +12660,7 @@ int verify_check_constraints(struct dbtable *table, uint8_t *rec,
     sc = table->schema;
     if (sc == NULL) {
         logmsg(LOGMSG_FATAL, "No .ONDISK tag for table %s.\n",
-               table->tablename_ip);
+               table->tablename_interned);
         abort();
     }
 

--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -81,7 +81,7 @@ master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
     for (i = 0, tblnum = 0; tblnum < num_dbs; tblnum++) {
         master_entry_t *ent = &new_arr[i];
         struct dbtable *tbl = dbs[tblnum];
-        ent->tblname = strdup(tbl->tablename);
+        ent->tblname = strdup(tbl->tablename_ip);
         ent->isstrdup = 1;
         ent->ixnum = -1;
         ent->rootpage = i + RTPAGE_START;
@@ -222,7 +222,6 @@ static void *create_master_row(struct dbtable **dbs, int num_dbs, int rootpage,
     struct dbtable *tbl;
     char *etype;
     char name[128];
-    char *dbname;
     char *sql;
     char *rec;
     int rc;
@@ -230,7 +229,7 @@ static void *create_master_row(struct dbtable **dbs, int num_dbs, int rootpage,
     assert(tblnum < num_dbs);
 
     tbl = dbs[tblnum];
-    dbname = tbl->tablename;
+    const char *dbname = tbl->tablename_ip;
 
     if (ixnum == -1) {
         strcpy(name, dbname);
@@ -251,7 +250,7 @@ static void *create_master_row(struct dbtable **dbs, int num_dbs, int rootpage,
 
     fill_mem_str(&mems[0], etype);
     fill_mem_str(&mems[1], name);
-    fill_mem_str(&mems[2], dbname);
+    fill_mem_str(&mems[2], (char *)dbname);
     fill_mem_int(&mems[3], rootpage);
     fill_mem_str(&mems[4], sql);
     fill_mem_str(&mems[5], csc2_schema);

--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -81,7 +81,7 @@ master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
     for (i = 0, tblnum = 0; tblnum < num_dbs; tblnum++) {
         master_entry_t *ent = &new_arr[i];
         struct dbtable *tbl = dbs[tblnum];
-        ent->tblname = strdup(tbl->tablename_ip);
+        ent->tblname = strdup(tbl->tablename_interned);
         ent->isstrdup = 1;
         ent->ixnum = -1;
         ent->rootpage = i + RTPAGE_START;
@@ -229,7 +229,7 @@ static void *create_master_row(struct dbtable **dbs, int num_dbs, int rootpage,
     assert(tblnum < num_dbs);
 
     tbl = dbs[tblnum];
-    const char *dbname = tbl->tablename_ip;
+    const char *dbname = tbl->tablename_interned;
 
     if (ixnum == -1) {
         strcpy(name, dbname);

--- a/db/sqlstat1.c
+++ b/db/sqlstat1.c
@@ -57,7 +57,7 @@ void *get_field_from_sqlite_stat_rec(struct ireq *iq, const void *rec,
     if (fix < 0) {
         logmsg(LOGMSG_ERROR,
                "%s: couldn't find '%s' field in %s's ONDISK tag\n", __func__,
-               fld, iq->usedb->tablename);
+               fld, iq->usedb->tablename_ip);
         return NULL;
     }
 
@@ -125,7 +125,7 @@ int sqlstat_find_record(struct ireq *iq, void *trans, const void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename, ".ONDISK", rec, ".ONDISK_IX_0", key,
+    rc = stag_to_stag_buf(sdb->tablename_ip, ".ONDISK", rec, ".ONDISK_IX_0", key,
                           NULL);
 
     if (rc)
@@ -155,7 +155,7 @@ int sqlstat_find_record(struct ireq *iq, void *trans, const void *rec,
 }
 
 /* given this tbl, ix and stat, create an ondisk record */
-int stat1_ondisk_record(struct ireq *iq, char *tbl, char *ix, char *stat,
+int stat1_ondisk_record(struct ireq *iq, const char *tbl, char *ix, char *stat,
                         void **out)
 {
     struct schema *s;
@@ -176,7 +176,7 @@ int stat1_ondisk_record(struct ireq *iq, char *tbl, char *ix, char *stat,
     /* cycle through fields & punt if we see something we don't recognize */
     for (fix = 0; fix < s->nmembers; fix++) {
         struct field *f = &s->member[fix];
-        char *cur = NULL;
+        const char *cur = NULL;
         int outdtsz = 0, null = 0;
 
         if (0 == strcmp(f->name, "tbl")) {
@@ -228,7 +228,7 @@ int sqlstat_find_get_record(struct ireq *iq, void *trans, void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename, ".ONDISK", rec, ".ONDISK_IX_0", key,
+    rc = stag_to_stag_buf(sdb->tablename_ip, ".ONDISK", rec, ".ONDISK_IX_0", key,
                           NULL);
 
     if (rc)

--- a/db/sqlstat1.c
+++ b/db/sqlstat1.c
@@ -57,7 +57,7 @@ void *get_field_from_sqlite_stat_rec(struct ireq *iq, const void *rec,
     if (fix < 0) {
         logmsg(LOGMSG_ERROR,
                "%s: couldn't find '%s' field in %s's ONDISK tag\n", __func__,
-               fld, iq->usedb->tablename_ip);
+               fld, iq->usedb->tablename_interned);
         return NULL;
     }
 
@@ -125,7 +125,7 @@ int sqlstat_find_record(struct ireq *iq, void *trans, const void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename_ip, ".ONDISK", rec, ".ONDISK_IX_0", key,
+    rc = stag_to_stag_buf(sdb->tablename_interned, ".ONDISK", rec, ".ONDISK_IX_0", key,
                           NULL);
 
     if (rc)
@@ -228,7 +228,7 @@ int sqlstat_find_get_record(struct ireq *iq, void *trans, void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename_ip, ".ONDISK", rec, ".ONDISK_IX_0", key,
+    rc = stag_to_stag_buf(sdb->tablename_interned, ".ONDISK", rec, ".ONDISK_IX_0", key,
                           NULL);
 
     if (rc)

--- a/db/sqlstat1.h
+++ b/db/sqlstat1.h
@@ -33,7 +33,7 @@ int sqlstat_delete_previous(struct ireq *iq, void *trans, const void *rec);
 void *get_field_from_sqlite_stat_rec(struct ireq *iq, const void *rec,
                                      const char *fld);
 
-int stat1_ondisk_record(struct ireq *iq, char *tbl, char *ix, char *stat,
+int stat1_ondisk_record(struct ireq *iq, const char *tbl, char *ix, char *stat,
                         void **out);
 int sqlstat_find_get_record(struct ireq *iq, void *trans, void *rec,
                             unsigned long long *genid);

--- a/db/tag.c
+++ b/db/tag.c
@@ -1555,7 +1555,7 @@ static int create_key_schema(dbtable *db, struct schema *schema, int alt)
     char *expr;
     int rc;
     int ascdesc;
-    char *dbname = db->tablename;
+    const char *dbname = db->tablename_ip;
     struct schema *s;
 
     /* keys not reqd for ver temp table; just ondisk tag */
@@ -2089,7 +2089,7 @@ void print_verbose_convert_failure(struct ireq *iq,
     if (!iq->debug || fail_reason == NULL || fail_reason->reason == CONVERT_OK)
         return;
 
-    convert_failure_reason_str(fail_reason, iq->usedb->tablename, fromtag,
+    convert_failure_reason_str(fail_reason, iq->usedb->tablename_ip, fromtag,
                                totag, str, sizeof(str));
     reqprintf(iq, "convert: %s\n", str);
     return;
@@ -2743,7 +2743,7 @@ int vtag_to_ondisk_vermap(const dbtable *db, uint8_t *rec, int *len,
     /* version sanity check */
     if (unlikely(ver == 0)) {
         logmsg(LOGMSG_FATAL, "%s:%d %s() %s %d -> %d\n", __FILE__, __LINE__,
-               __func__, db->tablename, ver, db->schema_version);
+               __func__, db->tablename_ip, ver, db->schema_version);
         cheap_stack_trace();
         exit(1);
     }
@@ -2756,7 +2756,7 @@ int vtag_to_ondisk_vermap(const dbtable *db, uint8_t *rec, int *len,
     to_schema = db->schema;
     if (to_schema == NULL) {
         logmsg(LOGMSG_FATAL, "could not get to_schema for .ONDISK in %s\n",
-               db->tablename);
+               db->tablename_ip);
         exit(1);
     }
 
@@ -2774,10 +2774,10 @@ int vtag_to_ondisk_vermap(const dbtable *db, uint8_t *rec, int *len,
          * smaller of the two buffers */
         /* find schema for older version */
         snprintf(ver_tag, sizeof ver_tag, "%s%d", gbl_ondisk_ver, ver);
-        from_schema = find_tag_schema(db->tablename, ver_tag);
+        from_schema = find_tag_schema(db->tablename_ip, ver_tag);
         if (unlikely(from_schema == NULL)) {
             logmsg(LOGMSG_FATAL, "%s:%d %s() %s %d -> %d\n", __FILE__, __LINE__,
-                   __func__, db->tablename, ver, db->schema_version);
+                   __func__, db->tablename_ip, ver, db->schema_version);
             cheap_stack_trace();
             exit(1);
         }
@@ -2797,7 +2797,7 @@ int vtag_to_ondisk_vermap(const dbtable *db, uint8_t *rec, int *len,
 
         if (rc) {
             char err[1024];
-            convert_failure_reason_str(&reason, db->tablename, ver_tag,
+            convert_failure_reason_str(&reason, db->tablename_ip, ver_tag,
                                        ".ONDISK", err, sizeof(err));
             logmsg(LOGMSG_ERROR, "%s: %s -> %s failed: %s\n", __func__, ver_tag,
                     ".ONDISK", err);
@@ -2854,7 +2854,7 @@ int vtag_to_ondisk(const dbtable *db, uint8_t *rec, int *len, uint8_t ver,
     /* version sanity check */
     if (unlikely(ver == 0)) {
         logmsg(LOGMSG_FATAL, "%s:%d %s() %s %d -> %d\n", __FILE__, __LINE__,
-               __func__, db->tablename, ver, db->schema_version);
+               __func__, db->tablename_ip, ver, db->schema_version);
         cheap_stack_trace();
         exit(1);
     }
@@ -2871,10 +2871,10 @@ int vtag_to_ondisk(const dbtable *db, uint8_t *rec, int *len, uint8_t ver,
 
     /* find schema for older version */
     snprintf(ver_tag, sizeof ver_tag, "%s%d", gbl_ondisk_ver, ver);
-    from_schema = find_tag_schema(db->tablename, ver_tag);
+    from_schema = find_tag_schema(db->tablename_ip, ver_tag);
     if (unlikely(from_schema == NULL)) {
         logmsg(LOGMSG_FATAL, "%s:%d %s() %s %d -> %d\n", __FILE__, __LINE__,
-               __func__, db->tablename, ver, db->schema_version);
+               __func__, db->tablename_ip, ver, db->schema_version);
         cheap_stack_trace();
         exit(1);
     }
@@ -2894,12 +2894,12 @@ int vtag_to_ondisk(const dbtable *db, uint8_t *rec, int *len, uint8_t ver,
     // rc = stag_to_stag_buf(db->tablename, ver_tag, from, ".ONDISK", (char
     // *)rec,
     // &reason);
-    rc = stag_to_stag_buf_flags(db->tablename, ver_tag, from, db->tablename,
+    rc = stag_to_stag_buf_flags(db->tablename_ip, ver_tag, from, db->tablename_ip,
                                 ".ONDISK", (char *)rec, CONVERT_NULL_NO_ERROR,
                                 &reason);
     if (rc) {
         char err[1024];
-        convert_failure_reason_str(&reason, db->tablename, ver_tag, ".ONDISK",
+        convert_failure_reason_str(&reason, db->tablename_ip, ver_tag, ".ONDISK",
                                    err, sizeof(err));
         logmsg(LOGMSG_ERROR, "%s: %s -> %s failed: %s\n", __func__, ver_tag,
                 ".ONDISK", err);
@@ -2910,7 +2910,7 @@ int vtag_to_ondisk(const dbtable *db, uint8_t *rec, int *len, uint8_t ver,
     to_schema = db->schema;
     if (to_schema == NULL) {
         logmsg(LOGMSG_FATAL, "could not get to_schema for .ONDISK in %s\n",
-               db->tablename);
+               db->tablename_ip);
         exit(1);
     }
     for (int i = 0; i < to_schema->nmembers; ++i) {
@@ -3165,10 +3165,10 @@ void *create_blank_record(dbtable *db, size_t *length)
         logmsg(LOGMSG_ERROR, "%s: out of memory for lrl %d\n", __func__, db->lrl);
         return NULL;
     }
-    schema = find_tag_schema(db->tablename, ".ONDISK");
+    schema = find_tag_schema(db->tablename_ip, ".ONDISK");
     if (!schema) {
         logmsg(LOGMSG_ERROR, "%s: cannot find .ONDISK schema for table %s\n",
-               __func__, db->tablename);
+               __func__, db->tablename_ip);
         free(record);
         return NULL;
     }
@@ -3344,7 +3344,7 @@ int validate_server_record(struct ireq *iq, const void *record, size_t reclen,
                 .source_sql_field_info = {0}};
 
             char str[128];
-            convert_failure_reason_str(&reason, iq->usedb->tablename, tag,
+            convert_failure_reason_str(&reason, iq->usedb->tablename_ip, tag,
                                        ondisktag, str, sizeof(str));
             if (iq->debug) {
                 reqprintf(iq, "ERR VERIFY DTA %s->.ONDISK '%s'", tag, str);
@@ -3352,7 +3352,7 @@ int validate_server_record(struct ireq *iq, const void *record, size_t reclen,
             reqerrstrhdr(
                 iq, "Null constraint violation for column '%s' on table '%s'. ",
                 reason.target_schema->member[reason.target_field_idx].name,
-                iq->usedb->tablename);
+                iq->usedb->tablename_ip);
             reqerrstr(iq, COMDB2_ADD_RC_CNVT_DTA,
                       "null constraint error data %s->.ONDISK '%s'", tag, str);
 
@@ -4542,7 +4542,7 @@ int has_index_changed(dbtable *tbl, char *keynm, int ct_check, int newkey,
     snprintf(oldtag, sizeof(oldtag), "%s", tag);
     snprintf(newtag, sizeof(newtag), ".NEW.%s", tag);
 
-    tblname = tbl->tablename;
+    tblname = tbl->tablename_ip;
 
     if (tblname == NULL) {
         logmsg(LOGMSG_INFO, "Invalid table name\n");
@@ -5023,7 +5023,7 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
         schema = calloc(1, sizeof(struct schema));
         schema->tag = tag;
 
-        add_tag_schema(db->tablename, schema);
+        add_tag_schema(db->tablename_ip, schema);
 
         schema->nmembers = dyns_get_table_field_count(rtag);
         if ((gbl_morecolumns && schema->nmembers > MAXCOLUMNS) ||
@@ -5066,11 +5066,11 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
                 (schema->member[field].type == SERVER_UINT ||
                  schema->member[field].type == CLIENT_UINT) &&
                 schema->member[field].len == sizeof(unsigned long long) &&
-                strncasecmp(db->tablename, gbl_ver_temp_table,
+                strncasecmp(db->tablename_ip, gbl_ver_temp_table,
                             sizeof(gbl_ver_temp_table) - 1) != 0) {
                 logmsg(LOGMSG_ERROR,
                        "Error in table %s: u_longlong is unsupported\n",
-                       db->tablename);
+                       db->tablename_ip);
                 reqerrstr(db->iq, ERR_SC, "u_longlong is not supported");
                 return -1;
             }
@@ -5234,14 +5234,14 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
             if (!alt) {
                 if (side_effects)
                     db->lrl =
-                        get_size_of_schema_by_name(db->tablename, ".ONDISK");
-                rc = clone_server_to_client_tag(db->tablename, ".ONDISK",
+                        get_size_of_schema_by_name(db->tablename_ip, ".ONDISK");
+                rc = clone_server_to_client_tag(db->tablename_ip, ".ONDISK",
                                                 ".ONDISK_CLIENT");
             } else {
                 if (side_effects)
-                    db->lrl = get_size_of_schema_by_name(db->tablename,
+                    db->lrl = get_size_of_schema_by_name(db->tablename_ip,
                                                          ".NEW..ONDISK");
-                rc = clone_server_to_client_tag(db->tablename, ".NEW..ONDISK",
+                rc = clone_server_to_client_tag(db->tablename_ip, ".NEW..ONDISK",
                                                 ".NEW..ONDISK_CLIENT");
             }
             if (rc)
@@ -5259,7 +5259,7 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
                         snprintf(tmptagname, sizeof(tmptagname),
                                  ".NEW..ONDISK_ix_%d", i);
                     db->ix_keylen[i] =
-                        get_size_of_schema_by_name(db->tablename, tmptagname);
+                        get_size_of_schema_by_name(db->tablename_ip, tmptagname);
 
                     if (!alt) {
                         snprintf(sname_buf, sizeof(sname_buf), ".ONDISK_IX_%d",
@@ -5273,7 +5273,7 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
                                  ".NEW..ONDISK_CLIENT_IX_%d", i);
                     }
 
-                    clone_server_to_client_tag(db->tablename, sname_buf,
+                    clone_server_to_client_tag(db->tablename_ip, sname_buf,
                                                cname_buf);
                 }
 
@@ -5306,12 +5306,12 @@ void fix_lrl_ixlen_tran(tran_type *tran)
 
     for (tbl = 0; tbl < thedb->num_dbs; tbl++) {
         db = thedb->dbs[tbl];
-        struct schema *s = find_tag_schema(db->tablename, ".ONDISK");
+        struct schema *s = find_tag_schema(db->tablename_ip, ".ONDISK");
         db->lrl = get_size_of_schema(s);
         nix = s->nix;
         for (ix = 0; ix < nix; ix++) {
             snprintf(namebuf, sizeof(namebuf), ".ONDISK_ix_%d", ix);
-            s = find_tag_schema(db->tablename, namebuf);
+            s = find_tag_schema(db->tablename_ip, namebuf);
             db->ix_keylen[ix] = get_size_of_schema(s);
         }
 
@@ -5322,9 +5322,9 @@ void fix_lrl_ixlen_tran(tran_type *tran)
 
         if (bdb_have_llmeta()) {
             int ver;
-            ver = get_csc2_version_tran(db->tablename, tran);
+            ver = get_csc2_version_tran(db->tablename_ip, tran);
             if (ver > 0) {
-                get_csc2_file_tran(db->tablename, ver, &db->csc2_schema,
+                get_csc2_file_tran(db->tablename_ip, ver, &db->csc2_schema,
                                    &db->csc2_schema_len, tran);
             }
         } else {
@@ -5363,20 +5363,20 @@ int have_all_schemas(void)
 
     for (tbl = 0; tbl < thedb->num_dbs; tbl++) {
         struct schema *s =
-            find_tag_schema(thedb->dbs[tbl]->tablename, ".ONDISK");
+            find_tag_schema(thedb->dbs[tbl]->tablename_ip, ".ONDISK");
         if (s == NULL) {
             logmsg(LOGMSG_ERROR, "Missing schema: table %s tag .ONDISK\n",
-                   thedb->dbs[tbl]->tablename);
+                   thedb->dbs[tbl]->tablename_ip);
             bad = 1;
         }
 
         if (sqlite_stat1 && table_field && index_field &&
-            strcasecmp(thedb->dbs[tbl]->tablename, "sqlite_stat1")) {
-            int nlen = strlen(thedb->dbs[tbl]->tablename);
+            strcasecmp(thedb->dbs[tbl]->tablename_ip, "sqlite_stat1")) {
+            int nlen = strlen(thedb->dbs[tbl]->tablename_ip);
             if (nlen >= table_field->len || nlen >= index_field->len) {
                 logmsg(LOGMSG_WARN,
                        "WARNING: table name %s too long for analyze\n",
-                       thedb->dbs[tbl]->tablename);
+                       thedb->dbs[tbl]->tablename_ip);
             }
         }
 
@@ -5384,10 +5384,10 @@ int have_all_schemas(void)
 
         for (ix = 0; s && ix < thedb->dbs[tbl]->nix; ix++) {
             snprintf(namebuf, sizeof(namebuf), ".ONDISK_ix_%d", ix);
-            s = find_tag_schema(thedb->dbs[tbl]->tablename, namebuf);
+            s = find_tag_schema(thedb->dbs[tbl]->tablename_ip, namebuf);
             if (s == NULL) {
                 logmsg(LOGMSG_ERROR, "Missing schema: table %s tag %s\n",
-                       thedb->dbs[tbl]->tablename, namebuf);
+                       thedb->dbs[tbl]->tablename_ip, namebuf);
                 bad = 1;
             }
         }
@@ -5404,7 +5404,7 @@ int getdefaultkeysize(const dbtable *tbl, int ixnum)
     char tagbuf[MAXTAGLEN];
 
     snprintf(tagbuf, MAXTAGLEN, ".DEFAULT_ix_%d", ixnum);
-    struct schema *s = find_tag_schema(tbl->tablename, tagbuf);
+    struct schema *s = find_tag_schema(tbl->tablename_ip, tagbuf);
     if (s == NULL)
         return -1;
     return get_size_of_schema(s);
@@ -5413,7 +5413,7 @@ int getdefaultkeysize(const dbtable *tbl, int ixnum)
 
 int getdefaultdatsize(const dbtable *tbl)
 {
-    struct schema *s = find_tag_schema(tbl->tablename, ".DEFAULT");
+    struct schema *s = find_tag_schema(tbl->tablename_ip, ".DEFAULT");
 
     if (s == NULL)
         return -1;
@@ -5423,7 +5423,7 @@ int getdefaultdatsize(const dbtable *tbl)
 
 int getondiskclientdatsize(const dbtable *db)
 {
-    struct schema *s = find_tag_schema(db->tablename, ".ONDISK_CLIENT");
+    struct schema *s = find_tag_schema(db->tablename_ip, ".ONDISK_CLIENT");
 
     if (s == NULL)
         return -1;
@@ -5432,7 +5432,7 @@ int getondiskclientdatsize(const dbtable *db)
 
 int getclientdatsize(const dbtable *db, char *sname)
 {
-    struct schema *s = find_tag_schema(db->tablename, sname);
+    struct schema *s = find_tag_schema(db->tablename_ip, sname);
 
     if (s == NULL)
         return -1;
@@ -6016,7 +6016,7 @@ static int backout_schemas_lockless(const char *tblname)
     return 0;
 }
 
-void backout_schemas(char *tblname)
+void backout_schemas(const char *tblname)
 {
     struct dbtag *dbt;
     int rc;
@@ -6330,7 +6330,7 @@ int resolve_tag_name(struct ireq *iq, const char *tagdescr, size_t taglen,
                     (int) taglen, tagdescr);
             return -1;
         }
-        add_tag_schema(iq->usedb->tablename, *dynschema);
+        add_tag_schema(iq->usedb->tablename_ip, *dynschema);
         strncpy0(tagname, (*dynschema)->tag, tagnamelen);
     } else if (taglen > 0) {
         /* static tag name */
@@ -6354,7 +6354,7 @@ int ondisk_type_is_vutf8(dbtable *db, const char *fieldname,
                          size_t fieldname_len)
 {
     int i;
-    struct schema *s = find_tag_schema(db->tablename, ".ONDISK");
+    struct schema *s = find_tag_schema(db->tablename_ip, ".ONDISK");
     for (i = 0; i < s->nmembers; i++) {
         if (strncmp(s->member[i].name, fieldname, fieldname_len) == 0)
             /* TODO delme */
@@ -6375,7 +6375,7 @@ long long get_record_unique_id(dbtable *db, void *rec)
     int outnull;
     int sz;
 
-    struct schema *s = find_tag_schema(db->tablename, ".ONDISK");
+    struct schema *s = find_tag_schema(db->tablename_ip, ".ONDISK");
     for (i = 0; i < s->nmembers; i++) {
         if (strcasecmp(s->member[i].name, "comdb2_seqno") == 0) {
             SERVER_BINT_to_CLIENT_INT(p + s->member[i].offset, 9, NULL, NULL,
@@ -6612,7 +6612,7 @@ void update_dbstore(dbtable *db)
     struct schema *ondisk = db->schema;
     if (ondisk == NULL) {
         logmsg(LOGMSG_FATAL, "%s: .ONDISK not found!! PANIC!! %s() @ %d\n",
-               db->tablename, __func__, __LINE__);
+               db->tablename_ip, __func__, __LINE__);
         cheap_stack_trace();
         exit(1);
     }
@@ -6624,24 +6624,24 @@ void update_dbstore(dbtable *db)
     }
 
     bzero(db->dbstore, sizeof db->dbstore);
-    logmsg(LOGMSG_DEBUG, "%s table '%s' version %d\n", __func__, db->tablename,
+    logmsg(LOGMSG_DEBUG, "%s table '%s' version %d\n", __func__, db->tablename_ip,
            db->schema_version);
 
     for (int v = 1; v <= db->schema_version; ++v) {
         char tag[MAXTAGLEN];
         struct schema *ver;
         snprintf(tag, sizeof tag, gbl_ondisk_ver_fmt, v);
-        ver = find_tag_schema(db->tablename, tag);
+        ver = find_tag_schema(db->tablename_ip, tag);
         if (ver == NULL) {
             logmsg(LOGMSG_FATAL, "%s: %s not found!! PANIC!! %s() @ %d\n",
-                   db->tablename, tag, __func__, __LINE__);
+                   db->tablename_ip, tag, __func__, __LINE__);
             cheap_stack_trace();
             abort();
         }
 
         db->versmap[v] = (unsigned int *)get_tag_mapping(ver, ondisk);
         logmsg(LOGMSG_DEBUG, "%s set table '%s' vers %d to %p\n", __func__,
-               db->tablename, v, db->versmap[v]);
+               db->tablename_ip, v, db->versmap[v]);
         db->vers_compat_ondisk[v] = 1;
         if (SC_TAG_CHANGE ==
             compare_tag_int(ver, ondisk, NULL, 0 /*non-strict compliance*/))
@@ -6659,7 +6659,7 @@ void update_dbstore(dbtable *db)
                 logmsg(LOGMSG_FATAL,
                        "%s: %s no such field: %s in .ONDISK. but in %s!! "
                        "PANIC!!\n",
-                       db->tablename, __func__, from->name, tag);
+                       db->tablename_ip, __func__, from->name, tag);
                 abort();
             }
 
@@ -6679,7 +6679,7 @@ void update_dbstore(dbtable *db)
                     if (db->dbstore[position].data == NULL) {
                         logmsg(LOGMSG_FATAL,
                                "%s: %s() @ %d calloc failed!! PANIC!!\n",
-                               db->tablename, __func__, __LINE__);
+                               db->tablename_ip, __func__, __LINE__);
                         abort();
                     }
                     rc = SERVER_to_SERVER(
@@ -6692,7 +6692,7 @@ void update_dbstore(dbtable *db)
                         logmsg(LOGMSG_FATAL,
                                "%s: %s() @ %d: SERVER_to_SERVER failed!! "
                                "PANIC!!\n",
-                               db->tablename, __func__, __LINE__);
+                               db->tablename_ip, __func__, __LINE__);
                         abort();
                     }
                 }
@@ -6708,7 +6708,7 @@ void replace_tag_schema(dbtable *db, struct schema *schema)
     struct dbtag *dbt;
 
     lock_taglock();
-    dbt = hash_find_readonly(gbl_tag_hash, &db->tablename);
+    dbt = hash_find_readonly(gbl_tag_hash, &db->tablename_ip);
     if (dbt == NULL) {
         unlock_taglock();
         return;
@@ -6812,7 +6812,6 @@ void freedb_int(dbtable *db, dbtable *replace)
     dbs_idx = db->dbs_idx;
 
     free(db->lrlfname);
-    free(db->tablename);
     /* who frees schema/ixschema? */
     free(db->sql);
 
@@ -6921,11 +6920,11 @@ struct schema *create_version_schema(char *csc2, int version,
     ver_schema->tag = tag;
 
     /* get rid of temp schema */
-    del_tag_schema(ver_db->tablename, s->tag);
+    del_tag_schema(ver_db->tablename_ip, s->tag);
     freeschema(s);
 
     /* get rid of temp table */
-    delete_schema(ver_db->tablename);
+    delete_schema(ver_db->tablename_ip);
     freedb(ver_db);
 
     return ver_schema;
@@ -6943,13 +6942,13 @@ static void clear_existing_schemas(dbtable *db)
     int i;
     for (i = 1; i <= db->schema_version; ++i) {
         sprintf(tag, gbl_ondisk_ver_fmt, i);
-        schema = find_tag_schema(db->tablename, tag);
-        del_tag_schema(db->tablename, tag);
+        schema = find_tag_schema(db->tablename_ip, tag);
+        del_tag_schema(db->tablename_ip, tag);
         freeschema(schema);
     }
 
-    schema = find_tag_schema(db->tablename, ".ONDISK");
-    del_tag_schema(db->tablename, ".ONDISK");
+    schema = find_tag_schema(db->tablename_ip, ".ONDISK");
+    del_tag_schema(db->tablename_ip, ".ONDISK");
     freeschema(schema);
 }
 
@@ -6961,17 +6960,17 @@ static int load_new_versions(dbtable *db, tran_type *tran)
         return 0;
 
     int i;
-    int version = get_csc2_version_tran(db->tablename, tran);
+    int version = get_csc2_version_tran(db->tablename_ip, tran);
     for (i = 1; i <= version; ++i) {
         char *csc2;
         int len;
-        get_csc2_file_tran(db->tablename, i, &csc2, &len, tran);
+        get_csc2_file_tran(db->tablename_ip, i, &csc2, &len, tran);
         struct schema *schema = create_version_schema(csc2, i, db->dbenv);
         if (schema == NULL) {
             logmsg(LOGMSG_ERROR, "Could not create schema version: %d\n", i);
             return 1;
         }
-        add_tag_schema(db->tablename, schema);
+        add_tag_schema(db->tablename_ip, schema);
         free(csc2);
     }
     return 0;
@@ -6982,13 +6981,13 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
     int rc;
     int bdberr;
     int foundix = db->dbs_idx;
-    int version = get_csc2_version_tran(db->tablename, tran);
+    int version = get_csc2_version_tran(db->tablename_ip, tran);
     int len;
     void *old_bdb_handle, *new_bdb_handle;
     char *csc2 = NULL;
 
     Pthread_mutex_lock(&csc2_subsystem_mtx);
-    rc = get_csc2_file_tran(db->tablename, version, &csc2, &len, tran);
+    rc = get_csc2_file_tran(db->tablename_ip, version, &csc2, &len, tran);
     if (rc) {
         logmsg(LOGMSG_ERROR, "get_csc2_file failed %s:%d\n", __FILE__, __LINE__);
         logmsg(LOGMSG_ERROR, "rc: %d len: %d csc2:\n%s\n", rc, len, csc2);
@@ -6996,7 +6995,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
     }
 
     dyns_init_globals();
-    rc = dyns_load_schema_string(csc2, db->dbenv->envname, db->tablename);
+    rc = dyns_load_schema_string(csc2, db->dbenv->envname, db->tablename_ip);
     if (rc) {
         logmsg(LOGMSG_ERROR, "dyns_load_schema_string failed %s:%d\n", __FILE__,
                 __LINE__);
@@ -7004,7 +7003,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
         goto err;
     }
 
-    dbtable *newdb = newdb_from_schema(db->dbenv, db->tablename, NULL,
+    dbtable *newdb = newdb_from_schema(db->dbenv, db->tablename_ip, NULL,
                                        db->dbnum, foundix, 0);
     if (newdb == NULL) {
         logmsg(LOGMSG_ERROR, "newdb_from_schema failed %s:%d\n", __FILE__, __LINE__);
@@ -7022,7 +7021,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
     rc = init_check_constraints(newdb);
     if (rc) {
         logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-               newdb->tablename);
+               newdb->tablename_ip);
         goto err;
     }
 
@@ -7034,7 +7033,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
 
     /* Must use tran or this can cause deadlocks */
     newdb->handle = bdb_open_more_tran(
-        db->tablename, thedb->basedir, newdb->lrl, newdb->nix,
+        db->tablename_ip, thedb->basedir, newdb->lrl, newdb->nix,
         (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
         newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
         newdb->numblobs + 1, thedb->bdb_env, arg_tran, 0, &bdberr);
@@ -7107,7 +7106,7 @@ int reload_all_db_tran(tran_type *tran)
     int rc;
     for (rc = 0, table = 0; table < thedb->num_dbs && rc == 0; table++) {
         dbtable *db = thedb->dbs[table];
-        backout_schemas(db->tablename);
+        backout_schemas(db->tablename_ip);
 
         if (load_new_ondisk(db, tran)) {
             logmsg(LOGMSG_ERROR, "Failed to load new .ONDISK\n");
@@ -7127,7 +7126,7 @@ int reload_all_db_tran(tran_type *tran)
 
 int reload_db_tran(dbtable *db, tran_type *tran)
 {
-    backout_schemas(db->tablename);
+    backout_schemas(db->tablename_ip);
     clear_existing_schemas(db);
     if (load_new_ondisk(db, tran)) {
         logmsg(LOGMSG_ERROR, "Failed to load new .ONDISK\n");
@@ -7458,7 +7457,7 @@ int create_key_from_ondisk_sch_blobs(const dbtable *db, struct schema *fromsch,
     }
 
     rc = _stag_to_stag_buf_flags_blobs(
-        fromsch, fromtag, inbuf, db->tablename, totag, outbuf, 0 /*flags*/,
+        fromsch, fromtag, inbuf, db->tablename_ip, totag, outbuf, 0 /*flags*/,
         reason, inblobs, NULL /*outblobs*/, maxblobs, tzname);
     if (rc)
         return rc;
@@ -7539,7 +7538,7 @@ inline int create_key_from_ondisk(dbtable *db, int ixnum, char **tail,
                                   struct convert_failure *reason,
                                   const char *tzname)
 {
-    struct schema *fromsch = find_tag_schema(db->tablename, fromtag);
+    struct schema *fromsch = find_tag_schema(db->tablename_ip, fromtag);
 
     return create_key_from_ondisk_sch(db, fromsch, ixnum, tail, taillen,
                                       mangled_key, fromtag, inbuf, inbuflen,
@@ -7552,7 +7551,7 @@ inline int create_key_from_ondisk_blobs(
     char *outbuf, struct convert_failure *reason, blob_buffer_t *inblobs,
     int maxblobs, const char *tzname)
 {
-    struct schema *fromsch = find_tag_schema(db->tablename, fromtag);
+    struct schema *fromsch = find_tag_schema(db->tablename_ip, fromtag);
 
     return create_key_from_ondisk_sch_blobs(
         db, fromsch, ixnum, tail, taillen, mangled_key, fromtag, inbuf,

--- a/db/tag.h
+++ b/db/tag.h
@@ -307,7 +307,7 @@ void *get_field_ptr_in_buf(struct schema *sc, int idx, const void *buf);
 int is_tag_ondisk_sc(struct schema *sc);
 int is_tag_ondisk(const char *table, const char *tag);
 int fixup_verified_record(const char *dbname, const char *from, char *to);
-void backout_schemas(char *tblname);
+void backout_schemas(const char *tblname);
 int broadcast_resume_threads(void);
 int have_all_schemas(void);
 const char *strtype(int type);

--- a/db/testcompr.c
+++ b/db/testcompr.c
@@ -268,7 +268,7 @@ static void compr_stat(CompStruct *comp)
 {
     char buf[128];
     snprintf(buf, sizeof(buf) - 1, "Percentage of original size for: %s\n",
-             comp->db->tablename);
+             comp->db->tablename_ip);
     logmsg(LOGMSG_USER, "%s", buf);
     sbuf2printf(comp->sb, ">%s", buf);
 
@@ -318,15 +318,15 @@ static void *handle_comptest_thd(void *_arg)
         if (strcmp(arg->table, "cdb2justcrle") == 0) {
             comp.just_crle = 1;
         } else if (strcmp(arg->table, "-all") != 0) {
-            if (strcmp(arg->table, db->tablename) != 0) {
+            if (strcmp(arg->table, db->tablename_ip) != 0) {
                 continue;
             }
         }
-        if (is_sqlite_stat(db->tablename)) {
+        if (is_sqlite_stat(db->tablename_ip)) {
             continue;
         }
 
-        logmsg(LOGMSG_DEBUG, "Processing table: %s\n", db->tablename);
+        logmsg(LOGMSG_DEBUG, "Processing table: %s\n", db->tablename_ip);
 
         comp.db = db;
         bzero(&comp.uncompressed, sizeof(comp.uncompressed));
@@ -348,14 +348,14 @@ static void *handle_comptest_thd(void *_arg)
         while (rc == IX_FND || rc == IX_FNDMORE) {
             if (gbl_sc_abort || db->sc_abort) {
                 logmsg(LOGMSG_ERROR, "Abort compression testing %s\n",
-                       db->tablename);
+                       db->tablename_ip);
                 ++arg->rc;
                 break;
             }
             rc = test_compress(&comp);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "Failed compressing %s, rc:%d (%s:%d)\n",
-                       db->tablename, rc, __FILE__, __LINE__);
+                       db->tablename_ip, rc, __FILE__, __LINE__);
                 ++arg->rc;
                 break;
             }

--- a/db/testcompr.c
+++ b/db/testcompr.c
@@ -268,7 +268,7 @@ static void compr_stat(CompStruct *comp)
 {
     char buf[128];
     snprintf(buf, sizeof(buf) - 1, "Percentage of original size for: %s\n",
-             comp->db->tablename_ip);
+             comp->db->tablename_interned);
     logmsg(LOGMSG_USER, "%s", buf);
     sbuf2printf(comp->sb, ">%s", buf);
 
@@ -318,15 +318,15 @@ static void *handle_comptest_thd(void *_arg)
         if (strcmp(arg->table, "cdb2justcrle") == 0) {
             comp.just_crle = 1;
         } else if (strcmp(arg->table, "-all") != 0) {
-            if (strcmp(arg->table, db->tablename_ip) != 0) {
+            if (strcmp(arg->table, db->tablename_interned) != 0) {
                 continue;
             }
         }
-        if (is_sqlite_stat(db->tablename_ip)) {
+        if (is_sqlite_stat(db->tablename_interned)) {
             continue;
         }
 
-        logmsg(LOGMSG_DEBUG, "Processing table: %s\n", db->tablename_ip);
+        logmsg(LOGMSG_DEBUG, "Processing table: %s\n", db->tablename_interned);
 
         comp.db = db;
         bzero(&comp.uncompressed, sizeof(comp.uncompressed));
@@ -348,14 +348,14 @@ static void *handle_comptest_thd(void *_arg)
         while (rc == IX_FND || rc == IX_FNDMORE) {
             if (gbl_sc_abort || db->sc_abort) {
                 logmsg(LOGMSG_ERROR, "Abort compression testing %s\n",
-                       db->tablename_ip);
+                       db->tablename_interned);
                 ++arg->rc;
                 break;
             }
             rc = test_compress(&comp);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "Failed compressing %s, rc:%d (%s:%d)\n",
-                       db->tablename_ip, rc, __FILE__, __LINE__);
+                       db->tablename_interned, rc, __FILE__, __LINE__);
                 ++arg->rc;
                 break;
             }

--- a/db/toblob.c
+++ b/db/toblob.c
@@ -809,11 +809,11 @@ int gather_blob_data(struct ireq *iq, const char *tag, blob_status_t *b,
 {
     int cblob;
     memset(b, 0, sizeof(*b));
-    b->numcblobs = get_schema_blob_count(iq->usedb->tablename_ip, tag);
+    b->numcblobs = get_schema_blob_count(iq->usedb->tablename_interned, tag);
     for (cblob = 0; cblob < b->numcblobs; cblob++) {
         int diskblob, blob_idx;
-        diskblob = blob_no_to_blob_no(iq->usedb->tablename_ip, tag, cblob, to_tag);
-        blob_idx = get_schema_blob_field_idx(iq->usedb->tablename_ip, tag, cblob);
+        diskblob = blob_no_to_blob_no(iq->usedb->tablename_interned, tag, cblob, to_tag);
+        blob_idx = get_schema_blob_field_idx(iq->usedb->tablename_interned, tag, cblob);
         if (diskblob < 0 || blob_idx < 0) {
             if (iq->debug)
                 reqprintf(

--- a/db/toblob.c
+++ b/db/toblob.c
@@ -809,11 +809,11 @@ int gather_blob_data(struct ireq *iq, const char *tag, blob_status_t *b,
 {
     int cblob;
     memset(b, 0, sizeof(*b));
-    b->numcblobs = get_schema_blob_count(iq->usedb->tablename, tag);
+    b->numcblobs = get_schema_blob_count(iq->usedb->tablename_ip, tag);
     for (cblob = 0; cblob < b->numcblobs; cblob++) {
         int diskblob, blob_idx;
-        diskblob = blob_no_to_blob_no(iq->usedb->tablename, tag, cblob, to_tag);
-        blob_idx = get_schema_blob_field_idx(iq->usedb->tablename, tag, cblob);
+        diskblob = blob_no_to_blob_no(iq->usedb->tablename_ip, tag, cblob, to_tag);
+        blob_idx = get_schema_blob_field_idx(iq->usedb->tablename_ip, tag, cblob);
         if (diskblob < 0 || blob_idx < 0) {
             if (iq->debug)
                 reqprintf(

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -4513,7 +4513,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             const uint8_t *p_buf_sqlq;
 
             /* synthetic block2_use */
-            iq->usedb = get_dbtable_by_name(thedb->static_table.tablename);
+            iq->usedb = get_dbtable_by_name(thedb->static_table.tablename_ip);
 
             /* synthetic block2_tz */
             strncpy0(iq->tzname, iq->sorese->tzname, sizeof(iq->tzname));

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2127,7 +2127,7 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
     if (iq->debug && iq->usedb) {
         /* TODO print trans twice? No parent_trans? */
         reqprintf(iq, "%p:START TRANSACTION OSQL ID %p DB %d '%s'", *trans,
-                  *trans, iq->usedb->dbnum, iq->usedb->tablename);
+                  *trans, iq->usedb->dbnum, iq->usedb->tablename_ip);
     }
 
     if (parent_trans)
@@ -2999,7 +2999,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
         /* TODO print trans twice? No parent_trans? */
         reqprintf(iq, "%x:START TRANSACTION ID %p DB %d '%s'",
                   (int)pthread_self(), trans, iq->usedb->dbnum,
-                  iq->usedb->tablename);
+                  iq->usedb->tablename_ip);
     }
 
     delay_if_sc_resuming(
@@ -3563,7 +3563,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                use record to form and delete other keys */
             snprintf(client_tag, MAXTAGLEN, ".DEFAULT_IX_0");
             snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_0");
-            rc = ctag_to_stag_buf(iq->usedb->tablename, client_tag,
+            rc = ctag_to_stag_buf(iq->usedb->tablename_ip, client_tag,
                                   (const char *)iq->p_buf_in, WHOLE_BUFFER,
                                   nulls, ondisk_tag, key, 0, NULL);
             if (rc == -1) {
@@ -3939,7 +3939,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
             /* convert key */
             bzero(nulls, sizeof(nulls));
-            rc = ctag_to_stag_buf(iq->usedb->tablename, ".DEFAULT_IX_0",
+            rc = ctag_to_stag_buf(iq->usedb->tablename_ip, ".DEFAULT_IX_0",
                                   (const char *)p_keydat, WHOLE_BUFFER, nulls,
                                   ".ONDISK_IX_0", key, 0, NULL);
             if (rc == -1) {
@@ -4068,13 +4068,13 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                    capture comdb clients that are trying to verify
                    only a prefix of the row (size < .default rowsize)
                  */
-                int rowsz = get_size_of_schema_by_name(iq->usedb->tablename,
+                int rowsz = get_size_of_schema_by_name(iq->usedb->tablename_ip,
                                                        ".DEFAULT");
                 if (rowsz != vlen) {
                     logmsg(
                         LOGMSG_ERROR,
                         "%s: %s prefix bug, client sz=%d, default-tag sz=%d\n",
-                        getorigin(iq), iq->usedb->tablename, newlen, rowsz);
+                        getorigin(iq), iq->usedb->tablename_ip, newlen, rowsz);
                 }
             }
 
@@ -4166,7 +4166,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             }
             if (iq->debug)
                 reqprintf(iq, "DB NUM %d '%s'", use.dbnum,
-                          iq->usedb->tablename);
+                          iq->usedb->tablename_ip);
             break;
         }
 
@@ -4216,7 +4216,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 }
 
                 if (iq->debug)
-                    reqprintf(iq, "DB '%s'", iq->usedb->tablename);
+                    reqprintf(iq, "DB '%s'", iq->usedb->tablename_ip);
             } else {
                 iq->usedb = getdbbynum(usekl.dbnum);
                 if (iq->usedb == 0) {
@@ -4230,7 +4230,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 }
                 if (iq->debug)
                     reqprintf(iq, "DB NUM %d '%s'", usekl.dbnum,
-                              iq->usedb->tablename);
+                              iq->usedb->tablename_ip);
             }
             break;
         }
@@ -4445,7 +4445,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 break;
             }
             dtalen =
-                get_size_of_schema_by_name(iq->usedb->tablename, ".ONDISK");
+                get_size_of_schema_by_name(iq->usedb->tablename_ip, ".ONDISK");
 
             if (!trans) {
                 if (osql_needtransaction == OSQL_BPLOG_NOTRANS) {
@@ -4486,7 +4486,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 if (iq->debug)
                     reqprintf(iq, "DELETE_OLDER %d %s genid %016llx rc "
                                   "%d\n",
-                              delolder.timestamp, iq->usedb->tablename, genid,
+                              delolder.timestamp, iq->usedb->tablename_ip, genid,
                               rc);
                 if (rc) {
                     fromline = __LINE__;
@@ -4495,7 +4495,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             } else {
                 if (iq->debug)
                     reqprintf(iq, "DELETE_OLDER %s none found\n",
-                              iq->usedb->tablename);
+                              iq->usedb->tablename_ip);
                 rc = ERR_NO_RECORDS_FOUND;
             }
             free(rec);
@@ -4746,7 +4746,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             // thread.
             // otherwise use upgrade_record shortcut.
             if (uptbl.nrecs > 1) {
-                rc = start_table_upgrade(iq->dbenv, iq->usedb->tablename,
+                rc = start_table_upgrade(iq->dbenv, iq->usedb->tablename_ip,
                                          uptbl.genid, 0, uptbl.nrecs, 1);
                 if (rc != 0)
                     GOTOBACKOUT;
@@ -6119,7 +6119,7 @@ static int keyless_range_delete_formkey(void *record, size_t record_len,
     snprintf(index_tag_name, sizeof(index_tag_name), ".ONDISK_IX_%d",
              index_num);
 
-    rc = stag_to_stag_buf(iq->usedb->tablename, ".ONDISK", record,
+    rc = stag_to_stag_buf(iq->usedb->tablename_ip, ".ONDISK", record,
                           index_tag_name, index, NULL);
     if (rc == -1) {
         if (iq->debug)
@@ -6174,12 +6174,12 @@ static int keyless_range_delete_post_delete(void *record, size_t record_len,
         int rc;
         struct javasp_rec *jrec;
         jrec = javasp_alloc_rec(record, record_len,
-                                rngdel_info->iq->usedb->tablename);
+                                rngdel_info->iq->usedb->tablename_ip);
         if (rngdel_info->saveblobs)
             javasp_rec_set_blobs(jrec, rngdel_info->oldblobs);
         rc = javasp_trans_tagged_trigger(
             rngdel_info->javasp_trans_handle, JAVASP_TRANS_LISTEN_AFTER_DEL,
-            jrec, NULL, rngdel_info->iq->usedb->tablename);
+            jrec, NULL, rngdel_info->iq->usedb->tablename_ip);
         javasp_dealloc_rec(jrec);
         if (rngdel_info->iq->debug)
             reqprintf(rngdel_info->iq,
@@ -6252,12 +6252,12 @@ int access_control_check_read(struct ireq *iq, tran_type *trans, int *bdberr)
 
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_read_by_mach_get(iq->dbenv->bdb_env, trans,
-                                             iq->usedb->tablename,
+                                             iq->usedb->tablename_ip,
                                              nodeix(iq->frommach), bdberr);
         if (rc <= 0) {
             reqerrstr(iq, ERR_ACCESS,
                       "Read access denied to %s from %s bdberr=%d\n",
-                      iq->usedb->tablename, iq->corigin, *bdberr);
+                      iq->usedb->tablename_ip, iq->corigin, *bdberr);
             return ERR_ACCESS;
         }
     }
@@ -6271,12 +6271,12 @@ int access_control_check_write(struct ireq *iq, tran_type *trans, int *bdberr)
 
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_write_by_mach_get(iq->dbenv->bdb_env, trans,
-                                              iq->usedb->tablename,
+                                              iq->usedb->tablename_ip,
                                               nodeix(iq->frommach), bdberr);
         if (rc <= 0) {
             reqerrstr(iq, ERR_ACCESS,
                       "Write access denied to %s from %s bdberr=%d\n",
-                      iq->usedb->tablename, iq->corigin, *bdberr);
+                      iq->usedb->tablename_ip, iq->corigin, *bdberr);
             return ERR_ACCESS;
         }
     }

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -327,7 +327,7 @@ int trigger_stat()
             continue;
         }
         const char *type = ctype == CONSUMER_TYPE_LUA ? "trigger" : "consumer";
-        const char *spname = SP4Q(qdb->tablename_ip);
+        const char *spname = SP4Q(qdb->tablename_interned);
         trigger_info_t *info =
             trigger_hash ? hash_find(trigger_hash, spname) : NULL;
         if (info) {

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -327,7 +327,7 @@ int trigger_stat()
             continue;
         }
         const char *type = ctype == CONSUMER_TYPE_LUA ? "trigger" : "consumer";
-        char *spname = SP4Q(qdb->tablename);
+        const char *spname = SP4Q(qdb->tablename_ip);
         trigger_info_t *info =
             trigger_hash ? hash_find(trigger_hash, spname) : NULL;
         if (info) {

--- a/db/verify.c
+++ b/db/verify.c
@@ -83,7 +83,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
         return;
     }
     logmsg(LOGMSG_INFO, "rrn %d genid 0x%016llx\n", rrn, genid);
-    dump_tagged_buf(db->tablename, ".ONDISK", (unsigned char *)dta);
+    dump_tagged_buf(db->tablename_ip, ".ONDISK", (unsigned char *)dta);
     for (ix = 0; ix < db->nix; ix++) {
         key = malloc(getkeysize(db, ix));
         if (key == NULL) {
@@ -92,7 +92,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             return;
         }
         snprintf(tag, sizeof(tag), ".ONDISK_IX_%d", ix);
-        rc = stag_to_stag_buf(db->tablename, ".ONDISK", dta, tag, key, NULL);
+        rc = stag_to_stag_buf(db->tablename_ip, ".ONDISK", dta, tag, key, NULL);
         if (rc) {
             logmsg(LOGMSG_INFO,
                    "dump_record_by_rrn:stag_to_stag_buf rrn %d genid %016llx "
@@ -102,7 +102,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             break;
         }
         logmsg(LOGMSG_INFO, "ix %d:\n", ix);
-        dump_tagged_buf(db->tablename, tag, (unsigned char *)key);
+        dump_tagged_buf(db->tablename_ip, tag, (unsigned char *)key);
         free(key);
     }
     free(dta);
@@ -128,7 +128,7 @@ void purge_by_genid(struct dbtable *db, unsigned long long *genid)
     /* genid can be NULL in which case we do an auto purge */
     if (genid)
         logmsg(LOGMSG_INFO, "Purging genid %016llx from table %s\n", *genid,
-               db->tablename);
+               db->tablename_ip);
 retry:
     tran = bdb_tran_begin(db->handle, NULL, &bdberr);
 

--- a/db/verify.c
+++ b/db/verify.c
@@ -83,7 +83,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
         return;
     }
     logmsg(LOGMSG_INFO, "rrn %d genid 0x%016llx\n", rrn, genid);
-    dump_tagged_buf(db->tablename_ip, ".ONDISK", (unsigned char *)dta);
+    dump_tagged_buf(db->tablename_interned, ".ONDISK", (unsigned char *)dta);
     for (ix = 0; ix < db->nix; ix++) {
         key = malloc(getkeysize(db, ix));
         if (key == NULL) {
@@ -92,7 +92,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             return;
         }
         snprintf(tag, sizeof(tag), ".ONDISK_IX_%d", ix);
-        rc = stag_to_stag_buf(db->tablename_ip, ".ONDISK", dta, tag, key, NULL);
+        rc = stag_to_stag_buf(db->tablename_interned, ".ONDISK", dta, tag, key, NULL);
         if (rc) {
             logmsg(LOGMSG_INFO,
                    "dump_record_by_rrn:stag_to_stag_buf rrn %d genid %016llx "
@@ -102,7 +102,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             break;
         }
         logmsg(LOGMSG_INFO, "ix %d:\n", ix);
-        dump_tagged_buf(db->tablename_ip, tag, (unsigned char *)key);
+        dump_tagged_buf(db->tablename_interned, tag, (unsigned char *)key);
         free(key);
     }
     free(dta);
@@ -128,7 +128,7 @@ void purge_by_genid(struct dbtable *db, unsigned long long *genid)
     /* genid can be NULL in which case we do an auto purge */
     if (genid)
         logmsg(LOGMSG_INFO, "Purging genid %016llx from table %s\n", *genid,
-               db->tablename_ip);
+               db->tablename_interned);
 retry:
     tran = bdb_tran_begin(db->handle, NULL, &bdberr);
 

--- a/db/views.c
+++ b/db/views.c
@@ -2678,7 +2678,7 @@ static cron_sched_t *_get_sched_byname(enum view_partition_period period,
 
 /* Returns time partition name if the specified 'table_name' is a shard,
   'table_name' otherwise. */
-char *resolve_table_name(char *table_name, char *buf, size_t buf_len)
+const char *resolve_table_name(const char *table_name, char *buf, size_t buf_len)
 {
     char *tp_name;
 

--- a/db/views.h
+++ b/db/views.h
@@ -384,6 +384,6 @@ int timepart_shards_grant_access(bdb_state_type *bdb_state, void *tran, char
 int timepart_shards_revoke_access(bdb_state_type *bdb_state, void *tran, char
                                   *name, char *user, int access_type);
 
-char *resolve_table_name(char *table_name, char *buf, size_t buf_len);
+const char *resolve_table_name(const char *table_name, char *buf, size_t buf_len);
 #endif
 

--- a/db/views_serial.c
+++ b/db/views_serial.c
@@ -494,7 +494,7 @@ static int _views_do_partition_create(void *tran, timepart_views_t *views,
                 if (rev_db->n_rev_constraints - 1 /*this */ + view->retention > MAXCONSTRAINTS) {
                     err->errval = VIEW_ERR_PARAM;
                     snprintf(err->errstr, sizeof(err->errstr), "FKEY %s->%s, %s has too many rev constraints %d > %d",
-                            db->tablename_ip, rev_db->tablename_ip, rev_db->tablename_ip,
+                            db->tablename_interned, rev_db->tablename_interned, rev_db->tablename_interned,
                             rev_db->n_rev_constraints + view->retention, MAXCONSTRAINTS);
                     goto error;
                 }

--- a/db/views_serial.c
+++ b/db/views_serial.c
@@ -494,7 +494,7 @@ static int _views_do_partition_create(void *tran, timepart_views_t *views,
                 if (rev_db->n_rev_constraints - 1 /*this */ + view->retention > MAXCONSTRAINTS) {
                     err->errval = VIEW_ERR_PARAM;
                     snprintf(err->errstr, sizeof(err->errstr), "FKEY %s->%s, %s has too many rev constraints %d > %d",
-                            db->tablename, rev_db->tablename, rev_db->tablename,
+                            db->tablename_ip, rev_db->tablename_ip, rev_db->tablename_ip,
                             rev_db->n_rev_constraints + view->retention, MAXCONSTRAINTS);
                     goto error;
                 }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -198,7 +198,7 @@ static int setup_dbconsumer(dbconsumer_t *q, struct consumer *consumer,
 {
     init_fake_ireq(thedb, &q->iq);
     int spname_len = info->spname_len;
-    strncpy0(q->name, qdb->tablename_ip, MAXTABLELEN);
+    strncpy0(q->name, qdb->tablename_interned, MAXTABLELEN);
     q->iq.usedb = qdb;
     q->emit_timeoutms = 60000; /* emit times-out after 1 min */
     q->consumer = consumer;

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -198,7 +198,7 @@ static int setup_dbconsumer(dbconsumer_t *q, struct consumer *consumer,
 {
     init_fake_ireq(thedb, &q->iq);
     int spname_len = info->spname_len;
-    strncpy0(q->name, qdb->tablename, MAXTABLELEN);
+    strncpy0(q->name, qdb->tablename_ip, MAXTABLELEN);
     q->iq.usedb = qdb;
     q->emit_timeoutms = 60000; /* emit times-out after 1 min */
     q->consumer = consumer;

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -97,7 +97,7 @@ static int db_comdbg_tables(Lua L) {
                 lua_createtable(L, 8, 0); 
 
                 lua_pushstring(L, "tablename");
-                lua_pushstring(L, db->tablename);
+                lua_pushstring(L, db->tablename_ip);
                 lua_settable(L, -3);
 
                 lua_pushstring(L, "dbnum");

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -97,7 +97,7 @@ static int db_comdbg_tables(Lua L) {
                 lua_createtable(L, 8, 0); 
 
                 lua_pushstring(L, "tablename");
-                lua_pushstring(L, db->tablename_ip);
+                lua_pushstring(L, db->tablename_interned);
                 lua_settable(L, -3);
 
                 lua_pushstring(L, "dbnum");

--- a/net/net.c
+++ b/net/net.c
@@ -1860,7 +1860,7 @@ static void dump_queue(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr)
 
 static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
                         int usertype, void *data, int datalen, int nodelay,
-                        int numtails, void **tails, int *taillens, int nodrop,
+                        int numtails, const void **tails, int *taillens, int nodrop,
                         int inorder, int trace)
 {
     if (gbl_libevent) {
@@ -1996,7 +1996,7 @@ static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
     }
     if (numtails > 0) {
         for (i = 0; i < numtails; i++) {
-            iov[iovcount].iov_base = tails[i];
+            iov[iovcount].iov_base = (void *)tails[i];
             iov[iovcount].iov_len = taillens[i];
             iovcount++;
         }
@@ -2111,7 +2111,7 @@ int net_send_nodrop(netinfo_type *netinfo_ptr, const char *host, int usertype,
 
 int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
                    void *data, int datalen, int nodelay, int numtails,
-                   void **tails, int *taillens)
+                   const void **tails, int *taillens)
 {
 
     return net_send_int(netinfo_ptr, host, usertype, data, datalen, nodelay,
@@ -2119,7 +2119,7 @@ int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
 }
 
 int net_send_tail(netinfo_type *netinfo_ptr, const char *host, int usertype,
-                  void *data, int datalen, int nodelay, void *tail, int tailen)
+                  void *data, int datalen, int nodelay, const void *tail, int tailen)
 {
 
 #ifdef _BLOCKSQL_DBG

--- a/net/net.c
+++ b/net/net.c
@@ -1860,7 +1860,7 @@ static void dump_queue(netinfo_type *netinfo_ptr, host_node_type *host_node_ptr)
 
 static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
                         int usertype, void *data, int datalen, int nodelay,
-                        int numtails, const void **tails, int *taillens, int nodrop,
+                        int numtails, void **tails, int *taillens, int nodrop,
                         int inorder, int trace)
 {
     if (gbl_libevent) {
@@ -1870,7 +1870,7 @@ static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
         if (nodrop)
             f |= NET_SEND_NODROP;
         return net_send_evbuffer(netinfo_ptr, host, usertype, data, datalen,
-                                    numtails, tails, taillens, f);
+                                 numtails, tails, taillens, f);
     }
     host_node_type *host_node_ptr;
     net_send_message_header tmphd, msghd;
@@ -1996,7 +1996,7 @@ static int net_send_int(netinfo_type *netinfo_ptr, const char *host,
     }
     if (numtails > 0) {
         for (i = 0; i < numtails; i++) {
-            iov[iovcount].iov_base = (void *)tails[i];
+            iov[iovcount].iov_base = tails[i];
             iov[iovcount].iov_len = taillens[i];
             iovcount++;
         }
@@ -2111,7 +2111,7 @@ int net_send_nodrop(netinfo_type *netinfo_ptr, const char *host, int usertype,
 
 int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
                    void *data, int datalen, int nodelay, int numtails,
-                   const void **tails, int *taillens)
+                   void **tails, int *taillens)
 {
 
     return net_send_int(netinfo_ptr, host, usertype, data, datalen, nodelay,
@@ -2119,7 +2119,7 @@ int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
 }
 
 int net_send_tail(netinfo_type *netinfo_ptr, const char *host, int usertype,
-                  void *data, int datalen, int nodelay, const void *tail, int tailen)
+                  void *data, int datalen, int nodelay, void *tail, int tailen)
 {
 
 #ifdef _BLOCKSQL_DBG

--- a/net/net.h
+++ b/net/net.h
@@ -297,12 +297,12 @@ void print_netinfo(netinfo_type *netinfo_ptr);
 */
 int net_send_tail(netinfo_type *netinfo,
                   const char *host, /* send to this node */
-                  int usertype, void *dta, int dtalen, int nodelay, void *tail,
+                  int usertype, void *dta, int dtalen, int nodelay, const void *tail,
                   int tailen);
 
 int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
                    void *data, int datalen, int nodelay, int numtails,
-                   void **tails, int *taillens);
+                   const void **tails, int *taillens);
 
 /* pick a sibling for sql offloading */
 char *net_get_osql_node(netinfo_type *netinfo_ptr);

--- a/net/net.h
+++ b/net/net.h
@@ -297,12 +297,12 @@ void print_netinfo(netinfo_type *netinfo_ptr);
 */
 int net_send_tail(netinfo_type *netinfo,
                   const char *host, /* send to this node */
-                  int usertype, void *dta, int dtalen, int nodelay, const void *tail,
+                  int usertype, void *dta, int dtalen, int nodelay, void *tail,
                   int tailen);
 
 int net_send_tails(netinfo_type *netinfo_ptr, const char *host, int usertype,
                    void *data, int datalen, int nodelay, int numtails,
-                   const void **tails, int *taillens);
+                   void **tails, int *taillens);
 
 /* pick a sibling for sql offloading */
 char *net_get_osql_node(netinfo_type *netinfo_ptr);

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -216,7 +216,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
 
     if (!checkonly && db && (db->dbtype != DBTYPE_QUEUEDB)) {
         logmsg(LOGMSG_ERROR, "%s: %s is not a queue\n", __func__,
-               db->tablename);
+               db->tablename_ip);
         rc = -1;
         goto done;
     }
@@ -224,7 +224,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
     if (!checkonly && (consumern < 0 || consumern >= MAXCONSUMERS)) {
         logmsg(LOGMSG_ERROR,
                "%s: %s consumer number %d out of range\n",
-               __func__, db->tablename, consumern);
+               __func__, db->tablename_ip, consumern);
         rc = -1;
         goto done;
     }
@@ -234,7 +234,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
             logmsg(
                 LOGMSG_ERROR,
                 "%s: %s consumer number %d in use already\n",
-                __func__, db->tablename, consumern);
+                __func__, db->tablename_ip, consumern);
             rc = -1;
             goto done;
         } else {
@@ -279,7 +279,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
     } else {
         logmsg(LOGMSG_ERROR, "%s: %s consumer number %d has "
                              "unknown delivery method '%s'\n",
-               __func__, db->tablename, consumern, method);
+               __func__, db->tablename_ip, consumern, method);
         free(consumer);
         rc = -1;
         goto done;
@@ -332,7 +332,7 @@ static int set_consumern_options(struct dbtable *db, int consumern,
         return set_consumer_options(consumer, opts);
     else {
         logmsg(LOGMSG_ERROR, "Bad consumer number %d for queue %s\n", consumern,
-               db->tablename);
+               db->tablename_ip);
         return -1;
     }
 }
@@ -352,7 +352,7 @@ int set_consumer_options(struct consumer *consumer, const char *opts)
     tok = strtok_r(copy, delims, &lasts);
     while (tok) {
         logmsg(LOGMSG_USER, "Queue %s consumer %d option '%s'\n",
-               consumer->db->tablename, consumer->consumern, tok);
+               consumer->db->tablename_ip, consumer->consumern, tok);
 
         tok = strtok_r(NULL, delims, &lasts);
     }
@@ -557,7 +557,7 @@ static int get_stats(struct dbtable *, int, void *, struct consumer_stat *);
 static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
 {
     if (db->dbtype != DBTYPE_QUEUE && db->dbtype != DBTYPE_QUEUEDB)
-        logmsg(LOGMSG_ERROR, "'%s' is not a queue\n", db->tablename);
+        logmsg(LOGMSG_ERROR, "'%s' is not a queue\n", db->tablename_ip);
     else {
         int ii;
         struct consumer_stat stats[MAXCONSUMERS] = {{0}};
@@ -567,14 +567,14 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
         bdbstats = bdb_queue_get_stats(db->handle);
 
         logmsg(LOGMSG_USER, "(scanning queue '%s' for stats, please wait...)\n",
-               db->tablename);
+               db->tablename_ip);
         if (!walk_queue)
             flags = BDB_QUEUE_WALK_FIRST_ONLY;
         if (fullstat)
             flags |= BDB_QUEUE_WALK_KNOWN_CONSUMERS_ONLY;
         get_stats(db, flags, NULL, stats);
 
-        logmsg(LOGMSG_USER, "queue '%s':-\n", db->tablename);
+        logmsg(LOGMSG_USER, "queue '%s':-\n", db->tablename_ip);
         logmsg(LOGMSG_USER, "  geese added     %u\n", db->num_goose_adds);
         logmsg(LOGMSG_USER, "  geese consumed  %u\n", db->num_goose_consumes);
         logmsg(LOGMSG_USER, "  bdb get bdbstats   %u log %u phys\n",
@@ -718,7 +718,7 @@ static void queue_flush(struct dbtable *db, int consumern)
     iq.usedb = db;
 
     logmsg(LOGMSG_INFO, "Beginning flush for queue '%s' consumer %d\n",
-           db->tablename, consumern);
+           db->tablename_ip, consumern);
 
     if (db->dbenv->master != gbl_myhostname) {
         logmsg(LOGMSG_WARN, "... but I am not the master node, so I do nothing.\n");
@@ -755,7 +755,7 @@ static void queue_flush(struct dbtable *db, int consumern)
 
     logmsg(LOGMSG_INFO,
            "Done flush for queue '%s' consumer %d, flushed %d items\n",
-           db->tablename, consumern, nflush);
+           db->tablename_ip, consumern, nflush);
 }
 
 struct flush_thd_data {

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -216,7 +216,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
 
     if (!checkonly && db && (db->dbtype != DBTYPE_QUEUEDB)) {
         logmsg(LOGMSG_ERROR, "%s: %s is not a queue\n", __func__,
-               db->tablename_ip);
+               db->tablename_interned);
         rc = -1;
         goto done;
     }
@@ -224,7 +224,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
     if (!checkonly && (consumern < 0 || consumern >= MAXCONSUMERS)) {
         logmsg(LOGMSG_ERROR,
                "%s: %s consumer number %d out of range\n",
-               __func__, db->tablename_ip, consumern);
+               __func__, db->tablename_interned, consumern);
         rc = -1;
         goto done;
     }
@@ -234,7 +234,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
             logmsg(
                 LOGMSG_ERROR,
                 "%s: %s consumer number %d in use already\n",
-                __func__, db->tablename_ip, consumern);
+                __func__, db->tablename_interned, consumern);
             rc = -1;
             goto done;
         } else {
@@ -279,7 +279,7 @@ static int add_consumer_int(struct dbtable *db, int consumern,
     } else {
         logmsg(LOGMSG_ERROR, "%s: %s consumer number %d has "
                              "unknown delivery method '%s'\n",
-               __func__, db->tablename_ip, consumern, method);
+               __func__, db->tablename_interned, consumern, method);
         free(consumer);
         rc = -1;
         goto done;
@@ -332,7 +332,7 @@ static int set_consumern_options(struct dbtable *db, int consumern,
         return set_consumer_options(consumer, opts);
     else {
         logmsg(LOGMSG_ERROR, "Bad consumer number %d for queue %s\n", consumern,
-               db->tablename_ip);
+               db->tablename_interned);
         return -1;
     }
 }
@@ -352,7 +352,7 @@ int set_consumer_options(struct consumer *consumer, const char *opts)
     tok = strtok_r(copy, delims, &lasts);
     while (tok) {
         logmsg(LOGMSG_USER, "Queue %s consumer %d option '%s'\n",
-               consumer->db->tablename_ip, consumer->consumern, tok);
+               consumer->db->tablename_interned, consumer->consumern, tok);
 
         tok = strtok_r(NULL, delims, &lasts);
     }
@@ -557,7 +557,7 @@ static int get_stats(struct dbtable *, int, void *, struct consumer_stat *);
 static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
 {
     if (db->dbtype != DBTYPE_QUEUE && db->dbtype != DBTYPE_QUEUEDB)
-        logmsg(LOGMSG_ERROR, "'%s' is not a queue\n", db->tablename_ip);
+        logmsg(LOGMSG_ERROR, "'%s' is not a queue\n", db->tablename_interned);
     else {
         int ii;
         struct consumer_stat stats[MAXCONSUMERS] = {{0}};
@@ -567,14 +567,14 @@ static void stat_thread_int(struct dbtable *db, int fullstat, int walk_queue)
         bdbstats = bdb_queue_get_stats(db->handle);
 
         logmsg(LOGMSG_USER, "(scanning queue '%s' for stats, please wait...)\n",
-               db->tablename_ip);
+               db->tablename_interned);
         if (!walk_queue)
             flags = BDB_QUEUE_WALK_FIRST_ONLY;
         if (fullstat)
             flags |= BDB_QUEUE_WALK_KNOWN_CONSUMERS_ONLY;
         get_stats(db, flags, NULL, stats);
 
-        logmsg(LOGMSG_USER, "queue '%s':-\n", db->tablename_ip);
+        logmsg(LOGMSG_USER, "queue '%s':-\n", db->tablename_interned);
         logmsg(LOGMSG_USER, "  geese added     %u\n", db->num_goose_adds);
         logmsg(LOGMSG_USER, "  geese consumed  %u\n", db->num_goose_consumes);
         logmsg(LOGMSG_USER, "  bdb get bdbstats   %u log %u phys\n",
@@ -718,7 +718,7 @@ static void queue_flush(struct dbtable *db, int consumern)
     iq.usedb = db;
 
     logmsg(LOGMSG_INFO, "Beginning flush for queue '%s' consumer %d\n",
-           db->tablename_ip, consumern);
+           db->tablename_interned, consumern);
 
     if (db->dbenv->master != gbl_myhostname) {
         logmsg(LOGMSG_WARN, "... but I am not the master node, so I do nothing.\n");
@@ -755,7 +755,7 @@ static void queue_flush(struct dbtable *db, int consumern)
 
     logmsg(LOGMSG_INFO,
            "Done flush for queue '%s' consumer %d, flushed %d items\n",
-           db->tablename_ip, consumern, nflush);
+           db->tablename_interned, consumern, nflush);
 }
 
 struct flush_thd_data {

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -3667,9 +3667,9 @@ static int _is_tablename_unique(const char *name)
     int llen = strlen(name);
 
     for (i = 0; i < thedb->num_dbs; i++) {
-        if (llen != strlen(thedb->dbs[i]->tablename_ip))
+        if (llen != strlen(thedb->dbs[i]->tablename_interned))
             continue;
-        if (strncasecmp(thedb->dbs[i]->tablename_ip, name, llen) == 0)
+        if (strncasecmp(thedb->dbs[i]->tablename_interned, name, llen) == 0)
             return -1;
     }
 

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -3667,9 +3667,9 @@ static int _is_tablename_unique(const char *name)
     int llen = strlen(name);
 
     for (i = 0; i < thedb->num_dbs; i++) {
-        if (llen != strlen(thedb->dbs[i]->tablename))
+        if (llen != strlen(thedb->dbs[i]->tablename_ip))
             continue;
-        if (strncasecmp(thedb->dbs[i]->tablename, name, llen) == 0)
+        if (strncasecmp(thedb->dbs[i]->tablename_ip, name, llen) == 0)
             return -1;
     }
 

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -334,7 +334,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
 
     /* Update table permissions for this new shard. */
     if (s->is_timepart) {
-        if ((rc = timepart_copy_access(thedb->bdb_env, tran, s->tablename_ip,
+        if ((rc = timepart_copy_access(thedb->bdb_env, tran, s->tablename,
                                        s->timepartname, 0)) != 0) {
             sc_errf(s, "Failed to set user permissions for time partition %s\n",
                     s->timepartname);

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -55,7 +55,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
     if (newdb->dbenv->master == gbl_myhostname && !gbl_is_physical_replicant) {
         /* I am master: create new db */
         newdb->handle = bdb_create_tran(
-            newdb->tablename, thedb->basedir, newdb->lrl, newdb->nix,
+            newdb->tablename_ip, thedb->basedir, newdb->lrl, newdb->nix,
             (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
             newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
             newdb->numblobs + 1, thedb->bdb_env, 0, &bdberr, trans);
@@ -63,7 +63,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
     } else {
         /* I am NOT master: open replicated db */
         newdb->handle = bdb_open_more_tran(
-            newdb->tablename, thedb->basedir, newdb->lrl, newdb->nix,
+            newdb->tablename_ip, thedb->basedir, newdb->lrl, newdb->nix,
             (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
             newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
             newdb->numblobs + 1, thedb->bdb_env, trans, 0, &bdberr);
@@ -72,7 +72,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
 
     if (newdb->handle == NULL) {
         logmsg(LOGMSG_ERROR, "bdb_open:failed to open table %s/%s, rcode %d\n",
-               thedb->basedir, newdb->tablename, bdberr);
+               thedb->basedir, newdb->tablename_ip, bdberr);
         return SC_BDB_ERROR;
     }
 
@@ -201,7 +201,7 @@ int add_table_to_environment(char *table, const char *csc2,
 
 err:
     newdb->iq = NULL;
-    backout_schemas(newdb->tablename);
+    backout_schemas(newdb->tablename_ip);
     cleanup_newdb(newdb);
     return rc;
 }
@@ -334,7 +334,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
 
     /* Update table permissions for this new shard. */
     if (s->is_timepart) {
-        if ((rc = timepart_copy_access(thedb->bdb_env, tran, s->tablename,
+        if ((rc = timepart_copy_access(thedb->bdb_env, tran, s->tablename_ip,
                                        s->timepartname, 0)) != 0) {
             sc_errf(s, "Failed to set user permissions for time partition %s\n",
                     s->timepartname);
@@ -342,7 +342,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
         }
     }
 
-    if ((rc = bdb_table_version_select(db->tablename, tran, &db->tableversion,
+    if ((rc = bdb_table_version_select(db->tablename_ip, tran, &db->tableversion,
                                        &bdberr)) != 0) {
         sc_errf(s, "Failed fetching table version bdberr %d\n", bdberr);
         return rc;
@@ -352,7 +352,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
     if (db->odh && db->instant_schema_change) {
         struct schema *ver_one;
         if ((rc = prepare_table_version_one(tran, db, &ver_one))) return rc;
-        add_tag_schema(db->tablename, ver_one);
+        add_tag_schema(db->tablename_ip, ver_one);
     }
 
     gbl_sc_commit_count++;

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -55,7 +55,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
     if (newdb->dbenv->master == gbl_myhostname && !gbl_is_physical_replicant) {
         /* I am master: create new db */
         newdb->handle = bdb_create_tran(
-            newdb->tablename_ip, thedb->basedir, newdb->lrl, newdb->nix,
+            newdb->tablename_interned, thedb->basedir, newdb->lrl, newdb->nix,
             (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
             newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
             newdb->numblobs + 1, thedb->bdb_env, 0, &bdberr, trans);
@@ -63,7 +63,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
     } else {
         /* I am NOT master: open replicated db */
         newdb->handle = bdb_open_more_tran(
-            newdb->tablename_ip, thedb->basedir, newdb->lrl, newdb->nix,
+            newdb->tablename_interned, thedb->basedir, newdb->lrl, newdb->nix,
             (short *)newdb->ix_keylen, newdb->ix_dupes, newdb->ix_recnums,
             newdb->ix_datacopy, newdb->ix_collattr, newdb->ix_nullsallowed,
             newdb->numblobs + 1, thedb->bdb_env, trans, 0, &bdberr);
@@ -72,7 +72,7 @@ static inline int get_db_handle(struct dbtable *newdb, void *trans)
 
     if (newdb->handle == NULL) {
         logmsg(LOGMSG_ERROR, "bdb_open:failed to open table %s/%s, rcode %d\n",
-               thedb->basedir, newdb->tablename_ip, bdberr);
+               thedb->basedir, newdb->tablename_interned, bdberr);
         return SC_BDB_ERROR;
     }
 
@@ -201,7 +201,7 @@ int add_table_to_environment(char *table, const char *csc2,
 
 err:
     newdb->iq = NULL;
-    backout_schemas(newdb->tablename_ip);
+    backout_schemas(newdb->tablename_interned);
     cleanup_newdb(newdb);
     return rc;
 }
@@ -342,7 +342,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
         }
     }
 
-    if ((rc = bdb_table_version_select(db->tablename_ip, tran, &db->tableversion,
+    if ((rc = bdb_table_version_select(db->tablename_interned, tran, &db->tableversion,
                                        &bdberr)) != 0) {
         sc_errf(s, "Failed fetching table version bdberr %d\n", bdberr);
         return rc;
@@ -352,7 +352,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
     if (db->odh && db->instant_schema_change) {
         struct schema *ver_one;
         if ((rc = prepare_table_version_one(tran, db, &ver_one))) return rc;
-        add_tag_schema(db->tablename_ip, ver_one);
+        add_tag_schema(db->tablename_interned, ver_one);
     }
 
     gbl_sc_commit_count++;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -79,7 +79,7 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
     }
     if (changed < 0) {
         /* some errors during constraint verifications */
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         resume_threads(thedb); /* can now restart stopped threads */
 
         /* these checks should be present in dryrun_int as well */
@@ -287,7 +287,7 @@ static int switch_versions_with_plan(void *tran, struct dbtable *db,
 
 static void backout(struct dbtable *db)
 {
-    backout_schemas(db->tablename);
+    backout_schemas(db->tablename_ip);
     live_sc_off(db);
 }
 
@@ -348,15 +348,15 @@ static void check_for_idx_rename(struct dbtable *newdb, struct dbtable *olddb)
             char namebuf1[128];
             char namebuf2[128];
             form_new_style_name(namebuf1, sizeof(namebuf1), newixs,
-                                newixs->csctag + offset, newdb->tablename);
+                                newixs->csctag + offset, newdb->tablename_ip);
             form_new_style_name(namebuf2, sizeof(namebuf2), oldixs,
-                                oldixs->csctag, olddb->tablename);
+                                oldixs->csctag, olddb->tablename_ip);
             logmsg(LOGMSG_INFO,
                    "ix %d changing name so INSERTING into sqlite_stat* "
                    "idx='%s' where tbl='%s' and idx='%s' \n",
-                   ixnum, newixs->csctag + offset, newdb->tablename,
+                   ixnum, newixs->csctag + offset, newdb->tablename_ip,
                    oldixs->csctag);
-            add_idx_stats(newdb->tablename, namebuf2, namebuf1);
+            add_idx_stats(newdb->tablename_ip, namebuf2, namebuf1);
         }
     }
 }
@@ -427,7 +427,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
             unlock_schema_lk();
         return SC_INTERNAL_ERROR;
     }
-    newdb->schema_version = get_csc2_version(newdb->tablename);
+    newdb->schema_version = get_csc2_version(newdb->tablename_ip);
 
     newdb->iq = iq;
 
@@ -640,11 +640,11 @@ convert_records:
 
     if (s->convert_sleep > 0) {
         sc_printf(s, "[%s] Sleeping after conversion for %d...\n",
-                  db->tablename, s->convert_sleep);
+                  db->tablename_ip, s->convert_sleep);
         logmsg(LOGMSG_INFO, "Sleeping after conversion for %d...\n",
                s->convert_sleep);
         sleep(s->convert_sleep);
-        sc_printf(s, "[%s] ...slept for %d\n", db->tablename, s->convert_sleep);
+        sc_printf(s, "[%s] ...slept for %d\n", db->tablename_ip, s->convert_sleep);
     }
 
 errout:
@@ -777,7 +777,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (newdb->schema_version == 1) {
         /* newdb's version has been reset */
         bdberr =
-            bdb_reset_csc2_version(transac, db->tablename, db->schema_version);
+            bdb_reset_csc2_version(transac, db->tablename_ip, db->schema_version);
         if (bdberr != BDBERR_NOERROR)
             BACKOUT;
     }
@@ -798,7 +798,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     /* load new csc2 data */
     rc = load_new_table_schema_tran(thedb, transac,
-                                    /*s->tablename*/ db->tablename, s->newcsc2);
+                                    /*s->tablename*/ db->tablename_ip, s->newcsc2);
     if (rc != 0) {
         sc_errf(s, "Error loading new schema into meta tables, "
                    "trying again\n");
@@ -843,7 +843,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     fix_constraint_pointers(db, newdb);
 
     /* update tags in memory */
-    commit_schemas(/*s->tablename*/ db->tablename);
+    commit_schemas(/*s->tablename*/ db->tablename_ip);
     update_dbstore(db); // update needs to occur after refresh of hashtbl
 
     MEMORY_SYNC;
@@ -873,11 +873,11 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     if (!gbl_create_mode) {
-        logmsg(LOGMSG_INFO, "Table %s is at version: %d\n", newdb->tablename,
+        logmsg(LOGMSG_INFO, "Table %s is at version: %d\n", newdb->tablename_ip,
                newdb->schema_version);
     }
 
-    llmeta_dump_mapping_table_tran(transac, thedb, db->tablename, 1);
+    llmeta_dump_mapping_table_tran(transac, thedb, db->tablename_ip, 1);
 
     sc_printf(s, "Schema change ok\n");
 
@@ -896,7 +896,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
          BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0)) {
         /* reliable per table versioning */
         if (gbl_disable_tpsc_tblvers && s->fix_tp_badvers) {
-            rc = table_version_set(transac, db->tablename,
+            rc = table_version_set(transac, db->tablename_ip,
                                    s->usedbtablevers + 1);
             db->tableversion = s->usedbtablevers + 1;
         } else
@@ -907,7 +907,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         }
     } else {
         if (gbl_disable_tpsc_tblvers && s->fix_tp_badvers) {
-            rc = table_version_set(transac, db->tablename, s->usedbtablevers);
+            rc = table_version_set(transac, db->tablename_ip, s->usedbtablevers);
             db->tableversion = s->usedbtablevers;
         } else
             db->tableversion = table_version_select(db, transac);
@@ -919,7 +919,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (olddb_bthashsz) {
         logmsg(LOGMSG_INFO,
                "Rebuilding bthash for table %s, size %dkb per stripe\n",
-               db->tablename, olddb_bthashsz);
+               db->tablename_ip, olddb_bthashsz);
         bdb_handle_dbp_add_hash(db->handle, olddb_bthashsz);
     }
 
@@ -949,12 +949,12 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 backout:
     live_sc_off(db);
     backout_constraint_pointers(newdb, db);
-    change_schemas_recover(/*s->tablename*/ db->tablename);
+    change_schemas_recover(/*s->tablename*/ db->tablename_ip);
     bdb_close_only_sc(new_bdb_handle, NULL, &bdberr);
 
     logmsg(LOGMSG_WARN,
            "##### BACKOUT #####   %s v: %d sc:%d lrl: %d odh:%d bdb:%p\n",
-           db->tablename, db->schema_version, db->instant_schema_change,
+           db->tablename_ip, db->schema_version, db->instant_schema_change,
            db->lrl, db->odh, db->handle);
 
     return -1;
@@ -1044,7 +1044,7 @@ int finalize_upgrade_table(struct schema_change_type *s)
         rc = trans_start_sc(&iq, NULL, &tran);
         if (rc != 0) continue;
 
-        rc = mark_schemachange_over_tran(s->db->tablename, tran);
+        rc = mark_schemachange_over_tran(s->db->tablename_ip, tran);
         if (rc != 0) continue;
 
         rc = trans_commit(&iq, tran, gbl_myhostname);

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -79,7 +79,7 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
     }
     if (changed < 0) {
         /* some errors during constraint verifications */
-        backout_schemas(newdb->tablename_ip);
+        backout_schemas(newdb->tablename_interned);
         resume_threads(thedb); /* can now restart stopped threads */
 
         /* these checks should be present in dryrun_int as well */
@@ -287,7 +287,7 @@ static int switch_versions_with_plan(void *tran, struct dbtable *db,
 
 static void backout(struct dbtable *db)
 {
-    backout_schemas(db->tablename_ip);
+    backout_schemas(db->tablename_interned);
     live_sc_off(db);
 }
 
@@ -348,15 +348,15 @@ static void check_for_idx_rename(struct dbtable *newdb, struct dbtable *olddb)
             char namebuf1[128];
             char namebuf2[128];
             form_new_style_name(namebuf1, sizeof(namebuf1), newixs,
-                                newixs->csctag + offset, newdb->tablename_ip);
+                                newixs->csctag + offset, newdb->tablename_interned);
             form_new_style_name(namebuf2, sizeof(namebuf2), oldixs,
-                                oldixs->csctag, olddb->tablename_ip);
+                                oldixs->csctag, olddb->tablename_interned);
             logmsg(LOGMSG_INFO,
                    "ix %d changing name so INSERTING into sqlite_stat* "
                    "idx='%s' where tbl='%s' and idx='%s' \n",
-                   ixnum, newixs->csctag + offset, newdb->tablename_ip,
+                   ixnum, newixs->csctag + offset, newdb->tablename_interned,
                    oldixs->csctag);
-            add_idx_stats(newdb->tablename_ip, namebuf2, namebuf1);
+            add_idx_stats(newdb->tablename_interned, namebuf2, namebuf1);
         }
     }
 }
@@ -427,7 +427,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
             unlock_schema_lk();
         return SC_INTERNAL_ERROR;
     }
-    newdb->schema_version = get_csc2_version(newdb->tablename_ip);
+    newdb->schema_version = get_csc2_version(newdb->tablename_interned);
 
     newdb->iq = iq;
 
@@ -640,11 +640,11 @@ convert_records:
 
     if (s->convert_sleep > 0) {
         sc_printf(s, "[%s] Sleeping after conversion for %d...\n",
-                  db->tablename_ip, s->convert_sleep);
+                  db->tablename_interned, s->convert_sleep);
         logmsg(LOGMSG_INFO, "Sleeping after conversion for %d...\n",
                s->convert_sleep);
         sleep(s->convert_sleep);
-        sc_printf(s, "[%s] ...slept for %d\n", db->tablename_ip, s->convert_sleep);
+        sc_printf(s, "[%s] ...slept for %d\n", db->tablename_interned, s->convert_sleep);
     }
 
 errout:
@@ -777,7 +777,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (newdb->schema_version == 1) {
         /* newdb's version has been reset */
         bdberr =
-            bdb_reset_csc2_version(transac, db->tablename_ip, db->schema_version);
+            bdb_reset_csc2_version(transac, db->tablename_interned, db->schema_version);
         if (bdberr != BDBERR_NOERROR)
             BACKOUT;
     }
@@ -798,7 +798,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     /* load new csc2 data */
     rc = load_new_table_schema_tran(thedb, transac,
-                                    /*s->tablename*/ db->tablename_ip, s->newcsc2);
+                                    /*s->tablename*/ db->tablename_interned, s->newcsc2);
     if (rc != 0) {
         sc_errf(s, "Error loading new schema into meta tables, "
                    "trying again\n");
@@ -843,7 +843,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     fix_constraint_pointers(db, newdb);
 
     /* update tags in memory */
-    commit_schemas(/*s->tablename*/ db->tablename_ip);
+    commit_schemas(/*s->tablename*/ db->tablename_interned);
     update_dbstore(db); // update needs to occur after refresh of hashtbl
 
     MEMORY_SYNC;
@@ -873,11 +873,11 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     if (!gbl_create_mode) {
-        logmsg(LOGMSG_INFO, "Table %s is at version: %d\n", newdb->tablename_ip,
+        logmsg(LOGMSG_INFO, "Table %s is at version: %d\n", newdb->tablename_interned,
                newdb->schema_version);
     }
 
-    llmeta_dump_mapping_table_tran(transac, thedb, db->tablename_ip, 1);
+    llmeta_dump_mapping_table_tran(transac, thedb, db->tablename_interned, 1);
 
     sc_printf(s, "Schema change ok\n");
 
@@ -896,7 +896,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
          BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0)) {
         /* reliable per table versioning */
         if (gbl_disable_tpsc_tblvers && s->fix_tp_badvers) {
-            rc = table_version_set(transac, db->tablename_ip,
+            rc = table_version_set(transac, db->tablename_interned,
                                    s->usedbtablevers + 1);
             db->tableversion = s->usedbtablevers + 1;
         } else
@@ -907,7 +907,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
         }
     } else {
         if (gbl_disable_tpsc_tblvers && s->fix_tp_badvers) {
-            rc = table_version_set(transac, db->tablename_ip, s->usedbtablevers);
+            rc = table_version_set(transac, db->tablename_interned, s->usedbtablevers);
             db->tableversion = s->usedbtablevers;
         } else
             db->tableversion = table_version_select(db, transac);
@@ -919,7 +919,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     if (olddb_bthashsz) {
         logmsg(LOGMSG_INFO,
                "Rebuilding bthash for table %s, size %dkb per stripe\n",
-               db->tablename_ip, olddb_bthashsz);
+               db->tablename_interned, olddb_bthashsz);
         bdb_handle_dbp_add_hash(db->handle, olddb_bthashsz);
     }
 
@@ -949,12 +949,12 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 backout:
     live_sc_off(db);
     backout_constraint_pointers(newdb, db);
-    change_schemas_recover(/*s->tablename*/ db->tablename_ip);
+    change_schemas_recover(/*s->tablename*/ db->tablename_interned);
     bdb_close_only_sc(new_bdb_handle, NULL, &bdberr);
 
     logmsg(LOGMSG_WARN,
            "##### BACKOUT #####   %s v: %d sc:%d lrl: %d odh:%d bdb:%p\n",
-           db->tablename_ip, db->schema_version, db->instant_schema_change,
+           db->tablename_interned, db->schema_version, db->instant_schema_change,
            db->lrl, db->odh, db->handle);
 
     return -1;
@@ -1044,7 +1044,7 @@ int finalize_upgrade_table(struct schema_change_type *s)
         rc = trans_start_sc(&iq, NULL, &tran);
         if (rc != 0) continue;
 
-        rc = mark_schemachange_over_tran(s->db->tablename_ip, tran);
+        rc = mark_schemachange_over_tran(s->db->tablename_interned, tran);
         if (rc != 0) continue;
 
         rc = trans_commit(&iq, tran, gbl_myhostname);

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -339,7 +339,7 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -411,7 +411,7 @@ int live_sc_post_add_record(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK",
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK",
                                 (const char *)od_dta, ".NEW..ONDISK", new_dta,
                                 &reason, blobs, maxblobs, 1);
     if (rc) {
@@ -651,11 +651,11 @@ static int bthash_callback(const char *table)
         if (bthashsz) {
             logmsg(LOGMSG_INFO,
                    "Building bthash for table %s, size %dkb per stripe\n",
-                   db->tablename, bthashsz);
+                   db->tablename_ip, bthashsz);
             bdb_handle_dbp_add_hash(db->handle, bthashsz);
         } else {
             logmsg(LOGMSG_INFO, "Deleting bthash for table %s\n",
-                   db->tablename);
+                   db->tablename_ip);
             bdb_handle_dbp_drop_hash(db->handle);
         }
         return 0;
@@ -884,10 +884,10 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
         struct schema *ver_one;
         char tag[MAXTAGLEN];
 
-        ondisk_schema = find_tag_schema(db->tablename, ".ONDISK");
+        ondisk_schema = find_tag_schema(db->tablename_ip, ".ONDISK");
         if (NULL == ondisk_schema) {
             logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
-                   db->tablename);
+                   db->tablename_ip);
             exit(1);
         }
         ver_one = clone_schema(ondisk_schema);
@@ -898,7 +898,7 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
             logmsg(LOGMSG_FATAL, "strdup failed %s @ %d\n", __func__, __LINE__);
             exit(1);
         }
-        add_tag_schema(db->tablename, ver_one);
+        add_tag_schema(db->tablename_ip, ver_one);
     }
 
     if (!IS_QUEUEDB_ROLLOVER_SCHEMA_CHANGE_TYPE(type)) {
@@ -918,10 +918,10 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
      * schema change.  But it is committed to the llmeta table, so we can fetch
      * it from there. */
     if (db != NULL) {
-        dbnum = llmeta_get_dbnum_tran(tran, db->tablename, &bdberr);
+        dbnum = llmeta_get_dbnum_tran(tran, db->tablename_ip, &bdberr);
         if (dbnum == -1) {
             logmsg(LOGMSG_ERROR, "failed to fetch dbnum for table \"%s\"\n",
-                   db->tablename);
+                   db->tablename_ip);
             rc = BDBERR_MISC;
             goto done;
         }

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -339,7 +339,7 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_interned, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -411,7 +411,7 @@ int live_sc_post_add_record(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK",
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_interned, ".ONDISK",
                                 (const char *)od_dta, ".NEW..ONDISK", new_dta,
                                 &reason, blobs, maxblobs, 1);
     if (rc) {
@@ -651,11 +651,11 @@ static int bthash_callback(const char *table)
         if (bthashsz) {
             logmsg(LOGMSG_INFO,
                    "Building bthash for table %s, size %dkb per stripe\n",
-                   db->tablename_ip, bthashsz);
+                   db->tablename_interned, bthashsz);
             bdb_handle_dbp_add_hash(db->handle, bthashsz);
         } else {
             logmsg(LOGMSG_INFO, "Deleting bthash for table %s\n",
-                   db->tablename_ip);
+                   db->tablename_interned);
             bdb_handle_dbp_drop_hash(db->handle);
         }
         return 0;
@@ -884,10 +884,10 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
         struct schema *ver_one;
         char tag[MAXTAGLEN];
 
-        ondisk_schema = find_tag_schema(db->tablename_ip, ".ONDISK");
+        ondisk_schema = find_tag_schema(db->tablename_interned, ".ONDISK");
         if (NULL == ondisk_schema) {
             logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
-                   db->tablename_ip);
+                   db->tablename_interned);
             exit(1);
         }
         ver_one = clone_schema(ondisk_schema);
@@ -898,7 +898,7 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
             logmsg(LOGMSG_FATAL, "strdup failed %s @ %d\n", __func__, __LINE__);
             exit(1);
         }
-        add_tag_schema(db->tablename_ip, ver_one);
+        add_tag_schema(db->tablename_interned, ver_one);
     }
 
     if (!IS_QUEUEDB_ROLLOVER_SCHEMA_CHANGE_TYPE(type)) {
@@ -918,10 +918,10 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
      * schema change.  But it is committed to the llmeta table, so we can fetch
      * it from there. */
     if (db != NULL) {
-        dbnum = llmeta_get_dbnum_tran(tran, db->tablename_ip, &bdberr);
+        dbnum = llmeta_get_dbnum_tran(tran, db->tablename_interned, &bdberr);
         if (dbnum == -1) {
             logmsg(LOGMSG_ERROR, "failed to fetch dbnum for table \"%s\"\n",
-                   db->tablename_ip);
+                   db->tablename_interned);
             rc = BDBERR_MISC;
             goto done;
         }

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -133,7 +133,7 @@ static int schema_cmp(struct dbenv *dbenv, struct dbtable *db,
                       const char *csc2cmp)
 {
     int rc =
-        dyns_load_schema_string((char *)csc2cmp, dbenv->envname, db->tablename);
+        dyns_load_schema_string((char *)csc2cmp, dbenv->envname, db->tablename_ip);
     if (rc) {
         logmsg(LOGMSG_ERROR, "schema_cmp: error loading comparison schema\n");
         return -1;
@@ -148,9 +148,9 @@ static int schema_cmp(struct dbenv *dbenv, struct dbtable *db,
         return -1;
     }
 
-    rc = compare_all_tags(db->tablename, stderr);
+    rc = compare_all_tags(db->tablename_ip, stderr);
 
-    backout_schemas(db->tablename);
+    backout_schemas(db->tablename_ip);
 
     return rc;
 }
@@ -290,7 +290,7 @@ int get_csc2_fname(const struct dbtable *db, const char *dir, char *fname,
 {
     int rc;
 
-    rc = snprintf(fname, fname_len, "%s/%s.csc2", dir, db->tablename);
+    rc = snprintf(fname, fname_len, "%s/%s.csc2", dir, db->tablename_ip);
     if (rc < 0 || rc >= fname_len) return -1;
 
     return 0;
@@ -312,22 +312,22 @@ int dump_all_csc2_to_disk()
             char *meta_csc2 = NULL;
             int meta_csc2_len;
 
-            version = get_csc2_version(thedb->dbs[ii]->tablename);
+            version = get_csc2_version(thedb->dbs[ii]->tablename_ip);
             if (version < 0) {
                 logmsg(LOGMSG_ERROR,
                        "dump_all_csc2_to_disk: error getting current schema "
                        "version for table %s\n",
-                       thedb->dbs[ii]->tablename);
+                       thedb->dbs[ii]->tablename_ip);
                 return -1;
             }
 
-            rc = get_csc2_file(thedb->dbs[ii]->tablename, version, &meta_csc2,
+            rc = get_csc2_file(thedb->dbs[ii]->tablename_ip, version, &meta_csc2,
                                &meta_csc2_len);
             if (rc != 0 || !meta_csc2) {
                 logmsg(LOGMSG_ERROR,
                        "dump_all_csc2_to_disk: could not load meta schema %d "
                        "for table %s rcode %d\n",
-                       version, thedb->dbs[ii]->tablename, rc);
+                       version, thedb->dbs[ii]->tablename_ip, rc);
                 return -1;
             }
 
@@ -336,7 +336,7 @@ int dump_all_csc2_to_disk()
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR,
                        "error printing out schema for table '%s'\n",
-                       thedb->dbs[ii]->tablename);
+                       thedb->dbs[ii]->tablename_ip);
                 return -1;
             }
         }
@@ -354,19 +354,19 @@ int dump_table_csc2_to_disk_fname(struct dbtable *db, const char *csc2_fname)
     char *meta_csc2 = NULL;
     int meta_csc2_len;
 
-    version = get_csc2_version(db->tablename);
+    version = get_csc2_version(db->tablename_ip);
     if (version < 0) {
         logmsg(LOGMSG_ERROR, "%s: error getting current schema "
                              "version for table %s\n",
-               __func__, db->tablename);
+               __func__, db->tablename_ip);
         return -1;
     }
 
-    rc = get_csc2_file(db->tablename, version, &meta_csc2, &meta_csc2_len);
+    rc = get_csc2_file(db->tablename_ip, version, &meta_csc2, &meta_csc2_len);
     if (rc != 0 || !meta_csc2) {
         logmsg(LOGMSG_ERROR, "%s: could not load meta schema %d "
                              "for table %s rcode %d\n",
-               __func__, version, db->tablename, rc);
+               __func__, version, db->tablename_ip, rc);
         return -1;
     }
 
@@ -374,11 +374,11 @@ int dump_table_csc2_to_disk_fname(struct dbtable *db, const char *csc2_fname)
     free(meta_csc2);
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "error printing out schema for table '%s'\n",
-               db->tablename);
+               db->tablename_ip);
         return -1;
     }
 
-    logmsg(LOGMSG_DEBUG, "rewrote csc2 file for table %s\n", db->tablename);
+    logmsg(LOGMSG_DEBUG, "rewrote csc2 file for table %s\n", db->tablename_ip);
 
     return 0;
 }
@@ -396,21 +396,21 @@ int dump_table_csc2_to_disk(const char *table)
 
     if (p_db->dbtype != DBTYPE_TAGGED_TABLE) return 1;
 
-    if ((version = get_csc2_version(p_db->tablename)) < 0) {
+    if ((version = get_csc2_version(p_db->tablename_ip)) < 0) {
         logmsg(LOGMSG_ERROR,
                "dump_all_csc2_to_disk: error getting current schema version "
                "for table %s\n",
-               p_db->tablename);
+               p_db->tablename_ip);
         return -1;
     }
 
-    if ((rc = get_csc2_file(p_db->tablename, version, &meta_csc2,
+    if ((rc = get_csc2_file(p_db->tablename_ip, version, &meta_csc2,
                             &meta_csc2_len)) ||
         !meta_csc2) {
         logmsg(LOGMSG_ERROR,
                "dump_all_csc2_to_disk: could not load meta schema %d for table "
                "%s rcode %d\n",
-               version, p_db->tablename, rc);
+               version, p_db->tablename_ip, rc);
         return -1;
     }
 
@@ -418,11 +418,11 @@ int dump_table_csc2_to_disk(const char *table)
     free(meta_csc2);
     if (rc) {
         logmsg(LOGMSG_ERROR, "error printing out schema for table '%s'\n",
-               p_db->tablename);
+               p_db->tablename_ip);
         return -1;
     }
 
-    logmsg(LOGMSG_DEBUG, "rewrote csc2 file for table %s\n", p_db->tablename);
+    logmsg(LOGMSG_DEBUG, "rewrote csc2 file for table %s\n", p_db->tablename_ip);
 
     return 0;
 }

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -34,7 +34,7 @@ static int delete_table(struct dbtable *db, tran_type *tran)
         return -1;
     }
 
-    const char *table = db->tablename_ip;
+    const char *table = db->tablename_interned;
     delete_db(table);
     MEMORY_SYNC;
     delete_schema(table);
@@ -100,7 +100,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
 
     delete_table(db, tran);
     /*Now that we don't have any data, please clear unwanted schemas.*/
-    bdberr = bdb_reset_csc2_version(tran, db->tablename_ip, db->schema_version);
+    bdberr = bdb_reset_csc2_version(tran, db->tablename_interned, db->schema_version);
     if (bdberr != BDBERR_NOERROR) return -1;
 
     if ((rc = bdb_del_file_versions(db->handle, tran, &bdberr))) {
@@ -121,7 +121,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     /* Delete all access permissions related to this table. */
-    if ((rc = bdb_del_all_table_access(db->handle, tran, db->tablename_ip)) != 0)
+    if ((rc = bdb_del_all_table_access(db->handle, tran, db->tablename_interned)) != 0)
     {
         sc_errf(s, "Failed to delete access permissions\n");
         return rc;
@@ -138,7 +138,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     live_sc_off(db);
 
     if (!gbl_create_mode) {
-        logmsg(LOGMSG_INFO, "Table %s is at version: %lld\n", db->tablename_ip,
+        logmsg(LOGMSG_INFO, "Table %s is at version: %lld\n", db->tablename_interned,
                db->tableversion);
     }
 

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -121,7 +121,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     /* Delete all access permissions related to this table. */
-    if ((rc = bdb_del_all_table_access(db->handle, tran, db->tablename)) != 0)
+    if ((rc = bdb_del_all_table_access(db->handle, tran, db->tablename_ip)) != 0)
     {
         sc_errf(s, "Failed to delete access permissions\n");
         return rc;

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -34,7 +34,7 @@ static int delete_table(struct dbtable *db, tran_type *tran)
         return -1;
     }
 
-    char *table = db->tablename;
+    const char *table = db->tablename_ip;
     delete_db(table);
     MEMORY_SYNC;
     delete_schema(table);
@@ -100,7 +100,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
 
     delete_table(db, tran);
     /*Now that we don't have any data, please clear unwanted schemas.*/
-    bdberr = bdb_reset_csc2_version(tran, db->tablename, db->schema_version);
+    bdberr = bdb_reset_csc2_version(tran, db->tablename_ip, db->schema_version);
     if (bdberr != BDBERR_NOERROR) return -1;
 
     if ((rc = bdb_del_file_versions(db->handle, tran, &bdberr))) {
@@ -138,7 +138,7 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     live_sc_off(db);
 
     if (!gbl_create_mode) {
-        logmsg(LOGMSG_INFO, "Table %s is at version: %lld\n", db->tablename,
+        logmsg(LOGMSG_INFO, "Table %s is at version: %lld\n", db->tablename_ip,
                db->tableversion);
     }
 

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -87,7 +87,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     newdb->iq = iq;
 
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
         dyns_cleanup_globals();
@@ -159,7 +159,7 @@ int finalize_fastinit_table(struct ireq *iq, struct schema_change_type *s,
             sc_pending = iq->sc_pending;
             while (sc_pending != NULL) {
                 if (strcasecmp(sc_pending->tablename,
-                               cnstrt->lcltable->tablename) == 0)
+                               cnstrt->lcltable->tablename_ip) == 0)
                     break;
                 sc_pending = sc_pending->sc_next;
             }

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -87,7 +87,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     newdb->iq = iq;
 
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
-        backout_schemas(newdb->tablename_ip);
+        backout_schemas(newdb->tablename_interned);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
         dyns_cleanup_globals();
@@ -159,7 +159,7 @@ int finalize_fastinit_table(struct ireq *iq, struct schema_change_type *s,
             sc_pending = iq->sc_pending;
             while (sc_pending != NULL) {
                 if (strcasecmp(sc_pending->tablename,
-                               cnstrt->lcltable->tablename_ip) == 0)
+                               cnstrt->lcltable->tablename_interned) == 0)
                     break;
                 sc_pending = sc_pending->sc_next;
             }

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -232,7 +232,7 @@ static int set_original_tablename(struct schema_change_type *s)
 {
     struct dbtable *db = get_dbtable_by_name(s->tablename);
     if (db) {
-        strncpy0(s->tablename, db->tablename, sizeof(s->tablename));
+        strncpy0(s->tablename, db->tablename_ip, sizeof(s->tablename));
         return 0;
     }
     return 1;
@@ -988,14 +988,14 @@ int resume_schema_change(void)
         // unset downgrading flag
         thedb->dbs[i]->sc_downgrading = 0;
 
-        if (bdb_get_in_schema_change(NULL /*tran*/, thedb->dbs[i]->tablename,
+        if (bdb_get_in_schema_change(NULL /*tran*/, thedb->dbs[i]->tablename_ip,
                                      &packed_sc_data, &packed_sc_data_len,
                                      &bdberr) ||
             bdberr != BDBERR_NOERROR) {
             logmsg(LOGMSG_WARN,
                    "resume_schema_change: failed to discover "
                    "whether table: %s is in the middle of a schema change\n",
-                   thedb->dbs[i]->tablename);
+                   thedb->dbs[i]->tablename_ip);
             continue;
         }
 
@@ -1005,7 +1005,7 @@ int resume_schema_change(void)
             logmsg(LOGMSG_WARN,
                    "resume_schema_change: table: %s is in the middle of a "
                    "schema change, resuming...\n",
-                   thedb->dbs[i]->tablename);
+                   thedb->dbs[i]->tablename_ip);
 
             s = new_schemachange_type();
             if (!s) {
@@ -1025,7 +1025,7 @@ int resume_schema_change(void)
             free(packed_sc_data);
 
             if (scabort) {
-                rc = bdb_set_in_schema_change(NULL, thedb->dbs[i]->tablename,
+                rc = bdb_set_in_schema_change(NULL, thedb->dbs[i]->tablename_ip,
                                               NULL, 0, &bdberr);
                 if (rc)
                     logmsg(LOGMSG_ERROR,
@@ -1159,11 +1159,11 @@ int open_temp_db_resume(struct dbtable *db, char *prefix, int resume, int temp,
     int bdberr;
     int nbytes;
 
-    nbytes = snprintf(NULL, 0, "%s%s", prefix, db->tablename);
+    nbytes = snprintf(NULL, 0, "%s%s", prefix, db->tablename_ip);
     if (nbytes <= 0) nbytes = 2;
     nbytes++;
     tmpname = malloc(nbytes);
-    snprintf(tmpname, nbytes, "%s%s", prefix, db->tablename);
+    snprintf(tmpname, nbytes, "%s%s", prefix, db->tablename_ip);
 
     db->handle = NULL;
 
@@ -1344,7 +1344,7 @@ int delete_temp_table(struct ireq *iq, struct dbtable *newdb)
 
     for (i = 0; i < 1000; i++) {
         if (!s->retry_bad_genids)
-            sc_printf(s, "removing temp table for <%s>\n", newdb->tablename);
+            sc_printf(s, "removing temp table for <%s>\n", newdb->tablename_ip);
         if ((rc = bdb_del(newdb->handle, tran, &bdberr)) ||
             bdberr != BDBERR_NOERROR) {
             rc = -1;
@@ -1378,7 +1378,7 @@ int delete_temp_table(struct ireq *iq, struct dbtable *newdb)
     if (rc != 0) {
         sc_errf(s, "Still failed to delete temp table for %s.  I am giving up "
                    "and going home.",
-                newdb->tablename);
+                newdb->tablename_ip);
         iq->usedb = usedb_sav;
         return -1;
     }
@@ -1416,7 +1416,7 @@ int do_setcompr(struct ireq *iq, const char *rec, const char *blob)
     if ((rc = put_db_compress_blobs(db, tran, ba)) != 0) goto out;
     if ((rc = trans_commit(iq, tran, gbl_myhostname)) == 0) {
         logmsg(LOGMSG_USER, "%s -- TABLE:%s  REC COMP:%s  BLOB COMP:%s\n",
-               __func__, db->tablename, bdb_algo2compr(ra), bdb_algo2compr(ba));
+               __func__, db->tablename_ip, bdb_algo2compr(ra), bdb_algo2compr(ba));
     } else {
         sbuf2printf(iq->sb, ">%s -- trans_commit rc:%d\n", __func__, rc);
     }
@@ -1541,7 +1541,7 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
                 delete_db(s->tablename);
             }
             if (s->newdb) {
-                backout_schemas(s->newdb->tablename);
+                backout_schemas(s->newdb->tablename_ip);
             }
         } else if (s->db) {
             if (s->already_finalized)
@@ -1549,7 +1549,7 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
             else if (s->newdb) {
                 backout_constraint_pointers(s->newdb, s->db);
             }
-            change_schemas_recover(s->db->tablename);
+            change_schemas_recover(s->db->tablename_ip);
         }
         /* TODO: (NC) Also delete view? */
         sc_del_unused_files_tran(s->db, tran);

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -157,17 +157,17 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize)
     if (newdb->dbenv->master == gbl_myhostname) {
         /* I am master: create new db */
         newdb->handle =
-            bdb_create_queue(newdb->tablename_ip, thedb->basedir, avgitemsz,
+            bdb_create_queue(newdb->tablename_interned, thedb->basedir, avgitemsz,
                              pagesize, thedb->bdb_env, 0, &bdberr);
     } else {
         /* I am NOT master: open replicated db */
         newdb->handle =
-            bdb_open_more_queue(newdb->tablename_ip, thedb->basedir, avgitemsz,
+            bdb_open_more_queue(newdb->tablename_interned, thedb->basedir, avgitemsz,
                                 pagesize, thedb->bdb_env, 0, NULL, &bdberr);
     }
     if (newdb->handle == NULL) {
         logmsg(LOGMSG_ERROR, "bdb_open:failed to open queue %s/%s, rcode %d\n",
-               thedb->basedir, newdb->tablename_ip, bdberr);
+               thedb->basedir, newdb->tablename_interned, bdberr);
         return SC_BDB_ERROR;
     }
     add_to_qdbs(newdb);
@@ -247,7 +247,7 @@ int perform_trigger_update_replicant(const char *queue_name, scdone_t type)
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open queue %s/%s, rcode %d\n",
-                   thedb->basedir, db->tablename_ip, bdberr);
+                   thedb->basedir, db->tablename_interned, bdberr);
             rc = -1;
             goto done;
         }
@@ -551,12 +551,12 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
         /* I am master: create new db */
         db->handle =
-            bdb_create_queue_tran(tran, db->tablename_ip, thedb->basedir, 65536,
+            bdb_create_queue_tran(tran, db->tablename_interned, thedb->basedir, 65536,
                                   65536, thedb->bdb_env, 1, &bdberr);
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open queue %s/%s, rcode %d\n",
-                   thedb->basedir, db->tablename_ip, bdberr);
+                   thedb->basedir, db->tablename_interned, bdberr);
             goto done;
         }
 
@@ -648,7 +648,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
         /* stop */
         dbqueuedb_stop_consumers(db);
-        rc = javasp_do_procedure_op(JAVASP_OP_RELOAD, db->tablename_ip, NULL,
+        rc = javasp_do_procedure_op(JAVASP_OP_RELOAD, db->tablename_interned, NULL,
                                     config);
         if (rc) {
             sbuf2printf(sb,
@@ -671,13 +671,13 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         /* stop */
         dbqueuedb_stop_consumers(db);
 
-        javasp_do_procedure_op(JAVASP_OP_UNLOAD, db->tablename_ip, NULL, config);
+        javasp_do_procedure_op(JAVASP_OP_UNLOAD, db->tablename_interned, NULL, config);
 
         /* get us out of database list */
         remove_from_qdbs(db);
 
         /* get us out of llmeta */
-        rc = bdb_llmeta_drop_queue(db->handle, tran, db->tablename_ip, &bdberr);
+        rc = bdb_llmeta_drop_queue(db->handle, tran, db->tablename_interned, &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: bdb_llmeta_drop_queue rc %d bdberr %d\n",
                    __func__, rc, bdberr);

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -157,17 +157,17 @@ int add_queue_to_environment(char *table, int avgitemsz, int pagesize)
     if (newdb->dbenv->master == gbl_myhostname) {
         /* I am master: create new db */
         newdb->handle =
-            bdb_create_queue(newdb->tablename, thedb->basedir, avgitemsz,
+            bdb_create_queue(newdb->tablename_ip, thedb->basedir, avgitemsz,
                              pagesize, thedb->bdb_env, 0, &bdberr);
     } else {
         /* I am NOT master: open replicated db */
         newdb->handle =
-            bdb_open_more_queue(newdb->tablename, thedb->basedir, avgitemsz,
+            bdb_open_more_queue(newdb->tablename_ip, thedb->basedir, avgitemsz,
                                 pagesize, thedb->bdb_env, 0, NULL, &bdberr);
     }
     if (newdb->handle == NULL) {
         logmsg(LOGMSG_ERROR, "bdb_open:failed to open queue %s/%s, rcode %d\n",
-               thedb->basedir, newdb->tablename, bdberr);
+               thedb->basedir, newdb->tablename_ip, bdberr);
         return SC_BDB_ERROR;
     }
     add_to_qdbs(newdb);
@@ -247,7 +247,7 @@ int perform_trigger_update_replicant(const char *queue_name, scdone_t type)
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open queue %s/%s, rcode %d\n",
-                   thedb->basedir, db->tablename, bdberr);
+                   thedb->basedir, db->tablename_ip, bdberr);
             rc = -1;
             goto done;
         }
@@ -551,12 +551,12 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
         /* I am master: create new db */
         db->handle =
-            bdb_create_queue_tran(tran, db->tablename, thedb->basedir, 65536,
+            bdb_create_queue_tran(tran, db->tablename_ip, thedb->basedir, 65536,
                                   65536, thedb->bdb_env, 1, &bdberr);
         if (db->handle == NULL) {
             logmsg(LOGMSG_ERROR,
                    "bdb_open:failed to open queue %s/%s, rcode %d\n",
-                   thedb->basedir, db->tablename, bdberr);
+                   thedb->basedir, db->tablename_ip, bdberr);
             goto done;
         }
 
@@ -648,7 +648,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
         /* stop */
         dbqueuedb_stop_consumers(db);
-        rc = javasp_do_procedure_op(JAVASP_OP_RELOAD, db->tablename, NULL,
+        rc = javasp_do_procedure_op(JAVASP_OP_RELOAD, db->tablename_ip, NULL,
                                     config);
         if (rc) {
             sbuf2printf(sb,
@@ -671,13 +671,13 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         /* stop */
         dbqueuedb_stop_consumers(db);
 
-        javasp_do_procedure_op(JAVASP_OP_UNLOAD, db->tablename, NULL, config);
+        javasp_do_procedure_op(JAVASP_OP_UNLOAD, db->tablename_ip, NULL, config);
 
         /* get us out of database list */
         remove_from_qdbs(db);
 
         /* get us out of llmeta */
-        rc = bdb_llmeta_drop_queue(db->handle, tran, db->tablename, &bdberr);
+        rc = bdb_llmeta_drop_queue(db->handle, tran, db->tablename_ip, &bdberr);
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: bdb_llmeta_drop_queue rc %d bdberr %d\n",
                    __func__, rc, bdberr);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -95,7 +95,7 @@ static inline void print_final_sc_stat(struct convert_record_data *data)
     sc_printf(
         data->s,
         "[%s] TOTAL converted %lld sc_adds %d sc_updates %d sc_deletess %d\n",
-        data->from->tablename,
+        data->from->tablename_ip,
         data->from->sc_nrecs - (data->from->sc_adds + data->from->sc_updates +
                                 data->from->sc_deletes),
         data->from->sc_adds, data->from->sc_updates, data->from->sc_deletes);
@@ -129,7 +129,7 @@ static inline int print_aggregate_sc_stat(struct convert_record_data *data,
         sc_printf(data->s,
                   "[%s] >> adds %u upds %d dels %u extra genids "
                   "%u\n",
-                  data->from->tablename, data->from->sc_adds,
+                  data->from->tablename_ip, data->from->sc_adds,
                   data->from->sc_updates, data->from->sc_deletes,
                   data->from->sc_adds + data->from->sc_updates);
 
@@ -142,7 +142,7 @@ static inline int print_aggregate_sc_stat(struct convert_record_data *data,
     sc_printf(data->s,
               "[%s] progress TOTAL %lld +%lld actual "
               "progress total %lld rate %lld r/s\n",
-              data->from->tablename, data->from->sc_nrecs, total_nrecs_diff,
+              data->from->tablename_ip, data->from->sc_nrecs, total_nrecs_diff,
               data->from->sc_nrecs -
                   (data->from->sc_adds + data->from->sc_updates),
               total_nrecs_diff / sc_report_freq);
@@ -211,7 +211,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
     if (!s->resume) {
         /* if we may have to resume this schema change, clear the progress in
          * llmeta */
-        if (bdb_clear_high_genid(NULL /*input_trans*/, db->tablename,
+        if (bdb_clear_high_genid(NULL /*input_trans*/, db->tablename_ip,
                                  db->dtastripe, &bdberr) ||
             bdberr != BDBERR_NOERROR) {
             logmsg(LOGMSG_ERROR, "init_sc_genids: failed to clear high "
@@ -243,7 +243,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
             if (rc == 1)
                 sc_genids[stripe] = 0ULL;
         } else
-            rc = bdb_get_high_genid(db->tablename, stripe, &sc_genids[stripe],
+            rc = bdb_get_high_genid(db->tablename_ip, stripe, &sc_genids[stripe],
                                     &bdberr);
         if (rc < 0 || bdberr != BDBERR_NOERROR) {
             sc_errf(s, "init_sc_genids: failed to find newest genid for "
@@ -252,7 +252,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
             free(rec);
             return -1;
         }
-        sc_printf(s, "[%s] resuming stripe %2d from 0x%016llx\n", db->tablename,
+        sc_printf(s, "[%s] resuming stripe %2d from 0x%016llx\n", db->tablename_ip,
                   stripe, sc_genids[stripe]);
     }
 
@@ -422,7 +422,7 @@ static int report_sc_progress(struct convert_record_data *data, int now)
         sc_printf(data->s,
                   "[%s] progress stripe %d changed genids %u progress %lld"
                   " recs +%lld (%lld r/s)\n",
-                  data->from->tablename, data->stripe, data->n_genids_changed,
+                  data->from->tablename_ip, data->stripe, data->n_genids_changed,
                   data->nrecs, diff_nrecs, diff_nrecs / copy_sc_report_freq);
 
         /* now do global sc data */
@@ -459,7 +459,7 @@ static int prepare_and_verify_newdb_record(struct convert_record_data *data,
         /* convert current.  this converts blob fields, but we need to make sure
          * we add the right blobs separately. */
         rc = convert_server_record_cachedmap(
-            data->to->tablename, data->tagmap, dta, data->rec->recbuf, data->s,
+            data->to->tablename_ip, data->tagmap, dta, data->rec->recbuf, data->s,
             data->from->schema, data->to->schema, data->wrblb,
             sizeof(data->wrblb) / sizeof(data->wrblb[0]));
         if (rc) {
@@ -687,7 +687,7 @@ static int convert_record(struct convert_record_data *data)
                 sc_printf(
                     data->s,
                     "[%s] finished converting stripe %d, last genid %llx\n",
-                    data->from->tablename, data->stripe,
+                    data->from->tablename_ip, data->stripe,
                     data->sc_genids[data->stripe]);
                 return 0;
             }
@@ -712,13 +712,13 @@ static int convert_record(struct convert_record_data *data)
             rc = 0;
             if (usellmeta && !is_dta_being_rebuilt(data->to->plan)) {
                 int bdberr;
-                rc = bdb_set_high_genid_stripe(NULL, data->to->tablename,
+                rc = bdb_set_high_genid_stripe(NULL, data->to->tablename_ip,
                                                data->stripe, -1ULL, &bdberr);
                 if (rc != 0) rc = -1; // convert_record expects -1
             }
             sc_printf(data->s,
                       "[%s] finished stripe %d, setting genid %llx, rc %d\n",
-                      data->from->tablename, data->stripe,
+                      data->from->tablename_ip, data->stripe,
                       data->sc_genids[data->stripe], rc);
             return rc;
         } else if (rc == RC_INTERNAL_RETRY) {
@@ -848,7 +848,7 @@ static int convert_record(struct convert_record_data *data)
             return -2;
         }
         rc = check_and_repair_blob_consistency(
-            &data->iq, data->iq.usedb->tablename, ".ONDISK", &data->blb, dta);
+            &data->iq, data->iq.usedb->tablename_ip, ".ONDISK", &data->blb, dta);
 
         if (data->s->force_rebuild || data->s->use_old_blobs_on_rebuild) {
             for (int ii = 0; ii < data->from->numblobs; ii++) {
@@ -951,7 +951,7 @@ static int convert_record(struct convert_record_data *data)
         (data->nrecs %
          BDB_ATTR_GET(thedb->bdb_attr, INDEXREBUILD_SAVE_EVERY_N)) == 0) {
         int bdberr;
-        rc = bdb_set_high_genid(data->trans, data->to->tablename, genid,
+        rc = bdb_set_high_genid(data->trans, data->to->tablename_ip, genid,
                                 &bdberr);
         if (rc != 0) {
             if (bdberr == BDBERR_DEADLOCK)
@@ -1136,7 +1136,7 @@ void *convert_records_thd(struct convert_record_data *data)
     data->outrc = -1;
     data->curkey = data->key1;
     data->lastkey = data->key2;
-    data->rec = allocate_db_record(data->to->tablename, ".NEW..ONDISK");
+    data->rec = allocate_db_record(data->to->tablename_ip, ".NEW..ONDISK");
     data->dta_buf = malloc(data->from->lrl);
     if (!data->dta_buf) {
         sc_errf(data->s, "convert_records_thd: ran out of memory trying to "
@@ -1220,7 +1220,7 @@ cleanup:
         sc_printf(data->s,
                   "[%s] successfully converted %lld records with %d retries "
                   "stripe %d\n",
-                  data->from->tablename, data->nrecs, data->totnretries,
+                  data->from->tablename_ip, data->nrecs, data->totnretries,
                   data->stripe);
     } else {
         if (gbl_sc_abort || data->from->sc_abort ||
@@ -1311,18 +1311,18 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
         for (ii = 0; ii < data.blb.numcblobs; ii++) {
             data.blb.cblob_disk_ixs[ii] = ii;
             data.blb.cblob_tag_ixs[ii] =
-                get_schema_blob_field_idx(data.from->tablename, ".ONDISK", ii);
+                get_schema_blob_field_idx(data.from->tablename_ip, ".ONDISK", ii);
         }
         for (ii = 0; ii < data.to->numblobs; ii++) {
             int map;
             map =
-                tbl_blob_no_to_tbl_blob_no(data.to->tablename, ".NEW..ONDISK",
-                                           ii, data.from->tablename, ".ONDISK");
+                tbl_blob_no_to_tbl_blob_no(data.to->tablename_ip, ".NEW..ONDISK",
+                                           ii, data.from->tablename_ip, ".ONDISK");
             if (map < 0 && map != -3) {
                 sc_errf(data.s,
                         "convert_all_records: error mapping blob %d "
                         "from %s:%s to %s:%s blob_no_to_blob_no rcode %d\n",
-                        ii, data.from->tablename, ".ONDISK", data.to->tablename,
+                        ii, data.from->tablename_ip, ".ONDISK", data.to->tablename_ip,
                         ".NEW..ONDISK", map);
                 return -1;
             }
@@ -1477,14 +1477,14 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
 
             if (sc_genids[ii] == -1ULL) {
                 sc_printf(threadData[ii].s, "[%s] stripe %d was done\n",
-                          from->tablename, threadData[ii].stripe);
+                          from->tablename_ip, threadData[ii].stripe);
                 threadSkipped[ii] = 1;
                 continue;
             } else
                 threadSkipped[ii] = 0;
 
             sc_printf(threadData[ii].s, "[%s] starting thread for stripe: %d\n",
-                      from->tablename, threadData[ii].stripe);
+                      from->tablename_ip, threadData[ii].stripe);
 
             /* start thread */
             /* convert_records_thd( &threadData[ ii ]); |+ serialized calls +|*/
@@ -1497,7 +1497,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                 sc_errf(threadData[ii].s,
                         "[%s] starting thread failed for"
                         " stripe: %d with return code: %d\n",
-                        from->tablename, threadData[ii].stripe, rc);
+                        from->tablename_ip, threadData[ii].stripe, rc);
 
                 outrc = -1;
                 break;
@@ -1565,7 +1565,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
     if (s->logical_livesc) {
         if (outrc == 0) {
             sc_printf(s, "[%s] All convert threads finished\n",
-                      from->tablename);
+                      from->tablename_ip);
         }
         stop_sc_redo_wait(from->handle, s);
     }
@@ -1930,7 +1930,7 @@ int upgrade_all_records(struct dbtable *db, unsigned long long *sc_genids,
             thread_data[idx] = data;
             thread_data[idx].stripe = idx;
             sc_printf(thread_data[idx].s,
-                      "[%s] starting thread for stripe: %d\n", db->tablename,
+                      "[%s] starting thread for stripe: %d\n", db->tablename_ip,
                       thread_data[idx].stripe);
 
             rc = pthread_create(&thread_data[idx].tid, &attr,
@@ -2474,7 +2474,7 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
                               "add key constraint duplicate key '%s' on table "
                               "'%s' index %d",
                               get_keynm_from_db_idx(data->to, ixfailnum),
-                              data->to->tablename, ixfailnum);
+                              data->to->tablename_ip, ixfailnum);
                 else
                     reqerrstr(data->s->iq, ERR_SC,
                               "unable to add record rc = %d", rc);
@@ -2488,7 +2488,7 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
 
     if (!is_dta_being_rebuilt(data->to->plan)) {
         int bdberr;
-        rc = bdb_set_high_genid(data->trans, data->to->tablename, genid,
+        rc = bdb_set_high_genid(data->trans, data->to->tablename_ip, genid,
                                 &bdberr);
         if (rc != 0) {
             if (bdberr == BDBERR_DEADLOCK)
@@ -3168,7 +3168,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
 
     /* init all buffer needed by this thread to do logical redo so we don't need
      * to malloc & free every single time */
-    data->rec = allocate_db_record(data->to->tablename, ".NEW..ONDISK");
+    data->rec = allocate_db_record(data->to->tablename_ip, ".NEW..ONDISK");
     data->iq.usedb = data->to;
     data->blob_hash = hash_init_o(offsetof(struct blob_recs, genid),
                                   sizeof(unsigned long long));
@@ -3359,7 +3359,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             sc_printf(s,
                       "[%s] logical redo at LSN [%u][%u] transactions done "
                       "+%lld (%lld txn/s). Redo List Size: %d\n",
-                      data->from->tablename, curLsn.file, curLsn.offset,
+                      data->from->tablename_ip, curLsn.file, curLsn.offset,
                       diff_nrecs, diff_nrecs / copy_sc_report_freq,
                       sc_redo_size(bdb_state));
         }

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -95,7 +95,7 @@ static inline void print_final_sc_stat(struct convert_record_data *data)
     sc_printf(
         data->s,
         "[%s] TOTAL converted %lld sc_adds %d sc_updates %d sc_deletess %d\n",
-        data->from->tablename_ip,
+        data->from->tablename_interned,
         data->from->sc_nrecs - (data->from->sc_adds + data->from->sc_updates +
                                 data->from->sc_deletes),
         data->from->sc_adds, data->from->sc_updates, data->from->sc_deletes);
@@ -129,7 +129,7 @@ static inline int print_aggregate_sc_stat(struct convert_record_data *data,
         sc_printf(data->s,
                   "[%s] >> adds %u upds %d dels %u extra genids "
                   "%u\n",
-                  data->from->tablename_ip, data->from->sc_adds,
+                  data->from->tablename_interned, data->from->sc_adds,
                   data->from->sc_updates, data->from->sc_deletes,
                   data->from->sc_adds + data->from->sc_updates);
 
@@ -142,7 +142,7 @@ static inline int print_aggregate_sc_stat(struct convert_record_data *data,
     sc_printf(data->s,
               "[%s] progress TOTAL %lld +%lld actual "
               "progress total %lld rate %lld r/s\n",
-              data->from->tablename_ip, data->from->sc_nrecs, total_nrecs_diff,
+              data->from->tablename_interned, data->from->sc_nrecs, total_nrecs_diff,
               data->from->sc_nrecs -
                   (data->from->sc_adds + data->from->sc_updates),
               total_nrecs_diff / sc_report_freq);
@@ -211,7 +211,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
     if (!s->resume) {
         /* if we may have to resume this schema change, clear the progress in
          * llmeta */
-        if (bdb_clear_high_genid(NULL /*input_trans*/, db->tablename_ip,
+        if (bdb_clear_high_genid(NULL /*input_trans*/, db->tablename_interned,
                                  db->dtastripe, &bdberr) ||
             bdberr != BDBERR_NOERROR) {
             logmsg(LOGMSG_ERROR, "init_sc_genids: failed to clear high "
@@ -243,7 +243,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
             if (rc == 1)
                 sc_genids[stripe] = 0ULL;
         } else
-            rc = bdb_get_high_genid(db->tablename_ip, stripe, &sc_genids[stripe],
+            rc = bdb_get_high_genid(db->tablename_interned, stripe, &sc_genids[stripe],
                                     &bdberr);
         if (rc < 0 || bdberr != BDBERR_NOERROR) {
             sc_errf(s, "init_sc_genids: failed to find newest genid for "
@@ -252,7 +252,7 @@ int init_sc_genids(struct dbtable *db, struct schema_change_type *s)
             free(rec);
             return -1;
         }
-        sc_printf(s, "[%s] resuming stripe %2d from 0x%016llx\n", db->tablename_ip,
+        sc_printf(s, "[%s] resuming stripe %2d from 0x%016llx\n", db->tablename_interned,
                   stripe, sc_genids[stripe]);
     }
 
@@ -422,7 +422,7 @@ static int report_sc_progress(struct convert_record_data *data, int now)
         sc_printf(data->s,
                   "[%s] progress stripe %d changed genids %u progress %lld"
                   " recs +%lld (%lld r/s)\n",
-                  data->from->tablename_ip, data->stripe, data->n_genids_changed,
+                  data->from->tablename_interned, data->stripe, data->n_genids_changed,
                   data->nrecs, diff_nrecs, diff_nrecs / copy_sc_report_freq);
 
         /* now do global sc data */
@@ -459,7 +459,7 @@ static int prepare_and_verify_newdb_record(struct convert_record_data *data,
         /* convert current.  this converts blob fields, but we need to make sure
          * we add the right blobs separately. */
         rc = convert_server_record_cachedmap(
-            data->to->tablename_ip, data->tagmap, dta, data->rec->recbuf, data->s,
+            data->to->tablename_interned, data->tagmap, dta, data->rec->recbuf, data->s,
             data->from->schema, data->to->schema, data->wrblb,
             sizeof(data->wrblb) / sizeof(data->wrblb[0]));
         if (rc) {
@@ -687,7 +687,7 @@ static int convert_record(struct convert_record_data *data)
                 sc_printf(
                     data->s,
                     "[%s] finished converting stripe %d, last genid %llx\n",
-                    data->from->tablename_ip, data->stripe,
+                    data->from->tablename_interned, data->stripe,
                     data->sc_genids[data->stripe]);
                 return 0;
             }
@@ -712,13 +712,13 @@ static int convert_record(struct convert_record_data *data)
             rc = 0;
             if (usellmeta && !is_dta_being_rebuilt(data->to->plan)) {
                 int bdberr;
-                rc = bdb_set_high_genid_stripe(NULL, data->to->tablename_ip,
+                rc = bdb_set_high_genid_stripe(NULL, data->to->tablename_interned,
                                                data->stripe, -1ULL, &bdberr);
                 if (rc != 0) rc = -1; // convert_record expects -1
             }
             sc_printf(data->s,
                       "[%s] finished stripe %d, setting genid %llx, rc %d\n",
-                      data->from->tablename_ip, data->stripe,
+                      data->from->tablename_interned, data->stripe,
                       data->sc_genids[data->stripe], rc);
             return rc;
         } else if (rc == RC_INTERNAL_RETRY) {
@@ -848,7 +848,7 @@ static int convert_record(struct convert_record_data *data)
             return -2;
         }
         rc = check_and_repair_blob_consistency(
-            &data->iq, data->iq.usedb->tablename_ip, ".ONDISK", &data->blb, dta);
+            &data->iq, data->iq.usedb->tablename_interned, ".ONDISK", &data->blb, dta);
 
         if (data->s->force_rebuild || data->s->use_old_blobs_on_rebuild) {
             for (int ii = 0; ii < data->from->numblobs; ii++) {
@@ -951,7 +951,7 @@ static int convert_record(struct convert_record_data *data)
         (data->nrecs %
          BDB_ATTR_GET(thedb->bdb_attr, INDEXREBUILD_SAVE_EVERY_N)) == 0) {
         int bdberr;
-        rc = bdb_set_high_genid(data->trans, data->to->tablename_ip, genid,
+        rc = bdb_set_high_genid(data->trans, data->to->tablename_interned, genid,
                                 &bdberr);
         if (rc != 0) {
             if (bdberr == BDBERR_DEADLOCK)
@@ -1136,7 +1136,7 @@ void *convert_records_thd(struct convert_record_data *data)
     data->outrc = -1;
     data->curkey = data->key1;
     data->lastkey = data->key2;
-    data->rec = allocate_db_record(data->to->tablename_ip, ".NEW..ONDISK");
+    data->rec = allocate_db_record(data->to->tablename_interned, ".NEW..ONDISK");
     data->dta_buf = malloc(data->from->lrl);
     if (!data->dta_buf) {
         sc_errf(data->s, "convert_records_thd: ran out of memory trying to "
@@ -1220,7 +1220,7 @@ cleanup:
         sc_printf(data->s,
                   "[%s] successfully converted %lld records with %d retries "
                   "stripe %d\n",
-                  data->from->tablename_ip, data->nrecs, data->totnretries,
+                  data->from->tablename_interned, data->nrecs, data->totnretries,
                   data->stripe);
     } else {
         if (gbl_sc_abort || data->from->sc_abort ||
@@ -1311,18 +1311,18 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
         for (ii = 0; ii < data.blb.numcblobs; ii++) {
             data.blb.cblob_disk_ixs[ii] = ii;
             data.blb.cblob_tag_ixs[ii] =
-                get_schema_blob_field_idx(data.from->tablename_ip, ".ONDISK", ii);
+                get_schema_blob_field_idx(data.from->tablename_interned, ".ONDISK", ii);
         }
         for (ii = 0; ii < data.to->numblobs; ii++) {
             int map;
             map =
-                tbl_blob_no_to_tbl_blob_no(data.to->tablename_ip, ".NEW..ONDISK",
-                                           ii, data.from->tablename_ip, ".ONDISK");
+                tbl_blob_no_to_tbl_blob_no(data.to->tablename_interned, ".NEW..ONDISK",
+                                           ii, data.from->tablename_interned, ".ONDISK");
             if (map < 0 && map != -3) {
                 sc_errf(data.s,
                         "convert_all_records: error mapping blob %d "
                         "from %s:%s to %s:%s blob_no_to_blob_no rcode %d\n",
-                        ii, data.from->tablename_ip, ".ONDISK", data.to->tablename_ip,
+                        ii, data.from->tablename_interned, ".ONDISK", data.to->tablename_interned,
                         ".NEW..ONDISK", map);
                 return -1;
             }
@@ -1477,14 +1477,14 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
 
             if (sc_genids[ii] == -1ULL) {
                 sc_printf(threadData[ii].s, "[%s] stripe %d was done\n",
-                          from->tablename_ip, threadData[ii].stripe);
+                          from->tablename_interned, threadData[ii].stripe);
                 threadSkipped[ii] = 1;
                 continue;
             } else
                 threadSkipped[ii] = 0;
 
             sc_printf(threadData[ii].s, "[%s] starting thread for stripe: %d\n",
-                      from->tablename_ip, threadData[ii].stripe);
+                      from->tablename_interned, threadData[ii].stripe);
 
             /* start thread */
             /* convert_records_thd( &threadData[ ii ]); |+ serialized calls +|*/
@@ -1497,7 +1497,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                 sc_errf(threadData[ii].s,
                         "[%s] starting thread failed for"
                         " stripe: %d with return code: %d\n",
-                        from->tablename_ip, threadData[ii].stripe, rc);
+                        from->tablename_interned, threadData[ii].stripe, rc);
 
                 outrc = -1;
                 break;
@@ -1565,7 +1565,7 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
     if (s->logical_livesc) {
         if (outrc == 0) {
             sc_printf(s, "[%s] All convert threads finished\n",
-                      from->tablename_ip);
+                      from->tablename_interned);
         }
         stop_sc_redo_wait(from->handle, s);
     }
@@ -1930,7 +1930,7 @@ int upgrade_all_records(struct dbtable *db, unsigned long long *sc_genids,
             thread_data[idx] = data;
             thread_data[idx].stripe = idx;
             sc_printf(thread_data[idx].s,
-                      "[%s] starting thread for stripe: %d\n", db->tablename_ip,
+                      "[%s] starting thread for stripe: %d\n", db->tablename_interned,
                       thread_data[idx].stripe);
 
             rc = pthread_create(&thread_data[idx].tid, &attr,
@@ -2474,7 +2474,7 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
                               "add key constraint duplicate key '%s' on table "
                               "'%s' index %d",
                               get_keynm_from_db_idx(data->to, ixfailnum),
-                              data->to->tablename_ip, ixfailnum);
+                              data->to->tablename_interned, ixfailnum);
                 else
                     reqerrstr(data->s->iq, ERR_SC,
                               "unable to add record rc = %d", rc);
@@ -2488,7 +2488,7 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
 
     if (!is_dta_being_rebuilt(data->to->plan)) {
         int bdberr;
-        rc = bdb_set_high_genid(data->trans, data->to->tablename_ip, genid,
+        rc = bdb_set_high_genid(data->trans, data->to->tablename_interned, genid,
                                 &bdberr);
         if (rc != 0) {
             if (bdberr == BDBERR_DEADLOCK)
@@ -3168,7 +3168,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
 
     /* init all buffer needed by this thread to do logical redo so we don't need
      * to malloc & free every single time */
-    data->rec = allocate_db_record(data->to->tablename_ip, ".NEW..ONDISK");
+    data->rec = allocate_db_record(data->to->tablename_interned, ".NEW..ONDISK");
     data->iq.usedb = data->to;
     data->blob_hash = hash_init_o(offsetof(struct blob_recs, genid),
                                   sizeof(unsigned long long));
@@ -3359,7 +3359,7 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             sc_printf(s,
                       "[%s] logical redo at LSN [%u][%u] transactions done "
                       "+%lld (%lld txn/s). Redo List Size: %d\n",
-                      data->from->tablename_ip, curLsn.file, curLsn.offset,
+                      data->from->tablename_interned, curLsn.file, curLsn.offset,
                       diff_nrecs, diff_nrecs / copy_sc_report_freq,
                       sc_redo_size(bdb_state));
         }

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -56,7 +56,7 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     char *newname = strdup(s->newtable);
     int rc = 0;
     int bdberr = 0;
-    char *oldname = NULL;
+    const char *oldname = NULL;
 
     assert(s->rename);
     if (!newname) {
@@ -82,14 +82,14 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
                                    db->schema_version, &bdberr);
     if (rc) {
         sc_errf(s, "Failed to rename metadata structure for %s\n",
-                db->tablename);
+                db->tablename_ip);
         goto tran_error;
     }
 
     /* update the table options */
     rc = rename_table_options(tran, db, newname);
     if (rc) {
-        sc_errf(s, "Failed to rename table options for %s\n", db->tablename);
+        sc_errf(s, "Failed to rename table options for %s\n", db->tablename_ip);
         goto tran_error;
     }
 
@@ -101,7 +101,7 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     }
 
     /* fragile, handle with care */
-    oldname = db->tablename;
+    oldname = db->tablename_ip;
     rc = rename_db(db, newname);
     if (rc) {
         /* crash the schema change, next master will hopefully have more memory
@@ -121,7 +121,7 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     /* set table version for the renamed name */
     rc = table_version_set(tran, newname, db->tableversion + 1);
     if (rc) {
-        sc_errf(s, "Failed to set table version for %s\n", db->tablename);
+        sc_errf(s, "Failed to set table version for %s\n", db->tablename_ip);
         goto tran_error;
     }
 
@@ -136,9 +136,6 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     gbl_sc_commit_count++;
 
     live_sc_off(db);
-
-    if (oldname)
-        free(oldname);
 
     return rc;
 

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -96,7 +96,7 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     /* Update table sequences */
     rc = rename_table_sequences(tran, db, newname);
     if (rc) {
-        sc_errf(s, "Failed to rename table sequences for %s\n", db->tablename);
+        sc_errf(s, "Failed to rename table sequences for %s\n", db->tablename_ip);
         goto tran_error;
     }
 

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -82,26 +82,26 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
                                    db->schema_version, &bdberr);
     if (rc) {
         sc_errf(s, "Failed to rename metadata structure for %s\n",
-                db->tablename_ip);
+                db->tablename_interned);
         goto tran_error;
     }
 
     /* update the table options */
     rc = rename_table_options(tran, db, newname);
     if (rc) {
-        sc_errf(s, "Failed to rename table options for %s\n", db->tablename_ip);
+        sc_errf(s, "Failed to rename table options for %s\n", db->tablename_interned);
         goto tran_error;
     }
 
     /* Update table sequences */
     rc = rename_table_sequences(tran, db, newname);
     if (rc) {
-        sc_errf(s, "Failed to rename table sequences for %s\n", db->tablename_ip);
+        sc_errf(s, "Failed to rename table sequences for %s\n", db->tablename_interned);
         goto tran_error;
     }
 
     /* fragile, handle with care */
-    oldname = db->tablename_ip;
+    oldname = db->tablename_interned;
     rc = rename_db(db, newname);
     if (rc) {
         /* crash the schema change, next master will hopefully have more memory
@@ -121,7 +121,7 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     /* set table version for the renamed name */
     rc = table_version_set(tran, newname, db->tableversion + 1);
     if (rc) {
-        sc_errf(s, "Failed to set table version for %s\n", db->tablename_ip);
+        sc_errf(s, "Failed to set table version for %s\n", db->tablename_interned);
         goto tran_error;
     }
 

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -51,7 +51,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
             rc = ERR_CONSTR;
             goto done;
         }
-        rc = stag_to_stag_buf(db->tablename, from, old_dta, ".NEW..ONDISK",
+        rc = stag_to_stag_buf(db->tablename_ip, from, old_dta, ".NEW..ONDISK",
                               new_dta, &reason);
         if (rc) {
             rc = ERR_CONSTR;
@@ -78,7 +78,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         /* Name: .NEW.COLUMNNAME -> .NEW..ONDISK_IX_nn */
         snprintf(lcl_tag, sizeof lcl_tag, ".NEW.%s", ct->lclkeyname);
-        rc = getidxnumbyname(db->tablename, lcl_tag, &lcl_idx);
+        rc = getidxnumbyname(db->tablename_ip, lcl_tag, &lcl_idx);
         if (rc) {
             logmsg(LOGMSG_ERROR, "could not get index for %s\n", lcl_tag);
             rc = ERR_CONSTR;
@@ -97,7 +97,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
         if (iq->idxInsert && !convert)
             memcpy(lcl_key, iq->idxInsert[lcl_idx], db->ix_keylen[lcl_idx]);
         else
-            rc = stag_to_stag_buf_blobs(db->tablename, from, od_dta, lcl_tag,
+            rc = stag_to_stag_buf_blobs(db->tablename_ip, from, od_dta, lcl_tag,
                                         lcl_key, NULL, blobs, maxblobs, 0);
         if (rc) {
             rc = ERR_CONSTR;
@@ -112,12 +112,12 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         int ri;
         rc = check_single_key_constraint(&ruleiq, ct, lcl_tag, lcl_key,
-                                         db->tablename, trans, &ri);
+                                         db->tablename_ip, trans, &ri);
         if (rc == RC_INTERNAL_RETRY) {
             break;
         } else if (rc && rc != ERR_CONSTR) {
             logmsg(LOGMSG_ERROR, "fk violation: %s @ %s -> %s @ %s, rc=%d\n",
-                   ct->lclkeyname, db->tablename, ct->keynm[ri], ct->table[ri],
+                   ct->lclkeyname, db->tablename_ip, ct->keynm[ri], ct->table[ri],
                    rc);
             fsnapf(stderr, lcl_key, lcl_len > 32 ? 32 : lcl_len);
             logmsg(LOGMSG_ERROR, "\n");
@@ -156,11 +156,11 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             char lkey[MAXKEYLEN];
             int fndrrn;
             unsigned long long genid;
-            if (strcasecmp(cnstrt->table[j], to_db->tablename)) {
+            if (strcasecmp(cnstrt->table[j], to_db->tablename_ip)) {
                 continue;
             }
             ldb = get_dbtable_by_name(cnstrt->table[j]);
-            if (strcasecmp(ldb->tablename, newdb->tablename)) {
+            if (strcasecmp(ldb->tablename_ip, newdb->tablename_ip)) {
                 logmsg(LOGMSG_FATAL, "%s: failed to find table\n", __func__);
                 abort();
                 return ERR_INTERNAL;
@@ -184,7 +184,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             snprintf(ondisk_tag, sizeof(ondisk_tag), ".NEW..ONDISK_IX_%d",
                      ixnum);
             /* Data -> Key : ONDISK -> .ONDISK_IX_nn */
-            rc = stag_to_stag_buf(newdb->tablename, from, od_dta, ondisk_tag,
+            rc = stag_to_stag_buf(newdb->tablename_ip, from, od_dta, ondisk_tag,
                                   lkey, NULL);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: failed to convert to '%s'\n",
@@ -192,7 +192,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
                 return ERR_CONVERT_IX;
             }
             /* here we convert the key into return db format */
-            rc = getidxnumbyname(cnstrt->lcltable->tablename,
+            rc = getidxnumbyname(cnstrt->lcltable->tablename_ip,
                                  cnstrt->lclkeyname, &rixnum);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: unknown keytag '%s'\n", __func__,
@@ -205,7 +205,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             int nulls = 0;
 
             rixlen = rc = stag_to_stag_buf_ckey(
-                ldb->tablename, ondisk_tag, lkey, cnstrt->lcltable->tablename,
+                ldb->tablename_ip, ondisk_tag, lkey, cnstrt->lcltable->tablename_ip,
                 rondisk_tag, rkey, &nulls, PK2FK);
             if (rc == -1) {
                 /* I followed the logic in check_update_constraints */
@@ -273,7 +273,7 @@ static int verify_constraints_forward_changes(struct dbtable *db, struct dbtable
                    that changed...otherwise, need to re-verify
                 */
                 for (j = 0; j < ct->nrules; j++) {
-                    if (!strcasecmp(db->tablename, ct->table[j])) {
+                    if (!strcasecmp(db->tablename_ip, ct->table[j])) {
                         rc = has_index_changed(db, ct->keynm[j], 1, 1 /*new*/,
                                                NULL, 0);
                         if (rc == 0)
@@ -414,30 +414,30 @@ int prepare_table_version_one(tran_type *tran, struct dbtable *db,
     char tag[MAXTAGLEN];
 
     /* For init with instant_sc, add ONDISK as version 1.  */
-    rc = get_csc2_file_tran(db->tablename, -1, &ondisk_text, NULL, tran);
+    rc = get_csc2_file_tran(db->tablename_ip, -1, &ondisk_text, NULL, tran);
     if (rc) {
         logmsg(LOGMSG_FATAL,
                "Couldn't get latest csc2 from llmeta for %s! PANIC!!\n",
-               db->tablename);
+               db->tablename_ip);
         exit(1);
     }
 
     /* db's version has been reset */
-    bdberr = bdb_reset_csc2_version(tran, db->tablename, db->schema_version);
+    bdberr = bdb_reset_csc2_version(tran, db->tablename_ip, db->schema_version);
     if (bdberr != BDBERR_NOERROR) return SC_BDB_ERROR;
 
     /* Add latest csc2 as version 1 */
-    rc = bdb_new_csc2(tran, db->tablename, 1, ondisk_text, &bdberr);
+    rc = bdb_new_csc2(tran, db->tablename_ip, 1, ondisk_text, &bdberr);
     free(ondisk_text);
     if (rc != 0) {
         logmsg(LOGMSG_FATAL, "Couldn't save in llmeta! PANIC!!");
         exit(1);
     }
 
-    ondisk_schema = find_tag_schema(db->tablename, ".ONDISK");
+    ondisk_schema = find_tag_schema(db->tablename_ip, ".ONDISK");
     if (NULL == ondisk_schema) {
         logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
-               db->tablename);
+               db->tablename_ip);
         exit(1);
     }
     ver_one = clone_schema(ondisk_schema);
@@ -624,7 +624,7 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
     }
 
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -754,8 +754,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     memset(plan, 0, sizeof(struct scplan));
 
-    oldsc = find_tag_schema(olddb->tablename, ".ONDISK");
-    newsc = find_tag_schema(olddb->tablename, ".NEW..ONDISK");
+    oldsc = find_tag_schema(olddb->tablename_ip, ".ONDISK");
+    newsc = find_tag_schema(olddb->tablename_ip, ".NEW..ONDISK");
     if (!oldsc || !newsc) {
         sc_errf(s, "%s: can't find both schemas! oldsc=%p newsc=%p\n", __func__,
                 oldsc, newsc);
@@ -831,8 +831,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     for (blobn = 0; blobn < newdb->numblobs; blobn++) {
         int map;
-        map = tbl_blob_no_to_tbl_blob_no(newdb->tablename, ".NEW..ONDISK",
-                                         blobn, olddb->tablename, ".ONDISK");
+        map = tbl_blob_no_to_tbl_blob_no(newdb->tablename_ip, ".NEW..ONDISK",
+                                         blobn, olddb->tablename_ip, ".ONDISK");
         /* Sanity check, although I don't see how this can possibly
          * happen - make sure we haven't already decided to use this
          * blob file for anything. */
@@ -856,8 +856,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
             plan->blob_plan[blobn] = -1;
         } else if (map >= 0 && map < olddb->numblobs) {
             int oldidx =
-                get_schema_blob_field_idx(olddb->tablename, ".ONDISK", map);
-            int newidx = get_schema_blob_field_idx(newdb->tablename,
+                get_schema_blob_field_idx(olddb->tablename_ip, ".ONDISK", map);
+            int newidx = get_schema_blob_field_idx(newdb->tablename_ip,
                                                    ".NEW..ONDISK", blobn);
 
             /* rebuild if the blob length changed (should only happen for vutf8
@@ -1055,7 +1055,7 @@ void set_odh_options_tran(struct dbtable *db, tran_type *tran)
     get_db_inplace_updates_tran(db, &db->inplace_updates, tran);
     get_db_compress_tran(db, &compr, tran);
     get_db_compress_blobs_tran(db, &blob_compr, tran);
-    db->schema_version = get_csc2_version_tran(db->tablename, tran);
+    db->schema_version = get_csc2_version_tran(db->tablename_ip, tran);
 
     set_bdb_option_flags(db, db->odh, db->inplace_updates,
                          db->instant_schema_change, db->schema_version, compr,
@@ -1105,12 +1105,12 @@ int compare_constraints(const char *table, struct dbtable *newdb)
          * would've been picked up in forward check */
 
         /*fprintf(stderr, "%s\n", ct->lcltable->tablename);*/
-        if (!strcasecmp(ct->lcltable->tablename, db->tablename))
+        if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip))
             continue;
 
         for (j = 0; j < ct->nrules; j++) {
             /* skip references to other tables*/
-            if (strcasecmp(ct->table[j], db->tablename))
+            if (strcasecmp(ct->table[j], db->tablename_ip))
                 continue;
             /* fprintf(stderr, "  rule %s:%s\n", ct->table[j], ct->keynm[j]);*/
             rc = has_index_changed(db, ct->keynm[j], 1, 0 /*old table key */,
@@ -1119,7 +1119,7 @@ int compare_constraints(const char *table, struct dbtable *newdb)
                 logmsg(LOGMSG_ERROR,
                        "error in checking reverse constraint table %s "
                        "key %s\n",
-                       ct->lcltable->tablename, ct->lclkeyname);
+                       ct->lcltable->tablename_ip, ct->lclkeyname);
                 free(verifylist);
                 return -2;
             } else if (rc == 0) {
@@ -1137,7 +1137,7 @@ int compare_constraints(const char *table, struct dbtable *newdb)
                     logmsg(LOGMSG_ERROR,
                            "error! constraints reference more tables "
                            "than available %d! last tbl '%s' key '%s'\n",
-                           nvlist, ct->lcltable->tablename, ct->lclkeyname);
+                           nvlist, ct->lcltable->tablename_ip, ct->lclkeyname);
                     free(verifylist);
                     return -2;
                 }
@@ -1179,14 +1179,14 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
      * reverse constraint array updated to get all reverse ct *'s removed */
     for (i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
-        if (!strcasecmp(rdb->tablename, newdb->tablename)) {
+        if (!strcasecmp(rdb->tablename_ip, newdb->tablename_ip)) {
             rdb = newdb;
         }
         Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (int j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename, db->tablename)) {
+            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
                 if ((j + 1) < rdb->n_rev_constraints) {
                     memmove(&rdb->rev_constraints[j],
                             &rdb->rev_constraints[j + 1],
@@ -1205,7 +1205,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                 int ridx = 0;
                 int dupadd = 0;
 
-                if (strcasecmp(newdb->constraints[j].table[k], rdb->tablename))
+                if (strcasecmp(newdb->constraints[j].table[k], rdb->tablename_ip))
                     continue;
                 for (ridx = 0; ridx < rdb->n_rev_constraints; ridx++) {
                     if (rdb->rev_constraints[ridx] == &newdb->constraints[j]) {
@@ -1218,7 +1218,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                     logmsg(LOGMSG_ERROR,
                            "not enough space to store reverse constraints! "
                            "table %s\n",
-                           rdb->tablename);
+                           rdb->tablename_ip);
                     return -1;
                 }
                 rdb->rev_constraints[rdb->n_rev_constraints++] =
@@ -1244,7 +1244,7 @@ int backout_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
 int fk_source_change(struct dbtable *newdb, FILE *out, struct schema_change_type *s)
 {
     int i;
-    struct dbtable *olddb = get_dbtable_by_name(newdb->tablename);
+    struct dbtable *olddb = get_dbtable_by_name(newdb->tablename_ip);
     for (i = 0; i < newdb->nix; ++i) {
         struct schema *index = newdb->ixschema[i];
         int offset = get_offset_of_keyname(index->csctag);
@@ -1286,7 +1286,7 @@ int check_sc_headroom(struct schema_change_type *s, struct dbtable *olddb,
     wanted = (diff * (uint64_t)(100 + headroom)) / 100ULL;
 
     sc_printf(
-        s, "Table %s, old %s, new %s, reqd. %s, avail %s\n", olddb->tablename,
+        s, "Table %s, old %s, new %s, reqd. %s, avail %s\n", olddb->tablename_ip,
         fmt_size(b1, sizeof(b1), oldsize), fmt_size(b2, sizeof(b2), newsize),
         fmt_size(b3, sizeof(b3), wanted), fmt_size(b4, sizeof(b4), avail));
 
@@ -1314,7 +1314,7 @@ int check_sc_headroom(struct schema_change_type *s, struct dbtable *olddb,
 /* compatible change if type unchanged but get larger in size */
 int compat_chg(struct dbtable *olddb, struct schema *s2, const char *ixname)
 {
-    struct schema *s1 = find_tag_schema(olddb->tablename, ixname);
+    struct schema *s1 = find_tag_schema(olddb->tablename_ip, ixname);
     if (s1->nmembers != s2->nmembers) return 1;
     int i;
     for (i = 0; i < s1->nmembers; ++i) {
@@ -1332,11 +1332,11 @@ int compatible_constraint_source(struct dbtable *olddb, struct dbtable *newdb,
                                  struct schema *newsc, const char *key,
                                  FILE *out, struct schema_change_type *s)
 {
-    const char *dbname = newdb->tablename;
+    const char *dbname = newdb->tablename_ip;
     int i, j, k;
     for (i = 0; i < thedb->num_dbs; ++i) {
         struct dbtable *db = thedb->dbs[i];
-        if (strcmp(db->tablename, dbname) == 0)
+        if (strcmp(db->tablename_ip, dbname) == 0)
             continue;
         for (j = 0; j < db->n_constraints; ++j) {
             constraint_t *ct = &db->constraints[j];
@@ -1346,10 +1346,10 @@ int compatible_constraint_source(struct dbtable *olddb, struct dbtable *newdb,
                     if (compat_chg(olddb, newsc, key) == 0) continue;
                     char *info = ">%s:%s -> %s:%s\n";
                     if (s && s->dryrun) {
-                        sbuf2printf(s->sb, info, db->tablename, ct->lclkeyname,
+                        sbuf2printf(s->sb, info, db->tablename_ip, ct->lclkeyname,
                                     dbname, ct->keynm[k]);
                     } else if (out) {
-                        logmsgf(LOGMSG_USER, out, info + 1, db->tablename,
+                        logmsgf(LOGMSG_USER, out, info + 1, db->tablename_ip,
                                 ct->lclkeyname, dbname, ct->keynm[k]);
                     }
                     return 1;
@@ -1369,7 +1369,7 @@ int remove_constraint_pointers(struct dbtable *db)
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename, db->tablename)) {
+            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
                 if ((j + 1) < rdb->n_rev_constraints) {
                     memmove(&rdb->rev_constraints[j],
                             &rdb->rev_constraints[j + 1],
@@ -1396,8 +1396,8 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename, db->tablename)) {
-                strcpy(ct->lcltable->tablename, newname);
+            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
+                ct->lcltable->tablename_ip = intern(newname);
             }
         }
         Pthread_mutex_unlock(&rdb->rev_constraints_lk);
@@ -1451,7 +1451,7 @@ int self_referenced_only(struct dbtable *db)
     rc = 1;
     for (i = 0; i < db->n_rev_constraints; i++) {
         constraint_t *ct = db->rev_constraints[i];
-        if (strcasecmp(ct->lcltable->tablename, db->tablename)) {
+        if (strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
             rc = 0;
             break;
         }
@@ -1459,7 +1459,7 @@ int self_referenced_only(struct dbtable *db)
     return rc;
 }
 
-void change_schemas_recover(char *table)
+void change_schemas_recover(const char *table)
 {
     struct dbtable *db = get_dbtable_by_name(table);
     if (db == NULL) {

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -51,7 +51,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
             rc = ERR_CONSTR;
             goto done;
         }
-        rc = stag_to_stag_buf(db->tablename_ip, from, old_dta, ".NEW..ONDISK",
+        rc = stag_to_stag_buf(db->tablename_interned, from, old_dta, ".NEW..ONDISK",
                               new_dta, &reason);
         if (rc) {
             rc = ERR_CONSTR;
@@ -78,7 +78,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         /* Name: .NEW.COLUMNNAME -> .NEW..ONDISK_IX_nn */
         snprintf(lcl_tag, sizeof lcl_tag, ".NEW.%s", ct->lclkeyname);
-        rc = getidxnumbyname(db->tablename_ip, lcl_tag, &lcl_idx);
+        rc = getidxnumbyname(db->tablename_interned, lcl_tag, &lcl_idx);
         if (rc) {
             logmsg(LOGMSG_ERROR, "could not get index for %s\n", lcl_tag);
             rc = ERR_CONSTR;
@@ -97,7 +97,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
         if (iq->idxInsert && !convert)
             memcpy(lcl_key, iq->idxInsert[lcl_idx], db->ix_keylen[lcl_idx]);
         else
-            rc = stag_to_stag_buf_blobs(db->tablename_ip, from, od_dta, lcl_tag,
+            rc = stag_to_stag_buf_blobs(db->tablename_interned, from, od_dta, lcl_tag,
                                         lcl_key, NULL, blobs, maxblobs, 0);
         if (rc) {
             rc = ERR_CONSTR;
@@ -112,12 +112,12 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         int ri;
         rc = check_single_key_constraint(&ruleiq, ct, lcl_tag, lcl_key,
-                                         db->tablename_ip, trans, &ri);
+                                         db->tablename_interned, trans, &ri);
         if (rc == RC_INTERNAL_RETRY) {
             break;
         } else if (rc && rc != ERR_CONSTR) {
             logmsg(LOGMSG_ERROR, "fk violation: %s @ %s -> %s @ %s, rc=%d\n",
-                   ct->lclkeyname, db->tablename_ip, ct->keynm[ri], ct->table[ri],
+                   ct->lclkeyname, db->tablename_interned, ct->keynm[ri], ct->table[ri],
                    rc);
             fsnapf(stderr, lcl_key, lcl_len > 32 ? 32 : lcl_len);
             logmsg(LOGMSG_ERROR, "\n");
@@ -156,11 +156,11 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             char lkey[MAXKEYLEN];
             int fndrrn;
             unsigned long long genid;
-            if (strcasecmp(cnstrt->table[j], to_db->tablename_ip)) {
+            if (strcasecmp(cnstrt->table[j], to_db->tablename_interned)) {
                 continue;
             }
             ldb = get_dbtable_by_name(cnstrt->table[j]);
-            if (strcasecmp(ldb->tablename_ip, newdb->tablename_ip)) {
+            if (strcasecmp(ldb->tablename_interned, newdb->tablename_interned)) {
                 logmsg(LOGMSG_FATAL, "%s: failed to find table\n", __func__);
                 abort();
                 return ERR_INTERNAL;
@@ -184,7 +184,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             snprintf(ondisk_tag, sizeof(ondisk_tag), ".NEW..ONDISK_IX_%d",
                      ixnum);
             /* Data -> Key : ONDISK -> .ONDISK_IX_nn */
-            rc = stag_to_stag_buf(newdb->tablename_ip, from, od_dta, ondisk_tag,
+            rc = stag_to_stag_buf(newdb->tablename_interned, from, od_dta, ondisk_tag,
                                   lkey, NULL);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: failed to convert to '%s'\n",
@@ -192,7 +192,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
                 return ERR_CONVERT_IX;
             }
             /* here we convert the key into return db format */
-            rc = getidxnumbyname(cnstrt->lcltable->tablename_ip,
+            rc = getidxnumbyname(cnstrt->lcltable->tablename_interned,
                                  cnstrt->lclkeyname, &rixnum);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: unknown keytag '%s'\n", __func__,
@@ -205,7 +205,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             int nulls = 0;
 
             rixlen = rc = stag_to_stag_buf_ckey(
-                ldb->tablename_ip, ondisk_tag, lkey, cnstrt->lcltable->tablename_ip,
+                ldb->tablename_interned, ondisk_tag, lkey, cnstrt->lcltable->tablename_interned,
                 rondisk_tag, rkey, &nulls, PK2FK);
             if (rc == -1) {
                 /* I followed the logic in check_update_constraints */
@@ -273,7 +273,7 @@ static int verify_constraints_forward_changes(struct dbtable *db, struct dbtable
                    that changed...otherwise, need to re-verify
                 */
                 for (j = 0; j < ct->nrules; j++) {
-                    if (!strcasecmp(db->tablename_ip, ct->table[j])) {
+                    if (!strcasecmp(db->tablename_interned, ct->table[j])) {
                         rc = has_index_changed(db, ct->keynm[j], 1, 1 /*new*/,
                                                NULL, 0);
                         if (rc == 0)
@@ -414,30 +414,30 @@ int prepare_table_version_one(tran_type *tran, struct dbtable *db,
     char tag[MAXTAGLEN];
 
     /* For init with instant_sc, add ONDISK as version 1.  */
-    rc = get_csc2_file_tran(db->tablename_ip, -1, &ondisk_text, NULL, tran);
+    rc = get_csc2_file_tran(db->tablename_interned, -1, &ondisk_text, NULL, tran);
     if (rc) {
         logmsg(LOGMSG_FATAL,
                "Couldn't get latest csc2 from llmeta for %s! PANIC!!\n",
-               db->tablename_ip);
+               db->tablename_interned);
         exit(1);
     }
 
     /* db's version has been reset */
-    bdberr = bdb_reset_csc2_version(tran, db->tablename_ip, db->schema_version);
+    bdberr = bdb_reset_csc2_version(tran, db->tablename_interned, db->schema_version);
     if (bdberr != BDBERR_NOERROR) return SC_BDB_ERROR;
 
     /* Add latest csc2 as version 1 */
-    rc = bdb_new_csc2(tran, db->tablename_ip, 1, ondisk_text, &bdberr);
+    rc = bdb_new_csc2(tran, db->tablename_interned, 1, ondisk_text, &bdberr);
     free(ondisk_text);
     if (rc != 0) {
         logmsg(LOGMSG_FATAL, "Couldn't save in llmeta! PANIC!!");
         exit(1);
     }
 
-    ondisk_schema = find_tag_schema(db->tablename_ip, ".ONDISK");
+    ondisk_schema = find_tag_schema(db->tablename_interned, ".ONDISK");
     if (NULL == ondisk_schema) {
         logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
-               db->tablename_ip);
+               db->tablename_interned);
         exit(1);
     }
     ver_one = clone_schema(ondisk_schema);
@@ -624,7 +624,7 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
     }
 
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_ip, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename_interned, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -754,8 +754,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     memset(plan, 0, sizeof(struct scplan));
 
-    oldsc = find_tag_schema(olddb->tablename_ip, ".ONDISK");
-    newsc = find_tag_schema(olddb->tablename_ip, ".NEW..ONDISK");
+    oldsc = find_tag_schema(olddb->tablename_interned, ".ONDISK");
+    newsc = find_tag_schema(olddb->tablename_interned, ".NEW..ONDISK");
     if (!oldsc || !newsc) {
         sc_errf(s, "%s: can't find both schemas! oldsc=%p newsc=%p\n", __func__,
                 oldsc, newsc);
@@ -831,8 +831,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     for (blobn = 0; blobn < newdb->numblobs; blobn++) {
         int map;
-        map = tbl_blob_no_to_tbl_blob_no(newdb->tablename_ip, ".NEW..ONDISK",
-                                         blobn, olddb->tablename_ip, ".ONDISK");
+        map = tbl_blob_no_to_tbl_blob_no(newdb->tablename_interned, ".NEW..ONDISK",
+                                         blobn, olddb->tablename_interned, ".ONDISK");
         /* Sanity check, although I don't see how this can possibly
          * happen - make sure we haven't already decided to use this
          * blob file for anything. */
@@ -856,8 +856,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
             plan->blob_plan[blobn] = -1;
         } else if (map >= 0 && map < olddb->numblobs) {
             int oldidx =
-                get_schema_blob_field_idx(olddb->tablename_ip, ".ONDISK", map);
-            int newidx = get_schema_blob_field_idx(newdb->tablename_ip,
+                get_schema_blob_field_idx(olddb->tablename_interned, ".ONDISK", map);
+            int newidx = get_schema_blob_field_idx(newdb->tablename_interned,
                                                    ".NEW..ONDISK", blobn);
 
             /* rebuild if the blob length changed (should only happen for vutf8
@@ -1055,7 +1055,7 @@ void set_odh_options_tran(struct dbtable *db, tran_type *tran)
     get_db_inplace_updates_tran(db, &db->inplace_updates, tran);
     get_db_compress_tran(db, &compr, tran);
     get_db_compress_blobs_tran(db, &blob_compr, tran);
-    db->schema_version = get_csc2_version_tran(db->tablename_ip, tran);
+    db->schema_version = get_csc2_version_tran(db->tablename_interned, tran);
 
     set_bdb_option_flags(db, db->odh, db->inplace_updates,
                          db->instant_schema_change, db->schema_version, compr,
@@ -1105,12 +1105,12 @@ int compare_constraints(const char *table, struct dbtable *newdb)
          * would've been picked up in forward check */
 
         /*fprintf(stderr, "%s\n", ct->lcltable->tablename);*/
-        if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip))
+        if (!strcasecmp(ct->lcltable->tablename_interned, db->tablename_interned))
             continue;
 
         for (j = 0; j < ct->nrules; j++) {
             /* skip references to other tables*/
-            if (strcasecmp(ct->table[j], db->tablename_ip))
+            if (strcasecmp(ct->table[j], db->tablename_interned))
                 continue;
             /* fprintf(stderr, "  rule %s:%s\n", ct->table[j], ct->keynm[j]);*/
             rc = has_index_changed(db, ct->keynm[j], 1, 0 /*old table key */,
@@ -1119,7 +1119,7 @@ int compare_constraints(const char *table, struct dbtable *newdb)
                 logmsg(LOGMSG_ERROR,
                        "error in checking reverse constraint table %s "
                        "key %s\n",
-                       ct->lcltable->tablename_ip, ct->lclkeyname);
+                       ct->lcltable->tablename_interned, ct->lclkeyname);
                 free(verifylist);
                 return -2;
             } else if (rc == 0) {
@@ -1137,7 +1137,7 @@ int compare_constraints(const char *table, struct dbtable *newdb)
                     logmsg(LOGMSG_ERROR,
                            "error! constraints reference more tables "
                            "than available %d! last tbl '%s' key '%s'\n",
-                           nvlist, ct->lcltable->tablename_ip, ct->lclkeyname);
+                           nvlist, ct->lcltable->tablename_interned, ct->lclkeyname);
                     free(verifylist);
                     return -2;
                 }
@@ -1179,14 +1179,14 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
      * reverse constraint array updated to get all reverse ct *'s removed */
     for (i = 0; i < thedb->num_dbs; i++) {
         struct dbtable *rdb = thedb->dbs[i];
-        if (!strcasecmp(rdb->tablename_ip, newdb->tablename_ip)) {
+        if (!strcasecmp(rdb->tablename_interned, newdb->tablename_interned)) {
             rdb = newdb;
         }
         Pthread_mutex_lock(&rdb->rev_constraints_lk);
         for (int j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
+            if (!strcasecmp(ct->lcltable->tablename_interned, db->tablename_interned)) {
                 if ((j + 1) < rdb->n_rev_constraints) {
                     memmove(&rdb->rev_constraints[j],
                             &rdb->rev_constraints[j + 1],
@@ -1205,7 +1205,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                 int ridx = 0;
                 int dupadd = 0;
 
-                if (strcasecmp(newdb->constraints[j].table[k], rdb->tablename_ip))
+                if (strcasecmp(newdb->constraints[j].table[k], rdb->tablename_interned))
                     continue;
                 for (ridx = 0; ridx < rdb->n_rev_constraints; ridx++) {
                     if (rdb->rev_constraints[ridx] == &newdb->constraints[j]) {
@@ -1218,7 +1218,7 @@ int restore_constraint_pointers_main(struct dbtable *db, struct dbtable *newdb,
                     logmsg(LOGMSG_ERROR,
                            "not enough space to store reverse constraints! "
                            "table %s\n",
-                           rdb->tablename_ip);
+                           rdb->tablename_interned);
                     return -1;
                 }
                 rdb->rev_constraints[rdb->n_rev_constraints++] =
@@ -1244,7 +1244,7 @@ int backout_constraint_pointers(struct dbtable *db, struct dbtable *newdb)
 int fk_source_change(struct dbtable *newdb, FILE *out, struct schema_change_type *s)
 {
     int i;
-    struct dbtable *olddb = get_dbtable_by_name(newdb->tablename_ip);
+    struct dbtable *olddb = get_dbtable_by_name(newdb->tablename_interned);
     for (i = 0; i < newdb->nix; ++i) {
         struct schema *index = newdb->ixschema[i];
         int offset = get_offset_of_keyname(index->csctag);
@@ -1286,7 +1286,7 @@ int check_sc_headroom(struct schema_change_type *s, struct dbtable *olddb,
     wanted = (diff * (uint64_t)(100 + headroom)) / 100ULL;
 
     sc_printf(
-        s, "Table %s, old %s, new %s, reqd. %s, avail %s\n", olddb->tablename_ip,
+        s, "Table %s, old %s, new %s, reqd. %s, avail %s\n", olddb->tablename_interned,
         fmt_size(b1, sizeof(b1), oldsize), fmt_size(b2, sizeof(b2), newsize),
         fmt_size(b3, sizeof(b3), wanted), fmt_size(b4, sizeof(b4), avail));
 
@@ -1314,7 +1314,7 @@ int check_sc_headroom(struct schema_change_type *s, struct dbtable *olddb,
 /* compatible change if type unchanged but get larger in size */
 int compat_chg(struct dbtable *olddb, struct schema *s2, const char *ixname)
 {
-    struct schema *s1 = find_tag_schema(olddb->tablename_ip, ixname);
+    struct schema *s1 = find_tag_schema(olddb->tablename_interned, ixname);
     if (s1->nmembers != s2->nmembers) return 1;
     int i;
     for (i = 0; i < s1->nmembers; ++i) {
@@ -1332,11 +1332,11 @@ int compatible_constraint_source(struct dbtable *olddb, struct dbtable *newdb,
                                  struct schema *newsc, const char *key,
                                  FILE *out, struct schema_change_type *s)
 {
-    const char *dbname = newdb->tablename_ip;
+    const char *dbname = newdb->tablename_interned;
     int i, j, k;
     for (i = 0; i < thedb->num_dbs; ++i) {
         struct dbtable *db = thedb->dbs[i];
-        if (strcmp(db->tablename_ip, dbname) == 0)
+        if (strcmp(db->tablename_interned, dbname) == 0)
             continue;
         for (j = 0; j < db->n_constraints; ++j) {
             constraint_t *ct = &db->constraints[j];
@@ -1346,10 +1346,10 @@ int compatible_constraint_source(struct dbtable *olddb, struct dbtable *newdb,
                     if (compat_chg(olddb, newsc, key) == 0) continue;
                     char *info = ">%s:%s -> %s:%s\n";
                     if (s && s->dryrun) {
-                        sbuf2printf(s->sb, info, db->tablename_ip, ct->lclkeyname,
+                        sbuf2printf(s->sb, info, db->tablename_interned, ct->lclkeyname,
                                     dbname, ct->keynm[k]);
                     } else if (out) {
-                        logmsgf(LOGMSG_USER, out, info + 1, db->tablename_ip,
+                        logmsgf(LOGMSG_USER, out, info + 1, db->tablename_interned,
                                 ct->lclkeyname, dbname, ct->keynm[k]);
                     }
                     return 1;
@@ -1369,7 +1369,7 @@ int remove_constraint_pointers(struct dbtable *db)
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
+            if (!strcasecmp(ct->lcltable->tablename_interned, db->tablename_interned)) {
                 if ((j + 1) < rdb->n_rev_constraints) {
                     memmove(&rdb->rev_constraints[j],
                             &rdb->rev_constraints[j + 1],
@@ -1396,8 +1396,8 @@ int rename_constraint_pointers(struct dbtable *db, const char *newname)
         for (j = 0; j < rdb->n_rev_constraints; j++) {
             constraint_t *ct = NULL;
             ct = rdb->rev_constraints[j];
-            if (!strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
-                ct->lcltable->tablename_ip = intern(newname);
+            if (!strcasecmp(ct->lcltable->tablename_interned, db->tablename_interned)) {
+                ct->lcltable->tablename_interned = intern(newname);
             }
         }
         Pthread_mutex_unlock(&rdb->rev_constraints_lk);
@@ -1451,7 +1451,7 @@ int self_referenced_only(struct dbtable *db)
     rc = 1;
     for (i = 0; i < db->n_rev_constraints; i++) {
         constraint_t *ct = db->rev_constraints[i];
-        if (strcasecmp(ct->lcltable->tablename_ip, db->tablename_ip)) {
+        if (strcasecmp(ct->lcltable->tablename_interned, db->tablename_interned)) {
             rc = 0;
             break;
         }

--- a/schemachange/sc_schema.h
+++ b/schemachange/sc_schema.h
@@ -91,6 +91,6 @@ void fix_constraint_pointers(struct dbtable *db, struct dbtable *newdb);
 
 int self_referenced_only(struct dbtable *db);
 
-void change_schemas_recover(char *table);
+void change_schemas_recover(const char *table);
 
 #endif

--- a/schemachange/sc_stripes.c
+++ b/schemachange/sc_stripes.c
@@ -99,7 +99,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
                 logmsg(LOGMSG_ERROR,
                        "morestripe: couldn't rename blob 1 for table "
                        "'%s' bdberr %d\n",
-                       db->tablename, bdberr);
+                       db->tablename_ip, bdberr);
                 bdb_tran_abort(thedb->bdb_env, sc_logical_tran, &bdberr);
                 unlock_schema_lk();
                 return SC_BDB_ERROR;
@@ -111,7 +111,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR,
                        "morestripe: couldn't record genid for table '%s'\n",
-                       db->tablename);
+                       db->tablename_ip);
                 bdb_tran_abort(thedb->bdb_env, sc_logical_tran, &bdberr);
                 unlock_schema_lk();
                 resume_threads(thedb);
@@ -124,7 +124,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
 
             logmsg(LOGMSG_INFO,
                    "Converted table '%s' to blobstripe with genid 0x%llx\n",
-                   db->tablename, genid);
+                   db->tablename_ip, genid);
         }
     }
 
@@ -138,7 +138,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
             logmsg(
                 LOGMSG_ERROR,
                 "morestripe: failed making extra stripes for table '%s': %d\n",
-                db->tablename, bdberr);
+                db->tablename_ip, bdberr);
             unlock_schema_lk();
             return SC_BDB_ERROR;
         }

--- a/schemachange/sc_stripes.c
+++ b/schemachange/sc_stripes.c
@@ -99,7 +99,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
                 logmsg(LOGMSG_ERROR,
                        "morestripe: couldn't rename blob 1 for table "
                        "'%s' bdberr %d\n",
-                       db->tablename_ip, bdberr);
+                       db->tablename_interned, bdberr);
                 bdb_tran_abort(thedb->bdb_env, sc_logical_tran, &bdberr);
                 unlock_schema_lk();
                 return SC_BDB_ERROR;
@@ -111,7 +111,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR,
                        "morestripe: couldn't record genid for table '%s'\n",
-                       db->tablename_ip);
+                       db->tablename_interned);
                 bdb_tran_abort(thedb->bdb_env, sc_logical_tran, &bdberr);
                 unlock_schema_lk();
                 resume_threads(thedb);
@@ -124,7 +124,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
 
             logmsg(LOGMSG_INFO,
                    "Converted table '%s' to blobstripe with genid 0x%llx\n",
-                   db->tablename_ip, genid);
+                   db->tablename_interned, genid);
         }
     }
 
@@ -138,7 +138,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
             logmsg(
                 LOGMSG_ERROR,
                 "morestripe: failed making extra stripes for table '%s': %d\n",
-                db->tablename_ip, bdberr);
+                db->tablename_interned, bdberr);
             unlock_schema_lk();
             return SC_BDB_ERROR;
         }

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -866,14 +866,14 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
 
     old_bdb_handle = db->handle;
 
-    logmsg(LOGMSG_DEBUG, "%s isopen %d\n", db->tablename,
+    logmsg(LOGMSG_DEBUG, "%s isopen %d\n", db->tablename_ip,
            bdb_isopen(db->handle));
 
     /* the master doesn't tell the replicants to close the db
      * ahead of time */
     rc = bdb_close_only_sc(old_bdb_handle, tran, &bdberr);
     if (rc || bdberr != BDBERR_NOERROR) {
-        logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename);
+        logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_ip);
         return 1;
     }
 
@@ -962,7 +962,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
         old_bdb_handle = db->handle;
         rc = bdb_close_only_sc(old_bdb_handle, tran, &bdberr);
         if (rc || bdberr != BDBERR_NOERROR) {
-            logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename);
+            logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_ip);
             return 1;
         }
 
@@ -997,7 +997,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
     if (bthashsz) {
         logmsg(LOGMSG_INFO,
                "Rebuilding bthash for table %s, size %dkb per stripe\n",
-               db->tablename, bthashsz);
+               db->tablename_ip, bthashsz);
         bdb_handle_dbp_add_hash(db->handle, bthashsz);
     }
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -866,14 +866,14 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
 
     old_bdb_handle = db->handle;
 
-    logmsg(LOGMSG_DEBUG, "%s isopen %d\n", db->tablename_ip,
+    logmsg(LOGMSG_DEBUG, "%s isopen %d\n", db->tablename_interned,
            bdb_isopen(db->handle));
 
     /* the master doesn't tell the replicants to close the db
      * ahead of time */
     rc = bdb_close_only_sc(old_bdb_handle, tran, &bdberr);
     if (rc || bdberr != BDBERR_NOERROR) {
-        logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_ip);
+        logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_interned);
         return 1;
     }
 
@@ -962,7 +962,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
         old_bdb_handle = db->handle;
         rc = bdb_close_only_sc(old_bdb_handle, tran, &bdberr);
         if (rc || bdberr != BDBERR_NOERROR) {
-            logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_ip);
+            logmsg(LOGMSG_ERROR, "Error closing old db: %s\n", db->tablename_interned);
             return 1;
         }
 
@@ -997,7 +997,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
     if (bthashsz) {
         logmsg(LOGMSG_INFO,
                "Rebuilding bthash for table %s, size %dkb per stripe\n",
-               db->tablename_ip, bthashsz);
+               db->tablename_interned, bthashsz);
         bdb_handle_dbp_add_hash(db->handle, bthashsz);
     }
 

--- a/schemachange/sc_util.c
+++ b/schemachange/sc_util.c
@@ -28,7 +28,7 @@ int close_all_dbs_tran(tran_type *tran)
         rc = bdb_close_only_sc(db->handle, tran, &bdberr);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "failed closing table '%s': %d\n",
-                   db->tablename, bdberr);
+                   db->tablename_ip, bdberr);
             return -1;
         }
     }
@@ -52,7 +52,7 @@ int open_all_dbs_tran(void *tran)
         if (rc != 0) {
             logmsg(LOGMSG_ERROR,
                    "morestripe: failed reopening table '%s': %d\n",
-                   db->tablename, bdberr);
+                   db->tablename_ip, bdberr);
             return -1;
         }
     }
@@ -86,7 +86,7 @@ int check_sc_ok(struct schema_change_type *s)
     return 0;
 }
 
-int llmeta_get_dbnum_tran(void *tran, char *tablename, int *bdberr)
+int llmeta_get_dbnum_tran(void *tran, const char *tablename, int *bdberr)
 {
     int rc;
     int dbnums[MAX_NUM_TABLES];
@@ -120,7 +120,7 @@ int llmeta_get_dbnum(char *tablename, int *bdberr)
 /* careful this can cause overflows, do not use */
 char *get_temp_db_name(struct dbtable *db, char *prefix, char tmpname[])
 {
-    sprintf(tmpname, "%s%s", prefix, db->tablename);
+    sprintf(tmpname, "%s%s", prefix, db->tablename_ip);
 
     return tmpname;
 }

--- a/schemachange/sc_util.c
+++ b/schemachange/sc_util.c
@@ -28,7 +28,7 @@ int close_all_dbs_tran(tran_type *tran)
         rc = bdb_close_only_sc(db->handle, tran, &bdberr);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "failed closing table '%s': %d\n",
-                   db->tablename_ip, bdberr);
+                   db->tablename_interned, bdberr);
             return -1;
         }
     }
@@ -52,7 +52,7 @@ int open_all_dbs_tran(void *tran)
         if (rc != 0) {
             logmsg(LOGMSG_ERROR,
                    "morestripe: failed reopening table '%s': %d\n",
-                   db->tablename_ip, bdberr);
+                   db->tablename_interned, bdberr);
             return -1;
         }
     }
@@ -120,7 +120,7 @@ int llmeta_get_dbnum(char *tablename, int *bdberr)
 /* careful this can cause overflows, do not use */
 char *get_temp_db_name(struct dbtable *db, char *prefix, char tmpname[])
 {
-    sprintf(tmpname, "%s%s", prefix, db->tablename_ip);
+    sprintf(tmpname, "%s%s", prefix, db->tablename_interned);
 
     return tmpname;
 }

--- a/schemachange/sc_util.h
+++ b/schemachange/sc_util.h
@@ -20,7 +20,7 @@
 int close_all_dbs(void);
 int open_all_dbs(void);
 int open_all_dbs_tran(void *tran);
-int llmeta_get_dbnum_tran(void *tran, char *tablename, int *bdberr);
+int llmeta_get_dbnum_tran(void *tran, const char *tablename, int *bdberr);
 int llmeta_get_dbnum(char *tablename, int *bdberr);
 char *get_temp_db_name(struct dbtable *db, char *prefix, char tmpname[]);
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -710,8 +710,8 @@ static int unodhfy_if_necessary(struct ireq *iq, blob_buffer_t *blobs,
     /* Check if we need to unpack vutf8. */
     assert(iq->usedb->sc_from != NULL && iq->usedb->sc_to != NULL);
 
-    from = find_tag_schema(iq->usedb->sc_from->tablename, ".ONDISK");
-    to = find_tag_schema(iq->usedb->sc_to->tablename, ".NEW..ONDISK");
+    from = find_tag_schema(iq->usedb->sc_from->tablename_ip, ".ONDISK");
+    to = find_tag_schema(iq->usedb->sc_to->tablename_ip, ".NEW..ONDISK");
 
     for (rc = 0, i = 0; i != to->nmembers; ++i) {
         /* If the field in the new schema is new, do nothing. */

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -536,12 +536,12 @@ int fastinit_table(struct dbenv *dbenvin, char *table)
         logmsg(LOGMSG_ERROR, "%s: malloc failed\n", __func__);
         return -1;
     }
-    strncpy0(s->tablename, db->tablename, sizeof(s->tablename));
+    strncpy0(s->tablename, db->tablename_ip, sizeof(s->tablename));
 
-    if (get_csc2_file(db->tablename, -1 /*highest csc2_version*/, &s->newcsc2,
+    if (get_csc2_file(db->tablename_ip, -1 /*highest csc2_version*/, &s->newcsc2,
                       NULL /*csc2len*/)) {
         logmsg(LOGMSG_ERROR, "%s: could not get schema for table: %s\n",
-               __func__, db->tablename);
+               __func__, db->tablename_ip);
         return -1;
     }
 
@@ -633,7 +633,7 @@ done:
         sbuf2printf(s->sb, "FAILED\n");
     }
     if (newdb) {
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         newdb->schema = NULL;
         freedb(newdb);
     }
@@ -1014,15 +1014,15 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     /* Don't lose precious flags like this */
     newdb->inplace_updates = s->headers && s->ip_updates;
     newdb->instant_schema_change = s->headers && s->instant_sc;
-    newdb->schema_version = get_csc2_version(newdb->tablename);
+    newdb->schema_version = get_csc2_version(newdb->tablename_ip);
 
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         abort();
     }
 
     if (verify_constraints_exist(NULL, newdb, newdb, s) != 0) {
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         abort();
     }
 
@@ -1030,7 +1030,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
 
     rc = open_temp_db_resume(newdb, new_prefix, 1, 0, NULL);
     if (rc) {
-        backout_schemas(newdb->tablename);
+        backout_schemas(newdb->tablename_ip);
         abort();
     }
 
@@ -1056,14 +1056,14 @@ int add_schema_change_tables()
         int bdberr;
         void *packed_sc_data = NULL;
         size_t packed_sc_data_len = 0;
-        if (bdb_get_in_schema_change(NULL /*tran*/, thedb->dbs[i]->tablename,
+        if (bdb_get_in_schema_change(NULL /*tran*/, thedb->dbs[i]->tablename_ip,
                                      &packed_sc_data, &packed_sc_data_len,
                                      &bdberr) ||
             bdberr != BDBERR_NOERROR) {
             logmsg(LOGMSG_ERROR,
                    "%s: failed to discover "
                    "whether table: %s is in the middle of a schema change\n",
-                   __func__, thedb->dbs[i]->tablename);
+                   __func__, thedb->dbs[i]->tablename_ip);
             continue;
         }
 
@@ -1072,7 +1072,7 @@ int add_schema_change_tables()
             struct schema_change_type *s;
             logmsg(LOGMSG_WARN, "%s: table: %s is in the middle of a "
                                 "schema change, adding table...\n",
-                   __func__, thedb->dbs[i]->tablename);
+                   __func__, thedb->dbs[i]->tablename_ip);
 
             s = new_schemachange_type();
             if (!s) {
@@ -1095,7 +1095,7 @@ int add_schema_change_tables()
             char *abort_filename =
                 comdb2_location("marker", "%s.scabort", thedb->envname);
             if (access(abort_filename, F_OK) == 0) {
-                rc = bdb_set_in_schema_change(NULL, thedb->dbs[i]->tablename,
+                rc = bdb_set_in_schema_change(NULL, thedb->dbs[i]->tablename_ip,
                                               NULL, 0, &bdberr);
                 if (rc)
                     logmsg(LOGMSG_ERROR,
@@ -1174,7 +1174,7 @@ int sc_timepart_add_table(const char *existingTableName,
                  existingTableName);
         goto error;
     }
-    if (get_csc2_file(db->tablename, -1 /*highest csc2_version*/, &schemabuf,
+    if (get_csc2_file(db->tablename_ip, -1 /*highest csc2_version*/, &schemabuf,
                       NULL /*csc2len*/)) {
         xerr->errval = SC_VIEW_ERR_BUG;
         snprintf(xerr->errstr, sizeof(xerr->errstr),
@@ -1291,12 +1291,12 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     /*do_crap*/
     {
         /* Find the existing table and use its current schema */
-        if (get_csc2_file(db->tablename, -1 /*highest csc2_version*/,
+        if (get_csc2_file(db->tablename_ip, -1 /*highest csc2_version*/,
                           &schemabuf, NULL /*csc2len*/)) {
             xerr->errval = SC_VIEW_ERR_BUG;
             snprintf(xerr->errstr, sizeof(xerr->errstr),
                      "%s: could not get schema for table: %s\n", __func__,
-                     db->tablename);
+                     db->tablename_ip);
             cleanup_strptr(&schemabuf);
             goto error;
         }

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -158,7 +158,7 @@ static int systblColumnsColumn(
 
   switch( i ){
     case STCOL_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
       break;
     }
     case STCOL_COLUMN: {

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -219,9 +219,9 @@ static int systblColumnsColumn(
           tran_type *trans = curtran_gettran();
           int64_t seq;
           int bdberr;
-          int rc = bdb_get_sequence(trans, pDb->tablename, pField->name, &seq, &bdberr);
+          int rc = bdb_get_sequence(trans, pDb->tablename_ip, pField->name, &seq, &bdberr);
           if (rc) {
-              logmsg(LOGMSG_ERROR, "bdb_get_sequence %s %s -> rc %d bdberr %d\n", pDb->tablename, pField->name, rc, bdberr);
+              logmsg(LOGMSG_ERROR, "bdb_get_sequence %s %s -> rc %d bdberr %d\n", pDb->tablename_ip, pField->name, rc, bdberr);
               curtran_puttran(trans);
               return -1;
           }

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -158,7 +158,7 @@ static int systblColumnsColumn(
 
   switch( i ){
     case STCOL_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_interned, -1, NULL);
       break;
     }
     case STCOL_COLUMN: {
@@ -219,9 +219,9 @@ static int systblColumnsColumn(
           tran_type *trans = curtran_gettran();
           int64_t seq;
           int bdberr;
-          int rc = bdb_get_sequence(trans, pDb->tablename_ip, pField->name, &seq, &bdberr);
+          int rc = bdb_get_sequence(trans, pDb->tablename_interned, pField->name, &seq, &bdberr);
           if (rc) {
-              logmsg(LOGMSG_ERROR, "bdb_get_sequence %s %s -> rc %d bdberr %d\n", pDb->tablename_ip, pField->name, rc, bdberr);
+              logmsg(LOGMSG_ERROR, "bdb_get_sequence %s %s -> rc %d bdberr %d\n", pDb->tablename_interned, pField->name, rc, bdberr);
               curtran_puttran(trans);
               return -1;
           }

--- a/sqlite/ext/comdb2/constraints.c
+++ b/sqlite/ext/comdb2/constraints.c
@@ -232,7 +232,7 @@ static int systblFKeyConstraintsColumn(sqlite3_vtab_cursor *cur,
         break;
     }
     case STCON_TABLE: {
-        sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
+        sqlite3_result_text(ctx, pDb->tablename_interned, -1, NULL);
         break;
     }
     case STCON_KEY: {

--- a/sqlite/ext/comdb2/constraints.c
+++ b/sqlite/ext/comdb2/constraints.c
@@ -232,7 +232,7 @@ static int systblFKeyConstraintsColumn(sqlite3_vtab_cursor *cur,
         break;
     }
     case STCON_TABLE: {
-        sqlite3_result_text(ctx, pDb->tablename, -1, NULL);
+        sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
         break;
     }
     case STCON_KEY: {

--- a/sqlite/ext/comdb2/indexuse.c
+++ b/sqlite/ext/comdb2/indexuse.c
@@ -62,9 +62,9 @@ static int get_index_usage(void **recsp, int *nrecs) {
 
     for (int dbn = 0; dbn < thedb->num_dbs; dbn++) {
         db = thedb->dbs[dbn];
-        if (strncmp(db->tablename, "sqlite_stat", strlen("sqlite_stat")) == 0)
+        if (strncmp(db->tablename_ip, "sqlite_stat", strlen("sqlite_stat")) == 0)
             continue;
-        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename);
+        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename_ip);
         for (int ixnum = 0; ixnum < db->nix; ixnum++) {
             if (nix == allocated) {
                 allocated = allocated * 2 + 16;
@@ -76,7 +76,7 @@ static int get_index_usage(void **recsp, int *nrecs) {
                 ixs = n;
             }
             struct index_usage *ix = &ixs[nix];
-            ix->tablename = strdup(db->tablename);
+            ix->tablename = strdup(db->tablename_ip);
             ix->ixnum = ixnum;
             ix->cscname = strdup(db->schema->ix[ixnum]->csctag);
             ix->sqlname =  strdup(db->schema->ix[ixnum]->sqlitetag);

--- a/sqlite/ext/comdb2/indexuse.c
+++ b/sqlite/ext/comdb2/indexuse.c
@@ -62,9 +62,9 @@ static int get_index_usage(void **recsp, int *nrecs) {
 
     for (int dbn = 0; dbn < thedb->num_dbs; dbn++) {
         db = thedb->dbs[dbn];
-        if (strncmp(db->tablename_ip, "sqlite_stat", strlen("sqlite_stat")) == 0)
+        if (strncmp(db->tablename_interned, "sqlite_stat", strlen("sqlite_stat")) == 0)
             continue;
-        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename_ip);
+        logmsg(LOGMSG_USER, "table '%s'\n", db->tablename_interned);
         for (int ixnum = 0; ixnum < db->nix; ixnum++) {
             if (nix == allocated) {
                 allocated = allocated * 2 + 16;
@@ -76,7 +76,7 @@ static int get_index_usage(void **recsp, int *nrecs) {
                 ixs = n;
             }
             struct index_usage *ix = &ixs[nix];
-            ix->tablename = strdup(db->tablename_ip);
+            ix->tablename = strdup(db->tablename_interned);
             ix->ixnum = ixnum;
             ix->cscname = strdup(db->schema->ix[ixnum]->csctag);
             ix->sqlname =  strdup(db->schema->ix[ixnum]->sqlitetag);

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -179,7 +179,7 @@ static int systblFieldsColumn(
 
   switch( i ){
     case STFIELD_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_interned, -1, NULL);
       break;
     }
     case STFIELD_KEY: {

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -179,7 +179,7 @@ static int systblFieldsColumn(
 
   switch( i ){
     case STFIELD_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
       break;
     }
     case STFIELD_KEY: {

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -169,7 +169,7 @@ static int systblKeysColumn(
 
   switch( i ){
     case STKEY_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
       break;
     }
     case STKEY_KEY: {

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -169,7 +169,7 @@ static int systblKeysColumn(
 
   switch( i ){
     case STKEY_TABLE: {
-      sqlite3_result_text(ctx, pDb->tablename_ip, -1, NULL);
+      sqlite3_result_text(ctx, pDb->tablename_interned, -1, NULL);
       break;
     }
     case STKEY_KEY: {

--- a/sqlite/ext/comdb2/permissions.c
+++ b/sqlite/ext/comdb2/permissions.c
@@ -90,10 +90,9 @@ static int get_base_table_list(tran_type *trans, char ***table_list,
 
     /* List of tables accessible to the current user */
     for (int i = 0; i < thedb->num_dbs; ++i) {
-        char *tbl;
         int err;
 
-        tbl = thedb->dbs[i]->tablename;
+        const char *tbl; tbl = thedb->dbs[i]->tablename_ip;
         if (bdb_check_user_tbl_access_tran(thedb->bdb_env, trans, usr, tbl,
                                            ACCESS_READ, &err) != 0) {
             continue;

--- a/sqlite/ext/comdb2/permissions.c
+++ b/sqlite/ext/comdb2/permissions.c
@@ -92,7 +92,7 @@ static int get_base_table_list(tran_type *trans, char ***table_list,
     for (int i = 0; i < thedb->num_dbs; ++i) {
         int err;
 
-        const char *tbl; tbl = thedb->dbs[i]->tablename_ip;
+        const char *tbl; tbl = thedb->dbs[i]->tablename_interned;
         if (bdb_check_user_tbl_access_tran(thedb->bdb_env, trans, usr, tbl,
                                            ACCESS_READ, &err) != 0) {
             continue;

--- a/sqlite/ext/comdb2/queues.c
+++ b/sqlite/ext/comdb2/queues.c
@@ -114,7 +114,7 @@ static int get_stats(struct systbl_queues_cursor *pCur) {
   uint32_t lockid = bdb_get_lid_from_cursortran(thd->clnt->dbtran.cursor_tran);
 
   dbqueuedb_get_name(qdb, &spname);
-  strcpy(pCur->queue_name, qdb->tablename);
+  strcpy(pCur->queue_name, qdb->tablename_ip);
   if (spname) {
       strcpy(pCur->spname, spname);
       free(spname);

--- a/sqlite/ext/comdb2/queues.c
+++ b/sqlite/ext/comdb2/queues.c
@@ -114,7 +114,7 @@ static int get_stats(struct systbl_queues_cursor *pCur) {
   uint32_t lockid = bdb_get_lid_from_cursortran(thd->clnt->dbtran.cursor_tran);
 
   dbqueuedb_get_name(qdb, &spname);
-  strcpy(pCur->queue_name, qdb->tablename_ip);
+  strcpy(pCur->queue_name, qdb->tablename_interned);
   if (spname) {
       strcpy(pCur->spname, spname);
       free(spname);

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -126,7 +126,7 @@ static int systblTablesColumn(
 ){
   systbl_tables_cursor *pCur = (systbl_tables_cursor*)cur;
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
-  char *x = pDb->tablename;
+  const char *x = pDb->tablename_ip;
 
   sqlite3_result_text(ctx, x, -1, NULL);
   return SQLITE_OK;

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -126,7 +126,7 @@ static int systblTablesColumn(
 ){
   systbl_tables_cursor *pCur = (systbl_tables_cursor*)cur;
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
-  const char *x = pDb->tablename_ip;
+  const char *x = pDb->tablename_interned;
 
   sqlite3_result_text(ctx, x, -1, NULL);
   return SQLITE_OK;

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -134,7 +134,7 @@ static int systblTblSizeColumn(
 ){
   systbl_tblsize_cursor *pCur = (systbl_tblsize_cursor*)cur;
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
-  char *x = pDb->tablename;
+  const char *x = pDb->tablename_ip;
 
   tran_type *trans = curtran_gettran();
   if (!trans) {

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -134,7 +134,7 @@ static int systblTblSizeColumn(
 ){
   systbl_tblsize_cursor *pCur = (systbl_tblsize_cursor*)cur;
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
-  const char *x = pDb->tablename_ip;
+  const char *x = pDb->tablename_interned;
 
   tran_type *trans = curtran_gettran();
   if (!trans) {

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -120,14 +120,14 @@ static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
     /* Check user access. */
     rc = bdb_check_user_tbl_access_tran(thedb->bdb_env, trans,
                                    thd->clnt->current_user.name,
-                                   thedb->qdbs[i]->tablename, ACCESS_READ,
+                                   thedb->qdbs[i]->tablename_ip, ACCESS_READ,
                                    &bdberr);
     if (rc != 0) {
         continue;
     }
 
     t = sqlite3_malloc(sizeof(trigger));
-    t->name = strdup(thedb->qdbs[i]->tablename);
+    t->name = strdup(thedb->qdbs[i]->tablename_ip);
     t->type = -1;
     bdb_state_type *bdb_state = thedb->qdbs[i]->handle;
     t->seq = (bdb_state && bdb_state->ondisk_header &&

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -120,14 +120,14 @@ static int triggerOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
     /* Check user access. */
     rc = bdb_check_user_tbl_access_tran(thedb->bdb_env, trans,
                                    thd->clnt->current_user.name,
-                                   thedb->qdbs[i]->tablename_ip, ACCESS_READ,
+                                   thedb->qdbs[i]->tablename_interned, ACCESS_READ,
                                    &bdberr);
     if (rc != 0) {
         continue;
     }
 
     t = sqlite3_malloc(sizeof(trigger));
-    t->name = strdup(thedb->qdbs[i]->tablename_ip);
+    t->name = strdup(thedb->qdbs[i]->tablename_interned);
     t->type = -1;
     bdb_state_type *bdb_state = thedb->qdbs[i]->handle;
     t->seq = (bdb_state && bdb_state->ondisk_header &&

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -211,7 +211,7 @@ static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
 
         if (db) {
             /* use original tablename */
-            strncpy0(dst, db->tablename_ip, MAXTABLELEN);
+            strncpy0(dst, db->tablename_interned, MAXTABLELEN);
         }
     }
     else
@@ -4030,7 +4030,7 @@ static int retrieve_fk_constraint(Parse *pParse, struct comdb2_ddl_context *ctx,
 
         /* Parent table name. */
         constraint->parent_table =
-            comdb2_strdup(ctx->mem, parent_table->tablename_ip);
+            comdb2_strdup(ctx->mem, parent_table->tablename_interned);
         if (constraint->parent_table == 0)
             goto oom;
 
@@ -6155,15 +6155,15 @@ void comdb2DropIndex(Parse *pParse, Token *pName1, Token *pName2, int ifExists)
             goto cleanup;
         }
 
-        if ((chkAndCopyTable(pParse, sc->tablename, table->tablename_ip,
-                             strlen(table->tablename_ip), 1, 1, 0)))
+        if ((chkAndCopyTable(pParse, sc->tablename, table->tablename_interned,
+                             strlen(table->tablename_interned), 1, 1, 0)))
             goto cleanup;
 
         if (authenticateSC(sc->tablename, pParse))
             goto cleanup;
     }
 
-    ctx->schema->name = table->tablename_ip;
+    ctx->schema->name = table->tablename_interned;
 
     /*
       Add all the columns, indexes and constraints in the table to the

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -40,7 +40,7 @@ extern int gbl_permit_small_sequences;
 
 extern int sqlite3GetToken(const unsigned char *z, int *tokenType);
 extern int sqlite3ParserFallback(int iToken);
-extern int comdb2_save_ddl_context(char *name, void *ctx, comdb2ma mem);
+extern int comdb2_save_ddl_context(const char *name, void *ctx, comdb2ma mem);
 extern void *comdb2_get_ddl_context(char *name);
 
 /******************* Utility ****************************/
@@ -211,7 +211,7 @@ static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
 
         if (db) {
             /* use original tablename */
-            strncpy0(dst, db->tablename, MAXTABLELEN);
+            strncpy0(dst, db->tablename_ip, MAXTABLELEN);
         }
     }
     else
@@ -2649,7 +2649,7 @@ struct comdb2_constraint {
 
 struct comdb2_schema {
     /* Name of the table */
-    char *name;
+    const char *name;
     /* Table options */
     uint32_t table_options;
     /* Staging list of new/existing columns */
@@ -4030,7 +4030,7 @@ static int retrieve_fk_constraint(Parse *pParse, struct comdb2_ddl_context *ctx,
 
         /* Parent table name. */
         constraint->parent_table =
-            comdb2_strdup(ctx->mem, parent_table->tablename);
+            comdb2_strdup(ctx->mem, parent_table->tablename_ip);
         if (constraint->parent_table == 0)
             goto oom;
 
@@ -4578,7 +4578,7 @@ void comdb2CreateTableLikeEnd(
     if (comdb2IsPrepareOnly(pParse))
         return;
 
-    char *newTab;
+    const char *newTab;
     char *otherTab;
 
     struct comdb2_ddl_context *ctx = pParse->comdb2_ddl_ctx;
@@ -6155,15 +6155,15 @@ void comdb2DropIndex(Parse *pParse, Token *pName1, Token *pName2, int ifExists)
             goto cleanup;
         }
 
-        if ((chkAndCopyTable(pParse, sc->tablename, table->tablename,
-                             strlen(table->tablename), 1, 1, 0)))
+        if ((chkAndCopyTable(pParse, sc->tablename, table->tablename_ip,
+                             strlen(table->tablename_ip), 1, 1, 0)))
             goto cleanup;
 
         if (authenticateSC(sc->tablename, pParse))
             goto cleanup;
     }
 
-    ctx->schema->name = table->tablename;
+    ctx->schema->name = table->tablename_ip;
 
     /*
       Add all the columns, indexes and constraints in the table to the


### PR DESCRIPTION
Make dbtable member tablename a pointer to interned string. 
This makes for easier comparison and also avoids unnecessary strdup.