### PR TITLE
Enable ufid-log by default, enable elect-highest-committed-gen

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -370,7 +370,6 @@ void clear_deferred_options(void)
 
 static char *legacy_options[] = {
     "allow_negative_column_size",
-    "berkattr elect_highest_committed_gen 0",
     "clean_exit_on_sigterm off",
     "create_default_user",
     "ddl_cascade_drop 0",

--- a/tests/load_cache.test/runit
+++ b/tests/load_cache.test/runit
@@ -6,7 +6,7 @@ bash -n "$0" | exit 1
 . ${TESTSROOTDIR}/tools/ddl.sh
 
 export debug=1
-export sleeptime=10
+export sleeptime=30
 export reppid=-1
 export failpct=15
 export loadrecs=1000000

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 . ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/waitmach.sh
 
 if [[ -z "$sleeptime" ]]; then 
     sleeptime=5

--- a/tests/truncatesc.test/lrl.options
+++ b/tests/truncatesc.test/lrl.options
@@ -8,7 +8,7 @@ logdelete_lock_trace on
 verbose_set_sc_in_progress on
 physrep_register_interval 30
 verbose_physrep on
-#setattr REP_PROCESSORS 0
-#setattr REP_WORKERS 0
+setattr REP_PROCESSORS 0
+setattr REP_WORKERS 0
 online_recovery on
 ack_trace


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Enables elect-highest-committed-generation. Each cluster participant keeps track of the highest generation number that it has written a commit-record for. This generation number is given precedence over a participant's LSN when determining the election winner. Enabling this will prevent an older (partitioned) master from unrolling commits which were replicated by a later generation. This change is incompatible with R6 and prior versions.

Additionally enables ufid_log by default.