### PR TITLE
Retry flag on

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3231,7 +3231,7 @@ static int node_in_list(int node, int list[], int listsz)
 
 /* ripped out ALL SUPPORT FOR ALL BROKEN CRAP MODES, aside from "newcoh" */
 
-int gbl_replicant_retry_on_not_durable = 0;
+int gbl_replicant_retry_on_not_durable = 1;
 static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
                                             seqnum_type *seqnum, int *timeoutms,
                                             uint64_t txnsize, int newcoh)
@@ -3260,7 +3260,7 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
     DB_LSN nodelsn;
     uint32_t nodegen;
     int num_successfully_acked = 0;
-    int total_connected;
+    int total_commissioned;
     int lock_desired = 0;
     int fake_incoherent = 0;
 
@@ -3290,25 +3290,16 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
         numskip = 0;
         numwait = 0;
 
-        if (durable_lsns) {
-            total_connected = net_get_sanctioned_replicants(bdb_state->repinfo->netinfo, REPMAX, connlist);
-        } else {
-            total_connected = net_get_all_commissioned_nodes(bdb_state->repinfo->netinfo, connlist);
-        }
-
-        if ((debug_switch_all_incoherent() && (rand() % 2))) {
-            fake_incoherent = 1;
-        }
-
-        if (total_connected == 0) {
-            goto done_wait;
+        if ((total_commissioned = net_get_all_commissioned_nodes(
+                 bdb_state->repinfo->netinfo, connlist)) == 0) {
+          goto done_wait;
         }
 
         if (track_once && bdb_state->attr->track_replication_times) {
             track_once = 0;
 
             Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-            for (int i = 0; i < total_connected; i++)
+            for (int i = 0; i < total_commissioned; i++)
                 bdb_track_replication_time(bdb_state, seqnum, connlist[i]);
             Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
@@ -3332,7 +3323,7 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
             }
         }
 
-        for (i = 0; i < total_connected; i++) {
+        for (i = 0; i < total_commissioned; i++) {
             int wait = 0;
             /* is_incoherent returns 0 for COHERENT & INCOHERENT_WAIT */
             if (!(is_incoherent_complete(bdb_state, connlist[i], &wait))) {
@@ -3348,6 +3339,10 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
 
         if (numnodes == 0) {
             goto done_wait;
+        }
+
+        if ((debug_switch_all_incoherent() && (rand() % 2))) {
+            fake_incoherent = 1;
         }
 
         for (i = 0; i < numnodes; i++) {
@@ -3548,7 +3543,7 @@ done_wait:
         int istest = 0;
         int was_durable = 0;
 
-        uint32_t cluster_size = total_connected + 1;
+        uint32_t cluster_size = total_commissioned + 1;
         uint32_t number_with_this_update = num_successfully_acked + 1;
         uint32_t durable_target = (cluster_size / 2) + 1;
 
@@ -3608,7 +3603,7 @@ done_wait:
                 "durable-commit-count=%u not-durable-commit-count=%u "
                 "commit-lsn=[%d][%d] commit-gen=%u calc-durable-lsn=[%d][%d] "
                 "calc-durable-gen=%u\n",
-                was_durable ? "durable" : "not-durable", total_connected,
+                was_durable ? "durable" : "not-durable", total_commissioned,
                 num_successfully_acked, durable_count, not_durable_count,
                 seqnum->lsn.file, seqnum->lsn.offset, seqnum->generation,
                 calc_lsn.file, calc_lsn.offset, calc_gen);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1918,7 +1918,7 @@ REGISTER_TUNABLE("debug_mixed_ddl_dml", "Reject write schedules which mix DDL an
 REGISTER_TUNABLE("sync_osql_cancel", "Synchronous osql cancellation (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_sync_osql_cancel, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: off)",
+REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("net_somaxconn",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -711,7 +711,7 @@
 (name='repl_wait', description='Replication wait system enabled for queues', type='BOOLEAN', value='ON', read_only='N')
 (name='replicant_latches', description='Also acquire latches on replicants. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicant_latency', description='Replicant drops log records.', type='BOOLEAN', value='OFF', read_only='N')
-(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
+(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='replicate_local', description='When enabled, record all database events to a comdb2_oplog table. This can be used to set clusters/instances that are fed data from a database cluster. Alternate ways of doing this are being planned, so enabling this option should not be needed in the near future. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_local_concurrent', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_rowlocks', description='Replicate rowlocks', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Turn the `gbl_replicant_retry_on_not_durable` ON.

Waiting for nodes in all sanctioned doesn't make sense. Wait just for commissioned.
