### PR TITLE
cdb2api: Get hostname from a cached FD

### DIFF
--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -257,8 +257,8 @@ typedef enum cdb2_event_ctrl {
 
 typedef enum cdb2_event_type {
     /* Network events */
-    CDB2_BEFORE_CONNECT = 1,
-    CDB2_AFTER_CONNECT = 1 << 1,
+    CDB2_BEFORE_NEWSQL_CONNECT = 1,
+    CDB2_AFTER_NEWSQL_CONNECT = 1 << 1,
     CDB2_BEFORE_PMUX = 1 << 2,
     CDB2_AFTER_PMUX = 1 << 3,
     CDB2_BEFORE_DBINFO = 1 << 4,
@@ -268,14 +268,16 @@ typedef enum cdb2_event_type {
     CDB2_BEFORE_READ_RECORD = 1 << 8,
     CDB2_AFTER_READ_RECORD = 1 << 9,
     CDB2_AT_RECEIVE_HEARTBEAT = 1 << 10,
+    CDB2_BEFORE_TCP_CONNECT = 1 << 11,
+    CDB2_AFTER_TCP_CONNECT = 1 << 12,
 
     /* Logical operation events.
        A logicial operation event typically
        consists of multiple network events. */
-    CDB2_AT_ENTER_RUN_STATEMENT = 1 << 11,
-    CDB2_AT_EXIT_RUN_STATEMENT = 1 << 12,
-    CDB2_AT_ENTER_NEXT_RECORD = 1 << 13,
-    CDB2_AT_EXIT_NEXT_RECORD = 1 << 14,
+    CDB2_AT_ENTER_RUN_STATEMENT = 1 << 13,
+    CDB2_AT_EXIT_RUN_STATEMENT = 1 << 14,
+    CDB2_AT_ENTER_NEXT_RECORD = 1 << 15,
+    CDB2_AT_EXIT_NEXT_RECORD = 1 << 16,
 
     /* Lifecycle events */
     CDB2_BEFORE_DISCOVERY = 1 << 27,

--- a/docs/pages/programming/c_api.md
+++ b/docs/pages/programming/c_api.md
@@ -542,8 +542,10 @@ Otherwise, the event will be registered locally to the handle, thus will be visi
 |---|---|
 |Network| `CDB2_BEFORE_DISCOVERY` | The callback is invoked before database destination discovery. |
 |Network| `CDB2_AFTER_DISCOVERY` | The callback is invoked after database destination discovery. |
-|Network| `CDB2_BEFORE_CONNECT` | The callback is invoked before the API starts connecting to a host. |
-|Network| `CDB2_AFTER_CONNECT` | The callback is invoked after the attempt to connect. |
+|Network| `CDB2_BEFORE_NEWSQL_CONNECT` | The callback is invoked before client attempts to connect to server. |
+|Network| `CDB2_AFTER_NEWSQL_CONNECT` | The callback is invoked after client attempts to connect to server. |
+|Network| `CDB2_BEFORE_TCP_CONNECT` | The callback is invoked before client attempts to establish a TCP connection to server. If the connection is obtained from sockpool, the callback will not be invoked. |
+|Network| `CDB2_AFTER_TCP_CONNECT` | The callback is invoked after client attempts to establish a TCP connection to server. If the connection is obtained from sockpool, the callback will not be invoked. |
 |Network| `CDB2_BEFORE_PMUX` | The callback is invoked before the API starts querying for the database port from `pmux`. |
 |Network| `CDB2_AFTER_PMUX` | The callback is invoked after the pmux attempt. |
 |Network| `CDB2_BEFORE_DBINFO` | The callback is invoked before the API starts retrieving the dbinfo. |


### PR DESCRIPTION
A connetion obtained from the in-process cache or sockpool does not have host information.
The patch fixes it.

The patch also includes changes needed for distributed tracing, which is a separate pull request against bb-plugins.

(DRQS 168421725)
