### PR TITLE
Making sql-cancel-cnonce thread-safe

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -681,7 +681,6 @@ struct sqlclntstate {
     pthread_t debug_sqlclntstate;
     int last_check_time;
     int query_timeout;
-    int stop_this_statement;
     int statement_timedout;
     struct conninfo conn;
 
@@ -1122,6 +1121,8 @@ struct sql_thread {
 
     /* current shard; cut 0 we support only one partition */
     int crtshard;
+    /* flag to signal that the sql engine should stop executing */
+    int stop_this_statement;
 };
 
 struct connection_info {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -609,7 +609,7 @@ int check_sql_client_disconnect(struct sqlclntstate *clnt, char *file, int line)
         clnt->last_check_time = gbl_epoch_time;
         if (!gbl_notimeouts && peer_dropped_connection(clnt)) {
             logmsg(LOGMSG_INFO, "Peer dropped connection %s:%d\n", file, line);
-            clnt->stop_this_statement = 1;
+            clnt->thd->sqlthd->stop_this_statement = 1;
             return 1;
         }
     }
@@ -645,7 +645,7 @@ int sql_tick(struct sql_thread *thd)
         sleep(1);
 
     /* statement cancelled? done */
-    if (clnt->stop_this_statement) {
+    if (thd->stop_this_statement) {
         rc = SQLITE_ABORT;
         goto done;
     }
@@ -9316,7 +9316,17 @@ void cancel_sql_statement(int id)
     {
         if (thd->id == id && thd->clnt) {
             found = 1;
-            thd->clnt->stop_this_statement = 1;
+            /* Previously the flag was defined in the clnt struct and we would do
+                   ```thd->clnt->stop_this_statement = 1```
+
+               this wasn't thread-safe: thd->clnt might be set to NULL
+               after the if check but before the line above, by the sql thread.
+               The race condition would crash the database.
+
+               To fix this we move the flag up to the sql_thread struct.
+               The code is protected by the gbl_sql_lock so `thd' can't disappear
+               under our noses. */
+            thd->stop_this_statement = 1;
             break;
         }
     }
@@ -9345,7 +9355,8 @@ void cancel_sql_statement_with_cnonce(const char *cnonce)
                 continue;
             found = (memcmp(snap.key, cnonce, cnonce_len) == 0);
             if (found) {
-                thd->clnt->stop_this_statement = 1;
+                /* See comments in cancel_sql_statement() */
+                thd->stop_this_statement = 1;
                 break;
             }
         }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1922,7 +1922,10 @@ int newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
         clnt->dbtran.mode = TRANLEVEL_SOSQL;
     }
     clnt->osql.sent_column_data = 0;
-    clnt->stop_this_statement = 0;
+
+    /* `thd' gets assigned in sqlenginepool. A fresh connection will not have this. */
+    if (clnt->thd && clnt->thd->sqlthd)
+        clnt->thd->sqlthd->stop_this_statement = 0;
     if (clnt->tzname[0] == 0 && sql_query->tzname) {
         strncpy0(clnt->tzname, sql_query->tzname, sizeof(clnt->tzname));
     }


### PR DESCRIPTION
Fix sql-cancel-cnonce race with sqlengine thread

(DRQS 169704115)