### PR TITLE
Fix compression code

### DIFF
--- a/comdb2rle/CMakeLists.txt
+++ b/comdb2rle/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_library(comdb2rle comdb2rle.c)
+include_directories(${PROJECT_SOURCE_DIR}/bbinc ${PROJECT_SOURCE_DIR}/util ${PROJECT_SOURCE_DIR}/berkdb)


### PR DESCRIPTION
This will separate out prev from pfx prev in encode_repeat_rev Thanks Akshat for writing code for test!

Given:
```
create table test {
schema {
    u_short a
    vutf8   b[1000]
    vutf8   c[500]
}
}$$
```
Then `insert into test values (0, 'hi', 'hj')`
```
Previously:
compressComdb2RLE_hints
   encode_repeat: 2 x 0x080000
     encode_prev: 0x0003686900000(many many 0s)000800000003686a
encode_wellknown: 498 x 0x00
Now:
compressComdb2RLE_hints
   encode_repeat: 2 x 0x080000
     encode_prev: 0x00036869
encode_wellknown: 998 x 0x00
     encode_prev: 0x0800000003686a
encode_wellknown: 498 x 0x00
```
This is because the record starts with 080000080000, so a will be compressed with part of b since 080000 repeats, so now you are at middle of b. Compression code says go to beginning of next field (c) in this case. We still need to compress the rest of b. Call what we still need to compress from b variable prev:
```
00036869 00000000 00000000 00000000  |..hi............|
(1000 0s)
3c0:00000000 00000000 00000000 00000000  |................|
3d0:00000000 00000000 00000000 00000000  |................|
```
Since c can also be compressed, the code calls encode_repeat_rev. Encode_repeat_rev will append the prefix of c ('hj') (0800 000003686A) to the end prev. With this new prev variable, the code will now encode it. But now prev doesn't end in 0s which is problematic. The code detects repetition by checking for a repeating byte from the end of prev, but the last byte isn't 0 anymore. Now when you encode prev, the repeating 0s won't be detected and prev will not be compressed at all. So the problem is just that you are trying to compress the 1000 0s with the prefix of c tagged on at the end.

Fix is to compress when we land in middle of field.