### PR TITLE
Store length of string in string_ref object

### DIFF
--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -445,8 +445,8 @@ static void eventlog_add_newsql(const struct reqlogger *logger)
             cson_value_new_string("newsql", strlen("newsql")));
 
     if (logger->sql_ref != NULL) {
-        const char *str = get_string(logger->sql_ref);
-        cson_object_set(newobj, "sql", cson_value_new_string(str, strlen(str)));
+        cson_object_set(newobj, "sql", cson_value_new_string(string_ref_cstr(logger->sql_ref),
+                                                             string_ref_len(logger->sql_ref)));
     }
 
     char expanded_fp[2 * FINGERPRINTSZ + 1];
@@ -472,8 +472,8 @@ static void populate_obj(cson_object *obj, const struct reqlogger *logger)
     }
 
     if (logger->sql_ref && eventlog_detailed) {
-        const char *str = get_string(logger->sql_ref);
-        cson_object_set(obj, "sql", cson_value_new_string(str, strlen(str)));
+        cson_object_set(obj, "sql", cson_value_new_string(string_ref_cstr(logger->sql_ref),
+                                                          string_ref_len(logger->sql_ref)));
         cson_object_set(obj, "bound_parameters", logger->bound_param_cson);
     }
 

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1418,7 +1418,7 @@ static void reqlog_start_request(struct reqlogger *logger)
                    check_list(&master_opcode_inv_list, logger->opcode)) {
             gather = 1;
         } else if (logger->sql_ref && master_num_stmts > 0) {
-            const char *str = get_string(logger->sql_ref);
+            const char *str = string_ref_cstr(logger->sql_ref);
             for (ii = 0; ii < master_num_stmts && ii < NUMSTMTS; ii++) {
                 if (strstr(str, master_stmts[ii])) {
                     gather = 1;
@@ -1472,7 +1472,7 @@ inline void reqlog_set_sql(struct reqlogger *logger, struct string_ref *sr)
     put_ref(&logger->sql_ref);
     if (sr) {
         logger->sql_ref = get_ref(sr);
-        reqlog_logf(logger, REQL_INFO, "sql=%s", get_string(logger->sql_ref));
+        reqlog_logf(logger, REQL_INFO, "sql=%s", string_ref_cstr(logger->sql_ref));
     }
 }
 
@@ -1936,7 +1936,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
             }
 
             if (rule->stmt[0] &&
-                (!logger->sql_ref || !strstr(get_string(logger->sql_ref), rule->stmt))) {
+                (!logger->sql_ref || !strstr(string_ref_cstr(logger->sql_ref), rule->stmt))) {
                 continue;
             }
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1060,13 +1060,13 @@ void sql_dump_hist_statements(void)
                    tm.tm_min, tm.tm_sec, rqid, h->conn.pindex,
                    (char *)h->conn.pename, h->conn.pid, h->conn.node,
                    (long long int)h->cost.time, (long long int)h->cost.prepTime,
-                   h->cost.cost, get_string(h->sql_ref));
+                   h->cost.cost, string_ref_cstr(h->sql_ref));
         } else {
             logmsg(LOGMSG_USER,
                    "%02d/%02d/%02d %02d:%02d:%02d %stime %lldms prepTime %lldms cost %f sql: %s\n",
                    tm.tm_mon + 1, tm.tm_mday, 1900 + tm.tm_year, tm.tm_hour,
                    tm.tm_min, tm.tm_sec, rqid, (long long int)h->cost.time,
-                   (long long int)h->cost.prepTime, h->cost.cost, get_string(h->sql_ref));
+                   (long long int)h->cost.prepTime, h->cost.cost, string_ref_cstr(h->sql_ref));
         }
     }
     Pthread_mutex_unlock(&gbl_sql_lock);
@@ -1225,7 +1225,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
 
     if (gbl_fingerprint_queries) {
         if (h->sql_ref) {
-            if (is_stored_proc_sql(get_string(h->sql_ref))) {
+            if (is_stored_proc_sql(string_ref_cstr(h->sql_ref))) {
                 cost = clnt->spcost.cost;
                 time = clnt->spcost.time;
                 prepTime = clnt->spcost.prepTime;
@@ -1237,13 +1237,13 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
                 rows = clnt->nrows;
             }
             if (clnt->work.zOrigNormSql) { /* NOTE: Not subject to prepare. */
-                add_fingerprint(clnt, stmt, get_string(h->sql_ref), clnt->work.zOrigNormSql,
+                add_fingerprint(clnt, stmt, string_ref_cstr(h->sql_ref), clnt->work.zOrigNormSql,
                                 cost, time, prepTime, rows, logger,
                                 fingerprint);
                 have_fingerprint = 1;
             } else if (clnt->work.zNormSql &&
                        sqlite3_is_success(clnt->prep_rc)) {
-                add_fingerprint(clnt, stmt, get_string(h->sql_ref), clnt->work.zNormSql, cost,
+                add_fingerprint(clnt, stmt, string_ref_cstr(h->sql_ref), clnt->work.zNormSql, cost,
                                 time, prepTime, rows, logger, fingerprint);
                 have_fingerprint = 1;
             } else {
@@ -5389,7 +5389,7 @@ static int enqueue_sql_query(struct sqlclntstate *clnt)
         }
 
         if (rc) {
-            logmsg(LOGMSG_DEBUG, "%s: failed to enqueue: %s\n", __func__, get_string(clnt->sql_ref));
+            logmsg(LOGMSG_DEBUG, "%s: failed to enqueue: %s\n", __func__, string_ref_cstr(clnt->sql_ref));
             put_ref(&sr); // failed to enqueue so we still own this reference
             /* say something back, if the client expects it */
             if (clnt->fail_dispatch) {

--- a/sqlite/ext/comdb2/sqlpoolqueue.c
+++ b/sqlite/ext/comdb2/sqlpoolqueue.c
@@ -52,7 +52,7 @@ static void collect(struct thdpool *pool, struct workitem *item, void *user)
     i = &q->records[q->count - 1];
     i->time_in_queue_ms = comdb2_time_epochms() - item->queue_time_ms;
     if (item->ref_persistent_info) {
-        i->info = strdup(get_string(item->ref_persistent_info));
+        i->info = strdup(string_ref_cstr(item->ref_persistent_info));
         i->info_is_null = 0;
     } else {
         i->info = NULL;

--- a/util/string_ref.c
+++ b/util/string_ref.c
@@ -37,6 +37,7 @@ static int gbl_creation_count;
 
 struct string_ref {
     int cnt;
+    size_t len;
     char str[1];
 };
 
@@ -46,9 +47,10 @@ struct string_ref {
 struct string_ref * create_string_ref(const char *str)
 {
     assert(str);
-    int len = strlen(str);
+    size_t len = strlen(str);
     struct string_ref *ref = malloc(sizeof(struct string_ref) + len);
     ref->cnt = 1;
+    ref->len = len;
     strcpy(ref->str, str);
 
 #ifdef TRACK_REFERENCES
@@ -117,11 +119,15 @@ void transfer_ref(struct string_ref **from, struct string_ref **to)
     *from = NULL;
 }
 
-const char *get_string(struct string_ref *ref)
+const char *string_ref_cstr(struct string_ref *ref)
 {
     return ref->str;
 }
 
+size_t string_ref_len(struct string_ref *ref)
+{
+    return ref->len;
+}
 
 #ifdef TRACK_REFERENCES
 static int print_it(void *obj, void *arg)

--- a/util/string_ref.h
+++ b/util/string_ref.h
@@ -40,11 +40,14 @@
  *
  */
 
+struct string_ref;
+
 struct string_ref * create_string_ref(const char *str);
 struct string_ref * get_ref(struct string_ref *ref);
 void put_ref(struct string_ref **ref);
 void transfer_ref(struct string_ref **from, struct string_ref **to);
-const char *get_string(struct string_ref *ref);
+const char *string_ref_cstr(struct string_ref *ref);
+size_t string_ref_len(struct string_ref *ref);
 int all_string_references_cleared();
 
 #endif

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -798,7 +798,7 @@ static void *thdpool_thd(void *voidarg)
              * still holding the pool lock. */
 
             if (work.ref_persistent_info)
-                thd->persistent_info = get_string(work.ref_persistent_info); // will reset this before put_ref() below
+                thd->persistent_info = string_ref_cstr(work.ref_persistent_info); // will reset this before put_ref() below
             else
                 thd->persistent_info = "working on unknown";
         }


### PR DESCRIPTION
Store length of string in string_ref object, and use that length instead of calling strlen().

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>