### PR TITLE
Reduce protobuf memory footprint (7.0)

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -860,6 +860,8 @@ struct sqlclntstate {
 
     // Latch last statement's cost for comdb2_last_cost to fetch
     int64_t last_cost;
+    /* 1 if client has requested flat column values. */
+    int flat_col_vals;
 };
 
 /* Query stats. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5370,6 +5370,7 @@ void reset_clnt(struct sqlclntstate *clnt, SBUF2 *sb, int initial)
     clnt->statement_query_effects = 0;
     clnt->wrong_db = 0;
     clnt->sqltick = 0;
+    clnt->flat_col_vals = 0;
 }
 
 void reset_clnt_flags(struct sqlclntstate *clnt)

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -19,6 +19,8 @@ enum CDB2ClientFeatures {
     ALLOW_QUEUING        = 4;
     /* To tell the server that the client is SSL-capable. */
     SSL                  = 5;
+    /* flat column values. see sqlresponse.proto for more details. */
+    FLAT_COL_VALS   = 6;
 }
 
 message CDB2_FLAG {

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -140,4 +140,13 @@ message CDB2_SQLRESPONSE {
     optional uint64 row_id   = 8; // in case of retry, this will be used to identify the rows which need to be discarded
     repeated CDB2ServerFeatures  features = 9; // This can tell client about features enabled in comdb2
     optional string info_string = 10;
+
+    /* True if return row data directly under CDB2_SQLRESPONSE, instead of using a nested `CDB2_SQLRESPONSE.column'
+       message. A nested message is more readable, but comes with an overhead: protobuf_c_message_pack_to_buffer() must
+       first pack a nested message into main memory to get its serialized size. This means that for each column value
+       that is being serialized, we end up using memory 2x of its size. We can avoid the overhead by collapsing the nested
+       CDB2_SQLRESPONSE.column message. */
+    optional bool flat_col_vals = 11;
+    repeated bytes values = 12;
+    repeated bool isnulls = 13;
 }


### PR DESCRIPTION
Row data is returned in a nested protobuf message, as below.

```
message CDB2_SQLRESPONSE {
    message Column {
        ...
    }
}
```

The patch, instead, returns row data directly under `CDB2_SQLRESPONSE`.

A nested message is more readable, but comes with an overhead: protobuf_c_message_pack_to_buffer() must first pack a nested message into main memory to get its serialized size. This means that for each column value that is being serialized, we end up using memory 2x of its size. We can avoid the overhead by collapsing the nested CDB2_SQLRESPONSE.column message into its parent message.

(DRQS 165828409)