### PR TITLE
Run only tests present in alltests.txt file

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,52 +1,66 @@
 export TESTSROOTDIR:=$(shell pwd)
+
 SRCHOME:=$(shell readlink -f $(TESTSROOTDIR)/../ || realpath $(TESTSROOTDIR)/../ )
 ifeq ($(SRCHOME),)
   SRCHOME:=$(TESTSROOTDIR)/..
 endif
+
 export SRCHOME
 ifeq ($(TESTID),)
-export TESTID:=$(shell $(TESTSROOTDIR)/tools/get_random.sh)
+  export TESTID:=$(shell $(TESTSROOTDIR)/tools/get_random.sh)
 endif
+
 include $(TESTSROOTDIR)/Makefile.common
 
 # List of disabled tests
 DISABLED_TESTS:=$(shell awk '/^DISABLED/{f=1;next};/<END>/{f=0}f' TODO | cut -d' ' -f1)
 
 # When SKIPSSL is on, skip running tests which rely on SSL
-ifeq ($(SKIPSSL), 1)
-SKIPS:=$(shell grep ssl *.test/lrl*  | grep 'ssl_client_mode VERIFY' | cut -f1 -d'/' | sort -u)
-DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
+ifeq ($(SKIPSSL),1)
+  SKIPS:=$(shell grep ssl *.test/lrl*  | grep 'ssl_client_mode VERIFY' | cut -f1 -d'/')
+  DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
 endif
 
 # Skip tests that need tcl
 ifeq ($(wildcard $(BUILDDIR)/tcl/libtclcdb2.so),)
-#if we have not compiled with tcl, skip tests that require tclcdb2
-SKIPS:=$(shell ls *.test/*.tcl | xargs grep 'package require tclcdb2' | cut -f1 -d'/' | sort -u)
-DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
+  #if we have not compiled with tcl, skip tests that require tclcdb2
+  SKIPS:=$(shell ls *.test/*.tcl | xargs grep 'package require tclcdb2' | cut -f1 -d'/')
+  DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
 endif
 
 # Skip any tests that we specifically want by reading 'tests/excluded.txt'
+# which should contain one line per test (line can be testname or testname.test)
 ifeq ($(wildcard excluded.txt),excluded.txt)
-SKIPS:=$(shell cat excluded.txt | sort -u)
-DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
+  SKIPS:=$(shell cat excluded.txt)
+  DISABLED_TESTS:="${DISABLED_TESTS} ${SKIPS}"
 endif
-
-export DISABLED_TESTS
 
 DOALL:=0
-
 ifeq ($(subst all,,$(MAKECMDGOALS)),) #if cmdgoals empty or 'all'
-DOALL:=1
+  # only used to assign TOTAL below, and to print as debug info in target showparams
+  DOALL:=1
 endif
 
-# List of all tests that need to run. This is essentially a list of all
-# non-disabled tests.
-export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
-    $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
+# List of all tests that need to run.
+ifeq ($(wildcard alltests.txt),alltests.txt)
+  # If file alltests.txt exists, only run the tests in that file (one line per test)
+  export ALL_TESTS:=$(patsubst %.test, %, $(shell sort -u alltests.txt) )
+else
+  ifneq ($(DISABLED_TESTS),)
+    DISABLED_TESTS:=" $(shell echo $(DISABLED_TESTS) | tr ' ' '\n' | sort -u) "
+  endif
 
+  export DISABLED_TESTS
+
+  # This is the list of all non-disabled tests.
+  export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
+      $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
+endif
+
+# get number of TOTAL tests running: used for printing progress report of tests
 TOTAL=$(words $(MAKECMDGOALS) )
 ifeq ($(DOALL),1)
-TOTAL=$(words $(ALL_TESTS) )
+  TOTAL=$(words $(ALL_TESTS) )
 endif
 
 all: init basicops all_tests
@@ -65,7 +79,7 @@ basicops_nokey: init
 	$(shell echo "SRCHOME=${SRCHOME} " >> ${TESTDIR}/test.log)
 	$(shell echo "TESTSROOTDIR=${TESTSROOTDIR} " >> ${TESTDIR}/test.log)
 	$(shell echo "TESTDIR=${TESTDIR} " >> ${TESTDIR}/test.log)
-	$(shell echo "DISABLED= $(sort ${DISABLED_TESTS}) " >> ${TESTDIR}/test.log)
+	$(shell echo "DISABLED= ${DISABLED_TESTS} " >> ${TESTDIR}/test.log)
 	$(shell echo "MAKECMDGOALS=${MAKECMDGOALS}" >> ${TESTDIR}/test.log)
 	$(shell echo "" >> ${TESTDIR}/test.log)
 

--- a/tests/dbcreate.disabled/comdb2makecluster/comdb2makecluster
+++ b/tests/dbcreate.disabled/comdb2makecluster/comdb2makecluster
@@ -175,9 +175,9 @@ echo "$DBNAME: starting"
 for node in $CLUSTER; do
     if [ $node == $myhostname ] ; then # dont ssh to ourself -- just start db locally
             if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
-                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
+                echo -e "!$TESTCASE: Execute the following command on ${node}: ${TEXTCOLOR}${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid${NOCOLOR}"
             else
-                ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &> $LOGDIR/${DBNAME}.${node}.db &
+                ${DEBUG_PREFIX} $COMDB2_EXE ${PARAMS} --lrl ${LRL} --pidfile ${TMPDIR}/${DBNAME}.${node}.pid &> $LOGDIR/${DBNAME}.${node}.db &
             fi
         continue
     fi

--- a/tests/halt_processor_tds.test/runit
+++ b/tests/halt_processor_tds.test/runit
@@ -106,12 +106,12 @@ function bounce_master
     master=`cdb2sql -tabs ${CDB2_OPTIONS} $db default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]' `
     PARAMS="$db --no-global-lrl"
     REP_ENV_VARS="${DBDIR}/replicant_env_vars"
-    CMD="cd ${DBDIR}; source ${REP_ENV_VARS}; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
+    CMD="cd ${DBDIR}; source ${REP_ENV_VARS}; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl --pidfile ${TMPDIR}/${db}.pid"
     if [[ -n "$master" ]]; then
         if [ $master == $(hostname) ]; then
             (
                 kill -9 $(cat ${TMPDIR}/${db}.${node}.pid)
-                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${db}.${node}.db 2>&1
+                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl --pidfile ${TMPDIR}/${db}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${db}.${node}.db 2>&1
             ) &
         else
             kill -9 $(cat ${TMPDIR}/${db}.${master}.pid)

--- a/tests/incremental_backup.test/runit
+++ b/tests/incremental_backup.test/runit
@@ -140,7 +140,7 @@ function test_restoredb {
   mv ${LOCTMPDIR}/restore/${DBNAME}_file_vers_map ${LOCTMPDIR}/restore/${DBNAME}_restore_file_vers_map
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl --pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
   ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1

--- a/tests/incremental_backup_load.test/runit
+++ b/tests/incremental_backup_load.test/runit
@@ -153,7 +153,7 @@ function test_restoredb {
   egrep -v "cluster nodes" ${LOCTMPDIR}/restore/${DBNAME}.lrl > ${LOCTMPDIR}/restore/${DBNAME}.single.lrl
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl --pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
   ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1

--- a/tests/incremental_backup_usenames.test/runit
+++ b/tests/incremental_backup_usenames.test/runit
@@ -127,7 +127,7 @@ function test_restoredb {
   mv ${LOCTMPDIR}/restore/${DBNAME}_file_vers_map ${LOCTMPDIR}/restore/${DBNAME}_restore_file_vers_map
 
   echo "~~~~~~~~~~"
-  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl -pidfile ${TMPDIR}/${DBNAME}_restore.pid &
+  $COMDB2_EXE ${DBNAME}_restore --lrl ${LOCTMPDIR}/restore/${DBNAME}.single.lrl --pidfile ${TMPDIR}/${DBNAME}_restore.pid &
   # wait for db to launch
   count=0
   ${CDB2SQL_EXE} ${DBNAME}_restore local "select 1" > ./sqloutput 2>&1

--- a/tests/incrementalcopy.test/runit
+++ b/tests/incrementalcopy.test/runit
@@ -112,7 +112,7 @@ egrep -v "cluster nodes" $lrl > $newlrl
 scp $newlrl $target:$newlrl
 
 # bring back up
-ssh $target ${COMDB2_EXE} $dbname -lrl $newlrl < /dev/null &
+ssh $target ${COMDB2_EXE} $dbname --lrl $newlrl < /dev/null &
 
 sleep 30
 

--- a/tests/killcluster.test/runit
+++ b/tests/killcluster.test/runit
@@ -62,12 +62,12 @@ function bouncecluster
     for node in $CLUSTER ; do
         PARAMS="$db --no-global-lrl"
         REP_ENV_VARS="${DBDIR}/replicant_env_vars"
-        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.pid"
+        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl --pidfile ${TMPDIR}/${db}.pid"
         if [ $node == $(hostname) ] ; then
             (
                 kill -9 $(cat ${TMPDIR}/${db}.${node}.pid)
                 sleep $sleeptime
-                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl -pidfile ${TMPDIR}/${db}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${db}.${node}.db 2>&1
+                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${db}.lrl --pidfile ${TMPDIR}/${db}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${db}.${node}.db 2>&1
             ) &
         else
             kill -9 $(cat ${TMPDIR}/${db}.${node}.pid)
@@ -84,7 +84,7 @@ function bouncelocal
         PARAMS="$db --no-global-lrl"
         kill -9 $(cat ${TMPDIR}/${db}.pid)
         sleep $sleeptime
-        ${DEBUG_PREFIX} ${COMDB2_EXE} $PARAMS -pidfile ${TMPDIR}/${db}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >>$TESTDIR/logs/${DBNAME}.db &
+        ${DEBUG_PREFIX} ${COMDB2_EXE} $PARAMS --pidfile ${TMPDIR}/${db}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >>$TESTDIR/logs/${DBNAME}.db &
     ) &
 }
 

--- a/tests/load_cache.test/runit
+++ b/tests/load_cache.test/runit
@@ -212,10 +212,10 @@ function copy_test
 
     write_prompt $func "Starting replicant database, replog is $replog"
     if [[ -n "$TEST_TIMEOUT" ]] ; then
-        ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1 ) &
+        ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname --lrl $repdir/${repname}.lrl --pidfile $repdir/${repname}.pid >$replog 2>&1 ) &
         reppid=$!
     else
-        ( $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1 ) &
+        ( $COMDB2_EXE $repname --lrl $repdir/${repname}.lrl --pidfile $repdir/${repname}.pid >$replog 2>&1 ) &
     fi
 
     waitmach localhost $repname -n

--- a/tests/lostwrite.test/runit
+++ b/tests/lostwrite.test/runit
@@ -68,12 +68,12 @@ function bouncemaster
     PARAMS="$DBNAME --no-global-lrl"
     if [[ ! -z "$node" ]]; then
         REP_ENV_VARS="${DBDIR}/replicant_env_vars"
-        CMD="source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        CMD="source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
         if [ "$node" == "$(hostname)" ] ; then
             (
             kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid) >/dev/null 2>&1
             sleep $sleeptime
-            ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
+            ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
             ) &
         else
             kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid) >/dev/null 2>&1

--- a/tests/nophyswrite.test/runit
+++ b/tests/nophyswrite.test/runit
@@ -57,7 +57,7 @@ function make_phys_rep
     fi
 
     write_prompt $func "Starting replicant database, replog is $replog"
-    ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1) &
+    ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname --lrl $repdir/${repname}.lrl --pidfile $repdir/${repname}.pid >$replog 2>&1) &
 }
 
 function setup

--- a/tests/overflowblobs.test/overfl_blobtst.sh
+++ b/tests/overflowblobs.test/overfl_blobtst.sh
@@ -250,8 +250,8 @@ cd2_64=$(newexe $dbex $tach linux_64)
 delbtrees $tmach $dest
 
 # restore the database on the remote side
-rsh $tmach "$cd2 $dbnm -lrl $dest/$dbnm.lrl -fullrecovery >/dev/null 2>&1"
-rsh $tmach "$cd2_64 $dbnm -lrl $dest/$dbnm.lrl -fullrecovery >/dev/null 2>&1"
+rsh $tmach "$cd2 $dbnm --lrl $dest/$dbnm.lrl -fullrecovery >/dev/null 2>&1"
+rsh $tmach "$cd2_64 $dbnm --lrl $dest/$dbnm.lrl -fullrecovery >/dev/null 2>&1"
 
 # verify script
 vfy=/bb/bin/db_verify

--- a/tests/phys_rep.test/runit
+++ b/tests/phys_rep.test/runit
@@ -53,9 +53,9 @@ fi
 replog=$DEST_DBDIR/$destdb.log
 
 if [[ -n "$repalive" ]]; then
-    ( $COMDB2_EXE $destdb -lrl $DEST_DBDIR/${destdb}.lrl -pidfile $DEST_DBDIR/${destdb}.pid >$replog 2>&1) &
+    ( $COMDB2_EXE $destdb --lrl $DEST_DBDIR/${destdb}.lrl --pidfile $DEST_DBDIR/${destdb}.pid >$replog 2>&1) &
 else
-    ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $destdb -lrl $DEST_DBDIR/${destdb}.lrl -pidfile $DEST_DBDIR/${destdb}.pid >$replog 2>&1) &
+    ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $destdb --lrl $DEST_DBDIR/${destdb}.lrl --pidfile $DEST_DBDIR/${destdb}.pid >$replog 2>&1) &
 fi
 
 out=

--- a/tests/recovertolsn.test/runit
+++ b/tests/recovertolsn.test/runit
@@ -112,12 +112,12 @@ function kill_restarttolsn
     sleep 1
 
     echo "$DBNAME: recovering to lsn $lsn"
-    $COMDB2_EXE --recovertolsn $lsn $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1
+    $COMDB2_EXE --recovertolsn $lsn $DBNAME >$TESTDIR/logs/${DBNAME}.db --pidfile ${TMPDIR}/$DBNAME.pid 2>&1
 
     mv -b $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.2
     echo "$DBNAME: starting single node"
-    echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-    $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
+    echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db --pidfile ${TMPDIR}/$DBNAME.pid"
+    $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db --pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
 
     popd
 

--- a/tests/recovery_pages.test/runit
+++ b/tests/recovery_pages.test/runit
@@ -87,17 +87,17 @@ restart_node()
         mv --backup=numbered $TESTDIR/logs/${DBNAME}.${node}.db $TESTDIR/logs/${DBNAME}.${node}.db.1
         sleep $delay
         if [ $node != `hostname` ] ; then
-            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
+            ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} --lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1 </dev/null &
             echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
         else
-            $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
+            $COMDB2_EXE ${DBNAME} --lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db --pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
         fi
     else
         mv --backup=numbered $TESTDIR/logs/${DBNAME}.db $TESTDIR/logs/${DBNAME}.db.1
         sleep $delay
         echo "$DBNAME: starting single node"
-        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid"
-        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db -pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
+        echo "$COMDB2_EXE $DBNAME $TESTDIR/logs/${DBNAME}.db --pidfile ${TMPDIR}/$DBNAME.pid"
+        $COMDB2_EXE $DBNAME >$TESTDIR/logs/${DBNAME}.db --pidfile ${TMPDIR}/$DBNAME.pid 2>&1 &
     fi
 
     popd

--- a/tests/repopulate_queues.test/runit
+++ b/tests/repopulate_queues.test/runit
@@ -8,7 +8,7 @@ rm -rf $DBDIR
 mkdir -p $DBDIR
 
 $COMDB2_EXE $db --create --dir $DBDIR/$db >/dev/null 2>&1
-$COMDB2_EXE $db -lrl $DBDIR/$db/$db.lrl >/dev/null 2>&1 &
+$COMDB2_EXE $db --lrl $DBDIR/$db/$db.lrl >/dev/null 2>&1 &
 sleep 10
 
 # Create a table
@@ -27,7 +27,7 @@ for i in `seq 1 5`; do
     mkdir -p $DBDIR/$db.repop
     $COMDB2_EXE $db --repopnewlrl $DBDIR/$db.repop/$db.lrl --lrl $DBDIR/$db/$db.lrl
     $COMDB2_EXE $db --create --lrl $DBDIR/$db.repop/$db.lrl
-    $COMDB2_EXE $db -lrl $DBDIR/$db.repop/$db.lrl &
+    $COMDB2_EXE $db --lrl $DBDIR/$db.repop/$db.lrl &
     sleep 10
     cdb2sql $db 'exec procedure sys.cmd.send("exit")'
     sleep 5

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -14,10 +14,10 @@ setup_debugger() {
             DEBUG_PREFIX="gdb --args"
             ;;
         valgrind)
-            DEBUG_PREFIX="valgrind --track-origins=yes"
+            DEBUG_PREFIX="valgrind --track-origins=yes --log-file=$TESTDIR/$TESTCASE.valgrind"
             ;;
         memcheck)
-            DEBUG_PREFIX="valgrind  --leak-check=full --show-reachable=yes --track-origins=yes --leak-resolution=high --num-callers=30"
+            DEBUG_PREFIX="valgrind  --leak-check=full --show-reachable=yes --track-origins=yes --leak-resolution=high --num-callers=30 --log-file=$TESTDIR/$TESTCASE.valgrind"
             ;;
         callgrind)
             DEBUG_PREFIX="valgrind --tool=callgrind --instr-atstart=no --dump-instr=yes --collect-systime=yes --collect-jumps=yes --callgrind-out-file=$TESTDIR/$TESTCASE.callgrind"
@@ -30,10 +30,13 @@ setup_debugger() {
             DEBUG_PREFIX="valgrind --tool=drd --read-var-info=yes "
             ;;
         helgrind)
-            DEBUG_PREFIX="valgrind --tool=helgrind "
+            DEBUG_PREFIX="valgrind --tool=helgrind --log-file=$TESTDIR/$TESTCASE.helgrind"
+            ;;
+        cachegrind)
+            DEBUG_PREFIX="valgrind --tool=cachegrind --cachegrind-out-file=$TESTDIR/$TESTCASE.cachegrind"
             ;;
         massif)
-            DEBUG_PREFIX="valgrind --tool=massif "
+            DEBUG_PREFIX="valgrind --tool=massif --massif-out-file=$TESTDIR/$TESTCASE.massifgrind"
             ;;
         perf)
             DEBUG_PREFIX="perf record -o $TESTDIR/$TESTCASE.perfdata -g "
@@ -434,9 +437,9 @@ DATETIME=$(date +"%Y-%m-%d %H:%M:%S")
 echo Done $TESTCASE with id $TESTID at $DATETIME >> ${TEST_LOG}
 echo "Duration $SECONDS seconds" >> ${TESTDIR}/logs/${DBNAME}.testcase
 
-if [[ "${DEBUGGER}" == *"grind" ]]; then 
+if [[ "${DEBUG_PREFIX}" == "valgrind"* ]]; then 
    echo "${DEBUGGER} files are located here:"
-   ls ${TESTDIR}/*.callgrind
+   ls ${TESTDIR}/*.*grind
 elif [[ "${DEBUGGER}" == *"perf" ]]; then 
    echo "perf files are located here:"
    ls ${TESTDIR}/*.perfdata

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -29,12 +29,12 @@ function bounce_cluster
     REP_ENV_VARS="${DBDIR}/replicant_env_vars"
     for node in $CLUSTER ; do
         PARAMS="$DBNAME --no-global-lrl"
-        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        CMD="sleep $sleeptime ; source ${REP_ENV_VARS} ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid"
         if [ $node == $(hostname) ] ; then
             (
                 kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
                 sleep $sleeptime
-                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
+                ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
             ) &
         else
             kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
@@ -56,7 +56,7 @@ function bounce_local
         PARAMS="$DBNAME --no-global-lrl"
         kill -9 $(cat ${TMPDIR}/${DBNAME}.pid)
         sleep $sleeptime
-        ${DEBUG_PREFIX} ${COMDB2_EXE} $PARAMS --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >>$TESTDIR/logs/${DBNAME}.db &
+        ${DEBUG_PREFIX} ${COMDB2_EXE} $PARAMS --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >>$TESTDIR/logs/${DBNAME}.db &
     ) &
 }
 

--- a/tests/tools/get_tests_inorder.sh
+++ b/tests/tools/get_tests_inorder.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
+# Get list of tests in order from longest to shortest duration
 
-#get list of tests in order from longest to shortest test to run
-DEFAULT_TIMEOUT=5
+DEFAULT_TIMEOUT=5  # default timeout for the tests is 5 seconds
 
 #get the tests with custom times
 custom_times=`grep "TEST_TIMEOUT=" *.test/Makefile | sed 's#export TEST_TIMEOUT=##; s#/Makefile:# #; s#m$##'`

--- a/tests/tools/linearizable/killcluster/killclustertest.sh
+++ b/tests/tools/linearizable/killcluster/killclustertest.sh
@@ -55,8 +55,8 @@ for x in $machines ; do
 
     else
 
-        echo "kill -9 \$(ps -ef | egrep comdb2 | egrep lrl | egrep -v bash | egrep $db | awk '{print \$2}') ; sleep 10 ; export MALLOC_CHECK_=2 ; /opt/bb/bin/comdb2 $db -lrl /db/comdb2/$db/$db.lrl -pidfile /tmp/$db.pid 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' > /db/comdb2/$db/$outfile.$x 2>&1"
-        ssh $x "kill -9 \$(ps -ef | egrep comdb2 | egrep lrl | egrep -v bash | egrep $db | awk '{print \$2}') ; sleep 10 ; export MALLOC_CHECK_=2 ; /opt/bb/bin/comdb2 $db -lrl /db/comdb2/$db/$db.lrl -pidfile /tmp/$db.pid 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' > /db/comdb2/$db/$outfile.$x 2>&1" < /dev/null &
+        echo "kill -9 \$(ps -ef | egrep comdb2 | egrep lrl | egrep -v bash | egrep $db | awk '{print \$2}') ; sleep 10 ; export MALLOC_CHECK_=2 ; /opt/bb/bin/comdb2 $db --lrl /db/comdb2/$db/$db.lrl --pidfile /tmp/$db.pid 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' > /db/comdb2/$db/$outfile.$x 2>&1"
+        ssh $x "kill -9 \$(ps -ef | egrep comdb2 | egrep lrl | egrep -v bash | egrep $db | awk '{print \$2}') ; sleep 10 ; export MALLOC_CHECK_=2 ; /opt/bb/bin/comdb2 $db --lrl /db/comdb2/$db/$db.lrl --pidfile /tmp/$db.pid 2>&1 | ts '[%Y-%m-%d %H:%M:%S]' > /db/comdb2/$db/$outfile.$x 2>&1" < /dev/null &
 
     fi
     #sleep 2

--- a/tests/tools/linearizable/scripts/recreatedb
+++ b/tests/tools/linearizable/scripts/recreatedb
@@ -85,8 +85,8 @@ cat $lrlpath >> $cpdir/$db.lrl
 
 outfile=$db.out.$(date +%Y%m%d%H%M%S)
 
-echo "comdb2 $db -lrl $cpdir/$db.lrl -pidfile /tmp/$db.pid >$cpdir/$outfile 2>&1 &"
-comdb2 $db -lrl $cpdir/$db.lrl -pidfile /tmp/$db.pid >$cpdir/$outfile 2>&1 &
+echo "comdb2 $db --lrl $cpdir/$db.lrl --pidfile /tmp/$db.pid >$cpdir/$outfile 2>&1 &"
+comdb2 $db --lrl $cpdir/$db.lrl --pidfile /tmp/$db.pid >$cpdir/$outfile 2>&1 &
 wait_for_db_up $db @localhost
 cat >> $cpdir/$db.lrl <<EOF
 cluster nodes $machines
@@ -123,8 +123,8 @@ printf "starting cluster "
 for m in $machines; do
     printf "%s " $m
     ssh $m "/opt/bb/bin/pmux -l"
-    echo ssh $m "$vg $exe $db -lrl $cpdir/$db.lrl -pidfile /tmp/$db.pid > $cpdir/${outfile}.$m 2>&1 "
-    ssh $m "$vg $exe $db -lrl $cpdir/$db.lrl -pidfile /tmp/$db.pid > $cpdir/${outfile}.$m 2>&1 " &
+    echo ssh $m "$vg $exe $db --lrl $cpdir/$db.lrl --pidfile /tmp/$db.pid > $cpdir/${outfile}.$m 2>&1 "
+    ssh $m "$vg $exe $db --lrl $cpdir/$db.lrl --pidfile /tmp/$db.pid > $cpdir/${outfile}.$m 2>&1 " &
 done
 echo
 

--- a/tests/truncatesc.test/runit
+++ b/tests/truncatesc.test/runit
@@ -152,9 +152,9 @@ function make_phys_rep
 
     write_prompt $func "Starting replicant database, replog is $replog"
     if [[ -n "$replive" ]]; then
-        ( $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1) &
+        ( $COMDB2_EXE $repname --lrl $repdir/${repname}.lrl --pidfile $repdir/${repname}.pid >$replog 2>&1) &
     else
-        ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname -lrl $repdir/${repname}.lrl -pidfile $repdir/${repname}.pid >$replog 2>&1) &
+        ( timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $repname --lrl $repdir/${repname}.lrl --pidfile $repdir/${repname}.pid >$replog 2>&1) &
     fi
 }
 

--- a/tests/watchdog_sql.test/runit
+++ b/tests/watchdog_sql.test/runit
@@ -10,7 +10,7 @@ mkdir -p $DBDIR
 $COMDB2_EXE $db --create --dir $DBDIR/$db >/dev/null 2>&1
 ulimit -c 0
 echo "watchthreshold 10" >> $DBDIR/$db/$db.lrl
-$COMDB2_EXE $db -lrl $DBDIR/$db/$db.lrl >$DBDIR/$db/out 2>&1 &
+$COMDB2_EXE $db --lrl $DBDIR/$db/$db.lrl >$DBDIR/$db/out 2>&1 &
 pid=$!
 sleep 10
 


### PR DESCRIPTION
As a means to only run a desired subset of all the tests when doing `make all`,
instead of needing to supply a list of all the tests to exclude in `excluded.txt`
this checkin provides a way of populating `alltests.txt` with a list of desired tests to run.
For example to only run curmoves test, in the `tests/` directory you would do:
```
$echo 'curmoves.test' > alltests.txt
$make 
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>