### PR TITLE
Fix printing an int variable correctly to avoid crash

### DIFF
--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -245,7 +245,7 @@ void osql_sess_reqlogquery(osql_sess_t *sess, struct reqlogger *reqlog)
     char *info = osql_sess_info(sess);
     reqlog_logf(
         reqlog, REQL_INFO,
-        "%s time %" PRId64 "ms queuetime=%" PRId64 "ms \"%s\"\n",
+        "%s time %dms queuetime=%dms \"%s\"\n",
         (info) ? info : "unknown", U2M(sess->sess_endus - sess->sess_startus),
         U2M(reqlog_get_queue_time(reqlog)), sess->sql ? sess->sql : "()");
     if (info)

--- a/tests/analyze_insert_burst.test/runit
+++ b/tests/analyze_insert_burst.test/runit
@@ -1,4 +1,5 @@
 #!/bin/sh
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 ##################################################################
 # Verify that analyze works correctly under high rate insertion. #
@@ -21,7 +22,7 @@ COMMIT
 EOF
 
 while true; do
-cdb2sql ${CDB2_OPTIONS} $dbnm default -f in.sql >/dev/null 2>&1
+cdb2sql ${CDB2_OPTIONS} $dbnm default -f in.sql > out.txt 2>&1 || failexit 'failure to insert, see out.txt'
 done &
 
 keep_inserting=$!


### PR DESCRIPTION
We print result of U2M() as a PRId64 and that can cause a crash,
so this is a fix to correctly print that element as int.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>