### PR TITLE
Replay errors for hint queries

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2760,7 +2760,7 @@ static void _prepare_error(struct sqlthdstate *thd,
                     rc, errstr);
         errstat_set_rcstrf(err, ERR_PREPARE_RETRY, "%s", errstr);
 
-        srs_tran_del_last_query(clnt);
+        //srs_tran_del_last_query(clnt);
         return;
     }
 


### PR DESCRIPTION
Signed-off-by: mohitkhullar <mkhullar1@bloomberg.net>

unlike R6, in R7 we add statement in history in run_stmt https://github.com/bloomberg/comdb2/blob/master/db/sqlinterfaces.c#L3872
however we error back before that in prepare_stmt error
https://github.com/bloomberg/comdb2/blob/master/db/sqlinterfaces.c#L3863