### PR TITLE
Tunables: exclude first internal entry if should not be displayed

### DIFF
--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -385,7 +385,6 @@
 (name='lclpooledbufs', description='', type='INTEGER', value='32', read_only='Y')
 (name='lease_renew_interval', description='How often we renew leases.', type='INTEGER', value='200', read_only='N')
 (name='leasebase_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
-(name='legacy_schema', description='Only allow legacy compatible csc2 schema', type='BOOLEAN', value='OFF', read_only='N')
 (name='libevent', description='Use libevent in net library. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='libevent_rte_only', description='Prevent listening on TCP socket. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='little_endian_btrees', description='Enabling this sets byte ordering for pages to little endian.', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Currenctly `select * from comdb2_tunables` includes
`(name='legacy_schema', description='Only allow legacy compatible csc2 schema', type='BOOLEAN', value='OFF', read_only='N')`
because it happens to be first item returned by hash_first().
This checkin fixes that by keep doing hash_next() until we find a non internal
tunables on open().

Also, adding a new column to print all flags in DEBUG mode so entry would look
like this:
`(name='legacy_schema', description='Only allow legacy compatible csc2 schema', type='BOOLEAN', value='OFF', flags='EXPERIMENTAL INTERNAL READEARLY ', read_only='N')`

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>