### PR TITLE
remove some unused code, simplify result in logical txn

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -656,11 +656,6 @@ tran_type *bdb_tran_begin_dirty(bdb_state_type *bdb_handle,
 tran_type *bdb_tran_begin_logical(bdb_state_type *bdb_state, int trak,
                                   int *bdberr);
 
-tran_type *bdb_start_ltran(bdb_state_type *bdb_state,
-                           unsigned long long ltranid, void *firstlsn,
-                           unsigned int flags);
-tran_type *bdb_start_ltran_rep_sc(bdb_state_type *bdb_state,
-                                  unsigned long long ltranid);
 void bdb_set_tran_lockerid(tran_type *tran, uint32_t lockerid);
 void bdb_get_tran_lockerid(tran_type *tran, uint32_t *lockerid);
 void *bdb_get_physical_tran(tran_type *ltran);

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1403,17 +1403,9 @@ tran_type *bdb_tran_continue_logical(bdb_state_type *bdb_state,
                                      unsigned long long tranid, int trak,
                                      int *bdberr);
 
-tran_type *bdb_tran_start_logical_forward_roll(bdb_state_type *bdb_state,
-                                               unsigned long long tranid,
-                                               int trak, int *bdberr);
-
 tran_type *bdb_tran_start_logical(bdb_state_type *bdb_state,
                                   unsigned long long tranid, int trak,
                                   int *bdberr);
-
-tran_type *bdb_tran_start_logical_sc(bdb_state_type *bdb_state,
-                                     unsigned long long tranid, int trak,
-                                     int *bdberr);
 
 int ll_undo_add_ix_lk(bdb_state_type *bdb_state, tran_type *tran,
                       char *table_name, int ixnum, void *key, int keylen,
@@ -1480,10 +1472,6 @@ int bdb_release_ltran_locks(bdb_state_type *bdb_state, struct tran_tag *ltran,
  */
 int bdb_update_startlsn_lk(bdb_state_type *bdb_state, struct tran_tag *intran,
                            DB_LSN *firstlsn);
-
-tran_type *bdb_tran_begin_logical_int(bdb_state_type *bdb_state,
-                                      unsigned long long tranid, int trak,
-                                      int *bdberr);
 
 tran_type *bdb_tran_begin_logical_norowlocks_int(bdb_state_type *bdb_state,
                                                  unsigned long long tranid,


### PR DESCRIPTION
Remove a few unused functions in logical txn code path, and simplify code that creates a logical txn.

NOTE: it seems that this was C&P from previous berkdb txn creation code, and not restructured afterwards.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
