### PR TITLE
Enable elect_highest_committed_gen by default

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -375,7 +375,6 @@ void clear_deferred_options(void)
 
 static char *legacy_options[] = {
     "allow_negative_column_size",
-    "berkattr elect_highest_committed_gen 0",
     "clean_exit_on_sigterm off",
     "create_default_user",
     "ddl_cascade_drop 0",


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

This prevents us from losing writes which replicate to a majority of the cluster.