### PR TITLE
Allow unsigned int tunables to be assigned full range of values

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -1072,7 +1072,7 @@ static void abort_election_on_exit(bdb_state_type *bdb_state)
 int gbl_elect_priority_bias = 0;
 
 int gbl_rand_elect_timeout = 1;
-int gbl_rand_elect_min_ms = 1000;
+uint32_t gbl_rand_elect_min_ms = 1000;
 int gbl_rand_elect_max_ms = 7000;
 
 static int elect_random_timeout(void)


### PR DESCRIPTION
Currently setting an unsigned int tunable to values larger than LONG_MAX
results in failure. This change allows us to properly assign values
up to ULONG_MAX. We use strtoul() for all tunables that are NOT SIGNED,
and strtol() for those wich are SIGNED.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>