### PR TITLE
Add all tables in query to event logging json, even if not used

### DIFF
--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -4930,6 +4930,9 @@ static int selectExpander(Walker *pWalker, Select *p){
   Expr *pE, *pRight, *pExpr;
   u16 selFlags = p->selFlags;
   u32 elistFlags = 0;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  Vdbe *v = sqlite3GetVdbe(pParse);
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
   p->selFlags |= SF_Expanded;
   if( db->mallocFailed  ){
@@ -5001,6 +5004,13 @@ static int selectExpander(Walker *pWalker, Select *p){
         pTab->nCol = nCol;
       }
 #endif
+
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+      if (!(IsVirtual(pTab) || pTab->pSelect)) {
+        // add all tables referenced in query even if not needed to execute query
+        sqlite3VdbeAddTable(v, pTab);
+      }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     }
 
     /* Locate the index named by the INDEXED BY clause, if any. */

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -174,6 +174,10 @@ insert into t1 values(10001, 'abc')
 select * from t1 where i = 10001
 EOF
 
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t2(a int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t3(b int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "select distinct t2.a from t2 left join t3 on t2.a = t3.b"
+
 # need to flush to get correct stmts in logfile
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
 
@@ -197,6 +201,14 @@ res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
     zcat $f | jq -c 'if (.type == "sql") and (.sql == "select * from t1 where i = 10001") then .id else empty end'
 done )
 assertres $res "null"
+
+echo "Test whether all tables referenced in query are present in event log even if not needed to execute query"
+echo "make sure string 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' is in the last 2 eventlog files:"
+echo "make sure that 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' has t2 and t3 in tables field (even though t3 isn't needed to execute this)"
+res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
+    zcat $f | jq -c 'if (.type == "sql") and (.sql == "select distinct t2.a from t2 left join t3 on t2.a = t3.b") and (.tables | tostring == "[\"t2\",\"t3\"]") then . else empty end'
+done | wc -l)
+assertres $res 1
 
 
 echo "Test having no limit for logfiles (turning off rolling)"

--- a/tests/yast.test/view.test
+++ b/tests/yast.test/view.test
@@ -663,7 +663,7 @@ do_test view-21.1 {
     CREATE VIEW v32768 AS SELECT * FROM v16384 UNION SELECT * FROM v16384;
     SELECT * FROM v32768 UNION SELECT * FROM v32768;
   }
-} {1 1 {too many references to "v1": max 65535}}
+} {1 1 {too many references to "t1": max 65535}}
 #ifcapable progress {
 #  do_test view-21.2 {
 #    db progress 1000 {expr 1}


### PR DESCRIPTION
Currently only tables that are actually needed to execute a query are written to the events log, but this change makes it so that all tables referenced in a query are written to the events log.
