### PR TITLE
Fix race between decom and connect thread

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -4890,13 +4890,13 @@ static void *connect_thread(void *arg)
         Pthread_mutex_lock(&(host_node_ptr->lock));
         ref = host_node_ptr->have_reader_thread +
               host_node_ptr->have_writer_thread;
-        Pthread_mutex_unlock(&(host_node_ptr->lock));
 
         Pthread_mutex_lock(&(host_node_ptr->waiter_lock));
         ref += host_node_ptr->nwaiters;
         if (host_node_ptr->nwaiters > 0)
             Pthread_cond_broadcast(&(host_node_ptr->waiter_wakeup));
         Pthread_mutex_unlock(&(host_node_ptr->waiter_lock));
+        Pthread_mutex_unlock(&(host_node_ptr->lock));
 
         if (ref == 0)
             break;

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -250,9 +250,12 @@ struct host_node_tag {
     unsigned long long num_flushes;
     pthread_mutex_t timestamp_lock; /* no more premature session killing */
 
-    int throttle_waiters;
-    pthread_mutex_t throttle_lock;
-    pthread_cond_t throttle_wakeup;
+    /* Number of waiters. This includes number of throttle waiters and connect
+       thread waiter. A host can't be safely removed unless its nwaiters is 0
+       and its reader or writer has exited. */
+    int nwaiters;
+    pthread_mutex_t waiter_lock;
+    pthread_cond_t waiter_wakeup;
     int last_queue_dump;
     int last_print_queue_time;
     int interval_max_queue_count;


### PR DESCRIPTION
A host struct may be removed from net and freed while its connect thread is waiting for either the reader thread or the writer thread to exit:

```
16:06:05 mydb:0x7f5e5ecda700 [replication m1 fd -1] accept_handle_new_host waiting for r/w thds to exit
16:06:05 mydb:connect_thread: host_node_ptr->decom_flag set for host m1
16:06:05 mydb:0x7f5e66e5a700 [replication m1 fd -1] rem_from_netinfo: node=m1
16:06:05 mydb:accept_handle_new_host:5298 pthread_mutex_lock(0x7f5e702cc888) rc:22 (Invalid argument) thd:0x7f5e646c7700
16:06:05 procmgr: mydb: task crashed - end of task 30884 [signal 6 Aborted]
```

This patch fixes it.
