### PR TITLE
Add a grace period for transactions.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1462,6 +1462,8 @@ void clean_exit(void)
        here in a second, so letting new reads in would be bad. */
     no_new_requests(thedb);
 
+    wait_for_transactions();
+
     print_all_time_accounting();
     wait_for_sc_to_stop("exit", __func__, __LINE__);
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -336,6 +336,7 @@ int gbl_mask_internal_tunables = 1;
 
 size_t gbl_cached_output_buffer_max_bytes = 8 * 1024 * 1024; /* 8 MiB */
 int gbl_sqlite_sorterpenalty = 5;
+extern int gbl_transaction_grace_period;
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1935,4 +1935,8 @@ REGISTER_TUNABLE("throttle_txn_chunks_msec", "Wait that many milliseconds before
 REGISTER_TUNABLE("externalauth", NULL, TUNABLE_BOOLEAN, &gbl_uses_externalauth, READONLY | NOARG | READEARLY,
                   NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("transaction_grace_period",
+                 "Time to wait for connections with pending transactions to go away on exit.  (Default: 60)",
+                 TUNABLE_INTEGER, &gbl_transaction_grace_period, 0, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -1119,6 +1119,7 @@ struct connection_info {
     char *sql;
     char *fingerprint;
     int64_t is_admin;
+    int64_t in_transaction;
 
     /* latched in sqlinterfaces, not returned */ 
     time_t connect_time_int;
@@ -1336,5 +1337,7 @@ tran_type *curtran_gettran(void);
 void curtran_puttran(tran_type *tran);
 int start_new_transaction(struct sqlclntstate *, struct sql_thread *);
 int sqlite3LockStmtTablesRecover(sqlite3_stmt *);
+
+void wait_for_transactions(void);
 
 #endif /* _SQL_H_ */

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -83,5 +83,6 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_CSTRING, "sql", -1, offsetof(struct connection_info, sql),
             CDB2_CSTRING, "fingerprint", -1, offsetof(struct connection_info, fingerprint),
             CDB2_INTEGER, "is_admin", -1, offsetof(struct connection_info, is_admin),
+            CDB2_INTEGER, "in_transaction", -1, offsetof(struct connection_info, in_transaction),
             SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/trangrace.test/Makefile
+++ b/tests/trangrace.test/Makefile
@@ -1,0 +1,9 @@
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/trangrace.test/runit
+++ b/tests/trangrace.test/runit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+if [[ -z "$CLUSTER" ]]; then
+    echo "Skipping for non-clustered"
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo Usage: dbname
+    exit 1
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+dbname=$1
+
+cdb2sql -s ${CDB2_OPTIONS} $dbname default "drop table if exists t"
+
+coproc stdbuf -oL cdb2sql -tabs -s ${CDB2_OPTIONS} $dbname default - 2>/dev/null &
+
+echo "create table t(a int)\$\$" >&${COPROC[1]}
+echo "select comdb2_host()" >&${COPROC[1]}
+read -u ${COPROC[0]} host
+echo "begin" >&${COPROC[1]}
+echo "insert into t values(1)"  >&${COPROC[1]}
+myhost=$(hostname -f)
+if [[ $myhost = $host ]]; then
+    cdb2sql -s ${CDB2_OPTIONS} $dbname local "exec procedure sys.cmd.send('exit')" >/dev/null
+else
+    ssh $host "$(which cdb2sql) -s ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('exit')\"" >/dev/null
+fi
+sleep 15
+echo "insert into t values(1)"  >&${COPROC[1]}
+echo "commit" >&${COPROC[1]}
+echo "select count(*) from t"  >&${COPROC[1]}
+read -u ${COPROC[0]} count
+if [[ $count -eq 2 ]]; then
+    echo Passed
+    exit 0
+else
+    echo "Failed: count $count, expected 2"
+    exit 1
+fi

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=946)
+(TUNABLES_COUNT=947)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -883,6 +883,7 @@
 (name='track_replication_times', description='Track how long each replicant takes to ack all transactions.', type='BOOLEAN', value='ON', read_only='N')
 (name='track_replication_times_max_lsns', description='Track replication times for up to this many transactions.', type='INTEGER', value='50', read_only='N')
 (name='tracked_locklist_init', description='Initial allocation count for tracked locks', type='INTEGER', value='10', read_only='N')
+(name='transaction_grace_period', description='Time to wait for connections with pending transactions to go away on exit.  (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='transient_page_reallocation', description='Orphaned pages are maintained locally', type='BOOLEAN', value='OFF', read_only='N')
 (name='udp', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='udp_average_over_epochs', description='Average over these many TCP epochs.', type='INTEGER', value='4', read_only='N')


### PR DESCRIPTION
DB will delay shutting down if there's connections with an active transaction.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>