### PR TITLE
Speedup truncate: cache version_num in process_unused_files

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3353,9 +3353,6 @@ void sql_dump_hints(void);
 
 extern int gbl_disable_exit_on_thread_error;
 
-void sc_del_unused_files(dbtable *db);
-void sc_del_unused_files_tran(dbtable *db, tran_type *tran);
-
 extern int gbl_support_sock_lu;
 
 extern int gbl_berkdb_iomap;

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -54,6 +54,7 @@
 #include <logmsg.h>
 
 #include <autoanalyze.h>
+#include "sc_callbacks.h"
 
 #if 0
 #define TEST_QSQL_REQ

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -936,11 +936,8 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     db->handle = old_bdb_handle;
 
-#if 0
-    /* handle in osql_scdone_commit_callback and osql_scdone_abort_callback */
-    /* delete files we don't need now */
-    sc_del_unused_files_tran(db, transac);
-#endif
+    /* deletion of btree files we don't need is handled in
+     * osql_scdone_commit_callback and osql_scdone_abort_callback */
     memset(newdb, 0xff, sizeof(struct dbtable));
     free(newdb);
     free(new_bdb_handle);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -38,6 +38,7 @@
 #include "sc_view.h"
 #include "logmsg.h"
 #include "comdb2_atomic.h"
+#include "sc_callbacks.h"
 #include <debug_switches.h>
 
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -19,6 +19,7 @@
 #include "translistener.h"
 #include "sc_schema.h"
 #include "logmsg.h"
+#include "sc_callbacks.h"
 
 #define BDB_TRAN_MAYBE_ABORT_OR_FATAL(a,b,c) do {                             \
     (c) = 0;                                                                  \

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -37,6 +37,8 @@ setup_debugger() {
             ;;
         perf)
             DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g "
+            # get report of performance via perf report -i $TESTDIR/$TESTCASE.perfdata
+            # or perf annotate -i $TESTDIR/$TESTCASE.perfdata
             ;;
         mutrace)   # mutex contention detection tool
             DEBUG_PREFIX="mutrace "

--- a/tests/sc_lotsoftables.test/lrl.options
+++ b/tests/sc_lotsoftables.test/lrl.options
@@ -3,3 +3,6 @@ setattr LOGREGIONSZ 16777216
 setattr MIN_KEEP_LOGS 2
 setattr MIN_KEEP_LOGS_AGE 10
 setattr PRIVATE_BLKSEQ_MAXAGE 10
+pagesizedta 512
+pagesizeblob 512
+pagesizeix 512

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -4,11 +4,8 @@ bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/runit_common.sh
 source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
-# Debug variable
-debug=0
-
 dbnm=$1
-tblcnt=150
+tblcnt=100
 
 if [ "x$dbnm" == "x" ] ; then
     echo "need a DB name"
@@ -33,23 +30,19 @@ function insert_records
         echo "insert into $tbl(a,b,c,d,e) values ($((j+10000)),'test1$j',$j,$j,'abc$j')" 
         let j=j+1
     done | cdb2sql ${CDB2_OPTIONS} $dbnm default - &>> $insfl
+    assertres $? 0
 }
 
-
-kill_by_pidfile() 
+function wait_till_ready
 {
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        failexit "kill_by_pidfile: pidfile $pidfile does not exist"
-    fi
+    node=$1
+    out=0
+    # wait until we can query it
+    echo "$DBNAME: waiting until ready"
+    while [[ "$out" != "1" ]]; do
+        sleep 2
+        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
+    done
 }
 
 kill_restart_cluster()
@@ -72,7 +65,6 @@ kill_restart_cluster()
     done
 }
 
-
 cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
 
 function flushall 
@@ -85,23 +77,39 @@ function flushall
 
 
 PRFIX=my_table_name_
+master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
+#cdb2sql ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.send('bdb setattr DELAYED_OLDFILE_CLEANUP 0')"
 
 echo "Test with insert, SC should not fail"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}0 { `cat t1_1.csc2 ` }"
+assertres $? 0
 
+echo "real time creating"
 #cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('debg 500')"
 for i in `seq 1 $tblcnt`; do
   echo "create t$i: "
   time cdb2sql ${CDB2_OPTIONS} $dbnm default "create table ${PRFIX}$i  { `cat t1_1.csc2 ` }"
+  assertres $? 0
   insert_records ${PRFIX}$i $i
-  echo truncate ${PRFIX}0
-  time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
-
   #flushall
 done
 
+echo "real time truncating"
+for i in `seq 1 20`; do
+  echo "truncate ${PRFIX}0"
+  time cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate ${PRFIX}0"
+  
+  if [ $((i % 5)) == 0 ] ; then
+      echo delfiles ${PRFIX}0
+      time cdb2sql ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.send('delfiles ${PRFIX}0')" &> delfiles.out
+  fi
+  insert_records ${PRFIX}0 1
+done
+
+echo "real time dropping"
 for i in `seq 1 $tblcnt`; do
     assertcnt ${PRFIX}$i $i
+    time cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table ${PRFIX}$i"
     #echo rebuild t1
     #time cdb2sql ${CDB2_OPTIONS} $dbnm default "rebuild t1"
     #assertcnt t$i $i
@@ -118,7 +126,6 @@ done
 #    cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr PRIVATE_BLKSEQ_MAXAGE 10')"
 #sleep 20
 
-#master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
 
 #for i in `seq 0 $tblcnt`; do
 #    assertcnt t$i $i
@@ -132,10 +139,11 @@ test_create_tbls() {
     tbl="f"
     while [ $i -lt 30 ] ; do
         tbl=$tbl$((i%10))
-        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "create table $tbl (i int unique)"
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "create table $tbl (i int unique, b blob)"
+        assertres $? 0
         val=$RANDOM
-        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "insert into $tbl values ($val)"
-        res=`$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --tabs default "select * from $tbl"`
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "insert into $tbl values ($val, NULL)"
+        res=`$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --tabs default "select i from $tbl"`
         assertres $res $val
         let i=i+1
     done
@@ -144,7 +152,12 @@ test_create_tbls() {
 
 test_create_tbls
 
-
+if [[ -n "$CLUSTER" ]] ; then
+    cdb2sql ${CDB2_OPTIONS} $dbnm --host master 'exec procedure sys.cmd.send("downgrade")'
+    for node in "$CLUSTER" ; do
+        wait_till_ready $node
+    done
+fi
 
 
 echo "Success"

--- a/tests/sc_lotsoftables.test/t1_1.csc2
+++ b/tests/sc_lotsoftables.test/t1_1.csc2
@@ -5,6 +5,20 @@ schema
     int      c
     int      d
     vutf8    e[10]
+    blob     b2  null=yes
+    blob     b3  null=yes
+    blob     b4  null=yes
+    blob     b5  null=yes
+    blob     b6  null=yes
+    blob     b7  null=yes
+    blob     b8  null=yes
+    blob     b9  null=yes
+    //blob     b10 null=yes
+    //blob     b11 null=yes
+    //blob     b12 null=yes
+    //blob     b13 null=yes
+    //blob     b14 null=yes
+    //blob     b15 null=yes
 }
 
 keys


### PR DESCRIPTION
When a db has many tables tables, truncate will take a long time because
delfiles will go through the entire directory to find files matching pattern
to be put in list for deletion. The inneficiency is because we fetch
version_num for every file in the directory: this checkin improves that
by caching those values in a local array.
Also dont check if tbl is under schemachange when we have tbllock.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>