### PR TITLE
Retry 3 times for a non-HASQL statement

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -16,7 +16,7 @@ limitations under the License. -->
   <groupId>com.bloomberg.comdb2</groupId>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdb2jdbc</artifactId>
-  <version>2.5.2</version>
+  <version>2.5.3</version>
   <packaging>jar</packaging>
   <properties>
     <maven.compiler.source>1.6</maven.compiler.source>


### PR DESCRIPTION
Libevent-based appsock doesn't handle an SSL connection (support for this is being worked on). Instead, libevent-based appsock turns itself off and disconnects an SSL client. The SSL client then reconnects, and goes through the old sbuf2 logic.

This requires the client to retry against a single-node database more than once. cdb2api already does this, but cdb2jdbc does not. This change ports the missing logic from cdb2api to cdb2jdbc.