### PR TITLE
newsql connection storm

### DIFF
--- a/db/appsock_handler.c
+++ b/db/appsock_handler.c
@@ -75,7 +75,7 @@ void close_appsock(SBUF2 *sb)
     if (sb != NULL) {
         net_end_appsock(sb);
         Pthread_mutex_lock(&appsock_conn_lk);
-        active_appsock_conns = ATOMIC_ADD32(active_appsock_conns, -1);
+        ATOMIC_ADD32(active_appsock_conns, -1);
         Pthread_mutex_unlock(&appsock_conn_lk);
     }
 }
@@ -382,7 +382,7 @@ void appsock_handler_start(struct dbenv *dbenv, SBUF2 *sb, int admin)
 
     total_appsock_conns++;
     Pthread_mutex_lock(&appsock_conn_lk);
-    curr_appsock_conns = active_appsock_conns = ATOMIC_ADD32(active_appsock_conns, 1);
+    curr_appsock_conns = ATOMIC_ADD32(active_appsock_conns, 1);
     Pthread_mutex_unlock(&appsock_conn_lk);
 
     if (curr_appsock_conns > bdb_attr_get(thedb->bdb_attr, BDB_ATTR_MAXSOCKCACHED)) {

--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -39,12 +39,12 @@ static void *save_stmt(struct sqlclntstate *clnt)
 
 static void restore_stmt(struct sqlclntstate *clnt, srs_tran_query_t *item)
 {
-    clnt->plugin.restore_stmt(clnt, item->stmt);
+    clnt->plugin.restore_stmt(clnt, item->stmt); /* newsql_restore_stmt */
 }
 
 static void destroy_stmt(struct sqlclntstate *clnt, srs_tran_query_t *item)
 {
-    clnt->plugin.destroy_stmt(clnt, item->stmt);
+    clnt->plugin.destroy_stmt(clnt, item->stmt); /* newsql_destroy_stmt_evbuffer */
 }
 
 static char *print_stmt(struct sqlclntstate *clnt, srs_tran_query_t *item)

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -96,4 +96,10 @@ void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
 void reqlog_set_nwrites(struct reqlogger *logger, int nwrites, int cascaded_nwrites);
+
+void reqlog_long_running_sql_statements(void);
+void log_long_running_sql_statements(void);
+
+void reqlog_long_running_clnt(struct sqlclntstate *);
+
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -1410,6 +1410,7 @@ struct sql_col_info {
     int *type;
 };
 
+void init_lru_evbuffer(struct sqlclntstate *);
 void add_lru_evbuffer(struct sqlclntstate *);
 void rem_lru_evbuffer(struct sqlclntstate *);
 void add_sql_evbuffer(struct sqlclntstate *);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4325,7 +4325,7 @@ int done_cb_evbuffer(struct sqlclntstate *clnt)
 void signal_clnt_as_done(struct sqlclntstate *clnt)
 {
     if (clnt->done_cb) {
-        clnt->done_cb(clnt);
+        clnt->done_cb(clnt); /* newsql_done_cb */
     } else {
         Pthread_mutex_lock(&clnt->wait_mutex);
         clnt->done = 1;

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -24,6 +24,7 @@
 #include "fdb_fend.h"
 #include "views.h"
 #include "logmsg.h"
+#include "reqlog.h"
 
 int gbl_client_queued_slow_seconds = 0;
 int gbl_client_running_slow_seconds = 0;
@@ -369,8 +370,7 @@ static void *watchdog_thread(void *arg)
             }
         }
 
-        int log_long_running_sql_statements();
-        log_long_running_sql_statements();
+        reqlog_long_running_sql_statements();
 
         /* we use counter to downsample the run events for lower frequence
            tasks, like deadlock detector */

--- a/net/net_appsock.h
+++ b/net/net_appsock.h
@@ -13,6 +13,7 @@ struct appsock_handler_arg {
     int fd;
     struct sockaddr_in addr;
     struct evbuffer *rd_buf;
+    struct event_base *base;
 };
 
 int add_appsock_handler(const char *, event_callback_fn);
@@ -20,12 +21,6 @@ int maxquerytime_cb(struct sqlclntstate *);
 
 typedef void(*run_on_base_fn)(void *);
 void run_on_base(struct event_base *, run_on_base_fn, void *);
-
-extern pthread_t appsock_timer_thd;
-extern struct event_base *appsock_timer_base;
-
-extern pthread_t appsock_rd_thd;
-extern struct event_base *appsock_rd_base;
 
 extern int32_t active_appsock_conns;
 extern int64_t gbl_denied_appsock_connection_count;
@@ -35,24 +30,20 @@ extern int gbl_libevent_appsock;
 #ifdef SKIP_CHECK_THD
 #  define check_thd(...)
 #else
-#  define check_thd(thd)                                                       \
-    if (!pthread_equal(thd, pthread_self())) {                                 \
-        fprintf(stderr, "FATAL ERROR: %s EVENT NOT DISPATCHED on " #thd "\n",  \
-                __func__);                                                     \
-        abort();                                                               \
+#  define check_thd(thd)                                                                    \
+    if (!pthread_equal(thd, pthread_self())) {                                              \
+        fprintf(stderr, "FATAL ERROR: %s EVENT NOT DISPATCHED on " #thd "\n", __func__);    \
+        abort();                                                                            \
     }
 #endif
 
-#define check_appsock_rd_thd() check_thd(appsock_rd_thd)
-#define check_appsock_timer_thd() check_thd(appsock_timer_thd)
-
-#define evtimer_once(a, b, c)                                                                                          \
-    ({                                                                                                                 \
-        int erc;                                                                                                       \
-        if ((erc = event_base_once(a, -1, EV_TIMEOUT, b, c, NULL)) != 0) {                                             \
-            logmsg(LOGMSG_ERROR, "%s:%d event_base_once failed\n", __func__, __LINE__);                                \
-        }                                                                                                              \
-        erc;                                                                                                           \
+#define evtimer_once(a, b, c)                                                               \
+    ({                                                                                      \
+        int erc;                                                                            \
+        if ((erc = event_base_once(a, -1, EV_TIMEOUT, b, c, NULL)) != 0) {                  \
+            logmsg(LOGMSG_ERROR, "%s:%d event_base_once failed\n", __func__, __LINE__);     \
+        }                                                                                   \
+        erc;                                                                                \
     })
 
 #ifndef container_of

--- a/net/sqlwriter.h
+++ b/net/sqlwriter.h
@@ -48,6 +48,7 @@ typedef int(sql_pack_fn)(struct sqlwriter *, void *pack_arg);
 struct sqlwriter_arg {
     int fd;
     struct sqlclntstate *clnt;
+    struct event_base *timer_base;
     sql_pack_fn *pack;
     sql_pack_fn *pack_hb;
 };

--- a/net/sqlwriter.h
+++ b/net/sqlwriter.h
@@ -62,6 +62,7 @@ int sql_peer_check(struct sqlwriter *);
 struct event_base *sql_wrbase(struct sqlwriter *);
 struct evbuffer *sql_wrbuf(struct sqlwriter *);
 
+int done_cb_evbuffer(struct sqlclntstate *);
 int recover_deadlock_evbuffer(struct sqlclntstate *);
 
 void sql_enable_ssl(struct sqlwriter *, SSL *);

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -124,13 +124,18 @@ static void free_newsql_appdata_evbuffer(int dummyfd, short what, void *arg)
     close(fd);
 }
 
-static void newsql_cleanup(int dummyfd, short what, void *arg)
+static void newsql_cleanup_fn(int dummyfd, short what, void *arg)
 {
     check_appsock_timer_thd();
     struct newsql_appdata_evbuffer *appdata = arg;
     sql_disable_heartbeat(appdata->writer);
     sql_disable_timeout(appdata->writer);
     evtimer_once(appsock_rd_base, free_newsql_appdata_evbuffer, appdata);
+}
+
+static void newsql_cleanup(struct newsql_appdata_evbuffer *appdata)
+{
+    evtimer_once(appsock_timer_base, newsql_cleanup_fn, appdata);
 }
 
 static int newsql_flush_evbuffer(struct sqlclntstate *clnt)
@@ -174,7 +179,8 @@ static int newsql_done_cb(struct sqlclntstate *clnt)
 {
     struct newsql_appdata_evbuffer *appdata = clnt->appdata;
     if (clnt->query_rc == CDB2ERR_IO_ERROR) { /* dispatch timed out */
-        return evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
+        return 0;
     }
     if (clnt->osql.replay == OSQL_RETRY_DO) {
         clnt->done_cb = NULL;
@@ -191,7 +197,7 @@ static int newsql_done_cb(struct sqlclntstate *clnt)
     if (sql_done(appdata->writer) == 0) {
         newsql_read_again(-1, 0, appdata);
     } else {
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
     }
     return 0;
 }
@@ -312,7 +318,7 @@ static void wr_dbinfo(int fd, short what, void *arg)
 static void wr_dbinfo_int(struct newsql_appdata_evbuffer *appdata, int write_result)
 {
     if (write_result <= 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
         return;
     }
     struct evbuffer *wr_buf = sql_wrbuf(appdata->writer);
@@ -442,8 +448,9 @@ static void process_query(struct newsql_appdata_evbuffer *appdata, CDB2QUERY *qu
     appdata->query = query;
     CDB2SQLQUERY *sqlquery = appdata->sqlquery = query->sqlquery;
     struct sqlclntstate *clnt = &appdata->clnt;
-    if (sqlquery == NULL)
+    if (sqlquery == NULL) {
         goto out;
+    }
     if (!appdata->active) {
         if (add_appsock_connection_evbuffer(clnt) != 0) {
             add_lru_evbuffer(clnt);
@@ -478,7 +485,7 @@ out:
     if (do_read) {
         evtimer_once(appsock_rd_base, newsql_read_again, appdata);
     } else {
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
     }
 }
 
@@ -597,7 +604,7 @@ static void ssl_accept_evbuffer(int fd, short what, void *arg)
     }
 error:
     write_response(&appdata->clnt, RESPONSE_ERROR, "Client certificate authentication failed", CDB2ERR_CONNECT_ERROR);
-    evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+    newsql_cleanup(appdata);
 }
 
 static int rd_evbuffer_ssl(struct newsql_appdata_evbuffer *appdata)
@@ -666,7 +673,7 @@ static void process_ssl_request(struct newsql_appdata_evbuffer *appdata)
     return;
 
 cleanup:
-    evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+    newsql_cleanup(appdata);
 }
 
 static void process_newsql_payload(struct newsql_appdata_evbuffer *appdata, CDB2QUERY *query)
@@ -684,7 +691,7 @@ static void process_newsql_payload(struct newsql_appdata_evbuffer *appdata, CDB2
         break;
     default:
         logmsg(LOGMSG_ERROR, "%s bad type:%d fd:%d\n", __func__, appdata->hdr.type, appdata->fd);
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
         break;
     }
 }
@@ -697,7 +704,7 @@ static void rd_payload(int dummyfd, short what, void *arg)
         goto payload;
     }
     if (rd_evbuffer(appdata) <= 0 && (what & EV_READ)) {
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
         return;
     }
     if (evbuffer_get_length(appdata->rd_buf) < appdata->hdr.length) {
@@ -709,7 +716,7 @@ payload:
         int len = appdata->hdr.length;
         void *data = evbuffer_pullup(appdata->rd_buf, len);
         if (data == NULL || (query = cdb2__query__unpack(&pb_alloc, len, data)) == NULL) {
-            evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+            newsql_cleanup(appdata);
             return;
         }
         evbuffer_drain(appdata->rd_buf, len);
@@ -725,7 +732,7 @@ static void rd_hdr(int dummyfd, short what, void *arg)
         goto hdr;
     }
     if (rd_evbuffer(appdata) <= 0 && (what & EV_READ)) {
-        evtimer_once(appsock_timer_base, newsql_cleanup, appdata);
+        newsql_cleanup(appdata);
         return;
     }
     if (evbuffer_get_length(appdata->rd_buf) < sizeof(struct newsqlheader)) {

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -639,12 +639,12 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
         } else if (appdata->query) {
             /* cleanup if we did not add to history (single stmt or select inside a tran) */
             cdb2__query__free_unpacked(appdata->query, &appdata->newsql_protobuf_allocator.protobuf_allocator);
-            appdata->query = NULL;
             /* clnt.sql points into the protobuf unpacked buffer, which becomes
              * invalid after cdb2__query__free_unpacked. Reset the pointer here.
              */
             clnt.sql = NULL;
         }
+        appdata->query = NULL;
 
         query = read_newsql_query(dbenv, &clnt, sb);
     }

--- a/tests/mem_protobuf.test/runit
+++ b/tests/mem_protobuf.test/runit
@@ -6,4 +6,9 @@ set -e
 
 dbnm=$1
 host=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT comdb2_host()'`
-cdb2sql $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("memstat")' | grep protobuf | grep 'appsockpool\|appsock_rd'
+result=$(cdb2sql --tabs $dbnm --host $host "select case when count(*) > 0 then 'pass' else 'fail' end as result from comdb2_memstats where scope in ('appsockpool', 'appsock')")
+if [[ "$result" == "pass" ]]; then
+    exit 0
+else
+    exit 1
+fi


### PR DESCRIPTION
1. Add 4 'appsock' threads and round-robin new connections between them.
2. Make the cleanup event higher priority.
3. Fix active appsock connection accounting.
4. Update `gather_connections` - we will no longer fallback from libevent
   to sbuf2 since SSL is now supported. We don't need to account for
   connections from both systems. It will be all libevent or all sbuf2.