### PR TITLE
Better error messages for foreign key constraint violations

### DIFF
--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -149,15 +149,14 @@ int add_table_to_environment(char *table, const char *csc2,
 
     if ((iq == NULL || iq->tranddl <= 1) &&
         verify_constraints_exist(newdb, NULL, NULL, s) != 0) {
-        logmsg(LOGMSG_ERROR, "%s: Verify constraints failed \n", __func__);
+        logmsg(LOGMSG_ERROR, "%s: failed to verify constraints\n", __func__);
         rc = -1;
         goto err;
     }
 
     if ((iq == NULL || iq->tranddl <= 1) &&
         populate_reverse_constraints(newdb)) {
-        logmsg(LOGMSG_ERROR, "%s: populating reverse constraints failed\n",
-               __func__);
+        logmsg(LOGMSG_ERROR, "%s: failed to populate reverse constraints\n", __func__);
         rc = -1;
         goto err;
     }

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1093,12 +1093,8 @@ err:
         return -2;
     } else if (rc == ERR_CONSTR) {
         if (data->s->iq)
-            reqerrstr(data->s->iq, ERR_SC,
-                      "Error verifying constraints changed rrn %d genid 0x%llx",
-                      rrn, genid);
-        sc_errf(data->s, "Error verifying constraints changed!"
-                         " rrn %d genid 0x%llx\n",
-                rrn, genid);
+            reqerrstr(data->s->iq, ERR_SC, "Record violates foreign constraints rrn %d genid 0x%llx", rrn, genid);
+        sc_errf(data->s, "Record violates foreign constraints rrn %d genid 0x%llx\n", rrn, genid);
         return -2;
     } else if (rc == ERR_VERIFY_PI) {
         if (data->s->iq)

--- a/tests/constraints.test/t03_01.req.exp
+++ b/tests/constraints.test/t03_01.req.exp
@@ -6,10 +6,10 @@
 [insert into t1 values (1321, 1321, 1234, null) -- Non default, no NULL contraint.] rc 0
 (rows inserted=1)
 [insert into t2 values (1234, 1121)] rc 0
-[insert into t2 values (1534, 1121) ---  Foreign key constraint, 1534 does not exists in t1.] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'UID1' -> table 't1' index '0' key 'UID'
+[insert into t2 values (1534, 1121) ---  Foreign key constraint, 1534 does not exists in t1.] failed with rc 3 Transaction violates foreign key constraint t2(uid) -> t1(uid): key value does not exist in parent table
 (rows deleted=1)
 [delete from t1 where uid = 1321] rc 0
-[delete from t1 where value = 1234 -- Foreign key contraint, can't delete.] failed with rc 3 verify key constraint cannot resolve constraint table 't1' index '0' key 'UID' -> table 't2' index '0' 
+[delete from t1 where value = 1234 -- Foreign key contraint, can't delete.] failed with rc 3 Transaction violates foreign key constraint t2(uid) -> t1(uid): key value is still referenced from child table
 (uid=1234, value=1234, dup_value=1234, allowed_null_value=1234)
 (uid=4321, value=4321, dup_value=1234, allowed_null_value=1234)
 [select * from t1 order by uid] rc 0

--- a/tests/constraints.test/t07.req.exp
+++ b/tests/constraints.test/t07.req.exp
@@ -1,6 +1,6 @@
-[insert into fk values(1)] failed with rc 3 verify key constraint cannot resolve constraint table 'fk' key 'i' -> table 'pk' index '0' key 'i'
+[insert into fk values(1)] failed with rc 3 Transaction violates foreign key constraint fk(i) -> pk(i): key value does not exist in parent table
 (rows inserted=1)
 (rows inserted=1)
-[update fk set i = 2] failed with rc 3 verify key constraint cannot resolve constraint table 'fk' key 'i' -> table 'pk' index '0' key 'i'
+[update fk set i = 2] failed with rc 3 Transaction violates foreign key constraint fk(i) -> pk(i): key value does not exist in parent table
 (rows inserted=1)
 (rows updated=1)

--- a/tests/constraints.test/t09.req.exp
+++ b/tests/constraints.test/t09.req.exp
@@ -31,7 +31,7 @@ constraints
     //Need to add tbl first then alter with this line : "UID5" -> "t5":"UID6"
 }
 }] rc 0
-[insert into t5(uid, uida, uidb, uidc, uidd, uide, value) values(1,1,1,1,1,1,1)] failed with rc 3 verify key constraint cannot resolve constraint table 't5' key 'UID1' -> table 't2' index '0' key 'UID1'
+[insert into t5(uid, uida, uidb, uidc, uidd, uide, value) values(1,1,1,1,1,1,1)] failed with rc 3 Transaction violates foreign key constraint t5(uid) -> t2(uid): key value does not exist in parent table
 (rows inserted=1)
 [insert into t2(uid, value) values(1,1)] rc 0
 (rows inserted=1)
@@ -39,7 +39,7 @@ constraints
 [insert into t5(uid, uida, uidb, uidc, uidd, uide, value) values(1,2,1,1,1,1,1)] failed with rc 299 add key constraint duplicate key 'UID1' on table 't5' index 0
 (rows deleted=1)
 [delete from t5 where uid = 1] rc 0
-[insert into t5(uid, uida, uidb, uidc, uidd, uide, value) values(1,2,1,1,1,1,1)] failed with rc 3 verify key constraint cannot resolve constraint table 't5' key 'UID2' -> table 't2' index '0' key 'UID1'
+[insert into t5(uid, uida, uidb, uidc, uidd, uide, value) values(1,2,1,1,1,1,1)] failed with rc 3 Transaction violates foreign key constraint t5(uida) -> t2(uid): key value does not exist in parent table
 [create table t6  { schema
 {
   int uid

--- a/tests/constraints.test/t10.req.exp
+++ b/tests/constraints.test/t10.req.exp
@@ -17,14 +17,14 @@
 [begin] rc 0
 [create table c {schema{int i} keys{dup "key" = i} constraints{"key" -> <"m" : "pk">}}] rc 0
 [create table m {schema{int i} keys{"pk" = i}}] rc 0
-[commit] failed with rc 240 constraint error for table "c" key "key" -> <"m":"pk">: foreign table not found
+[commit] failed with rc 240 constraint error for table "c" key "key" -> <"m":"pk">: parent table not found
 ("transactional create"='transactional create')
 [select "transactional create"] rc 0
 [begin] rc 0
 [create table m {schema{int i} keys{"pk" = i}}] rc 0
 [create table c {schema{int i} keys{dup "key" = i} constraints{"key" -> <"m" : "pk">}}] rc 0
 [commit] rc 0
-[insert into c values (1)] failed with rc 3 verify key constraint cannot resolve constraint table 'c' key 'key' -> table 'm' index '0' key 'pk'
+[insert into c values (1)] failed with rc 3 Transaction violates foreign key constraint c(i) -> m(i): key value does not exist in parent table
 (rows inserted=1)
 [insert into m values (1)] rc 0
 (rows inserted=1)
@@ -116,26 +116,26 @@
 [commit] rc 0
 ("transactional alter (bad case 1)"='transactional alter (bad case 1)')
 [select "transactional alter (bad case 1)"] rc 0
-[alter table m {schema{int i}}] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[alter table m {schema{int i}}] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: parent key not found
 ("transactional alter (bad case 2)"='transactional alter (bad case 2)')
 [select "transactional alter (bad case 2)"] rc 0
 [begin] rc 0
 [alter table m {schema{int i}}] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
-[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: parent key not found
 ("transactional alter (bad case 3)"='transactional alter (bad case 3)')
 [select "transactional alter (bad case 3)"] rc 0
 [begin] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
 [alter table m {schema{int i}}] rc 0
-[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: parent key not found
 ("transactional alter (bad case 4)"='transactional alter (bad case 4)')
 [select "transactional alter (bad case 4)"] rc 0
 [begin] rc 0
 [alter table c {schema{int i} keys{dup "key" = i}}] rc 0
 [alter table m {schema{int i}}] rc 0
 [alter table d {schema{int i} keys{dup "key" = i}}] rc 0
-[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "key" -> <"m":"pk">: parent key not found
 ("transactional alter (good case)"='transactional alter (good case)')
 [select "transactional alter (good case)"] rc 0
 [begin] rc 0
@@ -158,7 +158,7 @@
 [drop table d] rc 0
 [alter table m {schema{int i}}] rc 0
 [drop table e] rc 0
-[commit] failed with rc 240 constraint error for table "e" key "key" -> <"m":"pk">: foreign key not found
+[commit] failed with rc 240 constraint error for table "e" key "key" -> <"m":"pk">: parent key not found
 ("transactional alter & drop (good case)"='transactional alter & drop (good case)')
 [select "transactional alter & drop (good case)"] rc 0
 [begin] rc 0
@@ -171,10 +171,10 @@
 [select "tests for self referenced schema"] rc 0
 ("add self-referenced bad 1"='add self-referenced bad 1')
 [select "add self-referenced bad 1"] rc 0
-[create table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"k" -> <"s" : "i">}}] failed with rc 240 constraint error for table "s" key "k" -> <"s":"i">: local key not found
+[create table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"k" -> <"s" : "i">}}] failed with rc 240 constraint error for table "s" key "k" -> <"s":"i">: foreign key not found
 ("add self-referenced bad 2"='add self-referenced bad 2')
 [select "add self-referenced bad 2"] rc 0
-[create table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "k">}}] failed with rc 240 constraint error for table "s" key "j" -> <"s":"k">: foreign key not found
+[create table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "k">}}] failed with rc 240 constraint error for table "s" key "j" -> <"s":"k">: parent key not found
 ("add self-referenced good"='add self-referenced good')
 [select "add self-referenced good"] rc 0
 [create table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "i">}}] rc 0
@@ -186,10 +186,10 @@
 [alter table s {schema{int i int j}}] rc 0
 ("alter self-referenced bad 1"='alter self-referenced bad 1')
 [select "alter self-referenced bad 1"] rc 0
-[alter table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"k" -> <"s" : "i">}}] failed with rc 240 constraint error for table "s" key "k" -> <"s":"i">: local key not found
+[alter table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"k" -> <"s" : "i">}}] failed with rc 240 constraint error for table "s" key "k" -> <"s":"i">: foreign key not found
 ("alter self-referenced bad 2"='alter self-referenced bad 2')
 [select "alter self-referenced bad 2"] rc 0
-[alter table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "k">}}] failed with rc 240 constraint error for table "s" key "j" -> <"s":"k">: foreign key not found
+[alter table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "k">}}] failed with rc 240 constraint error for table "s" key "j" -> <"s":"k">: parent key not found
 ("alter self-referenced good"='alter self-referenced good')
 [select "alter self-referenced good"] rc 0
 [alter table s {schema{int i int j} keys{dup "i" = i dup "j" = j} constraints{"j" -> <"s" : "i">}}] rc 0

--- a/tests/ddl_no_csc2.test/t01_alter_table.expected
+++ b/tests/ddl_no_csc2.test/t01_alter_table.expected
@@ -235,7 +235,7 @@ keys
 	}
 ')
 (type='index', name='$COMDB2_PK_7BDB9F9', tbl_name='t3', rootpage=9, sql='create index "$COMDB2_PK_7BDB9F9" on "t3" ("i", "j");', csc2=NULL)
-[ALTER TABLE t1 DROP INDEX 'idx'] failed with rc 240 constraint error for table "t2" key "IDX" -> <"t1":"IDX">: foreign key not found
+[ALTER TABLE t1 DROP INDEX 'idx'] failed with rc 240 constraint error for table "t2" key "IDX" -> <"t1":"IDX">: parent key not found
 (tablename='t1')
 (tablename='t2')
 (tablename='t3')

--- a/tests/ddl_no_csc2.test/t06_fk.expected
+++ b/tests/ddl_no_csc2.test/t06_fk.expected
@@ -37,13 +37,13 @@ keys
 	}
 ')
 ("transactional alter (bad case 1)"='transactional alter (bad case 1)')
-[alter table m drop index "COMDB2_PK"] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[alter table m drop index "COMDB2_PK"] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: parent key not found
 ("transactional alter (bad case 2)"='transactional alter (bad case 2)')
-[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: parent key not found
 ("transactional alter (bad case 3)"='transactional alter (bad case 3)')
-[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: parent key not found
 ("transactional alter (bad case 4)"='transactional alter (bad case 4)')
-[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "d" key "$KEY_5A448109" -> <"m":"COMDB2_PK">: parent key not found
 (name='c', csc2='schema
 	{
 		int i null = yes 
@@ -179,7 +179,7 @@ keys
 	}
 ')
 ("transactional alter & drop (bad case)"='transactional alter & drop (bad case)')
-[commit] failed with rc 240 constraint error for table "e" key "$KEY_6724A8B9" -> <"m":"COMDB2_PK">: foreign key not found
+[commit] failed with rc 240 constraint error for table "e" key "$KEY_6724A8B9" -> <"m":"COMDB2_PK">: parent key not found
 (name='c', csc2='schema
 	{
 		int i null = yes 
@@ -304,10 +304,10 @@ constraints
 ')
 ("drop self-referenced table"='drop self-referenced table')
 ("tests for nullfkey (enabled by default)"='tests for nullfkey (enabled by default)')
-[insert into t2 values(1)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key '$KEY_1E994F88' -> table 't1' index '0' key '$KEY_877B2989'
+[insert into t2 values(1)] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value does not exist in parent table
 (rows inserted=1)
 (rows inserted=1)
-[delete from t1 where i=1] failed with rc 3 verify key constraint cannot resolve constraint table 't1' index '0' key '$KEY_877B2989' -> table 't2' index '0' 
+[delete from t1 where i=1] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value is still referenced from child table
 (rows inserted=1)
 (rows inserted=1)
 (i=NULL)
@@ -337,7 +337,7 @@ constraints
 		"$KEY_1E994F88" -> <"t1":"IDX1"> 
 	}
 ')
-[insert into t2 values(1)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key '$KEY_1E994F88' -> table 't1' index '0' key 'IDX1'
+[insert into t2 values(1)] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value does not exist in parent table
 (rows inserted=1)
 (rows inserted=1)
 (i=1)
@@ -364,7 +364,7 @@ constraints
 		"IDX2" -> <"t1":"IDX1"> 
 	}
 ')
-[insert into t2 values(1)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'IDX2' -> table 't1' index '0' key 'IDX1'
+[insert into t2 values(1)] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value does not exist in parent table
 (rows inserted=1)
 (rows inserted=1)
 (i=1)
@@ -402,7 +402,7 @@ constraints
 (i=1, j=2)
 (i=1, j=3)
 (i=1, j=4)
-[update t2 set i=2 where i=1] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key '$KEY_1E994F88' -> table 't1' index '0' key '$KEY_877B2989'
+[update t2 set i=2 where i=1] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value does not exist in parent table
 (rows updated=1)
 (i=2, j=1)
 (i=2, j=2)

--- a/tests/ddl_no_csc2.test/t09_check.expected
+++ b/tests/ddl_no_csc2.test/t09_check.expected
@@ -11,7 +11,7 @@
 ')
 (rows inserted=1)
 (rows inserted=1)
-[ALTER TABLE t1 ADD CONSTRAINT valid_colors CHECK (color IN ('red', 'green', 'blue'))] failed with rc 240 Error verifying constraints changed rrn xx genid xx
+[ALTER TABLE t1 ADD CONSTRAINT valid_colors CHECK (color IN ('red', 'green', 'blue'))] failed with rc 240 Record violates foreign constraints rrn xx genid xx
 (csc2='schema
 	{
 		cstring color[11] null = yes 
@@ -71,7 +71,7 @@ constraints
 (name='CONS1', type='CHECK', tablename=NULL, keyname=NULL, foreigntablename=NULL, foreignkeyname=NULL, iscascadingdelete=NULL, iscascadingupdate=NULL, expr='i > 10')
 (name='$CONSTRAINT_9C3BA03F', type='CHECK', tablename=NULL, keyname=NULL, foreigntablename=NULL, foreignkeyname=NULL, iscascadingdelete=NULL, iscascadingupdate=NULL, expr='i < 100')
 [INSERT INTO t2 values(1)] failed with rc 403 CHECK constraint violation CHECK constraint failed for 'CONS1' unable to add record rc = 320
-[INSERT INTO t2 values(11)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key '$KEY_1E994F88' -> table 't1' index '0' key '$KEY_877B2989'
+[INSERT INTO t2 values(11)] failed with rc 3 Transaction violates foreign key constraint t2(i) -> t1(i): key value does not exist in parent table
 [INSERT INTO t2 values(111)] failed with rc 403 CHECK constraint violation CHECK constraint failed for '$CONSTRAINT_9C3BA03F' unable to add record rc = 320
 (rows inserted=3)
 [INSERT INTO t2 values(1)] failed with rc 403 CHECK constraint violation CHECK constraint failed for 'CONS1' unable to add record rc = 320

--- a/tests/keycompr.test/t00.expected
+++ b/tests/keycompr.test/t00.expected
@@ -30,7 +30,7 @@
 [insert into t(i, j) values(1, 15)] rc 0
 (rows inserted=1)
 [insert into u(i) values(1)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 16)] rc 0
 (rows inserted=1)

--- a/tests/keycompr.test/t01.expected
+++ b/tests/keycompr.test/t01.expected
@@ -30,7 +30,7 @@
 [insert into t(i, j) values(1, 15)] rc 0
 (rows inserted=1)
 [insert into u(i) values(1)] rc 0
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 16)] rc 0
 (rows inserted=1)

--- a/tests/keycompr.test/t02.expected
+++ b/tests/keycompr.test/t02.expected
@@ -30,64 +30,64 @@
 [insert into t(i, j) values(1, 15)] rc 0
 (rows inserted=1)
 [insert into u(i) values(1)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 16)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 17)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 18)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 19)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 20)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 21)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 22)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 23)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 24)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 25)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 26)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 27)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 28)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 29)] rc 0
-[delete from t where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
-[update t set i = 2 where 1] failed with rc 3 verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
+[delete from t where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
+[update t set i = 2 where 1] failed with rc 3 Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
 (rows inserted=1)
 [insert into t(i, j) values(1, 30)] rc 0
 (i=1, j=1, k=NULL)

--- a/tests/prefix_foreign_keys_rev.test/t00.req.out
+++ b/tests/prefix_foreign_keys_rev.test/t00.req.out
@@ -12,12 +12,12 @@
 (rows inserted=1)
 (rows inserted=1)
 (rows inserted=1)
-[insert into t2 values(3, 99, 500)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'pq0' -> table 't1' index '0' key 'a'
+[insert into t2 values(3, 99, 500)] failed with rc 3 Transaction violates foreign key constraint t2(p, q) -> t1(a, b, c): key value does not exist in parent table
 (p=1, q=88, r=200)
 (p=1, q=99, r=100)
 (p=2, q=88, r=400)
 (p=2, q=99, r=300)
-[insert into t2 values(1, 77, 600)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'pq0' -> table 't1' index '0' key 'a'
+[insert into t2 values(1, 77, 600)] failed with rc 3 Transaction violates foreign key constraint t2(p, q) -> t1(a, b, c): key value does not exist in parent table
 (p=1, q=88, r=200)
 (p=1, q=99, r=100)
 (p=2, q=88, r=400)
@@ -28,14 +28,14 @@
 (p=2, q=88, r=400)
 (p=2, q=99, r=300)
 (p=3, q=NULL, r=700)
-[insert into t3 values(3, 99)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(3, 99)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (r='1', s=NULL)
 (r='1', s='88')
 (r='1', s='99')
 (r='2', s=NULL)
 (r='2', s='88')
 (r='2', s='99')
-[insert into t3 values(1, 77)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(1, 77)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (r='1', s=NULL)
 (r='1', s='88')
 (r='1', s='99')

--- a/tests/prefix_foreign_keys_rev.test/t00.req.out.no_nullfkey
+++ b/tests/prefix_foreign_keys_rev.test/t00.req.out.no_nullfkey
@@ -8,36 +8,36 @@
 (rows inserted=1)
 (rows inserted=1)
 (rows inserted=1)
-[insert into t3 values(1, null)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(1, null)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (rows inserted=1)
 (rows inserted=1)
-[insert into t3 values(2, null)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
-[insert into t2 values(3, 99, 500)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'pq0' -> table 't1' index '0' key 'a'
+[insert into t3 values(2, null)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
+[insert into t2 values(3, 99, 500)] failed with rc 3 Transaction violates foreign key constraint t2(p, q) -> t1(a, b, c): key value does not exist in parent table
 (p=1, q=88, r=200)
 (p=1, q=99, r=100)
 (p=2, q=88, r=400)
 (p=2, q=99, r=300)
-[insert into t2 values(1, 77, 600)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'pq0' -> table 't1' index '0' key 'a'
+[insert into t2 values(1, 77, 600)] failed with rc 3 Transaction violates foreign key constraint t2(p, q) -> t1(a, b, c): key value does not exist in parent table
 (p=1, q=88, r=200)
 (p=1, q=99, r=100)
 (p=2, q=88, r=400)
 (p=2, q=99, r=300)
-[insert into t2 values(3, null, 700)] failed with rc 3 verify key constraint cannot resolve constraint table 't2' key 'pq0' -> table 't1' index '0' key 'a'
+[insert into t2 values(3, null, 700)] failed with rc 3 Transaction violates foreign key constraint t2(p, q) -> t1(a, b, c): key value does not exist in parent table
 (p=1, q=88, r=200)
 (p=1, q=99, r=100)
 (p=2, q=88, r=400)
 (p=2, q=99, r=300)
-[insert into t3 values(3, 99)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(3, 99)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (r='1', s='88')
 (r='1', s='99')
 (r='2', s='88')
 (r='2', s='99')
-[insert into t3 values(1, 77)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(1, 77)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (r='1', s='88')
 (r='1', s='99')
 (r='2', s='88')
 (r='2', s='99')
-[insert into t3 values(1, null)] failed with rc 3 verify key constraint cannot resolve constraint table 't3' key 'rs0' -> table 't1' index '0' key 'a'
+[insert into t3 values(1, null)] failed with rc 3 Transaction violates foreign key constraint t3(r, s) -> t1(a, b, c): key value does not exist in parent table
 (r='1', s='88')
 (r='1', s='99')
 (r='2', s='88')

--- a/tests/verify_db.test/runit
+++ b/tests/verify_db.test/runit
@@ -202,7 +202,7 @@ constraints
 
 # will fail, constraint violation
 cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into child_t(a,b,blb) values (1, 1, x'aa')" &> err_fk.out
-echo "[insert into child_t(a,b,blb) values (1, 1, x'aa')] failed with rc 3 verify key constraint cannot resolve constraint table 'child_t' key 'K1' -> table 'parent_t' index '0' key 'A'" > err_fk.expected
+echo "[insert into child_t(a,b,blb) values (1, 1, x'aa')] failed with rc 3 Transaction violates foreign key constraint child_t(a) -> parent_t(a): key value does not exist in parent table" > err_fk.expected
 if ! diff err_fk.out err_fk.expected ; then
     failexit "diff ${PWD}/{err_fk.out,err_fk.expected}"
 fi
@@ -236,7 +236,7 @@ cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into parent_t values (2)"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into child_t(a,b,blb) values (2, 2, x'bb')" &> err_fk2.out 
 
 # constraint 3 still not satisfied
-echo "[insert into child_t(a,b,blb) values (2, 2, x'bb')] failed with rc 3 verify key constraint cannot resolve constraint table 'child_t' key 'K3' -> table 'parent_t' index '0' key 'A'" > err_fk2.expected
+echo "[insert into child_t(a,b,blb) values (2, 2, x'bb')] failed with rc 3 Transaction violates foreign key constraint child_t(length(blb)) -> parent_t(a): key value does not exist in parent table" > err_fk2.expected
 if ! diff err_fk2.out err_fk2.expected ; then
     failexit "diff ${PWD}/{err_fk2.out,err_fk2.expected}"
 fi


### PR DESCRIPTION
Reword foreign key constraint error messages to include foreign key details and cause of failure. 

For instance, the following error message

```
verify key constraint cannot resolve constraint table 't' index '0' key 'I' -> table 'u' index '0' 
```

would become

```
Transaction violates foreign key constraint u(i) -> t(i, j, k): key value is still referenced from child table
```
