### PR TITLE
made tunable writable

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -814,7 +814,7 @@ REGISTER_TUNABLE("no_round_robin_stripes", "Disables 'round_robin_stripes'",
                  TUNABLE_BOOLEAN, &gbl_round_robin_stripes,
                  INVERSE_VALUE | READONLY | NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("no_sc_inco_chk", NULL, TUNABLE_BOOLEAN, &gbl_sc_inco_chk,
-                 READONLY | NOARG, NULL, NULL, NULL, NULL);
+                 NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("no_static_tag_blob_fix", NULL, TUNABLE_BOOLEAN,
                  &gbl_force_notnull_static_tag_blobs,
                  INVERSE_VALUE | READONLY | NOARG, NULL, NULL, NULL, NULL);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -517,7 +517,7 @@
 (name='no_null_blob_fix', description='Disables 'null_blob_fix'', type='BOOLEAN', value='OFF', read_only='Y')
 (name='no_rep_process_txn_trace', description='Disables 'rep_process_txn_trace'', type='BOOLEAN', value='ON', read_only='Y')
 (name='no_round_robin_stripes', description='Disables 'round_robin_stripes'', type='BOOLEAN', value='ON', read_only='Y')
-(name='no_sc_inco_chk', description='', type='BOOLEAN', value='ON', read_only='Y')
+(name='no_sc_inco_chk', description='', type='BOOLEAN', value='ON', read_only='N')
 (name='no_static_tag_blob_fix', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='no_timeouts_on_release_locks', description='Disable client-timeouts if we're releasing locks', type='BOOLEAN', value='ON', read_only='N')
 (name='no_toblock_net_throttle', description='Disables 'toblock_net_throttle'', type='BOOLEAN', value='ON', read_only='Y')

--- a/tests/tunables.test/t01_dyn_tunables.expected
+++ b/tests/tunables.test/t01_dyn_tunables.expected
@@ -54,3 +54,5 @@
 (name='allow_negative_column_size')
 (value=1000)
 (value=2000)
+(value='ON')
+(value='OFF')

--- a/tests/tunables.test/t01_dyn_tunables.sql
+++ b/tests/tunables.test/t01_dyn_tunables.sql
@@ -67,3 +67,8 @@ select c.name from comdb2_tunables c, comdb2_tunables d where c.name like '%colu
 select value from comdb2_tunables where name = 'max_query_fingerprints'
 put tunable 'max_query_fingerprints' 2000;
 select value from comdb2_tunables where name = 'max_query_fingerprints'
+
+# TEST 'no_sc_inco_chk'
+select value from comdb2_tunables where name = 'no_sc_inco_chk'
+put tunable 'no_sc_inco_chk' 0;
+select value from comdb2_tunables where name = 'no_sc_inco_chk'


### PR DESCRIPTION
Work for {DRQS 166825589} 
no_sc_inco_chk is read-only by defaullt. DBAs want it to be writable in DR test mode. 