### PR TITLE
when we use a virtual table/system table, get its lock

### DIFF
--- a/sqlite/src/vtab.c
+++ b/sqlite/src/vtab.c
@@ -1174,6 +1174,7 @@ int sqlite3VtabEponymousTableInit(Parse *pParse, Module *pMod){
     sqlite3VtabEponymousTableClear(db, pMod);
     return 0;
   }
+  sqlite3VdbeAddTable(pParse->pVdbe, pTab);
   return 1;
 }
 


### PR DESCRIPTION
Master build does not get a table lock when using virtual tables (i.e. system tables).  7.0 had a fix for one use case in this commit 13adf2153, but that only addresses the simple "select from virtual table" case.  This patch makes sure we have a table lock for any type of statement that uses a virtual table.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

