### PR TITLE
Tunable to control warning about mismatch of equiv types (upmerge from 7.0)

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -380,6 +380,7 @@ extern int gbl_disable_seekscan_optimization;
 extern int gbl_pgcomp_dryrun;
 extern int gbl_pgcomp_dbg_stdout;
 extern int gbl_pgcomp_dbg_ctrace;
+extern int gbl_warn_on_equiv_type_mismatch;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2281,4 +2281,7 @@ REGISTER_TUNABLE("pgcomp_dbg_ctrace", "Enable debugging ctrace for page compacti
 REGISTER_TUNABLE("dump_history_on_too_many_verify_errors",
                  "Dump osql history and client info on too many verify errors (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_dump_history_on_too_many_verify_errors, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("warn_on_equiv_type_mismatch", "Warn about mismatch of different but equivalent data types "
+                 "returned by different sqlite versions (Default off)", TUNABLE_BOOLEAN,
+                 &gbl_warn_on_equiv_type_mismatch, NOARG | EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Comdb2 can additionally run an older Sqlite version to ensure it returns stable column names and data types across major Comdb2 versions. It also emits a warning in the server logs when a mismatch is detected.

This patch introduces a tunable 'warn_on_equiv_type_mismatch' (off by default), which when disabled, forces Comdb2 to not warn on mismatch of equivalent data types.

This tunable only takes effect when 'old_column_names' is enabled.

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>