### PR TITLE
fix non-blkseq schema change removal of old files

### DIFF
--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2110,7 +2110,7 @@ osql_create_transaction(struct javasp_trans_state *javasp_trans_handle,
                 *trans = bdb_get_physical_tran(iq->sc_logical_tran);
                 irc = create_child_transaction(iq, *trans, &(iq->sc_tran));
                 if (irc == 0 && gbl_sc_close_txn)
-                    irc = create_child_transaction(iq, *parent_trans,
+                    irc = create_child_transaction(iq, *trans,
                                                    &(iq->sc_close_tran));
             }
         }


### PR DESCRIPTION
C&P error here probably.  We need to create a child txn so that we remove the old files.  If there is no blkseq, parent_trans is NULL (and we do not want to create an independent txn here!).
Instead, we need to pass the "real" parent transaction here, which is iq->sc_logical_tran->physical_tran == trans.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
