### PR TITLE
do not free the table info twice

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -2575,6 +2575,8 @@ void sqlite3VdbeTransferTables(
   }
   pTo->tbls = pTbls;
   pTo->numTables += pFrom->numTables;
+  pFrom->numTables = 0;
+  pFrom->tbls = NULL;
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 


### PR DESCRIPTION
https://github.com/bloomberg/comdb2/pull/3113 introduced a double free (moving table info has to remove them from the sub-parser vdbe)

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

