### PR TITLE
physrep_ignore lrl option allows physreps to ignore traffic to certain tables

### DIFF
--- a/bdb/phys_rep_lsn.h
+++ b/bdb/phys_rep_lsn.h
@@ -15,6 +15,23 @@ struct LOG_INFO {
 struct __db_env;
 struct bdb_state_tag;
 
+typedef unsigned char u_int8_t;
+
+/* Mark this table to be ignored (not replicated to) */
+int physrep_add_ignore_table(char *tablename);
+
+/* Return 1 if this btree should be ignored */
+int physrep_ignore_btree(const char *filename);
+
+/* Return 1 if this table should be ignored */
+int physrep_ignore_table(const char *tablename);
+
+/* Return count of ignored tables */
+int physrep_ignore_table_count(void);
+
+/* List ignored tables */
+int physrep_list_ignored_tables(void);
+
 LOG_INFO get_last_lsn(struct bdb_state_tag *);
 uint32_t get_next_offset(struct __db_env *, LOG_INFO log_info);
 int apply_log(struct __db_env *, unsigned int file, unsigned int offset,

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1342,6 +1342,7 @@ typedef enum {
 
 
 /* DB (private) error return codes. */
+#define DB_IGNORED			(-30900) /* Ignore logging to this btree */
 #define	DB_ALREADY_ABORTED	(-30899)
 #define	DB_DELETED		(-30898)/* Recovery file marked deleted. */
 #define	DB_LOCK_NOTEXIST	(-30897)/* Object to lock is gone. */
@@ -2181,6 +2182,7 @@ struct __lc_cache {
 
 struct __ufid_to_db_t {
 	u_int8_t ufid[DB_FILE_ID_LEN];
+    int ignore : 1;
 	char *fname;
 	DB *dbp;
 };
@@ -2271,6 +2273,8 @@ struct __db_env {
 	int		(*rep_send)	/* Send function. */
 			__P((DB_ENV *, const DBT *, const DBT *,
 				   const DB_LSN *, char*, int, void *));
+	int	 (*rep_ignore) 
+			__P((const char *));
 	int	 (*txn_logical_start)
 			__P((DB_ENV *, void *state, u_int64_t ltranid,
 			DB_LSN *lsn));
@@ -2512,6 +2516,7 @@ struct __db_env {
 		char*, int, void *)));
 	int  (*set_rep_db_pagesize) __P((DB_ENV *, int));
 	int  (*get_rep_db_pagesize) __P((DB_ENV *, int *));
+	int  (*set_rep_ignore) __P((DB_ENV *, int (*func)(const char *filename)));
 	void *tx_handle;		/* Txn handle and methods. */
 	int  (*get_tx_max) __P((DB_ENV *, u_int32_t *));
 	int  (*set_tx_max) __P((DB_ENV *, u_int32_t));

--- a/berkdb/dbinc/db_am.h
+++ b/berkdb/dbinc/db_am.h
@@ -55,7 +55,7 @@
 	if (argp->type > 1000) { \
 		if ((ret = __ufid_to_db(dbenv, argp->txnid, &file_dbp, \
 						argp->ufid_fileid, lsnp)) != 0) { \
-			if (ret	== DB_DELETED) { \
+			if (ret	== DB_DELETED || ret == DB_IGNORED) { \
 				ret = 0; \
 				goto done; \
 			} \
@@ -109,7 +109,7 @@ int __log_flush(DB_ENV *dbenv, const DB_LSN *);
 			&file_dbp, argp->fileid, inc_count, lsnp, 0);	\
 	} 								\
 	if (ret) { 							\
-		if (ret	== DB_DELETED && IS_RECOVERING(dbenv)) {	\
+		if (ret == DB_IGNORED || (ret == DB_DELETED && IS_RECOVERING(dbenv))) {	\
 			ret = 0;					\
 			goto done;					\
 		}							\

--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -65,6 +65,7 @@ static int __rep_unlock_recovery_lock __P((DB_ENV *, const char *func, int line)
 static int __rep_wrlock_recovery_blocked __P((DB_ENV *));
 static int __rep_set_rep_db_pagesize __P((DB_ENV *, int));
 static int __rep_get_rep_db_pagesize __P((DB_ENV *, int *));
+static int __rep_set_ignore __P((DB_ENV *, int (*func)(const char *filename)));
 static int __rep_start __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));
 static int __rep_stat __P((DB_ENV *, DB_REP_STAT **, u_int32_t));
 static int __rep_deadlocks __P((DB_ENV *, u_int64_t *));
@@ -127,6 +128,7 @@ __rep_dbenv_create(dbenv)
 		dbenv->set_rep_limit = __rep_set_limit;
 		dbenv->set_rep_request = __rep_set_request;
 		dbenv->set_rep_transport = __rep_set_rep_transport;
+		dbenv->set_rep_ignore = __rep_set_ignore;
 		dbenv->set_truncate_sc_callback = __rep_set_truncate_sc_callback;
 		dbenv->set_rep_truncate_callback = __rep_set_rep_truncate_callback;
 		dbenv->set_rep_recovery_cleanup = __rep_set_rep_recovery_cleanup;
@@ -1004,6 +1006,25 @@ __rep_set_truncate_sc_callback(dbenv, truncate_sc_callback)
 		return (EINVAL);
 	}
 	dbenv->truncate_sc_callback = truncate_sc_callback;
+	return (0);
+}
+
+/*
+ * __rep_set_ignore --
+ *  Register function which tells replication to ignore certain fileids 
+ */
+static int
+__rep_set_ignore(dbenv, f_ignore)
+	DB_ENV *dbenv;
+	int (*f_ignore) __P((const char *));
+{
+	PANIC_CHECK(dbenv);
+	if (f_ignore == NULL) {
+		__db_err(dbenv,
+			"DB_ENV->set_rep_ignore_fileid_func: no send function specified");
+		return (EINVAL);
+	}
+	dbenv->rep_ignore = f_ignore;
 	return (0);
 }
 

--- a/db/config.c
+++ b/db/config.c
@@ -36,6 +36,7 @@
 #include "rtcpu.h"
 #include "config.h"
 #include "phys_rep.h"
+#include "phys_rep_lsn.h"
 #include "macc_glue.h"
 
 extern int gbl_create_mode;
@@ -1349,6 +1350,13 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         free(type);
         start_replication();
 
+    } else if (tokcmp(tok, ltok, "physrep_ignore") == 0) {
+        /* Tables that should ignore replication */
+        while ((tok = segtok(line, len, &st, &ltok)) != NULL && ltok > 0) {
+            char *table = tokdup(tok, ltok);
+            logmsg(LOGMSG_INFO, "Physrep ignoring table %s\n", table);
+            physrep_add_ignore_table(table);
+        }
     } else if (tokcmp(tok, ltok, "replicate_wait") == 0) {
         tok = segtok(line, len, &st, &ltok);
 

--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -4,6 +4,7 @@
 #include "vdbeInt.h"
 #include <ctrace.h>
 #include <poll.h>
+#include <phys_rep_lsn.h>
 
 /**
  * sqlite master global entries
@@ -330,6 +331,10 @@ struct dbtable *get_sqlite_db(struct sql_thread *thd, int iTable, int *ixnum)
 
     tbl = get_dbtable_by_name(tblname);
     if (!tbl)
+        return NULL;
+
+    extern int gbl_is_physical_replicant;
+    if (gbl_is_physical_replicant && physrep_ignore_table(tblname))
         return NULL;
 
     if (ixnum)

--- a/tests/physrep_ignore_table.test/Makefile
+++ b/tests/physrep_ignore_table.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif
+

--- a/tests/physrep_ignore_table.test/lrl.options
+++ b/tests/physrep_ignore_table.test/lrl.options
@@ -1,0 +1,1 @@
+ufid_log on

--- a/tests/physrep_ignore_table.test/runit
+++ b/tests/physrep_ignore_table.test/runit
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+#set -x
+
+export COPYCOMDB2_EXE=${BUILDDIR}/db/copycomdb2
+export DESTDB=${TESTCASE}dest${TESTID}
+export DEST_DBDIR=${DBDIR}/$DESTDB
+export stopfile=./stopfile.txt
+
+if [[ -z "$TEST_TIMEOUT" ]] ; then 
+    export TEST_TIMEOUT=5m 
+fi
+
+function failexit
+{
+    touch $stopfile
+    echo "Failed: $1"
+    echo "CHECK PHYSREP NOW"
+    sleep 9999999999
+    exit -1
+}
+
+function create_tables
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1(a int, b blob)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index t1a on t1(a)"
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t2(a int, b blob)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index t2a on t2(a)"
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t3(a int, b blob)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index t3a on t3(a)"
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t4(a int, b blob)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index t4a on t4(a)"
+}
+
+function fill_tables
+{
+    j=0
+    while [[ $j -lt 100 ]]; do
+        # create large blob files
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select *, randomblob(16384) from generate_series(1, 50)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t2 select *, randomblob(16384) from generate_series(1, 50)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t3 select *, randomblob(16384) from generate_series(1, 50)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t4 select *, randomblob(16384) from generate_series(1, 50)"
+
+        # create large indexes
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 (a) select * from generate_series(1, 1000)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t2 (a) select * from generate_series(1, 1000)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t3 (a) select * from generate_series(1, 1000)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t4 (a) select * from generate_series(1, 1000)"
+        let j=j+1
+    done
+}
+
+function create_physrep
+{
+    mkdir -p $DEST_DBDIR
+    if [[ -z "$CLUSTER" ]]; then
+        export cl="-y @localhost"
+    else
+        export cl="-y @$(echo $CLUSTER | tr ' ' ',')"
+    fi
+    if [[ -n "$CLUSTER" ]]; then
+        if [[ "$CLUSTER" =~ .*$myhost.* ]]; then
+            rmt=""
+        else
+            clarray=($CLUSTER)
+            rmt="${clarray[0]}:"
+        fi
+    fi
+    
+    ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H $DESTDB $cl $rmt${DBDIR}/${DBNAME}.lrl $DEST_DBDIR $DEST_DBDIR
+    
+    if [ ! $? -eq 0 ]; then
+        echo "copycomdb2 failed"
+        exit 1
+    fi
+    
+    df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> $DEST_DBDIR/${DESTDB}.lrl
+    
+    if [ -n "$PMUXPORT" ] ; then
+        echo "portmux_port $PMUXPORT" >> $DEST_DBDIR/${DESTDB}.lrl
+        echo "portmux_bind_path $pmux_socket" >> $DEST_DBDIR/${DESTDB}.lrl
+    fi
+
+    # ignore tables t2 and t4
+    echo "physrep_ignore t2 t4" >> $DEST_DBDIR/${DESTDB}.lrl
+    
+    export replog=$DEST_DBDIR/$DESTDB.log
+    
+    ( timeout $TEST_TIMEOUT $COMDB2_EXE $DESTDB -lrl $DEST_DBDIR/${DESTDB}.lrl -pidfile $DEST_DBDIR/${DESTDB}.pid >$replog 2>&1) &
+
+    sleep 2
+
+    # give this a bit to run recovery
+    j=0
+    while [[ $j -lt 30 ]]; do
+        ${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB "select 1" >/dev/null 2>&1
+        [[ $? == 0 ]] && break 1
+        let j=j+1
+    done
+}
+
+function flush_nodes
+{
+    if [[ -z "$CLUSTER" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('flush')"
+    else
+        for node in $CLUSTER ; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "exec procedure sys.cmd.send(\"flush\")"
+        done
+    fi
+}
+
+function check_physrep_file_sizes
+{
+    ls -l $DEST_DBDIR/t2_* | while read perm i1 own grp sz mon day tm fl ; do
+        [[ "$fl" == *"datas"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
+        [[ "$fl" == *"blobs"* ]] && [[ "$sz" != 131072 ]] && failexit "$fl was not truncated"
+        [[ "$fl" == *"index"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
+    done
+
+    ls -l $DEST_DBDIR/t4_* | while read perm i1 own grp sz mon day tm fl ; do
+        [[ "$fl" == *"datas"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
+        [[ "$fl" == *"blobs"* ]] && [[ "$sz" != 131072 ]] && failexit "$fl was not truncated"
+        [[ "$fl" == *"index"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
+    done
+}
+
+function verify_ignored_tables
+{
+    # Give physreps 100 seconds to catch up
+    t1=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB @localhost "select count(*) from t1" 2>&1)
+    t1p=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DBNAME default "select count(*) from t1" 2>&1)
+
+    j=0
+    while [[ "$j" -lt 100 && "$t1" != "$t1p" ]] ; do
+        sleep 1
+        t1=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB @localhost "select count(*) from t1" 2>&1)
+        t1p=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DBNAME default "select count(*) from t1" 2>&1)
+        let j=j+1
+    done
+    [[ "$t1" != "$t1p" ]] && failexit "physrep has different count than parent: cluster=$t1 vs physrep=$t1p"
+
+    # Physrep t2 should be ignored
+    t2=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB @localhost "select count(*) from t2" 2>&1)
+    [[ "$t2" != *"no such table"* ]] && failexit "ignored table t2 accessible from physrep"
+
+    # Physrep t3 should match parent 
+    t3=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB @localhost "select count(*) from t3" 2>&1)
+    t3p=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DBNAME default "select count(*) from t3" 2>&1)
+    [[ "$t3" != "$t3p" ]] && failexit "physrep has different count than parent"
+
+    # Physrep t4 should be ignored
+    t4=$(${CDB2SQL_EXE} -s --tabs ${CDB2_OPTIONS} $DESTDB @localhost "select count(*) from t4" 2>&1)
+    [[ "$t4" != *"no such table"* ]] && failexit "ignored table t4 accessible from physrep"
+}
+
+function insert_new_records
+{
+    j=0
+    while [[ $j -lt 10 ]]; do
+
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select *, randomblob(16384) from generate_series(1, 10)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t2 select *, randomblob(16384) from generate_series(1, 10)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t3 select *, randomblob(16384) from generate_series(1, 10)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t4 select *, randomblob(16384) from generate_series(1, 10)"
+
+        # create large indexes
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 (a) select * from generate_series(1, 200)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t2 (a) select * from generate_series(1, 200)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t3 (a) select * from generate_series(1, 200)"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t4 (a) select * from generate_series(1, 200)"
+        let j=j+1
+    done
+}
+
+function run_test
+{
+    rm $stopfile
+
+    create_tables
+    fill_tables
+    flush_nodes
+    create_physrep
+    verify_ignored_tables
+    check_physrep_file_sizes
+    insert_new_records
+    verify_ignored_tables
+    check_physrep_file_sizes
+
+    kill -9 $(cat $DEST_DBDIR/${DESTDB}.pid)
+}
+
+run_test
+if [[ -f "$stopfile" ]]; then
+    echo "Testcase failed"
+    exit 1
+else
+    echo "Success"    
+    exit 0
+fi


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Tables which are ignored are truncated to 2 pages as the database starts.  SQL against any ignored table will fail with a 'no such table' error.  I will add similar logic to tagged api.  The behavior is verified by the physrep_ignore_table test.