### PR TITLE
Exclude consumers from long request logging.

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2206,7 +2206,7 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
             if (last_long_request_epoch != comdb2_time_epoch()) {
                 last_long_request_epoch = comdb2_time_epoch();
 
-                if (long_request_out != default_out) {
+                if (long_request_out != default_out && long_request_thresh && logger->clnt && !can_consume(logger->clnt)) {
 
                     if (logger->iq && logger->iq->sorese) {
                         char *sqlinfo = osql_sess_info(logger->iq->sorese);


### PR DESCRIPTION
Still include them if we've set the threshold to 0, which implies we want to see everything.

Signed-off-by: Michael Ponomarenko <mponomarenko@bloomberg.net>
