### PR TITLE
Fix scindex.test to properly send cmds to all cluster nodes

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -515,9 +515,18 @@ static int bdb_verify_data_stripe(verify_common_t *par, int dtastripe,
                 locprint(par, "!%016llx ix %d fetch rc %d", genid_flipped, ix,
                          rc);
             } else if (genid != verify_genid) {
+
+                unsigned long long v_genid_flipped;
+
+#ifdef _LINUX_SOURCE
+                buf_put(&verify_genid, sizeof(unsigned long long), (uint8_t *)&v_genid_flipped,
+                        (uint8_t *)&v_genid_flipped + sizeof(unsigned long long));
+#else
+                v_genid_flipped = verify_genid;
+#endif
                 par->verify_status = 1;
                 locprint(par, "!%016llx ix %d genid mismatch %016llx",
-                         genid_flipped, ix, verify_genid);
+                         genid_flipped, ix, v_genid_flipped);
             }
 
             ckey->c_close(ckey);

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -294,7 +294,7 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
 
     /* Add the genid to hash for quick lookup. */
     unsigned long long *genid_ptr =
-      pool_getablk(thdinfo->ct_add_table_genid_pool);
+        pool_getablk(thdinfo->ct_add_table_genid_pool);
     memcpy(genid_ptr, &genid, sizeof(unsigned long long));
     hash_add(thdinfo->ct_add_table_genid_hash, genid_ptr);
 
@@ -331,6 +331,8 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
         logmsg(LOGMSG_ERROR, "insert_add_op: insert_add_index rc = %d\n", rc);
         return -1;
     }
+    if (iq->debug)
+        reqprintf(iq, "insert_add_op: GENID 0x%llx", genid);
 
     blkstate->ct_id_key++;
     return 0;
@@ -1125,7 +1127,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
          * If a key is a dup violation then we don't want SC to fail,
          * rather the UPD should fail (when processing that idx in this loop).
          * So when table cursor points to next genid, only then we can call
-         * live_sc on the stored genid. 
+         * live_sc on the stored (ie previous) genid. 
          */
         if (genid && genid != curop->genid) {
             LIVE_SC_DELAYED_KEY_ADDS(0 /* not last */);

--- a/db/indices.c
+++ b/db/indices.c
@@ -550,7 +550,7 @@ int upd_record_indices(struct ireq *iq, void *trans, int *opfailcode,
         ditk.usedb = iq->usedb;
     }
 
-    /* Delay key add if schema change has constraints so we can * verify them.
+    /* Delay key add if schema change has constraints so we can verify them.
      * FIXME: What if the table does not have index to begin with?
      * (Redo based live sc works for this case)
      */
@@ -1158,8 +1158,10 @@ int upd_new_record_indices(
             iq, trans, newgenid, use_new_tag ? sc_new : new_dta,
             use_new_tag ? iq->usedb->lrl : nd_len, ins_keys, use_new_tag,
             add_idx_blobs, !verify_retry);
-    } else
-        reqprintf(iq, "is deferredAdd so will add to indices at the end");
+    } else {
+        if (iq->debug)
+            reqprintf(iq, "is deferredAdd so will add to indices at the end");
+    }
 
     return rc;
 }

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -3860,6 +3860,11 @@ clipper_usage:
             state = 1;
         } else if (tokcmp(tok, ltok, "off") == 0) {
             state = 0;
+            /* NB: turning off IPU will result in corrupt indices and blobs
+             * as reported by verif() (because the masked genid will not be
+             * handled correctly, look at bdb_normalise_genid() and its use)
+             * and it is necessary to run a rebuild after turning off IPU.
+             */
         } else {
             logmsg(LOGMSG_ERROR, "Expected on/off\n");
             goto out;

--- a/db/record.c
+++ b/db/record.c
@@ -1942,7 +1942,7 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
     rc = remap_update_columns(iq->usedb->tablename, ".ONDISK", updCols,
                               ".NEW..ONDISK", myupdatecols);
     if (iq->debug) {
-        reqprintf(iq, "upd_new_record returns %d", rc);
+        reqprintf(iq, "remap_update_columns returns %d", rc);
     }
 
     if (0 != rc) {
@@ -2189,6 +2189,10 @@ int upd_new_record(struct ireq *iq, void *trans, unsigned long long oldgenid,
         }
     }
 
+    if (iq->debug) {
+        reqpushprefixf(iq, "upd_new_record_indices: ");
+        prefixes++;
+    }
     retrc = upd_new_record_indices(iq, trans, newgenid, ins_keys, new_dta,
                                    old_dta, use_new_tag, sc_old, sc_new, nd_len,
                                    del_keys, add_idx_blobs, del_idx_blobs,

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -514,6 +514,9 @@ int live_sc_post_upd_record(struct ireq *iq, void *trans,
                   oldgenid, newgenid, deferredAdd);
     }
 
+    if (iq->debug) {
+        reqpushprefixf(iq, "upd_new_record: ");
+    }
     rc = upd_new_record(iq, trans, oldgenid, old_dta, newgenid, new_dta,
                         ins_keys, del_keys, od_len, updCols, blobs, deferredAdd,
                         oldblobs, newblobs, 1);
@@ -529,7 +532,7 @@ int live_sc_post_upd_record(struct ireq *iq, void *trans,
 
     ATOMIC_ADD32(usedb->sc_updates, 1);
     if (iq->debug) {
-        reqpopprefixes(iq, 1);
+        reqpopprefixes(iq, 2);
     }
     return rc;
 }

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -462,8 +462,7 @@ struct dbtable *create_db_from_schema(struct dbenv *thedb,
                                       struct schema_change_type *s, int dbnum,
                                       int foundix, int schema_version)
 {
-    struct dbtable *newdb =
-        newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix, 0);
+    struct dbtable *newdb = newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix, 0);
 
     if (newdb == NULL) return NULL;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1002,8 +1002,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
 
     if (s->dbnum != -1) db->dbnum = s->dbnum;
 
-    db->sc_to = newdb =
-        newdb_from_schema(thedb, s->tablename, NULL, db->dbnum, foundix, 0);
+    db->sc_to = newdb = newdb_from_schema(thedb, s->tablename, NULL, db->dbnum, foundix, 0);
 
     if (newdb == NULL) {
         return -1;

--- a/tests/scindex.test/runit
+++ b/tests/scindex.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
-set -x
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 set -x
 # Grab my database name.
@@ -9,8 +10,7 @@ dbnm=$1
 # Verify that the user at least supplied a dbname
 if [[ -z "$dbnm" ]]; then
 
-    echo "Testcase requires <dbname> argument."
-    exit 1
+    failexit "Testcase requires <dbname> argument."
 
 fi
 
@@ -192,20 +192,19 @@ function insert_rand_t1
 
     # Insert the record
     if [[ "1" == "$debug" ]]; then
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"insert into t1(id, b1) values ($id, x'$bl')\""
-        cdb2sql ${CDB2_OPTIONS} $db default "insert into t1(id, b1) values ($id, x'$bl')"
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"insert into t1(id, b1) values ($id, x'$bl')\""
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "insert into t1(id, b1) values ($id, x'$bl')"
     else
-        out=$(cdb2sql ${CDB2_OPTIONS} $db default "insert into t1(id, b1) values ($id, x'$bl')" 2>&1)
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "insert into t1(id, b1) values ($id, x'$bl')" 2>&1)
     fi
     if [[ $? != 0 ]]; then
-        echo "insert_rand_t1 failed, $out"
-        exit 1
+        failexit "insert_rand_t1 failed, $out"
     fi
 
     # If the 'bgdebug' flag is set, write this to a file. */
     if [[ "1" == "$bgdebug" ]]; then
         
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"insert into t1(id, b1) values ($id, x'$bl')\"" >> $bgtmpfl
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"insert into t1(id, b1) values ($id, x'$bl')\"" >> $bgtmpfl
     fi
 
     return 0
@@ -227,20 +226,19 @@ function update_noblob_rand_t1
 
     # Update a record, discard the result
     if [[ "1" == "$debug" ]]; then
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid where id=$id\""
-        cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid where id=$id"
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid where id=$id\""
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid where id=$id"
     else
-        out=$(cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid where id=$id" 2>&1)
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid where id=$id" 2>&1)
     fi
     if [[ $? != 0 ]]; then
-        echo "update_noblob_rand_t1 failed, $out"
-        exit 1
+        failexit "update_noblob_rand_t1 failed, $out"
     fi
 
     # If the 'bgdebug' flag is set, write this to a file. */
     if [[ "1" == "$bgdebug" ]]; then
         
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid where id=$id\"" >> $bgtmpfl
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid where id=$id\"" >> $bgtmpfl
     fi
 
     return 0
@@ -276,35 +274,34 @@ function update_onlyblob_rand_t1
 
         if [[ "1" == "$nullblob" ]]; then
 
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set b1=NULL where id=$id\""
-            cdb2sql ${CDB2_OPTIONS} $db default "update t1 set b1=NULL where id=$id"
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set b1=NULL where id=$id\""
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set b1=NULL where id=$id"
 
         else
 
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set b1=x'$bl' where id=$id\""
-            cdb2sql ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bl' where id=$id"
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set b1=x'$bl' where id=$id\""
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bl' where id=$id"
 
         fi
 
     else
         if [[ "1" == "$nullblob" ]]; then
-            out=$(cdb2sql ${CDB2_OPTIONS} $db default "update t1 set b1=NULL where id=$id" 2>&1)
+            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set b1=NULL where id=$id" 2>&1)
         else
-            out=$(cdb2sql ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bl' where id=$id" 2>&1)
+            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set b1=x'$bl' where id=$id" 2>&1)
         fi
     fi
     if [[ $? != 0 ]]; then
-        echo "update_onlyblob_rand_t1 failed, $out"
-        exit 1
+        failexit "update_onlyblob_rand_t1 failed, $out"
     fi
 
     # If the 'bgdebug' flag is set, write this to a file. */
     if [[ "1" == "$bgdebug" ]]; then
         
         if [[ "1" == "$nullblob" ]]; then
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set b1=NULL where id=$id\"" >> $bgtmpfl
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set b1=NULL where id=$id\"" >> $bgtmpfl
         else
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set b1=x'$bl' where id=$id\"" >> $bgtmpfl
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set b1=x'$bl' where id=$id\"" >> $bgtmpfl
         fi
     fi
 
@@ -342,35 +339,34 @@ function update_rand_t1
 
         if [[ "1" == "$nullblob" ]]; then
 
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=NULL where id=$id\""
-            cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=NULL where id=$id"
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=NULL where id=$id\""
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=NULL where id=$id"
 
         else
 
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=x'$bl' where id=$id\""
-            cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=x'$bl' where id=$id"
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=x'$bl' where id=$id\""
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=x'$bl' where id=$id"
 
         fi
 
     else
         if [[ "1" == "$nullblob" ]]; then
-            out=$(cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=NULL where id=$id" 2>&1)
+            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=NULL where id=$id" 2>&1)
         else
-            out=$(cdb2sql ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=x'$bl' where id=$id" 2>&1)
+            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "update t1 set id=$upid, b1=x'$bl' where id=$id" 2>&1)
         fi
     fi
     if [[ $? != 0 ]]; then
-        echo "update_rand_t1 failed, $out"
-        exit 1
+        failexit "update_rand_t1 failed, $out"
     fi
 
     # If the 'bgdebug' flag is set, write this to a file. */
     if [[ "1" == "$bgdebug" ]]; then
         
         if [[ "1" == "$nullblob" ]]; then
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=NULL where id=$id\"" >> $bgtmpfl
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=NULL where id=$id\"" >> $bgtmpfl
         else
-            echo "cdb2sql ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=x'$bl' where id=$id\"" >> $bgtmpfl
+            echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"update t1 set id=$upid, b1=x'$bl' where id=$id\"" >> $bgtmpfl
         fi
 
     fi
@@ -394,20 +390,19 @@ function delete_rand_t1
 
     # Delete a record, discard the result
     if [[ "1" == "$debug" ]]; then
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"delete from t1 where id=$id\""
-        cdb2sql ${CDB2_OPTIONS} $db default "delete from t1 where id=$id"
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"delete from t1 where id=$id\""
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "delete from t1 where id=$id"
     else
-        out=$(cdb2sql ${CDB2_OPTIONS} $db default "delete from t1 where id=$id" 2>&1)
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} $db default "delete from t1 where id=$id" 2>&1)
     fi
     if [[ $? != 0 ]]; then
-        echo "delete_rand_t1 failed, $out"
-        exit 1
+        failexit "delete_rand_t1 failed, $out"
     fi
 
     # If the 'bgdebug' flag is set, write this to a file. */
     if [[ "1" == "$bgdebug" ]]; then
         
-        echo "cdb2sql ${CDB2_OPTIONS} $db default \"delete from t1 where id=$id\"" >> $bgtmpfl
+        echo "$CDB2SQL_EXE ${CDB2_OPTIONS} $db default \"delete from t1 where id=$id\"" >> $bgtmpfl
 
     fi
 
@@ -449,7 +444,7 @@ function do_verify
 {
     typeset cnt=0
 
-    cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify_t1.out
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify_t1.out
 
     if ! grep succeeded verify_t1.out > /dev/null ; then
 
@@ -482,8 +477,8 @@ function do_schemachange
 do_verify
 sleep 2
 do_verify
-echo "Add int index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add int index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -499,12 +494,12 @@ EOF
 if [[ $? != 0 ]]; then
     errquit "Schemachange has failed."
 fi
-echo "do_verify after first schema change"
+echo "do_schemachange: do_verify after first schema change"
 do_verify
 
 sleep 2
-echo "Change int index to <DESCEND>"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Change int index to <DESCEND>"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -520,12 +515,12 @@ EOF
 if [[ $? != 0 ]]; then
     errquit "Schemachange has failed."
 fi
-echo "do_verify after second schema change"
+echo "do_schemachange: do_verify after second schema change"
 do_verify
 
 sleep 2
-echo "Change int index back to <ASCEND>"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Change int index back to <ASCEND>"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -544,8 +539,8 @@ fi
 
 do_verify
 sleep 2
-echo "Add partial index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add partial index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -565,8 +560,8 @@ fi
 do_verify
 
 sleep 2
-echo "Change partial index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Change partial index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -586,8 +581,8 @@ fi
 do_verify
 
 sleep 2
-echo "Change partial index (blob)"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Change partial index (blob)"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -607,8 +602,8 @@ fi
 do_verify
 
 sleep 2
-echo "Drop partial index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Drop partial index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -627,8 +622,8 @@ fi
 do_verify
 
 sleep 2
-echo "Add expression index (sum)"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add expression index (sum)"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -648,8 +643,8 @@ fi
 do_verify
 
 sleep 2
-echo "Add expression index (blob)"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add expression index (blob)"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -670,8 +665,8 @@ fi
 do_verify
 
 sleep 2
-echo "Add compound expression index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add compound expression index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -693,8 +688,8 @@ fi
 do_verify
 
 sleep 2
-echo "Add condition to expression index"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Add condition to expression index"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -716,8 +711,8 @@ fi
 do_verify
 
 sleep 2
-echo "Change expression index to <DESCEND>"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+echo "do_schemachange: Change expression index to <DESCEND>"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -742,7 +737,7 @@ do_verify
 # Trap to errquit if the user presses Ctrl-C
 trap "errquit \"Cancelling test on INT EXIT\"" INT EXIT
 
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<EOF
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<EOF
 drop table if exists t1
 create table t1 {
 schema
@@ -772,11 +767,13 @@ gent1insert $maxt1 insert_t1.cfg
 
 # Insert records into t1.k
 echo "Inserting records into t1."
-cdb2sql -s ${CDB2_OPTIONS} $dbnm default - < insert_t1.cfg >/dev/null
+$CDB2SQL_EXE -s ${CDB2_OPTIONS} $dbnm default - < insert_t1.cfg >/dev/null
 
 # Select t1 back.
 echo "Selecting t1."
-cdb2sql ${CDB2_OPTIONS} $dbnm default "select id, b1 from t1 order by id" > select_t1.txt
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "select id, b1 from t1 order by id" > select_t1.txt
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('debg 500')"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('ndebg 500')"
 
 ii=0
 # Print status message.
@@ -797,14 +794,16 @@ while [[ $ii -lt $nwrts ]]; do
 
 done
 
+master=`getmaster`
+
 echo "Starting schemachange"
-cdb2sql ${CDB2_OPTIONS} $dbnm default "PUT SCHEMACHANGE COMMITSLEEP 3"
-cdb2sql ${CDB2_OPTIONS} $dbnm default "PUT SCHEMACHANGE CONVERTSLEEP 3"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --host $master "PUT SCHEMACHANGE COMMITSLEEP 3"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --host $master "PUT SCHEMACHANGE CONVERTSLEEP 3"
 
 do_schemachange
 
 echo "Drop all indexes"
-cdb2sql ${CDB2_OPTIONS} $dbnm default - <<"EOF"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default - <<"EOF"
 alter table t1 {
 schema
 {
@@ -818,8 +817,8 @@ if [[ $? != 0 ]]; then
 fi
 do_verify
 
-# delay key adds
-cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('goslow')"
+echo "delay key adds (goslow)"
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm --host $master "exec procedure sys.cmd.send('goslow')"
 
 # do schemachange test again
 do_schemachange
@@ -847,7 +846,7 @@ trap - INT EXIT
 
 # Select t1 back.
 echo "Selecting t1."
-cdb2sql ${CDB2_OPTIONS} $dbnm default "select id, b1 from t1 order by id" > select_t1_final.txt
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "select id, b1 from t1 order by id" > select_t1_final.txt
 
 # See if t1 was updated during this test.
 wr_t1=$(( upd_t1 + del_t1 + ins_t1 ))
@@ -862,9 +861,7 @@ if [[ "0" != "$wr_t1" && $? == 0 ]]; then
     echo "Testcase is broken: the post-commit t1 should have changed."
 
     # Tell the user how to see this.
-    echo "Run 'diff ${PWD}/{select_t1.txt,select_t1_final.txt}' to see the error."
-
-    exit 1
+    failexit "Run 'diff ${PWD}/{select_t1.txt,select_t1_final.txt}' to see the error."
 
 fi
 

--- a/tests/stripe_order_inserts.test/runit
+++ b/tests/stripe_order_inserts.test/runit
@@ -31,8 +31,7 @@ N=8   # number of stripes
 
 echo "Round robin"
 
-dbnm=rrdb$TESTID
-DBNAME=$dbnm
+DBNAME=rrdb$TESTID
 DBDIR=$TESTDIR/$DBNAME
 CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
@@ -43,36 +42,36 @@ COMDB2_UNITTEST=0 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"0\"" INT EXIT
 
-res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
+res=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "select 1"`
 assertres $res 1
 
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table t1 (i int)"
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "create table t1 (i int)"
 
 echo begin > ins.in
 for i in `seq 1 $N` ; do
     echo "insert into t1 values($i)"
 done >> ins.in
 echo commit >> ins.in
-cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in $dbnm default
+cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in ${DBNAME} default
 
 
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create procedure addrecs version 'sptest' {$(cat addrecs.lua)}"
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "put default procedure addrecs 'sptest'"
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure addrecs('t1', $N)"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "create procedure addrecs version 'sptest' {$(cat addrecs.lua)}"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "put default procedure addrecs 'sptest'"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure addrecs('t1', $N)"
 
 assertcnt t1 8
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select printf("%llx",cast(substr(comdb2_rowid,3) as integer)%16) as genid from t1' > stripes.out
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default 'select printf("%llx",cast(substr(comdb2_rowid,3) as integer)%16) as genid from t1' > stripes.out
 for i in `seq 1 $N` ; do
     cnt=`grep -c $((i-1)) stripes.out`
     assertres "$cnt" "1"
 done
 
 # verify via pgdump command -- same thing as above but checks the actual btrees
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb dblist')" > dblist.out
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb dblist')" > dblist.out
 for i in `seq 1 $N` ; do
     fileid=`cat dblist.out | grep "XXX.t1_" | grep datas$((i-1)) | awk '{print $1}'`
     [ "x$fileid" == "x" ] && failexit "dblist does not contain info about t1"
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:2" || failexit "page does not contain 1 row"
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:2" || failexit "page does not contain 1 row"
 done
 
 call_unsetup 1
@@ -81,8 +80,7 @@ trap - INT EXIT
 
 echo "NO round robin"
 
-dbnm=norrdb$TESTID
-DBNAME=$dbnm
+DBNAME=norrdb$TESTID
 DBDIR=$TESTDIR/$DBNAME
 CDB2_CONFIG=$DBDIR/comdb2db.cfg
 CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
@@ -93,27 +91,27 @@ COMDB2_UNITTEST=0 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
 # Trap to call_unsetup if the test exits
 trap "call_unsetup \"Cancelling test\"" INT EXIT
 
-res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
+res=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "select 1"`
 assertres $res 1
 
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create table t2 (i int)"
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "create table t2 (i int)"
 echo begin > ins.in
 for i in `seq 1 $N` ; do
     echo "insert into t2 values($i)"
 done >> ins.in
 echo commit >> ins.in
-cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in $dbnm default
+cdb2sql --tabs ${CDB2_OPTIONS} -f ins.in ${DBNAME} default
 
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "create procedure addrecs version 'sptest' {$(cat addrecs.lua)}"
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "put default procedure addrecs 'sptest'"
-#cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure addrecs('t2', $N)"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "create procedure addrecs version 'sptest' {$(cat addrecs.lua)}"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "put default procedure addrecs 'sptest'"
+#cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure addrecs('t2', $N)"
 
 assertcnt t2 8
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb dblist')" > dblist2.out
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb dblist')" > dblist2.out
 for i in `seq 1 $N` ; do
     fileid=`cat dblist2.out | grep "XXX.t2_" | grep datas$((i-1)) | awk '{print $1}'`
     [ "x$fileid" == "x" ] && failexit "dblist does not contain info about t2"
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:"
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:"
 done > entry_counts.out
 
 
@@ -124,15 +122,15 @@ assertres "$other" "1"
 
 
 for i in `seq 1 $N` ; do
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "insert into t2 values($i)"
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "insert into t2 values($i)"
 done
 
 assertcnt t2 16
-cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb dblist')" > dblist2.out
+cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb dblist')" > dblist2.out
 for i in `seq 1 $N` ; do
     fileid=`cat dblist2.out | grep "XXX.t2_" | grep datas$((i-1)) | awk '{print $1}'`
     [ "x$fileid" == "x" ] && failexit "dblist does not contain info about t2"
-    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:"
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('bdb pgdump $fileid 1')" | grep "entries:"
 done > entry_counts2.out
 
 

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-
 # Common bash functions across many of the runit scripts
 
-C2SQL="$CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME}"
 
 # exit after displaying error message
 failexit()
@@ -27,7 +25,6 @@ assertres ()
 }
 
 
-
 # assert that number of rows of table in $1 is targecnt in $2, optional comment in $3
 # assertcnt (table, targetcnt, comment)
 assertcnt ()
@@ -38,7 +35,7 @@ assertcnt ()
     local tbl=$1
     local target=$2
     comment=$3
-    local cnt=$($C2SQL default "select count(*) from $tbl")
+    local cnt=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "select count(*) from $tbl")
     if [ $? -ne 0 ] ; then
         echo "assertcnt: select error"
     fi
@@ -52,19 +49,19 @@ assertcnt ()
 
 getmaster()
 {
-    $C2SQL default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'
+    $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'
 }
 
 getclusternodes()
 {
-    $C2SQL default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':'
+    $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':'
 }
 
 sendtocluster()
 {
     msg=$1
     for n in `getclusternodes` ; do
-        $C2SQL --host $n "$msg"
+        $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} --host $n "$msg"
     done
 }
 
@@ -72,11 +69,10 @@ sendtocluster()
 do_verify()
 {
     tbl=$1
-    $C2SQL default "exec procedure sys.cmd.verify('$tbl', 'parallel')" &> verify_$tbl.out
+    $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.verify('$tbl', 'parallel')" &> verify_$tbl.out
 
     if ! grep succeeded verify_$tbl.out > /dev/null ; then
         grep succeeded verify_$tbl.out | head -10
         failexit "verify $tbl had errors"
     fi
 }
-


### PR DESCRIPTION
scindex.test brought to light bug reported in (#2704) in single node
though it was passing clustered tests because it did not correctly send
sleep cmds to all cluster nodes--fixed in this checkin. Also:

* Added reqprint stmts which were neccessary for debugging the issue.
* Fixed stripe_order_inserts by undoing a change in runit_common.sh
* Verify dta to print mismatched genid correctly flipped
* Add comment that we should NOT turn off ipu without subsequent rebuild

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>