### PR TITLE
Option to rename a table by creating an alias instead for sql schema purposes

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2100,6 +2100,26 @@ int bdb_table_version_upsert(bdb_state_type *bdb_state, tran_type *tran,
                              int *bdberr);
 
 /**
+ * Set the sql alias for a table "bdb_state->name" to newname
+ *
+ */
+int bdb_set_table_sqlalias(const char *tablename, tran_type *tran,
+                           char *newname);
+
+/**
+ * Get the sql alias for a table "bdb_state->name"" in newname (malloced)
+ *
+ */
+int bdb_get_table_sqlalias_tran(const char *tablename, tran_type *tran,
+                                char **newname);
+
+/**
+ * Delete the sql alias for a table "bdb_state->name
+ *
+ */
+int bdb_del_table_sqlalias_tran(const char *tablename, tran_type *tran);
+
+/**
  * Set the TABLE VERSION ENTRY for table "bdb_state->name" to "val"
  * (It creates or, if existing, updates an entry)
  *

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -48,7 +48,8 @@ typedef enum scdone {
     change_stripe,           // 20
     user_view,               // 21
     add_queue_file,          // 22
-    del_queue_file           // 23
+    del_queue_file,          // 23
+    rename_table_alias       // 24
 } scdone_t;
 
 #define IS_QUEUEDB_ROLLOVER_SCHEMA_CHANGE_TYPE(a) \

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -8653,6 +8653,43 @@ int bdb_clear_table_parameter(void *parent_tran, const char *table,
     return bdb_set_table_parameter(parent_tran, table, parameter, NULL);
 }
 
+/**
+ * Set the sql alias for a table "bdb_state->name" to newname
+ *
+ */
+int bdb_set_table_sqlalias(const char *tablename, tran_type *tran,
+                           char *newname)
+{
+    int rc = 0;
+
+    rc = bdb_set_table_parameter(tran, tablename, "sqlalias", newname);
+
+    return rc;
+}
+
+/**
+ * Get the sql alias for a table "bdb_state->name" in newname (malloced)
+ *
+ */
+int bdb_get_table_sqlalias_tran(const char *tablename, tran_type *tran,
+                                char **newname)
+{
+    int rc = 0;
+
+    rc = bdb_get_table_parameter_tran(tablename, "sqlalias", newname, tran);
+
+    return rc;
+}
+
+/**
+ * Delete the sql alias for a table "bdb_state->name"
+ *
+ */
+int bdb_del_table_sqlalias_tran(const char *tablename, tran_type *tran)
+{
+    return bdb_set_table_parameter(tran, tablename, "sqlalias", NULL);
+}
+
 struct queue_key {
     int file_type;
     char dbname[LLMETA_TBLLEN + 1];

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -474,6 +474,8 @@ enum RECOVER_DEADLOCK_FLAGS {
     RECOVER_DEADLOCK_FORCE_FAIL = 0x00000002
 };
 
+enum { SC_RENAME_LEGACY = 1, SC_RENAME_ALIAS = 2 };
+
 enum CURTRAN_FLAGS { CURTRAN_RECOVERY = 0x00000001 };
 
 /* Raw stats, kept on a per origin machine basis.  This whole struct is
@@ -596,6 +598,7 @@ typedef struct dbtable {
     struct dbenv *dbenv; /*chain back to my environment*/
     char *lrlfname;
     char *tablename;
+    char *sqlaliasname;
     struct ireq *iq; /* iq used at sc time */
 
     int dbnum; /* zero unless setup as comdbg table */
@@ -868,6 +871,7 @@ struct dbenv {
     dbtable **dbs;
     dbtable static_table;
     hash_t *db_hash;
+    hash_t *sqlalias_hash;
 
     /* Queues */
     int num_qdbs;
@@ -2344,6 +2348,7 @@ void resume_threads(struct dbenv *env);
 void replace_db_idx(struct dbtable *p_db, int idx);
 int add_db(struct dbtable *db);
 void delete_db(char *db_name);
+void hash_sqlalias_db(dbtable *db, const char *newname);
 int rename_db(struct dbtable *db, const char *newname);
 int ix_find_rnum_by_recnum(struct ireq *iq, int recnum_in, int ixnum,
                            void *fndkey, int *fndrrn, unsigned long long *genid,

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "net.h"
 #include "sql_stmt_cache.h"
+#include "sc_rename_table.h"
 
 /* Maximum allowable size of the value of tunable. */
 #define MAX_TUNABLE_VALUE_SIZE 512

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2073,6 +2073,11 @@ REGISTER_TUNABLE("sockbplog_sockpool",
 REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE(
+    "lightweight_rename",
+    "Replaces the ondisk file rename with an aliasing at llmeta level",
+    TUNABLE_BOOLEAN, &gbl_lightweight_rename, 0, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("alternate_normalize",
                  "Use alternate SQL normalization algorithm.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_alternate_normalize,

--- a/db/glue.c
+++ b/db/glue.c
@@ -4069,11 +4069,12 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                "odh %s  "
                "isc %s  "
                "odh_datacopy %s  "
-               "ipu %s",
+               "ipu %s "
+               "alias %s",
                tbl->tablename, tbl->schema_version, tbl->odh ? "yes" : "no",
                tbl->instant_schema_change ? "yes" : "no",
-               datacopy_odh ? "yes" : "no",
-               tbl->inplace_updates ? "yes" : "no");
+               datacopy_odh ? "yes" : "no", tbl->inplace_updates ? "yes" : "no",
+               tbl->sqlaliasname ? tbl->sqlaliasname : "<none>");
     }
 
     if (gbl_create_mode) {

--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -230,7 +230,7 @@ static void *create_master_row(struct dbtable **dbs, int num_dbs, int rootpage,
     assert(tblnum < num_dbs);
 
     tbl = dbs[tblnum];
-    dbname = tbl->tablename;
+    dbname = tbl->sqlaliasname ? tbl->sqlaliasname : tbl->tablename;
 
     if (ixnum == -1) {
         strcpy(name, dbname);

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -698,7 +698,8 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                 else if (s->addonly)
                     type = add;
                 else if (s->rename)
-                    type = rename_table;
+                    type = (s->rename == SC_RENAME_LEGACY) ? rename_table
+                                                           : rename_table_alias;
                 else if (s->type == DBTYPE_TAGGED_TABLE)
                     type = alter;
                 else if (s->add_view || s->drop_view)

--- a/db/verify.c
+++ b/db/verify.c
@@ -314,7 +314,8 @@ static int get_tbl_and_lock_in_tran(verify_common_t *par, const char *table,
     *db = locdb;
     *tran = loctran;
     int rc;
-    if ((rc = bdb_lock_tablename_read(thedb->bdb_env, table, loctran)) != 0) {
+    if ((rc = bdb_lock_tablename_read(thedb->bdb_env, locdb->tablename,
+                                      loctran)) != 0) {
         char err[LINE_MAX];
         snprintf(err, sizeof(err), "?Readlock rc:%d table:%s", rc, table);
         logmsg(LOGMSG_ERROR, "%s\n", err + 1);

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -292,6 +292,7 @@ accept_on_child_nets|  off |listen on separate port for osql/signal nets
 disable_etc_services_lookup|  off |When on, disables using /etc/services first to resolve ports
 rowlocks_deadlock_trace|off |Prints deadlock trace in phys.c
 mask_internal_tunables|on|When enabled, comdb2_tunables system table would not list INTERNAL tunables
+lightweight_rename|off|When enabled, rename will add an alias instead of completely changing the table name
 
 #### `sqllogger` commands
 

--- a/schemachange/sc_rename_table.h
+++ b/schemachange/sc_rename_table.h
@@ -17,9 +17,13 @@
 #ifndef INCLUDE_SC_RENAME_H
 #define INCLUDE_SC_RENAME_H
 
+extern int gbl_lightweight_rename;
+
 struct ireq;
 int do_rename_table(struct ireq *, struct schema_change_type *, tran_type *);
 int finalize_rename_table(struct ireq *, struct schema_change_type *,
                           tran_type *);
+int finalize_rename_table_alias(struct ireq *, struct schema_change_type *,
+                                tran_type *);
 
 #endif

--- a/tests/renametable.test/lightweight.testopts
+++ b/tests/renametable.test/lightweight.testopts
@@ -1,0 +1,1 @@
+lightweight_rename 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -387,6 +387,7 @@
 (name='leasebase_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='libevent', description='Use libevent in net library. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='libevent_rte_only', description='Prevent listening on TCP socket. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
+(name='lightweight_rename', description='Replaces the ondisk file rename with an aliasing at llmeta level', type='BOOLEAN', value='OFF', read_only='N')
 (name='little_endian_btrees', description='Enabling this sets byte ordering for pages to little endian.', type='BOOLEAN', value='ON', read_only='N')
 (name='lk_hash', description='', type='INTEGER', value='32', read_only='Y')
 (name='lk_part', description='', type='INTEGER', value='73', read_only='Y')


### PR DESCRIPTION
Option to rename a table by creating an alias instead. This does not rename the ondisk files; sql will use the table alias instead of its name, while the rest of the system still uses the old name.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
