### PR TITLE
reuse the malloced sql string in sockbplog

### DIFF
--- a/db/osqlsession.h
+++ b/db/osqlsession.h
@@ -33,6 +33,13 @@ typedef struct osql_uuid_req osql_uuid_req_t;
 osql_sess_t *osql_sess_create(const char *sql, int sqlen, char *tzname,
                               int type, unsigned long long rqid, uuid_t uuid,
                               const char *host, bool is_reorder_on);
+/**
+ * Same as osql_sess_create, but sql is already a malloced cstr
+ *
+ */
+osql_sess_t *osql_sess_create_socket(const char *sql, char *tzname, int type,
+                                     unsigned long long rqid, uuid_t uuid,
+                                     const char *host, bool is_reorder_on);
 
 /**
  * Terminates an in-use osql session (for which we could potentially

--- a/plugins/sockbplog/sockbplog.c
+++ b/plugins/sockbplog/sockbplog.c
@@ -54,8 +54,8 @@ static int handle_sockbplog_request_session(SBUF2 *sb, char *host)
         logmsg(LOGMSG_ERROR, "Received req %d sql %s\n", type, sql);
 
     /* create a session/bplog */
-    sess = osql_sess_create(sql, strlen(sql) + 1, tzname, type, rqid, uuid,
-                            host, flags & OSQL_FLAGS_REORDER_ON);
+    sess = osql_sess_create_socket(sql, tzname, type, rqid, uuid, host,
+                                   flags & OSQL_FLAGS_REORDER_ON);
     if (!sess) {
         logmsg(LOGMSG_ERROR, "Malloc failure for new ireq\n");
         sbuf2printf(sb, "Error: Out of memory");
@@ -82,17 +82,17 @@ static int handle_sockbplog_request_session(SBUF2 *sb, char *host)
     if (gbl_sockbplog_debug)
         logmsg(LOGMSG_ERROR, "%p %s called\n", (void *)pthread_self(), __func__);
 
-    free(sql);
     return 0;
 
 err:
     logmsg(LOGMSG_ERROR, "%p %s called and failed rc %d\n", (void *)pthread_self(),
            __func__, rc);
 err_nomsg:
-    free(sql);
     if (sess) {
         osql_sess_remclient(sess);
         osql_sess_close(&sess, 0);
+    } else {
+        free(sql);
     }
     return rc;
 }


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

Currently sockbplog allocates  and copies the sql string twice: once from socket, second when session is created. This removes the need to copy it twice, and reuses the already allocated sql string.
