### PR TITLE
legacy_defaults: cap sorter mmap size at 256 MiB

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -419,6 +419,7 @@ static char *legacy_options[] = {
     "setattr MASTER_LEASE 0",
     "setattr NET_SEND_GBLCONTEXT 1",
     "setattr SC_DONE_SAME_TRAN 0",
+    "sqlsortermaxmmapsize 268435456",
     "unnatural_types 1",
     "init_with_queue_ondisk_header off",
     "init_with_queue_compr off",


### PR DESCRIPTION
MMAP IO from SQLite sorter may cause a database process to run out of its ulimit (max 2G per file; merge-sort requires 2 x 2G which is 4G per sorter). Cap it at 256 MiB instead. The performance impact is negligible: when sorting large data, regardless of mmap or traditional read/write, the disk IO will be the dominating factor.