### PR TITLE
docs: fix simple typo, contraints -> constraints

### DIFF
--- a/sqlite/src/insert.c
+++ b/sqlite/src/insert.c
@@ -1572,7 +1572,7 @@ void sqlite3GenerateConstraintChecks(
     ** the UNIQUE constraints have run.
     */
     if( onError==OE_Replace      /* IPK rule is REPLACE */
-     && onError!=overrideError   /* Rules for other contraints are different */
+     && onError!=overrideError   /* Rules for other constraints are different */
      && pTab->pIndex             /* There exist other constraints */
     ){
       ipkTop = sqlite3VdbeAddOp0(v, OP_Goto)+1;

--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -2613,7 +2613,7 @@ static int whereLoopAddBtreeIndex(
       pBtm = pTerm;
       pTop = 0;
       if( pTerm->wtFlags & TERM_LIKEOPT ){
-        /* Range contraints that come from the LIKE optimization are
+        /* Range constraints that come from the LIKE optimization are
         ** always used in pairs. */
         pTop = &pTerm[1];
         assert( (pTop-(pTerm->pWC->a))<pTerm->pWC->nTerm );


### PR DESCRIPTION
There is a small typo in sqlite/src/insert.c, sqlite/src/where.c.

Should read `constraints` rather than `contraints`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md