### PR TITLE
clean free and is_timepartition code paths

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5840,8 +5840,9 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
     if (sc->db)
         iq->usedb = sc->db;
 
-    if (!timepart_is_timepart(sc->tablename, 1) &&
-        sc->partition.type == PARTITION_NONE) {
+    int is_partition = timepart_is_partition(sc->tablename);
+
+    if (!is_partition && sc->partition.type == PARTITION_NONE) {
         /* schema change for a regular table */
         rc = start_schema_change_tran(iq, NULL);
         if ((rc != SC_ASYNC && rc != SC_COMMIT_PENDING) ||
@@ -5853,8 +5854,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
             iq->sc_pending = iq->sc;
             iq->osql_flags |= OSQL_FLAGS_SCDONE;
         }
-    } else if (!timepart_is_timepart(sc->tablename, 1) &&
-               sc->partition.type != PARTITION_NONE) {
+    } else if (!is_partition && sc->partition.type != PARTITION_NONE) {
         assert(sc->partition.type == PARTITION_TIMED);
 
         /* create a new time partition object */

--- a/db/views.h
+++ b/db/views.h
@@ -278,12 +278,6 @@ void comdb2_partition_info_all(const char *option);
  */
 int comdb2_partition_check_name_reuse(const char *tblname, char **partname, int *indx);
 
-/** 
- * Check if a name is a timepart
- *
- */
-int timepart_is_timepart(const char *name, int lock);
-
 /**
  * Run "func" for each shard, starting with "first_shard".
  * Callback receives the name of the shard and argument struct
@@ -374,6 +368,14 @@ int timepart_shards_revoke_access(bdb_state_type *bdb_state, void *tran, char
                                   *name, char *user, int access_type);
 
 /**
+ * Check if name is time partition
+ * NOTE: partition repository is temporary locked; answer can
+ * change afterwards
+ *
+ */
+int timepart_is_partition(const char *name);
+
+/**
  * Check if a table name is the next shard for a time partition
  * and if so, returns the pointer to the partition name
  * NOTE: this is expensive, so only use it in schema resume
@@ -418,7 +420,7 @@ int timepart_publish_view(void *tran, timepart_view_t *view,
  * Free a time partition object
  *
  */
-int timepart_free_view(timepart_view_t *view);
+void timepart_free_view(timepart_view_t *view);
 
 /**
  * Create the in memory view object
@@ -444,5 +446,14 @@ const char *timepart_view_name(int i);
  *
  */
 void timepart_alias_table(timepart_view_t *view, struct dbtable *db);
+
+/**
+ * Get the malloc-ed name of shard "i" for partition "p" if it exists
+ * NULL otherwise
+ * If version is provided, and shard exists, return its schema version
+ *
+ */
+char *timepart_shard_name(const char *p, int i, int aliased,
+                          unsigned long long *version);
 
 #endif

--- a/sqlite/src/insert.c
+++ b/sqlite/src/insert.c
@@ -15,10 +15,10 @@
 #include "sqliteInt.h"
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 #include "cdb2_constants.h"
-#include "views.h" // timepart_is_timepart()
 int need_index_checks_for_upsert(Table *pTab, Upsert *pUpsert, int onError, int noConflict);
 int is_comdb2_index_unique(const char *tbl, char *idx);
 int gbl_sqlite_makerecord_for_comdb2 = 1;
+extern struct dbtable *get_dbtable_by_name(const char *name);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*
@@ -876,8 +876,8 @@ void sqlite3Insert(
     }
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( unlikely(timepart_is_timepart(pTab->zName, 1)) ){
-      sqlite3ErrorMsg(pParse, "UPSERT not supported on time-based partitioned table \"%s\"",
+    if( unlikely(get_dbtable_by_name(pTab->zName) == NULL) ){
+      sqlite3ErrorMsg(pParse, "UPSERT not supported on partition or view \"%s\"",
               pTab->zName);
       goto insert_cleanup;
     }

--- a/tests/upsert.test/t03_timepart.expected
+++ b/tests/upsert.test/t03_timepart.expected
@@ -1,6 +1,6 @@
 (part='---------------------------------- PART #01 ----------------------------------')
 (SLEEP(5)=5)
 (rows inserted=1)
-[INSERT INTO t1_tp VALUES(1) ON CONFLICT DO NOTHING] failed with rc -3 UPSERT not supported on time-based partitioned table "t1_tp"
-[INSERT INTO t1_tp VALUES(1) ON CONFLICT(i) DO UPDATE SET i = i+1] failed with rc -3 UPSERT not supported on time-based partitioned table "t1_tp"
+[INSERT INTO t1_tp VALUES(1) ON CONFLICT DO NOTHING] failed with rc -3 UPSERT not supported on partition or view "t1_tp"
+[INSERT INTO t1_tp VALUES(1) ON CONFLICT(i) DO UPDATE SET i = i+1] failed with rc -3 UPSERT not supported on partition or view "t1_tp"
 (i=1)


### PR DESCRIPTION
For partition free code path, remove unused return code.
For partition check, simplify locking by remembering the initial check in sqlite parser. 

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

