### PR TITLE
Dedup req-all-reqs

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -154,6 +154,7 @@ extern int gbl_dump_full_net_queue;
 extern int gbl_debug_partial_write;
 extern int gbl_max_clientstats_cache;
 extern int gbl_decoupled_logputs;
+extern int gbl_dedup_rep_all_reqs;
 extern int gbl_apply_queue_memory;
 extern int gbl_inmem_repdb_maxlog;
 extern int gbl_inmem_repdb_memory;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1347,6 +1347,8 @@ REGISTER_TUNABLE("verbose_send_cohlease",
 REGISTER_TUNABLE("reset_on_unelectable_cluster", "Reset master if unelectable.",
                  TUNABLE_BOOLEAN, &gbl_reset_on_unelectable_cluster,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("dedup_rep_all_reqs", "Only allow a single rep-all on queue to the master. (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_dedup_rep_all_reqs, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("decoupled_logputs",
                  "Perform logputs out-of-band. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_decoupled_logputs, EXPERIMENTAL | INTERNAL, NULL, NULL,


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum@bloomberg.net>

Only allow a single rep_all_req on the outgoing queue to master