### PR TITLE
Skip check for ulonglong on startup (upmerge from 7.0)

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5893,7 +5893,6 @@ int gbl_hostname_refresh_time = 60;
 
 int close_all_dbs_tran(tran_type *tran);
 
-int reload_all_db_tran(tran_type *tran);
 int open_all_dbs_tran(void *tran);
 int reload_lua_sfuncs();
 int reload_lua_afuncs();

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -769,6 +769,11 @@ typedef struct dbtable {
 
     bool disableskipscan : 1;
     bool do_local_replication : 1;
+    /* A flag to temporarily disable check for the presence of u_longlong types
+       in the (csc2) schema even when forbid_ulonglong is enabled. This allows
+       certain maintenance operations on legacy tables, using forbid_ulonglong
+       type, to work properly. */
+    bool skip_error_on_ulonglong_check : 1;
 } dbtable;
 
 struct dbview {

--- a/db/tag.c
+++ b/db/tag.c
@@ -5081,7 +5081,8 @@ static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects)
                    commands, like rebuild and truncate, to succeed.
                 */
                 if (gbl_ready && (db->skip_error_on_ulonglong_check != 1)) {
-                    reqerrstr(db->iq, ERR_SC, "u_longlong is not supported");
+                    if (db->iq)
+                        reqerrstr(db->iq, ERR_SC, "u_longlong is not supported");
                     return -1;
                 }
             }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -431,6 +431,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     newdb->iq = iq;
 
+    newdb->skip_error_on_ulonglong_check = (s->same_schema) ? 1 : 0;
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
         backout(newdb);
         cleanup_newdb(newdb);
@@ -439,8 +440,10 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         sc_errf(s, "Failed to process schema!\n");
         if (local_lock)
             unlock_schema_lk();
+        newdb->skip_error_on_ulonglong_check = 0;
         return -1;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
 
     if ((rc = sql_syntax_check(iq, newdb))) {
         Pthread_mutex_unlock(&csc2_subsystem_mtx);

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -86,14 +86,17 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     newdb->iq = iq;
 
+    newdb->skip_error_on_ulonglong_check = 1;
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
         backout_schemas(newdb->tablename);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
         dyns_cleanup_globals();
+        newdb->skip_error_on_ulonglong_check = 0;
         Pthread_mutex_unlock(&csc2_subsystem_mtx);
         return -1;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
     dyns_cleanup_globals();
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -844,11 +844,14 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
         return 1;
     }
     newdb->dbnum = db->dbnum;
+    newdb->skip_error_on_ulonglong_check = 1;
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
         /* can happen if new schema has no .DEFAULT tag but needs one */
+        newdb->skip_error_on_ulonglong_check = 0;
         backout_schemas(table);
         return 1;
     }
+    newdb->skip_error_on_ulonglong_check = 0;
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1016,10 +1016,12 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     newdb->instant_schema_change = s->headers && s->instant_sc;
     newdb->schema_version = get_csc2_version(newdb->tablename);
 
+    newdb->skip_error_on_ulonglong_check = 1;
     if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
         backout_schemas(newdb->tablename);
         abort();
     }
+    newdb->skip_error_on_ulonglong_check = 0;
 
     if (verify_constraints_exist(NULL, newdb, newdb, s) != 0) {
         backout_schemas(newdb->tablename);


### PR DESCRIPTION
PR-2594 fixed the logic of broken forbid_ulonglong tunable that was added to
disallow use of ulonglong types in a table schema. This new logic, however,
now prevents existing databases from starting that have been using ulonglong.

The change, introduced by this PR, skips this check until the database is fully
up, allowing affected databases to start ignoring forbid_ulonglong tunable in
the lrl. The tunable becomes effective and is enforced once the database has
started. Besides, maintenance operations (like rebuild, truncate) should succeed
on old u_longlong tables

An error is always logged, unconditionally, to allow enabling ALRMs

Refer: https://github.com/bloomberg/comdb2/pull/2594

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>