### PR TITLE
net: Schemachange rebuild performance

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -5056,7 +5056,7 @@ wait_for_running_transactions(dbenv)
 			pthread_cond_timedwait(&dbenv->ser_cond, &dbenv->ser_lk, &ts);
 			count++;
 			if (count > 5) {
-				logmsg(LOGMSG_ERROR, "%s: waiting for processor threads to "
+				logmsg(LOGMSG_DEBUG, "%s: waiting for processor threads to "
 						"complete\n", __func__);
 			}
 		}

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -568,7 +568,7 @@ static int prepare_and_verify_newdb_record(struct convert_record_data *data,
     return 0;
 }
 
-int gbl_sc_logbytes_per_second = 10000000;
+int gbl_sc_logbytes_per_second = 4 * (40 * 1024 * 1024); // 4 logs/sec
 static pthread_mutex_t sc_bps_lk = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t sc_bps_cd = PTHREAD_COND_INITIALIZER;
 static u_int64_t sc_bytes_this_second;


### PR DESCRIPTION
* `rep_process_message`, `rep_verify_match` can easily take longer than
  heartbeat timeout. The writer will drop connection and lose everything
  buffered in the read/write queues, even though nothing is broken.
  Change `heartbeat_send` to not drop connection. If things are not making
  it to the sibling, then corresponding reader will disconnect.

* Increase `sc_logbytes_per_second`. We can easily do 4 log files/sec (I've
  observed more than 5 per sec on 8 node cluster.)

* Tweak rd/wr buffers.

* Tweak some logmsg trace