### PR TITLE
simplify the llog_scdone code

### DIFF
--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -65,10 +65,9 @@ int bdb_bump_dbopen_gen(const char *type, const char *message,
                         const char *funcName, const char *fileName, int lineNo);
 
 int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
-                         tran_type *tran, const char *origtable, int *bdberr);
-int bdb_llog_scdone(bdb_state_type *, scdone_t, int wait, int *bdberr);
-int bdb_llog_scdone_origname(bdb_state_type *, scdone_t, int wait,
-                             const char *origtable, int *bdberr);
+                         tran_type *tran, const char *tbl, int tbllen, int *bdberr);
+int bdb_llog_scdone(bdb_state_type *, scdone_t, const char *tablename, 
+                    int tablenamelen, int wait, int *bdberr);
 int bdb_llog_luareload(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_analyze(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_views(bdb_state_type *, char *name, int wait, int *bdberr);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11714,7 +11714,8 @@ int bt_hash_table(char *table, int szkb)
     trans_commit(&iq, tran, gbl_myhostname);
 
     // scdone log
-    rc = bdb_llog_scdone(bdb_state, bthash, 1, &bdberr);
+    rc = bdb_llog_scdone(bdb_state, bthash, bdb_state->name, 
+                         strlen(bdb_state->name) + 1, 1, &bdberr);
     if (rc || bdberr != BDBERR_NOERROR) {
         logmsg(LOGMSG_ERROR, 
                 "Failed to send logical log scdone bthash rc=%d bdberr=%d\n",
@@ -11767,7 +11768,8 @@ int del_bt_hash_table(char *table)
     trans_commit(&iq, tran, gbl_myhostname);
 
     // scdone log
-    rc = bdb_llog_scdone(bdb_state, bthash, 1, &bdberr);
+    rc = bdb_llog_scdone(bdb_state, bthash, bdb_state->name,
+                         strlen(bdb_state->name) + 1, 1, &bdberr);
     if (rc || bdberr != BDBERR_NOERROR) {
         logmsg(LOGMSG_ERROR, "Failed to send logical log scdone bthash rc=%d bdberr=%d\n",
                 rc, bdberr);

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -702,7 +702,8 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
     /* log for replicants to do the same */
     if (!same_tran) {
-        rc = bdb_llog_scdone(db->handle, scdone_type, 1, &bdberr);
+        rc = bdb_llog_scdone(thedb->bdb_env, scdone_type, db->tablename,
+                             strlen(db->tablename) + 1, 1, &bdberr);
         if (rc) {
             sbuf2printf(sb, "!Failed to broadcast queue %s\n", sc->drop_table ? "drop" : "add");
             logmsg(LOGMSG_ERROR, "Failed to broadcast queue %s\n", sc->drop_table ? "drop" : "add");
@@ -754,8 +755,8 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
     }
 
     if (same_tran) {
-        rc = bdb_llog_scdone_tran(db->handle, scdone_type, tran, sc->tablename,
-                                  &bdberr);
+        rc = bdb_llog_scdone_tran(thedb->bdb_env, scdone_type, tran, sc->tablename,
+                                  strlen(sc->tablename) + 1, &bdberr);
         if (rc) {
             sbuf2printf(sb, "!Failed write scdone , rc=%d\n", rc);
             goto done;
@@ -1010,8 +1011,8 @@ int finalize_add_qdb_file(struct ireq *iq, struct schema_change_type *s,
         goto done;
     }
     bdberr = 0;
-    rc = bdb_llog_scdone_tran(s->db->handle, add_queue_file, sc_phys_tran,
-                              NULL, &bdberr);
+    rc = bdb_llog_scdone_tran(thedb->bdb_env, add_queue_file, sc_phys_tran,
+                              s->db->tablename, strlen(s->db->tablename) + 1, &bdberr);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: bdb_llog_scdone_tran rc %d bdberr %d\n",
                __func__, rc, bdberr);
@@ -1078,8 +1079,9 @@ int finalize_del_qdb_file(struct ireq *iq, struct schema_change_type *s,
         goto done;
     }
     bdberr = 0;
-    rc = bdb_llog_scdone_tran(s->db->handle, del_queue_file, sc_phys_tran,
-                              NULL, &bdberr);
+    rc = bdb_llog_scdone_tran(thedb->bdb_env, del_queue_file, sc_phys_tran,
+                              s->db->tablename, strlen(s->db->tablename) + 1,
+                              &bdberr);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: bdb_llog_scdone_tran rc %d bdberr %d\n",
                __func__, rc, bdberr);

--- a/schemachange/sc_stripes.c
+++ b/schemachange/sc_stripes.c
@@ -154,7 +154,7 @@ int do_alter_stripes_int(struct schema_change_type *s)
     unlock_schema_lk();
 
     if ((rc = bdb_llog_scdone_tran(thedb->bdb_env, change_stripe, phys_tran,
-                                   NULL, &bdberr)) != 0) {
+                                   NULL, 0, &bdberr)) != 0) {
         logmsg(LOGMSG_ERROR, "morestripe: couldn't write scdone record\n");
         return SC_INTERNAL_ERROR;
     }

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -254,6 +254,8 @@ struct schema_change_type {
     uint64_t seed;
 };
 
+typedef int (*ddl_t)(struct ireq *, struct schema_change_type *, tran_type *);
+
 struct ireq;
 typedef struct {
     tran_type *trans;
@@ -439,5 +441,9 @@ char *get_ddl_type_str(struct schema_change_type *s);
 char *get_ddl_csc2(struct schema_change_type *s);
 
 int comdb2_is_user_op(char *user, char *password);
+
+int llog_scdone_rename_wrapper(bdb_state_type *bdb_state, scdone_t type,
+                               struct schema_change_type *s, tran_type *tran,
+                               int *bdberr);
 
 #endif


### PR DESCRIPTION
Currently we log scdone in various cases and the code path is overly complicated.  We (l)log scdone for things with names that are tables, and things with names that are not tables; also for things that we do not care to pass names (like user views).
A code that is simply (de)serializing 2 DBT structures could be simpler. 

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
