### PR TITLE
mark resume flag de-novo sc for missing shards during resume

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -895,7 +895,8 @@ static int verify_sc_resumed_for_shard(const char *shardname,
     strncpy0(new_sc->tablename, shardname, sizeof(new_sc->tablename));
     new_sc->iq = NULL;
     new_sc->tran = NULL;
-    new_sc->resume = 0;
+    /*new_sc->resume = 0; ALL RESUMED SC-s HAVE THIS SET, TO PREVENT RESUME DEADLOCK ON BDB LOCK */
+    new_sc->resume = SC_RESUME;
     new_sc->nothrevent = 0;
     new_sc->finalize = 0;
 


### PR DESCRIPTION
Currently, if we have to resume more than sc_async_maxthreads during master swing, server deadlocks, unless the schemachange objects are marked s->resume == SC_RESUME.
Unfortunately, the de novo schema changes for missing shards, created during resume, do not have this flag marked, deadlocking the master.   This fixes it.
 
Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
