### PR TITLE
Enable fail_dispatch on new clients by default

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5174,6 +5174,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     }
     clnt->recno = 1;
     clnt->done = 1;
+    clnt->fail_dispatch = 1;
     strcpy(clnt->tzname, "America/New_York");
     clnt->dtprec = gbl_datetime_precision;
     bzero(&clnt->conninfo, sizeof(clnt->conninfo));


### PR DESCRIPTION
We enable it only after read client's configuration, however for new clients the queries can be rejected without giving an error back, as we haven't read client's configuration yet, leading to >10 second delay. Since client sets it after reading server's shared mem flags, have it turned on by default from server side.

Signed-off-by: mohitkhullar <mkhullar1@bloomberg.net>

