### PR TITLE
Fix FDB memory leaks

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1106,7 +1106,7 @@ static enum mach_class get_fdb_class(const char **p_dbname, int *local)
     enum mach_class my_lvl = CLASS_UNKNOWN;
     enum mach_class remote_lvl = CLASS_UNKNOWN;
     const char *tmpname;
-    const char *class;
+    char *class;
 
     *local = 0;
 
@@ -1123,7 +1123,7 @@ static enum mach_class get_fdb_class(const char **p_dbname, int *local)
         } else {
             remote_lvl = mach_class_name2class(class);
         }
-
+        free(class); /* class is strndup'd */
         *p_dbname = dbname;
     } else {
         /* implicit is same class */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -6308,6 +6308,11 @@ skip:
     {
         /* release the fdb cursor */
         if (pCur->fdbc) {
+            /* free memory allocated in cursor_move_remote(). */
+            if (pCur->writeTransaction)
+                free(pCur->dtabuf);
+            free(pCur->keybuf);
+
             rc = pCur->fdbc->close(pCur);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: failed fdb_cursor_close rc=%d\n", __func__,


### PR DESCRIPTION
Make sure that an FDB cursor's row buffer is freed.

(DRQS 166409931)