### PR TITLE
Turn off TLS compression

### DIFF
--- a/util/ssl_support.c
+++ b/util/ssl_support.c
@@ -68,7 +68,7 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
     int servermode;
     struct stat buf;
     STACK_OF(X509_NAME) *cert_names;
-    long protocols = 0;
+    long options = 0;
     int ii;
 
 #if SBUF2_SERVER
@@ -268,15 +268,19 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
     };
     #undef XMACRO_SSL_NO_PROTOCOLS
 
+#ifdef SSL_OP_NO_COMPRESSION
+    options |= SSL_OP_NO_COMPRESSION;
+#endif
+
     for (ii = 0; ii != sizeof(ssl_no_protocols) / sizeof(ssl_no_protocols[0]);
          ++ii) {
         if (ssl_no_protocols[ii].tlsver < mintlsver)
-            protocols |= ssl_no_protocols[ii].opensslver;
+            options |= ssl_no_protocols[ii].opensslver;
     }
 
     /* Disable SSL protocols to prevent POODLE attack (CVE-2014-3566). */
-    if (protocols != 0)
-        SSL_CTX_set_options(myctx, protocols);
+    if (options != 0)
+        SSL_CTX_set_options(myctx, options);
 
     /* We need the flag to be able to write as fast as possible.
        We let sbuf2/comdb2buf take care of uncomplete writes. */


### PR DESCRIPTION
TLS compression is venerable to the CRIME attack. It's also slower than using uncompressed data, on a high-speed network where data transmits faster than compression can process.
