### PR TITLE
Convert to timedwait in analyze to fix deadlock

### DIFF
--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -957,12 +957,27 @@ static void *table_thread(void *arg)
 static int dispatch_table_thread(table_descriptor_t *td)
 {
     int rc;
+    struct timespec timeout;
     /* grab lock */
     Pthread_mutex_lock(&table_thd_mutex);
 
     /* wait for thread availability */
     while (analyze_cur_table_threads >= analyze_max_table_threads) {
-        Pthread_cond_wait(&table_thd_cond, &table_thd_mutex);
+        clock_gettime(CLOCK_REALTIME, &timeout);
+        ++timeout.tv_sec; // 1 second timeout
+        rc = pthread_cond_timedwait(&table_thd_cond, &table_thd_mutex, &timeout);
+        if (rc == ETIMEDOUT) {
+            if (bdb_lock_desired(thedb->bdb_env)) {
+                rc = recover_deadlock_simple(thedb->bdb_env);
+                if (rc) {
+                    logmsg(LOGMSG_WARN, "%s: recover_deadlock rc=%d\n", __func__, rc);
+                }
+            }
+        } else if (rc) {
+            logmsg(LOGMSG_FATAL, "pthread_cond_timedwait:%d rc:%d (%s) thd:%p\n", __LINE__, rc, strerror(rc),
+                   (void *)pthread_self());
+            abort();
+        }
     }
 
     /* grab table thread */
@@ -982,19 +997,35 @@ static int dispatch_table_thread(table_descriptor_t *td)
 /* wait for table to complete */
 static int wait_for_table(table_descriptor_t *td)
 {
+    int rc;
+    struct timespec timeout;
     /* lock table mutex */
     Pthread_mutex_lock(&table_thd_mutex);
 
     /* wait for the state to change */
     while (td->table_state == TABLE_STARTUP ||
            td->table_state == TABLE_RUNNING) {
-        Pthread_cond_wait(&table_thd_cond, &table_thd_mutex);
+        clock_gettime(CLOCK_REALTIME, &timeout);
+        ++timeout.tv_sec; // 1 second timeout
+        rc = pthread_cond_timedwait(&table_thd_cond, &table_thd_mutex, &timeout);
+        if (rc == ETIMEDOUT) {
+            if (bdb_lock_desired(thedb->bdb_env)) {
+                rc = recover_deadlock_simple(thedb->bdb_env);
+                if (rc) {
+                    logmsg(LOGMSG_WARN, "%s: recover_deadlock rc=%d\n", __func__, rc);
+                }
+            }
+        } else if (rc) {
+            logmsg(LOGMSG_FATAL, "pthread_cond_timedwait:%d rc:%d (%s) thd:%p\n", __LINE__, rc, strerror(rc),
+                   (void *)pthread_self());
+            abort();
+        }
     }
 
     /* release */
     Pthread_mutex_unlock(&table_thd_mutex);
 
-    int rc = 0;
+    rc = 0;
     if (TABLE_COMPLETE == td->table_state) {
         sbuf2printf(td->sb, ">Analyze table '%s' is complete\n", td->table);
     } else if (TABLE_SKIPPED == td->table_state) {

--- a/tests/analyze_recover_deadlock.test/Makefile
+++ b/tests/analyze_recover_deadlock.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/analyze_recover_deadlock.test/README
+++ b/tests/analyze_recover_deadlock.test/README
@@ -1,0 +1,2 @@
+Test running analyze followed by downgrade to see if analyze completes.
+Recover deadlock should be called in analyze thread.

--- a/tests/analyze_recover_deadlock.test/lrl.options
+++ b/tests/analyze_recover_deadlock.test/lrl.options
@@ -1,0 +1,2 @@
+test_delay_analyze_commit
+osql_send_startgen off

--- a/tests/analyze_recover_deadlock.test/runit
+++ b/tests/analyze_recover_deadlock.test/runit
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+set -e
+
+function getrepnode {
+    rep=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster where is_master='N' and coherent_state='coherent' limit 1")
+    if [ "$rep" = "" ]; then
+        echo "Failed to get replicant"
+        exit 1
+    fi
+    echo $rep
+}
+
+function getmaster {
+    master=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster where is_master='Y'")
+    if [ "$master" = "" ]; then
+        echo "Failed to get master"
+        exit 1
+    fi
+    echo $master
+}
+
+function fillintables {
+    master=$1
+    for table in t v;
+    do
+        cdb2sql $dbnm --host $master "drop table if exists $table" >/dev/null
+        cdb2sql $dbnm --host $master "create table $table(a int unique)" >/dev/null
+        cdb2sql $dbnm --host $master "insert into $table select * from generate_series(1, 10000)" >/dev/null
+        sleep 3
+    done
+}
+
+# check if a pid is done executing given a timeout and starting point
+function checkifdone {
+    cpid=$1
+    timeout=$2
+    st=$3
+
+    elapsed=0
+
+    # verify pid
+    ps -p $cpid >/dev/null 2>&1
+    while [[ $? == 0 && $elapsed -lt $timeout ]] ; do
+        sleep 1
+
+        # check to see if it's time to break out of the loop
+        et=$SECONDS
+        elapsed=$(( et - st ))
+
+        # verify pid
+        ps -p $cpid >/dev/null 2>&1
+    done
+}
+
+function runtest {
+    rep=$1
+    master=$2
+    analyzestr=$3
+
+    # pre checks
+    analyzedelay=$(cdb2sql --tabs $dbnm --host $rep "select value from comdb2_tunables where name='test_delay_analyze_commit'")
+    if [ "$analyzedelay" != "ON" ]; then
+        echo "Unable to set test_delay_analyze_commit to ON"
+        exit 1
+    fi
+
+    cdb2sql $dbnm --host $rep "exec procedure sys.cmd.send('analyze tblthd 1')" >/dev/null
+    numthds=$(cdb2sql --tabs $dbnm --host $rep "select value from comdb2_tunables where name='analyze_tbl_threads'")
+    if [ $numthds != 1 ]; then
+        echo "Unable to set analyze_tbl_threads to 1, got $numthds instead"
+        exit 1
+    fi
+
+    # run analyze on replicant
+    cdb2sql $dbnm --host $rep "$analyzestr" 2>analyze.txt &
+    analyzepid=$!
+    sleep 3
+
+    # run election on master
+    cdb2sql $dbnm --host $master "exec procedure sys.cmd.send('downgrade')" 2>election.txt &
+    electionpid=$!
+
+    # error if either are still running after one minute
+    timeout=60
+    st=$SECONDS
+
+    set +e # next block of code relies on checking error codes
+    checkifdone $analyzepid $timeout $st
+    checkifdone $electionpid $timeout $st
+
+    failed=0
+
+    ps -p $analyzepid >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "Error: Analyze still running after 1 minute"
+        kill -9 $analyzepid >/dev/null 2>&1 
+        failed=1
+    fi
+
+    ps -p $electionpid >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "Error: Election still running after 1 minute"
+        kill -9 $electionpid >/dev/null 2>&1 
+        failed=1
+    fi
+    set -e
+
+    # check for other errors
+    analyzeerrors=$(cat analyze.txt)
+    electionerrors=$(cat election.txt)
+
+    rm analyze.txt
+    rm election.txt
+
+    if [ "$analyzeerrors" != "" ]; then
+        echo "Analyze Error: $analyzeerrors"
+        failed=1
+    fi
+
+    if [ "$electionerrors" != "" ]; then
+        echo "Election Error: $electionerrors"
+        failed=1
+    fi
+
+    if [ $failed -eq 1 ]; then
+        exit 1
+    fi
+}
+
+rep=`getrepnode`
+master=`getmaster`
+
+fillintables $master
+
+echo "Test recover_deadlock called in wait_for_table"
+runtest $rep $master "analyze t"
+
+echo "wait_for_table test passed"
+
+sleep 3
+
+echo "Test recover_deadlock called in dispatch_table_thread"
+rep=`getrepnode`
+master=`getmaster`
+runtest $rep $master "analyze"
+
+echo "dispatch_table_thread test passed"


### PR DESCRIPTION
Fix deadlocks caused by running analyze on one node and downgrade on master

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
