### PR TITLE
make stopped a global variable

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2851,7 +2851,8 @@ void berk_set_long_trace_func(void (*func)(const char *msg));
 void berk_init_rep_lockobj(void);
 
 long long get_unique_longlong(struct dbenv *env);
-void no_new_requests(struct dbenv *dbenv);
+void block_new_requests(struct dbenv *dbenv);
+void allow_new_requests(struct dbenv *dbenv);
 
 int get_next_seqno(void *tran, long long *seqno);
 int add_oplog_entry(struct ireq *iq, void *trans, int type, void *logrec,

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -544,7 +544,7 @@ void stop_threads(struct dbenv *dbenv)
     }
     UNLOCK(&stop_thds_time_lk);
 
-    dbenv->stopped = 1;
+    block_new_requests(dbenv);
     dbenv->no_more_sql_connections = 1;
 
     if (gbl_appsock_thdpool)
@@ -587,7 +587,7 @@ void resume_threads(struct dbenv *dbenv)
     resume_all_sql_pools();
     if (gbl_osqlpfault_thdpool)
         thdpool_resume(gbl_osqlpfault_thdpool);
-    dbenv->stopped = 0;
+    allow_new_requests(dbenv);
     dbenv->no_more_sql_connections = 0;
     MEMORY_SYNC;
     if (!dbenv->purge_old_blkseq_is_running ||


### PR DESCRIPTION
Every couple of db exits result in a crash.  While this is not a problem, it generates a bit of confusion.  We are freeing thedb while other threads (watcher for example) are still calling db_is_stopped.  Watcher thread in particular needs to run to make sure the db exists and it is not deadlocked forever.  Make the variable global is a simple hack.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
