### PR TITLE
remove always that is not always

### DIFF
--- a/sqlite/src/trigger.c
+++ b/sqlite/src/trigger.c
@@ -661,7 +661,7 @@ void sqlite3UnlinkAndDeleteTrigger(sqlite3 *db, int iDb, const char *zName){
   assert( sqlite3SchemaMutexHeld(db, iDb, 0) );
   pHash = &(db->aDb[iDb].pSchema->trigHash);
   pTrigger = sqlite3HashInsert(pHash, zName, 0);
-  if( ALWAYS(pTrigger) ){
+  if( pTrigger ){
     if( pTrigger->pSchema==pTrigger->pTabSchema ){
       Table *pTab = tableOfTrigger(pTrigger);
       Trigger **pp;


### PR DESCRIPTION
Creating a user view and dropping a user view (i.e. not a tpt) triggers a trigger ALWAYS check in debug mode that crashes tunables.  Trivial fix.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
