### PR TITLE
Remove debug code in the physrep-ignore-table test

### DIFF
--- a/tests/physrep_ignore_table.test/runit
+++ b/tests/physrep_ignore_table.test/runit
@@ -15,8 +15,6 @@ function failexit
 {
     touch $stopfile
     echo "Failed: $1"
-    echo "CHECK PHYSREP NOW"
-    sleep 9999999999
     exit -1
 }
 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Remove a sleep that I accidentally left in the physrep_ignore_table test.
