### PR TITLE
Allow incoherent nodes to catchup

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -1548,9 +1548,8 @@ more:
 					goto errlock;
 			} else {
 				fromline = __LINE__;
-				if ((ret = __rep_apply(dbenv, rp, rec, ret_lsnp,
-								commit_gen, 0)) != 0)
-					goto errlock;
+				ret = __rep_apply(dbenv, rp, rec, ret_lsnp,
+								commit_gen, 0);
 			}
 		} else {
 			send_master_req(dbenv, __func__, __LINE__);
@@ -1558,7 +1557,7 @@ more:
 			goto errlock;
 		}
 
-		if (rp->rectype == REP_LOG_MORE && !gbl_decoupled_logputs) {
+		if ((ret == 0 || ret == DB_REP_ISPERM) && rp->rectype == REP_LOG_MORE && !gbl_decoupled_logputs) {
 			MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
 			master = rep->master_id;
 			MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
@@ -1589,8 +1588,8 @@ more:
 				logmsg(LOGMSG_USER, "%s line %d continuing REP_ALL_REQ lsn "
 						"%d:%d\n", __func__, __LINE__, lsn.file, lsn.offset);
 			}
+		    fromline = __LINE__;
 		}
-		fromline = __LINE__;
 		goto errlock;
 
 	case REP_LOG_REQ:

--- a/net/net.c
+++ b/net/net.c
@@ -5679,6 +5679,9 @@ int handle_accepted_socket(SBUF2 *sb, netinfo_type *netinfo_ptr, int is_inline, 
          return 0;
       }
 
+      sbuf2settimeout(sb, 0, 0);
+      sbuf2setbufsize(sb, netinfo_ptr->bufsz);
+
       /* grab pool memory for connect_and_accept_t */
       Pthread_mutex_lock(&(netinfo_ptr->connlk));
       ca=(connect_and_accept_t *)pool_getablk(netinfo_ptr->connpool);


### PR DESCRIPTION
Signed-off-by: mohitkhullar <mkhullar1@bloomberg.net>
REP_LOG_MORE was ignore by replicant, and it never asked for more logs from master