### PR TITLE
Reduce protobuf memory footprint

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2914,6 +2914,9 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl,
 #if WITH_SSL
     features[n_features++] = CDB2_CLIENT_FEATURES__SSL;
 #endif
+    /* Request server to send back row data flat, instead of storing it in
+       a nested data structure. This helps reduce server's memory footprint. */
+    features[n_features++] = CDB2_CLIENT_FEATURES__FLAT_COL_VALS;
 
     if (hndl) { 
         features[n_features++] = CDB2_CLIENT_FEATURES__ALLOW_MASTER_DBINFO;
@@ -4966,23 +4969,47 @@ int cdb2_column_type(cdb2_hndl_tp *hndl, int col)
     return ret;
 }
 
+static int col_values_flattened(CDB2SQLRESPONSE *resp)
+{
+    return (resp->has_flat_col_vals && resp->flat_col_vals);
+}
+
 int cdb2_column_size(cdb2_hndl_tp *hndl, int col)
 {
-    if ((hndl->lastresponse == NULL) || (hndl->lastresponse->value == NULL))
+    CDB2SQLRESPONSE *lastresponse = hndl->lastresponse;
+    /* sanity check. just in case. */
+    if (lastresponse == NULL)
         return -1;
-    return hndl->lastresponse->value[col]->value.len;
+    /* data came back in the child column structure */
+    if (lastresponse->value != NULL)
+        return lastresponse->value[col]->value.len;
+    /* data came back in the parent CDB2SQLRESPONSE structure */
+    return (col_values_flattened(lastresponse)) ? lastresponse->values[col].len : -1;
 }
 
 void *cdb2_column_value(cdb2_hndl_tp *hndl, int col)
 {
-    if ((hndl->lastresponse == NULL) || (hndl->lastresponse->value == NULL))
+    CDB2SQLRESPONSE *lastresponse = hndl->lastresponse;
+    /* sanity check. just in case. */
+    if (lastresponse == NULL)
         return NULL;
-    if (hndl->lastresponse->value[col]->value.len == 0 &&
-        hndl->lastresponse->value[col]->has_isnull != 1 &&
-        hndl->lastresponse->value[col]->isnull != 1) {
-        return (void *)"";
+    /* data came back in the child column structure */
+    if (lastresponse->value != NULL) {
+        /* handle empty values */
+        if (lastresponse->value[col]->value.len == 0 && lastresponse->value[col]->has_isnull != 1 &&
+            lastresponse->value[col]->isnull != 1) {
+            return (void *)"";
+        }
+        return lastresponse->value[col]->value.data;
     }
-    return hndl->lastresponse->value[col]->value.data;
+    /* data came back in the parent CDB2SQLRESPONSE structure */
+    if (col_values_flattened(lastresponse)) {
+        /* handle empty values */
+        if (lastresponse->values[col].len == 0 && !lastresponse->isnulls[col])
+            return (void *)"";
+        return lastresponse->values[col].data;
+    }
+    return NULL;
 }
 
 int cdb2_bind_param(cdb2_hndl_tp *hndl, const char *varname, int type,

--- a/db/sql.h
+++ b/db/sql.h
@@ -859,6 +859,8 @@ struct sqlclntstate {
     int last_sent_row_sec; /* used to delay releasing locks when bdb_lock is
                               desired */
     int8_t rowbuffer;
+    /* 1 if client has requested flat column values. */
+    int flat_col_vals;
 };
 
 /* Query stats. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5217,6 +5217,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     set_asof_snapshot(clnt, 0, __func__, __LINE__);
     clnt->sqltick = 0;
     clnt->rowbuffer = 1;
+    clnt->flat_col_vals = 0;
     if (gbl_sockbplog) {
         init_bplog_socket(clnt);
     }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -612,14 +612,27 @@ static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
     if (!appdata->sqlquery->little_endian)
 #endif
         flip = 1;
+
+    /* nested column values */
     CDB2SQLRESPONSE__Column cols[ncols];
     CDB2SQLRESPONSE__Column *value[ncols];
+
+    /* flat column values */
+    ProtobufCBinaryData bd[ncols];
+    protobuf_c_boolean isnulls[ncols];
+
+    memset(&bd, 0, sizeof(ProtobufCBinaryData) * ncols);
+    memset(&isnulls, 0, sizeof(protobuf_c_boolean) * ncols);
+
     for (int i = 0; i < ncols; ++i) {
-        value[i] = &cols[i];
+        if (!clnt->flat_col_vals)
+            value[i] = &cols[i];
         cdb2__sqlresponse__column__init(&cols[i]);
         if (!sqlite3_can_get_column_type_and_data(clnt, stmt) ||
                 column_type(clnt, stmt, i) == SQLITE_NULL) {
             newsql_null(cols, i);
+            if (clnt->flat_col_vals)
+                isnulls[i] = cols[i].has_isnull ? cols[i].isnull : 0;
             continue;
         }
         int type = appdata->type[i];
@@ -688,15 +701,27 @@ static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
         default:
             return -1;
         }
+
+        if (clnt->flat_col_vals)
+            bd[i] = cols[i].value;
     }
     CDB2SQLRESPONSE r = CDB2__SQLRESPONSE__INIT;
     r.response_type = RESPONSE_TYPE__COLUMN_VALUES;
-    r.n_value = ncols;
-    r.value = value;
+    if (clnt->flat_col_vals) {
+        r.has_flat_col_vals = 1;
+        r.flat_col_vals = 1;
+        r.n_values = r.n_isnulls = ncols;
+        r.values = bd;
+        r.isnulls = isnulls;
+    } else {
+        r.n_value = ncols;
+        r.value = value;
+    }
     if (clnt->num_retry) {
         r.has_row_id = 1;
         r.row_id = arg->row_id;
     }
+
     if (postpone) {
         return newsql_save_postponed_row(clnt, &r);
     } else if (arg->pingpong) {

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -716,6 +716,13 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
 
     CDB2SQLQUERY *sql_query = query->sqlquery;
 
+    for (int ii = 0; ii < sql_query->n_features; ++ii) {
+        if (CDB2_CLIENT_FEATURES__FLAT_COL_VALS == sql_query->features[ii]) {
+            clnt.flat_col_vals = 1;
+            break;
+        }
+    }
+
     if (!clnt.admin && do_query_on_master_check(dbenv, &clnt, sql_query))
         goto done;
 

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -21,6 +21,8 @@ enum CDB2ClientFeatures {
     ALLOW_QUEUING        = 4;
     /* To tell the server that the client is SSL-capable. */
     SSL                  = 5;
+    /* flat column values. see sqlresponse.proto for more details. */
+    FLAT_COL_VALS   = 6;
 }
 
 message CDB2_FLAG {

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -150,4 +150,13 @@ message CDB2_SQLRESPONSE {
     optional uint64 row_id   = 8; // in case of retry, this will be used to identify the rows which need to be discarded
     repeated CDB2ServerFeatures  features = 9; // This can tell client about features enabled in comdb2
     optional string info_string = 10;
+
+    /* True if return row data directly under CDB2_SQLRESPONSE, instead of using a nested `CDB2_SQLRESPONSE.column'
+       message. A nested message is more readable, but comes with an overhead: protobuf_c_message_pack_to_buffer() must
+       first pack a nested message into main memory to get its serialized size, and encode the size in the message header.
+       This means that for each column value that is being serialized, we end up using memory 2x of its size.
+       We can avoid the overhead by collapsing the nested CDB2_SQLRESPONSE.column message into its parent message. */
+    optional bool flat_col_vals = 11;
+    repeated bytes values = 12;
+    repeated bool isnulls = 13;
 }


### PR DESCRIPTION
Currently row data is returned in a nested protobuf message, as below.

```
message CDB2_SQLRESPONSE {
    message Column {
        ...
    }
}
```

The patch, instead, returns row data directly under CDB2_SQLRESPONSE.

A nested message is more readable, but comes with an overhead: `protobuf_c_message_pack_to_buffer()` must first pack a nested message into main memory to get its serialized size. This means that for each column value that is being serialized, we end up using memory 2x of its size. We can avoid the overhead by collapsing the nested `CDB2_SQLRESPONSE.column` message into its parent message.

(DRQS 165828409)