### PR TITLE
Add alternate SQL normalization algorithm with better unary operator recognition.

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -249,6 +249,7 @@ extern int gbl_client_queued_slow_seconds;
 extern int gbl_client_running_slow_seconds;
 extern int gbl_client_abort_on_slow;
 extern int gbl_max_trigger_threads;
+extern int gbl_alternate_normalize;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2067,4 +2067,9 @@ REGISTER_TUNABLE("sockbplog_sockpool",
 REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("alternate_normalize",
+                 "Use alternate SQL normalization algorithm.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_alternate_normalize,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -148,6 +148,7 @@ extern int gbl_expressions_indexes;
 extern int gbl_old_column_names;
 extern hash_t *gbl_fingerprint_hash;
 extern pthread_mutex_t gbl_fingerprint_hash_mu;
+extern int gbl_alternate_normalize;
 
 /* Once and for all:
 
@@ -3509,7 +3510,12 @@ static void normalize_stmt_and_store(
       }
     } else {
       assert(clnt->sql);
-      char *zOrigNormSql = sqlite3Normalize(0, clnt->sql, iDefDqId);
+      char *zOrigNormSql;
+      if (gbl_alternate_normalize) {
+        zOrigNormSql = sqlite3Normalize_alternate(0, clnt->sql, iDefDqId);
+      } else {
+        zOrigNormSql = sqlite3Normalize(0, clnt->sql, iDefDqId);
+      }
       if (zOrigNormSql) {
         assert(clnt->work.zOrigNormSql==0);
         clnt->work.zOrigNormSql = strdup(zOrigNormSql);

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -4726,6 +4726,7 @@ void sqlite3ParserReset(Parse*);
 #ifdef SQLITE_ENABLE_NORMALIZE
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 char *sqlite3Normalize(Vdbe*, const char*,int);
+char *sqlite3Normalize_alternate(Vdbe*, const char*,int);
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 char *sqlite3Normalize(Vdbe*, const char*);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/tokenize.c
+++ b/sqlite/src/tokenize.c
@@ -790,6 +790,159 @@ static void addSpaceSeparator(sqlite3_str *pStr){
   }
 }
 
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+/*
+** This function should return non-zero if the specified token type is able
+** to be the left-hand operand of a binary sub-expression that makes use of
+** either a plus or minus (binary) operator.
+*/
+static int isLeftOperand(int tokenType){
+  switch( tokenType ){
+    case TK_NULL:
+    case TK_TRUEFALSE:
+    case TK_STRING:
+    case TK_INTEGER:
+    case TK_FLOAT:
+    case TK_VARIABLE:
+    case TK_BLOB:
+    case TK_ID:       return 1;
+    default:          return 0;
+  }
+}
+
+char *sqlite3Normalize_alternate(
+  Vdbe *pVdbe,       /* VM being reprepared */
+  const char *zSql,  /* The original SQL string */
+  int iDefDqId       /* Zero if double quoted strings should always be
+                      * treated as identifiers when there is no Vdbe
+                      * available */
+){
+  sqlite3 *db;       /* The database connection */
+  int i;             /* Next unread byte of zSql[] */
+  int n;             /* length of current token */
+  int tokenType;     /* type of current token */
+  int prevType = 0;  /* Previous non-whitespace token */
+  int nParen;        /* Number of nested levels of parentheses */
+  int iStartIN;      /* Start of RHS of IN operator in z[] */
+  int nParenAtIN;    /* Value of nParent at start of RHS of IN operator */
+  int j;             /* Bytes of normalized SQL generated so far */
+  sqlite3_str *pStr; /* The normalized SQL string under construction */
+
+  db = pVdbe ? sqlite3VdbeDb(pVdbe) : 0;
+  tokenType = -1;
+  nParen = iStartIN = nParenAtIN = 0;
+  pStr = sqlite3_str_new(db);
+  assert( pStr!=0 );  /* sqlite3_str_new() never returns NULL */
+  for(i=0; zSql[i] && pStr->accError==0; i+=n){
+    if( tokenType!=TK_SPACE ){
+      prevType = tokenType;
+    }
+    n = sqlite3GetToken((unsigned char*)zSql+i, &tokenType);
+    if( NEVER(n<=0) ) break;
+    switch( tokenType ){
+      case TK_SPACE: {
+        break;
+      }
+      case TK_NULL: {
+        if( prevType==TK_IS || prevType==TK_NOT ){
+          sqlite3_str_append(pStr, " NULL", 5);
+          break;
+        }
+        /* Fall through */
+      }
+      case TK_STRING:
+      case TK_INTEGER:
+      case TK_FLOAT:
+      case TK_VARIABLE:
+      case TK_BLOB: {
+        sqlite3_str_append(pStr, "?", 1);
+        break;
+      }
+      case TK_LP: {
+        nParen++;
+        if( prevType==TK_IN ){
+          iStartIN = pStr->nChar;
+          nParenAtIN = nParen;
+        }
+        sqlite3_str_append(pStr, "(", 1);
+        break;
+      }
+      case TK_RP: {
+        if( iStartIN>0 && nParen==nParenAtIN ){
+          assert( pStr->nChar>=iStartIN );
+          pStr->nChar = iStartIN+1;
+          sqlite3_str_append(pStr, "?,?,?", 5);
+          iStartIN = 0;
+        }
+        nParen--;
+        sqlite3_str_append(pStr, ")", 1);
+        break;
+      }
+      case TK_ID: {
+        iStartIN = 0;
+        j = pStr->nChar;
+        if( sqlite3Isquote(zSql[i]) ){
+          char *zId = sqlite3_mprintf("%.*s", n, zSql+i);
+          int nId;
+          int eType = 0;
+          if( zId==0 ) break;
+          sqlite3Dequote(zId);
+          if( zSql[i]=='"' && sqlite3VdbeUsesDoubleQuotedString(pVdbe, zId, iDefDqId) ){
+            sqlite3_str_append(pStr, "?", 1);
+            sqlite3DbFree(db, zId);
+            break;
+          }
+          nId = sqlite3Strlen30(zId);
+          if( sqlite3GetToken((u8*)zId, &eType)==nId && eType==TK_ID ){
+            addSpaceSeparator(pStr);
+            sqlite3_str_append(pStr, zId, nId);
+          }else{
+            sqlite3_str_appendf(pStr, "\"%w\"", zId);
+          }
+          sqlite3DbFree(db, zId);
+        }else{
+          addSpaceSeparator(pStr);
+          sqlite3_str_append(pStr, zSql+i, n);
+        }
+        while( j<pStr->nChar ){
+          pStr->zText[j] = sqlite3Tolower(pStr->zText[j]);
+          j++;
+        }
+        break;
+      }
+      case TK_NOSQL: {
+        addSpaceSeparator(pStr);
+        sqlite3_str_append(pStr, zSql+i, n);
+        break;
+      }
+      case TK_PLUS:
+      case TK_MINUS: {
+        if( isLeftOperand(prevType) ){
+          sqlite3_str_append(pStr, zSql+i, n);
+        }
+        break;
+      }
+      case TK_SELECT: {
+        iStartIN = 0;
+        /* fall through */
+      }
+      default: {
+        if( sqlite3IsIdChar(zSql[i]) ) addSpaceSeparator(pStr);
+        j = pStr->nChar;
+        sqlite3_str_append(pStr, zSql+i, n);
+        while( j<pStr->nChar ){
+          pStr->zText[j] = sqlite3Toupper(pStr->zText[j]);
+          j++;
+        }
+        break;
+      }
+    }
+  }
+  if( tokenType!=TK_SEMI ) sqlite3_str_append(pStr, ";", 1);
+  return sqlite3_str_finish(pStr);
+}
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+
 /*
 ** Compute a normalization of the SQL given by zSql[0..nSql-1].  Return
 ** the normalization in space obtained from sqlite3DbMalloc().  Or return

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -18,6 +18,8 @@
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 #include "logmsg.h"
+
+int gbl_alternate_normalize = 1;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifndef SQLITE_OMIT_DEPRECATED
@@ -2093,7 +2095,11 @@ const char *sqlite3_normalized_sql(sqlite3_stmt *pStmt){
   if( p->zNormSql==0 && ALWAYS(p->zSql!=0) ){
     sqlite3_mutex_enter(p->db->mutex);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    p->zNormSql = sqlite3Normalize(p, p->zSql, 0);
+    if( gbl_alternate_normalize ){
+      p->zNormSql = sqlite3Normalize_alternate(p, p->zSql, 0);
+    }else{
+      p->zNormSql = sqlite3Normalize(p, p->zSql, 0);
+    }
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     p->zNormSql = sqlite3Normalize(p, p->zSql);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -277,6 +277,7 @@
 (candidate='comdb2_extract_table_names()')
 (candidate='comdb2_host()')
 (candidate='comdb2_node()')
+(candidate='comdb2_normalize_sql()')
 (candidate='comdb2_port()')
 (candidate='comdb2_prevquerycost()')
 (candidate='comdb2_semver()')

--- a/tests/replay_eventlog.test/lrl.options
+++ b/tests/replay_eventlog.test/lrl.options
@@ -3,3 +3,4 @@ ssl_client_mode OPTIONAL
 sync full
 do reql events detailed on
 nowatch
+alternate_normalize 0

--- a/tests/yast.test/normalize.test
+++ b/tests/yast.test/normalize.test
@@ -1,0 +1,433 @@
+# 2018-01-08
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+#
+# Tests for the sqlite3_normalize() extension function.
+#
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+set testprefix normalize
+
+if {![info exists DB]} {set DB ""}
+
+do_test 200 {
+  execsql {
+    CREATE TABLE t1(a,b);
+  }
+} {}
+do_test 201 {
+  set STMT [sqlite3_prepare_v3 $DB \
+      "SELECT a, b FROM t1 WHERE b = ? ORDER BY a;" -1 0 TAIL]
+
+  sqlite3_bind_null $STMT 1
+} {}
+do_test 202 {
+  sqlite3_normalized_sql $STMT
+} {SELECT a,b FROM t1 WHERE b=?ORDER BY a;}
+do_test 203 {
+  sqlite3_finalize $STMT
+} {SQLITE_OK}
+
+do_test 210 {
+  set STMT [sqlite3_prepare_v3 $DB \
+      "SELECT a, b FROM t1 WHERE b = ? ORDER BY a;" -1 2 TAIL]
+
+  sqlite3_bind_null $STMT 1
+} {}
+do_test 211 {
+  sqlite3_normalized_sql $STMT
+} {SELECT a,b FROM t1 WHERE b=?ORDER BY a;}
+do_test 212 {
+  sqlite3_finalize $STMT
+} {SQLITE_OK}
+
+do_test 220 {
+  set STMT [sqlite3_prepare_v3 $DB \
+      "SELECT a, b FROM t1 WHERE b = 'a' ORDER BY a;" -1 2 TAIL]
+} {SELECT a, b FROM t1 WHERE b = 'a' ORDER BY a;}
+do_test 221 {
+  sqlite3_normalized_sql $STMT
+} {SELECT a,b FROM t1 WHERE b=?ORDER BY a;}
+do_test 222 {
+  sqlite3_finalize $STMT
+} {SQLITE_OK}
+
+do_test 297 {
+  execsql {
+    DROP TABLE t1;
+  }
+} {}
+do_test 298 {
+  execsql {
+    CREATE TABLE t1(a,b,c,d,e,col_f,w,x,y,z);
+    CREATE TABLE t2(x,col_y);
+  }
+} {}
+do_test 299 {
+  sqlite3_create_function db
+} {SQLITE_OK}
+
+foreach {tnum sql flags norm} {
+  300
+  {SELECT * FROM t1 WHERE a IN (1) AND b=51.42}
+  0x2
+  {0 {SELECT*FROM t1 WHERE a IN(?,?,?)AND b=?;}}
+
+  310
+  {SELECT a, b+15, c FROM t1 WHERE d NOT IN (SELECT x FROM t2);}
+  0x2
+  {0 {SELECT a,b+?,c FROM t1 WHERE d NOT IN(SELECT x FROM t2);}}
+
+  320
+  { SELECT NULL, b FROM t1 -- comment text
+     WHERE d IN (WITH t(a) AS (VALUES(5)) /* CTE */
+                 SELECT a FROM t)
+        OR e='hello';
+  }
+  0x2
+  {0 {SELECT?,b FROM t1 WHERE d IN(WITH t(a)AS(VALUES(?))SELECT a FROM t)OR e=?;}}
+
+  321
+  {/*Initial comment*/
+   -- another comment line
+   SELECT NULL  /* comment */ , b FROM t1 -- comment text
+     WHERE d IN (WITH t(a) AS (VALUES(5)) /* CTE */
+                 SELECT a FROM t)
+        OR e='hello';
+  }
+  0x2
+  {0 {SELECT?,b FROM t1 WHERE d IN(WITH t(a)AS(VALUES(?))SELECT a FROM t)OR e=?;}}
+
+  330
+  {/* Query containing parameters */
+   SELECT x,?1,y,@abc,z,?99,w FROM t1 /* Trailing comment */}
+  0x2
+  {0 {SELECT x,?,y,?,z,?,w FROM t1;}}
+
+  340
+  {/* Long list on the RHS of IN */
+   SELECT 15 IN (1,2,3,(SELECT * FROM t1),'xyz',x'abcd',22*(x+5),null);}
+  0x2
+  {1 {no such column: x}}
+
+  350
+  {SELECT x'abc'; -- illegal token}
+  0x2
+  {1 {unrecognized token: "x'abc'"}}
+
+  360
+  {SELECT a,NULL,b FROM t1 WHERE c IS NOT NULL or D is null or e=5}
+  0x2
+  {0 {SELECT a,?,b FROM t1 WHERE c IS NOT NULL OR d IS NULL OR e=?;}}
+
+  370
+  {/* IN list exactly 5 bytes long */
+   SELECT * FROM t1 WHERE x IN (1,2,3);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(?,?,?);}}
+
+  400
+  {SELECT a FROM t1 WHERE x IN (1,2,3) AND sqlite_version();}
+  0x2
+  {0 {SELECT a FROM t1 WHERE x IN(?,?,?)AND sqlite_version();}}
+
+  410
+  {SELECT a FROM t1 WHERE x IN (1,2,3) AND sleep();}
+  0x2
+  {1 {wrong number of arguments to function sleep()}}
+
+  420
+  {SELECT a FROM t1 WHERE x IN (1,2,3) AND sleep('abc');}
+  0x2
+  {0 {SELECT a FROM t1 WHERE x IN(?,?,?)AND sleep(?);}}
+
+  430
+  {SELECT "a" FROM t1 WHERE "x" IN ("1","2",'3');}
+  0x2
+  {0 {SELECT a FROM t1 WHERE x IN(?,?,?);}}
+
+  440
+  {SELECT 'a' FROM t1 WHERE 'x';}
+  0x2
+  {0 {SELECT?FROM t1 WHERE?;}}
+
+  450
+  {SELECT [a] FROM t1 WHERE [x];}
+  0x2
+  {0 {SELECT a FROM t1 WHERE x;}}
+
+  460
+  {SELECT * FROM t1 WHERE x IN (x);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(x);}}
+
+  470
+  {SELECT * FROM t1 WHERE x IN (x,a);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(x,a);}}
+
+  480
+  {SELECT * FROM t1 WHERE x IN ([x],"a");}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(x,a);}}
+
+  500
+  {SELECT * FROM t1 WHERE x IN ([x],"a",'b',sqlite_version());}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(x,a,?,sqlite_version());}}
+
+  520
+  {SELECT * FROM t1 WHERE x IN (SELECT x FROM t1);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(SELECT x FROM t1);}}
+
+  540
+  {SELECT * FROM t1 WHERE x IN ((SELECT x FROM t1));}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN((SELECT x FROM t1));}}
+
+  550
+  {SELECT a, a+1, a||'b', a+"b" FROM t1;}
+  0x2
+  {0 {SELECT a,a+?,a||?,a+b FROM t1;}}
+
+  570
+  {SELECT * FROM t1 WHERE x IN (1);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(?,?,?);}}
+
+  580
+  {SELECT * FROM t1 WHERE x IN (1,2);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(?,?,?);}}
+
+  590
+  {SELECT * FROM t1 WHERE x IN (1,2,3);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(?,?,?);}}
+
+  600
+  {SELECT * FROM t1 WHERE x IN (1,2,3,4);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(?,?,?);}}
+
+  610
+  {SELECT * FROM t1 WHERE x IN (SELECT x FROM t1);}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(SELECT x FROM t1);}}
+
+  620
+  {SELECT * FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (1,2,3));}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(?,?,?));}}
+
+  630
+  {SELECT * FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (x));}
+  0x2
+  {0 {SELECT*FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(x));}}
+
+  640
+  {SELECT x FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (
+   SELECT x FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (
+   SELECT x FROM t1 WHERE x IN (x)))));}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(x)))));}}
+
+  650
+  {SELECT x FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (
+   SELECT x FROM t1 WHERE x IN (SELECT x FROM t1 WHERE x IN (
+   SELECT x FROM t1 WHERE x IN (1)))));}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(SELECT x FROM t1 WHERE x IN(?,?,?)))));}}
+
+  660
+  {SELECT x FROM t1 WHERE x IN (1) UNION ALL SELECT x FROM t1 WHERE x IN (1);}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IN(?,?,?)UNION ALL SELECT x FROM t1 WHERE x IN(?,?,?);}}
+
+  670
+  {SELECT "col_f", [col_f] FROM t1;}
+  0x2
+  {0 {SELECT col_f,col_f FROM t1;}}
+
+  680
+  {SELECT a, "col_f" FROM t1 LEFT OUTER JOIN t2 ON [t1].[col_f] == [t2].[col_y];}
+  0x2
+  {0 {SELECT a,col_f FROM t1 LEFT OUTER JOIN t2 ON t1.col_f==t2.col_y;}}
+
+  690
+  {SELECT * FROM ( WITH x AS ( SELECT * FROM t1 WHERE x IN ( 1)) SELECT 10);}
+  0x2
+  {0 {SELECT*FROM(WITH x AS(SELECT*FROM t1 WHERE x IN(?,?,?))SELECT?);}}
+
+  700
+  {SELECT rowid, oid, _rowid_ FROM t1;}
+  0x2
+  {0 {SELECT rowid,oid,_rowid_ FROM t1;}}
+
+  710
+  {SELECT x FROM t1 WHERE x IS NULL;}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IS NULL;}}
+
+  740
+  {SELECT x FROM t1 WHERE x IS NOT NULL;}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IS NOT NULL;}}
+
+  750
+  {SELECT x FROM t1 WHERE x = NULL;}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x=?;}}
+
+  760
+  {SELECT x FROM t1 WHERE x IN ([x] IS NOT NULL, NULL, 1, 'a', "b", x'00');}
+  0x2
+  {0 {SELECT x FROM t1 WHERE x IN(x IS NOT NULL,?,?,?,b,?);}}
+
+  900
+  {INSERT INTO t1 (x) VALUES("sl1"), (1), ("sl2"), ('i');}
+  0x2
+  {0 {INSERT INTO t1(x)VALUES(?),(?),(?),(?);}}
+
+  910
+  {UPDATE t1 SET x = "sl1" WHERE x IN (1, "sl2", 'i');}
+  0x2
+  {0 {UPDATE t1 SET x=?WHERE x IN(?,?,?);}}
+
+  920
+  {UPDATE t1 SET x = "y" WHERE x IN (1, "sl1", 'i');}
+  0x2
+  {0 {UPDATE t1 SET x=y WHERE x IN(?,?,?);}}
+
+  930
+  {DELETE FROM t1 WHERE x IN (1, "sl1", 'i');}
+  0x2
+  {0 {DELETE FROM t1 WHERE x IN(?,?,?);}}
+
+  1000
+  {SELECT +1;}
+  0x2
+  {0 {SELECT?;}}
+
+  1010
+  {SELECT -1;}
+  0x2
+  {0 {SELECT?;}}
+
+  1020
+  {SELECT ++1;}
+  0x2
+  {0 {SELECT?;}}
+
+  1030
+  {SELECT (+1);}
+  0x2
+  {0 {SELECT(?);}}
+
+  1040
+  {SELECT (-1);}
+  0x2
+  {0 {SELECT(?);}}
+
+  1050
+  {SELECT -(+1);}
+  0x2
+  {0 {SELECT(?);}}
+
+  1060
+  {SELECT -(-1);}
+  0x2
+  {0 {SELECT(?);}}
+
+  1070
+  {SELECT 1+1;}
+  0x2
+  {0 {SELECT?+?;}}
+
+  1080
+  {SELECT 1-1;}
+  0x2
+  {0 {SELECT?-?;}}
+
+  1090
+  {SELECT 1+1+abs(-1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1100
+  {SELECT +1+1+abs(-1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1110
+  {SELECT -1+1+abs(-1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1120
+  {SELECT 1-1+abs(-1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+
+  1130
+  {SELECT +1-1+abs(-1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+
+  1140
+  {SELECT -1-1+abs(-1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+
+  1150
+  {SELECT 1+1+abs(+1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1160
+  {SELECT +1+1+abs(+1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1170
+  {SELECT -1+1+abs(+1);}
+  0x2
+  {0 {SELECT?+?+abs(?);}}
+
+  1180
+  {SELECT 1-1+abs(+1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+
+  1190
+  {SELECT +1-1+abs(+1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+
+  1200
+  {SELECT -1-1+abs(+1);}
+  0x2
+  {0 {SELECT?-?+abs(?);}}
+} {
+  do_test $tnum {
+    set code [catch {
+      set STMT [sqlite3_prepare_v3 $DB $sql -1 $flags TAIL]
+      sqlite3_normalized_sql $STMT
+    } res]
+    if {[info exists STMT]} {
+      sqlite3_finalize $STMT; unset STMT
+    }
+    list $code $res
+  } $norm
+}
+
+finish_test


### PR DESCRIPTION
These changes add a new tunable named 'alternate_normalize'.  When true, an alternative algorithm is used to normalize SQL queries.  Currently, the only difference involves the handling of the unary plus and minus operators; however, in the future, these normalization algorithms may diverge further.

The enhanced unary operator handling works by looking at the previously seen token type.  If that token type can participate in a binary sub-expression involving the plus or minus operator, then that operator must be retained in the final normalized SQL query, verbatim; otherwise, it can simply be discarded.

It is likely (?) that this new algorithm will not catch 100% of the possible corner cases involving binary sub-expressions; however, it is a notable improvement over what we have now.

The new tunable was added to permit better backward compatibility just-in-case we wish to backport these changes to the 7.0 release branch.

Signed-off-by: Joe Mistachkin <joe@mistachkin.com>

