### PR TITLE
Fix selectv rcode

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -773,6 +773,7 @@ struct sqlclntstate {
     /* read-set validation */
     CurRangeArr *arr;
     CurRangeArr *selectv_arr;
+    int selectv_rangechk; /* set to 1 to enable selectv-range-commit optimization. */
     char *prev_cost_string;
 
     int num_retry;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2044,7 +2044,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                     if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
                         clnt->early_retry = EARLY_ERR_GENCHANGE;
                 }
-                if (gbl_selectv_rangechk)
+                if (clnt->selectv_rangechk)
                     rc = selectv_range_commit(clnt);
                 if (rc) {
                     irc = osql_sock_abort(clnt, OSQL_SOCK_REQ);

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -277,8 +277,7 @@ static int rese_commit(struct sqlclntstate *clnt, struct sql_thread *thd,
 
     usedb_only = osql_shadtbl_usedb_only(clnt);
 
-    if (!force_master && usedb_only &&
-        (!gbl_selectv_rangechk || !clnt->selectv_arr)) {
+    if (!force_master && usedb_only && (!clnt->selectv_rangechk || !clnt->selectv_arr)) {
         sql_debug_logf(clnt, __func__, __LINE__, "empty-sv_arr, returning\n");
         return 0;
     }

--- a/tests/selectv_rcode.test/no_reorder.testopts
+++ b/tests/selectv_rcode.test/no_reorder.testopts
@@ -1,0 +1,1 @@
+reorder_socksql_no_deadlock off


### PR DESCRIPTION
In socksql mode, if selectv-range-check is enabled, but osql-reordering is disabled, selectv transactions may receive errors out of order.

Consider the following example:

```SQL

TXN 1                                          | TXN 2
                                               |
SET VERIFYRETRY OFF                            |
BEGIN                                          |
SELECTV * FROM t WHERE id = 1 -- SELECTV       |
UPDATE t SET id = 2 WHERE id = 1 -- UPDREC     |
                                               | UPDATE t SET id = 3 WHERE id = 1
COMMIT                                         |
```

Without reordering, master processes the opcodes in the order in which they were received. A selectv range is sent to master at commit time. Therefore, TXN 1 will get a verify error (since UPDREC is received and processed before SELECTV), instead of a selectv-constraint error.

An easy way to address the issue is to disable selectv-range-check in socksql mode if osql-reordering isn't enabled.
