### PR TITLE
added support for 'nonsql' metric'

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -490,6 +490,7 @@ long n_bad_parm;
 long n_bad_swapin;
 long n_retries;
 long n_missed;
+long n_dbinfo;
 
 int n_commits;
 long long n_commit_time; /* in micro seconds.*/

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1624,6 +1624,7 @@ extern long n_bad_parm;
 extern long n_bad_swapin;
 extern long n_retries;
 extern long n_missed;
+extern long n_dbinfo;
 extern history *reqhist;
 extern int gbl_sbuftimeout;
 extern int sqldbgflag;

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -92,6 +92,7 @@ struct comdb2_metrics_store {
     int64_t minimum_truncation_file;
     int64_t minimum_truncation_offset;
     int64_t minimum_truncation_timestamp;
+    int64_t nonsql; 
 };
 
 static struct comdb2_metrics_store stats;
@@ -237,6 +238,9 @@ comdb2_metric gbl_metrics[] = {
     {"standing_queue_time", "How long the database has had a standing queue",
      STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
      &stats.standing_queue_time, NULL},
+    {"nonsql", "Number of non-sql requests (eg: tagged)", 
+     STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE,
+     &stats.nonsql, NULL},
 #if 0
     {"minimum_truncation_file", "Minimum truncation file", STATISTIC_INTEGER,
      STATISTIC_COLLECTION_TYPE_LATEST, &stats.minimum_truncation_file, NULL},
@@ -332,6 +336,7 @@ int refresh_metrics(void)
 
     stats.commits = n_commits;
     stats.fstraps = n_fstrap;
+    stats.nonsql = n_fstrap + n_qtrap - n_dbinfo; 
     stats.retries = n_retries;
     stats.sql_cost = gbl_nsql_steps + gbl_nnewsql_steps;
     stats.sql_count = gbl_nsql + gbl_nnewsql;


### PR DESCRIPTION
This PR extends the R6 metric 'nonsql' to R7. 
This metric is calculated as follows : 

nonsql = number of FstsndSocket requests (n_fstrap) + number of Fstsnd requests (n_qtrap) - Number of dbinfo requests (n_dbinfo) 

