### PR TITLE
report schemachange error back to client

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -1053,6 +1053,7 @@ void key_piece_add(char *buf,
         nk->cmp = 0;
         nk->stbl = gettable(ONDISKTAG);
         if (nk->stbl < 0) {
+            csc2_error("ERROR: TABLE with ONDISK TAG NOT FOUND.- ABORTING\n"),  
             any_errors++;
             return;
         }
@@ -2414,7 +2415,6 @@ static int dyns_load_schema_int(char *filename, char *schematxt, char *dbname,
     }
 
     if (yyparse() || any_errors || check_options()) {
-        csc2_error("FOUND ERRORS IN SCHEMA. ABORTING!\n");
         if (fhopen)
             fclose((FILE *)yyin);
         return -1;

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -30,10 +30,8 @@ int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
     int rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->tablename);
     if (rc != 0) {
         char *err;
-        char *syntax_err;
         err = csc2_get_errors();
-        syntax_err = csc2_get_syntax_errors();
-        if (iq) reqerrstr(iq, ERR_SC, "%s", syntax_err);
+        if (iq) reqerrstr(iq, ERR_SC, "%s", err);
         sc_errf(s, "%s", err);
         sc_errf(s, "Failed to load schema\n");
         return SC_INTERNAL_ERROR;


### PR DESCRIPTION
When try to create an index on a blob or Vutf-8 field, We get the following error : "Failed with rc 240 (null)" -> clearly doesn't provide much insight into the error. 

This PR ensure that we report the error back to client : " Failed with rc 240. Key <keynum> contains a blob or vutf8 field <field name>. This is not supported" 
