### PR TITLE
pmux: Fix use command to return port

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -138,7 +138,7 @@ static int use_port(const char *svc, int port)
 
     // service can tell us repeatedly that it's using the port, thats fine
     if (usedport == port) // we dont need to do anything
-        return 0;
+        return port;
 
     // service was using a different port before so remove that mapping
     if (usedport != -1) {
@@ -159,7 +159,7 @@ static int use_port(const char *svc, int port)
     }
     port_map.insert(std::make_pair(std::string(svc), port));
     pmux_store->sav_port(svc, port);
-    return 0;
+    return port;
 }
 
 static int alloc_port(const char *svc)

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -209,6 +209,7 @@ int portmux_cmd(const char *cmd, const char *app, const char *service,
     return port;
 }
 
+/* returns port number, or -1 for error*/
 int portmux_use(const char *app, const char *service, const char *instance,
                 int port)
 {


### PR DESCRIPTION
Mainly to stop spew when libevent is disabled
```
ERROR] portmux_cmd: atoi error (res='0' name=comdb2/replication/akdb)
ERROR] portmux_cmd: atoi error (res='0' name=comdb2/replication/akdb)
ERROR] portmux_cmd: atoi error (res='0' name=comdb2/replication/akdb)
ERROR] portmux_cmd: atoi error (res='0' name=comdb2/replication/akdb)
```