### PR TITLE
Fix upsert edge case in delayed_key_add

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -71,6 +71,7 @@ int debug_switch_test_delay_analyze_commit(void);        /* 0 */
 int debug_switch_all_incoherent(void);                   /* 0 */
 int debug_switch_replicant_latency(void);                   /* 0 */
 int debug_switch_test_sync_osql_cancel(void);            /* 0 */
+int debug_switch_convert_record_sleep(void);             /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -1223,16 +1223,6 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         }
         struct forward_ct *curop = &ctrq->ctop.fwdct;
         int flags = curop->flags;
-        /* Keys for records from INSERT .. ON CONFLICT DO NOTHING have
-         * already been added to the indexes in add_record() to ensure
-         * we don't add duplicates in the data files. We still push them
-         * to ct_add_table to be able to perform cascade updates to the
-         * child tables.
-         */
-        if (flags & OSQL_IGNORE_FAILURE || flags & OSQL_ITEM_REORDERED) {
-            goto next_record;
-        }
-
         /* only do once per genid *after* processing all idxs from tmptbl 
          * (which are in sequence for the same genid): 
          * If a key is a dup violation then we don't want SC to fail,
@@ -1308,6 +1298,21 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
                 return ERR_INTERNAL;
             }
             cached_index_genid = genid;
+        }
+
+        /* Keys for records from INSERT .. ON CONFLICT DO NOTHING have
+         * already been added to the indexes in add_record() to ensure
+         * we don't add duplicates in the data files. We still push them
+         * to ct_add_table to be able to perform cascade updates to the
+         * child tables.
+         *
+         * Do it only after we've retrieved the ondisk data (ie `od_dta') for the upserted genid.
+         * Otherwise we would use the ondisk data from the previous insert statement in the transaction
+         * (or NULL if there isn't any) for the last live_sc_delayed_key_adds() call, and hence would have
+         * wrong data in the new index.
+         */
+        if (flags & OSQL_IGNORE_FAILURE || flags & OSQL_ITEM_REORDERED) {
+            goto next_record;
         }
 
         if (ixnum == -1) {

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -625,6 +625,9 @@ static int convert_record(struct convert_record_data *data)
     void *dta = NULL;
     int no_wait_rowlock = 0;
 
+    if (debug_switch_convert_record_sleep())
+        sleep(5);
+
     if (data->s->sc_thd_failed) {
         if (!data->s->retry_bad_genids)
             sc_errf(data->s,

--- a/tests/sc_upsert.test/Makefile
+++ b/tests/sc_upsert.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sc_upsert.test/lrl.options
+++ b/tests/sc_upsert.test/lrl.options
@@ -1,0 +1,2 @@
+dtastripe 8
+logmsg level info

--- a/tests/sc_upsert.test/runit
+++ b/tests/sc_upsert.test/runit
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+set -e
+
+# For simplicity, do everything against master
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select host from comdb2_cluster where is_master="Y"'`
+
+# parent table
+cdb2sql $dbnm --host $master 'CREATE TABLE t1 { tag ondisk { int i } keys { "KEYI" = i } }'
+cdb2sql $dbnm --host $master 'INSERT INTO t1 VALUES (1)'
+
+# child table 1
+cdb2sql $dbnm --host $master 'CREATE TABLE t2 { tag ondisk { int i int j } keys { dup "KEYI" = i } constraints { "KEYI" -> "t1" : "KEYI"} }'
+# child table 2
+cdb2sql $dbnm --host $master 'CREATE TABLE t3 { tag ondisk { int i int j } keys { dup "KEYI" = i } constraints { "KEYI" -> "t1" : "KEYI"} }'
+
+# insert 9 records. there'll be one stripe which has 1 more record than the rest
+for i in `seq 1 9`; do
+  cdb2sql $dbnm --host $master "INSERT INTO t3 VALUES (1, $i)"
+done
+
+# scconvert delay
+cdb2sql $dbnm --host $master "EXEC PROCEDURE sys.cmd.send('convert_record_sleep 1')"
+
+# alter child table 2
+cdb2sql $dbnm --host $master 'ALTER TABLE t3 { tag ondisk { int i int j } keys { dup "KEYI" = i "KEYJ" = j } constraints { "KEYI" -> "t1" : "KEYI"} }' &
+
+# when we wake up, the stripe that has 1 more record is still converting while the rest have already finished
+sleep 12
+
+# This insert will land on a stripe which has finished converting
+cdb2sql $dbnm --host $master <<EOF
+BEGIN
+INSERT INTO t2 VALUES (1, 999)
+INSERT INTO t3 VALUES (1, 10) ON CONFLICT DO NOTHING
+COMMIT
+EOF
+
+wait
+
+# make sure the table verifies clean
+cdb2sql $dbnm --host $master 'EXEC PROCEDURE sys.cmd.verify("t3")'
+
+cdb2sql --tabs $dbnm --host $master 'SELECT * FROM t3'
+
+wrongdata=`cdb2sql --tabs $dbnm --host $master 'SELECT COUNT(*) FROM t3 WHERE j=999'`
+if [ "$wrongdata" != 0 ]; then
+    echo 'seeing bad records!' >&2
+    exit 1
+fi
+
+
+# alter child table 2 back
+cdb2sql $dbnm --host $master 'ALTER TABLE t3 { tag ondisk { int i int j } keys { dup "KEYI" = i } constraints { "KEYI" -> "t1" : "KEYI"} }'
+
+
+cdb2sql $dbnm --host $master 'ALTER TABLE t3 { tag ondisk { int i int j } keys { dup "KEYI" = i "KEYJ" = j } constraints { "KEYI" -> "t1" : "KEYI"} }' &
+
+# when we wake up, the stripe that has 1 more record is still converting while the rest have already finished
+sleep 12
+
+# This insert will land on a stripe which has finished converting
+cdb2sql $dbnm --host $master <<EOF
+BEGIN
+INSERT INTO t2 VALUES (1, 999)
+INSERT INTO t3 VALUES (1, 11) ON CONFLICT DO NOTHING
+COMMIT
+EOF
+
+# This insert will land on a stripe which has finished converting
+cdb2sql $dbnm --host $master <<EOF
+BEGIN
+INSERT INTO t2 VALUES (1, 999)
+INSERT INTO t3 VALUES (1, 12) ON CONFLICT DO NOTHING
+COMMIT
+EOF
+
+# Make sure the schema change succeeds
+wait

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -125,6 +125,7 @@
 (name='compress_page_compact_log', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='comptxn_inherit_locks', description='Compensating transactions inherit pagelocks', type='BOOLEAN', value='ON', read_only='N')
 (name='consolidate_dbreg_ranges', description='Combine adjacent dbreg ranges for same file', type='BOOLEAN', value='ON', read_only='N')
+(name='convert_record_sleep', description='Force a 5-second delay in each convert_record() call', type='BOOLEAN', value='OFF', read_only='N')
 (name='convflush', description='', type='INTEGER', value='100', read_only='Y')
 (name='core_on_sparse_file', description='Generate a core if we catch berkeley creating a sparse file', type='BOOLEAN', value='OFF', read_only='N')
 (name='crc32c', description='Use crc32c (alternate faster implementation of CRC32, different checksums) for page checksums. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -78,6 +78,7 @@ static struct debug_switches {
     int all_incoherent;
     int replicant_latency;
     int test_sync_osql_cancel;
+    int convert_record_sleep;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -135,6 +136,7 @@ int init_debug_switches(void)
     debug_switches.all_incoherent = 0;
     debug_switches.replicant_latency = 0;
     debug_switches.test_sync_osql_cancel = 0;
+    debug_switches.convert_record_sleep = 0;
 
     register_int_switch("alternate_verify_fail", "alternate_verify_fail",
                         &debug_switches.alternate_verify_fail);
@@ -245,6 +247,8 @@ int init_debug_switches(void)
     register_int_switch("replicant_latency", "Replicant drops log records.", &debug_switches.replicant_latency);
     register_int_switch("test_sync_osql_cancel", "Force a delay in osql_sess_rcvop test synchronous osql cancel",
                         &debug_switches.test_sync_osql_cancel);
+    register_int_switch("convert_record_sleep", "Force a 5-second delay in each convert_record() call",
+                        &debug_switches.convert_record_sleep);
     return 0;
 }
 
@@ -459,4 +463,8 @@ int debug_switch_replicant_latency(void)
 int debug_switch_test_sync_osql_cancel(void)
 {
     return debug_switches.test_sync_osql_cancel;
+}
+int debug_switch_convert_record_sleep(void)
+{
+    return debug_switches.convert_record_sleep;
 }


### PR DESCRIPTION
When adding an index, if the sc pointer is on the right of an upsert (in other words, the stripe has finished converting before the upsert lands on the stripe), we may either skip adding the new record to the new index (which results in a missing key verify failure), or even worse add wrong data to the new index.

This patch fixes it.

(DRQS 168963987)