### PR TITLE
pushnext for non-singlemeta

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3985,6 +3985,8 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
     }
 
     if (!dbenv->meta) {
+        /* open the meta file for the "static table". */
+        (void)open_auxdbs(&dbenv->static_table, 0);
         for (ii = 0; ii < dbenv->num_dbs; ii++) {
             rc = open_auxdbs(dbenv->dbs[ii], 0);
             /* We still have production comdb2s that don't have meta, so we

--- a/db/pushlogs.c
+++ b/db/pushlogs.c
@@ -109,6 +109,20 @@ static void *pushlogs_thread(void *voidarg)
         /* put some junk into meta table */
         init_fake_ireq(thedb, &iq);
         db = &thedb->static_table;
+        /* if we do not have a meta, try creating one on the spot. */
+        if (thedb->meta == NULL && db->meta == NULL) {
+            wrlock_schema_lk();
+            int ret = open_auxdbs(&thedb->static_table, 1);
+            unlock_schema_lk();
+            if (ret != 0) {
+                logmsg(LOGMSG_ERROR, "pushlogs_thread: failed opening meta\n");
+                Pthread_mutex_unlock(&schema_change_in_progress_mutex);
+                Pthread_mutex_lock(&mutex);
+                have_thread = 0;
+                Pthread_mutex_unlock(&mutex);
+                break;
+            }
+        }
         iq.usedb = db;
         rc = trans_start(&iq, NULL, &trans);
         if (rc != 0) {


### PR DESCRIPTION
Simple fix to make pushnext work on non-singlemeta databases.