### PR TITLE
osql: Clean repository before rep_start {DRQS 168492353} 7.0

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1894,6 +1894,7 @@ char *bdb_coherent_state_string(const char *);
 int osql_process_message_decom(char *);
 void osql_net_exiting(void);
 void osql_cleanup_netinfo(void);
+int osql_repository_cancelall(void);
 
 int bdb_list_all_fileids_for_newsi(bdb_state_type *, hash_t *);
 

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -5018,6 +5018,8 @@ static int bdb_upgrade_int(bdb_state_type *bdb_state, uint32_t newgen,
     bdb_state_type *child;
     int i;
 
+    osql_repository_cancelall();
+
     /* if we were passed a child, find his parent */
     if (bdb_state->parent)
         bdb_state = bdb_state->parent;

--- a/db/glue.c
+++ b/db/glue.c
@@ -3007,10 +3007,6 @@ static int new_master_callback(void *bdb_handle, char *host,
             }
             load_auto_analyze_counters();
             trigger_timepart = 1;
-
-            if (oldgen != gen) {
-                osql_repository_cancelall();
-            }
         }
         ctrace("I AM NEW MASTER NODE %s\n", host);
 


### PR DESCRIPTION
Fixes race condition between cleaning repository after upgrade, and
replicant restarting OSQL session. Without this fix, the replicant would
restart session first, then master node would clean repository, thus
losing the session. This would have caused the following failures:

On the master node:
EST 2022/02/09 18:07:50 bidxspdb:discarding packet for 1 29f8aa01-cd74-46a4-827b-4275afa5991a, session not found
EST 2022/02/09 18:07:55 bidxspdb:Missing SORESE sql session 0 29f8aa01-cd74-46a4-827b-4275afa5991a on c2pfbf-rr-001 from 0

On the replicant:
EST 2022/02/09 18:08:50 bidxspdb:Master c2pfbf-rr-001 failed to acknowledge session 1 29f8aa01-cd74-46a4-827b-4275afa5991a

On the client:
rc: 402 errstr: Client api should run query against a different node