### PR TITLE
Print in reqlog table deadlock count

### DIFF
--- a/berkdb/lock/lock_deadlock.c
+++ b/berkdb/lock/lock_deadlock.c
@@ -40,7 +40,7 @@ extern int gbl_rowlocks;
 
 extern void stack_me(char *location);
 extern void log_snap_info_key(snap_uid_t *);
-extern void log_deadlock_cycle(locker_info *idmap, u_int32_t *deadmap, u_int32_t nlockers, u_int32_t victim);
+extern void eventlog_deadlock_cycle(locker_info *idmap, u_int32_t *deadmap, u_int32_t nlockers, u_int32_t victim);
 
 #define	CLEAR_MAP(M, N) {						\
 	u_int32_t __i;							\
@@ -869,7 +869,7 @@ dokill:
 		if (gbl_print_deadlock_cycles) {
 			__dd_print_deadlock_cycle(idmap, *deadp, nlockers, killid);
 
-			log_deadlock_cycle(idmap, *deadp, nlockers, killid);
+			eventlog_deadlock_cycle(idmap, *deadp, nlockers, killid);
 #ifdef DEBUG_LOCKS
 			__lock_dump_active_locks(dbenv, stderr);
 #endif

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4679,6 +4679,8 @@ void *statthd(void *p)
                                  NULL, 0, "updated rows", &hdr, statlogger, tbl, 0);
                     log_tbl_item(tbl->write_count[RECORD_WRITE_DEL], &tbl->saved_write_count[RECORD_WRITE_DEL],
                                  NULL, 0, "deleted rows", &hdr, statlogger, tbl, 0);
+                    log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count,
+                                 NULL, 0, "deadlock count", &hdr, statlogger, tbl, 0);
                 }
                 unlock_schema_lk();
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -646,6 +646,8 @@ typedef struct dbtable {
     /* counters for writes to this table */
     unsigned write_count[RECORD_WRITE_MAX];
     unsigned saved_write_count[RECORD_WRITE_MAX];
+    unsigned deadlock_count;
+    unsigned saved_deadlock_count;
     unsigned aa_saved_counter; // zeroed out at autoanalyze
     time_t aa_lastepoch;
     unsigned aa_counter_upd;   // counter which includes updates

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -806,8 +806,8 @@ void eventlog_process_message(char *line, int lline, int *toff)
     }
 }
 
-void log_deadlock_cycle(locker_info *idmap, u_int32_t *deadmap,
-                        u_int32_t nlockers, u_int32_t victim)
+void eventlog_deadlock_cycle(locker_info *idmap, u_int32_t *deadmap,
+                             u_int32_t nlockers, u_int32_t victim)
 {
     if (!eventlog_enabled || eventlog == NULL) {
         return;

--- a/db/record.c
+++ b/db/record.c
@@ -631,6 +631,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
 err:
+    if (retrc == RC_INTERNAL_RETRY) {
+        iq->usedb->deadlock_count++;
+    }
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
     if (dynschema)
@@ -1543,6 +1546,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     }
 
 err:
+    if (retrc == RC_INTERNAL_RETRY) {
+        iq->usedb->deadlock_count++;
+    }
     free_blob_status_data(&oldblobs);
     if (iq->debug)
         reqpopprefixes(iq, prefixes);
@@ -1834,6 +1840,9 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
 
 err:
     dbglog_record_db_write(iq, "delete");
+    if (retrc == RC_INTERNAL_RETRY) {
+        iq->usedb->deadlock_count++;
+    }
     if (!retrc && iq->__limits.maxcost && iq->cost > iq->__limits.maxcost)
         retrc = ERR_LIMIT;
 


### PR DESCRIPTION
Print in reqlog number of times which writing to a table
resulted in a deadlock, ex:

```
01/24 02:32:22:   fp=25dae224c1358406a8f0ec4188cd93db sql="UPDATE t1 SET b=?,g=?,j=j+?WHERE f=?;"
01/24 02:32:22:   fp=2eb391ee3844f33b4fdf755e7890e13e sql="UPDATE t2 SET b=?,g=?,j=j+?WHERE f=?;"
01/24 02:33:10:   diff n_reqs 0 n_retries 3 newsql 47 newsqlsteps 612 n_commit_time 2309 ms n_cache_hits 844 n_cache_misses 23
01/24 02:33:10:   DIFF REQUEST STATS FOR TABLE 't1'
01/24 02:33:10:       OSQL_USEDB             4
01/24 02:33:10:       OSQL_QBLOB             13
01/24 02:33:10:       OSQL_UPDREC            5
01/24 02:33:10:       OSQL_UPDCOLS           5
01/24 02:33:10:       OSQL_DONE_SNAP         6
01/24 02:33:10:       OSQL_SCHEMACHANGE      1
01/24 02:33:10:       OSQL_INSERT            8
01/24 02:33:10:       OSQL_STARTGEN          6
01/24 02:33:10:       nsql                   11
01/24 02:33:10:       inserted rows          7
01/24 02:33:10:       updated rows           4
01/24 02:33:10:       deadlock count         2
01/24 02:33:10:   DIFF REQUEST STATS FOR TABLE 't2'
01/24 02:33:10:       OSQL_USEDB             5
01/24 02:33:10:       OSQL_QBLOB             12
01/24 02:33:10:       OSQL_UPDREC            6
01/24 02:33:10:       OSQL_UPDCOLS           6
01/24 02:33:10:       OSQL_DONE_SNAP         4
01/24 02:33:10:       OSQL_SCHEMACHANGE      1
01/24 02:33:10:       OSQL_INSERT            6
01/24 02:33:10:       OSQL_STARTGEN          4
01/24 02:33:10:       nsql                   9
01/24 02:33:10:       inserted rows          5
01/24 02:33:10:       updated rows           6
01/24 02:33:10:       deadlock count         1
01/24 02:33:10:   6 locks, avg time 0ms, worst time 1ms
01/24 02:33:10:   49 preads, 512000 bytes, avg time 0ms
01/24 02:33:10:   77 pwrites, 1707008 bytes, avg time 0ms
01/24 02:33:10:   n_memp_pgs=149, memp_pgs avg time=0ms
01/24 02:33:10:   ndeadlocks 3, nlockwaits 6, vreplays 0, locks aborted 0
```

FTR, we can already get on master node the sql-s that resulted in deadlocks by doing:

```
> zgrep deadlockretries /var/log/cdb2/mydb.events.1611473512345
{"time":1611473534265478,"type":"txn","cnonce":"3766303130312d363832372d316366633230302d30303130333933326239303639613562","id":"3ac92bb2-0884-45b9-9bec-37f0cb2b27b6","rc":0,"error_code":44,"error":"Error processing","deadlockretries":1,"host":"","perf":{"tottime":4003450,"processingtime":2000976,"qtime":2002474,"lockwaits":1,"lockwaittime":1167,"reads":2,"readtime":29}}
{"time":1611473538287399,"type":"txn","cnonce":"3766303130312d363833322d323064363230302d30306630313630386264303639613562","id":"39ba78d4-8f88-4fb8-943b-100858219b23","rc":0,"error_code":44,"error":"Error processing","deadlockretries":1,"host":"","perf":{"tottime":4052592,"processingtime":2001193,"qtime":2051399,"lockwaits":1,"lockwaittime":0,"reads":2,"readtime":7}}
{"time":1611473542360729,"type":"txn","cnonce":"3766303130312d363833632d6136633230302d30303030333865616330303639613562","id":"1e94565d-863e-4f47-bb17-68e3d6efcfc8","rc":0,"error_code":44,"error":"Error processing","deadlockretries":1,"host":"","perf":{"tottime":7028970,"processingtime":4002197,"qtime":3026773,"lockwaits":1,"lockwaittime":1,"reads":2,"readtime":8}}
```

Note also that if we enable "exec procedure sys.cmd.send('print_deadlock_cycles on')" then we can see the full deadlock cycle partecipants:
```
> zgrep deadlock_cycle /var/log/cdb2/mydb.events.1611473512345
{"time":1611473536267429,"host":"titani.home","deadlock_cycle":[{"cnonce":"7f0101-6826-22be200-00103932b9069a5b","lid":"0x80000044","lcount":3},{"cnonce":"7f0101-6827-1cfc200-00103932b9069a5b","lid":"0x80000041","lcount":3,"victim":true}]}
{"time":1611473540288337,"host":"titani.home","deadlock_cycle":[{"cnonce":"7f0101-6833-f9e200-00e01608bd069a5b","lid":"0x8000004b","lcount":3},{"cnonce":"7f0101-6832-20d6200-00f01608bd069a5b","lid":"0x80000049","lcount":3,"victim":true}]}
{"time":1611473545362101,"host":"titani.home","deadlock_cycle":[{"cnonce":"7f0101-683b-18bc200-000038eac0069a5b","lid":"0x80000052","lcount":3},{"cnonce":"7f0101-683c-a6c200-000038eac0069a5b","lid":"0x80000050","lcount":3,"victim":true}]}
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>