### PR TITLE
Fix copycomdb2 script to work even when lz4 is not installed

### DIFF
--- a/db/copycomdb2
+++ b/db/copycomdb2
@@ -272,13 +272,6 @@ done
 [ -z "$comdb2ar_rmt" ] && comdb2ar_rmt="${comdb2ar}"
 [ -z "$lz4_rmt" ] && lz4_rmt="${lz4}"
 
-if [[ -z "$lz4_rmt" ]]; then
-    ar_compress_rmt="cat"
-    ar_decompress_rmt="cat"
-else
-    ar_compress_rmt="$lz4_rmt stdin stdout"
-    ar_decompress_rmt="$lz4_rmt -d stdin stdout"
-fi
 
 [ $copy_data = no -a $copy_lrls = no ] && die "cannot use -s and -d together"
 
@@ -380,15 +373,33 @@ fi
 # determine if we should strip or preserve cluster node information.
 if [ "$srcmach" = "$HOSTNAME" -a "$destmach" != "$HOSTNAME" ]; then
     copy_mode=PUSH
+    # need valid lz4 in destination
+    [ -z $comdb2ar_rmt ] && die "comdb2ar_rmt not set"
+    $rsh $destmach "test -e $comdb2ar_rmt" < /dev/null || die "$destmach:$comdb2ar_rmt not available"
+    $rsh $destmach "test -e $lz4_rmt" < /dev/null || lz4_rmt=""
     [ $movemode = no ] || die "move mode can only be used locally"
 elif [ "$srcmach" != "$HOSTNAME" -a "$destmach" = "$HOSTNAME" ]; then
     copy_mode=PULL
+    [ -z $comdb2ar_rmt ] && die "comdb2ar_rmt not set"
+    $rsh $srcmach "test -e $comdb2ar_rmt" < /dev/null || die "$srcmach:$comdb2ar_rmt not available"
+    $rsh $srcmach "test -e $lz4_rmt" < /dev/null || lz4_rmt=""
     [ $movemode = no ] || die "move mode can only be used locally"
 elif [ "$srcmach" = "$HOSTNAME" -a "$destmach" = "$HOSTNAME" ]; then
     copy_mode=LOCAL
 else
     die "cannot work on two remote machines (srcmach=$srcmach, destmach=$destmach)"
 fi
+
+if [[ -z "$lz4_rmt" ]]; then
+    ar_compress_rmt="cat"
+    ar_decompress_rmt="cat"
+    ar_compress="cat"  # need both local and rmt to be same
+    ar_decompress="cat"
+else
+    ar_compress_rmt="$lz4_rmt stdin stdout"
+    ar_decompress_rmt="$lz4_rmt -d stdin stdout"
+fi
+
 
 # if we want an incremental copy, create the partial files on the
 # destination, and get them to the source

--- a/tests/load_cache.test/runit
+++ b/tests/load_cache.test/runit
@@ -203,7 +203,7 @@ function copy_test
     fi
 
     write_prompt $func "Creating physical rep $repname"
-    ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H $repname $cl $rmt${DBDIR}/${DBNAME}.lrl $repdir $repdir
+    ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -P ${COMDB2AR_EXE} -H $repname $cl $rmt${DBDIR}/${DBNAME}.lrl $repdir $repdir || failexit "Failure copying physical rep"
 
     if [[ "$autocache" != "ON" ]] ; then
         echo "cache_flush_interval 10" >> $repdir/${repname}.lrl


### PR DESCRIPTION
While it is expected that servers will always have lz4 installed,
there may be cases where lz4 is unavailable in a source or destination machine,
and in that case copycomdb2 can simply use `cat` as the tool to read
data (in both source and destination)--this patch does just that.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>