### PR TITLE
Desync master

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -881,6 +881,8 @@ struct dbenv {
 
     char *master; /*current master node, from callback*/
     int gen;      /*election generation for current master node*/
+    int egen;     /*last election generation for which I received callback */
+    pthread_mutex_t egen_mtx;
 
     int cacheszkb;
     int cacheszkbmin;


### PR DESCRIPTION
## Desync Master

### Issue
```
node1:
19:47:11 somedb:NEWMASTER is ME for GENERATION 1895

node2:
19:47:10 somedb:NEWMASTER is ME for GENERATION 1893
19:47:12 somedb:I AM NEW MASTER NODE node2
19:47:12 somedb:bdb_downgrade_int line 4979 called for election
19:47:12 somedb:call_for_election: creating elect thread
19:47:12 somedb:bdb_downgrade_int returning
19:47:12 somedb:NEW MASTER NODE node1
then lots of
EDT 2021/06/04 19:52:35 somedb:purge_old_files_thread: bdb_purge_unused_files failed rc=-1 bdberr=21  (ie: BDBERR_READONLY, I won't do this, I'm not master)
```

### Diagnosis

When we get a DB_REP_NEWMASTER https://github.com/bloomberg/comdb2/blob/f17474921000e898109f8a1cd040820d0b384855/bdb/rep.c#L4062, two new_master_callbacks are called. 

One on this route -> `bdb_upgrade` -> `bdb_upgrade_downgrade_reopen_wrap` -> `new_master_callback` https://github.com/bloomberg/comdb2/blob/15984d1eeb059acbe366713dfd8b80e00e3f390d/bdb/file.c#L5429
One from within `bdb_setmaster` (which sets `repinfo->master` and then calls `new_master_callback`) later in the `process_berkdb`. https://github.com/bloomberg/comdb2/blob/d68a8f3747986d7bca054552fae22887eae6bf9a/bdb/rep.c#L4108

I think in between those callbacks the master changes, and a `new_master_callback` is called on some other thread. I am thinking 1) via the `bdb_downgrade_noelect` -> `bdb_upgrade_downgrade_reopen_wrap`-> `new_master_callback` path (which happens either if the `hostdown_thread` detects a master going down or from sql “upgrade <somenode>”). So, while the rest of the cluster goes from node1 to node2. While node1 has received the callback for node2, it then overwrites it by the `bdb_setmaster->new_master_callback` route. [1] or 2)  `process_berkdb` is called on another thread.

I have been trying to replicate this by placing a sleep between the two routes above (`bdb_upgrade_downgrade_reopen_wrap` -> `new_master_callback` and `bdb_setmaster` -> `new_master_callback`). I have been able to get a `new_master_callback` in between those two. Thereby [1] happens, which makes the purge_old_files_thread error appears continuously, however, as soon as the sleep finishes the later callbacks quickly set the master to the correct one and the errors disappear. I am not able to reliably reproduce it. It happens every now and then. While, I had added a test for this, I removed it for this PR since the test is not reliable enough.

### Fix

Regardless of how we get to this state, I think it's fair to ignore any callback with an older `egen`.
