### PR TITLE
Add autocommit flag to parameters

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -86,6 +86,8 @@ public class Driver implements java.sql.Driver {
 
     protected void populateOptions() throws SQLException {
         try {
+            options.put("allow_pmux_route", new BooleanOption("allow_pmux_route", "AllowPmuxRoute"));
+            options.put("autocommit", new BooleanOption("autocommit", "AutoCommit"));
             options.put("maxquerytime", new IntegerOption("maxquerytime", "QueryTimeout"));
             options.put("timeout", new IntegerOption("timeout", "Timeout"));
             options.put("sotimeout", new IntegerOption("sotimeout", "SoTimeout"));
@@ -114,7 +116,6 @@ public class Driver implements java.sql.Driver {
             options.put("trust_store_password", new StringOption("trust_store_password", "SSLCAPass"));
             options.put("trust_store_type", new StringOption("trust_store_type", "SSLCAType"));
             options.put("crl", new StringOption("crl", "SSLCRL"));
-            options.put("allow_pmux_route", new BooleanOption("allow_pmux_route", "AllowPmuxRoute"));
             options.put("statement_query_effects",
                     new BooleanOption("statement_query_effects", "StatementQueryEffects"));
             options.put("verify_retry", new BooleanOption("verify_retry", "VerifyRetry"));


### PR DESCRIPTION
Allow passing the autocommit flag as a connection parameter

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
  Feature

* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
    Add the ability to pass the autocommit flag as a connection parameter

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
  Some frameworks (JPA, Spring ORM, Hibernate, etc) work at a Datasource level. Connection lifecycle is handled by the framework itself; users don't have a mechanism to customize Connection objects so properties like `autocommit` can't be changed programmatically. 
  
  Adding a parameter to the JDBC URL allows users to set values for this property at the Datasource level.
