### PR TITLE
avoid deadlock when sql engine if full with coordinators

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1839,6 +1839,7 @@ extern int gbl_dohast_verbose;
 extern int gbl_dohsql_max_queued_kb_highwm;
 extern int gbl_dohsql_full_queue_poll_msec;
 extern int gbl_dohsql_max_threads;
+extern int gbl_dohsql_pool_thr_slack;
 
 extern int gbl_logical_live_sc;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1622,6 +1622,12 @@ REGISTER_TUNABLE(
     TUNABLE_INTEGER, &gbl_dohsql_max_threads, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE(
+    "dohsql_pool_thread_slack",
+    "Forbid parallel sql coordinators from running on this many sql engines"
+    " (if 0, defaults to 1).",
+    TUNABLE_INTEGER, &gbl_dohsql_pool_thr_slack, NOZERO, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE(
     "dohsql_full_queue_poll_msec",
     "Poll milliseconds while waiting for coordinator to consume from queue.",
     TUNABLE_INTEGER, &gbl_dohsql_full_queue_poll_msec, 0, NULL, NULL, NULL,

--- a/db/shard_range.h
+++ b/db/shard_range.h
@@ -25,6 +25,7 @@ enum {
     SHARD_ERR_MALLOC = -3,
     SHARD_ERR_PARAMS = -4,
     SHARD_ERR_TOOMANYTHR = -5,
+    SHARD_ERR_LOAD = -6,
 };
 
 struct Expr;

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -87,6 +87,29 @@ To dump the SQL thread pool every time the queue is full:
 
 `sqlenginepool maxq dump_on_error on`
 
+### Parallel sql execution
+
+A subset of sql queries can run in parallel, using multiple sql engines and scaling up the numbers of rows per second returned to the client.
+The statements that can be run in parallel are decomposed in a set of sql statements, which run in parallel in dedicated sql engines.  
+The sql engine initiating the parallel execution becomes the coordinator, which does row aggregation and final computations before sending
+the rows back to the client.
+A trivial case is the `UNION ALL` query.  Each `SELECT` query that is part of a `UNION ALL` statement runs in parallel with the rest.  
+This feature makes possible to scale up the throughput of sql queries, proportional with the amount of allocated resources.  Additionally, this
+feature can also benefit cases where per row retrieval cost is high, either due to I/O latency or the computation required.
+
+Settings:
+
+|Option              |Default              |Description
+|--------------------|---------------------|------------
+|dohast_disable | 0 | Disable SQL decomposition phase, required to distribute the sql query (in effect, disables the parallel execution mode). 
+|dohsql_disable | 0 | Disable parallel sql execution (the SQL decomposition is still performed)
+|dohsql_verbose | 0 | Enable debug information for parallel execution phase
+|dohast_verbose | 0 | Enable debug information for parallel execution phase
+|dohsql_max_queued_kb_highwm | 10000 | Maximum shard queue size, in KB; throttles amount of cached rows by each parallel component
+|dohsql_max_threads | 8 | Allow only up to 8 parallel components. If more are required, statement runs sequential
+|dohsql_pool_thread_slack | 1 | Reserve a number of sql engines to run only non-parallel load (including parallel components).  
+
+
 ### Networks
 
 There are a few references to various "networks" in the descriptions below.  All machines specified by the 

--- a/tests/dohsql_overload.test/Makefile
+++ b/tests/dohsql_overload.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/dohsql_overload.test/README
+++ b/tests/dohsql_overload.test/README
@@ -1,0 +1,1 @@
+This test checks the queuing of parallel queries when pool is full. Test will timeout if there is a problem.

--- a/tests/dohsql_overload.test/lrl.options
+++ b/tests/dohsql_overload.test/lrl.options
@@ -1,0 +1,2 @@
+table t t.csc2
+sqlenginepool maxt 2

--- a/tests/dohsql_overload.test/runit
+++ b/tests/dohsql_overload.test/runit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default 'select comdb2_host()'`
+echo "target machine is $mach"
+if [[ -z "$mach" ]] ; then
+    echo "Failed to get machine name"
+    exit 1
+fi
+
+set -e 
+
+cdb2sql --host ${mach} ${CDB2_OPTIONS} ${DBNAME} default 'insert into t select value from generate_series(1, 100)'
+
+for i in 1 2 3 4 5 6 7 8 9 10 ; do
+    cdb2sql --host ${mach} ${CDB2_OPTIONS} ${DBNAME} default 'select * from t union all select * from t' > /dev/null &
+done
+
+wait
+
+echo "SUCCESS"

--- a/tests/dohsql_overload.test/t.csc2
+++ b/tests/dohsql_overload.test/t.csc2
@@ -1,0 +1,4 @@
+schema
+{
+   int  a
+}

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=938)
+(TUNABLES_COUNT=939)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -231,6 +231,7 @@
 (name='dohsql_full_queue_poll_msec', description='Poll milliseconds while waiting for coordinator to consume from queue.', type='INTEGER', value='10', read_only='N')
 (name='dohsql_max_queued_kb_highwm', description='Maximum shard queue size, in KB; shard sqlite will pause once queued bytes limit is reached.', type='INTEGER', value='10000', read_only='N')
 (name='dohsql_max_threads', description='Maximum number of parallel threads, otherwise run sequential.', type='INTEGER', value='8', read_only='N')
+(name='dohsql_pool_thread_slack', description='Forbid parallel sql coordinators from running on this many sql engines (if 0, defaults to 1).', type='INTEGER', value='0', read_only='N')
 (name='dohsql_verbose', description='Run distributed queries in verbose/debug mode', type='BOOLEAN', value='OFF', read_only='N')
 (name='dont_abort_on_in_use_rqid', description='Disable 'abort_on_in_use_rqid'', type='BOOLEAN', value='OFF', read_only='Y')
 (name='dont_forbid_ulonglong', description='Disables 'forbid_ulonglong'', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
Bug: if all sql engines in a node are running coordinators for parallel sql execution, there is no progress since workers have no sql engines to run on.  Therefore, while the coordinators are blocked in sql engines waiting for workers to proceed, workers are waiting in queue for additional sql engines.  
Fix: we introduce a new configurable setting, "**dohsql_pool_thread_slack**", that reserves a number of sql engines for non-coordinator work.  It is never less than 1.  
In a nutshell, the reserved engines are able to drain the sql queue, which includes parallel sql workers, and allow the dohsql coordinators to make progress.


Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
