### PR TITLE
Remove poll from wait_for_seqnum

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2943,7 +2943,6 @@ again:
     if (bdb_state->seqnum_info->seqnums[node_ix].lsn.file == INT_MAX ||
         bdb_lock_desired(bdb_state)) {
         /* add 1 ms of latency if we have someone catching up */
-        poll(NULL, 0, 1);
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
         if (bdb_state->attr->wait_for_seqnum_trace) {


### PR DESCRIPTION
While waiting for acks from nodes, we poll while holding the seqnum lock if any nodes are catching up.  I don't have a good test case for this, but have seen it cause large transactions to slow down.  I'm proposing we remove this code.  I believe the initial intent was to allow down nodes more of a chance to catch up.