### PR TITLE
SSL metrics

### DIFF
--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -98,6 +98,8 @@ struct comdb2_metrics_store {
     int64_t reprepares;
     int64_t nonsql;
     int64_t vreplays;
+    int64_t nsslfullhandshakes;
+    int64_t nsslpartialhandshakes;
 };
 
 static struct comdb2_metrics_store stats;
@@ -264,6 +266,10 @@ comdb2_metric gbl_metrics[] = {
     {"verify_replays", "Number of replays on verify errors",
       STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.vreplays,
       NULL},
+    {"nsslfullhandshakes", "Number of SSL full handshakes", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.nsslfullhandshakes, NULL},
+    {"nsslpartialhandshakes", "Number of SSL partial handshakes", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.nsslpartialhandshakes, NULL}
 };
 
 const char *metric_collection_type_string(comdb2_collection_type t) {
@@ -501,6 +507,8 @@ int refresh_metrics(void)
     }
     stats.diskspace = refresh_diskspace(thedb, trans);
     stats.vreplays = gbl_verify_tran_replays;
+    stats.nsslfullhandshakes = gbl_ssl_num_full_handshakes;
+    stats.nsslpartialhandshakes = gbl_ssl_num_partial_handshakes;
     curtran_puttran(trans);
 
     return 0;

--- a/db/metrics.h
+++ b/db/metrics.h
@@ -82,4 +82,7 @@ extern uint64_t gbl_last_election_time_ms;
 extern uint64_t gbl_total_election_time_ms;
 extern uint64_t gbl_election_count;
 
+extern uint64_t gbl_ssl_num_full_handshakes;
+extern uint64_t gbl_ssl_num_partial_handshakes;
+
 #endif /* _STATISTICS_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -17,6 +17,8 @@
 #ifndef _SQL_H_
 #define _SQL_H_
 
+#include <openssl/asn1.h> /* for ub_common_name */
+
 #include "cdb2api.h"
 #include "comdb2.h"
 
@@ -1130,6 +1132,10 @@ struct connection_info {
     char *sql;
     char *fingerprint;
     int64_t is_admin;
+    int64_t is_ssl; /* 1 if this an SSL connection */
+    int64_t has_cert; /* 1 if the SSL connection has an X509 certificate */
+    char *common_name; /* common name in the certificate */
+    char common_name_str[ub_common_name];
 
     /* latched in sqlinterfaces, not returned */ 
     time_t connect_time_int;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6515,6 +6515,15 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
     c->state_int = clnt->state;
     c->time_in_state_int = clnt->state_start_time;
     c->is_admin = clnt->admin;
+    c->is_ssl = clnt->plugin.has_ssl(clnt);
+    c->has_cert = clnt->plugin.has_x509(clnt);
+    if (!c->has_cert) {
+        c->common_name = NULL;
+    } else {
+        memset(c->common_name_str, 0, sizeof(c->common_name_str));
+        clnt->plugin.get_x509_attr(clnt, NID_commonName, c->common_name_str, sizeof(c->common_name_str));
+        c->common_name = c->common_name_str;
+    }
     Pthread_mutex_lock(&clnt->state_lk);
     if (clnt->state == CONNECTION_RUNNING || clnt->state == CONNECTION_QUEUED) {
         char zFingerprint[FINGERPRINTSZ * 2 + 1];

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -68,6 +68,11 @@ int gbl_nid_dbname = NID_commonName;
 /* Minimum acceptable TLS version */
 double gbl_min_tls_ver = 0;
 
+/* number of full ssl handshakes */
+uint64_t gbl_ssl_num_full_handshakes = 0;
+/* number of partial ssl handshakes (via session resumption) */
+uint64_t gbl_ssl_num_partial_handshakes = 0;
+
 ssl_mode gbl_client_ssl_mode = SSL_UNKNOWN;
 ssl_mode gbl_rep_ssl_mode = SSL_UNKNOWN;
 SSL_CTX *gbl_ssl_ctx = NULL;
@@ -359,6 +364,9 @@ void ssl_stats(void)
         logmsg(LOGMSG_USER,
                "Verify database name in client certificate: YES (%s)\n",
                OBJ_nid2ln(gbl_nid_dbname));
+
+    logmsg(LOGMSG_USER, "  %" PRId64 " full handshakes, %" PRId64 " partial handshakes\n",
+           gbl_ssl_num_full_handshakes, gbl_ssl_num_partial_handshakes);
 
     logmsg(LOGMSG_USER, "Replicant SSL mode: %s\n",
            ssl_mode_to_string(gbl_rep_ssl_mode));

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -25,6 +25,7 @@
 #include <openssl/ssl.h>
 
 #include <bdb_api.h>
+#include <comdb2_atomic.h>
 #include <hostname_support.h>
 #include <intern_strings.h>
 #include <net_appsock.h>
@@ -42,6 +43,8 @@
 extern int gbl_nid_dbname;
 extern SSL_CTX *gbl_ssl_ctx;
 extern ssl_mode gbl_client_ssl_mode;
+extern uint64_t gbl_ssl_num_full_handshakes;
+extern uint64_t gbl_ssl_num_partial_handshakes;
 
 struct ping_pong {
     int status;
@@ -290,6 +293,8 @@ static void wr_dbinfo_int(struct newsql_appdata_evbuffer *appdata, int write_res
 
 static void wr_dbinfo_ssl(struct newsql_appdata_evbuffer *appdata)
 {
+    /* clears openssl's error queue */
+    ERR_clear_error();
     struct evbuffer *wr_buf = sql_wrbuf(appdata->writer);
     int len = evbuffer_get_length(wr_buf);
     if (len > KB(16)) len = KB(16);
@@ -529,8 +534,17 @@ static void ssl_accept_evbuffer(int dummyfd, short what, void *arg)
 {
     struct newsql_appdata_evbuffer *appdata = arg;
     SSL *ssl = appdata->ssl_data->ssl;
+    /* clears openssl's error queue */
+    ERR_clear_error();
+
     int rc = SSL_do_handshake(ssl);
     if (rc == 1) {
+        /* keep track of number of full and partial handshakes */
+        if (SSL_session_reused(ssl))
+            ATOMIC_ADD64(gbl_ssl_num_partial_handshakes, 1);
+        else
+            ATOMIC_ADD64(gbl_ssl_num_full_handshakes, 1);
+
         if (enable_ssl_evbuffer(appdata) == 0) {
             rd_hdr(-1, 0, appdata);
             return;
@@ -564,6 +578,9 @@ static int rd_evbuffer_ssl(struct newsql_appdata_evbuffer *appdata)
     SSL *ssl = appdata->ssl_data->ssl;
     int len = KB(16);
     struct iovec v = {0};
+    /* clears openssl's error queue */
+    ERR_clear_error();
+
     if (evbuffer_reserve_space(appdata->rd_buf, len, &v, 1) == -1) {
         return -1;
     }

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -35,6 +35,8 @@ extern ssl_mode gbl_client_ssl_mode;
 extern SSL_CTX *gbl_ssl_ctx;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern int gbl_nid_dbname;
+extern unsigned long long gbl_ssl_num_full_handshakes;
+extern unsigned long long gbl_ssl_num_partial_handshakes;
 
 int gbl_protobuf_prealloc_buffer_size = 8192;
 
@@ -342,6 +344,13 @@ retry_read:
             logmsg(LOGMSG_ERROR, "%s\n", err);
             return NULL;
         }
+
+        /* keep track of number of full and partial handshakes */
+        if (SSL_session_reused(sslio_get_ssl(sb)))
+            ATOMIC_ADD64(gbl_ssl_num_partial_handshakes, 1);
+        else
+            ATOMIC_ADD64(gbl_ssl_num_full_handshakes, 1);
+
         /* Extract the user from the certificate. */
         ssl_set_clnt_user(clnt);
         goto retry_read;

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -94,5 +94,8 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_CSTRING, "sql", -1, offsetof(struct connection_info, sql),
             CDB2_CSTRING, "fingerprint", -1, offsetof(struct connection_info, fingerprint),
             CDB2_INTEGER, "is_admin", -1, offsetof(struct connection_info, is_admin),
+            CDB2_INTEGER, "is_ssl", -1, offsetof(struct connection_info, is_ssl),
+            CDB2_INTEGER, "has_cert", -1, offsetof(struct connection_info, has_cert),
+            CDB2_CSTRING, "common_name", -1, offsetof(struct connection_info, common_name),
             SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/simple_ssl.test/runit
+++ b/tests/simple_ssl.test/runit
@@ -95,4 +95,22 @@ if [ $? != 0 ]; then
     exit 1
 fi
 
+has_handshake_cnt=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT value FROM comdb2_metrics WHERE name='nsslfullhandshakes'")
+if [ $has_handshake_cnt = 0 ]; then
+    echo 'No handshake counter???' >&2
+    exit 1
+fi
+
+all_ssl=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT COUNT(*) FROM comdb2_connections WHERE is_ssl = 0")
+if [ $all_ssl != 0 ]; then
+    echo 'Has plaintext connections???' >&2
+    exit 1
+fi
+
+all_have_cert=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT COUNT(*) FROM comdb2_connections WHERE has_cert = 0")
+if [ $all_have_cert != 0 ]; then
+    echo 'Has connections with no cert???' >&2
+    exit 1
+fi
+
 echo "Passed."


### PR DESCRIPTION
The patch keeps track of numbers of SSL full and partial handshakes in the comdb2_metrics table.
It also keeps track of per-connection SSL attributes such as the Common Name in the comdb2_connections table.

Signed-off-by: Rivers Zhang <hzhang320@bloomberg.net>
