### PR TITLE
schema change typing cleanup

### DIFF
--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -191,7 +191,6 @@ static void *queuedb_cron_event(struct cron_event *evt, struct errstat *err)
                 strncpy0(
                     sc->tablename, tbl_bdb_state->name, sizeof(sc->tablename)
                 );
-                sc->type = DBTYPE_QUEUEDB;
                 sc->del_qdb_file = 1;
                 sc->nothrevent = 1;
                 sc->finalize = 1;
@@ -221,7 +220,6 @@ static void *queuedb_cron_event(struct cron_event *evt, struct errstat *err)
             strncpy0(
                 sc->tablename, tbl_bdb_state->name, sizeof(sc->tablename)
             );
-            sc->type = DBTYPE_QUEUEDB;
             sc->add_qdb_file = 1;
             sc->qdb_file_ver = flibc_htonll(bdb_get_cmp_context(tbl_bdb_state));
             sc->nothrevent = 1;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -579,14 +579,14 @@ char *get_ddl_type_str(struct schema_change_type *s)
         return "UPGRADE";
     else if (s->type == DBTYPE_TAGGED_TABLE)
         return "ALTER";
-    else if (s->type == DBTYPE_QUEUE)
-        return "ALTER QUEUE";
     else if (s->type == DBTYPE_MORESTRIPE)
         return "ALTER STRIPE";
     else if (s->add_view || s->drop_view)
         return "VIEW";
     else if (s->add_qdb_file || s->del_qdb_file)
         return "QUEUE_DB";
+    else if (s->qdb_legacy)
+        return "ALTER QUEUE";
 
     return "UNKNOWN";
 }
@@ -669,14 +669,14 @@ static int do_schema_change_tran_int(sc_arg_t *arg, int no_reset)
         rc = do_upgrade_table(s);
     else if (s->type == DBTYPE_TAGGED_TABLE)
         rc = do_ddl(do_alter_table, finalize_alter_table, iq, s, trans, alter);
-    else if (s->type == DBTYPE_QUEUE)
-        rc = do_alter_queues(s);
     else if (s->type == DBTYPE_MORESTRIPE)
         rc = do_alter_stripes(s);
     else if (s->add_view)
         rc = do_ddl(do_add_view, finalize_add_view, iq, s, trans, user_view);
     else if (s->drop_view)
         rc = do_ddl(do_drop_view, finalize_drop_view, iq, s, trans, user_view);
+    else if (s->qdb_legacy)
+        rc = do_alter_queues(s);
     else if (s->add_qdb_file)
         rc = do_ddl(do_add_qdb_file, finalize_add_qdb_file, iq, s, trans,
                     add_queue_file);

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -168,8 +168,9 @@ size_t schemachange_packed_size(struct schema_change_type *s)
         sizeof(s->delsp) + sizeof(s->defaultsp) + sizeof(s->is_sfunc) +
         sizeof(s->is_afunc) + sizeof(s->lua_func_flags) + sizeof(s->rename) + 
         sizeof(s->newtable) + sizeof(s->usedbtablevers) + sizeof(s->add_view) + 
-        sizeof(s->drop_view) + sizeof(s->add_qdb_file) + sizeof(s->del_qdb_file)
-        + sizeof(s->qdb_file_ver) + _partition_packed_size(&s->partition);
+        sizeof(s->drop_view) + sizeof(s->add_qdb_file) + sizeof(s->del_qdb_file) +
+        sizeof(s->qdb_legacy) + sizeof(s->qdb_file_ver) +
+        _partition_packed_size(&s->partition);
 
     return s->packed_len;
 }
@@ -329,6 +330,7 @@ void *buf_put_schemachange(struct schema_change_type *s, void *p_buf,
     p_buf = buf_put(&s->add_qdb_file, sizeof(s->add_qdb_file), p_buf, p_buf_end);
     p_buf = buf_put(&s->del_qdb_file, sizeof(s->del_qdb_file), p_buf, p_buf_end);
     p_buf = buf_put(&s->qdb_file_ver, sizeof(s->qdb_file_ver), p_buf, p_buf_end);
+    p_buf = buf_put(&s->qdb_legacy, sizeof(s->qdb_legacy), p_buf, p_buf_end);
 
     p_buf = buf_put(&s->partition.type, sizeof(s->partition.type), p_buf,
                     p_buf_end);
@@ -582,6 +584,8 @@ void *buf_get_schemachange(struct schema_change_type *s, void *p_buf,
     p_buf = (uint8_t *)buf_get(&s->del_qdb_file, sizeof(s->del_qdb_file),
                                p_buf, p_buf_end);
     p_buf = (uint8_t *)buf_get(&s->qdb_file_ver, sizeof(s->qdb_file_ver),
+                               p_buf, p_buf_end);
+    p_buf = (uint8_t *)buf_get(&s->qdb_legacy, sizeof(s->qdb_legacy),
                                p_buf, p_buf_end);
 
     p_buf = (uint8_t *)buf_get(&s->partition.type, sizeof(s->partition.type),

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -498,14 +498,14 @@ int morestripe(struct dbenv *dbenvin, int newstripe, int blobstripe)
 }
 
 int create_queue(struct dbenv *dbenvin, char *queuename, int avgitem,
-                 int pagesize, int isqueuedb)
+                 int pagesize)
 {
     struct schema_change_type *s = new_schemachange_type();
     if (!s) {
         logmsg(LOGMSG_ERROR, "%s: malloc failed\n", __func__);
         return -1;
     }
-    s->type = isqueuedb ? DBTYPE_QUEUEDB : DBTYPE_QUEUE;
+    s->qdb_legacy = 1;
     strncpy0(s->tablename, queuename, sizeof(s->tablename));
     s->avgitemsz = avgitem;
     s->pagesize = pagesize;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -95,8 +95,7 @@ struct schema_change_type {
     /*  ==========    persistent members ========== */
     unsigned long long rqid;
     uuid_t uuid;
-    int type; /* DBTYPE_TAGGED_TABLE or DBTYPE_QUEUE or DBTYPE_QUEUEDB
-                 or DBTYPE_MORESTRIPE */
+    int type; /* DBTYPE_TAGGED_TABLE or DBTYPE_MORESTRIPE */
     size_t tablename_len;
     char tablename[MAXTABLELEN];    /* name of table/queue */
     int rename;                     /* rename table? */
@@ -175,6 +174,7 @@ struct schema_change_type {
     int add_qdb_file;
     int del_qdb_file;
     unsigned long long qdb_file_ver; /* part of file name to add */
+    int qdb_legacy;
 
     /* ========== runtime members ========== */
     int onstack; /* if 1 don't free */
@@ -347,8 +347,7 @@ size_t schemachange_packed_size(struct schema_change_type *s);
 int start_schema_change_tran(struct ireq *, tran_type *tran);
 int start_schema_change(struct schema_change_type *);
 int finalize_schema_change(struct ireq *, tran_type *);
-int create_queue(struct dbenv *, char *queuename, int avgitem, int pagesize,
-                 int isqueuedb);
+int create_queue(struct dbenv *, char *queuename, int avgitem, int pagesize);
 int start_table_upgrade(struct dbenv *dbenv, const char *tbl,
                         unsigned long long genid, int full, int partial,
                         int sync);


### PR DESCRIPTION
Modern schema change uses flags to determine its type, while legacy operation typing was fathered in unchanged; the latter relies on sc->type field, and share the enum with dbtable objects.  This was ok when we had only a handful of schema change types, but nowadays is just confusing.   In this PR  we are eliminating using sc->type for legacy queue operations. 

NOTE: this is an independent PR part of a larger cleanup effort for schema change typing.   

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

