### PR TITLE
Use official maven docker image

### DIFF
--- a/cdb2jdbc/Makefile
+++ b/cdb2jdbc/Makefile
@@ -33,15 +33,15 @@ jdbc-docker-build-container:
 
 jdbc-docker-build: jdbc-docker-build-container
 	docker run \
-        -v /tmp/smoketestca:/ca \
-        --rm \
+    -v /tmp/smoketestca:/ca \
+    --rm \
 		--user $(shell id -u):$(shell id -g) \
 		--env HOME=/tmp \
 		-v $(BASEDIR):/jdbc.build \
 		-v $(BASEDIR)/cdb2jdbc/maven.m2:/maven.m2 \
 		-w /jdbc.build \
 		jdbc-docker-builder:$(VERSION) \
-		/bin/maven/bin/mvn -f /jdbc.build/cdb2jdbc/pom.xml \
+		mvn -f /jdbc.build/cdb2jdbc/pom.xml \
 			-Denv.skipTests=$(envSkipTests) \
 			-DargLine="-Dcdb2jdbc.test.database=$(envTestDatabase) \
                        -Dcdb2jdbc.test.cluster=$(envTestCluster) \

--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -27,7 +27,7 @@ limitations under the License. -->
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>3.2.0</version>
+      <version>3.8.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/contrib/docker/Dockerfile.jdbc.build
+++ b/contrib/docker/Dockerfile.jdbc.build
@@ -1,18 +1,10 @@
-FROM openjdk:8
+FROM maven:3.6.3-adoptopenjdk-8
 
-# Download maven
-RUN \
-  wget https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.5.0/apache-maven-3.5.0-bin.tar.gz && \
-  tar -xvf apache-maven-3.5.0-bin.tar.gz -C /bin && \
-  mv /bin/apache-maven-3.5.0 bin/maven
+RUN apt-get update \
+    && apt-get install -y protobuf-compiler  \
+    && apt-get clean
 
 # Sets maven to use a useful settings.xml file
 COPY \
   contrib/docker/maven-settings.xml /bin/maven/conf/settings.xml
 
-# Install protobuf 3.2 and give all users exec access
-RUN \
-  wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip && \
-  unzip protoc-3.2.0-linux-x86_64.zip -d protoc && \
-  mv protoc/bin/protoc /bin && \
-  chmod 755 /bin/protoc


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
  Updates the base image used to build the java docker container. Also, installs `protoc` from the official repos.
    
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
  I'd argue it is, as it uses more recent versions of both `maven` and `protoc`.
