### PR TITLE
Print taskname and pid in longreqs file

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2989,15 +2989,13 @@ clipper_usage:
             int qid;
             tok = segtok(line, lline, &st, &ltok);
             if (ltok == 0 || (qid = toknum(tok, ltok)) == 0)
-                logmsg(LOGMSG_ERROR, "Usage: sql cancel queryid.  You can get query id with "
-                       "\"sql dump\".\n");
+                logmsg(LOGMSG_ERROR, "Usage: sql cancel queryid.  You can get query id with \"sql dump\".\n");
             else
                 cancel_sql_statement(qid);
         } else if (tokcmp(tok, ltok, "cancelcnonce") == 0) {
             tok = segtok(line, lline, &st, &ltok);
             if (ltok == 0)
-                logmsg(LOGMSG_ERROR, "Usage: sql cancelcnonce CNONCE.  You can get cnonce with "
-                       "\"sql dump\".\n");
+                logmsg(LOGMSG_ERROR, "Usage: sql cancelcnonce CNONCE.  You can get cnonce with \"sql dump\".\n");
             else {
                 char *cnonce = tokdup(tok, ltok);
                 cancel_sql_statement_with_cnonce(cnonce);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1577,6 +1577,12 @@ static void log_header_ll(struct reqlogger *logger, struct output *out)
                     expanded_fp);
     }
 
+    struct sqlclntstate *clnt = logger->clnt;
+    if(clnt) {
+        dumpf(logger, out, " pid %d task %s",
+              clnt->conninfo.pid, clnt->argv0 ? clnt->argv0 : "???");
+    }
+
     dumpf(logger, out, " rqid %s from %s rc %d\n", logger->id,
           reqorigin(logger), logger->rc);
 
@@ -1586,12 +1592,11 @@ static void log_header_ll(struct reqlogger *logger, struct output *out)
             uint64_t rate = iq->txnsize / iq->reptimems;
 
             dumpf(logger, out,
-                  "  Committed %llu log bytes in %d ms rep time (%llu "
-                  "bytes/ms)\n",
+                  "  Committed %llu log bytes in %d ms rep time (%llu bytes/ms)\n",
                   iq->txnsize, iq->reptimems, rate);
         }
 
-        dumpf(logger, out, "  nretries %d reply len %td\n", iq->retries,
+        dumpf(logger, out, " nretries %d reply len %td\n", iq->retries,
               (ptrdiff_t)(iq->p_buf_out - iq->p_buf_out_start));
     }
 


### PR DESCRIPTION
Print taskname and pid info in longreqs file if available
Output will look like this:
```
03/25 12:15:22: LONG REQUEST 12005 msec for fingerprint 8234cb486c4bda0221a8c8bd20119e04 pid 29406 task /comdb2/cdb2sql rqid  from localhost rc 0
03/25 12:15:22:   sql=select 1,sleep(12), (0) cdb2sql, ncols=2, queuetime=0ms
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>