### PR TITLE
Release-locks from SQL sessions / Re-bias election

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -86,7 +86,7 @@ static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
 static int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
 int gbl_ufid_dbreg_test = 0;
-int gbl_ufid_log = 0;
+int gbl_ufid_log = 1;
 
 /* Get the recovery LSN. */
 int

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -5830,7 +5830,7 @@ __rep_process_txn_concurrent(dbenv, rctl, rec, ltrans, ctrllsn, maxlsn,
 	}
 }
 
-int gbl_ufid_add_on_collect = 0;
+int gbl_ufid_add_on_collect = 1;
 
 // PUBLIC: int __rep_collect_txn_from_log __P((DB_ENV *, DB_LSN *, LSN_COLLECTION *, int *, struct __recovery_processor *));
 int

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -716,7 +716,7 @@ int gbl_only_match_commit_records = 1;
 int gbl_sql_release_locks_on_si_lockwait = 1;
 /* If this is set, recom_replay will see the same row multiple times in a scan &
  * fail */
-int gbl_sql_release_locks_on_emit_row = 0;
+int gbl_sql_release_locks_on_emit_row = 1;
 int gbl_sql_release_locks_on_slow_reader = 1;
 int gbl_sql_no_timeouts_on_release_locks = 1;
 int gbl_sql_release_locks_in_update_shadows = 1;

--- a/db/config.c
+++ b/db/config.c
@@ -370,7 +370,6 @@ void clear_deferred_options(void)
 
 static char *legacy_options[] = {
     "allow_negative_column_size",
-    "berkattr elect_highest_committed_gen 0",
     "clean_exit_on_sigterm off",
     "create_default_user",
     "ddl_cascade_drop 0",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1661,9 +1661,8 @@ REGISTER_TUNABLE("client_heartbeat_ms",
 
 REGISTER_TUNABLE("rep_release_wait_ms",
                  "Release sql-locks if rep-thd is blocked for this many ms."
-                 "  (Default: 60000)",
-                 TUNABLE_INTEGER, &gbl_rep_wait_release_ms,
-                 EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+                 "  (Default: 10000)",
+                 TUNABLE_INTEGER, &gbl_rep_wait_release_ms, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("rep_wait_core_ms",
                  "Abort if rep-thread waits longer than this threshold for "
@@ -2008,10 +2007,10 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOLEAN, &gbl_ufid_log,
+REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: on)", TUNABLE_BOOLEAN, &gbl_ufid_log,
                  EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default: off)", TUNABLE_BOOLEAN, 
+REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default: on)", TUNABLE_BOOLEAN, 
                  &gbl_ufid_add_on_collect, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2593,7 +2593,7 @@ int release_locks_int(const char *trace, const char *func, int line)
 }
 
 /* Release-locks if rep-thread is blocked longer than this many ms */
-int gbl_rep_wait_release_ms = 60000;
+int gbl_rep_wait_release_ms = 10000;
 
 int release_locks_on_emit_row(struct sqlthdstate *thd,
                               struct sqlclntstate *clnt)

--- a/tests/tablelocks.test/lrl.options
+++ b/tests/tablelocks.test/lrl.options
@@ -1,1 +1,2 @@
 table t1 t1.csc2
+sql_release_locks_on_emit_row_lockwait 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -863,7 +863,7 @@
 (name='sql_queueing_critical_trace', description='Produce trace when SQL request queue is this deep.', type='INTEGER', value='100', read_only='N')
 (name='sql_queueing_disable_trace', description='Disable trace when SQL requests are starting to queue.', type='BOOLEAN', value='OFF', read_only='N')
 (name='sql_release_locks_in_update_shadows', description='Release sql locks in update_shadows on lockwait', type='BOOLEAN', value='ON', read_only='N')
-(name='sql_release_locks_on_emit_row_lockwait', description='Release sql locks when we are about to emit a row', type='BOOLEAN', value='OFF', read_only='N')
+(name='sql_release_locks_on_emit_row_lockwait', description='Release sql locks when we are about to emit a row', type='BOOLEAN', value='ON', read_only='N')
 (name='sql_release_locks_on_si_lockwait', description='Release sql locks from si if the rep thread is waiting', type='BOOLEAN', value='ON', read_only='N')
 (name='sql_release_locks_on_slow_reader', description='Release sql locks if a tcp write to the client blocks', type='BOOLEAN', value='ON', read_only='N')
 (name='sql_time_threshold', description='Sets the threshold time in ms after which queries are reported as running a long time. (Default: 5000 ms)', type='INTEGER', value='5000', read_only='Y')


### PR DESCRIPTION
Allow sql sessions to release their locks when the database is emitting a row, and lower the release-locks threshold from 60 seconds to 10 seconds.  This addresses a scenario that we observed in production earlier this month where several replicants became incoherent while servicing some expensive joins.  The behavior change is that an SQL thread will call recover-deadlock if it has blocked replication for longer than 10 seconds.

The second change enables elect-highest-committed-generation.  Each cluster participant keeps track of the highest generation number that it has written a commit-record for.  This generation number is given precedence over a participant's LSN when determining the election winner.  Enabling this will prevent an older (partitioned) master from unrolling commits which were replicated by a later generation.  This change is incompatible with R6 and prior versions.

Signed-off-by: Mark Hannum <mhannum72@gmail.com>