### PR TITLE
Perform 'legacy_schema' checks only on master node

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -45,9 +45,11 @@
 #include <logmsg.h>
 #include "str0.h"
 
-extern int yyparse(void);
-extern int compute_key_data(void);
-extern int compute_all_data(int tidx);
+int yyparse(void);
+int compute_key_data(void);
+int compute_all_data(int tidx);
+int comdb2_iam_master();
+
 extern int gbl_ready;
 
 char *revision = "$Revision: 1.24 $";
@@ -105,7 +107,7 @@ int dyns_used_bools(void) { return used_bools; }
 
 #define CHECK_LEGACY_SCHEMA(A)                                                 \
     do {                                                                       \
-        if (gbl_legacy_schema && (A)) {                                        \
+        if (gbl_legacy_schema && comdb2_iam_master() && (A)) {                 \
             csc2_syntax_error(                                                 \
                 "ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");         \
             any_errors++;                                                      \

--- a/db/glue.c
+++ b/db/glue.c
@@ -6224,6 +6224,10 @@ int comdb2_is_user_op(char *user, char *password)
     return rc;
 }
 
+int comdb2_iam_master() {
+    return (thedb->master == gbl_myhostname) ? 1 : 0;
+}
+
 static int sync_state_to_protobuf(int sync) {
     switch (sync) {
         case REP_SYNC_FULL:


### PR DESCRIPTION
This will prevent the replicant nodes from panicking in the unlikely event when they have legacy_schema turned ON and are processing newer csc2 constructs in the schema sent from master node that has this tunable turned OFF.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>