### PR TITLE
Tunable to warn if a transaction writes alot of rows

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -144,6 +144,7 @@ extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;
 extern int gbl_rep_verify_will_recover_trace;
+extern uint32_t gbl_written_rows_warn;
 extern int gbl_max_wr_rows_per_txn;
 extern int gbl_force_serial_on_writelock;
 extern int gbl_processor_thd_poll;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1374,6 +1374,10 @@ REGISTER_TUNABLE("rep_verify_will_recover_trace",
 REGISTER_TUNABLE("max_wr_rows_per_txn",
                  "Set the max written rows per transaction.", TUNABLE_INTEGER,
                  &gbl_max_wr_rows_per_txn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("written_rows_warn",
+                 "Set warning threshold for rows written in a transaction.  "
+                 "(Default: 0)", TUNABLE_INTEGER, &gbl_written_rows_warn, 0, 
+                 NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("print_deadlock_cycles",
                  "Print all deadlock cycles. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_print_deadlock_cycles, NOARG, NULL, NULL, NULL, NULL);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1,4 +1,4 @@
-(TUNABLES_COUNT=969)
+(TUNABLES_COUNT=970)
 (name='aa_count_upd', description='Also consider updates towards the count of operations.', type='BOOLEAN', value='OFF', read_only='N')
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
@@ -965,5 +965,6 @@
 (name='warn_on_replicant_log_write', description='Warn if replicant is writing to logs', type='BOOLEAN', value='ON', read_only='N')
 (name='warn_slow_replicants', description='Warn if any replicant's average response times over the last 10 seconds are significantly worse than the second worst replicant's.', type='BOOLEAN', value='ON', read_only='N')
 (name='watchthreshold', description='Panic if node has been unhealty (unresponsive, out of resources, etc.) for more than this many seconds. The default value is 60.', type='INTEGER', value='60', read_only='Y')
+(name='written_rows_warn', description='Set warning threshold for rows written in a transaction.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='zliblevel', description='If zlib compression is enabled, this determines the compression level.', type='INTEGER', value='6', read_only='N')
 (name='ztrace', description='', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Print warning if equal or greater than threshold.  This is to allow us to audit large writes.  This is a slight reworking of maxrowsaudit branch.