### PR TITLE
alter table T partitioned by ...

### DIFF
--- a/db/views.h
+++ b/db/views.h
@@ -438,4 +438,11 @@ int timepart_num_views(void);
  */
 const char *timepart_view_name(int i);
 
+/**
+ * Alias the existing table so we can create a partition with
+ * same name
+ *
+ */
+void timepart_alias_table(timepart_view_t *view, struct dbtable *db);
+
 #endif

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1320,6 +1320,8 @@ int sc_timepart_truncate_table(void *tran, const char *tableName,
     int rc;
 
     init_schemachange_type(&sc);
+    sc.onstack = 1;
+
     strncpy0(sc.tablename, tableName, MAXTABLELEN);
 
     sc.fastinit = 1;

--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -229,7 +229,8 @@ create_table_args ::= LP columnlist conslist_opt(X) RP(E) comdb2opt(O) table_opt
   comdb2CreateTableEnd(pParse,&X,&E,F,O);
 }
 partitioned ::= . 
-partitioned ::= PARTITIONED BY partition_options.
+partitioned ::= partitioned_by.
+partitioned_by ::= PARTITIONED BY partition_options.
 partition_options ::= TIME PERIOD STRING(P) RETENTION INTEGER(R) START STRING(S). {
   comdb2CreateTimePartition(pParse, &P, &R, &S);
 }
@@ -1973,6 +1974,8 @@ alter_table_commit_pending ::= SET COMMIT PENDING. {
   comdb2AlterCommitPending(pParse);
 }
 
+alter_table_partitioned ::= partitioned_by.
+
 alter_table_action ::= alter_table_add_column.
 alter_table_action ::= alter_table_drop_column.
 alter_table_action ::= alter_table_alter_column.
@@ -1985,6 +1988,7 @@ alter_table_action ::= alter_table_drop_cons.
 alter_table_action ::= alter_table_add_index.
 alter_table_action ::= alter_table_drop_index.
 alter_table_action ::= alter_table_commit_pending.
+alter_table_action ::= alter_table_partitioned.
 
 alter_table_action_list ::= DO NOTHING.
 alter_table_action_list ::= alter_table_action.

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -184,3 +184,81 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_time
 cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
 (name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
 (name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "t",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_F64CD191",
+  },
+  {
+   "TABLENAME"    : "$1_A2620AE4",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t3",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_43868980",
+  },
+  {
+   "TABLENAME"    : "$2_CE9DB8D",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t5",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_65276E68",
+  },
+  {
+   "TABLENAME"    : "$1_DEE0E531",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='t', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+(name='t2', period='daily', retention=2, nshards=2, version=0, shard0name='t3')
+(name='t5', period='daily', retention=2, nshards=2, version=1, shard0name='<none>')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='t', shardname='$0_F64CD191')
+(name='t', shardname='$1_A2620AE4')
+(name='t2', shardname='$0_43868980')
+(name='t2', shardname='$2_CE9DB8D')
+(name='t5', shardname='$0_65276E68')
+(name='t5', shardname='$1_DEE0E531')
+cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
+(name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t5', arg2=NULL, arg3=NULL)
+cdb2sql ${CDB2_OPTIONS} dorintdb default select * from '$0_65276E68'
+(d=100, e=NULL)
+(d=200, e=NULL)
+(d=300, e=NULL)
+(d=101, e=1)
+(d=201, e=1)
+(d=301, e=1)
+cdb2sql ${CDB2_OPTIONS} dorintdb default select * from '$1_DEE0E531'
+(d=102, e=2)
+(d=202, e=2)
+(d=302, e=2)

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -183,6 +183,62 @@ cmdmt="cdb2sql -tabs ${CDB2_OPTIONS} --host $master $dbname default"
 
 timepart_stats 0
 
+# 8.
+# create table and alter to a partition; check inserts
+echo $cmd "create table t5 (d int)"
+$cmd "create table t5 (d int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE create table t5"
+   exit 1
+fi
+
+$cmd "insert into t5 values (100), (200), (300)"
+if (( $? != 0 )) ; then
+   echo "FAILURE insert into table t5"
+   exit 1
+fi
+
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()+15)'`
+echo $cmd "ALTER TABLE t5 ADD COLUMN e int, PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+$cmd "ALTER TABLE t5 ADD COLUMN e int, PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+if (( $? != 0 )) ; then
+   echo "FAILURE to alter table t5 and add partion"
+   exit 1
+fi
+
+timepart_stats 0
+
+$cmd "insert into t5 values (101, 1), (201, 1), (301, 1)"
+if (( $? != 0 )) ; then
+   echo "FAILURE insert into table t5 round 2"
+   exit 1
+fi
+
+sleep 15
+
+$cmd "insert into t5 values (102, 2), (202, 2), (302, 2)"
+if (( $? != 0 )) ; then
+   echo "FAILURE insert into table t5 round 3"
+   exit 1
+fi
+
+echo $cmd "select * from '\$0_65276E68'"
+echo $cmd "select * from '\$0_65276E68'" >> $OUT
+$cmd "select * from '\$0_65276E68'" >> $OUT
+echo $cmd "select * from '\$1_DEE0E531'"
+echo $cmd "select * from '\$1_DEE0E531'" >> $OUT
+$cmd "select * from '\$1_DEE0E531'" >> $OUT
+
+# 9.
+# check attempt to alter an already partitioned table
+echo $cmd "ALTER TABLE t5 PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+$cmd "ALTER TABLE t5 PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'" 
+if (( $? == 0 )) ; then
+   echo "FAILURE to prevent duplicate partitioning"
+   exit 1
+fi
+
+
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
 


### PR DESCRIPTION
Partitioned table part 2:
Following the new concept that partitioning is a property of a table, we add the ability to partition an existing table by altering  its properties.
Currently supported partitioning is time based; syntax is:

"ALTER TABLE tablename PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '2021-11-03T America/New_York'"

Because partitioning is a property no different than other schema constraints, we can mix operations like:

ALTER TABLE t add column b, partitioned by ...


Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

