### PR TITLE
Fix chunk transaction crash

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8523,7 +8523,17 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
     int newlocks_rc = SQLITE_OK;
     int bdberr = 0;
 
+    uint8_t **pIdxInsert = NULL, **pIdxDelete = NULL;
+
     if (clnt->dbtran.crtchunksize >= clnt->dbtran.maxchunksize) {
+
+        /* Latch expressional index keys. We do not want them to be
+           cleaned up by the micro transaction we are about to commit. */
+        if (gbl_expressions_indexes && pCur->db->ix_expr) {
+            pIdxInsert = clnt->idxInsert;
+            pIdxDelete = clnt->idxDelete;
+            clnt->idxInsert = clnt->idxDelete = NULL;
+        }
 
         /* commit current transaction and reopen another one */
 
@@ -8621,6 +8631,11 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
         clnt->dbtran.crtchunksize++;
     }
 done:
+    /* Restore the expressional index keys onto clnt for the next OP_Insert/OP_Delete. */
+    if (pIdxInsert != NULL || pIdxDelete != NULL) {
+        clnt->idxInsert = pIdxInsert;
+        clnt->idxDelete = pIdxDelete;
+    }
     return rc;
 }
 

--- a/tests/transchunk.test/log.expected
+++ b/tests/transchunk.test/log.expected
@@ -52,3 +52,6 @@ Checking error on setting wrong transaction mode
 (out='    OSQL_DONE            5611')
 Checking deduping multiple chunk sets
 (out='    OSQL_DONE            501')
+chunk + indexes on expressions
+(rows inserted=3)
+(COUNT(*)=0)

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -248,6 +248,18 @@ EOF
 
 check_done_2
 
+echo "chunk + indexes on expressions" >> $outlog
+$r >> $outlog 2>&1 << "EOF"
+CREATE TABLE t3 { tag ondisk { int i } keys { "KEY"=(int)"i+1" } }$$
+INSERT INTO t3 VALUES(1),(2),(3)
+SET TRANSACTION BLOCKSQL
+SET TRANSACTION CHUNK 1
+BEGIN
+DELETE FROM t3 WHERE 1
+COMMIT
+SELECT COUNT(*) FROM t3
+EOF
+
 
 # get testcase output
 testcase_output=$(cat $outlog)


### PR DESCRIPTION
A chunk transaction has an unwanted side effect of cleaning up expressional index keys on micro-transaction commit. Replicant may then send junk OSQL_INSIDX/OSQL_DELIDX schedules to the master and eventually crash in the temptable code.

The patch fixes it by latching the expressional index keys before spawning a micro-transaction and restoring them back onto clnt after the micro-transaction commits.

(DRQS 169860714)
