### PR TITLE
Make listen() backlog configurable

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1921,4 +1921,8 @@ REGISTER_TUNABLE("sync_osql_cancel", "Synchronous osql cancellation (Default: on
 REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("net_somaxconn",
+                 "listen() backlog setting.  (Default: 0, implies system default)",
+                 TUNABLE_INTEGER, &gbl_net_maxconn, READONLY, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/net/net.c
+++ b/net/net.c
@@ -118,6 +118,8 @@ extern int gbl_net_portmux_register_interval;
 int gbl_verbose_net = 0;
 int subnet_blackout_timems = 5000;
 
+int gbl_net_maxconn = 0;
+
 #ifdef PER_THREAD_MALLOC
 #define HOST_MALLOC(h, sz) comdb2_malloc((h)->msp, (sz))
 #else
@@ -6758,7 +6760,7 @@ int net_listen(int port)
     }
 
     /* listen for connections on socket */
-    if (listen(listenfd, SOMAXCONN) < 0) {
+    if (listen(listenfd, gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN) < 0) {
         logmsg(LOGMSG_ERROR, "%s: listen rc %d %s\n", __func__, errno,
                 strerror(errno));
         return -1;

--- a/net/net.h
+++ b/net/net.h
@@ -474,4 +474,6 @@ int64_t net_get_num_accept_timeouts(netinfo_type *netinfo_ptr);
 void net_set_conntime_dump_period(netinfo_type *netinfo_ptr, int value);
 int net_get_conntime_dump_period(netinfo_type *netinfo_ptr);
 
+extern int gbl_net_maxconn;
+
 #endif

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=942)
+(TUNABLES_COUNT=943)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -499,6 +499,7 @@
 (name='net_poll', description='Allow a connection to linger for this many milliseconds before identifying itself. Connections that take longer are shut down. (Default: 100ms)', type='INTEGER', value='100', read_only='Y')
 (name='net_portmux_register_interval', description='Check on this interval if our port is correctly registered with pmux for the replication net. (Default: 600ms)', type='INTEGER', value='600', read_only='Y')
 (name='net_send_gblcontext', description='Enable net_send for USER_TYPE_GBLCONTEXT.', type='BOOLEAN', value='OFF', read_only='N')
+(name='net_somaxconn', description='listen() backlog setting.  (Default: 0, implies system default)', type='INTEGER', value='0', read_only='Y')
 (name='net_throttle_percent', description='', type='INTEGER', value='50', read_only='Y')
 (name='net_verbose', description='net_verbose', type='BOOLEAN', value='OFF', read_only='N')
 (name='netbufsz', description='Size of the network buffer (per node) for the replication network. (Default: 1MB)', type='INTEGER', value='1048576', read_only='Y')

--- a/util/tcputil.c
+++ b/util/tcputil.c
@@ -60,6 +60,8 @@ static int get_sndrcv_bufsize(void)
     return retval;
 }
 
+extern int gbl_net_maxconn;
+
 static int get_somaxconn(void)
 {
     static int once = 0;
@@ -76,7 +78,7 @@ static int get_somaxconn(void)
 
         once = 1;
     }
-    return retval;
+    return gbl_net_maxconn ? gbl_net_maxconn : retval;
 }
 
 /* Closing the socket fd on failure to prevent


### PR DESCRIPTION
Starting enough connections against a single node can result in failure if we have more pending connections then the server's listen() backlog. Make the backlog tunable.