### PR TITLE
Fix table constraints systable bug 7.0

### DIFF
--- a/tests/comdb2sys.test/runit
+++ b/tests/comdb2sys.test/runit
@@ -142,6 +142,10 @@ rc=$?
 
 ./testindexusage $a_dbn
 rc2=$?
+
+./testtableconstraints $a_dbn
+rc3=$?
+[[ $rc3 -ne 0 ]] && rc2=$rc3
 [[ $rc2 -ne 0 ]] && rc=$rc2
 
 exit $rc

--- a/tests/comdb2sys.test/testtableconstraints
+++ b/tests/comdb2sys.test/testtableconstraints
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+a_dbn=$1
+rc=0
+OpUsr='op'
+NoOpUsr='nop'
+password='password'
+ParentTable='foo'
+ChildTable='bar'
+EnabledTable='baz'
+
+# Setup authentication and create parent table
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+put password '$password' for $OpUsr
+put password '$password' for $NoOpUsr 
+grant op to '$OpUsr'
+
+set user '$OpUsr'
+set password '$password'
+put authentication on
+create table $ParentTable{schema {int i int j} keys {"K1"=i "K2"=j}};
+EOF
+
+# Create child table
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+set user '$OpUsr'
+set password '$password'
+create table $ChildTable{schema {int i int j} keys {"K1"=i "K2"=j} constraints {"K1"-><"$ParentTable":"K1"> "K2"-><"$ParentTable":"K2">}};
+EOF
+
+# Create table without constraints that NoOpUsr will have access to
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+set user '$OpUsr'
+set password '$password'
+create table $EnabledTable{schema {int i} keys {"K1"=i}};
+EOF
+
+# Deny NoOpUsr access to all tables except for EnabledTable
+
+tables=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+set user '$OpUsr'
+set password '$password'
+select name from comdb2_systables union select tablename from comdb2_tables
+EOF
+)
+
+for table in $tables
+do
+    table=$(echo $table | grep -oP name=\'\(.*?\)\')
+    table=${table:6:-1}
+    if [[ ! -z "$table" ]]
+    then
+        cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+        set user '$OpUsr'
+        set password '$password'
+        revoke read on $table to '$NoOpUsr'
+EOF
+    fi
+done
+
+# Read from comdb2_constraints. OpUsr should see foo's constraints and NoOpUsr should see no constraints.
+
+(cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+    set user '$OpUsr'
+    set password '$password'
+    grant ddl on $EnabledTable to $NoOpUsr
+    grant read on comdb2_constraints to $NoOpUsr
+    select * from comdb2_constraints
+EOF
+) > testtableconstraints.out1
+
+(cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+    set user '$NoOpUsr'
+    set password '$password'
+    select * from comdb2_constraints
+EOF
+) > testtableconstraints.out2
+
+
+constraint1=$(grep -o "tablename='bar', keyname='K1', foreigntablename='foo', foreignkeyname='K1', iscascadingdelete='N', iscascadingupdate='N'" testtableconstraints.out1)
+constraint2=$(grep -o "tablename='bar', keyname='K2', foreigntablename='foo', foreignkeyname='K2', iscascadingdelete='N', iscascadingupdate='N'" testtableconstraints.out1)
+badconstriant=$(grep -o "keyname" testtableconstraints.out2)
+
+if [ ! -z "$badconstriant" ] | [ -z "$constraint1" ] | [ -z "$constraint2" ]
+then
+    rc=1
+    echo "Failed testtableconstraints"
+fi
+
+# Cleanup
+cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
+    set user '$OpUsr'
+    set password '$password'
+    put authentication off
+EOF
+
+exit $rc


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
> Bug fix
* What are the current behavior and expected behavior, if this is a bugfix ?
> [`systblConstraintsNext`](https://github.com/bloomberg/comdb2/compare/7.0...morgando:comdb2:fix-constraints-systable-7.0?expand=1#diff-97cd7562d8911d21ed051bf4fd6ac441219bd41fd5cdb8d6efb15fb0e4b469c8R115) advances the cursor to the next record in `comdb2_tableconstraints`. This function is expected to only point the cursor at tables that (1) the current user has access to and (2) have unread constraints. The current implementation of this function finds the next table with available constraints and then finds the next table that the user has access to. If the next table that the user has access to causes the table cursor to advance to a table with no available constraints, then the db will try to read these constraints and segfault.

* What are the steps required to reproduce the bug, if this is a bugfix ?
> [This test script reproduces the sequence of events described above](https://github.com/bloomberg/comdb2/compare/7.0...morgando:comdb2:fix-constraints-systable-7.0?expand=1#diff-14455bbf308f72e5674c9697a826d61741cd194564bb583f19468362fee275dcR1)
