### PR TITLE
Removing partitioning for a "table"

### DIFF
--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -159,11 +159,5 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     if (gbl_replicate_local)
         local_replicant_write_clear(iq, tran, db);
 
-#if 0
-    /* handle in osql_scdone_commit_callback and osql_scdone_abort_callback */
-    /* delete files we don't need now */
-    sc_del_unused_files_tran(db, tran);
-#endif
-
     return 0;
 }

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1049,6 +1049,7 @@ clone_schemachange_type(struct schema_change_type *sc)
     newsc->timepartition_name = sc->timepartition_name;
     newsc->timepartition_version = sc->timepartition_version;
     newsc->partition = sc->partition;
+    newsc->usedbtablevers = sc->usedbtablevers;
 
     if (!p_buf) {
         free_schema_change_type(newsc);

--- a/sqlite/src/comdb2build.h
+++ b/sqlite/src/comdb2build.h
@@ -116,7 +116,7 @@ void comdb2CreatePartition(Parse* p, Token* table, Token* name,
 void comdb2DropPartition(Parse* p, Token* name);
 void comdb2CreateTimePartition(Parse* p, Token* period, Token* retention,
                                Token* start);
-void comdb2SaveMergeTable(Parse* p, Token* name, Token* database);
+void comdb2SaveMergeTable(Parse* p, Token* name, Token* database, int alter);
 
 void comdb2analyze(Parse*, int opt, Token*, Token*, int);
 

--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -234,10 +234,16 @@ partitioned_by ::= PARTITIONED BY partition_options.
 partition_options ::= TIME PERIOD STRING(P) RETENTION INTEGER(R) START STRING(S). {
   comdb2CreateTimePartition(pParse, &P, &R, &S);
 }
+partition_options ::= NONE. {
+    comdb2SaveMergeTable(pParse, NULL, NULL, 1);
+}
 merge ::= .
 merge ::= merge_with.
 merge_with ::= MERGE nm(Y) dbnm(Z). {
-  comdb2SaveMergeTable(pParse, &Y, &Z);
+  comdb2SaveMergeTable(pParse, &Y, &Z, 0);
+}
+merge_with_alter ::= MERGE nm(Y) dbnm(Z). {
+  comdb2SaveMergeTable(pParse, &Y, &Z, 1);
 }
 
 %endif SQLITE_BUILDING_FOR_COMDB2
@@ -2016,7 +2022,7 @@ alter_table_commit_pending ::= SET COMMIT PENDING. {
 }
 
 alter_table_partitioned ::= partitioned_by.
-alter_table_merge ::= merge_with.
+alter_table_merge ::= merge_with_alter.
 
 alter_table_action ::= alter_table_add_column.
 alter_table_action ::= alter_table_drop_column.

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -847,3 +847,126 @@ Create table and merge existing table in it
 (a=1)
 (a=3)
 (a=5)
+TEST 14
+Create partitioned table, add records, drop partitiong and check table
+cdb2sql ${CDB2_OPTIONS} dorintdb default select * from t14 order by 1
+(a=10, b=20)
+(a=30, b=40)
+(a=50, b=60)
+cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "t",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_F64CD191",
+  },
+  {
+   "TABLENAME"    : "$1_A2620AE4",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t3",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_43868980",
+  },
+  {
+   "TABLENAME"    : "$2_CE9DB8D",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t14",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_528953B1",
+  },
+  {
+   "TABLENAME"    : "$1_9ABA178A",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='t', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+(name='t2', period='daily', retention=2, nshards=2, version=0, shard0name='t3')
+(name='t14', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='t', shardname='$0_F64CD191')
+(name='t', shardname='$1_A2620AE4')
+(name='t2', shardname='$0_43868980')
+(name='t2', shardname='$2_CE9DB8D')
+(name='t14', shardname='$0_528953B1')
+(name='t14', shardname='$1_9ABA178A')
+cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
+(name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t14', arg2=NULL, arg3=NULL)
+cdb2sql ${CDB2_OPTIONS} dorintdb default select * from t14 order by 1
+(a=10, b=20)
+(a=30, b=40)
+(a=50, b=60)
+cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "t",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_F64CD191",
+  },
+  {
+   "TABLENAME"    : "$1_A2620AE4",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t3",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_43868980",
+  },
+  {
+   "TABLENAME"    : "$2_CE9DB8D",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='t', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+(name='t2', period='daily', retention=2, nshards=2, version=0, shard0name='t3')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='t', shardname='$0_F64CD191')
+(name='t', shardname='$1_A2620AE4')
+(name='t2', shardname='$0_43868980')
+(name='t2', shardname='$2_CE9DB8D')
+cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
+(name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t', arg2=NULL, arg3=NULL)

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -383,7 +383,39 @@ fi
 echo $cmd "select * from t11 order by a"
 $cmd "select * from t11 order by a" >> $OUT
 
+header 14 "Create partitioned table, add records, drop partitiong and check table"
+echo $cmd "CREATE TABLE t14(a int, b int) PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'"
+$cmd "CREATE TABLE t14(a int, b int) PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START '${starttime}'"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create partition t14"
+   exit 1
+fi
 
+echo $cmd "insert into t14 values (10,20), (30,40), (50,60)"
+$cmd "insert into t14 values (10,20), (30,40), (50,60)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t14"
+   exit 1
+fi
+
+echo $cmd "select * from t14 order by 1"
+echo $cmd "select * from t14 order by 1" >> $OUT
+$cmd "select * from t14 order by 1" >> $OUT
+
+timepart_stats 0
+
+echo $cmd "ALTER TABLE t14 PARTITIONED BY NONE"
+$cmd "ALTER TABLE t14 PARTITIONED BY NONE"
+if (( $? != 0 )) ; then
+   echo "FAILURE to remote partitioning for t14"
+   exit 1
+fi
+
+echo $cmd "select * from t14 order by 1"
+echo $cmd "select * from t14 order by 1" >> $OUT
+$cmd "select * from t14 order by 1" >> $OUT
+
+timepart_stats 0
 
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual


### PR DESCRIPTION
Introducing syntax:

ALTER TABLE t PARTITIONED BY NONE

This replaces partition "t" with a table "t" that contains all the data of the original shards.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

