### PR TITLE
Tests: Run without verify at the end

### DIFF
--- a/tests/dokillall
+++ b/tests/dokillall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 TESTID=$1
-if [ -z $TESTID ] ; then
+if [ -z "${TESTID}" ] ; then
     echo "Need testid to kill all tests with this testid"
     exit 1
 fi

--- a/tests/perfect_ckp.test/runit
+++ b/tests/perfect_ckp.test/runit
@@ -31,7 +31,7 @@ if [ "$tier" = "" ]; then
 fi
 
 echo Creating table
-cdb2sql -s ${CDB2_OPTIONS} $dbnm $tier "drop table t" >/dev/null
+cdb2sql -s ${CDB2_OPTIONS} $dbnm $tier "drop table if exists t" >/dev/null
 cdb2sql -s ${CDB2_OPTIONS} $dbnm $tier "create table t { schema {int i} }" >/dev/null
 
 ###### Step 2: Start background writers ######

--- a/tests/queuedb_rollover.test/qdb1.sh
+++ b/tests/queuedb_rollover.test/qdb1.sh
@@ -34,18 +34,23 @@ done | cdb2sql $SP_OPTIONS
 
 sleep 60
 
-if [ $SP_HOST == `hostname` ]; then
+if [ -n "$CLUSTER" ] ; then
+    if [ $SP_HOST == `hostname` ]; then
+	cp ${TESTDIR}/logs/${DBNAME}.db qdb1-log1.log
+    else
+	scp ${SP_HOST}:${TESTDIR}/${DBNAME}.db qdb1-log1.log
+    fi
+
+    master=$(cdb2sql --tabs $SP_OPTIONS "select comdb2_sysinfo('master')")
+
+    if [ $master == `hostname` ]; then
+        cp ${TESTDIR}/logs/${DBNAME}.db qdb1-master-log1.log
+    else
+        scp ${master}:${TESTDIR}/${DBNAME}.db qdb1-master-log1.log
+    fi
+else
     cp ${TESTDIR}/logs/${DBNAME}.db qdb1-log1.log
-else
-    scp ${SP_HOST}:${TESTDIR}/${DBNAME}.db qdb1-log1.log
-fi
-
-master=$(cdb2sql --tabs $SP_OPTIONS "select comdb2_sysinfo('master')")
-
-if [ $master == `hostname` ]; then
     cp ${TESTDIR}/logs/${DBNAME}.db qdb1-master-log1.log
-else
-    scp ${master}:${TESTDIR}/${DBNAME}.db qdb1-master-log1.log
 fi
 
 cdb2sql $SP_OPTIONS "select queuename, depth from comdb2_queues order by queuename;"

--- a/tests/repopulate_queues.test/runit
+++ b/tests/repopulate_queues.test/runit
@@ -6,6 +6,7 @@ db=$DBNAME
 
 rm -rf $DBDIR
 mkdir -p $DBDIR
+df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> $DBDIR/$db/$db.lrl
 
 $COMDB2_EXE $db --create --dir $DBDIR/$db >/dev/null 2>&1
 $COMDB2_EXE $db --lrl $DBDIR/$db/$db.lrl >/dev/null 2>&1 &

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -90,6 +90,7 @@ fi
 
 export HOSTNAME=${HOSTNAME:-`hostname`}
 export CLEANUPDBDIR=${CLEANUPDBDIR:-1}
+export VERIFY_DB_AT_FINISH=${VERIFY_DB_AT_FINISH:-$((2-CLEANUPDBDIR))} # if not specified, depend on $CLEANUPDBDIR
 source $TESTSROOTDIR/setup.common
 export PATH="${paths}/:${PATH}"
 export pmux_port=${PMUXPORT:-5105}  # assign to 5105 if it was not set as a make parameter
@@ -141,7 +142,7 @@ find_cores() {
     local LCLDBDIR=$2
     local COREAGE=${FINDCOREAGE:-60}
     local CPAT=$(< /proc/sys/kernel/core_pattern)  # like cat core_pattern
-    [[ ${CPAT:0:1} == '|' ]] && return #TODO: handle cores controled by coredumpctl
+    [[ "${CPAT:0:1}" == "|" ]] && CPAT=core  #TODO: handle cores controled by coredumpctl
     local COREDIR=$(dirname $CPAT 2>/dev/null)
     if [ "x$COREDIR" == "x" ] || [ "x$COREDIR" == "x." ] ; then  # when just 'core'
         COREDIR=$LCLDBDIR
@@ -154,9 +155,10 @@ find_cores() {
     local CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '$COREFL' 2> /dev/null"
     local PIDFL=${TMPDIR}/${LCLDBNM}.pid
 
+    eval cr=\$\(${CORECMD}\)       # or can do cr=$(eval ${CORECMD}) or cr=$(find ${COREDIR} | grep $COREFL)
 
     # always check localhost because thats where we create db
-    if [ $has_pattern -eq 1 ] ; then
+    if [[ -z "${cr}" ]] && [[ $has_pattern -eq 1 ]] ; then
         local PID=$(cat ${PIDFL} 2> /dev/null)
         COREFL=`echo $CPAT | sed "s/%e/comdb2/g; s/.%t/.[^.]*/g; s/.%u/.[^.]*/g; s/.%g/.[^.]*/; s/.%s/.[^.]*/; s/.%h/.[^.]*/; s/%p/$PID/g; s/\.\./\./;"`
         COREFL=$COREDIR/$COREFL
@@ -211,7 +213,7 @@ find_cores() {
         fi
         if [ $has_pattern -eq 1 ] ; then
             PIDFL=${TMPDIR}/${LCLDBNM}.pid
-            local PID=`ssh -o StrictHostKeyChecking=no $node "cat ${PIDFL} 2> /dev/null" </dev/null`
+            local PID=`ssh -n -o StrictHostKeyChecking=no $node "cat ${PIDFL} 2> /dev/null"`
             if [ "x$PID" == "x" ] ; then
                 continue
             fi
@@ -220,15 +222,15 @@ find_cores() {
             CORECMD="find ${COREDIR} -mmin -$COREAGE -regex '${COREFL}.*' 2> /dev/null"
         fi
 
-        cr=`ssh -o StrictHostKeyChecking=no $node "$CORECMD" < /dev/null`
+        cr=`ssh -n -o StrictHostKeyChecking=no $node "$CORECMD"`
 
         if [[ -n "$cr" ]] ; then
             echo "$node:$cr" # this is the return value of the function
             local space=$(df .  | awk '{print $4}' | grep -v Available)
-            local size=$(ssh $node "ls -s $cr | cut -f1 -d' '")
+            local size=$(ssh -n -o StrictHostKeyChecking=no $node "ls -s $cr | cut -f1 -d' '")
             if [[ $size -lt $space ]] ; then # if there is space, copy locally
                 local copy_core=$LCLDBDIR/${node}.`basename $cr`
-                scp -o StrictHostKeyChecking=no $node:${cr} $copy_core < /dev/null
+                scp -o StrictHostKeyChecking=no $node:${cr} $copy_core
                 echo "Core file $node:${cr} copied to $copy_core" > $LCLDBDIR/core_stacktrace.$node.txt
                 echo 'where' | gdb -q $COMDB2_EXE $copy_core &>> $LCLDBDIR/core_stacktrace.$node.txt
                 echo 't a a bt full' | gdb -q $COMDB2_EXE $copy_core &>> $LCLDBDIR/core_stacktrace_long.$node.txt
@@ -255,12 +257,12 @@ call_setup() {
 
     cr=`find_cores ${DBNAME} $DBDIR`
 
-    if [[ -z "$cr" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
+    if [[ -z "${cr}" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
         cr=`find_cores ${SECONDARY_DBNAME} ${SECONDARY_DBDIR}`
     fi
 
 
-    if [[ -n "$cr" ]] ; then
+    if [[ -n "${cr}" ]] ; then
         echo "!$TESTCASE: setup failed with core dumped ($cr)" | tee -a ${TEST_LOG}
         call_unsetup
         sleep 0.1
@@ -275,12 +277,13 @@ call_setup() {
 }
 
 
+# check if we can perform a 'select 1' query to the db
 check_db_at_finish() {
     local LCLDBNM="$1"
     local LCLCONFIG="$2"
     local LCLOPTIONS="--cdb2cfg ${LCLCONFIG}"
 
-    if [[ -z "$CLUSTER" ]] ; then
+    if [[ -z "${CLUSTER}" ]] ; then
         out=$(timeout --kill-after=5s 1m $CDB2SQL_EXE ${LCLOPTIONS} --admin --tabs --host localhost $LCLDBNM 'select 1' 2>&1)
         if [ "$out" != "1" ] ; then
             timeout --kill-after=5s 1m $CDB2SQL_EXE -v ${LCLOPTIONS} --admin --tabs --host localhost $LCLDBNM 'select 1' &> ${TESTDIR}/logs/${LCLDBNM}.atfinish
@@ -299,6 +302,7 @@ check_db_at_finish() {
     done
 }
 
+# run verify on all the tables of the db
 verify_db_at_finish() {
     local LCLDBNM="$1"
     local LCLCONFIG="$2"
@@ -317,7 +321,7 @@ verify_db_at_finish() {
 }
 
 exit_if_above_max_test_failures () {
-    MAX_TEST_FAILURES=10    # stop running if more that this number of failures in test.log
+    MAX_TEST_FAILURES=100    # stop running if more that this number of failures in test.log
     F=`grep failed ${TESTDIR}/test.log | wc -l`
     if [ "$F" -ge "$MAX_TEST_FAILURES" ] ; then 
         echo "$TESTCASE: Max number of allowed test failures ($MAX_TEST_FAILURES) reached" >> ${TESTDIR}/test.log
@@ -354,7 +358,8 @@ fi
 
 cr=`find_cores ${DBNAME} $DBDIR`
 
-if [[ -z "$cr" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
+#-z true if the length is zero
+if [[ -z "${cr}" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
     cr=`find_cores ${SECONDARY_DBNAME} ${SECONDARY_DBDIR}`
 fi
 
@@ -374,15 +379,15 @@ if [ $CHECK_DB_AT_FINISH -eq 1 ] ; then
     dbdown=`check_db_at_finish ${DBNAME} $CDB2_CONFIG`
 
     # if no crashes, check secondary
-    if [[ -z "$dbdown" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
+    if [[ -z "${dbdown}" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
         dbdown=`check_db_at_finish ${SECONDARY_DBNAME} $SECONDARY_CDB2_CONFIG`
     fi
 
-    # if no crashes, run verify
-    if [[ -z "$dbdown" ]] ; then
+    # if no crashes and $VERIFY_DB_AT_FINISH > 0 then run verify
+    if [[ -z "${dbdown}" ]] && [[ $VERIFY_DB_AT_FINISH -gt 0 ]]; then
         verify_ret=`verify_db_at_finish ${DBNAME} $CDB2_CONFIG`
         # if no issues with verify, run verify on secondary
-        if [[ -z "$verify_ret" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
+        if [[ -z "${verify_ret}" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
             verify_ret=`verify_db_at_finish ${SECONDARY_DBNAME} $SECONDARY_CDB2_CONFIG`
         fi
     fi
@@ -436,7 +441,7 @@ call_unsetup
 # find any cores after unsetup -- ONLY works if CLEANUPDBDIR=0 because unsetup cleans up dir
 cr=`find_cores ${DBNAME} $DBDIR`
 
-if [[ -z "$cr" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
+if [[ -z "${cr}" ]] && [[ -n "${SECONDARY_DBNAME}" ]] ; then
     cr=`find_cores ${SECONDARY_DBNAME} ${SECONDARY_DBDIR}`
 fi
 

--- a/tests/setup
+++ b/tests/setup
@@ -24,7 +24,7 @@ done
 vars="HOSTNAME TESTID SRCHOME TESTCASE DBNAME DBDIR BUILDDIR TESTSBUILDDIR TESTSROOTDIR TESTDIR TMPDIR CDB2_OPTIONS CDB2_CONFIG COMDB2_EXE CDB2SQL_EXE COMDB2AR_EXE PMUX_EXE pmux_port"
 for required in $vars; do
     q=${!required}
-    if [[ -z "$q" ]]; then
+    if [[ -z "${q}" ]]; then
         echo "$required not set" >&2
         exit 1
     fi
@@ -68,8 +68,8 @@ check_db_port_running_node() {
         echo "pid running on dbport: $opid"
         [ -n "$opid" ] && ps -p $opid -o comm,args
     else
-        ssh $SSH_OPT $node "netstat -na | grep $dbport" </dev/null
-        opid=`ssh $SSH_OPT $node "fuser -n tcp $dbport" </dev/null`
+        ssh -n $SSH_OPT $node "netstat -na | grep $dbport"
+        opid=`ssh -n $SSH_OPT $node "fuser -n tcp $dbport"`
         echo "pid running on dbport: $opid"
     fi
     $CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node:$dbport $DBNAME 'select comdb2_dbname()' 2>&1
@@ -87,11 +87,11 @@ setup_db() {
     LRL="$DBDIR/$DBNAME.lrl"
     > ${LRL}
 
-    if [[ -z "$SKIPSSL" ]] ; then
+    if [[ -z "${SKIPSSL}" ]] ; then
         echo -e "ssl_client_mode REQUIRE\nssl_cert_path $TESTDIR" >> ${LRL}
     fi
 
-    if [[ -z "$SKIPDEBUG" ]] ; then
+    if [[ -z "${SKIPDEBUG}" ]] ; then
         echo "logmsg level debug" >> ${LRL}
     fi
     if [[ -n "$RTEONLY" ]] ; then
@@ -182,7 +182,7 @@ setup_db() {
     #fi
 
     # start it
-    if [[ -z "$CLUSTER" ]]; then
+    if [[ -z "${CLUSTER}" ]]; then
 
         if [[ -n ${DEBUG_PREFIX} && ${INTERACTIVE_DEBUG} -eq 1 ]]; then
             echo -e "!$TESTCASE: Execute the following command in a separate terminal: ${TEXTCOLOR}cd $DBDIR && ${DEBUG_PREFIX} $COMDB2_EXE ${DBNAME} ${PARAMS} ${NOCOLOR}"
@@ -236,7 +236,7 @@ setup_db() {
             if [ $node == $HOSTNAME ] ; then
                 continue
             fi
-            cat $ARFILE | ssh $SSH_OPT $node "cd ${DBDIR}; $COMDB2AR_EXE $COMDB2AR_EXOPTS $COMDB2AR_AROPTS -u 95 x $DBDIR" &> $LOGDIR/${DBNAME}.${node}.copy &
+            cat $ARFILE | ssh  $SSH_OPT $node "cd ${DBDIR}; $COMDB2AR_EXE $COMDB2AR_EXOPTS $COMDB2AR_AROPTS -u 95 x $DBDIR" &> $LOGDIR/${DBNAME}.${node}.copy &
             pids[$i]=$!
             let i=i+1
         done
@@ -321,7 +321,7 @@ if [ -n "${SECONDARY_DB_PREFIX}" ] ; then
     sec_vars="SECONDARY_DBNAME SECONDARY_DBDIR SECONDARY_CDB2_OPTIONS"
     for required in $sec_vars; do
         q=${!required}
-        if [[ -z "$q" ]]; then
+        if [[ -z "${q}" ]]; then
             echo "$required not set" >&2
             exit 1
         fi

--- a/tests/stopall
+++ b/tests/stopall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 export TESTID=$1
-if [ -z $TESTID ] ; then
+if [ -z "${TESTID}" ] ; then
     echo "Need testid to kill all tests with this testid"
     exit 1
 fi

--- a/tests/unsetup
+++ b/tests/unsetup
@@ -8,8 +8,8 @@ set -x
 [[ $COMDB2_UNITTEST == 1 ]] && exit 0
 
 echo "!$TESTCASE: stopping"
-[ -z "$TESTDIR" ] && TESTDIR=${PWD}/test_${TESTID}
-[ -z "$TMPDIR" ] && TMPDIR=${TESTDIR}/tmp
+TESTDIR=${TESTDIR:-${PWD}/test_${TESTID}}
+TMPDIR=${TMPDIR:-${TESTDIR}/tmp}
 
 #parameter $1 indicates if test is successful or not
 successful=$1
@@ -78,7 +78,7 @@ core_all_nodes() {
             continue
         fi
         pidfl=${TMPDIR}/${DBNAME}.pid
-        ssh -o StrictHostKeyChecking=no $node "cat ${pidfl} | xargs kill -6 " </dev/null
+        ssh -n -o StrictHostKeyChecking=no $node "cat ${pidfl} | xargs kill -6 "
     done
 }
 
@@ -109,7 +109,7 @@ cleanup_cluster() {
         fi
         dbport=`${TESTSROOTDIR}/tools/send_msg_port.sh -h $node "get comdb2/replication/${DBNAME}" ${pmux_port}`
         echo "deregistering $DBNAME (port $dbport) from $node pmux:$pmux_port"
-        ssh -o StrictHostKeyChecking=no $node "${deregister_db_port}" < /dev/null
+        ssh -n -o StrictHostKeyChecking=no $node "${deregister_db_port}"
         if [ "x$DBDIR" == "x" ] ; then 
             continue
         fi
@@ -118,12 +118,12 @@ cleanup_cluster() {
             echo copy $node:${DBDIR} content locally to $DBDIR/$node/ for investigation
             mkdir $DBDIR/$node/
             # from the next line, scp may result in a an extra copy of the core
-            scp -r -o StrictHostKeyChecking=no $node:${DBDIR} $DBDIR/$node/ < /dev/null &
-            scp -r -o StrictHostKeyChecking=no $node:${TESTDIR}/var/log/cdb2/${DBNAME}* $DBDIR/$node/ < /dev/null &
+            scp -r -o StrictHostKeyChecking=no $node:${DBDIR} $DBDIR/$node/ &
+            scp -r -o StrictHostKeyChecking=no $node:${TESTDIR}/var/log/cdb2/${DBNAME}* $DBDIR/$node/ &
         elif [ "$CLEANUPDBDIR" != "0" ] ; then 
-            ssh -o StrictHostKeyChecking=no $node "rm -rf ${DBDIR} $TMPDIR/${DBNAME}" < /dev/null &
+            ssh -n -o StrictHostKeyChecking=no $node "find ${DBDIR} | grep -q core || rm -rf ${DBDIR} $TMPDIR/${DBNAME}" &
             if [ "$CLEANUPDBDIR" == "2" ] ; then 
-                ssh -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.* ${TESTDIR}/var/log/cdb2/${DBNAME}.*" < /dev/null &
+                ssh -n -o StrictHostKeyChecking=no $node "rm -f $TESTDIR/${DBNAME}.db ${TMPDIR}/${DBNAME}.* ${TMPDIR}/cdb2/${DBNAME}.* ${TESTDIR}/var/log/cdb2/${DBNAME}.*" &
             fi
         fi
     done
@@ -131,7 +131,7 @@ cleanup_cluster() {
 
     # the local node always has a copy of DBDIR even if not part of cluster
     if [ "$CLEANUPDBDIR" != "0" ] && [ "$successful" == "1" ] && [ "x$DBDIR" != "x" ] ; then 
-        rm -rf ${DBDIR} ${TMPDIR}/${DBNAME}
+        find ${DBDIR} | grep -q core || rm -rf ${DBDIR} ${TMPDIR}/${DBNAME}
         if [ "$CLEANUPDBDIR" == "2" ] ; then
             rm -f ${TESTDIR}/var/log/cdb2/${DBNAME}.* `find $TESTDIR/${TESTCASE}.test/* | grep -v Makefile`
             rm -f $TESTDIR/logs/${DBNAME}.{setup,init,conn,copy,arstatus} # non clustered


### PR DESCRIPTION
- Skip running verify at the end of each test unless running with 
  CLEANUPDBDIR <= 1 or if passed explicitly via `make VERIFY_DB_AT_FINISH=1`
- Don't delete $DBDIR if there is a core in it.
- `ssh` to nodes takes `-n` parameter and does not need `< /dev/null`

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>