### PR TITLE
Fix sc_resume.test: restart node function

### DIFF
--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -163,7 +163,6 @@ function insert_records_oneshot
     echo "done inserting round $nins"
 }
 
-
 function kill_by_pidfile() {
     pidfile=$1
     if [[ -f $pidfile ]]; then
@@ -183,26 +182,39 @@ function kill_by_pidfile() {
 function kill_restart_node 
 {
     node=$1
+    if [ -z "$node" ] ; then # if not set
+        failexit "kill_restart_node: needs node to be passed in as parameter"
+    fi
+    delay=$2
+    if [ -z "$delay" ] ; then # if not set
+        delay=0
+    fi
+
     pushd $DBDIR
     # cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
+    export LOGDIR=$TESTDIR/logs
 
     if [ -n "$CLUSTER" ] ; then
         kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
+        mv --backup=numbered $LOGDIR/${DBNAME}.${node}.db $LOGDIR/${DBNAME}.${node}.db.1
         sleep 1
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+        if [ $node == `hostname` ] ; then
+            PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
+            $COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
         else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
+            PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
+            CMD="cd ${DBDIR}; source ${REP_ENV_VARS} ; $COMDB2_EXE ${DBNAME} ${PARAMS} 2>&1 | tee $TESTDIR/${DBNAME}.db"
+            ssh -n -o StrictHostKeyChecking=no -tt $node ${CMD} &> $LOGDIR/${DBNAME}.${node}.db &
+            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
         fi
     else
         kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
+        mv --backup=numbered $LOGDIR/${DBNAME}.db $LOGDIR/${DBNAME}.db.1
         sleep 1
         echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
+        PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
+        echo "$COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.db"
+        $COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.db &
     fi
 
     popd
@@ -369,7 +381,7 @@ do_verify t1
 
 cdb2sql ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("flush")'
 echo restart master to make sure when it comes up we are still at version 1
-kill_restart_node $master 
+kill_restart_node $master 1
 sleep 5
 master=`getmaster`
 assert_sc_status 0
@@ -393,7 +405,7 @@ sleep 15
 seed2=`get_sc_seed`
 
 echo "kill master node $master in the middle of rebuild"
-kill_restart_node $master 
+kill_restart_node $master 1
 assert_vers t1 1
 
 if [ -f rebuild.failed ] ; then
@@ -447,7 +459,7 @@ sleep 15
 seed3=`get_sc_seed`
 
 echo "kill master node $master in the middle of alter"
-kill_restart_node $master 
+kill_restart_node $master 1
 
 if [ -f alter2.failed ] ; then
     echo "Alter t1_3 failed as expected"
@@ -518,7 +530,7 @@ sleep 15
 
 seed4=`get_sc_seed`
 echo "kill master node $master in the middle of alter"
-kill_restart_node $master 
+kill_restart_node $master 1
 
 if [ -f alter3.failed ] ; then
     echo "Alter t1_3 failed as expected"
@@ -583,7 +595,7 @@ echo 'alter to t1_1, then to t1_2 again'
 
 master=`getmaster`
 echo "master node now $master"
-kill_restart_node $master
+kill_restart_node $master 1
 
 sleep 5
 cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t1  { `cat t1_1.csc2 ` }"
@@ -624,7 +636,7 @@ function update_column_c
 update_column_c &
 
 echo "kill master node $master in the middle of alter"
-kill_restart_node $master
+kill_restart_node $master 1
 
 sleep 20
 

--- a/tests/setup
+++ b/tests/setup
@@ -272,9 +272,8 @@ setup_db() {
                 echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${CMD}${NOCOLOR}"
             else
                 scp $SSH_OPT ${REP_ENV_VARS} $node:${REP_ENV_VARS}
-                # redirect output from CMD to a subshell which runs awk to prepend time
                 # could also use connection sharing and close master ssh session in unsetup
-                ssh -n $SSH_OPT -tt $node ${CMD} &>$LOGDIR/${DBNAME}.${node}.db &
+                ssh -n $SSH_OPT -tt $node ${CMD} &> $LOGDIR/${DBNAME}.${node}.db &
                 # $! will be pid of ssh (if we had used pipe, $! would be pid of awk)
                 echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
             fi


### PR DESCRIPTION
Fix node restart function for test to make it correctly print
timing information in the db log output and also prepare to
move it in cluster_utils.sh scritp to be used by other tests.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>