### PR TITLE
Provide mechanism to audit large writes

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -145,6 +145,7 @@ extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;
 extern int gbl_rep_verify_will_recover_trace;
+extern uint32_t gbl_written_rows_warn;
 extern uint32_t gbl_max_wr_rows_per_txn;
 extern uint32_t gbl_max_cascaded_rows_per_txn;
 extern uint32_t gbl_max_time_per_txn_ms;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1413,6 +1413,10 @@ REGISTER_TUNABLE("rep_verify_will_recover_trace",
 REGISTER_TUNABLE("max_wr_rows_per_txn",
                  "Set the max written rows per transaction.", TUNABLE_INTEGER,
                  &gbl_max_wr_rows_per_txn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("written_rows_warn",
+                 "Set warning threshold for rows written in a transaction.  "
+                 "(Default: 0)",
+                 TUNABLE_INTEGER, &gbl_written_rows_warn, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_cascaded_rows_per_txn",
                  "Set the max cascaded rows updated per transaction.", TUNABLE_INTEGER,
                  &gbl_max_cascaded_rows_per_txn, 0, NULL, NULL, NULL, NULL);

--- a/db/glue.c
+++ b/db/glue.c
@@ -713,6 +713,7 @@ int trans_commit_logical_tran(void *trans, int *bdberr)
 
 int gbl_javasp_early_release = 1;
 int gbl_debug_add_replication_latency = 0;
+int gbl_written_rows_warn = 0;
 
 static int trans_commit_int(struct ireq *iq, void *trans, char *source_host,
                             int timeoutms, int adaptive, int logical,
@@ -726,6 +727,12 @@ static int trans_commit_int(struct ireq *iq, void *trans, char *source_host,
     void *bdb_handle = thedb->bdb_env;
 
     memset(&ss, -1, sizeof(ss));
+
+    if (gbl_written_rows_warn > 0 && iq->written_row_count > gbl_written_rows_warn) {
+        uuidstr_t us;
+        logmsg(LOGMSG_USER, "[%llu %s] writes %d rows\n", iq->sorese->rqid, comdb2uuidstr(iq->sorese->uuid, us),
+               iq->written_row_count);
+    }
 
     rc = trans_commit_seqnum_int(bdb_handle, thedb, iq, trans, &ss, logical,
                                  blkseq, blklen, blkkey, blkkeylen);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1006,5 +1006,6 @@
 (name='warn_on_replicant_log_write', description='Warn if replicant is writing to logs', type='BOOLEAN', value='ON', read_only='N')
 (name='warn_slow_replicants', description='Warn if any replicant's average response times over the last 10 seconds are significantly worse than the second worst replicant's.', type='BOOLEAN', value='ON', read_only='N')
 (name='watchthreshold', description='Panic if node has been unhealty (unresponsive, out of resources, etc.) for more than this many seconds. The default value is 60.', type='INTEGER', value='60', read_only='Y')
+(name='written_rows_warn', description='Set warning threshold for rows written in a transaction.  (Default: 300000)', type='INTEGER', value='0', read_only='N')
 (name='zliblevel', description='If zlib compression is enabled, this determines the compression level.', type='INTEGER', value='6', read_only='N')
 (name='ztrace', description='', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
This PR allows us to audit large transactions via the written_rows_warn tunable.