### PR TITLE
tracking admin mode connection

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1107,6 +1107,7 @@ struct connection_info {
     char *state;
     char *sql;
     char *fingerprint;
+    int64_t is_admin;
 
     /* latched in sqlinterfaces, not returned */ 
     time_t connect_time_int;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6447,6 +6447,7 @@ int gather_connection_info(struct connection_info **info, int *num_connections) 
        c[cid].host = clnt->origin;
        c[cid].state_int = clnt->state;
        c[cid].time_in_state_int = clnt->state_start_time;
+       c[cid].is_admin = clnt->admin;
        Pthread_mutex_lock(&clnt->state_lk);
        if (clnt->state == CONNECTION_RUNNING ||
            clnt->state == CONNECTION_QUEUED) {

--- a/net/net.c
+++ b/net/net.c
@@ -5339,7 +5339,6 @@ void do_appsock(netinfo_type *netinfo_ptr, struct sockaddr_in *cliaddr,
         findpeer(new_fd, paddr, sizeof(paddr));
         if (!gbl_forbid_remote_admin ||
             (cliaddr->sin_addr.s_addr == htonl(INADDR_LOOPBACK))) {
-            logmsg(LOGMSG_INFO, "Accepting admin user from %s\n", paddr);
             admin = 1;
         } else {
             logmsg(LOGMSG_INFO, "Rejecting non-local admin user from %s\n",

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -93,5 +93,6 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_INTERVALDS, "time_in_state", -1, offsetof(struct connection_info, time_in_state),
             CDB2_CSTRING, "sql", -1, offsetof(struct connection_info, sql),
             CDB2_CSTRING, "fingerprint", -1, offsetof(struct connection_info, fingerprint),
+            CDB2_INTEGER, "is_admin", -1, offsetof(struct connection_info, is_admin),
             SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/cdb2_admin.test/Makefile
+++ b/tests/cdb2_admin.test/Makefile
@@ -1,0 +1,10 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif
+unexport CLUSTER

--- a/tests/cdb2_admin.test/README
+++ b/tests/cdb2_admin.test/README
@@ -1,0 +1,6 @@
+This test verifies cdb2api connections made in admin mode. 
+
+Main Idea: 
+1.) Establish an admin connection
+2.) Test if it's recorded in comdb2_connections under the 'is_admin' column 
+

--- a/tests/cdb2_admin.test/runit
+++ b/tests/cdb2_admin.test/runit
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+[[ $debug == 1 ]] && set -x
+set -x
+dbname=$1
+cdb2sql --admin $dbname "SELECT SLEEP(2)" &
+is_admin=$(cdb2sql --tabs $dbname "SELECT is_admin FROM comdb2_connections WHERE pid=$!")
+wait
+[ $is_admin != 1 ] && { exit 1; }
+exit 0


### PR DESCRIPTION
Currently, we print a trace message when a new admin connection is accepted. 
This simple PR replaces the trace message with an entry in comdb2_connections system table. 
It also includes a tool for establish and verifying the same, as well as a test runner 
