### PR TITLE
Add a comdb2_csc2 table for schemas (alternative to sqlite_master)

### DIFF
--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -127,7 +127,7 @@ add_library(sqlite
   src/wherecode.c
   src/whereexpr.c
   src/window.c
-)
+        ext/comdb2/csc2.c)
 include(${PROJECT_SOURCE_DIR}/sqlite/definitions.cmake)
 add_definitions(${SQLITE_FLAGS})
 target_compile_definitions(sqlite PRIVATE ${SQLITE_FLAGS})

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -88,6 +88,7 @@ int systblSystabPermissionsInit(sqlite3 *db);
 int systblTimepartPermissionsInit(sqlite3 *db);
 int systblFdbInfoInit(sqlite3 *db);
 int systblMemstatsInit(sqlite3 *db);
+int systblCsc2Init(sqlite3 *db);
 
 /* Simple yes/no answer for booleans */
 #define YESNO(x) ((x) ? "Y" : "N")

--- a/sqlite/ext/comdb2/csc2.c
+++ b/sqlite/ext/comdb2/csc2.c
@@ -1,0 +1,68 @@
+// Copyright 2022 Bloomberg Finance L.P.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sqlite3.h>
+#include <comdb2.h>
+#include <ezsystables.h>
+#include <comdb2systblInt.h>
+
+static sqlite3_module systblCsc2Module = {
+        .access_flag = CDB2_ALLOW_USER,
+        .systable_lock = "comdb2_tables"
+};
+
+struct csc2 {
+    char *tablename;
+    char *schema;
+};
+
+int collect_csc2(void **data, int *count) {
+    sqlite_int64 id = 0;
+    *count = 0;
+    struct csc2 *csc2 = NULL;
+    int rc;
+
+    // we may overallocate here, alternative is looping through the tables twice
+    csc2 = malloc(sizeof(struct csc2) * thedb->num_dbs);
+
+    while ((rc = comdb2_next_allowed_table(&id)) == SQLITE_OK && id < thedb->num_dbs) {
+        csc2[*count].tablename = strdup(thedb->dbs[id]->tablename);
+        csc2[*count].schema = strdup(thedb->dbs[id]->csc2_schema);
+        (*count)++;
+        id++;
+    }
+    if (rc) {
+        free(csc2);
+        return rc;
+    }
+    *data = csc2;
+    return 0;
+}
+
+void release_csc2(void *data, int count) {
+    struct csc2 *csc2 = (struct csc2*) data;
+    for (int i = 0; i < count; i++) {
+        free(csc2[i].tablename);
+        free(csc2[i].schema);
+    }
+    free(data);
+}
+
+int systblCsc2Init(sqlite3 *db) {
+    create_system_table(db, "comdb2_csc2", &systblCsc2Module, collect_csc2, release_csc2, sizeof(struct csc2),
+                        CDB2_CSTRING, "tablename", -1, offsetof(struct csc2, tablename),
+                        CDB2_CSTRING, "schema", -1, offsetof(struct csc2, schema),
+                        SYSTABLE_END_OF_FIELDS);
+    return 0;
+}

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -334,6 +334,8 @@ int comdb2SystblInit(
     rc = sqlite3_carray_init(db, 0, 0);
   if (rc == SQLITE_OK)
     rc = systblMemstatsInit(db);
+  if (rc == SQLITE_OK)
+        rc = systblCsc2Init(db);
 #endif
   return rc;
 }

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -366,6 +366,7 @@
 (name='comdb2_constraints')
 (name='comdb2_cron_events')
 (name='comdb2_cron_schedulers')
+(name='comdb2_csc2')
 (name='comdb2_fdb_info')
 (name='comdb2_fingerprints')
 (name='comdb2_functions')
@@ -410,3 +411,19 @@
 (name='comdb2_users')
 (name='comdb2_views')
 [SELECT * FROM comdb2_systables ORDER BY name] rc 0
+(tablename='t1', schema='schema
+{
+    int uid
+    int value
+    int dup_value
+    int allowed_null_value null=yes
+}
+
+keys
+{
+    "UID"      = uid
+    "VALUE" = value
+dup "DUP_VALUE" = value
+}
+')
+[select * from comdb2_csc2 where tablename='t1'] rc 0

--- a/tests/comdb2sys.test/comdb2sys.req
+++ b/tests/comdb2sys.test/comdb2sys.req
@@ -16,3 +16,4 @@ SELECT COUNT(*)=1 FROM comdb2_appsock_handlers WHERE name = 'newsql';
 SELECT COUNT(*)=1 FROM comdb2_opcode_handlers WHERE name = 'blockop';
 SELECT type FROM comdb2_temporary_file_sizes ORDER BY type;
 SELECT * FROM comdb2_systables ORDER BY name;
+select * from comdb2_csc2 where tablename='t1'


### PR DESCRIPTION
sqlite_master is an sqlite detail - would like to a have a comdb2-specific way to get schemas.