### PR TITLE
net: Limit appsock threads for 'do_inline_poll 0'

### DIFF
--- a/bdb/attr.c
+++ b/bdb/attr.c
@@ -96,7 +96,13 @@ static void bdb_attr_set_int(bdb_state_type *bdb_state, bdb_attr_type *bdb_attr,
         bdb_attr->track_replication_times = value;
         if (bdb_state && value == 0)
             bdb_disable_replication_time_tracking(bdb_state);
-        break;
+        return;
+
+    case BDB_ATTR_MAXAPPSOCKSLIMIT:
+        bdb_attr->maxappsockslimit = value;
+        void cap_appsock_thds(void);
+        cap_appsock_thds();
+        return;
     }
 
 #define DEF_ATTR(NAME, name, type, dflt, desc)                                 \

--- a/db/appsock_handler.c
+++ b/db/appsock_handler.c
@@ -102,7 +102,6 @@ int appsock_init(void)
     thdpool_set_delt_fn(gbl_appsock_thdpool, appsock_thd_end);
     thdpool_set_minthds(gbl_appsock_thdpool, 1);
     thdpool_set_linger(gbl_appsock_thdpool, 10);
-
     thdpool_set_mem_size(gbl_appsock_thdpool, 4 * 1024);
 
     return 0;
@@ -441,4 +440,14 @@ int set_rowlocks(void *trans, int enable)
     }
 
     return 0;
+}
+
+void cap_appsock_thds(void)
+{
+    extern int gbl_do_inline_poll;
+    if (gbl_do_inline_poll) return;
+    int max = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_MAXAPPSOCKSLIMIT);
+    int limit = max + (max * 0.333);
+    logmsg(LOGMSG_INFO, "%s: max:%d limit:%d\n", __func__, max, limit);
+    thdpool_set_maxthds(gbl_appsock_thdpool, limit);
 }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -1120,6 +1120,14 @@ const char *tunable_type(comdb2_tunable_type type)
     return "???";
 }
 
+static int update_do_inline_poll(void * dum, void *val)
+{
+    gbl_do_inline_poll = *(int *)val;
+    void cap_appsock_thds(void);
+    cap_appsock_thds();
+    return 0;
+}
+
 /* Register all db tunables. */
 int register_db_tunables(struct dbenv *db)
 {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -275,7 +275,7 @@ REGISTER_TUNABLE("disallow_portmux_route", "Disables 'allow_portmux_route'",
                  NULL);
 REGISTER_TUNABLE("do_inline_poll", "Enable to allow inline poll after accept",
                  TUNABLE_BOOLEAN, &gbl_do_inline_poll, READONLY | NOARG, NULL,
-                 NULL, NULL, NULL);
+                 NULL, update_do_inline_poll, NULL);
 REGISTER_TUNABLE("dont_abort_on_in_use_rqid", "Disable 'abort_on_in_use_rqid'",
                  TUNABLE_BOOLEAN, &gbl_abort_on_clear_inuse_rqid,
                  INVERSE_VALUE | READONLY | NOARG, NULL, NULL, NULL, NULL);

--- a/net/net.c
+++ b/net/net.c
@@ -6344,6 +6344,9 @@ int net_init(netinfo_type *netinfo_ptr)
     /* XXX just give things a chance to settle down before we return */
     usleep(10000);
 
+    void cap_appsock_thds(void);
+    cap_appsock_thds();
+
     return 0;
 }
 


### PR DESCRIPTION
Default appsock thdpool does not limit number of threads. With
'do_inline_poll 0', if there is spike in new connections, server can
quickly fail to create threads and further fail in strange ways (lose a
node, fail to create elect thread, etc).

Cap the number of threads to a little higher than the number fo maximum
appsock connections.