### PR TITLE
Add hardware crc32 function calls for arm arch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,9 +152,12 @@ else()
   add_definitions(-DUSE_SYS_ALLOC)
 endif()
 
-if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64 OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL armv7l OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL aarch64)
+if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
   # This is mostly misused as little-endian
   add_definitions(-D_LINUX_SOURCE)
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL armv7l OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL aarch64)
+  add_definitions(-D_LINUX_SOURCE)
+  include(crc32c/arm.cmake)
 endif()
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL Linux)

--- a/crc32c/CMakeLists.txt
+++ b/crc32c/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_library(crc32c crc32c.c)
 include_directories(${PROJECT_SOURCE_DIR}/util)
+
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL x86_64)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse4.2 -mpclmul")
+elseif(${CMAKE_SYSTEM_PROCESSOR} STREQUAL armv7l OR ${CMAKE_SYSTEM_PROCESSOR} STREQUAL aarch64)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CRC32_ARMV7_C_FLAGS}")
 endif()

--- a/crc32c/arm.cmake
+++ b/crc32c/arm.cmake
@@ -1,0 +1,38 @@
+include(CheckCSourceCompiles)
+
+set(SAV_CMAKE_C_FLAGS ${CMAKE_C_FLAGS})
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crc+crypto")
+CHECK_C_SOURCE_COMPILES(
+"#include <arm_acle.h>
+int main()
+{
+   __crc32cb(0,0); __crc32ch(0,0); __crc32cw(0,0); __crc32cd(0,0);
+   return 0;
+} " HAS_CRC32_ARM)
+set(CMAKE_C_FLAGS ${SAV_CMAKE_C_FLAGS})
+
+if(NOT HAS_CRC32_ARM)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=armv8-a+crc")
+  CHECK_C_SOURCE_COMPILES(
+  "#include <arm_acle.h>
+  int main()
+  {
+     __crc32cb(0,0); __crc32ch(0,0); __crc32cw(0,0); __crc32cd(0,0);
+     return 0;
+  } " HAS_CRC32_ARM_CRC)
+  set(CMAKE_C_FLAGS ${SAV_CMAKE_C_FLAGS})
+endif()
+
+if(HAS_CRC32_ARM_CRC OR HAS_CRC32_ARM)
+  if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL aarch64)
+    add_definitions(-D_HAS_CRC32_ARMV8)
+  else()
+    add_definitions(-D_HAS_CRC32_ARMV7)
+  endif()
+endif()
+
+if(HAS_CRC32_ARM_CRC)
+  set(CRC32_ARMV7_C_FLAGS "-march=armv8-a+crc")
+elseif(HAS_CRC32_ARM)
+  set(CRC32_ARMV7_C_FLAGS "-march=armv8-a+crc+crypto")
+endif()

--- a/crc32c/crc32c.h
+++ b/crc32c/crc32c.h
@@ -32,6 +32,12 @@ uint32_t crc32c_comdb2(const uint8_t* buf, uint32_t sz);
 
 #define crc32c(buf, sz) crc32c_comdb2(buf,sz)
 
+#elif defined(_HAS_CRC32_ARMV7) || defined(_HAS_CRC32_ARMV8) 
+
+void crc32c_init(int v);
+uint32_t crc32c_comdb2(const uint8_t* buf, uint32_t sz);
+#define crc32c(buf, sz) crc32c_comdb2(buf,sz)
+
 #else
 #define crc32c_init(...)
 #define crc32c(x, y) crc32c_software((x), (y), CRC32C_SEED)

--- a/db/config.c
+++ b/db/config.c
@@ -199,8 +199,7 @@ int handle_cmdline_options(int argc, char **argv, char **lrlname)
     int c;
     int options_idx;
 
-    while ((c = bb_getopt_long(argc, argv, "hv", long_options, &options_idx)) !=
-           -1) {
+    while ((c = bb_getopt_long(argc, argv, "hv", long_options, &options_idx)) != -1) {
         if (c == 'h') print_usage_and_exit(0);
         if (c == 'v') print_version_and_exit();
         if (c == '?') return 1;

--- a/tests/bb_getopt_long.test/getopt_test.c
+++ b/tests/bb_getopt_long.test/getopt_test.c
@@ -112,11 +112,9 @@ int main(int argc, char *argv[])
     int ret = 0;
 
 #if defined NORMAL_GETOPT
-    while ((ret = getopt_long(argc, argv, "ha:pu", long_options, &options_idx)) !=
-           -1) {
+    while ((ret = getopt_long(argc, argv, "ha:pu", long_options, &options_idx)) != -1) {
 #else
-    while ((ret = bb_getopt_long(argc, argv, "ha:pu", long_options,
-                               &options_idx)) != -1) {
+    while ((ret = bb_getopt_long(argc, argv, "ha:pu", long_options, &options_idx)) != -1) {
 #endif
         char c = ret;
         if (c == 'h') {

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -36,7 +36,7 @@ setup_debugger() {
             DEBUG_PREFIX="valgrind --tool=massif "
             ;;
         perf)
-            DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g "
+            DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g -s "
             # get report of performance via perf report -i $TESTDIR/$TESTCASE.perfdata
             # or perf annotate -i $TESTDIR/$TESTCASE.perfdata
             ;;

--- a/tests/tools/insert_lots_mt.cpp
+++ b/tests/tools/insert_lots_mt.cpp
@@ -167,7 +167,7 @@ void *thr(void *arg)
 }
 
 void usage(const char *p, const char *err) {
-    fprintf(stderr, err);
+    fprintf(stderr, "%s\n", err);
     fprintf(stderr, "Usage %s --dbname DBNAME --numthreads NUMTHREADS --cntperthread CNTPERTHREAD\n"
                     "--iterations ITERATIONS [--transize TRANSIZE] [--atcommit commit|rollback|disconnect]\n", p);
     exit(1);
@@ -180,7 +180,7 @@ int main(int argc, char *argv[])
     int iterations = 0;
 
     if(argc < 5)
-        usage(argv[0], "Required parameters were NOT provided\n"); //exit too
+        usage(argv[0], "Required parameters were NOT provided"); //exit too
 
     static struct option long_options[] =
     {
@@ -194,9 +194,9 @@ int main(int argc, char *argv[])
         {NULL, 0, NULL, 0}
     };
 
-    char c;
+    int c;
     int index;
-    while ((c = getopt_long(argc, argv, "d:n:c:i:t:rd?", long_options, &index))!=EOF) {
+    while ((c = getopt_long(argc, argv, "d:n:c:i:t:rd?", long_options, &index)) != -1) {
         //printf("c '%c' %d index %d optarg '%s'\n", c, c, index, optarg);
         switch(c) {
             case 'd': dbname = strdup(optarg); break;
@@ -220,13 +220,13 @@ int main(int argc, char *argv[])
     }
 
     if (!dbname)
-        usage(argv[0], "Parameter dbname is not set\n"); //exit too
+        usage(argv[0], "Parameter dbname is not set"); //exit too
     if (numthreads < 1)
-        usage(argv[0], "Parameter numthreads is not set\n"); //exit too
+        usage(argv[0], "Parameter numthreads is not set"); //exit too
     if (cntperthread < 1)
-        usage(argv[0], "Parameter cntperthread is not set\n"); //exit too
+        usage(argv[0], "Parameter cntperthread is not set"); //exit too
     if (iterations < 1)
-        usage(argv[0], "Parameter iterations is not set\n"); //exit too
+        usage(argv[0], "Parameter iterations is not set"); //exit too
 
     //printf("%s %d %d %d %d\n", dbname, numthreads, cntperthread, iterations, transize);//
 

--- a/tools/cdb2sql/cdb2sql.cpp
+++ b/tools/cdb2sql/cdb2sql.cpp
@@ -1742,8 +1742,8 @@ static int do_repeat(char *sql)
     /* Print the summary */
     if (time_mode) {
         printf("summary:\n");
-        printf("  total prep time  %d ms\n", start_time_ms_tot);
-        printf("  total run time   %d ms\n", run_time_ms_tot);
+        printf("  total prep time  %lld ms\n", start_time_ms_tot);
+        printf("  total run time   %lld ms\n", run_time_ms_tot);
     }
 
     return 0;


### PR DESCRIPTION
Use family of functions __crc32cb() and friends to compute crc32c in hardware
if such feature is present in the arm cpu.

Simple test is attached and shows a speedup of about 6 times on the `armv7l/arm8` architechture:
```
    software:  1318717usec
    hardware:   227700usec
```

and a speedup of 10 times for the same test on the `aarch64` architechture:

```
    software:   284895usec
    hardware:    27514usec
```

for completeness, the intel architechture gives a speedup of > 10 times:

```
    software:   329866usec
    hardware:    26930usec
```

NB: The above results for the test were done on different types of processors
(ie. not server-grade) and as such it is not appropriate to compare the runtimes
between architechtures.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>