### PR TITLE
Improving RANDOMROOM connect mode

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -1903,6 +1903,19 @@ readloop:
         }
     }
 
+    private int getRandomExclude(int min, int max, int exclude) {
+        Random rnd = new Random(System.currentTimeMillis());
+        int val = 0;
+        if (max - min < 2)
+            return min;
+        for (int i = 0; i < 10; i++) {
+            val = rnd.nextInt() % (max - min) + min;
+            if (val != exclude)
+                return val;
+        }
+        return val;
+    }
+
     private boolean reopen(boolean refresh_dbinfo_if_failed) {
         /* get the index of the preferred machine */
         if (prefIdx == -1 && prefmach != null) {
@@ -1943,13 +1956,12 @@ readloop:
             }
         }
 
-        if (myPolicy == POLICY_RANDOM && myDbHosts.size() > 0) {
-            Random rnd = new Random(System.currentTimeMillis());
-            dbHostIdx = Math.abs(rnd.nextInt()) % myDbHosts.size();
+        if (dbHostIdx == -1 && myDbHosts.size() > 0 &&
+            (myPolicy == POLICY_RANDOM || myPolicy == POLICY_RANDOMROOM && numHostsSameRoom == 0)) {
+            dbHostIdx = getRandomExclude(0, myDbHosts.size(), masterIndexInMyDbHosts);
         } else if (myPolicy == POLICY_RANDOMROOM
                 && dbHostIdx == -1 && numHostsSameRoom > 0) {
-            Random rnd = new Random(System.currentTimeMillis());
-            dbHostIdx = Math.abs(rnd.nextInt()) % numHostsSameRoom;
+            dbHostIdx = getRandomExclude(0, numHostsSameRoom, masterIndexInMyDbHosts);
             /* connect to same room once */
             for (int i = 0; i != numHostsSameRoom; ++i) {
                 int try_node = (dbHostIdx + i) % numHostsSameRoom;
@@ -1981,11 +1993,11 @@ readloop:
                     }
                 }
             }
-            dbHostIdx = (numHostsSameRoom - 1);
+            dbHostIdx = getRandomExclude(numHostsSameRoom, myDbHosts.size(), masterIndexInMyDbHosts);
         }
 
         /**
-         * First, try slave nodes.
+         * First, try replicants.
          */
 
         // last time we were at dbHostIdx, this time start from (dbHostIdx + 1)
@@ -2057,7 +2069,7 @@ readloop:
         }
 
         /**
-         * None of slave nodes works! Try master node.
+         * None of replicant works! Try master node.
          */
         if (masterIndexInMyDbHosts >= 0) {
             io = new SockIO(myDbHosts.get(masterIndexInMyDbHosts),

--- a/tests/cdb2api_random_room_dr1.test/Makefile
+++ b/tests/cdb2api_random_room_dr1.test/Makefile
@@ -1,0 +1,6 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/cdb2api_random_room_dr1.test/runit
+++ b/tests/cdb2api_random_room_dr1.test/runit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+# Verify that if a datacenter is down, we connect to a random node in the other data center
+
+bash -n "$0" | exit 1
+
+[ -z "${CLUSTER}" ] && { echo "Test requires a cluster"; exit 0; }
+
+dbnm=$1
+
+hosts=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster"`
+nhosts=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster" | wc -l`
+
+# Let's assume those machines are in us_west datacenter
+literal='@'
+for host in $hosts; do
+    literal="$literal$host:dc=us_west,"
+done
+
+# We're in us_east
+cp $DBDIR/comdb2db.cfg $DBDIR/q1.cfg
+echo "comdb2_config:room=us_east" >>$DBDIR/q1.cfg
+
+# us_east has example.com and example.org (both are reserved test domain)
+literal="${literal}example.com:dc=us_east,example.org:dc=us_east"
+
+# Now try to connect to the database. All connections will go to us_west
+for i in `seq 1 100`; do
+    cdb2sql --cdb2cfg $DBDIR/q1.cfg $dbnm $literal 'select comdb2_host()' >>output
+done
+
+sort output | uniq
+
+# old code would always connect to the same node in us_west;
+# New code randomly chooses one.
+# Make sure we've connected to all nodes in us_west
+nconnected=`sort output | uniq | wc -l`
+if [ $nconnected -ne $nhosts ]; then
+    echo failed
+    exit 1
+fi


### PR DESCRIPTION
RANDOMROOM does not randomize after the API has gone through all nodes in client's data center. So requests from the client's data center will pile up on the same machine in another data center. This pull request fixes it.

(DRQS 168611139)