### PR TITLE
Fix weighted_standing_queue test

### DIFF
--- a/tests/weighted_standing_queue.test/runit
+++ b/tests/weighted_standing_queue.test/runit
@@ -39,8 +39,9 @@ if [ "$has_weighted_queue" -ne "0" ]; then
 fi
 
 #### Real queuing - this *should* be considered to have a standing queue
-yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
-yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
+for i in `seq 1 4`; do
+  yes "SELECT 1" | cdb2sql $dbnm --host $host - >/dev/null &
+done
 sleep 60 
 jobs -p | xargs kill -9 >/dev/null 2>&1
 cdb2sql --admin $dbnm --host $host 'select * from comdb2_metrics where name like "%queue_depth%" or name like "%standing_queue%"'


### PR DESCRIPTION
The weighted_standing_queue test fails intermittently because on a busy machine queries may not be queued promptly. We can simply add more background processes to improve the chances of queuing.
