### PR TITLE
comdb2_transaction_logs: Incorrect log stream in blocking mode

### DIFF
--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -231,8 +231,6 @@ static int tranlogNext(sqlite3_vtab_cursor *cur){
                       sleepms = 10000;
               }
           } while ((rc = pCur->logc->get(pCur->logc, &pCur->curLsn, &pCur->data, DB_NEXT)));
-          rc = pCur->logc->get(pCur->logc, &pCur->curLsn,
-                  &pCur->data, DB_NEXT) != 0;
       } else {
           pCur->hitLast = 1;
       }


### PR DESCRIPTION
While reading from this virtual table in blocking-mode some logs
could erroneously get skipped due to an incorrect logic.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>