### PR TITLE
Print queries and client info on too many verify errors

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -90,6 +90,7 @@ extern int gbl_net_throttle_percent;
 extern int gbl_notimeouts;
 extern int gbl_watchdog_disable_at_start;
 extern int gbl_osql_verify_retries_max;
+extern int gbl_dump_history_on_too_many_verify_errors;
 extern int gbl_page_latches;
 extern int gbl_prefault_udp;
 extern int gbl_print_syntax_err;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2236,4 +2236,7 @@ REGISTER_TUNABLE("pgcomp_dbg_stdout", "Enable debugging stdout trace for page co
                  &gbl_pgcomp_dbg_stdout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("pgcomp_dbg_ctrace", "Enable debugging ctrace for page compaction (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_pgcomp_dbg_ctrace, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("dump_history_on_too_many_verify_errors",
+                 "Dump osql history and client info on too many verify errors (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_dump_history_on_too_many_verify_errors, 0, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -68,6 +68,18 @@ static void srs_free_tran_entry(struct sqlclntstate *clnt,
     free(item);
 }
 
+void srs_tran_print_history(struct sqlclntstate *clnt, int indent)
+{
+    srs_tran_query_t *item = NULL;
+    srs_tran_t *history = clnt->osql.history;
+    if (history == NULL)
+        return;
+    int num = 0;
+    LISTC_FOR_EACH(&history->lst, item, lnk) {
+        logmsg(LOGMSG_WARN, "%*c %3d) %s\n", indent, ' ', num++, print_stmt(clnt, item));
+    }
+}
+
 /**
  * Create a history of sql for this transaction
  * that will allow replay in the case of verify errors
@@ -304,7 +316,7 @@ static int srs_tran_replay_int(struct sqlclntstate *clnt, int(dispatch_fn)(struc
         /* don't repeat if we fail with unexplicable error, i.e. not a logical
          * error */
         if (rc < 0) {
-            if (clnt->osql.replay != OSQL_RETRY_NONE) {
+            if (osql->replay != OSQL_RETRY_NONE) {
                 logmsg(LOGMSG_ERROR,
                        "%p Replaying failed abnormally, calling abort, nq=%d tnq=%d\n",
                        clnt, nq, tnq);
@@ -322,15 +334,12 @@ static int srs_tran_replay_int(struct sqlclntstate *clnt, int(dispatch_fn)(struc
             }
             break;
         }
-    } while (clnt->osql.replay == OSQL_RETRY_DO &&
-             clnt->verify_retries <= gbl_osql_verify_retries_max);
+    } while (osql->replay == OSQL_RETRY_DO && clnt->verify_retries <= gbl_osql_verify_retries_max);
 
-    if (clnt->verify_retries >= gbl_osql_verify_retries_max) {
+    if (clnt->verify_retries >= gbl_osql_verify_retries_max && osql->xerr.errval) {
         uuidstr_t us;
-        logmsg(LOGMSG_ERROR,
-               "transaction %llx %s failed %d times with verify errors\n",
-               clnt->osql.rqid, comdb2uuidstr(clnt->osql.uuid, us),
-               clnt->verify_retries);
+        logmsg(LOGMSG_ERROR, "transaction %llx %s failed %d times with verify errors\n", osql->rqid,
+               comdb2uuidstr(osql->uuid, us), clnt->verify_retries);
         /* Set to NONE to suppress the error from srs_tran_destroy(). */
         osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_NONE);
     }

--- a/db/osql_srs.h
+++ b/db/osql_srs.h
@@ -64,4 +64,5 @@ int srs_tran_empty(struct sqlclntstate *clnt);
 int srs_tran_replay(struct sqlclntstate *);
 int srs_tran_replay_inline(struct sqlclntstate *);
 
+void srs_tran_print_history(struct sqlclntstate *clnt, int indent);
 #endif

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -256,6 +256,7 @@
 (name='dump_after_byteswap', description='dump page after byteswap', type='BOOLEAN', value='OFF', read_only='N')
 (name='dump_blkseq', description='Dump all blkseq inserts and replays', type='BOOLEAN', value='OFF', read_only='N')
 (name='dump_cache_max_pages', description='Maximum number of pages that will dump into a pagelist.  Setting to 0 means that there is no limit.  (Default: 0)', type='INTEGER', value='0', read_only='N')
+(name='dump_history_on_too_many_verify_errors', description='Dump osql history and client info on too many verify errors (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='dump_locks_on_repwait', description='Dump locks on repwaits', type='BOOLEAN', value='OFF', read_only='N')
 (name='dump_page_on_byteswap_error', description='fsnap a malformed page from byteswap', type='BOOLEAN', value='OFF', read_only='N')
 (name='dump_pool_on_full', description='dump_pool_on_full', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
If a transaction retries too many times on verify error, print its osql history and client info. This will help developers identify the application code that generates the contention.

(DRQS 170139901)