### PR TITLE
New SC fix for conflicts which can occur in the logical redo thread

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -473,6 +473,8 @@ DEF_ATTR(SC_NO_REBUILD_THR_SLEEP, sc_no_rebuild_thr_sleep, QUANTITY, 10,
 DEF_ATTR(SC_FORCE_DELAY, sc_force_delay, BOOLEAN, 0,
          "Force schemachange to delay after every record inserted - to have sc "
          "backoff.")
+DEF_ATTR(SC_PAUSE_REDO, sc_pause_redo, BOOLEAN, 0,
+         "Pauses the newsc asychronous redo-thread for testing.")
 DEF_ATTR(SC_RESUME_AUTOCOMMIT, sc_resume_autocommit, BOOLEAN, 1,
          "Always resume autocommit schemachange if possible.")
 DEF_ATTR(SC_RESUME_WATCHDOG_TIMER, sc_resume_watchdog_timer, QUANTITY, 60,

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1355,6 +1355,8 @@ unsigned long long bdb_get_current_lsn(bdb_state_type *bdb_state,
 
 int bdb_set_tran_lowpri(bdb_state_type *bdb_state, tran_type *tran);
 
+void bdb_set_tran_verify_updateid(tran_type *tran);
+
 int bdb_am_i_coherent(bdb_state_type *bdb_state);
 
 int bdb_get_num_notcoherent(bdb_state_type *bdb_state);
@@ -1549,6 +1551,21 @@ int bdb_llmeta_get_sc_history(tran_type *t, sc_hist_row **hist_out, int *num,
 
 int bdb_del_schema_change_history(tran_type *t, const char *tablename,
                                   uint64_t seed);
+
+typedef struct {
+    uint64_t genid;
+    unsigned int file;
+    unsigned int offset;
+} llmeta_sc_redo_data;
+
+int bdb_llmeta_get_all_sc_redo_genids(tran_type *t, const char *tablename,
+                                      llmeta_sc_redo_data **redo_out, int *num, int *bdberr);
+
+int bdb_newsc_set_redo_genid(tran_type *t, const char *tablename, uint64_t genid, unsigned int file, unsigned int offset, int *bdberr);
+
+int bdb_newsc_del_redo_genid(tran_type *t, const char *tablename, uint64_t genid, int *bdberr);
+
+int bdb_newsc_del_all_redo_genids(tran_type *t, const char *tablename, int *bdberr);
 
 int bdb_set_high_genid(tran_type *input_trans, const char *tablename,
                        unsigned long long genid, int *bdberr);

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -455,6 +455,8 @@ struct tran_tag {
 
     int micro_commit;
 
+    unsigned verify_updateid : 1;
+
     /* Rowlocks commit support */
     pool_t *rc_pool;
     DBT **rc_list;

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -455,8 +455,9 @@ int bdb_clear_logical_live_sc(bdb_state_type *bdb_state, int lock)
         return -1;
     }
 
-    if (bdb_state->logical_live_sc == 0)
+    if (bdb_state->logical_live_sc == 0) {
         return 0;
+    }
 
     if (lock) {
         trans = bdb_tran_begin(bdb_state, NULL, &bdberr);

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -295,7 +295,7 @@ int ll_dta_del(bdb_state_type *bdb_state, tran_type *tran, int rrn,
      * the luxury of letting ix_find* to protect the row from changing because
      * we may have released the page lock before getting the row lock. So the
      * row may have been changed in this gap and we need to verify here again */
-    int verify_updateid = (tran->logical_tran && dtafile == 0);
+    int verify_updateid = ((tran->verify_updateid || tran->logical_tran) && dtafile == 0);
 
     if (dta_out) {
         bzero(dta_out, sizeof(DBT));

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2709,3 +2709,8 @@ int bdb_set_tran_lowpri(bdb_state_type *bdb_state, tran_type *tran)
     return bdb_state->dbenv->set_tran_lowpri(bdb_state->dbenv,
                                              tran->tid->txnid);
 }
+
+void bdb_set_tran_verify_updateid(tran_type *tran)
+{
+    tran->verify_updateid = 1;
+}

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -402,6 +402,7 @@ enum RCODES {
     ERR_NO_RECORDS_FOUND = 317,
     ERR_NULL_CONSTRAINT = 318,
     ERR_VERIFY_PI = 319,
+    ERR_INDEX_CONFLICT = 330,
     ERR_UNCOMMITABLE_TXN =
         404, /* txn is uncommitable, returns ERR_VERIFY rather than retry */
     ERR_INCOHERENT =
@@ -2027,6 +2028,7 @@ void backend_sync_stat(struct dbenv *dbenv);
 void init_fake_ireq_auxdb(struct dbenv *dbenv, struct ireq *iq, int auxdb);
 void init_fake_ireq(struct dbenv *, struct ireq *);
 int set_tran_lowpri(struct ireq *iq, tran_type *tran);
+void set_tran_verify_updateid(tran_type *tran);
 
 /* long transaction routines */
 

--- a/db/glue.c
+++ b/db/glue.c
@@ -267,6 +267,11 @@ int set_tran_lowpri(struct ireq *iq, tran_type *tran)
     return bdb_set_tran_lowpri(bdb_handle, tran);
 }
 
+void set_tran_verify_updateid(tran_type *tran)
+{
+    bdb_set_tran_verify_updateid(tran);
+}
+
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 /*        TRANSACTIONAL STUFF        */
 /*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/

--- a/db/indices.c
+++ b/db/indices.c
@@ -711,6 +711,8 @@ int upd_new_record_add2indices(struct ireq *iq, void *trans,
                                      NULL, 0, trans);
             if (rc == IX_FND && fndgenid == vgenid) {
                 return ERR_VERIFY;
+            } else if (rc == IX_FND) {
+                return ERR_INDEX_CONFLICT;
             } else if (rc == RC_INTERNAL_RETRY) {
                 return RC_INTERNAL_RETRY;
             } else if (rc != IX_FNDMORE && rc != IX_NOTFND &&

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -616,6 +616,7 @@ can be queried with the `stat autonalyze` command.
 |SC_USE_NUM_THREADS|0 (QUANTITY) | Start up to this many threads for parallel rebuilding durin schema change.  0 means use one per `dtastripe`.  Setting is capped at `dtastripe`.
 |SC_NO_REBUILD_THR_SLEEP|10 (QUANTITY) | Sleep this many microsec when conversion threads count is at max
 |SC_FORCE_DELAY|0 (BOOLEAN) | Force schemachange to delay after every record inserted -- to have sc backoff
+|SC_PAUSE_REDO|0 (BOOLEAN) | Pauses the newsc asynchronous redo-thread for testing
 
 #### UDP tunables
 

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -660,6 +660,10 @@ static int convert_record(struct convert_record_data *data)
                 data->dta_buf, data->trans, data->from->lrl, &dtalen, NULL);
         }
 
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG, "(%u) %s rc=%d genid %llx (%llu)\n",
+            (unsigned int)pthread_self(), __func__, rc, genid, genid);
+#endif
         if (rc == 0) {
             dta = data->dta_buf;
             check_genid = bdb_normalise_genid(data->to->handle, genid);
@@ -1404,6 +1408,9 @@ int convert_all_records(struct dbtable *from, struct dbtable *to,
                        __func__, __LINE__, rc, bdberr);
                 return -1;
             }
+ 
+            /* If we aren't resuming, delete everything from this table */
+            bdb_newsc_del_all_redo_genids(NULL, s->tablename, &bdberr);
         }
         sc_set_logical_redo_lwm(s->tablename, thdData->start_lsn.file);
         thdData->stripe = -1;
@@ -2009,6 +2016,20 @@ static void clear_blob_hash(hash_t *h)
     hash_clear(h);
 }
 
+static int free_redo_genid_recs(void *obj, void *arg)
+{
+    free(obj);
+    return 0;
+}
+
+static void clear_redo_genid_hash(hash_t *h)
+{
+    if (!h)
+        return;
+    hash_for(h, free_redo_genid_recs, NULL);
+    hash_clear(h);
+}
+
 static int unpack_blob_record(struct convert_record_data *data, void *blb_buf,
                               int dtalen, blob_status_t *blb, int blbix)
 {
@@ -2320,6 +2341,96 @@ static int unpack_and_upgrade_ondisk_record(struct convert_record_data *data,
     return 0;
 }
 
+static void populate_redo_genids(struct convert_record_data *data)
+{
+    llmeta_sc_redo_data *redo_genids;
+    int num = 0, bdberr = 0, rc = 0;
+
+    if ((rc = bdb_llmeta_get_all_sc_redo_genids(NULL, data->s->tablename,
+                                                &redo_genids, &num, &bdberr)) == 0) {
+        for (int i = 0; i < num; i++) {
+            struct redo_genid_lsns *r = calloc(sizeof(struct redo_genid_lsns), 1), *before_lsn;
+            r->genid = redo_genids[i].genid;
+            r->lsn.file = redo_genids[i].file;
+            r->lsn.offset = redo_genids[i].offset;
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%s adding genid %llx [%u][%u] to redo_lsns list\n",
+                __func__, r->genid, r->lsn.file, r->lsn.offset);
+#endif
+            hash_add(data->redo_genids, r);
+            LISTC_FOR_EACH(&data->redo_lsns, before_lsn, linkv)
+            {
+                if (log_compare(&r->lsn, &before_lsn->lsn) <= 0) {
+                    listc_add_before(&data->redo_lsns, r, before_lsn);
+                    break;
+                }
+            }
+            if (before_lsn == NULL) {
+                listc_abl(&data->redo_lsns, r);
+            }
+        }
+        free(redo_genids);
+    }
+}
+
+static void set_redo_genid(struct convert_record_data *data, unsigned long long genid,
+    const DB_LSN *lsn)
+{
+
+    int bdberr = 0;
+    int rc = bdb_newsc_set_redo_genid(data->trans, data->s->tablename, genid, lsn->file, lsn->offset, &bdberr);
+    if (rc != 0) {
+        logmsg(LOGMSG_ERROR, "%u: Error setting redo genid, %d bdberr=%d\n",
+               (unsigned int)pthread_self(), rc, bdberr);
+    }
+
+    struct redo_genid_lsns *r, *fnd;
+
+    if ((fnd = hash_find(data->redo_genids, &genid)) != NULL) {
+        logmsg(LOGMSG_ERROR, "%s: adding genid %llx to redo-hash twice?\n", __func__, genid);
+        abort();
+    } 
+
+    r = calloc(sizeof(struct redo_genid_lsns), 1);
+    r->genid = genid;
+    r->lsn.file = lsn->file;
+    r->lsn.offset = lsn->offset;
+    listc_abl(&data->redo_lsns, r);
+    hash_add(data->redo_genids, r);
+}
+
+static int get_redo_genid(struct convert_record_data *data, unsigned long long genid, DB_LSN *lsn)
+{
+    int rc = -1;
+    struct redo_genid_lsns *r;
+
+    if ((r = hash_find(data->redo_genids, &genid)) != NULL) {
+        int rc2, bdberr;
+        if ((rc2 = bdb_newsc_del_redo_genid(data->trans, data->s->tablename, genid, &bdberr)) != 0) {
+            logmsg(LOGMSG_ERROR, "%u: %s del_redo_genid returns %d bdberr=%d\n",
+                    (unsigned int)pthread_self(), __func__, rc2, bdberr);
+        }
+        hash_del(data->redo_genids, r);
+        listc_rfl(&data->redo_lsns, r);
+        (*lsn) = r->lsn;
+        free(r);
+        rc = 0;
+    }
+
+    return rc;
+}
+
+static int get_min_redo_lsn(struct convert_record_data *data, unsigned long long *genid, DB_LSN *lsn)
+{
+    if (listc_size(&data->redo_lsns) == 0) {
+        return -1;
+    }
+    struct redo_genid_lsns *l = LISTC_TOP(&data->redo_lsns);
+    (*lsn) = l->lsn;
+    (*genid) = l->genid;
+    return 0;
+}
+
 static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
                             bdb_osql_log_rec_t *rec, DBT *logdta)
 {
@@ -2463,12 +2574,22 @@ static int live_sc_redo_add(struct convert_record_data *data, DB_LOGC *logc,
         }
         if (rc) {
             if (data->s->iq) {
-                if (rc == IX_DUP)
-                    reqerrstr(data->s->iq, ERR_SC,
-                              "add key constraint duplicate key '%s' on table "
-                              "'%s' index %d",
-                              get_keynm_from_db_idx(data->to, ixfailnum),
-                              data->to->tablename, ixfailnum);
+                if (rc == IX_DUP) {
+                    DB_LSN current;
+                    rc = del_new_record(&data->iq, data->trans, ngenid, -1ULL,
+                            data->odh.recptr, data->wrblb, 0);
+                    if (rc && rc != ERR_VERIFY) {
+                        logmsg(LOGMSG_FATAL, "Debug assert - unexpected condition\n");
+                        abort();
+                    }
+                    bdb_get_commit_genid(thedb->bdb_env, &current);
+#ifdef LOGICAL_LIVESC_DEBUG
+                    logmsg(LOGMSG_DEBUG, "%u: setting newsc genid %llx lsn=[%u][%u] on addindex conflict\n", (unsigned int)pthread_self(), genid, current.file, current.offset);
+#endif
+                    set_redo_genid(data, ngenid, &current);
+                    rc = 0;
+                    goto done;
+                }
                 else
                     reqerrstr(data->s->iq, ERR_SC,
                               "unable to add record rc = %d", rc);
@@ -2595,8 +2716,24 @@ static int live_sc_redo_delete(struct convert_record_data *data, DB_LOGC *logc,
 #endif
 
     data->iq.usedb = data->to;
-    rc = del_new_record(&data->iq, data->trans, genid, -1ULL, data->odh.recptr,
-                        data->freeblb, 0);
+    DB_LSN redolsn;
+    if (get_redo_genid(data, genid, &redolsn) == 0) {
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG, "%s found redo-genid %llu with redolsn[%d][%d], mylsn is [%d][%d]\n",
+            __func__, genid, redolsn.file, redolsn.offset, rec->lsn.file, rec->lsn.offset);
+#endif
+            
+// FAIL SC HERE
+        if (log_compare(&redolsn, &rec->lsn) < 0) {
+            logmsg(LOGMSG_FATAL, "%s:%d genid %llx lsn %u:%u less than redo-lsn %u:%u\n",
+                    __func__, __LINE__, genid, redolsn.file, redolsn.offset, rec->lsn.file, rec->lsn.offset);
+            abort();
+        }
+//#endif
+    } else {
+        rc = del_new_record(&data->iq, data->trans, genid, -1ULL, data->odh.recptr,
+                data->freeblb, 0);
+    }
     if (rc == ERR_VERIFY) {
         /* not an error if we dont find it */
         rc = 0;
@@ -2766,18 +2903,124 @@ static int live_sc_redo_update(struct convert_record_data *data, DB_LOGC *logc,
         rc = del_new_record(&data->iq, data->trans, oldgenid, -1ULL,
                             data->oldodh.recptr, data->freeblb, 0);
     } else {
-        /* try to update the record in the new btree */
-        rc = upd_new_record(&data->iq, data->trans, oldgenid,
-                            data->oldodh.recptr, genid, data->odh.recptr, -1ULL,
-                            -1ULL, updlen, updCols, data->wrblb, 0,
-                            data->freeblb, data->wrblb, 0);
-        if (rc == ERR_VERIFY) {
+        /* Search for genid in llmeta */
+        DB_LSN current, redolsn;
+        if ((rc = get_redo_genid(data, oldgenid, &redolsn)) == 0) {
+
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%s found redo-genid %llu with redolsn[%d][%d], mylsn is [%d][%d]\n",
+                    __func__, oldgenid, redolsn.file, redolsn.offset, rec->lsn.file, rec->lsn.offset);
+            logmsg(LOGMSG_DEBUG, "%s:%d Adding rather than updating oldgenid= %llx genid=%llx\n", 
+                   __func__, __LINE__, oldgenid, genid);
+#endif
+
+            unsigned long long dirty_keys = -1ULL;
+            int dta_needs_conversion = 1;
+            int usellmeta = 0;
+            if (!data->to->plan) {
+                usellmeta = 1; /* new dta does not have old genids */
+            } else if (data->to->plan->dta_plan) {
+                usellmeta = 0; /* the genid is in new dta */
+            } else {
+                usellmeta = 1; /* dta is not being built */
+            }
+
+            if (usellmeta && data->s->rebuild_index)
+                dta_needs_conversion = 0;
+
+            rc = prepare_and_verify_newdb_record(data, data->odh.recptr, updlen, &dirty_keys, 0);
+            if (rc) {
+                logmsg(LOGMSG_ERROR,
+                        "%s:%d failed to prepare and verify new record rc=%d\n",
+                        __func__, __LINE__, rc);
+                goto done;
+            }
+
+            char *tagname = ".NEW..ONDISK";
+            uint8_t *p_tagname_buf = (uint8_t *)tagname;
+            uint8_t *p_tagname_buf_end = p_tagname_buf + 12;
+            uint8_t *p_buf_data = data->rec->recbuf;
+            uint8_t *p_buf_data_end = p_buf_data + data->rec->bufsize;
+            if (!dta_needs_conversion) {
+                p_buf_data = data->odh.recptr;
+                p_buf_data_end = p_buf_data + updlen;
+            }
+            unsigned long long ngenid = genid;
+            int opfailcode = 0, ixfailnum = 0;
+            int nrrn = 2;
+            int addflags = RECFLAGS_NO_TRIGGERS | RECFLAGS_NO_CONSTRAINTS |
+                RECFLAGS_NEW_SCHEMA | RECFLAGS_ADD_FROM_SC_LOGICAL |
+                RECFLAGS_KEEP_GENID | RECFLAGS_NO_BLOBS;
+
+            rc = add_record(
+                &data->iq, data->trans, p_tagname_buf, p_tagname_buf_end,
+                p_buf_data, p_buf_data_end, NULL, data->wrblb, MAXBLOBS,
+                &opfailcode, &ixfailnum, &nrrn, &ngenid,
+                (gbl_partial_indexes && data->to->ix_partial) ? dirty_keys : -1ULL,
+                BLOCK2_ADDKL, 0, addflags, 0);
+
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%u: add_record (%llx to %llx) returns %d opfailcode=%d ixfailnum=%d\n",
+                    (unsigned int)pthread_self(), oldgenid, genid, rc, opfailcode, ixfailnum);
+#endif
+
+            if (rc == IX_DUP) {
+                rc = ERR_INDEX_CONFLICT;
+            }
+        } else {
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "Updating record [%d][%d], updlen=%d, odhlen=%d oldodhlen=%d\n",
+                rec->lsn.file, rec->lsn.offset, updlen, data->odh.length, data->oldodh.length);
+#endif
+            /* try to update the record in the new btree */
+            rc = upd_new_record(&data->iq, data->trans, oldgenid,
+                    data->oldodh.recptr, genid, data->odh.recptr, -1ULL,
+                    -1ULL, updlen, updCols, data->wrblb, 0,
+                    data->freeblb, data->wrblb, 0);
+            logmsg(LOGMSG_USER, "%u: Upd_new_record %llx to %llx returns %d\n",
+                    (unsigned int)pthread_self(), oldgenid, genid, rc);
+        }
+#ifdef LOGICAL_LIVESC_DEBUG
+        int saverc = rc;
+#endif
+        if (rc == ERR_VERIFY || rc == ERR_INDEX_CONFLICT) {
             /* either the oldgenid is not found or the newgenid already exists
              * -- try delete the oldgenid again.
              * TODO: differentiate the above two cases and no need to call
              * delete again for the first case */
+            if (rc == ERR_INDEX_CONFLICT) {
+#ifdef LOGICAL_LIVESC_DEBUG
+                logmsg(LOGMSG_DEBUG, "%u: Deleting new record %llx on ix conflict\n", (unsigned int)pthread_self(), genid);
+#endif
+                rc = del_new_record(&data->iq, data->trans, genid, -1ULL,
+                                data->odh.recptr, data->wrblb, 0);
+                if (rc && rc != ERR_VERIFY) {
+                    logmsg(LOGMSG_FATAL, "Debug assert - unexpected condition\n");
+                    abort();
+                }
+#ifdef LOGICAL_LIVESC_DEBUG
+                logmsg(LOGMSG_DEBUG, "%u: rc from del_new_record is %d\n", (unsigned int)pthread_self(), rc);
+                //rc from del_new_record is %d\n", (unsigned int)pthread_self(), rc);
+#endif
+                bdb_get_commit_genid(thedb->bdb_env, &current);
+#ifdef LOGICAL_LIVESC_DEBUG
+                logmsg(LOGMSG_USER, "%u: setting newsc genid to %llx lsn=[%u][%u]\n",
+                    (unsigned int)pthread_self(), genid, current.file, current.offset);
+#endif
+                set_redo_genid(data, genid, &current);
+                rc = 0;
+            }
+
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_USER, "%u: Deleting old record %llx on %d newgenid=%llx\n",
+                (unsigned int)pthread_self(), oldgenid, saverc, genid);
+#endif
+            /* This is a race between the converter threads and the redo threads */
             rc = del_new_record(&data->iq, data->trans, oldgenid, -1ULL,
                                 data->oldodh.recptr, data->freeblb, 0);
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%u: del_new_record oldgenid=%llx rcode=%d\n", (unsigned int)pthread_self(), oldgenid, rc);
+#endif
         }
     }
     if (rc == ERR_VERIFY) {
@@ -2827,6 +3070,8 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
                                     DB_LOGC *logc, bdb_osql_log_rec_t *rec,
                                     DBT *logdta)
 {
+    unsigned long long mingenid;
+    DB_LSN minlsn;
     int rc = 0;
 
     if (rec->dtastripe < 0 || rec->dtastripe >= gbl_dtastripe) {
@@ -2840,17 +3085,39 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
         is_genid_right_of_stripe_pointer(data->to->handle, rec->genid,
                                          data->sc_genids)) {
         /* skip those still to the right of sc cursor */
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG,
+               "%s:%d genid %llx is to the right of stripe pointer\n",
+               __func__, __LINE__, rec->genid);
+#endif
         return 0;
     }
+
+    if (get_min_redo_lsn(data, &mingenid, &minlsn) == 0 &&
+        log_compare(&minlsn, &rec->lsn) < 0) {
+        logmsg(LOGMSG_ERROR, "%s:%d conflicting genid %llx not deleted after "
+               "%u:%u, redo-lsn %u:%u\n", __func__, __LINE__, mingenid,
+               minlsn.file, minlsn.offset, rec->lsn.file, rec->lsn.offset);
+        return ERR_INDEX_CONFLICT;
+    }
+
     switch (rec->type) {
     case DB_llog_undo_add_dta:
     case DB_llog_undo_add_dta_lk:
         if (bdb_inplace_cmp_genids(data->to->handle, rec->genid,
                                    data->sc_genids[rec->dtastripe]) == 0) {
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%s:%d skipping just-converted genid %llx\n",
+                   __func__, __LINE__, rec->genid);
+#endif
             /* small optimization to skip last record that was done by the
              * convert thread */
             return 0;
         }
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG, "%s:%d redo thread adding genid %llx\n", __func__,
+               __LINE__, rec->genid);
+#endif
         rc = live_sc_redo_add(data, logc, rec, logdta);
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -2862,6 +3129,10 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
     case DB_llog_undo_del_dta:
     case DB_llog_undo_del_dta_lk:
         rc = live_sc_redo_delete(data, logc, rec, logdta);
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG, "%s:%d redo thread deleting genid %llx\n", __func__,
+               __LINE__, rec->genid);
+#endif
         if (rc) {
             logmsg(LOGMSG_ERROR,
                    "%s: [%s] failed to redo delete lsn[%u:%u] rc=%d\n",
@@ -2872,6 +3143,10 @@ static int live_sc_redo_logical_rec(struct convert_record_data *data,
         break;
     case DB_llog_undo_upd_dta:
     case DB_llog_undo_upd_dta_lk:
+#ifdef LOGICAL_LIVESC_DEBUG
+        logmsg(LOGMSG_DEBUG, "%s:%d redo thread updating genid %llx\n", __func__,
+               __LINE__, rec->genid);
+#endif
         rc = live_sc_redo_update(data, logc, rec, logdta);
         if (rc) {
             logmsg(LOGMSG_ERROR,
@@ -2967,6 +3242,7 @@ again:
         goto done;
     }
     set_tran_lowpri(&data->iq, data->trans);
+    set_tran_verify_updateid(data->trans);
     data->iq.timeoutms = gbl_sc_timeoutms;
     data->iq.debug = debug_this_request(gbl_debug_until);
     if (data->iq.debug) {
@@ -3171,6 +3447,15 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
         s->iq->sc_should_abort = 1;
         goto cleanup;
     }
+
+    data->redo_genids = hash_init(sizeof(unsigned long long));
+    if (!data->redo_genids) {
+        logmsg(LOGMSG_ERROR, "%s: failed to init redo_genids hash\n", __func__);
+        s->iq->sc_should_abort = 1;
+        goto cleanup;
+    }
+
+    listc_init(&data->redo_lsns, offsetof(struct redo_genid_lsns, linkv));
     data->dta_buf = malloc(data->from->lrl + ODH_SIZE);
     data->old_dta_buf = malloc(data->from->lrl + ODH_SIZE);
     data->unpack_dta_buf = malloc(data->from->lrl + ODH_SIZE);
@@ -3201,7 +3486,22 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
     s->curLsn = &curLsn;
     Pthread_mutex_unlock(&s->livesc_mtx);
 
+    if (serial) {
+        populate_redo_genids(data);
+    }
+
     while (1) {
+        /* pause right here if we've been told to */
+        while (BDB_ATTR_GET(thedb->bdb_attr, SC_PAUSE_REDO)) {
+            sc_printf(s,
+                "[%s] logical redo thread pausing on sc_pause_redo\n", __func__);
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "%u %s pausing on SC_PAUSE_REDO\n",
+                (unsigned int)pthread_self(), __func__);
+#endif
+            sleep(1);
+        }
+
         /* abort schema change if we need to */
         if (gbl_sc_abort || data->from->sc_abort || s->sc_thd_failed ||
             (s->iq && s->iq->sc_should_abort)) {
@@ -3221,6 +3521,11 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
         if (!serial) {
             /* Get the next lsn to redo, wait upto 10s unless all convert
              * threads have finished */
+#ifdef LOGICAL_LIVESC_DEBUG
+            if (finalizing) {
+                logmsg(LOGMSG_DEBUG, "%s final get_next_redo_lsn\n", __func__);
+            }
+#endif
             redo = get_next_redo_lsn(bdb_state, s);
         }
         if (!serial && redo == NULL) {
@@ -3236,6 +3541,9 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             pCur->hitLast = 1;
             if (finalizing) {
                 /* done */
+#ifdef LOGICAL_LIVESC_DEBUG
+                logmsg(LOGMSG_DEBUG, "%s %u empty redo and finalize break\n", __func__, __LINE__);
+#endif
                 break;
             }
             /* Update eofLsn to current end of log file */
@@ -3261,7 +3569,9 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
                 while (nretries < 500) {
                     rc = bdb_llog_cursor_find(pCur, &(redo->lsn));
                     if (rc || (pCur->log && !pCur->hitLast)) {
-                        /* found the committed transaction */
+#ifdef LOGICAL_LIVESC_DEBUG
+                        logmsg(LOGMSG_DEBUG, "%s %u Cant find committed transaction?\n", __func__, __LINE__);
+#endif
                         break;
                     }
                     /* retry again and wait for the transaction to commit */
@@ -3272,6 +3582,10 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
                     /* Error out if we cannot find the committed transaction */
                     sc_errf(s, "[%s] logical redo failed to find [%u:%u]\n",
                             s->tablename, redo->lsn.file, redo->lsn.offset);
+#ifdef LOGICAL_LIVESC_DEBUG
+                    logmsg(LOGMSG_DEBUG, "%s %u logical redo failed to find [%u:%u]\n",
+                        __func__, __LINE__, redo->lsn.file, redo->lsn.offset);
+#endif
                     s->iq->sc_should_abort = 1;
                     goto cleanup;
                 }
@@ -3281,6 +3595,12 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
                             "txnid %x, got %x\n",
                             s->tablename, redo->lsn.file, redo->lsn.offset,
                             redo->txnid, pCur->log->txnid);
+#ifdef LOGICAL_LIVESC_DEBUG
+                    logmsg(LOGMSG_DEBUG, "%s %u logical redo failed to find [%u:%u], "
+                                        "expect txnid %x, got %x\n",
+                                        __func__, __LINE__, redo->lsn.file, redo->lsn.offset,
+                                        redo->txnid, pCur->log->txnid);
+#endif
                     s->iq->sc_should_abort = 1;
                     goto cleanup;
                 }
@@ -3288,6 +3608,10 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             if (rc) {
                 sc_errf(s, "[%s] logical redo failed at [%u:%u]\n",
                         s->tablename, pCur->curLsn.file, pCur->curLsn.offset);
+#ifdef LOGICAL_LIVESC_DEBUG
+                logmsg(LOGMSG_DEBUG, "%s %u logical redo failed at [%u:%u]\n",
+                        __func__, __LINE__, redo->lsn.file, redo->lsn.offset);
+#endif
                 s->iq->sc_should_abort = 1;
                 goto cleanup;
             }
@@ -3322,7 +3646,11 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
         }
 
         if (finalizing && log_compare(&curLsn, &finalizeLsn) >= 0) {
-            break; // done
+#ifdef LOGICAL_LIVESC_DEBUG
+            logmsg(LOGMSG_DEBUG, "Redo breaking out of loop, curlsn=%u:%u, finalizelsn=%u:%u\n",
+                curLsn.file, curLsn.offset, finalizeLsn.file, finalizeLsn.offset);
+#endif
+            break;
         }
         unsigned int lwm = sc_get_logical_redo_lwm_table(s->tablename);
         if (lwm != curLsn.file) {
@@ -3360,8 +3688,12 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
         if (pCur->hitLast) {
             if (s->got_tablelock) {
                 /* loop one more time after we get table lock */
-                if (finalizing)
+                if (finalizing) {
+#ifdef LOGICAL_LIVESC_DEBUG
+                    logmsg(LOGMSG_DEBUG, "%s %u Breaking out of redo loop\n", __func__, __LINE__);
+#endif
                     break;
+                }
                 finalizing = 1;
                 // get the lsn of current end of log
                 bdb_get_commit_genid(thedb->bdb_env, &finalizeLsn);
@@ -3369,6 +3701,23 @@ void *live_sc_logical_redo_thd(struct convert_record_data *data)
             poll(NULL, 0, 100);
             s->hitLastCnt++;
             continue;
+        }
+    }
+
+    if (listc_size(&data->redo_lsns) > 0) {
+        struct redo_genid_lsns *redo_lsns;
+        int bdberr;
+        sc_printf(s,
+                  "[%s] Index conflict detected from redo thread\n", s->tablename);
+        s->iq->sc_should_abort = 1;
+        if (rc == 0) {
+            rc = ERR_INDEX_CONFLICT;
+        }
+        bdb_newsc_del_all_redo_genids(NULL, data->s->tablename, &bdberr);
+        LISTC_FOR_EACH(&data->redo_lsns, redo_lsns, linkv) {
+            sc_printf(s,
+                      "[%s] genid %llx -> [%u][%u]\n", s->tablename, redo_lsns->genid,
+                      redo_lsns->lsn.file, redo_lsns->lsn.offset);
         }
     }
 
@@ -3384,6 +3733,12 @@ cleanup:
 
     if (data->blob_hash)
         hash_free(data->blob_hash);
+
+    if (data->redo_genids) {
+        clear_redo_genid_hash(data->redo_genids);
+        hash_free(data->redo_genids);
+        data->redo_genids = NULL;
+    }
 
     sc_printf(s,
               "[%s] logical redo thread exiting, log cursor at [%u:%u], redid "

--- a/schemachange/sc_records.h
+++ b/schemachange/sc_records.h
@@ -32,6 +32,12 @@ struct common_members {
     uint32_t total_lasttime; // last time we computed total stats
 };
 
+struct redo_genid_lsns {
+    unsigned long long genid;
+    DB_LSN lsn;
+    LINKC_T(struct redo_genid_lsns) linkv;
+};
+
 /* for passing state data to schema change threads/functions */
 struct convert_record_data {
     pthread_t tid;
@@ -77,6 +83,8 @@ struct convert_record_data {
                            converting the records */
     unsigned long long cv_genid; /* the genid of the record that we get
                                     constraint violation on */
+    LISTC_T(struct redo_genid_lsns) redo_lsns;
+    hash_t *redo_genids;
 };
 
 int convert_all_records(struct dbtable *from, struct dbtable *to,

--- a/tests/sc_redo.test/Makefile
+++ b/tests/sc_redo.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_redo.test/README
+++ b/tests/sc_redo.test/README
@@ -1,0 +1,18 @@
+We determined that under new-sc, the asynchronous redo thread can apply changes
+which cause constraint violations in the new table for records which never 
+co-existed in the old table.  Simple schedule from the paper demonstrates this
+issue.  Assume table t has a single integer column, 'a', and is populated with
+two records of values 1 and 2:
+
+CONV-TD-1 : CONVERT-RECORD-WITH-VALUE-1
+CLTXN-1   : UPDATE t SET a = 100 WHERE a = 1 ; COMMIT
+CLTXN-2   : UPDATE t SET a = 1 WHERE a = 100 ; COMMIT
+CLTXN-3   : UPDATE t SET a = 100 WHERE a = 2 ; COMMIT
+CONV-TD-2 : CONVERT-RECORD-WITH-VALUE-100 (FORMERLY VALUE 2)
+REDO-TD   : UPDATE t SET a = 100 (CONFLICT)
+
+The solution is abort this operation when we've proved the conflict existed in
+the original table.  When the conflict occurs, Keep track of the genid and the 
+current end-of-logfile in llmeta.  We can prove a conflict's co-existence if
+the asynchronous redo thread can process to the end-of-logfile observed at the
+time of the conflict without updating or removing this genid.

--- a/tests/sc_redo.test/logicalsc.testopts
+++ b/tests/sc_redo.test/logicalsc.testopts
@@ -1,0 +1,1 @@
+on logical_live_sc

--- a/tests/sc_redo.test/lrl.options
+++ b/tests/sc_redo.test/lrl.options
@@ -1,0 +1,16 @@
+init_with_instant_schema_change
+init_with_ondisk_header
+init_with_inplace_updates 
+enable_new_snapshot
+round_robin_stripes
+nowatch
+logmsg level info
+init_with_genid48
+decoupled_logputs off
+#verbose_set_sc_in_progress on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+dtastripe 16
+blobstripe
+verbose_toblock_backouts on

--- a/tests/sc_redo.test/runit
+++ b/tests/sc_redo.test/runit
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export baseiters=400
+export basevalue=100000000
+export statusinterval=400
+export updatethds=16
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function touchstop
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Touched stop-file"
+}
+
+function verify_up
+{
+    [[ $debug == "1" ]] && set -x
+    typeset node=$1
+    typeset func="verify_up-$node"
+    write_prompt $func "Running $func"
+    typeset count=0
+    typeset r=1
+    while [[ "$r" -ne "0" && "$count" -lt 2000 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+    [[ $r != 0 ]] && failexit "node $node did not recover in time"
+}
+
+function populate_thread
+{
+    [[ $debug == "1" ]] && set -x
+    typeset seed=${1:-0}
+    typeset func="populate_thread-$seed"
+    write_prompt $func "Running $func"
+    typeset i=0
+    typeset cnt=0
+    while [[ "$i" -lt $baseiters ]]; do
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(${seed})" >/dev/null 2>&1)
+        [[ $? -ne 0 ]] && failexit "Error populating table: $x"
+        let seed=seed+$updatethds
+        let cnt=cnt+1
+        let i=i+1
+        [[ $(( (cnt % statusinterval) )) == 0 ]] && write_prompt $func "$cnt iterations"
+    done
+    write_prompt $func "Completed $func"
+}
+
+function populate_table
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="populate_table"
+    write_prompt $func "Running $func"
+    typeset j=0
+    while [[ "$j" -lt $updatethds ]]; do
+        populate_thread $j &
+        let j=j+1
+    done
+    wait
+}
+
+function update_thread
+{
+    [[ $debug == "1" ]] && set -x
+    typeset seed=${1}
+    typeset func="update_thread-$seed"
+    write_prompt $func "Running $func"
+    typeset targetval=$(( basevalue + seed ))
+    typeset cnt=0
+
+    while [[ ! -f $stopfile ]]; do
+        origval=$(( ( (RANDOM % baseiters) * updatethds) + seed ))
+        
+        if [[ $(( cnt % 2 )) == 1 ]]; then
+
+            # Update to target and back
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "update t1 set a=${targetval} where a=${origval}" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Error updating table: $x"
+
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "update t1 set a=${origval} where a=${targetval}" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Error updating table: $x"
+        else 
+
+            # Insert and delete target
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "insert into t1 (a) values(${targetval})" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Error inserting into table: $x"
+
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "delete from t1 where a = ${targetval}" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Error deleting from table: $x"
+
+        fi
+        let cnt=cnt+1
+        [[ $(( (cnt % statusinterval) )) == 0 ]] && write_prompt $func "$cnt iterations"
+    done
+}
+
+function start_update_threads
+{
+    typeset func="start_update_threads"
+    write_prompt $func "Running $func"
+    typeset j=0
+    while [[ "$j" -lt $updatethds ]]; do
+        update_thread $j &
+        let j=j+1
+    done
+}
+
+function rebuild_thread
+{
+    typeset func="rebuild_thread"
+    write_prompt $func "Running $func"
+    typeset cnt=0
+    typeset vers=2
+
+    while [[ ! -f $stopfile ]]; do
+
+        if [[ $(( cnt % 2 )) == 1  ]]; then
+            write_prompt $func "Rebuilding and adding a column: new record size should be 10"
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "alter table t1 options rebuild { `cat t1_2.csc2 ` }" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Failed to rebuild: $x"
+        else
+            write_prompt $func "Rebuilding and removing a column: new record size should be 5"
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "alter table t1 options rebuild { `cat t1_1.csc2 ` }" 2>&1)
+            [[ $? -ne 0 ]] && failexit "Failed to rebuild: $x"
+        fi
+        let vers=vers+1
+
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "exec procedure sys.cmd.verify('t1', 'verbose')" 2>&1)
+        good=$(echo "$x" | grep -i 'succeed')
+        [[ "$good" == "" ]] && failexit "Error verifying table t1"
+
+        let cnt=cnt+1
+        write_prompt $func "Completed $cnt iterations"
+    done
+    write_prompt $func "Finished $func"
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    typeset maxtime=$(( 8 * 60 ))
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset cnt=0
+
+    rm $stopfile
+
+    write_prompt $func "Running $func"
+    create_table
+    create_unique_index
+    populate_table
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from t1 order by a" >records.txt 2>&1
+    $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "alter table t1 { `cat t1_2.csc2 ` }" 
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from t1 order by a" >records2.txt 2>&1
+
+    start_update_threads
+    rebuild_thread &
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        if [[ -z "$CLUSTER" ]]; then
+            verify_up $(hostname)
+        else
+            for node in $CLUSTER; do
+                verify_up $node
+            done
+        fi
+        let cnt=cnt+1
+        sleep 5
+    done
+
+    # Different thread failed the test
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+
+    # Verify that the table has all the original records
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from t1 order by a" >check.txt 2>&1
+    diff records.txt check.txt >/dev/null 2>&1
+    if [[ $? != 0 ]]; then
+        diff records2.txt check.txt >/dev/null 2>&1
+        [[ $? != 0 ]] && failexit "Result table is different"
+    fi
+}
+
+run_test
+echo "Success"

--- a/tests/sc_redo.test/t1_1.csc2
+++ b/tests/sc_redo.test/t1_1.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    int a null = yes
+}
+
+keys
+{
+    "A" =  a
+}
+

--- a/tests/sc_redo.test/t1_2.csc2
+++ b/tests/sc_redo.test/t1_2.csc2
@@ -1,0 +1,11 @@
+schema
+{
+    int a null = yes
+    int b null = yes
+}
+
+keys
+{
+    "A" =  a
+}
+

--- a/tests/sc_redo_step.test/Makefile
+++ b/tests/sc_redo_step.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/sc_redo_step.test/lrl.options
+++ b/tests/sc_redo_step.test/lrl.options
@@ -1,0 +1,17 @@
+init_with_instant_schema_change
+init_with_ondisk_header
+init_with_inplace_updates 
+enable_new_snapshot
+round_robin_stripes
+nowatch
+logmsg level info
+init_with_genid48
+decoupled_logputs off
+verbose_set_sc_in_progress off
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+dtastripe 1
+blobstripe
+verbose_toblock_backouts on
+on logical_live_sc

--- a/tests/sc_redo_step.test/runit
+++ b/tests/sc_redo_step.test/runit
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export baseiters=400
+export basevalue=100000000
+export statusinterval=400
+export updatethds=16
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function set_sc_delay
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="set_sc_delay"
+    typeset arg=$1
+    typeset amount=$(( arg * 1000 ))
+    write_prompt $func "Running $func"
+
+    if [[ -n "$CLUSTER" ]]; then
+        for n in $CLUSTER; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('scdelay $amount')"
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')"
+        done
+    else
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('scdelay $amount')"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')"
+    fi
+}
+
+function clear_sc_delay
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="clear_sc_delay"
+    write_prompt $func "Running $func"
+
+    if [[ -n "$CLUSTER" ]]; then
+        for n in $CLUSTER; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('scdelay 0')"
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 0')"
+        done
+    else
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('scdelay 0')"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 0')"
+    fi
+}
+
+function rebuild
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="rebuild"
+    write_prompt $func "Running $func"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "rebuild t1" 2>&1)
+    [[ $? -ne 0 ]] && failexit "Rebuild failed, $x"
+}
+
+function add_uniq_index
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="add_uniq_index"
+    write_prompt $func "Running $func"
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "create unique index uniqix1 on t1(a)" 2>&1)
+    if [[ $? -ne 0 ]] ; then
+        write_prompt $func "Add unique index correctly failed: $x"
+    else
+        failexit "Add unique index should have failed"
+    fi
+}
+
+function force_redo_constraint_violation
+{
+    [[ $debug == "1" ]] && set -x
+    typeset beforeend=${1:-0}
+    typeset master=$(get_master)
+    typeset func="force_redo_constraint_violation"
+
+    write_prompt $func "Running $func"
+    write_prompt $func "Inserting records 10 and 1, there is no unique index"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1)" 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(10)" 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(100)" 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1000)" 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    write_prompt $func "Set convert-delay to 3 seconds"
+    set_sc_delay 3
+
+    write_prompt $func "Select the records and genids so we can see what's happening in the db"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select *, printf('%llx', cast(substr(comdb2_rowid,3) as integer)) as genid from t1"
+
+    write_prompt $func "Pausing the redo thread"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('bdb setattr SC_PAUSE_REDO 1')" 2>&1)
+    [[ $? != 0 ]] && failexit "Error setting sc_pause_redo: $x"
+
+    write_prompt $func "Add unique index"
+    add_uniq_index &
+
+    write_prompt $func "Sleep for 10 to let all records be converted"
+    sleep 10
+ 
+    write_prompt $func "Update to force a conflict in the redo thread"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a=10 where a=1" 2>&1)
+
+    write_prompt $func "Unpause the redo-thread"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('bdb setattr SC_PAUSE_REDO 0')" >/dev/null 2>&1)
+    [[ $? != 0 ]] && failexit "Error setting sc_pause_redo: $x"
+
+    if [[ $beforeend -eq 1 ]]; then
+        write_prompt $func "Make another non-conflicting update before the sc is done to make sure the SC stops"
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a=100 where a=100" 2>&1)
+        [[ $? != 0 ]] && failexit "Error updating record, $x"
+    else
+        write_prompt $func "This should fail at SC END because there are genids left in the redo-genid list"
+    fi
+
+    write_prompt $func "We want the REDO conflict rather than converter conflict to fail the sc"
+    write_prompt $func "Just Wait for sc to finish"
+    wait
+    [[ -f "$stopfile" ]] && failexit "Testcase failed"
+    
+    clear_sc_delay
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "delete from t1 where 1" 2>&1)
+    write_prompt $func "Success"
+}
+
+function force_redo_duplicate
+{
+    [[ $debug == "1" ]] && set -x
+    typeset master=$(get_master)
+    typeset func="force_redo_duplicate"
+    write_prompt $func "Running $func"
+    write_prompt $func "Inserting records 1 and 2 against unique index"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1)" >/dev/null 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(2)" >/dev/null 2>&1)
+    [[ $? != 0 ]] && failexit "Error inserting record: $x"
+
+    write_prompt $func "Set convert-delay to 3 seconds"
+    set_sc_delay 3
+
+    write_prompt $func "Start rebuild"
+    rebuild &
+
+    write_prompt $func "Pausing the redo thread"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('bdb setattr SC_PAUSE_REDO 1')" >/dev/null 2>&1)
+    [[ $? != 0 ]] && failexit "Error setting sc_pause_redo: $x"
+
+    write_prompt $func "Sleeping for 1"
+    sleep 1
+
+    write_prompt $func "Updating 1 -> 100"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a = 100 where a = 1" 2>&1)
+    [[ $? != 0 ]] && failexit "Error updating record (1): $x"
+
+    write_prompt $func "Updating 100 -> 1"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a = 1 where a = 100" 2>&1)
+    [[ $? != 0 ]] && failexit "Error updating record (2): $x"
+
+    write_prompt $func "Updating 2 -> 100"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a = 100 where a = 2" 2>&1)
+    [[ $? != 0 ]] && failexit "Error updating record (1): $x"
+
+    write_prompt $func "Sleeping for 4"
+    sleep 4
+
+    write_prompt $func "Unpausing the redo thread"
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('bdb setattr SC_PAUSE_REDO 0')" >/dev/null 2>&1)
+    [[ $? != 0 ]] && failexit "Error unpausing sc_pause_redo: $x"
+
+    write_prompt $func "SC should succeed because conflicting records never co-existed"
+
+    wait
+    [[ -f "$stopfile" ]] && failexit "Testcase failed"
+
+    clear_sc_delay
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "delete from t1 where 1" 2>&1)
+    write_prompt $func "Success"
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    typeset maxtime=$(( 8 * 60 ))
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset cnt=0
+
+    rm $stopfile
+
+    write_prompt $func "Running $func"
+    create_table
+    create_unique_index
+    force_redo_duplicate
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "alter table t1 drop index 'uniqix1'")
+    [[ $? != 0 ]] && failexit "Failed to drop index: $x"
+    force_redo_constraint_violation
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "alter table t1 drop index 'uniqix1'")
+    force_redo_constraint_violation 1
+}
+
+run_test
+echo "Success"

--- a/tests/tools/ddl.sh
+++ b/tests/tools/ddl.sh
@@ -36,8 +36,18 @@ function create_index
     write_prompt $func "Running $func"
     typeset table=${1:-t1}
     typeset column=${2:-a}
-    typeset ixname=${2:-ix1}
+    typeset ixname=${3:-ix1}
     $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "create index $ixname on $table($column)" 
+}
+
+function drop_index
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="drop_index"
+    write_prompt $func "Running $func"
+    typeset table=${1:-t1}
+    typeset ixname=${2:-ix1}
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "alter table $table drop index '$ixname'" 
 }
 
 function create_unique_index
@@ -47,6 +57,6 @@ function create_unique_index
     write_prompt $func "Running $func"
     typeset table=${1:-t1}
     typeset column=${2:-a}
-    typeset ixname=${2:-uniqix1}
+    typeset ixname=${3:-uniqix1}
     $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "create unique index $ixname on $table($column)" 
 }

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=953)
+(TUNABLES_COUNT=954)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -760,6 +760,7 @@
 (name='sc_hist_keep', description='Number of items to keep in llmeta for comdb2_sc_history sys table.', type='INTEGER', value='20', read_only='N')
 (name='sc_logical_save_lsn_every_n', description='Save schema change redo lsn to llmeta every n-th transactions.', type='INTEGER', value='10', read_only='N')
 (name='sc_no_rebuild_thr_sleep', description='Sleep this many microsec when conversion threads count is at max.', type='INTEGER', value='10', read_only='N')
+(name='sc_pause_redo', description='Pauses the newsc asychronous redo-thread for testing.', type='BOOLEAN', value='OFF', read_only='N')
 (name='sc_restart_sec', description='Delay restarting schema change for this many seconds after startup/new master election.', type='INTEGER', value='0', read_only='N')
 (name='sc_resume_autocommit', description='Always resume autocommit schemachange if possible.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_resume_watchdog_timer', description='sc_resuming_watchdog timer', type='INTEGER', value='60', read_only='N')

--- a/util/walkback.c
+++ b/util/walkback.c
@@ -919,8 +919,16 @@ static void comdb2_cheapstack_sym_valist(FILE *f, char *fmt, va_list args)
 
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...)
 {
+    /* Generate non-interleaved cheapstacks */
+#if defined CHEAPSTACK_LOCK
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+#endif
     va_list args;
     va_start(args, fmt);
     comdb2_cheapstack_sym_valist(f, fmt, args);
     va_end(args);
+#if defined CHEAPSTACK_LOCK
+    pthread_mutex_unlock(&lk);
+#endif
 }


### PR DESCRIPTION

Signed-off-by: Mark Hannum <mhannum72@gmail.com>

We discovered cases where the newsc logical redo thread can experience constraint violations against records which never co-existed in the original table.  I've added a test, sc_redo_logicalsc_generated, which reproduces this case.  See tests/sc_redo.test/README for a detailed description of the case that this PR addresses.

This is still a WIP- I'm putting this in a little early to see how it fares under RR.