### PR TITLE
Fix cdb2api_unit test

### DIFF
--- a/tests/cdb2api_unit.test/Makefile
+++ b/tests/cdb2api_unit.test/Makefile
@@ -26,6 +26,9 @@ test_get_comdb2db_hosts: unit_get_comdb2db_hosts.c
 
 	grep "define CNONCE_STR_SZ " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	sed "/typedef struct cnonce {/,/^} cnonce_t/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	grep "define CDB2HOSTNAME_LEN" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	grep "define CDB2_AUTO_CONSUME_TIMEOUT_MS" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	grep "static int CDB2_AUTO_CONSUME_TIMEOUT_MS" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_NODES " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_CONTEXTS " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "define MAX_STACK " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
@@ -41,8 +44,9 @@ test_get_comdb2db_hosts: unit_get_comdb2db_hosts.c
 	grep "static int COMDB2DB_TIMEOUT " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	grep "static int CDB2_SOCKET_TIMEOUT " $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	sed "/struct context_messages {/,/^}/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
-	sed "/struct cdb2_hndl {/,/^}/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
+	sed "/struct cdb2_hndl {/,/^}/!d" $(SRCHOME)/cdb2api/cdb2api.c | grep -v ssl >> test_get_comdb2db_hosts.c
 	cat unit_get_comdb2db_hosts.c >> test_get_comdb2db_hosts.c
 	sed "/static void set_cdb2_timeouts(/,/^}/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
 	sed "/static int get_comdb2db_hosts(/,/^}/!d" $(SRCHOME)/cdb2api/cdb2api.c >> test_get_comdb2db_hosts.c
-	gcc -D_LINUX_SOURCE -g -std=c99 -I$(BUILDDIR)/protobuf -I$(SRCHOME)/util -I$(SRCHOME)/bbinc -I$(SRCHOME)/cdb2api $(CURRDIR)/test_get_comdb2db_hosts.c -o test_get_comdb2db_hosts
+	# ignore compilation errors here and thus force the test to invoke the executable, which then errors out and reports an error as the executable does not exist.
+	-gcc -D_LINUX_SOURCE -g -std=c99 -I$(BUILDDIR)/protobuf -I$(SRCHOME)/util -I$(SRCHOME)/bbinc -I$(SRCHOME)/cdb2api $(CURRDIR)/test_get_comdb2db_hosts.c -o test_get_comdb2db_hosts

--- a/tests/cdb2api_unit.test/unit_get_comdb2db_hosts.c
+++ b/tests/cdb2api_unit.test/unit_get_comdb2db_hosts.c
@@ -31,19 +31,19 @@ static char cdb2_default_cluster[64] = "";
 static char cdb2_dnssuffix[255] = "";
 
 // forward declare the function we are testing
-static int get_comdb2db_hosts(cdb2_hndl_tp *hndl, char comdb2db_hosts[][COMDB2HOSTNAME_LEN],
+static int get_comdb2db_hosts(cdb2_hndl_tp *hndl, char comdb2db_hosts[][CDB2HOSTNAME_LEN],
                               int *comdb2db_ports, int *master,
                               const char *comdb2db_name, int *num_hosts,
                               int *comdb2db_num, const char *dbname,
-                              char db_hosts[][COMDB2HOSTNAME_LEN],
+                              char db_hosts[][CDB2HOSTNAME_LEN],
                               int *num_db_hosts, int *dbnum, int read_cfg,
                               int dbinfo_or_dns);
 
 
 // we need here all the functions that get_comdb2db_hosts() calls
 static int read_available_comdb2db_configs(
-    cdb2_hndl_tp *hndl, char comdb2db_hosts[][COMDB2HOSTNAME_LEN], const char *comdb2db_name,
-    int *num_hosts, int *comdb2db_num, const char *dbname, char db_hosts[][COMDB2HOSTNAME_LEN],
+    cdb2_hndl_tp *hndl, char comdb2db_hosts[][CDB2HOSTNAME_LEN], const char *comdb2db_name,
+    int *num_hosts, int *comdb2db_num, const char *dbname, char db_hosts[][CDB2HOSTNAME_LEN],
     int *num_db_hosts, int *dbnum, int noLock, int defaultOnly)
 {
     if (global_state == 1) return -1;
@@ -81,7 +81,7 @@ static int read_available_comdb2db_configs(
 
 
 static int cdb2_dbinfo_query(cdb2_hndl_tp *hndl, const char *type, const char *dbname,
-                             int dbnum, const char *host, char valid_hosts[][COMDB2HOSTNAME_LEN],
+                             int dbnum, const char *host, char valid_hosts[][CDB2HOSTNAME_LEN],
                              int *valid_ports, int *master_node,
                              int *num_valid_hosts,
                              int *num_valid_sameroom_hosts)
@@ -106,7 +106,7 @@ static int cdb2_dbinfo_query(cdb2_hndl_tp *hndl, const char *type, const char *d
 }
 
 static int get_host_by_name(const char *comdb2db_name, 
-                            char comdb2db_hosts[][COMDB2HOSTNAME_LEN], int *num_hosts)
+                            char comdb2db_hosts[][CDB2HOSTNAME_LEN], int *num_hosts)
 {
     assert(global_state != 1);
     assert(global_state != 2);
@@ -163,8 +163,8 @@ int main()
                // should populate and check comdb2db_hosts
 
     {
-    char comdb2db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
-    char db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
+    char comdb2db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
+    char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, NULL, NULL,
             db_hosts, &num_db_hosts, NULL, 1, 1);
@@ -184,8 +184,8 @@ int main()
                // should populate and check db_hosts
 
     {
-    char comdb2db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
-    char db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
+    char comdb2db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
+    char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, NULL, NULL,
             db_hosts, &num_db_hosts, NULL, 1, 1);
@@ -204,8 +204,8 @@ int main()
     global_state = 5; // read_available_comdb2db_configs returns 0, will call cdb2_dbinfo_query
 
     {
-    char comdb2db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
-    char db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
+    char comdb2db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
+    char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL,
@@ -226,8 +226,8 @@ int main()
     global_state = 6; // cdb2_dbinfo_query will return -1, will call get_host_by_name
 
     {
-    char comdb2db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
-    char db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
+    char comdb2db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
+    char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL,
@@ -244,8 +244,8 @@ int main()
     global_state = 7; // cdb2_dbinfo_query will return -1, will call get_host_by_name
 
     {
-    char comdb2db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
-    char db_hosts[MAX_NODES][COMDB2HOSTNAME_LEN] = {0};
+    char comdb2db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
+    char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master, 
             NULL, &num_hosts, &comdb2db_num, NULL,

--- a/tests/tools/cdb2api_unit.c
+++ b/tests/tools/cdb2api_unit.c
@@ -251,8 +251,8 @@ void test_read_comdb2db_cfg()
     num_hosts = 0;
     num_db_hosts = 0;
     const char *buf3 = "\
-  comdb2dbnm:1estsuite_longname_to_testbuffer_overflow_when_assigning_hostname,2estsuite_longname_to_testbuffer_overflow_when_assigning_hostname,3estsuite_longname_to_testbuffer_overflow_when_assigning_hostname   \n\
-  mydb:4estsuite_longname_to_testbuffer_overflow_when_assigning_hostname,5estsuite_longname_to_testbuffer_overflow_when_assigning_hostname,6estsuite_longname_to_testbuffer_overflow_when_assigning_hostname   \n\
+  comdb2dbnm:1estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters,2estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters,3estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters   \n\
+  mydb:4estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters,5estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters,6estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_it_longer_than_128_characters   \n\
   comdb2_config:default_type:aestsuite_longname_to_testbuffer_overflow_when_assigning_the_default_type_testsuite_longname_to_testbuffer_overflow_when_assigning_the_default_type   \n\
   comdb2_config:room:bestsuite_longname_to_testbuffer_overflow_when_assigning_the_room_testsuite_longname_to_testbuffer_overflow_when_assigning_the_room \n\
   comdb2_config:comdb2dbname:cestsuite_longname_to_testbuffer_overflow_when_assigning_the_comdb2dbname \n\
@@ -266,12 +266,12 @@ void test_read_comdb2db_cfg()
 
     assert(num_db_hosts == 3);
     assert(num_hosts == 3);
-    assert(strcmp(comdb2db_hosts[0], "1estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
-    assert(strcmp(comdb2db_hosts[1], "2estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
-    assert(strcmp(comdb2db_hosts[2], "3estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
-    assert(strcmp(db_hosts[0], "4estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
-    assert(strcmp(db_hosts[1], "5estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
-    assert(strcmp(db_hosts[2], "6estsuite_longname_to_testbuffer_overflow_when_assigning_hostna") == 0);
+    assert(strcmp(comdb2db_hosts[0], "1estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
+    assert(strcmp(comdb2db_hosts[1], "2estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
+    assert(strcmp(comdb2db_hosts[2], "3estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
+    assert(strcmp(db_hosts[0], "4estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
+    assert(strcmp(db_hosts[1], "5estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
+    assert(strcmp(db_hosts[2], "6estsuite_longname_to_testbuffer_overflow_when_assigning_hostname_and_we_are_going_to_need_a_lot_more_characters_here_to_make_i") == 0);
     assert(strcmp(cdb2_default_cluster, "aestsuite_longname_to_testbuffer_overflow_when_assigning_the_de") == 0);
     assert(strcmp(cdb2_machine_room, "bestsuite_longn") == 0);
     assert(strcmp(cdb2_comdb2dbname, "cestsuite_longname_to_testbuffe") == 0);


### PR DESCRIPTION
Omit SSL variables from the generated unit-test source file.