### PR TITLE
better error message when chunk in non-socksql txn modes

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3980,6 +3980,17 @@ static int process_set_command(cdb2_hndl_tp *hndl, const char *sql)
             skip_len += 10;
             set_tok = strtok_r(rest, " ", &rest);
         }
+        /* special case for transaction chunk */
+        if (set_tok && strncasecmp(set_tok, "transaction", 11) == 0) {
+            char *set_tok2 = strtok_r(rest, " ", &rest);
+            if (set_tok2 && strncasecmp(set_tok2, "chunk", 5) == 0) {
+                /* skip "transaction" if chunk, set we can set
+                 * both transaction and chunk mode
+                 */
+                skip_len += 12;
+                set_tok = set_tok2;
+            }
+        }
         if (!set_tok) {
             free(dup_sql);
             return 0;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1596,6 +1596,10 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                                  "N \"%s\"",
                                  sqlstr);
                         rc = ii + 1;
+                    } else if (clnt->dbtran.mode != TRANLEVEL_SOSQL) {
+                        snprintf(err, sizeof(err),
+                                 "transaction chunks require SOCKSQL transaction mode");
+                        rc = ii + 1;
                     } else {
                         clnt->dbtran.maxchunksize = tmp;
                         /* in chunked mode, we disable verify retries */
@@ -1627,8 +1631,13 @@ static int process_set_commands(struct dbenv *dbenv, struct sqlclntstate *clnt,
                                                  "high availability\n");
                         }
                     }
-                    if (clnt->dbtran.mode == TRANLEVEL_INVALID)
+                    if (clnt->dbtran.mode == TRANLEVEL_INVALID) {
                         rc = ii + 1;
+                    } else if (clnt->dbtran.mode != TRANLEVEL_SOSQL && clnt->dbtran.maxchunksize) {
+                        snprintf(err, sizeof(err),
+                                 "transaction chunks require SOCKSQL transaction mode");
+                        rc = ii + 1;
+                    }
                 }
             } else if (strncasecmp(sqlstr, "timeout", 7) == 0) {
                 sqlstr += 7;

--- a/tests/transchunk.test/log.expected
+++ b/tests/transchunk.test/log.expected
@@ -40,3 +40,15 @@ Failure tests
 (count(*)=502)
 (out='    OSQL_DONE            5611')
 (count(*)=0)
+Checking error on wrong default transaction mode
+[begin] failed with rc -3 transaction chunks require SOCKSQL transaction mode
+[delete from t where 1] failed with rc -3 transaction chunks require SOCKSQL transaction mode
+[commit] failed with rc -8 Wrong sql handle state
+(out='    OSQL_DONE            5611')
+Checking error on setting wrong transaction mode
+[begin] failed with rc -3 transaction chunks require SOCKSQL transaction mode
+[delete from t where 1] failed with rc -3 transaction chunks require SOCKSQL transaction mode
+[commit] failed with rc -8 Wrong sql handle state
+(out='    OSQL_DONE            5611')
+Checking deduping multiple chunk sets
+(out='    OSQL_DONE            501')

--- a/tests/transchunk.test/lrl.options
+++ b/tests/transchunk.test/lrl.options
@@ -1,3 +1,5 @@
+dbnum 123
 table t t.csc2
 table t2 t2.csc2
 always_send_cnonce off
+sql_tranlevel_default recom

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -22,6 +22,12 @@ function check_done
     $rtm "exec procedure sys.cmd.send('long')" | grep -A 3 "'t'" | grep DONE >> $outlog
 }
 
+function check_done_2
+{ 
+    $rtm "exec procedure sys.cmd.send('long')" | grep -A 3 "'t2'" | grep DONE >> $outlog
+}
+
+
 echo "Starting"
 echo "Starting" > $outlog
 
@@ -36,6 +42,7 @@ EOF
 echo "Inserting chunks of 99 rows"
 echo "Inserting chunks of 99 rows" >> $outlog
 $r >> $outlog << "EOF" 
+set transaction blocksql
 set transaction chunk 99 
 begin 
 insert into t select * from t2
@@ -59,6 +66,7 @@ check_done
 echo "Inserting chunks of 1 row"
 echo "Inserting chunks of 1 row" >> $outlog
 $r >> $outlog << "EOF" 
+set transaction blocksql
 set transaction chunk 1 
 begin
 insert into t select * from t2
@@ -82,6 +90,7 @@ check_done
 echo "Multiple inserts in a transaction chunks of 1"
 echo "Multiple inserts in a transaction chunks of 1" >> $outlog
 $r >> $outlog << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -98,6 +107,7 @@ check_done
 echo "Failure tests"
 echo "Failure tests" >> $outlog
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -107,6 +117,7 @@ EOF
 check_done
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -119,6 +130,7 @@ check_done
 $rt "select * from t order by a limit 3" >> $outlog
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -130,6 +142,7 @@ EOF
 check_done
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -143,6 +156,7 @@ $rt "select * from t where a>1000" >> $outlog
 check_done
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (1)
@@ -161,6 +175,7 @@ $rt "select count(*) from t" >> $outlog
 check_done
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 1
 begin
 insert into t values (123456789)
@@ -176,6 +191,7 @@ check_done
 
 $r >> $outlog 2>&1 << "EOF"
 insert into t select value from generate_series(7, 1000)
+set transaction blocksql
 set transaction chunk 1
 begin
 delete from t where a <500
@@ -187,6 +203,7 @@ check_done
 $rt "select count(*) from t" >> $outlog
 
 $r >> $outlog 2>&1 << "EOF"
+set transaction blocksql
 set transaction chunk 10
 begin
 delete from t where 1
@@ -196,6 +213,41 @@ EOF
 check_done
 
 $rt "select count(*) from t" >> $outlog
+
+
+echo "Checking error on wrong default transaction mode" >> $outlog
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 10
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+echo "Checking error on setting wrong transaction mode" >> $outlog
+$r >> $outlog 2>&1 << "EOF"
+set transaction snapisol
+set transaction chunk 10
+begin
+delete from t where 1
+commit
+EOF
+
+check_done
+
+echo "Checking deduping multiple chunk sets" >> $outlog
+$r >> $outlog 2>&1 << "EOF"
+set transaction chunk 1
+set transaction blocksql
+set transaction chunk 10
+begin
+delete from t2 where 1
+commit
+EOF
+
+check_done_2
+
 
 # get testcase output
 testcase_output=$(cat $outlog)


### PR DESCRIPTION
Transaction chunks only work in socksql mode; this patch sends an error to the client if the transaction mode is wrong, instead of trying to run the transaction anyway without chunks.  Also, it allows setting both transaction mode and chunk at the same time.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
