### PR TITLE
Add Transaction State Systable

### DIFF
--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -63,6 +63,7 @@
 #include "txn_properties.h"
 
 static unsigned int curtran_counter = 0;
+extern int gbl_debug_txn_sleep;
 extern int __txn_getpriority(DB_TXN *txnp, int *priority);
 
 #if 0
@@ -1037,6 +1038,9 @@ static tran_type *bdb_tran_begin_ll_int(bdb_state_type *bdb_state,
                                         int tranclass, int *bdberr,
                                         u_int32_t inflags)
 {
+    if (gbl_debug_txn_sleep)
+        sleep(gbl_debug_txn_sleep);
+
     tran_type *tran;
     int rc;
     DB_TXN *parent_tid;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -343,6 +343,7 @@ int gbl_debug_omit_dta_write;
 int gbl_debug_omit_idx_write;
 int gbl_debug_omit_blob_write;
 int gbl_debug_omit_zap_on_rebuild = 0;
+int gbl_debug_txn_sleep = 0;
 int gbl_debug_skip_constraintscheck_on_insert;
 int gbl_readonly = 0;
 int gbl_init_single_meta = 1;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -362,6 +362,7 @@ extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_debug_omit_zap_on_rebuild;
+extern int gbl_debug_txn_sleep;
 extern int gbl_instrument_consumer_lock;
 extern int gbl_reject_mixed_ddl_dml;
 extern int gbl_debug_create_master_entry;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1315,6 +1315,10 @@ REGISTER_TUNABLE("debug.omit_zap_on_rebuild",
                  " (Default: 0)", TUNABLE_BOOLEAN,
                  &gbl_debug_omit_zap_on_rebuild, INTERNAL, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("debug.txn_sleep",
+                 "Sleep during a transaction to test transaction state systable", TUNABLE_INTEGER,
+                 &gbl_debug_txn_sleep, INTERNAL, NULL, NULL, NULL,
+                 NULL);
 REGISTER_TUNABLE("bdboslog", NULL, TUNABLE_INTEGER, &gbl_namemangle_loglevel,
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("deadlock_rep_retry_max", NULL, TUNABLE_INTEGER,

--- a/db/transactionstate_systable.h
+++ b/db/transactionstate_systable.h
@@ -1,0 +1,32 @@
+/*
+   Copyright 2022 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef __TRANSACTIONSTATE_SYSTABLE_H_
+#define __TRANSACTIONSTATE_SYSTABLE_H_
+
+typedef struct thd_info {
+    char *state;
+    double time;
+    char *machine;
+    char *opcode;
+    char *function;
+    int64_t isIdle;
+} thd_info;
+
+int get_thd_info(thd_info **data, int *npoints);
+void free_thd_info(thd_info *data, int npoints);
+
+#endif

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -599,6 +599,18 @@ Lists all the transaction log records.
 * `timestamp` - Timestamp
 * `payload` - Paylod
 
+## comdb2_transaction_state
+
+Lists the state of all threads processing transactions.
+
+    comdb2_transaction_state(state, time, machine, opcode, function)
+
+* `state` - Thread state ('busy' or 'idle')
+* `time` - The amount of time (ms) that the thread has been processing this request 
+* `machine` - The ID of the machine that the thread is running on
+* `opcode` - The opcode that the thread is processing
+* `function` - The backend function that the thread is running
+
 ## comdb2_triggers
 
 Lists triggers in the database.

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(sqlite
   ext/comdb2/timepartitions.c
   ext/comdb2/timeseries.c
   ext/comdb2/tranlog.c
+  ext/comdb2/transactionstate.c
   ext/comdb2/triggers.c
   ext/comdb2/tunables.c
   ext/comdb2/typesamples.c

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -87,6 +87,7 @@ int systblTablePermissionsInit(sqlite3 *db);
 int systblSystabPermissionsInit(sqlite3 *db);
 int systblTimepartPermissionsInit(sqlite3 *db);
 int systblFdbInfoInit(sqlite3 *db);
+int systblTransactionStateInit(sqlite3 *db);
 int systblMemstatsInit(sqlite3 *db);
 
 /* Simple yes/no answer for booleans */

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -334,6 +334,8 @@ int comdb2SystblInit(
     rc = sqlite3_carray_init(db, 0, 0);
   if (rc == SQLITE_OK)
     rc = systblMemstatsInit(db);
+  if (rc == SQLITE_OK)
+    rc = systblTransactionStateInit(db);
 #endif
   return rc;
 }

--- a/sqlite/ext/comdb2/transactionstate.c
+++ b/sqlite/ext/comdb2/transactionstate.c
@@ -1,0 +1,50 @@
+/*
+   Copyright 2022 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+#include "comdb2.h"
+#include "comdb2systblInt.h"
+#include "sql.h"
+#include "ezsystables.h"
+#include "types.h"
+#include "transactionstate_systable.h"
+
+sqlite3_module systblTransactionStateModule = {
+    .access_flag = CDB2_ALLOW_USER,
+};
+
+int get_thread_info(void **data, int *npoints) {
+    return get_thd_info((thd_info **) data, npoints);
+}
+
+void free_thread_info(void *data, int npoints) {
+    free_thd_info((thd_info *) data, npoints);
+}
+
+int systblTransactionStateInit(sqlite3 *db) {
+    return create_system_table(
+        db, "comdb2_transaction_state", &systblTransactionStateModule,
+        get_thread_info, free_thread_info, sizeof(thd_info),
+        CDB2_CSTRING, "state", -1, offsetof(thd_info, state),
+        CDB2_REAL, "time", offsetof(thd_info, isIdle), offsetof(thd_info, time),
+        CDB2_CSTRING, "machine", offsetof(thd_info, isIdle), offsetof(thd_info, machine),
+        CDB2_CSTRING, "opcode", offsetof(thd_info, isIdle), offsetof(thd_info, opcode),
+        CDB2_CSTRING, "function", offsetof(thd_info, isIdle), offsetof(thd_info, function),
+        SYSTABLE_END_OF_FIELDS);
+}

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -268,6 +268,7 @@
 (candidate='comdb2_timepartshards')
 (candidate='comdb2_timeseries')
 (candidate='comdb2_transaction_logs')
+(candidate='comdb2_transaction_state')
 (candidate='comdb2_triggers')
 (candidate='comdb2_tunables')
 (candidate='comdb2_type_samples')

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -66,6 +66,7 @@ unknown @ls sub-command foo
 (name='comdb2_timepartshards')
 (name='comdb2_timeseries')
 (name='comdb2_transaction_logs')
+(name='comdb2_transaction_state')
 (name='comdb2_triggers')
 (name='comdb2_tunables')
 (name='comdb2_type_samples')

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -406,6 +406,7 @@
 (name='comdb2_timepartshards')
 (name='comdb2_timeseries')
 (name='comdb2_transaction_logs')
+(name='comdb2_transaction_state')
 (name='comdb2_triggers')
 (name='comdb2_tunables')
 (name='comdb2_type_samples')

--- a/tests/comdb2sys.test/runit
+++ b/tests/comdb2sys.test/runit
@@ -146,6 +146,10 @@ rc=$?
 
 ./testindexusage $a_dbn
 rc2=$?
+
+./testtransactionstate $a_dbn
+rc3=$?
+[[ $rc3 -ne 0 ]] && rc2=$rc3 
 [[ $rc2 -ne 0 ]] && rc=$rc2
 
 exit $rc

--- a/tests/comdb2sys.test/testtransactionstate
+++ b/tests/comdb2sys.test/testtransactionstate
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+a_dbn=$1
+master=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_cluster where is_master="Y"')
+master=$(echo $master | grep -oP \'\(.*?\)\')
+master=${master:1:-1}
+
+setup () {
+cdb2sql ${CDB2_OPTIONS} $a_dbn --host $master 'put tunable debug.txn_sleep = 5'
+cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+create table txtest(a int); \$\$
+insert into txtest(a) values(1);
+EOF
+}
+
+setup &
+sleep 1 
+cdb2sql ${CDB2_OPTIONS} $a_dbn --host $master 'select * from comdb2_transaction_state' >> testtransactionstate.out
+
+nbusy=$(grep -o 'busy' testtransactionstate.out | wc -l)
+rc=$(($nbusy==0 ? 1 : 0)) # There should be at least one busy thread 
+
+if [[ $rc -ne 0  ]]; then
+    echo "Failed transaction state test"
+fi
+
+exit $rc

--- a/tests/userschema.test/t00.expected
+++ b/tests/userschema.test/t00.expected
@@ -53,6 +53,7 @@
 (tablename='comdb2_timepartshards', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_timeseries', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_transaction_logs', username='mohit', READ='Y', WRITE='Y', DDL='Y')
+(tablename='comdb2_transaction_state', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_triggers', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_tunables', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_type_samples', username='mohit', READ='Y', WRITE='Y', DDL='Y')


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.): 
> Feature.
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement: 
> Transaction state is currently queried via a command (`@send dmpl`). This PR adds a system table (`comdb2_transaction_state`) that contains transaction state. In the future, users should query this system table instead of using `dmpl` to get transaction state.
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
