### PR TITLE
Add id to fname hash to dbreg

### DIFF
--- a/berkdb/dbinc/log.h
+++ b/berkdb/dbinc/log.h
@@ -144,6 +144,12 @@ struct __log_persist {
 	u_int32_t mode;			/* Log file mode. */
 };
 
+
+struct __id_to_fname {
+	int32_t id;
+	struct __fname *fname;
+};
+
 /*
  * LOG --
  *	Shared log region.  One of these is allocated in shared memory,
@@ -160,6 +166,7 @@ struct __log {
 
 	LOGP	 persist;		/* Persistent information. */
 
+	hash_t *idhash;
 	SH_TAILQ_HEAD(__fq1, __fname) fq;	/* List of file names. */
 	int32_t	fid_max;		/* Max fid allocated. */
 	roff_t	free_fid_stack;		/* Stack of free file ids. */

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -651,13 +651,10 @@ __dbreg_id_to_fname(dblp, lid, have_lock, fnamep)
 
 	if (!have_lock)
 		MUTEX_LOCK(dbenv, &lp->fq_mutex);
-	for (fnp = SH_TAILQ_FIRST(&lp->fq, __fname);
-	    fnp != NULL; fnp = SH_TAILQ_NEXT(fnp, q, __fname)) {
-		if (fnp->id == lid) {
-			*fnamep = fnp;
-			ret = 0;
-			break;
-		}
+	struct __id_to_fname *id_to_fname;
+	if ((id_to_fname = hash_find(lp->idhash, &lid)) != NULL && id_to_fname->fname->id == lid) {
+		*fnamep = id_to_fname->fname;
+		ret = 0;
 	}
 	if (!have_lock)
 		MUTEX_UNLOCK(dbenv, &lp->fq_mutex);

--- a/berkdb/log/log.c
+++ b/berkdb/log/log.c
@@ -190,6 +190,7 @@ __log_init(dbenv, dblp)
 	memset(region, 0, sizeof(*region));
 
 	region->fid_max = 0;
+	region->idhash = hash_init(sizeof(int32_t));
 	SH_TAILQ_INIT(&region->fq);
 	region->free_fid_stack = INVALID_ROFF;
 	region->free_fids = region->free_fids_alloced = 0;


### PR DESCRIPTION
This is to speed up dbreg_to_fname, which prior to this PR would walk the list of fname structures searching for a specific id.  This is a WIP.  This, along with https://github.com/bloomberg/comdb2/pull/2630 and https://github.com/bloomberg/comdb2/pull/2631 addresses the recovery slowness issue that we see when a database has a large number of btrees.