### PR TITLE
Fix lazy_id_mutex deadlock

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -1087,6 +1087,7 @@ int bdb_rename_table(bdb_state_type *bdb_state, tran_type *tran, char *newname,
     rc = close_dbs_flush(bdb_state);
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "upgrade: open_dbs as master failed\n");
+        __dbreg_unlock_lazy_id(bdb_state->dbenv);
         return -1;
     }
 
@@ -1096,6 +1097,7 @@ int bdb_rename_table(bdb_state_type *bdb_state, tran_type *tran, char *newname,
     if (rc != 0) {
         logmsg(LOGMSG_ERROR, "upgrade: open_dbs as master failed\n");
         bdb_state->origname = saved_origname;
+        __dbreg_unlock_lazy_id(bdb_state->dbenv);
         return -1;
     }
 
@@ -1106,6 +1108,7 @@ int bdb_rename_table(bdb_state_type *bdb_state, tran_type *tran, char *newname,
         bdb_state->name = saved_name;
         bdb_state->origname = saved_origname;
         logmsg(LOGMSG_ERROR, "upgrade: open_dbs as master failed\n");
+        __dbreg_unlock_lazy_id(bdb_state->dbenv);
         return -1;
     }
     bdb_state->name = saved_name;

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -397,7 +397,6 @@ __ufid_add_dbp(dbenv, dbp)
 
 	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
 	if ((ufid = hash_find(dbenv->ufid_to_db_hash, dbp->fileid))) {
-#if 0
 		if (ufid->dbp != NULL && ufid->dbp != dbp) {
 			/* There may be 2 dbp's for the same ufid, if a replicant upgrades to a
 			   master and later assigns a dbreg ID to a btree (see __dbreg_lazy_id).
@@ -405,7 +404,6 @@ __ufid_add_dbp(dbenv, dbp)
 			   __db_close() doesn't mistakenly clear the new dbp. */
 			ufid->dbp->added_to_ufid = 0;
 		}
-#endif
 	} else {
 		if ((ret = __os_malloc(dbenv, sizeof(*ufid), &ufid)) != 0) {
 			abort();
@@ -1170,11 +1168,14 @@ __dbreg_lazy_id(dbp)
 	lp = dblp->reginfo.primary;
 	fnp = dbp->log_filename;
 
+	/* The lazy_id_mutex protects replication from allocating
+	   a new dbreg ID in the middle of a schema change. */
 	MUTEX_LOCK(dbenv, &lp->lazy_id_mutex);
 	/* The fq_mutex protects the FNAME list and id management. */
 	MUTEX_LOCK(dbenv, &lp->fq_mutex);
 	if (fnp->id != DB_LOGFILEID_INVALID) {
 		MUTEX_UNLOCK(dbenv, &lp->fq_mutex);
+		MUTEX_UNLOCK(dbenv, &lp->lazy_id_mutex);
 		return (0);
 	}
 	id = DB_LOGFILEID_INVALID;


### PR DESCRIPTION
Ensure that lazy_id_mutex is always released.

(DRQS 170729627)