### PR TITLE
Only alert query plan differences once or when cost changes

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1379,8 +1379,10 @@ long long run_sql_thd_return_ll(const char *query, struct sql_thread *thd,
 
 struct query_plan_item {
     char *plan;
+    double avg_cost_per_row;
     double total_cost_per_row;
     int nexecutions;
+    int alert_once_cost; /* Only log query plan cost differences once, reset if the avg cost changes. Init to 1 */
 };
 int free_query_plan_hash(hash_t *query_plan_hash);
 int clear_query_plans();


### PR DESCRIPTION
Only alert query plan differences once, unless cost of an already alerted query plan changes

Signed-off-by: Salil Chandra <schandra107@bloomberg.net>

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
