### PR TITLE
Getting rid of premature ssl_shutdown optimization

### DIFF
--- a/bbinc/ssl_io.h
+++ b/bbinc/ssl_io.h
@@ -22,8 +22,13 @@
 
 /* Gracefully shutdown an SSL connection. The fd remains resuable.
    Return 0 upon success. */
-int SBUF2_FUNC(sslio_close)(SBUF2 *, int reuse);
+int SBUF2_FUNC(sslio_close)(SBUF2 *, int wait_for_peer);
 #define sslio_close SBUF2_FUNC(sslio_close)
+
+/* Free the SSL struct, without calling SSL_shutdown(). This should be called
+   only on a non-recoverable SSL error (ie SSL_ERROR_SYSCALL or SSL_ERROR_SSL). */
+void SBUF2_FUNC(sslio_free)(SBUF2 *);
+#define sslio_free SBUF2_FUNC(sslio_free)
 
 int SBUF2_FUNC(sslio_read)(SBUF2 *, char *cc, int len);
 #define sslio_read SBUF2_FUNC(sslio_read)

--- a/bbinc/ssl_support.h
+++ b/bbinc/ssl_support.h
@@ -106,7 +106,7 @@
 
 #define PRINT_SSL_ERRSTR_MT(cb, msg)            \
 do {                                            \
-    char *__b = alloca(120);                    \
+    char *__b = alloca(256);                    \
     ERR_error_string(ERR_get_error(), __b);     \
     cb(msg ": %s", __b);                        \
 } while (0)

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -625,8 +625,10 @@ static int rd_evbuffer_ssl(struct newsql_appdata_evbuffer *appdata)
     case SSL_ERROR_ZERO_RETURN: disable_ssl_evbuffer(appdata); // fallthrough
     case SSL_ERROR_WANT_READ: return 1;
     case SSL_ERROR_SYSCALL:
-        logmsg(LOGMSG_ERROR, "%s:%d SSL_read rc:%d err:%d errno:%d [%s]\n",
-               __func__, __LINE__, rc, err, errno, strerror(errno));
+        /* ignore previous cdb2_close() implementation which did not send the "close_nofity" alert. */
+        if (errno != 0 && errno != ECONNRESET)
+            logmsg(LOGMSG_ERROR, "%s:%d SSL_read rc:%d err:%d errno:%d [%s]\n",
+                   __func__, __LINE__, rc, err, errno, strerror(errno));
         break;
     default:
         logmsg(LOGMSG_ERROR, "%s:%d SSL_read rc:%d err:%d [%s]\n",

--- a/util/sbuf2.c
+++ b/util/sbuf2.c
@@ -582,13 +582,7 @@ ssl_downgrade:
                 break;
             case SSL_ERROR_ZERO_RETURN:
                 /* Peer has done a clean shutdown. */
-                SSL_shutdown(sb->ssl);
-                SSL_free(sb->ssl);
-                sb->ssl = NULL;
-                if (sb->cert) {
-                    X509_free(sb->cert);
-                    sb->cert = NULL;
-                }
+                sslio_close(sb, 0);
                 goto ssl_downgrade;
             case SSL_ERROR_SYSCALL:
                 sb->protocolerr = 0;
@@ -600,6 +594,7 @@ ssl_downgrade:
                     ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr),
                                  my_ssl_eprintln, "IO error. errno %d.", errno);
                 }
+                sslio_free(sb);
                 break;
             case SSL_ERROR_SSL:
                 errno = EIO;
@@ -607,6 +602,7 @@ ssl_downgrade:
                 ssl_sfliberrprint(sb->sslerr, sizeof(sb->sslerr),
                                   my_ssl_eprintln,
                                   "A failure in SSL library occured");
+                sslio_free(sb);
                 break;
             default:
                 errno = EIO;
@@ -676,13 +672,7 @@ ssl_downgrade:
                 break;
             case SSL_ERROR_ZERO_RETURN:
                 /* Peer has done a clean shutdown. */
-                SSL_shutdown(sb->ssl);
-                SSL_free(sb->ssl);
-                sb->ssl = NULL;
-                if (sb->cert) {
-                    X509_free(sb->cert);
-                    sb->cert = NULL;
-                }
+                sslio_close(sb, 0);
                 goto ssl_downgrade;
             case SSL_ERROR_SYSCALL:
                 sb->protocolerr = 0;
@@ -694,6 +684,7 @@ ssl_downgrade:
                     ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr),
                                  my_ssl_eprintln, "IO error. errno %d.", errno);
                 }
+                sslio_free(sb);
                 break;
             case SSL_ERROR_SSL:
                 errno = EIO;
@@ -701,6 +692,7 @@ ssl_downgrade:
                 ssl_sfliberrprint(sb->sslerr, sizeof(sb->sslerr),
                                   my_ssl_eprintln,
                                   "A failure in SSL library occured");
+                sslio_free(sb);
                 break;
             default:
                 errno = EIO;

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -440,10 +440,8 @@ void SBUF2_FUNC(sslio_free)(SBUF2 *sb)
     if (sb->ssl == NULL)
         return;
 
-    if (sb->cert) {
-        X509_free(sb->cert);
-        sb->cert = NULL;
-    }
+    X509_free(sb->cert);
+    sb->cert = NULL;
 
     SSL_free(sb->ssl);
     sb->ssl = NULL;
@@ -457,10 +455,10 @@ int SBUF2_FUNC(sslio_close)(SBUF2 *sb, int wait_for_peer)
     if (sb->ssl == NULL)
         return 0;
 
-    rc = SSL_shutdown(sb->ssl);
     if (!wait_for_peer)
-        rc = 0;
+        SSL_set_shutdown(sb->ssl, SSL_SENT_SHUTDOWN);
     else {
+        rc = SSL_shutdown(sb->ssl);
         if (rc == 0)
             rc = SSL_shutdown(sb->ssl);
         if (rc == 1)

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -457,10 +457,10 @@ int SBUF2_FUNC(sslio_close)(SBUF2 *sb, int reuse)
     if (sb->ssl == NULL)
         return 0;
 
-    if (!reuse)
-        SSL_set_shutdown(sb->ssl, SSL_SENT_SHUTDOWN);
-    else {
-        rc = SSL_shutdown(sb->ssl);
+    rc = SSL_shutdown(sb->ssl);
+    if (!reuse) /* If a bidirectional shutdown isn't needed, ignore any error from the SSL_shutdown call above. */
+        rc = 0;
+    else { /* If a bidirectional shutdown is needed, do the 2-step shutdown process */
         if (rc == 0)
             rc = SSL_shutdown(sb->ssl);
         if (rc == 1)


### PR DESCRIPTION
Previously `cdb2_close()` did not send the "close_notify" alert, if a connection wasn't to be reused (an undrained cursor, for instance). This would undesirably result in `ECONNRESET` on the server.

This patch gets rid of the optimization.

(DRQS 171159124)
(JIRA RDSICDBDBA-914)