### PR TITLE
include fdb name and class in report

### DIFF
--- a/db/fdb_systable.h
+++ b/db/fdb_systable.h
@@ -1,0 +1,34 @@
+/*
+   Copyright 2019 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef __FDB_SYSTABLE_H_
+#define __FDB_SYSTABLE_H_
+
+typedef struct fdb_systable_ent {
+    char *dbname;
+    char *location;
+    char *tablename;
+    char *indexname;
+    int64_t rootpage;
+    int64_t remoterootpage;
+    int64_t version;
+} fdb_systable_ent_t;
+
+/* Collect/Free existing fdb information */
+int fdb_systable_info_collect(void **data, int *npoints);
+void fdb_systable_info_free(void *data, int npoints);
+
+#endif

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -155,6 +155,20 @@ Information about schedulers running.
 * `description` - Details the purpose of the scheduler; for example, there is
                   a time partition scheduler, or a memory modules stat scheduler
 
+## comdb2_fdb_info
+
+The cached remote schemas used for distributed sql execution.
+
+    comdb2_fdb_info(dbname, location, tablename, indexname, rootpage, remoterootpage, version)
+
+* `dbname` - Name of the remote database that executes a subset of sql
+* `location` - Name of the remote database class, 'LOCAL', 'DEV', 'ALPHA', 'BETA', 'PROD'
+* `tablename` - Name of the remote table (NOTE: we cache schemas only for accessed tables)
+* `indexname` - Name of the index, if this is an index entry, NULL otherwise
+* `rootpage  - Value of the local rootpage sqlite uses to refer to remote table/index
+* `remoterootpage` - Value of the remote rootpage
+* `version` - Schema version of the remote table; used to pull new schema on access
+
 ## comdb2_functions
 
 The functions available to call from sql.

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(sqlite
   ext/comdb2/typesamples.c
   ext/comdb2/users.c
   ext/comdb2/views.c
+  ext/comdb2/fdb.c
   ext/misc/carray.c
   ext/misc/completion.c
   ext/misc/regexp.c

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -54,6 +54,7 @@ extern const sqlite3_module systblTimeseriesModule;
 extern const sqlite3_module systblReplStatsModule;
 extern const sqlite3_module systblLogicalOpsModule;
 extern const sqlite3_module systblSystabsModule;
+extern const sqlite3_module systblFdbInfoModule;
 extern sqlite3_module systblTablePermissionsModule;
 extern sqlite3_module systblSystabPermissionsModule;
 extern sqlite3_module systblTimepartPermissionsModule;
@@ -83,6 +84,7 @@ int systblFunctionsInit(sqlite3 *db);
 int systblTablePermissionsInit(sqlite3 *db);
 int systblSystabPermissionsInit(sqlite3 *db);
 int systblTimepartPermissionsInit(sqlite3 *db);
+int systblFdbInfoInit(sqlite3 *db);
 
 /* Simple yes/no answer for booleans */
 #define YESNO(x) ((x) ? "Y" : "N")

--- a/sqlite/ext/comdb2/fdb.c
+++ b/sqlite/ext/comdb2/fdb.c
@@ -1,0 +1,49 @@
+/*
+   Copyright 2019-2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+#if (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \
+    && !defined(SQLITE_OMIT_VIRTUALTABLE)
+
+#if defined(SQLITE_BUILDING_FOR_COMDB2) && !defined(SQLITE_CORE)
+# define SQLITE_CORE 1
+#endif
+
+#include <stddef.h>
+#include "sqlite3.h"
+#include "ezsystables.h"
+#include "fdb_systable.h"
+
+sqlite3_module systblFdbInfoModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
+int systblFdbInfoInit(sqlite3 *db)
+{
+    return create_system_table(
+        db, "comdb2_fdb_info", &systblFdbInfoModule,
+        fdb_systable_info_collect, fdb_systable_info_free,
+        sizeof(fdb_systable_ent_t),
+        CDB2_CSTRING, "dbname", -1, offsetof(fdb_systable_ent_t, dbname),
+        CDB2_CSTRING, "location", -1, offsetof(fdb_systable_ent_t, location),
+        CDB2_CSTRING, "tablename", -1, offsetof(fdb_systable_ent_t, tablename),
+        CDB2_CSTRING, "indexname", -1, offsetof(fdb_systable_ent_t, indexname),
+        CDB2_INTEGER, "rootpage", -1, offsetof(fdb_systable_ent_t, rootpage),
+        CDB2_INTEGER, "remoterootpage", -1, offsetof(fdb_systable_ent_t, remoterootpage),
+        CDB2_INTEGER, "version", -1, offsetof(fdb_systable_ent_t, version),
+        SYSTABLE_END_OF_FIELDS);
+}
+
+#endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \
+          && !defined(SQLITE_OMIT_VIRTUALTABLE) */

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -318,6 +318,8 @@ int comdb2SystblInit(
   if (rc == SQLITE_OK)
     rc = systblTimepartPermissionsInit(db);
   if (rc == SQLITE_OK)
+    rc = systblFdbInfoInit(db);
+  if (rc == SQLITE_OK)
     rc = sqlite3_carray_init(db, 0, 0);
 #endif
   return rc;

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -227,6 +227,7 @@
 (candidate='comdb2_constraints')
 (candidate='comdb2_cron_events')
 (candidate='comdb2_cron_schedulers')
+(candidate='comdb2_fdb_info')
 (candidate='comdb2_fingerprints')
 (candidate='comdb2_functions')
 (candidate='comdb2_index_usage')

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -29,6 +29,7 @@ unknown @ls sub-command foo
 (name='comdb2_constraints')
 (name='comdb2_cron_events')
 (name='comdb2_cron_schedulers')
+(name='comdb2_fdb_info')
 (name='comdb2_fingerprints')
 (name='comdb2_functions')
 (name='comdb2_index_usage')

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -366,6 +366,7 @@
 (name='comdb2_constraints')
 (name='comdb2_cron_events')
 (name='comdb2_cron_schedulers')
+(name='comdb2_fdb_info')
 (name='comdb2_fingerprints')
 (name='comdb2_functions')
 (name='comdb2_index_usage')

--- a/tests/misstable_remsql.test/output_2.log
+++ b/tests/misstable_remsql.test/output_2.log
@@ -15,3 +15,9 @@ Index "$ID_1C16AC86" for table "t2" Rootp 1073741839 Remrootp 5 Version=0
 Index "$ID_52596C31" for table "t" Rootp 1073741835 Remrootp 3 Version=0
 Table "t" Rootp 1073741834 Remrootp 2 Version=0
 Table "t2" Rootp 1073741838 Remrootp 4 Version=0
+(dbname='dorintdb', tablename='sqlite_stat1', indexname=NULL, rootpage=1073741836, remoterootpage=6, version=0)
+(dbname='dorintdb', tablename='sqlite_stat4', indexname=NULL, rootpage=1073741837, remoterootpage=7, version=0)
+(dbname='dorintdb', tablename='t2', indexname='$ID_1C16AC86', rootpage=1073741839, remoterootpage=5, version=0)
+(dbname='dorintdb', tablename='t', indexname='$ID_52596C31', rootpage=1073741835, remoterootpage=3, version=0)
+(dbname='dorintdb', tablename='t', indexname=NULL, rootpage=1073741834, remoterootpage=2, version=0)
+(dbname='dorintdb', tablename='t2', indexname=NULL, rootpage=1073741838, remoterootpage=4, version=0)

--- a/tests/misstable_remsql.test/test_missing.sh
+++ b/tests/misstable_remsql.test/test_missing.sh
@@ -31,14 +31,14 @@ cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remd
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
 # trying a missing table
 cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remdbname}.t_missing order by id"  &>> $output
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
 # trying again the good query on a different table
 cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remdbname}.t2 order by id" >> $output 2>&1
@@ -48,7 +48,9 @@ cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remd
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
+
+
 
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
@@ -82,14 +84,14 @@ cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cm
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"  2>&1 | cut -f 5- -d ' ' >> $output
 
 # trying a missing table
 cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remdbname}.t_missing order by id" >> $output 2>&1
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"  2>&1 | cut -f 5- -d ' ' >> $output
 
 # trying a good query
 cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remdbname}.t order by id" >> $output 2>&1
@@ -99,7 +101,9 @@ cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remd
 
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
+
+cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select dbname, tablename, indexname, rootpage, remoterootpage, version from comdb2_fdb_info" >> $output
 
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output_2.log > output_2.log.actual

--- a/tests/sc_addcolumn_remsql.test/test_sc.sh
+++ b/tests/sc_addcolumn_remsql.test/test_sc.sh
@@ -8,7 +8,7 @@ set -x
 function fdbinfo
 {
     echo cdb2sql --tabs ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "exec procedure sys.cmd.send('fdb info db')"
-    cdb2sql --tabs ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "exec procedure sys.cmd.send('fdb info db')" >> $output 2>&1
+    cdb2sql --tabs ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "exec procedure sys.cmd.send('fdb info db')"  2>&1 | cut -f 5- -d ' ' >> $output
     if (( $? != 0 )) ; then
         echo "Failed to retrieved fdb info ${a_dbname}"
         exit 1

--- a/tests/sc_remsql.test/test_sc.sh
+++ b/tests/sc_remsql.test/test_sc.sh
@@ -37,7 +37,7 @@ cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remd
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
 echo cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"  2>&1 | cut -f 5- -d ' ' >> $output
 
 # schema change the remote V1->V1'
 cdb2sql $REM_CDB2_OPTIONS $a_remdbname default "alter table t { `cat t.csc2 ` }"
@@ -54,7 +54,7 @@ cdb2sql ${SRC_CDB2_OPTIONS} -cost --host $mach $a_dbname default "select * from 
 # get the new version V2'
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
 echo cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"
-cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"  2>&1 | cut -f 5- -d ' ' >> $output
 
 sed "s/DBNAME/${a_remdbname}/g" output.log > output.log.actual
 

--- a/tests/ssl_remsql.test/test_ssl.sh
+++ b/tests/ssl_remsql.test/test_ssl.sh
@@ -23,7 +23,7 @@ cdb2sql -s --cdb2cfg $cdb2cfg2 $db2 --host $node "select * from LOCAL_${db1}.t o
 # get the version V2
 #comdb2sc $a_dbname send fdb info db >> $output 2>&1
 echo cdb2sql --tabs --cdb2cfg $cdb2cfg2 $db2 --host $node "exec procedure sys.cmd.send(\"fdb info db\")" 
-cdb2sql --tabs --cdb2cfg $cdb2cfg2 $db2 --host $node "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+cdb2sql --tabs --cdb2cfg $cdb2cfg2 $db2 --host $node "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
 # validate results 
 testcase_output=$(cat $output)

--- a/tests/userschema.test/t00.expected
+++ b/tests/userschema.test/t00.expected
@@ -16,6 +16,7 @@
 (tablename='comdb2_constraints', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_cron_events', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_cron_schedulers', username='mohit', READ='Y', WRITE='Y', DDL='Y')
+(tablename='comdb2_fdb_info', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_fingerprints', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_functions', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_index_usage', username='mohit', READ='Y', WRITE='Y', DDL='Y')

--- a/tests/writes_remsql.test/test_writes.sh
+++ b/tests/writes_remsql.test/test_writes.sh
@@ -79,7 +79,7 @@ run_test()
    # get the version V2
    #comdb2sc $a_dbname send fdb info db >> $output 2>&1
    echo cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"
-   cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+   cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
    work_exp_output=${exp_output}.actual
    sed "s/ t / LOCAL_${a_remdbname}.t /g" ${exp_output}  > ${work_exp_output}

--- a/tests/writes_remsql_names.test/writes_remsql_names.sh
+++ b/tests/writes_remsql_names.test/writes_remsql_names.sh
@@ -78,7 +78,7 @@ run_test()
    # get the version V2
    #comdb2sc $a_dbname send fdb info db >> $output 2>&1
    echo ${CDB2SQL_EXE} ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")"
-   ${CDB2SQL_EXE} ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" >> $output 2>&1
+   ${CDB2SQL_EXE} ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
    work_exp_output=${exp_output}.actual
    sed "s/ t / LOCAL_${a_remdbname}.${tblname} /g" ${exp_output}  > ${work_exp_output}


### PR DESCRIPTION
New format includes remote db name and class:

Db "dhtestdb" Class "dev" Table "sqlite_stat1" Rootp 1073741826 Remrootp 2 Version=0
Db "dhtestdb" Class "dev" Table "sqlite_stat4" Rootp 1073741827 Remrootp 3 Version=0
Db "dhogeadb" Class "local" Table "sqlite_stat1" Rootp 1073741828 Remrootp 2 Version=0
Db "dhogeadb" Class "local" Table "sqlite_stat4" Rootp 1073741829 Remrootp 3 Version=0
Db "dhogeadb" Class "local" Table "t" Rootp 1073741830 Remrootp 4 Version=0


Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>