### PR TITLE
Admin mode

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -781,6 +781,7 @@ int gbl_osql_odh_blob = 1;
 int gbl_clean_exit_on_sigterm = 1;
 
 int gbl_is_physical_replicant;
+int gbl_server_admin_mode = 0;
 
 comdb2_tunables *gbl_tunables; /* All registered tunables */
 int init_gbl_tunables();

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3618,6 +3618,7 @@ extern int gbl_rcache;
 extern int gbl_throttle_txn_chunks_msec;
 extern int gbl_sql_release_locks_on_slow_reader;
 extern int gbl_fail_client_write_lock;
+extern int gbl_server_admin_mode;
 
 void csc2_free_all(void);
 

--- a/db/config.c
+++ b/db/config.c
@@ -47,6 +47,7 @@ extern int gbl_recovery_lsn_offset;
 extern int gbl_rep_node_pri;
 extern int gbl_bad_lrl_fatal;
 extern int gbl_disable_new_snapshot;
+extern int gbl_server_admin_mode;
 
 int gbl_disable_access_controls;
 
@@ -75,6 +76,7 @@ static struct option long_options[] = {
     {"tunable", required_argument, NULL, 0},
     {"version", no_argument, NULL, 'v'},
     {"insecure", no_argument, &gbl_disable_access_controls, 1},
+    {"admin-mode", no_argument, &gbl_server_admin_mode, 1},
     {NULL, 0, NULL, 0}};
 
 static const char *help_text =

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2180,5 +2180,7 @@ REGISTER_TUNABLE("foreign_metadb_class", "Forces metadb for fdb queries to class
 
 REGISTER_TUNABLE("allow_unauthenticated_tag_access", NULL, TUNABLE_BOOLEAN, &gbl_unauth_tag_access, NOARG | READEARLY,
                  NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("admin_mode", "Fail non-admin client requests (Default: False)", TUNABLE_BOOLEAN, &gbl_server_admin_mode, NOARG | READEARLY,
+                 NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -971,6 +971,9 @@ int handle_buf_main2(struct dbenv *dbenv, SBUF2 *sb, const uint8_t *p_buf,
         return ERR_REJECTED;
     }
 
+    if (qtype != REQ_OFFLOAD && gbl_server_admin_mode)
+        return ERR_REJECTED;
+
     net_delay(frommach);
 
     ndispatch = 0;

--- a/net/net.c
+++ b/net/net.c
@@ -85,6 +85,7 @@ extern int gbl_pmux_route_enabled;
 extern int gbl_exit;
 extern int gbl_net_portmux_register_interval;
 extern int gbl_accept_on_child_nets;
+extern int gbl_server_admin_mode;
 
 extern void myfree(void *ptr);
 extern int db_is_exiting(void);
@@ -5330,6 +5331,12 @@ void do_appsock(netinfo_type *netinfo_ptr, struct sockaddr_in *cliaddr,
         }
     } else if (firstbyte != sbuf2ungetc(firstbyte, sb)) {
         logmsg(LOGMSG_ERROR, "sbuf2ungetc failed %s:%d\n", __FILE__, __LINE__);
+        sbuf2close(sb);
+        return;
+    }
+
+
+    if (gbl_server_admin_mode && !admin) {
         sbuf2close(sb);
         return;
     }

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -917,7 +917,7 @@ static void newsql_setup_clnt_evbuffer(struct appsock_handler_arg *arg, int admi
         local = 1;
     }
 
-    if (thedb->no_more_sql_connections || (admin && !allow_admin(local))) {
+    if (thedb->no_more_sql_connections || (gbl_server_admin_mode && !admin) || (admin && !allow_admin(local))) {
         evbuffer_free(arg->rd_buf);
         shutdown(arg->fd, SHUT_RDWR);
         close(arg->fd);


### PR DESCRIPTION
This mode disallows non-admin client requests, which may be useful in an emergency (e.g., to stop a crash triggered by a client request while we fix the cluster).