### PR TITLE
do not assume there is a sc running when failing cmacc parsing

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2484,14 +2484,9 @@ struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
         goto err;
     }
 
-    rc = add_cmacc_stmt(newtable, 0, 0);
-    if (rc) {
-        errstat_set_rcstrf(err, -1,
-                           "Failed to load schema: can't "
-                           "process schema file %s\n",
-                           newtable->tablename);
+    rc = add_cmacc_stmt(newtable, 0, 0, err);
+    if (rc)
         goto err;
-    }
 
     rc = init_check_constraints(newtable);
     if (rc) {

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2373,7 +2373,8 @@ int del_bt_hash_table(char *table);
 int stat_bt_hash_table(char *table);
 int stat_bt_hash_table_reset(char *table);
 int fastinit_table(struct dbenv *dbenvin, char *table);
-int add_cmacc_stmt(struct dbtable *db, int alt, int allow_ull);
+int add_cmacc_stmt(struct dbtable *db, int alt, int allow_ull,
+                   struct errstat *err);
 int add_cmacc_stmt_no_side_effects(struct dbtable *db, int alt);
 
 void cleanup_newdb(struct dbtable *);

--- a/db/config.c
+++ b/db/config.c
@@ -647,10 +647,12 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
 
     /* just got a bunch of data. remember it so key forming
        routines and SQL can get at it */
-    rc = add_cmacc_stmt(db, 0, 0);
+    struct errstat err = {0};
+    rc = add_cmacc_stmt(db, 0, 0, &err);
     if (rc) {
         logmsg(LOGMSG_ERROR,
-               "Failed to load schema: can't process schema file %s\n", tok);
+               "Failed to load schema: can't process schema file %s\n%s\n", tok,
+               err.errstr);
         return -1;
     }
 

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -136,8 +136,10 @@ int add_table_to_environment(char *table, const char *csc2,
     newdb->iq = iq;
     newdb->timepartition_name = timepartition_name;
 
-    if (add_cmacc_stmt(newdb, 0, 0)) {
+    struct errstat err = {0};
+    if (add_cmacc_stmt(newdb, 0, 0, &err)) {
         logmsg(LOGMSG_ERROR, "%s: add_cmacc_stmt failed\n", __func__);
+        sc_client_error(s, "%s", err.errstr);
         rc = SC_CSC2_ERROR;
         goto err;
     }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -424,8 +424,11 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     newdb->iq = iq;
 
-    if ((add_cmacc_stmt(newdb, 1, (s->same_schema) ? 1 : 0)) ||
-        (init_check_constraints(newdb))) {
+    struct errstat err = {0};
+    rc = add_cmacc_stmt(newdb, 1, (s->same_schema) ? 1 : 0, &err);
+    if (rc)
+        sc_client_error(s, "%s", err.errstr);
+    if (rc || (init_check_constraints(newdb))) {
         backout(newdb);
         cleanup_newdb(newdb);
         dyns_cleanup_globals();

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -86,7 +86,11 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     newdb->iq = iq;
 
-    if ((add_cmacc_stmt(newdb, 1, 1)) || (init_check_constraints(newdb))) {
+    struct errstat err = {0};
+    rc = add_cmacc_stmt(newdb, 1, 1, &err);
+    if (rc)
+        sc_client_error(s, "%s", err.errstr);
+    if (rc || (init_check_constraints(newdb))) {
         backout_schemas(newdb->tablename);
         cleanup_newdb(newdb);
         sc_errf(s, "Failed to process schema!\n");

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -897,7 +897,11 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
         return 1;
     }
     newdb->dbnum = db->dbnum;
-    if ((add_cmacc_stmt(newdb, 1, 1)) || (init_check_constraints(newdb))) {
+    struct errstat err = {0};
+    rc = add_cmacc_stmt(newdb, 1, 1, &err);
+    if (rc)
+        logmsg(LOGMSG_ERROR, "%s\n", err.errstr);
+    if (rc || (init_check_constraints(newdb))) {
         /* can happen if new schema has no .DEFAULT tag but needs one */
         backout_schemas(table);
         return 1;


### PR DESCRIPTION
Per title, cmacc parsing of a csc2 file assumes there is a schema change running if an error happens (i.e. db->iq && db->iq->sc are populated).
The code runs also when there is no schema change.  Changing some db settings (like ulonglong permission) can generate an error while parsing a previously accepted csc2 and crash the server.
The fix removes the assumption there is a sc running if csc2 fails to parse; the parser caller, who knows if there is an sc or not, will handle the error message.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
