### PR TITLE
Adjust zap of inline portion by one byte

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -6588,9 +6588,11 @@ static TYPES_INLINE int SERVER_BYTEARRAY_to_SERVER_BLOB(
              * data may not be NUL terminated */
             memcpy(cout + BLOB_ON_DISK_LEN, cin, inlen - 1);
             *outdtsz += (inlen - 1);
-        }
-        if (inlen < outlen - BLOB_ON_DISK_LEN) {
-            memset(cout + BLOB_ON_DISK_LEN + inlen, 0, outlen - inlen - BLOB_ON_DISK_LEN);
+
+            // looks like for this function inlen is always > 0 so should always reach this conditional
+            if (inlen < outlen - BLOB_ON_DISK_LEN + 1) {
+                memset(cout + BLOB_ON_DISK_LEN + inlen - 1, 0, outlen - inlen - BLOB_ON_DISK_LEN + 1);
+            }
         }
     } else if (outblob) {
         if (inlen > gbl_blob_sz_thresh_bytes)


### PR DESCRIPTION
See conditional above lines added. Size copied to out buffer is (inlen - 1), not inlen, so zap an extra byte

Consider case where byte[3] x'FFFFFF' is added. inlen = 4. Suppose out is zapped with x'EE'. 
This would result in 0:08000000 03FFFFFF EE0000 because we add inlen = 4 starting from the first F instead of inlen - 1 = 3 to find out where to first zap with 0s. Thus need to zap extra byte. 

Add new code in inlen > 0 conditional since if inlen = 0 then inlen - 1 = -1 which could potentially cause problems. But I think that inlen should always be > 0 in this function, since first byte is null byte.

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
