### PR TITLE
ssl_new_ctx(): fix openssl version ifdef

### DIFF
--- a/util/ssl_support.c
+++ b/util/ssl_support.c
@@ -380,7 +380,7 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
 #endif /* HAVE_CRL */
 
 #ifndef OPENSSL_NO_ECDH
-#if OPENSSL_VERSION_NUMBER >= 0x10200000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
     SSL_CTX_set_ecdh_auto(myctx, 1);
 #else
     EC_KEY *ecdh = EC_KEY_new_by_curve_name(NID_X9_62_prime256v1);


### PR DESCRIPTION
I happened to notice that the OPENSSL_VERSION_NUMBER check seems wrong. As [documented](https://www.openssl.org/docs/man1.1.0/man3/OPENSSL_VERSION_NUMBER.html), it is structured as:

```
 MNNFFPPS: major minor fix patch status
```

And this code should be checking whether openssl is at version 1.0.2 or greater, since that is where `SSL_CTX_set_ecdh_auto()` was introduced (see [changelog](https://www.openssl.org/news/changelog.html)).

Note: this is completely untested.

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ? bug fix
* What are the current behavior and expected behavior, if this is a bugfix ? `SSL_CTX_set_ecdh_auto()` is incorrectly not being called with openssl version 1.0.2, even though it is available, so the fallback code is used instead. Not a big deal, but still wrong.
* What are the steps required to reproduce the bug, if this is a bugfix ? I have not attempted to reproduce anything.
* What is the current behavior and new behavior, if this is a feature change or enhancement ? See above.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
