### PR TITLE
netpoll

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -770,6 +770,7 @@ REGISTER_TUNABLE("net_poll",
                  "shut down. (Default: 100ms)",
                  TUNABLE_INTEGER, &gbl_net_poll, READONLY, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("netpoll", "Alias of net_poll", TUNABLE_INTEGER, &gbl_net_poll, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("net_portmux_register_interval",
                  "Check on this interval if our port is correctly registered "
                  "with pmux for the replication net. (Default: 600ms)",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -548,6 +548,7 @@
 (name='net_verbose', description='net_verbose', type='BOOLEAN', value='OFF', read_only='N')
 (name='netbufsz', description='Size of the network buffer (per node) for the replication network. (Default: 1MB)', type='INTEGER', value='1048576', read_only='Y')
 (name='netconndumptime', description='Dump connection statistics to ctrace this often.', type='INTEGER', value='3158070', read_only='N')
+(name='netpoll', description='Alias of net_poll', type='INTEGER', value='100', read_only='Y')
 (name='new_indexes', description='Let replicants send indexes values to master', type='BOOLEAN', value='OFF', read_only='N')
 (name='new_master_dummy_add_delay', description='Force a transaction after this delay, after becoming master.', type='INTEGER', value='5', read_only='N')
 (name='newqdelmode', description='Enables new queue deletion mode.', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
This patch adds a "netpoll" LRL directive, which is just an alias for "net_poll", to be consistent with the `send net_poll` message trap.

(DRQS 170771155)