### PR TITLE
Revert planner change to force use of unique index

### DIFF
--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -4556,18 +4556,10 @@ static int whereShortCut(WhereLoopBuilder *pBuilder){
     for(pIdx=pTab->pIndex; pIdx; pIdx=pIdx->pNext){
       int opMask;
       assert( pLoop->aLTermSpace==pLoop->aLTerm );
-#ifdef SQLITE_BUILDING_FOR_COMDB2
-      if( !(is_comdb2_index_unique(pIdx->pTable->zName, pIdx->zName))
-       || pIdx->pPartIdxWhere!=0
-       || pIdx->nKeyCol>ArraySize(pLoop->aLTermSpace)
-      ) continue;
-#else
       if( !IsUniqueIndex(pIdx)
        || pIdx->pPartIdxWhere!=0 
        || pIdx->nKeyCol>ArraySize(pLoop->aLTermSpace) 
       ) continue;
-
-#endif
       opMask = pIdx->uniqNotNull ? (WO_EQ|WO_IS) : WO_EQ;
       for(j=0; j<pIdx->nKeyCol; j++){
         pTerm = sqlite3WhereFindTerm(pWC, iCur, j, 0, opMask, pIdx);

--- a/tests/read_committed_unique.test/Makefile
+++ b/tests/read_committed_unique.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/read_committed_unique.test/README
+++ b/tests/read_committed_unique.test/README
@@ -1,0 +1,12 @@
+3
+
+There's a reason we lie to SQLite about uniqueness of keys.  SQLite is an immediate constraint
+system.  Comdb2 is a deferred constraint system.  Comdb2 can violate integrity constraints
+during a transaction, as long as they're resolved at commit time.  SQLite doesn't do this,
+and assumes it can check immediately if a key exists as a constraint check.  It also knows
+that no other matches will be found on a unique index and doesn't generate OP_Next opcode
+to check other matches, which breaks queries against records temporarily added during a read
+committed transaction.  When it begins to sound like a good idea to stop lying to SQLite
+for whatever reason - (1) make sure it passes this test, (2) find the next place that breaks
+(3) add the new failure test (4) increment the number on line one of this file as a
+warning to future developers.

--- a/tests/read_committed_unique.test/expected
+++ b/tests/read_committed_unique.test/expected
@@ -1,0 +1,11 @@
+[drop table if exists t] rc 0
+[create table t(i int unique, j int)] rc 0
+(rows inserted=1)
+[insert into t values(1, 10)] rc 0
+[set transaction read committed] rc 0
+[begin] rc 0
+[insert into t values(1, 100)] rc 0
+(i=1, j=10)
+(i=1, j=100)
+[select * from t where i = 1] rc 0
+[rollback] rc 0

--- a/tests/read_committed_unique.test/runit
+++ b/tests/read_committed_unique.test/runit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - > out <<'EOF'
+drop table if exists t
+create table t(i int unique, j int)$$
+insert into t values(1, 10)
+set transaction read committed
+begin
+insert into t values(1, 100)
+select * from t where i = 1
+rollback
+EOF
+
+diff out expected


### PR DESCRIPTION
Adds a separate testcase so the next person who attempts this "optimization" has advance warning that it doesn't work.

This reverts commit f1780550ca2bfc6af5fa14afde65a7de6803ff8a.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>