### PR TITLE
Eventlog: print number of writes and cascaded writes per transaction

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4694,6 +4694,8 @@ void *statthd(void *p)
                                  NULL, 0, "updated rows", &hdr, statlogger, tbl, 0);
                     log_tbl_item(tbl->write_count[RECORD_WRITE_DEL], &tbl->saved_write_count[RECORD_WRITE_DEL],
                                  NULL, 0, "deleted rows", &hdr, statlogger, tbl, 0);
+                    log_tbl_item(tbl->casc_write_count, &tbl->saved_casc_write_count,
+                                 NULL, 0, "cascaded upd/del rows", &hdr, statlogger, tbl, 0);
                     log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count,
                                  NULL, 0, "deadlock count", &hdr, statlogger, tbl, 0);
                 }

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -649,6 +649,9 @@ typedef struct dbtable {
     /* counters for writes to this table */
     unsigned write_count[RECORD_WRITE_MAX];
     unsigned saved_write_count[RECORD_WRITE_MAX];
+    /* counters for cascaded writes to this table */
+    unsigned casc_write_count;
+    unsigned saved_casc_write_count;
     unsigned deadlock_count;
     unsigned saved_deadlock_count;
     unsigned aa_saved_counter; // zeroed out at autoanalyze

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -467,8 +467,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                               "RTNKYCNSTRT CANT FORM DST TBL %s INDEX %d (%s)",
                               iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
                 reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
-                          "key constraint cannot form destination table '%s' "
-                          "index %d (%s)",
+                          "key constraint cannot form destination table '%s' index %d (%s)",
                           iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
                 *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                 Pthread_mutex_unlock(&iq->usedb->rev_constraints_lk);
@@ -490,8 +489,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                             "RTNKYCNSTRT NEWDTA CANT FORM TBL %s INDEX %d (%s)",
                             iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
                     reqerrstr(iq, COMDB2_CSTRT_RC_INVL_IDX,
-                              "key constraint: new data cannot form table '%s' "
-                              "index %d (%s)",
+                              "key constraint: new data cannot form table '%s' index %d (%s)",
                               iq->usedb->tablename, ixnum, cnstrt->keynm[j]);
                     *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
                     Pthread_mutex_unlock(&iq->usedb->rev_constraints_lk);
@@ -504,8 +502,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                    after update */
                 if (!memcmp(lkey, nkey, ixlen)) {
                     if (iq->debug)
-                        reqprintf(iq, "RTNKYCNSTRT SKIP CNSTRT CHECK DUE TO "
-                                      "SAME KEY DATA. TBL %s INDEX %d (%s)",
+                        reqprintf(iq, "RTNKYCNSTRT SKIP CNSTRT CHECK DUE TO SAME KEY DATA. TBL %s INDEX %d (%s)",
                                   iq->usedb->tablename, ixnum,
                                   cnstrt->keynm[j]);
                     continue;
@@ -548,8 +545,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                    This means that this record is not referenced..just let it
                    through!*/
                 if (iq->debug)
-                    reqprintf(iq, "RTNKYCNSTRT SRC TBL %s INDEX %d (%s). "
-                                  "SKIPPING RULE CHECK.",
+                    reqprintf(iq, "RTNKYCNSTRT SRC TBL %s INDEX %d (%s). SKIPPING RULE CHECK.",
                               cnstrt->lcltable->tablename, rixnum,
                               cnstrt->lclkeyname);
                 continue; /* just move on, there should be nothing to check */
@@ -557,8 +553,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
 
             if (skip_lookup_for_nullfkey(iq->usedb, rixnum, nulls)) {
                 if (iq->debug)
-                    reqprintf(iq, "RTNKYCNSTRT NULL COLUMN PREVENTS FOREIGN "
-                                  "REF %s INDEX %d (%s). SKIPPING RULE CHECK.",
+                    reqprintf(iq, "RTNKYCNSTRT NULL COLUMN PREVENTS FOREIGN REF %s INDEX %d (%s). SKIPPING RULE CHECK.",
                               cnstrt->lcltable->tablename, rixnum,
                               cnstrt->lclkeyname);
                 continue; /* just move on, there should be nothing to check */
@@ -595,8 +590,7 @@ int check_update_constraints(struct ireq *iq, void *trans,
                      * until verify time */
 
                     if (iq->debug)
-                        reqprintf(iq, "RTNKYCNSTRT CANT FORM NEW SRC TBL %s "
-                                      "INDEX %d (%s). PENDING RULE CHECK.",
+                        reqprintf(iq, "RTNKYCNSTRT CANT FORM NEW SRC TBL %s INDEX %d (%s). PENDING RULE CHECK.",
                                   cnstrt->lcltable->tablename, rixnum,
                                   cnstrt->lclkeyname);
                     memcpy(rnkey, nkey, ixlen);
@@ -766,13 +760,11 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
         if (bct->nonewrefs) {
             if (iq->debug)
                 reqprintf(iq,
-                          "VERBKYCNSTRT CANT FORM NEW DATA TBL %s "
-                          "INDEX %d FROM %s INDEX %d ",
+                          "VERBKYCNSTRT CANT FORM NEW DATA TBL %s INDEX %d FROM %s INDEX %d ",
                           bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
             reqmoref(iq, " RC %d", rc);
             reqerrstr(iq, COMDB2_CSTRT_RC_INVL_DTA,
-                      "verify key constraint cannot form new data table "
-                      "'%s' index %d from %s index %d ",
+                      "verify key constraint cannot form new data table '%s' index %d from %s index %d ",
                       bct->dstdb->tablename, bct->dixnum, bct->tablename, bct->sixnum);
             *errout = OP_FAILED_INTERNAL + ERR_FORM_KEY;
             close_constraint_table_cursor(cur);
@@ -887,8 +879,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             if (rc != 0) {
                 if (iq->debug) {
                     reqprintf(iq,
-                              "VERBKYCNSTRT CANT CASCADE DELETE "
-                              "TBL %s RRN %d RC %d ",
+                              "VERBKYCNSTRT CANT CASCADE DELETE TBL %s RRN %d RC %d ",
                               bct->tablename, rrn, rc);
                 }
                 if (rc == ERR_TRAN_TOO_BIG) {
@@ -897,8 +888,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     *errout = OP_FAILED_INTERNAL + ERR_TRAN_TOO_BIG;
                 } else {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
-                              "verify key constraint cannot cascade delete "
-                              "table '%s' rc %d",
+                              "verify key constraint cannot cascade delete table '%s' rc %d",
                               bct->tablename, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                 }
@@ -961,14 +951,12 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             if (rc != 0) {
                 if (iq->debug) {
                     reqprintf(iq,
-                              "VERBKYCNSTRT CANT SET NULL ON DELETE "
-                              "TBL %s RRN %d RC %d ",
+                              "VERBKYCNSTRT CANT SET NULL ON DELETE TBL %s RRN %d RC %d ",
                               bct->tablename, rrn, rc);
                 }
                 if (rc == ERR_NULL_CONSTRAINT) {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
-                              "verify key constraint cannot set null on delete "
-                              "table '%s' rc %d",
+                              "verify key constraint cannot set null on delete table '%s' rc %d",
                               bct->tablename, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_NULL_CONSTRAINT;
                 } else if (rc == ERR_TRAN_TOO_BIG) {
@@ -976,8 +964,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     *errout = OP_FAILED_INTERNAL + ERR_TRAN_TOO_BIG;
                 } else {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
-                              "verify key constraint cannot set null on delete "
-                              "table '%s' rc %d",
+                              "verify key constraint cannot set null on delete table '%s' rc %d",
                               bct->tablename, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                 }
@@ -1037,8 +1024,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
             if (rc != 0) {
                 if (iq->debug) {
                     reqprintf(iq,
-                              "VERBKYCNSTRT CANT CASCADE UPDATE "
-                              "TBL %s RRN %d RC %d ",
+                              "VERBKYCNSTRT CANT CASCADE UPDATE TBL %s RRN %d RC %d ",
                               bct->tablename, rrn, rc);
                 }
                 if (rc == ERR_TRAN_TOO_BIG) {
@@ -1047,8 +1033,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
                     *errout = OP_FAILED_INTERNAL + ERR_TRAN_TOO_BIG;
                 } else {
                     reqerrstr(iq, COMDB2_CSTRT_RC_CASCADE,
-                              "verify key constraint cannot cascade update "
-                              "table '%s' rc %d",
+                              "verify key constraint cannot cascade update table '%s' rc %d",
                               bct->tablename, rc);
                     *errout = OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT;
                 }

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -537,6 +537,12 @@ static void populate_obj(cson_object *obj, const struct reqlogger *logger)
                             cson_value_new_string(logger->clnt->argv0, strlen(logger->clnt->argv0)));
     }
 
+    if (logger->nwrites > 0) {
+        cson_object_set(obj, "nwrites", cson_new_int(logger->nwrites));
+    }
+    if (logger->cascaded_nwrites > 0) {
+        cson_object_set(obj, "casc_nwrites", cson_new_int(logger->cascaded_nwrites));
+    }
     eventlog_context(obj, logger);
     eventlog_perfdata(obj, logger);
     eventlog_tables(obj, logger);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2011,8 +2011,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
 
     /* check for bad cstrings */
     if (logger->reqflags & REQL_BAD_CSTR_FLAG) {
-        logmsg(LOGMSG_WARN, "WARNING: THIS DATABASE IS RECEIVING NON NUL "
-                            "TERMINATED CSTRINGS\n");
+        logmsg(LOGMSG_WARN,
+               "WARNING: THIS DATABASE IS RECEIVING NON NUL TERMINATED CSTRINGS\n");
         log_header(logger, default_out, 0);
     }
 
@@ -2917,6 +2917,12 @@ inline void reqlog_set_clnt(struct reqlogger *logger, struct sqlclntstate *clnt)
 inline int reqlog_get_retries(const struct reqlogger *logger)
 {
     return logger->iq ? logger->iq->retries : 0;
+}
+
+inline void reqlog_set_nwrites(struct reqlogger *logger, int nwrites, int cascaded_nwrites)
+{
+    logger->nwrites = nwrites;
+    logger->cascaded_nwrites = cascaded_nwrites;
 }
 
 struct dump_client_sql_options  {

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -94,4 +94,6 @@ int reqlog_get_error_code(const struct reqlogger *logger);
 void reqlog_set_path(struct reqlogger *logger, struct client_query_stats *path);
 void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
+void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
+void reqlog_set_nwrites(struct reqlogger *logger, int nwrites, int cascaded_nwrites);
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -100,9 +100,11 @@ struct reqlogger {
     /* the bound parameters */
     cson_value *bound_param_cson;
 
-    uint32_t nsqlreqs;  /* Number of sqlreqs so far */
-    int sqlrows;
-    double sqlcost;
+    uint32_t nwrites;   /* number of writes for this txn */
+    uint32_t cascaded_nwrites; /* number of cascaded writes for this txn */
+    uint32_t nsqlreqs;  /* Atomically counted number of sqlreqs so far */
+    int      sqlrows;
+    double   sqlcost;
 
     uint64_t startus;     /* logger start timestamp */
     uint64_t startprcsus; /* processing start timestamp */

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5927,6 +5927,7 @@ add_blkseq:
     } else {
         iq->dbenv->txns_aborted++;
     }
+    reqlog_set_nwrites(iq->reqlogger, iq->written_row_count, iq->cascaded_row_count);
 
     /* update stats (locklessly so we may get gibberish - I know this
      * and don't care) */


### PR DESCRIPTION
Print number of writes and cascaded writes for every transaction in eventlog
file so an entry will now have `nwrites` and `casc_nwrites` additional fields:

```
{
  "time": 1619552710156440,
  "type": "txn",
  "cnonce": "3766303130312d356163642d3535623334336166383230302d30306530636262646666393730663563",
  "id": "48f28bc5-1fbb-4605-9573-883026aee4bf",
  "host": "",
  "nwrites": 101,
  "casc_nwrites": 100,
  "perf": {
    "tottime": 5465,
    "processingtime": 5427,
    "qtime": 38
  }
}
```

Also, keep a counter of cascaded deletes and updates for a table and display
the delta in statreqs every minute:

```
04/27 15:46:01:   DIFF REQUEST STATS FOR TABLE 't2'
04/27 15:46:01:       OSQL_DELREC            200
04/27 15:46:01:       OSQL_UPDREC            200
04/27 15:46:01:       OSQL_UPDCOLS           200
04/27 15:46:01:       OSQL_DONE_SNAP         704
04/27 15:46:01:       OSQL_SCHEMACHANGE      1
04/27 15:46:01:       OSQL_INSERT            900
04/27 15:46:01:       OSQL_STARTGEN          704
04/27 15:46:01:       nsql                   910
04/27 15:46:01:       inserted rows          899
04/27 15:46:01:       updated rows           1196
04/27 15:46:01:       deleted rows           915
04/27 15:46:01:       cascaded upd/del rows 1713
```

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>
