### PR TITLE
windows functions violate some of our sql generating asserts

### DIFF
--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -6335,6 +6335,9 @@ default_prec:
     }
     case TK_COLUMN: {
       char *name;
+      if (!pExpr->y.pTab) /* windows function? */
+        return NULL;
+
       assert(pExpr->y.pTab &&
         (pExpr->iColumn >= -3 && pExpr->y.pTab->nCol > pExpr->iColumn));
       switch(pExpr->iColumn) {


### PR DESCRIPTION
Dohsql is not windows function ready.  I didn't think we have released this new syntax.  Make sure we do not try to parse them for now.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>


