### PR TITLE
Simplify the memory management when searching using bdb_temp_table_find_exact()

### DIFF
--- a/bdb/bdb_osqlcur.c
+++ b/bdb/bdb_osqlcur.c
@@ -699,7 +699,6 @@ static int _bdb_tran_deltbl_isdeleted(bdb_cursor_ifn_t *pcur_ifn,
                                       int ignore_limit, int *bdberr, int check)
 {
     bdb_cursor_impl_t *cur = pcur_ifn->impl;
-    unsigned long long *pgenid;
     int rc = 0;
 
     /* we dont ever expect to get here with a synthetic genid */
@@ -763,17 +762,9 @@ static int _bdb_tran_deltbl_isdeleted(bdb_cursor_ifn_t *pcur_ifn,
 
         if (cur->skip) {
             /* we have a skip cursor */
-            pgenid = (unsigned long long *)malloc(sizeof(*pgenid));
-            if (!pgenid) {
-                *bdberr = BDBERR_MALLOC;
-                return -1;
-            }
-            *pgenid = genid;
 
-            rc = bdb_temp_table_find_exact(cur->state, cur->skip, pgenid,
-                                           sizeof(*pgenid), bdberr);
-            if (rc != IX_FND)
-                free(pgenid);
+            rc = bdb_temp_table_find_exact(cur->state, cur->skip, &genid,
+                                           sizeof(genid), bdberr);
             if (rc < 0)
                 return rc;
 

--- a/bdb/bdb_osqllog.c
+++ b/bdb/bdb_osqllog.c
@@ -1303,26 +1303,26 @@ static int bdb_osql_log_apply_ll(bdb_state_type *bdb_state,
              * doesn't
              * exist before inserting it.  */
             if (tabletype == BDBC_BL) {
-                unsigned long long *gcopy = malloc(sizeof(unsigned long long));
-                *gcopy = get_search_genid(bdb_state, genid);
+                unsigned long long gcopy = get_search_genid(bdb_state, genid);
 
-                rc = bdb_temp_table_find_exact(bdb_state, cur, gcopy,
-                                               sizeof(*gcopy), bdberr);
+                rc = bdb_temp_table_find_exact(bdb_state, cur, &gcopy,
+                                               sizeof(gcopy), bdberr);
                 if (rc != IX_FND) {
-                    rc = bdb_temp_table_insert(bdb_state, cur, gcopy,
-                                               sizeof(*gcopy), dta, dtalen,
+                    rc = bdb_temp_table_insert(bdb_state, cur, &gcopy,
+                                               sizeof(gcopy), dta, dtalen,
                                                bdberr);
                     if (trak & SQL_DBG_SHADOW) {
-                        logmsg(LOGMSG_USER, "INSERTING SEARCH-GENID %llx, GENID %llx INTO "
+                        logmsg(LOGMSG_USER,
+                               "INSERTING SEARCH-GENID %llx, GENID %llx INTO "
                                "THE BLOB SHADOW TABLE\n",
-                               *gcopy, genid);
+                               gcopy, genid);
                     }
-                    free(gcopy);
                 } else {
                     if (trak & SQL_DBG_SHADOW) {
-                        logmsg(LOGMSG_USER, "NOT INSERTING ALREADY EXISTING SEARCH-GENID "
+                        logmsg(LOGMSG_USER,
+                               "NOT INSERTING ALREADY EXISTING SEARCH-GENID "
                                "%lld, GENID %lld INTO THE BLOB SHADOW TABLE\n",
-                               *gcopy, genid);
+                               gcopy, genid);
                     }
                 }
             } else {

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -4948,17 +4948,9 @@ step1:
 
     /* Check the virtual stripe */
     if (cur->addcur && cur->type == BDBC_DT && 0 == got_rl && cur->pageorder) {
-        /* Temptable find-exact semantics require that I malloc the key. */
-        void *fndkey = malloc(keylen);
-
-        /* Copy key. */
-        memcpy(fndkey, key, keylen);
-
         /* Find my record. */
-        rc = bdb_temp_table_find_exact(cur->state, cur->addcur, fndkey, keylen,
+        rc = bdb_temp_table_find_exact(cur->state, cur->addcur, key, keylen,
                                        bdberr);
-        if (rc != IX_FND)
-            free(fndkey);
         if (rc < 0)
             return rc;
 
@@ -4996,7 +4988,6 @@ step1:
                 if (dtalen > 0 && bdb_osql_log_is_optim_data(addptr)) {
                     bdb_osql_log_addc_ptr_t *newptr;
                     int rowlen;
-                    unsigned long long *pgenid;
 
                     /* Rebuild the row from the logfiles. */
                     rc = bdb_osql_log_get_optim_data_addcur(
@@ -5018,21 +5009,15 @@ step1:
                     if (rc < 0)
                         return rc;
 
-                    /* Malloc pgenid for find_exact. */
-                    pgenid = (unsigned long long *)malloc(sizeof(*pgenid));
-
-                    /* Copy it. */
-                    *pgenid = *genid_ck;
-
                     /* Re-find the newly inserted position */
                     rc = bdb_temp_table_find_exact(cur->state, cur->addcur,
-                                                   (char *)pgenid, 8, bdberr);
+                                                   genid_ck, sizeof(*genid_ck),
+                                                   bdberr);
                     if (rc != IX_FND) {
                         logmsg(LOGMSG_ERROR, "%s: fail to retrieve back the "
                                         "updated row rc=%d bdberr=%d\n",
                                 __func__, rc, *bdberr);
                         rc = -1; /* we have to find this row back */
-                        free(pgenid);
                     }
 
                     /* Retrieve the header. */
@@ -5538,14 +5523,10 @@ step1:
          * something was added, reposition the cursor. */
         if ((crt_how == DB_NEXT || crt_how == DB_PREV) && cur->repo_addcur &&
             cur->agenid != 0) {
-            unsigned long long *agenid = malloc(sizeof(*agenid));
-
-            /* Set the reposition genid. */
-            *agenid = cur->agenid;
-
             /* Reposition the cursor. */
-            rc = bdb_temp_table_find_exact(cur->state, cur->addcur,
-                                           (char *)agenid, 8, bdberr);
+            rc =
+                bdb_temp_table_find_exact(cur->state, cur->addcur, &cur->agenid,
+                                          sizeof(cur->agenid), bdberr);
 
             /* Things shouldn't be disappearing from addcur. */
             assert(rc == IX_FND);
@@ -5615,21 +5596,11 @@ step1:
                                 cur, *genid_ck);
                     }
 
-                    /* Temp_table semantics require that I malloc the key. */
-                    srec = (unsigned long long *)malloc(sizeof(*srec));
-
-                    /* Copy the current key. */
-                    memcpy(srec, genid_ck, sizeof(*srec));
-
                     /* Find this record. */
                     int find_rc =
-                        bdb_temp_table_find(cur->state, cur->vs_skip,
-                                            (char *)srec, 8, NULL, bdberr);
+                        bdb_temp_table_find(cur->state, cur->vs_skip, &genid_ck,
+                                            sizeof(genid_ck), NULL, bdberr);
 
-                    /* Temp_table semantics also require that we free key if not
-                     * found */
-                    if (find_rc != IX_FND)
-                        free(srec);
                     if (find_rc) {
                         if (cur->trak) {
                             logmsg(LOGMSG_USER, 
@@ -5719,7 +5690,6 @@ step1:
             if (dtalen > 0 && bdb_osql_log_is_optim_data(addptr)) {
                 bdb_osql_log_addc_ptr_t *newptr;
                 int rowlen;
-                unsigned long long *pgenid;
 
                 /* Rebuild the row from the logfiles. */
                 rc = bdb_osql_log_get_optim_data_addcur(
@@ -5740,21 +5710,15 @@ step1:
                 if (rc < 0)
                     return rc;
 
-                /* Malloc pgenid for find_exact. */
-                pgenid = (unsigned long long *)malloc(sizeof(*pgenid));
-
-                /* Copy it. */
-                *pgenid = *genid_ck;
-
                 /* Re-find the newly inserted position */
-                rc = bdb_temp_table_find_exact(cur->state, cur->addcur,
-                                               (char *)pgenid, 8, bdberr);
+                rc =
+                    bdb_temp_table_find_exact(cur->state, cur->addcur, genid_ck,
+                                              sizeof(*genid_ck), bdberr);
                 if (rc != IX_FND) {
                     logmsg(LOGMSG_ERROR, "%s: fail to retrieve back the updated row "
                                     "rc=%d bdberr=%d\n",
                             __func__, rc, *bdberr);
                     rc = -1; /* we have to find this row back */
-                    free(pgenid);
                 }
 
                 /* Retrieve the header. */

--- a/bdb/fetch.c
+++ b/bdb/fetch.c
@@ -255,23 +255,16 @@ static int bdb_fetch_blobs_by_rrn_and_genid_int_int(
             rc2 = 0;
 
             if (use_shadow_table) {
-                unsigned long long *pgenid =
-                    (unsigned long long *)malloc(sizeof(genid));
-
-                if (!pgenid) {
-                    *bdberr = BDBERR_MALLOC;
-                    return -1;
-                }
+                unsigned long long shadblbgenid;
 
                 /* Shadow-blobs are stored with a masked genid. */
-                *pgenid = get_search_genid(bdb_state, genid);
+                shadblbgenid = get_search_genid(bdb_state, genid);
 
                 tmpcursor_t *cur = bdb_tran_open_shadow(
                     bdb_state, dbnum, parent->shadow_tran, dtafilenums[blobn],
                     BDBC_BL, 1, bdberr);
                 if (!cur) {
                     if (*bdberr) {
-                        free(pgenid);
                         return -1;
                     }
 
@@ -281,10 +274,10 @@ static int bdb_fetch_blobs_by_rrn_and_genid_int_int(
                      */
                     use_shadow_table = 0;
                 } else {
-                    rc2 = bdb_temp_table_find_exact(bdb_state, cur, pgenid,
-                                                    sizeof(*pgenid), bdberr);
+                    rc2 =
+                        bdb_temp_table_find_exact(bdb_state, cur, &shadblbgenid,
+                                                  sizeof(shadblbgenid), bdberr);
                     if (rc2 != IX_FND)
-                        free(pgenid);
                     if (rc2 < 0)
                         return -1;
 

--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -2051,9 +2051,6 @@ static int bdb_temp_table_find_exact_hash(struct temp_cursor *cur,
 
 }
 
-/* Caller needs to free the key if return is not IX_FND
- * if IX_FND this function will free key [eventually not immediately]
- */
 int bdb_temp_table_find_exact(bdb_state_type *bdb_state,
                               struct temp_cursor *cur, void *key, int keylen,
                               int *bdberr)
@@ -2063,6 +2060,7 @@ int bdb_temp_table_find_exact(bdb_state_type *bdb_state,
     DBT dkey, ddata;
     int exists = 0;
     arr_elem_t *elem;
+    void *keydup;
 
     if (cur->tbl->temp_table_type == TEMP_TABLE_TYPE_LIST) {
         logmsg(LOGMSG_ERROR, "bdb_temp_table_find_exact operation not supported for "
@@ -2115,22 +2113,22 @@ int bdb_temp_table_find_exact(bdb_state_type *bdb_state,
 
     REOPEN_CURSOR(cur);
 
-    /*Pthread_setspecific(cur->tbl->curkey, cur);*/
+    /* Make a copy of the user key */
+    if ((keydup = malloc(keylen)) == NULL)
+        return ENOMEM;
+
+    memcpy(keydup, key, keylen);
 
     memset(&dkey, 0, sizeof(DBT));
     memset(&ddata, 0, sizeof(DBT));
     dkey.flags = ddata.flags = DB_DBT_MALLOC;
-    dkey.data = key;
+    dkey.data = keydup;
     dkey.size = keylen;
 
     cur->valid = 0;
     rc = cur->cur->c_get(cur->cur, &dkey, &ddata, DB_SET);
-    /*
-    printf("Got data %p %d key %p %d\n",
-           ddata.data, ddata.size, dkey.data, dkey.size); */
 
     if (rc == DB_NOTFOUND) {
-        exists = 0;
         goto done;
     } else if (rc) {
         *bdberr = rc;
@@ -2165,7 +2163,7 @@ int bdb_temp_table_find_exact(bdb_state_type *bdb_state,
 done:
     dbghexdump(3, key, keylen);
     dbgtrace(3, "temp_table_find(cursor %d) = %d", cur->curid, rc);
-    return (exists) ? IX_FND : IX_NOTFND;
+    return (exists) ? IX_FND : (free(keydup), IX_NOTFND);
 }
 
 static int key_memcmp(void *_, int key1len, const void *key1, int key2len,

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -586,7 +586,6 @@ int osql_fetch_shadblobs_by_genid(BtCursor *pCur, int *blobnum,
 {
 
     int rc = 0;
-    /*int   i = 0;*/
     shad_tbl_t *tbl = NULL;
     void *tmptblblb;
     blob_key_t *tmptblkey;
@@ -671,14 +670,9 @@ int osql_get_shadowdata(BtCursor *pCur, unsigned long long genid, void **buf,
         return -1;
     }
 
-    unsigned long long *key =
-        (unsigned long long *)malloc(sizeof(unsigned long long));
-    *key = genid;
-
-    rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->add_cur, key,
-                                   sizeof(*key), bdberr);
+    rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->add_cur, &genid,
+                                   sizeof(genid), bdberr);
     if (rc != IX_FND) {
-        free(key);
         return -1;
     }
 
@@ -958,20 +952,13 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
 
            upd table tells us the origin of synthetic genid
          */
-        unsigned long long *pgenid =
-            (unsigned long long *)malloc(sizeof(*pgenid));
-        if (!pgenid) {
-            logmsg(LOGMSG_ERROR, "malloc %zu\n", sizeof(*pgenid));
-            return -1;
-        }
-        *pgenid = pCur->genid;
 
-        rc = bdb_temp_table_find_exact(bdbenv, tbl->upd_cur, pgenid,
-                                       sizeof(*pgenid), &bdberr);
+        rc = bdb_temp_table_find_exact(bdbenv, tbl->upd_cur, &pCur->genid,
+                                       sizeof(pCur->genid), &bdberr);
         if (bdberr) {
-            logmsg(LOGMSG_ERROR, "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (1)\n",
-                __func__, tmp, *pgenid, rc, bdberr);
-            free(pgenid);
+            logmsg(LOGMSG_ERROR,
+                   "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (1)\n",
+                   __func__, tmp, pCur->genid, rc, bdberr);
             return -1;
         }
 
@@ -983,9 +970,10 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
             /* we delete the original upd entry */
             rc = bdb_temp_table_delete(bdbenv, tbl->upd_cur, &bdberr);
             if (rc) {
-                logmsg(LOGMSG_ERROR, "%s: fail to update genid %llx (%lld) rc=%d "
-                                "bdberr=%d (2)\n",
-                        __func__, tmp, *pgenid, rc, bdberr);
+                logmsg(LOGMSG_ERROR,
+                       "%s: fail to update genid %llx (%lld) rc=%d "
+                       "bdberr=%d (2)\n",
+                       __func__, tmp, pCur->genid, rc, bdberr);
                 return -1;
             }
 
@@ -999,9 +987,6 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                         __func__, tmp, genid, rc, bdberr);
                 return -1;
             }
-        } else {
-            /* this was an insert; no need to touch anything in upd table */
-            free(pgenid);
         }
 
         /* delete the original index from add and its indexes */
@@ -1310,22 +1295,14 @@ int osql_save_updcols(struct BtCursor *pCur, struct sql_thread *thd,
     /* find the old map, if it exists */
     if (is_genid_synthetic(pCur->genid)) {
         /* union of updCols here, if updCols exists */
-        updCols_key_t *pkey = (updCols_key_t *)malloc(sizeof(*pkey));
-        if (!pkey) {
-            logmsg(LOGMSG_ERROR, "malloc %zu\n", sizeof(*pkey));
-            return -1;
-        }
+        updCols_key_t key = {.seq = pCur->genid, .id = -1ULL};
 
-        pkey->seq = pCur->genid;
-        pkey->id = -1ULL;
-
-        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->blb_cur, pkey,
-                                       sizeof(*pkey), &bdberr);
+        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->blb_cur, &key,
+                                       sizeof(key), &bdberr);
         if (bdberr) {
-            logmsg(LOGMSG_ERROR, 
-                    "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (1)\n",
-                    __func__, tmp, pkey->seq, rc, bdberr);
-            free(pkey);
+            logmsg(LOGMSG_ERROR,
+                   "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (1)\n",
+                   __func__, tmp, key.seq, rc, bdberr);
             return -1;
         }
 
@@ -1352,8 +1329,7 @@ int osql_save_updcols(struct BtCursor *pCur, struct sql_thread *thd,
                         __func__, rc, bdberr);
             }
             updCols = oldUpdCols;
-        } else
-            free(pkey);
+        }
     }
 
     /* insert into the blobs table with a blobid of -1 */
@@ -1751,15 +1727,11 @@ static int process_local_shadtbl_updcols(struct sqlclntstate *clnt,
     if (!tbl->updcols)
         return 0;
 
-    updCols_key_t *key = (updCols_key_t *)malloc(sizeof(updCols_key_t));
-    savkey = key->seq = seq;
-    key->id = -1;
+    updCols_key_t key = {.seq = seq, .id = -1};
+    savkey = seq;
 
-    rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->blb_cur, key,
-                                   sizeof(*key), bdberr);
-    if (IX_FND != rc)
-        free(key);
-
+    rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->blb_cur, &key,
+                                   sizeof(key), bdberr);
     if (rc < 0) {
         return rc;
     } else if (IX_EMPTY == rc || IX_NOTFND == rc) {
@@ -1840,7 +1812,6 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
          * bdb_temp_table_find(). */
         rc = bdb_temp_table_find(tbl->env->bdb_env, tbl->blb_cur, &key,
                                  sizeof(key), NULL, bdberr);
-
         tmptblkey = bdb_temp_table_key(tbl->blb_cur);
         idx = i;
         if (rc == IX_EMPTY || rc == IX_NOTFND ||
@@ -1902,20 +1873,14 @@ static int process_local_shadtbl_index(struct sqlclntstate *clnt,
     }
 
     for (i = 0; i < tbl->nix; i++) {
-        index_key_t *key;
-        /* key gets set into cur->key, and is freed when a new key is
-           submitted or when the cursor is closed */
+        index_key_t key = {.seq = seq, .ixnum = i};
         if (gbl_partial_indexes && tbl->ix_partial && !(dk & (1ULL << i)))
             continue;
-        key = (index_key_t *)malloc(sizeof(index_key_t));
-        key->seq = seq;
-        key->ixnum = i;
 
-        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tmp_cur, key,
-                                       sizeof(*key), bdberr);
+        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tmp_cur, &key,
+                                       sizeof(key), bdberr);
         if (rc != IX_FND) {
             logmsg(LOGMSG_ERROR, "%s: error missing index record!\n", __func__);
-            free(key);
             return SQLITE_INTERNAL;
         }
 
@@ -1964,15 +1929,10 @@ static int process_local_shadtbl_add(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         if (!is_genid_synthetic(key))
             goto next;
 
-        unsigned long long *seq;
-        seq = (unsigned long long *)malloc(sizeof(unsigned long long));
-        *seq = key;
         /* lookup the upd_cur: if this is an actual update then skip it
          * TODO: we could package and ship it rite here, rite now (later) */
-        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->upd_cur, seq,
-                                       sizeof(*seq), bdberr);
-        if (rc != IX_FND)
-            free(seq);
+        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->upd_cur, &key,
+                                       sizeof(key), bdberr);
 
         if (rc < 0)
             return rc;
@@ -2053,7 +2013,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
 {
 
     osqlstate_t *osql = &clnt->osql;
-    unsigned long long *seq = NULL;
+    unsigned long long seq;
     int rc = 0;
     unsigned long long genid = 0;
     int osql_nettype = tran2netrpl(clnt->dbtran.mode);
@@ -2071,19 +2031,16 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         char *data = NULL;
         int ldata = 0;
 
-        seq = (unsigned long long *)malloc(sizeof(unsigned long long));
-
-        *seq = *(unsigned long long *)bdb_temp_table_key(tbl->upd_cur);
+        seq = *(unsigned long long *)bdb_temp_table_key(tbl->upd_cur);
         genid = *(unsigned long long *)bdb_temp_table_data(tbl->upd_cur);
 
         /* locate the row in the add_cur */
-        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->add_cur, seq,
-                                       sizeof(*seq), bdberr);
+        rc = bdb_temp_table_find_exact(tbl->env->bdb_env, tbl->add_cur, &seq,
+                                       sizeof(seq), bdberr);
         if (rc != IX_FND) {
             logmsg(LOGMSG_ERROR,
                    "%s: this genid %llu must exist! bug rc = %d\n", __func__,
-                   *seq, rc);
-            free(seq);
+                   seq, rc);
             return SQLITE_INTERNAL;
         }
 
@@ -2100,7 +2057,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         if (osql->is_reorder_on) {
             rc = osql_send_updrec(osql->host, osql->rqid, osql->uuid, genid,
                                   (gbl_partial_indexes && tbl->ix_partial)
-                                      ? get_ins_keys(clnt, tbl, *seq)
+                                      ? get_ins_keys(clnt, tbl, seq)
                                       : -1ULL,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_del_keys(clnt, tbl, genid)
@@ -2117,7 +2074,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         }
 
         int *updCols = NULL;
-        rc = process_local_shadtbl_updcols(clnt, tbl, &updCols, bdberr, *seq);
+        rc = process_local_shadtbl_updcols(clnt, tbl, &updCols, bdberr, seq);
         if (rc)
             return SQLITE_INTERNAL;
 
@@ -2126,12 +2083,11 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         if (rc)
             return SQLITE_INTERNAL;
         /* indexes to add */
-        rc = process_local_shadtbl_index(clnt, tbl, bdberr, *seq, 0);
+        rc = process_local_shadtbl_index(clnt, tbl, bdberr, seq, 0);
         if (rc)
             return SQLITE_INTERNAL;
 
-        rc =
-            process_local_shadtbl_qblob(clnt, tbl, updCols, bdberr, *seq, data);
+        rc = process_local_shadtbl_qblob(clnt, tbl, updCols, bdberr, seq, data);
         if (rc)
             return SQLITE_INTERNAL;
 
@@ -2142,7 +2098,7 @@ static int process_local_shadtbl_upd(struct sqlclntstate *clnt, shad_tbl_t *tbl,
         if (!osql->is_reorder_on) {
             rc = osql_send_updrec(osql->host, osql->rqid, osql->uuid, genid,
                                   (gbl_partial_indexes && tbl->ix_partial)
-                                      ? get_ins_keys(clnt, tbl, *seq)
+                                      ? get_ins_keys(clnt, tbl, seq)
                                       : -1ULL,
                                   (gbl_partial_indexes && tbl->ix_partial)
                                       ? get_del_keys(clnt, tbl, genid)
@@ -2575,31 +2531,27 @@ static int _saved_dta_row(struct temp_cursor *cur, char **row, int *rowlen)
 static int delete_synthetic_row(struct BtCursor *pCur, struct sql_thread *thd,
                                 shad_tbl_t *tbl)
 {
-    unsigned long long *genid =
-        (unsigned long long *)malloc(sizeof(unsigned long long));
-    unsigned long long *genid2 =
-        (unsigned long long *)malloc(sizeof(unsigned long long));
+    unsigned long long genid, *pgenid;
     bdb_state_type *bdbenv = tbl->env->bdb_env;
     int rc = 0;
     int bdberr = 0;
     char *saved_dta_row = NULL;
     int saved_dta_row_len = 0;
 
-    *genid = pCur->genid;
-    *genid2 = pCur->genid;
+    genid = pCur->genid;
 
     /* if this is an update, please delete also update record */
     if (tbl->upd_cur) {
-        rc = bdb_temp_table_find_exact(bdbenv, tbl->upd_cur, genid2,
-                                       sizeof(*genid2), &bdberr);
+        rc = bdb_temp_table_find_exact(bdbenv, tbl->upd_cur, &genid,
+                                       sizeof(genid), &bdberr);
         if (rc == IX_FND) {
             rc = bdb_temp_table_delete(bdbenv, tbl->upd_cur, &bdberr);
             if (rc) {
-                logmsg(LOGMSG_ERROR, "%s:%d: fail to delete genid %llx (%lld) rc=%d "
-                                "bdberr=%d (3)\n",
-                        __FILE__, __LINE__, *genid2, pCur->genid, rc, bdberr);
+                logmsg(LOGMSG_ERROR,
+                       "%s:%d: fail to delete genid %llx (%lld) rc=%d "
+                       "bdberr=%d (3)\n",
+                       __FILE__, __LINE__, genid, genid, rc, bdberr);
 
-                free(genid);
                 return rc;
             }
             /* we might as well leak the blobs here, as the table will get
@@ -2608,36 +2560,34 @@ static int delete_synthetic_row(struct BtCursor *pCur, struct sql_thread *thd,
             /* check the original genid; if this was a pre-existing row that was
                updated,
                replace the update with an actual delete */
-            genid2 = (unsigned long long *)bdb_temp_table_data(tbl->upd_cur);
-            if (!is_genid_synthetic(*genid2)) {
-                rc = bdb_tran_deltbl_setdeleted(pCur->bdbcur, *genid2, NULL, 0,
+            pgenid = (unsigned long long *)bdb_temp_table_data(tbl->upd_cur);
+            if (!is_genid_synthetic(*pgenid)) {
+                rc = bdb_tran_deltbl_setdeleted(pCur->bdbcur, *pgenid, NULL, 0,
                                                 &bdberr);
                 if (rc) {
-                    logmsg(LOGMSG_ERROR, "%s: fail to delete genid %llx (%lld) "
-                                    "rc=%d bdberr=%d (5)\n",
-                            __func__, *genid2, pCur->genid, rc, bdberr);
+                    logmsg(LOGMSG_ERROR,
+                           "%s: fail to delete genid %llx (%lld) "
+                           "rc=%d bdberr=%d (5)\n",
+                           __func__, *pgenid, genid, rc, bdberr);
                 }
             }
         } else {
-            free(genid2);
-
             if (rc != IX_NOTFND && rc != IX_PASTEOF && rc != IX_EMPTY) {
-                logmsg(LOGMSG_ERROR, 
-                        "%s: fail to find genid %llx (%lld) rc=%d bdberr=%d\n",
-                        __func__, *genid, pCur->genid, rc, bdberr);
-                free(genid);
+                logmsg(LOGMSG_ERROR,
+                       "%s: fail to find genid %llx (%lld) rc=%d bdberr=%d\n",
+                       __func__, genid, genid, rc, bdberr);
                 return rc;
             }
         }
     }
 
     /* find the add table entry */
-    rc = bdb_temp_table_find_exact(bdbenv, tbl->add_cur, genid, sizeof(*genid),
+    rc = bdb_temp_table_find_exact(bdbenv, tbl->add_cur, &genid, sizeof(genid),
                                    &bdberr);
     if (rc != IX_FND) {
-        logmsg(LOGMSG_ERROR, "%s: fail to find genid %llx (%lld) rc=%d bdberr=%d\n",
-                __func__, *genid, pCur->genid, rc, bdberr);
-        free(genid);
+        logmsg(LOGMSG_ERROR,
+               "%s: fail to find genid %llx (%lld) rc=%d bdberr=%d\n", __func__,
+               genid, genid, rc, bdberr);
         return rc;
     }
 
@@ -2650,9 +2600,9 @@ static int delete_synthetic_row(struct BtCursor *pCur, struct sql_thread *thd,
     /* delete entry from add table */
     rc = bdb_temp_table_delete(bdbenv, tbl->add_cur, &bdberr);
     if (rc) {
-        logmsg(LOGMSG_ERROR, 
-                "%s: fail to delete genid %llx (%lld) rc=%d bdberr=%d (3)\n",
-                __func__, *genid, pCur->genid, rc, bdberr);
+        logmsg(LOGMSG_ERROR,
+               "%s: fail to delete genid %llx (%lld) rc=%d bdberr=%d (3)\n",
+               __func__, genid, genid, rc, bdberr);
         return rc;
     }
 
@@ -2660,9 +2610,9 @@ static int delete_synthetic_row(struct BtCursor *pCur, struct sql_thread *thd,
     rc = delete_record_indexes(pCur, saved_dta_row, saved_dta_row_len, thd,
                                &bdberr);
     if (rc) {
-        logmsg(LOGMSG_ERROR, 
-                "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (4)\n",
-                __func__, *genid, pCur->genid, rc, bdberr);
+        logmsg(LOGMSG_ERROR,
+               "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (4)\n",
+               __func__, genid, genid, rc, bdberr);
     }
 
     return rc;


### PR DESCRIPTION
This is a backport of #1360, and fixes a few memory leaks in osqlshadtbl.c.

(DRQS 168353890)