### PR TITLE
Make listen() backlog configurable

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -359,6 +359,8 @@ int gbl_mask_internal_tunables = 1;
 size_t gbl_cached_output_buffer_max_bytes = 8 * 1024 * 1024; /* 8 MiB */
 int gbl_sqlite_sorterpenalty = 5;
 
+extern int gbl_net_maxconn;
+
 /*
   =========================================================
   Value/Update/Verify functions for some tunables that need

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2107,4 +2107,8 @@ REGISTER_TUNABLE("sc_logbytes_per_second",
                  "Throttle schema-changes to this many logbytes per second.  (Default: 10000000)",
                  TUNABLE_INTEGER, &gbl_sc_logbytes_per_second, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("net_somaxconn",
+                 "listen() backlog setting.  (Default: 0, implies system default)",
+                 TUNABLE_INTEGER, &gbl_net_maxconn, READONLY, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/net/event.c
+++ b/net/event.c
@@ -2494,7 +2494,7 @@ static void net_accept(netinfo_type *netinfo_ptr)
     }
     make_socket_nonblocking(fd);
     unsigned flags = LEV_OPT_LEAVE_SOCKETS_BLOCKING | LEV_OPT_CLOSE_ON_FREE;
-    n->listener = evconnlistener_new(base, do_accept, n, flags, SOMAXCONN, fd);
+    n->listener = evconnlistener_new(base, do_accept, n, flags, gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN, fd);
     logmsg(LOGMSG_INFO, "%s svc:%s accepting on port:%d fd:%d\n", __func__,
            netinfo_ptr->service, netinfo_ptr->myport, fd);
 }

--- a/net/net.c
+++ b/net/net.c
@@ -95,6 +95,8 @@ extern int db_is_exiting(void);
 int gbl_verbose_net = 0;
 int subnet_blackout_timems = 5000;
 
+int gbl_net_maxconn = 0;
+
 #ifdef PER_THREAD_MALLOC
 #define HOST_MALLOC(h, sz) ((gbl_libevent) ? malloc((sz)) : comdb2_malloc((h)->msp, (sz)))
 #else
@@ -6580,7 +6582,7 @@ int net_listen(int port)
     }
 
     /* listen for connections on socket */
-    if (listen(listenfd, SOMAXCONN) < 0) {
+    if (listen(listenfd, gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN) < 0) {
         logmsg(LOGMSG_ERROR, "%s: listen rc %d %s\n", __func__, errno,
                 strerror(errno));
         return -1;

--- a/net/net.h
+++ b/net/net.h
@@ -443,6 +443,8 @@ int net_send_all(netinfo_type *, int, void **, int *, int *, int *);
 
 extern int gbl_libevent;
 extern int gbl_libevent_rte_only;
+extern int gbl_net_maxconn;
+
 #if 0
 void add_tcp_event(int, void(*)(int, short, void *), void *);
 void add_udp_event(int, void(*)(int, short, void *), void *);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -519,6 +519,7 @@
 (name='net_poll', description='Allow a connection to linger for this many milliseconds before identifying itself. Connections that take longer are shut down. (Default: 100ms)', type='INTEGER', value='100', read_only='Y')
 (name='net_portmux_register_interval', description='Check on this interval if our port is correctly registered with pmux for the replication net. (Default: 600ms)', type='INTEGER', value='600', read_only='Y')
 (name='net_send_gblcontext', description='Enable net_send for USER_TYPE_GBLCONTEXT.', type='BOOLEAN', value='OFF', read_only='N')
+(name='net_somaxconn', description='listen() backlog setting.  (Default: 0, implies system default)', type='INTEGER', value='0', read_only='Y')
 (name='net_throttle_percent', description='', type='INTEGER', value='50', read_only='Y')
 (name='net_verbose', description='net_verbose', type='BOOLEAN', value='OFF', read_only='N')
 (name='netbufsz', description='Size of the network buffer (per node) for the replication network. (Default: 1MB)', type='INTEGER', value='1048576', read_only='Y')

--- a/util/tcputil.c
+++ b/util/tcputil.c
@@ -60,6 +60,8 @@ static int get_sndrcv_bufsize(void)
     return retval;
 }
 
+extern int gbl_net_maxconn;
+
 static int get_somaxconn(void)
 {
     static int once = 0;
@@ -76,7 +78,7 @@ static int get_somaxconn(void)
 
         once = 1;
     }
-    return retval;
+    return gbl_net_maxconn ? gbl_net_maxconn : retval;
 }
 
 /* Closing the socket fd on failure to prevent


### PR DESCRIPTION
Starting enough connections against a single node can result in failure if we have more pending connections then the server's listen() backlog.  Make the backlog tunable.