### PR TITLE
Fixing a minor memory leak in fileid hash

### DIFF
--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -845,7 +845,8 @@ __db_refresh(dbp, txn, flags, deferred_closep)
 	DB_LOCKREQ lreq;
 	DB_MPOOL *dbmp;
 	int ret, t_ret;
-    int aft, bef;
+	int aft, bef;
+	struct fileid_adj_fileid *fidadj;
 
 	ret = 0;
 
@@ -1069,6 +1070,10 @@ never_opened:
         if (gbl_instrument_dblist && aft != (bef - 1))
             abort();
 		if (dbp->inadjlist) {
+			if ((fidadj = hash_find(dbenv->fidhash, dbp->fileid)) != NULL) {
+				hash_del(dbenv->fidhash, fidadj);
+				free(fidadj);
+			}
 			listc_rfl(&dbenv->dbs[dbp->adj_fileid], dbp);
 			dbp->inadjlist = 0;
             if (gbl_instrument_dblist)


### PR DESCRIPTION
A DB's fileid hash entry needs to be freed in __db_refresh(), in case the DB's DBENV is never refreshed.