### PR TITLE
Perform 'legacy_schema' checks only on master node (backport from master)

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -30,10 +30,11 @@
 #include <logmsg.h>
 #include "str0.h"
 
-extern int yyparse(void);
-extern int compute_key_data(void);
-extern void init_globals(void);
-extern int compute_all_data(int tidx);
+int yyparse(void);
+int compute_key_data(void);
+void init_globals(void);
+int compute_all_data(int tidx);
+int comdb2_iam_master();
 
 char *revision = "$Revision: 1.24 $";
 int unionflag = 0;
@@ -90,6 +91,16 @@ void dyns_allow_bools(void) { allow_bools = 1; }
 void dyns_disallow_bools(void) { allow_bools = 0; }
 
 int dyns_used_bools(void) { return used_bools; }
+
+#define CHECK_LEGACY_SCHEMA(A)                                                 \
+    do {                                                                       \
+        if (gbl_legacy_schema && comdb2_iam_master() && (A)) {                 \
+            csc2_syntax_error(                                                 \
+                "ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");         \
+            any_errors++;                                                      \
+            return;                                                            \
+        }                                                                      \
+    } while (0)
 
 void start_constraint_list(char *keyname)
 {
@@ -788,11 +799,7 @@ void key_setdatakey(void) { workkeyflag |= DATAKEY; }
 
 void key_setuniqnulls(void)
 {
-    if (gbl_legacy_schema) {
-        csc2_syntax_error("ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");
-        any_errors++;
-        return;
-    }
+    CHECK_LEGACY_SCHEMA(1);
     workkeyflag |= UNIQNULLS;
 }
 
@@ -989,12 +996,7 @@ static void key_add_comn(int ix, char *tag, char *exprname,
             current_line, tag, MAXIDXNAMELEN - 1);
     }
     if (where && strlen(where) != 0) {
-        if (gbl_legacy_schema) {
-            csc2_syntax_error(
-                "ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");
-            any_errors++;
-            return;
-        }
+        CHECK_LEGACY_SCHEMA(1);
         keys[ii]->where = csc2_strdup(where);
     } else {
         keys[ii]->where = NULL;
@@ -1039,12 +1041,7 @@ void key_piece_add(char *buf,
     char *cp, *tag;
 
     if (is_expr) {
-        if (gbl_legacy_schema) {
-            csc2_syntax_error(
-                "ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");
-            any_errors++;
-            return;
-        }
+        CHECK_LEGACY_SCHEMA(1);
         struct key *nk = (struct key *)csc2_malloc(sizeof(struct key));
         struct key *kp;
         int keyfields = 0;
@@ -1483,15 +1480,10 @@ void rec_c_add(int typ, int size, char *name, char *cmnt)
                 break;
             case T_DATETIME:
             case T_DATETIMEUS:
-                if (gbl_legacy_schema && (tables[ntables]
-                                              .sym[tables[ntables].nsym]
-                                              .fopts[i]
-                                              .opttype != FLDOPT_NULL)) {
-                    csc2_syntax_error(
-                        "ERROR: TABLE SCHEMA NOT SUPPORTED IN LEGACY MODE\n");
-                    any_errors++;
-                    return;
-                }
+                CHECK_LEGACY_SCHEMA((tables[ntables]
+                                     .sym[tables[ntables].nsym]
+                                     .fopts[i]
+                                     .opttype != FLDOPT_NULL));
             case T_PSTR:
             case T_CSTR:
             case T_VUTF8:

--- a/db/glue.c
+++ b/db/glue.c
@@ -6367,6 +6367,10 @@ int comdb2_is_user_op(char *user, char *password)
     return rc;
 }
 
+int comdb2_iam_master() {
+    return (thedb->master == gbl_myhostname) ? 1 : 0;
+}
+
 tran_type *curtran_gettran(void)
 {
     int bdberr;


### PR DESCRIPTION
This will prevent the replicant nodes from panicking in the unlikely event when they have legacy_schema turned ON and are processing newer csc2 constructs in the schema sent from master node that has this tunable turned OFF.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>