### PR TITLE
Tools to allow tracking of rep-messages through qstat

### DIFF
--- a/bdb/rep_qstat.h
+++ b/bdb/rep_qstat.h
@@ -35,6 +35,9 @@ typedef struct net_queue_stat {
     /* Other counts */
     int64_t unknown_count;
     int64_t total_count;
+
+    /* Debug tunables */
+    int did_pstack;
 } net_queue_stat_t;
 
 void net_rep_qstat_init(netinfo_type *netinfo_ptr);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -325,6 +325,13 @@ unsigned long long get_genid(bdb_state_type *bdb_state, unsigned int dtafile);
 void seed_genid48(bdb_state_type *bdb_state, uint64_t seed);
 extern int set_pbkdf2_iterations(int val);
 
+/* bdb/rep_qstat.c */
+extern unsigned long long track_qstat;
+extern int qstat_stack_threshold;
+extern int rep_qstat_tunable_track(void *context, void *reptype);
+extern int rep_qstat_tunable_untrack(void *context, void *reptype);
+extern void *rep_qstat_tunable_value(void *context);
+
 static char *gbl_name = NULL;
 static int ctrace_gzip;
 extern int gbl_reorder_socksql_no_deadlock;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2177,6 +2177,18 @@ REGISTER_TUNABLE("net_somaxconn",
                  "listen() backlog setting.  (Default: 0, implies system default)",
                  TUNABLE_INTEGER, &gbl_net_maxconn, READONLY, NULL, NULL, NULL, NULL);
 
+/* rep_qstat_track & rep_qstat_untrack can be set multple times to track multple rep-messages */
+REGISTER_TUNABLE("rep_qstat_track", "Track queued replication message.  (Default: 0)",
+                 TUNABLE_STRING, &track_qstat, 0, rep_qstat_tunable_value, NULL,
+                 rep_qstat_tunable_track, NULL);
+
+REGISTER_TUNABLE("rep_qstat_untrack", "Untrack queued replication message.  (Default: 0)",
+                 TUNABLE_STRING, &track_qstat, 0, rep_qstat_tunable_value, NULL,
+                 rep_qstat_tunable_untrack, NULL);
+
+REGISTER_TUNABLE("rep_qstat_stack_threshold", "Rep-qstat dumpstack threshold.  (Default: 0)",
+                 TUNABLE_INTEGER, &qstat_stack_threshold, 0, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("throttle_txn_chunks_msec", "Wait that many milliseconds before starting a new chunk  (Default: 0)",
                  TUNABLE_INTEGER, &gbl_throttle_txn_chunks_msec, 0, NULL, NULL, NULL, NULL);
 

--- a/net/info.c
+++ b/net/info.c
@@ -139,8 +139,9 @@ void net_cmd(netinfo_type *netinfo_ptr, char *line, int lline, int st, int op1)
 
     static const char *help_msg[] = {"stat    - basic stats",
                                      "dump #  - detailed dump of node #",
-                                     "help    - help menu", NULL,
-                                     "conn     - dump connection stats"};
+                                     "qstat   - dump all qstats", 
+                                     "conn    - dump connection stats",
+                                     "help    - help menu", NULL};
 
     tok = segtok(line, lline, &st, &ltok);
     if (ltok == 0 || tokcmp(tok, ltok, "stat") == 0) {
@@ -152,6 +153,8 @@ void net_cmd(netinfo_type *netinfo_ptr, char *line, int lline, int st, int op1)
             dump_node(netinfo_ptr, host);
             free(host);
         }
+    } else if (tokcmp(tok, ltok, "qstat") == 0) {
+        net_dump_qstats(netinfo_ptr);
     } else if (tokcmp(tok, ltok, "help") == 0) {
         int ii;
         for (ii = 0; help_msg[ii]; ii++)

--- a/net/net.c
+++ b/net/net.c
@@ -6633,6 +6633,19 @@ int net_get_stats(netinfo_type *netinfo_ptr, struct net_stats *stat) {
     return 0;
 }
 
+void net_dump_qstats(netinfo_type *netinfo_ptr)
+{
+    struct host_node_tag *ptr;
+    if (netinfo_ptr->qstat_dump_rtn == NULL) {
+        return;
+    }
+    Pthread_rwlock_rdlock(&(netinfo_ptr->lock));
+    for (ptr = netinfo_ptr->head; ptr != NULL; ptr = ptr->next) {
+        (netinfo_ptr->qstat_dump_rtn)(netinfo_ptr, ptr->qstat, stderr);
+    }
+    Pthread_rwlock_unlock(&(netinfo_ptr->lock));
+}
+
 int net_get_host_stats(netinfo_type *netinfo_ptr, const char *host, struct net_host_stats *stat) {
     struct host_node_tag *ptr;
     stat->queue_size = 0;

--- a/net/net.h
+++ b/net/net.h
@@ -439,6 +439,7 @@ int64_t net_get_num_current_non_appsock_accepts(netinfo_type *netinfo_ptr);
 int64_t net_get_num_accept_timeouts(netinfo_type *netinfo_ptr);
 void net_set_conntime_dump_period(netinfo_type *netinfo_ptr, int value);
 int net_get_conntime_dump_period(netinfo_type *netinfo_ptr);
+void net_dump_qstats(netinfo_type *netinfo_ptr);
 int net_send_all(netinfo_type *, int, void **, int *, int *, int *);
 
 extern int gbl_libevent;


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum@bloomberg.net>

Tools and tunables that allow us to track messages on the replication net-queue.
