### PR TITLE
Fix delete-referenced-file bug

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -7884,8 +7884,9 @@ int bdb_check_files_on_disk(bdb_state_type *bdb_state, const char *tblname,
 
     assert(bdb_state->parent == NULL);
 
+    /* Always use most recent logfile when placing on oldfile list */
     if (bdb_state->attr->keep_referenced_files) {
-        lognum = bdb_get_lowfilenum(bdb_state, bdberr);
+        lognum = bdb_get_last_logfile(bdb_state, bdberr);
         if (lognum < 0)
             return -1;
     }
@@ -8085,8 +8086,9 @@ static int bdb_process_unused_files(bdb_state_type *bdb_state, tran_type *tran,
 
     assert(bdb_state->parent != NULL);
 
+    /* Always use most recent logfile when placing on oldfile list */
     if (delay && bdb_state->attr->keep_referenced_files) {
-        lognum = bdb_get_lowfilenum(bdb_state, bdberr);
+        lognum = bdb_get_last_logfile(bdb_state, bdberr);
         if (lognum < 0)
             return -1;
     }
@@ -8347,6 +8349,7 @@ int bdb_purge_unused_files(bdb_state_type *bdb_state, tran_type *tran,
     unsigned lowfilenum = 0;
     struct stat sb;
 
+    /* Purge if cluster low-logfile is larger */
     if (bdb_state->attr->keep_referenced_files) {
         lowfilenum = bdb_get_lowfilenum(bdb_state, bdberr);
         if (lowfilenum < 0)


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This fixes the 'delete-referenced-files' bug reproduced by the sc_downgrade test.  I'm leaving the test disabled in master though, because it seems to reliably reproduce a different lock-inversion bug (which I'm still investigating).