### PR TITLE
Don't leak the checkboard lock

### DIFF
--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -324,8 +324,10 @@ int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops, 
            3) Replicant detects that master has swung, and restarts the transaction against the new master.
            4) Replicant reader-thread processes the wrong-master error from the old master, and restarts
               the transaction again. */
-        if (errstat->errval != 0 && entry->master != from)
+        if (errstat->errval != 0 && entry->master != from) {
+            Pthread_mutex_unlock(&checkboard->mtx);
             return 0;
+        }
         entry->err = *errstat;
     } else
         bzero(&entry->err, sizeof(entry->err));


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

A recent checkin unintentionally leaked the checkboard lk from osql_chkboard_sqlsession_rc.  Release this lock before returning.