### PR TITLE
preserve locks when spawning the trigger vdbe code

### DIFF
--- a/sqlite/src/trigger.c
+++ b/sqlite/src/trigger.c
@@ -973,6 +973,9 @@ static TriggerPrg *codeRowTrigger(
     transferParseError(pParse, pSubParse);
     if( db->mallocFailed==0 && pParse->nErr==0 ){
       pProgram->aOp = sqlite3VdbeTakeOpArray(v, &pProgram->nOp, &pTop->nMaxArg);
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+      sqlite3VdbeTransferTables(pParse->pVdbe, pSubParse->pVdbe);
+#endif
     }
     pProgram->nMem = pSubParse->nMem;
     pProgram->nCsr = pSubParse->nTab;

--- a/sqlite/src/vdbe.h
+++ b/sqlite/src/vdbe.h
@@ -260,6 +260,7 @@ VdbeOp *sqlite3VdbeAddOpList(Vdbe*, int nOp, VdbeOpList const *aOp,int iLineno);
 void sqlite3VdbeAddParseSchemaOp(Vdbe*,int,char*);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 void sqlite3VdbeAddTable(Vdbe*,Table*);
+void sqlite3VdbeTransferTables(Vdbe*,Vdbe*);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 void sqlite3VdbeChangeOpcode(Vdbe*, u32 addr, u8);
 void sqlite3VdbeChangeP1(Vdbe*, u32 addr, int P1);

--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -2550,11 +2550,29 @@ void sqlite3VdbeAddTable(
   pTbls = p->tbls;
   pTbls = sqlite3DbRealloc(p->db, pTbls, (numTables+1)*sizeof(Table*));
   if( pTbls==0 ) return;
-  memset(&pTbls[numTables], 0, (numTables+1-p->numTables)*sizeof(Table*));
   pTbls[numTables] = pTab;
   pTab->nTabRef++;
   p->tbls = pTbls;
   p->numTables++;
+}
+
+void sqlite3VdbeTransferTables(
+   Vdbe *pTo,
+   Vdbe *pFrom
+){
+  if (!pTo || !pFrom) return;
+
+  Table **pTbls = pTo->tbls;
+  int numTables = pTo->numTables;
+  assert( numTables>=0 );
+  pTbls = sqlite3DbRealloc(pTo->db, pTbls, (numTables+pFrom->numTables)*sizeof(Table*));
+  if( pTbls==0 ) return;
+  int i;
+  for(i=0; i<pFrom->numTables; i++){
+    pTbls[numTables+i] = pFrom->tbls[i];
+  }
+  pTo->tbls = pTbls;
+  pTo->numTables += pFrom->numTables;
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 


### PR DESCRIPTION
Currently, the time partition writes are not protected by a table lock (a shard lock in this case).  This is because the table information we need to grab the table locks is thrown away by sqlite. 
In detail, any writes for a partition are actually "instead-of" trigger executions.  Sqlite uses a different parser to generate code for the trigger code.  That parser learns about that tables involved and stores it in its additional vdbe engine.  Both the parser and its additional vdbe engine are thrown away after the trigger code is generated and transferred to the parent vdbe.

The patch makes sure the table information we collected when we parse the trigger code is passed back to the parent vdbe.  This ensures the proper table locks are acquired.

NOTE:  queries follow a different implementation path in sqlite and they are protected by table locks.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
