### PR TITLE
do not get a curtran in recover_deadlock if we do not have one already

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9378,7 +9378,8 @@ int put_curtran_flags(bdb_state_type *bdb_state, struct sqlclntstate *clnt,
     clnt->is_overlapping = 0;
 
     if (!clnt->dbtran.cursor_tran) {
-        logmsg(LOGMSG_DEBUG, "%s called without curtran\n", __func__);
+        /* this should be visible */
+        logmsg(LOGMSG_ERROR, "%s called without curtran\n", __func__);
         return 0;
     }
 
@@ -9535,6 +9536,20 @@ static int recover_deadlock_flags_int(bdb_state_type *bdb_state,
     if (clnt->recover_deadlock_rcode) {
         assert(bdb_lockref() == 0);
         return clnt->recover_deadlock_rcode;
+    }
+
+    /*
+     * BIG NOTE: if there is no cursor tran, do not get one here!
+     *
+     * Example: we call this when starting a transaction, or
+     * waiting for a transaction to provide an rc; remote tran
+     * does not have a curtran to span all transaction (instead,
+     * it allocates curtrans for individual operations, like
+     * begin&commit regular workflow)
+     *
+     */
+    if (!clnt->dbtran.cursor_tran) {
+        return 0;
     }
 
     assert(bdb_lockref() > 0);


### PR DESCRIPTION
Per title; recover_deadlock called for sqlclntstate callers that do not already have a curtran gifts them one!  Since caller does not expect one, it is never freed and we leak a read bdb lock.
The trace that detects this was LOGMSG_DEBUG; this PR makes it visible to avoid future complications like this.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
