### PR TITLE
Fix an issue with comdb2_sc_status

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -170,6 +170,7 @@ typedef enum {
     LLMETA_SEQUENCE_VALUE = 53,
     LLMETA_LUA_SFUNC_FLAG = 54,
     LLMETA_NEWSC_REDO_GENID = 55, /* 55 + TABLENAME + GENID -> MAX-LSN */
+    LLMETA_SCHEMACHANGE_STATUS_V2 = 56,
 } llmetakey_t;
 
 struct llmeta_file_type_key {
@@ -4350,7 +4351,7 @@ int bdb_set_schema_change_status(tran_type *input_trans, const char *db_name,
     }
 
     /*add the key type */
-    schema_change.file_type = LLMETA_SCHEMACHANGE_STATUS;
+    schema_change.file_type = LLMETA_SCHEMACHANGE_STATUS_V2;
 
     /*copy the table name and check its length so that we have a clean key*/
     strncpy0(schema_change.dbname, db_name, sizeof(schema_change.dbname));
@@ -4513,9 +4514,7 @@ backout:
 int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status_out, void ***sc_data_out, int *num,
                                  int *bdberr)
 {
-    void **data = NULL;
-    int nkey = 0, rc = 1;
-    llmetakey_t k = htonl(LLMETA_SCHEMACHANGE_STATUS);
+    int rc = 1;
     llmeta_sc_status_data *status = NULL;
     void **sc_data = NULL;
 
@@ -4523,13 +4522,31 @@ int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status
     *status_out = NULL;
     *sc_data_out = NULL;
 
-    rc = kv_get(tran, &k, sizeof(k), &data, &nkey, bdberr);
+    /* Extract old (v1) sc status data */
+    llmetakey_t k_v1 = htonl(LLMETA_SCHEMACHANGE_STATUS);
+    int nkey_v1 = 0;
+    void **data_v1 = NULL;
+    rc = kv_get(tran, &k_v1, sizeof(k_v1), &data_v1, &nkey_v1, bdberr);
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: failed kv_get rc %d\n", __func__, rc);
         return -1;
     }
+
+    /* Extract new (v2) sc status data */
+    llmetakey_t k_v2 = htonl(LLMETA_SCHEMACHANGE_STATUS_V2);
+    int nkey_v2 = 0;
+    void **data_v2 = NULL;
+    rc = kv_get(tran, &k_v2, sizeof(k_v2), &data_v2, &nkey_v2, bdberr);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "%s: failed kv_get rc %d\n", __func__, rc);
+        return -1;
+    }
+
+    int nkey = nkey_v1 + nkey_v2;
+
     if (nkey == 0)
         return 0;
+
     status = calloc(nkey, sizeof(llmeta_sc_status_data) * nkey);
     if (status == NULL) {
         logmsg(LOGMSG_ERROR, "%s: failed malloc\n", __func__);
@@ -4545,10 +4562,10 @@ int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status
         return -1;
     }
 
-    for (int i = 0; i < nkey; i++) {
+    for (int i = 0; i < nkey_v1; i++) {
         const uint8_t *p_buf;
-        p_buf = llmeta_sc_status_data_get(&status[i], data[i],
-                                          (uint8_t *)(data[i]) +
+        p_buf = llmeta_sc_status_data_get(&status[i], data_v1[i],
+                                          (uint8_t *)(data_v1[i]) +
                                               sizeof(llmeta_sc_status_data));
         sc_data[i] = malloc(status[i].sc_data_len);
         if (sc_data[i] == NULL) {
@@ -4560,11 +4577,32 @@ int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status
         memcpy(sc_data[i], p_buf, status[i].sc_data_len);
     }
 
-    for (int i = 0; i < nkey; i++) {
-        if (data[i])
-            free(data[i]);
+    for (int i = 0; i < nkey_v1; i++) {
+        if (data_v1[i])
+            free(data_v1[i]);
     }
-    free(data);
+    free(data_v1);
+
+    for (int i = 0; i < nkey_v2; i++) {
+        const uint8_t *p_buf;
+        p_buf = llmeta_sc_status_data_get(&status[nkey_v1+i], data_v2[i],
+                                          (uint8_t *)(data_v2[i]) +
+                                              sizeof(llmeta_sc_status_data));
+        sc_data[nkey_v1 + i] = malloc(status[nkey_v1 + i].sc_data_len);
+        if (sc_data[nkey_v1 + i] == NULL) {
+            logmsg(LOGMSG_ERROR, "%s: failed malloc\n", __func__);
+            *bdberr = BDBERR_MALLOC;
+            goto err;
+        }
+
+        memcpy(sc_data[nkey_v1 + i], p_buf, status[nkey_v1 + i].sc_data_len);
+    }
+
+    for (int i = 0; i < nkey_v2; i++) {
+        if (data_v2[i])
+            free(data_v2[i]);
+    }
+    free(data_v2);
 
     *num = nkey;
     *status_out = status;
@@ -4572,13 +4610,22 @@ int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status
     return 0;
 
 err:
-    for (int i = 0; i < nkey; i++) {
-        if (data[i])
-            free(data[i]);
+    for (int i = 0; i < nkey_v1; i++) {
+        if (data_v1[i])
+            free(data_v1[i]);
         if (sc_data[i])
             free(sc_data[i]);
     }
-    free(data);
+    free(data_v1);
+
+    for (int i = 0; i < nkey_v2; i++) {
+        if (data_v2[i])
+            free(data_v2[i]);
+        if (sc_data[nkey_v1 + i])
+            free(sc_data[nkey_v1 + i]);
+    }
+    free(data_v2);
+
     free(status);
     free(sc_data);
     return -1;
@@ -10675,4 +10722,54 @@ int bdb_del_view(tran_type *t, const char *view_name)
         logmsg(LOGMSG_INFO, "View '%s' deleted\n", view_name);
     }
     return rc;
+}
+
+#include "schemachange.h"
+
+/*
+  DRQS-170879936:
+
+  In version R8, some backwards incompatible changes got introduced into
+  the schema change object that broke the object's original deserializer
+  function (buf_get_schemachange()). As a result, reading an sc status object
+  created by R7 would fail if read by R8 (via comdb2_sc_status).
+
+  The fix was to keep the both the versions of the deserializer functions and
+  invoke them appropriately.
+
+  The current (potential hackish) method to pick the right version on the
+  deserializer function is based on the content of the first 4 bytes of the
+  LLMETA_SCHEMACHANGE_STATUS payload, where it is assumed that the valid
+  values of s->kind (between SC_INVALID and SC_LAST, exclusive) will not
+  coincide with the first 4 bytes of the rqid (fastseed) stored as the first
+  member in old (7.0's) LLMETA_SCHEMACHANGE_STATUS payload.
+*/
+static int buf_get_schemachange_key_type(void *p_buf, void *p_buf_end)
+{
+    int first = 0;
+
+    if (p_buf >= p_buf_end) return -1;
+
+    buf_get(&first, sizeof(first), p_buf, p_buf_end);
+
+    if (first > SC_INVALID && first < SC_LAST) {
+        return LLMETA_SCHEMACHANGE_STATUS_V2;
+    }
+    return LLMETA_SCHEMACHANGE_STATUS;
+}
+
+void *buf_get_schemachange(struct schema_change_type *s, void *p_buf,
+                           void *p_buf_end)
+{
+    int sc_key_type = buf_get_schemachange_key_type(p_buf, p_buf_end);
+
+    switch (sc_key_type) {
+    case LLMETA_SCHEMACHANGE_STATUS:
+        return buf_get_schemachange_v1(s, (void *)p_buf, (void *)p_buf_end);
+    case LLMETA_SCHEMACHANGE_STATUS_V2:
+        return buf_get_schemachange_v2(s, (void *)p_buf, (void *)p_buf_end);
+    default:
+        break;
+    }
+    return NULL;
 }

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1,5 +1,5 @@
 /*
-   Copyright 2015 Bloomberg Finance L.P.
+   Copyright 2015, 2022 Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -190,8 +190,7 @@ static void *buf_put_dests(struct schema_change_type *s, void *p_buf,
     return p_buf;
 }
 
-void *buf_put_schemachange(struct schema_change_type *s, void *p_buf,
-                           void *p_buf_end)
+void *buf_put_schemachange(struct schema_change_type *s, void *p_buf, void *p_buf_end)
 {
 
     if (p_buf >= p_buf_end) return NULL;
@@ -368,8 +367,205 @@ static const void *buf_get_dests(struct schema_change_type *s,
     return p_buf;
 }
 
-void *buf_get_schemachange(struct schema_change_type *s, void *p_buf,
-                           void *p_buf_end)
+void *buf_get_schemachange_v1(struct schema_change_type *s, void *p_buf,
+                              void *p_buf_end)
+{
+    int type = 0,          fastinit = 0,   addonly = 0,    fulluprecs = 0,
+        partialuprecs = 0, alteronly = 0,  is_trigger = 0, drop_table = 0,
+        addsp = 0,         delsp = 0,      defaultsp = 0,  is_sfunc = 0,
+        is_afunc = 0,      rename = 0;
+
+    if (p_buf >= p_buf_end) return NULL;
+
+    p_buf = (uint8_t *)buf_get(&s->rqid, sizeof(s->rqid), p_buf, p_buf_end);
+
+    p_buf =
+        (uint8_t *)buf_no_net_get(&s->uuid, sizeof(s->uuid), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&type, sizeof(type), p_buf, p_buf_end); /* s->type */
+
+    p_buf = (uint8_t *)buf_get(&s->tablename_len, sizeof(s->tablename_len),
+                               p_buf, p_buf_end);
+    if (s->tablename_len != strlen((const char *)p_buf) + 1 ||
+        s->tablename_len > sizeof(s->tablename)) {
+        s->tablename_len = -1;
+        return NULL;
+    }
+    p_buf = (uint8_t *)buf_no_net_get(s->tablename, s->tablename_len, p_buf,
+                                      p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->fname_len, sizeof(s->fname_len), p_buf,
+                               p_buf_end);
+    if (s->fname_len != strlen((const char *)p_buf) + 1 ||
+        s->fname_len > sizeof(s->fname)) {
+        s->fname_len = -1;
+        return NULL;
+    }
+    p_buf = (uint8_t *)buf_no_net_get(s->fname, s->fname_len, p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->aname_len, sizeof(s->aname_len), p_buf,
+                               p_buf_end);
+    if (s->aname_len != strlen((const char *)p_buf) + 1 ||
+        s->aname_len > sizeof(s->aname)) {
+        s->aname_len = -1;
+        return NULL;
+    }
+
+    p_buf = (uint8_t *)buf_get(s->aname, s->aname_len, p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->avgitemsz, sizeof(s->avgitemsz), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&fastinit, sizeof(fastinit), p_buf, p_buf_end); /* s->fastinit */
+
+    p_buf = (uint8_t *)buf_get(&s->newdtastripe, sizeof(s->newdtastripe), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->blobstripe, sizeof(s->blobstripe), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->live, sizeof(s->live), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&addonly, sizeof(addonly), p_buf, p_buf_end); /* s->addonly */
+    p_buf = (uint8_t *)buf_get(&fulluprecs, sizeof(fulluprecs), p_buf, p_buf_end); /* s->fulluprecs */
+    p_buf = (uint8_t *)buf_get(&partialuprecs, sizeof(partialuprecs), p_buf, p_buf_end); /* s->partialuprecs */
+    p_buf = (uint8_t *)buf_get(&alteronly, sizeof(alteronly), p_buf, p_buf_end); /* s->alteronly */
+    p_buf = (uint8_t *)buf_get(&is_trigger, sizeof(is_trigger), p_buf, p_buf_end); /* s->is_trigger */
+
+    p_buf = (uint8_t *)buf_get(&s->newcsc2_len, sizeof(s->newcsc2_len), p_buf,
+                               p_buf_end);
+
+    if (s->newcsc2_len) {
+        if (s->newcsc2_len != strlen((const char *)p_buf) + 1) {
+            s->newcsc2_len = -1;
+            return NULL;
+        }
+
+        s->newcsc2 = (char *)malloc(s->newcsc2_len);
+        if (!s->newcsc2) return NULL;
+
+        p_buf = (uint8_t *)buf_no_net_get(s->newcsc2, s->newcsc2_len, p_buf,
+                                          p_buf_end);
+    } else
+        s->newcsc2 = NULL;
+
+    p_buf =
+        (uint8_t *)buf_get(&s->scanmode, sizeof(s->scanmode), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->delay_commit, sizeof(s->delay_commit), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->force_rebuild, sizeof(s->force_rebuild),
+                               p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->force_dta_rebuild,
+                               sizeof(s->force_dta_rebuild), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->force_blob_rebuild,
+                               sizeof(s->force_blob_rebuild), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->force, sizeof(s->force), p_buf, p_buf_end);
+
+    p_buf =
+        (uint8_t *)buf_get(&s->headers, sizeof(s->headers), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->header_change, sizeof(s->header_change),
+                               p_buf, p_buf_end);
+
+    p_buf =
+        (uint8_t *)buf_get(&s->compress, sizeof(s->compress), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->compress_blobs, sizeof(s->compress_blobs),
+                               p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->ip_updates, sizeof(s->ip_updates), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->instant_sc, sizeof(s->instant_sc), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->preempted, sizeof(s->preempted), p_buf,
+                               p_buf_end);
+
+    p_buf =
+        (uint8_t *)buf_get(&s->use_plan, sizeof(s->use_plan), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->commit_sleep, sizeof(s->commit_sleep), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->convert_sleep, sizeof(s->convert_sleep),
+                               p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->same_schema, sizeof(s->same_schema), p_buf,
+                               p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->dbnum, sizeof(s->dbnum), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->flg, sizeof(s->flg), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->rebuild_index, sizeof(s->rebuild_index),
+                               p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->index_to_rebuild,
+                               sizeof(s->index_to_rebuild), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&drop_table, sizeof(drop_table), p_buf, p_buf_end); /* s->drop_table */
+
+    p_buf =
+        (uint8_t *)buf_get(&s->original_master_node,
+                           sizeof(s->original_master_node), p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get_dests(s, p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&s->spname_len, sizeof(s->spname_len), p_buf,
+                               p_buf_end);
+    p_buf =
+        (uint8_t *)buf_no_net_get(s->spname, s->spname_len, p_buf, p_buf_end);
+
+    p_buf = (uint8_t *)buf_get(&addsp, sizeof(addsp), p_buf, p_buf_end); /* s->addsp */
+    p_buf = (uint8_t *)buf_get(&delsp, sizeof(delsp), p_buf, p_buf_end); /* s->delsp */
+    p_buf = (uint8_t *)buf_get(&defaultsp, sizeof(defaultsp), p_buf, p_buf_end); /* s->defaultsp */
+    p_buf = (uint8_t *)buf_get(&is_sfunc, sizeof(is_sfunc), p_buf, p_buf_end); /* s->is_sfunc */
+    p_buf = (uint8_t *)buf_get(&is_afunc, sizeof(is_afunc), p_buf, p_buf_end); /* s->is_afunc */
+    p_buf = (uint8_t *)buf_get(&rename, sizeof(rename), p_buf, p_buf_end); /* s->rename */
+
+    p_buf = (uint8_t *)buf_no_net_get(s->newtable, sizeof(s->newtable), p_buf,
+                                      p_buf_end);
+    p_buf = (uint8_t *)buf_get(&s->usedbtablevers, sizeof(s->usedbtablevers),
+                               p_buf, p_buf_end);
+
+    if (fastinit && drop_table)
+        s->kind = SC_DROPTABLE;
+    else if (fastinit)
+        s->kind = SC_TRUNCATETABLE;
+    else if (alteronly)
+        s->kind = SC_ALTERTABLE;
+    else if (addonly)
+        s->kind = SC_ADDTABLE;
+    else if (rename)
+        s->kind = SC_RENAMETABLE;
+    else if (fulluprecs)
+        s->kind = SC_FULLUPRECS;
+    else if (partialuprecs)
+        s->kind = SC_PARTIALUPRECS;
+    else if (is_trigger && addonly)
+        s->kind = SC_ADD_TRIGGER;
+    else if (is_trigger && drop_table)
+        s->kind = SC_DEL_TRIGGER;
+    else if (drop_table)
+        s->kind = SC_DROPTABLE;
+    else if (addsp)
+        s->kind = SC_ADDSP;
+    else if (delsp)
+        s->kind = SC_DELSP;
+    else if (defaultsp)
+        s->kind = SC_DEFAULTSP;
+
+    return p_buf;
+}
+
+void *buf_get_schemachange_v2(struct schema_change_type *s,
+                              void *p_buf, void *p_buf_end)
 {
 
     if (p_buf >= p_buf_end) return NULL;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -122,6 +122,7 @@ enum schema_change_kind {
     SC_ALTERTABLE_INDEX = 27,
     SC_DROPTABLE_INDEX = 28,
     SC_REBUILDTABLE_INDEX = 29,
+    SC_LAST /* End marker */
 };
 
 #define IS_SC_DBTYPE_TAGGED_TABLE(s) ((s)->kind > SC_DROP_VIEW)
@@ -411,7 +412,10 @@ void *buf_put_schemachange(struct schema_change_type *s, void *p_buf,
                            void *p_buf_end);
 void *buf_get_schemachange(struct schema_change_type *s, void *p_buf,
                            void *p_buf_end);
-
+void *buf_get_schemachange_v1(struct schema_change_type *s, void *p_buf,
+                              void *p_buf_end);
+void *buf_get_schemachange_v2(struct schema_change_type *s, void *p_buf,
+                              void *p_buf_end);
 /* This belong into sc_util.h */
 int check_sc_ok(struct schema_change_type *s);
 


### PR DESCRIPTION
In version R8, some backwards incompatible changes got introduced into the schema change object that broke the object's original deserializer function (buf_get_schemachange()). As a result, reading an sc status object created by R7 would fail if read by R8 (via comdb2_sc_status).

The fix was to keep the both the versions of the deserializer functions and invoke them appropriately.

The current (potential hackish) method to pick the right version on the deserializer function is based on the content of the first 4 bytes of the LLMETA_SCHEMACHANGE_STATUS payload, where it is assumed that the valid values of s->kind (between  SC_INVALID and SC_LAST, exclusive) will not coincide with the first 4 bytes of the rqid (fastseed) stored as the first member in  old (7.0's) LLMETA_SCHEMACHANGE_STATUS payload.

Refer: DRQS-170879936

Signed-off-by: Nirbhay Choubey <nchoubey@bloomberg.net>