### PR TITLE
do not use a permanent field for a temp action, use an argument

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2485,7 +2485,7 @@ struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
         goto err;
     }
 
-    rc = add_cmacc_stmt(newtable, 0);
+    rc = add_cmacc_stmt(newtable, 0, 0);
     if (rc) {
         errstat_set_rcstrf(err, -1,
                            "Failed to load schema: can't "

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -784,11 +784,6 @@ typedef struct dbtable {
 
     unsigned disableskipscan : 1;
     unsigned do_local_replication : 1;
-    /* A flag to temporarily disable check for the presence of u_longlong types
-       in the (csc2) schema even when forbid_ulonglong is enabled. This allows
-       certain maintenance operations on legacy tables, using forbid_ulonglong
-       type, to work properly. */
-    unsigned skip_error_on_ulonglong_check : 1;
 
     /* name of the timepartition, if this is a shard */
     const char *timepartition_name;
@@ -2378,7 +2373,7 @@ int del_bt_hash_table(char *table);
 int stat_bt_hash_table(char *table);
 int stat_bt_hash_table_reset(char *table);
 int fastinit_table(struct dbenv *dbenvin, char *table);
-int add_cmacc_stmt(struct dbtable *db, int alt);
+int add_cmacc_stmt(struct dbtable *db, int alt, int allow_ull);
 int add_cmacc_stmt_no_side_effects(struct dbtable *db, int alt);
 
 void cleanup_newdb(struct dbtable *);

--- a/db/config.c
+++ b/db/config.c
@@ -647,7 +647,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
 
     /* just got a bunch of data. remember it so key forming
        routines and SQL can get at it */
-    rc = add_cmacc_stmt(db, 0);
+    rc = add_cmacc_stmt(db, 0, 0);
     if (rc) {
         logmsg(LOGMSG_ERROR,
                "Failed to load schema: can't process schema file %s\n", tok);

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -136,7 +136,7 @@ int add_table_to_environment(char *table, const char *csc2,
     newdb->iq = iq;
     newdb->timepartition_name = timepartition_name;
 
-    if (add_cmacc_stmt(newdb, 0)) {
+    if (add_cmacc_stmt(newdb, 0, 0)) {
         logmsg(LOGMSG_ERROR, "%s: add_cmacc_stmt failed\n", __func__);
         rc = SC_CSC2_ERROR;
         goto err;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -424,8 +424,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     newdb->iq = iq;
 
-    newdb->skip_error_on_ulonglong_check = (s->same_schema) ? 1 : 0;
-    if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
+    if ((add_cmacc_stmt(newdb, 1, (s->same_schema) ? 1 : 0)) ||
+        (init_check_constraints(newdb))) {
         backout(newdb);
         cleanup_newdb(newdb);
         dyns_cleanup_globals();
@@ -433,10 +433,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
         sc_errf(s, "Failed to process schema!\n");
         if (local_lock)
             unlock_schema_lk();
-        newdb->skip_error_on_ulonglong_check = 0;
         return -1;
     }
-    newdb->skip_error_on_ulonglong_check = 0;
 
     if ((rc = sql_syntax_check(iq, newdb))) {
         Pthread_mutex_unlock(&csc2_subsystem_mtx);

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -86,17 +86,14 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     newdb->iq = iq;
 
-    newdb->skip_error_on_ulonglong_check = 1;
-    if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
+    if ((add_cmacc_stmt(newdb, 1, 1)) || (init_check_constraints(newdb))) {
         backout_schemas(newdb->tablename);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");
         dyns_cleanup_globals();
-        newdb->skip_error_on_ulonglong_check = 0;
         Pthread_mutex_unlock(&csc2_subsystem_mtx);
         return -1;
     }
-    newdb->skip_error_on_ulonglong_check = 0;
     dyns_cleanup_globals();
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -897,14 +897,11 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
         return 1;
     }
     newdb->dbnum = db->dbnum;
-    newdb->skip_error_on_ulonglong_check = 1;
-    if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
+    if ((add_cmacc_stmt(newdb, 1, 1)) || (init_check_constraints(newdb))) {
         /* can happen if new schema has no .DEFAULT tag but needs one */
-        newdb->skip_error_on_ulonglong_check = 0;
         backout_schemas(table);
         return 1;
     }
-    newdb->skip_error_on_ulonglong_check = 0;
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -608,7 +608,7 @@ int do_dryrun(struct schema_change_type *s)
     newdb->odh = s->headers;
     newdb->instant_schema_change = newdb->odh && s->instant_sc;
 
-    if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
+    if ((add_cmacc_stmt(newdb, 1, 0)) || (init_check_constraints(newdb))) {
         rc = -1;
         goto done;
     }
@@ -1010,12 +1010,10 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     newdb->instant_schema_change = s->headers && s->instant_sc;
     newdb->schema_version = get_csc2_version(newdb->tablename);
 
-    newdb->skip_error_on_ulonglong_check = 1;
-    if ((add_cmacc_stmt(newdb, 1)) || (init_check_constraints(newdb))) {
+    if ((add_cmacc_stmt(newdb, 1, 1)) || (init_check_constraints(newdb))) {
         backout_schemas(newdb->tablename);
         abort();
     }
-    newdb->skip_error_on_ulonglong_check = 0;
 
     if (verify_constraints_exist(NULL, newdb, newdb, s) != 0) {
         backout_schemas(newdb->tablename);


### PR DESCRIPTION
We do not need a permanent struct member to temporary do an action, just pass an argument.  (Small update towards macc code encapsulation).

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
