### PR TITLE
Pass flags to berk as property when creating locks

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1403,8 +1403,6 @@ unsigned long long bdb_get_current_lsn(bdb_state_type *bdb_state,
                                        unsigned int *file,
                                        unsigned int *offset);
 
-int bdb_set_tran_lowpri(bdb_state_type *bdb_state, tran_type *tran);
-
 int bdb_am_i_coherent(bdb_state_type *bdb_state);
 
 int bdb_get_num_notcoherent(bdb_state_type *bdb_state);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2708,9 +2708,3 @@ unsigned long long bdb_get_current_lsn(bdb_state_type *bdb_state,
         *offset = outlsn.offset;
     return current_context;
 }
-
-int bdb_set_tran_lowpri(bdb_state_type *bdb_state, tran_type *tran)
-{
-    return bdb_state->dbenv->set_tran_lowpri(bdb_state->dbenv,
-                                             tran->tid->txnid);
-}

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2540,7 +2540,6 @@ struct __db_env {
 
 	/* overrides for minwrite deadlock */
 	int (*set_deadlock_override) __P((DB_ENV *, u_int32_t));
-	int (*set_tran_lowpri) __P((DB_ENV *, u_int32_t));
 	int master_use_minwrite_ever;
 	int replicant_use_minwrite_noread;
 	int page_extent_size;

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -71,7 +71,6 @@ static int __dbenv_get_lsn_chaining __P((DB_ENV *, int *));
 static int __dbenv_set_bulk_stops_on_page __P((DB_ENV *, int));
 static int __dbenv_memp_dump_bufferpool_info __P((DB_ENV *, FILE *));
 static int __dbenv_set_deadlock_override __P((DB_ENV *, u_int32_t));
-static int __dbenv_set_tran_lowpri __P((DB_ENV *, u_int32_t));
 static int __dbenv_set_num_recovery_processor_threads __P((DB_ENV *, int));
 static int __dbenv_set_num_recovery_worker_threads __P((DB_ENV *, int));
 static void __dbenv_set_recovery_memsize __P((DB_ENV *, int));
@@ -264,7 +263,6 @@ __dbenv_init(dbenv)
 		dbenv->memp_dump_bufferpool_info =
 		    __dbenv_memp_dump_bufferpool_info;
 		dbenv->set_deadlock_override = __dbenv_set_deadlock_override;
-		dbenv->set_tran_lowpri = __dbenv_set_tran_lowpri;
 		dbenv->get_rep_master = __dbenv_get_rep_master;
 		dbenv->get_rep_eid = __dbenv_get_rep_eid;
 		dbenv->get_page_extent_size = __dbenv_get_page_extent_size;
@@ -1207,14 +1205,6 @@ __dbenv_set_deadlock_override(dbenv, opt)
 	}
 
 	return 0;
-}
-
-static int
-__dbenv_set_tran_lowpri(dbenv, txnid)
-	DB_ENV *dbenv;
-	u_int32_t txnid;
-{
-	return __lock_locker_set_lowpri(dbenv, txnid);
 }
 
 static void

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1981,7 +1981,6 @@ void backend_sync_stat(struct dbenv *dbenv);
 
 void init_fake_ireq_auxdb(struct dbenv *dbenv, struct ireq *iq, int auxdb);
 void init_fake_ireq(struct dbenv *, struct ireq *);
-int set_tran_lowpri(struct ireq *iq, tran_type *tran);
 
 /* long transaction routines */
 
@@ -1992,6 +1991,7 @@ void tran_dump(struct long_trn_stat *tstats);
 /* transactional stuff */
 int trans_start(struct ireq *, tran_type *parent, tran_type **out);
 int trans_start_sc(struct ireq *, tran_type *parent, tran_type **out);
+int trans_start_sc_lowpri(struct ireq *, tran_type **out);
 int trans_start_set_retries(struct ireq *, tran_type *parent, tran_type **out,
                             uint32_t retries, uint32_t priority);
 int trans_start_nonlogical(struct ireq *iq, void *parent_trans, tran_type **out_trans);

--- a/util/txn_properties.h
+++ b/util/txn_properties.h
@@ -21,5 +21,6 @@
 struct txn_properties {
     uint32_t priority;
     uint32_t retries;
+    uint32_t flags;
 };
 #endif


### PR DESCRIPTION
This way we can create a low priority transaction immediately
instead of setting it after creation.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>