### PR TITLE
Bypass IAM auth check for analyze

### DIFF
--- a/db/db_access.c
+++ b/db/db_access.c
@@ -305,7 +305,8 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
     /* Check read access if its not user schema. */
     /* Check it only if engine is open already. */
     if (gbl_uses_externalauth && (thd->clnt->in_sqlite_init == 0) &&
-        externalComdb2AuthenticateUserRead && !clnt->admin) {
+        externalComdb2AuthenticateUserRead && !clnt->admin /* not admin connection */
+        && !clnt->current_user.bypass_auth /* not analyze */) {
         clnt->authdata = get_authdata(clnt);
         if (gbl_externalauth_warn && !clnt->authdata)
             logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -739,8 +739,10 @@ static int analyze_table_int(table_descriptor_t *td,
     int sampled_table = 0;
 
     clnt.current_user        = td->current_user;
-    clnt.appdata             = td->appdata;
-    clnt.plugin.get_authdata = td->get_authdata;
+    if (td->appdata != NULL)
+        clnt.appdata = td->appdata;
+    if (td->get_authdata != NULL)
+        clnt.plugin.get_authdata = td->get_authdata;
 
     logmsg(LOGMSG_INFO, "Analyze thread starting, table %s (%d%%)\n", td->table, td->scale);
 


### PR DESCRIPTION
The `access_control_check_sql_read()` function is invoked on each cursor move, in case that authentication changes in the middle of the query. Therefore the same logic in #3551 should probably be applied to the function, as well.
