### PR TITLE
use proper enum for alteronly everywhere

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5913,7 +5913,7 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
             /* we need to  generate retention-1 table adds, with schema provided
              * by previous alter; we need to convert an alter to a add sc
              */
-            arg.s->alteronly = 0; /* this is an add! */
+            arg.s->alteronly = SC_ALTER_NONE; /* this is an add! */
             arg.s->addonly = 1;
             arg.indx = 1; /* first shard is already there */
         }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -568,7 +568,7 @@ convert_records:
     assert(db->sc_from == db && s->db == db);
     assert(db->sc_to == newdb && s->newdb == newdb);
     assert(db->doing_conversion == 1);
-    if (s->resume && s->alteronly && !s->finalize_only) {
+    if (s->resume && s->alteronly != SC_ALTER_NONE && !s->finalize_only) {
         if (gbl_test_sc_resume_race && !get_stopsc(__func__, __LINE__)) {
             logmsg(LOGMSG_INFO, "%s:%d sleeping 5s for sc_resume test\n",
                    __func__, __LINE__);

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -557,7 +557,7 @@ uint64_t sc_get_seed_table(char *table)
 
 void add_ongoing_alter(struct schema_change_type *sc)
 {
-    assert(sc->alteronly);
+    assert(sc->alteronly != SC_ALTER_NONE);
     Pthread_mutex_lock(&ongoing_alter_mtx);
     if (ongoing_alters == NULL) {
         ongoing_alters =
@@ -569,7 +569,7 @@ void add_ongoing_alter(struct schema_change_type *sc)
 
 void remove_ongoing_alter(struct schema_change_type *sc)
 {
-    assert(sc->alteronly);
+    assert(sc->alteronly != SC_ALTER_NONE);
     Pthread_mutex_lock(&ongoing_alter_mtx);
     if (ongoing_alters != NULL) {
         hash_del(ongoing_alters, sc);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -635,7 +635,8 @@ static int do_schema_change_tran_int(sc_arg_t *arg, int no_reset)
 
     if (s->alteronly == SC_ALTER_PENDING || s->preempted == SC_ACTION_RESUME)
         detached = 1;
-    if (s->resume && s->alteronly && s->preempted == SC_ACTION_PAUSE)
+    if (s->resume && s->alteronly != SC_ALTER_NONE &&
+        s->preempted == SC_ACTION_PAUSE)
         detached = 1;
 
     if (s->addsp)

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -435,7 +435,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
     db = getqueuebyname(sc->tablename);
 
     /* dropping/altering a queue that doesn't exist? */
-    if ((sc->drop_table || sc->alteronly) && db == NULL) {
+    if ((sc->drop_table || sc->alteronly != SC_ALTER_NONE) && db == NULL) {
         sbuf2printf(sb, "!Trigger %s doesn't exist.\n", sc->tablename);
         sbuf2printf(sb, "FAILED\n");
         rc = -1;
@@ -470,7 +470,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
 
     char **dests;
 
-    if (sc->addonly || sc->alteronly) {
+    if (sc->addonly || sc->alteronly != SC_ALTER_NONE) {
         struct dest *d;
 
         dests = malloc(sizeof(char *) * sc->dests.count);
@@ -582,7 +582,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
                    __func__, rc, bdberr);
             goto done;
         }
-    } else if (sc->alteronly) {
+    } else if (sc->alteronly != SC_ALTER_NONE) {
         rc = bdb_llmeta_alter_queue(thedb->bdb_env, tran, sc->tablename, config,
                                     sc->dests.count, dests, &bdberr);
         if (rc) {
@@ -748,7 +748,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         }
     }
 
-    if (sc->addonly || sc->alteronly) {
+    if (sc->addonly || sc->alteronly != SC_ALTER_NONE) {
         dbqueuedb_admin(thedb);
     }
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -102,8 +102,8 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
 
     /* This section looks for resumed / resuming schema changes:
      * if there is one, then we attach to it here */
-    if (!s->resume &&
-        (s->addonly || s->drop_table || s->fastinit || s->alteronly)) {
+    if (!s->resume && (s->addonly || s->drop_table || s->fastinit ||
+                       s->alteronly != SC_ALTER_NONE)) {
         struct schema_change_type *last_sc = NULL;
         struct schema_change_type *stored_sc = NULL;
 
@@ -310,7 +310,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     arg->sc = iq->sc;
     s->started = 0;
 
-    if (s->resume && s->alteronly && !s->finalize_only) {
+    if (s->resume && s->alteronly != SC_ALTER_NONE && !s->finalize_only) {
         if (gbl_test_sc_resume_race) {
             logmsg(LOGMSG_INFO, "%s:%d sleeping 5s for sc_resume test\n",
                    __func__, __LINE__);
@@ -562,7 +562,7 @@ int do_dryrun(struct schema_change_type *s)
     // not sure if useful to print: sc_printf(s, "starting dryrun\n");
     db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
-        if (s->alteronly) {
+        if (s->alteronly != SC_ALTER_NONE) {
             sbuf2printf(s->sb, ">Table %s does not exists\n", s->tablename);
             rc = -1;
             goto done;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -59,6 +59,12 @@ struct dest {
     LINKC_T(struct dest) lnk;
 };
 
+enum schema_alter_option {
+    SC_ALTER_NONE = 0,
+    SC_ALTER_ONLY = 1,
+    SC_ALTER_PENDING = 2
+};
+
 /* status for schema_change_type->addonly */
 enum { SC_NOT_ADD = 0, SC_TO_ADD = 1, SC_DONE_ADD = 2 };
 
@@ -109,7 +115,7 @@ struct schema_change_type {
     int addonly;
     int partialuprecs; /* 1 if we're doing partial-table upgrade */
     int fulluprecs;    /* 1 if we're doing full-table upgrade */
-    int alteronly;
+    enum schema_alter_option alteronly;
     int is_trigger;
     size_t newcsc2_len;
     char *newcsc2; /* malloced buffer containing the new schema */
@@ -326,12 +332,6 @@ enum schema_change_preempt {
     SC_ACTION_RESUME = 2,
     SC_ACTION_COMMIT = 3,
     SC_ACTION_ABORT = 4
-};
-
-enum schema_alter_option {
-    SC_ALTER_NONE = 0,
-    SC_ALTER_ONLY = 1,
-    SC_ALTER_PENDING = 2
 };
 
 #include <bdb_schemachange.h>

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -759,7 +759,7 @@ void comdb2AlterTableCSC2(
                               ERROR_ON_TBL_NOT_FOUND, 1, 0, NULL))
         goto out;
 
-    sc->alteronly = 1;
+    sc->alteronly = SC_ALTER_ONLY;
     sc->nothrevent = 1;
     sc->live = 1;
     sc->use_plan = 1;
@@ -869,7 +869,7 @@ static inline void comdb2Rebuild(Parse *pParse, Token* nm, Token* lnm, int opt)
     else
         sc->live = 1;
 
-    sc->alteronly = 1;
+    sc->alteronly = SC_ALTER_ONLY;
     sc->commit_sleep = gbl_commit_sleep;
     sc->convert_sleep = gbl_convert_sleep;
 
@@ -1047,7 +1047,7 @@ void comdb2RebuildIndex(Parse* pParse, Token* nm, Token* lnm, Token* index, int 
 
     free(indexname);
 
-    sc->alteronly = 1;
+    sc->alteronly = SC_ALTER_ONLY;
     sc->nothrevent = 1;
     sc->rebuild_index = 1;
     sc->index_to_rebuild = index_num;
@@ -5533,7 +5533,7 @@ void comdb2CreateIndex(
     if (pParse->rc)
         goto cleanup;
 
-    sc->alteronly = 1;
+    sc->alteronly = SC_ALTER_ONLY;
     sc->nothrevent = 1;
     sc->live = 1;
     sc->use_plan = 1;
@@ -6259,7 +6259,7 @@ void comdb2DropIndex(Parse *pParse, Token *pName1, Token *pName2, int ifExists)
     if (pParse->rc)
         goto cleanup;
 
-    sc->alteronly = 1;
+    sc->alteronly = SC_ALTER_ONLY;
     sc->nothrevent = 1;
     sc->live = 1;
     sc->use_plan = 1;


### PR DESCRIPTION
Simple, per title.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
