### PR TITLE
sqlitex: Cache db handle

### DIFF
--- a/bbinc/comdb2_query_preparer.h
+++ b/bbinc/comdb2_query_preparer.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2020 Bloomberg Finance L.P.
+   Copyright 2019, 2021, Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ struct comdb2_query_preparer {
     int (*do_cleanup)(struct sqlclntstate *);
     int (*sqlitex_is_initializing)(void *);
     char *(*sqlitex_table_name)(void *);
+    int (*do_cleanup_thd)(struct sqlthdstate *);
 };
 typedef struct comdb2_query_preparer comdb2_query_preparer_t;
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -115,6 +115,7 @@ struct sqlthdstate {
      * is especially needed to differentiate between fdb cursors opened by core
      * versus query preparer plugin. */
     bool query_preparer_running;
+    void *sqldbx;
 };
 
 typedef struct osqltimings {


### PR DESCRIPTION
Cache sqlite handle in sql thd so that it can be reused for other statements.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>