### PR TITLE
block renaming time partitions

### DIFF
--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -2433,6 +2433,11 @@ void sqlite3AlterRenameTable(Parse *pParse, Token *pSrcName, Token *pName,
         return;
     }
 
+    if (timepart_is_timepart(table, 1)) {
+        setError(pParse, SQLITE_MISUSE, "Time partitions cannot be renamed");
+        return;
+    }
+
     if (comdb2TokenToStr(pName, newTable, sizeof(newTable))) {
         setError(pParse, SQLITE_MISUSE, "Table name is too long");
         return;

--- a/tests/renametable.test/runit
+++ b/tests/renametable.test/runit
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 dbnm=$1
-#cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - > output.txt 2>&1
-cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - > output.txt 2>&1
+OUT=output.txt
+
+cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - > $OUT 2>&1
 insert into t values (40)
 insert into t values (20)
 insert into t values (30)
@@ -48,6 +49,29 @@ insert into t values (110)
 update t set id=id+1
 select * from t order by id
 EOF
+
+#make sure we do not allow rename for partitions
+# create the partition
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table testtv (a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE creating a new table tvtest"
+   exit 1
+fi
+
+starttime1=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-60*60*(24+1))'`
+echo cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TIME PARTITION ON testtv as tv PERIOD 'daily' RETENTION 3 START '${starttime1}'"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TIME PARTITION ON testtv as tv PERIOD 'daily' RETENTION 3 START '${starttime1}'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE creating a time partition tv"
+   exit 1
+fi
+sleep 10
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table tv rename to tv2"
+if (( $? == 0 )) ; then
+   echo "FAILURE blocking time partition rename"
+   exit 1
+fi
 
 df=`diff output.txt reqoutput.txt`
 if [ $? -ne 0 ] ; then


### PR DESCRIPTION
Renaming time partitions is not supported.  Return proper error if clients accidentally try to rename a partition.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
