### PR TITLE
Allow leaders of physrep-clusters to truncate repdb

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -7429,7 +7429,7 @@ __truncate_repdb(dbenv)
 		return 0;
 	}
 
-	if (!F_ISSET(rep, REP_ISCLIENT) || !db_rep->rep_db)
+	if ((!F_ISSET(rep, REP_ISCLIENT) && !gbl_is_physical_replicant) || !db_rep->rep_db)
 		return DB_NOTFOUND;
 
 	MUTEX_LOCK(dbenv, db_rep->db_mutexp);


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Allow new leaders of physrep clusters to truncate repdb.
