### PR TITLE
Test & fix for trigger-sc latency: don't retain the sp-lock

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -251,6 +251,8 @@ extern int gbl_ufid_remove_dbp;
 extern unsigned gbl_ddlk;
 extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;
+extern int gbl_debug_add_replication_latency;
+extern int gbl_javasp_early_release;
 
 extern long long sampling_threshold;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1904,6 +1904,14 @@ REGISTER_TUNABLE("ufid_dbreg_test", "Enable ufid-dbreg test.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_ufid_dbreg_test, EXPERIMENTAL |
                  INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("javasp_early_release", "Release javasp-lock before distributed commit.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_javasp_early_release, EXPERIMENTAL | INTERNAL, 
+                 NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("debug_add_replication_latency", "Sleep after distributed commit.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_add_replication_latency, EXPERIMENTAL | INTERNAL, 
+                 NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("ref_sync_pollms",
                  "Set pollms for ref_sync thread.  "
                  "(Default: 250)",

--- a/db/translistener.h
+++ b/db/translistener.h
@@ -128,6 +128,9 @@ void javasp_trans_set_trans(struct javasp_trans_state *javasp_trans_handle,
 /* Call this at the end of a transaction (committed or aborted).  Cleans up. */
 void javasp_trans_end(struct javasp_trans_state *javasp_trans_handle);
 
+/* Call this prior to distributed commit to release splock */
+void javasp_trans_release(struct javasp_trans_state *javasp_trans_handle);
+
 /* This is used to determine if we want to be notified about a particular
  * event - if we don't care, then the block processor needn't waste time
  * creating temporary things.  It is not an error to report events that

--- a/tests/triggersc_latency.test/Makefile
+++ b/tests/triggersc_latency.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/triggersc_latency.test/README
+++ b/tests/triggersc_latency.test/README
@@ -1,0 +1,2 @@
+Demonstrates the effect of slow-replication on adding and removing triggers
+This is fixed by the javasp_early_release tunable (which is defaulted to 'on')

--- a/tests/triggersc_latency.test/lrl.options
+++ b/tests/triggersc_latency.test/lrl.options
@@ -1,0 +1,4 @@
+logmsg level info
+debug_add_replication_latency on
+# uncomment to see bug
+# javasp_early_release off

--- a/tests/triggersc_latency.test/runit
+++ b/tests/triggersc_latency.test/runit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function insert_records
+{
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1)" > /dev/null 2>&1
+    done
+}
+
+function run_test
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="run_test"
+    write_prompt $func "Running $func"
+
+    create_table
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<'EOF'
+create procedure sp version 'v1' {
+local function main()
+    db:emit(1)
+end
+}$$
+EOF
+    insert_records &
+    insert_records &
+    insert_records &
+    insert_records &
+    insert_records &
+    insert_records &
+
+    failed=0
+    j=0
+
+    while [[ $j -lt 10 && "$failed" == "0" ]]; do
+        mod=$(( j % 2 ))
+        begin=$(date +%s)
+        if [[ "$mod" == "0" ]]; then
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create lua trigger sp on (table t1 for insert)"
+        else
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop lua trigger sp"
+        fi
+        finished=$(date +%s)
+        elapsed=$(( finished - begin ))
+        echo "Update-trigger time is $elapsed"
+        if [[ $elapsed -ge 2 ]]; then
+            failed=1
+            echo "Failing test: trigger operations took $elapsed seconds"
+        fi
+
+        let j=j+1
+    done
+
+    touch "$stopfile"
+    wait
+    [[ "$failed" -ne "0" ]] && failexit "testcase failed"
+}
+
+rm $stopfile
+run_test
+echo "Success"


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This PR decreases the length of time that a block-processor retains the splock- we can safely release the splock prior to distributed commit.  The 'triggersc_latency' test demonstrates the issue by introducing fake replication latency.  This test will fail if the javasp_early_release tunable is toggled to 'off'.