### PR TITLE
previous rebase remove an update from expected output

### DIFF
--- a/tests/upsert.test/t03_timepart.expected
+++ b/tests/upsert.test/t03_timepart.expected
@@ -1,10 +1,6 @@
 (part='---------------------------------- PART #01 ----------------------------------')
 (SLEEP(5)=5)
 (rows inserted=1)
-[INSERT INTO t1_tp VALUES(1)] failed with rc 299 add key constraint duplicate key '$KEY_877B2989' on table '$1_7FC6B09' index 0
 [INSERT INTO t1_tp VALUES(1) ON CONFLICT DO NOTHING] failed with rc -3 UPSERT not supported on partition or view "t1_tp"
 [INSERT INTO t1_tp VALUES(1) ON CONFLICT(i) DO UPDATE SET i = i+1] failed with rc -3 UPSERT not supported on partition or view "t1_tp"
-(tablename='$0_A2BDF977')
-(tablename='$1_7FC6B09')
-(tablename='sqlite_stat1')
-(tablename='sqlite_stat4')
+(i=1)


### PR DESCRIPTION
Put back updated t03_timepart.expected lost during a rebase conflict resolution.  This fixes upsert test.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
