### PR TITLE
Use hash to find fileids rather than walking a list

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1382,6 +1382,12 @@ void timeval_add(struct timeval *tvp,
                   struct timeval *uvp,
                   struct timeval *vvp);
 
+struct fileid_adj_fileid
+{
+	u_int8_t fileid[DB_FILE_ID_LEN];
+	int adj_fileid;
+};
+
 /* Database handle. */
 struct __db {
 	/*******************************************************
@@ -2479,6 +2485,7 @@ struct __db_env {
 
 	LISTC_T(DB) *dbs;
 	int maxdb;
+	hash_t *fidhash;
 
 	LISTC_T(HEAP) regions;
 	int bulk_stops_on_page;


### PR DESCRIPTION
We've found this list to be a performance killer during recover for databases which have a large number of btrees.  I've added a simple plhash filled reference to the adj_fileid index.  This is a work-in-progress.