### PR TITLE
Disable tracking string refs for normal build

### DIFF
--- a/util/string_ref.c
+++ b/util/string_ref.c
@@ -23,7 +23,9 @@
 #include "mem_override.h"
 #include "logmsg.h"
 
+#ifndef NDEBUG
 #define TRACK_REFERENCES
+#endif
 
 #ifdef TRACK_REFERENCES
 #include <plhash.h>


### PR DESCRIPTION
The feature to track via a hash string references was added to see list of
leftover references on exit, and we are currently cleaning up correctly all
such references. Thus it is no longer necessary to have tracking enabled by
default, rather only do so for `Debug` builds.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>