### PR TITLE
remove unused argument newdb_from_schema

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2380,7 +2380,7 @@ int add_cmacc_stmt_no_side_effects(struct dbtable *db, int alt);
 
 void cleanup_newdb(struct dbtable *);
 struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
-                             int dbnum, int dbix, int is_foreign);
+                                  int dbnum, int dbix);
 struct dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
                   int isqueuedb);
 int init_check_constraints(struct dbtable *tbl);

--- a/db/config.c
+++ b/db/config.c
@@ -634,7 +634,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
     }
 
     /* create one */
-    db = newdb_from_schema(dbenv, tblname, fname, dbnum, dbenv->num_dbs, 0);
+    db = newdb_from_schema(dbenv, tblname, fname, dbnum, dbenv->num_dbs);
     if (db == NULL) {
         return -1;
     }

--- a/db/tag.c
+++ b/db/tag.c
@@ -6788,7 +6788,7 @@ struct schema *create_version_schema(char *csc2, int version,
         goto err;
     }
 
-    ver_db = newdb_from_schema(dbenv, gbl_ver_temp_table, NULL, 0, 0, 0);
+    ver_db = newdb_from_schema(dbenv, gbl_ver_temp_table, NULL, 0, 0);
     if (ver_db == NULL) {
         logmsg(LOGMSG_ERROR, "newdb_from_schema failed %s:%d\n", __FILE__, __LINE__);
         goto err;
@@ -6903,8 +6903,8 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
         goto err;
     }
 
-    dbtable *newdb = newdb_from_schema(db->dbenv, db->tablename, NULL,
-                                       db->dbnum, foundix, 0);
+    dbtable *newdb =
+        newdb_from_schema(db->dbenv, db->tablename, NULL, db->dbnum, foundix);
     if (newdb == NULL) {
         logmsg(LOGMSG_ERROR, "newdb_from_schema failed %s:%d\n", __FILE__, __LINE__);
         goto err;

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -126,7 +126,7 @@ int add_table_to_environment(char *table, const char *csc2,
         logmsg(LOGMSG_INFO, "Dumping schema for reference: '%s'\n", csc2);
         return SC_CSC2_ERROR;
     }
-    newdb = newdb_from_schema(thedb, table, NULL, 0, thedb->num_dbs, 0);
+    newdb = newdb_from_schema(thedb, table, NULL, 0, thedb->num_dbs);
 
     if (newdb == NULL) {
         return SC_INTERNAL_ERROR;

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -462,7 +462,8 @@ struct dbtable *create_db_from_schema(struct dbenv *thedb,
                                       struct schema_change_type *s, int dbnum,
                                       int foundix, int schema_version)
 {
-    struct dbtable *newdb = newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix, 0);
+    struct dbtable *newdb =
+        newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix);
 
     if (newdb == NULL) return NULL;
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -890,7 +890,7 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
     }
 
     /* TODO remove NULL arg; pre-llmeta holdover */
-    newdb = newdb_from_schema(thedb, table, NULL, db->dbnum, foundix, 0);
+    newdb = newdb_from_schema(thedb, table, NULL, db->dbnum, foundix);
     if (newdb == NULL) {
         /* shouldn't happen */
         backout_schemas(table);

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -596,7 +596,7 @@ int do_dryrun(struct schema_change_type *s)
         goto done;
     }
 
-    newdb = newdb_from_schema(thedb, s->tablename, NULL, 0, 0, 1);
+    newdb = newdb_from_schema(thedb, s->tablename, NULL, 0, 0);
     if (!newdb) {
         rc = -1;
         goto done;
@@ -996,7 +996,8 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
 
     if (s->dbnum != -1) db->dbnum = s->dbnum;
 
-    db->sc_to = newdb = newdb_from_schema(thedb, s->tablename, NULL, db->dbnum, foundix, 0);
+    db->sc_to = newdb =
+        newdb_from_schema(thedb, s->tablename, NULL, db->dbnum, foundix);
 
     if (newdb == NULL) {
         return -1;


### PR DESCRIPTION
Very trivial change, remove argument not used. 
Chunked this while refactoring some piece of sc.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
