### PR TITLE
make sure we pick the next shard in sc if already created

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5845,7 +5845,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         arg.s = sc;
         arg.s->iq = iq;
         rc = timepart_foreach_shard(sc->tablename,
-                                    start_schema_change_tran_wrapper, &arg, 0);
+                                    start_schema_change_tran_wrapper, &arg, -1);
     }
     iq->usedb = NULL;
 

--- a/db/views.c
+++ b/db/views.c
@@ -2262,6 +2262,8 @@ done:
 /**
  * Run "func" for each shard, starting with "first_shard".
  * Callback receives the name of the shard and argument struct
+ * NOTE: first_shard == -1 means include the next shard if
+ * already created
  *
  */
 int timepart_foreach_shard(const char *view_name,
@@ -2270,6 +2272,7 @@ int timepart_foreach_shard(const char *view_name,
 {
     timepart_views_t *views;
     timepart_view_t *view;
+    char next_shard[MAXTABLELEN + 1];
     int rc = 0;
     int i;
 
@@ -2286,10 +2289,18 @@ int timepart_foreach_shard(const char *view_name,
         arg->view_name = view_name;
         arg->nshards = view->nshards;
     }
+
     for (i = first_shard; i < view->nshards; i++) {
         if (arg)
             arg->indx = i;
-        rc = func(view->shards[i].tblname, arg);
+        if (i == -1) {
+            rc = _next_shard_exists(view, next_shard, sizeof(next_shard));
+            if (rc == VIEW_ERR_EXIST) {
+                rc = func(next_shard, arg);
+            }
+        } else {
+            rc = func(view->shards[i].tblname, arg);
+        }
         if (rc) {
             break;
         }

--- a/db/views.h
+++ b/db/views.h
@@ -314,7 +314,9 @@ int timepart_foreach_shard(const char *view_name,
 
 /**
  * Under views lock, call a function for each shard
- * 
+ * NOTE: first_shard == -1 means include the next shard if
+ * already created
+ *
  */
 int timepart_for_each_shard(const char *name,
       int (*func)(const char *shardname));

--- a/tests/sc_race_timepart.test/Makefile
+++ b/tests/sc_race_timepart.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/sc_race_timepart.test/README
+++ b/tests/sc_race_timepart.test/README
@@ -1,0 +1,1 @@
+This tests altering a time partition during the rollout time window

--- a/tests/sc_race_timepart.test/lrl.options
+++ b/tests/sc_race_timepart.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/sc_race_timepart.test/run.log.alpha
+++ b/tests/sc_race_timepart.test/run.log.alpha
@@ -1,0 +1,19 @@
+(rows inserted=1)
+(name='sqlite_stat1')
+(name='sqlite_stat4')
+(name='$1_E5EE49E6')
+(name='$2_D109E17F')
+(name='$0_F64CD191')
+(name='testview1', shardname='$2_D109E17F')
+(name='testview1', shardname='$1_E5EE49E6')
+(a=1, b='hello', c=NULL)
+(name='$0_F64CD191', csc2='schema
+{
+   int      a
+   cstring  b[10]
+   int c null=yes
+}
+keys
+{
+   "pk"  = a
+}')

--- a/tests/sc_race_timepart.test/runit
+++ b/tests/sc_race_timepart.test/runit
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# args
+# <dbname>
+dbname=$1
+
+VIEW1="testview1"
+OUT="run.log"
+
+rm $OUT 2>/dev/null
+touch $OUT
+
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+60 -2*24*3600)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'"
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+# no race between insert and rollout, want insert in last shard
+sleep 10
+
+#insert one row
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into ${VIEW1} values (1, 'hello')" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+#trigger a prepare
+cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat t2.csc2`}"
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "select name from sqlite_master where type='table'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "select name, shardname from comdb2_timepartshards" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi 
+
+#wait for the last rollout, before re-preparing a view
+sleep 60
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "select * from ${VIEW1}" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "select name,csc2 from sqlite_master where name='\$0_F64CD191'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+difs=`diff $OUT $OUT.alpha`
+if [[ ! -z "${difs}" ]] ; then
+   echo "diff $OUT $OUT.alpha"
+   echo ${difs}
+   echo "FAILURE"
+   exit 1
+fi
+
+
+echo "SUCCESS"

--- a/tests/sc_race_timepart.test/t.csc2
+++ b/tests/sc_race_timepart.test/t.csc2
@@ -1,0 +1,9 @@
+schema
+{
+   int      a
+   cstring  b[10]
+}
+keys
+{
+   "pk"  = a
+}

--- a/tests/sc_race_timepart.test/t2.csc2
+++ b/tests/sc_race_timepart.test/t2.csc2
@@ -1,0 +1,10 @@
+schema
+{
+   int      a
+   cstring  b[10]
+   int c null=yes
+}
+keys
+{
+   "pk"  = a
+}


### PR DESCRIPTION
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

There is a time window during partition in which we already have a new shard ready not rolled in.  Any schema change happening during this time will miss it.  This patch make sure the ready-to-rollin shard is also schema changed.