### PR TITLE
Always free both normalized sqls (fixes fingerprint mismatch bug)

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2942,6 +2942,7 @@ static struct fingerprint_track *prepare_fingerprint(struct sqlclntstate *clnt,
     /* Generate normalized sql */
     if (!(flags & PREPARE_NO_NORMALIZE)) {
         free_normalized_sql(clnt);
+        free_original_normalized_sql(clnt);
         normalize_stmt_and_store(clnt, rec, 0);
         zNormSql = clnt->work.zNormSql;
     } else {
@@ -3792,6 +3793,7 @@ static void handle_stored_proc(struct sqlthdstate *thd,
     **       however, the parser now recognizes it and so it
     **       can be normalized.
     */
+    free_normalized_sql(clnt);
     free_original_normalized_sql(clnt);
     normalize_stmt_and_store(clnt, NULL, 1);
 
@@ -4493,6 +4495,7 @@ static int preview_and_calc_fingerprint(struct sqlclntstate *clnt)
         **       query that is not an "EXEC", "BEGIN", "COMMIT",
         **       or "ROLLBACK".
         */
+        free_normalized_sql(clnt);
         free_original_normalized_sql(clnt);
         normalize_stmt_and_store(clnt, NULL, is_stored_proc_sql(clnt->sql));
 

--- a/tests/fingerprints.test/t06.req
+++ b/tests/fingerprints.test/t06.req
@@ -1,0 +1,4 @@
+create table t(a int); $$
+@send clear_fingerprints // bug would set all following normalized sql to this
+select * from t;
+select fingerprint, count, normalized_sql from comdb2_fingerprints;

--- a/tests/fingerprints.test/t06.req.out
+++ b/tests/fingerprints.test/t06.req.out
@@ -1,0 +1,3 @@
+Cleared 31 fingerprints
+(fingerprint='812bdde365a22a61bcd52bf005990c37', count=1, normalized_sql='EXEC PROCEDURE sys.cmd.send(?);')
+(fingerprint='c4fe7ad6cc25bb59daf8101f2196edf6', count=1, normalized_sql='SELECT*FROM t;')


### PR DESCRIPTION
Currently if you run a send command, every query run afterwards will be mistaken as 'EXEC PROCEDURE sys.cmd.send(?);' and will have this same fingerprint, leading to a fingerprint mismatch. This is because zOrigNormSql is not freed, and the fingerprint is added in this code. For normal queries, it should be going through the else if block.

if (clnt->work.zOrigNormSql) { /* NOTE: Not subject to prepare. */
                add_fingerprint(clnt, stmt, string_ref_cstr(h->sql_ref), clnt->work.zOrigNormSql,
                                cost, time, prepTime, rows, logger,
                                fingerprint);
                have_fingerprint = 1;
            } else if (clnt->work.zNormSql &&
                       sqlite3_is_success(clnt->prep_rc)) {
                add_fingerprint(clnt, stmt, string_ref_cstr(h->sql_ref), clnt->work.zNormSql, cost,
                                time, prepTime, rows, logger, fingerprint);
                have_fingerprint = 1; 

See test for an example of current bug.

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
