### PR TITLE
Only get tablelock once for repeated USEDB of same tbl

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1841,7 +1841,10 @@ enum query_lock_type {
     TABLENAME_LOCKED_READ = 2,
     TABLENAME_LOCKED_EITHER = 3
 };
-int bdb_has_tablename_locked(bdb_state_type *, const char *name, uint32_t lid, enum query_lock_type type);
+int bdb_has_tablename_locked(bdb_state_type *, const char *tblname,
+                             uint32_t lid, enum query_lock_type type);
+int bdb_has_trans_tablename_locked(bdb_state_type *bdb_state, const char *tblname,
+                                   tran_type *tran, enum query_lock_type type);
 int bdb_lock_row_write(bdb_state_type *bdb_state, tran_type *tran,
                        unsigned long long genid);
 int bdb_trylock_row_write(bdb_state_type *bdb_state, tran_type *tran,

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -3045,8 +3045,7 @@ __lock_query(dbenv, locker, obj, lock_mode)
 {
 	int ret;
 	LOCKREGION(dbenv, (DB_LOCKTAB *)dbenv->lk_handle);
-	ret = __lock_query_internal(dbenv->lk_handle,
-		locker, obj, lock_mode);
+	ret = __lock_query_internal(dbenv->lk_handle, locker, obj, lock_mode);
 	UNLOCKREGION(dbenv, (DB_LOCKTAB *)dbenv->lk_handle);
 	return (ret);
 }


### PR DESCRIPTION
Currently we get tablelock for every OSQL_USEDB message. In this case:
```
begin
insert into t1
insert into t2
insert into t1
commit
```
the inserts get processed in order t1,t1,t2 is because of osql table reordering. This change will skip getting tablelock for
subsequent USEDBs of the same table if we already got it once before.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>