### PR TITLE
Auth: Remove OP permissions on user/table drop

### DIFF
--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -276,6 +276,15 @@ static int bdb_del_user_tbl_access(bdb_state_type *bdb_state, tran_type *tran,
     int rc = 0;
     int bdberr;
 
+    if ((rc = bdb_tbl_op_access_delete(bdb_state, tran, 0, table_name,
+                                       user, &bdberr)) != 0) {
+        logmsg(LOGMSG_ERROR,
+               "error deleting user access information (user: %s, table: %s, "
+               "rc: %d, bdberr: %d)\n",
+               user, table_name, rc, bdberr);
+        return rc;
+    }
+
     if ((rc = bdb_tbl_access_read_delete(bdb_state, tran, table_name, user,
                                          &bdberr)) != 0) {
         logmsg(LOGMSG_ERROR,

--- a/db/bpfunc.c
+++ b/db/bpfunc.c
@@ -353,6 +353,13 @@ static int exec_grant(void *tran, bpfunc_t *func, struct errstat *err)
 
     if (rc)
         errstat_set_rcstrf(err, rc, "%s access denied", __func__);
+
+    if (rc == 0) {
+        rc = net_send_authcheck_all(thedb->handle_sibling);
+    }
+
+    ++gbl_bpfunc_auth_gen;
+
     return rc;
 }
 
@@ -373,8 +380,15 @@ static int exec_password(void *tran, bpfunc_t *func, struct errstat *err)
                       : bdb_user_password_set(tran, pwd->user, pwd->password);
 
     if (rc == 0 && pwd->disable) {
-        /* Also delete all the table accesses for this user. */
-        rc = bdb_del_all_user_access(thedb->bdb_env, tran, pwd->user);
+        int bdberr;
+        /* Delete OP access for this user. */
+        rc = bdb_tbl_op_access_delete(thedb->bdb_env, tran, 0, "",
+                                      pwd->user, &bdberr);
+
+        if (rc == 0) {
+            /* Also delete all the table accesses for this user. */
+            rc = bdb_del_all_user_access(thedb->bdb_env, tran, pwd->user);
+        }
     }
 
     if (rc == 0) {

--- a/tests/auth.test/t18.expected
+++ b/tests/auth.test/t18.expected
@@ -1,0 +1,7 @@
+(user='---------- user1: OP user ----------')
+(rows inserted=1)
+(user='---------- user2: non-OP user ----------')
+(i=1)
+(user='---------- user1: OP user ----------')
+(user='---------- user2: non-OP user ----------')
+[select * from t1] failed with rc -106 Read access denied to t1 for user user2 bdberr=15

--- a/tests/auth.test/t18.req
+++ b/tests/auth.test/t18.req
@@ -1,0 +1,35 @@
+# This test is to ensure that the user's OP privilege must also be dropped
+# along with user.
+
+# OP user: create a table and grant read to 'user2'
+set user 'user1'
+set password 'password1'
+select '---------- user1: OP user ----------' as user;
+create table t1(i int unique)$$
+insert into t1 values(1);
+# grant OP to 'user2'
+grant OP to 'user2';
+
+# 'user2' now should be able to read from t1
+set user 'user2'
+set password 'new_password'
+select '---------- user2: non-OP user ----------' as user;
+select * from t1;
+
+# Recreate 'user2'
+set user 'user1'
+set password 'password1'
+select '---------- user1: OP user ----------' as user;
+put password off for 'user2'
+put password 'new_password' for 'user2'
+
+# 'user2' now must not have read permission on t1
+set user 'user2'
+set password 'new_password'
+select '---------- user2: non-OP user ----------' as user;
+select * from t1;
+
+# Cleanup
+set user 'user1'
+set password 'password1'
+drop table t1;


### PR DESCRIPTION
Also bump up global auth generation when a permission is granted or revoked.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>