### PR TITLE
Fix readdir crash

### DIFF
--- a/bbinc/bb_oscompat.h
+++ b/bbinc/bb_oscompat.h
@@ -34,6 +34,7 @@ int comdb2_gethostbyname(char **name, struct in_addr *addr);
 char *comdb2_getcanonicalname(char *name);
 void comdb2_getservbyname(const char *, const char *, short *);
 int bb_readdir(DIR *d, void *buf, struct dirent **dent);
+size_t bb_dirent_size(char *path);
 char *comdb2_realpath(const char *path, char *resolved_path);
 
 #ifdef __cplusplus

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -7974,7 +7974,7 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
 
     /* must be large enough to hold a dirent struct with the longest possible
      * filename */
-    buf = malloc(4096);
+    buf = malloc(bb_dirent_size(bdb_state->dir));
     if (!buf) {
         logmsg(LOGMSG_ERROR, "%s: malloc failed\n", __func__);
         *bdberr = BDBERR_MALLOC;
@@ -8199,7 +8199,7 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
 
     /* must be large enough to hold a dirent struct with the longest possible
      * filename */
-    buf = alloca(4096);
+    buf = alloca(bb_dirent_size(bdb_state->parent->dir));
 
     /* open the db's directory */
     dirp = opendir(bdb_state->parent->dir);
@@ -8847,14 +8847,14 @@ int bdb_list_all_fileids_for_newsi(bdb_state_type *bdb_state,
     DIR *dirp;
     int error;
 
-    buf = malloc(4096);
+    if (bdb_state->parent)
+        bdb_state = bdb_state->parent;
+
+    buf = malloc(bb_dirent_size(bdb_state->dir));
     if (!buf) {
         logmsg(LOGMSG_ERROR, "%s: malloc failed\n", __func__);
         return -1;
     }
-
-    if (bdb_state->parent)
-        bdb_state = bdb_state->parent;
 
     dbenv = bdb_state->dbenv;
 

--- a/db/config.c
+++ b/db/config.c
@@ -1424,18 +1424,20 @@ static int read_config_dir(struct dbenv *dbenv, char *dir)
 {
     DIR *d = NULL;
     int rc = 0;
-    struct dirent ent, *out;
+    struct dirent *ent, *out;
+
+    ent = malloc(bb_dirent_size(dir));
 
     d = opendir(dir);
     if (d == NULL) {
         rc = -1;
         goto done;
     }
-    while (bb_readdir(d, &ent, &out) == 0 && out != NULL) {
+    while (bb_readdir(d, ent, &out) == 0 && out != NULL) {
         int len;
-        len = strlen(ent.d_name);
-        if (strcmp(ent.d_name + len - 4, ".lrl") == 0) {
-            char *file = comdb2_asprintf("%s/%s", dir, ent.d_name);
+        len = strlen(ent->d_name);
+        if (strcmp(ent->d_name + len - 4, ".lrl") == 0) {
+            char *file = comdb2_asprintf("%s/%s", dir, ent->d_name);
             pre_read_lrl_file(dbenv, file);
             rc = (read_lrl_file(dbenv, file, 0) == NULL);
             if (rc) logmsg(LOGMSG_ERROR, "Error processing %s\n", file);
@@ -1446,6 +1448,7 @@ static int read_config_dir(struct dbenv *dbenv, char *dir)
 
 done:
     if (d) closedir(d);
+    free(ent);
     return rc;
 }
 

--- a/db/eventlog.c
+++ b/db/eventlog.c
@@ -111,7 +111,7 @@ static void eventlog_roll_cleanup()
 
     /* must be large enough to hold a dirent struct with the longest possible
      * filename */
-    struct dirent *buf = alloca(4096);
+    struct dirent *buf = alloca(bb_dirent_size(dname));
     struct dirent *de;
     DIR *d = opendir(dname);
     if (!d) {

--- a/util/bb_oscompat.c
+++ b/util/bb_oscompat.c
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <limits.h>
 #include <stdlib.h>
+#include <unistd.h>
 
 #include <bb_oscompat.h>
 #include <logmsg.h>
@@ -111,6 +112,14 @@ void comdb2_getservbyname(const char *name, const char *proto, short *port)
     if (result) {
         *port = result->s_port;
     }
+}
+
+size_t bb_dirent_size(char *path)
+{
+    long name_max = pathconf(path, _PC_NAME_MAX);
+    if (name_max == -1)
+        name_max = 4096;
+    return offsetof(struct dirent, d_name) + name_max + 1;
 }
 
 int bb_readdir(DIR *d, void *buf, struct dirent **dent) {


### PR DESCRIPTION
Allocate a `dirent` structure that is large enough for `readdir()`.