### PR TITLE
sp: Non-fatal string conversion during emit

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2239,9 +2239,10 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
     if (rc == SQLITE_OK) {
         /* send return code */
 
+        Pthread_mutex_lock(&clnt->wait_mutex);
+
         write_response(clnt, RESPONSE_EFFECTS, 0, 0);
 
-        Pthread_mutex_lock(&clnt->wait_mutex);
         /* do not turn heartbeats if this is a chunked transaction */
         if (sideeffects != TRANS_CLNTCOMM_CHUNK)
             clnt->ready_for_heartbeats = 0;

--- a/lua/ltypes.c
+++ b/lua/ltypes.c
@@ -525,12 +525,7 @@ int luabb_tointervalds_noerr(Lua L, int idx, intv_t *ret)
     return -1;
 }
 
-/*
-** WARNING: luabb_tostring RETURNS AN EPHEMERAL STRING.
-** DON'T CALL INTO ANY lua_* FUNCTIONS WITH IT.
-** A GC-RUN CAN TRASH RETURNED MEMORY.
-*/
-const char *luabb_tostring(Lua L, int idx)
+static const char *luabb_tostring_int(Lua L, int idx, int fatal)
 {
     idx = to_positive_index(L, idx);
     const char *ret = NULL;
@@ -554,8 +549,23 @@ const char *luabb_tostring(Lua L, int idx)
             lua_pop(L, 1);
             return ret;
     }
-    luabb_type_err(L, "string", idx);
+    luabb_type_err_int(L, "string", idx, fatal);
     return NULL;
+}
+
+/*
+** WARNING: luabb_tostring RETURNS AN EPHEMERAL STRING.
+** DON'T CALL INTO ANY lua_* FUNCTIONS WITH IT.
+** A GC-RUN CAN TRASH RETURNED MEMORY.
+*/
+const char *luabb_tostring(Lua L, int idx)
+{
+    return luabb_tostring_int(L, idx, 1);
+}
+
+const char *luabb_tostring_noerr(Lua L, int idx)
+{
+    return luabb_tostring_int(L, idx, 0);
 }
 
 static int luabb_toblob_int(Lua lua, int idx, blob_t *ret)

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -656,7 +656,9 @@ void *sp_column_ptr(struct response_data *arg, int col, int type, size_t *len)
             *len = strlen(c);
             break;
         default:
-            c = strdup(luabb_tostring(L, idx));
+            c = (char *)luabb_tostring_noerr(L, idx);
+            if (!c) break;
+            c = strdup(c);
             *len = strlen(c);
             luabb_pushcstring_dl(L, c);
             lua_replace(L, idx);

--- a/lua/sp_int.h
+++ b/lua/sp_int.h
@@ -99,6 +99,7 @@ int luabb_todatetime_noerr(Lua, int index, datetime_t *);
 int luabb_tointervalym_noerr(Lua, int index, intv_t *);
 int luabb_tointervalds_noerr(Lua, int index, intv_t *);
 int luabb_toblob_noerr(Lua, int index, blob_t *);
+const char *luabb_tostring_noerr(Lua, int);
 
 void luabb_pushblob(Lua, const blob_t *);
 void luabb_pushblob_dl(Lua, const blob_t *); //dl -> dup-less

--- a/tests/sp.test/t14.req
+++ b/tests/sp.test/t14.req
@@ -1,0 +1,9 @@
+create procedure str_conv version 'sptest' {
+local function main()
+    db:num_columns(1)
+    db:column_type('cstring', 1)
+    db:column_name('a', 1)
+    db:emit({a={}})
+end
+}$$
+exec procedure str_conv()

--- a/tests/sp.test/t14.req.out
+++ b/tests/sp.test/t14.req.out
@@ -1,0 +1,2 @@
+(version='sptest')
+[exec procedure str_conv()] failed with rc -3 [db:emit({a={}})...]:6: conversion to:string failed from:table


### PR DESCRIPTION
I'm guessing I missed adding this variant for strings, thinking
(incorrectly) that conversion to string cannot fail. This initial work
was done here: 3a57baab34c151c1674e3e75119ae0997fedb4f5

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>