### PR TITLE
Don't let multiple threads update disk space stats

### DIFF
--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -283,6 +283,9 @@ static int64_t refresh_diskspace(struct dbenv *dbenv, tran_type *tran)
     struct dbtable *db;
     unsigned int num_logs;
 
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    Pthread_mutex_lock(&lk);
+
     for(ndb = 0; ndb < dbenv->num_dbs; ndb++)
     {
         db = dbenv->dbs[ndb];
@@ -294,6 +297,8 @@ static int64_t refresh_diskspace(struct dbenv *dbenv, tran_type *tran)
         total += calc_table_size_tran(tran, db, 0);
     }
     total += bdb_logs_size(dbenv->bdb_env, &num_logs);
+
+    Pthread_mutex_unlock(&lk);
     return total;
 }
 


### PR DESCRIPTION
```
#!/bin/bash

for i in {1..10}; do
    yes "select value from comdb2_metrics where name='diskspace'" | cdb2sql -tabs -s mikedb local - | grep -v 'cdb2sql>' &
done
```

10 tables, 1M rows of 1 int column each.

Without patch:
2067310574
2067302382
1994369006
2165090286
2385356782
2115930094

With patch:
1994427563
1994427563
1994427563
1994427563
1994427563
1994427563
1994427563
1994427563