### PR TITLE
Exit verify on master change

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -641,8 +641,10 @@ tran_type *bdb_tran_begin_flags(bdb_state_type *bdb_handle,
                                 tran_type *parent_tran, int *bdberr,
                                 uint32_t flags);
 
-tran_type *bdb_tran_begin(bdb_state_type *bdb_handle, tran_type *parent_tran,
-                          int *bdberr);
+tran_type *bdb_tran_begin_internal(bdb_state_type *bdb_handle, tran_type *parent_tran,
+                          int *bdberr, const char *func, int line);
+
+#define bdb_tran_begin(A, B, C) ({tran_type *retval; retval = bdb_tran_begin_internal(A, B, C, __func__, __LINE__); retval;})
 
 tran_type *bdb_tran_begin_mvcc(bdb_state_type *bdb_handle,
                                tran_type *parent_tran, int *bdberr);
@@ -2243,6 +2245,7 @@ void bdb_get_txn_stats(bdb_state_type *bdb_state, int64_t *active,
                        int64_t *maxactive, int64_t *commits, int64_t *aborts);
 
 uint32_t bdb_get_rep_gen(bdb_state_type *bdb_state);
+int bdb_recoverlk_blocked(bdb_state_type *bdb_state);
 
 void send_newmaster(bdb_state_type *bdb_state, int online);
 

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -184,7 +184,7 @@ ret:
 static inline int check_connection_and_progress(verify_common_t *par, int t_ms)
 {
     unsigned int last = par->last_connection_check; // get a copy of the last timestamp
-    if (bdb_lock_desired(par->bdb_state)) {
+    if (bdb_lock_desired(par->bdb_state) || bdb_recoverlk_blocked(par->bdb_state)) {
         logmsg(LOGMSG_WARN, "master change, stopped verify\n");
         par->lock_desired = 1;
         par->client_dropped_connection = 1;

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -2164,7 +2164,7 @@ static void *pglogs_asof_thread(void *arg)
     /* We need to stop this thread when truncating the log */
     if (!db_is_exiting()) {
         haslock = 1;
-        dbenv->lock_recovery_lock(dbenv);
+        dbenv->lock_recovery_lock(dbenv, __func__, __LINE__);
     }
 
     while (!db_is_exiting()) {
@@ -2350,7 +2350,7 @@ static void *pglogs_asof_thread(void *arg)
         }
 #endif
 
-        dbenv->unlock_recovery_lock(dbenv);
+        dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
         clear_newsi_pool();
         if (!dont_poll) {
             pollms = bdb_state->attr->asof_thread_poll_interval_ms <= 0
@@ -2358,11 +2358,11 @@ static void *pglogs_asof_thread(void *arg)
                          : bdb_state->attr->asof_thread_poll_interval_ms;
             poll(NULL, 0, pollms);
         }
-        dbenv->lock_recovery_lock(dbenv);
+        dbenv->lock_recovery_lock(dbenv, __func__, __LINE__);
     }
 
     if (haslock)
-        dbenv->unlock_recovery_lock(dbenv);
+        dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 
     return NULL;
 }

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2041,6 +2041,11 @@ uint32_t bdb_get_rep_gen(bdb_state_type *bdb_state)
     return mygen;
 }
 
+int bdb_recoverlk_blocked(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->wrlock_recovery_blocked(bdb_state->dbenv);
+}
+
 void send_newmaster(bdb_state_type *bdb_state, int online)
 {
     bdb_state->dbenv->rep_start(bdb_state->dbenv, NULL, 0, DB_REP_MASTER);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1325,10 +1325,13 @@ tran_type *bdb_tran_continue_logical(bdb_state_type *bdb_state,
     return tran;
 }
 
-tran_type *bdb_tran_begin(bdb_state_type *bdb_state, tran_type *parent,
-                          int *bdberr)
+tran_type *bdb_tran_begin_internal(bdb_state_type *bdb_state, tran_type *parent,
+                          int *bdberr, const char *func, int line)
 {
     tran_type *tran;
+#if DEBUG_RECOVERY_LOCK
+    logmsg(LOGMSG_USER, "%s called from %s:%d\n", __func__, func, line);
+#endif
     tran = bdb_tran_begin_pp(bdb_state, parent, NULL, bdberr, 0);
     return tran;
 }

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2703,8 +2703,10 @@ struct __db_env {
 	void (*rep_set_gen)(DB_ENV *, uint32_t gen);
 	int (*set_rep_recovery_cleanup) __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *lsn, int is_master)));
 	int (*rep_recovery_cleanup)(DB_ENV *, DB_LSN *lsn, int is_master);
-	int (*lock_recovery_lock)(DB_ENV *);
-	int (*unlock_recovery_lock)(DB_ENV *);
+	int (*wrlock_recovery_lock)(DB_ENV *, const char *func, int line);
+    int (*wrlock_recovery_blocked)(DB_ENV *);
+	int (*lock_recovery_lock)(DB_ENV *, const char *func, int line);
+	int (*unlock_recovery_lock)(DB_ENV *, const char *func, int line);
 	/* Trigger/consumer signalling support */
 	int(*trigger_subscribe) __P((DB_ENV *, const char *, pthread_cond_t **,
 					 pthread_mutex_t **, const uint8_t **));

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -59,8 +59,10 @@ static int __rep_set_check_standalone __P((DB_ENV *, int (*)(DB_ENV *)));
 static int __rep_set_truncate_sc_callback __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *)));
 static int __rep_set_rep_truncate_callback __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *, uint32_t is_master)));
 static int __rep_set_rep_recovery_cleanup __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *, int is_master)));
-static int __rep_lock_recovery_lock __P((DB_ENV *));
-static int __rep_unlock_recovery_lock __P((DB_ENV *));
+static int __rep_lock_recovery_lock __P((DB_ENV *, const char *func, int line));
+static int __rep_wrlock_recovery_lock __P((DB_ENV *, const char *func, int line));
+static int __rep_unlock_recovery_lock __P((DB_ENV *, const char *func, int line));
+static int __rep_wrlock_recovery_blocked __P((DB_ENV *));
 static int __rep_set_rep_db_pagesize __P((DB_ENV *, int));
 static int __rep_get_rep_db_pagesize __P((DB_ENV *, int *));
 static int __rep_start __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
@@ -129,6 +131,8 @@ __rep_dbenv_create(dbenv)
 		dbenv->set_rep_truncate_callback = __rep_set_rep_truncate_callback;
 		dbenv->set_rep_recovery_cleanup = __rep_set_rep_recovery_cleanup;
 		dbenv->rep_set_gen = __rep_set_gen_pp;
+		dbenv->wrlock_recovery_lock = __rep_wrlock_recovery_lock;
+        dbenv->wrlock_recovery_blocked = __rep_wrlock_recovery_blocked;
 		dbenv->lock_recovery_lock = __rep_lock_recovery_lock;
 		dbenv->unlock_recovery_lock = __rep_unlock_recovery_lock;
 		dbenv->set_check_standalone = __rep_set_check_standalone;
@@ -921,20 +925,72 @@ __rep_set_rep_truncate_callback(dbenv, rep_truncate_callback)
 	return (0);
 }
 
+#if DEBUG_RECOVERY_LOCK
+void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
+#endif
+
+static int recoverlk_blocked = 0;
+
 static int
-__rep_lock_recovery_lock(dbenv)
-    DB_ENV *dbenv;
+__rep_wrlock_recovery_lock(dbenv, func, line)
+	DB_ENV *dbenv;
+	const char *func;
+	int line;
 {
-    Pthread_rwlock_rdlock(&dbenv->recoverlk);
-    return 0;
+    recoverlk_blocked = 1;
+	Pthread_rwlock_wrlock(&dbenv->recoverlk);
+    recoverlk_blocked = 0;
+#if DEBUG_RECOVERY_LOCK
+	logmsg(LOGMSG_USER, "%s line %d WRITE-LOCK recoverlk, readers=%d\n", func, line,
+        dbenv->recoverlk.__data.__readers);
+    comdb2_cheapstack_sym(stderr, "%s:%d", func, line);
+#endif
+	return 0;
 }
 
 static int
-__rep_unlock_recovery_lock(dbenv)
+__rep_wrlock_recovery_blocked(dbenv)
     DB_ENV *dbenv;
 {
-    Pthread_rwlock_unlock(&dbenv->recoverlk);
-    return 0;
+    return recoverlk_blocked;
+}
+
+#if DEBUG_RECOVERY_LOCK
+pthread_mutex_t prlk = PTHREAD_MUTEX_INITIALIZER;
+#endif
+
+static int
+__rep_lock_recovery_lock(dbenv, func, line)
+	DB_ENV *dbenv;
+	const char *func;
+	int line;
+{
+	Pthread_rwlock_rdlock(&dbenv->recoverlk);
+#if DEBUG_RECOVERY_LOCK
+    Pthread_mutex_lock(&prlk);
+	logmsg(LOGMSG_USER, "%s line %d READ-LOCK recoverlk, readers=%d\n", func, line,
+        dbenv->recoverlk.__data.__readers);
+    comdb2_cheapstack_sym(stderr, "%s:%d", func, line);
+    Pthread_mutex_unlock(&prlk);
+#endif
+	return 0;
+}
+
+static int
+__rep_unlock_recovery_lock(dbenv, func, line)
+	DB_ENV *dbenv;
+	const char *func;
+	int line;
+{
+#if DEBUG_RECOVERY_LOCK
+    Pthread_mutex_lock(&prlk);
+	logmsg(LOGMSG_USER, "%s line %d UNLOCK recoverlk, readers=%d\n", func, line,
+        dbenv->recoverlk.__data.__readers);
+    comdb2_cheapstack_sym(stderr, "%s:%d", func, line);
+    Pthread_mutex_unlock(&prlk);
+#endif
+	Pthread_rwlock_unlock(&dbenv->recoverlk);
+	return 0;
 }
 
 static int


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

An open transaction created by verify will keep a replicant from running rep-verify-match, as that transaction maintains a read-reference to the recovery-lock.  This can occur on a master swing for a replicant which neither upgrades nor downgrades (so it's bib-lock is never desired).