### PR TITLE
Option to send serialized sqlite rows through cdb2api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ tests/tools/verify_atomics_work
 tests/tools/cdb2_open
 tests/tools/cdb2api_unit
 tests/tools/cdb2_close_early
+tests/tools/sqlite_clnt
 
 
 tests/*_generated.test

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -35,7 +35,8 @@ enum cdb2_hndl_alloc_flags {
     CDB2_RANDOM = 8,
     CDB2_RANDOMROOM = 16,
     CDB2_ROOM = 32,
-    CDB2_ADMIN = 64
+    CDB2_ADMIN = 64,
+    CDB2_SQL_ROWS = 128
 };
 
 enum cdb2_request_type {

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -1021,3 +1021,29 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
     return clnt;
 }
 
+/**
+ * Pack an sqlite result to be send to a remote db
+ *
+ */
+void fdb_sqlite_row(sqlite3_stmt *stmt, Mem *res)
+{
+    UnpackedRecord upr;
+    int nField;
+
+    bzero(&upr, sizeof(upr));
+    upr.aMem = sqlite3GetCachedResultRow(stmt, &nField);
+    assert(upr.aMem);
+    upr.nField = nField;
+
+    bzero(res, sizeof(*res));
+    sqlite3VdbeRecordPack(&upr, res);
+}
+
+/**
+ * Free a packed sqlite row after being used
+ *
+ */
+void fdb_sqlite_row_free(Mem *res)
+{
+    sqlite3VdbeMemRelease(res);
+}

--- a/db/sql.h
+++ b/db/sql.h
@@ -898,6 +898,8 @@ struct sqlclntstate {
     int sqlengine_state_line;
     int last_sqlengine_state;
 
+    int sqlite_row_format;
+
     // Latch last statement's cost for comdb2_last_cost to fetch
     int64_t last_cost;
 };
@@ -1242,6 +1244,18 @@ unsigned long long comdb2_table_version(const char *tablename);
 
 int fdb_add_remote_time(BtCursor *pCur, unsigned long long start,
                         unsigned long long end);
+
+/**
+ * Pack an sqlite result to be send to a remote db
+ *
+ */
+void fdb_sqlite_row(sqlite3_stmt *stmt, Mem *res);
+
+/**
+ * Free a packed sqlite row after being used
+ *
+ */
+void fdb_sqlite_row_free(Mem *res);
 
 int sqlite3LockStmtTables(sqlite3_stmt *pStmt);
 int sqlite3UnlockStmtTablesRemotes(struct sqlclntstate *clnt);

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -402,10 +402,28 @@ static int ssl_check(struct newsql_appdata_evbuffer *appdata, CDB2QUERY *query)
     return -1;
 }
 
+static void check_sqlite_row(struct newsql_appdata_evbuffer *appdata,
+                             CDB2QUERY *query)
+{
+    if (!query || !query->sqlquery)
+        return;
+
+    for (int i = 0; i < query->sqlquery->n_features; ++i) {
+        if (CDB2_CLIENT_FEATURES__SQLITE_ROW_FORMAT ==
+            query->sqlquery->features[i]) {
+            appdata->clnt.sqlite_row_format = 1;
+            break;
+        }
+    }
+}
+
 static void process_query(struct newsql_appdata_evbuffer *appdata, CDB2QUERY *query)
 {
     int do_read = 0;
     int commit_rollback;
+
+    check_sqlite_row(appdata, query);
+
     if (SSL_IS_PREFERRED(gbl_client_ssl_mode)) {
         switch (ssl_check(appdata, query)) {
         case 0: break;

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -307,6 +307,10 @@ static CDB2QUERY *read_newsql_query(struct dbenv *dbenv,
     int pre_enabled = 0;
     int was_timeout = 0;
 
+    /* reset here, if query has this feature,
+    it will be enabled before returning */
+    clnt->sqlite_row_format = 0;
+
 retry_read:
     rc = sbuf2fread_timeout((char *)&hdr, sizeof(hdr), 1, sb, &was_timeout);
     if (rc != 1) {
@@ -507,6 +511,15 @@ retry_read:
         cdb2__query__free_unpacked(query, &appdata->newsql_protobuf_allocator.protobuf_allocator);
         return NULL;
     }
+
+    for (int ii = 0; ii < query->sqlquery->n_features; ++ii) {
+        if (CDB2_CLIENT_FEATURES__SQLITE_ROW_FORMAT ==
+            query->sqlquery->features[ii]) {
+            clnt->sqlite_row_format = 1;
+            break;
+        }
+    }
+
     return query;
 }
 

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -25,6 +25,8 @@ enum CDB2ClientFeatures {
     FLAT_COL_VALS        = 6;
     /* request server to send back query fingerprint */
     REQUEST_FP           = 7;
+    /* rows come in sqlite format */
+    SQLITE_ROW_FORMAT    = 8;
 }
 
 message CDB2_FLAG {

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -93,6 +93,7 @@ enum ResponseType {
   COMDB2_INFO   = 4; // For info about features, or snapshot file/offset etc
   SP_TRACE      = 5;
   SP_DEBUG      = 6;
+  SQL_ROW       = 7;
 }
 
 enum CDB2SyncMode {
@@ -162,4 +163,7 @@ message CDB2_SQLRESPONSE {
 
     /* query fingerprint */
     optional bytes fp = 14;
+
+    /* sqlite row */
+    optional bytes sqlite_row = 15;
 }

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -70,6 +70,7 @@ add_exe(updater updater.c testutil.c)
 add_exe(utf8 utf8.c)
 add_exe(verify_atomics_work verify_atomics_work.c)
 add_exe(makerecord_timer makerecord_timer.c)
+add_exe(sqlite_clnt sqlite_clnt.c)
 
 target_link_libraries(cson_test cson)
 target_link_libraries(stepper util mem dlmalloc util)

--- a/tests/tools/sqlite_clnt.c
+++ b/tests/tools/sqlite_clnt.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#include <cdb2api.h>
+#include <sqlite3.h>
+#include <arpa/inet.h>
+
+void usage(FILE *f, char *argv0) {
+    fprintf(stderr, "Usage: %s <dbname> <tblname>\n", argv0);
+    exit(1);
+}
+
+int process_sqlite_row(const unsigned char *row, int rowlen);
+
+int main(int argc, char **argv)
+{
+    cdb2_hndl_tp *hndl = NULL;
+    int rc;
+    
+    if (argc != 3)
+        usage(stderr, argv[0]);
+
+    char *dbname = argv[1];
+    char *tblname = argv[2];
+
+    char *conf = getenv("CDB2_CONFIG");
+    if (conf)
+        cdb2_set_comdb2db_config(conf);
+
+    rc = cdb2_open(&hndl, dbname, /*"default"*/"local", CDB2_SQL_ROWS);
+    if (rc) {
+        fprintf(stderr, "Failed to open db %s rc %d\n", dbname, rc);
+        exit(1);
+    }
+
+    char *sql = sqlite3_mprintf("select * from %s order by 1", tblname);
+    if (!sql) {
+        fprintf(stderr, "Failed to allocate sql string\n");
+        exit(1);
+    }
+
+    rc = cdb2_run_statement(hndl, sql);
+    if (rc) {
+        fprintf(stderr, "Failed to run query rc %d \"%s\"\n", rc, sql);
+        free(sql);
+        cdb2_close(hndl);
+        exit(1);
+    }
+
+
+    int ncols = cdb2_numcolumns(hndl);
+    if (ncols != 1) {
+        fprintf(stderr, "Error: wrong number of columns %d, expected 1\n", ncols);
+        exit(1);
+    }
+
+    rc = cdb2_next_record(hndl);
+    int i = 1;
+    while (rc == CDB2_OK) {
+        const unsigned char *row = cdb2_column_value(hndl, 0);
+        int rowlen = cdb2_column_size(hndl, 0);
+
+        /*fprintf(stderr, "Got sqlite row length %d %p\n", rowlen, row);*/
+        rc = process_sqlite_row(row, rowlen);
+        if (rc) {
+            fprintf(stderr, "Failed to process row %d rc %d\n", i, rc);
+        }
+
+        rc = cdb2_next_record(hndl);
+        i++;
+    }
+    if (rc != CDB2_OK_DONE) {
+        fprintf(stderr, "Failing to return all rows rc %d\n", rc);
+        exit(1);
+    }
+
+    cdb2_close(hndl);
+
+    return 0;
+}
+
+int process_sqlite_row(const unsigned char *row, int rowlen)
+{
+    /* header size has to be a byte */
+    if (row[0] & 0x80) 
+        return -1;
+    int hdrSz = row[0];
+
+    /* simple format only: hdrsz(u8) type1(u8) type2(u8) */
+    if (hdrSz != 3)
+        return -1; 
+
+    int type1 = row[1];
+    int type2 = row[2];
+
+    /* first field should be int */
+    if (type1 != 6)
+        return -1;
+    
+    int val = htonl(*(int*)&row[hdrSz]);
+    val <<= 16;
+    val += htonl(*(int*)&row[hdrSz+4]);
+
+    /* second field should be a small string */
+    if (type2 < 12 || !(type2 & 0x01))
+        return -1;
+    
+    int lstr = (type2-12)/2;
+
+    fprintf(stdout, "(%d, \'%.*s\')\n", val, lstr, &row[hdrSz+8]);
+
+    return 0;    
+}


### PR DESCRIPTION
A client can set an option to receive rows in sqlite serialized format.
This is a stepping stone for more distributed sqlite work, which could rely on cdb2api instead of a custom transport protocol.