### PR TITLE
Convert to real function bdb_has_tablename_locked

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1833,12 +1833,12 @@ int bdb_lock_tablename_write(bdb_state_type *bdb_state, const char *tblname,
                              tran_type *tran);
 int bdb_lock_tablename_read(bdb_state_type *, const char *name, tran_type *);
 
-enum assert_lock_type {
-    ASSERT_TABLENAME_LOCKED_WRITE = 1,
-    ASSERT_TABLENAME_LOCKED_READ = 2,
-    ASSERT_TABLENAME_LOCKED_EITHER = 3
+enum query_lock_type {
+    TABLENAME_LOCKED_WRITE = 1,
+    TABLENAME_LOCKED_READ = 2,
+    TABLENAME_LOCKED_EITHER = 3
 };
-int bdb_assert_tablename_locked(bdb_state_type *, const char *name, uint32_t lid, enum assert_lock_type type);
+int bdb_has_tablename_locked(bdb_state_type *, const char *name, uint32_t lid, enum query_lock_type type);
 int bdb_lock_row_write(bdb_state_type *bdb_state, tran_type *tran,
                        unsigned long long genid);
 int bdb_trylock_row_write(bdb_state_type *bdb_state, tran_type *tran,

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -55,6 +55,7 @@
 
 extern int sc_ready(void);
 extern int gbl_debug_systable_locks;
+extern int32_t gbl_rep_lockid;
 
 /* bdb routines to support schema change */
 
@@ -179,9 +180,8 @@ int handle_scdone(DB_ENV *dbenv, u_int32_t rectype, llog_scdone_args *scdoneop,
     scdone_t sctype = ntohl(type);
 
     if (gbl_debug_systable_locks) {
-        extern int32_t gbl_rep_lockid;
-        bdb_assert_tablename_locked(dbenv->app_private, "_comdb2_systables", gbl_rep_lockid,
-                                    ASSERT_TABLENAME_LOCKED_WRITE);
+        assert(bdb_has_tablename_locked(dbenv->app_private, "_comdb2_systables", gbl_rep_lockid,
+                                        TABLENAME_LOCKED_WRITE));
     }
 
     if (sctype == rename_table) {

--- a/bdb/locks.c
+++ b/bdb/locks.c
@@ -740,21 +740,21 @@ int bdb_lock_tablename_write(bdb_state_type *bdb_state, const char *name,
     return rc;
 }
 
-int bdb_assert_tablename_locked(bdb_state_type *bdb_state, const char *tblname, uint32_t lockid,
-                                enum assert_lock_type type)
+/* return whether current lockid has given type of lock on tablename */
+int bdb_has_tablename_locked(bdb_state_type *bdb_state, const char *tblname,
+                             uint32_t lockid, enum query_lock_type type)
 {
     int have_write = 0, have_read = 0;
     char name[TABLELOCK_KEY_SIZE];
     DBT lk;
 
     form_tablelock_keyname(tblname, name, &lk);
-    if (type == ASSERT_TABLENAME_LOCKED_WRITE || type == ASSERT_TABLENAME_LOCKED_EITHER) {
+    if (type == TABLENAME_LOCKED_WRITE || type == TABLENAME_LOCKED_EITHER) {
         have_write = berkdb_check_held(bdb_state->dbenv, lockid, &lk, DB_LOCK_WRITE);
     }
-    if ((have_write == 0) && (type == ASSERT_TABLENAME_LOCKED_READ || type == ASSERT_TABLENAME_LOCKED_EITHER)) {
+    if ((have_write == 0) && (type == TABLENAME_LOCKED_READ || type == TABLENAME_LOCKED_EITHER)) {
         have_read = berkdb_check_held(bdb_state->dbenv, lockid, &lk, DB_LOCK_READ);
     }
-    assert(have_write | have_read);
     return have_write | have_read;
 }
 

--- a/db/dbqueuedb.c
+++ b/db/dbqueuedb.c
@@ -164,11 +164,11 @@ int dbqueuedb_get_stats(struct dbtable *db, struct consumer_stat *stats, uint32_
         bdb_set_tran_lockerid(trans, lockid);
 
         if (gbl_debug_systable_locks) {
-            bdb_assert_tablename_locked(bdb_state, "_comdb2_systables", lockid, ASSERT_TABLENAME_LOCKED_READ);
+            assert(bdb_has_tablename_locked(bdb_state, "_comdb2_systables", lockid, TABLENAME_LOCKED_READ));
         }
 
         if (gbl_assert_systable_locks) {
-            bdb_assert_tablename_locked(bdb_state, "comdb2_queues", lockid, ASSERT_TABLENAME_LOCKED_READ);
+            assert(bdb_has_tablename_locked(bdb_state, "comdb2_queues", lockid, TABLENAME_LOCKED_READ));
         }
     }
     if ((rc = bdb_lock_table_read(bdb_state, trans)) == 0) {

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -694,15 +694,15 @@ int scdone_callback(bdb_state_type *bdb_state, const char table[], void *arg,
         case llmeta_queue_add:
         case llmeta_queue_alter:
         case llmeta_queue_drop:
-            bdb_assert_tablename_locked(bdb_state, "comdb2_queues", gbl_rep_lockid, ASSERT_TABLENAME_LOCKED_WRITE);
+            assert(bdb_has_tablename_locked(bdb_state, "comdb2_queues", gbl_rep_lockid, TABLENAME_LOCKED_WRITE));
             break;
         case user_view:
-            bdb_assert_tablename_locked(bdb_state, "comdb2_views", gbl_rep_lockid, ASSERT_TABLENAME_LOCKED_WRITE);
+            assert(bdb_has_tablename_locked(bdb_state, "comdb2_views", gbl_rep_lockid, TABLENAME_LOCKED_WRITE));
             break;
         case add: // includes fastinit
         case drop:
         case alter:
-            bdb_assert_tablename_locked(bdb_state, "comdb2_tables", gbl_rep_lockid, ASSERT_TABLENAME_LOCKED_WRITE);
+            assert(bdb_has_tablename_locked(bdb_state, "comdb2_tables", gbl_rep_lockid, TABLENAME_LOCKED_WRITE));
             break;
         default:
             break;


### PR DESCRIPTION
Instead of having bdb_assert_tablename_locked assert on the return value
(which also means if debug is not enabled, the whole work that function does
is wasted), convert it to a real function which we can use independently,
and assert on the value returned from the existing callers.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
