### PR TITLE
Two simple fixes for newsc

### DIFF
--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -188,10 +188,10 @@ int add_snapisol_logging(bdb_state_type *bdb_state, tran_type *tran)
                            "%s: failed to init dirty table hash\n", __func__);
                     abort();
                 }
-                if (hash_find_readonly(tran->dirty_table_hash,
+            }
+            if (hash_find_readonly(tran->dirty_table_hash,
                                        &(bdb_state->name)) == NULL) {
-                    hash_add(tran->dirty_table_hash, bdb_state);
-                }
+                hash_add(tran->dirty_table_hash, bdb_state);
             }
         }
         return 1;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1408,18 +1408,15 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                   s->tablename);
         thdData->isThread = 1;
 
-        if (BDB_ATTR_GET(thedb->bdb_attr, SNAPISOL) == 0) {
-            /* enable logical logging for this table for the duration of the
-             * schema change */
-            rc = bdb_set_logical_live_sc(s->db->handle, 1 /* lock table */);
-            if (rc) {
-                logmsg(LOGMSG_ERROR,
-                       "%s:%d failed to set logical live sc, rc = %d\n",
-                       __func__, __LINE__, rc);
-                free(s->sc_convert_done);
-                s->sc_convert_done = NULL;
-                return -1;
-            }
+        /* enable logical logging for this table for the duration of the schema change */
+        rc = bdb_set_logical_live_sc(s->db->handle, 1 /* lock table */);
+        if (rc) {
+            logmsg(LOGMSG_ERROR,
+                    "%s:%d failed to set logical live sc, rc = %d\n",
+                    __func__, __LINE__, rc);
+            free(s->sc_convert_done);
+            s->sc_convert_done = NULL;
+            return -1;
         }
 
         s->logical_livesc = 1;


### PR DESCRIPTION
Two fixes: add to the dirty_table hash correctly in ll.c (not just when the hash is created), and work correctly if snapshot is enabled (bdb_set_logical_live_sc sets bdb_state->logical_live_sc flag).