### PR TITLE
Fix column name crash on mismatched schema between old and new SQLite

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3383,7 +3383,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
                     return rc;
             }
 
-            if (rec->stmt)
+            if (rec->stmt && sqlite3_column_count(rec->stmt) == column_count)
                 stmt_set_cached_columns(rec->stmt, column_names, column_decltypes, column_count);
         }
 


### PR DESCRIPTION
The old and new SQLite engine may produce different schema for the same table (e.g., sqlite_temp_master). Add a simple check to protect us from any discrepancies.

(DRQS 165223829)
