### PR TITLE
Trigger fixes

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -811,7 +811,8 @@ struct sqlclntstate {
     uint8_t is_overlapping;
     uint32_t init_gen;
     int8_t gen_changed;
-    uint8_t skip_peer_chk;
+    uint8_t skip_peer_chk; /* 1 if this is a temp table operation from an SP,
+                              where peer check and the dbopen_gen check at commit time are skipped. */
     uint8_t queue_me;
     uint8_t fail_dispatch;
     uint8_t in_sqlite_init; /* clnt is in sqlite init phase when this is set */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4983,7 +4983,7 @@ int sqlite3BtreeCommit(Btree *pBt)
         break;
 
     case TRANLEVEL_SOSQL:
-        if (gbl_early_verify && !clnt->early_retry && gbl_osql_send_startgen) {
+        if (!clnt->skip_peer_chk && gbl_early_verify && !clnt->early_retry && gbl_osql_send_startgen) {
             if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
                 clnt->early_retry = EARLY_ERR_GENCHANGE;
         }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2038,8 +2038,8 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt)
                     (clnt->sql) ? clnt->sql : "(???.)", clnt->osql.replay);
             }
             if (clnt->ctrl_sqlengine == SQLENG_FNSH_STATE) {
-                if (gbl_early_verify && !clnt->early_retry &&
-                    gbl_osql_send_startgen && clnt->start_gen) {
+                if (!clnt->skip_peer_chk && gbl_early_verify && !clnt->early_retry && gbl_osql_send_startgen &&
+                    clnt->start_gen) {
                     if (clnt->start_gen != bdb_get_rep_gen(thedb->bdb_env))
                         clnt->early_retry = EARLY_ERR_GENCHANGE;
                 }

--- a/db/trigger.c
+++ b/db/trigger.c
@@ -322,6 +322,11 @@ int trigger_stat()
     for (int i = 0; i < thedb->num_qdbs; ++i) {
         struct dbtable *qdb = thedb->qdbs[i];
         consumer_lock_read(qdb);
+        /* protect us from incomplete triggers (e.g., an old-style queue without a consumer */
+        if (qdb->consumers[0] == NULL) {
+            consumer_unlock(qdb);
+            continue;
+        }
         int ctype = dbqueue_consumer_type(qdb->consumers[0]);
         if (ctype != CONSUMER_TYPE_LUA && ctype != CONSUMER_TYPE_DYNLUA) {
             consumer_unlock(qdb);

--- a/tests/trigger.test/t02.expected
+++ b/tests/trigger.test/t02.expected
@@ -1,0 +1,7 @@
+(rows inserted=1)
+(version='trigger_2')
+(SLEEP(1) -- let trigger start=1)
+(rows inserted=1)
+(SLEEP(1) -- let trigger fire=1)
+('the alter-table statement should not hang'='the alter-table statement should not hang')
+(x=1, y=NULL)

--- a/tests/trigger.test/t02.req
+++ b/tests/trigger.test/t02.req
@@ -1,0 +1,29 @@
+CREATE TABLE t2 (x INTEGER)$$
+CREATE TABLE t2_1 (x INTEGER)$$
+INSERT INTO t2_1 VALUES (1)
+
+CREATE PROCEDURE trigger_2 VERSION 'trigger_2' {
+  local function main(event)
+    db:prepare("select * from t2_1"):exec()
+    local tbl = db:table("tbl", {{"i", "int"}})
+    local tp = event.type
+    local inew, iold
+    if tp == 'add' then
+      inew = event.new.x
+      tbl:insert({i=inew})
+    elseif tp == 'del' then
+      iold = event.old.x
+      tbl:insert({i=iold})
+    end
+    return 0
+  end
+}$$
+
+CREATE LUA TRIGGER trigger_2 ON (TABLE t2 FOR INSERT AND UPDATE AND DELETE)
+SELECT SLEEP(1) -- let trigger start
+INSERT INTO t2 VALUES(1)
+SELECT SLEEP(1) -- let trigger fire
+SELECT 'the alter-table statement should not hang'
+ALTER TABLE t2_1 ADD COLUMN y INTEGER$$
+SELECT * FROM t2_1 -- make sure schema change succeeded
+DROP LUA TRIGGER trigger_2


### PR DESCRIPTION
The patch fixes a few bugs in the trigger subsystem:
    1) table lock leaks from unclosed dbstmt structures;
    2) spurious falures from temp table operations;
    3) 'stat trigger' crash on incomplete triggers.

{DRQS 169515389}