### PR TITLE
Fix places where we assume that sizeof(pthread_t) == sizeof(int)

### DIFF
--- a/bbinc/thread_util.h
+++ b/bbinc/thread_util.h
@@ -31,7 +31,9 @@ void thread_util_dump_on_exit_disable(void);
 void thread_util_donework(void);
 
 /* define architecture thread identifies for sane debugging */
-#if defined(_LINUX_SOURCE)
+#if defined (__APPLE__)
+typedef pthread_t arch_tid;
+#elif defined(_LINUX_SOURCE)
 typedef pid_t arch_tid;
 #elif defined(_IBM_SOURCE)
 typedef tid_t arch_tid;

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -5371,7 +5371,7 @@ static void run_once(void)
 static void deadlock_happened(struct berkdb_deadlock_info *deadlock_info)
 {
     if (debug_switch_verbose_deadlocks_log())
-        ctrace("deadlk %u %x\n", deadlock_info->lid, (unsigned)pthread_self());
+        ctrace("deadlk %u %" PRIxPTR "\n", deadlock_info->lid, (intptr_t)pthread_self());
 }
 
 /* clone clone_bdb_state and then copy over the data file pointers from

--- a/bdb/locks.c
+++ b/bdb/locks.c
@@ -265,7 +265,8 @@ int berkdb_lock_random_rowlock(bdb_state_type *bdb_state, int lid, int flags,
     static __thread int rowlock_rand_seq = 0;
     int *p = (int *)lkname->data;
 
-    (*p) = (int)pthread_self();
+    intptr_t *lkprefix = (intptr_t*) p;
+    (*lkprefix) = (intptr_t) pthread_self();
     p = (int *)(&((char *)lkname->data)[24]);
     (*p) = rowlock_rand_seq++;
 

--- a/bdb/locktest.c
+++ b/bdb/locktest.c
@@ -315,7 +315,7 @@ static int sleep_sec = 5;
 static int stop;
 static void *test_get_put(void *_mode)
 {
-    db_lockmode_t mode = (db_lockmode_t)_mode;
+    db_lockmode_t mode = (db_lockmode_t)(intptr_t)_mode;
     uint64_t start, end;
     u_int32_t locker;
     DB_LOCK lock;
@@ -824,7 +824,7 @@ static void stripe(void)
 #define shuffle(x)                                                                                                     \
     do {                                                                                                               \
         int i;                                                                                                         \
-        unsigned int seed = (int)pthread_self();                                                                       \
+        unsigned int seed = (int)(intptr_t) pthread_self();                                                            \
         for (i = 0; i < arraylen(x) - 1; ++i) {                                                                        \
             int j = i + (rand_r(&seed) % (arraylen(x) - i));                                                           \
             uint8_t tmp[sizeof(x[0])];                                                                                 \

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -19,6 +19,7 @@ static const char revid[] =
 #include <strings.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <inttypes.h>
 #endif
 
 #include <stdlib.h>
@@ -153,8 +154,8 @@ int gbl_rep_process_msg_print_rc;
 		count++;															\
 		if (gbl_rep_process_msg_print_rc && ((now = time(NULL)) - lastpr)) {\
 			logmsg(LOGMSG_ERROR,											\
-				"td %u %s line %d from line %d returning %d, count=%u\n",	\
-				(uint32_t)pthread_self(), __func__, __LINE__, fromline,		\
+				"td %" PRIxPTR "%s line %d from line %d returning %d, count=%u\n",	\
+				(intptr_t)pthread_self(), __func__, __LINE__, fromline,		\
 				retrc, count);												\
 		}																	\
 		return retrc;														\
@@ -6737,9 +6738,9 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 													 &txn_rl_args)) != 0) {
 					if (gbl_extended_sql_debug_trace) {
 						logmsg(LOGMSG_USER,
-							   "td %u %s line %d lsn %d:%d "
+							   "td %" PRIxPTR "%s line %d lsn %d:%d "
 							   "txn_regop_rowlocks_read returns %d\n",
-							   (uint32_t)pthread_self(), __func__, __LINE__,
+							   (intptr_t)pthread_self(), __func__, __LINE__,
 							   lsn.file, lsn.offset, ret);
 					}
 					return (ret);
@@ -6747,10 +6748,10 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 
 				if (txn_rl_args->timestamp < epoch) {
 					if (gbl_extended_sql_debug_trace) {
-						logmsg(LOGMSG_USER, "td %u %s line %d lsn %d:%d "
+						logmsg(LOGMSG_USER, "td %" PRIxPTR "%s line %d lsn %d:%d "
 											"break-loop because timestamp "
 											"(%"PRIu64") < epoch (%d)\n",
-							   (uint32_t)pthread_self(), __func__, __LINE__,
+							   (intptr_t)pthread_self(), __func__, __LINE__,
 							   lsn.file, lsn.offset, txn_rl_args->timestamp,
 							   epoch);
 					}
@@ -6779,10 +6780,10 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 					}
 
 					if (gbl_extended_sql_debug_trace) {
-						logmsg(LOGMSG_USER, "td %u %s line %d lsn %d:%d "
+						logmsg(LOGMSG_USER, "td %" PRIxPTR "%s line %d lsn %d:%d "
 											"adding prev-lsn %d:%d at "
 											"index %d\n",
-							   (uint32_t)pthread_self(), __func__, __LINE__,
+							   (intptr_t)pthread_self(), __func__, __LINE__,
 							   lsn.file, lsn.offset, txn_rl_args->prev_lsn.file,
 							   txn_rl_args->prev_lsn.offset, *n_lsns);
 					}
@@ -6800,9 +6801,9 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 				if ((ret = __txn_regop_gen_read(dbenv, mylog.data,
 												&txn_gen_args)) != 0) {
 					if (gbl_extended_sql_debug_trace) {
-						fprintf(stderr, "td %u %s line %d lsn %d:%d"
+						fprintf(stderr, "td %" PRIxPTR "%s line %d lsn %d:%d"
 										"txn_regop_gen_read returns %d\n",
-								(uint32_t)pthread_self(), __func__, __LINE__,
+								(intptr_t)pthread_self(), __func__, __LINE__,
 								lsn.file, lsn.offset, ret);
 					}
 					return (ret);
@@ -6859,10 +6860,10 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 										if (gbl_extended_sql_debug_trace) {
 											logmsg(
 												LOGMSG_USER,
-												"td %u %s line %d lsn %d:%d "
+												"td %" PRIxPTR "%s line %d lsn %d:%d "
 												"adding prev-lsn %d:%d at "
 												"index %d\n",
-												(uint32_t)pthread_self(),
+												(intptr_t)pthread_self(),
 												__func__, __LINE__, lsn.file,
 												lsn.offset,
 												txn_gen_args->prev_lsn.file,
@@ -6880,9 +6881,9 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 					if ((ret = __txn_regop_read(dbenv, mylog.data,
 												&txn_args)) != 0) {
 						if (gbl_extended_sql_debug_trace) {
-							logmsg(LOGMSG_USER, "td %u %s line %d lsn %d:%d"
+							logmsg(LOGMSG_USER, "td %" PRIxPTR "%s line %d lsn %d:%d"
 												"txn_regop_read returns %d\n",
-								   (uint32_t)pthread_self(), __func__, __LINE__,
+								   (intptr_t)pthread_self(), __func__, __LINE__,
 								   lsn.file, lsn.offset, ret);
 						}
 						return (ret);
@@ -6896,10 +6897,10 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 						txn_args->timestamp, epoch);
 #endif
 						if (gbl_extended_sql_debug_trace) {
-							logmsg(LOGMSG_USER, "td %u %s line %d lsn %d:%d "
+							logmsg(LOGMSG_USER, "td %" PRIxPTR "%s line %d lsn %d:%d "
 												"break-loop because timestamp "
 												"(%d) < epoch (%d)\n",
-								   (uint32_t)pthread_self(), __func__, __LINE__,
+								   (intptr_t)pthread_self(), __func__, __LINE__,
 								   lsn.file, lsn.offset, txn_args->timestamp,
 								   epoch);
 						}
@@ -6942,10 +6943,10 @@ get_committed_lsns(dbenv, inlsns, n_lsns, epoch, file, offset)
 
 										if (gbl_extended_sql_debug_trace) {
 											logmsg(LOGMSG_USER,
-												   "td %u %s line %d lsn %d:%d "
+												   "td %" PRIxPTR "%s line %d lsn %d:%d "
 												   "adding prev-lsn %d:%d at "
 												   "index %d\n",
-												   (uint32_t)pthread_self(),
+												   (intptr_t)pthread_self(),
 												   __func__, __LINE__, lsn.file,
 												   lsn.offset,
 												   txn_args->prev_lsn.file,
@@ -6975,8 +6976,8 @@ err:
 	if ((t_ret = __log_c_close(logc)) != 0 && ret == 0) {
 		ret = t_ret;
 		if (gbl_extended_sql_debug_trace) {
-			logmsg(LOGMSG_USER, "td %u %s line %d log_c_close error: %d\n",
-				   (uint32_t)pthread_self(), __func__, __LINE__, ret);
+			logmsg(LOGMSG_USER, "td %" PRIxPTR "%s line %d log_c_close error: %d\n",
+				   (intptr_t)pthread_self(), __func__, __LINE__, ret);
 		}
 	}
 

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -34,6 +34,7 @@
 #include <limits.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <inttypes.h>
 
 #include "cdb2api.h"
 
@@ -3591,7 +3592,7 @@ static void parse_dbresponse(CDB2DBINFORESPONSE *dbinfo_response,
                              peer_ssl_mode *s_mode)
 {
     if (log_calls)
-        fprintf(stderr, "td %d %s:%d\n", (uint32_t)pthread_self(), __func__,
+        fprintf(stderr, "td %" PRIxPTR "%s:%d\n", (intptr_t)pthread_self(), __func__,
                 __LINE__);
     int num_hosts = dbinfo_response->n_nodes;
     *num_valid_hosts = 0;
@@ -3638,8 +3639,8 @@ static void parse_dbresponse(CDB2DBINFORESPONSE *dbinfo_response,
             *master_node = *num_valid_hosts;
 
         if (log_calls)
-            fprintf(stderr, "td %d %s:%d, %d) host=%s(%d)%s\n",
-                    (uint32_t)pthread_self(), __func__, __LINE__,
+            fprintf(stderr, "td %" PRIxPTR "%s:%d, %d) host=%s(%d)%s\n",
+                    (intptr_t) pthread_self(), __func__, __LINE__,
                     *num_valid_hosts, valid_hosts[*num_valid_hosts],
                     valid_ports[*num_valid_hosts],
                     (*master_node == *num_valid_hosts) ? "*" : "");

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -202,7 +202,7 @@ static void sqlengine_work_shard(struct thdpool *pool, void *work,
     struct sqlclntstate *clnt = (struct sqlclntstate *)work;
     int rc;
 
-    thr_set_user("shard thread", clnt->appsock_id);
+    thr_set_user("shard thread", (intptr_t) clnt->appsock_id);
 
     rdlock_schema_lk();
     sqlengine_prepare_engine(thd, clnt, 0);

--- a/db/glue.c
+++ b/db/glue.c
@@ -377,7 +377,7 @@ tran_type *trans_start_socksql(struct ireq *iq, int trak)
 
     iq->gluewhere = "bdb_tran_begin_socksql";
     if (gbl_extended_sql_debug_trace) {
-        logmsg(LOGMSG_USER, "td=%x %s called\n", (int)pthread_self(), __func__);
+        logmsg(LOGMSG_USER, "td=%" PRIxPTR "%s called\n", (intptr_t)pthread_self(), __func__);
     }
     out_trans = bdb_tran_begin_socksql(bdb_handle, trak, &bdberr);
     iq->gluewhere = "bdb_tran_begin_socksql done";
@@ -397,7 +397,7 @@ tran_type *trans_start_readcommitted(struct ireq *iq, int trak)
 
     iq->gluewhere = "bdb_tran_begin_readcommitted";
     if (gbl_extended_sql_debug_trace) {
-        logmsg(LOGMSG_USER, "td=%x %s called\n", (int)pthread_self(), __func__);
+        logmsg(LOGMSG_USER, "td=%" PRIxPTR "%s called\n", (intptr_t)pthread_self(), __func__);
     }
 
     out_trans = bdb_tran_begin_readcommitted(bdb_handle, trak, &bdberr);
@@ -421,8 +421,8 @@ tran_type *trans_start_snapisol(struct ireq *iq, int trak, int epoch, int file,
     iq->gluewhere = "bdb_tran_begin_snapisol";
 
     if (gbl_extended_sql_debug_trace) {
-        logmsg(LOGMSG_USER, "td=%x %s called with epoch=%d file=%d offset=%d\n",
-               (int)pthread_self(), __func__, epoch, file, offset);
+        logmsg(LOGMSG_USER, "td=%" PRIxPTR "%s called with epoch=%d file=%d offset=%d\n",
+               (intptr_t)pthread_self(), __func__, epoch, file, offset);
     }
     out_trans = bdb_tran_begin_snapisol(bdb_handle, trak, error, epoch, file,
                                         offset, is_ha_retry);
@@ -447,8 +447,8 @@ tran_type *trans_start_serializable(struct ireq *iq, int trak, int epoch,
     iq->gluewhere = "bdb_tran_begin";
 
     if (gbl_extended_sql_debug_trace) {
-        logmsg(LOGMSG_USER, "td=%x %s called with epoch=%d file=%d offset=%d\n",
-               (int)pthread_self(), __func__, epoch, file, offset);
+        logmsg(LOGMSG_USER, "td=%" PRIxPTR "%s called with epoch=%d file=%d offset=%d\n",
+               (intptr_t)pthread_self(), __func__, epoch, file, offset);
     }
     out_trans = bdb_tran_begin_serializable(bdb_handle, trak, &bdberr, epoch,
                                             file, offset, is_ha_retry);
@@ -517,7 +517,7 @@ static int trans_commit_seqnum_int(void *bdb_handle, struct dbenv *dbenv,
     else {
         bdb_tran_commit_logical_with_seqnum_size(
             bdb_handle, trans, blkseq, blklen, blkkey, blkkeylen,
-            (seqnum_type *)seqnum, &iq->txnsize, &bdberr);
+            (seqnum_type*)seqnum, &iq->txnsize, &bdberr);
     }
     iq->gluewhere = "bdb_tran_commit_with_seqnum_size done";
     if (bdberr != 0) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4674,9 +4674,9 @@ int start_new_transaction(struct sqlclntstate *clnt, struct sql_thread *thd)
 
     uuidstr_t us;
     char rqidinfo[40];
-    snprintf(rqidinfo, sizeof(rqidinfo), "rqid=%016llx %s appsock %u",
+    snprintf(rqidinfo, sizeof(rqidinfo), "rqid=%016llx %s appsock %" PRIxPTR,
              clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
-             clnt->appsock_id);
+             (intptr_t)clnt->appsock_id);
     thrman_setid(thrman_self(), rqidinfo);
 
     return 0;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4295,10 +4295,10 @@ void signal_clnt_as_done(struct sqlclntstate *clnt)
     }
 }
 
-void thr_set_user(const char *label, int id)
+void thr_set_user(const char *label, intptr_t id)
 {
     char thdinfo[40];
-    snprintf(thdinfo, sizeof(thdinfo), "appsock %u", id);
+    snprintf(thdinfo, sizeof(thdinfo), "appsock %" PRIxPTR, id);
     thrman_setid(thrman_self(), thdinfo);
 }
 
@@ -4324,7 +4324,7 @@ static void sqlengine_work_lua_thread(void *thddata, void *work)
     if (!clnt->exec_lua_thread)
         abort();
 
-    thr_set_user("appsock", clnt->appsock_id);
+    thr_set_user("appsock", (intptr_t)clnt->appsock_id);
 
     clnt->osql.timings.query_dispatched = osql_log_time();
     clnt->deque_timeus = comdb2_time_epochus();
@@ -4582,7 +4582,7 @@ void sqlengine_work_appsock(struct sqlthdstate *thd, struct sqlclntstate *clnt)
     sqlthd->clnt = clnt;
     clnt->thd = thd;
 
-    thr_set_user("appsock", clnt->appsock_id);
+    thr_set_user("appsock", (intptr_t)clnt->appsock_id);
 
     clnt->added_to_hist = clnt->isselect = 0;
     clnt_change_state(clnt, CONNECTION_RUNNING);

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -74,7 +74,7 @@ void start_internal_sql_clnt(struct sqlclntstate *clnt);
 int run_internal_sql_clnt(struct sqlclntstate *clnt, char *sql);
 void end_internal_sql_clnt(struct sqlclntstate *clnt);
 void reset_clnt_flags(struct sqlclntstate *);
-void thr_set_user(const char *label, int id);
+void thr_set_user(const char *label, intptr_t id);
 void sql_reset_sqlthread(struct sql_thread *thd);
 void query_stats_setup(struct sqlthdstate *thd, struct sqlclntstate *clnt);
 int handle_sqlite_requests(struct sqlthdstate *thd, struct sqlclntstate *clnt);

--- a/db/thrman.c
+++ b/db/thrman.c
@@ -375,7 +375,7 @@ char *thrman_describe(struct thr_handle *thr, char *buf, size_t szbuf)
         int fd = thr->fd;
         int pos = 0;
 
-        SNPRINTF(buf, szbuf, pos, "tid %u:%s", thr->archtid,
+        SNPRINTF(buf, szbuf, pos, "tid %" PRIxPTR ":%s", (intptr_t)thr->archtid,
                  thrman_type2a(thr->type));
 
         if (fd >= 0) {

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2055,8 +2055,8 @@ static int create_child_transaction(struct ireq *iq, tran_type *parent_trans,
         }
 
         if (verbose_deadlocks)
-            logmsg(LOGMSG_DEBUG, "%x %s:%d Using iq %p priority %d\n",
-                   (int)pthread_self(), __FILE__, __LINE__, iq, iq->priority);
+            logmsg(LOGMSG_DEBUG, "%" PRIxPTR "%s:%d Using iq %p priority %d\n",
+                   (intptr_t)pthread_self(), __FILE__, __LINE__, iq, iq->priority);
         irc = trans_start_set_retries(iq, parent_trans, trans, iq->retries, iq->priority);
     } else {
         irc = trans_start_set_retries(iq, parent_trans, trans, iq->retries, 0);
@@ -3021,8 +3021,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
     if (iq->debug) {
         /* TODO print trans twice? No parent_trans? */
-        reqprintf(iq, "%x:START TRANSACTION ID %p DB %d '%s'",
-                  (int)pthread_self(), trans, iq->usedb->dbnum,
+        reqprintf(iq, "%" PRIxPTR ":START TRANSACTION ID %p DB %d '%s'",
+                  (intptr_t)pthread_self(), trans, iq->usedb->dbnum,
                   iq->usedb->tablename);
     }
 
@@ -3063,7 +3063,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             /* remove all prefixes tothe debug trace and put in the transaction
              * and operation name prefix. */
             reqpopprefixes(iq, -1);
-            reqpushprefixf(iq, "%x:tran %p:%s ", (int)pthread_self(), trans,
+            reqpushprefixf(iq, "%" PRIxPTR ":tran %p:%s ", (intptr_t)pthread_self(), trans,
                            breq2a(hdr.opcode));
 
             reqprintflush(iq);
@@ -5125,8 +5125,8 @@ backout:
                              BDB_ATTR_DEADLOCK_LEAST_WRITES_EVER)) {
                 if (verbose_deadlocks)
                     logmsg(LOGMSG_ERROR,
-                           "%x %s:%d Setting iq %p priority from %d to %d\n",
-                           (int)pthread_self(), __FILE__, __LINE__, iq,
+                           "%" PRIxPTR "%s:%d Setting iq %p priority from %d to %d\n",
+                           (intptr_t)pthread_self(), __FILE__, __LINE__, iq,
                            iq->priority, priority);
 
                 if (((unsigned)priority) == UINT_MAX) {
@@ -5238,9 +5238,9 @@ backout:
        gonna execute fine */
     if (rc == ERR_NOMASTER && have_blkseq) {
         if (gbl_master_swing_osql_verbose)
-            logmsg(LOGMSG_USER, "%x %s:%d Skipping add blkseq due to early "
+            logmsg(LOGMSG_USER, "%" PRIxPTR "%s:%d Skipping add blkseq due to early "
                                 "bplog termination\n",
-                   (int)pthread_self(), __FILE__, __LINE__);
+                   (intptr_t)pthread_self(), __FILE__, __LINE__);
 
         /* we need to abort the logical/parent transaction
            we'll skip the rest of statistics */
@@ -5537,15 +5537,15 @@ add_blkseq:
                 }
                 parent_trans = NULL;
                 if (rc == IX_DUP) {
-                    logmsg(LOGMSG_WARN, "%x %s:%d replay detected!\n",
-                           (int)pthread_self(), __FILE__, __LINE__);
+                    logmsg(LOGMSG_WARN, "%" PRIxPTR "%s:%d replay detected!\n",
+                           (intptr_t)pthread_self(), __FILE__, __LINE__);
                     outrc = do_replay_case(iq, bskey, bskeylen, num_reqs, 0,
                                            replay_data, replay_len, __LINE__);
 #if DEBUG_DID_REPLAY
                     did_replay = 1;
 #endif
-                    logmsg(LOGMSG_DEBUG, "%x %s:%d replay returned %d!\n",
-                           (int)pthread_self(), __FILE__, __LINE__, outrc);
+                    logmsg(LOGMSG_DEBUG, "%" PRIxPTR "%s:%d replay returned %d!\n",
+                           (intptr_t)pthread_self(), __FILE__, __LINE__, outrc);
                     fromline = __LINE__;
 
                     goto cleanup;
@@ -5642,15 +5642,15 @@ add_blkseq:
             /* if it's a logical transaction and the commit fails we abort
              * inside the commit call */
             if (rc == IX_DUP) {
-                logmsg(LOGMSG_WARN, "%x %s:%d replay detected!\n",
-                       (int)pthread_self(), __FILE__, __LINE__);
+                logmsg(LOGMSG_WARN, "%" PRIxPTR "%s:%d replay detected!\n",
+                       (intptr_t)pthread_self(), __FILE__, __LINE__);
                 outrc = do_replay_case(iq, bskey, bskeylen, num_reqs, 0,
                                        replay_data, replay_len, __LINE__);
 #if DEBUG_DID_REPLAY
                 did_replay = 1;
 #endif
-                logmsg(LOGMSG_DEBUG, "%x %s:%d replay returned %d!\n",
-                       (int)pthread_self(), __FILE__, __LINE__, outrc);
+                logmsg(LOGMSG_DEBUG, "%" PRIxPTR "%s:%d replay returned %d!\n",
+                       (intptr_t)pthread_self(), __FILE__, __LINE__, outrc);
                 fromline = __LINE__;
 
                 goto cleanup;

--- a/net/net.c
+++ b/net/net.c
@@ -5379,8 +5379,8 @@ static void *accept_thread(void *arg)
 
     netinfo_ptr->accept_thread_arch_tid = getarchtid();
 
-    logmsg(LOGMSG_INFO, "%s: starting, tid=%d.\n", __func__,
-            netinfo_ptr->accept_thread_arch_tid);
+    logmsg(LOGMSG_INFO, "%s: starting, tid=%" PRIxPTR ".\n", __func__,
+           (intptr_t) netinfo_ptr->accept_thread_arch_tid);
 
     if (netinfo_ptr->start_thread_callback)
         netinfo_ptr->start_thread_callback(netinfo_ptr->callback_data);
@@ -5659,9 +5659,9 @@ static void *heartbeat_send_thread(void *arg)
     netinfo_ptr = (netinfo_type *)arg;
 
     netinfo_ptr->heartbeat_send_thread_arch_tid = getarchtid();
-    logmsg(LOGMSG_INFO, "heartbeat send thread starting.  time=%d.  tid=%d\n",
+    logmsg(LOGMSG_INFO, "heartbeat send thread starting.  time=%d.  tid=%" PRIxPTR "\n",
             netinfo_ptr->heartbeat_send_time,
-            netinfo_ptr->heartbeat_send_thread_arch_tid);
+           (intptr_t) netinfo_ptr->heartbeat_send_thread_arch_tid);
 
     if (netinfo_ptr->start_thread_callback)
         netinfo_ptr->start_thread_callback(netinfo_ptr->callback_data);
@@ -5875,9 +5875,9 @@ static void *heartbeat_check_thread(void *arg)
 
     netinfo_ptr = (netinfo_type *)arg;
     netinfo_ptr->heartbeat_check_thread_arch_tid = getarchtid();
-    logmsg(LOGMSG_INFO, "heartbeat check thread starting.  time=%d.  tid=%d\n",
+    logmsg(LOGMSG_INFO, "heartbeat check thread starting.  time=%d.  tid=%" PRIxPTR "\n",
             netinfo_ptr->heartbeat_check_time,
-            netinfo_ptr->heartbeat_check_thread_arch_tid);
+            (intptr_t)netinfo_ptr->heartbeat_check_thread_arch_tid);
 
     if (netinfo_ptr->start_thread_callback)
         netinfo_ptr->start_thread_callback(netinfo_ptr->callback_data);

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -522,8 +522,8 @@ static int handle_newsql_request(comdb2_appsock_arg_t *arg)
     if (!arg->admin && dbenv->rep_sync == REP_SYNC_NONE &&
         dbenv->master != gbl_myhostname) {
         logmsg(LOGMSG_DEBUG,
-               "%s:%d td %u new query on replicant with sync none, dropping\n",
-               __func__, __LINE__, (uint32_t)pthread_self());
+               "%s:%d td %" PRIxPTR "new query on replicant with sync none, dropping\n",
+               __func__, __LINE__, (intptr_t)pthread_self());
         return APPSOCK_RETURN_OK;
     }
 

--- a/util/cheapstub.c
+++ b/util/cheapstub.c
@@ -29,6 +29,7 @@
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #if defined(_LINUX_SOURCE) || defined(_SUN_SOURCE)
 #  include <execinfo.h>
@@ -55,8 +56,8 @@ static void cheapstub(FILE *f)
     int n = backtrace(buf, size);
 
     logmsgf(LOGMSG_USER, f,
-            "tid=%p(%u) stack trace, run addr2line -f -e <exe> on: \n",
-            (void *)tid, (uint32_t)tid);
+            "tid=%p %" PRIxPTR " stack trace, run addr2line -f -e <exe> on: \n",
+            (void *)tid, (intptr_t)tid);
     for  (int i = 2; i < n; ++i) {
         logmsgf(LOGMSG_USER, f, "%p ", buf[i]);
     }

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -1480,7 +1480,7 @@ static int portmux_poll_v(portmux_fd_t **fds, nfds_t nfds, int timeoutms,
                         }
                     }
                     socklen_t addrlen = sizeof(struct sockaddr_in);
-                    int rc = getpeername(clientfd, cliaddr, &addrlen);
+                    int rc = getpeername(clientfd, (struct sockaddr*) cliaddr, &addrlen);
                     if (rc ) {
                         close(clientfd);
                         clientfd = -1;


### PR DESCRIPTION
Fix places where we assume that sizeof(pthread_t) == sizeof(int)

Fixes compiler errors on x86 mac.