### PR TITLE
Fix incorrect index position caused by loss of precision

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -2376,6 +2376,9 @@ TYPES_INLINE int CLIENT_REAL_to_CLIENT_UINT(
             from_8 = flibc_dblflip(from_8);
         }
 
+        if (inopts->roundup)
+            from_8 = ceil(from_8);
+
         switch (outlen) {
         case 8:
             if (from_8 > FLIBC_DBL_ULLONG_MAX)
@@ -2429,6 +2432,9 @@ TYPES_INLINE int CLIENT_REAL_to_CLIENT_UINT(
         if (from_flip) {
             from_4 = flibc_floatflip(from_4);
         }
+
+        if (inopts->roundup)
+            from_4 = ceilf(from_4);
 
         switch (outlen) {
         case 8:
@@ -2516,6 +2522,9 @@ TYPES_INLINE int CLIENT_REAL_to_CLIENT_INT(
             from_8 = flibc_dblflip(from_8);
         }
 
+        if (inopts->roundup)
+            from_8 = ceil(from_8);
+
         switch (outlen) {
         case 8:
             if (from_8 > FLIBC_DBL_LLONG_MAX)
@@ -2569,6 +2578,9 @@ TYPES_INLINE int CLIENT_REAL_to_CLIENT_INT(
         if (from_flip) {
             from_4 = flibc_floatflip(from_4);
         }
+
+        if (inopts->roundup)
+            from_4 = ceilf(from_4);
 
         switch (outlen) {
         case 8:

--- a/db/types.h
+++ b/db/types.h
@@ -143,7 +143,8 @@ enum {
 #define FIELD_CONV_OPTS_COMMON                                                 \
     unsigned flags;                                                            \
     int dbpad;                                                                 \
-    int step;
+    int step;                                                                  \
+    int roundup;
 
 struct field_conv_opts {
     FIELD_CONV_OPTS_COMMON

--- a/sqlite/src/dttz.c
+++ b/sqlite/src/dttz.c
@@ -13,6 +13,7 @@
 #include <time.h>
 #include <strings.h>
 #include <alloca.h>
+#include <math.h>
 
 #include <sys/types.h>
 #include <inttypes.h>
@@ -423,4 +424,15 @@ const char *get_clnt_tz()
 {
   struct sql_thread *thd = pthread_getspecific(query_info_key);
   return ( thd && thd->clnt ) ? thd->clnt->tzname : NULL;
+}
+
+void next_milliseconds(dttz_t *in)
+{
+    if (in->dttz_prec == 6) {
+        in->dttz_frac = ((int)ceil(in->dttz_frac / 1000.0)) * 1000;
+        while (in->dttz_frac >= 1000000) {
+            in->dttz_frac -= 1000000;
+            ++in->dttz_sec;
+        }
+    }
 }

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -796,6 +796,7 @@ int sqlite3VdbeCheckFk(Vdbe *, int);
 int convMem2ClientDatetime(Mem *pMem, void *out);
 int convMem2ClientDatetimeStr(Mem *pMem, void *out, int outlen, int *outdtsz);
 int convDttz2ClientDatetime(const dttz_t *, const char *tzname, void *out, int sqltype);
+void next_milliseconds(dttz_t *in);
 const char *get_clnt_tz();
 
 int sqliteVdbeMemDecimalBasicArithmetics(Mem *a, Mem *b, int opcode, Mem * res, int flipped);


### PR DESCRIPTION
Consider the following statements.

```sql
CREATE TABLE t (i int, j int)
CREATE INDEX t_ij on t(i, j)
INSERT INTO t VALUES (1.1, 1), (1.1, 2), (2, 3)
SELECT * FROM t WHERE i = 1.1 AND j = 1
```

The last SELECT statement returns wrong rows, as shown below:

```sql
(i=1, j=1)
(i=1, j=2)
```

To understand the issue, first consider the following statement.
```
SELECT * FROM t WHERE i = 1 AND j = 1
```

The cursor on the index is first positioned on the smallest entry that's greater than or equal to (1, 1), that is, the very 1st row in this table. We then continue traversing the index till we see an entry greater than the search key. Hence we stop at (1, 2), returning (1, 1) to client.

However, when searching (1.1, 1), the floating point number is rounded down to 1 (just like how it was inserted). Therefore, instead of being positioned on (2, 3), the cursor is placed on (1, 1), again. Now, we're going to traverse the index till we meet an entry greater than (1.1, 1), that is, (2, 3) (table has (1, 1), (1, 2) and (2, 3)).

To fix this, a new `roundup` conversion flag is introduced. When lit, `mem_to_ondisk`, instead of rounding the given value down, it rounds it up to the next higher value in its lower precsion data type. For example, 1.1 would be rounded up to 2; "2023-01-01T000000.000001" would be rounded up to "2023-01-01T000000.001".

(DRQS 171250145)

Signed-off-by: Rivers Zhang <hzhang320@bloomberg.net>