### PR TITLE
Ability to override comdb2ar executable in incremental tests

### DIFF
--- a/tests/incremental_backup.test/runit
+++ b/tests/incremental_backup.test/runit
@@ -5,6 +5,10 @@ export debug=1
 
 export DBNAME=$1
 
+if [[ -n "$COMDB2AR_EXE_OVERRIDE" ]]; then
+    COMDB2AR_EXE=${COMDB2AR_EXE_OVERRIDE}
+fi
+
 LOCTMPDIR=$TMPDIR/$DBNAME
 mkdir $LOCTMPDIR
 

--- a/tests/incremental_backup_load.test/runit
+++ b/tests/incremental_backup_load.test/runit
@@ -4,6 +4,10 @@ export debug=1
 export sleeptime=30
 [[ $debug == 1 ]] && set -x
 
+if [[ -n "$COMDB2AR_EXE_OVERRIDE" ]]; then
+    COMDB2AR_EXE=${COMDB2AR_EXE_OVERRIDE}
+fi
+
 if [[ -z "$DBNAME" ]] ; then
   echo DBNAME missing
   exit 1

--- a/tests/incremental_backup_usenames.test/runit
+++ b/tests/incremental_backup_usenames.test/runit
@@ -3,6 +3,10 @@
 export debug=1
 [[ $debug == 1 ]] && set -x
 
+if [[ -n "$COMDB2AR_EXE_OVERRIDE" ]]; then
+    COMDB2AR_EXE=${COMDB2AR_EXE_OVERRIDE}
+fi
+
 export DBNAME=$1
 
 LOCTMPDIR=$TMPDIR/$DBNAME

--- a/tests/incrementalcopy.test/runit
+++ b/tests/incrementalcopy.test/runit
@@ -6,6 +6,11 @@ export debug=1
 # Write 10k rows.  Bring one node down.  Write another 1k rows.  Copy and
 # bring up db.  Make sure it passes verify, and has 10k rows after copy.
 
+if [[ -n "$COMDB2AR_EXE_OVERRIDE" ]]; then
+    COMDB2AR_EXE=${COMDB2AR_EXE_OVERRIDE}
+fi
+
+
 #set -e
 export sleeptime=15
 


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

Environment hooks to allow for testing of an external comdb2ar.
