### PR TITLE
spew view prepare sql string when sqlite fails

### DIFF
--- a/db/views_sqlite.c
+++ b/db/views_sqlite.c
@@ -283,7 +283,8 @@ static int _views_run_sql(sqlite3 *db, const char *stmt_str,
         /* can't control sqlite errors */
         err->errstr[sizeof(err->errstr) - 1] = '\0';
 
-        logmsg(LOGMSG_ERROR, "%s: sqlite error \"%s\"\n", __func__, err->errstr);
+        logmsg(LOGMSG_ERROR, "%s: sqlite error \"%s\" sql \"%s\"\n", __func__,
+               errstr, stmt_str);
 
         if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_TIMEPART_ABORT_ON_PREPERROR)) {
             abort();


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

NOTE: there is already a setattr we can set as well to core at an earlier time and get the actual string, but this will get us a less generic view prepare error.
