### PR TITLE
Testcase and fix for the epochms-rollover / downgrade bug

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -342,7 +342,8 @@ void send_master_req(DB_ENV *dbenv, const char *func, int line)
 
 	call_count++;
 	if (!gbl_master_req_waitms || (spanms = (comdb2_time_epochms() -
-			gbl_last_master_req)) > gbl_master_req_waitms) {
+			gbl_last_master_req)) > gbl_master_req_waitms ||
+			gbl_last_master_req > comdb2_time_epochms()) {
 		req_count++;
 		if (gbl_verbose_master_req && ((now = time(NULL)) - lastpr)) {
 			logmsg(LOGMSG_USER, "%s line %d sending REP_MASTER_REQ, "

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1331,9 +1331,11 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "reset_blkmax") == 0) {
         reset_blkmax();
         logmsg(LOGMSG_USER, "Reset blkmax\n");
-    }
-
-    else if (tokcmp(tok, ltok, "get_blkmax") == 0) {
+    } else if (tokcmp(tok, ltok, "reset_time") == 0) {
+        logmsg(LOGMSG_USER,
+               "Resetting epochms starttime\n");
+        timer_init(NULL);
+    } else if (tokcmp(tok, ltok, "get_blkmax") == 0) {
         int blkmax = get_blkmax();
         logmsg(LOGMSG_USER,
                 "Maximum concurrent block-processor threads is %d, maxwt is %d\n",

--- a/db/timers.c
+++ b/db/timers.c
@@ -43,7 +43,8 @@ static void (*timer_func)(struct timer_parm *) = NULL;
 
 void timer_init(void (*func)(struct timer_parm *))
 {
-    timer_func = func;
+    if (func != NULL)
+        timer_func = func;
     comdb2_time_init();
 }
 

--- a/tests/epochms_rollover.test/Makefile
+++ b/tests/epochms_rollover.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=12m
+endif

--- a/tests/epochms_rollover.test/lrl.options
+++ b/tests/epochms_rollover.test/lrl.options
@@ -1,0 +1,1 @@
+logmsg level info

--- a/tests/epochms_rollover.test/runit
+++ b/tests/epochms_rollover.test/runit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function reset_epochms
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="reset_epochms"
+    for node in $CLUSTER; do
+        $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $node "exec procedure sys.cmd.send('reset_time')" 
+    done
+}
+
+function wait_for_coherent
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="wait_for_coherent"
+    typeset timeout=${1:-15}
+    typeset cnt=0
+    typeset incoherent=1
+    while [[ "$cnt" -lt "$timeout" && "$incoherent" -ne 0 ]]; do
+        incoherent=0
+        for node in $CLUSTER; do
+            $CDB2SQL_EXE -tabs -admin ${CDB2_OPTIONS} $DBNAME --host $node "exec procedure sys.cmd.send('stat')" | egrep "NOT COHERENT" >/dev/null 2>&1
+            r=$?
+            if [[ $r == 0 ]]; then
+                echo "FOUND INCOHERENT NODE $node"
+                export incoherent=1
+            else
+                echo "NODE $node IS COHERENT"
+            fi
+        done
+        let cnt=cnt+1
+        sleep 1
+    done
+    [[ "$incoherent" -gt "0" ]] && failexit "Replicants stayed incoherent"
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    typeset maxtime=600
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+
+    write_prompt $func "Running $func"
+    j=0
+
+    while [[ $j -lt 10 ]]; do
+        master=$(get_master)
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $master $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        wait_for_coherent
+        let j=j+1
+    done
+
+    reset_epochms
+    sleep 80
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        master=$(get_master)
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $master $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        wait_for_coherent
+        sleep 80
+        reset_epochms
+    done
+
+    # Different thread failed the test
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    wait
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+
+rm $stopfile
+run_test
+wait
+echo "Success"


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This is the testcase and fix for the epochms-rollover / downgrade bug which occurs when the integer containing epochms exceeds it's maximum value.  This is intended to be reviewed and merged quickly.  I'll submit a more ambitious fix (which revises significantly more code) later this week.