### PR TITLE
Fix for mismatch between sql and fingerprint in longreqs file for Stored Procedures

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -124,6 +124,8 @@ int gbl_longreq_log_freq_sec = 60;
 
 static void log_all_events(struct reqlogger *logger, struct output *out);
 
+extern int is_stored_proc(struct sqlclntstate*);
+
 inline void sltdbt_get_stats(int *n_reqs, int *l_reqs)
 {
     *n_reqs = norm_reqs;
@@ -1939,8 +1941,13 @@ static void reqlog_log_longreq(struct sqlclntstate *clnt)
     if (gbl_fingerprint_queries) {
         unsigned char fp[FINGERPRINTSZ];
         size_t unused;
-        const char *normSql = (clnt->work.zNormSql) ? clnt->work.zNormSql :
+        const char *normSql = NULL;
+        if(is_stored_proc(clnt)){
+            normSql = clnt->work.zOrigNormSql;
+        } else {
+            normSql = (clnt->work.zNormSql) ? clnt->work.zNormSql :
           clnt->work.zOrigNormSql;
+        }
         if (normSql) {
             calc_fingerprint(normSql, &unused, fp);
             reqlog_set_fingerprint(&logger, (const char *)fp, FINGERPRINTSZ);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1002,7 +1002,7 @@ static int is_stored_proc_sql(const char *sql)
     return 0;
 }
 
-static int is_stored_proc(struct sqlclntstate *clnt)
+int is_stored_proc(struct sqlclntstate *clnt)
 {
     return is_stored_proc_sql(clnt->sql);
 }


### PR DESCRIPTION
$ cdb2sql sourcedb local "exec procedure test('select sleep(10)')"

from longreqs file: 
09/06 20:00:12: LONG REQUEST 5637 msec for fingerprint c540ad1f636d4e6a6edfb10b30b2acf9 pid 111547 task cdb2sql rqid  from localhost **running**
09/06 20:00:12:   sql=exec procedure test('select sleep(10)')

from comdb2_fingerprints: 
$ cdb2sql sourcedb local "select * from comdb2_fingerprints"                             
(fingerprint='649f7484b7d18837c4708ea034e0ef51', count=1, total_cost=0, total_time=10006, total_prep_time=3, total_rows=1, normalized_sql='EXEC PROCEDURE test(?);')
(fingerprint='3d3497108e5a1b88ae2df6e7e7e5b812', count=1, total_cost=0, total_time=5, total_prep_time=2, total_rows=2, normalized_sql='SELECT*FROM comdb2_fingerprints;')
(fingerprint='c540ad1f636d4e6a6edfb10b30b2acf9', count=1, total_cost=0, total_time=10006, total_prep_time=3, total_rows=1, normalized_sql='SELECT sleep(?);')

The fingerprint and the sql don't match in the longreqs file. This patch provides a fix.

