### PR TITLE
Add ability to abort transaction past a TTL limit

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -325,7 +325,8 @@ enum RCODES {
     ERR_NESTED = 1001,         /* this is not master, returns actual master */
     ERR_RMTDB_NESTED = 198,    /* reserved for use by rmtdb/prox2 */
     ERR_BADREQ = 199,          /* bad request parameters */
-    ERR_TRAN_TOO_BIG = 208,
+    ERR_TRAN_TOO_BIG = 208,    /* transaction exceeded size limit */
+    ERR_TXN_EXCEEDED_TIME_LIMIT = 209,
     ERR_BLOCK_FAILED = 220,  /* block update failed */
     ERR_NOTSERIAL = 230,     /* transaction not serializable */
     ERR_SC = 240,            /* schemachange failed */
@@ -1374,6 +1375,7 @@ struct ireq {
 
     uint64_t txnsize;
     unsigned long long last_genid;
+    uint64_t txn_ttl_ms; /* txn time to live -- abort after this time */
 
     /* if we replicated then these get updated */
     int reptimems;

--- a/db/comdb2_rcodes.h
+++ b/db/comdb2_rcodes.h
@@ -115,6 +115,7 @@ enum comdb2_cstrt_rc {
     COMDB2_CSTRT_RC_INVL_TAG = 10711,    /**< invalid tag detected */
     COMDB2_CSTRT_RC_INTL_ERR = 10712,    /**< internal error from berk */
     COMDB2_CSTRT_RC_TRN_TOO_BIG = 10713, /**< transaction too large */
+    COMDB2_CSTRT_RC_TRN_TIMEOUT = 10714, /**< transaction exceeded time limit */
 };
 
 enum comdb2_qadd_rc {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -141,6 +141,7 @@ extern int gbl_rep_verify_always_grab_writelock;
 extern int gbl_rep_verify_will_recover_trace;
 extern uint32_t gbl_max_wr_rows_per_txn;
 extern uint32_t gbl_max_cascaded_rows_per_txn;
+extern uint32_t gbl_max_time_per_txn_ms;
 extern int gbl_force_serial_on_writelock;
 extern int gbl_processor_thd_poll;
 extern int gbl_time_rep_apply;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1387,6 +1387,9 @@ REGISTER_TUNABLE("max_wr_rows_per_txn",
 REGISTER_TUNABLE("max_cascaded_rows_per_txn",
                  "Set the max cascaded rows updated per transaction.", TUNABLE_INTEGER,
                  &gbl_max_cascaded_rows_per_txn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("max_time_per_txn_ms",
+                 "Set the max time allowed for transaction to finish", TUNABLE_INTEGER,
+                 &gbl_max_time_per_txn_ms, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("print_deadlock_cycles",
                  "Print every Nth deadlock cycle, set to 0 to turn off. (Default: 100)", TUNABLE_INTEGER,
                  &gbl_print_deadlock_cycles, NOARG, NULL, NULL, NULL, NULL);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -54,8 +54,10 @@
 #include "intern_strings.h"
 #include "sc_global.h"
 #include "schemachange.h"
+#include "gettimeofday_ms.h"
 
 extern int gbl_reorder_idx_writes;
+extern uint32_t gbl_max_time_per_txn_ms;
 
 
 struct blocksql_tran {
@@ -901,6 +903,8 @@ static int process_this_session(
     int flags = 0;
 
     iq->queryid = osql_sess_queryid(sess);
+    if (gbl_max_time_per_txn_ms)
+        iq->txn_ttl_ms = gettimeofday_ms() + gbl_max_time_per_txn_ms; 
 
     if (sess->rqid != OSQL_RQID_USE_UUID)
         reqlog_set_rqid(iq->reqlogger, &sess->rqid, sizeof(unsigned long long));

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -402,6 +402,17 @@ a certain cost, or prevent it from running further.
 |querylimit maxcost off|Turn off returning errors for queries over a cost limit
 |querylimit warn maxcost off|Turn off warnings for queries over a cost limit
 
+
+### Transaction limit settings
+
+These options limit a transaction on the master node.
+
+|option|Default|Description
+|------|-------|-----------
+max_wr_rows_per_txn| 0 | Set the max written rows per transaction -- inludes all rows written by a transaction, including cascaded operations
+max_cascaded_rows_per_txn | 0 | Set the max allowed cascaded rows written (updated) per transaction
+max_time_per_txn_ms | 0 | Set the max time allowed for a transaction to complete
+
 ### Decimal rounding options
 
 The rounding policy for rounding for columns of decimal types can be controlled with the `decimal_rounding` option. 

--- a/tests/cdb2api.test/t29.expected
+++ b/tests/cdb2api.test/t29.expected
@@ -2,6 +2,6 @@
 (rows inserted=1)
 (i=1)
 (i=2)
-[select * from t1 where i in (select sleep(5))] failed with rc -107 query timed out
+[select * from t1 where i in (select sleep(2))] failed with rc -107 query timed out
 (i=1)
 (i=2)

--- a/tests/cdb2api.test/t29.req
+++ b/tests/cdb2api.test/t29.req
@@ -2,5 +2,5 @@ insert into t1 values(1)
 insert into t1 values(2)
 set maxquerytime 1
 select * from t1
-select * from t1 where i in (select sleep(5))
+select * from t1 where i in (select sleep(2))
 select * from t1

--- a/tests/cdb2api.test/testinfo.txt
+++ b/tests/cdb2api.test/testinfo.txt
@@ -1,2 +1,0 @@
-testname: cdb2api
-version: r000018

--- a/tests/close_old_connections.test/testinfo.txt
+++ b/tests/close_old_connections.test/testinfo.txt
@@ -1,2 +1,0 @@
-testname: close_old_connections
-version: r000000

--- a/tests/max_wr_rows.test/runit
+++ b/tests/max_wr_rows.test/runit
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
 
 # Tests max_wr_rows_per_txn tunable
 debug=1
@@ -12,16 +15,16 @@ if [[ -z "$stage" ]]; then
 fi
 
 if [[ -n "$CLUSTER" ]]; then
-    echo "This test only works in NON-CLUSTERED mode."
-    exit 1
+    failexit "This test only works in NON-CLUSTERED mode."
 fi
 
 
 function createtables
 {
     [[ "$debug" == 1 ]] && set -x
-    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t1 {schema{int id} keys{ \"id\" = id }}" >/dev/null 2>&1
-    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t2 {schema{int id} keys{ dup \"id\" = id } constraints { \"id\" -> \"t1\":\"id\" on delete cascade on update cascade }}" >/dev/null 2>&1
+    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t1 {schema{int id} keys{ \"id\" = id }}"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t2 {schema{int id} keys{ dup \"id\" = id } constraints { \"id\" -> \"t1\":\"id\" on delete cascade on update cascade }}"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t3 (i int)"
 }
 
 function insert_records
@@ -32,10 +35,9 @@ function insert_records
     local i=0
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t1 (id) values ($val)" >/dev/null 2>&1
-    while [[ $i -lt $cnt ]] ; do
-        cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t2 (id) values ($val)" >/dev/null 2>&1
-        let i=i+1
-    done
+    for ((i=0; i < $cnt; i++)) ; do
+        echo "insert into t2 (id) values ($val)" 
+    done | cdb2sql ${CDB2_OPTIONS} $db $stage &> out.txt || failexit "inserting, see out.txt"
 }
 
 function runtest
@@ -52,48 +54,42 @@ function runtest
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "select count(*) from t2 where id = 5" 2>&1)
 
     if [[ "$x" != "(count(*)=200)" ]]; then 
-        echo "Update of 4 to 5 didn't cascade!"
-        exit 1
+        failexit "Update of 4 to 5 didn't cascade!"
     fi
 
     # This should fail
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 10"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 10 failed to prevent delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 10 failed to prevent delete cascade for 1!"
     fi
 
     # This should also fail
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 50"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 50 failed to prevent delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 50 failed to prevent delete cascade for 1!"
     fi
 
     # This should succeed
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 51"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != "(rows deleted=1)" ]]; then
-        echo "Tunable of 51 failed to allow delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 51 failed to allow delete cascade for 1!"
     fi
 
     # This should fail
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 1 where id = 2" 2>&1)
     if [[ "$x" != *"cascaded update exceeds max writes"* ]]; then
-        echo "Tunable of 100 failed to prevent update cascade from 2 to 1!"
-        exit 1
+        failexit "Tunable of 100 failed to prevent update cascade from 2 to 1!"
     fi
 
     # This should succeed
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 101"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 1 where id = 2" 2>&1)
     if [[ "$x" != "(rows updated=1)" ]]; then
-        echo "Tunable of 101 failed to allow update cascade from 2 to 1!"
-        exit 1
+        failexit "Tunable of 101 failed to allow update cascade from 2 to 1!"
     fi
 
     # Generate a file that will do 100 inserts of 2 into t2 in a single txn
@@ -112,8 +108,7 @@ function runtest
 
     if [[ "$x" != *"208"* ]]; then
         rm $fl
-        echo "Tunable of 99 failed to prevent insert of 100 records!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent insert of 100 records!"
     fi
 
     # Try the transaction again allowing 100 writes per txn: this should succeed
@@ -121,8 +116,7 @@ function runtest
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage - < $fl 2>&1)
     if [[ "$x" != *"rc 0"* ]]; then
         rm $fl
-        echo "Tunable of 100 failed to allow insert of 100 records!"
-        exit 1
+        failexit "Tunable of 100 failed to allow insert of 100 records!"
     fi
 
     rm $fl
@@ -134,31 +128,27 @@ function runtest
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 99"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t2 set id = 100 where id = 1" 2>&1)
     if [[ "$x" != *"208"* ]]; then
-        echo "Tunable of 99 failed to prevent update of 100 records!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent update of 100 records!"
     fi
 
     # Reset tunable to 100 & update again
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t2 set id = 100 where id = 1" 2>&1)
     if [[ "$x" != "(rows updated=100)" ]]; then
-        echo "Tunable of 100 failed to allow update of 100 records!"
-        exit 1
+        failexit "Tunable of 100 failed to allow update of 100 records!"
     fi
 
     # Set tunable to 99, attempt to delete (and fail)
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 99"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t2 where id = 100" 2>&1)
     if [[ "$x" != *"208"* ]]; then
-        echo "Tunable of 99 failed to prevent delete of 100 records!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent delete of 100 records!"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_wr_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t2 where id = 100" 2>&1)
     if [[ "$x" != "(rows deleted=100)" ]]; then
-        echo "Tunable of 100 failed to allow delete of 100 records!"
-        exit 1
+        failexit "Tunable of 100 failed to allow delete of 100 records!"
     fi
 }
 
@@ -177,15 +167,13 @@ function runtest_max_cascades
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 100 failed to prevent delete cascade!"
-        exit 1
+        failexit "Tunable of 100 failed to prevent delete cascade!"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 1000"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1" 2>&1)
     if [[ "$x" != "(rows deleted=3)" ]]; then
-        echo "Tunable of 1000 failed to allow delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 1000 failed to allow delete cascade for 1!"
     fi
 
 
@@ -199,8 +187,7 @@ function runtest_max_cascades
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "select count(*) from t2 where id = 5" 2>&1)
 
     if [[ "$x" != "(count(*)=200)" ]]; then 
-        echo "Update of 4 to 5 didn't cascade!"
-        exit 1
+        failexit "Update of 4 to 5 didn't cascade!"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "select count(*) from t1 where id = 1"
@@ -209,40 +196,35 @@ function runtest_max_cascades
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 10"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 10 failed to prevent delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 10 failed to prevent delete cascade for 1!"
     fi
 
     # This should also fail
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 49"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 50 failed to prevent delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 50 failed to prevent delete cascade for 1!"
     fi
 
     # This should succeed
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 50"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 1" 2>&1)
     if [[ "$x" != "(rows deleted=1)" ]]; then
-        echo "Tunable of 51 failed to allow delete cascade for 1!"
-        exit 1
+        failexit "Tunable of 51 failed to allow delete cascade for 1!"
     fi
 
     # This should fail
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 99"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 1 where id = 2" 2>&1)
     if [[ "$x" != *"cascaded update exceeds max writes"* ]]; then
-        echo "Tunable of 99 failed to prevent update cascade from 2 to 1!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent update cascade from 2 to 1!"
     fi
 
     # This should succeed
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 1 where id = 2" 2>&1)
     if [[ "$x" != "(rows updated=1)" ]]; then
-        echo "Tunable of 100 failed to allow update cascade from 2 to 1!"
-        exit 1
+        failexit "Tunable of 100 failed to allow update cascade from 2 to 1!"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "select count(*) from t1 where id = 1"
@@ -255,36 +237,48 @@ function runtest_max_cascades
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 99"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 100 where id = 1" 2>&1)
     if [[ "$x" != *"cascaded update exceeds max writes"* ]]; then
-        echo "Tunable of 99 failed to prevent update of 100 cascading records!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent update of 100 cascading records!"
     fi
 
     # Reset tunable to 100 & update again
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "update t1 set id = 100 where id = 1" 2>&1)
     if [[ "$x" != "(rows updated=1)" ]]; then
-        echo "Tunable of 100 failed to allow update of 100 cascading records!"
-        exit 1
+        failexit "Tunable of 100 failed to allow update of 100 cascading records!"
     fi
 
     # Set tunable to 98, attempt to delete (and fail)
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 99"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 100" 2>&1)
     if [[ "$x" != *"cascaded delete exceeds max writes"* ]]; then
-        echo "Tunable of 99 failed to prevent delete of 100 cascading records!"
-        exit 1
+        failexit "Tunable of 99 failed to prevent delete of 100 cascading records!"
     fi
 
     cdb2sql ${CDB2_OPTIONS} $db $stage "PUT TUNABLE max_cascaded_rows_per_txn 100"
     x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "delete from t1 where id = 100" 2>&1)
     if [[ "$x" != "(rows deleted=1)" ]]; then
-        echo "Tunable of 100 failed to allow delete of 100 cascading records!"
-        exit 1
+        failexit "Tunable of 100 failed to allow delete of 100 cascading records!"
     fi
+}
+
+function runtest_max_ttl
+{
+    cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t3 (i) values (1)"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 2000')"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t3 (i) values (2)"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "put tunable max_time_per_txn_ms 1000"
+    local x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t3 (i) values (3)" 2>&1)
+    if [[ "$x" != *"Transaction exceeds max time limit"* ]]; then
+        failexit "Expected: Transaction exceeds max time limit"
+    fi
+    # also assert that the last insert did not succeed
+    local cnt=`cdb2sql ${CDB2_OPTIONS} --tabs $db $stage "select count(i) from t3"`
+    assertres $cnt 2
 }
 
 createtables
 runtest
 runtest_max_cascades
+runtest_max_ttl
 
 echo "Success"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -466,6 +466,7 @@
 (name='max_sql_idle_time', description='Warn when an SQL connection remains idle for this long.', type='INTEGER', value='3600', read_only='N')
 (name='max_sqlcache_hints', description='Maximum number of "hinted" query plans to keep (global). (Default: 100)', type='INTEGER', value='100', read_only='Y')
 (name='max_sqlcache_per_thread', description='Maximum number of plans to cache per sql thread (statement cache is per-thread). (Default: 10)', type='INTEGER', value='10', read_only='Y')
+(name='max_time_per_txn_ms', description='Set the max time allowed for transaction to finish', type='INTEGER', value='0', read_only='N')
 (name='max_trigger_threads', description='Maximum number of trigger threads allowed', type='INTEGER', value='1000', read_only='N')
 (name='max_vlog_lsns', description='Apply up to this many replication record trying to maintain a snapshot transaction.', type='INTEGER', value='10000000', read_only='N')
 (name='max_wr_rows_per_txn', description='Set the max written rows per transaction.', type='INTEGER', value='0', read_only='N')

--- a/tests/writes_remsql_names.test/testinfo.txt
+++ b/tests/writes_remsql_names.test/testinfo.txt
@@ -1,2 +1,0 @@
-testname: writes_remsql_names
-version: r000004


### PR DESCRIPTION
Add ability to fail a transaction depending on time duration by
setting tunable max_time_per_txn_ms which controls the maximum point in time
we can perform an ins/upd/del on the master as part of a given txn.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>