### PR TITLE
Synchronous osql cancellation (R7)

### DIFF
--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -542,6 +542,11 @@ int osql_sess_rcvop(unsigned long long rqid, uuid_t uuid, int type, void *data,
 
     if (is_msg_done && perr && htonl(perr->errval) == SQLITE_ABORT &&
         !bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DISABLE_SELECTVONLY_TRAN_NOP)) {
+        struct ireq *iq = sess->iq;
+        rc = osql_comm_signal_sqlthr_rc(&iq->sorese, &iq->errstat, &iq->snap_info, 0);
+        if (rc != 0)
+            logmsg(LOGMSG_WARN, "%s: osql_comm_signal_sqlthr_rc rc =%d\n", __func__, rc);
+
         /* release the session */
         if ((rc = osql_repository_put(sess, is_msg_done)) != 0) {
             logmsg(LOGMSG_ERROR, "%s: osql_repository_put rc =%d\n", __func__,

--- a/tests/sync_osql_cancel.test/Makefile
+++ b/tests/sync_osql_cancel.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sync_osql_cancel.test/lrl.options
+++ b/tests/sync_osql_cancel.test/lrl.options
@@ -1,0 +1,2 @@
+maxwt 1
+setattr DISABLE_SELECTVONLY_TRAN_NOP 1

--- a/tests/sync_osql_cancel.test/runit
+++ b/tests/sync_osql_cancel.test/runit
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Verify that a large number of rollbacks or disconnects won't cause bplog to
+# pile up on the master, by using synchronous osql cancellation.
+
+[ -z "$CLUSTER" ] && { echo "skipping, it's a cluster test"; exit 0; }
+
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t1 (i int)'
+
+for h in $CLUSTER; do
+  cdb2sql $dbnm --host $h "exec procedure sys.cmd.send('rep_delay 1')"
+done
+
+while true; do
+cat << EOF | cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default - >/dev/null 2>&1
+BEGIN
+INSERT INTO t1 VALUES (1)
+ROLLBACK
+EOF
+done &
+
+pid=$!
+sleep 30
+kill $pid
+
+for h in $CLUSTER; do
+  echo $h:
+  cdb2sql --tabs $dbnm --host $h "exec procedure sys.cmd.send('bdb temptable')"
+  nreqs=`cdb2sql --tabs $dbnm --host $h "exec procedure sys.cmd.send('bdb temptable')" | grep '# total objects' | awk '{print $NF;}'`
+  if [ $nreqs -gt 100 ]; then
+    echo Requests piled up on master! >&2
+    exit 1
+  fi
+done


### PR DESCRIPTION
An osql cancellation is done asynchronously in the sense that a replicant doesn't wait for it to complete on the master node. If there's a large number of rollbacks or client disconnects, and the master can't cancel them faster than they arrive, these requests will pile up on the master.

This patch makes osql cancellation synchronous, so that the master can be protected in this case.

(DRQS 164512050)