### PR TITLE
Increase the size of the cnonce string array

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -931,7 +931,7 @@ static cdb2_ssl_sess_list cdb2_ssl_sess_cache;
 
    See next_cnonce() for details. */
 #define CNONCE_STR_FMT "%lx-%x-%llx-"
-#define CNONCE_STR_SZ 52 /* 8 + 1 + 8 + 1 + 16 + 1 + 16 + 1 (NUL) */
+#define CNONCE_STR_SZ 60 /* 16 + 1 + 8 + 1 + 16 + 1 + 16 + 1 (NUL) */
 
 #define CNT_BITS 12
 #define TIME_MASK (-1ULL << CNT_BITS)


### PR DESCRIPTION
This fixes a bug where next_cnonce overwrites hndl->sql.