### PR TITLE
(7.0) Bypass IAM auth check for analyze

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1867,7 +1867,8 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
     }
 
     if (gbl_uses_externalauth && clnt->no_transaction == 0 &&
-        externalComdb2AuthenticateUserRead && !clnt->admin) {
+        externalComdb2AuthenticateUserRead && !clnt->admin /* not admin connection */
+        && !clnt->current_user.bypass_auth /* not analyze */) {
          clnt->authdata = get_authdata(clnt);
          if(externalComdb2AuthenticateUserRead(clnt->authdata, pCur->db->tablename)) {
              char msg[1024];

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -758,8 +758,10 @@ static int analyze_table_int(table_descriptor_t *td,
     int sampled_table = 0;
 
     clnt.current_user = td->current_user;
-    clnt.appdata = td->appdata;
-    clnt.plugin.get_authdata = td->get_authdata;
+    if (td->appdata != NULL)
+        clnt.appdata = td->appdata;
+    if (td->get_authdata != NULL)
+        clnt.plugin.get_authdata = td->get_authdata;
 
     logmsg(LOGMSG_INFO, "Analyze thread starting, table %s (%d%%)\n", td->table, td->scale);
 


### PR DESCRIPTION
The access_control_check_sql_read() function is invoked on each cursor move, in case that authentication changes in the middle of the query. Therefore the same logic in #3551 should probably be applied to the function, as well.
