### PR TITLE
Exclude sqlite_stats from querylimit

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2403,6 +2403,7 @@ static int get_matching_genid(BtCursor *cur, int rrn, unsigned long long *genid)
 static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 {
     struct sql_thread *thd = pCur->thd;
+    struct sqlclntstate *clnt;
     int bdberr = 0;
     int done = 0;
     int rc = SQLITE_OK;
@@ -2418,12 +2419,14 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
         return rc;
     }
 
-    /* If no tablescans are allowed, return an error */
-    if (!thd->clnt->limits.tablescans_ok) {
-        return SQLITE_LIMIT;
-    }
+    clnt = thd->clnt;
 
-    if (thd)
+    /* If no tablescans are allowed (sqlite_stats* tables are exempt), return an error */
+    if (!clnt->limits.tablescans_ok && pCur->db && !is_sqlite_stat(pCur->db->tablename))
+        return SQLITE_LIMIT;
+
+    /* Set had_tablescans flag if we're asked to warn of tablescans. */
+    if (clnt->limits.tablescans_warn)
         thd->had_tablescans = 1;
 
     outrc = SQLITE_OK;
@@ -2446,16 +2449,10 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
         return SQLITE_TRAN_NOLOG;
     }
     if (bdberr == BDBERR_DEADLOCK) {
-        logmsg(LOGMSG_ERROR, "%s: too much contention, retried %d times [%llx]\n",
-                __func__, gbl_move_deadlk_max_attempt,
-                (thd->clnt && thd->clnt->osql.rqid)
-                    ? thd->clnt->osql.rqid
-                    : 0);
-        ctrace("%s: too much contention, retried %d times [%llx]\n", __func__,
-               gbl_move_deadlk_max_attempt,
-               (thd->clnt && thd->clnt->osql.rqid)
-                   ? thd->clnt->osql.rqid
-                   : 0);
+        logmsg(LOGMSG_ERROR, "%s: too much contention, retried %d times [%llx]\n", __func__,
+               gbl_move_deadlk_max_attempt, clnt->osql.rqid);
+        ctrace("%s: too much contention, retried %d times [%llx]\n", __func__, gbl_move_deadlk_max_attempt,
+               clnt->osql.rqid);
         return SQLITE_DEADLOCK;
     }
     if (rc == IX_FND || rc == IX_NOTFND) {
@@ -2510,7 +2507,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 
         if (!gbl_selectv_rangechk) {
             if ((rc == IX_FND || rc == IX_FNDMORE) && pCur->is_recording &&
-                thd->clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
+                clnt->ctrl_sqlengine == SQLENG_INTRANS_STATE) {
                 rc = osql_record_genid(pCur, thd, pCur->genid);
                 if (rc) {
                     logmsg(LOGMSG_ERROR, "%s: failed to record genid %llx (%llu)\n",


### PR DESCRIPTION
It undesirably triggers querylimit warnings to process sqlite_stats*. Exclude these tables.

(DRQS 165333865)