### PR TITLE
Fix hungserv on schema change

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -8351,6 +8351,7 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
             if (oldfile_add(munged_name, lognum, __func__, __LINE__,
                             spew_debug)) {
                 print(bdb_state, "failed to collect old file %s\n", ent->d_name);
+                break;
             } else {
                 print(bdb_state, "collected old file %s\n", ent->d_name);
             }


### PR DESCRIPTION
Exit after first failure in adding file to old file list, instead of trying and failing on every file thereafter

Signed-off-by: Mohit Khullar <mkhullar1@bloomberg.net>

