### PR TITLE
fix rollback when a legacy tpt creation fails

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -3962,7 +3962,7 @@ int bdb_llmeta_get_all_sc_redo_genids(tran_type *t, const char *tablename, llmet
 
     for (int i = 0; i < nkey; i++) {
         llmeta_newsc_redo_genid_key k = {0};
-        struct llmeta_db_lsn_data_type d = {0};
+        struct llmeta_db_lsn_data_type d = {{0}};
         llmeta_newsc_redo_genid_key_get(&k, keys[i], (uint8_t *)(keys[i]) + sizeof(llmeta_newsc_redo_genid_key));
         sc_redo[i].genid = k.genid;
         llmeta_db_lsn_data_type_get(&d, data[i], (uint8_t *)(data[i]) + sizeof(struct llmeta_db_lsn_data_type));
@@ -6777,7 +6777,7 @@ int bdb_llmeta_print_record(bdb_state_type *bdb_state, void *key, int keylen,
             return -1;
         }
         llmeta_newsc_redo_genid_key k;
-        struct llmeta_db_lsn_data_type newsc_lsn = {0};
+        struct llmeta_db_lsn_data_type newsc_lsn = {{0}};
         llmeta_newsc_redo_genid_key_get(&k, p_buf_key, p_buf_end_key);
         llmeta_db_lsn_data_type_get(&newsc_lsn, p_buf_data, p_buf_end_data);
 

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1234,12 +1234,6 @@ static int _fdb_check_sqlite3_cached_stats(sqlite3 *db, fdb_t *fdb)
     return SQLITE_OK;
 }
 
-#ifdef __GNUC__
-#ifndef __clang__
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-truncation"
-#endif
-#endif
 static int _failed_AddAndLockTable(const char *dbname, int errcode,
                                    const char *prefix)
 {
@@ -1254,20 +1248,13 @@ static int _failed_AddAndLockTable(const char *dbname, int errcode,
             clnt->fdb_state.xerr.errval, clnt->fdb_state.xerr.errstr, errcode,
             prefix);
     } else {
-        clnt->fdb_state.xerr.errval = errcode;
         /* need to pass error to sqlite */
-        snprintf(clnt->fdb_state.xerr.errstr,
-                 sizeof(clnt->fdb_state.xerr.errstr), "%s for db \"%s\"",
-                 prefix, dbname);
+        errstat_set_rcstrf(&clnt->fdb_state.xerr, errcode, 
+                 "%s for db \"%s\"", prefix, dbname);
     }
 
     return SQLITE_ERROR; /* speak sqlite */
 }
-#ifdef __GNUC__
-#ifndef __clang__
-#pragma GCC diagnostic pop
-#endif
-#endif
 
 /**
  * Sqlite wrapper for adding a new database table


### PR DESCRIPTION
Currently, legacy tpt creation commits llmeta for tpt before checking if it can create the first shard.  In this case, we can get in a situation when we have a tpt with missing shards and the server fails to restart.
Example:
<code>
create table t(a int);

create time partition on t as tv ...

drop time partition tv //user change mind, shards remain in place though

create time partition on t as tv ... //  this fails because shards exist, but create the llmeta entry never less

drop table ... // manual shard drop

// at this point we have a tpt saved in llmeta that has no shards; restart will abort 
</code>
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

