### PR TITLE
Fix for a weird pthread_rwlock_xxx issue on Mac

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -6750,7 +6750,14 @@ void freedb_int(dbtable *db, dbtable *replace)
     }
 
     if (replace) {
+        pthread_rwlock_t lk_copy;
+        // Make a copy of original sc_live_lk
+        memcpy(&lk_copy, &db->sc_live_lk, sizeof(pthread_rwlock_t));
+
         memcpy(db, replace, sizeof(dbtable));
+
+        // Restore sc_live_lk
+        memcpy(&db->sc_live_lk, &lk_copy, sizeof(pthread_rwlock_t));
         db->dbs_idx = dbs_idx;
     } else
         free(db);


### PR DESCRIPTION
On Macbook, the DROP TABLE in the following sequence of commands could randomly hang while trying to acquire write lock on dbtable->sc_live_lk.

```
  create table test(i int)$$
  insert into test values(1);
  alter table test { schema { cstring i[5] }}$$
  drop table test;
```
In this experimental fix I tried to copy and restore the sc_live_lk from the original table.

This issue was reported by @zevbo.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>