### PR TITLE
remsql need to be able to downgrade live

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -995,7 +995,7 @@ run:
     }
     fdbc->sql_hint = sql;
 
-    rc = fdbc_if->move(cur, CFIRST);
+    rc = fdbc_if->move(cur, CFIRST | NORETRY);
     fdbc_if = cur->fdbc; /* retry might get another cursor */
     if (rc != IX_FND && rc != IX_FNDMORE) {
         /* maybe remote is old code, retry in unversioned mode */
@@ -2981,6 +2981,22 @@ done:
     return rc;
 }
 
+static void _update_fdb_version(BtCursor *pCur, char *errstr)
+{
+    /* extract protocol number */
+    unsigned int protocol_version;
+
+    protocol_version = atoll(errstr);
+
+    logmsg(LOGMSG_ERROR,
+           "%s: remote db %s requires protocol "
+           "version %d, downgrading from %d\n",
+           __func__, pCur->bt->fdb->dbname, protocol_version,
+           pCur->bt->fdb->server_version);
+
+    pCur->bt->fdb->server_version = protocol_version;
+}
+
 #define RETRY_GET_ROW 16
 static int fdb_cursor_move_sql(BtCursor *pCur, int how)
 {
@@ -2992,6 +3008,9 @@ static int fdb_cursor_move_sql(BtCursor *pCur, int how)
     unsigned long long end_rpc;
     int retry = 0;
 
+    int no_version_retry = how & NORETRY;
+    how &= 0x0F;
+
     if (fdbc) {
 retry:
         start_rpc = osql_log_time();
@@ -2999,6 +3018,7 @@ retry:
         /* this is a rewind, lets make sure the pipe is clean */
         if ((how == CFIRST || how == CLAST) &&
             (fdbc->streaming != FDB_CUR_IDLE)) {
+        version_retry:
             rc = fdb_cursor_reopen(pCur);
             if (rc || !pCur->fdbc /*did we fail to pass error back */) {
                 logmsg(LOGMSG_ERROR, "%s: failed to reconnect rc=%d\n", __func__,
@@ -3076,17 +3096,12 @@ retry:
 
                     rc = SQLITE_SCHEMA_REMOTE;
                 } else if (rc == FDB_ERR_FDB_VERSION) {
-                    /* extract protocol number */
-                    unsigned int protocol_version;
+                    _update_fdb_version(pCur, errstr);
 
-                    protocol_version = atoll(errstr);
-
-                    logmsg(LOGMSG_INFO, "%s: remote db %s requires protocol "
-                                    "version %d, downgrading from %d\n",
-                            __func__, pCur->bt->fdb->dbname, protocol_version,
-                            pCur->bt->fdb->server_version);
-
-                    pCur->bt->fdb->server_version = protocol_version;
+                    if (!no_version_retry && (how == CFIRST || how == CLAST)) {
+                        no_version_retry = 1;
+                        goto version_retry;
+                    }
                 } else if (rc == FDB_ERR_SSL) {
 #if WITH_SSL
                     /* extract ssl config */
@@ -3217,6 +3232,7 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
     int packed_keylen = 0;
     unsigned long long start_rpc;
     unsigned long long end_rpc;
+    int no_version_retry = 0;
 
     if (fdbc) {
         int sqllen;
@@ -3225,6 +3241,7 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
 
         /* this is a rewind, lets make sure the pipe is clean */
         if (fdbc->streaming != FDB_CUR_IDLE) {
+        version_retry:
             rc = fdb_cursor_reopen(pCur);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: failed to reconnect rc=%d\n", __func__,
@@ -3317,6 +3334,14 @@ static int fdb_cursor_find_sql_common(BtCursor *pCur, Mem *key, int nfields,
                     fdbc->ent->tbl->need_version = remote_version + 1;
 
                     rc = SQLITE_SCHEMA_REMOTE;
+                    rc = SQLITE_SCHEMA_REMOTE;
+                } else if (rc == FDB_ERR_FDB_VERSION) {
+                    _update_fdb_version(pCur, errstr);
+
+                    if (!no_version_retry) {
+                        no_version_retry = 1;
+                        goto version_retry;
+                    }
                 } else {
                     if (rc != FDB_ERR_SSL) {
                         if (state) {

--- a/db/sql.h
+++ b/db/sql.h
@@ -906,7 +906,7 @@ struct Btree {
     fdb_t *fdb;
 };
 
-enum { CFIRST, CNEXT, CPREV, CLAST };
+enum { CFIRST = 0, CNEXT = 1, CPREV = 2, CLAST = 3, NORETRY = 256 };
 
 typedef enum {
     CURSORCLASS_TEMPTABLE = 1,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2924,8 +2924,7 @@ static int cursor_move_remote(BtCursor *pCur, int *pRes, int how)
 
         return SQLITE_SCHEMA_REMOTE;
     } else if (rc == FDB_ERR_FDB_VERSION) {
-        /* corner case, the db was backout to a lower protocol */
-        /* TODO: */
+        /* lower level handles the retries here */
         abort();
     } else {
         assert(rc != 0);
@@ -5360,8 +5359,7 @@ cursor_find_remote(BtCursor *pCur,            /* The cursor to be moved */
 
         return SQLITE_SCHEMA_REMOTE;
     } else if (rc == FDB_ERR_FDB_VERSION) {
-        /* corner case, the db was backout to a lower protocol */
-        /* TODO: */
+        /* lower level handles the retries here */
         abort();
     } else {
         *pRes = -1;


### PR DESCRIPTION
Remote sql caches remote server version and uses it to select a proper communication protocol.  While downgrading a remote server is not possible in many cases, especially if it relies on newer features, this is still a common practice, especially in the early days of adoption of a new version. 
This patch allows a server to lively downgrade a remote server cache information and fallback to an older protocol.  The failed request is retriable in normal case; for current running transactions and queries, a remote bdb lock prevents a premature downgrade of the remote server, unless the latter crashes.  In this case, the query/transaction is not retriable and the client will get an I/O error.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

