### PR TITLE
Fix robomark build

### DIFF
--- a/sqlite/src/expr.c
+++ b/sqlite/src/expr.c
@@ -5874,12 +5874,7 @@ static char* sqlite3ExprDescribe_inner(
     case TK_ANY: {
       break;
     }
-    case TK_AND: {
-        if (pExpr->pRight &&
-                ExprHasProperty(pExpr->pRight, EP_FromJoin)) {
-
-        }
-    }
+    case TK_AND:
     case TK_OR:
     case TK_IS: {
       char *left = sqlite3ExprDescribe_inner(v, pExpr->pLeft, atRuntime,
@@ -6369,26 +6364,9 @@ default_prec:
       else
         return sqlite3_mprintf("\"%w\"", name);
     }
-    case TK_AGG_FUNCTION: {
-      if (pParamsOut /* comes from dohsql */ &&
-              !strcasecmp(pExpr->u.zToken, "count")) {
-        if (!pExpr->x.pList) {
-          return sqlite3_mprintf("count(*)");
-        } else if (pExpr->x.pList->nExpr == 1) {
-            char *arguments = sqlite3ExprDescribe_inner(v,
-                    pExpr->x.pList->a[0].pExpr, atRuntime, pParamsOut,
-                    useFullColnames);
-            if (arguments) {
-                char *ret = sqlite3_mprintf("count(%s)", arguments);
-                sqlite3_free(arguments);
-                return ret;
-            }
-        }
-      }
-    } 
-    case TK_AGG_COLUMN: {
+    case TK_AGG_FUNCTION: /* fallthrough */
+    case TK_AGG_COLUMN:
       break;
-    }
     case TK_UMINUS : {
        char *left = sqlite3ExprDescribe_inner(v, pExpr->pLeft, atRuntime,
                pParamsOut, useFullColnames);
@@ -6425,6 +6403,23 @@ default_prec:
 
       last = pExpr->op;
     }
+  }
+  if (op == TK_AGG_FUNCTION) {
+      if (pParamsOut /* comes from dohsql */ &&
+              !strcasecmp(pExpr->u.zToken, "count")) {
+        if (!pExpr->x.pList) {
+          return sqlite3_mprintf("count(*)");
+        } else if (pExpr->x.pList->nExpr == 1) {
+            char *arguments = sqlite3ExprDescribe_inner(v,
+                    pExpr->x.pList->a[0].pExpr, atRuntime, pParamsOut,
+                    useFullColnames);
+            if (arguments) {
+                char *ret = sqlite3_mprintf("count(%s)", arguments);
+                sqlite3_free(arguments);
+                return ret;
+            }
+        }
+      }
   }
   return NULL;
 }

--- a/sqlite/src/rowset.c
+++ b/sqlite/src/rowset.c
@@ -69,7 +69,7 @@
 #include <logmsg.h>
 
 int gbl_sqlite_use_temptable_for_rowset = 1;
-struct dbenv *thedb;
+extern struct dbenv *thedb;
 #endif
 
 /*


### PR DESCRIPTION
This patch fixes two build issues:
* First one is failure due to `multiple definition of 'thedb'` in `sqlite/src/rowset.c`, failing on all platforms
* The second failure happens only on sunos:
```
cg: assertion failed in file ../src/codegen/map_switch.cc at line 2833
cg: bad switch bounds
cg: 1 errors
cc: cg failed for comdb2/sqlite/src/expr.c
```
The 2nd failure was found to be linked to https://github.com/bloomberg/comdb2/commit/075fef81ac6e6890789fe1b5d42180fc378a56af (https://github.com/bloomberg/comdb2/pull/3342). I have tried to rework the part that the compiler complained about, in order to bypass the error.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>