### PR TITLE
Synchronous osql cancellation

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -70,6 +70,7 @@ int debug_switch_test_ddl_backout_blkseq(void);          /* 0 */
 int debug_switch_test_delay_analyze_commit(void);        /* 0 */
 int debug_switch_all_incoherent(void);                   /* 0 */
 int debug_switch_replicant_latency(void);                   /* 0 */
+int debug_switch_test_sync_osql_cancel(void);            /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/tests/sync_osql_cancel.test/Makefile
+++ b/tests/sync_osql_cancel.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sync_osql_cancel.test/runit
+++ b/tests/sync_osql_cancel.test/runit
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Verify that a large number of rollbacks or disconnects won't cause bplog to
+# pile up on the master, by using synchronous osql cancellation.
+
+[ -z "$CLUSTER" ] && { echo "skipping, it's a cluster test"; exit 0; }
+
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t1 (i int)'
+
+for h in $CLUSTER; do
+  cdb2sql $dbnm --host $h "exec procedure sys.cmd.send('test_sync_osql_cancel 1')"
+done
+
+while true; do
+cat << EOF | cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default - >/dev/null 2>&1
+BEGIN
+INSERT INTO t1 VALUES (1)
+ROLLBACK
+EOF
+done &
+
+pid=$!
+sleep 30
+kill $pid
+
+for h in $CLUSTER; do
+  echo $h:
+  cdb2sql --tabs $dbnm --host $h "exec procedure sys.cmd.send('appsockpool stat')"
+  nreqs=`cdb2sql --tabs $dbnm --host $h "exec procedure sys.cmd.send('appsockpool stat')" | grep 'Work items done immediate' | awk '{print $NF;}'`
+  if [ $nreqs -gt 100 ]; then
+    echo Requests piled up on master! >&2
+    exit 1
+  fi
+done

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -883,6 +883,7 @@
 (name='test_io_time', description='Check I/O in watchdog this often', type='INTEGER', value='10', read_only='N')
 (name='test_sc_resume_race', description='Test race between schemachange resume and blockprocessor', type='BOOLEAN', value='OFF', read_only='Y')
 (name='test_scindex_deadlock', description='Test index on expressions schema change deadlock', type='BOOLEAN', value='OFF', read_only='Y')
+(name='test_sync_osql_cancel', description='Force a delay in osql_sess_rcvop test synchronous osql cancel', type='BOOLEAN', value='OFF', read_only='N')
 (name='thread_stats', description='Berkeley DB will keep stats on what its threads are doing', type='BOOLEAN', value='ON', read_only='N')
 (name='throttlesqloverlog', description='On a full queue of SQL requests, dump the current thread pool this often (in secs). (Default: 5sec)', type='INTEGER', value='5', read_only='Y')
 (name='timeout_fdb_trans_sync', description='Timeout for retrieving a foreign table transaction', type='INTEGER', value='4000', read_only='N')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -77,6 +77,7 @@ static struct debug_switches {
     int test_delay_analyze_commit;
     int all_incoherent;
     int replicant_latency;
+    int test_sync_osql_cancel;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -133,6 +134,7 @@ int init_debug_switches(void)
     debug_switches.test_delay_analyze_commit = 0;
     debug_switches.all_incoherent = 0;
     debug_switches.replicant_latency = 0;
+    debug_switches.test_sync_osql_cancel = 0;
 
     register_int_switch("alternate_verify_fail", "alternate_verify_fail",
                         &debug_switches.alternate_verify_fail);
@@ -241,6 +243,8 @@ int init_debug_switches(void)
     register_int_switch("test_delay_analyze_commit", "Delay analyze commit", &debug_switches.test_delay_analyze_commit);
     register_int_switch("all_incoherent", "Master pretends nodes are incoherent.", &debug_switches.all_incoherent);
     register_int_switch("replicant_latency", "Replicant drops log records.", &debug_switches.replicant_latency);
+    register_int_switch("test_sync_osql_cancel", "Force a delay in osql_sess_rcvop test synchronous osql cancel",
+                        &debug_switches.test_sync_osql_cancel);
     return 0;
 }
 
@@ -451,4 +455,8 @@ int debug_switch_all_incoherent(void)
 int debug_switch_replicant_latency(void)
 {
     return debug_switches.replicant_latency;
+}
+int debug_switch_test_sync_osql_cancel(void)
+{
+    return debug_switches.test_sync_osql_cancel;
 }


### PR DESCRIPTION
An osql cancellation is done asynchronously in the sense that a replicant doesn't wait for it to complete on the master node. If there's a large number of rollbacks or client disconnects, and the master can't cancel them faster than they arrive, these requests will pile up on the master.

This patch makes osql cancellation synchronous, so that the master can be protected in this case.

(DRQS 164512050)