### PR TITLE
The replay_history test reproduces the replay-but-no-history error

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3797,7 +3797,11 @@ void run_stmt_setup(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
 {
     Vdbe *v = (Vdbe *)stmt;
     clnt->isselect = sqlite3_stmt_readonly(stmt);
-    clnt->has_recording |= v->recording;
+    if (clnt->in_client_trans) {
+        clnt->has_recording |= v->recording;
+    } else {
+        clnt->has_recording = v->recording;
+    }
     clnt->nsteps = 0;
     comdb2_set_sqlite_vdbe_tzname_int(v, clnt);
     comdb2_set_sqlite_vdbe_dtprec_int(v, clnt);

--- a/tests/replay_history.test/Makefile
+++ b/tests/replay_history.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/replay_history.test/README
+++ b/tests/replay_history.test/README
@@ -1,0 +1,9 @@
+This testcase reproduces a "Timeout while reading response from server" error
+reported by a customer.  The test does a 'selectv', and then an update on the
+same handle- neither of these is protected by a transaction.  Database trace
+shows that a replicant is attempting to replay a verify-retry, but that the
+sql-history is NULL.
+
+clnt->has_recording stays lit, and this prevents us from saving history.  I
+modified run_stmt_setup to overwrite clnt->has_recording with the vdbe 
+recording flag if the handle is not currently in a transaction.

--- a/tests/replay_history.test/lrl.options
+++ b/tests/replay_history.test/lrl.options
@@ -1,0 +1,10 @@
+nowatch
+logmsg level info
+init_with_genid48
+decoupled_logputs off
+verbose_set_sc_in_progress on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+dtastripe 16
+blobstripe

--- a/tests/replay_history.test/runit
+++ b/tests/replay_history.test/runit
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export maxrecord=100
+export recordcount=5
+export stopfile=./stopfile.txt
+export updaters=4
+export limit=1
+export pidlist=""
+#export verbose=1
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    for p in $pidlist; do
+        kill -9 $p
+    done
+    echo "Failed: $1"
+    exit -1
+}
+
+function verify_up
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="verify_up"
+    write_prompt $func "Running $func"
+    typeset node=$1
+    typeset count=0
+    typeset r=1
+    while [[ "$r" -ne "0" && "$count" -lt 10 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+    [[ $r != 0 ]] && failexit "node $node did not recover in time"
+}
+
+function updater
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="updater-$1"
+    typeset first=1
+    typeset r=0
+    typeset cnt=0
+
+    coproc $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default - 2>&1
+    export pidlist="$COPROC_PID $pidlist"
+
+    echo "set transaction read committed" >&"${COPROC[1]}"
+    
+    while [[ ! -f $stopfile ]]; do
+
+        typeset r0=$(( ( RANDOM % maxrecord ) + 1 ))
+        typeset r1=$(( ( RANDOM % maxrecord ) + 1 ))
+        typeset r2=$(( ( RANDOM % maxrecord ) + 1 ))
+
+        echo "selectv count(*) from t1 where a = $r0" >&"${COPROC[1]}"
+        if [[ "$first" == "1" ]]; then
+            read -r o <&"${COPROC[0]}" ; [[ "$verbose" == 1 ]] && write_prompt $func "set transaction: $o"
+            first=0
+        fi
+
+        read -r o <&"${COPROC[0]}" ; [[ "$verbose" == 1 ]] && write_prompt $func "selectv: $o"
+
+        read -r -t 0 x <&"${COPROC[0]}" 
+        r=$?
+        while [[ $r == 0 ]] ; do
+            read -r -t 1 x <&"${COPROC[0]}" 
+            read -r -t 0 y <&"${COPROC[0]}" 
+            r=$?
+            [[ "$verbose" == 1 ]] && write_prompt $func "selectv: $x"
+        done
+
+        echo "update t1 set a = $r2 where a = $r1 limit $limit" >&"${COPROC[1]}"
+        read -r o <&"${COPROC[0]}" ; [[ "$verbose" == 1 ]] && write_prompt $func "update: $o"
+
+        read -r -t 0 y <&"${COPROC[0]}" 
+        r=$?
+        while [[ $r == 0 ]] ; do
+            read -r -t 1 x <&"${COPROC[0]}"
+            read -r -t 0 y <&"${COPROC[0]}" 
+            r=$?
+            [[ "$verbose" == 1 ]] && write_prompt $func "update: $x"
+        done
+
+        [[ "$o" == *"Timeout while reading response"* ]] && failexit "Possible replay error:$o"
+        let cnt=cnt+1
+        [[ $(( cnt % 100 )) == 0 ]] && write_prompt $func "Completed $cnt iterations"
+    done
+    echo "quit" >&"${COPROC[1]}"
+    sleep 1
+}
+
+function populate_table
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="populate_table"
+    typeset j=0
+    write_prompt $func "Running $func"
+
+    while [[ $j -lt $recordcount ]]; do
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select value from generate_series(1, $maxrecord)" 2>&1)
+        [[ $? -ne 0 ]] && failexit "Failed populating t1: $x"
+        write_prompt $func "Added $maxrecord records"
+        let j=j+1
+    done
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    typeset maxtime=540
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset j=0
+
+    write_prompt $func "Running $func"
+
+    rm $stopfile
+
+    create_table
+    create_index
+    populate_table
+
+    while [[ $j -lt $updaters ]]; do
+        updater $j &
+        let j=j+1
+    done
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        if [[ -z "$CLUSTER" ]]; then
+            verify_up $(hostname)
+        else
+            for node in $CLUSTER; do
+                verify_up $node
+            done
+        fi
+        sleep 1
+    done
+
+    # Different thread failed the test
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+}
+
+run_test
+echo "Success"

--- a/tests/tools/ddl.sh
+++ b/tests/tools/ddl.sh
@@ -5,7 +5,7 @@
 function drop_table
 {
     [[ $debug == "1" ]] && set -x
-    typeset func="create_table"
+    typeset func="drop_table"
     write_prompt $func "Running $func"
     typeset table=${1:-t1}
     $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "drop table $table"


### PR DESCRIPTION
Overwrite have_recording flag if we are not in a transaction

Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This fixes a "Timeout while reading response from server" error reported by a customer.  The replay_history test does a 'selectv', and then an update using the same handle- neither of these is protected by a transaction.  Database trace shows that a replicant is attempting to replay a verify-retry, but that the sql-history is NULL.

On the database side, sql history isn't being recorded because clnt->has_recording flag is never reset after the initial SELECTV (this is another can of worms btw, as it's completely possible to get a verify-error against records which are not included in the SELECTV genid list).  The fix for this is to override is_recording if the client isn't in a transaction.