### PR TITLE
trigger: Move subscription setup from __db_open into __bam_open

### DIFF
--- a/berkdb/btree/bt_open.c
+++ b/berkdb/btree/bt_open.c
@@ -65,15 +65,8 @@ static const char revid[] = "$Id: bt_open.c,v 11.87 2003/07/17 01:39:09 margo Ex
 
 static void __bam_init_meta __P((DB *, BTMETA *, db_pgno_t, DB_LSN *));
 
-/*
- * __bam_open --
- *	Open a btree.
- *
- * PUBLIC: int __bam_open __P((DB *,
- * PUBLIC:      DB_TXN *, const char *, db_pgno_t, u_int32_t));
- */
-int
-__bam_open(dbp, txn, name, base_pgno, flags)
+static int
+__bam_open_int(dbp, txn, name, base_pgno, flags)
 	DB *dbp;
 	DB_TXN *txn;
 	const char *name;
@@ -111,6 +104,64 @@ __bam_open(dbp, txn, name, base_pgno, flags)
 
 	/* Start up the tree. */
 	return (__bam_read_root(dbp, txn, base_pgno, flags));
+}
+
+/*
+ * __bam_open --
+ *	Open a btree.
+ *
+ * PUBLIC: int __bam_open __P((DB *,
+ * PUBLIC:      DB_TXN *, const char *, db_pgno_t, u_int32_t));
+ */
+int
+__bam_open(dbp, txn, fname, base_pgno, flags)
+	DB *dbp;
+	DB_TXN *txn;
+	const char *fname;
+	db_pgno_t base_pgno;
+	u_int32_t flags;
+{
+	int ret = __bam_open_int(dbp, txn, fname, base_pgno, flags);
+	if (!fname || strncmp(fname, "XXX.__q", 7)) return ret;
+	/*
+	 ** Format of valid queuedb names:
+	 ** XXX.__qfoobar_5a04ca240000006c.queuedb
+	 ** or
+	 ** XXX.__qfoobar.queuedb
+	 **
+	 ** Both styles name a queuedb: __qfoobar
+	 ** See also, is_tablename_queue @ osqlcomm.c
+	 */
+	size_t s = strlen(fname);
+	char name[s], *n = name;
+	const char *f = fname + 4; /* skip 'XXX.' */
+	while (*f != '.') /* seek up to '.queuedb' */
+		*n++ = *f++;
+	*n = 0;
+	s = n - name;
+	if (s > 17) { // possibly new style queue name
+		n = name + s - 17;
+		if (*n == '_') {
+			char *g = n + 1;
+			while (*g) {
+				char c = *g;
+				if ((c >= '0' && c <= '9') ||
+				    (c >= 'a' && c <= 'f')) {
+					++g;
+				} else {
+					break;
+				}
+			}
+			if (*g == 0) {
+				// walks like a genid
+				// quacks like a genid
+				*n = 0;
+			}
+		}
+	}
+	dbp->trigger_subscription = __db_get_trigger_subscription(name);
+	dbp->dbenv->trigger_open(dbp->dbenv, name);
+	return ret;
 }
 
 /*

--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -267,49 +267,6 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 			ret = __lock_downgrade(dbenv,
 			    &dbp->handle_lock, DB_LOCK_READ, 0);
 	}
-	if (type == DB_BTREE && fname) {
-		size_t s = strlen(fname);
-		if (s > 7 && strncmp(fname, "XXX.__q", 7) == 0) {
-			/*
-			 ** Format of valid queuedb names:
-			 ** XXX.__qfoobar_5a04ca240000006c.queuedb
-			 ** or
-			 ** XXX.__qfoobar.queuedb
-			 **
-			 ** Both styles name a queuedb: __qfoobar
-			 ** See also, is_tablename_queue @ osqlcomm.c
-			 */
-			char name[s], *n = name;
-			const char *f = fname + 4;
-			while (*f != '.')
-				*n++ = *f++;
-			*n = 0;
-			s = n - name;
-			if (s > 17) { // possibly new style queue name
-				n = name + s - 17;
-				if (*n == '_') {
-					char *g = n + 1;
-					while (*g) {
-						char c = *g;
-						if ((c >= '0' && c <= '9') ||
-						    (c >= 'a' && c <= 'f')) {
-							++g;
-						} else {
-							break;
-						}
-					}
-					if (*g == 0) {
-						// walks like a genid
-						// quacks like a genid
-						*n = 0;
-					}
-				}
-			}
-			dbp->trigger_subscription =
-			    __db_get_trigger_subscription(name);
-			dbenv->trigger_open(dbenv, name);
-		}
-	}
 
 DB_TEST_RECOVERY_LABEL
 err:


### PR DESCRIPTION
This uses dbp->type instead of the type that is passed into __db_open,
which can be DB_UNKNOWN. Fixes {DRQS 167228291<GO>}

PORTED (#2972)

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>