### PR TITLE
ssl prefer modes

### DIFF
--- a/bbinc/ssl_support.h
+++ b/bbinc/ssl_support.h
@@ -57,12 +57,16 @@
 #endif
 #define SSL_MIN_TLS_VER_OPT "ssl_min_tls_ver"
 
-#define SSL_MODE_ALLOW          "ALLOW"
-#define SSL_MODE_REQUIRE        "REQUIRE"
-#define SSL_MODE_VERIFY_CA      "VERIFY_CA"
-#define SSL_MODE_VERIFY_HOST    "VERIFY_HOSTNAME"
+#define SSL_MODE_ALLOW "ALLOW"
+#define SSL_MODE_PREFER "PREFER"
+#define SSL_MODE_PREFER_VERIFY_CA "PREFER_VERIFY_CA"
+#define SSL_MODE_PREFER_VERIFY_HOST "PREFER_VERIFY_HOSTNAME"
+#define SSL_MODE_PREFER_VERIFY_DBNAME "PREFER_VERIFY_DBNAME"
+#define SSL_MODE_REQUIRE "REQUIRE"
+#define SSL_MODE_VERIFY_CA "VERIFY_CA"
+#define SSL_MODE_VERIFY_HOST "VERIFY_HOSTNAME"
 #define SSL_MODE_VERIFY_DBNAME "VERIFY_DBNAME"
-#define SSL_MODE_OPTIONAL       "OPTIONAL"
+#define SSL_MODE_OPTIONAL "OPTIONAL"
 
 /* Default file names */
 #define DEFAULT_SERVER_KEY "server.key"
@@ -125,15 +129,26 @@ do {                                            \
             PRINT_SSL_ERRSTR_MT(cb, msg);                       \
     } while (0)
 
+/* XXX Don't change the order of the enum types */
 typedef enum {
     SSL_DISABLE, /* invisible to users */
     SSL_UNKNOWN, /* invisible to users */
     SSL_ALLOW,
+    SSL_PREFER,
+    SSL_PREFER_VERIFY_CA,       /* implies PREFER */
+    SSL_PREFER_VERIFY_HOSTNAME, /* implies PREFER_VERIFY_CA */
+    SSL_PREFER_VERIFY_DBNAME,   /* implies PREFER_VERIFY_DBNAME */
     SSL_REQUIRE,
     SSL_VERIFY_CA,       /* It implies REQUIRE. */
     SSL_VERIFY_HOSTNAME, /* It impiles VERIFY_CA. */
     SSL_VERIFY_DBNAME    /* It impiles VERIFY_HOSTNAME. */
 } ssl_mode;
+
+#define SSL_IS_ABLE(mode) ((mode) >= SSL_ALLOW)
+#define SSL_IS_REQUIRED(mode) ((mode) >= SSL_REQUIRE)
+#define SSL_IS_OPTIONAL(mode) ((mode) < SSL_REQUIRE)
+#define SSL_IS_PREFERRED(mode) ((mode) >= SSL_PREFER)
+#define SSL_NEEDS_VERIFICATION(mode) ((mode) > SSL_PREFER && (mode) != SSL_REQUIRE)
 
 typedef enum {
     PEER_SSL_UNSUPPORTED,

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -661,7 +661,7 @@ void fill_ssl_info(CDB2DBINFORESPONSE *dbinfo_response)
     if (gbl_client_ssl_mode <= SSL_UNKNOWN)
         return;
     dbinfo_response->has_require_ssl = 1;
-    dbinfo_response->require_ssl = (gbl_client_ssl_mode >= SSL_REQUIRE);
+    dbinfo_response->require_ssl = SSL_IS_REQUIRED(gbl_client_ssl_mode);
 }
 
 void fill_dbinfo(CDB2DBINFORESPONSE *dbinfo_response, bdb_state_type *bdb_state)

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Constants.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Constants.java
@@ -106,10 +106,66 @@ public class Constants {
 
     public enum SSL_MODE {
           ALLOW
+        , PREFER
+        , PREFER_VERIFY_CA
+        , PREFER_VERIFY_HOSTNAME
+        , PREFER_VERIFY_DBNAME
         , REQUIRE
         , VERIFY_CA
         , VERIFY_HOSTNAME
-        , VERIFY_DBNAME
+        , VERIFY_DBNAME;
+
+        public static boolean isRequired(SSL_MODE mode) {
+            switch(mode) {
+                case ALLOW:
+                case PREFER:
+                case PREFER_VERIFY_CA:
+                case PREFER_VERIFY_HOSTNAME:
+                case PREFER_VERIFY_DBNAME:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+        public static boolean isOptional(SSL_MODE mode) {
+            switch(mode) {
+                case ALLOW:
+                case PREFER:
+                case PREFER_VERIFY_CA:
+                case PREFER_VERIFY_HOSTNAME:
+                case PREFER_VERIFY_DBNAME:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        public static boolean isPreferred(SSL_MODE mode) {
+            switch(mode) {
+                case PREFER:
+                case PREFER_VERIFY_CA:
+                case PREFER_VERIFY_HOSTNAME:
+                case PREFER_VERIFY_DBNAME:
+                case VERIFY_CA:
+                case VERIFY_HOSTNAME:
+                case VERIFY_DBNAME:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+        public static boolean needsVerification(SSL_MODE mode) {
+            switch(mode) {
+                case PREFER_VERIFY_CA:
+                case PREFER_VERIFY_HOSTNAME:
+                case PREFER_VERIFY_DBNAME:
+                case VERIFY_CA:
+                case VERIFY_HOSTNAME:
+                case VERIFY_DBNAME:
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 
     public enum PEER_SSL_MODE {

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/SSLPreferTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/SSLPreferTest.java
@@ -1,0 +1,59 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import java.util.logging.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class SSLPreferTest {
+
+    String ssldb, nonssldb, cluster, certpath, certpass;
+
+    @Before
+    public void setUp() {
+        nonssldb = System.getProperty("cdb2jdbc.test.database");
+        ssldb = System.getProperty("cdb2jdbc.test.ssldatabase");
+        cluster = System.getProperty("cdb2jdbc.test.cluster");
+        certpath = System.getProperty("cdb2jdbc.test.sslcertpath");
+        certpass = System.getProperty("cdb2jdbc.test.sslcertpass");
+    }
+
+
+    public void prefer_verify_ca(String db) throws SQLException {
+        Connection conn = null;
+        try {
+            conn = DriverManager.getConnection(String.format(
+                        "jdbc:comdb2://%s/%s?" +
+                        "ssl_mode=PREFER_VERIFY_CA&" +
+                        "trust_store=%s/truststore&" +
+                        "trust_store_password=%s&" +
+                        "key_store=%s/keystore&" +
+                        "key_store_password=%s",
+                        cluster, db, certpath, certpass, certpath, certpass));
+            conn.createStatement().executeQuery("SELECT 1");
+        } finally {
+            if (conn != null)
+                conn.close();
+        }
+    }
+
+    @Test public void prefer_verify_ca() throws SQLException {
+        /* Should work against either an SSL or a non-SSL db, since we're asking for 'prefer' */
+        prefer_verify_ca(nonssldb);
+        prefer_verify_ca(ssldb);
+    }
+
+
+    @Test public void prefer() throws SQLException {
+        Connection conn = null;
+        try {
+            conn = DriverManager.getConnection(String.format(
+                        "jdbc:comdb2://%s/%s?ssl_mode=PREFER",
+                        cluster, nonssldb));
+            conn.createStatement().executeQuery("SELECT 1");
+        } finally {
+            if (conn != null)
+                conn.close();
+        }
+    }
+}

--- a/db/db_access.c
+++ b/db/db_access.c
@@ -349,7 +349,7 @@ static int check_tag_access(struct ireq *iq) {
         return ERR_ACCESS;
     }
 
-    if (gbl_client_ssl_mode >= SSL_REQUIRE) {
+    if (SSL_IS_REQUIRED(gbl_client_ssl_mode)) {
         reqerrstr(iq, ERR_ACCESS, "The database requires SSL connections\n");
         return ERR_ACCESS;
     }

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -104,6 +104,14 @@ int ssl_process_lrl(char *line, size_t len)
         }
         if (tokcmp(tok, ltok, SSL_MODE_ALLOW) == 0)
             gbl_client_ssl_mode = SSL_ALLOW;
+        if (tokcmp(tok, ltok, SSL_MODE_PREFER) == 0)
+            gbl_client_ssl_mode = SSL_PREFER;
+        if (tokcmp(tok, ltok, SSL_MODE_PREFER_VERIFY_CA) == 0)
+            gbl_client_ssl_mode = SSL_PREFER_VERIFY_CA;
+        if (tokcmp(tok, ltok, SSL_MODE_PREFER_VERIFY_HOST) == 0)
+            gbl_client_ssl_mode = SSL_PREFER_VERIFY_HOSTNAME;
+        if (tokcmp(tok, ltok, SSL_MODE_PREFER_VERIFY_DBNAME) == 0)
+            gbl_client_ssl_mode = SSL_PREFER_VERIFY_DBNAME;
         else if (tokcmp(tok, ltok, SSL_MODE_REQUIRE) == 0)
             gbl_client_ssl_mode = SSL_REQUIRE;
         else if (tokcmp(tok, ltok, SSL_MODE_VERIFY_CA) == 0)
@@ -339,6 +347,14 @@ static const char *ssl_mode_to_string(ssl_mode mode)
         return "DISABLE";
     case SSL_ALLOW:
         return SSL_MODE_ALLOW;
+    case SSL_PREFER:
+        return SSL_MODE_PREFER;
+    case SSL_PREFER_VERIFY_CA:
+        return SSL_MODE_PREFER_VERIFY_CA;
+    case SSL_PREFER_VERIFY_HOSTNAME:
+        return SSL_MODE_PREFER_VERIFY_HOST;
+    case SSL_PREFER_VERIFY_DBNAME:
+        return SSL_MODE_PREFER_VERIFY_DBNAME;
     case SSL_REQUIRE:
         return SSL_MODE_REQUIRE;
     case SSL_VERIFY_CA:

--- a/docs/pages/config/ssl.md
+++ b/docs/pages/config/ssl.md
@@ -176,7 +176,7 @@ are refused to join the cluster.
 
 | LRL Directive | Description | Default Value |
 |---------------|-------------|---------------|
-| `ssl_client_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA`, `VERIFY_HOSTNAME` and `VERIFY_DBNAME` | `ALLOW` |
+| `ssl_client_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA`, `VERIFY_HOSTNAME`, `VERIFY_DBNAME`, `PREFER`, `PREFER_VERIFY_CA`, `PREFER_VERIFY_HOSTNAME` and `PREFER_VERIFY_DBNAME` | `ALLOW` |
 | `ssl_replicant_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA`, `VERIFY_HOSTNAME` and `VERIFY_DBNAME` | `ALLOW` |
 | `ssl_cert_path path` | Directory containing the server certificate files. Comdb2 searches `server.crt`, `server.key`, `root.crt` and `root.crl` for the server certificate, key, trusted CAs and CRL respectively | The data directory |
 | `ssl_cert file`| Path to the certificate | `<ssl_cert_path>/server.crt` |
@@ -191,7 +191,7 @@ are refused to join the cluster.
 
 | Option | Description | Default Value |
 |---------------|-------------|--------|
-| `ssl_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA`, `VERIFY_HOSTNAME` and `VERIFY_DBNAME` | `ALLOW` |
+| `ssl_mode mode` | Can be one of `ALLOW`, `REQUIRE`, `VERIFY_CA`, `VERIFY_HOSTNAME`, `VERIFY_DBNAME`, `PREFER`, `PREFER_VERIFY_CA`, `PREFER_VERIFY_HOSTNAME` and `PREFER_VERIFY_DBNAME` | `ALLOW` |
 | `ssl_cert_path path` | Directory containing client certificate files. libcdb2api searches `client.crt`, `client.key`, `root.crt` and `root.crl` for the client certificate, key, trusted CAs and CRL respectively | `N/A` |
 | `ssl_cert file` | Path to the client certificate | `<ssl_cert_path>/client.crt` |
 | `ssl_key file` | Path to the client key | `<ssl_cert_path>/client.key` |
@@ -205,10 +205,14 @@ are refused to join the cluster.
 
 |  Mode  | Encryption  | MITM | Overhead  |
 |---|---|---|---|
-|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead if the server requires SSL. No overhead otherwise. |
+|  `ALLOW` | Maybe |  Yes |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead if the peer requires SSL. No overhead otherwise. |
 |  `REQUIRE` | Yes  | Yes  |  SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead |
 | `VERIFY_CA` | Yes | Maybe if signed by 3rd party CA. No if self-signed or signed by a local CA. | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification |
 | `VERIFY_HOSTNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation |
 | `VERIFY_DBNAME` | Yes | No | SSL negotiation<sup>[1](#sslfootnote)</sup> + TLS protocol overhead + certificate verification + host name validation + database name validation |
+|  `PREFER` | Maybe |  Yes |  Behaves like `REQUIRE` if peer allows SSL; behaves like `ALLOW` otherwise. |
+|  `PREFER_VERIFY_CA` | Maybe |  Yes | Behaves LIKE `VERIFY_CA` if peer allows SSL; behaves like `ALLOW` otherwise.  |
+|  `PREFER_VERIFY_HOSTNAME` | Maybe |  Yes | Behaves LIKE `VERIFY_HOSTNAME` if peer allows SSL; behaves like `ALLOW` otherwise.  |
+|  `PREFER_VERIFY_DBNAME` | Maybe |  Yes | Behaves LIKE `VERIFY_DBNAME` if peer allows SSL; behaves like `ALLOW` otherwise.  |
 
-<a name="sslfootnote">[1]</a>: In order to establish an SSL connection to server, the client needs to negotiate with the server over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.
+<a name="sslfootnote">[1]</a>: In order to establish an SSL connection, the client and the server need to negotiate over the plaintext connection before upgrading to SSL. This happens only once for each connection establishment.

--- a/net/net.c
+++ b/net/net.c
@@ -939,7 +939,7 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
     *portnum = connect_message.my_portnum;
 
     if (connect_message.flags & CONNECT_MSG_SSL) {
-        if (gbl_rep_ssl_mode < SSL_ALLOW) {
+        if (!SSL_IS_ABLE(gbl_rep_ssl_mode)) {
             /* Reject if mis-configured. */
             logmsg(LOGMSG_ERROR,
                    "Misconfiguration: Peer requested SSL, "
@@ -955,7 +955,7 @@ static int read_connect_message(SBUF2 *sb, char hostname[], int hostnamel,
             logmsg(LOGMSG_ERROR, "%s\n", err);
             return -1;
         }
-    } else if (gbl_rep_ssl_mode >= SSL_REQUIRE) {
+    } else if (SSL_IS_REQUIRED(gbl_rep_ssl_mode)) {
         /* Reject if I require SSL. */
         logmsg(LOGMSG_WARN,
                "Replicant SSL connections are required.\n");
@@ -1018,7 +1018,7 @@ int write_connect_message(netinfo_type *netinfo_ptr,
     connect_message.to_portnum = host_node_ptr->port;
     /* It was `to_nodenum`. */
     connect_message.flags = 0;
-    if (gbl_rep_ssl_mode >= SSL_REQUIRE)
+    if (SSL_IS_REQUIRED(gbl_rep_ssl_mode))
         connect_message.flags |= CONNECT_MSG_SSL;
 
     if (netinfo_ptr->myhostname_len > HOSTNAME_LEN) {
@@ -1100,7 +1100,7 @@ int write_connect_message(netinfo_type *netinfo_ptr,
         }
     }
 
-    if (gbl_rep_ssl_mode >= SSL_REQUIRE) {
+    if (SSL_IS_REQUIRED(gbl_rep_ssl_mode)) {
         net_flush(host_node_ptr);
         if (sslio_connect(sb, gbl_ssl_ctx, gbl_rep_ssl_mode, gbl_dbname,
                           gbl_nid_dbname, 1) != 1) {

--- a/tests/setup
+++ b/tests/setup
@@ -87,7 +87,7 @@ setup_db() {
     LRL="$DBDIR/$DBNAME.lrl"
     > ${LRL}
 
-    if [[ -z "${SKIPSSL}" ]] ; then
+    if [[ -z "${SKIPSSL}" && $DBNAME != *"nossl"* ]] ; then
         echo -e "ssl_client_mode REQUIRE\nssl_cert_path $TESTDIR" >> ${LRL}
     fi
 

--- a/tests/ssl_prefer.test/Makefile
+++ b/tests/ssl_prefer.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/ssl_prefer.test/runit
+++ b/tests/ssl_prefer.test/runit
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#############################################
+# Test SSL prefer modes                     #
+#############################################
+
+dbnm=$1
+keydir=$DBDIR
+set -e
+
+# Generate my own CA
+openssl req -x509 -newkey rsa:4096 -keyout $keydir/mycakey.pem \
+            -out $keydir/mycacrt.pem -days 365 -nodes \
+            -subj "/C=US/ST=New York/L=New York/O=Bloomberg/OU=Comdb2/CN=*.bloomberg.com"
+chmod a+r $keydir/mycacrt.pem
+
+# these should succeed regardless of whether backend supports ssl
+SSL_MODE=PREFER cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+SSL_MODE=PREFER_VERIFY_CA cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+SSL_MODE=PREFER_VERIFY_HOSTNAME cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+
+if [[ $dbnm == *"nossl"* ]] ; then
+  SSL_MODE=ALLOW cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+  SSL_MODE=REQUIRE cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1' 2>&1 | grep 'does not support SSL'
+  SSL_MODE=VERIFY_CA cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1' 2>&1 | grep 'does not support SSL'
+  SSL_MODE=VERIFY_HOSTNAME cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1' 2>&1 | grep 'does not support SSL'
+else
+  SSL_MODE=ALLOW cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+  SSL_MODE=REQUIRE cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+  SSL_MODE=VERIFY_CA cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+  SSL_MODE=VERIFY_HOSTNAME cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1'
+  # Make sure that we validate server identity in prefer modes, if server supports ssl
+  SSL_MODE=PREFER_VERIFY_CA SSL_CA=$keydir/mycacrt.pem cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1' 2>&1 | grep 'certificate verify failed'
+  SSL_MODE=PREFER_VERIFY_HOSTNAME SSL_CA=$keydir/mycacrt.pem cdb2sql ${CDB2_OPTIONS} $dbnm default 'SELECT 1' 2>&1 | grep 'certificate verify failed'
+fi

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -108,7 +108,10 @@ static int ssl_verify(SBUF2 *sb, ssl_mode mode, const char *dbname, int nid)
         }
     }
 #endif
-    if (sb->ssl != NULL && mode >= SSL_VERIFY_CA) {
+    if (sb->ssl != NULL && SSL_NEEDS_VERIFICATION(mode)) {
+        /* Convert SSL_PREFER_VERIFY_XXX to SSL_VERIFY_XXX */
+        if (SSL_IS_OPTIONAL(mode))
+            mode += (SSL_REQUIRE - SSL_PREFER);
         sb->cert = SSL_get_peer_certificate(sb->ssl);
         if (sb->cert == NULL) {
             ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr), my_ssl_eprintln,

--- a/util/ssl_support.c
+++ b/util/ssl_support.c
@@ -86,7 +86,7 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
     /* If we are told to verify peer, and cacert file is NULL,
        we explicitly make one with the default name so that
        ssl_new_ctx() would fail if it could not load the CA. */
-    if (mode >= SSL_VERIFY_CA && *pca == NULL) {
+    if (SSL_NEEDS_VERIFICATION(mode) && *pca == NULL) {
         if (dir == NULL) {
             ssl_sfeprint(err, n, my_ssl_eprintln,
                          "A trusted CA certificate is required "


### PR DESCRIPTION
This patch adds 4 SSL modes which are useful if a client talks to multiple data sources that may or may not speak SSL, and the client wants to use SSL whenever possible.