### PR TITLE
Call sql_tick in direct-count

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -825,6 +825,9 @@ struct sqlclntstate {
     int translevel_changed;
     int admin;
 
+    /* Grab this mutex when calling sql_tick. This is to prevent race when
+       multiple threads are working on a single clnt (parallel-count, for instance). */
+    pthread_mutex_t sql_tick_lk;
     uint32_t start_gen;
     int emitting_flag;
     int need_recover_deadlock;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5083,6 +5083,7 @@ void cleanup_clnt(struct sqlclntstate *clnt)
     Pthread_cond_destroy(&clnt->write_cond);
     Pthread_mutex_destroy(&clnt->dtran_mtx);
     Pthread_mutex_destroy(&clnt->state_lk);
+    Pthread_mutex_destroy(&clnt->sql_tick_lk);
 }
 
 void reset_clnt(struct sqlclntstate *clnt, int initial)
@@ -5095,6 +5096,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
         Pthread_cond_init(&clnt->write_cond, NULL);
         Pthread_mutex_init(&clnt->dtran_mtx, NULL);
         Pthread_mutex_init(&clnt->state_lk, NULL);
+        Pthread_mutex_init(&clnt->sql_tick_lk, NULL);
     }
     else {
        clnt->sql_since_reset = 0;


### PR DESCRIPTION
We rely on sql_tick() to relinquish locks, send back smartbeats, honor query limits, detect disconnected client, etc. Direct-count does not call sql_tick() on berkdb cursor move, which means that it is not getting any of these useful features. This patch fixes it.
