### PR TITLE
Have cson use its own allocator

### DIFF
--- a/cson/CMakeLists.txt
+++ b/cson/CMakeLists.txt
@@ -3,4 +3,20 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL GNU)
 elseif(${CMAKE_C_COMPILER_ID} STREQUAL Clang)
   set_source_files_properties(cson_amalgamation_core.c PROPERTIES COMPILE_FLAGS "-Wno-unused-variable -Wno-unused-const-variable -Wno-unused-label")
 endif()
+
+set(module cson)
+set(MODULE CSON)
+
+configure_file(${PROJECT_SOURCE_DIR}/mem/mem.h.in mem_cson.h @ONLY)
+
 add_library(cson cson_amalgamation_core.c)
+
+include_directories(
+    build
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_BINARY_DIR}
+    ${PROJECT_SOURCE_DIR}/mem
+    ${PROJECT_BINARY_DIR}/mem
+)
+
+add_dependencies(cson mem)

--- a/cson/cson_amalgamation_core.c
+++ b/cson/cson_amalgamation_core.c
@@ -1,6 +1,9 @@
 /* auto-generated! Do not edit! */
+#include "mem_cson.h"
+#include "mem_override.h"
 #include "cson_amalgamation_core.h"
 /* begin file parser/JSON_parser.h */
+
 
 /*
 Copyright (c) 2007-2013 Jean Gressmann (jean@0x42.de)

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -42,6 +42,7 @@ XMACRO_COMDB2MA(COMDB2MA_STATIC_DFP_DECNUMBER,  "dfp_decNumber",    0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_PROTOBUF,       "protobuf",         0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_SCHEMACHANGE,   "schemachange",     0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_LUA,            "lua",              0, 0) \
+XMACRO_COMDB2MA(COMDB2MA_STATIC_CSON,           "cson",             0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_COUNT,                 NULL,               0, 0)
 
 #define XMACRO_COMDB2MA(idx, name, size, cap) idx,

--- a/tools/cdb2_sqlreplay/CMakeLists.txt
+++ b/tools/cdb2_sqlreplay/CMakeLists.txt
@@ -6,6 +6,9 @@ include_directories(
 set(libs
   cdb2api
   cson
+  mem
+  util
+  dlmalloc
   ${PROTOBUF-C_LIBRARY}
 )
 if(WITH_SSL)
@@ -13,6 +16,8 @@ if(WITH_SSL)
 endif()
 
 list(APPEND libs ${UNWIND_LIBRARY})
+
+include_directories(${PROJECT_SOURCE_DIR}/mem)
 
 target_link_libraries(cdb2_sqlreplay ${libs})
 if(COMDB2_BUILD_STATIC)

--- a/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
+++ b/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
@@ -36,6 +36,9 @@
 #include <algorithm>
 #include <unistd.h>
 
+extern "C" {
+#include "mem.h"
+}
 #include "assert.h"
 #include "cdb2api.h"
 #include "cson_amalgamation_core.h"
@@ -677,6 +680,8 @@ void process_events(cdb2_hndl_tp *db, std::istream &in) {
 int main(int argc, char **argv) {
     char *dbname;
     char *filename = nullptr;
+
+    comdb2ma_init(0, 0);
 
     init_handlers();
 


### PR DESCRIPTION
cson is rather malloc-heavy, and so performs poorly on systems with a poor system allocator.  Have it use its own allocator.