### PR TITLE
Incoherent throttle 7

### DIFF
--- a/tests/logfill.test/logput_window.testopts
+++ b/tests/logfill.test/logput_window.testopts
@@ -1,0 +1,1 @@
+logput_window 1000000


### PR DESCRIPTION
Don't send normal log-traffic to nodes which are incoherent, and trailing the master.  The 'logput_window' tunable existed previously, but was effectively disabled by the code.  This PR re-enables incoherent throttles but makes logput_window's default value (0) a disable switch.

This should be an effective strategy for the "machine turn" issue that we've been seeing in prod recently, in that it prevents "fill" traffic (which is requested by nodes which have fallen behind the master) from competing against normal log-traffic, which is written to the network inline with a transaction.