### PR TITLE
Add all tables in query to event logging json, even if not used

### DIFF
--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -4918,6 +4918,9 @@ static int selectExpander(Walker *pWalker, Select *p){
   Expr *pE, *pRight, *pExpr;
   u16 selFlags = p->selFlags;
   u32 elistFlags = 0;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  Vdbe *v = sqlite3GetVdbe(pParse);
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
   p->selFlags |= SF_Expanded;
   if( db->mallocFailed  ){
@@ -4989,6 +4992,13 @@ static int selectExpander(Walker *pWalker, Select *p){
         pTab->nCol = nCol;
       }
 #endif
+
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+      if (!(IsVirtual(pTab) || pTab->pSelect)) {
+        // add all tables referenced in query even if not needed to execute query
+        sqlite3VdbeAddTable(v, pTab);
+      }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     }
 
     /* Locate the index named by the INDEXED BY clause, if any. */

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -184,7 +184,12 @@ cdb2sql ${CDB2_OPTIONS} $DBNAME default -f in.sql
 
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "insert into t1 values(10001, 'abc')"
 
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t2(a int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t3(b int)"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "select distinct t2.a from t2 left join t3 on t2.a = t3.b"
+
 sleep 3
+
 # need to flush to get correct stmts in logfile
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
 
@@ -204,6 +209,13 @@ cat lastfls.txt
 
 res=$(cat lastfls.txt | xargs zgrep 'insert into t1 values(10001, '"'abc'"')' | grep -c '"type": "sql"')
 assertres $res 1
+
+echo "Test whether all tables referenced in query are present in event log even if not needed to execute query"
+echo "make sure string 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' is in the last 2 eventlog files:"
+echo "make sure that 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' has t2 and t3 in tables field (even though t3 isn't needed to execute this)"
+res=$(cat lastfls.txt | xargs zgrep 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' | grep '"type": "sql"' | grep -c '"tables": \["t2","t3"\]')
+assertres $res 1
+
 
 echo "Test having no limit for logfiles (turning off rolling)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events rollat 0')"


### PR DESCRIPTION
Currently only tables that are actually needed to execute a query are written to the events log, but this change makes it so that all tables referenced in a query are written to the events log.