### PR TITLE
tests: Tweak ddlk count for reorder_inserts.

### DIFF
--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -103,13 +103,13 @@ else
 fi
 
 ddcount=`grep -c DEADLOCK $mlog`
-
+limit=300
 if [[ $DBNAME == *"noreordergenerated"* ]] ; then
-    if [[ $ddcount -lt 500 ]] ; then
+    if [[ $ddcount -lt $limit ]] ; then
         failexit 'no reorder expected to get more than 500 deadlocks for this test'
     fi
 else
-    if [[ $ddcount -gt 500 ]] ; then
+    if [[ $ddcount -gt $limit ]] ; then
         failexit 'reorder expected to get less than 500 deadlocks for this test'
     fi
 fi


### PR DESCRIPTION
Hopefully, the new limits are more reliable.  This keeps failing at 500:
```
10:19:40> + [[ reorderinsertsnoreordergenerated20008 == *\n\o\r\e\o\r\d\e\r\g\e\n\e\r\a\t\e\d* ]]
10:19:40> + [[ 321 -lt 500 ]]
10:19:40> + failexit 'no reorder expected to get more than 500 deadlocks for this test'
```

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>