### PR TITLE
Fix scabort and truncate

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -5263,6 +5263,7 @@ void *get_field_ptr_in_buf(struct schema *sc, int idx, const void *buf)
     return (void *)(cptr + sc->member[idx].offset);
 }
 
+void reset_sc_stat();
 static int backout_schemas_lockless(const char *tblname)
 {
     struct dbtag *dbt;
@@ -5285,6 +5286,7 @@ static int backout_schemas_lockless(const char *tblname)
         sc = tmp;
     }
 
+    reset_sc_stat();
     return 0;
 }
 


### PR DESCRIPTION
`send scabort` would prevent any subsequent `truncate-table` statements from running. This patch fixes it.

(DRQS 170817909)