### PR TITLE
Dynamic allocation of constraints to allow for flexibility

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -23,7 +23,7 @@
 #define MAXBLOBS 15                     /* Should be bdb's MAXDTAFILES - 1 */
 #define MAXCOLNAME 99                   /* not incl. \0 */
 #define MAXCOLUMNS 1024
-#define MAXCONSTRAINTS 32
+#define MAXCONSTRAINTS 256
 #define MAXCONSUMERS 32 /* to match bdblib limit */
 #define MAXCUSTOPNAME 32
 #define MAX_DBNAME_LENGTH 64

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -309,7 +309,7 @@
 (name='max_bounded_parameters', description='Maximum number of bounded parameters per prepared statement', value=2048)
 (name='max_column_name_length', description='Maximum column name length', value=99)
 (name='max_columns', description='Maximum columns per table', value=1024)
-(name='max_constraints', description='Maximum number of constraints per table', value=32)
+(name='max_constraints', description='Maximum number of constraints per table', value=256)
 (name='max_consumers', description='Maximum queue consumers per table', value=32)
 (name='max_data_files', description='Maximum number of data files per table', value=16)
 (name='max_data_stipes', description='Maximum number of data stripes per table', value=16)


### PR DESCRIPTION
Right now the number of constraints are limited  to `MAXCONSTRAINTS = 32`. 

```C
typedef struct {
    ...
    char *table[MAXCONSTRAINTS];
    char *keynm[MAXCONSTRAINTS];
} constraint_t;
```

This limits the ability to support more complex schema designs. While we can increase the capacity to a greater number, this would arbitrarily increase our memory footprint so let's allocate these arrays dynamically.