### PR TITLE
one more test for test case for many inserts per chunked transaction

### DIFF
--- a/tests/transchunk_manyins.test/Makefile
+++ b/tests/transchunk_manyins.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/transchunk_manyins.test/README
+++ b/tests/transchunk_manyins.test/README
@@ -1,0 +1,1 @@
+This test checks the "SET TRANSACTION CHUNK N" effect on bulk insert loads, when the inserts are individual statements.

--- a/tests/transchunk_manyins.test/log.expected
+++ b/tests/transchunk_manyins.test/log.expected
@@ -1,0 +1,3 @@
+Starting coproc
+(out='    OSQL_DONE            49999')
+(count(*)=100000)

--- a/tests/transchunk_manyins.test/lrl.options
+++ b/tests/transchunk_manyins.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/transchunk_manyins.test/runit
+++ b/tests/transchunk_manyins.test/runit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+TMPDIR=${TMPDIR:-/tmp}
+
+#set -e 
+#set -x
+
+# args
+a_dbn=$1
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $a_dbn default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | awk '{print $1}' | cut -d':' -f1`
+r="cdb2sql -s ${CDB2_OPTIONS} $a_dbn default -"
+rt="cdb2sql -s ${CDB2_OPTIONS} $a_dbn default "
+rtm="cdb2sql -s -n ${master} ${CDB2_OPTIONS} $a_dbn default "
+
+outlog='log.run'
+
+txnsize=2
+#>>$outlog
+
+function check_done
+{ 
+    $rtm "exec procedure sys.cmd.send('long')" | grep -A 3 "'t'" | grep DONE >> $outlog
+}
+
+echo "Starting coproc"
+echo "Starting coproc" > $outlog
+
+coproc kiddo (${r} 2>&1)
+
+echo "set transaction chunk ${txnsize}" >&${kiddo[1]}
+echo "begin" >&${kiddo[1]}
+for i in {1..100000} ; do 
+    echo "insert into t values ($i)" >&${kiddo[1]}
+done
+echo "commit" >&${kiddo[1]}
+exec {kiddo[1]}>&-
+
+read out <&${kiddo[0]}
+
+if [[ "$out" != "" ]]; then
+    echo "Error \"$out\""
+    exit 1
+fi
+
+wait ${kiddo_pid}
+if  (( $? != 0 )) ; then
+    echo "Failed to insert ret code $?"
+    exit 1
+fi
+
+check_done
+
+$rt "select count(*) from t" >> $outlog
+
+# get testcase output
+testcase_output=$(cat $outlog)
+
+# get expected output
+expected_output=$(cat log.expected)
+
+# verify 
+if [[ "$testcase_output" != "$expected_output" ]]; then
+
+    echo "  ^^^^^^^^^^^^"
+    echo "The above testcase (${testcase}) has failed!!!"
+    echo " "
+    echo "Use 'diff <expected-output> <my-output>' to see why:"
+    echo "> diff ${PWD}/{log.expected,$outlog}"
+    echo " "
+    diff log.expected $outlog
+    echo " "
+    exit 1
+
+fi
+
+echo "Testcase passed."
+

--- a/tests/transchunk_manyins.test/t.csc2
+++ b/tests/transchunk_manyins.test/t.csc2
@@ -1,0 +1,8 @@
+schema
+	{
+		int a
+	}
+keys
+    {
+        "a" = a
+    }


### PR DESCRIPTION
New test for transaction chunks: 
{begin; 100k insert statements; commit}.
This is slightly different than existing testcase, which checks statements that generate lots of row writes.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

