### PR TITLE
Fix compiler warnings from newer gcc

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -6226,7 +6226,7 @@ backout:
 int bdb_feature_set_int(bdb_state_type *bdb_state, tran_type *input_trans,
                         int *bdberr, int add, int file_type)
 {
-    uint8_t key[LLMETA_IXLEN] = {0};
+    uint8_t key[LLMETA_IXLEN+sizeof(uint8_t)] = {0};
     int rc;
     struct llmeta_authentication authentication_data = {0};
     uint8_t *p_buf, *p_buf_start = NULL, *p_buf_end;

--- a/sqlite/src/vdbemem.c
+++ b/sqlite/src/vdbemem.c
@@ -3058,9 +3058,12 @@ static int _dttz_to_native_datetimeus(cdb2_client_datetimeus_t * cdt, const Mem 
 static int _native_datetime_to_dttz(cdb2_client_datetime_t * cdt, Mem * res) {
 
     char    tmp[11] = {0};
-    unsigned char buf[CLIENT_DATETIME_LEN];
-    unsigned char *p_buf=buf, *p_buf_end=(p_buf+CLIENT_DATETIME_LEN);
+    unsigned char buf[CLIENT_DATETIME_LEN+sizeof(char)];
+    unsigned char *p_buf=buf;
+    unsigned char *p_buf_end=buf+CLIENT_DATETIME_LEN;
     int     outdtsz  = 0; 
+
+    *p_buf_end = 0;
 
     if(!(client_datetime_put(cdt,p_buf, p_buf_end)))
     {
@@ -3082,9 +3085,11 @@ static int _native_datetime_to_dttz(cdb2_client_datetime_t * cdt, Mem * res) {
 static int _native_datetimeus_to_dttz(cdb2_client_datetimeus_t * cdt, Mem * res) {
 
     char    tmp[13] = {0};
-    unsigned char buf[CLIENT_DATETIME_LEN];
+    unsigned char buf[CLIENT_DATETIME_LEN+sizeof(char)];
     unsigned char *p_buf=buf, *p_buf_end=(p_buf+CLIENT_DATETIME_LEN);
     int     outdtsz  = 0; 
+
+    *p_buf_end = 0;
 
     if(!(client_datetimeus_put(cdt,p_buf, p_buf_end)))
     {

--- a/tests/tools/close_old_connections.c
+++ b/tests/tools/close_old_connections.c
@@ -58,7 +58,7 @@ static int run1(const char *sql)
 
 int main(int argc, char **argv)
 {
-    sigignore(SIGPIPE);
+    signal(SIGPIPE, SIG_IGN);
 
     char *cluster = getenv("CLUSTER");
     if (cluster) {

--- a/tests/tools/hatest.c
+++ b/tests/tools/hatest.c
@@ -776,7 +776,7 @@ int main(int argc, char *argv[])
     int exponent = 0;
     int isttyarg = 0;
 
-    sigignore(SIGPIPE);
+    signal(SIGPIPE, SIG_IGN);
 
     argc--;
     argv++;


### PR DESCRIPTION
We pass p_buf_end to functions in a few places that don't dereference it and just use it for bounds checks.  But it does point to uninitialized stack, which compilers don't like.

Signed-off-by: Michael Ponomarenko <mponomarenko@bloomberg.net>
