### PR TITLE
replace lock based retrieval of rep_deadlocks with atomic load 

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2210,5 +2210,5 @@ int bdb_debug_log(bdb_state_type *bdb_state, tran_type *tran, int op);
 
 /* Return 1 if this node is master, 0 otherwise */
 int bdb_iam_master(bdb_state_type *bdb_state);
-
+int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks);
 #endif

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -2273,3 +2273,10 @@ int bdb_rep_stats(bdb_state_type *bdb_state, int64_t *nrep_deadlocks) {
     free(stats);
     return 0;
 }
+
+int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks)
+{
+    *nrep_deadlocks = 0;
+    bdb_state->dbenv->rep_deadlocks(bdb_state->dbenv, (uint64_t *)nrep_deadlocks);
+    return 0;
+}

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2394,6 +2394,7 @@ struct __db_env {
 	int  (*rep_truncate_repdb) __P((DB_ENV *));
 	int  (*rep_start) __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
 	int  (*rep_stat) __P((DB_ENV *, DB_REP_STAT **, u_int32_t));
+	int (*rep_deadlocks) __P((DB_ENV *, u_int64_t *));
 	int  (*set_logical_start) __P((DB_ENV *, int (*) (DB_ENV *, void *,
 		u_int64_t, DB_LSN *)));
 	int  (*set_logical_commit) __P((DB_ENV *, int (*) (DB_ENV *, void *,

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -490,7 +490,7 @@ int refresh_metrics(void)
 
     refresh_queue_size(thedb);
 
-    bdb_rep_stats(thedb->bdb_env, &stats.rep_deadlocks);
+    bdb_rep_deadlocks(thedb->bdb_env, &stats.rep_deadlocks);
 
     stats.standing_queue_time = metrics_standing_queue_time();
 


### PR DESCRIPTION
{DRQS 169271784} 

A long transaction being applied locally can block out a metrics query (select * from comdb2_metrics) - mainly due to contention on rep-mutex. https://github.com/bloomberg/comdb2/pull/2312 introduces a way to fetch replication stats (rep_deadlocks) without relying on said mutex. This PR is a patch of the same on 7.0 
