### PR TITLE
Fix linker error in debug build 

### DIFF
--- a/util/time_accounting.h
+++ b/util/time_accounting.h
@@ -21,7 +21,7 @@
 
 #ifndef NDEBUG
 
-enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX } CHR_ENUM;
+typedef enum { CHR_IXADDK, CHR_DATADD, CHR_TMPSVOP, CHR_MAX } CHR_ENUM;
 
 /* NB: this construct is ment to encompass a function call like this:
  * ACCUMULATE_TIMING(CHR_FUNCTOMEASURE


### PR DESCRIPTION
A debug build fails with 'multiple definitions' error. This patch fixes it 