### PR TITLE
Consolidate clnt members no_transaction and skip_peer_chk

### DIFF
--- a/db/db_access.c
+++ b/db/db_access.c
@@ -190,7 +190,7 @@ int access_control_check_sql_write(struct BtCursor *pCur,
 
     /* Check read access if its not user schema. */
     /* Check it only if engine is open already. */
-    if (gbl_uses_password && (thd->clnt->no_transaction == 0)) {
+    if (gbl_uses_password && (thd->clnt->in_sqlite_init == 0)) {
         rc = bdb_check_user_tbl_access(
             pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
             pCur->db->tablename, ACCESS_WRITE, &bdberr);
@@ -239,7 +239,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 
     /* Check read access if its not user schema. */
     /* Check it only if engine is open already. */
-    if (gbl_uses_password && thd->clnt->no_transaction == 0) {
+    if (gbl_uses_password && thd->clnt->in_sqlite_init == 0) {
         rc = bdb_check_user_tbl_access(
             pCur->db->dbenv->bdb_env, thd->clnt->current_user.name,
             pCur->db->tablename, ACCESS_READ, &bdberr);

--- a/db/sql.h
+++ b/db/sql.h
@@ -703,8 +703,6 @@ struct sqlclntstate {
     struct user current_user;
     int authgen;
 
-    int no_transaction;
-
     int have_extended_tm;
     int extended_tm;
 
@@ -799,7 +797,7 @@ struct sqlclntstate {
     uint8_t is_overlapping;
     uint32_t init_gen;
     int8_t gen_changed;
-    uint8_t skip_peer_chk;
+    uint8_t in_sqlite_init; /* clnt is in sqlite init phase when this is set */
     uint8_t queue_me;
     uint8_t fail_dispatch;
 


### PR DESCRIPTION
Member variables no_transaction and skip_peer_chk have the same use
so we should need only one with a more descriptive name: `in_sqlite_init`.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>