### PR TITLE
Make query fingerprint available to cdb2api events

### DIFF
--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -291,7 +291,8 @@ typedef enum cdb2_event_arg {
     CDB2_PORT,
     CDB2_SQL,
     CDB2_RETURN_VALUE,
-    CDB2_QUERY_STATE
+    CDB2_QUERY_STATE,
+    CDB2_FINGERPRINT
 } cdb2_event_arg;
 
 typedef struct cdb2_event cdb2_event;

--- a/db/sql.h
+++ b/db/sql.h
@@ -870,6 +870,7 @@ struct sqlclntstate {
     plugin_func *recover_ddlk;
     replay_func *recover_ddlk_fail;
     unsigned skip_eventlog: 1;
+    unsigned request_fp: 1;
 };
 
 /* Query stats. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5232,6 +5232,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     clnt->sqltick = 0;
     clnt->rowbuffer = 1;
     clnt->flat_col_vals = 0;
+    clnt->request_fp = 0;
     if (gbl_sockbplog) {
         init_bplog_socket(clnt);
     }

--- a/docs/pages/programming/c_api.md
+++ b/docs/pages/programming/c_api.md
@@ -579,25 +579,25 @@ where `cb_hndl` is the handle upon which the event is fired.
 
 Besides the user argument, one can request additional arguments by setting `argc` to the number of the arguments, followed by the argument types. The arguments will be passed to `cb` in `argv`. The table below lists the argument types.
 
-|Event Type|`CDB2_HOSTNAME`|`CDB2_PORT`|`CDB2_SQL`|`CDB2_RETURN_VALUE`|
-|---|---|---|---|---|
-| `CDB2_BEFORE_CONNECT` | The hostname to connect to | The port to connect to | N/A | N/A |
-| `CDB2_AFTER_CONNECT` | The hostname to connect to | The port to connect to | N/A | file descriptor |
-| `CDB2_BEFORE_PMUX` | The server hostname | The pmux port | N/A | N/A |
-| `CDB2_AFTER_PMUX` | The server hostname | The pmux port | N/A | The database port |
-| `CDB2_BEFORE_DBINFO` | The server hostname  | The database port | N/A | N/A |
-| `CDB2_AFTER_DBINFO` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | 
-| `CDB2_BEFORE_SEND_QUERY` | The server hostname | The database port | The SQL query | N/A |
-| `CDB2_AFTER_SEND_QUERY` | The server hostname | The database port | The SQL query | 0 on success; Non-zero on failure |
-| `CDB2_BEFORE_READ_RECORD` | The server hostname | The database port | N/A | N/A |
-| `CDB2_AFTER_READ_RECORD` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure |
-| `CDB2_AT_ENTER_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) |
-| `CDB2_AT_EXIT_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) |
-| `CDB2_AT_ENTER_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) |
-| `CDB2_AT_EXIT_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) |
-| `CDB2_AT_DISCOVERY` | N/A | N/A | N/A | N/A |
-| `CDB2_AT_OPEN` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) |
-| `CDB2_AT_CLOSE` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) |
+|Event Type|`CDB2_HOSTNAME`|`CDB2_PORT`|`CDB2_SQL`|`CDB2_RETURN_VALUE`|`CDB2_FINGERPRINT`|
+|---|---|---|---|---|---|
+| `CDB2_BEFORE_CONNECT` | The hostname to connect to | The port to connect to | N/A | N/A | N/A |
+| `CDB2_AFTER_CONNECT` | The hostname to connect to | The port to connect to | N/A | file descriptor | N/A |
+| `CDB2_BEFORE_PMUX` | The server hostname | The pmux port | N/A | N/A | N/A |
+| `CDB2_AFTER_PMUX` | The server hostname | The pmux port | N/A | The database port | N/A |
+| `CDB2_BEFORE_DBINFO` | The server hostname  | The database port | N/A | N/A | N/A |
+| `CDB2_AFTER_DBINFO` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A |
+| `CDB2_BEFORE_SEND_QUERY` | The server hostname | The database port | The SQL query | N/A | N/A |
+| `CDB2_AFTER_SEND_QUERY` | The server hostname | The database port | The SQL query | 0 on success; Non-zero on failure | N/A |
+| `CDB2_BEFORE_READ_RECORD` | The server hostname | The database port | N/A | N/A | N/A |
+| `CDB2_AFTER_READ_RECORD` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A |
+| `CDB2_AT_ENTER_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | N/A |
+| `CDB2_AT_EXIT_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
+| `CDB2_AT_ENTER_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
+| `CDB2_AT_EXIT_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
+| `CDB2_AT_DISCOVERY` | N/A | N/A | N/A | N/A | N/A |
+| `CDB2_AT_OPEN` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A |
+| `CDB2_AT_CLOSE` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A |
 
 Return Value:
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -383,6 +383,21 @@ static int newsql_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
     resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
     resp.n_value = ncols;
     resp.value = value;
+    if (clnt->request_fp) {
+        /* client has requested the fingerprint. if the fingerprint is already
+           available in clnt, use it. otherwise compute its value and store
+           in clnt. */
+        uint8_t empty[FINGERPRINTSZ] = {0};
+        if (memcmp(clnt->work.aFingerprint, empty, FINGERPRINTSZ) == 0) {
+            size_t nNormSql = 0;
+            calc_fingerprint(clnt->work.zNormSql, &nNormSql,
+                    clnt->work.aFingerprint);
+        }
+        resp.has_fp = 1;
+        resp.fp.data = clnt->work.aFingerprint;
+        resp.fp.len = FINGERPRINTSZ;
+    }
+    resp.has_flat_col_vals = 1;
     return newsql_response(clnt, &resp, 0);
 }
 
@@ -1867,8 +1882,12 @@ int is_commit_rollback(struct sqlclntstate *clnt)
 int newsql_first_run(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
 {
     for (int ii = 0; ii < sql_query->n_features; ++ii) {
-        if (CDB2_CLIENT_FEATURES__FLAT_COL_VALS == sql_query->features[ii]) {
+        switch(sql_query->features[ii]) {
+        case CDB2_CLIENT_FEATURES__FLAT_COL_VALS:
             clnt->flat_col_vals = 1;
+            break;
+        case CDB2_CLIENT_FEATURES__REQUEST_FP:
+            clnt->request_fp = 1;
             break;
         }
     }

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -22,7 +22,9 @@ enum CDB2ClientFeatures {
     /* To tell the server that the client is SSL-capable. */
     SSL                  = 5;
     /* flat column values. see sqlresponse.proto for more details. */
-    FLAT_COL_VALS   = 6;
+    FLAT_COL_VALS        = 6;
+    /* request server to send back query fingerprint */
+    REQUEST_FP           = 7;
 }
 
 message CDB2_FLAG {

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -159,4 +159,7 @@ message CDB2_SQLRESPONSE {
     optional bool flat_col_vals = 11;
     repeated bytes values = 12;
     repeated bool isnulls = 13;
+
+    /* query fingerprint */
+    optional bytes fp = 14;
 }

--- a/tests/api_events.test/expected
+++ b/tests/api_events.test/expected
@@ -36,5 +36,6 @@ cdb2_next_record_int: Timeout while reading response from server
 4, nil
 ====== RUN STATEMENT/NEXT RECORD ======
 SQL is SELECT "You may say I'm a dreamer, but I'm not the only one."
+FP is 4f16a8ec9db90f803e406659938b2602
 RC is 0
 RC is 1

--- a/tests/api_events.test/runit
+++ b/tests/api_events.test/runit
@@ -5,5 +5,6 @@ dbnm=$1
 echo '
 comdb2_config:enable_static_libs
 comdb2_config:allow_pmux_route:false
+comdb2_config:request_fingerprint:true
 ' >>$DBDIR/comdb2db.cfg
 ${TESTSBUILDDIR}/api_events $dbnm 2>&1 | diff expected -

--- a/tests/tools/api_events.c
+++ b/tests/tools/api_events.c
@@ -30,6 +30,12 @@ static void *my_overwrite_rc_hook(cdb2_hndl_tp *hndl, void *user_arg, int argc, 
     return (void*)(intptr_t)(-1);
 }
 
+static void *my_fp_hook(cdb2_hndl_tp *hndl, void *user_arg, int argc, void **argv)
+{
+    printf("FP is %s\n", (char *)argv[0]);
+    return NULL;
+}
+
 static cdb2_event *init_once_event;
 
 static void register_once(void)
@@ -199,6 +205,7 @@ static int TEST_run_stmt_next_record_events(const char *db, const char *tier)
     cdb2_event *e1, *e2;
     cdb2_open(&h, db, tier, 0);
     e1 = cdb2_register_event(h, CDB2_AT_EXIT_RUN_STATEMENT, 0, my_arg_hook, NULL, 1, CDB2_SQL);
+    e1 = cdb2_register_event(h, CDB2_AT_EXIT_RUN_STATEMENT, 0, my_fp_hook, NULL, 1, CDB2_FINGERPRINT);
     e2 = cdb2_register_event(h, CDB2_AT_EXIT_NEXT_RECORD, 0, my_rc_hook, NULL, 1, CDB2_RETURN_VALUE);
     cdb2_run_statement(h, "SELECT \"You may say I'm a dreamer, but I'm not the only one.\"");
     while ((rc = cdb2_next_record(h)) == CDB2_OK);


### PR DESCRIPTION
This change makes it possible for an API event to retrieve a query fingerprint from the server.
