### PR TITLE
Avoid processing bplog error from non-master

### DIFF
--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -105,9 +105,8 @@ int osql_unregister_sqlthr(struct sqlclntstate *clnt);
  * A null errstat means no error.
  *
  */
-int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops,
-                                void *data, struct errstat *errstat,
-                                struct query_effects *effects);
+int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops, void *data, struct errstat *errstat,
+                                struct query_effects *effects, const char *from);
 
 /**
  * Wait the default time for the session to complete

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3206,8 +3206,7 @@ static void net_snap_uid_rpl(void *hndl, void *uptr, char *fromhost,
 {
     snap_uid_t snap_info;
     snap_uid_get(&snap_info, dtap, (uint8_t *)dtap + dtalen);
-    osql_chkboard_sqlsession_rc(OSQL_RQID_USE_UUID, snap_info.uuid, 0,
-                                &snap_info, NULL, &snap_info.effects);
+    osql_chkboard_sqlsession_rc(OSQL_RQID_USE_UUID, snap_info.uuid, 0, &snap_info, NULL, &snap_info.effects, fromhost);
 }
 
 int gbl_disable_cnonce_blkseq;
@@ -4903,8 +4902,7 @@ int osql_comm_signal_sqlthr_rc(osql_target_t *target, unsigned long long rqid,
     /* if error, lets send the error string */
     if (target->host == gbl_myhostname) {
         /* local */
-        return osql_chkboard_sqlsession_rc(rqid, uuid, nops, snap, xerr,
-                                           (snap) ? &snap->effects : NULL);
+        return osql_chkboard_sqlsession_rc(rqid, uuid, nops, snap, xerr, (snap) ? &snap->effects : NULL, target->host);
     }
 
     /* remote */
@@ -7218,9 +7216,9 @@ static void net_sorese_signal(void *hndl, void *uptr, char *fromhost,
             uint8_t *p_buf_end = (p_buf + sizeof(struct errstat));
             osqlcomm_errstat_type_get(&errstat, p_buf, p_buf_end);
 
-            osql_chkboard_sqlsession_rc(rqid, uuid, 0, NULL, &errstat, NULL);
+            osql_chkboard_sqlsession_rc(rqid, uuid, 0, NULL, &errstat, NULL, fromhost);
         } else {
-            osql_chkboard_sqlsession_rc(rqid, uuid, done.nops, NULL, NULL, p_effects);
+            osql_chkboard_sqlsession_rc(rqid, uuid, done.nops, NULL, NULL, p_effects, fromhost);
         }
 
     } else {


### PR DESCRIPTION
Replicant may receive a bplog error from the old master for a transaction which is already restarted against the new master. The error from the old master should obviously be ignored.

(DRQS 170651325)