### PR TITLE
Tests: Have separate replicate_env_vars per test

### DIFF
--- a/tests/dbcreate.disabled/comdb2makecluster/comdb2makecluster
+++ b/tests/dbcreate.disabled/comdb2makecluster/comdb2makecluster
@@ -167,9 +167,10 @@ for node in $CLUSTER; do
     fi
 done
 
-echo "export COMDB2_ROOT=$DBDIR" >> ${DBDIR}/replicant_vars
-echo "export PATH=$PATH" >> ${DBDIR}/replicant_vars
-CMD="source ${DBDIR}/replicant_vars ; $COMDB2_EXE ${DBNAME} --lrl $DBDIR/${DBNAME}.lrl"
+REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+echo "export COMDB2_ROOT=$DBDIR" >> ${REP_ENV_VARS}
+echo "export PATH=$PATH" >> ${REP_ENV_VARS}
+CMD="source ${REP_ENV_VARS} ; $COMDB2_EXE ${DBNAME} --lrl $DBDIR/${DBNAME}.lrl"
 echo "$DBNAME: starting"
 for node in $CLUSTER; do
     if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
@@ -185,7 +186,7 @@ for node in $CLUSTER; do
         echo -e "$DBNAME: Execute the following command on ${node}: ${TEXTCOLOR}${CMD}${NOCOLOR}"
         continue
     fi
-    scp -o StrictHostKeyChecking=no ${DBDIR}/replicant_vars $node:${DBDIR}/replicant_vars &>> $LOGDIR/setup.log
+    scp -o StrictHostKeyChecking=no ${REP_ENV_VARS} $node:${REP_ENV_VARS} &>> $LOGDIR/setup.log
     # redirect output from CMD to a subshell which runs awk to prepend time
     ssh -n -o StrictHostKeyChecking=no -tt $node ${CMD} &>$LOGDIR/${DBNAME}.${node}.db &
     # $! will be pid of ssh (if we had used pipe, $! would be pid of awk)

--- a/tests/halt_processor_tds.test/runit
+++ b/tests/halt_processor_tds.test/runit
@@ -105,7 +105,8 @@ function bounce_master
     [[ "$debug" == 1 ]] && echo "START ${FUNCNAME[0]}" && set -x
     master=`cdb2sql -tabs ${CDB2_OPTIONS} $db default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]' `
     PARAMS="$db --no-global-lrl"
-    CMD="source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
+    REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+    CMD="cd ${DBDIR}; source ${REP_ENV_VARS}; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
     if [[ -n "$master" ]]; then
         if [ $master == $(hostname) ]; then
             (

--- a/tests/killcluster.test/runit
+++ b/tests/killcluster.test/runit
@@ -61,7 +61,8 @@ function bouncecluster
     [[ "$debug" == 1 ]] && set -x
     for node in $CLUSTER ; do
         PARAMS="$db --no-global-lrl"
-        CMD="sleep $sleeptime ; source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
+        REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
         if [ $node == $(hostname) ] ; then
             (
                 kill -9 $(cat ${TMPDIR}/${db}.${node}.pid)

--- a/tests/lostwrite.test/runit
+++ b/tests/lostwrite.test/runit
@@ -67,7 +67,8 @@ function bouncemaster
 
     PARAMS="$DBNAME --no-global-lrl"
     if [[ ! -z "$node" ]]; then
-        CMD="source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+        CMD="source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
         if [ "$node" == "$(hostname)" ] ; then
             (
             kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid) >/dev/null 2>&1

--- a/tests/mem_be_nice.test/Makefile
+++ b/tests/mem_be_nice.test/Makefile
@@ -7,4 +7,4 @@ ifeq ($(TEST_TIMEOUT),)
 	export TEST_TIMEOUT=1m
 endif
 export MALLOC_ARENA_MAX=4
-$(shell echo "export MALLOC_ARENA_MAX=4" >> ${TESTDIR}/replicant_vars )
+$(shell mkdir -p ${DBDIR}/; echo "export MALLOC_ARENA_MAX=4" >> ${DBDIR}/replicant_env_vars )

--- a/tests/setup
+++ b/tests/setup
@@ -253,8 +253,9 @@ setup_db() {
             let i=i+1
         done
 
-        echo "export COMDB2_ROOT=$COMDB2_ROOT" >> ${TESTDIR}/replicant_vars
-        CMD="cd ${DBDIR}; source ${TESTDIR}/replicant_vars ; ${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${PARAMS} 2>&1 | tee $TESTDIR/${DBNAME}.db"
+        REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+        echo "export COMDB2_ROOT=$COMDB2_ROOT" >> ${REP_ENV_VARS}
+        CMD="cd ${DBDIR}; source ${REP_ENV_VARS} ; ${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${PARAMS} 2>&1 | tee $TESTDIR/${DBNAME}.db"
         echo "!$TESTCASE: starting"
         for node in $CLUSTER; do
             if [ $node == $HOSTNAME ] ; then # dont ssh to ourself -- just start db locally
@@ -270,7 +271,7 @@ setup_db() {
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
                 echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${CMD}${NOCOLOR}"
             else
-                scp $SSH_OPT ${TESTDIR}/replicant_vars $node:${TESTDIR}/replicant_vars
+                scp $SSH_OPT ${REP_ENV_VARS} $node:${REP_ENV_VARS}
                 # redirect output from CMD to a subshell which runs awk to prepend time
                 # could also use connection sharing and close master ssh session in unsetup
                 ssh -n $SSH_OPT -tt $node ${CMD} &>$LOGDIR/${DBNAME}.${node}.db &

--- a/tests/tools/bounce_database.sh
+++ b/tests/tools/bounce_database.sh
@@ -18,9 +18,10 @@ function bounce_cluster
     done
     sleep $sleeptime
 
+    REP_ENV_VARS="${DBDIR}/replicant_env_vars"
     for node in $CLUSTER ; do
         PARAMS="$DBNAME --no-global-lrl"
-        CMD="sleep $sleeptime ; source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
         if [ $node == $(hostname) ] ; then
             (
                 kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -26,9 +26,10 @@ function bounce_cluster
     done
     sleep $sleeptime
 
+    REP_ENV_VARS="${DBDIR}/replicant_env_vars"
     for node in $CLUSTER ; do
         PARAMS="$DBNAME --no-global-lrl"
-        CMD="sleep $sleeptime ; source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
         if [ $node == $(hostname) ] ; then
             (
                 kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)


### PR DESCRIPTION
Currently replicate_vars gets appended with every test.
This checkin moves that variable to $DBDIR/replicate_env_vars
to avoid such clobbering.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>