### PR TITLE
Return query cost as part of the effects

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3277,6 +3277,17 @@ after_callback:
     return rc;
 }
 
+static inline void get_effects_from_cdb2effects(CDB2EFFECTS *cdb2effects, cdb2_effects_tp *effects)
+{
+    effects->num_affected = cdb2effects->num_affected;
+    effects->num_selected = cdb2effects->num_selected;
+    effects->num_updated = cdb2effects->num_updated;
+    effects->num_deleted = cdb2effects->num_deleted;
+    effects->num_inserted = cdb2effects->num_inserted;
+    if (cdb2effects->has_cost)
+        effects->cost = cdb2effects->cost;
+}
+
 int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects)
 {
     int rc = 0;
@@ -3289,11 +3300,7 @@ int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects)
         if (lrc) {
             rc = -1;
         } else if (hndl->firstresponse && hndl->firstresponse->effects) {
-            effects->num_affected = hndl->firstresponse->effects->num_affected;
-            effects->num_selected = hndl->firstresponse->effects->num_selected;
-            effects->num_updated = hndl->firstresponse->effects->num_updated;
-            effects->num_deleted = hndl->firstresponse->effects->num_deleted;
-            effects->num_inserted = hndl->firstresponse->effects->num_inserted;
+            get_effects_from_cdb2effects(hndl->firstresponse->effects, effects);
             cdb2__sqlresponse__free_unpacked(hndl->firstresponse, NULL);
             free((void *)hndl->first_buf);
             hndl->first_buf = NULL;
@@ -3303,11 +3310,7 @@ int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects)
             rc = -1;
         }
     } else if (hndl->lastresponse->effects) {
-        effects->num_affected = hndl->lastresponse->effects->num_affected;
-        effects->num_selected = hndl->lastresponse->effects->num_selected;
-        effects->num_updated = hndl->lastresponse->effects->num_updated;
-        effects->num_deleted = hndl->lastresponse->effects->num_deleted;
-        effects->num_inserted = hndl->lastresponse->effects->num_inserted;
+        get_effects_from_cdb2effects(hndl->lastresponse->effects, effects);
         rc = 0;
     } else {
         rc = -1;

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -130,6 +130,7 @@ struct cdb2_effects_type {
     int num_updated;
     int num_deleted;
     int num_inserted;
+    int64_t cost;
 };
 
 /* datetime type definition */

--- a/docs/pages/programming/c_api.md
+++ b/docs/pages/programming/c_api.md
@@ -382,6 +382,7 @@ typedef struct cdb2_effects_type {
     int num_updated;
     int num_deleted;
     int num_inserted;
+    int64_t cost;
 } cdb2_effects_tp;
 ```
 

--- a/docs/pages/programming/client_protocol.md
+++ b/docs/pages/programming/client_protocol.md
@@ -394,6 +394,7 @@ message CDB2_EFFECTS {
     required int32 num_updated  = 3;
     required int32 num_deleted  = 4;
     required int32 num_inserted = 5;
+    optional int64 cost         = 6;
 }
 
 message CDB2_SQLRESPONSE {

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -184,7 +184,8 @@ static int fill_snapinfo(struct sqlclntstate *clnt, int *file, int *offset)
     effects.num_updated = clnt->effects.num_updated;                           \
     effects.num_deleted = clnt->effects.num_deleted;                           \
     effects.num_inserted = clnt->effects.num_inserted;                         \
-                                                                               \
+    effects.cost = query_cost(clnt->thd->sqlthd);                              \
+    effects.has_cost = 1;                                                      \
     sql_response.effects = &effects;
 
 #define _has_features(clnt, sql_response)                                      \

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -118,6 +118,7 @@ message CDB2_EFFECTS {
     required int32 num_updated  = 3;
     required int32 num_deleted  = 4;
     required int32 num_inserted = 5;
+    optional int64 cost = 6;
 }
 
 message CDB2_SQLRESPONSE {

--- a/tests/upsert.test/t02_upsert.expected
+++ b/tests/upsert.test/t02_upsert.expected
@@ -31,6 +31,7 @@ Number of rows selected 1
 Number of rows deleted 0
 Number of rows updated 0
 Number of rows inserted 0
+Query Cost 21
 [SELECT * FROM t1 ORDER BY i] rc 0
 Number of rows affected 0
 Number of rows selected 0
@@ -64,6 +65,7 @@ Number of rows selected 0
 Number of rows deleted 1
 Number of rows updated 0
 Number of rows inserted 1
+Query Cost 30
 [REPLACE INTO t1 VALUES(1,1)] rc 0
 (i=1, j=1)
 Number of rows affected 0
@@ -71,6 +73,7 @@ Number of rows selected 1
 Number of rows deleted 0
 Number of rows updated 0
 Number of rows inserted 0
+Query Cost 21
 [SELECT * FROM t1 ORDER BY i] rc 0
 Number of rows affected 0
 Number of rows selected 0
@@ -118,6 +121,7 @@ Number of rows selected 0
 Number of rows deleted 3
 Number of rows updated 0
 Number of rows inserted 3
+Query Cost 90
 [REPLACE INTO t1 VALUES(1,1), (2,2), (3,3)] rc 0
 (i=1, j=1)
 (i=2, j=2)
@@ -127,6 +131,7 @@ Number of rows selected 3
 Number of rows deleted 0
 Number of rows updated 0
 Number of rows inserted 0
+Query Cost 44
 [SELECT * FROM t1 ORDER BY i,j] rc 0
 Number of rows affected 0
 Number of rows selected 0
@@ -167,6 +172,7 @@ Number of rows selected 0
 Number of rows deleted 0
 Number of rows updated 1
 Number of rows inserted 0
+Query Cost 20
 [INSERT INTO t1 VALUES(0,1,2) ON CONFLICT (i) DO UPDATE SET j=j+1] rc 0
 (i=0, j=2, k=0)
 (i=1, j=0, k=1)
@@ -175,6 +181,7 @@ Number of rows selected 2
 Number of rows deleted 0
 Number of rows updated 0
 Number of rows inserted 0
+Query Cost 32
 [SELECT * FROM t1 ORDER BY i, j, k] rc 0
 Number of rows affected 0
 Number of rows selected 0

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1594,6 +1594,8 @@ static int run_statement(const char *sql, int ntypes, int *types,
             printf("Number of rows deleted %d\n", effects.num_deleted);
             printf("Number of rows updated %d\n", effects.num_updated);
             printf("Number of rows inserted %d\n", effects.num_inserted);
+            if (effects.cost > 0)
+                printf("Query Cost %d\n", effects.cost);
         } else {
             printf("Effects not sent by comdb2 server. \n");
         }


### PR DESCRIPTION
Return query cost as int64 and part of the effects, so users can use
that value from response without quering the db for comdb2_prevquerycost.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>