### PR TITLE
Sprinkle pthread_setname calls around

### DIFF
--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -442,6 +442,7 @@ int signal_buflock(struct buf_lock_t *p_slock)
 /* request handler */
 static void *thd_req(void *vthd)
 {
+    comdb2_name_thread(__func__);
     struct thd *thd = (struct thd *)vthd;
     struct dbenv *dbenv;
     struct timespec ts;

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1297,6 +1297,7 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
 
 void *bplog_commit_timepart_resuming_sc(void *p)
 {
+    comdb2_name_thread(__func__);
     struct ireq iq;
     struct schema_change_type *sc_pending = (struct schema_change_type *)p;
     struct schema_change_type *sc;

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -123,6 +123,7 @@ int gbl_blocking_physrep = 0;
 
 static void *keep_in_sync(void *args)
 {
+    comdb2_name_thread(__func__);
     /* vars for syncing */
     int rc;
     volatile int64_t gen, highest_gen = 0;

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -430,6 +430,7 @@ static int lock_variable;
 /* much of the code (most) here is stolen from record.c */
 static void *prefault_io_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     struct dbenv *dbenv;
     int rc = 0, needfree = 0;
     pfrq_t *req;

--- a/db/prefault_helper.c
+++ b/db/prefault_helper.c
@@ -55,6 +55,7 @@ void clear_pfk(struct dbenv *dbenv, int i, int numops)
 
 static void *prefault_helper_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     prefault_helper_thread_arg_type prefault_helper_thread_arg;
     struct dbenv *dbenv;
     int rc;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -597,6 +597,7 @@ void bdb_newsi_mempool_stat();
 static pthread_mutex_t exiting_lock = PTHREAD_MUTEX_INITIALIZER;
 void *clean_exit_thd(void *unused)
 {
+    comdb2_name_thread(__func__);
     if (!gbl_ready)
         return NULL;
 
@@ -618,6 +619,7 @@ void *clean_exit_thd(void *unused)
 
 static void *getschemalk(void *arg)
 {
+    comdb2_name_thread(__func__);
     int64_t holdtime = (int64_t)arg;
     logmsg(LOGMSG_USER, "Locking the schemalk in write mode for %"PRId64" seconds", holdtime);
     wrlock_schema_lk();

--- a/db/pushlogs.c
+++ b/db/pushlogs.c
@@ -49,6 +49,7 @@ static char junk[2048];
 
 static void *pushlogs_thread(void *voidarg)
 {
+    comdb2_name_thread(__func__);
     int rc;
     int lastreport = 0;
     thrman_register(THRTYPE_PUSHLOG);

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -290,6 +290,7 @@ static int sample_index_int(index_descriptor_t *ix_des)
 /* spawn a thread to sample an index */
 static void *sampling_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     int rc;
     index_descriptor_t *ix_des = (index_descriptor_t *)arg;
 
@@ -882,6 +883,7 @@ error:
 /* spawn thread to analyze a table */
 static void *table_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     int rc;
     table_descriptor_t *td = (table_descriptor_t *)arg;
     struct thr_handle *thd_self;

--- a/db/sqllog.c
+++ b/db/sqllog.c
@@ -78,6 +78,7 @@ static void free_event(struct log_event *e)
 
 static void *async_logthd(void *unused)
 {
+    comdb2_name_thread(__func__);
     struct log_event *e = NULL;
     int rc;
 

--- a/db/testcompr.c
+++ b/db/testcompr.c
@@ -282,6 +282,7 @@ static void compr_stat(CompStruct *comp)
 
 static void *handle_comptest_thd(void *_arg)
 {
+    comdb2_name_thread(__func__);
     CompArg *arg = _arg;
     CompStruct comp = {0};
     int rc;

--- a/db/timers.c
+++ b/db/timers.c
@@ -170,6 +170,7 @@ int comdb2_timer(int ms, int parm)
 
 void *timer_thread(void *p)
 {
+    comdb2_name_thread(__func__);
     int tnow;
     struct timer t;
     struct timer_parm waitft_parm;

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -192,6 +192,7 @@ int trigger_unregister(trigger_reg_t *t)
 
 static void *trigger_start_int(void *name_)
 {
+    comdb2_name_thread(__func__);
     GET_BDB_STATE_CAST(bdb_state, void *);
     char name[strlen(name_) + 1];
     strcpy(name, name_);

--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -101,6 +101,7 @@ static void watchdogsql(void)
 
 static void *watchdog_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     void *ptr;
     pthread_t dummy_tid;
     int rc;
@@ -402,6 +403,7 @@ void comdb2_die(int aborat)
 
 static void *watchdog_watcher_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     extern int gbl_watchdog_watch_threshold;
     int failed_once = 0;
 

--- a/net/akq.c
+++ b/net/akq.c
@@ -97,6 +97,7 @@ static void akq_worker_int(struct akq *q)
 
 static void *akq_worker(void *arg)
 {
+    comdb2_name_thread(__func__);
     struct akq *q = (struct akq *)arg;
     if (q->start) q->start(q);
     akq_worker_int(q);

--- a/net/net.c
+++ b/net/net.c
@@ -3529,6 +3529,7 @@ struct net_decom_node_arg {
  */
 static void *net_decom_node_delayed(void *p)
 {
+    comdb2_name_thread(__func__);
     struct net_decom_node_arg *args = (struct net_decom_node_arg *)p;
     sleep(2);
     net_decom_node(args->netinfo_ptr, args->host);
@@ -3831,8 +3832,14 @@ int gbl_net_writer_thread_poll_ms = 1000;
 
 static void *writer_thread(void *args)
 {
-    netinfo_type *netinfo_ptr;
     host_node_type *host_node_ptr;
+    host_node_ptr = args;
+
+    char thdname[32];
+    snprintf(thdname, sizeof(thdname), "writer_thread %s", host_node_ptr->host);
+    comdb2_name_thread(thdname);
+    netinfo_type *netinfo_ptr;
+
     write_data *write_list_ptr, *write_list_back;
     int rc, flags, maxage;
     struct timespec waittime;
@@ -3843,7 +3850,6 @@ static void *writer_thread(void *args)
     thread_started("net writer");
     ENABLE_PER_THREAD_MALLOC(__func__);
 
-    host_node_ptr = args;
     netinfo_ptr = host_node_ptr->netinfo_ptr;
 
     host_node_ptr->writer_thread_arch_tid = getarchtid();
@@ -4105,8 +4111,14 @@ static int process_hello_common(netinfo_type *netinfo_ptr,
 
 static void *reader_thread(void *arg)
 {
-    netinfo_type *netinfo_ptr;
+    // TODO: node!
     host_node_type *host_node_ptr;
+    host_node_ptr = arg;
+
+    char thdname[32];
+    snprintf(thdname, sizeof(thdname), "writer_thread %s", host_node_ptr->host);
+    comdb2_name_thread(thdname);
+    netinfo_type *netinfo_ptr;
     wire_header_type wire_header;
     int rc, set_qstat = 0;
     char fromhost[256], tohost[256];
@@ -4115,7 +4127,6 @@ static void *reader_thread(void *arg)
     thread_started("net reader");
     ENABLE_PER_THREAD_MALLOC(__func__);
 
-    host_node_ptr = arg;
     netinfo_ptr = host_node_ptr->netinfo_ptr;
 
     host_node_ptr->reader_thread_arch_tid = getarchtid();
@@ -4555,6 +4566,12 @@ static void *connect_thread(void *arg)
 {
     netinfo_type *netinfo_ptr;
     host_node_type *host_node_ptr;
+    host_node_ptr = arg;
+
+    char thdname[32];
+    snprintf(thdname, sizeof(thdname), "writer_thread %s", host_node_ptr->host);
+    comdb2_name_thread(thdname);
+
     socklen_t len;
     int fd;
     int rc;
@@ -4569,7 +4586,6 @@ static void *connect_thread(void *arg)
     struct pollfd pfd;
     int err;
 
-    host_node_ptr = arg;
     netinfo_ptr = host_node_ptr->netinfo_ptr;
 
     host_node_ptr->connect_thread_arch_tid = getarchtid();
@@ -5202,6 +5218,7 @@ int findpeer(int fd, char *addr, int len)
 /* reads the connect message & creates threads to monitor connection state */
 static void *connect_and_accept(void *arg)
 {
+    comdb2_name_thread(__func__);
     connect_and_accept_t *ca;
     netinfo_type *netinfo_ptr;
     SBUF2 *sb;
@@ -5353,6 +5370,7 @@ void do_appsock(netinfo_type *netinfo_ptr, struct sockaddr_in *cliaddr,
 
 static void *accept_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     netinfo_type *netinfo_ptr;
     struct pollfd pol;
     int rc;
@@ -5650,6 +5668,7 @@ static void *accept_thread(void *arg)
 
 static void *heartbeat_send_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     host_node_type *ptr;
     netinfo_type *netinfo_ptr;
 
@@ -5863,6 +5882,7 @@ void net_set_writefn(SBUF2 *sb, sbuf2writefn writefn)
 
 static void *heartbeat_check_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     host_node_type *ptr;
     netinfo_type *netinfo_ptr;
     int timestamp;

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -457,7 +457,11 @@ static void nop(int dummyfd, short what, void *arg)
 static __thread struct event_base *current_base;
 static void *net_dispatch(void *arg)
 {
+    char thdname[32];
     struct net_dispatch_info *n = arg;
+    snprintf(thdname, sizeof(thdname), "net_dispatch %s", n->who);
+    comdb2_name_thread(n->who);
+
     current_base = n->base;
     struct event *ev = event_new(n->base, -1, EV_PERSIST, nop, n);
     struct timeval ten = {10, 0};

--- a/plugins/dbqueuedb/dbqueuedb.c
+++ b/plugins/dbqueuedb/dbqueuedb.c
@@ -646,6 +646,7 @@ struct statthrargs {
 
 static void *stat_thread(void *argsptr)
 {
+    comdb2_name_thread(__func__);
     struct statthrargs *args = argsptr;
     thread_started("dbque stat");
     backend_thread_event(args->db->dbenv, COMDB2_THR_EVENT_START_RDONLY);
@@ -761,6 +762,7 @@ struct flush_thd_data {
 
 static void *flush_thd(void *argsptr)
 {
+    comdb2_name_thread(__func__);
     struct flush_thd_data *args = argsptr;
     thread_started("dbque flush");
     backend_thread_event(thedb, COMDB2_THR_EVENT_START_RDWR);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -766,6 +766,7 @@ int do_schema_change_tran(sc_arg_t *arg)
 
 int do_schema_change_tran_thd(sc_arg_t *arg)
 {
+    comdb2_name_thread(__func__);
     int rc;
     bdb_state_type *bdb_state = thedb->bdb_env;
     thread_started("schema_change");
@@ -777,6 +778,7 @@ int do_schema_change_tran_thd(sc_arg_t *arg)
 
 int do_schema_change_locked(struct schema_change_type *s, void *tran)
 {
+    comdb2_name_thread(__func__);
     int rc = 0;
     struct ireq *iq = NULL;
     iq = (struct ireq *)calloc(1, sizeof(*iq));
@@ -862,6 +864,7 @@ int finalize_schema_change_thd(struct ireq *iq, tran_type *trans)
 
 void *sc_resuming_watchdog(void *p)
 {
+    comdb2_name_thread(__func__);
     struct ireq iq;
     struct schema_change_type *stored_sc = NULL;
     int time = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_WATCHDOG_TIMER);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -1153,6 +1153,7 @@ extern pthread_key_t no_pgcompact;
  */
 void *convert_records_thd(struct convert_record_data *data)
 {
+    comdb2_name_thread(__func__);
     struct thr_handle *thr_self = thrman_self();
     enum thrtype oldtype = THRTYPE_UNKNOWN;
     int rc = 1;
@@ -1863,6 +1864,7 @@ static int upgrade_records(struct convert_record_data *data)
 
 static void *upgrade_records_thd(void *vdata)
 {
+    comdb2_name_thread(__func__);
     int rc;
 
     struct convert_record_data *data = (struct convert_record_data *)vdata;
@@ -3170,6 +3172,7 @@ static int sc_redo_size(bdb_state_type *bdb_state)
 
 void *live_sc_logical_redo_thd(struct convert_record_data *data)
 {
+    comdb2_name_thread(__func__);
     struct schema_change_type *s = data->s;
     struct thr_handle *thr_self = thrman_self();
     enum thrtype oldtype = THRTYPE_UNKNOWN;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -432,6 +432,7 @@ typedef struct {
 
 static void *finalize_schema_change_thd_tran(void *varg)
 {
+    comdb2_name_thread(__func__);
     finalize_t *arg = varg;
     void *trans = arg->trans;
     struct ireq *iq = arg->iq;

--- a/util/comdb2_pthread_create.c
+++ b/util/comdb2_pthread_create.c
@@ -74,6 +74,7 @@ static void free_memptr(void *inarg)
 
 static void *free_stack_thr(void *unused)
 {
+    comdb2_name_thread(__func__);
     thr_arg_t *arg;
     int signal_count;
     size_t stacksz;

--- a/util/locks_wrap.h
+++ b/util/locks_wrap.h
@@ -70,4 +70,6 @@
 #define Pthread_rwlock_wrlock(...)          WRAP_PTHREAD(pthread_rwlock_wrlock, __VA_ARGS__)
 #define Pthread_setspecific(...)            WRAP_PTHREAD(pthread_setspecific, __VA_ARGS__)
 
+extern void comdb2_name_thread(const char *name);
+
 #endif

--- a/util/object_pool.c
+++ b/util/object_pool.c
@@ -631,6 +631,7 @@ static int hash_elem_free_wrapper(void *elem, void *unused)
 
 static void *eviction_thread(void *arg)
 {
+    comdb2_name_thread(__func__);
     comdb2_objpool_t op;
     intptr_t rc;
     struct timespec tm;

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -682,6 +682,7 @@ static void *thdpool_thd(void *voidarg)
     struct thd *thd = voidarg;
     struct thdpool *pool = thd->pool;
 
+    comdb2_name_thread(pool->name);
     ATOMIC_ADD32(pool->nactthd, 1);
 #   ifndef NDEBUG
     logmsg(LOGMSG_DEBUG, "%s(%s): thread going active: %u active\n",
@@ -1296,4 +1297,12 @@ int thdpool_get_queue_depth(struct thdpool *pool)
 void thdpool_set_queued_callback(struct thdpool *pool, void(*callback)(void*)) 
 {
     pool->queued_callback = callback;
+}
+
+void comdb2_name_thread(const char *name) {
+#ifdef __linux
+    pthread_setname_np(pthread_self(), name);
+#elif defined __APPLE__
+    pthread_setname_np(name);
+#endif
 }


### PR DESCRIPTION
It helps to see thread names rather than addresses when debugging.

Signed-off-by: Michael Ponomarenko <mponomarenko@bloomberg.net>
