### PR TITLE
Don't allow a random deadlock in places they can't happen

### DIFF
--- a/berkdb/db/db_dispatch.c
+++ b/berkdb/db/db_dispatch.c
@@ -1456,6 +1456,7 @@ err:	if (ret != 0) {
 }
 
 /* Limbo support routines. */
+extern __thread int disable_random_deadlocks;
 
 /*
  * __db_lock_move --
@@ -1483,7 +1484,10 @@ __db_lock_move(dbenv, fileid, pgno, mode, ptxn, txn)
 	lock_dbt.data = &lock_obj;
 	lock_dbt.size = sizeof(lock_obj);
 
+    int rd = disable_random_deadlocks;
+    disable_random_deadlocks = 1;
     ret = __lock_get(dbenv, txn->txnid, 0, &lock_dbt, mode, &lock);
+    disable_random_deadlocks = rd;
     if (ret) {
         fprintf(stderr, "%s:%d: error getting a lock we already have?  ret=%d\n", 
                 __func__, __LINE__, ret);

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2065,7 +2065,9 @@ __lock_get_internal_int(lt, locker, in_locker, flags, obj, lock_mode, timeout,
 	db_timeout_t timeout;
 	DB_LOCK *lock;
 {
-	if (unlikely(gbl_ddlk && !LF_ISSET(DB_LOCK_NOWAIT) &&
+    extern __thread int disable_random_deadlocks;
+	if (disable_random_deadlocks == 0 && 
+        unlikely(gbl_ddlk && !LF_ISSET(DB_LOCK_NOWAIT) &&
 		rand() % gbl_ddlk == 0)) {
 		return DB_LOCK_DEADLOCK;
 	}


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

The ddlk debug tunable tells the lock-manager to throw random deadlocks.  This PR uses a thread-local variable to disable random deadlocks in places where Berkley assumes (correctly) that deadlocks cannot occur.