### PR TITLE
Add stripe item count for debug, clarify tableversion

### DIFF
--- a/bdb/bdb_verify.h
+++ b/bdb/bdb_verify.h
@@ -44,8 +44,8 @@ typedef struct {
     unsigned long long (*verify_indexes_callback)(void *parm, void *dta, void *blob_parm);
     char *header; // header string for printing for prog rep in default mode
     uint64_t items_processed;             // atomic inc: for progres report
-    uint64_t records_processed;           // progress report in default mode
     uint64_t saved_progress;              // previous progress counter
+    uint64_t records_processed;           // progress report in default mode
     int nrecs_progress;                   // progress done in this time window
     unsigned int last_connection_check;   // last reported time in ms
     int progress_report_seconds;          // freq of report in seconds

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -8031,7 +8031,7 @@ static int bdb_table_version_upsert_int(bdb_state_type *bdb_state,
     if (rc || *bdberr != BDBERR_NOERROR) {
         return rc;
     } else {
-        logmsg(LOGMSG_INFO, "Saved version %" PRIu64 " for table %s\n",
+        logmsg(LOGMSG_INFO, "Saved tableversion %" PRIu64 " for table %s\n",
                flibc_htonll(version), bdb_state->name);
     }
 
@@ -8242,8 +8242,8 @@ retry:
     *version = flibc_ntohll(*version);
 
     if (verbose)
-        logmsg(LOGMSG_INFO, "Retrieved version %lld for %s\n", *version,
-               tblname);
+        logmsg(LOGMSG_INFO, "Retrieved tableversion %lld for %s\n",
+               *version, tblname);
 
     *bdberr = BDBERR_NOERROR;
     return 0;
@@ -9891,8 +9891,7 @@ int bdb_rename_csc2_version(tran_type *trans, const char *tblname,
                 return rc;
             }
             logmsg(LOGMSG_DEBUG,
-                   "%s added table '%s' (old table '%s') version "
-                   "%d\n",
+                   "%s added table '%s' (old table '%s') version %d\n",
                    __func__, newtblname, tblname, ver);
         } else {
             if (ver == 0)

--- a/db/tag.c
+++ b/db/tag.c
@@ -6630,8 +6630,8 @@ void update_dbstore(dbtable *db)
     }
 
     bzero(db->dbstore, sizeof db->dbstore);
-    logmsg(LOGMSG_DEBUG, "%s table '%s' version %d\n", __func__, db->tablename,
-           db->schema_version);
+    logmsg(LOGMSG_DEBUG, "%s table '%s' schema version %d\n", __func__,
+           db->tablename, db->schema_version);
 
     for (int v = 1; v <= db->schema_version; ++v) {
         char tag[MAXTAGLEN];
@@ -6646,8 +6646,8 @@ void update_dbstore(dbtable *db)
         }
 
         db->versmap[v] = (unsigned int *)get_tag_mapping(ver, ondisk);
-        logmsg(LOGMSG_DEBUG, "%s set table '%s' vers %d to %p\n", __func__,
-               db->tablename, v, db->versmap[v]);
+        logmsg(LOGMSG_DEBUG, "%s set table '%s' schema version %d to %p\n",
+               __func__, db->tablename, v, db->versmap[v]);
         db->vers_compat_ondisk[v] = 1;
         if (SC_TAG_CHANGE ==
             compare_tag_int(ver, ondisk, NULL, 0 /*non-strict compliance*/))

--- a/tests/sc_repeated_updates.test/runit
+++ b/tests/sc_repeated_updates.test/runit
@@ -97,7 +97,7 @@ function update_same_record
     done
     succ=`grep -c "rows updated=1" update1.out`
     if [[ $succ -ne $loc_recs ]] ; then
-	failexit "update_same_record: all $loc_recs should have resulted in successful update instead of $succ"
+	    failexit "update_same_record: all $loc_recs should have resulted in successful update instead of $succ"
     fi
     echo "update_same_record: Done (update1)"
 }

--- a/tests/scindex.test/runit
+++ b/tests/scindex.test/runit
@@ -449,9 +449,9 @@ function do_verify
 {
     typeset cnt=0
 
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify.out
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify_t1.out
 
-    if ! grep succeeded verify.out > /dev/null ; then
+    if ! grep succeeded verify_t1.out > /dev/null ; then
 
         errquit "Verify failed."
 


### PR DESCRIPTION
Add stripe item count for debug in verify.
Clarify tableversion when retrieving/saving schemachange information.
and schema version in update_dbstore().

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>