### PR TITLE
Fix off-by-one bug in lockmgr

### DIFF
--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -26,7 +26,8 @@ extern size_t gbl_lkr_hash;
  * DB_LOCK_MAXID + 1 and go up to TXN_MAXIMUM.
  */
 #define	DB_LOCK_INVALIDID	0
-#define	DB_LOCK_MAXID		0x7fffffff
+#define DB_LOCK_MAXID_DEFAULT 0x7fffffff
+extern int DB_LOCK_MAXID;
 
 /*
  * Out of band value for a lock.  Locks contain an offset into a lock region,

--- a/berkdb/lock/lock_region.c
+++ b/berkdb/lock/lock_region.c
@@ -69,6 +69,9 @@ static const u_int8_t db_cdb_conflicts[] = {
 	/*  IW */   0, 0, 1, 0, 1
 };
 
+int DB_LOCK_MAXID = DB_LOCK_MAXID_DEFAULT;
+int gbl_db_lock_maxid_override;
+
 /*
  * __lock_open --
  *	Internal version of lock_open: only called from DB_ENV->open.
@@ -89,6 +92,12 @@ __lock_open(dbenv)
 		return (ret);
 	lt->dbenv = dbenv;
 
+	/* override from tunable */
+	if (gbl_db_lock_maxid_override) {
+		logmsg(LOGMSG_USER, "Overriding DB_LOCK_MAXID to %u\n", gbl_db_lock_maxid_override);
+		DB_LOCK_MAXID = gbl_db_lock_maxid_override;
+	}
+
 	/* Join/create the lock region. */
 	lt->reginfo.type = REGION_TYPE_LOCK;
 	lt->reginfo.id = INVALID_REGION_ID;
@@ -107,7 +116,7 @@ __lock_open(dbenv)
 
 	/* Set the local addresses. */
 	region = lt->reginfo.primary =
-	    R_ADDR(&lt->reginfo, lt->reginfo.rp->primary);
+		R_ADDR(&lt->reginfo, lt->reginfo.rp->primary);
 
 	/* Check for incompatible automatic deadlock detection requests. */
 	if (dbenv->lk_detect != DB_LOCK_NORUN) {

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -571,7 +571,7 @@ __txn_begin_int_int(txn, retries, we_start_at_this_lsn, flags)
 		region->cur_maxid != TXN_MAXIMUM)
 		region->last_txnid = TXN_MINIMUM - 1;
 
-	if (region->last_txnid == region->cur_maxid) {
+	if ((region->last_txnid + 1) == region->cur_maxid) {
 		if ((ret = __os_malloc(dbenv,
 			sizeof(u_int32_t) * region->maxtxns, &ids)) != 0)
 			goto err;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -108,6 +108,7 @@ extern int gbl_test_blob_race;
 extern int gbl_test_scindex_deadlock;
 extern int gbl_test_sc_resume_race;
 extern int gbl_berkdb_track_locks;
+extern int gbl_db_lock_maxid_override;
 extern int gbl_udp;
 extern int gbl_update_delete_limit;
 extern int gbl_updategenids;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1151,6 +1151,10 @@ REGISTER_TUNABLE("toblock_net_throttle",
 REGISTER_TUNABLE("track_berk_locks", NULL, TUNABLE_INTEGER,
                  &gbl_berkdb_track_locks, READONLY | NOARG, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("db_lock_maxid_override", "Override berkley lock_maxid for "
+                 "testing. (Default: 0)", TUNABLE_INTEGER,
+                 &gbl_db_lock_maxid_override, EXPERIMENTAL | INTERNAL, NULL,
+                 NULL, NULL, NULL);
 REGISTER_TUNABLE("udp", NULL, TUNABLE_BOOLEAN, &gbl_udp, READONLY | NOARG, NULL,
                  NULL, NULL, NULL);
 REGISTER_TUNABLE("unnatural_types", "Same as 'surprise'", TUNABLE_BOOLEAN,

--- a/tests/lock_maxid.test/Makefile
+++ b/tests/lock_maxid.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/lock_maxid.test/README
+++ b/tests/lock_maxid.test/README
@@ -1,0 +1,1 @@
+Testing that lockids are assigned correctly

--- a/tests/lock_maxid.test/lrl.options
+++ b/tests/lock_maxid.test/lrl.options
@@ -1,0 +1,6 @@
+table t t.csc2
+
+dtastripe 4
+appsockslimit 10
+maxappsockslimit 10
+db_lock_maxid_override 524287

--- a/tests/lock_maxid.test/runit
+++ b/tests/lock_maxid.test/runit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+export STOPFILE=stopfile.txt
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+
+function select_from_t
+{
+    timeout 8m yes "select * from t limit 1" | $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME>/dev/null 2>&1
+}
+
+function select_from_metrics
+{
+    timeout 8m yes "select name, type, value, collection_type from comdb2_metrics order by case when name = 'start_time' then 0 else 1 end" | $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME>/dev/null 2>&1
+}
+
+function schema_change_loop
+{
+    while [[ ! -f $STOPFILE ]]; do
+        $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "rebuild t" >/dev/null 2>&1
+        $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "create table t2(a int)" >/dev/null 2>&1
+        $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "drop table t2" >/dev/null 2>&1
+    done
+}
+
+function run_test
+{
+    rm $STOPFILE
+    create_table t
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "insert into t select value from generate_series(1, 1000)"
+
+    j=0
+    while [[ $j -lt 15 ]]; do
+        select_from_t &
+        let j=j+1
+    done
+
+    j=0
+    while [[ $j -lt 3 ]]; do
+        select_from_metrics &
+        let j=j+1
+    done
+
+    sleep 500
+    touch $STOPFILE
+    wait
+}
+
+run_test
+$CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select 1"

--- a/tests/lock_maxid.test/title
+++ b/tests/lock_maxid.test/title
@@ -1,0 +1,1 @@
+Max Lockid Tests


### PR DESCRIPTION
Patches to the lockmgr and transaction manager to fix an off-by-one error where the highest lockerid in a range can be returned even though it may still already be in use.  A new test, 'max_lockid', verifies the behavior: comdb2 will abort if these changes are reverted.