### PR TITLE
Sending smartbeats for long running transactions

### DIFF
--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -55,6 +55,7 @@ struct osql_sqlthr {
     int last_updated; /* poking support: when was the last time I got info, 0 is
                          never */
     int last_checked; /* poking support: when was the last poke sent */
+    int progressing;  /* smartbeat support: 1 if sess is making progress on master */
 };
 typedef struct osql_sqlthr osql_sqlthr_t;
 

--- a/tests/smartbeats.test/Makefile
+++ b/tests/smartbeats.test/Makefile
@@ -3,3 +3,6 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif


### PR DESCRIPTION
This is an addendum to #3081. The change allows hungserv to identify hung clients more accurately.