### PR TITLE
when altering a lightrenamed table, preserve the sql alias

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -6917,9 +6917,12 @@ void freedb_int(dbtable *db, dbtable *replace)
 {
     int i;
     int dbs_idx;
+    char *sqlaliasname = db->sqlaliasname;
 
     dbs_idx = db->dbs_idx;
 
+    if (!replace) 
+        free(sqlaliasname);
     free(db->lrlfname);
     free(db->tablename);
     /* who frees schema/ixschema? */
@@ -6981,6 +6984,7 @@ void freedb_int(dbtable *db, dbtable *replace)
     if (replace) {
         memcpy(db, replace, sizeof(dbtable));
         db->dbs_idx = dbs_idx;
+        db->sqlaliasname = sqlaliasname;
     } else
         free(db);
 }

--- a/tests/renametable.test/reqoutput.txt
+++ b/tests/renametable.test/reqoutput.txt
@@ -87,3 +87,16 @@
 (id=111)
 (id=111)
 [select * from t order by id] rc 0
+[alter table t add column b int] rc 0
+(id=11, b=NULL)
+(id=21, b=NULL)
+(id=31, b=NULL)
+(id=41, b=NULL)
+(id=51, b=NULL)
+(id=81, b=NULL)
+(id=91, b=NULL)
+(id=101, b=NULL)
+(id=101, b=NULL)
+(id=111, b=NULL)
+(id=111, b=NULL)
+[select * from t order by id] rc 0

--- a/tests/renametable.test/runit
+++ b/tests/renametable.test/runit
@@ -47,6 +47,9 @@ insert into t values (100)
 insert into t values (110)
 update t set id=id+1
 select * from t order by id
+alter table t add column b int
+\$\$
+select * from t order by id
 EOF
 
 df=`diff output.txt reqoutput.txt`


### PR DESCRIPTION
Ported https://github.com/bloomberg/comdb2/pull/2969 to 7.0
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

