### PR TITLE
Tests: use common restart node function from cluster_utils.sh

### DIFF
--- a/tests/ignore_bad_table.test/runit
+++ b/tests/ignore_bad_table.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 set -x
 
@@ -12,56 +13,6 @@ function get_node
     $SQLT 'select comdb2_host()'
 }
 
-function kill_by_pidfile() {
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        failexit "kill_by_pidfile: pidfile $pidfile does not exist"
-    fi
-}
-function kill_restart_node 
-{
-    node=$1
-    pushd $DBDIR
-    cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
-        sleep 1
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
-        sleep 1
-        echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
-    fi
-
-    popd
-
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-    echo "$DBNAME: db is up out=$out"
-}
 
 dbnm=$1
 
@@ -98,7 +49,7 @@ echo "Using node $node"
 #ssh -o StrictHostKeyChecking=no -tt $node "echo 'setattr ignore_bad_table 1' >> $DBDIR/${DBNAME}.lrl"
 
 echo "Restarting node $node"
-kill_restart_node $node
+kill_restart_node $node 1
 
 cdb2sql --tabs --host ${node} ${CDB2_OPTIONS} $DBNAME 'select 1'
 if [ "$?" != "0" ] ; then

--- a/tests/recovertolsn.test/runit
+++ b/tests/recovertolsn.test/runit
@@ -2,6 +2,8 @@
 bash -n "$0" | exit 1
 
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
 # Debug variable
 debug=0
 
@@ -57,41 +59,6 @@ function assert_schema
 }
 
 
-# Update all records in the table
-function update_all_records
-{
-    typeset prmsg=$1
-    typeset iter=0
-
-    [[ "$debug" == 1 ]] && set -x
-
-    while :; do 
-
-        cdb2sql -s ${CDB2_OPTIONS} $dbnm default "update t1 set c=x'1234' where b='test1'" >/dev/null 2>&1
-        let iter=iter+1
-
-        if [[ -n "$prmsg" && $(( iter % prmsg )) == 0 ]]; then
-
-            echo "Updated all of table t1 $iter times."
-
-        fi
-
-    done
-}
-
-function update_records
-{
-    j=0
-    nrecs=$1
-    echo "Updating $nrecs records."
-    echo "" > update.out
-
-    while [[ $j -lt $nrecs ]]; do 
-        cdb2sql ${CDB2_OPTIONS} $dbnm default "update t1 set c=c+100000 where a = $j" >> update.out 
-        let j=j+1
-    done
-}
-
 function insert_records
 {
     j=$1
@@ -126,62 +93,6 @@ function insert_records_oneshot
     done | cdb2sql ${CDB2_OPTIONS} $dbnm default -  &>> $insfl
     echo "done inserting round $nins"
 }
-
-
-function kill_by_pidfile() {
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        failexit "kill_by_pidfile: pidfile $pidfile does not exist"
-    fi
-}
-
-
-function kill_restart_node 
-{
-    node=$1
-    echo "kill_restart_node $node"
-    pushd $DBDIR
-    cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv -b $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
-        sleep 1
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv -b $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
-        sleep 1
-        echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
-    fi
-
-    popd
-
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-    echo "$DBNAME: db is up out=$out"
-}
-
 
 function kill_restarttolsn
 {
@@ -256,7 +167,7 @@ assertcnt t1 200
 assertsel rows1.txt
 do_verify t1
 
-kill_restart_node $master
+kill_restart_node $master 1
 cdb2sql ${CDB2_OPTIONS} --tabs --host $node $dbnm  'select 1'
 cdb2sql ${CDB2_OPTIONS} --tabs $dbnm default 'select 1'
 

--- a/tests/restart_node.test/runit
+++ b/tests/restart_node.test/runit
@@ -4,6 +4,7 @@ bash -n "$0" | exit 1
 #PS4='$(date +%Y%m%d-%H:%M:%S): '
 set -x
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 RESTART_DELAY=35
 INITNUMREC=100
@@ -49,51 +50,6 @@ assert_schema()
     fi
 }
 
-
-assert_sc_status()
-{
-    target=$1
-    cdb2sql --tabs --host $master ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("stat")' > stat1.out
-    if [ $? -ne 0 ] ; then
-        failexit "sending stat to new master $master"
-    fi
-
-    scrunning=`grep "schema change running" stat1.out | awk '{print $4}' `
-    echo "scrunning is $scrunning"
-    if [ "$scrunning" == "NO" ] ; then 
-        if [ $target != 0 ] ; then
-            failexit "scrunning is $scrunning, but target is $target"
-        fi
-    else 
-        if [ $target != 1 ] ; then
-            failexit "scrunning is $scrunning, but target is $target"
-        fi
-    fi
-}
-
-
-get_sc_seed()
-{
-    cdb2sql --tabs --host $master ${CDB2_OPTIONS} $dbnm 'exec procedure sys.cmd.send("stat")' > stat1.out
-    if [ $? -ne 0 ] ; then
-        failexit "sending stat to new master $master"
-    fi
-
-    grep "Schema change in progress with seed" stat1.out | awk '{print $7}'
-}
-
-
-assert_sc_seed()
-{
-    target=$1
-    scseed=`get_sc_seed`
-    echo "scseed is $scseed"
-    if [ "$scseed" != "$target" ] ; then 
-        failexit "scseed $scseed, but target is $target"
-    fi
-}
-
-
 insert_records()
 {
     j=$1
@@ -123,40 +79,6 @@ insert_records()
 }
 
 
-insert_records_oneshot()
-{
-    j=$1
-    nstop=$2
-    let nins=nins+1
-    insfl=insert${nins}.out
-    echo "Inserting $((nstop-j+1)) records ($j to $nstop)."
-    echo "" > $insfl
-
-    while [[ $j -le $nstop ]]; do 
-        # use for compare? echo "a=$j, b='test1$j', c='$j'" >> rows.out
-        echo "insert into t1(a,b,c) values ($j,'test1$j',$j)" 
-        let j=j+1
-    done | cdb2sql ${CDB2_OPTIONS} $dbnm default -  &>> $insfl
-    echo "done inserting round $nins"
-}
-
-
-kill_by_pidfile() 
-{
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        failexit "kill_by_pidfile: pidfile $pidfile does not exist"
-    fi
-}
-
 kill_restart_cluster()
 {
     delay=$1
@@ -175,61 +97,6 @@ kill_restart_cluster()
             out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
         done
     done
-}
-
-kill_restart_node()
-{
-    node=$1
-    delay=$2
-    pushd $DBDIR
-    cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
-        sleep $delay
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
-        sleep $delay
-        echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
-    fi
-
-    popd
-
-    out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-}
-
-
-get_schemachange_status()
-{
-    master=$1
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('stat')" | grep "Schema change in progress" > schemachange_status.out
-    if [ $? -eq 0 ] ; then
-        return 1 
-    fi
-    return 0
-}
-
-
-force_delay_master()
-{
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')"
-    cdb2sql ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('scdelay 300')"
 }
 
 echo "Test with insert, SC should not fail"

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -2,6 +2,7 @@
 bash -n "$0" | exit 1
 
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 # Debug variable
 debug=0
@@ -71,42 +72,6 @@ kill_restart_cluster()
     done
 }
 
-kill_restart_node()
-{
-    node=$1
-    delay=$2
-    pushd $DBDIR
-    cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
-        sleep $delay
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
-        sleep $delay
-        echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
-    fi
-
-    popd
-
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-}
 
 cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
 

--- a/tests/sc_resume.test/runit
+++ b/tests/sc_resume.test/runit
@@ -2,6 +2,7 @@
 bash -n "$0" | exit 1
 
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 #PS4='$(date +%Y%m%d-%H:%M:%S): '
 set -x
@@ -162,72 +163,6 @@ function insert_records_oneshot
     done | cdb2sql ${CDB2_OPTIONS} $dbnm default -  &>> $insfl
     echo "done inserting round $nins"
 }
-
-function kill_by_pidfile() {
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        failexit "kill_by_pidfile: pidfile $pidfile does not exist"
-    fi
-}
-
-
-function kill_restart_node 
-{
-    node=$1
-    if [ -z "$node" ] ; then # if not set
-        failexit "kill_restart_node: needs node to be passed in as parameter"
-    fi
-    delay=$2
-    if [ -z "$delay" ] ; then # if not set
-        delay=0
-    fi
-
-    pushd $DBDIR
-    # cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-    export LOGDIR=$TESTDIR/logs
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $LOGDIR/${DBNAME}.${node}.db $LOGDIR/${DBNAME}.${node}.db.1
-        sleep 1
-        if [ $node == `hostname` ] ; then
-            PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
-            $COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
-        else
-            PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
-            CMD="cd ${DBDIR}; source ${REP_ENV_VARS} ; $COMDB2_EXE ${DBNAME} ${PARAMS} 2>&1 | tee $TESTDIR/${DBNAME}.db"
-            ssh -n -o StrictHostKeyChecking=no -tt $node ${CMD} &> $LOGDIR/${DBNAME}.${node}.db &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $LOGDIR/${DBNAME}.db $LOGDIR/${DBNAME}.db.1
-        sleep 1
-        echo "$DBNAME: starting single node"
-        PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
-        echo "$COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.db"
-        $COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.db &
-    fi
-
-    popd
-
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-}
-
 
 function get_schemachange_status
 {

--- a/tests/sc_timepart.test/runit
+++ b/tests/sc_timepart.test/runit
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
 # Schema change for time partition testcase for comdb2
 ################################################################################
 
@@ -202,57 +204,6 @@ getmaster() {
     echo $master
 }
 
-function kill_by_pidfile() {
-    pidfile=$1
-    if [[ -f $pidfile ]]; then
-        local pid=$(cat $pidfile)
-        ps -p $pid -o args | grep -q "comdb2 ${DBNAME}"
-        if [[ $? -eq 0 ]]; then
-            echo "kill -9 $pid"
-            kill -9 $pid
-        fi
-        rm -f $pidfile
-    else
-        echo "kill_by_pidfile: pidfile $pidfile does not exist"
-        exit 1
-    fi
-}
-
-function kill_restart_node
-{
-    node=$1
-    pushd $DBDIR
-    # cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
-
-    if [ -n "$CLUSTER" ] ; then
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
-        sleep 1
-        if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
-            echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
-        else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
-        fi
-    else
-        kill_by_pidfile ${TMPDIR}/${DBNAME}.pid
-        mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
-        sleep 1
-        echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
-    fi
-
-    popd
-
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-}
 master=`getmaster`
 
 echo "TEST SC RESUME FOR TIMEPART TABLE"
@@ -262,7 +213,7 @@ cdb2sql ${CDB2_OPTIONS} --host $master $dbname "PUT SCHEMACHANGE CONVERTSLEEP 10
 cdb2sql ${CDB2_OPTIONS} $dbname default  "PUT SCHEMACHANGE CONVERTSLEEP 10"
 (cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat t_1.csc2`}" &> alter1.out || touch alter1.failed) &
 sleep 3
-kill_restart_node $master
+kill_restart_node $master 1
 if [ -f alter1.failed ] ; then
     echo "Alter failed as expected"
     cat alter1.out


### PR DESCRIPTION
Use common function from cluster_utils.sh in the tests which
call kill_restart_node().

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>