### PR TITLE
Update aFingerprint for stored proc to stop fingerprint mismatch message

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3797,6 +3797,13 @@ static void handle_stored_proc(struct sqlthdstate *thd,
     free_original_normalized_sql(clnt);
     normalize_stmt_and_store(clnt, NULL, 1);
 
+    if (clnt->work.zOrigNormSql) {
+        size_t nOrigNormSql = 0;
+
+        calc_fingerprint(clnt->work.zOrigNormSql, &nOrigNormSql,
+                            clnt->work.aFingerprint);
+    }
+
     memset(&clnt->spcost, 0, sizeof(struct sql_hist_cost));
     int rc = exec_procedure(thd, clnt, &errstr);
     if (rc) {


### PR DESCRIPTION
Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

Fingerprint mismatch message still occurs in following case:
select 1 (sets aFingerprint)
send command (doesn't set aFingerprint)
fingerprint (send command) is compared to aFingerprint (select 1) in sql_statement_done

Correct fingerprint is still added regardless

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
