### PR TITLE
Have message at warning level and fix tunable param

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3511,7 +3511,7 @@ static int init(int argc, char **argv)
         gbl_exit = 1;
     }
     if (gbl_fullrecovery) {       /*  11  */
-        logmsg(LOGMSG_FATAL, "force full recovery.\n");
+        logmsg(LOGMSG_WARN, "force full recovery.\n");
         gbl_exit = 1;
     }
 

--- a/db/config.c
+++ b/db/config.c
@@ -213,7 +213,7 @@ int handle_cmdline_options(int argc, char **argv, char **lrlname)
             gbl_exit = 1;
             break;
         case 2: /* recovertotime */
-            logmsg(LOGMSG_FATAL, "force full recovery to timestamp %u\n",
+            logmsg(LOGMSG_WARN, "force full recovery to timestamp %u\n",
                    gbl_recovery_timestamp);
             gbl_recovery_timestamp = strtoul(optarg, NULL, 10);
             gbl_fullrecovery = 1;
@@ -227,7 +227,7 @@ int handle_cmdline_options(int argc, char **argv, char **lrlname)
             p++;
             gbl_recovery_lsn_file = atoi(optarg);
             gbl_recovery_lsn_offset = atoi(p);
-            logmsg(LOGMSG_FATAL, "force full recovery to lsn %d:%d\n",
+            logmsg(LOGMSG_WARN, "force full recovery to lsn %d:%d\n",
                    gbl_recovery_lsn_file, gbl_recovery_lsn_offset);
             gbl_fullrecovery = 1;
             break;

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -304,7 +304,7 @@ int handle_ireq(struct ireq *iq)
         get_raw_node_stats(NULL, NULL, iq->frommach, sbuf2fileno(iq->sb));
     if (iq->rawnodestats && iq->opcode >= 0 && iq->opcode < MAXTYPCNT)
         iq->rawnodestats->opcode_counts[iq->opcode]++;
-    if (gbl_print_deadlock_cycles)
+    if (gbl_print_deadlock_cycles && IQ_HAS_SNAPINFO(iq))
         osql_snap_info = IQ_SNAPINFO(iq);
 
     comdb2_opcode_t *opcode = hash_find_readonly(gbl_opcode_hash, &iq->opcode);

--- a/tests/deadlock_load.test/lrl.options
+++ b/tests/deadlock_load.test/lrl.options
@@ -4,7 +4,7 @@ enable_new_snapshot
 enable_snapshot_isolation
 berkattr abort_on_replicant_log_write 1
 init_with_genid48
-logdelete_lock_trace
+logdelete_lock_trace on
 verbose_set_sc_in_progress on
 #setattr REP_PROCESSORS 0
 #setattr REP_WORKERS 0

--- a/tests/load_cache.test/lrl.options
+++ b/tests/load_cache.test/lrl.options
@@ -4,7 +4,7 @@ enable_new_snapshot
 enable_snapshot_isolation
 berkattr abort_on_replicant_log_write 1
 init_with_genid48
-logdelete_lock_trace
+logdelete_lock_trace on
 verbose_set_sc_in_progress on
 #setattr REP_PROCESSORS 0
 #setattr REP_WORKERS 0

--- a/tests/load_cache.test/runit
+++ b/tests/load_cache.test/runit
@@ -11,7 +11,6 @@ export reppid=-1
 export failpct=15
 export loadrecs=1000000
 export comdb2ar=${COMDB2AR_EXE}
-export COPYCOMDB2_EXE=${BUILDDIR}/db/copycomdb2
 
 [[ $debug == "1" ]] && set -x
 

--- a/tests/sc_async_constraints.test/lrl.options
+++ b/tests/sc_async_constraints.test/lrl.options
@@ -4,7 +4,7 @@ enable_new_snapshot
 enable_snapshot_isolation
 berkattr abort_on_replicant_log_write 1
 init_with_genid48
-logdelete_lock_trace
+logdelete_lock_trace on
 verbose_set_sc_in_progress on
 #setattr REP_PROCESSORS 0
 #setattr REP_WORKERS 0

--- a/tests/sc_truncate.test/lrl.options
+++ b/tests/sc_truncate.test/lrl.options
@@ -3,7 +3,6 @@ logmsg level info
 enable_new_snapshot
 enable_snapshot_isolation
 init_with_genid48
-#logdelete_lock_trace
 verbose_set_sc_in_progress on
 setattr REP_PROCESSORS 0
 setattr REP_WORKERS 0

--- a/tests/truncatesc.test/lrl.options
+++ b/tests/truncatesc.test/lrl.options
@@ -4,7 +4,7 @@ enable_new_snapshot
 enable_snapshot_isolation
 berkattr abort_on_replicant_log_write 1
 init_with_genid48
-logdelete_lock_trace
+logdelete_lock_trace on
 verbose_set_sc_in_progress on
 physrep_register_interval 30
 verbose_physrep on

--- a/tools/comdb2ar/serialise.cpp
+++ b/tools/comdb2ar/serialise.cpp
@@ -159,8 +159,7 @@ reopen:
             throw SerialiseError(filename, ss.str());
         }
         else if (EINVAL == errno){
-            std::clog << "Turning off directio, err: " << std::strerror(errno)
-                      << std::endl;
+            std::clog << "Turning off directio because of open() err: " << std::strerror(errno) << std::endl;
             flags ^= DO_DIRECT;
             goto reopen;
         }

--- a/tools/comdb2ar/util.cpp
+++ b/tools/comdb2ar/util.cpp
@@ -322,8 +322,7 @@ reopen:
     int fd = open(filename.c_str(), flags, 0666);
     if(fd == -1) {
         if (EINVAL == errno){
-            std::clog << "Turning off directio, err: " << std::strerror(errno)
-                      << std::endl;
+            std::clog << "Turning off directio because of open() err: " << std::strerror(errno) << std::endl;
             flags ^= O_DIRECT;
             goto reopen;
         } else {


### PR DESCRIPTION
* Have a message at warning level instead of fatal level
* Tunable logdelete_lock_trace needs parameter to turn on
* Clearer warning message in comdb2ar
* Avoid crash by checking for null before dereferencing via IQ_SNAPINFO(iq)

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>