### PR TITLE
trigger: Move subscription setup from __db_open into __bam_open

### DIFF
--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -267,49 +267,6 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 			ret = __lock_downgrade(dbenv,
 			    &dbp->handle_lock, DB_LOCK_READ, 0);
 	}
-	if (type == DB_BTREE && fname) {
-		size_t s = strlen(fname);
-		if (s > 7 && strncmp(fname, "XXX.__q", 7) == 0) {
-			/*
-			 ** Format of valid queuedb names:
-			 ** XXX.__qfoobar_5a04ca240000006c.queuedb
-			 ** or
-			 ** XXX.__qfoobar.queuedb
-			 **
-			 ** Both styles name a queuedb: __qfoobar
-			 ** See also, is_tablename_queue @ osqlcomm.c
-			 */
-			char name[s], *n = name;
-			const char *f = fname + 4;
-			while (*f != '.')
-				*n++ = *f++;
-			*n = 0;
-			s = n - name;
-			if (s > 17) { // possibly new style queue name
-				n = name + s - 17;
-				if (*n == '_') {
-					char *g = n + 1;
-					while (*g) {
-						char c = *g;
-						if ((c >= '0' && c <= '9') ||
-						    (c >= 'a' && c <= 'f')) {
-							++g;
-						} else {
-							break;
-						}
-					}
-					if (*g == 0) {
-						// walks like a genid
-						// quacks like a genid
-						*n = 0;
-					}
-				}
-			}
-			dbp->trigger_subscription =
-			    __db_get_trigger_subscription(name);
-			dbenv->trigger_open(dbenv, name);
-		}
-	}
 
 DB_TEST_RECOVERY_LABEL
 err:


### PR DESCRIPTION
This uses `dbp->type` instead of the `type` that is passed into `__db_open`, which can be `DB_UNKNOWN`. Fixes {DRQS 167228291<GO>}.

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>