### PR TITLE
Provide a tunable which throttles schema-change conversions

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -677,6 +677,9 @@ tran_type *bdb_tran_begin_snapisol(bdb_state_type *bdb_state, int trak,
                                    int *bdberr, int epoch, int file, int offset,
                                    int is_ha_retry);
 
+/* return log bytes written so far for this transaction */
+u_int64_t bdb_tran_logbytes(tran_type *tran);
+
 /* commit the transaction referenced by the tran handle */
 int bdb_tran_commit(bdb_state_type *bdb_handle, tran_type *tran, int *bdberr);
 

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2261,6 +2261,13 @@ int bdb_tran_commit_logical_with_seqnum_size(bdb_state_type *bdb_state,
     return rc;
 }
 
+u_int64_t bdb_tran_logbytes(tran_type *tran)
+{
+    u_int64_t logbytes = 0;
+    tran->tid->getlogbytes(tran->tid, &logbytes);
+    return logbytes;
+}
+
 int bdb_tran_abort_int_int(bdb_state_type *bdb_state, tran_type *tran,
                            int *bdberr, void *blkseq, int blklen, void *blkkey,
                            int blkkeylen, seqnum_type *seqnum, int *priority)

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -251,6 +251,7 @@ extern int gbl_client_running_slow_seconds;
 extern int gbl_client_abort_on_slow;
 extern int gbl_max_trigger_threads;
 extern int gbl_alternate_normalize;
+extern int gbl_sc_logbytes_per_second;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2079,4 +2079,8 @@ REGISTER_TUNABLE("alternate_normalize",
                  TUNABLE_BOOLEAN, &gbl_alternate_normalize,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("sc_logbytes_per_second",
+                 "Throttle schema-changes to this many logbytes per second.  (Default: 10000000)",
+                 TUNABLE_INTEGER, &gbl_sc_logbytes_per_second, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
A customer's table contained large blobs.  When the customer rebuilt the table, all of the database's replicants went incoherent.  This PR provides a tunable, gbl_sc_logbytes_per_second, which rate-limits the number of bytes that schema-changes may write in a single second.  I set a default value of 10000000 - we can tweak this as necessary via comdb2.lrl. 