### PR TITLE
Disable ufid remove-dbp code by default

### DIFF
--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -424,6 +424,9 @@ __ufid_add_dbp(dbenv, dbp)
 	return ret;
 }
 
+// Disable by default.
+int gbl_ufid_remove_dbp = 0;
+
 // PUBLIC: int __ufid_rem_dbp __P((DB_ENV *, u_int8_t *));
 //	This function is ufid's substitute for __dbreg_add_dbentry(dbp=NULL).
 //	The only difference between these 2 functions is that, __dbreg_add_dbentry(dbp=NULL)
@@ -438,6 +441,9 @@ __ufid_rem_dbp(dbenv, uid)
 	u_int8_t *uid;
 {
 	struct __ufid_to_db_t *ufid;
+	if (!gbl_ufid_remove_dbp) {
+		return 0;
+	}
 
 	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
 	if ((ufid = hash_find(dbenv->ufid_to_db_hash, uid))) {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -246,6 +246,7 @@ extern int gbl_fingerprint_max_queries;
 extern int gbl_ufid_log;
 extern int gbl_ufid_add_on_open;
 extern int gbl_ufid_add_on_collect;
+extern int gbl_ufid_remove_dbp;
 extern unsigned gbl_ddlk;
 extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1883,6 +1883,9 @@ REGISTER_TUNABLE("ufid_add_on_open", "Add to ufid-hash on db_open.  (Default: of
 REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default: off)", TUNABLE_BOOLEAN, 
                  &gbl_ufid_add_on_collect, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("ufid_remove_dbp", "Remove dbp from ufid-hash.  (Default: off)", TUNABLE_BOOLEAN, 
+                 &gbl_ufid_remove_dbp, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 

--- a/tests/ufid_recovery.test/lrl.options
+++ b/tests/ufid_recovery.test/lrl.options
@@ -1,2 +1,3 @@
 ufid_log on
+ufid_remove_dbp on
 dtastripe 1


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum@bloomberg.net>

We are rolling back changes between versions 761 and 767 to be re-enabled on a tunable.