### PR TITLE
Use temparray for shadow tables and SQLite temp tables

### DIFF
--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -890,8 +890,7 @@ static tmpcursor_t *open_shadow_int(bdb_state_type *bdb_state,
             return NULL;
 
         /* create a temporary table */
-        (*pshadows)[file].tbls[stripe] =
-            bdb_temp_table_create(bdb_state, bdberr);
+        (*pshadows)[file].tbls[stripe] = bdb_temp_array_create(bdb_state, bdberr);
         if (!(*pshadows)[file].tbls[stripe]) {
             logmsg(LOGMSG_ERROR, 
                     "%s: fail create shadow %d %d, rc = %d bdberr = %d\n",

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -241,9 +241,8 @@ static int key_memcmp(void *usermem, int key1len, const void *key1, int key2len,
 static int temp_table_compare(DB *db, const DBT *dbt1, const DBT *dbt2);
 
 /* refactored both insert and put code paths here */
-static int bdb_temp_table_insert_put(bdb_state_type *, struct temp_table *,
-                                     void *key, int keylen, void *data,
-                                     int dtalen, int *bdberr);
+static int bdb_temp_table_insert_put(bdb_state_type *, struct temp_table *, struct temp_cursor *cur, void *key,
+                                     int keylen, void *data, int dtalen, void *unpacked, int *bdberr);
 
 void *bdb_temp_table_get_cur(struct temp_cursor *skippy) { return skippy->cur; }
 
@@ -339,6 +338,7 @@ static int bdb_array_copy_to_temp_db(bdb_state_type *bdb_state,
     struct temp_cursor *cur;
     arr_elem_t *elem;
     unsigned long long nents = tbl->num_mem_entries;
+    unsigned long long rowid = tbl->rowid;
 
     bzero(&dbt_key, sizeof(DBT));
     bzero(&dbt_data, sizeof(DBT));
@@ -369,6 +369,7 @@ static int bdb_array_copy_to_temp_db(bdb_state_type *bdb_state,
     }
     tbl->inmemsz = 0;
     tbl->num_mem_entries = nents;
+    tbl->rowid = rowid;
 
     /* its now a btree! */
     tbl->temp_table_type = TEMP_TABLE_TYPE_BTREE;
@@ -387,6 +388,8 @@ static int bdb_array_copy_to_temp_db(bdb_state_type *bdb_state,
         }
 
         /* New cursor does not point to any data */
+        free(cur->key);
+        free(cur->data);
         cur->key = cur->data = NULL;
         cur->keylen = cur->datalen = 0;
     }
@@ -897,8 +900,7 @@ int bdb_temp_table_insert(bdb_state_type *bdb_state, struct temp_cursor *cur,
     DBT dkey, ddata;
     struct temp_table *tbl = cur->tbl;
 
-    int rc = bdb_temp_table_insert_put(bdb_state, tbl, key, keylen, data,
-                                       dtalen, bdberr);
+    int rc = bdb_temp_table_insert_put(bdb_state, tbl, cur, key, keylen, data, dtalen, NULL, bdberr);
     if (rc <= 0)
         goto done;
 
@@ -1037,8 +1039,7 @@ int bdb_temp_table_put(bdb_state_type *bdb_state, struct temp_table *tbl,
 {
     DBT dkey, ddata;
 
-    int rc = bdb_temp_table_insert_put(bdb_state, tbl, key, keylen, data,
-                                       dtalen, bdberr);
+    int rc = bdb_temp_table_insert_put(bdb_state, tbl, NULL, key, keylen, data, dtalen, unpacked, bdberr);
     if (rc <= 0)
         goto done;
 
@@ -1769,6 +1770,7 @@ int bdb_temp_table_delete(bdb_state_type *bdb_state, struct temp_cursor *cur,
 {
     int rc;
     arr_elem_t *elem;
+    struct temp_cursor *opencur;
 
     if (!cur->valid) {
         rc = -1;
@@ -1793,6 +1795,14 @@ int bdb_temp_table_delete(bdb_state_type *bdb_state, struct temp_cursor *cur,
         cur->tbl->inmemsz -= (elem->keylen + elem->dtalen);
         memmove(elem, elem + 1,
                 sizeof(arr_elem_t) * (cur->tbl->num_mem_entries - cur->ind));
+        /* Reposition all open cursors: if a cursor is on the right of
+           the deletion point, move it to the left by one. */
+        LISTC_FOR_EACH(&cur->tbl->cursors, opencur, lnk)
+        {
+            if (opencur != cur && opencur->ind >= cur->ind)
+                --opencur->ind;
+        }
+        --cur->ind;
         rc = 0;
         goto done;
     }
@@ -1892,35 +1902,39 @@ int bdb_temp_table_find(bdb_state_type *bdb_state, struct temp_cursor *cur,
     tmptbl_cmp cmpfn;
     arr_elem_t *elem;
     DBT dkey, ddata;
+    struct temp_table *tbl = cur->tbl;
 
-    if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
+    if (tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
         logmsg(LOGMSG_ERROR, 
                 "bdb_temp_table_find operation not supported for temp list.\n");
         return -1;
-    }
-    else if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_HASH) {
+    } else if (tbl->temp_table_type == TEMP_TABLE_TYPE_HASH) {
         return bdb_temp_table_find_hash(cur, key, keylen);
     }
 
-    if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_ARRAY) {
+    if (tbl->temp_table_type == TEMP_TABLE_TYPE_ARRAY) {
 
         /* Find the 1st occurrence of `key'. If `key' is not found,
            find the smallest element greater than `key' */
 
-        if (cur->tbl->num_mem_entries == 0) {
+        if (tbl->num_mem_entries == 0) {
             cur->valid = 0;
             return IX_EMPTY;
         }
 
         lo = 0;
-        hi = cur->tbl->num_mem_entries - 1;
+        hi = tbl->num_mem_entries - 1;
         found = -1;
-        cmpfn = cur->tbl->cmpfunc;
+        cmpfn = tbl->cmpfunc;
 
         while (lo <= hi) {
             mid = (lo + hi) >> 1;
-            elem = &cur->tbl->elements[mid];
-            cmp = cmpfn(NULL, elem->keylen, elem->key, keylen, key);
+            elem = &tbl->elements[mid];
+
+            if (unpacked != NULL)
+                cmp = cmpfn(NULL, elem->keylen, elem->key, -1, unpacked);
+            else
+                cmp = cmpfn(tbl->usermem, elem->keylen, elem->key, keylen, key);
 
             if (cmp < 0)
                 lo = mid + 1;
@@ -1934,9 +1948,13 @@ int bdb_temp_table_find(bdb_state_type *bdb_state, struct temp_cursor *cur,
 
         if (found != -1)
             cur->ind = found;
-        else if (lo < cur->tbl->num_mem_entries)
+        else if (lo < tbl->num_mem_entries)
             cur->ind = lo;
-        else {
+        else if (lo == tbl->num_mem_entries) {
+            /* If nothing can be found, return the last element.
+               See the btree code below. */
+            cur->ind = (lo - 1);
+        } else {
             cur->valid = 0;
             return IX_NOTFND;
         }
@@ -2047,34 +2065,35 @@ int bdb_temp_table_find_exact(bdb_state_type *bdb_state,
     int exists = 0;
     arr_elem_t *elem;
     void *keydup;
+    struct temp_table *tbl = cur->tbl;
 
-    if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
+    if (tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
         logmsg(LOGMSG_ERROR, "bdb_temp_table_find_exact operation not supported for "
                         "temp list.\n");
         return -1;
     }
 
-    if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_HASH) {
+    if (tbl->temp_table_type == TEMP_TABLE_TYPE_HASH) {
         return bdb_temp_table_find_exact_hash(cur, key, keylen);
     }
 
-    if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_ARRAY) {
+    if (tbl->temp_table_type == TEMP_TABLE_TYPE_ARRAY) {
 
         /* Find the 1st occurrence of `key'. */
 
-        if (cur->tbl->num_mem_entries == 0) {
+        if (tbl->num_mem_entries == 0) {
             cur->valid = 0;
             return IX_EMPTY;
         }
 
         lo = 0;
-        hi = cur->tbl->num_mem_entries - 1;
+        hi = tbl->num_mem_entries - 1;
         found = -1;
-        cmpfn = cur->tbl->cmpfunc;
+        cmpfn = tbl->cmpfunc;
 
         while (lo <= hi) {
             mid = (lo + hi) >> 1;
-            elem = &cur->tbl->elements[mid];
+            elem = &tbl->elements[mid];
             cmp = cmpfn(NULL, elem->keylen, elem->key, keylen, key);
 
             if (cmp < 0)
@@ -2343,15 +2362,14 @@ int bdb_temp_table_maybe_reset_priority_thread(bdb_state_type *bdb_state,
     return rc;
 }
 
-static int bdb_temp_table_insert_put(bdb_state_type *bdb_state,
-                                     struct temp_table *tbl, void *key,
-                                     int keylen, void *data, int dtalen,
-                                     int *bdberr)
+static int bdb_temp_table_insert_put(bdb_state_type *bdb_state, struct temp_table *tbl, struct temp_cursor *cur,
+                                     void *key, int keylen, void *data, int dtalen, void *unpacked, int *bdberr)
 {
-    int rc, cmp, lo, hi, mid;
+    int rc, cmp, lo, hi, mid, found;
     tmptbl_cmp cmpfn;
     arr_elem_t *elem;
     uint8_t *keycopy, *dtacopy;
+    struct temp_cursor *opencur;
 
     if (tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
         struct temp_list_node *c_node = calloc(1, sizeof(struct temp_list_node));
@@ -2409,24 +2427,53 @@ static int bdb_temp_table_insert_put(bdb_state_type *bdb_state,
         lo = 0;
         hi = tbl->num_mem_entries - 1;
         if (hi >= 0) {
+            found = -1;
             cmpfn = tbl->cmpfunc;
 
             while (lo <= hi) {
                 mid = (lo + hi) >> 1;
                 elem = &tbl->elements[mid];
-                cmp = cmpfn(NULL, elem->keylen, elem->key, keylen, key);
+                if (unpacked != NULL)
+                    cmp = cmpfn(NULL, elem->keylen, elem->key, -1, unpacked);
+                else
+                    cmp = cmpfn(tbl->usermem, elem->keylen, elem->key, keylen, key);
 
                 if (cmp < 0)
                     lo = mid + 1;
                 else if (cmp > 0)
                     hi = mid - 1;
-                else
+                else {
+                    found = mid;
                     lo = mid + 1;
+                }
             }
 
-            elem = &tbl->elements[lo];
-            memmove(elem + 1, elem,
-                    sizeof(arr_elem_t) * (tbl->num_mem_entries - lo));
+            if (found != -1) {
+                /*
+                ** We do not support duplicate items.
+                ** The existing entry will be replaced.
+                */
+                elem = &tbl->elements[found];
+                tbl->inmemsz -= (elem->keylen + elem->dtalen);
+                free(elem->key);
+                --tbl->num_mem_entries;
+                lo = found;
+            } else {
+                /* Make room for the new entry. */
+                elem = &tbl->elements[lo];
+                memmove(elem + 1, elem, sizeof(arr_elem_t) * (tbl->num_mem_entries - lo));
+
+                /* Reposition all open cursors. If a cursor is on the right of
+                   the insertion point, move it to the right by one. */
+                LISTC_FOR_EACH(&tbl->cursors, opencur, lnk)
+                {
+                    if (opencur != cur && opencur->ind >= lo)
+                        ++opencur->ind;
+                }
+
+                if (cur != NULL)
+                    cur->ind = lo;
+            }
         }
 
         elem = &tbl->elements[lo];

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -723,8 +723,7 @@ static int create_tablecursor(bdb_state_type *bdb_env, struct tmp_table **ptbl,
     tbl->table = bdb_temp_array_create(bdb_env, bdberr);
 
     if (!tbl->table) {
-        logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_create failed, bderr=%d\n",
-                __func__, *bdberr);
+        logmsg(LOGMSG_ERROR, "%s: bdb_temp_array_create failed, bderr=%d\n", __func__, *bdberr);
         free(tbl);
         return -1;
     }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -5171,14 +5171,13 @@ int sqlite3BtreeCreateTable(Btree *pBt, int *piTable, int flags)
         pNewTbl->tbl = tmptbl_clone->tbl;
         pNewTbl->owner = tmptbl_clone->owner;
     } else {
-        pNewTbl->tbl = bdb_temp_table_create(thedb->bdb_env, &bdberr);
+        pNewTbl->tbl = bdb_temp_array_create(thedb->bdb_env, &bdberr);
         if (pNewTbl->tbl != NULL) ATOMIC_ADD32(gbl_sql_temptable_count, 1);
     }
     if (pNewTbl->tbl == NULL) {
         --pBt->num_temp_tables;
         free(pNewTbl);
-        logmsg(LOGMSG_ERROR, "%s: bdb_temp_table_create failed: %d\n", __func__,
-               bdberr);
+        logmsg(LOGMSG_ERROR, "%s: bdb_temp_array_create failed: %d\n", __func__, bdberr);
         rc = SQLITE_INTERNAL;
         goto done;
     }


### PR DESCRIPTION
Temparray is superior to temptable, when it comes to storing temporary and usually small data. The patch replaces temptable in the 2 places with temparray, hence achieves better performance in certain workloads.
