### PR TITLE
A better alternative to find_tag_schema

### DIFF
--- a/db/constraints.c
+++ b/db/constraints.c
@@ -418,17 +418,11 @@ int check_update_constraints(struct ireq *iq, void *trans,
             }
             ixlen = getkeysize(iq->usedb, ixnum);
             snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_%d", ixnum);
-            /*
-            rc=stag_to_stag_buf(iq->usedb->tablename, ".ONDISK",rec_dta,
-               ondisk_tag, lkey, NULL);
-             */
             if (iq->idxDelete)
                 rc = create_key_from_ireq(iq, ixnum, 1, NULL, NULL, NULL,
                                           rec_dta, 0 /* not needed */, lkey);
             else
-                rc = create_key_from_ondisk(
-                    iq->usedb, ixnum, NULL, NULL, NULL, ".ONDISK", rec_dta,
-                    0 /* not needed */, ondisk_tag, lkey, NULL, NULL);
+                rc = create_key_from_ondisk(iq->usedb, ixnum, rec_dta, lkey);
             if (rc == -1) {
                 if (iq->debug)
                     reqprintf(iq,
@@ -445,19 +439,12 @@ int check_update_constraints(struct ireq *iq, void *trans,
 
             /* this part is for update */
             if (newrec_dta != NULL) {
-                /*
-                rc=stag_to_stag_buf(iq->usedb->tablename, ".ONDISK",newrec_dta,
-                   ondisk_tag, nkey, NULL);
-                 */
                 if (iq->idxInsert)
                     rc = create_key_from_ireq(iq, ixnum, 0, NULL, NULL, NULL,
                                               newrec_dta, 0 /* not needed */,
                                               nkey);
                 else
-                    rc = create_key_from_ondisk(iq->usedb, ixnum, NULL, NULL,
-                                                NULL, ".ONDISK", newrec_dta,
-                                                0 /* not needed */, ondisk_tag,
-                                                nkey, NULL, NULL);
+                    rc = create_key_from_ondisk(iq->usedb, ixnum, newrec_dta, nkey);
                 if (rc == -1) {
                     if (iq->debug)
                         reqprintf(
@@ -1001,7 +988,6 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
     int rc = 0, fndlen = 0, err = 0, limit = 0;
     int idx = 0, ixkeylen = -1;
     void *od_dta = NULL;
-    char ondisk_tag[MAXTAGLEN];
     char key[MAXKEYLEN];
     char *od_dta_tail = NULL;
     int od_tail_len = 0;
@@ -1189,7 +1175,6 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
             }
 
             ixkeylen = getkeysize(iq->usedb, doidx);
-            snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_%d", doidx);
             if (ixkeylen < 0) {
                 if (iq->debug)
                     reqprintf(iq, "%p:ADDKYCNSTRT BAD INDEX %d OR KEYLENGTH %d",
@@ -1203,19 +1188,13 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                 free_cached_delayed_indexes(iq);
                 return ERR_BADREQ;
             }
-            /*
-            rc=stag_to_stag_buf(iq->usedb->tablename, ".ONDISK",od_dta,
-               ondisk_tag, key, NULL);
-             */
             if (iq->idxInsert)
                 rc = create_key_from_ireq(iq, doidx, 0, &od_dta_tail,
                                           &od_tail_len, mangled_key, od_dta,
                                           ondisk_size, key);
             else
-                rc = create_key_from_ondisk(iq->usedb, doidx, &od_dta_tail,
-                                            &od_tail_len, mangled_key,
-                                            ".ONDISK", od_dta, ondisk_size,
-                                            ondisk_tag, key, NULL, iq->tzname);
+                rc = create_key_from_schema(iq->usedb, NULL, doidx, &od_dta_tail, &od_tail_len, mangled_key, od_dta,
+                                            ondisk_size, key, NULL, 0, iq->tzname);
             if (rc == -1) {
                 if (iq->debug)
                     reqprintf(iq, "%p:ADDKYCNSTRT CANT FORM INDEX %d", trans,
@@ -1501,17 +1480,11 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                 }
 
                 snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_%d", lixnum);
-                /*
-                rc=stag_to_stag_buf(iq->usedb->tablename, ".ONDISK",od_dta,
-                   ondisk_tag, lkey, NULL);
-                 */
                 if (iq->idxInsert) {
                     rc = create_key_from_ireq(iq, lixnum, 0, NULL, NULL, NULL,
                                               od_dta, 0 /* not needed */, lkey);
                 } else
-                    rc = create_key_from_ondisk(
-                        iq->usedb, lixnum, NULL, NULL, NULL, ".ONDISK", od_dta,
-                        0 /* not needed */, ondisk_tag, lkey, NULL, NULL);
+                    rc = create_key_from_ondisk(iq->usedb, lixnum, od_dta, lkey);
 
                 if (rc == -1) {
                     if (iq->debug)

--- a/db/indices.h
+++ b/db/indices.h
@@ -17,10 +17,8 @@
 #ifndef INCLUDED_INDICES_H
 #define INCLUDED_INDICES_H
 
-int check_for_upsert(struct ireq *iq, void *trans, struct schema *ondisktagsc,
-                     blob_buffer_t *blobs, size_t maxblobs, int *opfailcode,
-                     int *ixfailnum, int *retrc, const char *ondisktag,
-                     void *od_dta, size_t od_len, unsigned long long ins_keys,
+int check_for_upsert(struct ireq *iq, void *trans, blob_buffer_t *blobs, size_t maxblobs, int *opfailcode,
+                     int *ixfailnum, int *retrc, void *od_dta, size_t od_len, unsigned long long ins_keys,
                      int rec_flags);
 
 int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
@@ -28,7 +26,6 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
                        int *rrn, unsigned long long *genid,
                        unsigned long long vgenid, unsigned long long ins_keys,
                        int opcode, int blkpos, void *od_dta, size_t od_len,
-                       const char *ondisktag, struct schema *ondisktagsc,
                        int flags, bool reorder);
 
 int upd_record_indices(struct ireq *iq, void *trans, int *opfailcode,
@@ -40,10 +37,8 @@ int upd_record_indices(struct ireq *iq, void *trans, int *opfailcode,
                        blob_buffer_t *del_idx_blobs, int same_genid_with_upd,
                        unsigned long long vgenid, int *deferredAdd);
 
-int del_record_indices(struct ireq *iq, void *trans, int *opfailcode,
-                       int *ixfailnum, int rrn, unsigned long long genid,
-                       void *od_dta, unsigned long long del_keys, int flags,
-                       blob_buffer_t *del_idx_blobs, const char *ondisktag);
+int del_record_indices(struct ireq *iq, void *trans, int *opfailcode, int *ixfailnum, int rrn, unsigned long long genid,
+                       void *od_dta, unsigned long long del_keys, int flags, blob_buffer_t *del_idx_blobs);
 
 int upd_new_record_indices(
     struct ireq *iq, void *trans, unsigned long long newgenid,

--- a/db/osqlpfthdpool.c
+++ b/db/osqlpfthdpool.c
@@ -400,7 +400,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
         }
 
         for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-            char keytag[MAXTAGLEN];
             char key[MAXKEYLEN];
             int keysz = 0;
             keysz = getkeysize(iq.usedb, ixnum);
@@ -411,9 +410,7 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                        iq.usedb->tablename, ixnum);
                 break;
             }
-            snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                  (char *)fnddta, keytag, key, NULL);
+            rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)fnddta, key);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
@@ -435,7 +432,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
 
         /* enqueue faults for new keys */
         for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-            char keytag[MAXTAGLEN];
             char key[MAXKEYLEN];
             int keysz = 0;
             keysz = getkeysize(iq.usedb, ixnum);
@@ -446,9 +442,7 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                        iq.usedb->tablename, ixnum);
                 continue;
             }
-            snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                  (char *)req->record, keytag, key, NULL);
+            rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)req->record, key);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
@@ -498,7 +492,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
 
         /* enqueue faults for old keys */
         for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-            char keytag[MAXTAGLEN];
             char key[MAXKEYLEN];
             int keysz = 0;
             keysz = getkeysize(iq.usedb, ixnum);
@@ -509,9 +502,7 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                        iq.usedb->tablename, ixnum);
                 continue;
             }
-            snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                  (char *)fnddta, keytag, key, NULL);
+            rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)fnddta, key);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"
@@ -528,7 +519,6 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
 
         /* enqueue faults for new keys */
         for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-            char keytag[MAXTAGLEN];
             char key[MAXKEYLEN];
             int keysz = 0;
             keysz = getkeysize(iq.usedb, ixnum);
@@ -539,9 +529,7 @@ static void osqlpfault_do_work(struct thdpool *pool, void *work, void *thddata)
                        iq.usedb->tablename, ixnum);
                 continue;
             }
-            snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-            rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                  (char *)req->record, keytag, key, NULL);
+            rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)req->record, key);
             if (rc == -1) {
                 logmsg(LOGMSG_ERROR,
                        "osqlpfault_do_work:cannot convert .ONDISK to IDX"

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -739,7 +739,6 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                 }
 
                 for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-                    char keytag[MAXTAGLEN];
                     char key[MAXKEYLEN];
                     int keysz = 0;
                     keysz = getkeysize(iq.usedb, ixnum);
@@ -749,9 +748,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                                iq.usedb->tablename, ixnum);
                         break;
                     }
-                    snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                          (char *)fnddta, keytag, key, NULL);
+                    rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)fnddta, key);
                     if (rc == -1) {
                         break;
                     }
@@ -861,7 +858,6 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
 
                 /* enqueue faults for old keys */
                 for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-                    char keytag[MAXTAGLEN];
                     char key[MAXKEYLEN];
                     int keysz = 0;
                     keysz = getkeysize(iq.usedb, ixnum);
@@ -871,9 +867,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                                iq.usedb->tablename, ixnum);
                         continue;
                     }
-                    snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                          (char *)fnddta, keytag, key, NULL);
+                    rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)fnddta, key);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"
@@ -916,7 +910,6 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
 
                 /* enqueue faults for new keys */
                 for (ixnum = 0; ixnum < iq.usedb->nix; ixnum++) {
-                    char keytag[MAXTAGLEN];
                     char key[MAXKEYLEN];
                     int keysz = 0;
                     keysz = getkeysize(iq.usedb, ixnum);
@@ -926,9 +919,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                                iq.usedb->tablename, ixnum);
                         continue;
                     }
-                    snprintf(keytag, sizeof(keytag), ".ONDISK_IX_%d", ixnum);
-                    rc = stag_to_stag_buf(iq.usedb->tablename, ".ONDISK",
-                                          (char *)od_dta, keytag, key, NULL);
+                    rc = stag_ondisk_to_ix(iq.usedb, ixnum, (char *)od_dta, key);
                     if (rc == -1) {
                         logmsg(LOGMSG_ERROR,
                                "prefault_thd:cannot convert .ONDISK to IDX"

--- a/db/sqlstat1.c
+++ b/db/sqlstat1.c
@@ -124,8 +124,7 @@ int sqlstat_find_record(struct ireq *iq, void *trans, const void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename, ".ONDISK", rec, ".ONDISK_IX_0", key,
-                          NULL);
+    rc = stag_ondisk_to_ix(sdb, 0, rec, key);
 
     if (rc)
         return ERR_CONVERT_IX;
@@ -227,8 +226,7 @@ int sqlstat_find_get_record(struct ireq *iq, void *trans, void *rec,
 
     /* set db */
     sdb = iq->usedb;
-    rc = stag_to_stag_buf(sdb->tablename, ".ONDISK", rec, ".ONDISK_IX_0", key,
-                          NULL);
+    rc = stag_ondisk_to_ix(sdb, 0, rec, key);
 
     if (rc)
         return ERR_CONVERT_IX;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -6100,7 +6100,6 @@ static int keyless_range_delete_formkey(void *record, size_t record_len,
                                         void *index, size_t index_len,
                                         int index_num, void *userptr)
 {
-    char index_tag_name[MAXTAGLEN + 1];
     rngdel_info_t *rngdel_info = userptr;
     struct ireq *iq = rngdel_info->iq;
     int ixkeylen;
@@ -6117,11 +6116,7 @@ static int keyless_range_delete_formkey(void *record, size_t record_len,
         return -2;
     }
 
-    snprintf(index_tag_name, sizeof(index_tag_name), ".ONDISK_IX_%d",
-             index_num);
-
-    rc = stag_to_stag_buf(iq->usedb->tablename, ".ONDISK", record,
-                          index_tag_name, index, NULL);
+    rc = stag_ondisk_to_ix(iq->usedb, index_num, record, index);
     if (rc == -1) {
         if (iq->debug)
             reqprintf(iq, "%p:RNGDELKL CALLBACK CANT FORM INDEX %d",

--- a/db/verify.c
+++ b/db/verify.c
@@ -248,19 +248,8 @@ static int verify_formkey_callback(const dbtable *tbl, void *dta,
                                    void *blob_parm, int ix, void *keyout,
                                    int *keysz)
 {
-    int rc;
-
     *keysz = get_size_of_schema(tbl->ixschema[ix]);
-    /*
-    rc = stag_to_stag_buf(tbl->tablename, ".ONDISK", (const char*) dta,
-    struct convert_failure reason;
-    tbl->ixschema[ix]->tag, keyout, &reason);
-     */
-    rc = create_key_from_ondisk_blobs(tbl, ix, NULL, NULL, NULL, ".ONDISK", dta,
-                                      0 /*not needed*/, tbl->ixschema[ix]->tag,
-                                      keyout, NULL, blob_parm, MAXBLOBS, NULL);
-
-    return rc;
+    return create_key_from_schema_simple(tbl, NULL, ix, dta, keyout, blob_parm, MAXBLOBS);
 }
 
 static int verify_add_blob_buffer_callback(void *parm, void *dta, int dtasz,


### PR DESCRIPTION
The function `find_tag_schema` is used intensively to resolve the schema given a table and a tag name.  It is essentially a hash table (indexed by the table name) of hash tables (indexed by the tag name). The overhead of the double lookup, as well as the key forming (e.g., ix 0 would become ".ONDISK_IX_0"), counts almost 10% of the total cost in certain workloads.

The patch simply uses `iq.usedb.ixschema` array to retrieve a schema, turning the double hash table lookup into an extremely cheap array access.