### PR TITLE
On cleanup call thd_cleanup function for pool_t objects

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1248,9 +1248,10 @@ int bdb_del_list_free(void *list, int *bdberr)
     listc_t *list_ptr = list;
 
     /* free each item */
-    LISTC_FOR_EACH_SAFE(list_ptr, item, tmp, lnk)
-    /* remove and free item */
-    free(listc_rfl(list, item));
+    LISTC_FOR_EACH_SAFE(list_ptr, item, tmp, lnk) {
+        /* remove and free item */
+        free(listc_rfl(list, item));
+    }
 
     listc_free(list);
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1809,6 +1809,7 @@ extern int gbl_test_io_errors;
 /* init routines */
 int appsock_init(void);
 int thd_init(void);
+void thd_cleanup();
 void sqlinit(void);
 void sqlnet_init(void);
 int clnt_stats_init(void);

--- a/tests/grace_period_on_exit.test/lrl.options
+++ b/tests/grace_period_on_exit.test/lrl.options
@@ -1,0 +1,1 @@
+exitalarmsec 100

--- a/tests/logfill.test/Makefile
+++ b/tests/logfill.test/Makefile
@@ -4,5 +4,5 @@ else
 	include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=15m
+	export TEST_TIMEOUT=20m
 endif

--- a/tests/setup
+++ b/tests/setup
@@ -99,14 +99,6 @@ setup_db() {
     fi
     echo "eventlog_nkeep 0" >> ${LRL}
 
-    if [[ -f lrl ]]; then
-        cat lrl >> ${LRL}
-    fi
-    if [[ -f lrl.options ]]; then
-        # use sed to substitute in test specific variables into lrl
-        cat lrl.options | sed "s#\${TESTDIR}#${TESTDIR}#" >> ${LRL}
-    fi
-
     echo -e "name    ${DBNAME}\ndir     ${DBDIR}\n\nsetattr MASTER_REJECT_REQUESTS 0" >> ${LRL}
     echo -e "forbid_remote_admin off" >> ${LRL}
 
@@ -144,6 +136,15 @@ setup_db() {
         echo "comdb2_config:portmuxport=${PMUXPORT}" >> $CDB2_CONFIG
         echo "portmux_port ${PMUXPORT}" >> ${LRL}
         echo "portmux_bind_path $pmux_socket" >> ${LRL}
+    fi
+
+    # let test specific lrl options take precedence
+    if [[ -f lrl ]]; then
+        cat lrl >> ${LRL}
+    fi
+    if [[ -f lrl.options ]]; then
+        # use sed to substitute in test specific variables into lrl
+        cat lrl.options | sed "s#\${TESTDIR}#${TESTDIR}#" >> ${LRL}
     fi
 
     SSH_OPT="-o StrictHostKeyChecking=no "

--- a/tools/cdb2sockpool/cdb2sockpool.c
+++ b/tools/cdb2sockpool/cdb2sockpool.c
@@ -30,6 +30,7 @@
 
 #include <errno.h>
 #include <pthread.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -144,7 +145,7 @@ static int pthread_create_attrs(pthread_t *tid, int detachstate,
         tid = &local_tid;
     Pthread_attr_init(&attr);
 
-    if (stacksize > 0) {
+    if (stacksize > PTHREAD_STACK_MIN) {
         Pthread_attr_setstacksize(&attr, stacksize);
     }
     rc = pthread_attr_setdetachstate(&attr, detachstate);

--- a/util/averager.c
+++ b/util/averager.c
@@ -55,7 +55,8 @@ struct averager *averager_new(int limit, int maxpoints)
     return avg;
 }
 
-void averager_clear(struct averager *avg) {
+void averager_clear(struct averager *avg)
+{
     struct tick *t;
     t = listc_rtl(&avg->ticks);
     while (t) {


### PR DESCRIPTION
* cleanup pool_t objects via thd_cleanup: while not a leak, this frees more than 660KB on exit and makes it easier to identify next items to cleanup
* break down gbl_thd_linger cond_wait to one second chunks
  and break/exit as early as possible
* tests setup: append test lrl last to take precedence
* pthread_attr_setstacksize will fail if size < PTHREAD_STACK_MIN
* set gbl_db_is_exiting to timestamp of exiting

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>