### PR TITLE
Add testcase with cascading bug when updating two tbls in a transaction

### DIFF
--- a/db/constraints.c
+++ b/db/constraints.c
@@ -281,15 +281,17 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
                   int blkpos, int rec_flags)
 {
     block_state_t *blkstate = iq->blkstate;
-    int type = CTE_ADD, rc = 0;
+    int type = CTE_ADD;
     char key[MAXKEYLEN];
     cte cte_record;
     int err = 0;
+    int rc = 0;
 
     struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "insert_add_op: no thdinfo\n");
-        return -1;
+        rc = -1;
+        goto ret;
     }
 
     /* Add the genid to hash for quick lookup. */
@@ -301,7 +303,8 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
     void *cur = get_constraint_table_cursor(thdinfo->ct_add_table);
     if (cur == NULL) {
         logmsg(LOGMSG_ERROR, "insert_add_op: no cursor???\n");
-        return -1;
+        rc = -1;
+        goto ret;
     }
     memcpy(key, &type, sizeof(type));
     memcpy(key + sizeof(type), &blkstate->ct_id_key,
@@ -324,18 +327,22 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
     close_constraint_table_cursor(cur);
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "insert_add_op: bdb_temp_table_insert rc = %d\n", rc);
-        return -1;
+        rc = -1;
+        goto ret;
     }
     rc = insert_add_index(iq, genid);
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "insert_add_op: insert_add_index rc = %d\n", rc);
-        return -1;
+        rc = -1;
+        goto ret;
     }
-    if (iq->debug)
-        reqprintf(iq, "insert_add_op: GENID 0x%llx", genid);
-
     blkstate->ct_id_key++;
-    return 0;
+
+ret:
+    if (iq->debug)
+        reqprintf(iq, "insert_add_op: GENID 0x%llx IX %d RC %d", genid, ixnum, rc);
+
+    return rc;
 }
 
 static int insert_del_op(block_state_t *blkstate, struct dbtable *srcdb,
@@ -626,6 +633,14 @@ int check_update_constraints(struct ireq *iq, void *trans,
                 }
             }
 
+            if (iq->debug) {
+                reqprintf(iq, "insert_del_op TBL %s IX %d (%s) CHECK ON TBL %s IX %d (%s) ",
+                          iq->usedb->tablename, ixnum, cnstrt->keynm[j],  cnstrt->lcltable->tablename,
+                          rixnum, cnstrt->lclkeyname);
+                reqdumphex(iq, rkey, rixlen);
+                reqmoref(iq, " RC %d", rc);
+            }
+
             rc = insert_del_op(blkstate, cnstrt->lcltable, iq->usedb, op, 0,
                                rkey, (newrec_dta == NULL) ? NULL : rnkey,
                                rixlen, rixnum, ixnum, nornrefs, cnstrt->flags);
@@ -745,6 +760,13 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             continue;
         }
 
+        if (iq->debug) {
+            reqprintf(iq, "VERBKYCNSTRT NOT FOUND TBL %s IX %d AGAINST TBL %s IX %d ", bct->dstdb->tablename,
+                      bct->dixnum, bct->tablename, bct->sixnum);
+            reqdumphex(iq, bct->key, bct->sixlen);
+            reqmoref(iq, " RC %d", rc);
+        }
+
         /* Key was found, check the dependee (parent table) of the constraint.
          * If we find another key there with the same value, then we dont need
          * to do anything (if also key length and key are exactly the same).
@@ -825,15 +847,20 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
         /* key was found in parent tbl, no need to delete */
         if (rc == IX_FND || rc == IX_FNDMORE) {
             if (iq->debug) {
-                reqprintf(iq,
-                          "VERBKYCNSTRT VERIFIED TBL %s IX %d AGAINST "
-                          "TBL %s IX %d ",
+                reqprintf(iq, "VERBKYCNSTRT VERIFIED TBL %s IX %d AGAINST TBL %s IX %d ",
                           bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
                 reqdumphex(iq, bct->key, bct->sixlen);
                 reqmoref(iq, " RC %d", rc);
             }
             rc = bdb_temp_table_next(thedb->bdb_env, cur, &err);
             continue;
+        }
+
+        if (iq->debug) {
+            reqprintf(iq, "VERBKYCNSTRT NOT FOUND TBL %s IX %d AGAINST TBL %s IX %d ",
+                      bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
+            reqdumphex(iq, bct->key, bct->sixlen);
+            reqmoref(iq, " RC %d", rc);
         }
 
         /* key was not found in parent tbl, will need to delete from this tbl */
@@ -968,9 +995,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             continue;
         } else { /* key was not found in parent tbl and we are not cascading */
             if (iq->debug) {
-                reqprintf(iq,
-                          "VERBKYCNSTRT CANT RESOLVE CONSTRAINT TBL %s "
-                          "IDX '%d' KEY -> TBL %s IDX '%d' ",
+                reqprintf(iq, "VERBKYCNSTRT CANT RESOLVE CONSTRAINT TBL %s IDX '%d' KEY -> TBL %s IDX '%d' ",
                           bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
                 reqdumphex(iq, bct->key, bct->sixlen);
                 reqmoref(iq, " RC %d", rc);
@@ -1042,7 +1067,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
     od_dta = alloca(20 * 1024 + 8);
     if (od_dta == NULL) {
         if (iq->debug)
-            reqprintf(iq, "%p:ADDKYCNSTRT FAILED MALLOC", trans);
+            reqprintf(iq, "ADDKYCNSTRT FAILED MALLOC");
         reqerrstr(iq, COMDB2_CSTRT_RC_ALLOC,
                   "add key constraint failed malloc");
         *errout = OP_FAILED_INTERNAL;
@@ -1053,7 +1078,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
     struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
     if (thdinfo == NULL) {
         if (iq->debug)
-            reqprintf(iq, "%p:VERKYCNSTRT CANNOT GET ADD LIST CURSOR", trans);
+            reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST CURSOR");
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_CURSOR,
                   "verify key constraint: cannot get add list cursor");
         *errout = OP_FAILED_INTERNAL;
@@ -1063,7 +1088,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
     void *cur = get_constraint_table_cursor(thdinfo->ct_add_table);
     if (cur == NULL) {
         if (iq->debug)
-            reqprintf(iq, "%p:VERKYCNSTRT CANNOT GET ADD LIST CURSOR", trans);
+            reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST CURSOR");
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_CURSOR,
                   "verify key constraint cannot get add list cursor");
         *errout = OP_FAILED_INTERNAL;
@@ -1083,11 +1108,11 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         free_cached_delayed_indexes(iq);
         if (rc == IX_EMPTY) {
             if (iq->debug)
-                reqprintf(iq, "%p:VERKYCNSTRT FOUND NO KEYS TO ADD", trans);
+                reqprintf(iq, "VERKYCNSTRT FOUND NO KEYS TO ADD");
             return 0;
         }
         if (iq->debug)
-            reqprintf(iq, "%p:VERKYCNSTRT CANNOT GET ADD LIST RECORD", trans);
+            reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST RECORD");
         reqerrstr(iq, COMDB2_CSTRT_RC_INVL_REC,
                   "verify key constraint: cannot get add list record");
         *errout = OP_FAILED_INTERNAL;
@@ -1101,8 +1126,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         /* do something */
         if (ctrq == NULL) {
             if (iq->debug)
-                reqprintf(iq, "%p:VERKYCNSTRT CANNOT GET ADD LIST RECORD DATA",
-                          trans);
+                reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST RECORD DATA");
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                       "verify key constraint: cannot get add list record data");
             close_constraint_table_cursor(cur);
@@ -1141,7 +1165,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
 
         if (addrrn == -1) {
             if (iq->debug)
-                reqprintf(iq, "%p:ADDKYCNSTRT (AFPRI) FAILED, NO RRN\n", trans);
+                reqprintf(iq, "ADDKYCNSTRT (AFPRI) FAILED, NO RRN");
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_RRN,
                       "add key constraint failed, no rrn");
             *errout = OP_FAILED_INTERNAL + ERR_ADD_RRN;
@@ -1154,8 +1178,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         ondisk_size = getdatsize(iq->usedb);
         if (ondisk_size == -1) {
             if (iq->debug)
-                reqprintf(iq, "%p:ADDKYCNSTRT BAD TABLE %s\n", trans,
-                          iq->usedb->tablename);
+                reqprintf(iq, "ADDKYCNSTRT BAD TABLE %s\n", iq->usedb->tablename);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                       "add key constraint bad table '%s'",
                       iq->usedb->tablename);
@@ -1176,8 +1199,8 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
 
         if (fndlen != ondisk_size) {
             if (iq->debug)
-                reqprintf(iq, "%p:ADDKYCNSTRT FNDLEN %d != DTALEN %d RC %d",
-                          trans, fndlen, ondisk_size, rc);
+                reqprintf(iq, "ADDKYCNSTRT FNDLEN %d != DTALEN %d RC %d",
+                          fndlen, ondisk_size, rc);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
                       "add key constraint: record not found in table %s",
                       iq->usedb->tablename);
@@ -1220,8 +1243,8 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
             snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_%d", doidx);
             if (ixkeylen < 0) {
                 if (iq->debug)
-                    reqprintf(iq, "%p:ADDKYCNSTRT BAD INDEX %d OR KEYLENGTH %d",
-                              trans, doidx, ixkeylen);
+                    reqprintf(iq, "ADDKYCNSTRT BAD INDEX %d OR KEYLENGTH %d",
+                              doidx, ixkeylen);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
                           "add key constraint bad index %d or keylength %d",
                           doidx, ixkeylen);
@@ -1246,8 +1269,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                                             ondisk_tag, key, NULL, iq->tzname);
             if (rc == -1) {
                 if (iq->debug)
-                    reqprintf(iq, "%p:ADDKYCNSTRT CANT FORM INDEX %d", trans,
-                              ixnum);
+                    reqprintf(iq, "ADDKYCNSTRT CANT FORM INDEX %d", ixnum);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
                           "add key constraint cannot form index %d", ixnum);
                 *blkpos = curop->blkpos;
@@ -1266,7 +1288,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                          od_tail_len, ix_isnullk(iq->usedb, key, doidx));
 
             if (iq->debug) {
-                reqprintf(iq, "%p:ADDKYCNSTRT  TBL %s IX %d RRN %d KEY ", trans,
+                reqprintf(iq, "ADDKYCNSTRT  TBL %s IX %d RRN %d KEY ",
                           iq->usedb->tablename, doidx, addrrn);
                 reqdumphex(iq, key, ixkeylen);
                 reqmoref(iq, " RC %d", rc);
@@ -1336,7 +1358,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         return 0;
     }
     if (iq->debug)
-        reqprintf(iq, "%p:ADDKYCNSTRT ERROR READING ADD TABLE", trans);
+        reqprintf(iq, "ADDKYCNSTRT ERROR READING ADD TABLE");
     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
               "add key constraint error reading add table");
     *errout = OP_FAILED_INTERNAL;
@@ -1483,24 +1505,27 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
             rc = ix_find_by_rrn_and_genid_tran(iq, addrrn, genid, od_dta,
                                                &fndlen, ondisk_size, trans);
 
-            if (rc) {
+            if (rc == RC_INTERNAL_RETRY) {
                 *errout = OP_FAILED_INTERNAL;
                 close_constraint_table_cursor(cur);
+                return rc;
+            }
 
-                if (rc == RC_INTERNAL_RETRY)
-                    return rc;
-
+            /* NB: fndlen can be 0 rather than ondisk_size if there were no rows
+             * is the [last] stripe, so check (fndlen != ondisk_size) was not fully correct */
+            if (rc) {
                 if (iq->debug)
-                    reqprintf(iq,
-                              "VERKYCNSTRT CASCADE DELETED GENID 0x%llx "
-                              "FNDLEN %d DTALEN %d RC %d",
+                    reqprintf(iq, "VERKYCNSTRT CASCADE DELETED GENID 0x%llx FNDLEN %d DTALEN %d RC %d",
                               genid, fndlen, ondisk_size, rc);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
-                          "verify key constraint: record not found in table %s "
-                          "(cascaded)",
+                          "verify key constraint: record not found in table %s (cascaded)",
                           iq->usedb->tablename);
                 return ERR_INTERNAL;
             }
+
+            if (iq->debug)
+                reqprintf(iq, "VERKYCNSTRT CASCADE FOUND GENID 0x%llx FNDLEN %d DTALEN %d RC %d",
+                          genid, fndlen, ondisk_size, rc);
 
             for (cidx = 0; cidx < nct; cidx++) {
                 constraint_t *ct = &curop->usedb->constraints[cidx];
@@ -1543,8 +1568,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
 
                 if (rc == -1) {
                     if (iq->debug)
-                        reqprintf(iq,
-                                  "VERKYCNSTRT CANT FORM TBL %s INDEX %d (%s)",
+                        reqprintf(iq, "VERKYCNSTRT CANT FORM TBL %s INDEX %d (%s)",
                                   iq->usedb->tablename, lixnum, ct->lclkeyname);
                     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_TBL,
                               "verify key constraint cannot form table '%s' "
@@ -1652,8 +1676,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
 
                     if (rc != IX_FND && rc != IX_FNDMORE) {
                         if (iq->debug) {
-                            reqprintf(iq, "VERKYCNSTRT CANT RESOLVE CONSTRAINT "
-                                          "TBL %s IDX '%s' KEY ",
+                            reqprintf(iq, "VERKYCNSTRT CANT RESOLVE CONSTRAINT TBL %s IDX '%s' KEY ",
                                       ftable->tablename, ct->keynm[ridx]);
                             reqdumphex(iq, fkey, fixlen);
                             reqmoref(iq, " RC %d", rc);
@@ -1667,11 +1690,10 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
                         return ERR_BADREQ;
                     }
                     if (iq->debug) {
-                        reqprintf(
-                            iq,
-                            "VERKYCNSTRT VERIFIED RC=%d %s:%s AGAINST %s:%s",
-                            rc, iq->usedb->tablename, ct->lclkeyname,
-                            ct->table[ridx], ct->keynm[ridx]);
+                        reqprintf(iq, "VERKYCNSTRT VERIFIED %s:%s AGAINST %s:%s ",
+                            iq->usedb->tablename, ct->lclkeyname, ct->table[ridx], ct->keynm[ridx]);
+                            reqdumphex(iq, fkey, fixlen);
+                            reqmoref(iq, " RC %d", rc);
                     }
                 }
             }

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -4893,7 +4893,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
         if (osql_is_index_reorder_on(iq->osql_flags)) {
             if (iq->debug)
-                reqpushprefixf(iq, "process_defered_table:");
+                reqpushprefixf(iq, "%p process_defered_table: ", trans);
             rc = process_defered_table(iq, trans, &blkpos, &ixout, &errout);
             if (iq->debug)
                 reqpopprefixes(iq, 1);
@@ -4910,7 +4910,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
         }
 
         if (iq->debug)
-            reqpushprefixf(iq, "delayed_key_adds: %p", trans);
+            reqpushprefixf(iq, "%p delayed_key_adds: ", trans);
 
         int verror = 0;
         rc = delayed_key_adds(iq, trans, &blkpos, &ixout, &errout);
@@ -4932,7 +4932,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
         /* check foreign key constraints */
 
         if (iq->debug)
-            reqpushprefixf(iq, "verify_del_constraints: %p", trans);
+            reqpushprefixf(iq, "%p verify_del_constraints: ", trans);
         rc = verify_del_constraints(iq, trans, &verror);
         if (iq->debug)
             reqpopprefixes(iq, 1);
@@ -4948,7 +4948,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
         }
 
         if (iq->debug)
-            reqpushprefixf(iq, "verify_add_constraints: %p", trans);
+            reqpushprefixf(iq, "%p verify_add_constraints: ", trans);
 
         rc = verify_add_constraints(iq, trans, &verror);
         if (iq->debug)

--- a/tests/constraints.test/noreorder.testopts
+++ b/tests/constraints.test/noreorder.testopts
@@ -1,0 +1,1 @@
+reorder_idx_writes off

--- a/tests/constraints.test/t12.req
+++ b/tests/constraints.test/t12.req
@@ -8,6 +8,7 @@ insert into p values (1)
 insert into c values (1)
 
 select "test #1" as comment
+# txn will succeed because we cascade the delete on p at the end of commit, tbl will end up empty
 begin
 insert into c values (1)
 delete from p where i = 1
@@ -18,6 +19,7 @@ select * from p
 select "test #2" as comment
 insert into p values (1)
 insert into c values (1)
+# txn will succeed, we will cascade the update at the end of commit, and tbl c will have 2 entries of value 2
 begin
 insert into c values (1)
 update p set i = i+i where i = 1
@@ -32,6 +34,7 @@ delete from c;
 delete from p;
 insert into p values (1)
 insert into c values (1)
+# this is same as test 1
 begin
 insert into c values (1)
 delete from p where i = 1
@@ -41,3 +44,40 @@ select * from p order by i
 
 exec procedure sys.cmd.verify("p")
 exec procedure sys.cmd.verify("c")
+
+
+select "test #4" as comment
+delete from c;
+delete from p;
+insert into p values (1)
+insert into c values (1)
+# this is same as test 1
+begin
+update c set i = 2 where i = 1
+update p set i = 2 where i = 1
+commit
+select * from c order by i
+select * from p order by i
+
+exec procedure sys.cmd.verify("p")
+exec procedure sys.cmd.verify("c")
+
+
+select "test #5" as comment
+delete from c;
+delete from p;
+insert into p values (1)
+insert into p values (3)
+insert into c values (1)
+# this is same as test 1
+begin
+update c set i = 3 where i = 1
+update p set i = 2 where i = 1
+commit
+select * from c order by i
+select * from p order by i
+
+exec procedure sys.cmd.verify("p")
+exec procedure sys.cmd.verify("c")
+
+

--- a/tests/constraints.test/t12.req.exp
+++ b/tests/constraints.test/t12.req.exp
@@ -53,3 +53,50 @@
 [exec procedure sys.cmd.verify("p")] rc 0
 (out='Verify succeeded.')
 [exec procedure sys.cmd.verify("c")] rc 0
+(comment='test #4')
+[select "test #4" as comment] rc 0
+(rows deleted=0)
+[delete from c] rc 0
+(rows deleted=0)
+[delete from p] rc 0
+(rows inserted=1)
+[insert into p values (1)] rc 0
+(rows inserted=1)
+[insert into c values (1)] rc 0
+[begin] rc 0
+[update c set i = 2 where i = 1] rc 0
+[update p set i = 2 where i = 1] rc 0
+[commit] rc 0
+(i=2)
+[select * from c order by i] rc 0
+(i=2)
+[select * from p order by i] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("p")] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("c")] rc 0
+(comment='test #5')
+[select "test #5" as comment] rc 0
+(rows deleted=1)
+[delete from c] rc 0
+(rows deleted=1)
+[delete from p] rc 0
+(rows inserted=1)
+[insert into p values (1)] rc 0
+(rows inserted=1)
+[insert into p values (3)] rc 0
+(rows inserted=1)
+[insert into c values (1)] rc 0
+[begin] rc 0
+[update c set i = 3 where i = 1] rc 0
+[update p set i = 2 where i = 1] rc 0
+[commit] rc 0
+(i=3)
+[select * from c order by i] rc 0
+(i=2)
+(i=3)
+[select * from p order by i] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("p")] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("c")] rc 0

--- a/tests/constraints.test/t13.req
+++ b/tests/constraints.test/t13.req
@@ -8,6 +8,7 @@ insert into p values (1)
 insert into c values (1)
 
 select "test #1" as comment
+# txn will succeed because we cascade the delete on p at the end of commit, tbl will end up empty
 begin
 delete from p where i = 1
 insert into c values (1)
@@ -18,6 +19,7 @@ select * from p
 select "test #2" as comment
 insert into p values (1)
 insert into c values (1)
+# txn will succeed, we will cascade the update at the end of commit, and tbl c will have 2 entries of value 2
 begin
 update p set i = i+i where i = 1
 insert into c values (1)
@@ -33,6 +35,7 @@ delete from c;
 delete from p;
 insert into p values (1)
 insert into c values (1)
+# this is same as test 1
 begin
 delete from p where i = 1
 insert into c values (1)
@@ -42,3 +45,40 @@ select * from p order by i
 
 exec procedure sys.cmd.verify("p")
 exec procedure sys.cmd.verify("c")
+
+
+select "test #4" as comment
+delete from c;
+delete from p;
+insert into p values (1)
+insert into c values (1)
+# this is same as test 1
+begin
+update p set i = 2 where i = 1
+update c set i = 2 where i = 1
+commit
+select * from c order by i
+select * from p order by i
+
+exec procedure sys.cmd.verify("p")
+exec procedure sys.cmd.verify("c")
+
+
+select "test #5" as comment
+delete from c;
+delete from p;
+insert into p values (1)
+insert into p values (3)
+insert into c values (1)
+# this is same as test 1
+begin
+update p set i = 2 where i = 1
+update c set i = 3 where i = 1
+commit
+select * from c order by i
+select * from p order by i
+
+exec procedure sys.cmd.verify("p")
+exec procedure sys.cmd.verify("c")
+
+

--- a/tests/constraints.test/t13.req.exp
+++ b/tests/constraints.test/t13.req.exp
@@ -53,3 +53,50 @@
 [exec procedure sys.cmd.verify("p")] rc 0
 (out='Verify succeeded.')
 [exec procedure sys.cmd.verify("c")] rc 0
+(comment='test #4')
+[select "test #4" as comment] rc 0
+(rows deleted=0)
+[delete from c] rc 0
+(rows deleted=0)
+[delete from p] rc 0
+(rows inserted=1)
+[insert into p values (1)] rc 0
+(rows inserted=1)
+[insert into c values (1)] rc 0
+[begin] rc 0
+[update p set i = 2 where i = 1] rc 0
+[update c set i = 2 where i = 1] rc 0
+[commit] rc 0
+(i=2)
+[select * from c order by i] rc 0
+(i=2)
+[select * from p order by i] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("p")] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("c")] rc 0
+(comment='test #5')
+[select "test #5" as comment] rc 0
+(rows deleted=1)
+[delete from c] rc 0
+(rows deleted=1)
+[delete from p] rc 0
+(rows inserted=1)
+[insert into p values (1)] rc 0
+(rows inserted=1)
+[insert into p values (3)] rc 0
+(rows inserted=1)
+[insert into c values (1)] rc 0
+[begin] rc 0
+[update p set i = 2 where i = 1] rc 0
+[update c set i = 3 where i = 1] rc 0
+[commit] rc 0
+(i=3)
+[select * from c order by i] rc 0
+(i=2)
+(i=3)
+[select * from p order by i] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("p")] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("c")] rc 0

--- a/tests/constraints.test/t14.req
+++ b/tests/constraints.test/t14.req
@@ -3,3 +3,19 @@ drop table if exists p
 
 create table p {schema{int i int j} keys{"pki" = i "pkj" = j}} $$
 create table c {schema{int i} keys{"cki" = i} constraints{"cki" -> <"p" : "pki">} constraints{"cki" -> <"p" : "pkj">}} $$
+
+insert into p values (1, 1)
+insert into c values (1)
+
+insert into p values (2, 3)
+#neither of the two insert in c will succeed
+insert into c values (2)
+insert into c values (3)
+
+insert into p values (3, 2)
+# now the inserts will succeed
+insert into c values (2)
+insert into c values (3)
+
+select * from c order by i
+select * from p order by i

--- a/tests/constraints.test/t14.req.exp
+++ b/tests/constraints.test/t14.req.exp
@@ -2,3 +2,25 @@
 [drop table if exists p] rc 0
 [create table p {schema{int i int j} keys{"pki" = i "pkj" = j}}] rc 0
 [create table c {schema{int i} keys{"cki" = i} constraints{"cki" -> <"p" : "pki">} constraints{"cki" -> <"p" : "pkj">}}] rc 0
+(rows inserted=1)
+[insert into p values (1, 1)] rc 0
+(rows inserted=1)
+[insert into c values (1)] rc 0
+(rows inserted=1)
+[insert into p values (2, 3)] rc 0
+[insert into c values (2)] failed with rc 3 Transaction violates foreign key constraint c(i) -> p(j): key value does not exist in parent table
+[insert into c values (3)] failed with rc 3 Transaction violates foreign key constraint c(i) -> p(i): key value does not exist in parent table
+(rows inserted=1)
+[insert into p values (3, 2)] rc 0
+(rows inserted=1)
+[insert into c values (2)] rc 0
+(rows inserted=1)
+[insert into c values (3)] rc 0
+(i=1)
+(i=2)
+(i=3)
+[select * from c order by i] rc 0
+(i=1, j=1)
+(i=2, j=3)
+(i=3, j=2)
+[select * from p order by i] rc 0

--- a/tests/constraints.test/t15.req
+++ b/tests/constraints.test/t15.req
@@ -1,0 +1,86 @@
+drop table if exists c
+drop table if exists p
+
+create table p {schema{ cstring i[3] int j} keys{ "pki" = i dup "pkj" = j }} $$
+create table c {schema{ cstring a[3] int b} keys{ "ckb" = b dup "cka" = a} constraints{"cka" -> <"p" : "pki"> on update cascade on delete cascade }} $$
+
+select "only one value in the stripes" as comment
+insert into p values ("aa", 1)
+insert into c values ("aa", 1)
+
+select "this should succeed" as comment
+begin
+update p set i = "hh" where i = "aa"
+update c set b = 10 where b = 1
+commit
+select * from c order by a
+select * from p order by i
+
+select "putting back to orig" as comment
+begin
+update p set i = "aa" where i = "hh"
+update c set b = 1 where b = 10
+commit
+select * from c order by a
+select * from p order by i
+
+
+select "reversing the order of updates" as comment
+begin
+update c set b = 10 where b = 1
+update p set i = "hh" where i = "aa"
+commit
+select * from c order by a
+select * from p order by i
+
+select "putting back to orig" as comment
+begin
+update p set i = "aa" where i = "hh"
+update c set b = 1 where b = 10
+commit
+select * from c order by a
+select * from p order by i
+
+
+insert into p values ("bb", 2)
+insert into c values ("bb", 2)
+insert into p values ("cc", 3)
+insert into c values ("cc", 3)
+insert into p values ("dd", 4)
+insert into c values ("dd", 4)
+
+select "should succeed as well" as comment
+begin
+update p set i = "hh" where i = "aa"
+update c set b = 10 where b = 1
+commit
+select * from c order by a
+select * from p order by i
+
+select "putting back to orig" as comment
+begin
+update p set i = "aa" where i = "hh"
+update c set b = 1 where b = 10
+commit
+select * from c order by a
+select * from p order by i
+
+
+select "reversing the order again" as comment
+begin
+update c set b = 10 where b = 1
+update p set i = "hh" where i = "aa"
+commit
+select * from c order by a
+select * from p order by i
+
+select "putting back to orig" as comment
+begin
+update p set i = "aa" where i = "hh"
+update c set b = 1 where b = 10
+commit
+select * from c order by a
+select * from p order by i
+
+exec procedure sys.cmd.verify("p")
+exec procedure sys.cmd.verify("c")

--- a/tests/constraints.test/t15.req.exp
+++ b/tests/constraints.test/t15.req.exp
@@ -1,0 +1,130 @@
+[drop table if exists c] rc 0
+[drop table if exists p] rc 0
+[create table p {schema{ cstring i[3] int j} keys{ "pki" = i dup "pkj" = j }}] rc 0
+[create table c {schema{ cstring a[3] int b} keys{ "ckb" = b dup "cka" = a} constraints{"cka" -> <"p" : "pki"> on update cascade on delete cascade }}] rc 0
+(comment='only one value in the stripes')
+[select "only one value in the stripes" as comment] rc 0
+(rows inserted=1)
+[insert into p values ("aa", 1)] rc 0
+(rows inserted=1)
+[insert into c values ("aa", 1)] rc 0
+(comment='this should succeed')
+[select "this should succeed" as comment] rc 0
+[begin] rc 0
+[update p set i = "hh" where i = "aa"] rc 0
+[update c set b = 10 where b = 1] rc 0
+[commit] rc 0
+(a='hh', b=10)
+[select * from c order by a] rc 0
+(i='hh', j=1)
+[select * from p order by i] rc 0
+(comment='putting back to orig')
+[select "putting back to orig" as comment] rc 0
+[begin] rc 0
+[update p set i = "aa" where i = "hh"] rc 0
+[update c set b = 1 where b = 10] rc 0
+[commit] rc 0
+(a='aa', b=1)
+[select * from c order by a] rc 0
+(i='aa', j=1)
+[select * from p order by i] rc 0
+(comment='reversing the order of updates')
+[select "reversing the order of updates" as comment] rc 0
+[begin] rc 0
+[update c set b = 10 where b = 1] rc 0
+[update p set i = "hh" where i = "aa"] rc 0
+[commit] rc 0
+(a='hh', b=10)
+[select * from c order by a] rc 0
+(i='hh', j=1)
+[select * from p order by i] rc 0
+(comment='putting back to orig')
+[select "putting back to orig" as comment] rc 0
+[begin] rc 0
+[update p set i = "aa" where i = "hh"] rc 0
+[update c set b = 1 where b = 10] rc 0
+[commit] rc 0
+(a='aa', b=1)
+[select * from c order by a] rc 0
+(i='aa', j=1)
+[select * from p order by i] rc 0
+(rows inserted=1)
+[insert into p values ("bb", 2)] rc 0
+(rows inserted=1)
+[insert into c values ("bb", 2)] rc 0
+(rows inserted=1)
+[insert into p values ("cc", 3)] rc 0
+(rows inserted=1)
+[insert into c values ("cc", 3)] rc 0
+(rows inserted=1)
+[insert into p values ("dd", 4)] rc 0
+(rows inserted=1)
+[insert into c values ("dd", 4)] rc 0
+(comment='should succeed as well')
+[select "should succeed as well" as comment] rc 0
+[begin] rc 0
+[update p set i = "hh" where i = "aa"] rc 0
+[update c set b = 10 where b = 1] rc 0
+[commit] rc 0
+(a='bb', b=2)
+(a='cc', b=3)
+(a='dd', b=4)
+(a='hh', b=10)
+[select * from c order by a] rc 0
+(i='bb', j=2)
+(i='cc', j=3)
+(i='dd', j=4)
+(i='hh', j=1)
+[select * from p order by i] rc 0
+(comment='putting back to orig')
+[select "putting back to orig" as comment] rc 0
+[begin] rc 0
+[update p set i = "aa" where i = "hh"] rc 0
+[update c set b = 1 where b = 10] rc 0
+[commit] rc 0
+(a='aa', b=1)
+(a='bb', b=2)
+(a='cc', b=3)
+(a='dd', b=4)
+[select * from c order by a] rc 0
+(i='aa', j=1)
+(i='bb', j=2)
+(i='cc', j=3)
+(i='dd', j=4)
+[select * from p order by i] rc 0
+(comment='reversing the order again')
+[select "reversing the order again" as comment] rc 0
+[begin] rc 0
+[update c set b = 10 where b = 1] rc 0
+[update p set i = "hh" where i = "aa"] rc 0
+[commit] rc 0
+(a='bb', b=2)
+(a='cc', b=3)
+(a='dd', b=4)
+(a='hh', b=10)
+[select * from c order by a] rc 0
+(i='bb', j=2)
+(i='cc', j=3)
+(i='dd', j=4)
+(i='hh', j=1)
+[select * from p order by i] rc 0
+(comment='putting back to orig')
+[select "putting back to orig" as comment] rc 0
+[begin] rc 0
+[update p set i = "aa" where i = "hh"] rc 0
+[update c set b = 1 where b = 10] rc 0
+[commit] rc 0
+(a='aa', b=1)
+(a='bb', b=2)
+(a='cc', b=3)
+(a='dd', b=4)
+[select * from c order by a] rc 0
+(i='aa', j=1)
+(i='bb', j=2)
+(i='cc', j=3)
+(i='dd', j=4)
+[select * from p order by i] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("p")] rc 0
+(out='Verify succeeded.')
+[exec procedure sys.cmd.verify("c")] rc 0


### PR DESCRIPTION
This bug was introduced in PR #1425 and manifests itself when
disabling reorder_idx_writes which causes delayed key adds which
in turn triggers update_constraint_genid() which does not update
genid correctly thus causing a find of the genid in the child tbl
to not succeed (because cascade has updated the genid).
Changes in this checkin include:
* Added noreorder.testopts and t15.req which reproduces the bug
* Extended t12-t14.req with more examples
* Added and improved debug trace

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>