### PR TITLE
Improving log->put performance

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -725,15 +725,6 @@ int berkdb_send_rtn(DB_ENV *dbenv, const DBT *control, const DBT *rec,
     if (bdb_state->parent)
         bdb_state = bdb_state->parent;
 
-    /* Fast return if broadcasting in standalone mode. */
-    if (host == db_eid_broadcast) {
-        const char *hostlist[REPMAX];
-        int count =
-            net_get_all_nodes_connected(bdb_state->repinfo->netinfo, hostlist);
-        if (count == 0)
-            return 0;
-    }
-
     callcount++;
 
     /*
@@ -6056,4 +6047,11 @@ int request_durable_lsn_from_master(bdb_state_type *bdb_state,
     return 0;
 }
 
+int bdb_num_connected_nodes(bdb_state_type *bdb_state)
+{
+    const char *hostlist[REPMAX];
 
+    if (bdb_state->parent)
+        bdb_state = bdb_state->parent;
+    return net_get_all_nodes_connected(bdb_state->repinfo->netinfo, hostlist);
+}

--- a/berkdb/os/os_open.c
+++ b/berkdb/os/os_open.c
@@ -73,6 +73,7 @@ ___os_open(dbenv, name, flags, mode, fhpp)
 }
 
 int gbl_force_direct_io = 1;
+int gbl_wal_osync = 0;
 /*
  * __os_open_extend --
  *	Open a file descriptor (including page size and log size information).
@@ -188,7 +189,7 @@ ___os_open_extend(dbenv, name, log_size, page_size, flags, mode, fhpp)
 
 	/* if they didn't request direct on this file, it's a log file, and the
 	 * environment wants direct logs, request sync io, but not directio */
-	if (F_ISSET(dbenv, DB_ENV_DIRECT_LOG) && LF_ISSET(DB_OSO_LOG)) {
+	if (F_ISSET(dbenv, DB_ENV_DIRECT_LOG) && LF_ISSET(DB_OSO_LOG) && gbl_wal_osync) {
 		/* don't do O_DIRECT for logs */
 #if defined(_AIX) && !defined (TESTSUITE)
 		oflags |= O_DSYNC;

--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -41,6 +41,7 @@ extern pthread_mutex_t rep_candidate_lock;
 extern int gbl_passed_repverify;
 struct bdb_state_tag;
 void bdb_set_rep_handle_dead(struct bdb_state_tag *);
+int bdb_num_connected_nodes(struct bdb_state_tag *);
 #endif
 
 int gbl_verbose_master_req = 0;
@@ -142,6 +143,9 @@ __rep_send_message(dbenv, eid, rtype, lsnp, dbtp, flags, usr_ptr)
 				break;
 		}
 	}
+
+	if (eid == db_eid_broadcast && bdb_num_connected_nodes(dbenv->app_private) == 0)
+		return 0;
 
 	/* Set up control structure. */
 	memset(&cntrl, 0, sizeof(cntrl));

--- a/db/config.c
+++ b/db/config.c
@@ -420,6 +420,7 @@ static char *legacy_options[] = {
     "setattr SC_DONE_SAME_TRAN 0",
     "sqlsortermaxmmapsize 268435456",
     "unnatural_types 1",
+    "wal_osync 1",
     "init_with_queue_ondisk_header off",
     "init_with_queue_compr off",
     "init_with_queue_persistent_sequence off",

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -404,6 +404,7 @@ int gbl_file_permissions = 0660;
 extern int gbl_net_maxconn;
 extern int gbl_force_direct_io;
 extern int gbl_seekscan_maxsteps;
+extern int gbl_wal_osync;
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2312,4 +2312,6 @@ REGISTER_TUNABLE("seekscan_maxsteps",
                  "Overrides the max number of steps for a seekscan optimization", TUNABLE_INTEGER,
                  &gbl_seekscan_maxsteps, SIGNED, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("wal_osync", "Open WAL files using the O_SYNC flag (Default: off)", TUNABLE_BOOLEAN, &gbl_wal_osync, 0,
+                 NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1005,6 +1005,7 @@
 (name='views_dft_preempt_roll_secs', description='Amount of seconds to run phase 1 of time partition rollout before phase 2', type='INTEGER', value='1800', read_only='N')
 (name='views_dft_roll_delete_lag_secs', description='Amount of seconds to run phase 3 of time partition rollout after phase 2', type='INTEGER', value='5', read_only='N')
 (name='wait_for_seqnum_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
+(name='wal_osync', description='Open WAL files using the O_SYNC flag (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='warn_cstr', description='Warn on validation of cstrings', type='BOOLEAN', value='ON', read_only='N')
 (name='warn_nondbreg_records', description='warn on non-dbreg records before checkpoint', type='BOOLEAN', value='OFF', read_only='N')
 (name='warn_on_replicant_log_write', description='Warn if replicant is writing to logs', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
This patch introduces a new tunable to toggle the O_SYNC flag for log files. If O_SYNC isn't used, after the log buffer is written out when it's full, an asynchronous sync_file_range() call is issued on the log file, to speed up future fsync() calls. In other words, We turn the synchronous IO in log->put() into an asynchronous write-out of page cache, and hence we can move much of the IO latency off the critical path. log->flush(), however, does issue an fsync() call after flushing out the log buffer, to ensure data has made it to disk.