### PR TITLE
enable micro_commit only if rowlocks enabled

### DIFF
--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -666,7 +666,8 @@ tran_type *bdb_tran_begin_logical_int_int(bdb_state_type *bdb_state,
     tran->committed_begin_record = 0;
     tran->get_schema_lock = 0;
     tran->is_about_to_commit = 0;
-    tran->micro_commit = bdb_state->attr->rowlocks_micro_commit;
+    tran->micro_commit =
+        gbl_rowlocks ? bdb_state->attr->rowlocks_micro_commit : 0;
 
     if (tranid == 0)
         tran->logical_tranid = get_id(bdb_state);


### PR DESCRIPTION
micro_commit enables per btree physical transactions;  it was not probably not meant to be enabled for logical transactions if rowlocks are not enabled.  Logical transactions are used for ddl, and code works because gbl_locks_check_waiters is set (which allows the physical transaction to become a child of the logical transaction).  Disabling gbl_locks_check_waiters is a timebomb (it will prevent making the physical txn a child of the logical txn, so the locks will be released early, which is probably not what we want in non-rowlocks schema change).
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

