### PR TITLE
backup_logfiles: rm dir only if successful test

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3414,8 +3414,10 @@ static void setup_backup_logfiles_dir()
         if (rc)
             logmsg(LOGMSG_ERROR, "%s: Cannot create directory %s (bad path or parent directory): %d %s\n",
                    __func__, backupdir, errno, strerror(errno));
-        else
+        else {
+            logmsg(LOGMSG_DEBUG, "%s: Created directory %s\n", __func__, backupdir);
             gbl_backup_logfiles = 1;
+        }
     }
 cleanup:
     free(backupdir);

--- a/tests/backup_logfiles.test/runit
+++ b/tests/backup_logfiles.test/runit
@@ -47,19 +47,19 @@ master=`getmaster`
 # verify that backup dir has log.0000000001
 if [[ -n "$CLUSTER" ]]; then
     ssh -o StrictHostKeyChecking=no $master "ls -al $BACKUPDIR" > ls_out.txt
-    if [ "$CLEANUPDBDIR" != "0" ] ; then
-        ssh -o StrictHostKeyChecking=no $master "rm -rf $BACKUPDIR"
-    fi
 else
     ls -al $BACKUPDIR > ls_out.txt
 fi
 
-if [ "$CLEANUPDBDIR" != "0" ] ; then # clean locally (inited even in clustered)
-    rm -rf $BACKUPDIR
-    # may need to also rm ${TESTDIR}/backup_logfiles_dir
-fi
-
 cnt=`grep -c log.0000000001 ls_out.txt`
 assertres $cnt 1
+
+if [ "$CLEANUPDBDIR" != "0" ] ; then
+    if [[ -n "$CLUSTER" ]]; then
+        ssh -o StrictHostKeyChecking=no $master "rm -rf $BACKUPDIR"
+    fi
+    # clean locally (init created locally, even for clustered)
+    rm -rf $BACKUPDIR
+fi
 
 echo "Success"


### PR DESCRIPTION
We currently cleanup before evaluating test for success so in case of failure,
we dont have a backup logs directory to check what is wrong.
