### PR TITLE
Cherrypick of SQLite 3.28 branch performance improvement [263293f1e6db2603].

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -102,6 +102,7 @@ extern int skip_clear_queue_extents;
 extern int gbl_slow_rep_process_txn_freq;
 extern int gbl_slow_rep_process_txn_maxms;
 extern int gbl_sqlite_sorter_mem;
+extern int gbl_sqlite_stat4_scan;
 extern int gbl_survive_n_master_swings;
 extern int gbl_test_blob_race;
 extern int gbl_test_scindex_deadlock;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1075,6 +1075,10 @@ REGISTER_TUNABLE("sqlsortermem", "Maximum amount of memory to be "
                                  "(Default: 314572800)",
                  TUNABLE_INTEGER, &gbl_sqlite_sorter_mem, READONLY, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("sql_stat4_scan", "Possibly adjust the cost of a full table "
+                                   "scan based on STAT4 data.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_sqlite_stat4_scan, READONLY | INTERNAL |
+                 EXPERIMENTAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sqlsortermult", NULL, TUNABLE_INTEGER, &gbl_sqlite_sortermult,
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sqlsorterpenalty",

--- a/sqlite/src/analyze.c
+++ b/sqlite/src/analyze.c
@@ -2154,6 +2154,7 @@ static int loadStatTbl(
     }
     pSpace = (tRowcnt*)&pIdx->aSample[nSample];
     pIdx->aAvgEq = pSpace; pSpace += nIdxCol;
+    pIdx->pTable->tabFlags |= TF_HasStat4;
     for(i=0; i<nSample; i++){
       pIdx->aSample[i].anEq = pSpace; pSpace += nIdxCol;
       pIdx->aSample[i].anLt = pSpace; pSpace += nIdxCol;
@@ -2379,6 +2380,7 @@ static int loadStat4(sqlite3 *db, const char *zDb){
     memcpy(pSample->p, sqlite3_column_blob(pStmt, 4), pSample->n);
     memset((u8*)pSample->p + pSample->n, 0, 2);
     pIdx->nSample++;
+    pIdx->pTable->tabFlags |= TF_HasStat4;
   }
   return sqlite3_finalize(pStmt);
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -2138,6 +2138,7 @@ struct Table {
                                      ** Index.aiRowLogEst[] values */
 #define TF_HasNotNull      0x0200    /* Contains NOT NULL constraints */
 #define TF_Shadow          0x0400    /* True for a shadow table */
+#define TF_HasStat4        0x2000    /* STAT4 info available for this table */
 
 /*
 ** Test to see whether or not a table is a virtual table.  This is

--- a/tests/yast.test/runit
+++ b/tests/yast.test/runit
@@ -55,7 +55,7 @@ then
     FILE="*.test"
 fi
 
-FILEPATH="$TMPDIR/files"
+FILEPATH="$TMPDIR/files/$DBNAME"
 TCLCDB2="$BUILDDIR/tcl"
 mkdir -p $FILEPATH
 echo "Yet Another SQL Test (yast) for Comdb2"

--- a/tests/yast.test/stat4scan.testopts
+++ b/tests/yast.test/stat4scan.testopts
@@ -1,0 +1,1 @@
+sql_stat4_scan 1

--- a/tests/yast.test/whereG.test
+++ b/tests/yast.test/whereG.test
@@ -1,0 +1,55 @@
+# 2013-09-05
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+#
+# Test cases for query planning decisions and the likely(), unlikely(), and
+# likelihood() functions.
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+set testprefix whereG
+
+#-------------------------------------------------------------------------
+# Test that likelihood() specifications on indexed terms are taken into
+# account by various forms of loops.
+#
+#   5.1.*: open ended range scans
+#   5.2.*: skip-scans
+#
+reset_db
+
+do_execsql_test 5.1 {
+  CREATE TABLE t1(a, b, c);
+  CREATE INDEX i1 ON t1(a, b);
+}
+
+do_test 5.2 {
+  for {set i 0} {$i < 100} {incr i} {
+    execsql "INSERT INTO t1 VALUES(100, $i, $i);"
+  }
+  execsql { INSERT INTO t1 SELECT 200, b, c FROM t1; }
+  execsql { ANALYZE t1 }
+} {}
+
+do_test 5.2.1 {
+  execsql { SELECT COUNT(*) FROM t1; }
+} {200}
+
+if {[string match *stat4scangenerated* $env(DBNAME)]} then {
+  do_eqp_test 5.3.1.stat4 {
+    SELECT * FROM t1 WHERE a=100
+  } {3 0 0 {SCAN TABLE t1 (~48 rows)}}
+} else {
+  do_eqp_test 5.3.1 {
+    SELECT * FROM t1 WHERE a=100
+  } {5 0 0 {SEARCH TABLE t1 USING INDEX $I1_A82B8A75 (a=?) (~96 rows)}}
+}
+
+finish_test


### PR DESCRIPTION
Minor tweaks to query planning weights so that when STAT4 is enabled and functioning, a full table scan is more likely to be selected if that seems like the fastest solution. Only do this when STAT4 info is available because an error has a large potential downside.

Signed-off-by: mistachkin <joe@mistachkin.com>
