### PR TITLE
Test: Comment out unsupported test in zeroblob.test

### DIFF
--- a/tests/yast.test/zeroblob.test
+++ b/tests/yast.test/zeroblob.test
@@ -127,12 +127,12 @@ do_test zeroblob-2.1 {
 
 # Comparisons against zeroblobs work even when indexed.
 #
-do_test zeroblob-2.2 {
-  execsql {
-    CREATE INDEX i1_1 ON t1(b);
-    SELECT a FROM t1 WHERE b=zeroblob(10000);
-  }
-} {1 (null) 5}
+#do_test zeroblob-2.2 {
+#  execsql {
+#    CREATE INDEX i1_1 ON t1(b);
+#    SELECT a FROM t1 WHERE b=zeroblob(10000);
+#  }
+#} {1 (null) 5}
 
 # DISTINCT works for zeroblobs
 #


### PR DESCRIPTION
This upstream test tries to create an index on blob field, not supported by comdb2.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>