### PR TITLE
Fix race between startup and replication

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3912,7 +3912,6 @@ static int init(int argc, char **argv)
     load_dbstore_tableversion(thedb, NULL);
 
     gbl_backend_opened = 1;
-    unlock_schema_lk();
 
     sqlinit();
     rc = create_datacopy_arrays();
@@ -3928,6 +3927,7 @@ static int init(int argc, char **argv)
     create_sqlite_master(); /* create sql statements */
 
     load_auto_analyze_counters(); /* on starting, need to load counters */
+    unlock_schema_lk();
 
     /* There could have been an in-process schema change.  Add those tables now
      * before logical recovery */

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -328,6 +328,7 @@ extern int gbl_debug_sleep_in_sql_tick;
 extern int gbl_instrument_consumer_lock;
 extern int gbl_reject_mixed_ddl_dml;
 extern int gbl_debug_mixed_ddl_dml;
+extern int gbl_debug_create_master_entry;
 extern int gbl_sync_osql_cancel;
 extern int eventlog_nkeep;
 extern int gbl_replicant_retry_on_not_durable;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1941,6 +1941,10 @@ REGISTER_TUNABLE("reject_mixed_ddl_dml", "Reject write schedules which mix DDL a
 REGISTER_TUNABLE("debug_mixed_ddl_dml", "Reject write schedules which mix DDL and DML.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_debug_mixed_ddl_dml, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_create_master_entry", "Reproduce startup race in create_master_entry.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_create_master_entry, EXPERIMENTAL | INTERNAL, 
+                 NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("sync_osql_cancel", "Synchronous osql cancellation (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_sync_osql_cancel, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 

--- a/tests/init_sc_race.test/Makefile
+++ b/tests/init_sc_race.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/init_sc_race.test/lrl.options
+++ b/tests/init_sc_race.test/lrl.options
@@ -1,0 +1,68 @@
+table t0 t1ix1.csc2
+table t1 t1ix2.csc2
+table t2 t1ix3.csc2
+table t3 t1ix4.csc2
+table t4 t1ix5.csc2
+table t5 t1ix1.csc2
+table t6 t1ix2.csc2
+table t7 t1ix3.csc2
+table t8 t1ix4.csc2
+table t9 t1ix5.csc2
+
+table t10 t1ix1.csc2
+table t11 t1ix2.csc2
+table t12 t1ix3.csc2
+table t13 t1ix4.csc2
+table t14 t1ix5.csc2
+table t15 t1ix1.csc2
+table t16 t1ix2.csc2
+table t17 t1ix3.csc2
+table t18 t1ix4.csc2
+table t19 t1ix5.csc2
+
+table t20 t1ix1.csc2
+table t21 t1ix2.csc2
+table t22 t1ix3.csc2
+table t23 t1ix4.csc2
+table t24 t1ix5.csc2
+table t25 t1ix1.csc2
+table t26 t1ix2.csc2
+table t27 t1ix3.csc2
+table t28 t1ix4.csc2
+table t29 t1ix5.csc2
+
+table t30 t1ix1.csc2
+table t31 t1ix2.csc2
+table t32 t1ix3.csc2
+table t33 t1ix4.csc2
+table t34 t1ix5.csc2
+table t35 t1ix1.csc2
+table t36 t1ix2.csc2
+table t37 t1ix3.csc2
+table t38 t1ix4.csc2
+table t39 t1ix5.csc2
+
+table t40 t1ix1.csc2
+table t41 t1ix2.csc2
+table t42 t1ix3.csc2
+table t43 t1ix4.csc2
+table t44 t1ix5.csc2
+table t45 t1ix1.csc2
+table t46 t1ix2.csc2
+table t47 t1ix3.csc2
+table t48 t1ix4.csc2
+table t49 t1ix5.csc2
+
+nowatch
+logmsg level info
+disable_new_snapshot
+#disable_snapshot_isolation
+init_with_genid48
+decoupled_logputs off
+verbose_set_sc_in_progress on
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
+cache 512 mb
+dtastripe 16
+blobstripe
+debug_create_master_entry on

--- a/tests/init_sc_race.test/runit
+++ b/tests/init_sc_race.test/runit
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export tablecount=50
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function start_node
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="start_node"
+    typeset node=$1
+    write_prompt $func "Running $func"
+    ts=$(date +%s)
+    if [ $node != $(hostname) ] ; then
+        ssh -o StrictHostKeyChecking=no -tt $node COMDB2_ROOT=$COMDB2_ROOT $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl >$TESTDIR/logs/${DBNAME}.${node}.db.$ts 2>&1 </dev/null &
+        echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+    else
+        $COMDB2_EXE ${DBNAME} -lrl $DBDIR/${DBNAME}.lrl &> $TESTDIR/logs/${DBNAME}.${node}.db.$ts -pidfile ${TMPDIR}/${DBNAME}.${node}.pid &
+    fi
+}
+
+function start_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="start_cluster"
+    write_prompt $func "Running $func"
+    for node in $CLUSTER ; do
+        start_node $node
+    done
+}
+
+function stop_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="stop_cluster"
+    write_prompt $func "Running $func"
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+    done
+    sleep 5
+}
+
+function kill_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="stop_cluster"
+    write_prompt $func "Running $func"
+    for node in $CLUSTER ; do
+        ssh $node "pid=\$(ps -ef | egrep comdb2 | egrep lrl | egrep -v bash | egrep $DBNAME | awk '{print \$2}') ; kill -9 \$pid "
+    done
+}
+
+function verify_up
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="verify_up"
+    write_prompt $func "Running $func"
+    typeset node=$1
+    typeset count=0
+    typeset r=1
+    while [[ "$r" -ne "0" && "$count" -lt 5 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+    [[ $r != 0 ]] && failexit "node $node did not recover in time"
+}
+
+function add_records
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="add_records"
+    write_prompt $func "Running $func"
+    
+    i=0
+    while [[ $i -lt $tablecount ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t$i(a, b, c, d, e) values (1, 2, 3, 4, 5)"
+        let i=i+1
+    done
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    write_prompt $func "Running $func"
+    add_records
+    write_prompt $func "Tables should already be created"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select * from comdb2_tables"
+
+    stop_cluster
+    sleep 5
+    start_cluster
+
+    r=1
+    while [[ $r != 0 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "update t1 set a=1 where a=1" 
+        r=$?
+    done
+
+    j=11
+    while [[ $j -lt 40 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table t$j"
+        let j=j+1
+    done
+
+    for node in $CLUSTER; do
+        verify_up $node &
+    done
+    sleep 10
+    kill_cluster
+
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+
+run_test
+echo "Success"

--- a/tests/init_sc_race.test/t1ix1.csc2
+++ b/tests/init_sc_race.test/t1ix1.csc2
@@ -1,0 +1,13 @@
+schema
+    {
+        int a null = yes
+        int b null = yes
+        int c null = yes
+        int d null = yes
+        int e null = yes
+    }
+keys
+    {
+        dup "IX_0" = c
+    }
+

--- a/tests/init_sc_race.test/t1ix2.csc2
+++ b/tests/init_sc_race.test/t1ix2.csc2
@@ -1,0 +1,14 @@
+schema
+    {
+        int a null = yes
+        int b null = yes
+        int c null = yes
+        int d null = yes
+        int e null = yes
+    }
+keys
+    {
+        dup "IX_0" = a
+        dup "IX_1" = b
+    }
+

--- a/tests/init_sc_race.test/t1ix3.csc2
+++ b/tests/init_sc_race.test/t1ix3.csc2
@@ -1,0 +1,15 @@
+schema
+    {
+        int a null = yes
+        int b null = yes
+        int c null = yes
+        int d null = yes
+        int e null = yes
+    }
+keys
+    {
+        dup "IX_0" = a
+        dup "IX_1" = b
+        dup "IX_2" = c
+    }
+

--- a/tests/init_sc_race.test/t1ix4.csc2
+++ b/tests/init_sc_race.test/t1ix4.csc2
@@ -1,0 +1,16 @@
+schema
+    {
+        int a null = yes
+        int b null = yes
+        int c null = yes
+        int d null = yes
+        int e null = yes
+    }
+keys
+    {
+        dup "IX_0" = a
+        dup "IX_1" = b
+        dup "IX_2" = c
+        dup "IX_3" = d
+    }
+

--- a/tests/init_sc_race.test/t1ix5.csc2
+++ b/tests/init_sc_race.test/t1ix5.csc2
@@ -1,0 +1,17 @@
+schema
+    {
+        int a null = yes
+        int b null = yes
+        int c null = yes
+        int d null = yes
+        int e null = yes
+    }
+keys
+    {
+        dup "IX_0" = a
+        dup "IX_1" = b
+        dup "IX_2" = c
+        dup "IX_3" = d
+        dup "IX_4" = e
+    }
+

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 . ${TESTSROOTDIR}/tools/write_prompt.sh
-. ${TESTSROOTDIR}/tools/waitmach.sh
 
 if [[ -z "$sleeptime" ]]; then 
     sleeptime=5
@@ -95,6 +94,4 @@ function bounce_database
     else
         bounce_local $sleeptime
     fi
-
-    wait_up
 }


### PR DESCRIPTION
This tests and fixes a race condition where replication can start writing to the master_records structure before init has completed initializing it.  The fix is for init to maintain the schemalk until after the master_records structure has been initialized.

Signed-off-by: Mark Hannum <mhannum72@gmail.com>