### PR TITLE
Small refactor to print errors in cursor.c and portmuxusr.c

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -2438,25 +2438,19 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 
     bdberr = 0;
     rc = ddguard_bdb_cursor_move(thd, pCur, 0, &bdberr, how, NULL, 0);
-    if (bdberr == BDBERR_NOT_DURABLE) {
-        return SQLITE_CLIENT_CHANGENODE;
-    }
-    if (bdberr == BDBERR_TRANTOOCOMPLEX) {
-        return SQLITE_TRANTOOCOMPLEX;
-    }
-    if (bdberr == BDBERR_TRAN_CANCELLED) {
-        return SQLITE_TRAN_CANCELLED;
-    }
-    if (bdberr == BDBERR_NO_LOG) {
-        return SQLITE_TRAN_NOLOG;
-    }
-    if (bdberr == BDBERR_DEADLOCK) {
+    switch(bdberr) {
+    case BDBERR_NOT_DURABLE: return SQLITE_CLIENT_CHANGENODE;
+    case BDBERR_TRANTOOCOMPLEX: return SQLITE_TRANTOOCOMPLEX;
+    case BDBERR_TRAN_CANCELLED: return SQLITE_TRAN_CANCELLED;
+    case BDBERR_NO_LOG: return SQLITE_TRAN_NOLOG;
+    case BDBERR_DEADLOCK:
         logmsg(LOGMSG_ERROR, "%s: too much contention, retried %d times [%llx]\n", __func__,
                gbl_move_deadlk_max_attempt, clnt->osql.rqid);
         ctrace("%s: too much contention, retried %d times [%llx]\n", __func__, gbl_move_deadlk_max_attempt,
                clnt->osql.rqid);
         return SQLITE_DEADLOCK;
     }
+
     if (rc == IX_FND || rc == IX_NOTFND) {
         void *buf;
         int sz;
@@ -2520,7 +2514,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 
         rc = 0;
     } else if (rc == IX_ACCESS) {
-        return SQLITE_ACCESS;
+        outrc = SQLITE_ACCESS;
     } else if (rc) {
         logmsg(LOGMSG_ERROR, "%s dir %d rc %d bdberr %d\n", __func__, how, rc, bdberr);
         outrc = SQLITE_INTERNAL;
@@ -2569,30 +2563,21 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
     if (how == CNEXT) {
         pCur->num_nexts++;
 
-        if (gbl_prefaulthelper_sqlreadahead)
-            if (pCur->num_nexts == gbl_sqlreadaheadthresh) {
-                pCur->num_nexts = 0;
-                readaheadpf(&iq, pCur->db, pCur->ixnum, pCur->fndkey,
-                            getkeysize(pCur->db, pCur->ixnum),
-                            gbl_sqlreadahead);
-            }
+        if (gbl_prefaulthelper_sqlreadahead && pCur->num_nexts == gbl_sqlreadaheadthresh) {
+            pCur->num_nexts = 0;
+            readaheadpf(&iq, pCur->db, pCur->ixnum, pCur->fndkey,
+                        getkeysize(pCur->db, pCur->ixnum), gbl_sqlreadahead);
+        }
     }
 
     bdberr = 0;
     rc = ddguard_bdb_cursor_move(thd, pCur, 0, &bdberr, how, &iq, 0);
-    if (bdberr == BDBERR_NOT_DURABLE) {
-        return SQLITE_CLIENT_CHANGENODE;
-    }
-    if (bdberr == BDBERR_TRANTOOCOMPLEX) {
-        return SQLITE_TRANTOOCOMPLEX;
-    }
-    if (bdberr == BDBERR_TRAN_CANCELLED) {
-        return SQLITE_TRAN_CANCELLED;
-    }
-    if (bdberr == BDBERR_NO_LOG) {
-        return SQLITE_TRAN_NOLOG;
-    }
-    if (bdberr == BDBERR_DEADLOCK) {
+    switch(bdberr) {
+    case BDBERR_NOT_DURABLE: return SQLITE_CLIENT_CHANGENODE;
+    case BDBERR_TRANTOOCOMPLEX: return SQLITE_TRANTOOCOMPLEX;
+    case BDBERR_TRAN_CANCELLED: return SQLITE_TRAN_CANCELLED;
+    case BDBERR_NO_LOG: return SQLITE_TRAN_NOLOG;
+    case BDBERR_DEADLOCK:
         logmsg(LOGMSG_ERROR, "%s too much contention, retried %d times.\n", __func__,
                 gbl_move_deadlk_max_attempt);
         ctrace("%s: too much contention, retried %d times [%llx]\n", __func__,
@@ -2601,7 +2586,9 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
                    ? thd->clnt->osql.rqid
                    : 0);
         return SQLITE_DEADLOCK;
-    } else if (rc == IX_FND || rc == IX_NOTFND) {
+    }
+
+    if (rc == IX_FND || rc == IX_NOTFND) {
         void *buf;
         int sz;
         uint8_t _;
@@ -2641,8 +2628,6 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
     if (rc == IX_EMPTY) {
         pCur->empty = 1;
         *pRes = 1;
-    } else if (rc == IX_ACCESS) {
-        return SQLITE_ACCESS;
     } else if (rc == IX_PASTEOF) {
         pCur->eof = 1;
         *pRes = 1;
@@ -2681,6 +2666,8 @@ static int cursor_move_index(BtCursor *pCur, int *pRes, int how)
            logmsg(LOGMSG_ERROR, "%s: ondisk_to_sqlite_tz error rc = %d\n", __func__, rc);
             outrc = SQLITE_INTERNAL;
         }
+    } else if (rc == IX_ACCESS) {
+        outrc = SQLITE_ACCESS;
     } else if (rc) {
         logmsg(LOGMSG_ERROR, "%s dir %d rc %d bdberr %d\n", __func__, how, rc, bdberr);
         outrc = SQLITE_INTERNAL;

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -102,7 +102,10 @@ echo Starting $TESTCASE with id $TESTID at $DATETIME >> ${TEST_LOG}
 mkdir -p ${TESTDIR}/logs/
 
 call_unsetup() {
-    [[ $COMDB2_UNITTEST == 1 ]] && return
+    if [[ $COMDB2_UNITTEST == 1 ]] || [[ "$LEAVEDBRUNNING" == "1" ]] ; then 
+        return
+    fi
+
     ${TESTSROOTDIR}/unsetup $successful &> >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' | tee ${TESTDIR}/logs/${DBNAME}.unsetup | cut -c11- | grep "^!" )
 }
 

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -170,17 +170,22 @@ int portmux_cmd(const char *cmd, const char *app, const char *service,
     SBUF2 *ss;
     int rc, fd, port;
     rc = snprintf(name, sizeof(name), "%s/%s/%s", app, service, instance);
-    if (rc < 1 || rc >= sizeof(name))
+    if (rc < 1 || rc >= sizeof(name)) {
+        logmsg(LOGMSG_ERROR, "%s: snprintf truncated output, rc %d\n", __func__, rc);
         return -1;
+    }
     if (PORTMUX_VALIDATE_NAMES())
         portmux_validate_name(name, __func__);
     fd = tcpconnecth("localhost", get_portmux_port(), 0);
-    if (fd < 0)
+    if (fd < 0) {
+        logmsg(LOGMSG_ERROR, "%s: tcpconnecth fd -1\n", __func__);
         return -1;
+    }
 
     ss = sbuf2open(fd, SBUF2_WRITE_LINE);
     if (ss == 0) {
         close(fd);
+        logmsg(LOGMSG_ERROR, "%s: sbuf2open error\n", __func__);
         return -1;
     }
     sbuf2printf(ss, "%s %s%s\n", cmd, name, post);
@@ -188,11 +193,19 @@ int portmux_cmd(const char *cmd, const char *app, const char *service,
     sbuf2gets(res, sizeof(res), ss);
     sbuf2close(ss);
 
-    if (res[0] == 0)
+    if (res[0] == 0) {
+        logmsg(LOGMSG_ERROR, "%s: sbuf2gets read 0\n", __func__);
         return -1;
+    }
+    if (strcmp(res, "-1 service already active") == 0) {
+        logmsg(LOGMSG_ERROR, "%s: Service with this name (%s) is already active (running)\n", __func__, name);
+        return -1;
+    }
     port = atoi(res);
-    if (port <= 0)
+    if (port <= 0) {
+        logmsg(LOGMSG_ERROR, "%s: atoi error (res='%s' name=%s)\n", __func__, res, name);
         port = -1;
+    }
     return port;
 }
 


### PR DESCRIPTION
* Print clear message for any errors in portmuxusr.c
* Print error if MERGE_DEBUG is enabled--useful while debugging
* Leave db running after test is done if $LEAVEDBRUNNING is set

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>