### PR TITLE
Move commit-delay-on-copy logic into the database

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2598,6 +2598,9 @@ static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
     net_register_handler(bdb_state->repinfo->netinfo, USER_TYPE_COMMITDELAYNONE,
                          "commitdelaynone", berkdb_receive_rtn);
 
+    net_register_handler(bdb_state->repinfo->netinfo, USER_TYPE_COMMITDELAYTIMED, "commitdelaytimed",
+                         berkdb_receive_rtn);
+
     net_register_handler(bdb_state->repinfo->netinfo,
                          USER_TYPE_MASTERCMPCONTEXTLIST, "mastercmpcontextlist",
                          berkdb_receive_rtn);

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3626,6 +3626,15 @@ int get_myseqnum(bdb_state_type *bdb_state, uint8_t *p_net_seqnum)
     return rc;
 }
 
+int request_copydelay(void *bdb_state_in)
+{
+    int rc;
+    bdb_state_type *bdb_state = (bdb_state_type *)bdb_state_in;
+    rc = net_send_flags(bdb_state->repinfo->netinfo,
+                        bdb_state->repinfo->master_host, USER_TYPE_COMMITDELAYTIMED, NULL,
+                        0, NET_SEND_NODROP);
+    return rc;
+}
 
 int send_myseqnum_to_master(bdb_state_type *bdb_state, int nodelay)
 {
@@ -4982,12 +4991,29 @@ int enque_udppfault_filepage(bdb_state_type *bdb_state, unsigned int fileid,
     return rc;
 }
 
+#define MIN(a, b) (((a) < (b)) ? (a) : (b))
+
+int gbl_commit_delay_copy_ms = 0;
+int gbl_commit_delay_timeout = 10;
+static int64_t commit_delay_timeout = 0;
+
 int bdb_commitdelay(void *arg)
 {
     bdb_state_type *bdb_state = arg;
+
     if (bdb_state->parent)
         bdb_state = bdb_state->parent;
-    return bdb_state->attr->commitdelay;
+
+    if (bdb_state->attr->commitdelaymax <= 0)
+        return 0;
+
+    if (bdb_state->attr->commitdelay > 0)
+        return MIN(bdb_state->attr->commitdelay, bdb_state->attr->commitdelaymax);
+
+    if (time(NULL) < commit_delay_timeout)
+        return MIN(gbl_commit_delay_copy_ms, bdb_state->attr->commitdelaymax);
+
+    return 0;
 }
 
 static int berkdb_receive_rtn_int(void *ack_handle, void *usr_ptr,
@@ -5133,6 +5159,12 @@ static int berkdb_receive_rtn_int(void *ack_handle, void *usr_ptr,
                                                       p_buf_end);
 
         got_new_seqnum_from_node(bdb_state, &berkdb_seqnum, from_node, is_tcp);
+        break;
+
+    case USER_TYPE_COMMITDELAYTIMED:
+        commit_delay_timeout = time(NULL) + gbl_commit_delay_timeout;
+        logmsg(LOGMSG_WARN, "--- got commitdelaytimed req from node %s.  timeout=%" PRId64 "\n", from_node,
+               commit_delay_timeout);
         break;
 
     case USER_TYPE_COMMITDELAYMORE:
@@ -5762,6 +5794,18 @@ void *watcher_thread(void *arg)
             bdb_state->pending_seqnum_broadcast = 0;
         }
         Pthread_mutex_unlock(&bdb_state->pending_broadcast_lock);
+
+        int log_delete_is_stopped(void);
+        if (log_delete_is_stopped()) {
+            logmsg(LOGMSG_WARN, "Logdelete stopped, requesting copy commit-delay\n");
+            if (rep_master == bdb_state->repinfo->myhost) {
+                commit_delay_timeout = time(NULL) + gbl_commit_delay_timeout;
+                logmsg(LOGMSG_WARN, "--- delaying commits for copy on master.  timeout=%"PRId64"\n",
+                    commit_delay_timeout);
+            } else {
+                request_copydelay(bdb_state);
+            }
+        }
 
         /* check if we have connections to everyone in the sanc list */
         bdb_state->sanc_ok =

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5951,6 +5951,16 @@ int check_current_schemas(void)
     return 0;
 }
 
+int log_delete_is_stopped(void)
+{
+    int rc;
+    struct dbenv *dbenv = thedb;
+    Pthread_mutex_lock(&dbenv->log_delete_counter_mutex);
+    rc = dbenv->log_delete_state_list.count;
+    Pthread_mutex_unlock(&dbenv->log_delete_counter_mutex);
+    return rc;
+}
+
 void log_delete_add_state(struct dbenv *dbenv, struct log_delete_state *state)
 {
     Pthread_mutex_lock(&dbenv->log_delete_counter_mutex);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2858,6 +2858,7 @@ int sql_debug_logf(struct sqlclntstate *clnt, const char *func, int line,
                    const char *fmt, ...);
 
 enum { LOG_DEL_ABS_ON, LOG_DEL_ABS_OFF, LOG_DEL_REFRESH };
+int log_delete_is_stopped(void);
 void log_delete_counter_change(struct dbenv *dbenv, int action);
 void log_delete_add_state(struct dbenv *dbenv, struct log_delete_state *state);
 void log_delete_rem_state(struct dbenv *dbenv, struct log_delete_state *state);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -167,6 +167,8 @@ extern int gbl_net_writer_thread_poll_ms;
 extern int gbl_max_apply_dequeue;
 extern int gbl_catchup_window_trace;
 extern int gbl_early_ack_trace;
+extern int gbl_commit_delay_timeout;
+extern int gbl_commit_delay_copy_ms;
 extern int gbl_throttle_logput_trace;
 extern int gbl_fills_waitms;
 extern int gbl_finish_fill_threshold;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1524,6 +1524,12 @@ REGISTER_TUNABLE("early_ack_trace",
                  "Print trace when sending an early ack.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_early_ack_trace, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("commit_delay_timeout_seconds",
+                 "Set timeout for commit-delay on copy.  (Default: 10)",
+                 TUNABLE_INTEGER, &gbl_commit_delay_timeout, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("commit_delay_on_copy_ms",
+                 "Set automatic delay-ms for commit-delay on copy.  (Default: 0)",
+                 TUNABLE_INTEGER, &gbl_commit_delay_copy_ms, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("commit_delay_trace", "Verbose commit-delays.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_commit_delay_trace,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -776,6 +776,8 @@ These options are toggle-able at runtime.
 |default_sql_mspace_kbsz          | 1024            | Default size of memory regions owned by SQL threads, in KB 
 |osync                            |Off         | Enables `O_SYNC` on data files (reads still go through FS cache) if `directio` isn't set
 |commitdelaymax                   |0           | Introduce a delay after each transaction before returning control to the application.  Occasionally useful to allow replicants to catch up on startup with a very busy system.
+|commit_delay_timeout_seconds     |10          | Period of time a master will delay-commits if a copy is ongoing
+|commit_delay_on_copy_ms          |0           | Amount of time each commit will be delayed if a copy is ongoing
 |lock_conflict_trace              |Off         | Dump count of lock conflicts every second
 |no_lock_conflict_trace           |On          | Turns off `lock_conflict_trace`
 |gbl_exit_on_pthread_create_fail  |1           | If set, database will exit if thread pools aren't able to create threads.

--- a/net/net_types.h
+++ b/net/net_types.h
@@ -99,6 +99,7 @@ enum {
     USER_TYPE_TRANSFERMASTER_NAME,
     USER_TYPE_REQ_START_LSN,
     USER_TYPE_TRUNCATE_LOG,
+    USER_TYPE_COMMITDELAYTIMED = 43,
 
     NET_QUIESCE_THREADS = 100,
     NET_RESUME_THREADS = 101,
@@ -117,21 +118,21 @@ enum {
     NET_START_SC = 115,
     NET_STOP_SC = 116,
     NET_ODH_OPTIONS = 117,
-    NET_OSQL_BLOCK_REQ = 118, /* obsolete */
-    NET_OSQL_BLOCK_RPL = 119, /* obsolete */
+    NET_OSQL_BLOCK_REQ = 118,        /* obsolete */
+    NET_OSQL_BLOCK_RPL = 119,        /* obsolete */
     NET_SETLOCKS = 120,
     NET_SET_ALL_LOCKS = 121,
     NET_RELEASE_LOCKS = 122,
-    NET_OSQL_SOCK_REQ = 123,  /* this goes only on offload net */
-    NET_OSQL_SOCK_RPL = 124,  /* this goes only on offload net */
-    NET_OSQL_RECOM_REQ = 125, /* this goes only on offload net */
-    NET_OSQL_RECOM_RPL = 126, /* this goes only on offload net */
-    NET_HBEAT_SQL = 127,      /* this goes only on offload net */
-    NET_FORGETMENOT = 128,    /* to remind master of an incoherent node */
-    NET_USE_LLMETA = 129,  /* depricated, in this version of comdb2, * all dbs
-                              must be llmeta */
-    NET_OSQL_POKE = 130,   /* obsolete */
-    NET_OSQL_SIGNAL = 131, /* this goes only on offload net */
+    NET_OSQL_SOCK_REQ = 123,         /* this goes only on offload net */
+    NET_OSQL_SOCK_RPL = 124,         /* this goes only on offload net */
+    NET_OSQL_RECOM_REQ = 125,        /* this goes only on offload net */
+    NET_OSQL_RECOM_RPL = 126,        /* this goes only on offload net */
+    NET_HBEAT_SQL = 127,             /* this goes only on offload net */
+    NET_FORGETMENOT = 128,           /* to remind master of an incoherent node */
+    NET_USE_LLMETA = 129,            /* depricated, in this version of comdb2, * all dbs
+                                        must be llmeta */
+    NET_OSQL_POKE = 130,             /* obsolete */
+    NET_OSQL_SIGNAL = 131,           /* this goes only on offload net */
     NET_OSQL_SERIAL_REQ = 132,       /* this goes only on offload net */
     NET_OSQL_SERIAL_RPL = 133,       /* this goes only on offload net */
     NET_OSQL_BLOCK_REQ_PARAMS = 134, /* obsolete */
@@ -141,13 +142,13 @@ enum {
     NET_OSQL_SOCK_REQ_COST = 138,    /* like SOCK_REQ, but passes dbglog ids */
     NET_OSQL_SNAPISOL_REQ = 139,     /* this goes only on offload net */
     NET_OSQL_SNAPISOL_RPL = 140,     /* this goes only on offload net */
-    NET_RELOAD_LUA = 141, /* Delete the cached lua machines at load time */
-    NET_OSQL_MASTER_CHECK = 142,   /* this goes only on offload net */
-    NET_OSQL_MASTER_CHECKED = 143, /* this goes only on offload net */
-    NET_BLOCK_REQ = 144,   /* this is to process block request on master. */
-    NET_BLOCK_REPLY = 145, /*  process block request reply from master. */
-    NET_OSQL_SNAP_UID_REQ = 146, /* the request to check snapshot UID */
-    NET_OSQL_SNAP_UID_RPL = 147, /* the reply from master for uid check */
+    NET_RELOAD_LUA = 141,            /* Delete the cached lua machines at load time */
+    NET_OSQL_MASTER_CHECK = 142,     /* this goes only on offload net */
+    NET_OSQL_MASTER_CHECKED = 143,   /* this goes only on offload net */
+    NET_BLOCK_REQ = 144,             /* this is to process block request on master. */
+    NET_BLOCK_REPLY = 145,           /* process block request reply from master. */
+    NET_OSQL_SNAP_UID_REQ = 146,     /* the request to check snapshot UID */
+    NET_OSQL_SNAP_UID_RPL = 147,     /* the reply from master for uid check */
     NET_TRIGGER_REGISTER = 148,
     NET_TRIGGER_UNREGISTER = 149,
     NET_TRIGGER_START = 150,

--- a/tests/commit_delay_on_copy.test/Makefile
+++ b/tests/commit_delay_on_copy.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/commit_delay_on_copy.test/README
+++ b/tests/commit_delay_on_copy.test/README
@@ -1,0 +1,1 @@
+Test for commit-delay-on-copy

--- a/tests/commit_delay_on_copy.test/lrl.options
+++ b/tests/commit_delay_on_copy.test/lrl.options
@@ -1,0 +1,3 @@
+setattr COMMITDELAYMAX 2000
+commit_delay_on_copy_ms 2000
+commit_delay_trace 1

--- a/tests/commit_delay_on_copy.test/runit
+++ b/tests/commit_delay_on_copy.test/runit
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/timers.sh
+
+#export debug=1
+export fasttime=200
+export slowtime=2000
+
+function failexit
+{
+    [[ "$debug" == "1" ]] && set -x
+    echo "Failed: $1"
+    exit -1
+}
+
+function timeinsert
+{
+    typeset start=$(timems)
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values (1)" >/dev/null 2>&1
+    typeset end=$(timems)
+    echo $(( end - start ))
+}
+
+# Times an insert, fail test if it is too slow
+function insertfast
+{
+    x=$(timeinsert)
+    [[ "$debug" == "1" ]] && echo "Insert took $x ms"
+    [[ $x -gt $fasttime ]] && failexit "Insert was too slow"
+}
+
+# Times an insert, fail test if it is too fast
+function insertslow
+{
+    x=$(timeinsert)
+    [[ "$debug" == "1" ]] && echo "Insert took $x ms"
+    [[ $x -lt $slowtime ]] && failexit "Insert was too fast"
+}
+
+# Use 'go-slow' flag to create a slow archive
+function slowarchive
+{
+    typeset machine=$1
+    ssh $machine "$COMDB2AR_EXE -A c ${DBDIR}/${DBNAME}.lrl >/dev/null 2>/dev/null"
+}
+
+function test_insert_archive
+{
+    slowarchive $1 &
+    pid=$!
+
+    # sleep a bit to make sure watcher-thread notifies master
+    sleep 5
+
+    while :; do
+        insertslow
+        echo "Insert is commit-delayed"
+        if ps -p $pid >/dev/null ; then
+            echo "Slow archive is still running on $1"
+        else
+            echo "Slow archive stopped"
+            break
+        fi
+    done
+
+    # Get past the timeout
+    sleep 11
+
+    insertfast
+    echo "Insert is fast, archive has stopped"
+}
+
+function run_test
+{
+    create_table
+    insertfast
+
+    sleep 10
+
+    for machine in $CLUSTER; do
+        test_insert_archive $machine
+    done
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+run_test
+
+echo "Success!"

--- a/tests/tools/timers.sh
+++ b/tests/tools/timers.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Print current epoch-time including milliseconds
+function timems
+{
+    typeset t=${EPOCHREALTIME}
+    seconds=${t%%\.*}
+    rest=${t##*\.}
+    echo "${seconds}${rest:0:3}"
+}

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -122,6 +122,8 @@
 (name='clean_exit_on_sigterm', description='Attempt to do orderly shutdown on SIGTERM (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='coherency_lease', description='A coherency lease grants a replicant the right to be coherent for this many ms.', type='INTEGER', value='500', read_only='N')
 (name='coherency_lease_udp', description='Use udp to issue leases.', type='BOOLEAN', value='ON', read_only='N')
+(name='commit_delay_on_copy_ms', description='Set automatic delay-ms for commit-delay on copy.  (Default: 0)', type='INTEGER', value='0', read_only='N')
+(name='commit_delay_timeout_seconds', description='Set timeout for commit-delay on copy.  (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')
 (name='commitdelaybehindthresh', description='Call for election again and ask the master to delay commits if we are further than this far behind on startup.', type='INTEGER', value='1048576', read_only='N')
 (name='commitdelaymax', description='Introduce a delay after each transaction before returning control to the application. Occasionally useful to allow replicants to catch up on startup with a very busy system.', type='INTEGER', value='0', read_only='N')

--- a/tools/comdb2ar/comdb2ar.cpp
+++ b/tools/comdb2ar/comdb2ar.cpp
@@ -103,6 +103,7 @@ int main(int argc, char *argv[])
     bool force_mode = false;
     unsigned percent_full = 95;
     bool legacy_mode = false;
+    bool add_latency = false;
     bool do_direct_io = true;
     bool incr_create = false;
     bool incr_gen = false;
@@ -127,10 +128,14 @@ int main(int argc, char *argv[])
     ss << root << "/bin/comdb2";
     std::string comdb2_task(ss.str());
 
-    while((c = getopt(argc, argv, "hsSLC:I:b:x:u:rRSkKfODE:T:")) != EOF) {
+    while((c = getopt(argc, argv, "hsSLC:I:b:x:u:rRSkKfODE:T:A")) != EOF) {
         switch(c) {
             case 'O':
                 legacy_mode = true;
+                break;
+
+            case 'A':
+                add_latency = true;
                 break;
 
             case 'h':
@@ -307,6 +312,7 @@ int main(int argc, char *argv[])
                 incr_create,
                 incr_gen,
                 copy_physical,
+                add_latency,
                 incr_path
             );
         } catch(std::exception& e) {

--- a/tools/comdb2ar/comdb2ar.h
+++ b/tools/comdb2ar/comdb2ar.h
@@ -110,6 +110,7 @@ void serialise_database(
   bool incr_create,
   bool incr_gen,
   bool copy_physical,
+  bool add_latency,
   const std::string& incr_path
 );
 // Serialise a database into tape archive format and write it to stdout.

--- a/tools/comdb2ar/serialise.cpp
+++ b/tools/comdb2ar/serialise.cpp
@@ -763,6 +763,7 @@ void serialise_database(
   bool incr_create,
   bool incr_gen,
   bool copy_physical,
+  bool add_latency,
   const std::string& incr_path
 )
 // Serialise a database into tape archive format and write it to stdout.
@@ -1334,6 +1335,9 @@ void serialise_database(
                 makeabs(abspath, dbdir, *it);
                 FileInfo fi(FileInfo::OPTIONAL_FILE, abspath, dbdir);
                 serialise_file(fi, iom);
+                if (add_latency) {
+                    sleep(1);
+                }
             }
             catch (SerialiseError &err) {
                 std::cerr << "Warning: " << *it << ": " << err.what() << std::endl;
@@ -1359,6 +1363,9 @@ void serialise_database(
                 }
 
                 serialise_file(*it, iom, "", incr_path, incr_create);
+                if (add_latency) {
+                    sleep(1);
+                }
             }
 
             // Serialise all remaining log files, including incomplete ones
@@ -1383,6 +1390,9 @@ void serialise_database(
         FileInfo fi(FileInfo::LOG_FILE, absfile, dbdir);
 
         serialise_file(fi);
+        if (add_latency) {
+            sleep(1);
+        }
 
         long long log_number(lowest_log);
 
@@ -1454,6 +1464,9 @@ void serialise_database(
 
             // Ok, now serialise this file.
             serialise_file(*new_it, iom, "", incr_path, true);
+            if (add_latency) {
+                sleep(1);
+            }
         }
 
 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Setting a database's commit-delay from copycomdb2 is inherently fragile- so this PR moves this logic into the database.  Any replicant which is being used for a copy asks the leader to delay its commits for a period of time (determined by the commit_delay_timeout_seconds tunable, which defaults to 10 seconds).  commit_delay_on_copy_ms is the amount of time that a single-commit will be delayed (it defaults to 8 ms).

The commit_delay_on_copy test demonstrates this logic.