### PR TITLE
Fix cdb2_sqlreplay and testcase

### DIFF
--- a/tests/replay_eventlog.test/Makefile
+++ b/tests/replay_eventlog.test/Makefile
@@ -5,7 +5,7 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=5m
 endif
 
 

--- a/tests/replay_eventlog.test/runit
+++ b/tests/replay_eventlog.test/runit
@@ -325,8 +325,7 @@ if [[ -z "$CLUSTER" ]]; then
     cdb2sql --tabs ${SECONDARY_CDB2_OPTIONS} $SECONDARY_DBNAME default 'exec procedure sys.cmd.send("flush")'
     cdb2sql --tabs ${SECONDARY_CDB2_OPTIONS} $SECONDARY_DBNAME default 'exec procedure sys.cmd.send("reql events roll")'
 
-    zcat $logfl | grep --text -v 'sys.cmd.send' | sort -n > $slogflunziped
-
+    zcat $logfl | grep --text -v 'sys.cmd.send' | grep --text -v "comdb2_prevquerycost" | sort -n > $slogflunziped
 else
 
     for node in $CLUSTER ; do
@@ -335,7 +334,7 @@ else
         cdb2sql --tabs ${SECONDARY_CDB2_OPTIONS} $SECONDARY_DBNAME --host $node 'exec procedure sys.cmd.send("reql events roll")'
         ssh -o StrictHostKeyChecking=no $node "zcat $logfl" | grep --text -v 'sys.cmd.send' > ${node}.events.unzipped
     done
-    sort -n *.events.unzipped > $slogflunziped
+    sort -n *.events.unzipped | grep --text -v "comdb2_prevquerycost" > $slogflunziped
 fi
 
 cdb2sql ${SECONDARY_CDB2_OPTIONS} $SECONDARY_DBNAME default "select * from t1 order by alltypes_u_short" > replayed.txt


### PR DESCRIPTION
Fixes cdb2_sqlreplay program (wasn't fully consuming result set for cost query) and test case (wasn't excluding comdb2_getprevquerycost() queries from replay log)

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>
