### PR TITLE
Abort on tunable for testing

### DIFF
--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -453,6 +453,8 @@ __ufid_open(dbenv, txn, dbpp, inufid, name, lsnp)
 	return 0;
 }
 
+int gbl_abort_on_missing_ufid = 0;
+
 static int
 __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, create)
 	DB_ENV *dbenv;
@@ -482,7 +484,10 @@ __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, create)
 		}
 		(*dbpp) = ufid->dbp;
 	} else {
-		abort();
+		if (gbl_abort_on_missing_ufid) {
+			abort();
+		}
+		ret = DB_DELETED;
 	}
 	Pthread_mutex_unlock(&dbenv->ufid_to_db_lk);
 	if (close_dbp) {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -240,6 +240,7 @@ extern int gbl_max_trigger_threads;
 extern int gbl_do_inline_poll;
 extern int gbl_fingerprint_max_queries;
 extern int gbl_ufid_log;
+extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;
 
 extern long long sampling_threshold;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1860,6 +1860,10 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
 REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOLEAN, &gbl_ufid_log,
                  EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("abort_on_missing_ufid", "Abort if ufid is not found.  (Default: off)", 
+                 TUNABLE_BOOLEAN, &gbl_abort_on_missing_ufid, EXPERIMENTAL | INTERNAL | READONLY,
+                 NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("ufid_dbreg_test", "Enable ufid-dbreg test.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_ufid_dbreg_test, EXPERIMENTAL |
                  INTERNAL | READONLY, NULL, NULL, NULL, NULL);

--- a/tests/sc_downgrade.test/lrl.options
+++ b/tests/sc_downgrade.test/lrl.options
@@ -12,3 +12,4 @@ dtastripe 16
 blobstripe
 berkattr elect_highest_committed_gen 0
 ufid_log on
+abort_on_missing_ufid on


### PR DESCRIPTION
There's a file-deletion bug which is causing the sc_downgrade test to abort.  dbreg returns db_deleted when it can't open a file, so I will make ufid do the same.  I will create a patch for the file-deletion bug in a different pr.