### PR TITLE
make sure updating a view schema works if the client statement is ro

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -3645,7 +3645,8 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
 
     if (clnt->is_readonly &&
         /* exclude writes in a temp table for a select */
-        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || !clnt->isselect)) {
+        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || !clnt->isselect) &&
+        (pCur->rootpage != RTPAGE_SQLITE_MASTER)) {
         errstat_set_strf(&clnt->osql.xerr, "SET READONLY ON for the client");
         rc = SQLITE_ACCESS;
         goto done;
@@ -8503,7 +8504,8 @@ int sqlite3BtreeInsert(
 
     if (clnt->is_readonly &&
         /* exclude writes in a temp table for a select */
-        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || !clnt->isselect)) {
+        (pCur->cursor_class != CURSORCLASS_TEMPTABLE || !clnt->isselect) &&
+        (pCur->rootpage != RTPAGE_SQLITE_MASTER)) {
         errstat_set_strf(&clnt->osql.xerr, "SET READONLY ON for the client");
         rc = SQLITE_ACCESS;
         goto done;

--- a/tests/timepart_readonly.test/Makefile
+++ b/tests/timepart_readonly.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/timepart_readonly.test/README
+++ b/tests/timepart_readonly.test/README
@@ -1,0 +1,1 @@
+This tests SET READONLY ON option during partition rollout and impact on view schema updates.

--- a/tests/timepart_readonly.test/lrl.options
+++ b/tests/timepart_readonly.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/timepart_readonly.test/runit
+++ b/tests/timepart_readonly.test/runit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# args
+# <dbname>
+dbname=$1
+
+VIEW1="testview1"
+OUT="run.log"
+
+rm $OUT 2>/dev/null
+touch $OUT
+
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+2*60 -2*24*3600)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >> $OUT
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+# no race between insert and rollout, want insert in last shard
+sleep 10
+
+#insert one row
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into ${VIEW1} values (1, 'hello')" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+#wait for the last rollout, before re-preparing a view
+sleep 60
+
+#trigger a prepare
+cdb2sql ${CDB2_OPTIONS} $dbname default >> $OUT <<EOF
+set readonly on
+select * from ${VIEW1} 
+EOF
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/timepart_readonly.test/t.csc2
+++ b/tests/timepart_readonly.test/t.csc2
@@ -1,0 +1,9 @@
+schema
+{
+   int      a
+   cstring  b[10]
+}
+keys
+{
+   "pk"  = a
+}


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

When we removed iswrite and replaced it with slightly different isselect, we broke readonly for time partitions