### PR TITLE
tests: pass RTEONLY to use rte only mode

### DIFF
--- a/tests/setup
+++ b/tests/setup
@@ -94,6 +94,9 @@ setup_db() {
     if [[ -z "$SKIPDEBUG" ]] ; then
         echo "logmsg level debug" >> ${LRL}
     fi
+    if [[ -z "$RTEONLY" ]] ; then
+        echo "libevent_rte_only on" >> ${LRL}
+    fi
     echo "eventlog_nkeep 0" >> ${LRL}
 
     if [[ -f lrl ]]; then


### PR DESCRIPTION
To facilitate generic testing, you can run `make RTEONLY=1 basic` in order to force using rte mode only (useful for ex. in macOS which has annoying firewall and would ask for port usage at db start).

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>