### PR TITLE
Analyze crash 7

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -338,6 +338,7 @@ extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_json_escape_control_chars;
 extern int gbl_debug_sleep_in_sql_tick;
+extern int gbl_debug_sleep_in_analyze;
 extern int gbl_debug_omit_zap_on_rebuild;
 extern int gbl_instrument_consumer_lock;
 extern int gbl_reject_mixed_ddl_dml;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1975,6 +1975,9 @@ REGISTER_TUNABLE("physrep_exit_on_invalid_logstream", "Exit physreps on invalid 
 REGISTER_TUNABLE("debug_sleep_in_sql_tick", "Sleep for a second in sql tick.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_in_sql_tick, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_sleep_in_analyze", "Sleep in analyze sql tick.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_sleep_in_analyze, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("queue_walk_limit",
                  "When walking queues for metrics, stop after this many elements.  "
                  "(Default: 10000)",

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -967,7 +967,7 @@ static int dispatch_table_thread(table_descriptor_t *td)
         ++timeout.tv_sec; // 1 second timeout
         rc = pthread_cond_timedwait(&table_thd_cond, &table_thd_mutex, &timeout);
         if (rc == ETIMEDOUT) {
-            if (bdb_lock_desired(thedb->bdb_env)) {
+            if (pthread_getspecific(query_info_key) && bdb_lock_desired(thedb->bdb_env)) {
                 rc = recover_deadlock_simple(thedb->bdb_env);
                 if (rc) {
                     logmsg(LOGMSG_WARN, "%s: recover_deadlock rc=%d\n", __func__, rc);
@@ -1009,7 +1009,7 @@ static int wait_for_table(table_descriptor_t *td)
         ++timeout.tv_sec; // 1 second timeout
         rc = pthread_cond_timedwait(&table_thd_cond, &table_thd_mutex, &timeout);
         if (rc == ETIMEDOUT) {
-            if (bdb_lock_desired(thedb->bdb_env)) {
+            if (pthread_getspecific(query_info_key) && bdb_lock_desired(thedb->bdb_env)) {
                 rc = recover_deadlock_simple(thedb->bdb_env);
                 if (rc) {
                     logmsg(LOGMSG_WARN, "%s: recover_deadlock rc=%d\n", __func__, rc);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -613,6 +613,7 @@ int check_sql_client_disconnect(struct sqlclntstate *clnt, char *file, int line)
    The query is aborted if this returns non-zero.
  */
 int gbl_debug_sleep_in_sql_tick;
+int gbl_debug_sleep_in_analyze;
 int sql_tick(struct sql_thread *thd)
 {
     struct sqlclntstate *clnt;
@@ -634,7 +635,7 @@ int sql_tick(struct sql_thread *thd)
     /* Increment per-clnt sqltick */
     ++clnt->sqltick;
 
-    if (gbl_debug_sleep_in_sql_tick)
+    if (gbl_debug_sleep_in_sql_tick || (gbl_debug_sleep_in_analyze && clnt->is_analyze))
         sleep(1);
 
     /* statement cancelled? done */

--- a/tests/analyze_recover_deadlock.test/lrl.options
+++ b/tests/analyze_recover_deadlock.test/lrl.options
@@ -1,2 +1,10 @@
+setattr autoanalyze 0
+setattr min_aa_ops  1000
+setattr aa_min_percent 0
+setattr aa_count_upd  0
+setattr chk_aa_time  6
+setattr min_aa_time  20
+setattr aa_llmeta_save_freq  2
+
 test_delay_analyze_commit
 osql_send_startgen off

--- a/tests/analyze_recover_deadlock.test/runit
+++ b/tests/analyze_recover_deadlock.test/runit
@@ -55,6 +55,85 @@ function checkifdone {
     done
 }
 
+function runaatest {
+    rep=$1
+    master=$2
+
+    # pre checks
+    analyzedelay=$(cdb2sql --tabs $dbnm --host $rep "select value from comdb2_tunables where name='test_delay_analyze_commit'")
+    if [ "$analyzedelay" != "ON" ]; then
+        echo "Unable to set test_delay_analyze_commit to ON"
+        exit 1
+    fi
+
+    # one table-thread
+    cdb2sql $dbnm --host $rep "exec procedure sys.cmd.send('analyze tblthd 1')" >/dev/null
+    numthds=$(cdb2sql --tabs $dbnm --host $rep "select value from comdb2_tunables where name='analyze_tbl_threads'")
+    if [ $numthds != 1 ]; then
+        echo "Unable to set analyze_tbl_threads to 1, got $numthds instead"
+        exit 1
+    fi
+
+    # enable autoanalyze
+    for node in ${CLUSTER}
+    do
+        cdb2sql $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr autoanalyze 1')"
+    done
+
+    # sleep for a second per record while analyzing
+    for node in ${CLUSTER}
+    do
+        cdb2sql $dbnm --host $node "put tunable 'debug_sleep_in_analyze' 1"
+    done
+
+    # trigger autoanalyze
+    for table in t v;
+    do
+        cdb2sql $dbnm --host $rep "update $table set a=a where 1" >/dev/null
+    done
+
+    sleep 3
+
+    # run election on master
+    cdb2sql $dbnm --host $master "exec procedure sys.cmd.send('downgrade')" 2>election.txt &
+    electionpid=$!
+
+    timeout=60
+    st=$SECONDS
+
+    set +e # next block of code relies on checking error codes
+    checkifdone $electionpid $timeout $st
+    ps -p $electionpid >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+        echo "Error: Election still running after 1 minute"
+        kill -9 $electionpid >/dev/null 2>&1 
+        failed=1
+    fi
+    set -e
+
+    sleep 10
+
+    # disable sleep for a second per record while analyzing
+    for node in ${CLUSTER}
+    do
+        cdb2sql $dbnm --host $node "put tunable 'debug_sleep_in_analyze' 0"
+        cdb2sql $dbnm --host $node "exec procedure sys.cmd.send('bdb setattr autoanalyze 0')"
+    done
+
+
+    electionerrors=$(cat election.txt)
+
+    if [ "$electionerrors" != "" ]; then
+        echo "Election Error: $electionerrors"
+        failed=1
+    fi
+
+    if [ $failed -eq 1 ]; then
+        exit 1
+    fi
+}
+
+
 function runtest {
     rep=$1
     master=$2
@@ -148,3 +227,12 @@ master=`getmaster`
 runtest $rep $master "analyze"
 
 echo "dispatch_table_thread test passed"
+
+sleep 3
+
+echo "Test autoanalyze recover_deadlock"
+rep=`getrepnode`
+master=`getmaster`
+runaatest $rep $master
+
+echo "autoanalyze test passed"


### PR DESCRIPTION
A downgrade can crash auto-analyze, or analyze from a msg-trap.  I've updated the test case to include this scenario.
