### PR TITLE
ALTER TABLE t MERGE t2

### DIFF
--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -705,6 +705,24 @@ static int do_merge_table(struct ireq *iq, struct schema_change_type *s,
 
     newdb = s->newdb;
 
+    /* NOTE: add prepopulates newdb->csc2_schema, but alter does not
+     * we need this to be able to call populate_db_with_alt_schema
+     * later on
+     */
+    if (!newdb->csc2_schema) {
+        assert(bdb_have_llmeta() && s->kind == SC_ALTERTABLE);
+        int ver;
+        ver = get_csc2_version_tran(db->tablename, tran);
+        if (ver > 0) {
+            get_csc2_file_tran(db->tablename, ver, &newdb->csc2_schema,
+                               &newdb->csc2_schema_len, tran);
+        } else {
+            sc_client_error(s, "Cannot get csc2 for the table %s",
+                            db->tablename);
+            return -1;
+        }
+    }
+
     if (s->resume == SC_PREEMPT_RESUME) {
         newdb = db->sc_to;
         goto convert_records;
@@ -762,13 +780,21 @@ convert_records:
         return SC_MASTER_DOWNGRADE;
     }
 
-    struct errstat err = {0};
-    rc = populate_db_with_alt_schema(thedb, newdb, newdb->csc2_schema, &err);
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "%s\ncsc2: \"%s\"\n", err.errstr,
-               newdb->csc2_schema);
-        sc_client_error(s, "%s", err.errval, err.errstr);
-        return -1;
+    /* Merging two scenarios:
+     *- alter merge: in this case the schema is already populated with NEW tags
+     *- create merge: we need to populate schema with NEW tags
+     */
+    struct schema *tag = find_tag_schema(newdb->tablename, ".NEW..ONDISK");
+    if (!tag) {
+        struct errstat err = {0};
+        rc =
+            populate_db_with_alt_schema(thedb, newdb, newdb->csc2_schema, &err);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s\ncsc2: \"%s\"\n", err.errstr,
+                   newdb->csc2_schema);
+            sc_client_error(s, "%s", err.errval, err.errstr);
+            return -1;
+        }
     }
 
     add_ongoing_alter(s);
@@ -780,7 +806,8 @@ convert_records:
 
     remove_ongoing_alter(s);
 
-    backout_schemas(newdb->tablename);
+    if (!tag)
+        backout_schemas(newdb->tablename);
 
     if (rc == SC_PREEMPTED) {
         sc_client_error(s, "SCHEMACHANGE PREEMPTED");

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -970,3 +970,11 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_time
 cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
 (name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
 (name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+TEST 15
+Test ALTER table MERGE
+(a=11)
+(a=22)
+(a=33)
+(a=100)
+(a=200)
+[select * from t16 order by a] failed with rc -3 no such table: t16

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -417,6 +417,47 @@ $cmd "select * from t14 order by 1" >> $OUT
 
 timepart_stats 0
 
+header 15 "Test ALTER table MERGE"
+echo $cmd "CREATE TABLE t15(a int, b int)"
+$cmd "CREATE TABLE t15(a int, b int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create table t15"
+   exit 1
+fi
+echo $cmd "CREATE TABLE t16(a int)"
+$cmd "CREATE TABLE t16(a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create table t16"
+   exit 1
+fi
+
+echo $cmd "insert into t15 values (11,12), (22,23), (33,34)"
+$cmd "insert into t15 values (11,12), (22,23), (33,34)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t15"
+   exit 1
+fi
+
+echo $cmd "insert into t16 values (100), (200)"
+$cmd "insert into t16 values (100), (200)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t16"
+   exit 1
+fi
+
+echo $cmd "alter table t15 drop column b, merge t16"
+$cmd "alter table t15 drop column b, merge t16"
+if (( $? != 0 )) ; then
+   echo "FAILURE to alter merge"
+   exit 1
+fi
+
+echo $cmd "select * from t15 order by a"
+$cmd "select * from t15 order by a" >> $OUT
+
+echo $cmd "select * from t16 order by a"
+$cmd "select * from t16 order by a" >> $OUT 2>&1
+
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
 


### PR DESCRIPTION
New syntax:

ALTER TABLE t ..., MERGE t2

It complements CREATE TABLE ... MERGE.. syntax.   

Example:
CREATE TABLE t (a int, bint);
CREATE TABLE t2(a int);
ALTER TABLE t drop column b, MERGE t2

The last statement will alter the table t, and merge t2 into it, atomically.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
