### PR TITLE
do not free the table info twice

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -2573,6 +2573,8 @@ void sqlite3VdbeTransferTables(
   }
   pTo->tbls = pTbls;
   pTo->numTables += pFrom->numTables;
+  pFrom->numTables = 0;
+  pFrom->tbls = NULL;
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 


### PR DESCRIPTION
Fix regression in 7.0 as well, porting https://github.com/bloomberg/comdb2/pull/3134 to 7.0
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
