### PR TITLE
Disable the de-dup request by default

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -461,7 +461,7 @@ int gbl_verbose_repdups = 0;
 uint64_t subtract_lsn(void *bdb_state, DB_LSN *lsn1, DB_LSN *lsn2);
 void comdb2_early_ack(DB_ENV *, DB_LSN, uint32_t generation);
 
-int gbl_dedup_rep_all_reqs = 1;
+int gbl_dedup_rep_all_reqs = 0;
 
 int send_rep_all_req(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags,
 					 const char *func, int line)

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1351,7 +1351,7 @@ REGISTER_TUNABLE("verbose_send_cohlease",
 REGISTER_TUNABLE("reset_on_unelectable_cluster", "Reset master if unelectable.",
                  TUNABLE_BOOLEAN, &gbl_reset_on_unelectable_cluster,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("dedup_rep_all_reqs", "Only allow a single rep-all on queue to the master. (Default: on)",
+REGISTER_TUNABLE("dedup_rep_all_reqs", "Only allow a single rep-all on queue to the master. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_dedup_rep_all_reqs, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("decoupled_logputs",
                  "Perform logputs out-of-band. (Default: on)", TUNABLE_BOOLEAN,


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Trying to be conservative with enabling & disabling new features.  I'd like the de-dup rep-req-all request disabled by default.