### PR TITLE
do not leak array of pointers when transferring table info

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -2574,6 +2574,7 @@ void sqlite3VdbeTransferTables(
   pTo->tbls = pTbls;
   pTo->numTables += pFrom->numTables;
   pFrom->numTables = 0;
+  sqlite3DbFree(pFrom->db, pFrom->tbls);
   pFrom->tbls = NULL;
 }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */


### PR DESCRIPTION
Forgot the free the array of table pointers in a recent fix.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
