### PR TITLE
Fix sqlcancel race

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4368,6 +4368,8 @@ static void sqlengine_work_lua_thread(void *thddata, void *work)
     clnt->osql.timings.query_dispatched = osql_log_time();
     clnt->deque_timeus = comdb2_time_epochus();
     clnt->thd = thd;
+    /* Reset the cancel-statement flag */
+    thd->sqlthd->stop_this_statement = 0;
     sql_update_usertran_state(clnt);
 
     rdlock_schema_lk();
@@ -4620,6 +4622,8 @@ void sqlengine_work_appsock(struct sqlthdstate *thd, struct sqlclntstate *clnt)
     assert(sqlthd);
     sqlthd->clnt = clnt;
     clnt->thd = thd;
+    /* Reset the cancel-statement flag */
+    sqlthd->stop_this_statement = 0;
 
     thr_set_user("appsock", (intptr_t)clnt->appsock_id);
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1923,9 +1923,6 @@ int newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
     }
     clnt->osql.sent_column_data = 0;
 
-    /* `thd' gets assigned in sqlenginepool. A fresh connection will not have this. */
-    if (clnt->thd && clnt->thd->sqlthd)
-        clnt->thd->sqlthd->stop_this_statement = 0;
     if (clnt->tzname[0] == 0 && sql_query->tzname) {
         strncpy0(clnt->tzname, sql_query->tzname, sizeof(clnt->tzname));
     }


### PR DESCRIPTION
An appsock thread resets the cancel-statement flag on clnt->thd->sqlthd, before dispatching a query to an sql thread. However clnt->thd is [allocated on the stack](https://github.com/bloomberg/comdb2/blob/master/util/thdpool.c#L703) of an sql thread. This logic is very wrong. First of all, clnt->thd, in fact, points to the sql thread that appsock previously dispatched to. Appsock may very well dispatch the next query to a different sql thread, hence it may mistakenly change other query's cancel-statement flag. Second of all, clnt->thd will become garbage when the sql thread exits. Accessing it after this point will result in a segfault.

This patch moves the logic into sql thread, after clnt->thd is updated to the correct sql thread.

(DRQS 170013622)