### PR TITLE
Fix repeated downgrade crashes due to session management

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3272,16 +3272,15 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
                 we_used = end_time - begin_time;
 
                 /* lets make up a number for how many more ms we should wait
-                   based
-                   on how long we had to wait for one guy */
+                   based on how long we had to wait for one guy */
                 waitms = (we_used * bdb_state->attr->rep_timeout_lag) / 100;
 
                 if (waitms < bdb_state->attr->rep_timeout_minms)
                     waitms = bdb_state->attr->rep_timeout_minms;
 
                 if (bdb_state->rep_trace)
-                    logmsg(LOGMSG_USER, "fastest node to <%s> was %dms, will wait "
-                                    "another %dms for remainder\n",
+                    logmsg(LOGMSG_USER,
+                           "fastest node to <%s> was %dms, will wait another %dms for remainder\n",
                             lsn_to_str(str, &(seqnum->lsn)), we_used, waitms);
 
                 goto got_ack;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1220,9 +1220,7 @@ struct osql_sess {
     unsigned long long rqid; /* identifies the client request session */
     uuid_t uuid;
     snap_uid_t *snap_info;
-
     sess_impl_t *impl;
-
     struct ireq *iq; /* iq used by block processor thread */
 
     char tzname[DB_MAX_TZNAMEDB]; /* tzname used for this request */

--- a/db/osqlrepository.h
+++ b/db/osqlrepository.h
@@ -34,7 +34,7 @@ int osql_repository_add(osql_sess_t *sess);
  * Removes an osql session from the repository
  * Returns 0 on success
  */
-void osql_repository_rem(osql_sess_t *sess);
+int osql_repository_rem(osql_sess_t *sess);
 
 /**
  * Retrieves a session based on rqid

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -1121,8 +1121,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
         !bdb_latest_commit_is_durable(thedb->bdb_env)) {
         if (IQ_HAS_SNAPINFO(iq)) {
             logmsg(LOGMSG_ERROR,
-                   "%u replay rc changed from %d to NOT_DURABLE "
-                   "for blkseq '%s'\n",
+                   "%u replay rc changed from %d to NOT_DURABLE for blkseq '%s'\n",
                    line, outrc, cnonce);
         }
         outrc = ERR_NOT_DURABLE;

--- a/plugins/sockbplog/sockbplog.c
+++ b/plugins/sockbplog/sockbplog.c
@@ -90,7 +90,7 @@ err:
 err_nomsg:
     if (sess) {
         osql_sess_remclient(sess);
-        osql_sess_close(&sess, 0);
+        osql_sess_close(&sess, 0); /* false so we dont delete it from the repository */
     } else {
         free(sql);
     }

--- a/tests/bplog_leaks.test/runit
+++ b/tests/bplog_leaks.test/runit
@@ -21,7 +21,7 @@ after=`cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("memstat
 
 delta=`expr $after - $before`
 if [ $delta -gt 524288 ]; then
-    echo leaky? >&2
+    echo "leaky? ($after > $before)" >&2
     exit 1
 fi
 
@@ -40,6 +40,6 @@ done
 cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("bdb temptable")'
 ntmptbls=`cdb2sql --tabs $dbnm --host $master 'exec procedure sys.cmd.send("bdb temptable")' | grep 'total objects' | awk '{print $NF}'`
 if [ $ntmptbls -gt 100 ] ; then
-    echo leaky? >&2
+    echo "leaky? ($ntmptbls > 100)" >&2
     exit 1
 fi

--- a/tests/repeated_downgrades.test/README
+++ b/tests/repeated_downgrades.test/README
@@ -1,14 +1,17 @@
 Repeatedly downgrade master making sure writes are durable
 
-Expand downgrade.test to repeatedly downgrade master while
+Expand on downgrade.test to repeatedly downgrade master while
 inserting/deleting and checking to make sure that writes
-correctly succeeded: the main way this can fail is when
-the client performs a write and gets a success return code
-from replicant, however if master was in the middle of a
-downgrade that write may have not been durable--durable lsns were
+correctly succeeded. The main concern is to make sure writes
+during a downgrade/mastership change are durable:
+
+when the client performs a write and gets a success return code
+from replicant, if master was in the middle of a downgrade
+that write may have not been durable--durable lsns feature are
 supposed to fix this issue.
 
-Issues observed when running this test repeatedly:
+
+Initial issues observed when running this test repeatedly:
 
 1) Lost write, client receives rc 0 for write but db was downgrading and write did not propagate:
 
@@ -100,6 +103,8 @@ This and 4) will not occur if we disable decoupled logputs in the lrl: `decouple
 18 0x00007f3b8904802d in clone () from /lib64/libc.so.6
 ```
 
+This was caused by erroneously calling destroy when we shouldnt (not properly acting on rc).
+
 7) Another mysterious crash from Pthread_mutex_lock(&sess->mtx) with sess already freed (or just corrupt):
 
 ```
@@ -122,3 +127,64 @@ This and 4) will not occur if we disable decoupled logputs in the lrl: `decouple
 16 0x000055a892c1f235 in akq_worker (arg=0x7f0e60000d90) at ../net/akq.c:102
 17 0x00007f0e85fb3ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
 ```
+
+Another time similarly:
+
+```
+0  ___pthread_mutex_lock (mutex=0x8) at ../nptl/pthread_mutex_lock.c:67
+1  0x000055e5a4b375f9 in osql_sess_try_terminate (psess=0x7f98e433ab80, host=0x0) at ../db/osqlsession.c:398
+2  0x000055e5a4b3648b in osql_session_testterminate (obj=0x7f98e433ab80, arg=0x0) at ../db/osqlrepository.c:288
+3  0x000055e5a4d8f296 in hash_for (h=0x55e5a66f4b40, func=0x55e5a4b36458 <osql_session_testterminate>, arg=0x0) at ../util/plhash.c:1662
+4  0x000055e5a4b36634 in osql_repository_terminatenode (host=0x0) at ../db/osqlrepository.c:317
+5  0x000055e5a4b36766 in osql_repository_cancelall () at ../db/osqlrepository.c:334
+6  0x000055e5a4b05d02 in new_master_callback (bdb_handle=0x55e5a65a2180, host=0x55e5a651a600 "node2", assert_sc_clear=1) at ../db/glue.c:2914
+7  0x000055e5a4cfb152 in bdb_upgrade_int (bdb_state=0x55e5a65a2180, newgen=32, upgraded=0x7f993cf096e0) at ../bdb/file.c:5284
+8  0x000055e5a4cfb4f5 in bdb_upgrade_downgrade_reopen_wrap (bdb_state=0x55e5a65a2180, op=1, timeout=30, newgen=32, done=0x7f993cf096e0) at ../bdb/file.c:5414
+9  0x000055e5a4cfb68c in bdb_upgrade (bdb_state=0x55e5a65a2180, newgen=32, done=0x7f993cf096e0) at ../bdb/file.c:5460
+10 0x000055e5a4d5c34d in process_berkdb (bdb_state=0x55e5a65a2180, host=0x55e5a651a600 "node2", control=0x7f993cf097f0, rec=0x7f993cf09820) at ../bdb/rep.c:3936
+11 0x000055e5a4d5eaa6 in berkdb_receive_rtn_int (ack_handle=0x7f993cf09960, usr_ptr=0x55e5a65a2180, from_node=0x55e5a6569d00 "node1", usertype=1, dta=0x7f99140d7460, dtalen=68, is_tcp=1 '\001') at ../bdb/rep.c:5030
+12 0x000055e5a4d5ee26 in berkdb_receive_rtn (ack_handle=0x7f993cf09960, usr_ptr=0x55e5a65a2180, from_host=0x55e5a6569d00 "node1", usertype=1, dta=0x7f99140d7460, dtalen=68, is_tcp=1 '\001') at ../bdb/rep.c:5126
+13 0x000055e5a4f7ae8f in do_user_msg (e=0x7f992c002790, msg=0x7f993d12d158, payload=0x7f99140d7460 "") at ../net/event.c:1116
+14 0x000055e5a4f7af30 in akq_work_callback (work=0x7f993d12d150) at ../net/event.c:1137
+15 0x000055e5a4f991ca in akq_worker_int (q=0x7f992c000d90) at ../net/akq.c:93
+16 0x000055e5a4f99235 in akq_worker (arg=0x7f992c000d90) at ../net/akq.c:102
+17 0x00007f99468caea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
+(gdb) p mutex
+$2 = (pthread_mutex_t *) 0x8
+(gdb) up
+#1  0x000055e5a4b375f9 in osql_sess_try_terminate (psess=0x7f98e433ab80, host=0x0) at ../db/osqlsession.c:398
+398         Pthread_mutex_lock(&sess->mtx);
+(gdb) p sess
+$3 = (sess_impl_t *) 0x0
+```
+
+This is the other thread suffering the effect of bug in 6)
+
+8) Another crash with strange content in tran:
+
+```
+(gdb) p tran->selectv_genids
+$3 = (hash_t *) 0x3
+
+0  0x000055cc7b37c9f9 in hash_for (h=0x3, func=0x55cc7b10a15b <free_selectv_genids>, arg=0x0) at ../util/plhash.c:1655
+1  0x000055cc7b10a1d7 in osql_bplog_close (ptran=0x7fb1b4430a30) at ../db/osqlblockproc.c:398
+2  0x000055cc7b123e3e in osql_sess_close (psess=0x7fb18f3fb058, is_linked=true) at ../db/osqlsession.c:141
+3  0x000055cc7b124556 in osql_sess_rcvop (rqid=1, uuid=0x7fb18f3fb0e0 "}ڈ\024\216\250CӸ\231ͣ,E\214m", type=8, data=0x7fb18f3fb250, datalen=280, found=0x7fb18f3fb0fc) at ../db/osqlsession.c:327
+4  0x000055cc7b11b53c in net_osql_rpl_tail (hndl=0x0, uptr=0x0, fromhost=0x55cc7ccd3600 "node2", usertype=157, dtap=0x7fb18f3fb250, dtalen=280, tail=0x0, tailen=0) at ../db/osqlcomm.c:5499
+5  0x000055cc7b11adc2 in net_local_route_packet_tail (usertype=157, data=0x7fb18f3fb250, datalen=280, tail=0x0, taillen=0) at ../db/osqlcomm.c:5293
+6  0x000055cc7b122524 in offload_net_send (host=0x55cc7ccd3600 "node2", usertype=157, data=0x7fb18f3fb250, datalen=280, nodelay=1, tail=0x0, tailen=0) at ../db/osqlcomm.c:7502
+7  0x000055cc7b132737 in _send (target=0x7fb1cc128df8, usertype=157, data=0x7fb18f3fb250, datalen=280, nodelay=1, tail=0x0, tailen=0) at ../db/osqlsqlnet.c:93
+8  0x000055cc7b118ffa in osql_send_commit_by_uuid (target=0x7fb1cc128df8, uuid=0x7fb1cc128e20 "}ڈ\024\216\250CӸ\231ͣ,E\214m", nops=102, xerr=0x7fb18f3fb5f0, type=157, query_stats=0x0, snap_info=0x0) at ../db/osqlcomm.c:4653
+9  0x000055cc7b131127 in osql_send_abort_logic (clnt=0x7fb1cc1288a0, nettype=124) at ../db/osqlsqlthr.c:1568
+10 0x000055cc7b130168 in osql_sock_abort (clnt=0x7fb1cc1288a0, type=2) at ../db/osqlsqlthr.c:1250
+11 0x000055cc7b1c553d in do_commitrollback (thd=0x7fb18f3fb8e0, clnt=0x7fb1cc1288a0) at ../db/sqlinterfaces.c:2064
+12 0x000055cc7b1c5c1b in handle_sql_commitrollback (thd=0x7fb18f3fb8e0, clnt=0x7fb1cc1288a0, sideeffects=TRANS_CLNTCOMM_NORMAL) at ../db/sqlinterfaces.c:2195
+13 0x000055cc7b1c9102 in handle_non_sqlite_requests (thd=0x7fb18f3fb8e0, clnt=0x7fb1cc1288a0, outrc=0x7fb18f3fb848) at ../db/sqlinterfaces.c:3419
+14 0x000055cc7b1ca8ea in execute_sql_query (thd=0x7fb18f3fb8e0, clnt=0x7fb1cc1288a0) at ../db/sqlinterfaces.c:4169
+15 0x000055cc7b1cbbfa in sqlengine_work_appsock (thddata=0x7fb18f3fb8e0, work=0x7fb1cc1288a0) at ../db/sqlinterfaces.c:4644
+16 0x000055cc7b1cbd65 in sqlengine_work_appsock_pp (pool=0x55cc7cce29b0, work=0x7fb1cc1288a0, thddata=0x7fb18f3fb8e0, op=0) at ../db/sqlinterfaces.c:4682
+17 0x000055cc7b38de5d in thdpool_thd (voidarg=0x7fb1ac012e00) at ../util/thdpool.c:814
+18 0x00007fb1fef13ea7 in start_thread (arg=<optimized out>) at pthread_create.c:477
+```
+
+This was same as 6)

--- a/tests/repeated_downgrades.test/runit
+++ b/tests/repeated_downgrades.test/runit
@@ -75,8 +75,11 @@ downgrade()
     done
 }
 
-for i in {0..9} ; do
+N=10
+i=0
+while [ $i -lt $N ] ; do
     cdb2sql ${CDB2_OPTIONS} ${DBNAME} default "create table tt${i} (i int primary key)"
+    let i=i+1
 done
 
 echo "Downgrade continuously"
@@ -84,4 +87,4 @@ downgrade $DBNAME &> downgrade.out &
 dgpid=$!
 trap "kill $dgpid" INT EXIT
 
-${TESTSBUILDDIR}/inscntdel --dbname $DBNAME --numthreads 10 --iterations 1000
+${TESTSBUILDDIR}/inscntdel --dbname $DBNAME --numthreads $N --iterations 1000

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -239,6 +239,8 @@ find_cores() {
                 echo 't a a bt full' | gdb -q $COMDB2_EXE $copy_core &>> $LCLDBDIR/core_stacktrace_long.$node.txt
                 ln $COMDB2_EXE -t $LCLDBDIR #make a hardlink of the executable as well
                 echo "    see $LCLDBDIR/core_stacktrace.$node.txt"
+            else
+                echo "No space to copy core located at $node:${cr}"
             fi
         fi
     done


### PR DESCRIPTION
When a node is upgraded to be the new master, we attempt to terminate all the ongoing
osql sessions: bdb_upgrade_int() -> new_master_callback () -> osql_repository_cancelall()
This action clashes with new session management.

This checkin fixes erroneous cleanup of a session in sorese_rcvreq():

* In sorese_rcvreq() we were incorrectly treating return from osql_repository_put()
  and that resulted in calling osql_sess_remclient() twice and making client member -1
* Also resulted in erroneous call to call osql_sess_close() with false parameter
  even when sess *was* added to repository
* Initialize target otherwise we get a crash
* Assert that session client count never gets negative

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>