### PR TITLE
Fix remote write in higher isolation level

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -3813,8 +3813,7 @@ fdb_tran_t *fdb_trans_begin_or_join(struct sqlclntstate *clnt, fdb_t *fdb,
 {
     fdb_distributed_tran_t *dtran;
     fdb_tran_t *tran;
-    int isuuid = (clnt->osql.rqid == OSQL_RQID_USE_UUID) &&
-                 (fdb->server_version > FDB_VER_WR_NAMES);
+    int isuuid = gbl_noenv_messages && (fdb->server_version > FDB_VER_WR_NAMES);
 
     Pthread_mutex_lock(&clnt->dtran_mtx);
 

--- a/tests/remsql.test/output.expected
+++ b/tests/remsql.test/output.expected
@@ -20,3 +20,4 @@
 (TEST='REMSQL DEDUP TEST 3')
 (a=0, b=0)
 (a=0, b=3)
+(rows inserted=1)

--- a/tests/remsql.test/runit
+++ b/tests/remsql.test/runit
@@ -87,6 +87,12 @@ cdb2sql --cdb2cfg ${CDB2_CONFIG} $srcdbname default "UPDATE LOCAL_${dbname}.dedu
 # Ensure that we've updated only 1 row.
 cdb2sql --cdb2cfg ${CDB2_CONFIG} $srcdbname default "SELECT * FROM LOCAL_${dbname}.dedup" >>output.actual 2>&1
 
+#### remote write + higher isolation test ####
+cdb2sql -s --cdb2cfg ${cdb2config} $dbname default - >>output.actual <<EOF
+SET TRANSACTION READ COMMITTED
+INSERT INTO LOCAL_${dbname}.dedup VALUES (4, 4)
+EOF
+
 # validate results
 testcase_output=$(cat output.actual)
 expected_output=$(cat output.expected)


### PR DESCRIPTION
An FDB transaction's rqid isn't properly generated under noenv_message, in transaction isolation levels higher than socksql. This patch fixes it.