### PR TITLE
Force direct on any environment where the flag is set.

### DIFF
--- a/berkdb/log/log_put.c
+++ b/berkdb/log/log_put.c
@@ -2121,6 +2121,8 @@ __log_name(dblp, filenumber, namep, fhpp, flags)
 	char *oname;
 	char old[sizeof(LFPREFIX) + 5 + 20], new[sizeof(LFPREFIX) + 10 + 20];
 
+    flags |= DB_OSO_LOG;
+
 	dbenv = dblp->dbenv;
 	lp = dblp->reginfo.primary;
 

--- a/berkdb/os/os_open.c
+++ b/berkdb/os/os_open.c
@@ -72,6 +72,7 @@ ___os_open(dbenv, name, flags, mode, fhpp)
 	return (__os_open_extend(dbenv, name, 0, 0, flags, mode, fhpp));
 }
 
+int gbl_force_direct_io = 1;
 /*
  * __os_open_extend --
  *	Open a file descriptor (including page size and log size information).
@@ -79,6 +80,7 @@ ___os_open(dbenv, name, flags, mode, fhpp)
  * PUBLIC: int __os_open_extend __P((DB_ENV *,
  * PUBLIC:     const char *, u_int32_t, u_int32_t, u_int32_t, int, DB_FH **));
  */
+
 int
 ___os_open_extend(dbenv, name, log_size, page_size, flags, mode, fhpp)
 	DB_ENV *dbenv;
@@ -95,6 +97,9 @@ ___os_open_extend(dbenv, name, log_size, page_size, flags, mode, fhpp)
 
 	*fhpp = NULL;
 	oflags = 0;
+
+    if (gbl_force_direct_io && (F_ISSET(dbenv, DB_ENV_DIRECT_DB)) && !(LF_ISSET(DB_OSO_LOG)))
+        LF_SET(DB_OSO_DIRECT);
 
 #define	OKFLAGS								\
 	(DB_OSO_CREATE | DB_OSO_DIRECT | DB_OSO_EXCL | DB_OSO_LOG |	\

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -374,6 +374,7 @@ int gbl_sqlite_sorterpenalty = 5;
 int gbl_file_permissions = 0660;
 
 extern int gbl_net_maxconn;
+extern int gbl_force_direct_io;
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2210,4 +2210,8 @@ REGISTER_TUNABLE("track_weighted_queue_metrics_separately",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_track_weighted_queue_metrics_separately, INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("force_directio", "Force directio on all file opens if set on environment (Default: ON)",
+                 TUNABLE_BOOLEAN, &gbl_force_direct_io, 0, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -329,6 +329,7 @@
 (name='flush_scan_dbs_first', description='Don't hold bufpool mutex while opening files for flush', type='BOOLEAN', value='OFF', read_only='N')
 (name='forbid_remote_admin', description='Forbid non-local admin requests.  (Default: on)', type='BOOLEAN', value='OFF', read_only='N')
 (name='forbid_ulonglong', description='Disallow u_longlong. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='force_directio', description='Force directio on all file opens if set on environment (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='force_highslot', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='force_old_cursors', description='Replicant will use old cursors', type='BOOLEAN', value='OFF', read_only='N')
 (name='foreign_db_allow_cross_class', description='', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
Some codepaths always open a file with no O_DIRECT. On AIX a file can't be opened with both O_DIRECT and no O_DIRECT.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>
