### PR TITLE
Fix when there is not an exclusive appsock thread per query

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1136,6 +1136,11 @@ static int dohsql_send_intrans_response(struct sqlclntstate *a)
     return 0;
 }
 
+static void * dohsql_get_authdata(struct sqlclntstate *a)
+{
+    return NULL;
+}
+
 static int _shard_connect(struct sqlclntstate *clnt, dohsql_connector_t *conn,
                           const char *sql, int nparams,
                           struct param_data *params)

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1760,7 +1760,6 @@ int osql_dbq_consume_logic(struct sqlclntstate *clnt, const char *spname,
 extern int gbl_allow_user_schema;
 int (*externalComdb2AuthenticateUserRead)(void*, const char *tablename) = NULL;
 int (*externalComdb2AuthenticateUserWrite)(void*, const char *tablename) = NULL;
-extern void * (*externGetAuthData) (void*);
 
 static int access_control_check_sql_write(struct BtCursor *pCur,
                                           struct sql_thread *thd)
@@ -1793,8 +1792,7 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
 
      if (gbl_uses_externalauth && thd->clnt->no_transaction == 0 &&
         externalComdb2AuthenticateUserWrite) {
-         if (!clnt->authdata && externGetAuthData)
-             clnt->authdata = externGetAuthData(clnt);
+         clnt->authdata = get_authdata(clnt);
          if(externalComdb2AuthenticateUserWrite(clnt->authdata, pCur->db->tablename)) {
              char msg[1024];
              snprintf(msg, sizeof(msg),
@@ -1866,8 +1864,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 
     if (gbl_uses_externalauth && thd->clnt->no_transaction == 0 &&
         externalComdb2AuthenticateUserRead) {
-         if (!clnt->authdata && externGetAuthData)
-             clnt->authdata = externGetAuthData(clnt);
+         clnt->authdata = get_authdata(clnt);
          if(externalComdb2AuthenticateUserRead(clnt->authdata, pCur->db->tablename)) {
              char msg[1024];
              snprintf(msg, sizeof(msg),

--- a/db/sql.h
+++ b/db/sql.h
@@ -402,6 +402,7 @@ typedef int(skip_row_func)(struct sqlclntstate *, uint64_t);
 typedef int(log_context_func)(struct sqlclntstate *, struct reqlogger *);
 typedef uint64_t(ret_uint64_func)(struct sqlclntstate *);
 typedef int(override_type_func)(struct sqlclntstate *, int);
+typedef void *(auth_func)(struct sqlclntstate *);
 
 enum query_data_ops { QUERY_DATA_SET = 1, QUERY_DATA_GET = 2, QUERY_DATA_DELETE = 3 };
 
@@ -453,6 +454,7 @@ struct plugin_callbacks {
     ret_uint64_func *get_client_starttime; /* newsql_get_client_starttime */
     plugin_func *get_client_retries;       /* newsql_get_client_retries */
     plugin_func *send_intrans_response; /* newsql_send_intrans_response */
+    auth_func *get_authdata; /* newsql_get_authdata */
     /* optional */
     void *state;
     int (*column_count)(struct sqlclntstate *,
@@ -508,6 +510,7 @@ struct plugin_callbacks {
         make_plugin_callback(clnt, name, get_client_starttime);                \
         make_plugin_callback(clnt, name, get_client_retries);                  \
         make_plugin_callback(clnt, name, send_intrans_response);               \
+        make_plugin_callback(clnt, name, get_authdata);                        \
         make_plugin_optional_null(clnt, count);                                \
         make_plugin_optional_null(clnt, type);                                 \
         make_plugin_optional_null(clnt, int64);                                \
@@ -534,6 +537,7 @@ int set_high_availability(struct sqlclntstate *);
 int clr_high_availability(struct sqlclntstate *);
 uint64_t get_client_starttime(struct sqlclntstate *);
 int get_client_retries(struct sqlclntstate *);
+void *get_authdata(struct sqlclntstate *);
 
 struct clnt_ddl_context {
     /* Name of the table */

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -395,8 +395,7 @@ static int comdb2AuthenticateUserDDL(const char *tablename)
      struct sql_thread *thd = pthread_getspecific(query_info_key);
      struct sqlclntstate *clnt = get_sql_clnt();
      if (gbl_uses_externalauth && externalComdb2AuthenticateUserDDL) {
-         if (!clnt->authdata && externGetAuthData)
-             clnt->authdata = externGetAuthData(clnt);
+         clnt->authdata = get_authdata(clnt);
          if (externalComdb2AuthenticateUserDDL(clnt->authdata, tablename))
              return SQLITE_AUTH;
          return SQLITE_OK;
@@ -423,8 +422,7 @@ static int comdb2AuthenticateUserDDL(const char *tablename)
 static int comdb2CheckOpAccess(void) {
     struct sqlclntstate *clnt = get_sql_clnt();
     if (gbl_uses_externalauth && externalComdb2CheckOpAccess) {
-         if (!clnt->authdata && externGetAuthData)
-             clnt->authdata = externGetAuthData(clnt);
+         clnt->authdata = get_authdata(clnt);
          return externalComdb2CheckOpAccess(clnt->authdata);
     }    
     if (comdb2AuthenticateUserDDL(""))


### PR DESCRIPTION
Forgot to cherry-pick this and now that's not working. Random errors when eventbuf is on.

https://github.com/bloomberg/comdb2/pull/3102

Signed-off-by: mohitkhullar <mkhullar1@bloomberg.net>
