### PR TITLE
Provide tunable to add to ufid-hash in rep-collect-txn

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -245,6 +245,7 @@ extern int gbl_do_inline_poll;
 extern int gbl_fingerprint_max_queries;
 extern int gbl_ufid_log;
 extern int gbl_ufid_add_on_open;
+extern int gbl_ufid_add_on_collect;
 extern unsigned gbl_ddlk;
 extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1880,6 +1880,9 @@ REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOL
 REGISTER_TUNABLE("ufid_add_on_open", "Add to ufid-hash on db_open.  (Default: off)", TUNABLE_BOOLEAN, 
                  &gbl_ufid_add_on_open, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default: off)", TUNABLE_BOOLEAN, 
+                 &gbl_ufid_add_on_collect, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Add to ufid-hash while collecting a transaction in the replication thread.  We do this here rather than while processing a transaction to prevent lock-inversion with our trigger system.