### PR TITLE
Don't drain the cursor when closing the ResultSet or Connection 

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -19,8 +19,6 @@ import java.util.*;
 import java.util.concurrent.*;
 import java.util.logging.*;
 
-import com.bloomberg.comdb2.jdbc.Constants.*;
-
 /**
  * @author Rivers Zhang
  * @author Mohit Khullar
@@ -273,6 +271,14 @@ public class Comdb2Connection implements Connection {
     public void setStackAtOpen(boolean sendStack) {
         hndl.hasSendStack = true;
         hndl.setSendStack(sendStack);
+    }
+
+    public void setSkipResultSetDrain(boolean skipDrain) {
+        hndl.setSkipResultSetDrain(skipDrain);
+    }
+
+    public void setClearAck(boolean clearAck) {
+        hndl.setClearAck(clearAck);
     }
 
     public ArrayList<String> getDbHosts() throws NoDbHostFoundException{

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -122,6 +122,8 @@ public class Driver implements java.sql.Driver {
                     new BooleanOption("statement_query_effects", "StatementQueryEffects"));
             options.put("verify_retry", new BooleanOption("verify_retry", "VerifyRetry"));
             options.put("stack_at_open", new BooleanOption("stack_at_open", "StackAtOpen"));
+            options.put("skip_rs_drain", new BooleanOption("skip_rs_drain", "SkipResultSetDrain"));
+            options.put("clear_ack", new BooleanOption("clear_ack", "ClearAck"));
         } catch (Throwable e) {
             throw new SQLException(e);
         }


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ? Feature flag
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
When executing a Stored Procedure that reads data from a Lua Consumer queue, events are removed from the queue if/when the ResultSet is closed even in cases where the application has not read them, which causes data loss. This flag will allow us to control if this 'draining' will happen when closing the ResultSet.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
