### PR TITLE
Fix OP_Rewind crash

### DIFF
--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -2866,6 +2866,7 @@ void sqlite3CodeRhsOfIN(
       */
       if( addrOnce && !sqlite3ExprIsConstant(pE2) ){
         sqlite3VdbeChangeToNoop(v, addrOnce);
+        ExprClearProperty(pExpr, EP_Subrtn);
         addrOnce = 0;
       }
 

--- a/tests/sql.test/t13_01.req
+++ b/tests/sql.test/t13_01.req
@@ -1,0 +1,17 @@
+drop table if exists t1
+drop table if exists t2
+drop table if exists t3
+create table t1(a int, b int, c text)$$
+insert into t1 values (1, 1, "xyz")
+insert into t1 values (1, 1, "xyz")
+create index t1_a_b on t1(a, b)
+create table t2 (a int, b int, c int, d text)$$
+insert into t2 values (1, 1, 1, "xyz")
+create unique index t2_a on t2(a)
+create table t3 (a int, b text)$$
+insert into t3 values (1, "xyz")
+create unique index t3_a on t3(a)
+select 1 from t1, t2 t2a, t2 t2b, t3 where t2a.a = 1 and t3.a = t2a.b and t1.a = t2a.c and t1.b in (t2a.a, t2a.b) and t1.b = t2b.a
+drop table t1
+drop table t2
+drop table t3

--- a/tests/sql.test/t13_01.req.exp
+++ b/tests/sql.test/t13_01.req.exp
@@ -1,0 +1,6 @@
+(rows inserted=1)
+(rows inserted=1)
+(rows inserted=1)
+(rows inserted=1)
+(1=1)
+(1=1)


### PR DESCRIPTION
This is cherry picked from https://www.sqlite.org/src/info/778b1224a318d013. Without this change we might mistakenly code an OP_Gosub to a cancelled subroutine. A cancelled subroutine has no return address which means that we would not be able to come back from the subroutine to the OP_Gosub opcode. This would lead to an incorrect execution of the opcodes.

(DRQS 169753545)
