### PR TITLE
Verbosity of sqlexplain

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -805,6 +805,8 @@ struct sqlclntstate {
     uint8_t fail_dispatch;
     uint8_t in_sqlite_init; /* clnt is in sqlite init phase when this is set */
 
+    int where_trace_flags;
+
     int ncontext;
     char **context;
 

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -1230,7 +1230,7 @@ int newsql_dump_query_plan(struct sqlclntstate *clnt, sqlite3 *hndl)
 
     //if verbose explain get costs dumped to tmpfile by setting wheretrace
     if (clnt->is_explain == 2) {
-        sqlite3WhereTrace = 0xfff;
+        sqlite3WhereTrace = clnt->where_trace_flags;
         f = tmpfile();
         if (f == NULL) {
             logmsgperror("tmpfile");

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1721,12 +1721,32 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
                     clnt->get_cost = 0;
                 }
             } else if (strncasecmp(sqlstr, "explain", 7) == 0) {
+                /* is_explain flag:
+                   1 - show plan
+                   2 - show plan + wheretrace */
                 sqlstr += 7;
                 sqlstr = skipws(sqlstr);
                 if (strncasecmp(sqlstr, "on", 2) == 0) {
                     clnt->is_explain = 1;
                 } else if (strncasecmp(sqlstr, "verbose", 7) == 0) {
                     clnt->is_explain = 2;
+                    sqlstr += 7;
+                    sqlstr = skipws(sqlstr);
+
+                    /*
+                       0x2    -> show headnote and footnote from the solver
+                       0x4    -> show how the best index is picked
+                       0x8    -> show how the cost of each index is calculated
+                       0x10   -> show trace for stat4
+                       0x100  -> show all where terms
+                       0x200  -> show trace for Or terms
+                       0x840  -> show trace for virtual tables
+                     */
+
+                    if (sqlstr[0] == '\0')
+                        clnt->where_trace_flags = ~0;
+                    else
+                        clnt->where_trace_flags = (int)strtol(sqlstr, NULL, 16);
                 } else {
                     clnt->is_explain = 0;
                 }


### PR DESCRIPTION
Currently `set explain verbose` turns on almost all SQLite where trace. Sometime it's just too verbose. The change makes `set explain verbose` take an additional verbosity value such that user can specify what exactly should be shown. Common values are 0xffff, 0xfff and 0xff.