### PR TITLE
net: Fix spurious out-of-memory error.

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3867,7 +3867,11 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
     /* give it to berkeley db */
     time1 = comdb2_time_epoch();
 
-#ifdef _LINUX_SOURCE
+#ifdef __APPLE__
+    uint64_t id;
+    pthread_threadid_np(pthread_self(), &id);
+    rm.tid = id;
+#elif defined _LINUX_SOURCE
     rm.tid = syscall(__NR_gettid);
 #else
     rm.tid = getpid();


### PR DESCRIPTION
When peer does clean shutdown there is no further data to read.  I noticed the following in the logs:
```
[off c2   fd:73   readcb] readv rc:-1 errno:12:Cannot allocate memory
[off c3   fd:75   readcb] readv rc:-1 errno:12:Cannot allocate memory
[rep c2   fd:57   readcb] readv rc:-1 errno:12:Cannot allocate memory
[rep c3   fd:66   readcb] readv rc:-1 errno:12:Cannot allocate memory
```