### PR TITLE
written_rows_warn tunable can audit rows written by a transaction

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -144,6 +144,7 @@ extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;
 extern int gbl_rep_verify_will_recover_trace;
+extern int gbl_written_rows_warn;
 extern int gbl_max_wr_rows_per_txn;
 extern int gbl_force_serial_on_writelock;
 extern int gbl_processor_thd_poll;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1374,6 +1374,10 @@ REGISTER_TUNABLE("rep_verify_will_recover_trace",
 REGISTER_TUNABLE("max_wr_rows_per_txn",
                  "Set the max written rows per transaction.", TUNABLE_INTEGER,
                  &gbl_max_wr_rows_per_txn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("written_rows_warn",
+                 "Set warning threshold for rows written in a transaction.  "
+                 "(Default: 0)", TUNABLE_INTEGER, &gbl_written_rows_warn, 0, 
+                 NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("print_deadlock_cycles",
                  "Print all deadlock cycles. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_print_deadlock_cycles, NOARG, NULL, NULL, NULL, NULL);

--- a/db/glue.c
+++ b/db/glue.c
@@ -726,6 +726,7 @@ int trans_commit_logical_tran(void *trans, int *bdberr)
 
 int gbl_javasp_early_release = 1;
 int gbl_debug_add_replication_latency = 0;
+int gbl_written_rows_warn = 0;
 
 static int trans_commit_int(struct ireq *iq, void *trans, char *source_host,
                             int timeoutms, int adaptive, int logical,
@@ -740,6 +741,12 @@ static int trans_commit_int(struct ireq *iq, void *trans, char *source_host,
     struct dbenv *dbenv = dbenv_from_ireq(iq);
 
     memset(&ss, -1, sizeof(ss));
+
+    if (release_schema_lk && gbl_written_rows_warn > 0 && iq->written_row_count > gbl_written_rows_warn) {
+        uuidstr_t us;
+        logmsg(LOGMSG_USER, "transaction-audit txn %llu:%s modified %d rows\n", iq->sorese.rqid, comdb2uuidstr(iq->sorese.uuid, us),
+               iq->written_row_count);
+    }
 
     rc = trans_commit_seqnum_int(bdb_handle, dbenv, iq, trans, &ss, logical,
                                  blkseq, blklen, blkkey, blkkeylen);

--- a/db/record.c
+++ b/db/record.c
@@ -158,8 +158,9 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
     }
 
     if (!(flags & RECFLAGS_NEW_SCHEMA)) {
+        ++iq->written_row_count;
         if (gbl_max_wr_rows_per_txn &&
-            ((++iq->written_row_count) > gbl_max_wr_rows_per_txn)) {
+            (iq->written_row_count > gbl_max_wr_rows_per_txn)) {
             reqerrstr(iq, COMDB2_CSTRT_RC_TRN_TOO_BIG,
                       "Transaction exceeds max rows");
             retrc = ERR_TRAN_TOO_BIG;
@@ -695,8 +696,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     *ixfailnum = -1;
 
     if (!is_event_from_sc(flags)) {
+        ++iq->written_row_count;
         if (gbl_max_wr_rows_per_txn &&
-            ((++iq->written_row_count) > gbl_max_wr_rows_per_txn)) {
+            (iq->written_row_count > gbl_max_wr_rows_per_txn)) {
             reqerrstr(iq, COMDB2_CSTRT_RC_TRN_TOO_BIG,
                       "Transaction exceeds max rows");
             retrc = ERR_TRAN_TOO_BIG;
@@ -1513,12 +1515,15 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
         goto err;
     }
 
-    if (!is_event_from_sc(flags) && gbl_max_wr_rows_per_txn &&
-        ((++iq->written_row_count) > gbl_max_wr_rows_per_txn)) {
-        reqerrstr(iq, COMDB2_CSTRT_RC_TRN_TOO_BIG,
-                  "Transaction exceeds max rows");
-        retrc = ERR_TRAN_TOO_BIG;
-        goto err;
+    if (!is_event_from_sc(flags)) { 
+        ++iq->written_row_count;
+        if (gbl_max_wr_rows_per_txn &&
+            (iq->written_row_count > gbl_max_wr_rows_per_txn)) {
+            reqerrstr(iq, COMDB2_CSTRT_RC_TRN_TOO_BIG,
+                    "Transaction exceeds max rows");
+            retrc = ERR_TRAN_TOO_BIG;
+            goto err;
+        }
     }
 
     if (iq->debug) {


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum@bloomberg.net>

This PR allows us to audit large transactions via the written_rows_warn tunable.  The master version is https://github.com/bloomberg/comdb2/pull/3417