### PR TITLE
Reset uuid after a write commits

### DIFF
--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -48,6 +48,7 @@
 
 extern int64_t comdb2_time_epochus(void);
 
+static int gbl_print_cnonce_as_hex = 1;
 static char *gbl_eventlog_fname = NULL;
 static char *eventlog_fname(const char *dbname);
 int eventlog_nkeep = 2; // keep only last 2 event log files
@@ -464,12 +465,18 @@ static const char *ev_str[] = { "unset", "txn", "sql", "sp" };
 
 static inline void cson_snap_info_key(cson_object *obj, snap_uid_t *snap_info)
 {
-    if (obj && snap_info) {
+    if (!obj || !snap_info)
+        return;
+
+    if (gbl_print_cnonce_as_hex) {
         char cnonce[2 * snap_info->keylen + 1];
         /* util_tohex() takes care of null-terminating the resulting string. */
         util_tohex(cnonce, snap_info->key, snap_info->keylen);
         cson_object_set(obj, "cnonce",
                         cson_value_new_string(cnonce, snap_info->keylen * 2));
+    } else {
+        cson_object_set(obj, "cnonce",
+                        cson_value_new_string(snap_info->key, snap_info->keylen));
     }
 }
 

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1849,6 +1849,7 @@ uint64_t reqlog_current_us(struct reqlogger *logger)
 
 inline void reqlog_set_rqid(struct reqlogger *logger, void *id, int idlen)
 {
+    assert (idlen == sizeof(unsigned long long) || idlen == sizeof(uuid_t));
     if (idlen == sizeof(uuid_t))
         comdb2uuidstr(id, logger->id);
     else

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1263,6 +1263,8 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
 
     reqlog_set_rows(logger, clnt->nrows);
     reqlog_end_request(logger, stmt_rc, __func__, __LINE__);
+    if (clnt->osql.sock_started == 0)
+        comdb2uuid_clear(clnt->osql.uuid);
 
     if (have_fingerprint) {
         /*
@@ -1706,6 +1708,8 @@ static int handle_sql_wrongstate(struct sqlthdstate *thd,
     reset_clnt_flags(clnt);
 
     reqlog_end_request(thd->logger, -1, __func__, __LINE__);
+    if (clnt->osql.sock_started == 0)
+        comdb2uuid_clear(clnt->osql.uuid);
 
     if (srs_tran_destroy(clnt))
         logmsg(LOGMSG_ERROR, "Fail to destroy transaction replay session\n");
@@ -2323,6 +2327,8 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
 done:
     reset_clnt_flags(clnt);
     reqlog_end_request(thd->logger, -1, __func__, __LINE__);
+    if (clnt->osql.sock_started == 0)
+        comdb2uuid_clear(clnt->osql.uuid);
 
     /* if this is a retry, let the upper layer free the structure */
     if (clnt->osql.replay == OSQL_RETRY_NONE) {

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -169,7 +169,10 @@ NUM=2000
 for ((i=1;i<=$NUM;++i)); do echo "insert into t1 values($i, '$blb')"; done > in.sql 
 cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
 
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values(10001, 'abc')"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default - <<'EOF'
+insert into t1 values(10001, 'abc')
+select * from t1 where i = 10001
+EOF
 
 # need to flush to get correct stmts in logfile
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
@@ -188,6 +191,13 @@ res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
     zcat $f | jq -c 'if (.type == "sql") and (.sql == "insert into t1 values(10001, '"'abc'"')") then . else empty end'
 done | wc -l)
 assertres $res 1
+
+echo "make sure that 'select * from t1 where i = 10001' does not have id(rqid/uuid) set"
+res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
+    zcat $f | jq -c 'if (.type == "sql") and (.sql == "select * from t1 where i = 10001") then .id else empty end'
+done )
+assertres $res "null"
+
 
 echo "Test having no limit for logfiles (turning off rolling)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"

--- a/tests/tools/inscntdel.cpp
+++ b/tests/tools/inscntdel.cpp
@@ -22,7 +22,7 @@ static std::string sethasql("set hasql on");
 int runsql(cdb2_hndl_tp *h, std::string &sql)
 {
     int rc = cdb2_run_statement(h, sql.c_str());
-    //printf("Here: cdb2_run_statement: %s\n", sql.c_str());
+    //printf("Here: cdb2_run_statement: %s, cnonce=%s\n", sql.c_str(), cdb2_cnonce(h));
 
     if (rc != 0) {
         fprintf(stderr, "Error: cdb2_run_statement failed: %d %s (%s)\n", rc,
@@ -148,7 +148,6 @@ void *thr(void *arg)
             fprintf(stderr, "Error: count is %d but should be 0\n", cnt);
             exit(1);
         }
-
     }
 
     cdb2_close(db);


### PR DESCRIPTION
We currently log in eventlog select stmts with a uuid if it follows an insert
because we dont clean the clnt->osql.uuid variable. This checkin does just that:
resets it to zero after the write has commited. Also added a testcase to verify
that the select does not get logged with a uuid value.

Signed-off-by: Adi Zaimi <azaimi@bloomberg.net>