### PR TITLE
Include signal.h in bdb/rep.c

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -5250,6 +5250,8 @@ int request_delaymore(void *bdb_state_in)
 
 int gbl_rep_wait_core_ms = 0;
 
+#include <signal.h>
+
 static void abort_stalled_exit(int signum)
 {
     logmsg(LOGMSG_WARN, "Aborting stalled watchdog alarm\n");


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Dumb fix for missing include <signal.h> .. I accidentally pushed the wrong version.