### PR TITLE
Time partition: Make AS clause optional (WIP)

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -20,6 +20,7 @@
 #include "ast.h"
 #include "dohsql.h"
 #include "sql.h"
+#include "views.h"
 
 int gbl_dohast_disable = 0;
 int gbl_dohast_verbose = 0;
@@ -177,6 +178,10 @@ char *sqlite_struct_to_string(Vdbe *v, Select *p, Expr *extraRows,
                                   p->pSrc->a[0].zName);
         else
             tbl = sqlite3_mprintf("\"%w\"", p->pSrc->a[0].zName);
+    } else if (p->pSrc->nSrc) {
+        if (IS_TIMEPART_SHARD(p->pSrc->a[0].zName)) {
+            tbl = sqlite3_mprintf("\"%w\"", p->pSrc->a[0].zName);
+        }
     }
 
     if (unlikely(!tbl)) {

--- a/db/views.h
+++ b/db/views.h
@@ -25,6 +25,13 @@ enum view_partition_period {
     VIEW_PARTITION_MANUAL
 };
 
+#define TIMEPART_VIEW_PREFIX "$__V_"
+#define TIMEPART_SHARD_PREFIX "$__T_"
+#define IS_TIMEPART_VIEW(p)                                                    \
+    ((strncmp(p, TIMEPART_VIEW_PREFIX, sizeof(TIMEPART_VIEW_PREFIX) - 1)) == 0)
+#define IS_TIMEPART_SHARD(p)                                                   \
+    ((strncmp(p, TIMEPART_SHARD_PREFIX, sizeof(TIMEPART_SHARD_PREFIX) - 1)) == 0)
+
 #define IS_TIMEPARTITION(p)                                                    \
     ((p) == VIEW_PARTITION_DAILY || (p) == VIEW_PARTITION_WEEKLY ||            \
      (p) == VIEW_PARTITION_MONTHLY || (p) == VIEW_PARTITION_YEARLY ||          \

--- a/db/views_sqlite.c
+++ b/db/views_sqlite.c
@@ -208,8 +208,16 @@ static char *_views_create_view_query(timepart_view_t *view, sqlite3 *db,
     /* TODO: put conditions for shards */
     select_str = sqlite3_mprintf("");
     for (i = 0; i < view->nshards; i++) {
-        tmp_str = sqlite3_mprintf("%s%sSELECT %s FROM \"%w\"", select_str,
+        bool use_timepart_shard_prefix = false;
+        if ((IS_TIMEPART_VIEW(view->name)) &&
+            (strcmp(view->name+sizeof(TIMEPART_VIEW_PREFIX)-1,
+                    view->shards[i].tblname) == 0)) {
+            use_timepart_shard_prefix = true;
+        }
+        tmp_str = sqlite3_mprintf("%s%sSELECT %s FROM \"%s%w\"", select_str,
                                   (i > 0) ? " UNION ALL " : "", cols_str,
+                                  (use_timepart_shard_prefix) ?
+                                  TIMEPART_SHARD_PREFIX : "",
                                   view->shards[i].tblname);
         sqlite3_free(select_str);
         if (!tmp_str) {

--- a/db/views_systable.c
+++ b/db/views_systable.c
@@ -35,7 +35,11 @@ int timepart_systable_timepartitions_collect(void **data, int *nrecords)
     }
     for (narr = 0; narr < views->nviews; narr++) {
         view = views->views[narr];
-        arr[narr].name = strdup(view->name);
+        if (IS_TIMEPART_VIEW(view->name)) {
+            arr[narr].name = strdup(view->name + sizeof(TIMEPART_VIEW_PREFIX) - 1);
+        } else {
+            arr[narr].name = strdup(view->name);
+        }
         arr[narr].period = strdup(period_to_name(view->period));
         arr[narr].retention = view->retention;
         arr[narr].nshards = view->nshards;

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -1242,16 +1242,20 @@ void comdb2CreatePartition(Parse* pParse, Token* table,
         chkAndCopyTableTokens(pParse, tp->tablename, table, NULL, 1, 1, 0))
         goto clean_arg;
 
-    tp->partition_name = (char*) malloc(MAXTABLELEN);
-    if (!tp->partition_name) {
-        setError(pParse, SQLITE_NOMEM, "Out of Memory");
-        goto clean_arg;
+    if (partition_name->n) {
+        tp->partition_name = (char*) malloc(MAXTABLELEN);
+        if (!tp->partition_name) {
+            setError(pParse, SQLITE_NOMEM, "Out of Memory");
+            goto clean_arg;
+        }
+        if (partition_name->n >= MAXTABLELEN) {
+            setError(pParse, SQLITE_MISUSE, "Partition name is too long");
+            goto clean_arg;
+        }
+        strncpy0(tp->partition_name, partition_name->z, partition_name->n + 1);
+    } else {
+        tp->partition_name = strdup(tp->tablename);
     }
-    if (partition_name->n >= MAXTABLELEN) {
-        setError(pParse, SQLITE_MISUSE, "Partition name is too long");
-        goto clean_arg;
-    }
-    strncpy0(tp->partition_name, partition_name->z, partition_name->n + 1);
 
     char period_str[50];
 

--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -2296,11 +2296,16 @@ cmd ::= BULKIMPORT nm(A) DOT nm(B) nm(C) DOT nm(D). {
 
 ////////////////////////////// CREATE PARTITION ///////////////////////////////
 
+%type as_tp_nm_opt {Token}
+as_tp_nm_opt(A) ::= .      {A.z=0; A.n=0;}
+as_tp_nm_opt(A) ::= AS nm(X). {A = X;}
+
 cmd ::= createkw RANGE PARTITION ON nm(A) WHERE columnname(B) IN LP exprlist(C) RP. {
     comdb2CreateRangePartition(pParse, &A, &B, C);
 }
 
-cmd ::= createkw partition_type PARTITION ON nm(A) AS nm(P) PERIOD STRING(D) RETENTION INTEGER(R) START STRING(S). {
+cmd ::= createkw partition_type PARTITION ON nm(A) as_tp_nm_opt(P) PERIOD
+    STRING(D) RETENTION INTEGER(R) START STRING(S). {
     comdb2WriteTransaction(pParse);
     comdb2CreatePartition(pParse, &A, &P, &D, &R, &S);
 }

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -2115,6 +2115,7 @@ struct Table {
   int iDb;             /* iDb version */
   int hasPartIdx;
   int hasExprIdx;
+  u8 isTimepartView;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 


### PR DESCRIPTION
```
nctdb> create table t1(i int)$$
[create table t1(i int)] rc 0

nctdb> insert into t1 values(1);
(rows inserted=1)
[insert into t1 values(1)] rc 0

nctdb> create time partition on t1 period 'yearly' retention 4 start '2019-01-01';
[create time partition on t1 period 'yearly' retention 4 start '2019-01-01'] rc 0

nctdb> select * from t1;
(i=1)
[select * from t1] rc 0

nctdb> select * from comdb2_timepartitions 
(name='t1', period='yearly', retention=4, nshards=4, version=0, shard0name='t1', starttime=1546318800, sourceid='fbc9760b-b443-4edc-8e53-ceac4c444c7f')
```

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>