### PR TITLE
Fix cldeadlock: don't allocate a stringref if clnt has one.

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4822,7 +4822,9 @@ static int enqueue_sql_query(struct sqlclntstate *clnt)
 
     /* keep track so we can display it in stat thr */
     clnt->appsock_id = getarchtid();
-    clnt->sql_ref = create_string_ref(clnt->sql);
+    if (!clnt->sql_ref && clnt->sql) {
+        clnt->sql_ref = create_string_ref(clnt->sql);
+    }
 
     Pthread_mutex_unlock(&clnt->wait_mutex);
 

--- a/util/string_ref.c
+++ b/util/string_ref.c
@@ -39,19 +39,23 @@ static int gbl_creation_count;
 struct string_ref {
     int cnt;
     size_t len;
+    const char *func;
+    int line;
     char str[1];
 };
 
 
 /* Makes a copy of the string passed and uses that as a reference counted object
  */
-struct string_ref * create_string_ref(const char *str)
+struct string_ref * create_string_ref_internal(const char *str, const char *func, int line)
 {
     assert(str);
     size_t len = strlen(str);
     struct string_ref *ref = malloc(sizeof(struct string_ref) + len);
     ref->cnt = 1;
     ref->len = len;
+    ref->func = func;
+    ref->line = line;
     strcpy(ref->str, str);
 
 #ifdef TRACK_REFERENCES
@@ -134,7 +138,7 @@ size_t string_ref_len(struct string_ref *ref)
 static int print_it(void *obj, void *arg)
 {
     struct string_ref *ref = obj;
-    logmsg(LOGMSG_USER, "%s:%d\n", ref->str, ref->cnt);
+    logmsg(LOGMSG_USER, "%s:%d allocated %s:%d\n", ref->str, ref->cnt, ref->func, ref->line);
     return 0;
 }
 

--- a/util/string_ref.h
+++ b/util/string_ref.h
@@ -42,7 +42,8 @@
 
 struct string_ref;
 
-struct string_ref * create_string_ref(const char *str);
+struct string_ref * create_string_ref_internal(const char *str, const char *func, int line);
+#define create_string_ref(str) ({ struct string_ref *r; do { r = create_string_ref_internal(str, __func__, __LINE__); } while(0); r; })
 struct string_ref * get_ref(struct string_ref *ref);
 void put_ref(struct string_ref **ref);
 void transfer_ref(struct string_ref **from, struct string_ref **to);


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This PR fixes a stringref leak that the cldeadlock test was hitting.