### PR TITLE
sp: Run trigger code in protected mode

### DIFF
--- a/db/trigger.c
+++ b/db/trigger.c
@@ -165,9 +165,10 @@ static int trigger_unregister_int(trigger_reg_t *t)
     trigger_info_t *info;
     if ((info = hash_find(trigger_hash, t->spname)) != NULL &&
         strcmp(info->host, trigger_hostname(t)) == 0 &&
-        info->trigger_cookie == t->trigger_cookie) {
-        trigger_hash_del(info);
+        info->trigger_cookie == t->trigger_cookie
+    ){
         ctrace("TRIGGER:%s %016" PRIx64 " UNASSIGNED\n", info->spname, info->trigger_cookie);
+        trigger_hash_del(info);
         return CDB2_TRIG_REQ_SUCCESS;
     }
     return CDB2_TRIG_ASSIGNED_OTHER;

--- a/lua/sp.h
+++ b/lua/sp.h
@@ -28,7 +28,7 @@ struct spversion_t {
 
 int exec_procedure(struct sqlthdstate *, struct sqlclntstate *, char **err);
 void exec_thread(struct sqlthdstate *, struct sqlclntstate *);
-void *exec_trigger(struct trigger_reg *);
+void *exec_trigger(char *);
 void close_sp(struct sqlclntstate *);
 int is_pingpong(struct sqlclntstate *);
 

--- a/tests/trigger.test/t01.req
+++ b/tests/trigger.test/t01.req
@@ -1,8 +1,10 @@
 CREATE TABLE t1 (x INT);$$
 
 CREATE PROCEDURE trigger_1 VERSION 'trigger_1' {
+
+  local tbl = db:table("tbl", {{"i", "int"}})
+
   local function main(event)
-    local tbl = db:table("tbl", {{"i", "int"}})
     local tp = event.type
     local inew, iold
     if tp == 'add' then

--- a/tests/trigger.test/t02.req
+++ b/tests/trigger.test/t02.req
@@ -3,9 +3,11 @@ CREATE TABLE t2_1 (x INTEGER)$$
 INSERT INTO t2_1 VALUES (1)
 
 CREATE PROCEDURE trigger_2 VERSION 'trigger_2' {
+
+  local tbl = db:table("tbl", {{"i", "int"}})
+
   local function main(event)
     db:prepare("select * from t2_1"):exec()
-    local tbl = db:table("tbl", {{"i", "int"}})
     local tp = event.type
     local inew, iold
     if tp == 'add' then


### PR DESCRIPTION
There has been increased use of `luaL_error` (in `get_qdb`, for example) and this causes Lua  to `abort` when not running in protected mode.

Make all trigger code run in protected mode. Also reduces trigger specific code. They run pretty much like a consumer.

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>