### PR TITLE
Tests: fix check for env variable to force rte mode

### DIFF
--- a/tests/setup
+++ b/tests/setup
@@ -94,7 +94,7 @@ setup_db() {
     if [[ -z "$SKIPDEBUG" ]] ; then
         echo "logmsg level debug" >> ${LRL}
     fi
-    if [[ -z "$RTEONLY" ]] ; then
+    if [[ -n "$RTEONLY" ]] ; then
         echo "libevent_rte_only on" >> ${LRL}
     fi
     echo "eventlog_nkeep 0" >> ${LRL}


### PR DESCRIPTION
Logic for env variable check was inverted.