### PR TITLE
Port incoherent_throttle to 8.0

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1748,6 +1748,7 @@ void udp_backup(int, short, void *);
 void auto_analyze(int, short, void *);
 
 int do_ack(bdb_state_type *bdb_state, DB_LSN permlsn, uint32_t generation);
+void net_rep_throttle_init(netinfo_type *netinfo_ptr);
 void berkdb_receive_rtn(void *ack_handle, void *usr_ptr, char *from_host,
                         int usertype, void *dta, int dtalen, uint8_t is_tcp);
 void berkdb_receive_msg(void *ack_handle, void *usr_ptr, char *from_host,

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2718,6 +2718,9 @@ static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
 
     net_register_getlsn(bdb_state->repinfo->netinfo, net_getlsn_rtn);
 
+    /* Register logput throttle function */
+    net_rep_throttle_init(bdb_state->repinfo->netinfo);
+
     /* Register qstat if its enabled */
     net_rep_qstat_init(bdb_state->repinfo->netinfo);
 

--- a/net/net.c
+++ b/net/net.c
@@ -6239,6 +6239,12 @@ int net_register_appsock(netinfo_type *netinfo_ptr, APPSOCKFP func)
     return 0;
 }
 
+int net_register_throttle(netinfo_type *netinfo_ptr, NETTHROTTLEFP func)
+{
+    netinfo_ptr->throttle_rtn = func;
+    return 0;
+}
+
 int net_register_allow(netinfo_type *netinfo_ptr, NETALLOWFP func)
 {
     netinfo_ptr->allow_rtn = func;
@@ -6675,6 +6681,10 @@ int net_send_all(netinfo_type *netinfo_ptr, int num, void **data, int *sz,
     for (int i = 0; i < count; i++) {
         const char *h = hostlist[i];
         for (int j = 0; j < num; ++j) {
+            if ((flag[j] & NET_SEND_LOGPUT) && netinfo_ptr->throttle_rtn &&
+                (netinfo_ptr->throttle_rtn)(netinfo_ptr, h)) {
+                continue;
+            }
             if (net_send_flags(netinfo_ptr, h, type[j], data[j], sz[j], flag[j])) {
                 rc = 1;
             }

--- a/net/net.h
+++ b/net/net.h
@@ -86,6 +86,8 @@ typedef void UFUNCITERFP(struct netinfo_struct *netinfo, void *arg,
 
 typedef int NETALLOWFP(struct netinfo_struct *netinfo, const char *hostname);
 
+typedef int NETTHROTTLEFP(struct netinfo_struct *netinfo, const char *hostname);
+
 void net_setbufsz(netinfo_type *info, int bufsz);
 
 void net_set_callback_data(netinfo_type *info, void *data);
@@ -97,9 +99,10 @@ int net_close_connection(netinfo_type *net, const char *hostname);
 
 enum {
     NET_SEND_NODELAY = 0x00000001,
-    NET_SEND_NODROP = 0x00000002,
+    NET_SEND_NODROP  = 0x00000002,
     NET_SEND_INORDER = 0x00000004,
-    NET_SEND_TRACE = 0x00000008
+    NET_SEND_TRACE   = 0x00000008,
+    NET_SEND_LOGPUT  = 0x00000010
 };
 
 enum {
@@ -173,6 +176,10 @@ int net_register_netcmp(netinfo_type *netinfo_ptr, NETCMPFP func);
 int net_register_newnode(netinfo_type *netinfo_ptr, NEWNODEFP func);
 
 int net_register_appsock(netinfo_type *netinfo_ptr, APPSOCKFP func);
+
+/* callback to disable logputs if a node is too far behind */
+int net_register_throttle(netinfo_type *netinfo_ptr, NETTHROTTLEFP func);
+
 int net_register_admin_appsock(netinfo_type *netinfo_ptr, APPSOCKFP func);
 
 /* register a callback routine that will be called to find out if net

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -3075,11 +3075,13 @@ int net_send_all_evbuffer(netinfo_type *netinfo_ptr, int n, void **buf, int *len
     }
     int nodrop = 0;
     int nodelay = 0;
+    int logput = 0;
     int sz = (n * NET_SEND_MESSAGE_HEADER_LEN);
     for (int i = 0; i < n; ++i) {
         sz += len[i];
         nodrop |= flags[i] & NET_SEND_NODROP;
         nodelay |= flags[i] & NET_SEND_NODELAY;
+        logput |= flags[i] & NET_SEND_LOGPUT;
     }
     struct shared_msg **msg = NULL;
     if (sz > 256) {
@@ -3098,6 +3100,10 @@ int net_send_all_evbuffer(netinfo_type *netinfo_ptr, int n, void **buf, int *len
     struct net_info *ni = net_info_find(netinfo_ptr->service);
     struct event_info *e;
     LIST_FOREACH(e, &ni->event_list, net_list_entry) {
+        if (logput && netinfo_ptr->throttle_rtn &&
+            (netinfo_ptr->throttle_rtn)(netinfo_ptr, e->host)) {
+            continue;
+        }
         Pthread_mutex_lock(&e->wr_lk);
         if (e->flush_buf && !skip_send(e, nodrop, 1)) {
             if (msg) {

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -342,6 +342,7 @@ struct netinfo_struct {
     int decom_time;
     char *name;
     stats_type stats;
+    NETTHROTTLEFP *throttle_rtn;
     NETALLOWFP *allow_rtn;
     void *callback_data;
     void (*start_thread_callback)(void *);

--- a/tests/logfill.test/logput_window.testopts
+++ b/tests/logfill.test/logput_window.testopts
@@ -1,0 +1,1 @@
+logput_window 1000000


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Don't send normal log-traffic to nodes which are incoherent, and trailing the master. The 'logput_window' tunable existed previously, but was effectively disabled by the code. This PR re-enables incoherent throttles but makes logput_window's default value (0) a disable switch.

This should be an effective strategy for the "machine turn" issue that we've been seeing in prod recently, in that it prevents "fill" traffic (which is requested by nodes which have fallen behind the master) from competing against normal log-traffic, which is written to the network inline with a transaction.