### PR TITLE
Fix leaks from recent bplog changes

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1237,6 +1237,7 @@ struct osql_sess {
     int verify_retries; /* how many times we verify retried this one */
     blocksql_tran_t *tran;
     int is_tranddl;
+    int is_cancelled; /* 1 if session is cancelled */
 };
 typedef struct osql_sess osql_sess_t;
 

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -354,6 +354,7 @@ int osql_sess_rcvop_socket(osql_sess_t *sess, int type, void *data, int datalen,
         if (debug_switch_test_sync_osql_cancel())
             poll(NULL, 0, 1000);
         osql_comm_signal_sqlthr_rc(&sess->target, sess->rqid, sess->uuid, 0, &sess->xerr, NULL, 0);
+        sess->is_cancelled = 1;
         return 0;
     }
 

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -446,9 +446,11 @@ int handle_ireq(struct ireq *iq)
         }
     }
 
-    /* Finish off logging. */
     if (iq->sorese) {
+        /* Finish off logging. */
         osql_sess_reqlogquery(iq->sorese, iq->reqlogger);
+        /* Free the sorese transaction buffer */
+        free(iq->p_buf_out_start);
     }
     reqlog_end_request(iq->reqlogger, rc, __func__, __LINE__);
     release_node_stats(NULL, NULL, iq->frommach);

--- a/tests/bplog_leaks.test/Makefile
+++ b/tests/bplog_leaks.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/bplog_leaks.test/runit
+++ b/tests/bplog_leaks.test/runit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+set -e
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t1 (b blob)'
+
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
+
+# Three leaks:
+# 1) We leak the sql query, only in sockbplog mode
+# 2) We leak the bplog buffer, only in sockbplog mode
+# 3) We leak the osql transaction buffer in both net and sockbplog modes
+before=`cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $6}'`
+# Use a long query to make the leaks more visible
+yes "INSERT INTO t1 VALUES (x'`openssl rand -hex 16384`')" | head -1000 | cdb2sql ${CDB2_OPTIONS} $dbnm default - >/dev/null
+after=`cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("memstat uncategorized")' | grep total | tail -1 | awk '{print $6}'`
+
+delta=`expr $after - $before`
+if [ $delta -gt 524288 ]; then
+    echo leaky? >&2
+    exit 1
+fi
+
+
+# In sockbplog mode, for each osql cancel (rollback or client disconnect),
+# we leak the osql transaction and temptables
+
+for i in `seq 1 1000`; do
+cdb2sql ${CDB2_OPTIONS} $dbnm default - >/dev/null <<EOF
+BEGIN
+INSERT INTO t1 VALUES (x'')
+ROLLBACK
+EOF
+done
+
+cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("bdb temptable")'
+ntmptbls=`cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("bdb temptable")' | grep 'total objects' | awk '{print $NF}'`
+if [ $ntmptbls -gt 100 ] ; then
+    echo leaky? >&2
+    exit 1
+fi

--- a/tests/bplog_leaks.test/sockbplog.testopts
+++ b/tests/bplog_leaks.test/sockbplog.testopts
@@ -1,0 +1,1 @@
+sockbplog


### PR DESCRIPTION
The patch fixes memory leaks, temptable leaks and double-freeing from recent bplog refactoring and the bplog-over-socket changes.