### PR TITLE
Allow auto analyze on IAM enabled databases

### DIFF
--- a/db/db_access.c
+++ b/db/db_access.c
@@ -83,7 +83,8 @@ static int check_user_password(struct sqlclntstate *clnt)
     int password_rc = 0;
     int valid_user;
 
-    if ((gbl_uses_externalauth || gbl_uses_externalauth_connect) && externalComdb2AuthenticateUserMakeRequest && !clnt->admin) {
+    if ((gbl_uses_externalauth || gbl_uses_externalauth_connect) && externalComdb2AuthenticateUserMakeRequest &&
+            !clnt->admin && !clnt->current_user.bypass_auth) {
         clnt->authdata = get_authdata(clnt);
         if (gbl_externalauth_warn && !clnt->authdata) {
             logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -126,6 +126,8 @@ typedef struct table_descriptor {
     int override_llmeta;
     index_descriptor_t index[MAXINDEX];
     struct user current_user;
+    void *appdata;
+    void *get_authdata;
 } table_descriptor_t;
 
 /* loadStat4 (analyze.c) will ignore all stat entries
@@ -736,7 +738,9 @@ static int analyze_table_int(table_descriptor_t *td,
     clnt.osql_max_trans = 0; // allow large transactions
     int sampled_table = 0;
 
-    clnt.current_user = td->current_user;
+    clnt.current_user        = td->current_user;
+    clnt.appdata             = td->appdata;
+    clnt.plugin.get_authdata = td->get_authdata;
 
     logmsg(LOGMSG_INFO, "Analyze thread starting, table %s (%d%%)\n", td->table, td->scale);
 
@@ -1099,6 +1103,8 @@ int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
 
     if (clnt) {
         td.current_user = clnt->current_user;
+        td.appdata      = clnt->appdata;
+        td.get_authdata = clnt->plugin.get_authdata;
     }
     td.current_user.bypass_auth = bypass_auth;
 


### PR DESCRIPTION
Will need only for connect, for rest in_sqlite_init/no_transaction (7.0) takes care of it
{DRQS 170823925}
Signed-off-by: mohitkhullar <mkhullar1@bloomberg.net>
