### PR TITLE
Require dbpad when changing byte array size

### DIFF
--- a/db/tag.h
+++ b/db/tag.h
@@ -192,7 +192,8 @@ enum {
     /* bad rcodes */
     SC_BAD_NEW_FIELD = -3,
     SC_BAD_INDEX_CHANGE = -4,
-    SC_BAD_INDEX_NAME = -5
+    SC_BAD_INDEX_NAME = -5,
+    SC_BAD_DBPAD = -6
 };
 
 extern hash_t *gbl_tag_hash;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -64,10 +64,11 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
 {
     int changed = ondisk_schema_changed(s->tablename, newdb, stderr, s);
 
-    if (changed == SC_BAD_NEW_FIELD) {
+    if (changed == SC_BAD_NEW_FIELD || changed == SC_BAD_DBPAD) {
         /* we want to capture cases when "alter" is used
            to add a field to a table that has no dbstore or
-           isnull specified
+           isnull specified,
+           or change the size of a byte array with no dbpad specified
            It is still possible to do so by using "fastinit"
            with the new schema instead of "alter"
          */
@@ -91,6 +92,11 @@ static int prepare_changes(struct schema_change_type *s, struct dbtable *db,
             if (s->iq)
                 reqerrstr(s->iq, ERR_SC,
                           "cannot change index referenced by other tables");
+        } else if (changed == SC_BAD_DBPAD) {
+            sc_errf(s, "cannot change size of byte array without dbpad\n");
+            if (s->iq)
+                reqerrstr(s->iq, ERR_SC,
+                          "cannot change size of byte array without dbpad");
         }
         sc_errf(s, "Failed to process schema!\n");
         return -1;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1450,6 +1450,9 @@ int dryrun_int(struct schema_change_type *s, struct dbtable *db, struct dbtable 
             sbuf2printf(s->sb,
                         ">Cannot change index referenced by other tables\n");
             return -1;
+        } else if (changed == SC_BAD_DBPAD) {
+            sbuf2printf(s->sb, ">Cannot change size of byte array without dbpad\n");
+            return -1;
         } else {
             sbuf2printf(s->sb, ">Failed to process schema!\n");
             return -1;

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -848,7 +848,7 @@ int reload_schema(char *table, const char *csc2, tran_type *tran)
         changed = ondisk_schema_changed(table, newdb, NULL, NULL);
         /* let this fly, which will be ok for fastinit;
            master will catch early non-fastinit cases */
-        if (changed < 0 && changed != SC_BAD_NEW_FIELD) {
+        if (changed < 0 && changed != SC_BAD_NEW_FIELD && changed != SC_BAD_DBPAD) {
             if (changed == -2) {
                 logmsg(LOGMSG_ERROR, "Error reloading schema!\n");
             }

--- a/tests/ddl_csc2.test/t01_dbpad_check.expected
+++ b/tests/ddl_csc2.test/t01_dbpad_check.expected
@@ -1,0 +1,15 @@
+[alter table t {
+    schema {
+        byte a[4]
+    }
+}] failed with rc 240 cannot change size of byte array without dbpad
+[alter table t {
+    schema {
+        byte a[1]
+    }
+}] failed with rc 240 cannot change size of byte array without dbpad
+[alter table t {
+    schema {
+        byte a[4] dbstore=0
+    }
+}] failed with rc 240 cannot change size of byte array without dbpad

--- a/tests/ddl_csc2.test/t01_dbpad_check.sql
+++ b/tests/ddl_csc2.test/t01_dbpad_check.sql
@@ -1,0 +1,51 @@
+create table t {
+    schema {
+        byte a[2]
+    }
+};$$
+
+# not allowed: need dbpad to change size
+alter table t {
+    schema {
+        byte a[4]
+    }
+};$$
+
+# not allowed: need dbpad to change size
+alter table t {
+    schema {
+        byte a[1]
+    }
+};$$
+
+# not allowed: need dbpad to change size
+alter table t {
+    schema {
+        byte a[4] dbstore=0
+    }
+};$$
+
+# should pass
+alter table t {
+    schema {
+        byte a[3] dbpad=0
+    }
+};$$
+
+create table t2 {
+    schema {
+        byte a[2]
+    }
+};$$
+
+
+# should pass
+alter table t2 {
+    schema {
+        byte a[2]
+        int b dbstore=0
+    }
+};$$
+
+drop table t;
+drop table t2;


### PR DESCRIPTION
Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
