### PR TITLE
fix versioning across shards

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5896,7 +5896,12 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
         /* is this an alter? preserve existing table as first shard */
         if (!sc->addonly) {
             /* we need to create a light rename for first shard,
-             * together with the original alter */
+             * together with the original alter
+             * NOTE: we need to grab the table version first
+             */
+            arg.s->timepartition_version =
+                arg.s->db->tableversion + 1; /* next version */
+
             rc = start_schema_change_tran_wrapper(sc->tablename, &arg);
             if (rc) {
                 logmsg(LOGMSG_ERROR,

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1773,13 +1773,14 @@ int osql_schemachange_logic(struct schema_change_type *sc,
     sc->usedbtablevers = comdb2_table_version(sc->tablename);
 
     if (thd->clnt->dbtran.mode == TRANLEVEL_SOSQL) {
-        if (usedb && getdbidxbyname_ll(sc->tablename) < 0) { // view
-            unsigned long long version = 0;
-            char *viewname = timepart_newest_shard(sc->tablename, &version);
-            sc->usedbtablevers = version;
-            if (viewname)
-                free(viewname);
-            else
+        if (usedb && getdbidxbyname_ll(sc->tablename) < 0) {
+            unsigned long long version;
+            char *first_shardname =
+                timepart_shard_name(sc->tablename, 0, 1, &version);
+            if (first_shardname) {
+                sc->usedbtablevers = version;
+                free(first_shardname);
+            } else /* user view */
                 usedb = 0;
         }
 

--- a/db/views.h
+++ b/db/views.h
@@ -385,7 +385,8 @@ int timepart_is_partition(const char *name);
  * NOTE2: it grabs views repository
  *
  */
-const char *timepart_is_next_shard(const char *shardname);
+const char *timepart_is_next_shard(const char *shardname,
+                                   unsigned long long *version);
 
 /**
  * Create a view object with the specified parameters
@@ -446,6 +447,16 @@ const char *timepart_view_name(int i);
  *
  */
 void timepart_alias_table(timepart_view_t *view, struct dbtable *db);
+
+/**
+ * Create llmeta entries for the new shard for user access rights
+ * and table version
+ *
+ */
+int timepart_clone_access_version(tran_type *tran,
+                                  const char *timepartition_name,
+                                  const char *tablename,
+                                  unsigned long long version);
 
 /**
  * Get the malloc-ed name of shard "i" for partition "p" if it exists

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -344,9 +344,10 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
 
     /* Update table permissions for this new shard. */
     if (s->timepartition_name) {
-        if ((rc = timepart_copy_access(thedb->bdb_env, tran, s->tablename,
-                                       (char *)s->timepartition_name, 0)) !=
-            0) {
+        rc = timepart_clone_access_version(tran, s->timepartition_name,
+                                           s->tablename,
+                                           s->timepartition_version);
+        if (rc) {
             sc_errf(s, "Failed to set user permissions for time partition %s\n",
                     s->timepartition_name);
             return rc;

--- a/schemachange/sc_add_table.h
+++ b/schemachange/sc_add_table.h
@@ -22,7 +22,5 @@ int add_table_to_environment(char *table, const char *csc2,
                              struct schema_change_type *s, struct ireq *iq,
                              tran_type *trans, const char *timepartition_name);
 int finalize_add_table(struct ireq *, struct schema_change_type *, tran_type *);
-int timepart_copy_access(bdb_state_type *bdb_state, void *tran, char *dst,
-                         char *src, int acquire_schema_lk);
 
 #endif

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1108,6 +1108,7 @@ clone_schemachange_type(struct schema_change_type *sc)
     newsc->finalize_only = sc->finalize_only;
     newsc->is_osql = sc->is_osql;
     newsc->timepartition_name = sc->timepartition_name;
+    newsc->timepartition_version = sc->timepartition_version;
 
     if (!p_buf) {
         free_schema_change_type(newsc);

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -959,7 +959,8 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
         wrlock_schema_lk();
-        s->timepartition_name = timepart_is_next_shard(s->tablename);
+        s->timepartition_name =
+            timepart_is_next_shard(s->tablename, &s->timepartition_version);
         rc = do_add_table(iq, s, NULL);
         unlock_schema_lk();
         return rc;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -208,6 +208,8 @@ struct schema_change_type {
     int fix_tp_badvers;
 
     /* partition */
+    unsigned long long
+        timepartition_version; /* time partition tableversion, if any */
     struct comdb2_partition partition;
 
     /*********************** temporary fields for in progress

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -119,7 +119,8 @@ static int authenticateSC(const char *table, Parse *pParse);
 /* chkAndCopyTable expects the dst (OUT) buffer to be of MAXTABLELEN size. */
 static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
                                   size_t name_len, enum table_chk_flags error_flag,
-                                  int check_shard, int *table_exists, char **is_partition)
+                                  int check_shard, int *table_exists,
+                                  char **partition_first_shard)
 {
     int rc = 0;
     char *table_name;
@@ -217,13 +218,13 @@ static inline int chkAndCopyTable(Parse *pParse, char *dst, const char *name,
             /* use original tablename */
             strncpy0(dst, db->tablename, MAXTABLELEN);
         }
-        if (is_partition)
-            *is_partition = 0;
+        if (partition_first_shard)
+            *partition_first_shard = 0;
     }
     else
     {
-        if (is_partition)
-            *is_partition = firstshard;
+        if (partition_first_shard)
+            *partition_first_shard = firstshard;
         else
             free(firstshard);
     }
@@ -283,7 +284,7 @@ static inline int copyNoSqlToken(
 static inline int chkAndCopyTableTokens(Parse *pParse, char *dst, Token *t1,
                                         Token *t2, enum table_chk_flags error_flag,
                                         int check_shard, int *table_exists,
-                                        char **is_partition)
+                                        char **partition_first_shard)
 {
     int rc;
 
@@ -294,7 +295,7 @@ static inline int chkAndCopyTableTokens(Parse *pParse, char *dst, Token *t1,
         return rc;
 
     if ((rc = chkAndCopyTable(pParse, dst, t1->z, t1->n, error_flag, check_shard,
-                              table_exists, is_partition))) {
+                              table_exists, partition_first_shard))) {
         return rc;
     }
 

--- a/tests/timepart_retention1.test/run.log.alpha
+++ b/tests/timepart_retention1.test/run.log.alpha
@@ -2288,7 +2288,7 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions
  }
 ]
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
-(name='testview1', period='test2min', retention=1, nshards=1, version=1, shard0name='t')
+(name='testview1', period='test2min', retention=1, nshards=1, version=0, shard0name='t')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
 (name='testview1', shardname='t1')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
@@ -3021,7 +3021,7 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions
  }
 ]
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
-(name='testview1', period='test2min', retention=1, nshards=1, version=1, shard0name='t')
+(name='testview1', period='test2min', retention=1, nshards=1, version=0, shard0name='t')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
 (name='testview1', shardname='t1')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
@@ -3044,7 +3044,7 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions
  }
 ]
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
-(name='testview1', period='test2min', retention=1, nshards=1, version=1, shard0name='t')
+(name='testview1', period='test2min', retention=1, nshards=1, version=0, shard0name='t')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
 (name='testview1', shardname='t0')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
@@ -3777,7 +3777,7 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions
  }
 ]
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
-(name='testview1', period='test2min', retention=1, nshards=1, version=1, shard0name='t')
+(name='testview1', period='test2min', retention=1, nshards=1, version=0, shard0name='t')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
 (name='testview1', shardname='t0')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents
@@ -3800,7 +3800,7 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions
  }
 ]
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
-(name='testview1', period='test2min', retention=1, nshards=1, version=2, shard0name='t')
+(name='testview1', period='test2min', retention=1, nshards=1, version=0, shard0name='t')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
 (name='testview1', shardname='t1')
 cdb2sql ${CDB2_OPTIONS} dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents


### PR DESCRIPTION
Bug discovered while testing drop partition feature.  Make sure the rollout does not artificially increase the table version number.  Only a partition alter would increase the shards version.

(Also rename argument is_partition per previous PR comment).

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

