### PR TITLE
Turn off retries on non-durable commit by default.

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3102,7 +3102,7 @@ static int node_in_list(int node, int list[], int listsz)
 
 /* ripped out ALL SUPPORT FOR ALL BROKEN CRAP MODES, aside from "newcoh" */
 
-int gbl_replicant_retry_on_not_durable = 1;
+int gbl_replicant_retry_on_not_durable = 0;
 static int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state,
                                             seqnum_type *seqnum, int *timeoutms,
                                             uint64_t txnsize, int newcoh)

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2198,7 +2198,7 @@ REGISTER_TUNABLE("sockbplog_sockpool",
                  &gbl_sockbplog_sockpool, READONLY | NOARG, NULL, NULL, NULL,
                  NULL);
 
-REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: on)",
+REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durable writes.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_replicant_retry_on_not_durable, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE(

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -765,7 +765,7 @@
 (name='repl_wait', description='Replication wait system enabled for queues', type='BOOLEAN', value='ON', read_only='N')
 (name='replicant_latches', description='Also acquire latches on replicants. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicant_latency', description='Replicant drops log records.', type='BOOLEAN', value='OFF', read_only='N')
-(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='replicant_retry_on_not_durable', description='Replicant retries non-durable writes.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='replicate_local', description='When enabled, record all database events to a comdb2_oplog table. This can be used to set clusters/instances that are fed data from a database cluster. Alternate ways of doing this are being planned, so enabling this option should not be needed in the near future. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_local_concurrent', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='replicate_rowlocks', description='Replicate rowlocks', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Match 7.0.  This option was mean to return a "maybe" return code when we return from waiting for replicants, having received less than half the replies.  It doesn't work in its current state - we also end up returning an error when replicants are incoherent because they're operationally marked offline.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>