### PR TITLE
Epochms64 7

### DIFF
--- a/bbinc/averager.h
+++ b/bbinc/averager.h
@@ -21,13 +21,13 @@
 
 struct averager;
 struct averager *averager_new(int limit, int maxpoints);
-void averager_add(struct averager *avg, int value, int now);
+void averager_add(struct averager *avg, int value, int64_t now);
 double averager_avg(struct averager *avg);
 int averager_max(struct averager *avg);
 int averager_min(struct averager *avg);
 void averager_destroy(struct averager *avg);
 int averager_depth(struct averager *avg);
-void averager_purge_old(struct averager *avg, int now);
+void averager_purge_old(struct averager *avg, int64_t now);
 void averager_clear(struct averager *avg);
 
 struct point {

--- a/bbinc/epochlib.h
+++ b/bbinc/epochlib.h
@@ -29,7 +29,7 @@ void time_epoch_(int32_t *epoch);
 int comdb2_time_epoch(void);
 
 /* RETURNS # MILLISECONDS SINCE STARTUP */
-int comdb2_time_epochms(void);
+int64_t comdb2_time_epochms(void);
 
 /* Microseconds since start of epoch */
 int64_t comdb2_time_epochus(void);

--- a/bbinc/thdpool.h
+++ b/bbinc/thdpool.h
@@ -60,7 +60,7 @@ typedef void (*thdpool_work_fn)(struct thdpool *pool, void *work, void *thddata,
 struct workitem {
     void *work;
     thdpool_work_fn work_fn;
-    int queue_time_ms;
+    int64_t queue_time_ms;
     LINKC_T(struct workitem) linkv;
     int available;
     char *persistent_info;

--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -840,7 +840,7 @@ void bdb_lockspeed(bdb_state_type *bdb_state)
     int i;
     DB_LOCK lock;
     DBT lkname = {0};
-    int start, end;
+    int64_t start, end;
 
     dbenv->lock_id(dbenv, &lid);
     lkname.data = "hello";
@@ -851,7 +851,7 @@ void bdb_lockspeed(bdb_state_type *bdb_state)
         dbenv->lock_put(dbenv, &lock);
     }
     end = comdb2_time_epochms();
-    logmsg(LOGMSG_USER, "berkeley took %dms (%d per second)\n", end - start,
+    logmsg(LOGMSG_USER, "berkeley took %"PRId64"ms (%"PRId64" per second)\n", end - start,
            100000000 / (end - start) * 1000);
     dbenv->lock_id_free(dbenv, lid);
 }

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -425,7 +425,7 @@ int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe)
     char *oldname = NULL;
     int rc = 0;
     DB_ENV *env;
-    int start, end;
+    int64_t start, end;
 
     start = comdb2_time_epochms();
     now = comdb2_time_epoch();
@@ -517,7 +517,7 @@ int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe)
     if (bdb_state->attr->private_blkseq_close_warn_time) {
         end = comdb2_time_epochms();
         if ((end - start) > bdb_state->attr->private_blkseq_close_warn_time) {
-            logmsg(LOGMSG_WARN, "blkseq close took %dms\n", end - start);
+            logmsg(LOGMSG_WARN, "blkseq close took %"PRId64"ms\n", end - start);
         }
     }
 

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -696,7 +696,7 @@ struct bdb_callback_tag {
 
 struct waiting_for_lsn {
     DB_LSN lsn;
-    int start;
+    int64_t start;
     LINKC_T(struct waiting_for_lsn) lnk;
 };
 

--- a/bdb/bdb_thd_io.c
+++ b/bdb/bdb_thd_io.c
@@ -38,7 +38,7 @@ static int norm_writes = 0;
 static int bdb_pread(int fd, void *buf, size_t nbytes, off_t offset)
 {
     int rc;
-    int t1, t2;
+    int64_t t1, t2;
     int errno_sav;
 
     io_start();
@@ -49,7 +49,7 @@ static int bdb_pread(int fd, void *buf, size_t nbytes, off_t offset)
 
     t2 = comdb2_time_epochms();
     if ((t2 - t1) > 2000) {
-        logmsg(LOGMSG_WARN, "LONG PREAD: %d ms\n", t2 - t1);
+        logmsg(LOGMSG_WARN, "LONG PREAD: %"PRId64" ms\n", t2 - t1);
         long_reads++;
     } else {
         norm_reads++;
@@ -64,7 +64,7 @@ static int bdb_pread(int fd, void *buf, size_t nbytes, off_t offset)
 static ssize_t bdb_read(int fd, void *buf, size_t nbytes)
 {
     int rc;
-    int t1, t2;
+    int64_t t1, t2;
     int errno_sav;
 
     io_start();
@@ -74,7 +74,7 @@ static ssize_t bdb_read(int fd, void *buf, size_t nbytes)
     errno_sav = errno;
     t2 = comdb2_time_epochms();
     if ((t2 - t1) > 2000) {
-        logmsg(LOGMSG_WARN, "LONG READ: %d ms\n", t2 - t1);
+        logmsg(LOGMSG_WARN, "LONG READ: %"PRId64" ms\n", t2 - t1);
         long_reads++;
     } else {
         norm_reads++;
@@ -88,7 +88,7 @@ static ssize_t bdb_read(int fd, void *buf, size_t nbytes)
 static int bdb_fsync(int fd)
 {
     int rc;
-    int t1, t2;
+    int64_t t1, t2;
     int errno_sav;
 
     /* io_start(); */
@@ -98,7 +98,7 @@ static int bdb_fsync(int fd)
     errno_sav = errno;
     t2 = comdb2_time_epochms();
     if ((t2 - t1) > 2000)
-        logmsg(LOGMSG_WARN, "LONG FSYNC: %d ms\n", t2 - t1);
+        logmsg(LOGMSG_WARN, "LONG FSYNC: %"PRId64" ms\n", t2 - t1);
 
     /* io_cmplt(); */
 
@@ -109,7 +109,7 @@ static int bdb_fsync(int fd)
 static int bdb_pwrite(int fd, const void *buf, size_t nbytes, off_t offset)
 {
     int rc;
-    int t1, t2;
+    int64_t t1, t2;
     int errno_sav;
 
     io_start();
@@ -119,7 +119,7 @@ static int bdb_pwrite(int fd, const void *buf, size_t nbytes, off_t offset)
     errno_sav = errno;
     t2 = comdb2_time_epochms();
     if ((t2 - t1) > 2000) {
-        logmsg(LOGMSG_WARN, "LONG PWRITE: %d ms\n", t2 - t1);
+        logmsg(LOGMSG_WARN, "LONG PWRITE: %"PRId64" ms\n", t2 - t1);
         long_writes++;
     } else {
         norm_writes++;
@@ -134,7 +134,7 @@ static int bdb_pwrite(int fd, const void *buf, size_t nbytes, off_t offset)
 static ssize_t bdb_write(int fd, const void *buf, size_t nbytes)
 {
     int rc;
-    int t1, t2;
+    int64_t t1, t2;
     int errno_sav;
 
     io_start();
@@ -144,7 +144,7 @@ static ssize_t bdb_write(int fd, const void *buf, size_t nbytes)
     errno_sav = errno;
     t2 = comdb2_time_epochms();
     if ((t2 - t1) > 2000) {
-        logmsg(LOGMSG_WARN, "LONG WRITE: %d ms\n", t2 - t1);
+        logmsg(LOGMSG_WARN, "LONG WRITE: %"PRId64" ms\n", t2 - t1);
         long_writes++;
     } else {
         norm_writes++;

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1425,7 +1425,7 @@ static int bdb_flush_cache(bdb_state_type *bdb_state)
 static int bdb_flush_int(bdb_state_type *bdb_state, int *bdberr, int force)
 {
     int rc;
-    int start, end;
+    int64_t start, end;
 
     *bdberr = BDBERR_NOERROR;
 
@@ -1447,7 +1447,7 @@ static int bdb_flush_int(bdb_state_type *bdb_state, int *bdberr, int force)
             return -1;
         }
         end = comdb2_time_epochms();
-        ctrace("checkpoint took %dms\n", end - start);
+        ctrace("checkpoint took %"PRId64"ms\n", end - start);
     }
 
     return 0;

--- a/bdb/fstdump.c
+++ b/bdb/fstdump.c
@@ -372,7 +372,7 @@ static void *fstdump_thread_inner(fstdump_per_thread_t *fstdump, void *sendrec,
     }
 
     for (;;) {
-        int ms_before, ms_after, ms_diff;
+        int64_t ms_before, ms_after, ms_diff;
 
         u_int32_t flags;
 
@@ -428,7 +428,7 @@ static void *fstdump_thread_inner(fstdump_per_thread_t *fstdump, void *sendrec,
         if (ms_diff > common->bdb_parent_state->attr->fstdump_longreq) {
             const struct berkdb_thread_stats *thread_stats =
                 bdb_get_thread_stats();
-            logmsg(LOGMSG_ERROR, "fstdump_thread: LONG REQUEST dbcp->c_get %d ms\n",
+            logmsg(LOGMSG_ERROR, "fstdump_thread: LONG REQUEST dbcp->c_get %"PRId64" ms\n",
                     ms_diff);
             bdb_fprintf_stats(thread_stats, "  ", stderr);
         }

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -117,7 +117,7 @@ static int bdb_wait_for_seqnum_from_node_nowait_int(bdb_state_type *bdb_state,
 
 static void bdb_zap_lsn_waitlist(bdb_state_type *bdb_state, const char *host);
 
-static int last_slow_node_check_time = 0;
+static int64_t last_slow_node_check_time = 0;
 static pthread_mutex_t slow_node_check_lk = PTHREAD_MUTEX_INITIALIZER;
 
 struct rep_type_berkdb_rep_buf_hdr {
@@ -1240,7 +1240,7 @@ static void *elect_thread(void *args)
     bdb_state_type *bdb_state;
     char *master_host;
     int num;
-    int end, start;
+    int64_t end, start;
     int num_connected;
     int node_not_up = 0;
     uint32_t newgen;
@@ -2430,7 +2430,7 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     int rc;
     unsigned long long cntbytes;
     struct waiting_for_lsn *waitforlsn = NULL;
-    int now;
+    int64_t now;
     int track_times;
 
     track_times = bdb_state->attr->track_replication_times;
@@ -3240,7 +3240,8 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
                                             seqnum_type *seqnum, int *timeoutms,
                                             uint64_t txnsize, int newcoh)
 {
-    int i, now, cntbytes;
+    int i, cntbytes;
+    int64_t now;
     const char *nodelist[REPMAX];
     const char *connlist[REPMAX];
     int durable_lsns;
@@ -3256,7 +3257,7 @@ static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
     int outrc;
     int num_incoh = 0;
 
-    int begin_time, end_time;
+    int64_t begin_time, end_time;
     int we_used = 0;
     const char *base_node = NULL;
     char str[80];
@@ -5427,7 +5428,7 @@ int gbl_rep_wait_core_ms = 0;
 void *watcher_thread(void *arg)
 {
     bdb_state_type *bdb_state;
-    extern int gbl_rep_lock_time_ms;
+    extern int64_t gbl_rep_lock_time_ms;
     extern int gbl_truncating_log;
     char *master_host = db_eid_invalid;
     int stopped_count = 0;
@@ -5521,7 +5522,7 @@ void *watcher_thread(void *arg)
             create_master_lease_thread(bdb_state);
         }
 
-        int rep_lock_wait_time_ms = gbl_rep_lock_time_ms;
+        int64_t rep_lock_wait_time_ms = gbl_rep_lock_time_ms;
         int rep_wait_core_ms = gbl_rep_wait_core_ms;
         int elapsed;
 
@@ -5620,7 +5621,7 @@ void *watcher_thread(void *arg)
             }
 
             if (bdb_state->attr->track_replication_times) {
-                int now;
+                int64_t now;
                 now = comdb2_time_epochms();
                 Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
                 for (i = 0; i < count; i++) {

--- a/bdb/threads.c
+++ b/bdb/threads.c
@@ -389,7 +389,7 @@ void *checkpoint_thread(void *arg)
     int checkpointtimepoll;
     int checkpointrand;
     bdb_state_type *bdb_state;
-    int start, end;
+    int64_t start, end;
     int total_sleep_msec;
     unsigned long long end_sleep_time_msec;
     unsigned long long crt_time_msec;
@@ -453,7 +453,7 @@ void *checkpoint_thread(void *arg)
         end = comdb2_time_epochms();
         bdb_state->checkpoint_start_time = 0;
         MEMORY_SYNC;
-        ctrace("checkpoint (scheduled) took %d ms\n", end - start);
+        ctrace("checkpoint (scheduled) took %d ms\n", (int)(end - start));
         gbl_last_checkpoint_ms = (end - start);
         gbl_total_checkpoint_ms += gbl_last_checkpoint_ms;
         gbl_checkpoint_count++;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2820,7 +2820,7 @@ int berkdb_is_recovering(DB_ENV *dbenv);
 
 #define TIMEIT(x)			   \
 do {							\
-	int start, end, diff;	   \
+	int64_t start, end, diff;	   \
 	start = comdb2_time_epochms(); \
 	x						   \
 	end = comdb2_time_epochms();\
@@ -2831,7 +2831,7 @@ do {							\
 
 #define TIMEITX(x, y)		   \
 do {							\
-	int start, end, diff;	   \
+	int64_t start, end, diff;	   \
 	start = comdb2_time_epochms(); \
 	x						   \
 	end = comdb2_time_epochms();\

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -1072,7 +1072,7 @@ init_trickle_threads(void)
 
 int gbl_parallel_memptrickle = 1;
 
-extern int comdb2_time_epochms();
+extern int64_t comdb2_time_epochms();
 void thdpool_process_message(struct thdpool *pool, char *line, int lline,
     int st);
 
@@ -1128,7 +1128,7 @@ __memp_sync_int(dbenv, dbmfp, trickle_max, op, wrotep, restartable,
 	int do_parallel;
 	struct trickler *pt;
 	struct writable_range *range;
-	int start, end;
+	int64_t start, end;
 	int memp_sync_files_time = 0;
 	DB_LSN oldest_first_dirty_tx_begin_lsn;
 	int accum_sync, accum_skip;
@@ -1532,7 +1532,7 @@ done:
          */
         if (ret == 0 && (op == DB_SYNC_CACHE || op == DB_SYNC_FILE)) {
             if (dbmfp == NULL) {
-                int start, end;
+                int64_t start, end;
                 start = comdb2_time_epochms();
                 ret = __memp_sync_files(dbenv, dbmp);
                 end = comdb2_time_epochms();
@@ -1558,7 +1558,7 @@ err:	__os_free(dbenv, bharray);
 
 	if (wrote && ((end - start) > memp_sync_alarm_ms))
 		ctrace("memp_sync %d pages %d ms (memp_sync_files %d ms)\n",
-		    wrote, end - start, memp_sync_files_time);
+		    wrote, (int)(end - start), memp_sync_files_time);
 
 	return (ret);
 }

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -87,7 +87,7 @@ int gbl_finish_fill_threshold = 60000000;
 
 int gbl_max_logput_queue = 100000;
 int gbl_apply_thread_pollms = 100;
-int last_fill = 0;
+int64_t last_fill = 0;
 int gbl_req_all_threshold = 10000000;
 int gbl_req_all_time_threshold = 0;
 int gbl_req_delay_count_threshold = 5;
@@ -334,7 +334,7 @@ void send_master_req(DB_ENV *dbenv, const char *func, int line)
 {
 	static unsigned long long call_count = 0, req_count = 0;
 	static int lastpr = 0;
-	int now, spanms=0;
+	int64_t now, spanms=0;
 
 	call_count++;
 	if (!gbl_master_req_waitms || (spanms = (comdb2_time_epochms() -
@@ -422,7 +422,7 @@ struct queued_log {
 	REP_CONTROL *rp;
 	u_int32_t gen;
 	u_int32_t size;
-	u_int32_t enqueued_time;
+	int64_t enqueued_time;
 	char *data;
 };
 
@@ -466,7 +466,7 @@ static void *apply_thread(void *arg)
 	LOG *lp;
 	DB_LOG *dblp;
 	DB_LSN master_lsn, my_lsn, my_last_lsn, first_repdb_lsn;
-	int last_lsn_change_time = 0;
+	int64_t last_lsn_change_time = 0;
 	DB_ENV *dbenv = (DB_ENV *)arg;
 	struct queued_log *q;
 	struct timespec ts;
@@ -801,7 +801,8 @@ __rep_enqueue_log(dbenv, rp, rec, gen)
 	uint32_t gen;
 {
 	int rc, now;
-	int start, elapsed;
+	int64_t start;
+    int elapsed;
 	static unsigned long long count=0;
 	struct queued_log *q = (struct queued_log *)malloc(
 			sizeof(struct queued_log));
@@ -1002,7 +1003,8 @@ __rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen, online)
 	REP_GEN_VOTE_INFO *vig;
 	u_int32_t bytes, egen, committed_gen, flags, sendflags, gen, gbytes, rectype, type;
 	unsigned long long bytes_sent;
-	int check_limit, cmp, done, do_req, rc, starttime, endtime, tottime;
+	int check_limit, cmp, done, do_req, rc, tottime;
+    int64_t starttime, endtime;
 	int match, old, recovering, ret, t_ret, sendtime;
 	time_t savetime;
 #if defined INSTRUMENT_REP_APPLY
@@ -4475,7 +4477,7 @@ int bdb_transfer_pglogs_to_queues(void *bdb_state, void *pglogs,
 	int32_t timestamp, unsigned long long context);
 
 static unsigned long long getlock_poll_count = 0;
-int gbl_rep_lock_time_ms = 0;
+int64_t gbl_rep_lock_time_ms = 0;
 
 /*
  * __rep_process_txn --

--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -341,7 +341,7 @@ void *auto_analyze_main(void *unused)
     call_counter++;
     char my_buf[30];
 
-    int strt = comdb2_time_epochms();
+    int64_t strt = comdb2_time_epochms();
 
     if (save_freq > 0)
         BDB_READLOCK(__func__);
@@ -459,7 +459,7 @@ void *auto_analyze_main(void *unused)
     if (save_freq > 0)
         BDB_RELLOCK();
 
-    ctrace("AUTOANALYZE check took %d ms\n", comdb2_time_epochms() - strt);
+    ctrace("AUTOANALYZE check took %"PRId64" ms\n", comdb2_time_epochms() - strt);
 
     backend_thread_event(thedb, COMDB2_THR_EVENT_DONE_RDONLY);
     return NULL;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -302,7 +302,7 @@ int gbl_maxwthreads = 8;      /* max # of threads */
 int gbl_maxqueue = 192;       /* max pending requests.*/
 int gbl_thd_linger = 5;       /* number of seconds for threads to linger */
 int gbl_report = 0;           /* update rate to log */
-int gbl_report_last;
+int64_t gbl_report_last;
 long gbl_report_last_n;
 long gbl_report_last_r;
 char *gbl_mynode;     /* my hostname */

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1650,7 +1650,7 @@ extern int gbl_logmemsize;   /* log memory size */
 extern int gbl_fullrecovery; /* full recovery mode*/
 extern int gbl_local_mode;   /* local mode, no siblings */
 extern int gbl_report;       /* update rate to log */
-extern int gbl_report_last;
+extern int64_t gbl_report_last;
 extern long gbl_report_last_n;
 extern long gbl_report_last_r;
 extern int gbl_exit;           /* exit requested.*/

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -1004,7 +1004,7 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
     struct sqlclntstate *clnt;
     int rc = 0;
 
-    int                  deadline =  0;
+    int64_t                  deadline =  0;
     int                  wait = bdb_attr_get(thedb->bdb_attr, 
             BDB_ATTR_TIMEOUT_FDB_TRANS_SYNC);
 
@@ -1020,7 +1020,7 @@ struct sqlclntstate *fdb_svc_trans_get(char *tid, int isuuid)
             rc = osql_chkboard_get_clnt(*(unsigned long long *)tid, &clnt);
         if (rc && rc == -1) {
             if (deadline && comdb2_time_epochms() > deadline) {
-                logmsg(LOGMSG_ERROR, "%s: timeout waiting for transaction %d waited %u\n",
+                logmsg(LOGMSG_ERROR, "%s: timeout waiting for transaction %"PRId64" waited %u\n",
                         __func__, deadline, wait);
 
                 break;

--- a/db/glue.c
+++ b/db/glue.c
@@ -602,7 +602,7 @@ static int trans_wait_for_seqnum_int(void *bdb_handle, struct dbenv *dbenv,
 {
     int rc = 0;
     int sync;
-    int start_ms, end_ms;
+    int64_t start_ms, end_ms;
 
     if (iq->sc_pending) {
         sync = REP_SYNC_FULL;

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -63,7 +63,7 @@ static pool_t *p_reqs; /* request pool */
 struct dbq_entry_t {
     LINKC_T(struct dbq_entry_t) qlnk;
     LINKC_T(struct dbq_entry_t) rqlnk;
-    time_t queue_time_ms;
+    int64_t queue_time_ms;
     void *obj;
 };
 

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -435,7 +435,7 @@ static int wait_till_max_wait_or_timeout(osql_sqlthr_t *entry, int max_wait,
 
         Pthread_mutex_unlock(&entry->mtx);
 
-        int tm_recov_deadlk = comdb2_time_epochms();
+        int64_t tm_recov_deadlk = comdb2_time_epochms();
         /* this call could wait for a bdb read lock; in the meantime,
            someone might try to signal us */
         if (osql_comm_check_bdb_lock(__func__, __LINE__)) {
@@ -476,7 +476,7 @@ static int wait_till_max_wait_or_timeout(osql_sqlthr_t *entry, int max_wait,
             bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SOSQL_POKE_FREQ_SEC) * 1000;
 
         /* is it the time to check the master? have we already done so? */
-        int now = comdb2_time_epochms();
+        int64_t now = comdb2_time_epochms();
 
         if ((poke_timeout > 0) &&
             (entry->last_updated + poke_timeout + tm_recov_deadlk < now)) {

--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -51,9 +51,9 @@ struct osql_sqlthr {
 
     int status;       /* poking support; status at the last check */
     int timestamp;    /* poking support: timestamp at the last check */
-    int last_updated; /* poking support: when was the last time I got info, 0 is
+    int64_t last_updated; /* poking support: when was the last time I got info, 0 is
                          never */
-    int last_checked; /* poking support: when was the loast poke sent */
+    int64_t last_checked; /* poking support: when was the loast poke sent */
     struct sqlclntstate *clnt; /* cache clnt */
 };
 typedef struct osql_sqlthr osql_sqlthr_t;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -3947,7 +3947,7 @@ clipper_usage:
     } else if (tokcmp(tok, ltok, "lockspeed") == 0) {
         pthread_mutex_t lk;
         int i;
-        int start, end;
+        int64_t start, end;
 
         Pthread_mutex_init(&lk, NULL);
         start = comdb2_time_epochms();
@@ -3957,8 +3957,8 @@ clipper_usage:
         }
         end = comdb2_time_epochms();
 
-        logmsg(LOGMSG_USER, "pthread took %dms (%d per second)\n", end - start,
-               100000000 / (end - start) * 1000);
+        logmsg(LOGMSG_USER, "pthread took %dms (%d per second)\n", (int)(end - start),
+               (int)(100000000 / (end - start) * 1000));
         bdb_lockspeed(dbenv->bdb_env);
     } else if (tokcmp(tok, ltok, "logevents") == 0) {
         dump_log_event_counts();

--- a/db/record.c
+++ b/db/record.c
@@ -2722,8 +2722,8 @@ void testrep(int niter, int recsz)
     int bdberr;
     unsigned char *stuff;
     struct ireq iq;
-    int rc;
-    int now, last, n;
+    int rc, n;
+    int64_t now, last;
 
     stuff = malloc(recsz);
 

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2595,7 +2595,7 @@ int collect_clientstats(void *ent, void *arg)
 /* called (roughly) once a second to update our per node stats */
 void process_nodestats(void)
 {
-    static int last_time_ms = 0;
+    static int64_t last_time_ms = 0;
     int span_ms;
     clientstats_ptr_list cpl;
     nodestats_t *nodestats;

--- a/db/sql.h
+++ b/db/sql.h
@@ -859,7 +859,7 @@ struct sqlclntstate {
     int64_t num_resets;
     time_t connect_time;
     time_t last_reset_time;
-    int state_start_time;
+    int64_t state_start_time;
     enum connection_state state;
     pthread_mutex_t state_lk;
     /* The node doesn't change.  The pid does as connections get donated.  We
@@ -1091,9 +1091,9 @@ struct sql_thread {
     LINKC_T(struct sql_thread) lnk;
     pthread_mutex_t lk;
     struct Btree *bt, *bttmp;
-    int startms;
+    int64_t startms;
     int prepms;
-    int stime;
+    int64_t stime;
     int nmove;
     int nfind;
     int nwrite;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -838,7 +838,7 @@ pthread_mutex_t open_serial_lock = PTHREAD_MUTEX_INITIALIZER;
 int sqlite3_open_serial(const char *filename, sqlite3 **ppDb,
                         struct sqlthdstate *thd)
 {
-    static int exec_warn_ms = 0;
+    static int64_t exec_warn_ms = 0;
     int serial = gbl_serialise_sqlite3_open;
     if (serial)
         Pthread_mutex_lock(&open_serial_lock);
@@ -850,7 +850,7 @@ int sqlite3_open_serial(const char *filename, sqlite3 **ppDb,
             char *zErr = 0;
             rc2 = sqlite3_exec(*ppDb, zSql, NULL, NULL, &zErr);
             if (rc2 != SQLITE_OK) {
-                int current_time_ms = comdb2_time_epochms();
+                int64_t current_time_ms = comdb2_time_epochms();
                 if ((exec_warn_ms == 0) ||
                         (current_time_ms - exec_warn_ms) > 60000) { /* 1 min */
                     exec_warn_ms = current_time_ms;
@@ -2771,9 +2771,9 @@ int release_locks_on_emit_row(struct sqlthdstate *thd,
 {
     extern int gbl_locks_check_waiters;
     extern int gbl_sql_release_locks_on_emit_row;
-    extern int gbl_rep_lock_time_ms;
+    extern int64_t gbl_rep_lock_time_ms;
     extern int gbl_sql_random_release_interval;
-    int rep_lock_time_ms = gbl_rep_lock_time_ms;
+    int64_t rep_lock_time_ms = gbl_rep_lock_time_ms;
 
     /* Release if we're emitting during a master change */
     if (bdb_lock_desired(thedb->bdb_env))
@@ -3370,7 +3370,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
     const char *tail = NULL;
 
     /* if we did not get a cached stmt, need to prepare it in sql engine */
-    int startPrepMs = comdb2_time_epochms(); /* start of prepare phase */
+    int64_t startPrepMs = comdb2_time_epochms(); /* start of prepare phase */
     while (rec->stmt == NULL) {
         clnt->no_transaction = 1;
         comdb2_set_authstate(thd, clnt, flags);

--- a/net/net.c
+++ b/net/net.c
@@ -4506,7 +4506,7 @@ static char *subnet_suffices[MAXSUBNETS + 1] = {0};
 static uint8_t num_dedicated_subnets = 0;
 static time_t subnet_disabled[MAXSUBNETS + 1] = {0};
 static int last_bad_subnet_idx = -1;
-static time_t last_bad_subnet_time = 0;
+static int64_t last_bad_subnet_time = 0;
 uint8_t _non_dedicated_subnet = 0;
 pthread_mutex_t subnet_mtx = PTHREAD_MUTEX_INITIALIZER;
 
@@ -5526,7 +5526,7 @@ int handle_accepted_socket(SBUF2 *sb, netinfo_type *netinfo_ptr, int is_inline, 
       char paddr[64];
       struct pollfd pol;
       pthread_t tid;
-      unsigned int last_stat_dump_time = comdb2_time_epochms();
+      int64_t last_stat_dump_time = comdb2_time_epochms();
       watchlist_node_type *watchlist_node;
       connect_and_accept_t *ca;
       int new_fd = sbuf2fileno(sb);
@@ -5546,7 +5546,7 @@ int handle_accepted_socket(SBUF2 *sb, netinfo_type *netinfo_ptr, int is_inline, 
       pol.events=POLLIN;
 
       /* poll */
-      unsigned pollstart, pollend;
+      int64_t pollstart, pollend;
       pollstart = comdb2_time_epochms();
       rc = poll(&pol, 1, polltm);
       pollend = comdb2_time_epochms();

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -595,7 +595,7 @@ void sc_del_unused_files(struct dbtable *db)
  * then gbl_sc_del_unused_files_threshold_ms, if so it exits */
 void sc_del_unused_files_check_progress(void)
 {
-    int start_ms;
+    int64_t start_ms;
 
     Pthread_mutex_lock(&gbl_sc_lock);
     start_ms = sc_del_unused_files_start_ms;

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -66,7 +66,7 @@ int gbl_sc_report_freq = 15; /* seconds between reports */
 int gbl_sc_abort = 0;
 uint32_t gbl_sc_resume_start = 0;
 /* see sc_del_unused_files() and sc_del_unused_files_check_progress() */
-int sc_del_unused_files_start_ms = 0;
+int64_t sc_del_unused_files_start_ms = 0;
 int gbl_sc_del_unused_files_threshold_ms = 30000;
 
 int gbl_sc_commit_count = 0; /* number of schema change commits - these can

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -48,7 +48,7 @@ extern int gbl_sc_report_freq;      /* seconds between reports */
 extern int gbl_sc_abort;
 extern uint32_t gbl_sc_resume_start;
 /* see sc_del_unused_files() and sc_del_unused_files_check_progress() */
-extern int sc_del_unused_files_start_ms;
+extern int64_t sc_del_unused_files_start_ms;
 extern int gbl_sc_del_unused_files_threshold_ms;
 
 extern int gbl_sc_commit_count; /* number of schema change commits - these can

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -404,7 +404,7 @@ void delay_if_sc_resuming(struct ireq *iq)
 
     int diff;
     int printerr = 0;
-    int start_time = comdb2_time_epochms();
+    int64_t start_time = comdb2_time_epochms();
     while (gbl_sc_resume_start > 0) {
         if ((diff = comdb2_time_epochms() - start_time) > 300 && !printerr) {
             logmsg(LOGMSG_WARN, "Delaying since gbl_sc_resume_start has not "

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -15,7 +15,7 @@ sqlite3_module systblConnectionsModule = {
 int get_connections(void **data, int *num_points) {
     struct connection_info *info;
     int rc = gather_connection_info(&info, num_points);
-    int now = comdb2_time_epochms();
+    int64_t now = comdb2_time_epochms();
     if (rc)
         return rc;
     *data = info;

--- a/tests/tools/leakcheck.c
+++ b/tests/tools/leakcheck.c
@@ -23,7 +23,7 @@ void usage(FILE *f)
 
 static int iters = 1000;
 
-int comdb2_time_epochms(void)
+int64_t comdb2_time_epochms(void)
 {
     struct timeval tv;
     int rc;

--- a/util/averager.c
+++ b/util/averager.c
@@ -31,7 +31,7 @@
 
 struct tick {
     int value;
-    int time_added;
+    int64_t time_added;
     LINKC_T(struct tick) lnk;
 };
 
@@ -65,7 +65,7 @@ void averager_clear(struct averager *avg) {
     avg->sum = 0;
 }
 
-void averager_purge_old(struct averager *avg, int now)
+void averager_purge_old(struct averager *avg, int64_t now)
 {
     struct tick *t = NULL;
 
@@ -79,7 +79,7 @@ void averager_purge_old(struct averager *avg, int now)
     }
 }
 
-void averager_add(struct averager *avg, int value, int now)
+void averager_add(struct averager *avg, int value, int64_t now)
 {
     struct tick *t;
 

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -151,7 +151,7 @@ static void portmux_denagle(int fd)
 /* returns how many milliseconds of timeoutms remain, timed
  * from startms, zero if time is up, or -1 if timeoutms is -1
  */
-static int remaining_timeoutms(int startms, int timeoutms)
+static int remaining_timeoutms(int64_t startms, int timeoutms)
 {
     if (timeoutms == -1) {
         return -1;
@@ -585,7 +585,7 @@ static int portmux_route_to(struct in_addr in, const char *app,
     if (timeoutms <= 0)
         timeoutms = portmux_default_timeout;
 
-    int startms = comdb2_time_epochms();
+    int64_t startms = comdb2_time_epochms();
 
     len = snprintf(cmd, sizeof(cmd), "rte %s/%s/%s%s\n", app, service, instance,
                    PORTMUX_VALIDATE() ? " v" : "");
@@ -799,7 +799,7 @@ static bool portmux_client_side_validation(int fd, const char *app,
     int state = 0;
     int next_state = 0;
 
-    int startms = comdb2_time_epochms();
+    int64_t startms = comdb2_time_epochms();
     if (timeoutms < MIN_VALIDATION_TIMEOUTMS) {
         timeoutms = MIN_VALIDATION_TIMEOUTMS;
     }
@@ -951,7 +951,7 @@ static bool portmux_server_side_validation(portmux_fd_t *fds, int fd,
      * false if we have any communication errors or if the client sends us
      * V_NAK; returning true if the client sends us V_ACK.
      */
-    int startms = comdb2_time_epochms();
+    int64_t startms = comdb2_time_epochms();
 
     if (timeoutms < MIN_VALIDATION_TIMEOUTMS) {
         timeoutms = MIN_VALIDATION_TIMEOUTMS;
@@ -1301,7 +1301,7 @@ static int portmux_poll_v(portmux_fd_t **fds, nfds_t nfds, int timeoutms,
     int result = 0;
     bool build_pollfds = true;
 
-    int startms = comdb2_time_epochms();
+    int64_t startms = comdb2_time_epochms();
 
     while (true) {
         if (build_pollfds) {

--- a/util/timers.c
+++ b/util/timers.c
@@ -33,7 +33,7 @@
 static pthread_mutex_t timerlk = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t timerwait = PTHREAD_COND_INITIALIZER;
 struct timer {
-    int next;
+    int64_t next;
     int ms;
     int parm;
     int oneshot;
@@ -77,7 +77,7 @@ int64_t comdb2_time_epochus(void)
     return (((int64_t)tv.tv_sec) * 1000000 + tv.tv_usec);
 }
 
-int comdb2_time_epochms(void)
+int64_t comdb2_time_epochms(void)
 {
     struct timeval tv;
     int rc;
@@ -205,7 +205,7 @@ int comdb2_timer(int ms, int parm)
 
 void *timer_thread(void *p)
 {
-    int tnow;
+    int64_t tnow;
     struct timer t;
     struct timer_parm waitft_parm;
     int rc;


### PR DESCRIPTION
Testing 'long fix' for epochms rollover issue- this changes the return value of comdb2_time_epochms to an int64.  This is still a work-in-progress.