### PR TITLE
Make tzname NULL for partial datacopy

### DIFF
--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -2210,7 +2210,7 @@ static int insert_record_indexes(BtCursor *pCur, struct sql_thread *thd,
         if (pCur->db->ix_datacopy[ix]) {
             if (pCur->db->ix_datacopylen[ix] > 0) { // partial datacopy
                 datacopy = alloca(pCur->db->ix_datacopylen[ix]);
-                rc = stag_to_stag_buf_schemas(get_schema(pCur->db, -1), get_schema(pCur->db, ix)->partial_datacopy, pCur->ondisk_buf, datacopy, pCur->db->tablename);
+                rc = stag_to_stag_buf_schemas(get_schema(pCur->db, -1), get_schema(pCur->db, ix)->partial_datacopy, pCur->ondisk_buf, datacopy, NULL);
                 if (rc == -1) {
                     logmsg(LOGMSG_ERROR, "insert_record:partial datacopy conversion ix %d\n", ix);
                     return SQLITE_INTERNAL;

--- a/db/verify.c
+++ b/db/verify.c
@@ -254,7 +254,7 @@ static int verify_formkey_callback(const dbtable *tbl, void *dta,
 
 static int convert_to_partial_datacopy(const struct dbtable *tbl, const int pd_ix, const void *inbuf, void *outbuf)
 {
-    return stag_to_stag_buf_schemas(tbl->schema, tbl->schema->ix[pd_ix]->partial_datacopy, inbuf, outbuf, tbl->tablename);
+    return stag_to_stag_buf_schemas(tbl->schema, tbl->schema->ix[pd_ix]->partial_datacopy, inbuf, outbuf, NULL);
 }
 
 static int verify_add_blob_buffer_callback(void *parm, void *dta, int dtasz,


### PR DESCRIPTION
Only had wrong tzname for stag_to_stag calls, and server to server for datetime doesn't appear to use tzname at all, so bug should have no effect

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
