### PR TITLE
Support providing connection parameters via properties 

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -169,14 +169,15 @@ public class Driver implements java.sql.Driver {
 
         String[] tokens = url.split("\\/\\s*|\\s+");
 
-        Comdb2Connection ret = null;
-        String clusterStr = null;
-        String dbStr = null;
+        Comdb2Connection ret;
+        String clusterStr;
+        String dbStr;
         String port = null;
         String attributes = null;
 
-        ArrayList<String> hosts = new ArrayList<String>();
-        ArrayList<Integer> ports = new ArrayList<Integer>();
+        List<String> hosts = new ArrayList<String>();
+        List<Integer> ports = new ArrayList<Integer>();
+        Set<String> processedOptions = new HashSet<String>();
 
         if (tokens.length < 4) { /* Use legacy format */
             tokens = url.split(":\\s*|\\s+");
@@ -264,7 +265,25 @@ public class Driver implements java.sql.Driver {
                     Option opt = options.get(keyval[0]);
                     if (opt != null) {
                         opt.process(ret, keyval[1], info);
+                        processedOptions.add(opt.opt);
                     }
+                }
+            }
+        } catch (Throwable t) {
+            ret.close();
+            throw new SQLException(t);
+        }
+
+        try {
+            for (Object prop : info.keySet()) {
+                String propertyName = prop.toString();
+                if (processedOptions.contains(propertyName)) {
+                    continue;
+                }
+                Option opt = options.get(propertyName);
+                if (opt != null) {
+                    opt.process(ret, info.getProperty(propertyName), info);
+                    processedOptions.add(propertyName);
                 }
             }
         } catch (Throwable t) {


### PR DESCRIPTION
Support providing connection parameters via properties (in addition to jdbc url params)

Signed-off-by: Hector Geraldino <hgeraldino@gmail.com>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ? feature
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
JDBC allows passing connection parameters via DataSource properties. The properties are partially ignored by the current Driver implementation (are only used for addons), so this patch is to add support for configuring the connection using that mechanism. 
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
It's better to configure the connection via properties rather than adding flags to the jdbc url