### PR TITLE
Provide tunable which allows us to enable read-only tunables at runtime for tests

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -377,6 +377,7 @@ int gbl_page_order_table_scan;
 int gbl_old_column_names = 1;
 int gbl_enable_sq_flattening_optimization = 1;
 int gbl_mask_internal_tunables = 1;
+int gbl_allow_readonly_runtime_mod = 0;
 
 size_t gbl_cached_output_buffer_max_bytes = 8 * 1024 * 1024; /* 8 MiB */
 int gbl_sqlite_sorterpenalty = 5;
@@ -1550,7 +1551,7 @@ comdb2_tunable_err handle_runtime_tunable(const char *name, const char *value)
         return TUNABLE_ERR_INVALID_TUNABLE;
     }
 
-    if ((t->flags & READONLY) != 0) {
+    if ((t->flags & READONLY) != 0 && !gbl_allow_readonly_runtime_mod) {
         logmsg(LOGMSG_DEBUG, "Attempt to update a READ-ONLY tunable '%s'.\n",
                name);
         return TUNABLE_ERR_READONLY;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -641,6 +641,10 @@ REGISTER_TUNABLE("mask_internal_tunables",
                  "INTERNAL tunables (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_mask_internal_tunables, NOARG, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("allow_readonly_runtime_mod",
+                 "When enabled, allow modification of READONLY tunables at runtime.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_allow_readonly_runtime_mod, NOARG | INTERNAL, NULL, NULL, NULL, NULL);
+
 /*
   Note: master_retry_poll_ms' value < 0 was previously ignored without
   any error.


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum@bloomberg.net>

The 'zeroblkseq' test in the robomark test suite needs to modify the 'master_sends_query_effects' tunable at runtime. As this is marked READONLY, it's not normally permitted. This PR provides a tunable which will allow us to modify readonly tunables at runtime.
