### PR TITLE
Turn off gbl_replicant_retry_on_not_durable

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3231,7 +3231,7 @@ static int node_in_list(int node, int list[], int listsz)
 
 /* ripped out ALL SUPPORT FOR ALL BROKEN CRAP MODES, aside from "newcoh" */
 
-int gbl_replicant_retry_on_not_durable = 1;
+int gbl_replicant_retry_on_not_durable = 0;
 static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
                                             seqnum_type *seqnum, int *timeoutms,
                                             uint64_t txnsize, int newcoh)

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1918,7 +1918,7 @@ REGISTER_TUNABLE("debug_mixed_ddl_dml", "Reject write schedules which mix DDL an
 REGISTER_TUNABLE("sync_osql_cancel", "Synchronous osql cancellation (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_sync_osql_cancel, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
+REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("net_somaxconn",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -711,7 +711,7 @@
 (name='repl_wait', description='Replication wait system enabled for queues', type='BOOLEAN', value='ON', read_only='N')
 (name='replicant_latches', description='Also acquire latches on replicants. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicant_latency', description='Replicant drops log records.', type='BOOLEAN', value='OFF', read_only='N')
-(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='replicate_local', description='When enabled, record all database events to a comdb2_oplog table. This can be used to set clusters/instances that are fed data from a database cluster. Alternate ways of doing this are being planned, so enabling this option should not be needed in the near future. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_local_concurrent', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_rowlocks', description='Replicate rowlocks', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Turn of `gbl_replicant_retry_on_not_durable` for now. As it stands, it continuously results in `do_replay_case` traces.

```
node3  | 2021/07/08 23:51:31 do_replay_case from line 2837 replay returns 0 for fstblk 279708655-226-0x561433c961f0-00a02b3b59556a5c, cnonce 279708655-226-0x561433c961f0-00a02b3b59556a5c
node3  | 2021/07/08 23:51:31 do_replay_case from line 2837 replay returns 0 for fstblk 279708655-225-0x555cfb07d1f0-00f0764059556a5c, cnonce 279708655-225-0x555cfb07d1f0-00f0764059556a5c
node3  | 2021/07/08 23:51:31 do_replay_case from line 2837 replay returns 0 for fstblk 279708655-238-0x559414f1c1f0-0020e14859556a5c, cnonce 279708655-238-0x559414f1c1f0-0020e14859556a5c
....
```

Amends #2838. I am already working on expanding #2838 and will take this issue into consideration as well.