### PR TITLE
Fix memory corruptions in reqlogger

### DIFF
--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -63,6 +63,8 @@ struct tablelist {
 struct reqlogger {
     char origin[128];
 
+    pthread_mutex_t mtx;
+
     /* Everything from here onwards is transient and can be reset
      * with a bzero. */
     int start_transient;


### PR DESCRIPTION
Due to a recent changes, reqlogger instances can now be accessed/modified by two threads (appsock & watchdog). Add mutex to protect critical sections.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>