### PR TITLE
Weighted average standing-queue metrics

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -179,6 +179,8 @@ extern void bb_berkdb_reset_worst_lock_wait_time_us();
 extern int has_low_headroom(const char *path, int headroom, int debug);
 extern void *clean_exit_thd(void *unused);
 extern void bdb_durable_lsn_for_single_node(void *in_bdb_state);
+/* How frequent metrics are refreshed, once per this many seconds */
+int gbl_update_metrics_interval = 5;
 extern void update_metrics(void);
 extern void *timer_thread(void *);
 extern void comdb2_signal_timer();
@@ -4595,7 +4597,7 @@ void *statthd(void *p)
         if (have_scon_stats)
             logmsg(LOGMSG_USER, "\n");
 
-        if (count % 5 == 0)
+        if (count % gbl_update_metrics_interval == 0)
             update_metrics();
 
         if (!get_schema_change_in_progress(__func__, __LINE__)) {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -108,6 +108,7 @@ extern int gbl_allow_bplog_restarts;
 extern int gbl_test_blob_race;
 extern int gbl_test_scindex_deadlock;
 extern int gbl_test_sc_resume_race;
+extern int gbl_track_weighted_queue_metrics_separately;
 extern int gbl_berkdb_track_locks;
 extern int gbl_db_lock_maxid_override;
 extern int gbl_udp;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2201,4 +2201,10 @@ REGISTER_TUNABLE("sqlite_use_temptable_for_rowset",
 REGISTER_TUNABLE("max_identity_cache", "Max cache size of externalauth identities (Default: 500)",
                  TUNABLE_INTEGER, &gbl_identity_cache_max, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("track_weighted_queue_metrics_separately",
+                 "When on, report both average and weighted average queue metrics;"
+                 "When off, report only weighted average queue metrics "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_track_weighted_queue_metrics_separately, INTERNAL, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/weighted_standing_queue.test/Makefile
+++ b/tests/weighted_standing_queue.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/weighted_standing_queue.test/lrl.options
+++ b/tests/weighted_standing_queue.test/lrl.options
@@ -1,0 +1,4 @@
+sqlenginepool maxt 1
+# We must disable watchdog as we're setting maxt to 1 above-
+# The select-1 test from watchdog may kill the database if it can't run promptly
+nowatch

--- a/tests/weighted_standing_queue.test/runit
+++ b/tests/weighted_standing_queue.test/runit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+### Pulsed workload test to verify that queue metrics don't report false positives ###
+
+dbnm=$1
+host=`cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default 'SELECT comdb2_host()'`
+
+echo testing against $host ...
+
+cdb2sql $dbnm --host $host 'PUT TUNABLE track_weighted_queue_metrics_separately 1'
+
+#### Short-lived bursts: Run five SELECT-1 processes for 5 seconds, and sleep 25 seconds.
+####  This *should not* be considered to have a standing queue
+for i in `seq 1 4`; do
+  for j in `seq 1 5`; do
+    yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
+  done
+  sleep 5
+  jobs -p | xargs kill -9
+  sleep 25
+done
+
+cdb2sql --admin $dbnm --host $host 'select * from comdb2_metrics where name like "%queue_depth%" or name like "%standing_queue%"'
+
+has_weighted_queue=`cdb2sql --tabs --admin $dbnm --host $host 'select cast(value as integer) from comdb2_metrics where name = "weighted_standing_queue_time"'`
+has_queue=`cdb2sql --tabs --admin $dbnm --host $host 'select cast(value as integer) from comdb2_metrics where name = "standing_queue_time"'`
+
+#### Verify that the old queue metric reports a standing queue
+if [ "$has_queue" -eq "0" ]; then
+    echo No standing queue time??? >&2
+    exit 1
+fi
+
+#### Verify that the new queue metric does not report a standing queue
+if [ "$has_weighted_queue" -ne "0" ]; then
+    echo Has weighted standing queue time??? >&2
+    exit 1
+fi
+
+#### Real queuing - this *should* be considered to have a standing queue
+yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
+yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
+sleep 60 
+jobs -p | xargs kill -9 >/dev/null 2>&1
+cdb2sql --admin $dbnm --host $host 'select * from comdb2_metrics where name like "%queue_depth%" or name like "%standing_queue%"'
+
+has_weighted_queue=`cdb2sql --tabs --admin $dbnm --host $host 'select cast(value as integer) from comdb2_metrics where name = "weighted_standing_queue_time"'`
+#### Verify that the new queue metric reports a standing queue
+if [ "$has_weighted_queue" -eq "0" ]; then
+    echo No weighted standing queue time??? >&2
+    exit 1
+fi
+
+#### Verify that when track_weighted_queue_metrics_separately is off we report only weighted queue metrics
+cdb2sql $dbnm --host $host 'PUT TUNABLE track_weighted_queue_metrics_separately 0'
+samemetric=`cdb2sql --tabs --admin $dbnm --host $host 'select count(distinct value) from comdb2_metrics where name = "standing_queue_time" or name = "weighted_standing_queue_time"'`
+if [ "$samemetric" -ne "1" ]; then
+    echo Should keep track of only 1 metric! >&2
+    exit 1
+fi
+samemetric=`cdb2sql --tabs --admin $dbnm --host $host 'select count(distinct value) from comdb2_metrics where name = "queue_depth" or name = "weighted_queue_depth"'`
+if [ "$samemetric" -ne "1" ]; then
+    echo Should keep track of only 1 metric! >&2
+    exit 1
+fi
+
+echo Success!
+exit 0


### PR DESCRIPTION
Queue metrics, previously, were just moving averages. They did not respond well to a pulsed workload and often resulted in a false positive. This patch introduces weighted average queue metrics that are less sensitive to spikes.

(DRQS 169797794)