### PR TITLE
Re-introduce yacc patch - pass BISON_PKGDATADIR for non-standard location

### DIFF
--- a/csc2/CMakeLists.txt
+++ b/csc2/CMakeLists.txt
@@ -17,11 +17,22 @@ if(NOT yacc)
   message(FATAL_ERROR "yacc not found!")
 endif()
 
-add_custom_command(
-  OUTPUT maccparse.h maccparse.c
-  DEPENDS maccparse.y
-  COMMAND ${yacc} -d -o maccparse.c ${CMAKE_CURRENT_SOURCE_DIR}/maccparse.y
-)
+if(COMDB2_BBCMAKE)
+  get_filename_component(yaccpath ${yacc} DIRECTORY)
+  cmake_path(SET yaccpath ${yaccpath})
+  cmake_path(APPEND yaccpath ".." "share" "bison")
+  add_custom_command(
+    OUTPUT maccparse.h maccparse.c
+    DEPENDS maccparse.y
+    COMMAND ${CMAKE_COMMAND} -E env BISON_PKGDATADIR=${yaccpath} ${yacc} -d -o maccparse.c ${CMAKE_CURRENT_SOURCE_DIR}/maccparse.y
+  )
+else()
+  add_custom_command(
+    OUTPUT maccparse.h maccparse.c
+    DEPENDS maccparse.y
+    COMMAND ${yacc} -d -o maccparse.c ${CMAKE_CURRENT_SOURCE_DIR}/maccparse.y
+  )
+endif()
 
 find_program(lex NAMES flex lex)
 if(NOT lex)


### PR DESCRIPTION
Otherwise bison doesn't run when there's a mismatch between the called binary and the system installed bison.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>