### PR TITLE
Ufid 7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,12 @@ if(DEBUG_SC)
     add_definitions(-DDEBUG_SC)
 endif()
 
+option(UFID_HASH_DEBUG "Enable ufid-hash debug trace" OFF)
+mark_as_advanced(UFID_HASH_DEBUG)
+if(UFID_HASH_DEBUG)
+  add_definitions(-DUFID_HASH_DEBUG)
+endif()
+
 option(COMDB2_PER_THREAD_MALLOC "Turn OFF to run under Valgrind" ON)
 if(COMDB2_PER_THREAD_MALLOC)
   add_definitions(-DPER_THREAD_MALLOC)

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -7494,7 +7494,7 @@ int oldfile_list_empty(void)
     return ret;
 }
 
-int bdb_get_first_logfile(bdb_state_type *bdb_state, int *bdberr)
+int bdb_get_logfile(bdb_state_type *bdb_state, int *bdberr, int which)
 {
     DB_LOGC *logc;
     DBT logent;
@@ -7510,7 +7510,7 @@ int bdb_get_first_logfile(bdb_state_type *bdb_state, int *bdberr)
     }
     bzero(&logent, sizeof(DBT));
     logent.flags = DB_DBT_MALLOC;
-    rc = logc->get(logc, &current_lsn, &logent, DB_FIRST);
+    rc = logc->get(logc, &current_lsn, &logent, which);
     if (rc) {
         logc->close(logc, 0);
         logmsg(LOGMSG_ERROR, "%s: logc->get last LSN rc %d\n", __func__, rc);
@@ -7524,6 +7524,16 @@ int bdb_get_first_logfile(bdb_state_type *bdb_state, int *bdberr)
     logc->close(logc, 0);
 
     return lognum;
+}
+
+int bdb_get_first_logfile(bdb_state_type *bdb_state, int *bdberr)
+{
+    return bdb_get_logfile(bdb_state, bdberr, DB_FIRST);
+}
+
+int bdb_get_last_logfile(bdb_state_type *bdb_state, int *bdberr)
+{
+    return bdb_get_logfile(bdb_state, bdberr, DB_LAST);
 }
 
 /* Lets check new prefix for ongoing schema changes:
@@ -7616,7 +7626,7 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
     assert(bdb_state->parent == NULL);
 
     if (bdb_state->attr->keep_referenced_files) {
-        lognum = bdb_get_first_logfile(bdb_state, bdberr);
+        lognum = bdb_get_last_logfile(bdb_state, bdberr);
         if (lognum == -1)
             return -1;
     }
@@ -7814,7 +7824,7 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
     assert(bdb_state->parent != NULL);
 
     if (delay && bdb_state->attr->keep_referenced_files) {
-        lognum = bdb_get_first_logfile(bdb_state, bdberr);
+        lognum = bdb_get_last_logfile(bdb_state, bdberr);
         if (lognum == -1)
             return -1;
     }

--- a/bdb/rowlocks.c
+++ b/bdb/rowlocks.c
@@ -266,6 +266,9 @@ static int get_next_addrem_buffer(bdb_state_type *bdb_state, DB_LSN *lsn,
                       (u_int8_t *)logent.data + 2 * sizeof(u_int32_t));
         *nextlsn = prevlsn;
 
+        if (rectype < 10000 && rectype > 1000) {
+            rectype -= 1000;
+        }
         if (rectype == DB___db_pg_free || rectype == DB___db_pg_freedata)
             /* pg_free is generating an extra addrem that I don't understand.
              * skip it */
@@ -750,6 +753,10 @@ int bdb_reconstruct_key_update(bdb_state_type *bdb_state, DB_LSN *startlsn,
         LOGCOPY_TOLSN(&prevlsn,
                       (u_int8_t *)logent.data + 2 * sizeof(u_int32_t));
 
+        if (rectype < 10000 && rectype > 1000) {
+            rectype -= 1000;
+        }
+
         if (rectype == DB___bam_repl) {
             rc = __bam_repl_read_int(bdb_state->dbenv, logent.data, 0, &repl);
             if (rc) {
@@ -844,6 +851,10 @@ int bdb_reconstruct_inplace_update(bdb_state_type *bdb_state, DB_LSN *startlsn,
         /* Copy it's previous LSN. */
         LOGCOPY_TOLSN(&prevlsn,
                       (u_int8_t *)logent.data + 2 * sizeof(u_int32_t));
+
+        if (rectype < 10000 && rectype > 1000) {
+            rectype -= 1000;
+        }
 
         /* Find a btree-replace log record. */
         if (rectype == DB___bam_repl) {
@@ -1280,6 +1291,8 @@ int undo_commit(bdb_state_type *bdb_state, tran_type *tran,
 
 char *rectypestr(int rectype)
 {
+    if (rectype < 10000 && rectype > 1000)
+        rectype -= 1000;
     switch (rectype) {
     case DB_llog_savegenid:
         return "savegenid";

--- a/berkdb/btree/bt_rec.c
+++ b/berkdb/btree/bt_rec.c
@@ -131,6 +131,13 @@ __bam_split_recover(dbenv, dbtp, lsnp, op, info)
 	if (__memp_fget(mpf, &argp->right, 0, &rp) != 0)
 		rp = NULL;
 
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s [%d:%d] %s dbp %p lp-lsn [%d:%d] rp-lsn [%d:%d]\n",
+			__func__, lsnp->file, lsnp->offset, DB_REDO(op) ? "REDO" : "UNDO",
+			file_dbp, lp ? LSN(lp).file : -1, lp ? LSN(lp).offset : -1, 
+			rp ? LSN(rp).file : -1, rp ? LSN(rp).offset: -1);
+#endif
+
 	if (DB_REDO(op)) {
 		l_update = r_update = p_update = 0;
 		/*
@@ -795,6 +802,11 @@ __bam_cdel_recover(dbenv, dbtp, lsnp, op, info)
 	cmp_p = log_compare(&LSN(pagep), &argp->lsn);
 	CHECK_LSN(op, cmp_p, &LSN(pagep), &argp->lsn, lsnp, argp->fileid,
 	    argp->pgno);
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s (%s) lsn [%d:%d] pagelsn [%d:%d]\n", __func__,
+			DB_REDO(op) ? "REDO" : "UNDO", lsnp->file, lsnp->offset,
+			LSN(pagep).file, LSN(pagep).offset);
+#endif
 	if (cmp_p == 0 && DB_REDO(op)) {
 		/* Need to redo update described. */
 		indx = argp->indx + (TYPE(pagep) == P_LBTREE ? O_INDX : 0);
@@ -876,6 +888,11 @@ __bam_repl_recover(dbenv, dbtp, lsnp, op, info)
 	cmp_p = log_compare(&LSN(pagep), &argp->lsn);
 	CHECK_LSN(op, cmp_p, &LSN(pagep), &argp->lsn, lsnp, argp->fileid,
 	    argp->pgno);
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s (%s) lsn [%d:%d] pagelsn [%d:%d]\n", __func__,
+			DB_REDO(op) ? "REDO" : "UNDO", lsnp->file, lsnp->offset,
+			LSN(pagep).file, LSN(pagep).offset);
+#endif
 	if (cmp_p == 0 && DB_REDO(op)) {
 		/*
 		 * Need to redo update described.

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1414,6 +1414,7 @@ struct __db {
 
 #define	DB_LOGFILEID_INVALID	-1
 	FNAME *log_filename;		/* File's naming info for logging. */
+	int added_to_ufid;
 
 	db_pgno_t meta_pgno;		/* Meta page number */
 	u_int32_t lid;			/* Locker id for handle locking. */
@@ -2080,6 +2081,12 @@ struct __lc_cache {
 	pthread_mutex_t lk;
 };
 
+struct __ufid_to_db_t {
+	u_int8_t ufid[DB_FILE_ID_LEN];
+	char *fname;
+	DB *dbp;
+};
+
 typedef int (*collect_locks_f)(void *args, int64_t threadid, int32_t lockerid,
 		const char *mode, const char *status, const char *table,
 		int64_t page, const char *rectype);
@@ -2499,6 +2506,10 @@ struct __db_env {
 	pthread_mutex_t ltrans_hash_lk;
 	pthread_mutex_t ltrans_inactive_lk;
 	pthread_mutex_t ltrans_active_lk;
+
+	/* ufid to dbp hash */
+	hash_t *ufid_to_db_hash;
+	pthread_mutex_t ufid_to_db_lk;
 
 	/* Parallel recovery.  These are only valid on replicants. */
 	DB_LSN prev_commit_lsn;
@@ -2929,7 +2940,7 @@ int berkdb_verify_lsn_written_to_disk(DB_ENV *dbenv, DB_LSN *lsn,
 	int check_checkpoint);
 
 u_int32_t file_id_for_recovery_record(DB_ENV *env, DB_LSN *lsn,
-	int rectype, DBT *dbt);
+	int rectype, u_int8_t *ufid, int *is_ufid, DBT *dbt);
 
 int __rep_get_master(DB_ENV *dbenv, char **master, u_int32_t *gen, u_int32_t *egen);
 int __rep_get_eid(DB_ENV *dbenv,char **eid);

--- a/berkdb/common/db_err.c
+++ b/berkdb/common/db_err.c
@@ -110,6 +110,7 @@ __db_pgerr(dbp, pgno, errval)
 	 * Death, taxes, and lost data.
 	 * Guess which has occurred.
 	 */
+	__log_flush(dbp->dbenv, NULL);
 	__db_err(dbp->dbenv,
 	    "unable to create/retrieve page %lu", (u_long)pgno);
 	return (__db_panic(dbp->dbenv, errval));

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -72,6 +72,10 @@ static const char revid[] = "$Id: db.c,v 11.283 2003/11/14 05:32:29 ubell Exp $"
 static int __db_dbenv_mpool __P((DB *, const char *, u_int32_t));
 static int __db_disassociate __P((DB *));
 
+#if defined (UFID_HASH_DEBUG)
+	void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
+
 #if CONFIG_TEST
 static void __db_makecopy __P((DB_ENV *, const char *, const char *));
 static int  __db_testdocopy __P((DB_ENV *, const char *));
@@ -738,6 +742,10 @@ __db_close(dbp, txn, flags)
 
 	dbenv->close_flags = flags;
 
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s called on %p flags=0x%x:", __func__,
+			dbp, flags);
+#endif
 	/*
 	 * Validate arguments, but as a DB handle destructor, we can't fail.
 	 *
@@ -749,6 +757,10 @@ __db_close(dbp, txn, flags)
 		(void)__db_check_txn(dbp, txn, DB_LOCK_INVALIDID, 0);
 
 	dbpflags = dbp->flags;
+
+	if (dbp->added_to_ufid)
+		__ufid_close(dbenv, txn, dbp->fileid);
+
 	/* Refresh the structure and close any underlying resources. */
 	ret = __db_refresh(dbp, txn, flags, &deferred_close);
 

--- a/berkdb/db/db_am.c
+++ b/berkdb/db/db_am.c
@@ -30,6 +30,9 @@ static const char revid[] = "$Id: db_am.c,v 11.112 2003/09/13 19:23:42 bostic Ex
 #include <walkback.h>
 #include <pthread.h>
 #include <stdlib.h>
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
 
 static int __db_append_primary __P((DBC *, DBT *, DBT *));
 static int __db_secondary_get __P((DB *, DB_TXN *, DBT *, DBT *, u_int32_t));
@@ -799,9 +802,15 @@ __db_sync(dbp)
 
 	if (dbp->type == DB_QUEUE)
 		ret = __qam_sync(dbp);
-	else if ((t_ret = __memp_fsync(dbp->mpf)) != 0 && ret == 0) {
-		/* Flush any dirty pages from the cache to the backing file. */
-		ret = t_ret;
+	else {
+#if defined (UFID_HASH_DEBUG)
+			logmsg(LOGMSG_USER, "%s syncing %s mpf %p\n", __func__, dbp->fname ?
+					dbp->fname : "(noname)", dbp->mpf);
+#endif
+			if ((t_ret = __memp_fsync(dbp->mpf)) != 0 && ret == 0) {
+			/* Flush any dirty pages from the cache to the backing file. */
+			ret = t_ret;
+		}
 	}
 
 	return (ret);

--- a/berkdb/db/db_dispatch.c
+++ b/berkdb/db/db_dispatch.c
@@ -95,6 +95,10 @@ static int __db_txnlist_pgnoadd __P((DB_ENV *, DB_TXNHEAD *,
 #include "dbinc_auto/qam_auto.h"
 #include "dbinc_auto/txn_auto.h"
 
+#if defined (UFID_HASH_DEBUG)
+void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
+
 static int log_event_counts[10000] = { 0 };
 
 void
@@ -264,14 +268,20 @@ optostr(int op)
 }
 
 u_int32_t
-file_id_for_recovery_record(DB_ENV *env, DB_LSN *lsn, int rectype, DBT *dbt)
+file_id_for_recovery_record(DB_ENV *env, DB_LSN *lsn, int rectype,
+		u_int8_t *fuid, int *is_fuid, DBT *dbt)
 {
 	int off = -1;
 	u_int32_t fileid = UINT32_MAX;
 
+	*is_fuid = 0;
 	/* Skip custom log recs */
 	if (rectype < 10000) {
 		log_event_counts[rectype]++;
+		if (rectype > 1000) {
+			*is_fuid = 1;
+			rectype -= 1000;
+		}
 	}
 
 	/*
@@ -390,8 +400,13 @@ file_id_for_recovery_record(DB_ENV *env, DB_LSN *lsn, int rectype, DBT *dbt)
 	}
 
 	/* Get fileid out of the record */
-	if (off != -1)
-		LOGCOPY_32(&fileid, (char *)dbt->data + off);
+	if (off != -1) {
+        if (*is_fuid) {
+            memcpy(fuid, (char *)dbt->data + off, DB_FILE_ID_LEN);
+        } else {
+            LOGCOPY_32(&fileid, (char *)dbt->data + off);
+        }
+    }
 
 	/*
 	 * Some records have nothing to do with files.  These always
@@ -492,11 +507,16 @@ __db_dispatch(dbenv, dtab, dtabsize, db, lsnp, redo, info)
 		 * necessary during recovery.
 		 */
 		LOGCOPY_TOLSN(&prev_lsn, (u_int8_t *)db->data +
-		    sizeof(rectype) + sizeof(txnid));
-		if (txnid != 0 && prev_lsn.file == 0 && (ret =
-			__db_txnlist_add(dbenv, info, txnid, TXN_OK,
-			    NULL)) != 0)
+			sizeof(rectype) + sizeof(txnid));
+		if (txnid != 0 && prev_lsn.file == 0) { 
+			if ((ret = __db_txnlist_add(dbenv, info, txnid, TXN_OK,
+				NULL)) != 0)
 			 return (ret);
+#if defined (UFID_HASH_DEBUG)
+			comdb2_cheapstack_sym(stderr, "db_txnlist_add line %d for "
+					"[%d:%d]:", __LINE__, lsnp->file, lsnp->offset);
+#endif
+		}
 
 		/* FALLTHROUGH */
 	case DB_TXN_POPENFILES:
@@ -537,22 +557,35 @@ __db_dispatch(dbenv, dtab, dtabsize, db, lsnp, redo, info)
 			/* FALLTHROUGH */
 		default:
 			if (txnid != 0 && (ret =
-			    __db_txnlist_find(dbenv,
-			    info, txnid)) != TXN_COMMIT && ret != TXN_IGNORE) {
+				__db_txnlist_find(dbenv,
+				info, txnid)) != TXN_COMMIT && ret != TXN_IGNORE) {
 				/*
 				 * If not found then, this is an incomplete
 				 * abort.
 				 */
-				if (ret == TXN_NOTFOUND)
-					return (__db_txnlist_add(dbenv,
-					    info, txnid, TXN_IGNORE, lsnp));
+				if (ret == TXN_NOTFOUND) {
+					ret = __db_txnlist_add(dbenv,
+						info, txnid, TXN_IGNORE, lsnp);
+#if defined (UFID_HASH_DEBUG)
+					comdb2_cheapstack_sym(stderr, "db_txnlist_add line %d for "
+						"[%d:%d]:", __LINE__, lsnp->file, lsnp->offset);
+#endif
+					return ret;
+				}
 				make_call = 1;
-				if (ret == TXN_OK &&
-				    (ret = __db_txnlist_update(dbenv,
-				    info, txnid,
-				    rectype == DB___txn_xa_regop ?
-				    TXN_PREPARE : TXN_ABORT, NULL)) != 0)
-					return (ret);
+				if (ret == TXN_OK) {
+					ret = __db_txnlist_update(dbenv, info, txnid,
+							rectype == DB___txn_xa_regop ?
+							TXN_PREPARE : TXN_ABORT, NULL);
+#if defined (UFID_HASH_DEBUG)
+					comdb2_cheapstack_sym(stderr, "db_txnlist_update line %d for "
+						"[%d:%d] to %d:", __LINE__, lsnp->file, lsnp->offset,
+						rectype == DB___txn_xa_regop ?
+						TXN_PREPARE : TXN_ABORT);
+#endif
+					if (ret != 0)
+						return ret;
+				}
 			}
 		}
 		break;
@@ -669,6 +702,9 @@ __db_dispatch(dbenv, dtab, dtabsize, db, lsnp, redo, info)
 			 * the standard table, use the standard table's size
 			 * as our sanity check.
 			 */
+			if (rectype > 1000) {
+				rectype -= 1000;
+			}
 			if (rectype > dtabsize || dtab[rectype] == NULL) {
 				__db_err(dbenv,
 				    "Illegal record type %lu in log",
@@ -1013,6 +1049,12 @@ __db_txnlist_update(dbenv, listp, txnid, status, lsn)
 		return (ret);
 	elp->u.t.status = status;
 
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s updating txnid 0x%x status %d [%d:%d], "
+			"ret %d", __func__, txnid, status, lsn ? lsn->file : -1,
+			lsn ? lsn->offset : -1, ret);
+#endif
+
 	if (lsn != NULL && IS_ZERO_LSN(hp->maxlsn) && status == TXN_COMMIT)
 		hp->maxlsn = *lsn;
 
@@ -1269,6 +1311,39 @@ err:	__db_txnlist_end(dbenv, hp);
 }
 
 /*
+ * __db_add_limbo_fid -- add pages to the limbo list by fileid.
+ *	Get the file information and call pgnoadd for each page.
+ *
+ * PUBLIC: int __db_add_limbo_fid __P((DB_ENV *,
+ * PUBLIC:      void *, u_int8_t *, db_pgno_t, int32_t));
+ */
+int
+__db_add_limbo_fid(dbenv, info, ufid, pgno, count)
+	DB_ENV *dbenv;
+	void *info;
+	u_int8_t *ufid;
+	db_pgno_t pgno;
+	int32_t count;
+{
+	char *fname;
+	int ret;
+	if ((ret = __ufid_to_fname(dbenv, &fname, ufid)) != 0) {
+		__ufid_dump(dbenv);
+		__log_flush(dbenv, NULL);
+		abort();
+	}
+
+	do {
+		if ((ret =
+			__db_txnlist_pgnoadd(dbenv, info, -1, ufid, fname, pgno)) != 0)
+			return (ret);
+		pgno++;
+	} while (--count != 0);
+
+	return (0);
+}
+
+/*
  * __db_add_limbo -- add pages to the limbo list.
  *	Get the file information and call pgnoadd for each page.
  *
@@ -1517,10 +1592,19 @@ retry:		dbp_created = 0;
 		t = ctxn == NULL ? txn : ctxn;
 
 		/* First try to get a dbp by fileid. */
+		if (elp->u.p.fileid != -1) {
 		ret =
-		    __dbreg_id_to_db(dbenv, t, &dbp, elp->u.p.fileid, 0, NULL,
-		    0);
+			__dbreg_id_to_db(dbenv, t, &dbp, elp->u.p.fileid, 0, NULL,
+			0);
+		} else {
+			ret = __ufid_to_db(dbenv, t, &dbp, elp->u.p.uid, NULL);
+		}
 
+		DB_ASSERT(!F_ISSET((dbp), DB_AM_RECOVER));
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s dbp %p recover-flag=%x ret=%d\n", __func__, dbp,
+				F_ISSET((dbp), DB_AM_RECOVER), ret);
+#endif
 
 #if 0
 		if (ret == DB_DELETED) {
@@ -1535,8 +1619,10 @@ retry:		dbp_created = 0;
 		 * dealing with recovery of allocations.
 		 */
 		if (ret == DB_DELETED ||
-		    (ret == 0 && F_ISSET(dbp, DB_AM_DISCARD)))
+			(ret == 0 && F_ISSET(dbp, DB_AM_DISCARD))) {
+			ret = ENOENT;
 			goto next;
+		}
 
 		if (ret != 0) {
 			if ((ret = db_create(&dbp, dbenv, 0)) != 0)
@@ -1660,7 +1746,7 @@ next:
 			ret = t_ret;
 
 		if (dbp_created &&
-		    (t_ret = __db_close(dbp, txn, DB_NOSYNC)) != 0 && ret == 0)
+			(t_ret = __db_close(dbp, NULL, DB_NOSYNC)) != 0 && ret == 0)
 			ret = t_ret;
 		dbp = NULL;
 		if (state != LIMBO_PREPARE && state != LIMBO_TIMESTAMP) {
@@ -1731,6 +1817,11 @@ __db_limbo_fix(dbp, txn, ctxn, elp, lastp, meta, state)
 				goto err;
 			continue;
 		}
+
+		if (LSN(pagep).file == 0 && LSN(pagep).offset == 1) {
+			abort();
+		}
+
 		put_page = 1;
 
 		if (state == LIMBO_COMPENSATE || IS_ZERO_LSN(LSN(pagep))) {
@@ -1782,9 +1873,20 @@ __db_limbo_fix(dbp, txn, ctxn, elp, lastp, meta, state)
 					goto err;
 				}
 
-				if (dbc == NULL && (ret =
-				    __db_cursor(dbp, ctxn, &dbc, 0)) != 0)
+#if defined (UFID_HASH_DEBUG)
+				if (dbc == NULL) {
+					logmsg(LOGMSG_USER, "%s creating a cursor for %p "
+							"ctxn is %p\n", __func__, dbp, ctxn);
+				}
+#endif
+				if (dbc == NULL) {
+					if ((ret = __db_cursor(dbp, ctxn, &dbc, 0)) != 0)
 						goto err;
+#if defined (UFID_HASH_DEBUG)
+					logmsg(LOGMSG_USER, "%s created cursor recover=%d\n",
+							__func__, F_ISSET((dbc), DBC_RECOVER));
+#endif
+				}
 				/*
 				 * If the dbp is compensating (because we
 				 * opened it), the dbc will automatically be
@@ -1792,6 +1894,10 @@ __db_limbo_fix(dbp, txn, ctxn, elp, lastp, meta, state)
 				 * do the open, we have to mark it explicitly.
 				 */
 				F_SET(dbc, DBC_COMPENSATE);
+#if defined (UFID_HASH_DEBUG)
+				comdb2_cheapstack_sym(stderr, "%s calling __db_free for pg %d",
+						__func__, pagep->pgno);
+#endif
 				ret = __db_free(dbc, pagep);
 				put_page = 0;
 				/*
@@ -1859,6 +1965,9 @@ __db_limbo_prepare(dbp, txn, elp)
 			if (ret != ENOSPC)
 				return (ret);
 			continue;
+		}
+		if (LSN(pagep).file == 0 && LSN(pagep).offset == 1) {
+			abort();
 		}
 
 		if (IS_ZERO_LSN(LSN(pagep)))

--- a/berkdb/db/db_dup.c
+++ b/berkdb/db/db_dup.c
@@ -303,8 +303,8 @@ __db_pitem_opcode(dbc, pagep, indx, nbytes, hdr, data, opcode)
 	}
 
 	if (nbytes > P_FREESPACE(dbp, pagep)) {
-		logmsg(LOGMSG_ERROR, "%s nbytes:%u freespace:%lu\n",
-		    __func__, nbytes, P_FREESPACE(dbp, pagep));
+		logmsg(LOGMSG_ERROR, "%s nbytes:%u freespace:%"PRId64"\n",
+			__func__, nbytes, (int64_t)P_FREESPACE(dbp, pagep));
 		DB_ASSERT(nbytes <= P_FREESPACE(dbp, pagep));
 		return (EINVAL);
 	}

--- a/berkdb/db/db_meta.c
+++ b/berkdb/db/db_meta.c
@@ -66,6 +66,9 @@ static const char revid[] = "$Id: db_meta.c,v 11.77 2003/09/09 16:42:06 ubell Ex
 #include <stdlib.h>
 #include <logmsg.h>
 
+#if defined (UFID_HASH_DEBUG)
+void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
 
 /* definition in malloc.h clashes with dlmalloc */
 extern void *memalign(size_t boundary, size_t size);
@@ -102,8 +105,19 @@ __db_init_meta(dbp, p, pgno, pgtype)
 int gbl_core_on_sparse_file = 0;
 int gbl_check_sparse_files = 0;
 
-/* We already have the metapage locked. */
+#if defined (UFID_HASH_DEBUG)
+#define CHECK_ALLOC_PAGE_LSN(x) do { \
+	if (x.file == 0 && x.offset == 1) { \
+		logmsg(LOGMSG_USER, "Invalid page lsn for pgalloc\n"); \
+		__log_flush(dbc->dbp->dbenv, NULL); \
+		abort(); \
+	} \
+} while(0);
+#else
+#define CHECK_ALLOC_PAGE_LSN(x) 
+#endif
 
+/* We already have the metapage locked. */
 static int
 __db_new_from_freelist(DBC *dbc, DBMETA *meta, u_int32_t type, PAGE **pagepp)
 {
@@ -148,6 +162,7 @@ __db_new_from_freelist(DBC *dbc, DBMETA *meta, u_int32_t type, PAGE **pagepp)
 	 * mpool to extend the file.
 	 */
 	if (DBC_LOGGING(dbc)) {
+		CHECK_ALLOC_PAGE_LSN(lsn);
 		if ((ret = __db_pg_alloc_log(dbp, dbc->txn, &LSN(meta), 0,
 		    &LSN(meta), PGNO_BASE_MD, &lsn, pgno,
 		    (u_int32_t)type, newnext)) != 0)
@@ -378,6 +393,7 @@ __db_new(dbc, type, pagepp)
 
 				ZERO_LSN(pglsn);
 				/* Log the page creation. */
+				CHECK_ALLOC_PAGE_LSN(pglsn);
 				ret =
 				    __db_pg_alloc_log(dbc->dbp, t, &LSN(meta),
 				    0, &LSN(meta), PGNO_BASE_MD, &pglsn, pgno,
@@ -631,6 +647,7 @@ __db_new_original(dbc, type, pagepp)
 	 * mpool to extend the file.
 	 */
 	if (DBC_LOGGING(dbc)) {
+		CHECK_ALLOC_PAGE_LSN(lsn);
 		if ((ret = __db_pg_alloc_log(dbp, dbc->txn, &LSN(meta), 0,
 			    &LSN(meta), PGNO_BASE_MD, &lsn, pgno,
 			    (u_int32_t)type, newnext)) != 0)
@@ -782,9 +799,23 @@ log:			ret = __db_pg_free_log(dbp,
 			(void)__TLPUT(dbc, metalock);
 			goto err;
 		}
-	} else
+	} else {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "logging not set for cursor, metalsn [%d:%d]\n",
+				LSN(meta).file, LSN(meta).offset);
+		logmsg(LOGMSG_USER, "logging-on=%d recover=%d rep-client=%d\n",
+				LOGGING_ON((dbc)->dbp->dbenv), F_ISSET((dbc), DBC_RECOVER),
+				IS_REP_CLIENT((dbc)->dbp->dbenv));
+#endif
 		LSN_NOT_LOGGED(LSN(meta));
+	}
 	LSN(h) = LSN(meta);
+#if defined (UFID_HASH_DEBUG)
+	if (IS_NOT_LOGGED_LSN(LSN(h))) {
+		comdb2_cheapstack_sym(stderr, "%s setting not-logged for pg %d",
+				__func__, h->pgno);
+	}
+#endif
 
 	P_INIT(h, dbp->pgsize, h->pgno, PGNO_INVALID, meta->free, 0, P_INVALID);
 #ifdef DIAGNOSTIC

--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -37,7 +37,7 @@ static const char revid[] = "$Id: db_open.c,v 11.236 2003/09/27 00:29:03 sue Exp
 
 #include <string.h>
 
-#if defined (STACK_AT_DB_OPEN_CLOSE)
+#if defined (STACK_AT_DB_OPEN_CLOSE) || defined(UFID_HASH_DEBUG)
 #include <tohex.h>
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 #endif
@@ -258,7 +258,7 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 	 * files.
 	 */
 	if (!F_ISSET(dbp, DB_AM_RECOVER) &&
-	    fname != NULL && LOCK_ISSET(dbp->handle_lock)) {
+		fname != NULL && LOCK_ISSET(dbp->handle_lock)) {
 		if (txn != NULL) {
 			ret = __txn_lockevent(dbenv,
 			    txn, dbp, &dbp->handle_lock, dbp->lid);
@@ -270,6 +270,10 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 
 DB_TEST_RECOVERY_LABEL
 err:
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s called on %s flags=0x%x dbp %p ret %d:",
+            __func__, fname ? fname : "(nil)", flags, dbp, ret);
+#endif
 	return (ret);
 }
 

--- a/berkdb/dbreg/dbreg_rec.c
+++ b/berkdb/dbreg/dbreg_rec.c
@@ -253,6 +253,7 @@ __dbreg_register_recover(dbenv, dbtp, lsnp, op, info)
 		 * However, if we shut down without closing a file, we may, in
 		 * fact, not have the file open, and that's OK.
 		 */
+		__ufid_close(dbenv, NULL, argp->uid.data);
 		do_rem = 0;
 		MUTEX_THREAD_LOCK(dbenv, dblp->mutexp);
 #if defined (STACK_AT_DBREG_RECOVER)
@@ -464,6 +465,7 @@ reopen:if (txn != NULL) {
 
 	ret = __dbreg_do_open(dbenv, txn, lp, argp->uid.data, argp->name.data,
 	    argp->ftype, argp->fileid, argp->meta_pgno, info, argp->id);
+	__ufid_open(dbenv, txn, argp->name.data, argp->uid.data);
 
 	return ret;
 }

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -28,6 +28,11 @@ static const char revid[] = "$Id: dbreg_util.c,v 11.39 2003/11/10 17:42:34 sue E
 #include "printformats.h"
 #include "logmsg.h"
 #include "comdb2_atomic.h"
+#include "locks_wrap.h"
+#include <fsnapf.h>
+#if defined (UFID_HASH_DEBUG)
+#include <limits.h>
+#endif
 
 static int __dbreg_check_master __P((DB_ENV *, u_int8_t *, char *));
 
@@ -132,6 +137,10 @@ __ufid_sanity_check(dbenv, fnp)
 #if defined (STACK_AT_DBREG_LOG)
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 #include <tohex.h>
+#endif
+
+#if defined (UFID_HASH_DEBUG)
+void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 #endif
 
 /*
@@ -261,6 +270,8 @@ __dbreg_recovery_pages(dbenv)
 	return 0;
 }
 
+static int __ufid_close_files(DB_ENV *dbenv);
+
 /*
  * __dbreg_close_files --
  *	Remove the id's of open files and actually close those
@@ -284,6 +295,7 @@ __dbreg_close_files(dbenv)
 	if (!LOGGING_ON(dbenv))
 		return (0);
 
+	__ufid_close_files(dbenv);
 	dblp = dbenv->lg_handle;
 	ret = 0;
 	MUTEX_THREAD_LOCK(dbenv, dblp->mutexp);
@@ -328,6 +340,368 @@ __dbreg_close_files(dbenv)
 	return (ret);
 }
 
+static int close_ufid(void *obj, void *arg)
+{
+	struct __ufid_to_db_t *ufid = (struct __ufid_to_db_t *)obj;
+	DB_ENV *dbenv = (DB_ENV *)arg;
+	int ret = 0;
+	if (ufid->dbp) {
+#if defined (UFID_HASH_DEBUG)
+		if (F_ISSET(ufid->dbp, DB_AM_RECOVER))
+			logmsg(LOGMSG_USER, "%s closing %s\n", __func__, ufid->fname ?
+					ufid->fname : "(nil)");
+#endif
+		ufid->dbp->added_to_ufid = 0;
+		if (F_ISSET(ufid->dbp, DB_AM_RECOVER))
+			ret = __db_close(ufid->dbp, NULL, ufid->dbp->mpf == NULL ?
+					DB_NOSYNC : 0);
+		ufid->dbp = NULL;
+	}
+	return ret;
+}
+
+static int
+__ufid_close_files(dbenv)
+	DB_ENV *dbenv;
+{
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	hash_for(dbenv->ufid_to_db_hash, close_ufid, dbenv);
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	return 0;
+}
+
+// PUBLIC: int __ufid_rename __P(( DB_ENV *, const char *, const char *, u_int8_t *));
+int
+__ufid_rename(dbenv, oldname, newname, inufid)
+	DB_ENV *dbenv;
+	const char *oldname;
+	const char *newname;
+	u_int8_t *inufid;
+{
+	struct __ufid_to_db_t *ufid;
+	DB *close_dbp = NULL;
+	int ret = 0;
+	int close = 0;
+
+	if (!newname || strstr(newname, ".recovery_pages"))
+		return 0;
+
+	if (!strncmp(oldname, "__db", 4) || !strncmp(newname, "__db", 4))
+		close = 1;
+
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, inufid)) == NULL) {
+		if ((ret = __os_malloc(dbenv, sizeof(*ufid), &ufid)) != 0) {
+			abort();
+		}
+		memcpy(ufid->ufid, inufid, DB_FILE_ID_LEN);
+		ufid->fname = strdup(newname);
+		ufid->dbp = NULL;
+		hash_add(dbenv->ufid_to_db_hash, ufid);
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s adding %s\n", __func__, newname);
+#endif
+	} else {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s renaming %s to %s dbp %p\n", __func__,
+				ufid->fname, newname, ufid->dbp);
+#endif
+		free(ufid->fname);
+		ufid->fname = strdup(newname);
+		if (close && ufid->dbp) {
+			close_dbp = ufid->dbp;
+			ufid->dbp = NULL;
+		}
+	}
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+
+	if (close_dbp) {
+		close_dbp->added_to_ufid = 0;
+		if (close_dbp->mpf)
+			__memp_fsync(close_dbp->mpf);
+		F_SET(close_dbp, DB_AM_DISCARD);
+		if (F_ISSET(close_dbp, DB_AM_RECOVER))
+			ret = __db_close(close_dbp, NULL, close_dbp->mpf == NULL ?
+					DB_NOSYNC : 0);
+		else {
+			ret = __db_refresh(close_dbp, NULL, DB_NOSYNC, NULL);
+		}
+	}
+
+	return ret;
+}
+
+// PUBLIC: int __ufid_open __P(( DB_ENV *, DB_TXN *txn, const char *, u_int8_t *));
+int
+__ufid_open(dbenv, txn, fname, inufid)
+	DB_ENV *dbenv;
+	DB_TXN *txn;
+	const char *fname;
+	u_int8_t *inufid;
+{
+    DB *dbp;
+    return __ufid_to_db(dbenv, txn, &dbp, inufid, NULL);
+}
+
+/* Only called during readdir at beginning of process.  */
+static int
+__ufid_open_readdir(dbenv, fname)
+	DB_ENV *dbenv;
+	const char *fname;
+{
+	struct __ufid_to_db_t *ufid;
+	int ret = -1;
+	DB *dbp = NULL;
+
+	if (!fname || strstr(fname, ".recovery_pages"))
+		return 0;
+
+	if ((ret = db_create(&dbp, dbenv, 0)) != 0) {
+		logmsg(LOGMSG_ERROR, "%s error creating dbp for %s: %d\n", __func__,
+				fname, ret);
+		return ret;
+	}
+	dbp->added_to_ufid = 0;
+
+	u_int32_t flags = DB_ODDFILESIZE|DB_DATAFILE|DB_AM_RECOVER;
+	F_SET(dbp, DB_AM_RECOVER);
+	if ((ret = __db_open(dbp, NULL, fname, NULL, DB_UNKNOWN, flags,
+					__db_omode("rw----"), 0)) != 0) {
+		__db_close(dbp, NULL, dbp->mpf == NULL ? DB_NOSYNC : 0);
+		return ret;
+	}
+
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, dbp->fileid)) == NULL) {
+		if ((ret = __os_malloc(dbenv, sizeof(*ufid), &ufid)) != 0) {
+			abort();
+		}
+		memcpy(ufid->ufid, dbp->fileid, DB_FILE_ID_LEN);
+		ufid->fname = strdup(fname);
+		ufid->dbp = NULL;
+		hash_add(dbenv->ufid_to_db_hash, ufid);
+	} else if ((strcmp(ufid->fname, fname)) != 0) {
+		logmsg(LOGMSG_FATAL, "%s multiple files with fileid: %s vs %s\n",
+				__func__, ufid->fname, fname);
+		fsnapf(stderr, dbp->fileid, DB_FILE_ID_LEN);
+		fflush(stderr);
+		abort();
+	}
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	F_SET(dbp, DB_AM_DISCARD);
+	__db_close(dbp, NULL, dbp->mpf == NULL ? DB_NOSYNC : 0);
+	return 0;
+}
+
+// PUBLIC: int __ufid_close __P(( DB_ENV *, DB_TXN *, u_int8_t *));
+int
+__ufid_close(dbenv, txn, inufid)
+	DB_ENV *dbenv;
+	DB_TXN *txn;
+	u_int8_t *inufid;
+{
+	struct __ufid_to_db_t *ufid;
+	int ret = -1;
+	DB *close_dbp = NULL;
+#if defined (UFID_HASH_DEBUG)
+	char fname[PATH_MAX] = {0};
+#endif
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, inufid)) != NULL) {
+		ret = 0;
+		/* Close but leave in hash */
+		if (ufid->dbp) {
+			close_dbp = ufid->dbp;
+		}
+		ufid->dbp = NULL;
+#if defined (UFID_HASH_DEBUG)
+		strncpy(fname, ufid->fname, sizeof(fname));
+#endif
+	}
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	if (close_dbp) { 
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s closing %s\n", __func__, fname);
+#endif
+		close_dbp->added_to_ufid = 0;
+		if (F_ISSET(close_dbp, DB_AM_RECOVER))
+			ret = __db_close(close_dbp, NULL, close_dbp->mpf == NULL ?
+					DB_NOSYNC : 0);
+	}
+	return ret;
+}
+
+static int dump_ufid(void *obj, void *arg)
+{
+	struct __ufid_to_db_t *ufid = (struct __ufid_to_db_t *)obj;
+	FILE *f = (FILE *)arg;
+	fsnapf(f, ufid, DB_FILE_ID_LEN);
+	fprintf(f, "%s\n-\n", ufid->fname);
+	return 0;
+}
+
+// PUBLIC: void __ufid_dump __P(( DB_ENV *));
+void
+__ufid_dump(dbenv)
+	DB_ENV *dbenv;
+{
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	hash_for(dbenv->ufid_to_db_hash, dump_ufid, stderr);
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+}
+
+// PUBLIC: int __ufid_add_dbp __P(( DB_ENV *, DB *));
+int
+__ufid_add_dbp(dbenv, dbp)
+	DB_ENV *dbenv;
+	DB *dbp;
+{
+	struct __ufid_to_db_t *ufid;
+	int ret = 0;
+	DB *close_dbp = NULL;
+
+	if (F_ISSET(dbp, DB_AM_RECOVER))
+		abort();
+
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, dbp->fileid))) {
+		if (ufid->dbp != NULL) {
+			ufid->dbp->added_to_ufid = 0;
+			close_dbp = ufid->dbp;
+		}
+	} else {
+		if ((ret = __os_malloc(dbenv, sizeof(*ufid), &ufid)) != 0) {
+			abort();
+		}
+		memcpy(ufid->ufid, dbp->fileid, DB_FILE_ID_LEN);
+		if (dbp->fname)
+			ufid->fname = strdup(dbp->fname);
+		else
+			ufid->fname = NULL;
+		hash_add(dbenv->ufid_to_db_hash, ufid);
+	}
+
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s adding %p, closing %p\n", __func__,
+			dbp, close_dbp);
+#endif
+
+	ufid->dbp = dbp;
+	ufid->dbp->added_to_ufid = 1;
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	if (close_dbp) {
+		if (F_ISSET(close_dbp, DB_AM_RECOVER))
+			ret = __db_close(close_dbp, NULL, close_dbp->mpf == NULL ?
+					DB_NOSYNC : 0);
+	}
+	return ret;
+}
+
+// PUBLIC: int __ufid_to_db __P(( DB_ENV *, DB_TXN *, DB **, u_int8_t *, DB_LSN *));
+int
+__ufid_to_db(dbenv, txn, dbpp, inufid, lsnp)
+	DB_ENV *dbenv;
+	DB_TXN *txn;
+	DB **dbpp;
+	u_int8_t *inufid;
+	DB_LSN *lsnp;
+{
+	struct __ufid_to_db_t *ufid;
+	DB *close_dbp = NULL;
+	int ret = -1;
+	DB *dbp = NULL;
+	(*dbpp) = NULL;
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, inufid)) != NULL) {
+		ret = 0;
+		if (ufid->dbp == NULL) {
+			Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+			ret = db_create(&dbp, dbenv, 0);
+			if (ret) {
+				logmsg(LOGMSG_FATAL, "%s error creating: %d\n", __func__,
+						ret);
+				abort();
+			}
+			F_SET(dbp, DB_AM_RECOVER);
+			ret = __db_open(dbp, txn, ufid->fname, NULL, DB_UNKNOWN,
+					DB_ODDFILESIZE, __db_omode("rw----"), 0);
+			if (ret) {
+				__db_close(dbp, txn, 0);
+				if (ret == ENOENT) {
+					ret = DB_DELETED;
+				} else {
+					__log_flush(dbenv, NULL);
+					abort();
+				}
+			} else {
+#if defined (UFID_HASH_DEBUG)
+				logmsg(LOGMSG_USER, "%s opening %s\n", __func__, ufid->fname);
+#endif
+				Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+				if (ufid->dbp != NULL) {
+					close_dbp = dbp;
+#if defined (UFID_HASH_DEBUG)
+					logmsg(LOGMSG_USER, "%s another thread opened %s\n", __func__, ufid->fname);
+#endif
+				} else {
+					ufid->dbp = dbp;
+					dbp->added_to_ufid = 1;
+				}
+				Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+			}
+			Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+		}
+		(*dbpp) = ufid->dbp;
+	}
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	if (close_dbp != NULL) {
+		__db_close(close_dbp, NULL, DB_NOSYNC);
+	}
+	return ret;
+}
+
+#include <dirent.h>
+
+int
+__ufid_readdir(dbenv)
+	DB_ENV *dbenv;
+{
+	DIR *d;
+	char fname[PATH_MAX];
+	struct dirent *ent;
+	d = opendir(dbenv->comdb2_dirs.data_dir);
+	if (d == NULL) {
+		__db_err(dbenv, "Can't open data directory");
+		abort();
+	}
+	ent = readdir(d);
+	while (ent) {
+		snprintf(fname, sizeof(fname), "XXX.%s", ent->d_name);
+		__ufid_open_readdir(dbenv, fname);
+		ent = readdir(d);
+	}
+	closedir(d);
+	return 0;
+}
+
+// PUBLIC: int __ufid_to_fname __P(( DB_ENV *, char **, u_int8_t *));
+int
+__ufid_to_fname(dbenv, fname, inufid)
+	DB_ENV *dbenv;
+	char **fname;
+	u_int8_t *inufid;
+{
+	struct __ufid_to_db_t *ufid;
+	int ret = -1;
+	(*fname) = NULL;
+	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, inufid)) != NULL) {
+		(*fname) = ufid->fname;
+		ret = 0;
+	}
+	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
+	return ret;
+}
 
 // PUBLIC: int __dbreg_id_to_db __P(( DB_ENV *, DB_TXN *, DB **, int32_t, int, DB_LSN *, int));
 int

--- a/berkdb/env/env_open.c
+++ b/berkdb/env/env_open.c
@@ -377,6 +377,8 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		Pthread_mutex_init(&dbenv->ltrans_active_lk, NULL);
 		Pthread_mutex_init(&dbenv->locked_lsn_lk, NULL);
 	}
+    dbenv->ufid_to_db_hash = hash_init(DB_FILE_ID_LEN);
+    Pthread_mutex_init(&dbenv->ufid_to_db_lk, NULL);
 	dbenv->mintruncate_state = MINTRUNCATE_START;
 	ZERO_LSN(dbenv->mintruncate_first);
 	ZERO_LSN(dbenv->last_mintruncate_dbreg_start);
@@ -442,6 +444,12 @@ __dbenv_open(dbenv, db_home, flags, mode)
 		if ((ret = __txn_init_getallpgnos(dbenv, &dbenv->pgnos_dtab,
 		    &dbenv->pgnos_dtab_size)) != 0)
 			goto err;
+
+		if (dbenv->comdb2_dirs.data_dir) {
+			int __ufid_readdir(DB_ENV *dbenv);
+			logmsg(LOGMSG_INFO, "%s reading files into ufid hash\n", __func__);
+			__ufid_readdir(dbenv);
+		}
 
 		/* Open (or create) the checkpoint file, place handle in dbenv. */
 		if ((ret = __checkpoint_open(dbenv, db_home)) != 0)
@@ -886,6 +894,11 @@ __dbenv_close(dbenv, rep_check)
 	if (dbenv->ltrans_hash != NULL) {
         hash_clear(dbenv->ltrans_hash);
         hash_free(dbenv->ltrans_hash);
+    }
+
+    if (dbenv->ufid_to_db_hash != NULL) {
+        hash_clear(dbenv->ufid_to_db_hash);
+        hash_free(dbenv->ufid_to_db_hash);
     }
 
 	/* Release DB list */

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -85,6 +85,7 @@ static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *start_lsn);
 static int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
+int gbl_ufid_log = 0;
 
 /* Get the recovery LSN. */
 int

--- a/berkdb/fileops/fop_basic.c
+++ b/berkdb/fileops/fop_basic.c
@@ -24,6 +24,9 @@ static const char revid[] = "$Id: fop_basic.c,v 1.30 2003/07/24 01:26:22 margo E
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
 #include "dbinc/db_am.h"
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
 
 /*
  * This file implements the basic file-level operations.  This code
@@ -58,6 +61,9 @@ __fop_create(dbenv, txn, fhpp, name, appname, mode, flags)
 
 	real_name = NULL;
 
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s creating %s\n", __func__, name);
+#endif
 	if ((ret =
 	    __db_appname(dbenv, appname, name, 0, NULL, &real_name)) != 0)
 		return (ret);
@@ -262,11 +268,11 @@ __fop_rename(dbenv, txn, oldname, newname, fid, appname, flags)
 		fiddbt.data = fid;
 		fiddbt.size = DB_FILE_ID_LEN;
 		if ((ret = __fop_rename_log(dbenv, txn, &lsn, flags | DB_FLUSH,
-		    &old, &new, &fiddbt, (u_int32_t)appname)) != 0)
+			&old, &new, &fiddbt, (u_int32_t)appname)) != 0)
 			goto err;
 	}
-
-	ret = __memp_nameop(dbenv, fid, newname, o, n);
+   	ret = __memp_nameop(dbenv, fid, newname, o, n);
+	__ufid_rename(dbenv, oldname, newname, fid);
 
 err:	if (o != oldname)
 		__os_free(dbenv, o);

--- a/berkdb/fileops/fop_rec.c
+++ b/berkdb/fileops/fop_rec.c
@@ -24,6 +24,12 @@ static const char revid[] = "$Id: fop_rec.c,v 1.27 2003/10/07 20:23:28 ubell Exp
 #include "dbinc/db_am.h"
 #include "dbinc/mp.h"
 #include "dbinc/txn.h"
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
+
+extern int __ufid_rename(DB_ENV *, const char *oldname, const char *newname,
+		u_int8_t *inufid);
 
 /*
  * __fop_create_recover --
@@ -57,6 +63,10 @@ __fop_create_recover(dbenv, dbtp, lsnp, op, info)
 	if (DB_UNDO(op))
 		(void)__os_unlink(dbenv, real_name);
 	else if (DB_REDO(op)) {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s opening with create-flag %s\n", __func__,
+				(char *)argp->name.data);
+#endif
 		if ((ret = __os_open(dbenv, real_name,
 		    DB_OSO_CREATE | DB_OSO_EXCL, argp->mode, &fhp)) == 0)
 			(void)__os_closehandle(dbenv, fhp);
@@ -101,9 +111,10 @@ __fop_remove_recover(dbenv, dbtp, lsnp, op, info)
 		goto out;
 
 	/* Its ok if the file is not there. */
-	if (DB_REDO(op))
+	if (DB_REDO(op)) {
 		(void)__memp_nameop(dbenv,
-		    (u_int8_t *)argp->fid.data, NULL, real_name, NULL);
+			(u_int8_t *)argp->fid.data, NULL, real_name, NULL);
+	}
 
 	*lsnp = argp->prev_lsn;
 out:	if (real_name != NULL)
@@ -213,12 +224,16 @@ __fop_rename_recover(dbenv, dbtp, lsnp, op, info)
 		fhp = NULL;
 	}
 
-	if (DB_UNDO(op))
+	if (DB_UNDO(op)) {
 		(void)__memp_nameop(dbenv, fileid,
-		    (const char *)argp->oldname.data, real_new, real_old);
-	if (DB_REDO(op))
+			(const char *)argp->oldname.data, real_new, real_old);
+		__ufid_rename(dbenv, real_new, real_old, argp->fileid.data);
+	}
+	if (DB_REDO(op)) {
 		(void)__memp_nameop(dbenv, fileid,
-		    (const char *)argp->newname.data, real_old, real_new);
+			(const char *)argp->newname.data, real_old, real_new);
+		__ufid_rename(dbenv, real_old, real_new, argp->fileid.data);
+	}
 
 done:	*lsnp = argp->prev_lsn;
 out:	if (real_new != NULL)
@@ -329,10 +344,11 @@ __fop_file_remove_recover(dbenv, dbtp, lsnp, op, info)
 		 * On the forward pass, check if someone recreated the
 		 * file while we weren't looking.
 		 */
-		if (cstat == TXN_COMMIT)
+		if (cstat == TXN_COMMIT) {
 			(void)__memp_nameop(dbenv,
 			    is_real ? argp->real_fid.data : argp->tmp_fid.data,
 			    NULL, real_name, NULL);
+		}
 	}
 
 done:	*lsnp = argp->prev_lsn;

--- a/berkdb/mp/mp_fopen.c
+++ b/berkdb/mp/mp_fopen.c
@@ -621,6 +621,10 @@ __memp_fopen_pp(dbmfp, path, flags, mode, pagesize)
 	return (ret);
 }
 
+#if defined (UFID_HASH_DEBUG)
+	void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
+
 /*
  * __memp_fopen --
  *	DB_MPOOLFILE->open.
@@ -660,6 +664,10 @@ __memp_fopen(dbmfp, mfp, path, flags, mode, pagesize)
 	 */
 	if (path == NULL)
 		goto alloc;
+
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s opening on %p", __func__, mfp);
+#endif
 
 	/*
 	 * If our caller knows what mfp we're using, increment the ref count,
@@ -1080,6 +1088,22 @@ check_map:
 				F_CLR(mfp, MP_CAN_MMAP);
 			}
 		}
+#if 0
+		++mfp->mpf_cnt;
+		refinc = 1;
+
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s %s found matching %p refcnt %d\n",
+				__func__, path, mfp, mfp->mpf_cnt);
+#endif
+
+		MUTEX_UNLOCK(dbenv, &mfp->mutex);
+
+		if (dbmfp->ftype != 0)
+			mfp->ftype = dbmfp->ftype;
+
+		break;
+#endif
 	}
 
 	F_SET(dbmfp, MP_OPEN_CALLED);
@@ -1220,6 +1244,11 @@ __memp_fclose(dbmfp, flags)
 	dbmp = dbenv->mp_handle;
 	ret = 0;
 
+	mfp = dbmfp->mfp;
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s called on %p discard=%d", __func__, mfp,
+            LF_ISSET(DB_MPOOL_DISCARD));
+#endif
 	/*
 	 * Remove the DB_MPOOLFILE from the process' list.
 	 *
@@ -1229,8 +1258,12 @@ __memp_fclose(dbmfp, flags)
 	 * It's possible the DB_MPOOLFILE was never added to the DB_MPOOLFILE
 	 * file list, check the MP_OPEN_CALLED flag to be sure.
 	 */
-	if (dbmp == NULL)
+	if (dbmp == NULL) {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s not closing %p\n", __func__, mfp);
+#endif
 		goto done;
+	}
 
 	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
 
@@ -1313,6 +1346,11 @@ __memp_fclose(dbmfp, flags)
 	 * be NULL and MP_OPEN_CALLED will not be set.
 	 */
 	mfp = dbmfp->mfp;
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s closing %p file %s\n",
+			__func__, mfp, mfp && mfp->path_off ?
+			(char *)R_ADDR(dbmp->reginfo, mfp->path_off) : "(none)");
+#endif
 	DB_ASSERT((F_ISSET(dbmfp, MP_OPEN_CALLED) && mfp != NULL) ||
 	    (!F_ISSET(dbmfp, MP_OPEN_CALLED) && mfp == NULL));
 	if (!F_ISSET(dbmfp, MP_OPEN_CALLED))
@@ -1329,29 +1367,47 @@ __memp_fclose(dbmfp, flags)
 	MUTEX_LOCK(dbenv, &mfp->mutex);
 	if (--mfp->mpf_cnt == 0 || LF_ISSET(DB_MPOOL_DISCARD)) {
 		if (LF_ISSET(DB_MPOOL_DISCARD) ||
-		    F_ISSET(mfp, MP_TEMP) || mfp->unlink_on_close)
+		    F_ISSET(mfp, MP_TEMP) || mfp->unlink_on_close) {
+#if defined (UFID_HASH_DEBUG)
+			logmsg(LOGMSG_USER, "%s set deadfile for mpool %p file %s\n",
+					__func__, mfp, mfp && mfp->path_off ?
+					(char *)R_ADDR(dbmp->reginfo, mfp->path_off) : "(none)");
+#endif
 			mfp->deadfile = 1;
+		}
 		if (mfp->unlink_on_close) {
 			if ((t_ret = __db_appname(dbmp->dbenv,
-			    DB_APP_DATA, R_ADDR(dbmp->reginfo,
-			    mfp->path_off), 0, NULL, &rpath)) != 0 && ret == 0)
+				DB_APP_DATA, R_ADDR(dbmp->reginfo,
+				mfp->path_off), 0, NULL, &rpath)) != 0 && ret == 0)
 				ret = t_ret;
 			if (t_ret == 0) {
+#if defined (UFID_HASH_DEBUG)
+				logmsg(LOGMSG_USER, "%s unlinking mpool %p file %s\n",
+						__func__, mfp, mfp && mfp->path_off ?
+						(char *)R_ADDR(dbmp->reginfo, mfp->path_off) :
+						"(none)");
+#endif
 				if ((t_ret = __os_unlink(
-				    dbmp->dbenv, rpath) != 0) && ret == 0)
+					dbmp->dbenv, rpath) != 0) && ret == 0)
 					ret = t_ret;
 				__os_free(dbenv, rpath);
 			}
 		}
 		if (mfp->block_cnt == 0) {
 			if ((t_ret =
-			    __memp_mf_discard(dbmp, mfp)) != 0 && ret == 0)
+				__memp_mf_discard(dbmp, mfp)) != 0 && ret == 0)
 				ret = t_ret;
 			deleted = 1;
 		}
 	}
-	if (deleted == 0)
+	if (deleted == 0) {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s not discarding mpool %p file %s\n",
+				__func__, mfp, mfp && mfp->path_off ?
+				(char *)R_ADDR(dbmp->reginfo, mfp->path_off) : "(none)");
+#endif
 		MUTEX_UNLOCK(dbenv, &mfp->mutex);
+	}
 
 done:	/* Discard the DB_MPOOLFILE structure. */
 	if (dbmfp->pgcookie != NULL) {

--- a/berkdb/mp/mp_method.c
+++ b/berkdb/mp/mp_method.c
@@ -28,6 +28,11 @@ static const char revid[] = "$Id: mp_method.c,v 11.40 2003/06/30 17:20:19 bostic
 #include "dbinc_auto/rpc_client_ext.h"
 #endif
 
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
+
+
 static int __memp_get_mp_maxwrite __P((DB_ENV *, int *, int *));
 static int __memp_set_mp_maxwrite __P((DB_ENV *, int, int));
 static int __memp_get_mp_mmapsize __P((DB_ENV *, size_t *));
@@ -445,6 +450,10 @@ fsop:
 			__os_unlink(dbenv, recp_old_path);
 	} else {
 		ret = __os_rename(dbenv, fullold, fullnew, 1);
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s renamed %s to %s\n", __func__, fullold,
+				fullnew);
+#endif
 		if (recp_old_path && recp_new_path)
 			__os_rename(dbenv, recp_old_path, recp_new_path, 1);
 	}

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -63,6 +63,9 @@ int bdb_the_lock_desired(void);
 #define BDB_RELLOCK()           bdb_rellock(gbl_bdb_state, __func__, __LINE__)
 int bdb_the_lock_designed(void);
 
+#if defined (UFID_HASH_DEBUG)
+	void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
 /*
  * __memp_sync_pp --
  *	DB_ENV->memp_sync pre/post processing.
@@ -395,6 +398,10 @@ __memp_sync_restartable(dbenv, lsnp, restartable, fixed)
 			*lsnp = mp->lsn;
 
 			R_UNLOCK(dbenv, dbmp->reginfo);
+#if defined (UFID_HASH_DEBUG)
+			comdb2_cheapstack_sym(stderr, "%s not syncing mp->lsn [%d:%d]",
+					__func__, mp->lsn.file, mp->lsn.offset);
+#endif
 			return (0);
 		}
 		R_UNLOCK(dbenv, dbmp->reginfo);
@@ -1126,6 +1133,12 @@ __memp_sync_int(dbenv, dbmfp, trickle_max, op, wrotep, restartable,
 	DB_LSN oldest_first_dirty_tx_begin_lsn;
 	int accum_sync, accum_skip;
 	BH_TRACK swap;
+
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s [%d:%d]", __func__,
+			ckp_lsnp ? ckp_lsnp->file : -1, ckp_lsnp ?
+			ckp_lsnp->offset : -1);
+#endif
 
 	/*
 	 *  Perfect checkpoints: If the first dirty LSN is to the right

--- a/berkdb/os/os_open.c
+++ b/berkdb/os/os_open.c
@@ -28,6 +28,10 @@ static const char revid[] = "$Id: os_open.c,v 11.48 2003/09/10 00:27:29 bostic E
 static int __os_region_open __P((DB_ENV *, const char *, int, int, DB_FH **));
 #endif
 
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
+
 /*
  * __os_have_direct --
  *	Check to see if we support direct I/O.
@@ -109,13 +113,22 @@ ___os_open_extend(dbenv, name, log_size, page_size, flags, mode, fhpp)
 	oflags |= O_BINARY;
 #endif
 
+#if defined (UFID_HASH_DEBUG)
+	if (!strstr(name, "logs/log")) {
+		logmsg(LOGMSG_USER, "%s opening %s\n", __func__, name);
+	}
+#endif
 	/*
 	 * DB requires the POSIX 1003.1 semantic that two files opened at the
 	 * same time with DB_OSO_CREATE/O_CREAT and DB_OSO_EXCL/O_EXCL flags
 	 * set return an EEXIST failure in at least one.
 	 */
-	if (LF_ISSET(DB_OSO_CREATE))
+	if (LF_ISSET(DB_OSO_CREATE)) {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s set create flag for %s\n", __func__, name);
+#endif
 		 oflags |= O_CREAT;
+	}
 
 	if (LF_ISSET(DB_OSO_EXCL))
 		 oflags |= O_EXCL;
@@ -137,8 +150,12 @@ ___os_open_extend(dbenv, name, log_size, page_size, flags, mode, fhpp)
 	else
 		oflags |= O_RDWR;
 
-	if (LF_ISSET(DB_OSO_TRUNC))
+	if (LF_ISSET(DB_OSO_TRUNC)) {
+#if defined (UFID_HASH_DEBUG)
+		logmsg(LOGMSG_USER, "%s truncating %s\n", __func__, name);
+#endif
 		 oflags |= O_TRUNC;
+	}
 
 
 	/*

--- a/berkdb/os/os_unlink.c
+++ b/berkdb/os/os_unlink.c
@@ -19,6 +19,9 @@ static const char revid[] = "$Id: os_unlink.c,v 11.26 2003/01/08 05:29:43 bostic
 #endif
 
 #include "db_int.h"
+#if defined (UFID_HASH_DEBUG)
+#include <logmsg.h>
+#endif
 
 /*
  * __os_region_unlink --
@@ -69,6 +72,10 @@ ___os_unlink(dbenv, path)
 {
 	int ret, retries;
 	int tmp_file = 0;
+
+#if defined (UFID_HASH_DEBUG)
+	logmsg(LOGMSG_USER, "%s unlinking %s\n", __func__, path);
+#endif
 
 	if (dbenv->db_tmp_dir && *dbenv->db_tmp_dir)
 		if (memcmp(dbenv->db_tmp_dir, path,

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -3906,6 +3906,7 @@ worker_thd(struct thdpool *pool, void *work, void *thddata, int op)
 			__db_err(dbenv, "transaction failed at %lu:%lu rc=%d",
 				(u_long)rr->lsn.file, (u_long)rr->lsn.offset, rc);
 			/* and now? */
+            __log_flush(dbenv, NULL);
 			abort();
 		}
 
@@ -3998,15 +3999,33 @@ logical_record_file_affinity(int rectype)
 
 int gbl_processor_thd_poll;
 
+#include <plhash.h>
+
+struct fuid_integer {
+	u_int8_t fuid[DB_FILE_ID_LEN];
+	int fileid;
+};
+
+static int
+fuid_hash_free(void *obj, void *unused)
+{
+	free(obj);
+	return 0;
+}
+
 static void
 processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 {
 	struct __recovery_processor *rp;
 	struct __recovery_queue *rq;
 	struct __recovery_record *rr;
+    hash_t *fuid_hash = NULL;
+    u_int8_t fuid[DB_FILE_ID_LEN] = {0};
+    u_int8_t last_fuid[DB_FILE_ID_LEN] = {0};
 	DBT data_dbt, lock_prev_lsn_dbt;
 	DB_LOCK prev_lsn_lk;
 	int i;
+    int is_fuid;
 	int inline_worker;
 	int polltm;
 	DB_LOGC *logc = NULL;
@@ -4101,12 +4120,15 @@ processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 	/* First, bucket records per queue. */
 	data_dbt.flags = DB_DBT_REALLOC;
 
+	int fileid = 0;
+	int max_fileid = 0;
+
 	for (i = 0; i < rp->lc.nlsns; i++) {
-		int fileid;
 		u_int32_t rectype;
 
 		lsnp = &rp->lc.array[i].lsn;
 
+		is_fuid = 0;
 		if (rp->lc.array[i].rec.data == NULL) {
 			assert(!rp->lc.filled_from_cache);
 			if ((ret =
@@ -4120,12 +4142,24 @@ processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 			LOGCOPY_32(&rectype, data_dbt.data);
 			fileid =
 				(int)file_id_for_recovery_record(dbenv, NULL,
-				rectype, &data_dbt);
+				rectype, fuid, &is_fuid, &data_dbt);
 		} else {
 			LOGCOPY_32(&rectype, rp->lc.array[i].rec.data);
 			fileid =
 				(int)file_id_for_recovery_record(dbenv, NULL,
-				rectype, &rp->lc.array[i].rec);
+				rectype, fuid, &is_fuid, &rp->lc.array[i].rec);
+		}
+		if (is_fuid) {
+			if (!fuid_hash)
+				fuid_hash = hash_init(DB_FILE_ID_LEN);
+			struct fuid_integer *fint = hash_find(fuid_hash, fuid);
+			if (!fint) {
+				fint = malloc(sizeof(*fint));
+				memcpy(fint->fuid, fuid, DB_FILE_ID_LEN);
+				fint->fileid = (max_fileid + 1);
+				hash_add(fuid_hash, fint);
+			}
+			fileid = fint->fileid;
 		}
 
 		if (fileid >= 0) {
@@ -4135,6 +4169,9 @@ processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 		if (fileid == -1 && logical_record_file_affinity(rectype)) {
 			fileid = last_fileid;
 		}
+
+		if (fileid > max_fileid)
+			max_fileid = fileid;
 
 		/* If there is no fileid, or if this is a start or commit put in fileid 0  */
 		if (-1 == fileid || logical_start_commit(rectype)) {
@@ -4174,6 +4211,13 @@ processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 		rr->fileid = fileid;
 
 		listc_abl(&rp->recovery_queues[fileid]->records, rr);
+	}
+
+	if (fuid_hash) {
+		hash_for(fuid_hash, fuid_hash_free, NULL);
+		hash_clear(fuid_hash);
+		hash_free(fuid_hash);
+		fuid_hash = NULL;
 	}
 
 	if ((dbenv->flags & DB_ENV_ROWLOCKS) && listc_size(&queues) > 1) {

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -103,6 +103,9 @@ extern int gbl_is_physical_replicant;
 
 #endif
 
+#if defined (UFID_HASH_DEBUG)
+void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
 
 static int __txn_begin_int_set_retries(DB_TXN *txn, u_int32_t retries,
 	DB_LSN *we_start_at_this_lsn, u_int32_t flags);
@@ -2046,6 +2049,10 @@ __txn_dispatch_undo(dbenv, txnp, rdbt, key_lsn, txnlist)
 {
 	int ret;
 
+#if defined (UFID_HASH_DEBUG)
+	comdb2_cheapstack_sym(stderr, "%s undoing [%d:%d]", __func__,
+			key_lsn->file, key_lsn->offset);
+#endif
 	ret = __db_dispatch(dbenv, dbenv->recover_dtab,
 		dbenv->recover_dtab_size, rdbt, key_lsn, DB_TXN_ABORT, txnlist);
 	if (F_ISSET(txnp, TXN_CHILDCOMMIT))

--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -150,8 +150,11 @@ __txn_regop_gen_recover(dbenv, dbtp, lsnp, op, info)
 			    info, argp->txnid->txnid,
 			    argp->opcode == TXN_ABORT ?
 			    TXN_IGNORE : argp->opcode, lsnp);
-		else if (ret != TXN_OK)
+		else if (ret != TXN_OK) {
+			__db_txnlist_update(dbenv,
+					info, argp->txnid->txnid, argp->opcode, lsnp);
 			goto err;
+		}
 		/* else ret = 0; Not necessary because TXN_OK == 0 */
 	}
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -238,6 +238,9 @@ extern int gbl_lock_dba_user;
 extern int gbl_max_trigger_threads;
 extern int gbl_do_inline_poll;
 extern int gbl_fingerprint_max_queries;
+extern int gbl_log_index_locks_first;
+extern int gbl_ufid_log;
+
 extern long long sampling_threshold;
 
 extern size_t gbl_lk_hash;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1857,6 +1857,9 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOLEAN, &gbl_ufid_log,
+                 EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("ref_sync_pollms",
                  "Set pollms for ref_sync thread.  "
                  "(Default: 250)",

--- a/tests/sc_downgrade.test/Makefile
+++ b/tests/sc_downgrade.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=30m
+endif

--- a/tests/sc_downgrade.test/lrl.options
+++ b/tests/sc_downgrade.test/lrl.options
@@ -1,0 +1,14 @@
+nowatch
+logmsg level info
+disable_new_snapshot
+#disable_snapshot_isolation
+init_with_genid48
+decoupled_logputs off
+verbose_set_sc_in_progress on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+dtastripe 16
+blobstripe
+berkattr elect_highest_committed_gen 0
+ufid_log on

--- a/tests/sc_downgrade.test/runit
+++ b/tests/sc_downgrade.test/runit
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export tablecount=50
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function randomtable
+{
+    [[ $debug == "1" ]] && set -x
+    typeset table=$(( RANDOM % tablecount ))
+    echo "t$table"
+}
+
+function stop_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+    done
+    sleep 5
+}
+
+function create_tables
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="create_tables"
+    write_prompt $func "Running $func"
+
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        drop_table t$i
+        let i=i+1
+    done
+
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        tablestr="create table t$i (a int, b blob, c blob, d blob"
+        j=0
+        while [[ $j -lt $i ]]; do
+            tablestr="${tablestr},t$j int"
+            let j=j+1
+        done
+        tablestr="${tablestr})"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "$tablestr"
+        let i=i+1
+    done
+}
+
+# Table was corrupt on a replicant after this scenario:
+#
+# 1) master is downgraded because machine is being turned
+# 2) table is fastinit'd
+# 3) the former master bounces 
+# 4) profit
+#
+# Recovery on the bounced master contained the pagelsn of the corrupt page
+function select_from_node
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="select_from_node"
+    write_prompt $func "Running $func"
+    typeset node=$1
+
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select * from t${i}" 2>&1)
+            [[ $x == *"unknown error"* ]] && failexit "$x"
+        let i=i+1
+    done
+}
+
+function verify_up
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="verify_up"
+    write_prompt $func "Running $func"
+    typeset node=$1
+    typeset count=0
+    typeset r=1
+    while [[ "$r" -ne "0" && "$count" -lt 2000 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+    [[ $r != 0 ]] && failexit "node $node did not recover in time"
+}
+
+function downgrade
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="downgrade"
+    typeset node=$(get_master)
+    typeset count=0
+    typeset foundmaster=0
+    typeset maxcount=600
+    typeset initialmaster=0
+    write_prompt $func "Running $func $node"
+
+    x=$(get_master)
+    while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+        sleep 1
+        x=$(get_master)
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not find master"
+    initialmaster=$x
+
+    while [[ "$x" == "$initialmaster" && "$count" -lt $maxcount ]]; do
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+            let count=count+1
+        done
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $x $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        sleep 1
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+        done
+
+        [[ "$x" != "$node" ]] && foundmaster=1
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not downgrade master"
+}
+
+
+function truncate_table
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="truncate_table"
+    typeset table=$1
+    typeset count=0
+    typeset r=1
+    write_prompt $func "Running $func $table"
+    while [[ "$r" != 0 && "$count" -lt 600 ]]; do
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "truncate $table"
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+    [[ "$r" != "0" ]] && failexit "Error truncating table"
+}
+
+function truncate_random_tables
+{
+    typeset count=$1
+    typeset func="truncate_random_tables"
+    write_prompt $func "Running $func $count"
+    i=0
+    while [[ $i -lt $count ]]; do
+        table=$(randomtable)
+        truncate_table $table
+        let i=i+1
+    done
+}
+
+function truncate_all_tables
+{
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        truncate_table t$i
+        let i=i+1
+    done
+}
+
+function add_to_all_tables
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="add_to_all_tables"
+    write_prompt $func "Running $func"
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t$i (a) values(1)" >/dev/null 2>&1
+        let i=i+1
+    done
+}
+
+function truncate_loop
+{
+    [[ $debug == "1" ]] && set -x
+    while [[ ! -f $stopfile ]]; do
+        truncate_random_tables 10
+    done
+}
+
+function insert_loop
+{
+    [[ $debug == "1" ]] && set -x
+    while [[ ! -f $stopfile ]]; do
+        add_to_all_tables
+        sleep 1
+    done
+}
+
+function truncate_and_insert_loop
+{
+    [[ $debug == "1" ]] && set -x
+    while [[ ! -f $stopfile ]]; do
+        truncate_random_tables $table 10
+        add_to_all_tables
+        sleep 5
+    done
+}
+
+function pushnext
+{
+    [[ $debug == "1" ]] && set -x
+    i=0
+    node=$(get_master)
+
+    while [[ $i -lt 4 ]]; do
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $node $DBNAME "EXEC PROCEDURE sys.cmd.send('pushnext')"
+        let i=i+1
+        sleep 4
+    done
+}
+
+function downgrade_loop
+{
+    [[ $debug == "1" ]] && set -x
+    while [[ ! -f $stopfile ]]; do
+        node=$(get_master)
+        while [[ "$CLUSTER" != *"$node"* ]]; do
+            sleep 1
+            node=$(get_master)
+        done
+        #pushnext
+        downgrade
+        bounce_node $node
+        verify_up $node
+        select_from_node $node
+    done
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    typeset maxtime=1200
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+
+    write_prompt $func "Running $func"
+    create_tables
+
+    rm $stopfile
+    truncate_loop &
+    insert_loop &
+    #truncate_and_insert_loop &
+    downgrade_loop &
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        for node in $CLUSTER; do
+            verify_up $node
+        done
+        sleep 1
+    done
+
+    # Different thread failed the test
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+
+run_test
+stop_cluster
+wait
+echo "Success"

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -15,6 +15,30 @@ function get_master
     echo "$x"
 }
 
+function bounce_node
+{
+    [[ "$debug" == 1 ]] && set -x
+    typeset func="bounce_node"
+    typeset node=${1}
+    typeset sleeptime=${2:-5}
+    write_prompt $func "Running $func"
+    $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+    sleep $sleeptime
+    if [ $node == $(hostname) ] ; then
+        (
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+            sleep $sleeptime
+            ${DEBUG_PREFIX} ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.${node}.pid 2>&1 | gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >$TESTDIR/logs/${DBNAME}.${node}.db 2>&1
+        ) &
+    else
+        PARAMS="$DBNAME --no-global-lrl"
+        CMD="sleep $sleeptime ; source ${TESTDIR}/replicant_vars ; ${COMDB2_EXE} ${PARAMS} --lrl $DBDIR/${DBNAME}.lrl -pidfile ${TMPDIR}/${DBNAME}.pid"
+        kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+        ssh -o StrictHostKeyChecking=no -tt $node ${DEBUG_PREFIX} ${CMD} 2>&1 </dev/null > >(gawk '{ print strftime("%H:%M:%S>"), $0; fflush(); }' >> $TESTDIR/logs/${DBNAME}.${node}.db) &
+        echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+    fi
+}
+
 function bounce_cluster
 {
     [[ "$debug" == 1 ]] && set -x

--- a/util/walkback.c
+++ b/util/walkback.c
@@ -889,9 +889,11 @@ int comdb2_cheapstack_char_array(char *str, int maxln)
 #ifdef __GLIBC__
 extern int backtrace(void **, int);
 extern char **backtrace_symbols(void *const *, int);
+void backtrace_symbols_fd(void*const*,int,int);
 #else
 #define backtrace(A, B) 0
 #define backtrace_symbols(A, B) NULL
+#define backtrace_symbols_fd(A, B, C)
 #endif
 
 static void comdb2_cheapstack_sym_valist(FILE *f, char *fmt, va_list args)


### PR DESCRIPTION
Replace dbreg identifiers with ufid numbers in the log stream.  This fixes a bug where an addrem is applied to an incorrect b-tree- the 'sc_downgrade' test reproduces this.  sc_downgrade also reproduces a different bug in our 'purge-unused-files' logic.  I'll address this under a different PR.

I'm submitting a PR now with ufid_logging enabled to verify that things work correctly under robo-rivers.