### PR TITLE
Less spew from ENOTCONN

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2221,9 +2221,9 @@ static nodestats_t *add_clientstats(unsigned checksum,
                 socklen_t len = sizeof(peeraddr);
                 bzero(&peeraddr, sizeof(peeraddr));
                 if (getpeername(fd, (struct sockaddr *)&peeraddr, &len) < 0) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s: getpeername failed fd %d: %d %s\n", __func__,
-                           fd, errno, strerror(errno));
+                    if (errno != ENOTCONN)
+                        logmsg(LOGMSG_ERROR, "%s: getpeername failed fd %d: %d %s\n", __func__, fd, errno,
+                               strerror(errno));
                     bzero(&(entry->addr), sizeof(struct in_addr));
                 } else {
                     memcpy(&(entry->addr), &peeraddr.sin_addr,
@@ -2285,9 +2285,9 @@ static nodestats_t *find_clientstats(unsigned checksum, int node, int fd)
                 socklen_t len = sizeof(peeraddr);
                 bzero(&peeraddr, sizeof(peeraddr));
                 if (getpeername(fd, (struct sockaddr *)&peeraddr, &len) < 0) {
-                    logmsg(LOGMSG_ERROR,
-                           "%s: getpeername failed fd %d: %d %s\n", __func__,
-                           fd, errno, strerror(errno));
+                    if (errno != ENOTCONN)
+                        logmsg(LOGMSG_ERROR, "%s: getpeername failed fd %d: %d %s\n", __func__, fd, errno,
+                               strerror(errno));
                     bzero(&(entry->addr), sizeof(struct in_addr));
                 } else {
                     memcpy(&(entry->addr), &peeraddr.sin_addr,


### PR DESCRIPTION
An extremely busy database may encounter ENOTCONN from getpeername - by the time
the function is called, the client may have closed the connection. This should
not be treated as an error.

(DRQS 168611139)
