### PR TITLE
Tests: Exclude long running tests by default

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -50,11 +50,16 @@ else
     DISABLED_TESTS:=" $(shell echo $(DISABLED_TESTS) | tr ' ' '\n' | sort -u) "
   endif
 
-  export DISABLED_TESTS
+  ifeq ($(INCLUDE_LONG_RUNNING),1)
+    FLG=
+  else
+    # by default exclude all tests which run longer than 1 hour
+    FLG=--skip-long-running
+  endif
 
   # This is the list of all non-disabled tests.
   export ALL_TESTS:=$(patsubst %.test, %, $(filter-out $(DISABLED_TESTS), \
-      $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh)))
+      $(shell $(TESTSROOTDIR)/tools/get_tests_inorder.sh $(FLG))))
 endif
 
 # get number of TOTAL tests running: used for printing progress report of tests

--- a/tests/TODO
+++ b/tests/TODO
@@ -80,7 +80,6 @@ netloss.test              -- does not pass most of the time; requires kernel 4.x
 phys_rep.test
 sc_async_constraints.test
 async_sc_bench.test       -- benchmark for paper
-queuedb_rollover_extended.test -- takes a very long time
 <END>
 
 # vim: set sw=4 ts=4 et:

--- a/tests/deadlock_load.test/runit
+++ b/tests/deadlock_load.test/runit
@@ -49,7 +49,7 @@ function run_tests
     echo "Number of deadlocks: $deadlocks, elapsed-time: $elapsed seconds"
     if [ -n "${CLUSTER}" ] ; then
       if [[ $DBNAME == *"noreordergenerated"* ]] ; then
-        [[ $deadlocks -lt 1000 ]] && failexit $func "too few deadlocks: $deadlocks"
+        [[ $deadlocks -lt 500 ]] && failexit $func "too few deadlocks: $deadlocks"
       else
         [[ $deadlocks -gt 50 ]] && failexit $func "too many deadlocks: $deadlocks"
       fi

--- a/tests/tools/get_tests_inorder.sh
+++ b/tests/tools/get_tests_inorder.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # Get list of tests in order from longest to shortest duration
 
+SKIPLONGRUNNING=0
+SHOWTIMEOUT=
+LONGESTFIRST=1
+
+while true ; do
+  case "$1" in
+  --skip-long-running) SKIPLONGRUNNING=1; shift;;
+  --show-timeout) SHOWTIMEOUT=1; shift;;
+  --shortest-first) LONGESTFIRST=0; shift;;
+  * ) break;;
+  esac
+done
+
 DEFAULT_TIMEOUT=5  # default timeout for the tests is 5 seconds
 
 #get the tests with custom times
@@ -13,8 +26,13 @@ IFS=$'\n';
 #get the generated tests
 generated=$(for j in */*.testopts ; do 
     basedir=${j%%/*}
-    time=`echo -e "${custom_times} \n${default_times}" | grep $basedir | awk '{print $2}'`
+    time=`echo -e "${custom_times} \n${default_times}" | grep "^$basedir" | awk '{print $2}'`
     echo $j $time
 done | sed 's#.test/#_#g; s#\.testopts#_generated.test#g;' )
 
-echo -e "${custom_times} \n${default_times} \n${generated}" | sort -k2 -t' ' -nr | cut -f1 -d' '
+F=${SHOWTIMEOUT:+,\$2}
+if [ "$LONGESTFIRST" -eq 1 ] ; then
+    SORTORDER="r"
+fi
+
+echo -e "${custom_times} \n${default_times} \n${generated}" | sort -k2 -t' ' -n${SORTORDER} | awk '{ if(!'$SKIPLONGRUNNING' || $2 < 120) { print $1'$F' } }'


### PR DESCRIPTION
Exclude by default tests that run for more than a given limit (120min).
In order to run with such tests, we can run `make $INCLUDE_LONG_RUNNING`

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>