### PR TITLE
remove low level timepart check that is not used

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -5928,12 +5928,6 @@ static int backout_schemas_lockless(const char *tblname)
     return 0;
 }
 
-static int backout_schemas_shard_lockless(const char *shardname,
-                                          timepart_sc_arg_t *arg)
-{
-    return backout_schemas_lockless(shardname);
-}
-
 void backout_schemas(char *tblname)
 {
     struct dbtag *dbt;
@@ -5943,11 +5937,6 @@ void backout_schemas(char *tblname)
 
     dbt = hash_find_readonly(gbl_tag_hash, &tblname);
     if (dbt == NULL) {
-        if (likely(timepart_is_timepart(tblname, 1))) {
-            timepart_foreach_shard(tblname, backout_schemas_shard_lockless,
-                                   NULL, -1);
-        }
-
         unlock_taglock();
         return;
     }


### PR DESCRIPTION
Code removed is in backout_schemas, and introduces a reverse ordering between the low level tag lock and the higher level views lock. Checked all callers of that function, and all pass down a tablename, not a partition name.   Safe to clean.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
