### PR TITLE
Use different send command for fingerprints test

### DIFF
--- a/tests/fingerprints.test/t06.req
+++ b/tests/fingerprints.test/t06.req
@@ -1,4 +1,4 @@
 create table t(a int); $$
-@send clear_fingerprints // bug would set all following normalized sql to this
-select * from t;
-select fingerprint, count, normalized_sql from comdb2_fingerprints;
+@send hi // bug would set all following normalized sql to this
+select * from t; // make sure this is added to fingerprints
+select fingerprint, count, normalized_sql from comdb2_fingerprints where fingerprint='c4fe7ad6cc25bb59daf8101f2196edf6';

--- a/tests/fingerprints.test/t06.req.out
+++ b/tests/fingerprints.test/t06.req.out
@@ -1,3 +1,3 @@
-Cleared 31 fingerprints with a total of 7 plans
-(fingerprint='812bdde365a22a61bcd52bf005990c37', count=1, normalized_sql='EXEC PROCEDURE sys.cmd.send(?);')
+Non-registered tunable 'hi'.
+[ERROR] Unknown command <hi>
 (fingerprint='c4fe7ad6cc25bb59daf8101f2196edf6', count=1, normalized_sql='SELECT*FROM t;')


### PR DESCRIPTION
send clear_fingerprints would result in a different amount of fingerprints cleared in cluster vs single node, so use different send command for this test.

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
