### PR TITLE
Use non-blocking IO for libevent event loops

### DIFF
--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -2500,8 +2500,8 @@ static void net_accept(netinfo_type *netinfo_ptr)
         return;
     }
     make_socket_nonblocking(fd);
-    unsigned flags = LEV_OPT_LEAVE_SOCKETS_BLOCKING | LEV_OPT_CLOSE_ON_FREE;
-    n->listener = evconnlistener_new(base, do_accept, n, flags, gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN, fd);
+    n->listener = evconnlistener_new(base, do_accept, n, LEV_OPT_CLOSE_ON_FREE,
+                                     gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN, fd);
     logmsg(LOGMSG_INFO, "%s svc:%s accepting on port:%d fd:%d\n", __func__,
            netinfo_ptr->service, netinfo_ptr->myport, fd);
 }


### PR DESCRIPTION
Sockets accepted via LEV_OPT_LEAVE_SOCKETS_BLOCKING are not meant to be used in event loops. This patch gets rid of the flag.