### PR TITLE
Allow a cheapstack for certain lockerids when they are freed

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -421,6 +421,7 @@ struct txn_properties;
 #define DB_LOCK_ID_LOWPRI   0x001	/* Choose this as a deadlock victim */
 #define DB_LOCK_ID_TRACK    0x002	/* Track this lockid */
 #define DB_LOCK_ID_READONLY 0x004	/* Mark this as a read-only lockid */
+#define DB_LOCK_ID_TRACK_FREE   0x008
 
 /*
  * Simple R/W lock modes and for multi-granularity intention locking.

--- a/berkdb/db/db_am.c
+++ b/berkdb/db/db_am.c
@@ -113,7 +113,8 @@ __db_cursor_int(dbp, txn, dbtype, root, is_opd, lockerid, dbcp, flags)
 			    (adbc = TAILQ_FIRST(&dbp->active_queue)) != NULL)
 				dbc->lid = adbc->lid;
 			else {
-				if ((ret = __lock_id(dbenv, &dbc->lid)) != 0) {
+				if ((ret = __lock_id_flags(dbenv, &dbc->lid,
+                    DB_LOCK_ID_TRACK_FREE)) != 0) {
 					goto err;
 				}
 #ifdef LULU

--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -290,6 +290,7 @@ typedef struct __db_locker {
 #define DB_LOCKER_TRACK         	0x0100
 #define DB_LOCKER_READONLY      	0x0200
 #define DB_LOCKER_IN_LOGICAL_ABORT 	0x0800
+#define DB_LOCKER_TRACK_FREE        0x4000
 #define DB_LOCKER_TRACK_WRITELOCKS      0x8000
 	u_int8_t has_waiters;
 	u_int32_t flags;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -211,6 +211,7 @@ int gbl_penaltyincpercent = 20;
 int gbl_maxwthreadpenalty;
 int gbl_spstrictassignments = 0;
 int gbl_lock_conflict_trace = 0;
+int gbl_stack_tracked_free_lockerid = 0;
 int gbl_move_deadlk_max_attempt = 500;
 
 int gbl_uses_password;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1689,6 +1689,7 @@ extern int gbl_sc_report_freq;
 extern int gbl_thrman_trace;
 extern int gbl_move_deadlk_max_attempt;
 extern int gbl_lock_conflict_trace;
+extern int gbl_stack_tracked_free_lockerid;
 extern int gbl_enque_flush_interval;
 extern int gbl_inflate_log;
 extern pthread_attr_t gbl_pthread_attr_detached;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -598,6 +598,10 @@ REGISTER_TUNABLE("lock_conflict_trace",
                  "Dump count of lock conflicts every second. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_lock_conflict_trace, NOARG, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("stack_tracked_free_lockerid",
+                 "Print a stack of a free'd locker which tracked fre. (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_stack_tracked_free_lockerid, NOARG, NULL, NULL,
+                 NULL, NULL);
 REGISTER_TUNABLE("lock_dba_user",
                  "When enabled, 'dba' user cannot be removed and its access "
                  "permissions cannot be modified. (Default: off)",

--- a/tests/systable_locking.test/lrl.options
+++ b/tests/systable_locking.test/lrl.options
@@ -1,4 +1,5 @@
 nowatch
 logmsg level info
+stack_tracked_free_lockerid on
 #setattr REP_PROCESSORS 0
 #setattr REP_WORKERS 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -873,6 +873,7 @@
 (name='stack_disable', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='stack_enable', description='', type='BOOLEAN', value='ON', read_only='N')
 (name='stack_on_deadlock', description='stack_on_deadlock', type='BOOLEAN', value='OFF', read_only='N')
+(name='stack_tracked_free_lockerid', description='Print a stack of a free'd locker which tracked fre. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='stack_warn_threshold', description='', type='INTEGER', value='50', read_only='Y')
 (name='start_recovery_at_dbregs', description='Start recovery at dbregs', type='BOOLEAN', value='ON', read_only='N')
 (name='startup_sync_attempts', description='', type='INTEGER', value='5', read_only='N')


### PR DESCRIPTION
We're seeing an issue where our code aborts when attempting to get a lock from a lockerid which has been incorrectly freed.  The lockerid in each case has always been dbc->lid: a lockerid which is created when the cursor is allocated.  The code marks these cursors with the DB_LOCKER_TRACK_FREE, and will dump a cheapstack when that lockerid is freed on a tunable.  I'm hoping this gets us more information about how these lockerids are disappearing.
