### PR TITLE
Get location of backup_logfiles_dir only if it is in locations hash

### DIFF
--- a/bbinc/util.h
+++ b/bbinc/util.h
@@ -66,6 +66,7 @@ char *comdb2_asprintf(const char *fmt, ...);
 char *comdb2_vasprintf(const char *fmt, va_list args);
 
 char *comdb2_location(char *type, char *fmt, ...);
+char *comdb2_location_in_hash(char *type, char *fmt, ...);
 char *comdb2_filev(char *fmt, va_list args);
 char *comdb2_file(char *fmt, ...);
 void init_file_locations(char *);

--- a/util/comdb2file.c
+++ b/util/comdb2file.c
@@ -124,6 +124,30 @@ char *comdb2_location(char *type, char *fmt, ...)
     return out;
 }
 
+/* Return location only if it is found in the hash
+ * caller needs to free returned string */
+char *comdb2_location_in_hash(char *type, char *fmt, ...)
+{
+    struct location *l = hash_find_readonly(locations, &type);
+    if (l == NULL) {
+        return NULL;
+    }
+
+    char *out;
+    if (fmt) {
+        va_list args;
+        char *fmtout;
+        va_start(args, fmt);
+        fmtout = comdb2_vasprintf(fmt, args);
+        va_end(args);
+        out = comdb2_asprintf("%s/%s", l->dir, fmtout);
+        free(fmtout);
+    } else {
+        out = strdup(l->dir);
+    }
+    return out;
+}
+
 #define DEFAULT_LOCATION(type, file)                                           \
     do {                                                                       \
         char *f;                                                               \


### PR DESCRIPTION
Currently when we request location, it returns one with the db directory.
For backup_logfiles_dir we want to turn on feature only if location was set in lrl,
so adding a way to get locations only in the locations hash.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>