### PR TITLE
Skip check for ulonglong on startup

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5625,7 +5625,6 @@ int gbl_hostname_refresh_time = 60;
 
 int close_all_dbs_tran(tran_type *tran);
 
-int reload_all_db_tran(tran_type *tran);
 int open_all_dbs_tran(void *tran);
 void delete_prepared_stmts(struct sqlthdstate *thd);
 int reload_lua_sfuncs();

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -842,6 +842,11 @@ typedef struct dbtable {
 
     bool disableskipscan : 1;
     bool do_local_replication : 1;
+    /* A flag to temporarily disable check for the presence of u_longlong types
+       in the (csc2) schema even when forbid_ulonglong is enabled. This allows
+       certain maintenance operations on legacy tables, using forbid_ulonglong
+       type, to work properly. */
+    bool skip_error_on_ulonglong_check : 1;
 } dbtable;
 
 struct log_delete_state {

--- a/db/tag.c
+++ b/db/tag.c
@@ -5307,8 +5307,19 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
                 logmsg(LOGMSG_ERROR,
                        "Error in table %s: u_longlong is unsupported\n",
                        db->tablename);
-                reqerrstr(db->iq, ERR_SC, "u_longlong is not supported");
-                return -1;
+                /* Skip returning error on presence of u_longlong if:
+
+                   - we are still starting, or
+                   - we were explicitly asked to do so.
+
+                   This is done to allow existing databases with tables
+                   containing u_longlong to start and also certain operational
+                   commands, like rebuild and truncate, to succeed.
+                */
+                if (gbl_ready && (db->skip_error_on_ulonglong_check != 1)) {
+                    reqerrstr(db->iq, ERR_SC, "u_longlong is not supported");
+                    return -1;
+                }
             }
 
             /* count the blobs */
@@ -7108,11 +7119,14 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
     }
     newdb->schema_version = version;
     newdb->dbnum = db->dbnum;
+    newdb->skip_error_on_ulonglong_check = 1;
     rc = add_cmacc_stmt(newdb, 0);
     if (rc) {
         logmsg(LOGMSG_ERROR, "add_cmacc_stmt failed %s:%d\n", __FILE__, __LINE__);
+        newdb->skip_error_on_ulonglong_check = 0;
         goto err;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 
@@ -7185,30 +7199,6 @@ int reload_after_bulkimport(dbtable *db, tran_type *tran)
 }
 
 #include <bdb_int.h>
-
-int reload_all_db_tran(tran_type *tran)
-{
-    int table;
-    int rc;
-    for (rc = 0, table = 0; table < thedb->num_dbs && rc == 0; table++) {
-        dbtable *db = thedb->dbs[table];
-        backout_schemas(db->tablename);
-
-        if (load_new_ondisk(db, tran)) {
-            logmsg(LOGMSG_ERROR, "Failed to load new .ONDISK\n");
-            return 1;
-        }
-        if (load_new_versions(db, tran)) {
-            logmsg(LOGMSG_ERROR, "Failed to load .ONDISK.VER.nn\n");
-            return 1;
-        }
-
-        db->tableversion = table_version_select(db, tran);
-        update_dbstore(db);
-    }
-
-    return 0;
-}
 
 int reload_db_tran(dbtable *db, tran_type *tran)
 {

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -428,16 +428,18 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     newdb->schema_version = get_csc2_version(newdb->tablename);
 
     newdb->iq = iq;
-
+    newdb->skip_error_on_ulonglong_check = (s->same_schema) ? 1 : 0;
     if (add_cmacc_stmt(newdb, 1) != 0) {
         backout(newdb);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
         if (local_lock)
             unlock_schema_lk();
+        newdb->skip_error_on_ulonglong_check = 0;
         Pthread_mutex_unlock(&csc2_subsystem_mtx);
         return -1;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
 
     extern int gbl_partial_indexes;
     extern int gbl_expressions_indexes;

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -83,13 +83,16 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     newdb->iq = iq;
 
+    newdb->skip_error_on_ulonglong_check = 1;
     if (add_cmacc_stmt(newdb, 1) != 0) {
         backout_schemas(newdb->tablename);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
+        newdb->skip_error_on_ulonglong_check = 0;
         Pthread_mutex_unlock(&csc2_subsystem_mtx);
         return -1;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     /* create temporary tables.  to try to avoid strange issues always

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -837,11 +837,14 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
             return 1;
         }
         newdb->dbnum = db->dbnum;
+        newdb->skip_error_on_ulonglong_check = 1;
         if (add_cmacc_stmt(newdb, 1) != 0) {
             /* can happen if new schema has no .DEFAULT tag but needs one */
             backout_schemas(table);
+            newdb->skip_error_on_ulonglong_check = 0;
             return 1;
         }
+        newdb->skip_error_on_ulonglong_check = 0;
         newdb->meta = db->meta;
         newdb->dtastripe = gbl_dtastripe;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1003,10 +1003,12 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     newdb->instant_schema_change = s->headers && s->instant_sc;
     newdb->schema_version = get_csc2_version(newdb->tablename);
 
+    newdb->skip_error_on_ulonglong_check = 1;
     if (add_cmacc_stmt(newdb, 1) != 0) {
         backout_schemas(newdb->tablename);
         abort();
     }
+    newdb->skip_error_on_ulonglong_check = 0;
 
     if (verify_constraints_exist(NULL, newdb, newdb, s) != 0) {
         backout_schemas(newdb->tablename);


### PR DESCRIPTION
PR-2594 fixed the logic of broken `forbid_ulonglong` tunable that was added to
disallow use of `ulonglong` types in a table schema. This new logic, however,
now prevents existing databases from starting that have been using `ulonglong`.

The change, introduced by this PR, skips this check until the database is fully
up, allowing affected database to start ignoring `forbid_ulonglong` tunable in
the lrl. The tunable becomes effective and is enforced once the database has
started.

Refer: https://github.com/bloomberg/comdb2/pull/2594

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>