### PR TITLE
Port max_query_fingerprints to tunables sub-system

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -47,7 +47,6 @@ extern int gbl_upgrade_blocksql_2_socksql;
 extern int gbl_rep_node_pri;
 extern int gbl_bad_lrl_fatal;
 extern int gbl_disable_new_snapshot;
-extern int gbl_fingerprint_max_queries;
 
 int gbl_disable_access_controls;
 
@@ -1363,14 +1362,6 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         logmsg(LOGMSG_USER, "Waiting for %u seconds for replication\n",
                gbl_deferred_phys_update);
         free(wait);
-
-    } else if (tokcmp(tok, ltok, "max_query_fingerprints") == 0) {
-        tok = segtok(line, len, &st, &ltok);
-        if (ltok == 0) {
-            logmsg(LOGMSG_ERROR, "Expected max query fingerprints\n");
-            return -1;
-        }
-        gbl_fingerprint_max_queries = toknum(tok, ltok);
     } else {
         // see if any plugins know how to handle this
         struct lrl_handler *h;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -236,6 +236,7 @@ extern int gbl_create_dba_user;
 extern int gbl_lock_dba_user;
 extern int gbl_max_trigger_threads;
 extern int gbl_do_inline_poll;
+extern int gbl_fingerprint_max_queries;
 extern long long sampling_threshold;
 
 extern size_t gbl_lk_hash;
@@ -891,6 +892,18 @@ static int page_order_table_scan_update(void *context, void *value)
                  gbl_page_order_table_scan);
     logmsg(LOGMSG_USER, "Page order table scan set to %s.\n",
            (gbl_page_order_table_scan) ? "on" : "off");
+    return 0;
+}
+
+static int max_query_fingerprints_check(void *context, void *value)
+{
+    if ((*(int *)value) < gbl_fingerprint_max_queries) {
+        logmsg(LOGMSG_ERROR,
+               "'max_query_fingerprints' cannot be reduced at runtime "
+               "(current: %d)\n",
+               gbl_fingerprint_max_queries);
+        return 1;
+    }
     return 0;
 }
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017 Bloomberg Finance L.P.
+   Copyright 2017, 2021, Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -699,6 +699,11 @@ REGISTER_TUNABLE(
     "maxwt",
     "Maximum number of threads processing write requests. (Default: 8)",
     TUNABLE_INTEGER, &gbl_maxwthreads, READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("max_query_fingerprints",
+                 "Minimum number of queries to be placed into the fingerprint "
+                 "hash (Default: 1000)",
+                 TUNABLE_INTEGER, &gbl_fingerprint_max_queries, 0, NULL,
+                 max_query_fingerprints_check, NULL, NULL);
 REGISTER_TUNABLE("memnice", NULL, TUNABLE_INTEGER, &gbl_mem_nice,
                  READONLY | NOARG, NULL, NULL, memnice_update, NULL);
 REGISTER_TUNABLE("mempget_timeout", NULL, TUNABLE_INTEGER,

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -105,7 +105,6 @@ extern int gbl_reallyearly;
 extern int gbl_udp;
 extern int gbl_prefault_udp;
 extern int gbl_prefault_latency;
-extern int gbl_fingerprint_max_queries;
 extern struct thdpool *gbl_verify_thdpool;
 
 void debug_bulktraverse_data(char *tbl);
@@ -4793,15 +4792,6 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "clear_fingerprints") == 0) {
         int fpcount = clear_fingerprints();
         logmsg(LOGMSG_USER, "Cleared %d fingerprints\n", fpcount);
-    } else if (tokcmp(tok, ltok, "max_query_fingerprints") == 0) {
-        tok = segtok(line, lline, &st, &ltok);
-        if (ltok == 0) {
-            logmsg(LOGMSG_ERROR,
-                   "Expected max query fingerprints, current %d\n",
-                   gbl_fingerprint_max_queries);
-        } else {
-            gbl_fingerprint_max_queries = toknum(tok, ltok);
-        }
     } else {
         // see if any plugins know how to handle this
         struct message_handler *h;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=937)
+(TUNABLES_COUNT=938)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -439,6 +439,7 @@
 (name='max_latch_lockerid', description='Size of latch lockerid array', type='INTEGER', value='10000', read_only='N')
 (name='max_lua_instructions', description='Maximum lua opcodes to execute before we assume the stored procedure is looping and kill it. (Default: 10000)', type='INTEGER', value='10000', read_only='Y')
 (name='max_num_compact_pages_per_txn', description='', type='INTEGER', value='-1', read_only='N')
+(name='max_query_fingerprints', description='Minimum number of queries to be placed into the fingerprint hash (Default: 1000)', type='INTEGER', value='1000', read_only='N')
 (name='max_rowlocks_reposition', description='Release a physical cursor an re-establish.', type='INTEGER', value='10', read_only='N')
 (name='max_sql_idle_time', description='Warn when an SQL connection remains idle for this long.', type='INTEGER', value='3600', read_only='N')
 (name='max_sqlcache_hints', description='Maximum number of "hinted" query plans to keep (global). (Default: 100)', type='INTEGER', value='100', read_only='Y')

--- a/tests/tunables.test/t01_dyn_tunables.expected
+++ b/tests/tunables.test/t01_dyn_tunables.expected
@@ -51,4 +51,8 @@
 (out='Pool [appsockpool] max threads set to 0')
 (out='Pool [appsockpool] max threads set to 102')
 (appsockpool.maxt=102)
-(count(*)=3748)
+(name='allow_negative_column_size')
+(value=1000)
+[put tunable 'max_query_fingerprints' 500] failed with rc -3 Invalid tunable value
+(value=1000)
+(value=2000)

--- a/tests/tunables.test/t01_dyn_tunables.sql
+++ b/tests/tunables.test/t01_dyn_tunables.sql
@@ -59,5 +59,14 @@ exec procedure sys.cmd.send('appsockpool maxt xxx');
 exec procedure sys.cmd.send('appsockpool maxt 102');
 SELECT value AS 'appsockpool.maxt' FROM comdb2_tunables WHERE name = 'appsockpool.maxt';
 
-# Test joins on comdb2_tunables
-select count(*) from comdb2_tunables c, comdb2_tunables d where c.name like '%colum%';
+# Test joins on comdb2_tunables (added "order by + limit" so that the output
+# remains mostly unchanged on every tunable addition)
+select c.name from comdb2_tunables c, comdb2_tunables d where c.name like '%colum%' order by c.name limit 1;
+
+# Test 'max_query_fingerprints'
+select value from comdb2_tunables where name = 'max_query_fingerprints'
+put tunable 'max_query_fingerprints' 500;
+select value from comdb2_tunables where name = 'max_query_fingerprints'
+put tunable 'max_query_fingerprints' 2000;
+select value from comdb2_tunables where name = 'max_query_fingerprints'
+


### PR DESCRIPTION
In the current implementation there is no cleaner way to check its current value.

```
$ comdb2sc.tsk testdb send max_query_fingerprints
Expected max query fingerprints, current 1000
```
Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>