### PR TITLE
Tunable to control warning about mismatch of equiv types

### DIFF
--- a/db/db_fingerprint.c
+++ b/db/db_fingerprint.c
@@ -34,6 +34,7 @@ pthread_mutex_t gbl_fingerprint_hash_mu = PTHREAD_MUTEX_INITIALIZER;
 extern int gbl_fingerprint_queries;
 extern int gbl_verbose_normalized_queries;
 int gbl_fingerprint_max_queries = 1000;
+int gbl_warn_on_equiv_types;
 
 static int free_fingerprint(void *obj, void *arg)
 {
@@ -132,6 +133,16 @@ static void do_type_checks(struct sqlclntstate *clnt, sqlite3_stmt *stmt, struct
     for (int i = 0; i < cachedColCount; i++) {
         char *newtype = stmt_column_decltype(stmt, i);
         char *oldtype = stmt_cached_column_decltype(stmt, i);
+
+        /* Do not warn when old and new Sqlite versions return different but
+           equivalent data types for the column.
+        */
+        if (gbl_warn_on_equiv_types == 0 &&
+            ((strcmp(oldtype, "text") == 0 && strncmp(newtype, "char", 4) == 0) ||    // text vs char[N]
+             (strcmp(oldtype, "integer") == 0 && strcmp(newtype, "int") == 0))) {     // integer vs int
+            continue;
+        }
+
         if (strcmp(newtype, oldtype) != 0) {
             strbuf_appendf(newtypes, "%s%s %s", typesep, stmt_column_name(stmt, i), newtype);
             strbuf_appendf(oldtypes, "%s%s %s", typesep, stmt_cached_column_name(stmt, i), oldtype);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -356,6 +356,7 @@ extern int gbl_longreq_log_freq_sec;
 extern int gbl_pgcomp_dryrun;
 extern int gbl_pgcomp_dbg_stdout;
 extern int gbl_pgcomp_dbg_ctrace;
+extern int gbl_warn_on_equiv_types;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_page_order_table_scan;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2065,4 +2065,7 @@ REGISTER_TUNABLE("pgcomp_dbg_stdout", "Enable debugging stdout trace for page co
                  &gbl_pgcomp_dbg_stdout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("pgcomp_dbg_ctrace", "Enable debugging ctrace for page compaction (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_pgcomp_dbg_ctrace, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("warn_on_equiv_types", "Warn about mismatch of different but equivalent data types "
+                 "returned by different sqlite versions (Default off)", TUNABLE_BOOLEAN,
+                 &gbl_warn_on_equiv_types, NOARG | EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Comdb2 can additionally run an older Sqlite version to ensure it returns stable column names and data types across major Comdb2 versions. It also emits a warning in the server logs when a mismatch is detected.

This patch introduces a tunable `warn_on_equiv_type_mismatch` (off by default), which when disabled, forces Comdb2 to not warn on mismatch of equivalent data types.

This tunable only takes effect when `old_column_names` is enabled.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>