### PR TITLE
Remove experimental/internal from collect_before_locking

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1914,7 +1914,7 @@ REGISTER_TUNABLE("ufid_remove_dbp", "Remove dbp from ufid-hash.  (Default: off)"
                  &gbl_ufid_remove_dbp, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("collect_before_locking", "Collect a transaction from the log before acquiring locks.  (Default: on)",
-                 TUNABLE_BOOLEAN, &gbl_collect_before_locking, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+                 TUNABLE_BOOLEAN, &gbl_collect_before_locking, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=968)
+(TUNABLES_COUNT=969)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -122,6 +122,7 @@
 (name='clean_exit_on_sigterm', description='Attempt to do orderly shutdown on SIGTERM (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='coherency_lease', description='A coherency lease grants a replicant the right to be coherent for this many ms.', type='INTEGER', value='500', read_only='N')
 (name='coherency_lease_udp', description='Use udp to issue leases.', type='BOOLEAN', value='ON', read_only='N')
+(name='collect_before_locking', description='Collect a transaction from the log before acquiring locks.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='commit_delay_on_copy_ms', description='Set automatic delay-ms for commit-delay on copy.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='commit_delay_timeout_seconds', description='Set timeout for commit-delay on copy.  (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This makes collect_before_locking tunable visible.