### PR TITLE
pmux.test: dont read with timeout in test

### DIFF
--- a/bbinc/comdb2_atomic.h
+++ b/bbinc/comdb2_atomic.h
@@ -13,6 +13,7 @@
   #define ATOMIC_ADD32_PTR(mem, val) atomic_add_32_nv(mem, val)
 #elif defined(_LINUX_SOURCE)
   #define CAS32(mem, oldv, newv) __atomic_compare_exchange_n(&mem, &oldv, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
+  #define CAS64(mem, oldv, newv) __atomic_compare_exchange_n(&mem, &oldv, newv, 0, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)
   #define XCHANGE32(mem, newv) __atomic_exchange_n(&mem, newv, __ATOMIC_SEQ_CST)
   #define XCHANGE64(mem, newv) __atomic_exchange_n(&mem, newv, __ATOMIC_SEQ_CST)
   #define ATOMIC_LOAD32(mem) __atomic_load_n(&mem, __ATOMIC_SEQ_CST)

--- a/crc32c/crc32c.c
+++ b/crc32c/crc32c.c
@@ -417,9 +417,9 @@ void timediff(const char * s) {
 
     gettimeofday(&tmp, NULL);
     int sec = (tmp.tv_sec - tv.tv_sec)*1000000;
-    int msec = (tmp.tv_usec - tv.tv_usec);
+    int usec = (tmp.tv_usec - tv.tv_usec);
     if (tv.tv_sec)
-        printf("%20.20s diff = %12.dusec\n", s, sec + msec);
+        printf("%20.20s diff = %12.dusec\n", s, sec + usec);
     tv = tmp;
 }
 

--- a/tests/basic.test/runit
+++ b/tests/basic.test/runit
@@ -567,12 +567,12 @@ if [[ $DBNAME != *"rowlocksgenerated"* ]] ; then
     test_trigger
 fi
 
+# test that sql hist does not cause a crash
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("sql hist")'
-
-
 res=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select 1"`
 assertres $res 1
 
+# test for comdb2_rowid
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "create table trowid(i int)"
 $CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "insert into trowid values(12345)"
 myrowid=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_rowid from trowid"`

--- a/tests/pmux.test/runit
+++ b/tests/pmux.test/runit
@@ -83,30 +83,40 @@ cleanup() {
 
 trap cleanup INT EXIT
 
-rng=`echo "range" | nc -W 1 localhost ${COMDB2_PMUX_PORT}`
+# nc -N would be better but not supported by older versions
+rng=`echo "range" | nc -w 1 localhost ${COMDB2_PMUX_PORT}`
 assertres "$rng" "$RANGE"
 
-(time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 100) &> out.txt
+
+MAX_ALLOWED_RESPONSE_DELAY=100 #ms
+
+(time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 100) | tee pmux_queries.out1
 res=$?
 if [ $res -ne 0 ] ; then
     failexit "pmux_queries returns $res"
 fi
 
-cat out.txt
-runtime=`grep real out.txt | sed 's/[^m]*m\([^\.]*\)\..*/\1/g'`
-    if [ "$runtime" -lt 1 ] ; then
-    time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 10000
+runtime=`grep real pmux_queries.out1 | sed 's/[^m]*m\([^\.]*\)\..*/\1/g'`
+if [ "$runtime" -lt 1 ] ; then
+    time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 10000 | tee pmux_queries.out2
     res=$?
     if [ $res -ne 0 ] ; then
         failexit "pmux_queries returns $res"
     fi
 fi
 
-time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 100000 --speedtest
+time ${TESTSBUILDDIR}/pmux_queries --pmuxport ${COMDB2_PMUX_PORT} --numthreads 10 --iterations 100000 --speedtest | tee pmux_queries.out3
 res=$?
 if [ $res -ne 0 ] ; then
     failexit "pmux_queries returns $res"
 fi
+
+for i in 1 2 3; do
+    if [[ -f pmux_queries.out${i} ]] && [[ `grep "Done Main" pmux_queries.out${i} | cut -f2 -d'='` -gt $MAX_ALLOWED_RESPONSE_DELAY ]] ; then
+        failexit "pmux_queries.out${i} max latency above MAX_ALLOWED_RESPONSE_DELAY=$MAX_ALLOWED_RESPONSE_DELAY"
+    fi
+done
+
 
 PMUXPORT=${COMDB2_PMUX_PORT} START_PORT=$STARTRANGE NUM_PORTS=100 UNIX_PATH="${TMPDIR}/pmux.${COMDB2_PMUX_PORT}" ./portmux.py --failfast --verbose
 res=$?

--- a/tests/tools/verify_atomics_work.c
+++ b/tests/tools/verify_atomics_work.c
@@ -9,11 +9,13 @@
 #include <stdint.h>
 #include <comdb2_atomic.h>
 
+#define DEBUG
+
 #define FORL(ii,s,e) for(int ii = s; ii < e; ii++)
 #define THREADNUM 10
 #define NUMTOADD 1000000
 
-void * add_a_million(void *arg)
+void *add_a_million(void *arg)
 {
     uint32_t *a = arg;
     FORL(i, 0, NUMTOADD) {
@@ -21,6 +23,32 @@ void * add_a_million(void *arg)
     }
     return NULL;
 }
+
+uint32_t gbl_max;
+
+#define MAX 1000000
+void *get_max_rand(void *arg)
+{
+    uint32_t old;
+    srandom(time(NULL));
+    int mymax = 0;
+    FORL(i, 0, MAX) {
+        uint32_t new = rand();
+        if (mymax < new)
+            mymax = new;
+        while((old = ATOMIC_LOAD32(gbl_max)) < new && !CAS32(gbl_max, old, new))
+            ; // keep trying
+
+        /* the above while loop is equivalent to the more friendly:
+         int res = 0;
+         while (!res && (old = ATOMIC_LOAD32(gbl_max)) < new)
+            res = CAS32(gbl_max, old, new);
+         */
+    }
+    assert(mymax <= ATOMIC_LOAD32(gbl_max));
+    return NULL;
+}
+
 
 
 int main()
@@ -37,5 +65,14 @@ int main()
         pthread_join(thv[i], &val);
     }
     assert(a == THREADNUM * NUMTOADD);
+
+    FORL(i, 0, THREADNUM) {
+        pthread_create(&thv[i], NULL, get_max_rand, &a);
+    }
+
+    FORL(i, 0, THREADNUM) {
+        void *val;
+        pthread_join(thv[i], &val);
+    }
     return 0;
 }


### PR DESCRIPTION
Since we test in docker, read times fluctuate so this change allows to print the worst read time and fail from `runit` script if we exceed preset `MAX_DELAY`. This way we will at least know what the worst read time is and adjust test accordingly.