### PR TITLE
Fix hungserv on schemachange R7

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -7986,6 +7986,7 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
                                  __LINE__)) {
                 print(bdb_state, "failed to collect old file (list full) %s\n",
                       ent->d_name);
+                break;
             } else {
                 print(bdb_state, "collected old file %s\n", ent->d_name);
             }


### PR DESCRIPTION
Exit after first failure in adding file to old file list, instead of trying and failing on every file thereafter
Function names changed, can't cherry pick 

Signed-off-by: Mohit Khullar <mkhullar1@bloomberg.net>


