### PR TITLE
Use gbl_maxretries rather than 500

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -904,7 +904,7 @@ int bdb_rename_file_versioning_table(bdb_state_type *bdb_state,
     orig_name = bdb_state->name;
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__,
                retries);
         return -1;

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -1384,7 +1384,7 @@ int bdb_llmeta_set_tables(
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         goto cleanup;
     }
@@ -1530,7 +1530,7 @@ retry:
     /* handle return codes */
     if (rc && *bdberr != BDBERR_NOERROR) {
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -1676,7 +1676,7 @@ static int bdb_new_file_version(
 
 retry:
 
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_INFO, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -1892,7 +1892,7 @@ int bdb_chg_file_versions(
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -2057,7 +2057,7 @@ static int bdb_del_file_version(
 
 retry:
 
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_INFO, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -2240,7 +2240,7 @@ bdb_set_pagesize(tran_type *input_trans, /* if this is !NULL it will be used as
         buf_put(&pagesize, sizeof(pagesize), p_pgsz_buf, p_pgsz_buf_end);
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -2405,7 +2405,7 @@ int bdb_new_file_version_all(bdb_state_type *bdb_state, tran_type *input_tran,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -2577,7 +2577,7 @@ retry:
     /* handle return codes */
     if (rc || *bdberr != BDBERR_NOERROR) {
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -2808,7 +2808,7 @@ retry:
     /* handle return codes */
     if (rc || *bdberr != BDBERR_NOERROR) {
         if (*bdberr == BDBERR_DEADLOCK && !tran) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -2878,7 +2878,7 @@ int bdb_add_dummy_llmeta_wait(int wait_for_seqnum)
     tran_type *tran;
     int rc;
     int bdberr;
-    int retries = 500;
+    int retries = gbl_maxretries;
     uint8_t key[LLMETA_IXLEN] = {0};
 
     if (!bdb_have_llmeta()) {
@@ -3042,7 +3042,7 @@ int bdb_new_csc2(tran_type *input_trans, /* if this is !NULL it will be used as
 /* csc2_vers added to key below */
 retry:
 
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -3207,7 +3207,7 @@ retry:
             if (trans)
                 return -1;
 
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, "%s: *ERROR* bdb_lite_fetch_keys_bwd too much "
@@ -3359,7 +3359,7 @@ retry:
         rc = bdb_get_csc2_highest(tran, db_name, &csc2_vers, bdberr);
         if (rc || *bdberr != BDBERR_NOERROR) {
             if (*bdberr == BDBERR_DEADLOCK) {
-                if (++retries < 500 /*gbl_maxretries*/)
+                if (++retries < gbl_maxretries)
                     goto retry;
 
                 logmsg(LOGMSG_ERROR, "%s:*ERROR* bdb_get_csc2_highest too much "
@@ -3392,7 +3392,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -3633,7 +3633,7 @@ int bdb_set_in_schema_change(
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d "
                         "retries\n",
                 __func__, retries);
@@ -3772,7 +3772,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK && !input_trans) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -4229,7 +4229,7 @@ int bdb_set_schema_change_status(tran_type *input_trans, const char *db_name,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__,
                retries);
         return -1;
@@ -4522,7 +4522,7 @@ static int bdb_set_high_genid_int(
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -4707,7 +4707,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -4863,7 +4863,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, "%s: *ERROR* bdb_lite_fetch_keys_bwd too much "
@@ -4946,7 +4946,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, "%s: *ERROR* bdb_lite_fetch_keys_bwd too much "
@@ -5766,7 +5766,7 @@ static int bdb_tbl_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -5888,7 +5888,7 @@ int bdb_tbl_op_access_set(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -6016,7 +6016,7 @@ int bdb_tbl_op_access_delete(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -6107,7 +6107,7 @@ int bdb_feature_set_int(bdb_state_type *bdb_state, tran_type *input_trans,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -6385,7 +6385,7 @@ static int bdb_tbl_access_delete(bdb_state_type *bdb_state,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -6881,7 +6881,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -6967,7 +6967,7 @@ int bdb_set_analyzecoverage_table(tran_type *input_trans, const char *tbl_name,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -7120,7 +7120,7 @@ retry:
     if (rc || *bdberr != BDBERR_NOERROR) {
 
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -7185,7 +7185,7 @@ retry:
 
     if (rc || *bdberr != BDBERR_NOERROR) {
         if (*bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 
@@ -7255,7 +7255,7 @@ int bdb_set_rowlocks_state(tran_type *input_trans, int rlstate, int *bdberr)
     llmeta_rowlocks_state_data_type_put(&rowlocks_data, p_buf, p_buf_end);
 
 retry:
-    if (++retries >= 500) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -7372,7 +7372,7 @@ int bdb_set_analyzethreshold_table(tran_type *input_trans, const char *tbl_name,
     }
 
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         return -1;
     }
@@ -7682,10 +7682,10 @@ int llmeta_set_tablename_alias(void *ptran, const char *tablename_alias,
 
     retries = 0;
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__, retries);
         if (errstr)
-            *errstr = strdup("failed to commit transaction, tried 500 times");
+            *errstr = strdup("failed to commit transaction, hit max retries");
         return -1;
     }
 
@@ -7779,13 +7779,13 @@ retry:
                                    &bdberr);
     if (rc || bdberr != BDBERR_NOERROR) {
         if (bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, "%s: giving up after %d retries\n", __func__,
                     retries);
             if (errstr)
-                *errstr = strdup("failed to read record, tried 500 times");
+                *errstr = strdup("failed to read record, hit max retries");
 
             free(data_buf);
             return NULL;
@@ -7834,11 +7834,11 @@ int llmeta_rem_tablename_alias(const char *tablename_alias, char **errstr)
 
     retries = 0;
 retry:
-    if (++retries >= 500 /*gbl_maxretries*/) {
+    if (++retries >= gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "%s:%d giving up after %d retries\n", __func__,
                 __LINE__, retries);
         if (errstr)
-            *errstr = strdup("failed to commit transaction, tried 500 times");
+            *errstr = strdup("failed to commit transaction, hit max retries");
         return -1;
     }
 
@@ -8230,7 +8230,7 @@ retry:
 
         /* errored case */
         if (tran == NULL && *bdberr == BDBERR_DEADLOCK) {
-            if (++retries < 500 /*gbl_maxretries*/)
+            if (++retries < gbl_maxretries)
                 goto retry;
 
             logmsg(LOGMSG_ERROR, 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Title says it all: use gbl_maxretries rather than a hardcoded 500.