### PR TITLE
Punt in verify if bdblock is desired

### DIFF
--- a/bdb/bdb_verify.h
+++ b/bdb/bdb_verify.h
@@ -56,6 +56,7 @@ typedef struct {
     unsigned int threads_completed; // atomic inc
     verify_mode_t verify_mode;
     uint8_t client_dropped_connection;
+    uint8_t lock_desired;
     uint8_t verify_status; // 0 success, 1 failure
     verify_peer_check_func *peer_check;
     verify_response_func *verify_response;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -155,6 +155,7 @@ extern int gbl_incoherent_logput_window;
 extern int gbl_dump_net_queue_on_partial_write;
 extern int gbl_dump_full_net_queue;
 extern int gbl_debug_partial_write;
+extern int gbl_debug_sleep_on_verify;
 extern int gbl_max_clientstats_cache;
 extern int gbl_decoupled_logputs;
 extern int gbl_apply_queue_memory;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1446,6 +1446,9 @@ REGISTER_TUNABLE("dump_net_queue_on_partial_write",
 REGISTER_TUNABLE("debug_partial_write", "Simulate partial write in net.  "
                  "(Default: 0)", TUNABLE_INTEGER, &gbl_debug_partial_write,
                  EXPERIMENTAL | INTERNAL, NULL,NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_verify_sleep", "Sleep one-second per record in verify.  "
+                 "(Default: off)", TUNABLE_BOOLEAN, &gbl_debug_sleep_on_verify,
+                 EXPERIMENTAL | INTERNAL, NULL,NULL, NULL, NULL);
 REGISTER_TUNABLE(
     "max_clientstats",
     "Max number of client stats stored in comdb2_clientstats. (Default: 10000)",

--- a/tests/verify_upgrade.test/Makefile
+++ b/tests/verify_upgrade.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=8m
+endif

--- a/tests/verify_upgrade.test/README
+++ b/tests/verify_upgrade.test/README
@@ -1,0 +1,1 @@
+Make sure that verify will punt on master change

--- a/tests/verify_upgrade.test/lrl.options
+++ b/tests/verify_upgrade.test/lrl.options
@@ -1,0 +1,2 @@
+logmsg level info
+debug_verify_sleep on

--- a/tests/verify_upgrade.test/runit
+++ b/tests/verify_upgrade.test/runit
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function downgrade
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="downgrade"
+    typeset node=$(get_master)
+    typeset count=0
+    typeset foundmaster=0
+    typeset maxcount=600
+    typeset initialmaster=0
+    write_prompt $func "Running $func $node"
+
+    x=$(get_master)
+    while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+        sleep 1
+        x=$(get_master)
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not find master"
+    initialmaster=$x
+
+    while [[ "$x" == "$initialmaster" && "$count" -lt $maxcount ]]; do
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+            let count=count+1
+        done
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $x $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        sleep 1
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+        done
+
+        [[ "$x" != "$node" ]] && foundmaster=1
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not downgrade master"
+}
+
+function downgrade_loop
+{
+    [[ $debug == "1" ]] && set -x
+    while [[ ! -f $stopfile ]]; do
+        node=$(get_master)
+        while [[ "$CLUSTER" != *"$node"* ]]; do
+            sleep 1
+            node=$(get_master)
+        done
+        downgrade
+        sleep 5
+    done
+}
+
+function run_verify
+{
+    x=$(cdb2sql $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('t1')")
+    echo "Verify returns $?, $x"
+}
+
+function run_test
+{
+    create_table
+    create_index
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "INSERT INTO t1 SELECT * FROM generate_series(1, 100)"
+    downgrade_loop &
+
+    # These should halt on master swing
+    for ((i=0;i<3;++i)); do
+        run_verify
+    done
+
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+
+run_test
+echo "Success"


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

We are getting watchdogged in prod because verify maintains the bdblock, and subsequently blocks upgrades.  This is a simple fix: punt in verify if the bdblock is desired.