### PR TITLE
dbq_add: Fix use of uninitialized value.

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -5312,7 +5312,7 @@ int dbq_add(struct ireq *iq, void *trans, const void *dta, size_t dtalen)
 {
     int bdberr;
     void *bdb_handle;
-    unsigned long long genid;
+    unsigned long long genid = 0;
     bdb_handle = get_bdb_handle_ireq(iq, AUXDB_NONE);
     if (!bdb_handle)
         return ERR_NO_AUXDB;
@@ -5337,7 +5337,7 @@ int dbq_add(struct ireq *iq, void *trans, const void *dta, size_t dtalen)
     recorded_hit:
         /* Add this genid to the replication list; queue consumers will block
          * on this until it has replicated. */
-        iq->repl_list = add_genid_to_repl_list(genid, iq->repl_list);
+        if (genid) iq->repl_list = add_genid_to_repl_list(genid, iq->repl_list);
         return 0;
     }
     if (bdberr == BDBERR_DEADLOCK)


### PR DESCRIPTION
==190900== Use of uninitialised value of size 8
==190900==    at 0x15BE878: hash_add (plhash.c:1993)
==190900==    by 0x9533F2: add_genid_to_repl_list (repl_wait.c:108)
==190900==    by 0x8EBCAC: dbq_add (glue.c:5340)
==190900==    by 0x9FB5AF: sp_trigger_run (translistener.c:831)
==190900==    by 0x9FB672: javasp_trans_tagged_trigger (translistener.c:860)
==190900==    by 0x94BF4E: add_record (record.c:534)
==190900==    by 0x9113CE: osql_process_packet (osqlcomm.c:7119)
==190900==    by 0x8FDC68: process_this_session (osqlblockproc.c:1441)
==190900==    by 0x8FE25C: apply_changes (osqlblockproc.c:1559)
==190900==    by 0x8FBD2B: osql_bplog_commit (osqlblockproc.c:513)
==190900==    by 0x9F4051: toblock_main_int (toblock.c:4834)
==190900==    by 0x9F7D03: toblock_main (toblock.c:6073)

Signed-off-by: Akshat Sikarwar <asikarwar1@bloomberg.net>