### PR TITLE
Return cost components as json; add getter cdb2_get_info()

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3328,6 +3328,18 @@ int cdb2_get_effects(cdb2_hndl_tp *hndl, cdb2_effects_tp *effects)
     return rc;
 }
 
+int cdb2_get_info(cdb2_hndl_tp *hndl, cdb2_response_info_type tp, struct cdb2_get_info_out *out)
+{
+    if (tp == CDB2_IT_COST) {
+        out->int_component = hndl->lastresponse->stmt_info->cost;
+    } else if (tp == CDB2_IT_EXTENDED_COST && hndl->lastresponse && hndl->lastresponse->stmt_info) {
+        out->str_component = hndl->lastresponse->stmt_info->extended_cost;
+    } else
+        return 1;
+
+    return 0;
+}
+ 
 static void free_events(cdb2_hndl_tp *hndl)
 {
     cdb2_event *curre, *preve;

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -293,6 +293,17 @@ typedef enum cdb2_event_arg {
     CDB2_QUERY_STATE
 } cdb2_event_arg;
 
+typedef enum cdb2_response_info_type {
+    CDB2_IT_COST = 1,
+    CDB2_IT_EXTENDED_COST,
+    CDB2_IT_EFFECTS
+} cdb2_response_info_type;
+
+struct cdb2_get_info_out {
+    int64_t int_component;
+    const char *str_component;
+};
+
 typedef struct cdb2_event cdb2_event;
 
 typedef void *(*cdb2_event_callback)(cdb2_hndl_tp *hndl, void *user_arg,
@@ -302,6 +313,8 @@ cdb2_event *cdb2_register_event(cdb2_hndl_tp *hndl, cdb2_event_type types,
                                 cdb2_event_ctrl ctrls, cdb2_event_callback cb,
                                 void *user_arg, int argc, ...);
 int cdb2_unregister_event(cdb2_hndl_tp *hndl, cdb2_event *e);
+int cdb2_get_info(cdb2_hndl_tp *hndl, cdb2_response_info_type tp, struct cdb2_get_info_out *out);
+
 #if defined __cplusplus
 }
 #endif

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2195,6 +2195,9 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
 
     rc = do_commitrollback(thd, clnt);
 
+    free(clnt->query_stats);
+    clnt->query_stats = NULL;
+
     clnt->ins_keys = 0ULL;
     clnt->del_keys = 0ULL;
 
@@ -5537,12 +5540,11 @@ static enum req_code read_req(struct sqlconn *conn)
     return rq.rq;
 }
 
-/* Called when a query is done, while all the cursors are still open.  Traverses
-   the list of cursors and saves the query path and cost. */
+/* Called when a query is done, while all the cursors are still open.
+ * Traverses the list of cursors and saves the query path and cost. */
 static int record_query_cost(struct sql_thread *thd, struct sqlclntstate *clnt)
 {
     struct client_query_path_component *stats;
-    int i;
     struct client_query_stats *query_info;
     struct query_path_component *c;
     int max_components;
@@ -5568,14 +5570,12 @@ static int record_query_cost(struct sql_thread *thd, struct sqlclntstate *clnt)
     query_info->n_read_ios = -1;
     query_info->cost = query_cost(thd);
     query_info->n_components = max_components;
-    query_info->n_rows =
-        0; /* client computes from #records read, this is only
-             useful for writes where this information doesn't come
-             back */
+    query_info->n_rows = 0; /* client computes from #records read, this is only
+                               useful for writes where this information doesn't come back */
     query_info->queryid = clnt->queryid;
     memset(query_info->reserved, 0xff, sizeof(query_info->reserved));
 
-    i = 0;
+    int i = 0;
     LISTC_FOR_EACH(&thd->query_stats, c, lnk)
     {
         if (i >= max_components) {
@@ -5588,16 +5588,17 @@ static int record_query_cost(struct sql_thread *thd, struct sqlclntstate *clnt)
             query_info->n_components--;
             continue;
         }
-        stats[i].nfind = c->nfind;
-        stats[i].nnext = c->nnext;
-        stats[i].nwrite = c->nwrite;
-        stats[i].ix = c->ix;
-        stats[i].table[0] = 0;
+        struct client_query_path_component *st = &stats[i];
+        st->nfind = c->nfind;
+        st->nnext = c->nnext;
+        st->nwrite = c->nwrite;
+        st->ix = c->ix;
+        st->table[0] = 0;
         if (c->rmt_db[0]) {
-            snprintf0(stats[i].table, sizeof(stats[i].table), "%s.%s",
+            snprintf0(st->table, sizeof(st->table), "%s.%s",
                       c->rmt_db, c->lcl_tbl_name[0] ? c->lcl_tbl_name : "NULL");
         } else if (c->lcl_tbl_name[0]) {
-            strncpy0(stats[i].table, c->lcl_tbl_name, sizeof(stats[i].table));
+            strncpy0(st->table, c->lcl_tbl_name, sizeof(st->table));
         }
         i++;
     }
@@ -5668,6 +5669,52 @@ int comdb2_get_server_port()
 {
     return thedb->sibling_port[0][NET_REPLICATION];
 }
+
+
+/* get sql query cost and return it as char *
+ * function will allocate memory for string
+ * and caller should free that memory area
+ */
+char *get_query_cost_as_json(struct sqlclntstate *clnt)
+{
+    if (!clnt->query_stats)
+        return NULL;
+
+    strbuf *out = strbuf_new();
+    struct client_query_stats *st = clnt->query_stats;
+
+    strbuf_appendf(out, "{\"Cost\":%.2lf,\"NumRows\":%d%s", st->cost, clnt->nrows,
+                   (st->n_components > 0 ? ",\n \"Components\": [" : ""));
+
+    for (int ii = 0; ii < st->n_components; ii++) {
+        struct client_query_path_component *p = &st->path_stats[ii];
+        strbuf_appendf(out, "\n   {\"Type\":");
+        if (p->table[0] == '\0') {
+            strbuf_appendf(out, "\"Temp Index Lookup\",\"NumFind\":%d", p->nfind);
+            if (p->nnext)
+                strbuf_appendf(out, ",\"NumPrevOrNext\":%d", p->nnext);
+            if (p->nwrite)
+                strbuf_appendf(out, ",\"NumWrites\":%d ", p->nwrite);
+        } else {
+            if (p->ix >= 0) {
+                strbuf_appendf(out, "\"Index Lookup\"");
+                strbuf_appendf(out, ",\"Index\":%d", p->ix);
+            } else
+                strbuf_appendf(out, "\"Table Scan\"");
+            strbuf_appendf(out, ",\"Table\":\"%s\",\"NumFind\":%d", p->table, p->nfind);
+            if (p->nnext > 0) {
+                strbuf_appendf(out, ",\"NumNextOrPrev\":%d", p->nnext);
+            }
+        }
+        strbuf_appendf(out, "}%s", (ii == st->n_components - 1) ? "\n]" : ",");
+    }
+    strbuf_appendf(out, "}");
+
+    char *str = strbuf_disown(out);
+    strbuf_free(out);
+    return str;
+}
+
 
 /* get sql query cost and return it as char *
  * function will allocate memory for string

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -72,6 +72,8 @@ enum {
 
 struct sql_thread;
 double query_cost(struct sql_thread *thd);
+double query_cost(struct sql_thread *thd);
+char *get_query_cost_as_json(struct sqlclntstate *clnt);
 void run_internal_sql(char *sql);
 void start_internal_sql_clnt(struct sqlclntstate *clnt);
 int run_internal_sql_clnt(struct sqlclntstate *clnt, char *sql);

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -150,4 +150,9 @@ message CDB2_SQLRESPONSE {
     optional uint64 row_id   = 8; // in case of retry, this will be used to identify the rows which need to be discarded
     repeated CDB2ServerFeatures  features = 9; // This can tell client about features enabled in comdb2
     optional string info_string = 10;
+    message stmtinfo {
+        optional int64 cost = 1;
+        optional string extended_cost = 2;
+    }
+    optional stmtinfo stmt_info = 11;
 }

--- a/tests/limitsortingtbl.test/runit
+++ b/tests/limitsortingtbl.test/runit
@@ -72,8 +72,8 @@ if [ $availsize -gt 1000000 ] ; then
     echo "since available space is more than 1GB, run the next heavy query"
     cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb setattr sqlite_sorter_tempdir_reqfree 6')"
     cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('bdb attr ')" | grep -i sqlite_sorter_tempdir_reqfree
-    cdb2sql -cost ${CDB2_OPTIONS} $DBNAME default "SELECT t1.* FROM t1,t2,t2 order by t1.k" > /dev/null 2> sel3.cost
-    lines=$(grep Rows sel3.cost | cut -f3 -d':' | xargs echo)
+    cdb2sql --cost ${CDB2_OPTIONS} $DBNAME default "SELECT t1.* FROM t1,t2,t2 order by t1.k" > /dev/null 2> sel3.cost
+    lines=$(grep NumRows sel3.cost | cut -f3 -d':' | cut -f1 -d',' | xargs echo)
     if [ $lines -ne 27000000 ] ; then
         failexit "Output lines should be 27000000, not $lines"
     fi

--- a/tests/odh_blobs.test/expected
+++ b/tests/odh_blobs.test/expected
@@ -15,19 +15,19 @@ AAAABBBBCCCCDDDDEEEEFFFFGGGG
 HHHHIIIIJJJJKKKKLLLLMMMMNNNN
 aaaabbbbccccddddeeeeffffgggg
 --------------
-    table t finds 1 next/prev 4[TABLE SCAN]
-    table t finds 1 next/prev 4[TABLE SCAN]
-    table t finds 1 next/prev 4[TABLE SCAN]
+   {"Type":"Table Scan","Table":"t","NumFind":1,"NumNextOrPrev":4}
+   {"Type":"Table Scan","Table":"t","NumFind":1,"NumNextOrPrev":4}
+   {"Type":"Table Scan","Table":"t","NumFind":1,"NumNextOrPrev":4}
 1111111122222222
 ABCDEFG
 HHHHIIIIJJJJKKKKLLLLMMMMNNNN
 aaaabbbbccccddddeeeeffffgggg
-    table t finds 2
-    index 0 on table t finds 1 next/prev 2
-    table t finds 1
-    index 0 on table t finds 1 next/prev 1
-    table t finds 1
-    index 0 on table t finds 1 next/prev 1
+   {"Type":"Table Scan","Table":"t","NumFind":2},
+   {"Type":"Index Lookup","Index":0,"Table":"t","NumFind":1,"NumNextOrPrev":2}
+   {"Type":"Table Scan","Table":"t","NumFind":1},
+   {"Type":"Index Lookup","Index":0,"Table":"t","NumFind":1,"NumNextOrPrev":1}
+   {"Type":"Table Scan","Table":"t","NumFind":1},
+   {"Type":"Index Lookup","Index":0,"Table":"t","NumFind":1,"NumNextOrPrev":1}
 1111111122222222
 A
 AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA

--- a/tests/odh_blobs.test/runit
+++ b/tests/odh_blobs.test/runit
@@ -56,7 +56,7 @@ select * from t where length(txt) = 28
 select * from t where length(txt) = 16
 select * from t where length(txt) = 7
 EOF
-cdb2sql ${CDB2_OPTIONS} -s --tabs --cost $dbnm --host $fixednode - 2>&1 | grep 'TABLE SCAN' >>actual 2>&1
+cdb2sql ${CDB2_OPTIONS} -s --tabs --cost $dbnm --host $fixednode - 2>&1 | grep -i 'table scan' >>actual 2>&1
 
 wait
 
@@ -67,7 +67,7 @@ select * from t where length(txt) = 28
 select * from t where length(txt) = 16
 select * from t where length(txt) = 7
 EOF
-cdb2sql ${CDB2_OPTIONS} -s --tabs --cost $dbnm --host $fixednode - 2>&1 | grep 'finds' >>actual 2>&1
+cdb2sql ${CDB2_OPTIONS} -s --tabs --cost $dbnm --host $fixednode - 2>&1 | grep -i 'numfind' >>actual 2>&1
 
 ### Test 4: removing ODH
 

--- a/tests/sc_remsql.test/output.log
+++ b/tests/sc_remsql.test/output.log
@@ -34,12 +34,13 @@ Table "t" Rootp 1073741826 Remrootp 2 Version=0
 (id=23, b1=x'58')
 (id=123, b1=x'59')
 (id=11115, b1=x'60')
-Cost: 0.00 NRows: 10
-    index 0 on table DBNAME.t finds 1
-    table DBNAME.sqlite_stat1 finds 1
-    table DBNAME.sqlite_stat4 finds 1
-    index 0 on table DBNAME.t finds 1 next/prev 9
-
+{"Cost":0.00,"NumRows":10,
+ "Components": [
+   {"Type":"Index Lookup","Index":0,"Table":"DBNAME.t","NumFind":1},
+   {"Type":"Table Scan","Table":"DBNAME.sqlite_stat1","NumFind":1},
+   {"Type":"Table Scan","Table":"DBNAME.sqlite_stat4","NumFind":1},
+   {"Type":"Index Lookup","Index":0,"Table":"DBNAME.t","NumFind":1,"NumNextOrPrev":9}
+]}
 Table "sqlite_stat1" Rootp 1073741828 Remrootp 4 Version=0
 Table "sqlite_stat4" Rootp 1073741829 Remrootp 5 Version=0
 Index "$ID_52596C31" for table "t" Rootp 1073741831 Remrootp 3 Version=1

--- a/tests/sc_remsql.test/test_sc.sh
+++ b/tests/sc_remsql.test/test_sc.sh
@@ -49,7 +49,7 @@ sleep 5
 cdb2sql $REM_CDB2_OPTIONS $a_remdbname default 'select table_version("t")' >> $output
 
 # retrieve data
-cdb2sql ${SRC_CDB2_OPTIONS} -cost --host $mach $a_dbname default "select * from LOCAL_${a_remdbname}.t order by id" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --cost --host $mach $a_dbname default "select * from LOCAL_${a_remdbname}.t order by id" >> $output 2>&1
 
 # get the new version V2'
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1

--- a/tests/sql_cost.test/runit
+++ b/tests/sql_cost.test/runit
@@ -2,6 +2,7 @@
 bash -n "$0" | exit 1
 
 export CDB2_OPTIONS="${CDB2_OPTIONS} --cost"
+export CDB2SQL_EXE="stdbuf -oL $CDB2SQL_EXE" # force unbuffered stdout
 
 ${TESTSROOTDIR}/tools/compare_results.sh -d $1
 [ $? -eq 0 ] || exit 1

--- a/tests/sql_cost.test/t00_subquery.expected
+++ b/tests/sql_cost.test/t00_subquery.expected
@@ -1,23 +1,17 @@
-Cost: 0.00 NRows: 0
-
-Cost: 0.00 NRows: 0
-
+{"Cost":0.00,"NumRows":0}
 [create table t1(i int unique, j int)] rc 0
+{"Cost":0.00,"NumRows":0}
 [create table t2(x int unique, y int)] rc 0
 (rows inserted=10)
-Cost: 0.00 NRows: 10
-
+{"Cost":0.00,"NumRows":10}
 [insert into t1 select value, 1 from generate_series(1, 10)] rc 0
 (rows inserted=10)
-Cost: 0.00 NRows: 10
-
+{"Cost":0.00,"NumRows":10}
 [insert into t2 select value, 2 from generate_series(1, 10)] rc 0
 (comment='Subquery flattening optimization enabled')
-Cost: 0.00 NRows: 1
-
-Cost: 0.00 NRows: 0
-
+{"Cost":0.00,"NumRows":1}
 [select 'Subquery flattening optimization enabled' as comment] rc 0
+{"Cost":0.00,"NumRows":0}
 [put tunable enable_sq_flattening_optimization 1] rc 0
 (i=1, j=1, x=NULL, y=NULL)
 (i=2, j=1, x=NULL, y=NULL)
@@ -29,18 +23,17 @@ Cost: 0.00 NRows: 0
 (i=8, j=1, x=NULL, y=NULL)
 (i=9, j=1, x=NULL, y=NULL)
 (i=10, j=1, x=NULL, y=NULL)
-Cost: 220.00 NRows: 10
-    table t1 finds 10
-    index 0 on table t1 finds 1 next/prev 10
-    index 0 on table t2 finds 10
-
+{"Cost":220.00,"NumRows":10,
+ "Components": [
+   {"Type":"Table Scan","Table":"t1","NumFind":10},
+   {"Type":"Index Lookup","Index":0,"Table":"t1","NumFind":1,"NumNextOrPrev":10},
+   {"Type":"Index Lookup","Index":0,"Table":"t2","NumFind":10}
+]}
 [select i, j, a.x, a.y from t1 left join (select x,y from t2 where x=11) a on t1.i = a.x order by i asc] rc 0
 (comment='Subquery flattening optimization disabled')
-Cost: 0.00 NRows: 1
-
-Cost: 0.00 NRows: 0
-
+{"Cost":0.00,"NumRows":1}
 [select 'Subquery flattening optimization disabled' as comment] rc 0
+{"Cost":0.00,"NumRows":0}
 [put tunable enable_sq_flattening_optimization 0] rc 0
 (i=1, j=1, x=NULL, y=NULL)
 (i=2, j=1, x=NULL, y=NULL)
@@ -52,16 +45,15 @@ Cost: 0.00 NRows: 0
 (i=8, j=1, x=NULL, y=NULL)
 (i=9, j=1, x=NULL, y=NULL)
 (i=10, j=1, x=NULL, y=NULL)
-Cost: 131.00 NRows: 10
-    index 0 on table t2 finds 1
-    table t1 finds 10
-    index 0 on table t1 finds 1 next/prev 10
-    temp index finds 10 
-
-Cost: 0.00 NRows: 0
-
-Cost: 0.00 NRows: 0
-
+{"Cost":131.00,"NumRows":10,
+ "Components": [
+   {"Type":"Index Lookup","Index":0,"Table":"t2","NumFind":1},
+   {"Type":"Table Scan","Table":"t1","NumFind":10},
+   {"Type":"Index Lookup","Index":0,"Table":"t1","NumFind":1,"NumNextOrPrev":10},
+   {"Type":"Temp Index Lookup","NumFind":10}
+]}
 [select i, j, a.x, a.y from t1 left join (select x,y from t2 where x=11) a on t1.i = a.x order by i asc] rc 0
+{"Cost":0.00,"NumRows":0}
 [drop table t2] rc 0
+{"Cost":0.00,"NumRows":0}
 [drop table t1] rc 0

--- a/tests/tools/compare_results.sh
+++ b/tests/tools/compare_results.sh
@@ -56,10 +56,10 @@ for sqlfile in $sqlfiles; do
 
     for schema in `ls $testname.*.csc2 2> /dev/null` ; do
         table=`echo $schema | cut -d "." -f2`
-        cdb2sql ${CDB2_OPTIONS} $dbname default "drop table if exists $table" > $prep_log 2>&1
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default "drop table if exists $table" > $prep_log 2>&1
         [ $? -eq 0 ] || prepare_abort $prep_log $testname
 
-        cdb2sql ${CDB2_OPTIONS} $dbname default "create table $table { `cat $schema` }" > $prep_log 2>&1
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default "create table $table { `cat $schema` }" > $prep_log 2>&1
         [ $? -eq 0 ] || prepare_abort $prep_log $testname
     done
 
@@ -67,13 +67,13 @@ for sqlfile in $sqlfiles; do
 
     if [ -f ${testname}.fastinit ] ; then
         for t in `cat ${testname}.fastinit`; do
-            cmd="cdb2sql ${CDB2_OPTIONS} $dbname default 'truncate $t'"
+            cmd="$CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default 'truncate $t'"
             echo $cmd "> $testname.output"
             eval $cmd 2>&1 >> $testname.fastinit_out
         done
     fi
 
-    cmd="cdb2sql ${CDB2_OPTIONS} $script_mode -f $sqlfile $dbname default "
+    cmd="$CDB2SQL_EXE ${CDB2_OPTIONS} $script_mode -f $sqlfile $dbname default "
     echo $cmd "> $testname.output"
     eval $cmd 2>&1 | perl -pe "s/.n_writeops_done=([0-9]+)/rows inserted='\1'/;
                           s/BLOCK2_SEQV2\(824\)/BLOCK_SEQ(800)/;


### PR DESCRIPTION
Include statement cost and extended cost as part of lastresponse
so we avoid extra call to the db to get cost.

* Always return numeric value of cost
* If get_cost is set, return extended cost info--cost components
* `cdb2sql --cost` prints extended cost as json string using cdb2api
  getter function cdb2_get_info()

Example json extended cost from cdb2sql:

```
> cdb2sql adidb -cost 'select moredata from t2 where uid in (select uid from t1 where i=2)' | tail +2
{"Cost":32.40,"NumRows":1,
 "Components": [
   {"Type":"Table Scan","Table":"t1","NumFind":1,"NumNextOrPrev":1},
   {"Type":"Table Scan","Table":"t2","NumFind":1},
   {"Type":"Index Lookup","Index":0,"Table":"t2","NumFind":1,"NumNextOrPrev":1},
   {"Type":"Temp Index Lookup","NumFind":1,"NumPrevOrNext":1,"NumWrites":1 }
]}
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>