### PR TITLE
Check for read/write permissions once per table in query

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1663,11 +1663,11 @@ int bdb_set_sc_start_lsn(tran_type *tran, const char *table, void *plsn,
 int bdb_delete_sc_start_lsn(tran_type *tran, const char *table, int *bdberr);
 
 enum {
-    ACCESS_INVALID = 0,
-    ACCESS_READ = 1,
-    ACCESS_WRITE = 2,
-    ACCESS_DDL = 3,
-    ACCESS_USERSCHEMA = 4
+    ACCESS_INVALID = 1,
+    ACCESS_READ = 2,
+    ACCESS_WRITE = 4,
+    ACCESS_DDL = 8,
+    ACCESS_USERSCHEMA = 16
 };
 
 int bdb_tbl_access_write_set(bdb_state_type *bdb_state, tran_type *input_trans,

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1762,6 +1762,10 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
 
     struct sqlclntstate *clnt = thd->clnt;
 
+    if (pCur->permissions & ACCESS_WRITE) {
+        return 0;
+    }
+
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_write_by_mach_get(
             pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename,
@@ -1818,6 +1822,7 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
         }
     }
 
+    pCur->permissions |= ACCESS_WRITE;
     return 0;
 }
 
@@ -1830,6 +1835,9 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 
     if (pCur->cursor_class == CURSORCLASS_TEMPTABLE)
         return 0;
+    if (pCur->permissions & ACCESS_READ) {
+        return 0;
+    }
 
     if (gbl_uses_accesscontrol_tableXnode) {
         rc = bdb_access_tbl_read_by_mach_get(
@@ -1886,6 +1894,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
         }
     }
 
+    pCur->permissions |= ACCESS_READ;
     return 0;
 }
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -1059,6 +1059,8 @@ struct BtCursor {
     int tableversion;
 
     void *query_preparer_data;
+
+    int permissions; /* permissions for read/write access to table */
 };
 
 struct sql_hist {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8290,6 +8290,7 @@ int sqlite3BtreeCursor(
     }
 
     cur->on_list = 0;
+    cur->permissions = 0;
 
     if (rc != SQLITE_OK && rc != SQLITE_EMPTY && rc != SQLITE_DEADLOCK) {
         /* we were leaking cursors and locks here during incoherent;


### PR DESCRIPTION
Check for read/write permissions only once per table in a query instead of on every cursor move