### PR TITLE
Compare query plans and log if not using optimal plan for query

### DIFF
--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -11,6 +11,7 @@ set(src
   db_access.c
   db_fingerprint.c
   db_metrics.c
+  db_query_plan.c
   db_tunables.c
   db_util.c
   dbglog_iface.c

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -343,6 +343,8 @@ int gbl_debug_omit_dta_write;
 int gbl_debug_omit_idx_write;
 int gbl_debug_omit_blob_write;
 int gbl_debug_omit_zap_on_rebuild = 0;
+int gbl_debug_print_query_plans = 0;
+double gbl_query_plan_percentage = 50;
 int gbl_debug_skip_constraintscheck_on_insert;
 int gbl_readonly = 0;
 int gbl_init_single_meta = 1;
@@ -737,6 +739,7 @@ int gbl_memstat_freq = 60 * 5;
 int gbl_accept_on_child_nets = 0;
 int gbl_disable_etc_services_lookup = 0;
 int gbl_fingerprint_queries = 1;
+int gbl_query_plans = 1;
 int gbl_prioritize_queries = 1;
 int gbl_verbose_normalized_queries = 0;
 int gbl_verbose_prioritize_queries = 0;
@@ -5283,6 +5286,9 @@ static void register_all_int_switches()
     register_int_switch("fingerprint_queries",
                         "Compute fingerprint for SQL queries",
                         &gbl_fingerprint_queries);
+    register_int_switch("query_plans",
+                        "Keep track of query plans and their costs for each query",
+                        &gbl_query_plans);
     register_int_switch("verbose_normalized_queries",
                         "For new fingerprints, show normalized queries.",
                         &gbl_verbose_normalized_queries);

--- a/db/db_query_plan.c
+++ b/db/db_query_plan.c
@@ -1,0 +1,186 @@
+/*
+   Copyright 2022 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+#include "sql.h"
+
+hash_t *gbl_query_plan_hash = NULL;
+pthread_mutex_t gbl_query_plan_hash_mu = PTHREAD_MUTEX_INITIALIZER;
+int gbl_query_plan_max_queries = 1000;
+extern int gbl_debug_print_query_plans;
+extern double gbl_query_plan_percentage;
+
+static char *form_query_plan(const struct client_query_stats *query_stats) {
+    struct strbuf *query_plan_buf;
+    const struct client_query_path_component *c;
+    char *query_plan;
+
+    if (query_stats->n_components == 0) {
+        return NULL;
+    }
+
+    query_plan_buf = strbuf_new();
+    for (int i = 0; i < query_stats->n_components; i++) {
+        if (i > 0) {
+            strbuf_append(query_plan_buf, ", ");
+        }
+        c = &query_stats->path_stats[i];
+        strbuf_appendf(query_plan_buf, "table %s index %d", c->table, c->ix);
+    }
+
+    query_plan = strdup((char *)strbuf_buf(query_plan_buf));
+    strbuf_free(query_plan_buf);
+    return query_plan;
+}
+
+static void add_query_plan_int(const char *query, const char *query_plan, hash_t *query_plan_hash, int *alert_once_query, double current_cost_per_row) {
+    struct query_plan_item *q = hash_find(query_plan_hash, &query_plan);
+    if (q == NULL) {
+        /* make sure we haven't generated an unreasonable number of these */
+        int nents = hash_get_num_entries(query_plan_hash);
+        if (nents >= gbl_query_plan_max_queries) {
+            if (*alert_once_query) {
+                logmsg(LOGMSG_WARN,
+                       "Stopped tracking query plans for query %s, hit max #plans %d.\n",
+                       query, gbl_query_plan_max_queries);
+                *alert_once_query = 0;
+            }
+            return;
+        } else {
+            q = calloc(1, sizeof(struct query_plan_item));
+            q->plan = strdup(query_plan);
+            q->total_cost_per_row = current_cost_per_row;
+            q->nexecutions = 1;
+            hash_add(query_plan_hash, q);
+        }
+    } else {
+        q->total_cost_per_row += current_cost_per_row;
+        q->nexecutions++;
+    }
+
+    // compare query plans
+    double average_cost_per_row = q->total_cost_per_row / q->nexecutions;
+    void *ent;
+    unsigned int bkt;
+    double alt_avg;
+    double significance = 1 + gbl_query_plan_percentage / 100;
+    for (q = (struct query_plan_item*)hash_first(query_plan_hash, &ent, &bkt); q; q = (struct query_plan_item*)hash_next(query_plan_hash, &ent, &bkt)) {
+        alt_avg = q->total_cost_per_row / q->nexecutions;
+        if (alt_avg * significance < average_cost_per_row) { // should be at least equal if same query plan
+            logmsg(LOGMSG_WARN, "For query %s:\n"
+            "Currently using query plan %s, which has an average cost per row of %f.\n"
+            "But query plan %s has a lower average cost per row of %f.\n", query, query_plan, average_cost_per_row, q->plan, alt_avg);
+        }
+    }
+}
+
+void add_query_plan(const struct client_query_stats *query_stats, int rows, const char *query) {
+    char *query_plan = form_query_plan(query_stats);
+    if (!query_plan || rows <= 0) { // can't calculate cost per row if 0 rows
+        return;
+    }
+
+    double current_cost_per_row = query_stats->cost / rows;
+    Pthread_mutex_lock(&gbl_query_plan_hash_mu);
+    if (gbl_query_plan_hash == NULL) {
+        gbl_query_plan_hash = hash_init_strptr(0);
+    }
+    struct query_item *q = hash_find(gbl_query_plan_hash, &query);
+    if (q == NULL) {
+        /* make sure we haven't generated an unreasonable number of these */
+        int nents = hash_get_num_entries(gbl_query_plan_hash);
+        if (nents >= gbl_query_plan_max_queries) {
+            static int alert_once = 1;
+            if (alert_once) {
+                logmsg(LOGMSG_WARN,
+                       "Stopped tracking new queries in query plan, hit max #queries %d.\n",
+                       gbl_query_plan_max_queries);
+                alert_once = 0;
+            }
+        } else {
+            q = calloc(1, sizeof(struct query_item));
+            q->query = strdup(query);
+            q->query_plan_hash = hash_init_strptr(0);
+            q->alert_once_query = 1;
+            add_query_plan_int(query, query_plan, q->query_plan_hash, &q->alert_once_query, current_cost_per_row);
+            hash_add(gbl_query_plan_hash, q);
+        }
+    } else {
+        add_query_plan_int(query, query_plan, q->query_plan_hash, &q->alert_once_query, current_cost_per_row);
+    }
+
+    if (gbl_debug_print_query_plans) {
+        void *ent, *ent2;
+        unsigned int bkt, bkt2;
+        struct query_plan_item *p;
+        logmsg(LOGMSG_WARN, "START\n");
+        for (q = (struct query_item*)hash_first(gbl_query_plan_hash, &ent, &bkt); q; q = (struct query_item*)hash_next(gbl_query_plan_hash, &ent, &bkt)) {
+            logmsg(LOGMSG_WARN, "QUERY: %s\n", q->query);
+            for (p = (struct query_plan_item*)hash_first(q->query_plan_hash, &ent2, &bkt2); p; p = (struct query_plan_item*)hash_next(q->query_plan_hash, &ent2, &bkt2)) {
+                logmsg(LOGMSG_WARN, "plan: %s, total cost per row: %f, num executions: %d, average: %f\n", p->plan, p->total_cost_per_row, p->nexecutions, p->total_cost_per_row / p->nexecutions);
+            }
+        }
+        logmsg(LOGMSG_WARN, "END\n\n");
+    }
+
+    Pthread_mutex_unlock(&gbl_query_plan_hash_mu);
+    free(query_plan);
+}
+
+void clear_query_plans(int *queries_count, int *plans_count) {
+    Pthread_mutex_lock(&gbl_query_plan_hash_mu);
+    if (gbl_query_plan_hash == NULL) {
+        Pthread_mutex_unlock(&gbl_query_plan_hash_mu);
+        if (queries_count)
+            *queries_count = 0;
+        if (plans_count)
+            *plans_count = 0;
+        return;
+    }
+
+    // update queries count if not null
+    hash_info(gbl_query_plan_hash, NULL, NULL, NULL, NULL, queries_count, NULL, NULL);
+
+    void *ent, *ent2;
+    unsigned int bkt, bkt2;
+    struct query_item *q;
+    struct query_plan_item *p;
+    int plans_count_tmp = 0;
+    int current_query_num_plans;
+    for (q = (struct query_item*)hash_first(gbl_query_plan_hash, &ent, &bkt); q; q = (struct query_item*)hash_next(gbl_query_plan_hash, &ent, &bkt)) {
+        // update plans count
+        hash_info(q->query_plan_hash, NULL, NULL, NULL, NULL, &current_query_num_plans, NULL, NULL);
+        plans_count_tmp += current_query_num_plans;
+
+        // free query plan hash
+        for (p = (struct query_plan_item*)hash_first(q->query_plan_hash, &ent2, &bkt2); p; p = (struct query_plan_item*)hash_next(q->query_plan_hash, &ent2, &bkt2)) {
+            free(p->plan);
+            free(p);
+        }
+        hash_clear(q->query_plan_hash);
+        hash_free(q->query_plan_hash);
+
+        free(q->query);
+        free(q);
+    }
+    hash_clear(gbl_query_plan_hash);
+    hash_free(gbl_query_plan_hash);
+    gbl_query_plan_hash = NULL;
+
+    Pthread_mutex_unlock(&gbl_query_plan_hash_mu);
+    if (plans_count)
+        *plans_count = plans_count_tmp;
+    return;
+}

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -347,6 +347,8 @@ extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_debug_omit_zap_on_rebuild;
+extern int gbl_debug_print_query_plans;
+extern double gbl_query_plan_percentage;
 extern int gbl_instrument_consumer_lock;
 extern int gbl_reject_mixed_ddl_dml;
 extern int gbl_debug_create_master_entry;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1307,6 +1307,15 @@ REGISTER_TUNABLE("debug.omit_zap_on_rebuild",
                  " (Default: 0)", TUNABLE_BOOLEAN,
                  &gbl_debug_omit_zap_on_rebuild, INTERNAL, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("debug.print_query_plans",
+                 "Print query plan hash table every time after running a query. (Default: 0)", TUNABLE_BOOLEAN,
+                 &gbl_debug_print_query_plans, INTERNAL, NULL, NULL, NULL,
+                 NULL);
+REGISTER_TUNABLE("query_plan_percentage",
+                 "Alarm if the average cost per row of current query plan is n percent above the cost for different query plan."
+                 " (Default: 50)", TUNABLE_DOUBLE,
+                 &gbl_query_plan_percentage, 0, NULL, NULL, NULL,
+                 NULL);
 REGISTER_TUNABLE("bdboslog", NULL, TUNABLE_INTEGER, &gbl_namemangle_loglevel,
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("deadlock_rep_retry_max", NULL, TUNABLE_INTEGER,

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -4948,6 +4948,10 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "clear_fingerprints") == 0) {
         int fpcount = clear_fingerprints();
         logmsg(LOGMSG_USER, "Cleared %d fingerprints\n", fpcount);
+    } else if (tokcmp(tok, ltok, "clear_query_plans") == 0) {
+        int queries_count, plans_count;
+        clear_query_plans(&queries_count, &plans_count);
+        logmsg(LOGMSG_USER, "Cleared %d queries with a total of %d plans\n", queries_count, plans_count);
     } else if (tokcmp(tok, ltok, "get_verify_thdpool_status") == 0) {
         if (gbl_verify_thdpool)
             thdpool_print_stats(stdout, gbl_verify_thdpool);

--- a/db/sql.h
+++ b/db/sql.h
@@ -1351,6 +1351,19 @@ long long run_sql_return_ll(const char *query, struct errstat *err);
 long long run_sql_thd_return_ll(const char *query, struct sql_thread *thd,
                                 struct errstat *err);
 
+struct query_item {
+    char *query;
+    hash_t *query_plan_hash;
+    int alert_once_query; // init to 1
+};
+struct query_plan_item {
+    char *plan;
+    double total_cost_per_row;
+    int nexecutions;
+};
+void clear_query_plans(int *queries, int *plans);
+void add_query_plan(const struct client_query_stats *query_stats, int rows, const char *query);
+
 /* Connection tracking */
 int gather_connection_info(struct connection_info **info, int *num_connections);
 void free_connection_info(struct connection_info *info, int num_connections);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -143,6 +143,7 @@ extern int gbl_old_column_names;
 extern hash_t *gbl_fingerprint_hash;
 extern pthread_mutex_t gbl_fingerprint_hash_mu;
 extern int gbl_alternate_normalize;
+extern int gbl_query_plans;
 
 /* Once and for all:
 
@@ -1206,6 +1207,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
     int64_t time;
     int64_t prepTime;
     int64_t rows;
+    const char *query = NULL;
 
     if (gbl_fingerprint_queries) {
         if (h->sql_ref) {
@@ -1225,11 +1227,13 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
                                 cost, time, prepTime, rows, logger,
                                 fingerprint);
                 have_fingerprint = 1;
+                query = clnt->work.zOrigNormSql;
             } else if (clnt->work.zNormSql &&
                        sqlite3_is_success(clnt->prep_rc)) {
                 add_fingerprint(clnt, stmt, string_ref_cstr(h->sql_ref), clnt->work.zNormSql, cost,
                                 time, prepTime, rows, logger, fingerprint);
                 have_fingerprint = 1;
+                query = clnt->work.zNormSql;
             } else {
                 reqlog_reset_fingerprint(logger, FINGERPRINTSZ);
             }
@@ -1238,7 +1242,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
         }
     }
 
-    if (clnt->query_stats == NULL) {
+    if (1 || clnt->query_stats == NULL) {
         record_query_cost(thd, clnt);
         reqlog_set_path(logger, clnt->query_stats);
     }
@@ -1251,6 +1255,10 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
     reqlog_end_request(logger, stmt_rc, __func__, __LINE__);
     if (clnt->osql.sock_started == 0)
         comdb2uuid_clear(clnt->osql.uuid);
+
+    if (gbl_query_plans && query) {
+        add_query_plan(clnt->query_stats, clnt->nrows, query);
+    }
 
     if (have_fingerprint) {
         /*

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -939,6 +939,7 @@ These options are toggle-able at runtime.
 |sockbplog_sockpool | off | Osql bplog sent over sockets is using local sockpool
 |throttle_txn_chunks_msec | 0 | Wait that many milliseconds before starting a new transaction chunk
 |externalauth| off | Enable use of external auth plugin
+|query_plan_percentage| 50 | Alarm if the average cost per row of current query plan is n percent above the cost for different query plan.
 
 
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -690,6 +690,8 @@
 (name='private_blkseq_maxtraverse', description='', type='INTEGER', value='4', read_only='N')
 (name='private_blkseq_stripes', description='Number of stripes for the blkseq table.', type='INTEGER', value='8', read_only='N')
 (name='qscanmode', description='Enables queue scan mode optimisation.', type='BOOLEAN', value='OFF', read_only='N')
+(name='query_plan_percentage', description='Alarm if the average cost per row of current query plan is n percent above the cost for different query plan. (Default: 50)', type='DOUBLE', value='50', read_only='N')
+(name='query_plans', description='Keep track of query plans and their costs for each query', type='BOOLEAN', value='ON', read_only='N')
 (name='queuedb_file_interval', description='Check on this interval each queuedb against its configured maximum file size. (Default: 60000ms)', type='INTEGER', value='60000', read_only='Y')
 (name='queuedb_file_threshold', description='Maximum queuedb file size (in MB) before enqueueing to the alternate file.  (Default: 0)', type='INTEGER', value='0', read_only='Y')
 (name='queuedb_genid_filename', description='Use genid in queuedb filenames.  (Default: on)', type='BOOLEAN', value='ON', read_only='Y')


### PR DESCRIPTION
Always show query plan in events log

Log if current query plan is a certain percentage worse than prev query plan for same query in terms of avg cost per row (configurable by query_plan_percentage tunable, default=50). Can view all query plans/queries currently in table + stats with debug.print_query_plans tunable. Can turn off functionality with query_plans tunable. Can clear query plans by running send clear_query_plans.

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
