### PR TITLE
Fix string to datetime conversion in an order-by

### DIFF
--- a/sqlite/src/dttz.c
+++ b/sqlite/src/dttz.c
@@ -419,3 +419,8 @@ static void monthsFunc(sqlite3_context *context, int argc, sqlite3_value **argv)
       sqlite3_result_null(context);
 }
 
+const char *get_clnt_tz()
+{
+  struct sql_thread *thd = pthread_getspecific(query_info_key);
+  return ( thd && thd->clnt ) ? thd->clnt->tzname : NULL;
+}

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -789,6 +789,7 @@ int sqlite3VdbeCheckFk(Vdbe *, int);
 int convMem2ClientDatetime(Mem *pMem, void *out);
 int convMem2ClientDatetimeStr(Mem *pMem, void *out, int outlen, int *outdtsz);
 int convDttz2ClientDatetime(const dttz_t *, const char *tzname, void *out, int sqltype);
+const char *get_clnt_tz();
 
 int sqliteVdbeMemDecimalBasicArithmetics(Mem *a, Mem *b, int opcode, Mem * res, int flipped);
 

--- a/sqlite/src/vdbesort.c
+++ b/sqlite/src/vdbesort.c
@@ -1476,9 +1476,16 @@ static int vdbeSorterSort(SortSubtask *pTask, SorterList *pList){
   pList->pList = p;
 
   sqlite3_free(aSlot);
-  assert( pTask->pUnpacked->errCode==SQLITE_OK 
-       || pTask->pUnpacked->errCode==SQLITE_NOMEM 
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  assert( pTask->pUnpacked->errCode==SQLITE_OK
+       || pTask->pUnpacked->errCode==SQLITE_NOMEM
+       || pTask->pUnpacked->errCode==SQLITE_CONV_ERROR
   );
+#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+  assert( pTask->pUnpacked->errCode==SQLITE_OK
+       || pTask->pUnpacked->errCode==SQLITE_NOMEM
+  );
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   return pTask->pUnpacked->errCode;
 }
 


### PR DESCRIPTION
`str_to_dttz()`, which converts a string to a datetime, expects a valid timezone. However, `Mem_Str` objects deserialized from `SerialGet()` do not have their `tz` set, causing `str_to_dttz()` to return an error. Furthermore, `compareDateTimeInterval()` does not check for the conversion error, which then causes VDBESorter to return an undefined row order.