### PR TITLE
Fix SSL initialization error for OpenSSL versions below 1.1.0

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3829,9 +3829,6 @@ static int init(int argc, char **argv)
 
     init_file_locations(lrlname);
 
-    /* prepare the server class ahead of time */
-    get_my_mach_class();
-
     if (gbl_create_mode && lrlname == NULL) {
        if (gbl_dbdir == NULL)
           gbl_dbdir = comdb2_location("database", "%s", dbname);
@@ -3887,6 +3884,9 @@ static int init(int argc, char **argv)
     }
     logmsg(LOGMSG_INFO, "SSL backend initialized.\n");
 #endif
+
+    /* prepare the server class ahead of time, after libssl is initialized. */
+    get_my_mach_class();
 
     if (init_blob_cache() != 0) return -1;
 


### PR DESCRIPTION
OpenSSL versions older than 1.1.0 require an explicit initialization. The server's and client's ssl_init routines are consolidated into a single one, as part of bbcmake changes. As a result, the cdb2_ssl_init() call in util/rtcpu.c prevents ssl_bend_init() from explicitly initializing OpenSSL.

The patch fixes it by removing the cdb2_ssl_init() call in util/rtcpu.c.
