### PR TITLE
Fix build

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3756,7 +3756,8 @@ static int process_rep_mon_hash(void *obj, void *arg)
             rm->tid, rm->host, rm->type, now - rm->starttime);
         char pstack_cmd[128];
         snprintf(pstack_cmd, sizeof(pstack_cmd), "pstack %d", (int)rm->tid);
-        system(pstack_cmd);
+        int rc = system(pstack_cmd);
+        (void)rc;
         /* Linux pstacks tid, non-linux halts hash-for */
 #ifndef _LINUX_SOURCE
         return 1;


### PR DESCRIPTION
Fix the following error:

```
comdb2/bdb/rep.c:3759:9: error: ignoring return value of 'system', declared with attribute warn_unused_result [-Werror=unused-result]
         system(pstack_cmd);
```