### PR TITLE
Enable per-thread malloc for libevent net

### DIFF
--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -417,7 +417,7 @@ static void *thd_req(void *vthd)
     int numwriterthreads;
 
     thread_started("request");
-    THREAD_TYPE("tag");
+    ENABLE_PER_THREAD_MALLOC(__func__);
 
     thr_self = thrman_register(THRTYPE_REQ);
     logger = thrman_get_reqlogger(thr_self);

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -115,9 +115,9 @@ typedef void (*stats_fn)(const struct mallinfo *mallinfo, int verbose,
 */
 #ifdef PER_THREAD_MALLOC
 extern __thread const char *thread_type_key;
-#define THREAD_TYPE(key) do { thread_type_key = (key); } while (0)
+#define ENABLE_PER_THREAD_MALLOC(key) do { thread_type_key = (key); } while (0)
 #else
-#define THREAD_TYPE(key) do { (void)key; } while (0)
+#define ENABLE_PER_THREAD_MALLOC(key) do { (void)key; } while (0)
 #endif
 
 /*

--- a/net/event.c
+++ b/net/event.c
@@ -450,6 +450,9 @@ static void *net_dispatch(void *arg)
     struct net_dispatch_info *n = arg;
     struct event *ev = event_new(n->base, -1, EV_PERSIST, nop, n);
     struct timeval ten = {10, 0};
+
+    ENABLE_PER_THREAD_MALLOC(n->who);
+
     event_add(ev, &ten);
     if (start_callback) {
         start_callback(start_stop_callback_data);

--- a/tests/netmem.test/runit
+++ b/tests/netmem.test/runit
@@ -3,4 +3,8 @@ bash -n "$0" | exit 1
 set -e
 dbnm=$1
 mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("memstat net")' | grep "replication@$mach"
+for c in $CLUSTER; do
+    if [ "$c" -ne "$mach" ]; then
+        cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host "$c" 'exec procedure sys.cmd.send("memstat net")' | grep "$mach"
+    fi
+done

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -694,7 +694,7 @@ static void *thdpool_thd(void *voidarg)
 
     thread_started("thdpool");
 
-    THREAD_TYPE(pool->name);
+    ENABLE_PER_THREAD_MALLOC(pool->name);
     thd->archtid = getarchtid();
 
     if (pool->per_thread_data_sz > 0) {


### PR DESCRIPTION
Also rename THREAD_TYPE to ENABLE_PER_THREAD_MALLOC to better explain what the macro really does.