### PR TITLE
Fix memory leak from dbqueue_get_front_genid()

### DIFF
--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -399,6 +399,7 @@ static unsigned long long dbqueue_get_front_genid(struct dbtable *table,
     rc = dbq_get(&iq, consumer, NULL, &fnddta, &fnddtalen, &fnddtaoff, NULL, NULL, lockid);
     if (rc == 0) {
         genid = dbq_item_genid(fnddta);
+        free(fnddta);
     } else if (rc != IX_NOTFND) {
         logmsg(LOGMSG_ERROR,
                "dbq_get_front_genid: dbq_item_genid failed "


### PR DESCRIPTION
dbq DBT structure is DB_DBT_REALLOC'd. Make sure it's freed.

(DRQS 166534314)
