### PR TITLE
Make page compaction tracing a runtime option

### DIFF
--- a/berkdb/btree/bt_pgcompact.c
+++ b/berkdb/btree/bt_pgcompact.c
@@ -21,12 +21,10 @@
 #include <alloca.h>
 #include <assert.h>
 #include <errno.h>
+#include <libgen.h>
 #include <string.h>
 #include <stdint.h>
-
-#ifdef PGCOMP_DBG
 #include <pthread.h>
-#endif
 
 #endif
 
@@ -46,6 +44,8 @@
 
 #include <lz4.h>
 #include "thdpool.h"
+#include "logmsg.h"
+#include "ctrace.h"
 
 #if LZ4_VERSION_NUMBER < 10701
 #define LZ4_compress_default LZ4_compress_limitedOutput
@@ -58,7 +58,6 @@
 #define P_BI      0x04	/* Bi-directional - L2R then R2L */
 #define NUM_MAX_RETRIES 5
 
-#ifdef PGCOMP_DBG
 enum {
 	 REASON_EXIT = 0
 	,REASON_OFF
@@ -95,7 +94,7 @@ static const char *reasons[] = {
 	,"Key is deleted"
 	,"Page is internal"
 	,"Page is empty"
-	,"Page is full"
+	,"Page is not sparse"
 	,"Parent has too few children"
 	,"Reached leftmost/rightmost"
 	,"Does not fit"
@@ -112,15 +111,31 @@ static const char *reasons[] = {
 	,"WHOAH!!! Merged 2 compressed pages"
 	,"WHOAH!!! Moved prefix'd records"
 };
-static int lcl_pgcompact_dryrun = 0;
-#define REASON(i) fprintf(stderr, "(!) (0x%x) %s %d: %s() - %s.\n",	\
-		pthread_self(), __FILE__, __LINE__, __func__, reasons[i])
 
-#define TRACE(...) fprintf(stderr, __VA_ARGS__)
-#else
-#define REASON(i)
-#define TRACE(...)
-#endif
+int gbl_pgcomp_dryrun = 0; /* dry-run */
+int gbl_pgcomp_dbg_stdout = 0;
+int gbl_pgcomp_dbg_ctrace = 0;
+
+#define REASON(i)																		            \
+	do {																				            \
+		if (gbl_pgcomp_dbg_stdout)														            \
+			logmsg(LOGMSG_INFO, "(!) (thd %p) %s %d: %s() - %s.\n",						            \
+					(void *)pthread_self(), basename(__FILE__), __LINE__, __func__, reasons[i]);	\
+        if (gbl_pgcomp_dbg_ctrace)                                                                  \
+			ctrace("(!) (thd %p) %s %d: %s() - %s.\n",						                        \
+					(void *)pthread_self(), basename(__FILE__), __LINE__, __func__, reasons[i]);	\
+	} while (0)
+
+#define TRACE(fmt, ...)																		            \
+	do {																					            \
+		if (gbl_pgcomp_dbg_stdout)																	    \
+			logmsg(LOGMSG_INFO, "(!) (thd %p) %s %d: %s() " fmt,							            \
+					(void *)pthread_self(), basename(__FILE__), __LINE__, __func__, ## __VA_ARGS__);	\
+        if (gbl_pgcomp_dbg_ctrace)                                                                      \
+			ctrace("(!) (thd %p) %s %d: %s() " fmt,							                            \
+					(void *)pthread_self(), basename(__FILE__), __LINE__, __func__, ## __VA_ARGS__);	\
+	} while (0)
+
 
 static int
 __bam_validate_subtree(dbc, nfb, direct)
@@ -132,10 +147,12 @@ __bam_validate_subtree(dbc, nfb, direct)
 	db_pgno_t pgno;
 	BTREE_CURSOR *cp;
 	EPG *epg;
+	DB *dbp;
 
 	cp = (BTREE_CURSOR *)dbc->internal;
 	h = cp->csp->page;
 	pgno = PGNO(h);
+	dbp = dbc->dbp;
 
 	if (TYPE(h) != P_LBTREE) { /* Page is not leaft. Done. */
 		REASON(REASON_NLEAF);
@@ -152,9 +169,10 @@ __bam_validate_subtree(dbc, nfb, direct)
 		return (1);
 	}
 	
-	if (P_FREESPACE(dbc->dbp, h) <= nfb) {
+	if (P_FREESPACE(dbp, h) <= nfb) {
 		/* Page has a good fill ratio. Done. */
 		REASON(REASON_FULL);
+		TRACE("pgno %d ff %.2f\n", pgno, 1 - P_FREESPACE(dbp, h) / (double)(dbp->pgsize - SIZEOF_PAGE));
 		return (1);
 	}
 
@@ -687,8 +705,7 @@ __bam_pgcompact(dbc, dbt, ff, tgtff)
 	local_disable_backward = gbl_disable_backward_scan;
 	local_max_np_per_txn = gbl_max_num_compact_pages_per_txn;
 
-	TRACE("(!) 0x%x %s %d: %s() begins.\n",
-			pthread_self(), __FILE__, __LINE__, __func__);
+	TRACE("begins.\n");
 
 	if (F_ISSET(dbc, DBC_OPD)) {
 		REASON(REASON_DUP);
@@ -717,15 +734,12 @@ __bam_pgcompact(dbc, dbt, ff, tgtff)
 	nfb = ntb - nub;                    /* expected free */
 	//nsfb = (u_int32_t)((1 - tgtff) * (double)ntb); /* target free */
 
-	TRACE("(!) 0x%x %s %d: %s() I'm looking at pgno %d file %s.\n",
-			pthread_self(), __FILE__, __LINE__, __func__, PGNO(h), dbp->fname);
+	TRACE("I'm looking at pgno %d file %s.\n", PGNO(h), dbp->fname);
 
-#ifdef PGCOMP_DBG
-	if (lcl_pgcompact_dryrun) {
+	if (gbl_pgcomp_dryrun) {
 		REASON(REASON_DRYRUN);
 		goto done;
 	}
-#endif
 
 	if (__bam_validate_subtree(dbc, nfb, &direct) != 0)
 		goto done;
@@ -1448,6 +1462,7 @@ __bam_ispgcompactible(dbc, pgno, dbt, ff)
 	pgff = P_FREESPACE(dbp, h) / (double)(dbp->pgsize - SIZEOF_PAGE);
 	if (pgff < (1 - ff)) { /* #5 */
 		REASON(REASON_FULL);
+		TRACE("pgno %d ff %.2f\n", pgno, 1 - pgff);
 		goto error_out;
 	}
 

--- a/berkdb/env/env_pgcompact.c
+++ b/berkdb/env/env_pgcompact.c
@@ -73,8 +73,8 @@ retry:
 
 	ret = __db_pgcompact(dbp, txn, dbt, ff, tgtff);
 
-err:
 	__dbreg_prefault_complete(dbenv, fileid);
+err:
 	if (ret == 0)
 		ret = __txn_commit(txn, DB_TXN_NOSYNC);
 	else

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -361,6 +361,9 @@ extern int gbl_replicant_retry_on_not_durable;
 extern int gbl_enable_internal_sql_stmt_caching;
 extern int gbl_longreq_log_freq_sec;
 extern int gbl_disable_seekscan_optimization;
+extern int gbl_pgcomp_dryrun;
+extern int gbl_pgcomp_dbg_stdout;
+extern int gbl_pgcomp_dbg_ctrace;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2218,5 +2218,10 @@ REGISTER_TUNABLE("track_weighted_queue_metrics_separately",
 REGISTER_TUNABLE("force_directio", "Force directio on all file opens if set on environment (Default: ON)",
                  TUNABLE_BOOLEAN, &gbl_force_direct_io, 0, NULL, NULL, NULL, NULL);
 
-
+REGISTER_TUNABLE("pgcomp_dryrun", "Dry-run page compaction (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_pgcomp_dryrun, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("pgcomp_dbg_stdout", "Enable debugging stdout trace for page compaction (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_pgcomp_dbg_stdout, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("pgcomp_dbg_ctrace", "Enable debugging ctrace for page compaction (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_pgcomp_dbg_ctrace, 0, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/tests/online_compaction.test/lrl.options
+++ b/tests/online_compaction.test/lrl.options
@@ -10,3 +10,6 @@ page_compact_thresh_ff 34.6
 # sparse table)
 cachekbmin 0
 cache 4 mb
+logmsg level info
+pgcomp_dbg_stdout 1
+pgcomp_dbg_ctrace 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -649,6 +649,7 @@
 (name='pflt_toblock_lcl', description='Prefault toblock operations locally', type='BOOLEAN', value='ON', read_only='N')
 (name='pflt_toblock_rep', description='Prefault toblock operations on replicants', type='BOOLEAN', value='ON', read_only='N')
 (name='pfltverbose', description='Verbose errors in prefaulting code', type='BOOLEAN', value='ON', read_only='N')
+(name='pgcomp_dbg', description='Enable debugging trace for page compaction (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='pgcompactpool.dump_on_full', description='Dump status on full queue.', type='BOOLEAN', value='OFF', read_only='N')
 (name='pgcompactpool.exit_on_error', description='Exit on pthread error.', type='BOOLEAN', value='ON', read_only='N')
 (name='pgcompactpool.linger', description='Thread linger time (in seconds).', type='INTEGER', value='10', read_only='N')


### PR DESCRIPTION
Currently page compaction tracing is a compile time option. Make it a runtime option so that it can be toggled at runtime.