### PR TITLE
encapsulate rest of cmacc csc2 code

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -62,6 +62,10 @@
 #define MAX_PASSWORD_LEN 19
 #define MAXBBNODENUM 32768 /* Legacy: maximum number assigned to a machine in BBENV */
 
+/* moved here from csc2, better place */
+/*max length of index name, its char[64] in stat1 - 10 for $_12345678*/
+#define MAXIDXNAMELEN 54
+
 /*
   Print at the given offset, detect overflow and update offset
   accordingly.

--- a/csc2/dynschemaload.h
+++ b/csc2/dynschemaload.h
@@ -27,8 +27,6 @@ typedef struct dpthinfo {
 enum dyns_cnst {
     MAX_TAG_LEN = 32,
     MAXTBLS = 32,
-    MAXIDXNAMELEN = 54 /*max length of index name, its char[64] in stat1 - 10
-                          for $_12345678*/
 };
 
 char *dyns_field_option_text(int option);

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -103,11 +103,20 @@ int gbl_sequence_feature = 1;
 void csc2_error(const char *fmt, ...);
 void csc2_syntax_error(const char *fmt, ...);
 
-void dyns_allow_bools(void) { allow_bools = 1; }
+void csc2_allow_bools(void)
+{
+    allow_bools = 1;
+}
 
-void dyns_disallow_bools(void) { allow_bools = 0; }
+void csc2_disallow_bools(void)
+{
+    allow_bools = 0;
+}
 
-int dyns_used_bools(void) { return used_bools; }
+int csc2_used_bools(void)
+{
+    return used_bools;
+}
 
 #define CHECK_LEGACY_SCHEMA(A)                                                 \
     do {                                                                       \

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -101,6 +101,7 @@ set(src
   dohast.c
   machclass.c
   osqluprec.c
+  macc_glue.c
   ${PROJECT_BINARY_DIR}/protobuf/bpfunc.pb-c.c
   ${PROJECT_SOURCE_DIR}/tools/cdb2_dump/cdb2_dump.c
   ${PROJECT_SOURCE_DIR}/tools/cdb2_load/cdb2_load.c

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -84,7 +84,6 @@ void berk_memp_sync_alarm_ms(int);
 #include "types.h"
 #include "timer.h"
 #include <plhash.h>
-#include <dynschemaload.h>
 #include "verify.h"
 #include "ssl_bend.h"
 #include "switches.h"
@@ -137,6 +136,7 @@ void berk_memp_sync_alarm_ms(int);
 #include "phys_rep.h"
 #include "comdb2_query_preparer.h"
 #include <net_appsock.h>
+#include "sc_csc2.h"
 
 #define tokdup strndup
 
@@ -1873,216 +1873,6 @@ void cleanup_newdb(dbtable *tbl)
     free(tbl);
 }
 
-dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
-                           int dbnum, int dbix)
-{
-    dbtable *tbl;
-    int ii;
-    int tmpidxsz;
-    int rc;
-
-    tbl = calloc(1, sizeof(dbtable));
-    if (tbl == NULL) {
-        logmsg(LOGMSG_FATAL, "%s: Memory allocation error\n", __func__);
-        return NULL;
-    }
-
-    tbl->dbs_idx = dbix;
-
-    tbl->dbtype = DBTYPE_TAGGED_TABLE;
-    if (fname)
-        tbl->lrlfname = strdup(fname);
-    tbl->tablename = strdup(tblname);
-    tbl->dbenv = env;
-    tbl->dbnum = dbnum;
-    tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
-    Pthread_rwlock_init(&tbl->sc_live_lk, NULL);
-    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
-    if (dbnum == 0) {
-        /* if no dbnumber then no default tag is required ergo lrl can be 0 */
-        if (tbl->lrl < 0)
-            tbl->lrl = 0;
-        else if (tbl->lrl > MAXLRL) {
-            logmsg(LOGMSG_ERROR, "bad data lrl %d in csc schema %s\n", tbl->lrl,
-                    tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-    } else {
-        /* this table must have a default tag */
-        int ntags, itag;
-        ntags = dyns_get_table_count();
-        for (itag = 0; itag < ntags; itag++) {
-            if (strcasecmp(dyns_get_table_tag(itag), ".DEFAULT") == 0)
-                break;
-        }
-        if (ntags == itag) {
-            logmsg(LOGMSG_ERROR, "csc schema %s requires comdbg compatibility but "
-                            "has no default tag\n",
-                    tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-
-        if (tbl->lrl < 1 || tbl->lrl > MAXLRL) {
-            logmsg(LOGMSG_ERROR, "bad data lrl %d in csc schema %s\n", tbl->lrl,
-                    tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-    }
-    tbl->nix = dyns_get_idx_count();
-    if (tbl->nix > MAXINDEX) {
-        logmsg(LOGMSG_ERROR, "too many indices %d in csc schema %s\n", tbl->nix,
-                tblname);
-        cleanup_newdb(tbl);
-        return NULL;
-    }
-    for (ii = 0; ii < tbl->nix; ii++) {
-        tmpidxsz = dyns_get_idx_size(ii);
-        if (tmpidxsz < 1 || tmpidxsz > MAXKEYLEN) {
-            logmsg(LOGMSG_ERROR, "index %d bad keylen %d in csc schema %s\n", ii,
-                    tmpidxsz, tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-        tbl->ix_keylen[ii] = tmpidxsz; /* ix lengths are adjusted later */
-
-        tbl->ix_dupes[ii] = dyns_is_idx_dup(ii);
-        if (tbl->ix_dupes[ii] < 0) {
-            logmsg(LOGMSG_ERROR, "cant find index %d dupes in csc schema %s\n", ii,
-                    tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-
-        tbl->ix_recnums[ii] = dyns_is_idx_recnum(ii);
-        if (tbl->ix_recnums[ii] < 0) {
-            logmsg(LOGMSG_ERROR, "cant find index %d recnums in csc schema %s\n", ii,
-                    tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        }
-
-        tbl->ix_datacopy[ii] = dyns_is_idx_datacopy(ii);
-        if (tbl->ix_datacopy[ii] < 0) {
-            logmsg(LOGMSG_ERROR, "cant find index %d datacopy in csc schema %s\n",
-                    ii, tblname);
-            cleanup_newdb(tbl);
-            return NULL;
-        } else if (tbl->ix_datacopy[ii]) {
-            tbl->has_datacopy_ix = 1;
-        }
-
-        tbl->ix_nullsallowed[ii] = dyns_is_idx_uniqnulls(ii);
-        if (tbl->ix_nullsallowed[ii] < 0) {
-          logmsg(LOGMSG_ERROR, "cant find index %d uniqnulls in csc schema %s\n",
-                  ii, tblname);
-          cleanup_newdb(tbl);
-          return NULL;
-        }
-    }
-
-    init_reverse_constraints(tbl);
-
-    tbl->n_constraints = dyns_get_constraint_count();
-    if (tbl->n_constraints > 0) {
-        char *consname = NULL;
-        char *keyname = NULL;
-        int rulecnt = 0, flags = 0;
-        tbl->constraints = calloc(tbl->n_constraints, sizeof(constraint_t));
-        for (ii = 0; ii < tbl->n_constraints; ii++) {
-            rc = dyns_get_constraint_at(ii, &consname, &keyname, &rulecnt, &flags);
-            if (rc != 0) {
-                logmsg(LOGMSG_ERROR, "Cannot get constraint at %d (cnt=%zu)!\n", ii, tbl->n_constraints);
-                cleanup_newdb(tbl);
-                return NULL;
-            }
-            tbl->constraints[ii].flags = flags;
-            tbl->constraints[ii].lcltable = tbl;
-            tbl->constraints[ii].consname = consname ? strdup(consname) : 0;
-            tbl->constraints[ii].lclkeyname = (keyname) ? strdup(keyname) : 0;
-            tbl->constraints[ii].nrules = rulecnt;
-
-            tbl->constraints[ii].table = calloc(tbl->constraints[ii].nrules, MAXTABLELEN * sizeof(char *));
-            tbl->constraints[ii].keynm = calloc(tbl->constraints[ii].nrules, MAXKEYLEN * sizeof(char *));
-
-            if (tbl->constraints[ii].nrules > 0) {
-                int jj = 0;
-                for (jj = 0; jj < tbl->constraints[ii].nrules; jj++) {
-                    char *tblnm = NULL;
-                    rc = dyns_get_constraint_rule(ii, jj, &tblnm, &keyname);
-                    if (rc != 0) {
-                        logmsg(LOGMSG_ERROR, "cannot get constraint rule %d table %s:%s\n",
-                                jj, tblname, keyname);
-                        cleanup_newdb(tbl);
-                        return NULL;
-                    }
-                    tbl->constraints[ii].table[jj] = strdup(tblnm);
-                    tbl->constraints[ii].keynm[jj] = strdup(keyname);
-                }
-            }
-        } /* for (ii...) */
-    }     /* if (n_constraints > 0) */
-    tbl->ixuse = calloc(tbl->nix, sizeof(unsigned long long));
-    tbl->sqlixuse = calloc(tbl->nix, sizeof(unsigned long long));
-    return tbl;
-}
-
-int init_check_constraints(dbtable *tbl)
-{
-    char *consname = NULL;
-    char *check_expr = NULL;
-    strbuf *sql;
-    int rc;
-
-    tbl->n_check_constraints = dyns_get_check_constraint_count();
-    if (tbl->n_check_constraints == 0) {
-        return 0;
-    }
-
-    tbl->check_constraints = calloc(tbl->n_check_constraints, sizeof(check_constraint_t));
-    tbl->check_constraint_query = calloc(tbl->n_check_constraints, sizeof(char *));
-    if ((tbl->check_constraints == NULL) || (tbl->check_constraint_query == NULL)) {
-        logmsg(LOGMSG_ERROR, "%s:%d failed to allocate memory\n", __func__, __LINE__);
-        return 1;
-    }
-
-    sql = strbuf_new();
-
-    for (int i = 0; i < tbl->n_check_constraints; i++) {
-        rc = dyns_get_check_constraint_at(i, &consname, &check_expr);
-        if (rc == -1)
-            abort();
-        tbl->check_constraints[i].consname = consname ? strdup(consname) : 0;
-        tbl->check_constraints[i].expr = check_expr ? strdup(check_expr) : 0;
-
-        strbuf_clear(sql);
-
-        strbuf_appendf(sql, "WITH \"%s\" (\"%s\"", tbl->tablename,
-                       tbl->schema->member[0].name);
-        for (int j = 1; j < tbl->schema->nmembers; ++j) {
-            strbuf_appendf(sql, ", %s", tbl->schema->member[j].name);
-        }
-        strbuf_appendf(sql, ") AS (SELECT @%s", tbl->schema->member[0].name);
-        for (int j = 1; j < tbl->schema->nmembers; ++j) {
-            strbuf_appendf(sql, ", @%s", tbl->schema->member[j].name);
-        }
-        strbuf_appendf(sql, ") SELECT (%s) FROM \"%s\"",
-                       tbl->check_constraints[i].expr, tbl->tablename);
-        tbl->check_constraint_query[i] = strdup(strbuf_buf(sql));
-        if (tbl->check_constraint_query[i] == NULL) {
-            logmsg(LOGMSG_ERROR, "%s:%d failed to allocate memory\n", __func__,
-                   __LINE__);
-            cleanup_newdb(tbl);
-            strbuf_free(sql);
-            return 1;
-        }
-    }
-    strbuf_free(sql);
-    return 0;
-}
-
 static int resize_reverse_constraints(struct dbtable *db, size_t newsize)
 {
     constraint_t **temp = realloc(db->rev_constraints, newsize * sizeof(constraint_t *));
@@ -2460,56 +2250,6 @@ static inline int db_get_alias(void *tran, dbtable *tbl)
     return 0;
 }
 
-struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
-                                   char *csc2, int dbnum, int indx,
-                                   int sc_alt_tablename, int allow_ull,
-                                   struct errstat *err)
-{
-    struct dbtable *newtable = NULL;
-    int rc;
-
-    dyns_init_globals();
-
-    rc = dyns_load_schema_string(csc2, dbenv->envname, tablename);
-    if (rc) {
-        errstat_set_rcstrf(err, -1, "dyns_load_schema_string failed for %s",
-                           tablename);
-        goto err;
-    }
-
-    newtable = newdb_from_schema(dbenv, tablename, NULL, dbnum, indx);
-    if (!newtable) {
-        errstat_set_rcstrf(err, -1, "newdb_from_schema failed for %s",
-                           tablename);
-        rc = -1;
-        goto err;
-    }
-
-    rc = add_cmacc_stmt(newtable, sc_alt_tablename, allow_ull, err);
-    if (rc) {
-        goto err;
-    }
-
-    rc = init_check_constraints(newtable);
-    if (rc) {
-        errstat_set_rcstrf(err, -1,
-                           "Failed to load check constraints "
-                           "for %s",
-                           newtable->tablename);
-        goto err;
-    }
-
-err:
-    if (rc) {
-        if (newtable) {
-            cleanup_newdb(newtable);
-            newtable = NULL;
-        }
-    }
-
-    dyns_cleanup_globals();
-    return newtable;
-}
 
 /* gets the table names and dbnums from the low level meta table and sets up the
  * dbenv accordingly.  returns 0 on success and anything else otherwise */
@@ -2588,7 +2328,7 @@ static int llmeta_load_tables(struct dbenv *dbenv, void *tran)
 
         struct errstat err = {0};
         tbl = create_new_dbtable(dbenv, tblnames[i], csc2text, dbnums[i], i, 0,
-                                 0, &err);
+                                 0, 0, &err);
         free(csc2text);
         csc2text = NULL;
         if (!tbl) {
@@ -3578,7 +3318,7 @@ static int init_sqlite_tables(struct dbenv *dbenv)
 
         tbl = create_new_dbtable(dbenv, (char *)sqlite_stats_name[i],
                                  (char *)sqlite_stats_csc2[i], 0,
-                                 dbenv->num_dbs, 0, 0, &err);
+                                 dbenv->num_dbs, 0, 0, 0, &err);
         if (!tbl) {
             logmsg(LOGMSG_ERROR, "%s\n", err.errstr);
             return -1;
@@ -3713,7 +3453,7 @@ static int init(int argc, char **argv)
         print_usage_and_exit(1);
     }
 
-    dyns_allow_bools();
+    csc2_allow_bools();
 
     rc = bdb_osql_log_repo_init(&bdberr);
     if (rc) {
@@ -4084,12 +3824,12 @@ static int init(int argc, char **argv)
      * Still alow bools for people who want to copy/test prod dbs
      * that use them.  Don't allow new databases to have bools. */
     if ((get_my_mach_class() == CLASS_TEST) && gbl_create_mode) {
-        if (dyns_used_bools()) {
+        if (csc2_used_bools()) {
             logmsg(LOGMSG_FATAL, "bools in schema.  This is now deprecated.\n");
             logmsg(LOGMSG_FATAL, "Exiting since this is a test machine.\n");
             exit(1);
         }
-        dyns_disallow_bools();
+        csc2_disallow_bools();
     }
 
     /* Now process all the directives we saved up from the lrl file. */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -99,6 +99,7 @@ typedef long long tranid_t;
 #include "perf.h"
 #include "constraints.h"
 #include "osqlrpltypes.h"
+#include "macc_glue.h"
 
 /* buffer offset, given base ptr & right ptr */
 #define BUFOFF(base, right) ((int)(((char *)right) - ((char *)base)))
@@ -2364,30 +2365,16 @@ int dtas_next_pageorder(struct ireq *iq, const unsigned long long *genid_vector,
                         int stay_in_stripe, void *dta, void *trans, int dtalen,
                         int *reqdtalen, int *ver);
 
-int check_table_schema(struct dbenv *dbenv, const char *table,
-                       const char *csc2file);
-
-struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
-                                   char *csc2, int dbnum, int indx,
-                                   int sc_alt_tablename, int allow_ull,
-                                   struct errstat *err);
-
 struct dbtable *find_table(const char *table);
 int bt_hash_table(char *table, int szkb);
 int del_bt_hash_table(char *table);
 int stat_bt_hash_table(char *table);
 int stat_bt_hash_table_reset(char *table);
 int fastinit_table(struct dbenv *dbenvin, char *table);
-int add_cmacc_stmt(struct dbtable *db, int is_sc_name, int allow_ull,
-                   struct errstat *err);
-int add_cmacc_stmt_no_side_effects(struct dbtable *db, int is_sc_name);
 
 void cleanup_newdb(struct dbtable *);
-struct dbtable *newdb_from_schema(struct dbenv *env, char *tblname, char *fname,
-                                  int dbnum, int dbix);
 struct dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pagesize,
                   int isqueuedb);
-int init_check_constraints(struct dbtable *tbl);
 int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
 void stop_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
@@ -3629,5 +3616,12 @@ extern int gbl_rcache;
 extern int gbl_throttle_txn_chunks_msec;
 extern int gbl_sql_release_locks_on_slow_reader;
 extern int gbl_fail_client_write_lock;
+
+void csc2_free_all(void);
+
+/* hack to temporary allow bools on production stage */
+void csc2_allow_bools(void);
+void csc2_disallow_bools(void);
+int csc2_used_bools(void);
 
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/config.c
+++ b/db/config.c
@@ -36,6 +36,7 @@
 #include "rtcpu.h"
 #include "config.h"
 #include "phys_rep.h"
+#include "macc_glue.h"
 
 extern int gbl_create_mode;
 extern int gbl_fullrecovery;
@@ -625,43 +626,31 @@ static int lrltokignore(char *tok, int ltok)
 static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
                                  char *fname, int dbnum, char *tok)
 {
-    int rc;
     struct dbtable *db;
-    rc = dyns_load_schema(fname, (char *)gbl_dbname, tblname);
-    if (rc != 0) {
-        logmsg(LOGMSG_ERROR, "Error loading %s schema.\n", tok);
+    char *csc2;
+
+    csc2 = load_text_file(fname);
+    if (!csc2) {
+        logmsg(LOGMSG_ERROR, "Error loading text from file %s\n", fname);
         return -1;
     }
 
-    /* create one */
-    db = newdb_from_schema(dbenv, tblname, fname, dbnum, dbenv->num_dbs);
-    if (db == NULL) {
+    struct errstat err = {0};
+    db = create_new_dbtable(dbenv, tblname, csc2, dbnum, dbenv->num_dbs, 0, 0,
+                            0, &err);
+    if (!db) {
+        logmsg(LOGMSG_ERROR, "%s\ncsc2:\"%s\"\n", err.errstr, csc2);
+        free(csc2);
         return -1;
     }
 
+    db->csc2_schema = csc2;
     db->dbs_idx = dbenv->num_dbs;
     dbenv->dbs[dbenv->num_dbs++] = db;
 
     /* Add table to the hash. */
     hash_add(dbenv->db_hash, db);
 
-    /* just got a bunch of data. remember it so key forming
-       routines and SQL can get at it */
-    struct errstat err = {0};
-    rc = add_cmacc_stmt(db, 0, 0, &err);
-    if (rc) {
-        logmsg(LOGMSG_ERROR,
-               "Failed to load schema: can't process schema file %s\n%s\n", tok,
-               err.errstr);
-        return -1;
-    }
-
-    /* Initialize table's check constraint members. */
-    if (init_check_constraints(db)) {
-        logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-               db->tablename);
-        return -1;
-    }
     return 0;
 }
 
@@ -1061,9 +1050,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
                 }
             }
 
-            dyns_init_globals();
             rc = new_table_from_schema(dbenv, tblname, fname, dbnum, tok);
-            dyns_cleanup_globals();
             if (rc)
                 return rc;
 

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -23,6 +23,7 @@
 #include "endian_core.h"
 #include <flibc.h>
 #include "str0.h"
+#include "dynschematypes.h"
 
 typedef struct {
     char name[32];    /* name of field as a \0 terminated string */

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -1,0 +1,996 @@
+/*
+   Copyright 2015, 2022, Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include "macc_glue.h"
+#include "tag.h"
+#include "dynschematypes.h"
+#include "dynschemaload.h"
+
+static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum,
+                                  int dbix);
+static int init_check_constraints(dbtable *tbl);
+static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
+                          int no_side_effects, struct errstat *err);
+
+struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
+                                   char *csc2, int dbnum, int indx,
+                                   int sc_alt_tablename, int allow_ull,
+                                   int no_side_effects, struct errstat *err)
+{
+    struct dbtable *newtable = NULL;
+    int rc;
+
+    dyns_init_globals();
+
+    rc = dyns_load_schema_string(csc2, dbenv->envname, tablename);
+    if (rc) {
+        char *syntax_error = csc2_get_syntax_errors();
+        if (syntax_error) {
+            errstat_set_rcstrf(err, -1, "%s", syntax_error);
+        } else {
+            errstat_set_rcstrf(err, -1, "dyns_load_schema_string failed for %s",
+                               tablename);
+        }
+        goto err;
+    }
+
+    newtable = newdb_from_schema(dbenv, tablename, dbnum, indx);
+    if (!newtable) {
+        errstat_set_rcstrf(err, -1, "newdb_from_schema failed for %s",
+                           tablename);
+        rc = -1;
+        goto err;
+    }
+
+    rc = add_cmacc_stmt(newtable, sc_alt_tablename, allow_ull, no_side_effects,
+                        err);
+    if (rc) {
+        goto err;
+    }
+
+    rc = init_check_constraints(newtable);
+    if (rc) {
+        errstat_set_rcstrf(err, -1,
+                           "Failed to load check constraints "
+                           "for %s",
+                           newtable->tablename);
+        goto err;
+    }
+
+err:
+    if (rc) {
+        if (newtable) {
+            cleanup_newdb(newtable);
+            newtable = NULL;
+        }
+    }
+
+    dyns_cleanup_globals();
+    return newtable;
+}
+
+int populate_db_with_alt_schema(struct dbenv *dbenv, struct dbtable *db,
+                                char *csc2, struct errstat *err)
+{
+    int rc;
+
+    dyns_init_globals();
+
+    rc = dyns_load_schema_string(csc2, dbenv->envname, db->tablename);
+    if (rc) {
+        errstat_set_rcstrf(err, -1, "%s failed to load alternate schema rc %d",
+                           __func__, rc);
+        goto done;
+    }
+
+    /* create the .NEW. tags, but don't update db->lrl, numix, numblobs
+     * or anything like that. */
+    rc = add_cmacc_stmt(db, 1 /* altname */, 0 /* no ull*/,
+                        1 /* no side effects */, err);
+    if (rc) {
+        goto done;
+    }
+
+done:
+    dyns_cleanup_globals();
+    return rc;
+}
+
+static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum,
+                                  int dbix)
+{
+    dbtable *tbl;
+    int ii;
+    int tmpidxsz;
+    int rc;
+
+    tbl = calloc(1, sizeof(dbtable));
+    if (tbl == NULL) {
+        logmsg(LOGMSG_FATAL, "%s: Memory allocation error\n", __func__);
+        return NULL;
+    }
+
+    tbl->dbs_idx = dbix;
+
+    tbl->dbtype = DBTYPE_TAGGED_TABLE;
+    tbl->tablename = strdup(tblname);
+    tbl->dbenv = env;
+    tbl->dbnum = dbnum;
+    tbl->lrl = dyns_get_db_table_size(); /* this gets adjusted later */
+    Pthread_rwlock_init(&tbl->sc_live_lk, NULL);
+    Pthread_mutex_init(&tbl->rev_constraints_lk, NULL);
+    if (dbnum == 0) {
+        /* if no dbnumber then no default tag is required ergo lrl can be 0 */
+        if (tbl->lrl < 0)
+            tbl->lrl = 0;
+        else if (tbl->lrl > MAXLRL) {
+            logmsg(LOGMSG_ERROR, "bad data lrl %d in csc schema %s\n", tbl->lrl,
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+    } else {
+        /* this table must have a default tag */
+        int ntags, itag;
+        ntags = dyns_get_table_count();
+        for (itag = 0; itag < ntags; itag++) {
+            if (strcasecmp(dyns_get_table_tag(itag), ".DEFAULT") == 0)
+                break;
+        }
+        if (ntags == itag) {
+            logmsg(LOGMSG_ERROR,
+                   "csc schema %s requires comdbg compatibility but "
+                   "has no default tag\n",
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+
+        if (tbl->lrl < 1 || tbl->lrl > MAXLRL) {
+            logmsg(LOGMSG_ERROR, "bad data lrl %d in csc schema %s\n", tbl->lrl,
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+    }
+    tbl->nix = dyns_get_idx_count();
+    if (tbl->nix > MAXINDEX) {
+        logmsg(LOGMSG_ERROR, "too many indices %d in csc schema %s\n", tbl->nix,
+               tblname);
+        cleanup_newdb(tbl);
+        return NULL;
+    }
+    for (ii = 0; ii < tbl->nix; ii++) {
+        tmpidxsz = dyns_get_idx_size(ii);
+        if (tmpidxsz < 1 || tmpidxsz > MAXKEYLEN) {
+            logmsg(LOGMSG_ERROR, "index %d bad keylen %d in csc schema %s\n",
+                   ii, tmpidxsz, tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+        tbl->ix_keylen[ii] = tmpidxsz; /* ix lengths are adjusted later */
+
+        tbl->ix_dupes[ii] = dyns_is_idx_dup(ii);
+        if (tbl->ix_dupes[ii] < 0) {
+            logmsg(LOGMSG_ERROR, "cant find index %d dupes in csc schema %s\n",
+                   ii, tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+
+        tbl->ix_recnums[ii] = dyns_is_idx_recnum(ii);
+        if (tbl->ix_recnums[ii] < 0) {
+            logmsg(LOGMSG_ERROR,
+                   "cant find index %d recnums in csc schema %s\n", ii,
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+
+        tbl->ix_datacopy[ii] = dyns_is_idx_datacopy(ii);
+        if (tbl->ix_datacopy[ii] < 0) {
+            logmsg(LOGMSG_ERROR,
+                   "cant find index %d datacopy in csc schema %s\n", ii,
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        } else if (tbl->ix_datacopy[ii]) {
+            tbl->has_datacopy_ix = 1;
+        }
+
+        tbl->ix_nullsallowed[ii] = dyns_is_idx_uniqnulls(ii);
+        if (tbl->ix_nullsallowed[ii] < 0) {
+            logmsg(LOGMSG_ERROR,
+                   "cant find index %d uniqnulls in csc schema %s\n", ii,
+                   tblname);
+            cleanup_newdb(tbl);
+            return NULL;
+        }
+    }
+
+    init_reverse_constraints(tbl);
+
+    tbl->n_constraints = dyns_get_constraint_count();
+    if (tbl->n_constraints > 0) {
+        char *consname = NULL;
+        char *keyname = NULL;
+        int rulecnt = 0, flags = 0;
+        tbl->constraints = calloc(tbl->n_constraints, sizeof(constraint_t));
+        for (ii = 0; ii < tbl->n_constraints; ii++) {
+            rc = dyns_get_constraint_at(ii, &consname, &keyname, &rulecnt,
+                                        &flags);
+            if (rc != 0) {
+                logmsg(LOGMSG_ERROR, "Cannot get constraint at %d (cnt=%zu)!\n",
+                       ii, tbl->n_constraints);
+                cleanup_newdb(tbl);
+                return NULL;
+            }
+            tbl->constraints[ii].flags = flags;
+            tbl->constraints[ii].lcltable = tbl;
+            tbl->constraints[ii].consname = consname ? strdup(consname) : 0;
+            tbl->constraints[ii].lclkeyname = (keyname) ? strdup(keyname) : 0;
+            tbl->constraints[ii].nrules = rulecnt;
+
+            tbl->constraints[ii].table = calloc(tbl->constraints[ii].nrules,
+                                                MAXTABLELEN * sizeof(char *));
+            tbl->constraints[ii].keynm =
+                calloc(tbl->constraints[ii].nrules, MAXKEYLEN * sizeof(char *));
+
+            if (tbl->constraints[ii].nrules > 0) {
+                int jj = 0;
+                for (jj = 0; jj < tbl->constraints[ii].nrules; jj++) {
+                    char *tblnm = NULL;
+                    rc = dyns_get_constraint_rule(ii, jj, &tblnm, &keyname);
+                    if (rc != 0) {
+                        logmsg(LOGMSG_ERROR,
+                               "cannot get constraint rule %d table %s:%s\n",
+                               jj, tblname, keyname);
+                        cleanup_newdb(tbl);
+                        return NULL;
+                    }
+                    tbl->constraints[ii].table[jj] = strdup(tblnm);
+                    tbl->constraints[ii].keynm[jj] = strdup(keyname);
+                }
+            }
+        } /* for (ii...) */
+    }     /* if (n_constraints > 0) */
+    tbl->ixuse = calloc(tbl->nix, sizeof(unsigned long long));
+    tbl->sqlixuse = calloc(tbl->nix, sizeof(unsigned long long));
+    return tbl;
+}
+
+char *indexes_expressions_unescape(char *expr);
+extern int gbl_new_indexes;
+extern char gbl_ver_temp_table[];
+/* create keys for each schema */
+static int create_key_schema(dbtable *db, struct schema *schema, int alt,
+                             struct errstat *err)
+{
+    char buf[MAXCOLNAME + 1];
+    int ix;
+    int piece;
+    struct field *m;
+    int offset;
+    char altname[MAXTAGLEN];
+    char tmptagname[MAXTAGLEN + sizeof(".NEW.")];
+    char *where;
+    char *expr;
+    int rc;
+    int ascdesc;
+    char *dbname = db->tablename;
+    struct schema *s;
+
+    /* keys not reqd for ver temp table; just ondisk tag */
+    if (strncasecmp(dbname, gbl_ver_temp_table, strlen(gbl_ver_temp_table)) ==
+        0)
+        return 0;
+
+    schema->nix = dyns_get_idx_count();
+    schema->ix = calloc(schema->nix, sizeof(struct schema *));
+
+    for (ix = 0; ix < schema->nix; ix++) {
+        snprintf(buf, sizeof(buf), "%s_ix_%d", schema->tag, ix);
+        s = schema->ix[ix] = calloc(1, sizeof(struct schema));
+
+        s->tag = strdup(buf);
+        s->nmembers = dyns_get_idx_piece_count(ix);
+        s->member = calloc(schema->ix[ix]->nmembers, sizeof(struct field));
+
+        s->flags = SCHEMA_INDEX;
+
+        if (dyns_is_idx_dup(ix))
+            s->flags |= SCHEMA_DUP;
+
+        if (dyns_is_idx_recnum(ix))
+            s->flags |= SCHEMA_RECNUM;
+
+        if (dyns_is_idx_datacopy(ix))
+            s->flags |= SCHEMA_DATACOPY;
+
+        if (dyns_is_idx_uniqnulls(ix))
+            s->flags |= SCHEMA_UNIQNULLS;
+
+        s->nix = 0;
+        s->ix = NULL;
+        s->ixnum = ix;
+        if ((strcasecmp(schema->tag, ".ONDISK") == 0 ||
+             strcasecmp(schema->tag, ".NEW..ONDISK") == 0) &&
+            (db->ixschema && db->ixschema[ix] == NULL))
+            db->ixschema[ix] = s;
+        offset = 0;
+        for (piece = 0; piece < s->nmembers; piece++) {
+            m = &s->member[piece];
+            m->flags = 0;
+            expr = NULL;
+            m->isExpr = 0;
+            dyns_get_idx_piece(ix, piece, buf, sizeof(buf), &m->type,
+                               (int *)&m->offset, (int *)&m->len, &ascdesc,
+                               &expr);
+            if (expr) {
+                expr = indexes_expressions_unescape(expr);
+                m->name = expr;
+                m->isExpr = 1;
+                m->idx = -1;
+                if (expr == NULL) {
+                    errstat_set_rcstrf(err, -1, "unterminated string literal");
+                    rc = 1;
+                    goto errout;
+                }
+                switch (m->type) {
+                case 0:
+                    abort();
+                case SERVER_BLOB:
+                case SERVER_VUTF8:
+                case SERVER_BLOB2:
+                    errstat_set_rcstrf(err, -1, "blob index is not supported.");
+                    rc = 1;
+                    goto errout;
+                case SERVER_BCSTR:
+                    if (m->len < 2) {
+                        errstat_set_rcstrf(
+                            err, -1,
+                            "string must be at least 2 bytes in in length.");
+                        rc = 1;
+                        goto errout;
+                    }
+                    break;
+                case SERVER_DATETIME:
+                    /* server CLIENT_DATETIME is a server_datetime_t */
+                    m->len = sizeof(server_datetime_t);
+                    break;
+                case SERVER_DATETIMEUS:
+                    /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
+                    m->len = sizeof(server_datetimeus_t);
+                    break;
+                case SERVER_INTVYM:
+                    /* server CLIENT_INTVYM is a server_intv_ym_t */
+                    m->len = sizeof(server_intv_ym_t);
+                    break;
+                case SERVER_INTVDS:
+                    /* server CLIENT_INTVDS is a server_intv_ds_t */
+                    m->len = sizeof(server_intv_ds_t);
+                    break;
+                case SERVER_INTVDSUS:
+                    /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
+                    m->len = sizeof(server_intv_dsus_t);
+                    break;
+                case SERVER_DECIMAL:
+                    switch (m->len) {
+                    case 14:
+                        m->len = sizeof(server_decimal32_t);
+                        break;
+                    case 24:
+                        m->len = sizeof(server_decimal64_t);
+                        break;
+                    case 43:
+                        m->len = sizeof(server_decimal128_t);
+                        break;
+                    default:
+                        abort();
+                    }
+                    break;
+                default:
+                    /* other types just add one for the flag byte */
+                    m->len++;
+                    break;
+                }
+                if (offset + m->len > MAXKEYLEN) {
+                    errstat_set_rcstrf(err, -1, "index %d is too large.", ix);
+                    rc = 1;
+                    goto errout;
+                }
+                db->ix_expr = 1;
+            } else {
+                m->name = strdup(buf);
+                m->idx = find_field_idx(dbname, schema->tag, m->name);
+                if (m->idx == -1) {
+                    errstat_set_rcstrf(err, -1, "field %s not found in %s\n",
+                                       m->name, schema->tag);
+                    rc = -ix - 1;
+                    goto errout;
+                }
+                m->type = schema->member[m->idx].type;
+                m->len = schema->member[m->idx].len;
+
+                /* the dbstore default is still needed during schema change, so
+                 * populate that */
+                if (schema->member[m->idx].in_default) {
+                    m->in_default =
+                        malloc(schema->member[m->idx].in_default_len);
+                    m->in_default_len = schema->member[m->idx].in_default_len;
+                    m->in_default_type = schema->member[m->idx].in_default_type;
+                    memcpy(m->in_default, schema->member[m->idx].in_default,
+                           m->in_default_len);
+                }
+                memcpy(&m->convopts, &schema->member[m->idx].convopts,
+                       sizeof(struct field_conv_opts));
+                if (gbl_new_indexes && strncasecmp(dbname, "sqlite_stat", 11) &&
+                    strcasecmp(dbname, "comdb2_oplog") &&
+                    strcasecmp(dbname, "comdb2_commit_log") &&
+                    (!gbl_replicate_local ||
+                     strcasecmp(m->name, "comdb2_seqno"))) {
+                    m->isExpr = 1;
+                    db->ix_partial = 1;
+                    db->ix_expr = 1;
+                }
+            }
+            if (ascdesc)
+                m->flags |= INDEX_DESCEND;
+            /* we could check here if there are decimals in the index, and mark
+             * it "datacopy" special */
+            if (db->ix_datacopy[ix] == 0 && m->type == SERVER_DECIMAL) {
+                db->ix_collattr[ix]++; /* special tail */
+            } else if (m->type == SERVER_DECIMAL) {
+                db->ix_datacopy[ix]++; /* special tail */
+            }
+            m->offset = offset;
+            offset += m->len;
+        }
+        /* rest of fields irrelevant for indexes */
+        add_tag_schema(dbname, s);
+        rc = dyns_get_idx_tag(ix, altname, MAXTAGLEN, &where);
+        if (rc == 0 && (strcasecmp(schema->tag, ".ONDISK") == 0 ||
+                        strcasecmp(schema->tag, ".NEW..ONDISK") == 0)) {
+            if (alt == 0) {
+                add_tag_alias(dbname, s, altname);
+            } else {
+                snprintf(tmptagname, sizeof(tmptagname), ".NEW.%s", altname);
+                add_tag_alias(dbname, s, tmptagname);
+            }
+            if (where) {
+                s->where = strdup(where);
+                db->ix_partial = 1;
+            }
+        }
+    }
+    return 0;
+
+errout:
+    freeschema(s);
+    free(schema->ix);
+    schema->ix = NULL;
+    schema->nix = 0;
+    return rc;
+}
+
+/* Setup the dbload/dbstore values for a field.  Only do this for the
+ * ondisk tag.  The in/out default values are stored in server format
+ * but with the same type as the dbload/dbstore value uses in the csc2
+ * (why? - why not just convert it here so later on we can memcpy?)
+ */
+static int init_default_value(struct field *fld, int fldn, int loadstore)
+{
+    const char *name;
+    void **p_default;
+    int *p_default_len;
+    int *p_default_type;
+    int mastersz;
+    void *typebuf = NULL;
+    int opttype = 0;
+    int optsz;
+    int rc, outrc = 0;
+
+    switch (loadstore) {
+    case FLDOPT_DBSTORE:
+        name = "dbstore";
+        p_default = &fld->in_default;
+        p_default_len = &fld->in_default_len;
+        p_default_type = &fld->in_default_type;
+        break;
+
+    case FLDOPT_DBLOAD:
+        name = "dbload";
+        p_default = &fld->out_default;
+        p_default_len = &fld->out_default_len;
+        p_default_type = &fld->out_default_type;
+        break;
+
+    default:
+        logmsg(LOGMSG_FATAL, "init_default_value: loadstore=%d?!\n", loadstore);
+        exit(1);
+    }
+
+    if (fld->type == SERVER_VUTF8) {
+        mastersz = 16 * 1024;
+    } else if (fld->type == SERVER_DATETIME || fld->type == SERVER_DATETIMEUS) {
+        mastersz =
+            CLIENT_DATETIME_EXT_LEN; /* We want to get back cstring here. */
+    } else {
+        mastersz = max_type_size(fld->type, fld->len);
+    }
+
+    if (mastersz > 0)
+        typebuf = calloc(1, mastersz);
+
+    char *func_str = NULL;
+    rc = dyns_get_table_field_option(".ONDISK", fldn, loadstore, &opttype,
+                                     &optsz, typebuf, mastersz, &func_str);
+
+    *p_default = NULL;
+    *p_default_len = 0;
+
+    if (rc == -1 && opttype != CLIENT_MINTYPE) {
+        /* csc2 doesn't like its default value data, or our buffer is too small
+         */
+        logmsg(LOGMSG_ERROR, "init_default_value: %s for %s is invalid\n", name,
+               fld->name);
+        outrc = -1;
+    } else if (rc == 0) {
+        int outdtsz;
+        int is_null = 0;
+
+        /* if we are dealing with a default for vutf8 we must be sure to save it
+         * a
+         * as a cstring, we don't want to have to hold on to a "default blob" */
+        if (opttype == CLIENT_VUTF8) {
+            opttype = CLIENT_CSTR;
+            *p_default_len = optsz + 1 /* csc2lib doesn't count NUL byte*/;
+        } else
+            *p_default_len = fld->len;
+
+        *p_default_type = client_type_to_server_type(opttype);
+
+        if (opttype == CLIENT_FUNCTION) {
+            *p_default = strdup(func_str);
+            outrc = 0;
+            goto out;
+        }
+
+        *p_default = calloc(1, *p_default_len);
+
+        if (opttype == CLIENT_DATETIME || opttype == CLIENT_DATETIMEUS) {
+            opttype = CLIENT_CSTR;
+            if (strncasecmp(typebuf, "CURRENT_TIMESTAMP", 17) == 0)
+                is_null = 1; /* use isnull flag for current timestamp since
+                                null=yes is used for dbstore null */
+        }
+
+        if (*p_default == NULL) {
+            logmsg(LOGMSG_ERROR, "init_default_value: out of memory\n");
+            outrc = -1;
+        } else {
+            /* csc2lib doesn't count the \0 in the size for cstrings - but type
+             * system does and will balk if no \0 is found. */
+            if (opttype == CLIENT_CSTR)
+                optsz++;
+
+            if (opttype == CLIENT_SEQUENCE && loadstore == FLDOPT_DBSTORE) {
+                set_resolve_master(*p_default, *p_default_len);
+                rc = 0;
+            } else {
+                rc = CLIENT_to_SERVER(typebuf, optsz, opttype,
+                                      is_null /*isnull*/, NULL /*convopts*/,
+                                      NULL /*blob*/, *p_default, *p_default_len,
+                                      *p_default_type, 0, &outdtsz,
+                                      &fld->convopts, NULL /*blob*/);
+            }
+            if (rc == -1) {
+                logmsg(LOGMSG_ERROR, "%s initialisation failed for field %s\n",
+                       name, fld->name);
+                free(*p_default);
+                *p_default = NULL;
+                *p_default_len = 0;
+                *p_default_type = 0;
+                outrc = -1;
+            }
+        }
+    }
+
+out:
+    if (typebuf)
+        free(typebuf);
+
+    return outrc;
+}
+
+/* have a cmacc parsed and sanity-checked csc schema.
+   convert to sql statement, execute, save schema in db
+   structure and sanity check again (sqlite schema must
+   match cmacc).  libcmacc2 puts results into globals.
+   process them here after each .csc file is read
+ */
+static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
+                          int no_side_effects, struct errstat *err)
+{
+    /* loaded from csc2 at this point */
+    int field;
+    int rc;
+    struct schema *schema;
+    char buf[MAXCOLNAME + 1] = {0}; /* scratch space buffer */
+    int offset;
+    int ntags;
+    int itag;
+    char *tag = NULL;
+    int isnull;
+    char tmptagname[MAXTAGLEN] = {0};
+    char *rtag = NULL;
+    int have_comdb2_seqno_field;
+
+    /* save cmacc structures into db structs */
+
+    /* table */
+    ntags = dyns_get_table_count();
+    for (itag = 0; itag < ntags; itag++) {
+        have_comdb2_seqno_field = 0;
+        if (rtag) {
+            free(rtag);
+            rtag = NULL;
+        }
+
+        if (alt == 0) {
+            tag = strdup(dyns_get_table_tag(itag));
+            rtag = strdup(tag);
+        } else {
+            rtag = strdup(dyns_get_table_tag(itag));
+            snprintf(tmptagname, sizeof(tmptagname), ".NEW.%s", rtag);
+            tag = strdup(tmptagname);
+        }
+        schema = calloc(1, sizeof(struct schema));
+        schema->tag = tag;
+
+        add_tag_schema(db->tablename, schema);
+
+        schema->nmembers = dyns_get_table_field_count(rtag);
+        if ((gbl_morecolumns && schema->nmembers > MAXCOLUMNS) ||
+            (!gbl_morecolumns && schema->nmembers > MAXDYNTAGCOLUMNS)) {
+            errstat_set_rcstrf(err, -1, "too many columns (max: %d)",
+                               gbl_morecolumns ? MAXCOLUMNS : MAXDYNTAGCOLUMNS);
+            return -1;
+        }
+        schema->member = calloc(schema->nmembers, sizeof(struct field));
+        schema->flags = SCHEMA_TABLE;
+        schema->recsize = dyns_get_table_tag_size(rtag); /* wrong for .ONDISK */
+        /* we generate these later */
+        schema->ix = NULL;
+        schema->nix = 0;
+        offset = 0;
+        int is_disk_schema = (strncasecmp(rtag, ".ONDISK", 7) == 0);
+
+        for (field = 0; field < schema->nmembers; field++) {
+            int padval;
+            int type;
+            int sz;
+
+            dyns_get_table_field_info(
+                rtag, field, buf, sizeof(buf),
+                (int *)&schema->member[field].type,
+                (int *)&schema->member[field].offset, NULL,
+                (int *)&schema->member[field].len, /* want fullsize, not size */
+                NULL, is_disk_schema);
+            schema->member[field].idx = -1;
+            schema->member[field].name = strdup(buf);
+            schema->member[field].in_default = NULL;
+            schema->member[field].in_default_len = 0;
+            schema->member[field].in_default_type = 0;
+            schema->member[field].flags |= NO_NULL;
+
+            extern int gbl_forbid_ulonglong;
+            if (gbl_forbid_ulonglong &&
+                (schema->member[field].type == SERVER_UINT ||
+                 schema->member[field].type == CLIENT_UINT) &&
+                schema->member[field].len == sizeof(unsigned long long)) {
+                logmsg(LOGMSG_ERROR,
+                       "Error in table %s: u_longlong is unsupported\n",
+                       db->tablename);
+                /* Skip returning error on presence of u_longlong if:
+
+                   - we haven't fully started, or
+                   - we were explicitly asked (by the callers) to do so
+
+                   This is done to allow existing databases with tables
+                   containing u_longlong to start and also certain operational
+                   commands, like table rebuilds, truncates and time partition
+                   rollouts, to succeed.
+                */
+                if (gbl_ready && !allow_ull) {
+                    errstat_set_rcstrf(err, -1, "u_longlong is not supported");
+                    return -1;
+                }
+            }
+
+            /* count the blobs */
+            if (schema->member[field].type == CLIENT_BLOB ||
+                schema->member[field].type == CLIENT_VUTF8 ||
+                schema->member[field].type == CLIENT_BLOB2 ||
+                schema->member[field].type == SERVER_BLOB ||
+                schema->member[field].type == SERVER_BLOB2 ||
+                schema->member[field].type == SERVER_VUTF8) {
+                schema->member[field].blob_index = schema->numblobs;
+                schema->numblobs++;
+            } else {
+                schema->member[field].blob_index = -1;
+            }
+
+            /* for special on-disk schema, change types to be
+               special on-disk types */
+            if (is_disk_schema) {
+                if (strcasecmp(schema->member[field].name, "comdb2_seqno") == 0)
+                    have_comdb2_seqno_field = 1;
+
+                /* cheat: change type to be ondisk type */
+                switch (schema->member[field].type) {
+                case SERVER_BLOB:
+                    /* TODO use the enums that are used in types.c */
+                    /* blobs are stored as flag byte + 32 bit length */
+                    schema->member[field].len = 5;
+                    break;
+                case SERVER_VUTF8:
+                case SERVER_BLOB2:
+                    /* TODO use the enums that are used in types.c */
+                    /* vutf8s are stored as flag byte + 32 bit length, plus
+                     * optionally strings up to a certain length can be stored
+                     * in the record itself */
+                    if (schema->member[field].len == -1)
+                        schema->member[field].len = 5;
+                    else
+                        schema->member[field].len += 5;
+                    break;
+                case SERVER_BCSTR: {
+                    int clnt_type = 0;
+                    int clnt_offset = 0;
+                    int clnt_len = 0;
+
+                    dyns_get_table_field_info(rtag, field, buf, sizeof(buf),
+                                              &clnt_type, &clnt_offset, NULL,
+                                              &clnt_len, NULL, 0);
+
+                    if (clnt_type == CLIENT_PSTR || clnt_type == CLIENT_PSTR2) {
+                        schema->member[field].len++;
+                    } else {
+                        /* no change needed from client length */
+                    }
+                } break;
+                case SERVER_DATETIME:
+                    /* server CLIENT_DATETIME is a server_datetime_t */
+                    schema->member[field].len = sizeof(server_datetime_t);
+                    break;
+                case SERVER_DATETIMEUS:
+                    /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
+                    schema->member[field].len = sizeof(server_datetimeus_t);
+                    break;
+                case SERVER_INTVYM:
+                    /* server CLIENT_INTVYM is a server_intv_ym_t */
+                    schema->member[field].len = sizeof(server_intv_ym_t);
+                    break;
+                case SERVER_INTVDS:
+                    /* server CLIENT_INTVDS is a server_intv_ds_t */
+                    schema->member[field].len = sizeof(server_intv_ds_t);
+                    break;
+                case SERVER_INTVDSUS:
+                    /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
+                    schema->member[field].len = sizeof(server_intv_dsus_t);
+                    break;
+                case SERVER_DECIMAL:
+                    switch (schema->member[field].len) {
+                    case 14:
+                        schema->member[field].len = sizeof(server_decimal32_t);
+                        break;
+                    case 24:
+                        schema->member[field].len = sizeof(server_decimal64_t);
+                        break;
+                    case 43:
+                        schema->member[field].len = sizeof(server_decimal128_t);
+                        break;
+                    default:
+                        abort();
+                    }
+                    break;
+                default:
+                    /* other types just add one for the flag byte */
+                    schema->member[field].len++;
+                    break;
+                }
+                schema->member[field].offset = offset;
+                offset += schema->member[field].len;
+
+                /* correct recsize */
+                if (field == schema->nmembers - 1) {
+                    /* we are on the last field */
+                    schema->recsize = offset;
+                }
+#if 0
+              schema->member[field].type = 
+                  client_type_to_server_type(schema->member[field].type);
+#endif
+                if (!no_side_effects) {
+                    db->schema = schema;
+                    if (db->ixschema)
+                        free(db->ixschema);
+                    db->ixschema = calloc(sizeof(struct schema *), db->nix);
+
+                    db->do_local_replication = have_comdb2_seqno_field;
+                }
+            }
+
+            if (strcmp(rtag, ".ONDISK") == 0) {
+                /* field allowed to be null? */
+                rc = dyns_get_table_field_option(rtag, field, FLDOPT_NULL,
+                                                 &type, &sz, &isnull,
+                                                 sizeof(int), NULL);
+                if (rc == 0 && isnull)
+                    schema->member[field].flags &= ~NO_NULL;
+
+                /* dbpad value (used for byte array conversions).  If it is
+                 * present
+                 * then type must be integer. */
+                rc = dyns_get_table_field_option(rtag, field, FLDOPT_PADDING,
+                                                 &type, &sz, &padval,
+                                                 sizeof(padval), NULL);
+                if (rc == 0 && CLIENT_INT == type) {
+                    schema->member[field].convopts.flags |= FLD_CONV_DBPAD;
+                    schema->member[field].convopts.dbpad = padval;
+                }
+
+                /* input default */
+                rc = init_default_value(&schema->member[field], field,
+                                        FLDOPT_DBSTORE);
+                if (rc != 0) {
+                    if (rtag)
+                        free(rtag);
+                    errstat_set_rcstrf(err, -1, "invalid default column value");
+                    return -1;
+                }
+
+                /* output default  */
+                rc = init_default_value(&schema->member[field], field,
+                                        FLDOPT_DBLOAD);
+                if (rc != 0) {
+                    if (rtag)
+                        free(rtag);
+                    errstat_set_rcstrf(err, -1, "invalid dbpad value");
+                    return -1;
+                }
+            }
+        }
+        if (create_key_schema(db, schema, alt, err) > 0)
+            return -1;
+        if (is_disk_schema) {
+            int i, rc;
+            /* csc2 doesn't have the correct recsize for ondisk schema - use
+             * our value instead. */
+            schema->recsize = offset;
+            if (!alt) {
+                if (!no_side_effects)
+                    db->lrl =
+                        get_size_of_schema_by_name(db->tablename, ".ONDISK");
+                rc = clone_server_to_client_tag(db->tablename, ".ONDISK",
+                                                ".ONDISK_CLIENT");
+            } else {
+                if (!no_side_effects)
+                    db->lrl = get_size_of_schema_by_name(db->tablename,
+                                                         ".NEW..ONDISK");
+                rc = clone_server_to_client_tag(db->tablename, ".NEW..ONDISK",
+                                                ".NEW..ONDISK_CLIENT");
+            }
+            if (rc)
+                logmsg(LOGMSG_ERROR,
+                       "clone_server_to_client_tag returns error rc=%d", rc);
+
+            if (!no_side_effects) {
+                char sname_buf[MAXTAGLEN], cname_buf[MAXTAGLEN];
+                db->nix = dyns_get_idx_count();
+                for (i = 0; i < db->nix; i++) {
+                    if (!alt)
+                        snprintf(tmptagname, sizeof(tmptagname),
+                                 ".ONDISK_ix_%d", i);
+                    else
+                        snprintf(tmptagname, sizeof(tmptagname),
+                                 ".NEW..ONDISK_ix_%d", i);
+                    db->ix_keylen[i] =
+                        get_size_of_schema_by_name(db->tablename, tmptagname);
+
+                    if (!alt) {
+                        snprintf(sname_buf, sizeof(sname_buf), ".ONDISK_IX_%d",
+                                 i);
+                        snprintf(cname_buf, sizeof(cname_buf),
+                                 ".ONDISK_CLIENT_IX_%d", i);
+                    } else {
+                        snprintf(sname_buf, sizeof(sname_buf),
+                                 ".NEW..ONDISK_IX_%d", i);
+                        snprintf(cname_buf, sizeof(cname_buf),
+                                 ".NEW..ONDISK_CLIENT_IX_%d", i);
+                    }
+
+                    clone_server_to_client_tag(db->tablename, sname_buf,
+                                               cname_buf);
+                }
+
+                db->numblobs = schema->numblobs;
+            }
+        }
+    }
+    if (rtag)
+        free(rtag);
+    return 0;
+}
+
+static int init_check_constraints(dbtable *tbl)
+{
+    char *consname = NULL;
+    char *check_expr = NULL;
+    strbuf *sql;
+    int rc;
+
+    tbl->n_check_constraints = dyns_get_check_constraint_count();
+    if (tbl->n_check_constraints == 0) {
+        return 0;
+    }
+
+    tbl->check_constraints =
+        calloc(tbl->n_check_constraints, sizeof(check_constraint_t));
+    tbl->check_constraint_query =
+        calloc(tbl->n_check_constraints, sizeof(char *));
+    if ((tbl->check_constraints == NULL) ||
+        (tbl->check_constraint_query == NULL)) {
+        logmsg(LOGMSG_ERROR, "%s:%d failed to allocate memory\n", __func__,
+               __LINE__);
+        return 1;
+    }
+
+    sql = strbuf_new();
+
+    for (int i = 0; i < tbl->n_check_constraints; i++) {
+        rc = dyns_get_check_constraint_at(i, &consname, &check_expr);
+        if (rc == -1)
+            abort();
+        tbl->check_constraints[i].consname = consname ? strdup(consname) : 0;
+        tbl->check_constraints[i].expr = check_expr ? strdup(check_expr) : 0;
+
+        strbuf_clear(sql);
+
+        strbuf_appendf(sql, "WITH \"%s\" (\"%s\"", tbl->tablename,
+                       tbl->schema->member[0].name);
+        for (int j = 1; j < tbl->schema->nmembers; ++j) {
+            strbuf_appendf(sql, ", %s", tbl->schema->member[j].name);
+        }
+        strbuf_appendf(sql, ") AS (SELECT @%s", tbl->schema->member[0].name);
+        for (int j = 1; j < tbl->schema->nmembers; ++j) {
+            strbuf_appendf(sql, ", @%s", tbl->schema->member[j].name);
+        }
+        strbuf_appendf(sql, ") SELECT (%s) FROM \"%s\"",
+                       tbl->check_constraints[i].expr, tbl->tablename);
+        tbl->check_constraint_query[i] = strdup(strbuf_buf(sql));
+        if (tbl->check_constraint_query[i] == NULL) {
+            logmsg(LOGMSG_ERROR, "%s:%d failed to allocate memory\n", __func__,
+                   __LINE__);
+            cleanup_newdb(tbl);
+            strbuf_free(sql);
+            return 1;
+        }
+    }
+    strbuf_free(sql);
+    return 0;
+}

--- a/db/macc_glue.h
+++ b/db/macc_glue.h
@@ -1,0 +1,32 @@
+/*
+   Copyright 2015, 2021, Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef INCLUDED_MACC_GLUE_H
+#define INCLUDED_MACC_GLUE_H
+
+#include "comdb2.h"
+
+/* create a dbtable with the provided schema "csc2" */
+struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
+                                   char *csc2, int dbnum, int indx,
+                                   int sc_alt_tablename, int allow_ull,
+                                   int no_sideeffects, struct errstat *err);
+
+/* populate an existing db with .NEW tags for provided schema "csc2" */
+int populate_db_with_alt_schema(struct dbenv *dbenv, struct dbtable *db,
+                                char *csc2, struct errstat *err);
+
+#endif /* !INCLUDED_MACC_GLUE_H */

--- a/db/socket_interfaces.c
+++ b/db/socket_interfaces.c
@@ -39,9 +39,6 @@
 #include "socket_interfaces.h"
 #include <endian_core.h>
 
-#include <dynschematypes.h>
-#include <dynschemaload.h>
-
 #include <sys/time.h>
 #include <logmsg.h>
 #include <net_appsock.h>

--- a/db/socket_interfaces.h
+++ b/db/socket_interfaces.h
@@ -38,9 +38,6 @@
 #include "types.h"
 #include "tag.h"
 
-#include <dynschematypes.h>
-#include <dynschemaload.h>
-
 enum sockreq_types {
     SOCKREQ_BLKLONGBEGIN = 100,
     SOCKREQ_SETTIMEOUT = 101,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -52,8 +52,6 @@
 #include "thdpool.h"
 #include "ssl_bend.h"
 
-#include <dynschematypes.h>
-#include <dynschemaload.h>
 #include <cdb2api.h>
 
 #include <sys/time.h>

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -39,9 +39,6 @@
 #include "types.h"
 #include "tag.h"
 
-#include <dynschematypes.h>
-#include <dynschemaload.h>
-
 #include <sqlite3.h>
 #include "comdb2uuid.h"
 

--- a/db/tag.c
+++ b/db/tag.c
@@ -48,9 +48,6 @@
 #include "block_internal.h"
 #include "prefault.h"
 
-#include <dynschematypes.h>
-#include <dynschemaload.h>
-
 #include "sql.h"
 #include <bdb_api.h>
 #include <strbuf.h>
@@ -60,6 +57,7 @@
 #include "debug_switches.h"
 #include "logmsg.h"
 #include "schemachange.h" /* sc_errf() */
+#include "dynschematypes.h"
 
 extern struct dbenv *thedb;
 extern pthread_mutex_t csc2_subsystem_mtx;
@@ -1532,219 +1530,6 @@ int clone_server_to_client_tag(const char *table, const char *fromtag,
 
     unlock_taglock();
     return 0;
-}
-
-char *indexes_expressions_unescape(char *expr);
-extern int gbl_new_indexes;
-/* create keys for each schema */
-static int create_key_schema(dbtable *db, struct schema *schema, int alt,
-                             struct errstat *err)
-{
-    char buf[MAXCOLNAME + 1];
-    int ix;
-    int piece;
-    struct field *m;
-    int offset;
-    char altname[MAXTAGLEN];
-    char tmptagname[MAXTAGLEN + sizeof(".NEW.")];
-    char *where;
-    char *expr;
-    int rc;
-    int ascdesc;
-    char *dbname = db->tablename;
-    struct schema *s;
-
-    /* keys not reqd for ver temp table; just ondisk tag */
-    if (strncasecmp(dbname, gbl_ver_temp_table,
-                    sizeof(gbl_ver_temp_table) - 1) == 0)
-        return 0;
-
-    schema->nix = dyns_get_idx_count();
-    schema->ix = calloc(schema->nix, sizeof(struct schema *));
-
-    for (ix = 0; ix < schema->nix; ix++) {
-        snprintf(buf, sizeof(buf), "%s_ix_%d", schema->tag, ix);
-        s = schema->ix[ix] = calloc(1, sizeof(struct schema));
-
-        s->tag = strdup(buf);
-        s->nmembers = dyns_get_idx_piece_count(ix);
-        s->member = calloc(schema->ix[ix]->nmembers, sizeof(struct field));
-
-        s->flags = SCHEMA_INDEX;
-
-        if (dyns_is_idx_dup(ix))
-            s->flags |= SCHEMA_DUP;
-
-        if (dyns_is_idx_recnum(ix))
-            s->flags |= SCHEMA_RECNUM;
-
-        if (dyns_is_idx_datacopy(ix))
-            s->flags |= SCHEMA_DATACOPY;
-
-        if (dyns_is_idx_uniqnulls(ix))
-            s->flags |= SCHEMA_UNIQNULLS;
-
-        s->nix = 0;
-        s->ix = NULL;
-        s->ixnum = ix;
-        if ((strcasecmp(schema->tag, ".ONDISK") == 0 ||
-             strcasecmp(schema->tag, ".NEW..ONDISK") == 0) &&
-            (db->ixschema && db->ixschema[ix] == NULL))
-            db->ixschema[ix] = s;
-        offset = 0;
-        for (piece = 0; piece < s->nmembers; piece++) {
-            m = &s->member[piece];
-            m->flags = 0;
-            expr = NULL;
-            m->isExpr = 0;
-            dyns_get_idx_piece(ix, piece, buf, sizeof(buf), &m->type,
-                               (int *)&m->offset, (int *)&m->len, &ascdesc,
-                               &expr);
-            if (expr) {
-                expr = indexes_expressions_unescape(expr);
-                m->name = expr;
-                m->isExpr = 1;
-                m->idx = -1;
-                if (expr == NULL) {
-                    errstat_set_rcstrf(err, -1, "unterminated string literal");
-                    rc = 1;
-                    goto errout;
-                }
-                switch (m->type) {
-                case 0:
-                    abort();
-                case SERVER_BLOB:
-                case SERVER_VUTF8:
-                case SERVER_BLOB2:
-                    errstat_set_rcstrf(err, -1, "blob index is not supported.");
-                    rc = 1;
-                    goto errout;
-                case SERVER_BCSTR:
-                    if (m->len < 2) {
-                        errstat_set_rcstrf(
-                            err, -1,
-                            "string must be at least 2 bytes in in length.");
-                        rc = 1;
-                        goto errout;
-                    }
-                    break;
-                case SERVER_DATETIME:
-                    /* server CLIENT_DATETIME is a server_datetime_t */
-                    m->len = sizeof(server_datetime_t);
-                    break;
-                case SERVER_DATETIMEUS:
-                    /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
-                    m->len = sizeof(server_datetimeus_t);
-                    break;
-                case SERVER_INTVYM:
-                    /* server CLIENT_INTVYM is a server_intv_ym_t */
-                    m->len = sizeof(server_intv_ym_t);
-                    break;
-                case SERVER_INTVDS:
-                    /* server CLIENT_INTVDS is a server_intv_ds_t */
-                    m->len = sizeof(server_intv_ds_t);
-                    break;
-                case SERVER_INTVDSUS:
-                    /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
-                    m->len = sizeof(server_intv_dsus_t);
-                    break;
-                case SERVER_DECIMAL:
-                    switch (m->len) {
-                    case 14:
-                        m->len = sizeof(server_decimal32_t);
-                        break;
-                    case 24:
-                        m->len = sizeof(server_decimal64_t);
-                        break;
-                    case 43:
-                        m->len = sizeof(server_decimal128_t);
-                        break;
-                    default:
-                        abort();
-                    }
-                    break;
-                default:
-                    /* other types just add one for the flag byte */
-                    m->len++;
-                    break;
-                }
-                if (offset + m->len > MAXKEYLEN) {
-                    errstat_set_rcstrf(err, -1, "index %d is too large.", ix);
-                    rc = 1;
-                    goto errout;
-                }
-                db->ix_expr = 1;
-            } else {
-                m->name = strdup(buf);
-                m->idx = find_field_idx(dbname, schema->tag, m->name);
-                if (m->idx == -1) {
-                    errstat_set_rcstrf(err, -1, "field %s not found in %s\n",
-                                       m->name, schema->tag);
-                    rc = -ix - 1;
-                    goto errout;
-                }
-                m->type = schema->member[m->idx].type;
-                m->len = schema->member[m->idx].len;
-
-                /* the dbstore default is still needed during schema change, so
-                 * populate that */
-                if (schema->member[m->idx].in_default) {
-                    m->in_default =
-                        malloc(schema->member[m->idx].in_default_len);
-                    m->in_default_len = schema->member[m->idx].in_default_len;
-                    m->in_default_type = schema->member[m->idx].in_default_type;
-                    memcpy(m->in_default, schema->member[m->idx].in_default,
-                           m->in_default_len);
-                }
-                memcpy(&m->convopts, &schema->member[m->idx].convopts,
-                       sizeof(struct field_conv_opts));
-                if (gbl_new_indexes && strncasecmp(dbname, "sqlite_stat", 11) &&
-                    strcasecmp(dbname, "comdb2_oplog") &&
-                    strcasecmp(dbname, "comdb2_commit_log") &&
-                    (!gbl_replicate_local ||
-                     strcasecmp(m->name, "comdb2_seqno"))) {
-                    m->isExpr = 1;
-                    db->ix_partial = 1;
-                    db->ix_expr = 1;
-                }
-            }
-            if (ascdesc)
-                m->flags |= INDEX_DESCEND;
-            /* we could check here if there are decimals in the index, and mark
-             * it "datacopy" special */
-            if (db->ix_datacopy[ix] == 0 && m->type == SERVER_DECIMAL) {
-                db->ix_collattr[ix]++; /* special tail */
-            } else if (m->type == SERVER_DECIMAL) {
-                db->ix_datacopy[ix]++; /* special tail */
-            }
-            m->offset = offset;
-            offset += m->len;
-        }
-        /* rest of fields irrelevant for indexes */
-        add_tag_schema(dbname, s);
-        rc = dyns_get_idx_tag(ix, altname, MAXTAGLEN, &where);
-        if (rc == 0 && (strcasecmp(schema->tag, ".ONDISK") == 0 ||
-                        strcasecmp(schema->tag, ".NEW..ONDISK") == 0)) {
-            if (alt == 0) {
-                add_tag_alias(dbname, s, altname);
-            } else {
-                snprintf(tmptagname, sizeof(tmptagname), ".NEW.%s", altname);
-                add_tag_alias(dbname, s, tmptagname);
-            }
-            if (where) {
-                s->where = strdup(where);
-                db->ix_partial = 1;
-            }
-        }
-    }
-    return 0;
-
-errout:
-    freeschema(s);
-    free(schema->ix);
-    schema->ix = NULL;
-    schema->nix = 0;
-    return rc;
 }
 
 /* Given a partial string, find the length of a key.
@@ -4739,467 +4524,6 @@ void printrecord(char *buf, struct schema *sc, int len)
     logmsg(LOGMSG_USER, "] ");
 }
 
-/* Setup the dbload/dbstore values for a field.  Only do this for the
- * ondisk tag.  The in/out default values are stored in server format
- * but with the same type as the dbload/dbstore value uses in the csc2
- * (why? - why not just convert it here so later on we can memcpy?)
- */
-static int init_default_value(struct field *fld, int fldn, int loadstore)
-{
-    const char *name;
-    void **p_default;
-    int *p_default_len;
-    int *p_default_type;
-    int mastersz;
-    void *typebuf = NULL;
-    int opttype = 0;
-    int optsz;
-    int rc, outrc = 0;
-
-    switch (loadstore) {
-    case FLDOPT_DBSTORE:
-        name = "dbstore";
-        p_default = &fld->in_default;
-        p_default_len = &fld->in_default_len;
-        p_default_type = &fld->in_default_type;
-        break;
-
-    case FLDOPT_DBLOAD:
-        name = "dbload";
-        p_default = &fld->out_default;
-        p_default_len = &fld->out_default_len;
-        p_default_type = &fld->out_default_type;
-        break;
-
-    default:
-        logmsg(LOGMSG_FATAL, "init_default_value: loadstore=%d?!\n", loadstore);
-        exit(1);
-    }
-
-    if (fld->type == SERVER_VUTF8) {
-        mastersz = 16 * 1024;
-    } else if (fld->type == SERVER_DATETIME || fld->type == SERVER_DATETIMEUS) {
-        mastersz = CLIENT_DATETIME_EXT_LEN; /* We want to get back cstring here. */
-    } else {
-        mastersz = max_type_size(fld->type, fld->len);
-    }
-
-    if (mastersz > 0)
-        typebuf = calloc(1, mastersz);
-
-    char *func_str = NULL;
-    rc = dyns_get_table_field_option(".ONDISK", fldn, loadstore, &opttype,
-                                     &optsz, typebuf, mastersz, &func_str);
-
-    *p_default = NULL;
-    *p_default_len = 0;
-
-    if (rc == -1 && opttype != CLIENT_MINTYPE) {
-        /* csc2 doesn't like its default value data, or our buffer is too small
-         */
-        logmsg(LOGMSG_ERROR, "init_default_value: %s for %s is invalid\n", name,
-                fld->name);
-        outrc = -1;
-    } else if (rc == 0) {
-        int outdtsz;
-        int is_null = 0;
-
-        /* if we are dealing with a default for vutf8 we must be sure to save it
-         * a
-         * as a cstring, we don't want to have to hold on to a "default blob" */
-        if (opttype == CLIENT_VUTF8) {
-            opttype = CLIENT_CSTR;
-            *p_default_len = optsz + 1 /* csc2lib doesn't count NUL byte*/;
-        } else
-            *p_default_len = fld->len;
-
-        *p_default_type = client_type_to_server_type(opttype);
-
-        if(opttype  == CLIENT_FUNCTION) {
-            *p_default = strdup(func_str);
-            outrc = 0;
-            goto out;
-        }
-
-        *p_default = calloc(1, *p_default_len);
-
-        if (opttype == CLIENT_DATETIME || opttype == CLIENT_DATETIMEUS) {
-            opttype = CLIENT_CSTR;
-            if (strncasecmp(typebuf, "CURRENT_TIMESTAMP", 17) == 0)
-                is_null = 1; /* use isnull flag for current timestamp since
-                                null=yes is used for dbstore null */
-        }
-
-        if (*p_default == NULL) {
-            logmsg(LOGMSG_ERROR, "init_default_value: out of memory\n");
-            outrc = -1;
-        } else {
-            /* csc2lib doesn't count the \0 in the size for cstrings - but type
-             * system does and will balk if no \0 is found. */
-            if (opttype == CLIENT_CSTR)
-                optsz++;
-
-            if (opttype == CLIENT_SEQUENCE && loadstore == FLDOPT_DBSTORE) {
-                set_resolve_master(*p_default, *p_default_len);
-                rc = 0;
-            } else {
-                rc = CLIENT_to_SERVER(typebuf, optsz, opttype, is_null /*isnull*/, NULL /*convopts*/, NULL /*blob*/,
-                                      *p_default, *p_default_len, *p_default_type, 0, &outdtsz, &fld->convopts,
-                                      NULL /*blob*/);
-            }
-            if (rc == -1) {
-                logmsg(LOGMSG_ERROR, "%s initialisation failed for field %s\n", name,
-                       fld->name);
-                free(*p_default);
-                *p_default = NULL;
-                *p_default_len = 0;
-                *p_default_type = 0;
-                outrc = -1;
-            }
-        }
-    }
-
-out:
-    if (typebuf)
-        free(typebuf);
-
-    return outrc;
-}
-
-/* have a cmacc parsed and sanity-checked csc schema.
-   convert to sql statement, execute, save schema in db
-   structure and sanity check again (sqlite schema must
-   match cmacc).  libcmacc2 puts results into globals.
-   process them here after each .csc file is read
- */
-static int add_cmacc_stmt_int(dbtable *db, int alt, int side_effects,
-                              int allow_ull, struct errstat *err)
-{
-    /* loaded from csc2 at this point */
-    int field;
-    int rc;
-    struct schema *schema;
-    char buf[MAXCOLNAME + 1] = {0}; /* scratch space buffer */
-    int offset;
-    int ntags;
-    int itag;
-    char *tag = NULL;
-    int isnull;
-    char tmptagname[MAXTAGLEN] = {0};
-    char *rtag = NULL;
-    int have_comdb2_seqno_field;
-
-    /* save cmacc structures into db structs */
-
-    /* table */
-    ntags = dyns_get_table_count();
-    for (itag = 0; itag < ntags; itag++) {
-        have_comdb2_seqno_field = 0;
-        if (rtag) {
-            free(rtag);
-            rtag = NULL;
-        }
-
-        if (alt == 0) {
-            tag = strdup(dyns_get_table_tag(itag));
-            rtag = strdup(tag);
-        } else {
-            rtag = strdup(dyns_get_table_tag(itag));
-            snprintf(tmptagname, sizeof(tmptagname), ".NEW.%s", rtag);
-            tag = strdup(tmptagname);
-        }
-        schema = calloc(1, sizeof(struct schema));
-        schema->tag = tag;
-
-        add_tag_schema(db->tablename, schema);
-
-        schema->nmembers = dyns_get_table_field_count(rtag);
-        if ((gbl_morecolumns && schema->nmembers > MAXCOLUMNS) ||
-            (!gbl_morecolumns && schema->nmembers > MAXDYNTAGCOLUMNS)) {
-            errstat_set_rcstrf(err, -1, "too many columns (max: %d)",
-                               gbl_morecolumns ? MAXCOLUMNS : MAXDYNTAGCOLUMNS);
-            return -1;
-        }
-        schema->member = calloc(schema->nmembers, sizeof(struct field));
-        schema->flags = SCHEMA_TABLE;
-        schema->recsize = dyns_get_table_tag_size(rtag); /* wrong for .ONDISK */
-        /* we generate these later */
-        schema->ix = NULL;
-        schema->nix = 0;
-        offset = 0;
-        int is_disk_schema = (strncasecmp(rtag, ".ONDISK", 7) == 0);
-
-        for (field = 0; field < schema->nmembers; field++) {
-            int padval;
-            int type;
-            int sz;
-
-            dyns_get_table_field_info(
-                rtag, field, buf, sizeof(buf),
-                (int *)&schema->member[field].type,
-                (int *)&schema->member[field].offset, NULL,
-                (int *)&schema->member[field].len, /* want fullsize, not size */
-                NULL, is_disk_schema);
-            schema->member[field].idx = -1;
-            schema->member[field].name = strdup(buf);
-            schema->member[field].in_default = NULL;
-            schema->member[field].in_default_len = 0;
-            schema->member[field].in_default_type = 0;
-            schema->member[field].flags |= NO_NULL;
-
-            extern int gbl_forbid_ulonglong;
-            if (gbl_forbid_ulonglong &&
-                (schema->member[field].type == SERVER_UINT ||
-                 schema->member[field].type == CLIENT_UINT) &&
-                schema->member[field].len == sizeof(unsigned long long) &&
-                strncasecmp(db->tablename, gbl_ver_temp_table,
-                            sizeof(gbl_ver_temp_table) - 1) != 0) {
-                logmsg(LOGMSG_ERROR,
-                       "Error in table %s: u_longlong is unsupported\n",
-                       db->tablename);
-                /* Skip returning error on presence of u_longlong if:
-
-                   - we haven't fully started, or
-                   - we are rolling out a new time partition shard, or
-                   - we were explicitly asked (by the callers) to do so
-
-                   This is done to allow existing databases with tables
-                   containing u_longlong to start and also certain operational
-                   commands, like table rebuilds, truncates and time partition
-                   rollouts, to succeed.
-                */
-                if (gbl_ready && !allow_ull && !db->timepartition_name) {
-                    errstat_set_rcstrf(err, -1, "u_longlong is not supported");
-                    return -1;
-                }
-            }
-
-            /* count the blobs */
-            if (schema->member[field].type == CLIENT_BLOB ||
-                schema->member[field].type == CLIENT_VUTF8 ||
-                schema->member[field].type == CLIENT_BLOB2 ||
-                schema->member[field].type == SERVER_BLOB ||
-                schema->member[field].type == SERVER_BLOB2 ||
-                schema->member[field].type == SERVER_VUTF8) {
-                schema->member[field].blob_index = schema->numblobs;
-                schema->numblobs++;
-            } else {
-                schema->member[field].blob_index = -1;
-            }
-
-            /* for special on-disk schema, change types to be
-               special on-disk types */
-            if (is_disk_schema) {
-                if (strcasecmp(schema->member[field].name, "comdb2_seqno") == 0)
-                    have_comdb2_seqno_field = 1;
-
-                /* cheat: change type to be ondisk type */
-                switch (schema->member[field].type) {
-                case SERVER_BLOB:
-                    /* TODO use the enums that are used in types.c */
-                    /* blobs are stored as flag byte + 32 bit length */
-                    schema->member[field].len = 5;
-                    break;
-                case SERVER_VUTF8:
-                case SERVER_BLOB2:
-                    /* TODO use the enums that are used in types.c */
-                    /* vutf8s are stored as flag byte + 32 bit length, plus
-                     * optionally strings up to a certain length can be stored
-                     * in the record itself */
-                    if (schema->member[field].len == -1)
-                        schema->member[field].len = 5;
-                    else
-                        schema->member[field].len += 5;
-                    break;
-                case SERVER_BCSTR: {
-                    int clnt_type = 0;
-                    int clnt_offset = 0;
-                    int clnt_len = 0;
-
-                    dyns_get_table_field_info(rtag, field, buf, sizeof(buf),
-                                              &clnt_type, &clnt_offset, NULL,
-                                              &clnt_len, NULL, 0);
-
-                    if (clnt_type == CLIENT_PSTR || clnt_type == CLIENT_PSTR2) {
-                        schema->member[field].len++;
-                    } else {
-                        /* no change needed from client length */
-                    }
-                } break;
-                case SERVER_DATETIME:
-                    /* server CLIENT_DATETIME is a server_datetime_t */
-                    schema->member[field].len = sizeof(server_datetime_t);
-                    break;
-                case SERVER_DATETIMEUS:
-                    /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
-                    schema->member[field].len = sizeof(server_datetimeus_t);
-                    break;
-                case SERVER_INTVYM:
-                    /* server CLIENT_INTVYM is a server_intv_ym_t */
-                    schema->member[field].len = sizeof(server_intv_ym_t);
-                    break;
-                case SERVER_INTVDS:
-                    /* server CLIENT_INTVDS is a server_intv_ds_t */
-                    schema->member[field].len = sizeof(server_intv_ds_t);
-                    break;
-                case SERVER_INTVDSUS:
-                    /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
-                    schema->member[field].len = sizeof(server_intv_dsus_t);
-                    break;
-                case SERVER_DECIMAL:
-                    switch (schema->member[field].len) {
-                    case 14:
-                        schema->member[field].len = sizeof(server_decimal32_t);
-                        break;
-                    case 24:
-                        schema->member[field].len = sizeof(server_decimal64_t);
-                        break;
-                    case 43:
-                        schema->member[field].len = sizeof(server_decimal128_t);
-                        break;
-                    default:
-                        abort();
-                    }
-                    break;
-                default:
-                    /* other types just add one for the flag byte */
-                    schema->member[field].len++;
-                    break;
-                }
-                schema->member[field].offset = offset;
-                offset += schema->member[field].len;
-
-                /* correct recsize */
-                if (field == schema->nmembers - 1) {
-                    /* we are on the last field */
-                    schema->recsize = offset;
-                }
-#if 0
-              schema->member[field].type = 
-                  client_type_to_server_type(schema->member[field].type);
-#endif
-                if (side_effects) {
-                    db->schema = schema;
-                    if (db->ixschema)
-                        free(db->ixschema);
-                    db->ixschema = calloc(sizeof(struct schema *), db->nix);
-
-                    db->do_local_replication = have_comdb2_seqno_field;
-                }
-            }
-
-            if (strcmp(rtag, ".ONDISK") == 0) {
-                /* field allowed to be null? */
-                rc = dyns_get_table_field_option(
-                    rtag, field, FLDOPT_NULL, &type, &sz, &isnull, sizeof(int), NULL);
-                if (rc == 0 && isnull)
-                    schema->member[field].flags &= ~NO_NULL;
-
-                /* dbpad value (used for byte array conversions).  If it is
-                 * present
-                 * then type must be integer. */
-                rc = dyns_get_table_field_option(rtag, field, FLDOPT_PADDING,
-                                                 &type, &sz, &padval,
-                                                 sizeof(padval), NULL);
-                if (rc == 0 && CLIENT_INT == type) {
-                    schema->member[field].convopts.flags |= FLD_CONV_DBPAD;
-                    schema->member[field].convopts.dbpad = padval;
-                }
-
-                /* input default */
-                rc = init_default_value(&schema->member[field], field, FLDOPT_DBSTORE);
-                if (rc != 0) {
-                    if (rtag)
-                        free(rtag);
-                    errstat_set_rcstrf(err, -1, "invalid default column value");
-                    return -1;
-                }
-
-                /* output default  */
-                rc = init_default_value(&schema->member[field], field, FLDOPT_DBLOAD);
-                if (rc != 0) {
-                    if (rtag)
-                        free(rtag);
-                    errstat_set_rcstrf(err, -1, "invalid dbpad value");
-                    return -1;
-                }
-            }
-        }
-        if (create_key_schema(db, schema, alt, err) > 0)
-            return -1;
-        if (is_disk_schema) {
-            int i, rc;
-            /* csc2 doesn't have the correct recsize for ondisk schema - use
-             * our value instead. */
-            schema->recsize = offset;
-            if (!alt) {
-                if (side_effects)
-                    db->lrl =
-                        get_size_of_schema_by_name(db->tablename, ".ONDISK");
-                rc = clone_server_to_client_tag(db->tablename, ".ONDISK",
-                                                ".ONDISK_CLIENT");
-            } else {
-                if (side_effects)
-                    db->lrl = get_size_of_schema_by_name(db->tablename,
-                                                         ".NEW..ONDISK");
-                rc = clone_server_to_client_tag(db->tablename, ".NEW..ONDISK",
-                                                ".NEW..ONDISK_CLIENT");
-            }
-            if (rc)
-                logmsg(LOGMSG_ERROR,
-                       "clone_server_to_client_tag returns error rc=%d", rc);
-
-            if (side_effects) {
-                char sname_buf[MAXTAGLEN], cname_buf[MAXTAGLEN];
-                db->nix = dyns_get_idx_count();
-                for (i = 0; i < db->nix; i++) {
-                    if (!alt)
-                        snprintf(tmptagname, sizeof(tmptagname),
-                                 ".ONDISK_ix_%d", i);
-                    else
-                        snprintf(tmptagname, sizeof(tmptagname),
-                                 ".NEW..ONDISK_ix_%d", i);
-                    db->ix_keylen[i] =
-                        get_size_of_schema_by_name(db->tablename, tmptagname);
-
-                    if (!alt) {
-                        snprintf(sname_buf, sizeof(sname_buf), ".ONDISK_IX_%d",
-                                 i);
-                        snprintf(cname_buf, sizeof(cname_buf),
-                                 ".ONDISK_CLIENT_IX_%d", i);
-                    } else {
-                        snprintf(sname_buf, sizeof(sname_buf),
-                                 ".NEW..ONDISK_IX_%d", i);
-                        snprintf(cname_buf, sizeof(cname_buf),
-                                 ".NEW..ONDISK_CLIENT_IX_%d", i);
-                    }
-
-                    clone_server_to_client_tag(db->tablename, sname_buf,
-                                               cname_buf);
-                }
-
-                db->numblobs = schema->numblobs;
-            }
-        }
-    }
-    if (rtag)
-        free(rtag);
-    return 0;
-}
-
-int add_cmacc_stmt(dbtable *db, int alt, int allow_ull, struct errstat *err)
-{
-    return add_cmacc_stmt_int(db, alt, 1, allow_ull, err);
-}
-int add_cmacc_stmt_no_side_effects(dbtable *db, int alt)
-{
-    struct errstat err = {0};
-    int rc = add_cmacc_stmt_int(db, alt, 0, 0, &err);
-    if (rc)
-        logmsg(LOGMSG_ERROR, "%s\n", err.errstr);
-    return rc;
-}
-
 /* this routine is called from comdb2 when all is well
    (we checked that all schemas are defined, etc.) */
 void fix_lrl_ixlen_tran(tran_type *tran)
@@ -6785,47 +6109,35 @@ void freedb(dbtable *db)
 struct schema *create_version_schema(char *csc2, int version,
                                      struct dbenv *dbenv)
 {
+    struct schema *ver_schema = NULL;
     dbtable *ver_db;
     char *tag;
-    int rc;
+    struct errstat err = {0};
 
     Pthread_mutex_lock(&csc2_subsystem_mtx);
-    dyns_init_globals();
-    rc = dyns_load_schema_string(csc2, dbenv->envname, gbl_ver_temp_table);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "dyns_load_schema_string failed %s:%d\n", __FILE__,
-                __LINE__);
-        goto err;
-    }
 
-    ver_db = newdb_from_schema(dbenv, gbl_ver_temp_table, NULL, 0, 0);
-    if (ver_db == NULL) {
-        logmsg(LOGMSG_ERROR, "newdb_from_schema failed %s:%d\n", __FILE__, __LINE__);
-        goto err;
-    }
-
-    rc = add_cmacc_stmt_no_side_effects(ver_db, 0);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "add_cmacc_stmt failed %s:%d\n", __FILE__, __LINE__);
-        goto err;
+    ver_db = create_new_dbtable(
+        thedb, gbl_ver_temp_table, csc2, 0 /* no altname */, 0 /* fake dbnum */,
+        0 /* fake dbs_idx */, 1 /* allow ull */, 1 /* no side effects */, &err);
+    if (!ver_db) {
+        logmsg(LOGMSG_ERROR, "%s\ncsc2: \"%s\"\n", err.errstr, csc2);
+        goto done;
     }
 
     struct schema *s = find_tag_schema(gbl_ver_temp_table, ".ONDISK");
     if (s == NULL) {
         logmsg(LOGMSG_ERROR, "find_tag_schema failed %s:%d\n", __FILE__, __LINE__);
-        goto err;
+        goto done;
     }
 
     tag = malloc(gbl_ondisk_ver_len);
     if (tag == NULL) {
         logmsg(LOGMSG_ERROR, "malloc failed %s:%d\n", __FILE__, __LINE__);
-        goto err;
+        goto done;
     }
-    dyns_cleanup_globals();
-    Pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     sprintf(tag, gbl_ondisk_ver_fmt, version);
-    struct schema *ver_schema = clone_schema(s);
+    ver_schema = clone_schema(s);
     free(ver_schema->tag);
     ver_schema->tag = tag;
 
@@ -6837,12 +6149,9 @@ struct schema *create_version_schema(char *csc2, int version,
     delete_schema(ver_db->tablename);
     freedb(ver_db);
 
-    return ver_schema;
-
-err:
-    dyns_cleanup_globals();
+done:
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
-    return NULL;
+    return ver_schema;
 }
 
 static void clear_existing_schemas(dbtable *db)
@@ -6904,39 +6213,16 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
         goto err;
     }
 
-    dyns_init_globals();
-    rc = dyns_load_schema_string(csc2, db->dbenv->envname, db->tablename);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "dyns_load_schema_string failed %s:%d\n", __FILE__,
-                __LINE__);
-        logmsg(LOGMSG_ERROR, "rc: %d len: %d csc2:\n%s\n", rc, len, csc2);
+    struct errstat err = {0};
+    dbtable *newdb = create_new_dbtable(thedb, db->tablename, csc2, db->dbnum,
+                                        foundix, 0, 1, 0, &err);
+    if (!newdb) {
+        logmsg(LOGMSG_ERROR, "%s (%s:%d)\n", err.errstr, __FILE__, __LINE__);
         goto err;
     }
 
-    dbtable *newdb =
-        newdb_from_schema(db->dbenv, db->tablename, NULL, db->dbnum, foundix);
-    if (newdb == NULL) {
-        logmsg(LOGMSG_ERROR, "newdb_from_schema failed %s:%d\n", __FILE__, __LINE__);
-        goto err;
-    }
     newdb->schema_version = version;
     newdb->dbnum = db->dbnum;
-    struct errstat err = {0};
-    rc = add_cmacc_stmt(newdb, 0, 1, &err);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "add_cmacc_stmt failed %s:%d\n%s\n", __FILE__,
-               __LINE__, err.errstr);
-        goto err;
-    }
-
-    /* Initialize table's check constraint members. */
-    rc = init_check_constraints(newdb);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "Failed to load check constraints for %s\n",
-               newdb->tablename);
-        goto err;
-    }
-
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 
@@ -6956,7 +6242,6 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
         cheap_stack_trace();
         goto err;
     }
-    dyns_cleanup_globals();
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
 
     old_bdb_handle = db->handle;
@@ -6986,7 +6271,6 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
     return 0;
 
 err:
-    dyns_cleanup_globals();
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
     free(csc2);
     return 1;

--- a/db/tag.h
+++ b/db/tag.h
@@ -419,4 +419,11 @@ int create_key_from_ireq(struct ireq *iq, int ixnum, int isDelete, char **tail,
 char* typestr(int type, int len);
 
 struct schema *get_schema(const struct dbtable *db, int ix);
+
+int find_field_idx(const char *table, const char *tagname, const char *field);
+
+/* used to clone ONDISK to ONDISK_CLIENT */
+int clone_server_to_client_tag(const char *table, const char *fromtag,
+                               const char *newtag);
+
 #endif

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -25,6 +25,7 @@
 #include "sc_logic.h"
 #include "sc_csc2.h"
 #include "views.h"
+#include "macc_glue.h"
 
 extern int gbl_is_physical_replicant;
 
@@ -112,44 +113,23 @@ int add_table_to_environment(char *table, const char *csc2,
         return -1;
     }
 
-    rc = dyns_load_schema_string((char *)csc2, thedb->envname, table);
-
-    if (rc) {
-        char *err;
-        char *syntax_err;
-        err = csc2_get_errors();
-        syntax_err = csc2_get_syntax_errors();
-        sc_client_error(s, "%s", syntax_err);
-        sc_errf(s, "%s\n", err);
+    struct errstat err = {0};
+    newdb = create_new_dbtable(thedb, table, (char *)csc2, 0 /*dbnum*/,
+                               thedb->num_dbs, 0 /*no altname*/,
+                               timepartition_name ? 1 : 0 /* allow null if tpt rollout */, 
+                               0 /* side effects */, &err);
+    if (!newdb) {
+        sc_client_error(s, "%s", err.errstr);
         sc_errf(s, "error adding new table locally\n");
         logmsg(LOGMSG_INFO, "Failed to load schema for table %s\n", table);
         logmsg(LOGMSG_INFO, "Dumping schema for reference: '%s'\n", csc2);
-        return SC_CSC2_ERROR;
-    }
-    newdb = newdb_from_schema(thedb, table, NULL, 0, thedb->num_dbs);
 
-    if (newdb == NULL) {
-        return SC_INTERNAL_ERROR;
+        return SC_CSC2_ERROR;
     }
 
     newdb->dtastripe = gbl_dtastripe;
     newdb->iq = iq;
     newdb->timepartition_name = timepartition_name;
-
-    struct errstat err = {0};
-    if (add_cmacc_stmt(newdb, 0, 0, &err)) {
-        logmsg(LOGMSG_ERROR, "%s: add_cmacc_stmt failed\n", __func__);
-        sc_client_error(s, "%s", err.errstr);
-        rc = SC_CSC2_ERROR;
-        goto err;
-    }
-
-    if (init_check_constraints(newdb)) {
-        logmsg(LOGMSG_ERROR, "%s: failed to initialize check constraint(s)\n",
-               __func__);
-        rc = SC_CSC2_ERROR;
-        goto err;
-    }
 
     if ((iq == NULL || iq->tranddl <= 1) &&
         verify_constraints_exist(newdb, NULL, NULL, s) != 0) {
@@ -253,11 +233,9 @@ int do_add_table(struct ireq *iq, struct schema_change_type *s,
         local_lock = 1;
     }
     Pthread_mutex_lock(&csc2_subsystem_mtx);
-    dyns_init_globals();
     rc = add_table_to_environment(s->tablename, s->newcsc2, s, iq, trans,
                                   s->timepartition_name);
 
-    dyns_cleanup_globals();
     Pthread_mutex_unlock(&csc2_subsystem_mtx);
     if (rc) {
         sc_errf(s, "error adding new table locally\n");

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -771,10 +771,8 @@ static int scdone_add(const char tablename[], void *arg, scdone_t type)
 
     logmsg(LOGMSG_INFO, "Replicant adding table:%s\n", tablename);
 
-    dyns_init_globals();
     rc = add_table_to_environment(table_copy, csc2text, NULL, NULL, tran,
                                   timepart_is_next_shard(table_copy, NULL));
-    dyns_cleanup_globals();
     if (rc) {
         logmsg(LOGMSG_FATAL, "%s: error adding table %s.\n", __func__,
                tablename);

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -31,6 +31,7 @@
 #include "sc_alter_table.h"
 #include "sc_util.h"
 #include "views.h"
+#include "macc_glue.h"
 
 extern int gbl_broken_max_rec_sz;
 
@@ -89,7 +90,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     int saved_broken_max_rec_sz = fix_broken_max_rec_sz(s->db->lrl);
     newdb = s->newdb =
         create_new_dbtable(thedb, s->tablename, s->newcsc2, db->dbnum, foundix,
-                           1 /* sc_alt_name */, 1 /* allow ull */, &err);
+                           1 /* sc_alt_name */, 1 /* allow ull */, 0, &err);
     gbl_broken_max_rec_sz = saved_broken_max_rec_sz;
 
     if (!newdb) {

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -19,6 +19,7 @@
 #include "logmsg.h"
 #include "sc_csc2.h"
 #include "sc_schema.h"
+#include "macc_glue.h"
 
 /************ SCHEMACHANGE TO BUF UTILITY FUNCTIONS
  * *****************************/
@@ -877,11 +878,7 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
     void *old_bdb_handle, *new_bdb_handle;
     struct dbtable *newdb;
     int changed = 0;
-
-    int rc = dyns_load_schema_string((char *)csc2, thedb->envname, table);
-    if (rc != 0) {
-        return rc;
-    }
+    int rc;
 
     int foundix = getdbidxbyname_ll(table);
     if (foundix == -1) {
@@ -889,23 +886,18 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
         exit(1);
     }
 
-    /* TODO remove NULL arg; pre-llmeta holdover */
-    newdb = newdb_from_schema(thedb, table, NULL, db->dbnum, foundix);
+    struct errstat err = {0};
+    newdb = create_new_dbtable(thedb, table, (char *)csc2, db->dbnum, foundix,
+                               1, 1, 0, &err);
+
     if (newdb == NULL) {
         /* shouldn't happen */
+        logmsg(LOGMSG_ERROR, "%s (%s:%d)\n", err.errstr, __FILE__, __LINE__);
         backout_schemas(table);
         return 1;
     }
+
     newdb->dbnum = db->dbnum;
-    struct errstat err = {0};
-    rc = add_cmacc_stmt(newdb, 1, 1, &err);
-    if (rc)
-        logmsg(LOGMSG_ERROR, "%s\n", err.errstr);
-    if (rc || (init_check_constraints(newdb))) {
-        /* can happen if new schema has no .DEFAULT tag but needs one */
-        backout_schemas(table);
-        return 1;
-    }
     newdb->meta = db->meta;
     newdb->dtastripe = gbl_dtastripe;
 
@@ -1009,9 +1001,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
 
     if (csc2) {
         /* genuine schema change. */
-        dyns_init_globals();
         int rc = reload_csc2_schema(db, tran, csc2, table);
-        dyns_cleanup_globals();
         if (rc)
             return rc;
     } else {

--- a/schemachange/sc_util.c
+++ b/schemachange/sc_util.c
@@ -17,6 +17,7 @@
 #include "schemachange.h"
 #include "sc_util.h"
 #include "logmsg.h"
+#include "cdb2_constants.h"
 
 int close_all_dbs_tran(tran_type *tran)
 {

--- a/sqlite/ext/comdb2/limits.c
+++ b/sqlite/ext/comdb2/limits.c
@@ -25,7 +25,6 @@
 #include "comdb2systbl.h"
 #include "comdb2systblInt.h"
 #include "cdb2_constants.h"
-#include "csc2/dynschemaload.h" //MAXIDXNAMELEN
 #include "sqliteLimit.h"
 
 struct limit_t {


### PR DESCRIPTION
Last phase of cmacc encapsulation.  
All code that uses cmacc/yacc library is in macc_glue.c, which is accessed by either create_new_dbtable() or populate_db_with_alt_schema() api.  This consolidates code from comdb2.c and tag.c.
macc_glue.c serves as an abstraction layer between csc2 parser code and the rest of the system.  It provides a new dbtable created based on a csc2 cstring, or augments an existing dbtable with new .NEW schema definition based on provided csc2 cstring.



Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
