### PR TITLE
Expose gbl_ddlk tunable to tunables

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -249,6 +249,7 @@ extern int gbl_alternate_normalize;
 extern int gbl_sc_logbytes_per_second;
 extern int gbl_fingerprint_max_queries;
 extern int gbl_ufid_log;
+extern unsigned gbl_ddlk;
 extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1973,6 +1973,9 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
 REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOLEAN, &gbl_ufid_log,
                  EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,
+                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("abort_on_missing_ufid", "Abort if ufid is not found.  (Default: off)", 
                  TUNABLE_BOOLEAN, &gbl_abort_on_missing_ufid, EXPERIMENTAL | INTERNAL | READONLY,
                  NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Expose gbl_ddlk, generate-random-deadlock, to tunables