### PR TITLE
Omit \r from statements displayed by cdb2_sqlreplay

### DIFF
--- a/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
+++ b/tools/cdb2_sqlreplay/cdb2_sqlreplay.cpp
@@ -618,6 +618,7 @@ void dump_sql_event(cson_value *event) {
     char *sqlptr = cson_value_get_string(sqlval);
     std::string sql(sqlptr);
     std::replace(sql.begin(), sql.end(), '\n', ' ');
+    std::replace(sql.begin(), sql.end(), '\r', ' ');
     printf("tranid 0 %s", sql.c_str());
 }
 


### PR DESCRIPTION
We already replace '\n' with ' ' in cdb2_sqlreplay output - do the same for '\r'.

Signed-off-by: Mike Ponomarenko <mponomarenko@bloomberg.net>