### PR TITLE
Provide a hook for plugins to specify a different fastseed generator.

### DIFF
--- a/db/envstubs.c
+++ b/db/envstubs.c
@@ -56,6 +56,8 @@ static inline void fastseed_set_dup(int dup) { fastseed_dup = dup; }
 
 extern int gbl_mynodeid;
 
+uint64_t (*external_fastseed)(void) = NULL;
+
 /* TODO: fastseed - compatibility mode only - remove */
 uint64_t comdb2fastseed(void)
 {
@@ -64,6 +66,9 @@ uint64_t comdb2fastseed(void)
     int retries;
     int seed[2];
     uint64_t out;
+
+    if (external_fastseed)
+        return external_fastseed();
 
     node = gbl_mynodeid;
     if (node < 1 || node > MAXNODE) {


### PR DESCRIPTION
Porting from 7.0

This is used in 2 places: rqids when noenv messages are disabled (soon to go away), and values for comdb2_seqno, which is going to go away once we replace the current local replicants with physical local replicants.  So hopefully this change is temporary, and all fastseed related code can be deleted.