### PR TITLE
ssl: option to always allow local connections

### DIFF
--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -67,6 +67,8 @@ int gbl_nid_dbname = NID_commonName;
 #endif
 /* Minimum acceptable TLS version */
 double gbl_min_tls_ver = 0;
+/* (test-only) are connections from localhost always allowed? */
+int gbl_ssl_allow_localhost = 0;
 
 ssl_mode gbl_client_ssl_mode = SSL_UNKNOWN;
 ssl_mode gbl_rep_ssl_mode = SSL_UNKNOWN;
@@ -278,6 +280,10 @@ int ssl_process_lrl(char *line, size_t len)
             return EINVAL;
         }
         gbl_min_tls_ver = atof(tok);
+    } else if (tokcmp(line, ltok, "ssl_allow_localhost") == 0) {
+        logmsg(LOGMSG_WARN, "Always allow connections from localhost. "
+                            "This option is for testing only and should not be enabled on production.");
+        gbl_ssl_allow_localhost = 1;
     }
     return 0;
 }

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -25,6 +25,7 @@
 #include <pb_alloc.h>
 #include <mem_protobuf.h> /* comdb2_malloc_protobuf */
 #include <sql.h>
+#include <ssl_glue.h>
 #include <str0.h>
 
 #include <newsql.h>
@@ -485,6 +486,9 @@ retry_read:
             cdb2__query__free_unpacked(query, &appdata->newsql_protobuf_allocator.protobuf_allocator);
             query = NULL;
             goto retry_read;
+        } else if (ssl_whitelisted(clnt->origin)) {
+            /* allow plaintext local connections */
+            return query;
         } else {
             write_response(clnt, RESPONSE_ERROR, "The database requires SSL connections.", CDB2ERR_CONNECT_ERROR);
         }

--- a/util/ssl_glue.c
+++ b/util/ssl_glue.c
@@ -281,3 +281,18 @@ int ssl_verify_hostname(X509 *cert, int fd)
 
     return rc;
 }
+
+#if SBUF2_SERVER
+extern int gbl_ssl_allow_localhost;
+int ssl_whitelisted(const char *host)
+{
+    if (gbl_ssl_allow_localhost) {
+        if (host != NULL) {
+            if (strcasecmp(host, "localhost") || strcasecmp(host, "localhost.localdomain")) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+#endif

--- a/util/ssl_glue.h
+++ b/util/ssl_glue.h
@@ -20,4 +20,13 @@
 int ssl_verify_dbname(X509 *, const char *, int);
 int ssl_x509_get_attr(const X509 *, int, char *, size_t);
 int ssl_verify_hostname(X509 *, int);
+
+#ifndef SBUF2_SERVER
+#define SBUF2_SERVER 1
+#endif
+#if SBUF2_SERVER /* visible to server only */
+/* returns 1 if the connection is whitelisted */
+int ssl_whitelisted(const char *);
+#endif
+
 #endif /* INCLUDED_SSL_GLUE_H */


### PR DESCRIPTION
This change adds an option which always allow connections from localhost when SSL is enabled. The option is needed so that we can test SSL internally without breaking existing tooling.
