### PR TITLE
Exit verify on master change

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -611,8 +611,10 @@ tran_type *bdb_tran_begin_flags(bdb_state_type *bdb_handle,
                                 tran_type *parent_tran, int *bdberr,
                                 uint32_t flags);
 
-tran_type *bdb_tran_begin(bdb_state_type *bdb_handle, tran_type *parent_tran,
-                          int *bdberr);
+tran_type *bdb_tran_begin_internal(bdb_state_type *bdb_handle, tran_type *parent_tran,
+                          int *bdberr, const char *func, int line);
+
+#define bdb_tran_begin(A, B, C) ({tran_type *retval; retval = bdb_tran_begin_internal(A, B, C, __func__, __LINE__); retval;})
 
 tran_type *bdb_tran_begin_mvcc(bdb_state_type *bdb_handle,
                                tran_type *parent_tran, int *bdberr);
@@ -2127,6 +2129,7 @@ void bdb_get_txn_stats(bdb_state_type *bdb_state, int64_t *active,
                        int64_t *maxactive, int64_t *commits, int64_t *aborts);
 
 uint32_t bdb_get_rep_gen(bdb_state_type *bdb_state);
+int bdb_recoverlk_blocked(bdb_state_type *bdb_state);
 
 void send_newmaster(bdb_state_type *bdb_state, int online);
 

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -206,10 +206,10 @@ ret:
 
 static inline int print_verify_progress(verify_common_t *par, int now)
 {
-    if (bdb_lock_desired(par->bdb_state)) {
+    if (bdb_lock_desired(par->bdb_state) || bdb_recoverlk_blocked(par->bdb_state)) {
         logmsg(LOGMSG_WARN, "master change, stopped verify\n");
         locprint(par->sb, par->lua_callback, par->lua_params,
-                      "verify stopping on master change\n");
+                      "verify stopping on master change");
         par->lock_desired = 1;
         par->client_dropped_connection = 1;
         goto out;

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -2160,7 +2160,7 @@ static void *pglogs_asof_thread(void *arg)
     /* We need to stop this thread when truncating the log */
     if (!db_is_stopped()) {
         haslock = 1;
-        dbenv->lock_recovery_lock(dbenv);
+        dbenv->lock_recovery_lock(dbenv, __func__, __LINE__);
     }
 
     while (!db_is_stopped()) {
@@ -2346,7 +2346,7 @@ static void *pglogs_asof_thread(void *arg)
         }
 #endif
 
-        dbenv->unlock_recovery_lock(dbenv);
+        dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
         clear_newsi_pool();
         if (!dont_poll) {
             pollms = bdb_state->attr->asof_thread_poll_interval_ms <= 0
@@ -2354,11 +2354,11 @@ static void *pglogs_asof_thread(void *arg)
                          : bdb_state->attr->asof_thread_poll_interval_ms;
             poll(NULL, 0, pollms);
         }
-        dbenv->lock_recovery_lock(dbenv);
+        dbenv->lock_recovery_lock(dbenv, __func__, __LINE__);
     }
 
     if (haslock)
-        dbenv->unlock_recovery_lock(dbenv);
+        dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 
     return NULL;
 }

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2204,6 +2204,11 @@ uint32_t bdb_get_rep_gen(bdb_state_type *bdb_state)
     return mygen;
 }
 
+int bdb_recoverlk_blocked(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->wrlock_recovery_blocked(bdb_state->dbenv);
+}
+
 void send_newmaster(bdb_state_type *bdb_state, int online)
 {
     bdb_state->dbenv->rep_start(bdb_state->dbenv, NULL, 0, DB_REP_MASTER);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -1397,10 +1397,13 @@ tran_type *bdb_tran_continue_logical(bdb_state_type *bdb_state,
     return tran;
 }
 
-tran_type *bdb_tran_begin(bdb_state_type *bdb_state, tran_type *parent,
-                          int *bdberr)
+tran_type *bdb_tran_begin_internal(bdb_state_type *bdb_state, tran_type *parent,
+                          int *bdberr, const char *func, int line)
 {
     tran_type *tran;
+#if DEBUG_RECOVERY_LOCK
+    logmsg(LOGMSG_USER, "%s called from %s:%d\n", __func__, func, line);
+#endif
     tran = bdb_tran_begin_pp(bdb_state, parent, 0, bdberr, 0);
     return tran;
 }

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2600,8 +2600,10 @@ struct __db_env {
 	void (*rep_set_gen)(DB_ENV *, uint32_t gen);
 	int (*set_rep_recovery_cleanup) __P((DB_ENV *, int (*)(DB_ENV *, DB_LSN *lsn, int is_master)));
 	int (*rep_recovery_cleanup)(DB_ENV *, DB_LSN *lsn, int is_master);
-	int (*lock_recovery_lock)(DB_ENV *);
-	int (*unlock_recovery_lock)(DB_ENV *);
+	int (*wrlock_recovery_lock)(DB_ENV *, const char *func, int line);
+	int (*wrlock_recovery_blocked)(DB_ENV *);
+	int (*lock_recovery_lock)(DB_ENV *, const char *func, int line);
+	int (*unlock_recovery_lock)(DB_ENV *, const char *func, int line);
 	/* Trigger/consumer signalling support */
 	int(*trigger_subscribe) __P((DB_ENV *, const char *, pthread_cond_t **,
 					 pthread_mutex_t **, const uint8_t **active));

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -6521,12 +6521,12 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 		wait_for_sc_to_stop("log-truncate", __func__, __LINE__);
 	}
 
-	Pthread_rwlock_wrlock(&dbenv->recoverlk);
+	dbenv->wrlock_recovery_lock(dbenv, __func__, __LINE__);
 	have_recover_lk = 1;
 	if (i_am_master) {
 		if (truncate_count > 0) {
 			logmsg(LOGMSG_ERROR, "%s forbidding concurrent truncates\n", __func__);
-			Pthread_rwlock_unlock(&dbenv->recoverlk);
+			dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 			return -1;
 		}
 		truncate_count++;
@@ -6534,7 +6534,7 @@ __rep_dorecovery(dbenv, lsnp, trunclsnp, online)
 
 	/* Figure out if we are backing out any commited transactions. */
 	if ((ret = __log_cursor(dbenv, &logc)) != 0) {
-		Pthread_rwlock_unlock(&dbenv->recoverlk);
+		dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 		logmsg(LOGMSG_ERROR, "%s error getting log cursor\n", __func__);
 		if (i_am_master) {
 			truncate_count--;
@@ -6656,7 +6656,7 @@ restart:
 	logmsg(LOGMSG_INFO, "%s finished truncate, trunclsnp is [%d:%d]\n", __func__,
 			trunclsnp->file, trunclsnp->offset);
 
-	Pthread_rwlock_unlock(&dbenv->recoverlk);
+	dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 	have_recover_lk = 0;
 
 	if (online) {
@@ -6686,7 +6686,7 @@ err:
 	}
 
 	if (have_recover_lk) {
-		Pthread_rwlock_unlock(&dbenv->recoverlk);
+	    dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
 	}
 
 	if ((t_ret = __log_c_close(logc)) != 0 && ret == 0)


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

An open transaction created by verify will keep a replicant from running rep-verify-match, as that transaction maintains a read-reference to the recovery-lock. This can occur on a master swing for a replicant which neither upgrades nor downgrades (so it's bib-lock is never desired).

This is the 7.0 version of https://github.com/bloomberg/comdb2/pull/3506