### PR TITLE
Do type checks for first non-typed call for each fingerprint

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -73,6 +73,9 @@ struct fingerprint_track {
     char ** cachedColNames; /* Cached column names from sqlitex */
     char ** cachedColDeclTypes; /* Cached column types from sqlitex */
     int cachedColCount;     /* Cached column count from sqlitex */
+    int haveTypes;          /* Set if we cached types, but did not necessarily do type checks */
+    int didTypeChecks;      /* Set if we already did type checks */
+    int didNameChecks;      /* Set if we already did name checks */
 };
 
 typedef int(plugin_query_data_func)(struct sqlclntstate *, void **, int *, int, int);


### PR DESCRIPTION
This fixes an issue where type checks were skipped because the first request that came in for a fingerprint was typed.  This does the check for the first non-typed call.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>