### PR TITLE
fastinit and alter cmacc code encapsulation

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2367,15 +2367,20 @@ int dtas_next_pageorder(struct ireq *iq, const unsigned long long *genid_vector,
 int check_table_schema(struct dbenv *dbenv, const char *table,
                        const char *csc2file);
 
+struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
+                                   char *csc2, int dbnum, int indx,
+                                   int sc_alt_tablename, int allow_ull,
+                                   struct errstat *err);
+
 struct dbtable *find_table(const char *table);
 int bt_hash_table(char *table, int szkb);
 int del_bt_hash_table(char *table);
 int stat_bt_hash_table(char *table);
 int stat_bt_hash_table_reset(char *table);
 int fastinit_table(struct dbenv *dbenvin, char *table);
-int add_cmacc_stmt(struct dbtable *db, int alt, int allow_ull,
+int add_cmacc_stmt(struct dbtable *db, int is_sc_name, int allow_ull,
                    struct errstat *err);
-int add_cmacc_stmt_no_side_effects(struct dbtable *db, int alt);
+int add_cmacc_stmt_no_side_effects(struct dbtable *db, int is_sc_name);
 
 void cleanup_newdb(struct dbtable *);
 struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,

--- a/schemachange/sc_csc2.c
+++ b/schemachange/sc_csc2.c
@@ -25,31 +25,6 @@
 static int schema_cmp(struct dbenv *dbenv, struct dbtable *db,
                       const char *csc2cmp);
 
-int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
-                        int *foundix, struct ireq *iq)
-{
-    /* load schema from string or file */
-    int rc = dyns_load_schema_string(s->newcsc2, thedb->envname, s->tablename);
-    if (rc != 0) {
-        char *err;
-        char *syntax_err;
-        err = csc2_get_errors();
-        syntax_err = csc2_get_syntax_errors();
-        sc_client_error(s, "%s", syntax_err);
-        sc_errf(s, "%s", err);
-        sc_errf(s, "Failed to load schema\n");
-        return SC_INTERNAL_ERROR;
-    }
-
-    /* find which db has a matching name */
-    if ((*foundix = getdbidxbyname_ll(s->tablename)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
-        exit(1);
-    }
-
-    return SC_OK;
-}
-
 /* Given a table name, this makes sure that what we know about the schema
  * matches what is written in our meta table.  If we have nothing in our table
  * we populate it from the given file. */

--- a/schemachange/sc_csc2.h
+++ b/schemachange/sc_csc2.h
@@ -17,9 +17,6 @@
 #ifndef INCLUDE_SC_CSC2_H
 #define INCLUDE_SC_CSC2_H
 
-int load_db_from_schema(struct schema_change_type *s, struct dbenv *thedb,
-                        int *foundix, struct ireq *iq);
-
 /* Given a table name, this makes sure that what we know about the schema
  * matches what is written in our meta table.  If we have nothing in our table
  * we populate it from the given file. */

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -32,6 +32,24 @@
 #include "sc_util.h"
 #include "views.h"
 
+extern int gbl_broken_max_rec_sz;
+
+/* return old value */
+int fix_broken_max_rec_sz(int lrl)
+{
+    int ret = gbl_broken_max_rec_sz;
+
+    if (lrl > COMDB2_MAX_RECORD_SIZE) {
+        /* NOTE: this algebra seems funny, shouldn't we
+         * set lrl to COMDB2_MAX_RECORD_SIZE here?
+         */
+        // we want to allow fastiniting this tbl
+        gbl_broken_max_rec_sz = lrl - COMDB2_MAX_RECORD_SIZE;
+    }
+
+    return ret;
+}
+
 int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 {
     struct dbtable *db;
@@ -42,6 +60,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     char new_prefix[32];
     int foundix;
     struct scinfo scinfo;
+    struct errstat err = {0};
 
     iq->usedb = db = s->db = get_dbtable_by_name(s->tablename);
     if (db == NULL) {
@@ -58,47 +77,37 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     set_schemachange_options_tran(s, db, &scinfo, tran);
 
-    extern int gbl_broken_max_rec_sz;
-    int saved_broken_max_rec_sz = gbl_broken_max_rec_sz;
-
-    if (s->db->lrl > COMDB2_MAX_RECORD_SIZE) {
-        // we want to allow fastiniting this tbl
-        gbl_broken_max_rec_sz = s->db->lrl - COMDB2_MAX_RECORD_SIZE;
-    }
 
     Pthread_mutex_lock(&csc2_subsystem_mtx);
-    dyns_init_globals();
-    if ((rc = load_db_from_schema(s, thedb, &foundix, iq))) {
-        dyns_cleanup_globals();
-        Pthread_mutex_unlock(&csc2_subsystem_mtx);
-        return rc;
+
+    /* find which db has a matching name */
+    if ((foundix = getdbidxbyname_ll(s->tablename)) < 0) {
+        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
+        exit(1);
     }
 
+    int saved_broken_max_rec_sz = fix_broken_max_rec_sz(s->db->lrl);
+    newdb = s->newdb =
+        create_new_dbtable(thedb, s->tablename, s->newcsc2, db->dbnum, foundix,
+                           1 /* sc_alt_name */, 1 /* allow ull */, &err);
     gbl_broken_max_rec_sz = saved_broken_max_rec_sz;
 
-    newdb = s->newdb = create_db_from_schema(thedb, s, db->dbnum, foundix, 1);
-    if (newdb == NULL) {
-        sc_errf(s, "Internal error\n");
-        dyns_cleanup_globals();
+    if (!newdb) {
+        sc_client_error(s, "%s", err.errstr);
         Pthread_mutex_unlock(&csc2_subsystem_mtx);
         return SC_INTERNAL_ERROR;
     }
 
+    newdb->dtastripe = gbl_dtastripe; // we have only one setting currently
+    newdb->odh = s->headers;
+    /* don't lose precious flags like this */
+    newdb->instant_schema_change = s->headers && s->instant_sc;
+    newdb->inplace_updates = s->headers && s->ip_updates;
     newdb->iq = iq;
 
-    struct errstat err = {0};
-    rc = add_cmacc_stmt(newdb, 1, 1, &err);
-    if (rc)
-        sc_client_error(s, "%s", err.errstr);
-    if (rc || (init_check_constraints(newdb))) {
-        backout_schemas(newdb->tablename);
-        cleanup_newdb(newdb);
-        sc_errf(s, "Failed to process schema!\n");
-        dyns_cleanup_globals();
-        Pthread_mutex_unlock(&csc2_subsystem_mtx);
-        return -1;
-    }
-    dyns_cleanup_globals();
+    /* reset csc2? */
+    newdb->schema_version = 1;
+
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     /* create temporary tables.  to try to avoid strange issues always

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -458,25 +458,6 @@ int prepare_table_version_one(tran_type *tran, struct dbtable *db,
     return SC_OK;
 }
 
-struct dbtable *create_db_from_schema(struct dbenv *thedb,
-                                      struct schema_change_type *s, int dbnum,
-                                      int foundix, int schema_version)
-{
-    struct dbtable *newdb =
-        newdb_from_schema(thedb, s->tablename, NULL, dbnum, foundix);
-
-    if (newdb == NULL) return NULL;
-
-    newdb->dtastripe = gbl_dtastripe; // we have only one setting currently
-    newdb->odh = s->headers;
-    /* don't lose precious flags like this */
-    newdb->instant_schema_change = s->headers && s->instant_sc;
-    newdb->inplace_updates = s->headers && s->ip_updates;
-    newdb->schema_version = schema_version;
-
-    return newdb;
-}
-
 int fetch_sc_seed(const char *tablename, struct dbenv *thedb,
                              unsigned long long *stored_sc_genid,
                              unsigned int *stored_sc_host)

--- a/schemachange/sc_struct.h
+++ b/schemachange/sc_struct.h
@@ -17,10 +17,6 @@
 #ifndef INCLUDE_SC_STRUCT_H
 #define INCLUDE_SC_STRUCT_H
 
-struct dbtable *create_db_from_schema(struct dbenv *thedb,
-                                 struct schema_change_type *s, int dbnum,
-                                 int foundix, int version);
-
 void print_schemachange_info(struct schema_change_type *s, struct dbtable *db,
                              struct dbtable *newdb);
 

--- a/tests/ddl_no_csc2.test/t01_alter_table.expected
+++ b/tests/ddl_no_csc2.test/t01_alter_table.expected
@@ -456,7 +456,7 @@ tag "tag2"
 		u_longlong j 
 	}
 ')
-[ALTER TABLE t1 DROP COLUMN j] failed with rc 240 (null)
+[ALTER TABLE t1 DROP COLUMN j] failed with rc 240 dyns_load_schema_string failed for t1
 (csc2='schema
 	{
 		int i null = yes 

--- a/tests/yast.test/zeroblob.test
+++ b/tests/yast.test/zeroblob.test
@@ -342,7 +342,7 @@ do_execsql_test 13.100 {
   CREATE INDEX t1bbc ON t1(b, b+c);
   INSERT INTO t1(a,b,c) VALUES(1,zeroblob(8),3);
   SELECT a, quote(b), length(b), c FROM t1;
-} {1 (null) 1 X'0000000000000000' 8 3}
+} {1 {dyns_load_schema_string failed for t1} 1 X'0000000000000000' 8 3}
 
 # test_restore_config_pagecache
 finish_test


### PR DESCRIPTION
Following https://github.com/bloomberg/comdb2/pull/3136, this code encapsulate cmacc code for alter and fastinit, removing some redundant code as well.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
