### PR TITLE
Change systable access error to match user table access error 

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12546,7 +12546,7 @@ int comdb2_check_vtab_access(sqlite3 *db, sqlite3_module *module)
                 logmsg(LOGMSG_INFO, "%s\n", msg);
                 errstat_set_rc(&thd->clnt->osql.xerr, SQLITE_ACCESS);
                 errstat_set_str(&thd->clnt->osql.xerr, msg);
-                return SQLITE_AUTH;
+                return SQLITE_ACCESS;
             }
             return SQLITE_OK;
         }

--- a/tests/auth.test/t11.expected
+++ b/tests/auth.test/t11.expected
@@ -77,27 +77,27 @@
 [set user 'replicant'] rc 0
 [set password 'secret'] rc 0
 ( replicant =' cannot access following system tables ')
-[select 1 from comdb2_appsock_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_clientstats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_cluster limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_fingerprints limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_locks limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_metrics limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_replication_netqueue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_threadpools limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartevents limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartitions limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartshards limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_appsock_handlers limit 1] failed with rc -106 Read access denied to comdb2_appsock_handlers for user replicant bdberr=15
+[select 1 from comdb2_clientstats limit 1] failed with rc -106 Read access denied to comdb2_clientstats for user replicant bdberr=15
+[select 1 from comdb2_cluster limit 1] failed with rc -106 Read access denied to comdb2_cluster for user replicant bdberr=15
+[select 1 from comdb2_fingerprints limit 1] failed with rc -106 Read access denied to comdb2_fingerprints for user replicant bdberr=15
+[select 1 from comdb2_locks limit 1] failed with rc -106 Read access denied to comdb2_locks for user replicant bdberr=15
+[select 1 from comdb2_logical_operations limit 1] failed with rc -106 Read access denied to comdb2_logical_operations for user replicant bdberr=15
+[select 1 from comdb2_metrics limit 1] failed with rc -106 Read access denied to comdb2_metrics for user replicant bdberr=15
+[select 1 from comdb2_net_userfuncs limit 1] failed with rc -106 Read access denied to comdb2_net_userfuncs for user replicant bdberr=15
+[select 1 from comdb2_opcode_handlers limit 1] failed with rc -106 Read access denied to comdb2_opcode_handlers for user replicant bdberr=15
+[select 1 from comdb2_plugins limit 1] failed with rc -106 Read access denied to comdb2_plugins for user replicant bdberr=15
+[select 1 from comdb2_procedures limit 1] failed with rc -106 Read access denied to comdb2_procedures for user replicant bdberr=15
+[select 1 from comdb2_queues limit 1] failed with rc -106 Read access denied to comdb2_queues for user replicant bdberr=15
+[select 1 from comdb2_repl_stats limit 1] failed with rc -106 Read access denied to comdb2_repl_stats for user replicant bdberr=15
+[select 1 from comdb2_replication_netqueue limit 1] failed with rc -106 Read access denied to comdb2_replication_netqueue for user replicant bdberr=15
+[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -106 Read access denied to comdb2_sqlpool_queue for user replicant bdberr=15
+[select 1 from comdb2_threadpools limit 1] failed with rc -106 Read access denied to comdb2_threadpools for user replicant bdberr=15
+[select 1 from comdb2_timepartevents limit 1] failed with rc -106 Read access denied to comdb2_timepartevents for user replicant bdberr=15
+[select 1 from comdb2_timepartitions limit 1] failed with rc -106 Read access denied to comdb2_timepartitions for user replicant bdberr=15
+[select 1 from comdb2_timepartshards limit 1] failed with rc -106 Read access denied to comdb2_timepartshards for user replicant bdberr=15
+[select 1 from comdb2_timeseries limit 1] failed with rc -106 Read access denied to comdb2_timeseries for user replicant bdberr=15
+[select 1 from comdb2_tunables limit 1] failed with rc -106 Read access denied to comdb2_tunables for user replicant bdberr=15
 [select " cannot access following system tables " as " replicant "] rc 0
 ( replicant =' limited access to following system tables ')
 [select " limited access to following system tables " as " replicant "] rc 0
@@ -125,26 +125,26 @@
 [set user 'sysmon'] rc 0
 [set password 'secret'] rc 0
 ( sysmon =' cannot access following system tables ')
-[select 1 from comdb2_appsock_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_clientstats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_cluster limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_locks limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_replication_netqueue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_threadpools limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartevents limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartitions limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartshards limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_transaction_logs limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_appsock_handlers limit 1] failed with rc -106 Read access denied to comdb2_appsock_handlers for user sysmon bdberr=15
+[select 1 from comdb2_clientstats limit 1] failed with rc -106 Read access denied to comdb2_clientstats for user sysmon bdberr=15
+[select 1 from comdb2_cluster limit 1] failed with rc -106 Read access denied to comdb2_cluster for user sysmon bdberr=15
+[select 1 from comdb2_locks limit 1] failed with rc -106 Read access denied to comdb2_locks for user sysmon bdberr=15
+[select 1 from comdb2_logical_operations limit 1] failed with rc -106 Read access denied to comdb2_logical_operations for user sysmon bdberr=15
+[select 1 from comdb2_net_userfuncs limit 1] failed with rc -106 Read access denied to comdb2_net_userfuncs for user sysmon bdberr=15
+[select 1 from comdb2_opcode_handlers limit 1] failed with rc -106 Read access denied to comdb2_opcode_handlers for user sysmon bdberr=15
+[select 1 from comdb2_plugins limit 1] failed with rc -106 Read access denied to comdb2_plugins for user sysmon bdberr=15
+[select 1 from comdb2_procedures limit 1] failed with rc -106 Read access denied to comdb2_procedures for user sysmon bdberr=15
+[select 1 from comdb2_queues limit 1] failed with rc -106 Read access denied to comdb2_queues for user sysmon bdberr=15
+[select 1 from comdb2_repl_stats limit 1] failed with rc -106 Read access denied to comdb2_repl_stats for user sysmon bdberr=15
+[select 1 from comdb2_replication_netqueue limit 1] failed with rc -106 Read access denied to comdb2_replication_netqueue for user sysmon bdberr=15
+[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -106 Read access denied to comdb2_sqlpool_queue for user sysmon bdberr=15
+[select 1 from comdb2_threadpools limit 1] failed with rc -106 Read access denied to comdb2_threadpools for user sysmon bdberr=15
+[select 1 from comdb2_timepartevents limit 1] failed with rc -106 Read access denied to comdb2_timepartevents for user sysmon bdberr=15
+[select 1 from comdb2_timepartitions limit 1] failed with rc -106 Read access denied to comdb2_timepartitions for user sysmon bdberr=15
+[select 1 from comdb2_timepartshards limit 1] failed with rc -106 Read access denied to comdb2_timepartshards for user sysmon bdberr=15
+[select 1 from comdb2_timeseries limit 1] failed with rc -106 Read access denied to comdb2_timeseries for user sysmon bdberr=15
+[select 1 from comdb2_transaction_logs limit 1] failed with rc -106 Read access denied to comdb2_transaction_logs for user sysmon bdberr=15
+[select 1 from comdb2_tunables limit 1] failed with rc -106 Read access denied to comdb2_tunables for user sysmon bdberr=15
 [select " cannot access following system tables " as " sysmon "] rc 0
 ( sysmon =' limited access to following system tables ')
 [select " limited access to following system tables " as " sysmon "] rc 0
@@ -174,28 +174,28 @@
 [set user 'other'] rc 0
 [set password 'secret'] rc 0
 ( other =' cannot access following system tables ')
-[select 1 from comdb2_appsock_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_clientstats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_cluster limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_fingerprints limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_locks limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_logical_operations limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_metrics limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_net_userfuncs limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_opcode_handlers limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_plugins limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_procedures limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_queues limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_repl_stats limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_replication_netqueue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_threadpools limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartevents limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartitions limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timepartshards limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_timeseries limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_transaction_logs limit 1] failed with rc -5 authorization denied
-[select 1 from comdb2_tunables limit 1] failed with rc -5 authorization denied
+[select 1 from comdb2_appsock_handlers limit 1] failed with rc -106 Read access denied to comdb2_appsock_handlers for user other bdberr=15
+[select 1 from comdb2_clientstats limit 1] failed with rc -106 Read access denied to comdb2_clientstats for user other bdberr=15
+[select 1 from comdb2_cluster limit 1] failed with rc -106 Read access denied to comdb2_cluster for user other bdberr=15
+[select 1 from comdb2_fingerprints limit 1] failed with rc -106 Read access denied to comdb2_fingerprints for user other bdberr=15
+[select 1 from comdb2_locks limit 1] failed with rc -106 Read access denied to comdb2_locks for user other bdberr=15
+[select 1 from comdb2_logical_operations limit 1] failed with rc -106 Read access denied to comdb2_logical_operations for user other bdberr=15
+[select 1 from comdb2_metrics limit 1] failed with rc -106 Read access denied to comdb2_metrics for user other bdberr=15
+[select 1 from comdb2_net_userfuncs limit 1] failed with rc -106 Read access denied to comdb2_net_userfuncs for user other bdberr=15
+[select 1 from comdb2_opcode_handlers limit 1] failed with rc -106 Read access denied to comdb2_opcode_handlers for user other bdberr=15
+[select 1 from comdb2_plugins limit 1] failed with rc -106 Read access denied to comdb2_plugins for user other bdberr=15
+[select 1 from comdb2_procedures limit 1] failed with rc -106 Read access denied to comdb2_procedures for user other bdberr=15
+[select 1 from comdb2_queues limit 1] failed with rc -106 Read access denied to comdb2_queues for user other bdberr=15
+[select 1 from comdb2_repl_stats limit 1] failed with rc -106 Read access denied to comdb2_repl_stats for user other bdberr=15
+[select 1 from comdb2_replication_netqueue limit 1] failed with rc -106 Read access denied to comdb2_replication_netqueue for user other bdberr=15
+[select 1 from comdb2_sqlpool_queue limit 1] failed with rc -106 Read access denied to comdb2_sqlpool_queue for user other bdberr=15
+[select 1 from comdb2_threadpools limit 1] failed with rc -106 Read access denied to comdb2_threadpools for user other bdberr=15
+[select 1 from comdb2_timepartevents limit 1] failed with rc -106 Read access denied to comdb2_timepartevents for user other bdberr=15
+[select 1 from comdb2_timepartitions limit 1] failed with rc -106 Read access denied to comdb2_timepartitions for user other bdberr=15
+[select 1 from comdb2_timepartshards limit 1] failed with rc -106 Read access denied to comdb2_timepartshards for user other bdberr=15
+[select 1 from comdb2_timeseries limit 1] failed with rc -106 Read access denied to comdb2_timeseries for user other bdberr=15
+[select 1 from comdb2_transaction_logs limit 1] failed with rc -106 Read access denied to comdb2_transaction_logs for user other bdberr=15
+[select 1 from comdb2_tunables limit 1] failed with rc -106 Read access denied to comdb2_tunables for user other bdberr=15
 [select " cannot access following system tables " as " other "] rc 0
 ( other =' limited access to following system tables ')
 [select " limited access to following system tables " as " other "] rc 0


### PR DESCRIPTION
We report table access violations differently for user tables and system tables. 
$cdb2sql aardb dev "select * from aar_table"
[select * from aar_table] failed with rc -106 Read access denied to aar_table for user default bdberr=15

$cdb2sql aardb dev "select * from comdb2_tunables()"
[select * from comdb2_tunables()] failed with rc -5 authorization denied

This PR unifies the two i.e systable access violation errors will now mimic user table access violation errors