### PR TITLE
Fewer temptables for new snapshot

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3460,7 +3460,8 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
     struct stat sb;
     char logname[1024];
     int low_headroom_count = 0;
-    int lowfilenum;
+    int lowfilenum;                 /* the lowest log file across the cluster */
+    int local_lowfilenum = INT_MAX; /* the lowest log file of this node */
     int lwm_lowfilenum = -1;
     char **list = NULL;
     int attrlowfilenum;
@@ -3518,13 +3519,14 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
     extern int gbl_logical_live_sc;
     if (gbl_logical_live_sc) {
         unsigned int sc_logical_lwm = sc_get_logical_redo_lwm();
-        if (sc_logical_lwm && sc_logical_lwm < lowfilenum) {
-            lowfilenum = sc_logical_lwm;
-            if (bdb_state->attr->debug_log_deletion) {
-                logmsg(
-                    LOGMSG_USER,
-                    "Setting lowfilenum to %d for schema change logical redo\n",
-                    lowfilenum);
+        if (sc_logical_lwm) {
+            if (sc_logical_lwm < local_lowfilenum)
+                local_lowfilenum = sc_logical_lwm;
+            if (sc_logical_lwm < lowfilenum) {
+                lowfilenum = sc_logical_lwm;
+                if (bdb_state->attr->debug_log_deletion) {
+                    logmsg(LOGMSG_USER, "Setting lowfilenum to %d for schema change logical redo\n", lowfilenum);
+                }
             }
         }
     }
@@ -3534,8 +3536,12 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
     /* if we have a maximum filenum defined in bdb attributes which is lower,
      * use that instead. */
     attrlowfilenum = bdb_state->attr->logdeletelowfilenum;
-    if (attrlowfilenum >= 0 && attrlowfilenum < lowfilenum)
-        lowfilenum = attrlowfilenum;
+    if (attrlowfilenum >= 0) {
+        if (attrlowfilenum < lowfilenum)
+            lowfilenum = attrlowfilenum;
+        if (attrlowfilenum < local_lowfilenum)
+            local_lowfilenum = attrlowfilenum;
+    }
 
     /* get the filenum of our logical LWM. We can delete any log files
        lower than that */
@@ -3552,6 +3558,8 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
            can be deleted. */
         if (lwmlsn.file - 1 < lowfilenum)
             lowfilenum = lwmlsn.file - 1;
+        if (lwmlsn.file - 1 < local_lowfilenum)
+            local_lowfilenum = lwmlsn.file - 1;
         lwm_lowfilenum = (lwmlsn.file - 1);
     }
 
@@ -3560,6 +3568,8 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
                 "%s:%d failed to get snapisol/serializable lwm lsn number!\n",
                 __FILE__, __LINE__);
     } else {
+        if (snapylsn.file <= local_lowfilenum)
+            local_lowfilenum = snapylsn.file - 1;
         if (snapylsn.file <= lowfilenum) {
             if (bdb_state->attr->debug_log_deletion) {
                 logmsg(LOGMSG_USER,
@@ -3587,6 +3597,8 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
         asoflsn = bdb_asof_current_lsn;
         Pthread_mutex_unlock(&bdb_asof_current_lsn_mutex);
 
+        if (asoflsn.file <= local_lowfilenum)
+            local_lowfilenum = asoflsn.file - 1;
         if (asoflsn.file <= lowfilenum) {
             if (bdb_state->attr->debug_log_deletion) {
                 logmsg(LOGMSG_USER,
@@ -3801,6 +3813,14 @@ low_headroom:
             if (filenum > send_filenum)
                 send_filenum = filenum;
 
+            /*
+             * As long as the file is below our own local low number, we can
+             * get rid of the new snapshot temptables. We do not need to keep those
+             * around if we're only holding log files for other replicants to recover.
+             */
+            if (filenum <= local_lowfilenum && gbl_new_snapisol_asof)
+                bdb_snapshot_asof_delete_log(bdb_state, filenum, sb.st_mtime);
+
             if ((filenum <= lowfilenum && delete_adjacent) || is_low_headroom) {
                 /* delete this file if we got this far AND it's under the
                  * replicated low number */
@@ -3819,10 +3839,6 @@ low_headroom:
                     print(bdb_state, "lwm at log delete time:  %u:%u\n",
                           lwmlsn.file, lwmlsn.offset);
 
-                if (gbl_new_snapisol_asof) {
-                    bdb_snapshot_asof_delete_log(bdb_state, filenum,
-                                                 sb.st_mtime);
-                }
                 int deleted = 0;
 
                 if (gbl_backup_logfiles && bdb_state->repinfo->master_host == bdb_state->repinfo->myhost) {

--- a/tests/newsi_temptables.test/Makefile
+++ b/tests/newsi_temptables.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=20m
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/newsi_temptables.test/lrl.options
+++ b/tests/newsi_temptables.test/lrl.options
@@ -1,0 +1,8 @@
+enable_new_snapshot
+setattr LOGFILESIZE 4194304
+setattr LOGMEMSIZE 1048576
+setattr LOGDELETE_RUN_INTERVAL 5
+setattr DEBUG_LOG_DELETION 1
+MIN_KEEP_LOGS 5
+MIN_KEEP_LOGS_AGE 10
+private_blkseq_maxage 10

--- a/tests/newsi_temptables.test/runit
+++ b/tests/newsi_temptables.test/runit
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+[ -z "$CLUSTER" ] && { echo "skipping newsi_temptables test, it's a cluster test"; exit 0; }
+
+db=$1
+
+cdb2sql --tabs ${CDB2_OPTIONS} $db default "CREATE TABLE t (b blob)"
+replicant=`cdb2sql --tabs ${CDB2_OPTIONS} $db default 'select comdb2_host()'`
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $db default 'select host from comdb2_cluster where is_master="Y"'`
+
+cdb2sql --tabs $db --host $master 'exec procedure sys.cmd.send("flush")'
+
+# Kill replicant
+echo killing db on $replicant
+ssh -o StrictHostKeyChecking=no $replicant "pgrep -a comdb2 | grep $db | awk '{print \$1}' | xargs kill -9"
+
+# Push 200 log files with big bloby inserts
+cur=$(cdb2sql --tabs $db --host $master "exec procedure sys.cmd.send('bdb logstat')" | grep st_cur_file | awk '{print $NF}')
+target=$(( 200 + cur ))
+while [[ $cur -lt $target ]]; do
+    cdb2sql $db -tabs --host $master "INSERT INTO t VALUES (randomblob(1048576))" >/dev/null
+    cur=$(cdb2sql --tabs $db --host $master "exec procedure sys.cmd.send('bdb logstat')" | grep st_cur_file | awk '{print $NF}')
+done
+
+# do a checkpoint here
+cdb2sql --tabs $db --host $master 'exec procedure sys.cmd.send("flush")'
+
+# Give db enough time to clean up newsi temptables
+sleep 20
+
+cdb2sql $db -tabs --host $master "exec procedure sys.cmd.send('bdb log_archive')"
+cdb2sql $db -tabs --host $master "exec procedure sys.cmd.send('bdb temptable')"
+
+# Make sure we don't keep too many temptables
+nactive=$(cdb2sql $db -tabs --host $master "exec procedure sys.cmd.send('bdb temptable')" | grep '# active' | awk '{ print $NF }')
+if [ $nactive -gt 40 ]; then
+    echo 'too many temptables'
+    exit 1
+fi


### PR DESCRIPTION
Mike's idea: do not keep temptables around for log files if we're holding them only for other replicants to recover.

(DRQS 168188318)