### PR TITLE
Keep track of buffer pool fill factor

### DIFF
--- a/bdb/info.c
+++ b/bdb/info.c
@@ -536,6 +536,9 @@ static void cache_stats(FILE *out, bdb_state_type *bdb_state, int extra)
 
     prn_lstat(st_gbytes);
     prn_lstat(st_bytes);
+    prn_lstat(st_total_bytes);
+    prn_lstat(st_used_bytes);
+    logmsgf(LOGMSG_USER, out, "st_ff_pct: %d\n", (int)(stats->st_used_bytes * 100 / stats->st_total_bytes));
     prn_lstat(st_ncache);
     prn_lstat(st_regsize);
     prn_lstat(st_map);

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -1558,6 +1558,8 @@ int bdb_temp_table_close(bdb_state_type *bdb_state, struct temp_table *tbl,
                                         DB_STAT_CLEAR)) == 0) {
             bdb_state->temp_stats->st_gbytes += tmp->st_gbytes;
             bdb_state->temp_stats->st_bytes += tmp->st_bytes;
+            bdb_state->temp_stats->st_total_bytes += tmp->st_total_bytes;
+            bdb_state->temp_stats->st_used_bytes += tmp->st_used_bytes;
             bdb_state->temp_stats->st_ncache += tmp->st_ncache;
             bdb_state->temp_stats->st_regsize += tmp->st_regsize;
             bdb_state->temp_stats->st_map += tmp->st_map;
@@ -1654,6 +1656,8 @@ int bdb_temp_table_destroy_lru(struct temp_table *tbl,
                                     DB_STAT_CLEAR)) == 0) {
         bdb_state->temp_stats->st_gbytes += tmp->st_gbytes;
         bdb_state->temp_stats->st_bytes += tmp->st_bytes;
+        bdb_state->temp_stats->st_total_bytes += tmp->st_total_bytes;
+        bdb_state->temp_stats->st_used_bytes += tmp->st_used_bytes;
         bdb_state->temp_stats->st_ncache += tmp->st_ncache;
         bdb_state->temp_stats->st_regsize += tmp->st_regsize;
         bdb_state->temp_stats->st_map += tmp->st_map;
@@ -2502,6 +2506,8 @@ int bdb_temp_table_stat(bdb_state_type *bdb_state, DB_MPOOL_STAT **gspp)
 
     sp->st_gbytes = parent->temp_stats->st_gbytes;
     sp->st_bytes = parent->temp_stats->st_bytes;
+    sp->st_total_bytes = parent->temp_stats->st_total_bytes;
+    sp->st_used_bytes = parent->temp_stats->st_used_bytes;
     sp->st_ncache = parent->temp_stats->st_ncache;
     sp->st_regsize = parent->temp_stats->st_regsize;
     sp->st_map = parent->temp_stats->st_map;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -877,6 +877,8 @@ struct __db_mpoolfile {
 struct __db_mpool_stat {
 	u_int64_t st_gbytes;		/* Total cache size: GB. */
 	u_int64_t st_bytes;		/* Total cache size: B. */
+	u_int64_t st_total_bytes;	/* Total cache size: st_gbytes + st_bytes. */
+	u_int64_t st_used_bytes;	/* Total used cache size: B. */
 	u_int64_t st_ncache;		/* Number of caches. */
 	u_int64_t st_regsize;		/* Cache size. */
 	u_int64_t st_map;		/* Pages from mapped files. */

--- a/berkdb/mp/mp_alloc.c
+++ b/berkdb/mp/mp_alloc.c
@@ -165,6 +165,8 @@ static void dump_page_stats(DB_ENV *dbenv) {
 
 	logmsgf(LOGMSG_USER, out, "st_gbytes: %"PRId64"\n", mpool_stats->st_gbytes);
 	logmsgf(LOGMSG_USER, out, "st_bytes: %"PRId64"\n", mpool_stats->st_bytes);
+	logmsgf(LOGMSG_USER, out, "st_total_bytes: %"PRId64"\n", mpool_stats->st_total_bytes);
+	logmsgf(LOGMSG_USER, out, "st_used_bytes: %"PRId64"\n", mpool_stats->st_bytes);
 	logmsgf(LOGMSG_USER, out, "st_ncache: %"PRId64"\n", mpool_stats->st_ncache);
 	logmsgf(LOGMSG_USER, out, "st_regsize: %"PRId64"\n", mpool_stats->st_regsize);
 	logmsgf(LOGMSG_USER, out, "st_map: %"PRId64"\n", mpool_stats->st_map);
@@ -312,8 +314,10 @@ __memp_alloc_flags(dbmp, memreg, mfp, len, offsetp, flags, retp)
 	 * right size.  In the latter case we branch back here and try again.
 	 */
 alloc:	if ((ret = __db_shalloc(memreg->addr, len, MUTEX_ALIGN, &p)) == 0) {
-		if (mfp != NULL)
+		if (mfp != NULL) {
 			c_mp->stat.st_pages++;
+			c_mp->stat.st_used_bytes += len;
+		}
 		R_UNLOCK(dbenv, memreg);
 
 found:		if (offsetp != NULL)

--- a/berkdb/mp/mp_region.c
+++ b/berkdb/mp/mp_region.c
@@ -280,6 +280,7 @@ __mpool_init(dbenv, dbmp, reginfo_off, htab_buckets)
 	 */
 	mp->stat.st_gbytes = dbenv->mp_gbytes;
 	mp->stat.st_bytes = dbenv->mp_bytes;
+	mp->stat.st_total_bytes = dbenv->mp_gbytes * GIGABYTE + dbenv->mp_bytes;
 	return (0);
 
 mem_err:__db_err(dbenv, "Unable to allocate memory for mpool region");

--- a/berkdb/mp/mp_stat.c
+++ b/berkdb/mp/mp_stat.c
@@ -106,6 +106,8 @@ __memp_stat(dbenv, gspp, fspp, flags)
 		c_mp = dbmp->reginfo[0].primary;
 		sp->st_gbytes = c_mp->stat.st_gbytes;
 		sp->st_bytes = c_mp->stat.st_bytes;
+		sp->st_total_bytes = c_mp->stat.st_total_bytes;
+		sp->st_used_bytes = c_mp->stat.st_used_bytes;
 		sp->st_ncache = dbmp->nreg;
 		sp->st_regsize = dbmp->reginfo[0].rp->size;
 


### PR DESCRIPTION
The change will help us identify databases that have overly allocated cache.
