### PR TITLE
De-dup rep_all_req from newmaster

### DIFF
--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -461,6 +461,9 @@ int gbl_abort_on_incorrect_upgrade;
 extern int last_fill;
 extern int gbl_decoupled_logputs;
 
+int send_rep_all_req(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags,
+					 const char *func, int line);
+
 int
 __rep_new_master(dbenv, cntrl, eid)
 	DB_ENV *dbenv;
@@ -560,8 +563,8 @@ __rep_new_master(dbenv, cntrl, eid)
 		} else {
 			/* Let the apply-thread make this request */
 			if (log_compare(&lsn, &cntrl->lsn) < 0 && !gbl_decoupled_logputs) {
-				if (__rep_send_message(dbenv, eid, REP_ALL_REQ, &lsn, 
-							NULL, DB_REP_NODROP|DB_REP_NOBUFFER, NULL) == 0) {
+				if (send_rep_all_req(dbenv, eid, &lsn, DB_REP_NODROP|DB_REP_NOBUFFER,
+					__func__, __LINE__) == 0) {
 					if (gbl_verbose_fills) {
 						logmsg(LOGMSG_USER, "%s line %d sending REP_ALL_REQ "
 								"for %d:%d\n", __func__, __LINE__, lsn.file,
@@ -609,10 +612,10 @@ empty:		MUTEX_LOCK(dbenv, db_rep->db_mutexp);
 			 */
 			lp->wait_recs = rep->max_gap;
 			MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
-			if (__rep_send_message(dbenv, rep->master_id,
-				REP_ALL_REQ, &lsn, NULL, DB_REP_NODROP, NULL) == 0) {
+			if (send_rep_all_req(dbenv, rep->master_id, &lsn, DB_REP_NODROP,
+				__func__, __LINE__) == 0) {
 				last_fill = comdb2_time_epochms();
-			} 
+			}
 		} else
 			MUTEX_UNLOCK(dbenv, db_rep->db_mutexp);
 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

The 'de-dup' REP_ALL_REQ missed these cases inside of NEWMASTER.
