### PR TITLE
reqlog: More improvements to periodic logging of long requests

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2946,6 +2946,8 @@ void reqlog_set_path(struct reqlogger *logger, struct client_query_stats *path);
 void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
 
+void reqlog_log_all_longreqs(void);
+
 void process_nodestats(void);
 void nodestats_report(FILE *fh, const char *prefix, int disp_rates);
 void nodestats_node_report(FILE *fh, const char *prefix, int disp_rates,

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -63,8 +63,6 @@ struct tablelist {
 struct reqlogger {
     char origin[128];
 
-    pthread_mutex_t mtx;
-
     /* Everything from here onwards is transient and can be reset
      * with a bzero. */
     int start_transient;

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -355,8 +355,7 @@ static void *watchdog_thread(void *arg)
             }
         }
 
-        int log_long_running_sql_statements();
-        log_long_running_sql_statements();
+        reqlog_log_all_longreqs();
 
         /* we use counter to downsample the run events for lower frequence
            tasks, like deadlock detector */


### PR DESCRIPTION
* Log periodic messages about longreqs via separate logger objects (and not use one owned by sql thread)
* This will also prevent watcher thread (that does the periodic logging) from stealing log events accumulated by sql threads into their logger objects
* Revert logger mutex changes (introduced in a recent patch)
* Disable periodic logging if longreq_log_freq_sec < 0
* Also disable it when sql_time_threshold <= 0

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>