### PR TITLE
Fix MakeRecord optimization

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8480,19 +8480,16 @@ int sqlite3BtreeInsert(
     struct sql_thread *thd = pCur->thd;
     struct sqlclntstate *clnt = pCur->clnt;
 
-    /* If pPayload is NULL, ondisk_buf and ondisk_blobs contain comdb2 row data
+    pKey = pPayload->pKey;
+    nKey = pPayload->nKey;
+    pData = pPayload->pData;
+    nData = pPayload->nData;
+
+    /* If pData is NULL, ondisk_buf and ondisk_blobs contain comdb2 row data
        and are ready to be inserted as is. */
-    if (pPayload == NULL) {
+    if (pData == NULL) {
         pblobs = pCur->ondisk_blobs;
-        pKey = NULL;
-        nKey = 0;
-        pData = NULL;
-        nData = 0;
     } else {
-        pKey = pPayload->pKey;
-        nKey = pPayload->nKey;
-        pData = pPayload->pData;
-        nData = pPayload->nData;
         pblobs = alloca(sizeof(blob_buffer_t) * MAXBLOBS);
         memset(pblobs, 0, sizeof(blob_buffer_t) * MAXBLOBS);
     }
@@ -8687,7 +8684,7 @@ int sqlite3BtreeInsert(
         }
 
         if (likely(pCur->cursor_class != CURSORCLASS_STAT24) && likely(pCur->bt == NULL || pCur->bt->is_remote == 0) &&
-            pPayload != NULL) {
+            pData != NULL) {
             rc = sqlite_to_ondisk(pCur->db->schema, pData, nData, pCur->ondisk_buf, clnt->tzname, pblobs, MAXBLOBS,
                                   &thd->clnt->fail_reason, pCur);
             if (rc < 0) {

--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -5410,6 +5410,7 @@ case OP_Insert: {
   assert( pKey->flags & MEM_Int );
   assert( memIsValid(pKey) );
   REGISTER_TRACE(pOp->p3, pKey);
+  memset(&x, 0, sizeof(BtreePayload));
   x.nKey = pKey->u.i;
 
   if( pOp->p4type==P4_TABLE && HAS_UPDATE_HOOK(db) ){
@@ -5443,7 +5444,7 @@ case OP_Insert: {
   /* Data is already serialized to comdb2 row format and stored in the btree cursor. */
   if( pData->flags & MEM_Comdb2 ){
     seekResult = ((pOp->p5 & OPFLAG_USESEEKRESULT) ? pC->seekResult : 0);
-    rc = sqlite3BtreeInsert(pC->uc.pCursor, NULL,
+    rc = sqlite3BtreeInsert(pC->uc.pCursor, &x,
         (pOp->p5 & OPFLAG_ISUPDATE)!=0, seekResult, pOp->p5
     );
   }else{

--- a/tests/basic.test/nogenid48.testopts
+++ b/tests/basic.test/nogenid48.testopts
@@ -1,0 +1,1 @@
+init_with_time_based_genids


### PR DESCRIPTION
It does not work with the legacy genid format. This patch fixes it.
