### PR TITLE
fix parallel sql termination race

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -184,6 +184,13 @@ void handle_child_error(struct sqlclntstate *clnt, int errcode)
     }
 }
 
+static void _mark_shard_done(dohsql_connector_t *conn)
+{
+    Pthread_mutex_lock (&conn->mtx);
+    conn->status = DOH_CLIENT_DONE;
+    Pthread_mutex_unlock (&conn->mtx);
+}
+
 static void sqlengine_work_shard(struct thdpool *pool, void *work,
                                  void *thddata)
 {
@@ -239,7 +246,7 @@ static void sqlengine_work_shard(struct thdpool *pool, void *work,
     /*thrman_setid(thrman_self(), "[done]");*/
 
     /* after this clnt is toast */
-    ((dohsql_connector_t *)clnt->plugin.state)->status = DOH_CLIENT_DONE;
+    _mark_shard_done(clnt->plugin.state);
 }
 
 static int inner_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col)


### PR DESCRIPTION
There is a shard termination race in parallel sql execution (dohsql).  The shard worker marks the status complete (DOH_CLIENT_DONE), while the coordinator checks that status and writes it to a different state (DOH_MASTER_DONE) if not complete.  The second is done under a mutex, but the first is not.  Therefore, it is possible for the coordinator to not see the shard status update and override it to a state that does not permit it to finish later on. 
The user request finishes properly but the coordinator sql engine never terminates and ends up blocking one sqlite engine .  

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>