### PR TITLE
Provide a way to retrieve exact number of logbytes a txn has written

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -462,6 +462,7 @@ struct tran_tag {
     DB_LOCK *rc_locks;
     u_int32_t rc_max;
     u_int32_t rc_count;
+    u_int64_t logbytes;
 
     /* Newsi pglogs queue hash */
     hash_t *pglogs_queue_hash;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -978,6 +978,7 @@ struct __db_txn {
 	DB_LSN		last_lsn;	/* Lsn of last log write. */
 	u_int32_t	txnid;		/* Unique transaction id. */
 	u_int32_t	tid;		/* Thread id for use in MT XA. */
+	u_int64_t   logbytes;
 	roff_t		off;		/* Detail structure within region. */
 	db_timeout_t	lock_timeout;	/* Timeout for locks for this txn. */
 	db_timeout_t	expire;		/* Time this txn expires. */
@@ -1046,10 +1047,11 @@ struct __db_txn {
 					/* Methods. */
 	int	  (*abort) __P((DB_TXN *));
 	int	  (*commit) __P((DB_TXN *, u_int32_t));
-	int	  (*commit_getlsn) __P((DB_TXN *, u_int32_t, DB_LSN *, void *));
+	int	  (*commit_getlsn) __P((DB_TXN *, u_int32_t, u_int64_t *, DB_LSN *, void *));
 	int	  (*commit_rowlocks) __P((DB_TXN *, u_int32_t, u_int64_t,
-		      u_int32_t, DB_LSN *,DBT *, DB_LOCK *,
-		      u_int32_t, DB_LSN *, DB_LSN *, void *));
+			  u_int32_t, DB_LSN *,DBT *, DB_LOCK *,
+		      u_int32_t, u_int64_t *, DB_LSN *, DB_LSN *, void *));
+	int   (*getlogbytes) __P((DB_TXN *, u_int64_t *));
 	int	  (*discard) __P((DB_TXN *, u_int32_t));
 	u_int32_t (*id) __P((DB_TXN *));
 	int	  (*prepare) __P((DB_TXN *, u_int8_t *));

--- a/berkdb/dist/gen_rec.awk
+++ b/berkdb/dist/gen_rec.awk
@@ -673,8 +673,10 @@ function log_function() {
 		printf("flags | DB_LOG_NOCOPY);\n") >> CFILE;
 
 		# Update the transactions last_lsn.
-		printf("\t\tif (ret == 0 && txnid != NULL)\n") >> CFILE;
+		printf("\t\tif (ret == 0 && txnid != NULL) {\n") >> CFILE;
 		printf("\t\t\ttxnid->last_lsn = *ret_lsnp;\n") >> CFILE;
+		printf("\t\t\ttxnid->logbytes += logrec.size;\n") >> CFILE;
+		printf("\t\t}\n") >> CFILE;
 		printf("\t}\n\n") >> CFILE;
 		printf("\tif (!is_durable)\n") >> CFILE;
 		printf("\t\tLSN_NOT_LOGGED(*ret_lsnp);\n") >> CFILE;
@@ -683,8 +685,10 @@ function log_function() {
 		printf("ret_lsnp, (DBT *)&logrec, flags);\n") >> CFILE;
 
 		# Update the transactions last_lsn.
-		printf("\tif (ret == 0 && txnid != NULL)\n") >> CFILE;
+		printf("\tif (ret == 0 && txnid != NULL) {\n") >> CFILE;
 		printf("\t\ttxnid->last_lsn = *ret_lsnp;\n\n") >> CFILE;
+		printf("\t\ttxnid->logbytes += logrec.size;\n\n") >> CFILE;
+        printf("\t}\n") >> CFILE;
 	}
 
 	# If out of disk space log writes may fail.  If we are debugging


### PR DESCRIPTION
Keep a per-transaction counter of the number of log bytes written.  Provide a way to retrieve this value while the transaction is active, and at commit.  This is a WIP.