### PR TITLE
Bring back fix from #3088

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -19,7 +19,9 @@ static const char revid[] = "$Id: mp_sync.c,v 11.80 2003/09/13 19:20:41 bostic E
 #include "dbinc/txn.h"
 
 #include <sys/types.h>
+#ifndef _AIX
 #include <sys/stat.h>
+#endif
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>

--- a/berkdb/os/os_handle.c
+++ b/berkdb/os/os_handle.c
@@ -13,7 +13,9 @@ static const char revid[] = "$Id: os_handle.c,v 11.32 2003/02/16 15:54:03 bostic
 
 #ifndef NO_SYSTEM_INCLUDES
 #include <sys/types.h>
+#ifndef _AIX
 #include <sys/stat.h>
+#endif
 #include <fcntl.h>
 #include <string.h>
 #include <unistd.h>


### PR DESCRIPTION
AIX redefines stat to stat64.  We don't need the definitions here for AIX, so avoid bringing in the headers.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>
