### PR TITLE
Fix comdb2_local.lrl read twice

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1506,7 +1506,7 @@ int read_lrl_files(struct dbenv *dbenv, const char *lrlname)
 
         /* local defaults */
         lrlfile = comdb2_location("config", "comdb2_local.lrl");
-        loaded_comdb2 = global_is_local(lrlfile, crtdir, "comdb2_local.lrl");
+        loaded_comdb2_local = global_is_local(lrlfile, crtdir, "comdb2_local.lrl");
         if (!read_lrl_file(dbenv, lrlfile, 0)) {
             free(lrlfile);
             return 0;


### PR DESCRIPTION
The typo means that the flag is not set when the `comdb2_local.lrl` files is read so it tries to read the file again.