### PR TITLE
Don't block on lock from the delete-old-files thread

### DIFF
--- a/bdb/info.c
+++ b/bdb/info.c
@@ -119,6 +119,7 @@ static void txn_stats(FILE *out, bdb_state_type *bdb_state)
     bdb_state->dbenv->txn_stat(bdb_state->dbenv, &stats, 0);
 
     logmsgf(LOGMSG_USER, out, "st_last_ckp: %s\n", lsn_to_str(str, &(stats->st_last_ckp)));
+    logmsgf(LOGMSG_USER, out, "st_ckp_lsn: %s\n", lsn_to_str(str, &(stats->st_ckp_lsn)));
     prn_stat(st_time_ckp);
     prn_stat(st_last_txnid);
     prn_stat(st_maxtxns);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -282,6 +282,7 @@ struct txn_properties;
 #define DB_TXN_DONT_GET_REPO_MTX   0x0080000 /* Get the repo mutex on this commit */
 #define DB_TXN_SCHEMA_LOCK         0x0100000 /* Get the schema-lock */
 #define DB_TXN_LOGICAL_GEN         0x0200000 /* Contains generation info (txn_regop_rl) */
+#define DB_TXN_FOP_NOBLOCK         0x0400000 /* Don't block on fop operations */
 /*
  * Flags private to DB_ENV->set_encrypt.
  */
@@ -1072,6 +1073,7 @@ struct __db_txn {
 #define	TXN_RESTORED	0x080		/* Transaction has been restored. */
 #define	TXN_SYNC	0x100		/* Sync on prepare and commit. */
 #define	TXN_RECOVER_LOCK	0x200 /* Transaction holds the recovery lock */
+#define TXN_FOP_NOBLOCK		0x400 /* Dont block on fop transactions */
 	u_int32_t	flags;
 
 	void     *app_private;		/* pointer to bdb transaction object */
@@ -1107,6 +1109,7 @@ struct __db_txn_active {
 
 struct __db_txn_stat {
 	DB_LSN	  st_last_ckp;		/* lsn of the last checkpoint */
+	DB_LSN	  st_ckp_lsn;		/* ckp-lsn of last checkpoint */
 	time_t	  st_time_ckp;		/* time of last checkpoint */
 	u_int32_t st_last_txnid;	/* last transaction id given out */
 	u_int32_t st_maxtxns;		/* maximum txns possible */

--- a/berkdb/mp/mp_alloc.c
+++ b/berkdb/mp/mp_alloc.c
@@ -135,6 +135,7 @@ static void dump_page_stats(DB_ENV *dbenv) {
 	dbenv->txn_stat(dbenv, &txn_stats, 0);
    
 	logmsgf(LOGMSG_USER, out, "st_last_ckp: %u:%u\n",  txn_stats->st_last_ckp.file, txn_stats->st_last_ckp.offset);
+	logmsgf(LOGMSG_USER, out, "st_ckp_lsn: %u:%u\n",  txn_stats->st_ckp_lsn.file, txn_stats->st_ckp_lsn.offset);
 	logmsgf(LOGMSG_USER, out, "st_time_ckp: %lu\n", txn_stats->st_time_ckp);
 	logmsgf(LOGMSG_USER, out, "st_last_txnid: %u\n", txn_stats->st_last_txnid);
 	logmsgf(LOGMSG_USER, out, "st_maxtxns: %u\n", txn_stats->st_maxtxns);

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -327,6 +327,8 @@ __txn_begin_main(dbenv, parent, txnpp, flags, prop)
 		F_SET(txn, TXN_SYNC);
 	if (LF_ISSET(DB_TXN_NOWAIT))
 		F_SET(txn, TXN_NOWAIT);
+	if (prop && prop->flags & DB_TXN_FOP_NOBLOCK) 
+		F_SET(txn, TXN_FOP_NOBLOCK);
 
 	if ((ret =
 		__txn_begin_int_with_prop(txn, prop,

--- a/berkdb/txn/txn_stat.c
+++ b/berkdb/txn/txn_stat.c
@@ -18,6 +18,7 @@ static const char revid[] = "$Id: txn_stat.c,v 11.22 2003/09/13 19:20:43 bostic 
 #endif
 
 #include "db_int.h"
+#include "dbinc/db_swap.h"
 #include "dbinc/log.h"
 #include "dbinc/txn.h"
 
@@ -41,7 +42,7 @@ __txn_stat_pp(dbenv, statp, flags)
 	ENV_REQUIRES_CONFIG(dbenv, dbenv->tx_handle, "txn_stat", DB_INIT_TXN);
 
 	if ((ret = __db_fchk(dbenv,
-	    "DB_ENV->txn_stat", flags, DB_STAT_CLEAR)) != 0)
+		"DB_ENV->txn_stat", flags, DB_STAT_CLEAR)) != 0)
 		return (ret);
 
 	rep_check = IS_ENV_REPLICATED(dbenv) ? 1 : 0;
@@ -67,7 +68,11 @@ __txn_stat(dbenv, statp, flags)
 	DB_TXNREGION *region;
 	DB_TXN_STAT *stats;
 	TXN_DETAIL *txnp;
+	DB_LOGC *dbc = NULL;
+	DBT dbt = { 0 };
+	__txn_ckp_args *ckp = NULL;
 	size_t nbytes;
+	int32_t type;
 	u_int32_t maxtxn, ndx;
 	int ret;
 
@@ -89,29 +94,53 @@ __txn_stat(dbenv, statp, flags)
 	nbytes = sizeof(DB_TXN_STAT) + sizeof(DB_TXN_ACTIVE) * maxtxn;
 	if ((ret = __os_umalloc(dbenv, nbytes, &stats)) != 0)
 		return (ret);
+	ret = dbenv->log_cursor(dbenv, &dbc, 0);
+	if (ret) {
+		logmsg(LOGMSG_ERROR, "log_cursor ret %d\n", ret);
+		return (ret);
+	}
+	dbt.flags = DB_DBT_MALLOC;
 
 	R_LOCK(dbenv, &mgr->reginfo);
 	memcpy(stats, &region->stat, sizeof(*stats));
 	stats->st_last_txnid = region->last_txnid;
 	stats->st_last_ckp = region->last_ckp;
+	ZERO_LSN(stats->st_ckp_lsn);
+	ret = dbc->get(dbc, &stats->st_last_ckp, &dbt, DB_SET);
+	if (!ret) {
+		LOGCOPY_32(&type, dbt.data);
+		if (type == DB___txn_ckp) {
+			ret = __txn_ckp_read(dbenv, dbt.data, &ckp);
+			if (ret == 0) {
+				stats->st_ckp_lsn = ckp->ckp_lsn;
+			}
+		}
+	}
+	if (dbt.data)
+		__os_ufree(dbenv, dbt.data);
+	if (ckp)
+		__os_free(dbenv, ckp);
+	if (dbc)
+		dbc->close(dbc, 0);
+
 	stats->st_time_ckp = region->time_ckp;
 	stats->st_txnarray = (DB_TXN_ACTIVE *)&stats[1];
 
 	for (ndx = 0,
-	    txnp = SH_TAILQ_FIRST(&region->active_txn, __txn_detail);
-	    txnp != NULL && ndx < maxtxn;
-	    txnp = SH_TAILQ_NEXT(txnp, links, __txn_detail), ++ndx) {
+		txnp = SH_TAILQ_FIRST(&region->active_txn, __txn_detail);
+		txnp != NULL && ndx < maxtxn;
+		txnp = SH_TAILQ_NEXT(txnp, links, __txn_detail), ++ndx) {
 		stats->st_txnarray[ndx].txnid = txnp->txnid;
 		if (txnp->parent == INVALID_ROFF)
 			stats->st_txnarray[ndx].parentid = TXN_INVALID;
 		else
 			stats->st_txnarray[ndx].parentid =
-			    ((TXN_DETAIL *)R_ADDR(&mgr->reginfo,
-			    txnp->parent))->txnid;
+				((TXN_DETAIL *)R_ADDR(&mgr->reginfo,
+				txnp->parent))->txnid;
 		stats->st_txnarray[ndx].lsn = txnp->begin_lsn;
 		if ((stats->st_txnarray[ndx].xa_status = txnp->xa_status) != 0)
 			memcpy(stats->st_txnarray[ndx].xid,
-			    txnp->xid, DB_XIDDATASIZE);
+				txnp->xid, DB_XIDDATASIZE);
 	}
 
 	stats->st_region_wait = mgr->reginfo.rp->mutex.mutex_set_wait;
@@ -123,7 +152,7 @@ __txn_stat(dbenv, statp, flags)
 		memset(&region->stat, 0, sizeof(region->stat));
 		region->stat.st_maxtxns = region->maxtxns;
 		region->stat.st_maxnactive =
-		    region->stat.st_nactive = stats->st_nactive;
+			region->stat.st_nactive = stats->st_nactive;
 	}
 
 	R_UNLOCK(dbenv, &mgr->reginfo);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1339,7 +1339,7 @@ static void *purge_old_files_thread(void *arg)
         /* ok, get to work now */
         retries = 0;
     retry:
-        rc = trans_start_sc(&iq, NULL, &trans);
+        rc = trans_start_sc_fop(&iq, &trans);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "%s: failed to create transaction\n", __func__);
             sleep_with_check_for_exiting(empty_pause);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2038,6 +2038,7 @@ void tran_dump(struct long_trn_stat *tstats);
 /* transactional stuff */
 int trans_start(struct ireq *, tran_type *parent, tran_type **out);
 int trans_start_sc(struct ireq *, tran_type *parent, tran_type **out);
+int trans_start_sc_fop(struct ireq *, tran_type **out);
 int trans_start_sc_lowpri(struct ireq *, tran_type **out);
 int trans_start_set_retries(struct ireq *, tran_type *parent, tran_type **out,
                             uint32_t retries, uint32_t priority);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -214,6 +214,8 @@ extern int gbl_client_heartbeat_ms;
 extern int gbl_rep_wait_release_ms;
 extern int gbl_rep_wait_core_ms;
 extern int gbl_random_get_curtran_failures;
+extern int gbl_txn_fop_noblock;
+extern int gbl_debug_random_block_on_fop;
 extern int gbl_random_thdpool_work_timeout;
 extern int gbl_thdpool_queue_only;
 extern int gbl_random_sql_work_delayed;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1706,6 +1706,12 @@ REGISTER_TUNABLE("random_get_curtran_failures",
                  TUNABLE_INTEGER, &gbl_random_get_curtran_failures,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("dont_block_delete_files_thread", "Ignore files that would block delete-files thread.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_txn_fop_noblock, 0, NULL, NULL, NULL, NULL);
+
+REGISTER_TUNABLE("debug_random_fop_block", "Randomly return .  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_random_block_on_fop, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("random_thdpool_work_timeout",
                  "Force a random thread pool work item timeout 1/this many "
                  "times.  (Default: 0)",

--- a/db/glue.c
+++ b/db/glue.c
@@ -179,6 +179,9 @@ static int syncmode_callback(bdb_state_type *bdb_state);
 /* How many times we became, or ceased to be, master node. */
 int gbl_master_changes = 0;
 
+/* Dont block when removing old files */
+int gbl_txn_fop_noblock = 0;
+
 static void *get_bdb_handle(struct dbtable *db, int auxdb)
 {
     void *bdb_handle;
@@ -354,8 +357,14 @@ int trans_start_sc(struct ireq *iq, tran_type *parent_trans,
 
 int trans_start_sc_lowpri(struct ireq *iq, tran_type **out_trans)
 {
-    struct txn_properties p = { .flags = DB_LOCK_ID_LOWPRI };
+    struct txn_properties p = {.flags = DB_LOCK_ID_LOWPRI};
     return trans_start_int(iq, NULL, out_trans, 0, 0, &p, 0);
+}
+
+int trans_start_sc_fop(struct ireq *iq, tran_type **out_trans)
+{
+    struct txn_properties p = {.flags = DB_TXN_FOP_NOBLOCK};
+    return trans_start_int(iq, NULL, out_trans, 0, 0, gbl_txn_fop_noblock ? &p : NULL, 0);
 }
 
 int trans_start_set_retries(struct ireq *iq, tran_type *parent_trans,

--- a/db/pushlogs.c
+++ b/db/pushlogs.c
@@ -104,8 +104,6 @@ static void *pushlogs_thread(void *voidarg)
         if (done)
             break;
 
-        Pthread_mutex_lock(&schema_change_in_progress_mutex);
-
         /* put some junk into meta table */
         init_fake_ireq(thedb, &iq);
         db = &thedb->static_table;
@@ -113,7 +111,6 @@ static void *pushlogs_thread(void *voidarg)
         rc = trans_start(&iq, NULL, &trans);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "pushlogs_thread: cannot create transaction\n");
-            Pthread_mutex_unlock(&schema_change_in_progress_mutex);
             Pthread_mutex_lock(&mutex);
             have_thread = 0;
             Pthread_mutex_unlock(&mutex);
@@ -123,14 +120,12 @@ static void *pushlogs_thread(void *voidarg)
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "pushlogs_thread: error %d adding to meta table\n",
                     rc);
-            Pthread_mutex_unlock(&schema_change_in_progress_mutex);
             trans_abort(&iq, trans);
             Pthread_mutex_lock(&mutex);
             have_thread = 0;
             Pthread_mutex_unlock(&mutex);
             break;
         }
-        Pthread_mutex_unlock(&schema_change_in_progress_mutex);
         rc = trans_commit(&iq, trans, gbl_myhostname);
         if (rc != 0) {
             logmsg(LOGMSG_ERROR, "pushlogs_thread: cannot commit txn %d\n", rc);

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -665,6 +665,7 @@ can be queried with the `stat autonalyze` command.
 |REP_VERIFY_MIN_PROGRESS | 10485760 | Abort replicant if it doesn't make this much progress while rolling back logs to sync up to master.
 |REP_VERIFY_LIMIT_ENABLED | 1 | Enable aborting replicant if it doesn't make sufficient progress while rolling back logs to sync up to master.
 |DELETE_OLD_FILE_DEBUG | 0 | Spew debug info about deleting old files during schema change.
+|DONT_BLOCK_DELETE_FILES_THREAD | 0 | Don't delete any files that would cause delete files thread to block
 |file_permissions | 0660 | Default filesystem permissions for database files.
 
 #### Log configuration

--- a/tests/delfile_block.test/Makefile
+++ b/tests/delfile_block.test/Makefile
@@ -1,0 +1,12 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=7m
+endif
+
+export DUMPLOCK_ON_TIMEOUT=1
+export CORE_ON_TIMEOUT=1

--- a/tests/delfile_block.test/README
+++ b/tests/delfile_block.test/README
@@ -1,0 +1,1 @@
+Test behavior of delfiles thread when we fail to delete a file because it is locked

--- a/tests/delfile_block.test/lrl.options
+++ b/tests/delfile_block.test/lrl.options
@@ -1,0 +1,10 @@
+setattr PRIVATE_BLKSEQ_MAXAGE 1
+setattr MIN_KEEP_LOGS 1
+setattr MIN_KEEP_LOGS_AGE 0 
+setattr LOGDELETEAGE 0
+setattr DEBUG_LOG_DELETION 1
+dont_block_delete_files_thread 1
+debug_random_fop_block 1
+delete_old_file_debug 1
+setattr CHECKPOINTTIME 10
+setattr CHECKPOINTRAND 5

--- a/tests/delfile_block.test/reproleak.testopts
+++ b/tests/delfile_block.test/reproleak.testopts
@@ -1,0 +1,1 @@
+debug_random_fop_block 0

--- a/tests/delfile_block.test/runit
+++ b/tests/delfile_block.test/runit
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ "$debug" == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export maxtable=50
+
+function create_tables
+{
+    typeset j=0
+    typeset func=create_tables
+    write_prompt $func "Creating tables"
+    while [[ "$j" -lt "$maxtable" ]]; do
+        $CDB2SQL_EXE -s --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "create table t${j} (a int)" >/dev/null 2>&1
+        [[ "$?" == "0" ]] && write_prompt $func "Created table t${j}"
+        let j=j+1
+    done
+    $CDB2SQL_EXE --tabs --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "select * from comdb2_tables" | while read x ; do
+        write_prompt $func "Found table $x"
+    done
+}
+
+function truncate_tables
+{
+    typeset j=0
+    typeset func=truncate_tables
+    write_prompt $func "Deleting tables"
+    while [[ "$j" -lt "$maxtable" ]]; do
+        $CDB2SQL_EXE -s --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "truncate t${j}" >/dev/null 2>&1
+        [[ "$?" == "0" ]] && write_prompt $func "Truncated t${j}"
+        let j=j+1
+    done
+}
+
+function drop_tables
+{
+    typeset j=0
+    typeset func=drop_tables
+    write_prompt $func "Deleting tables"
+    while [[ "$j" -lt "$maxtable" ]]; do
+        $CDB2SQL_EXE -s --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "drop table t${j}" >/dev/null 2>&1
+        [[ "$?" == "0" ]] && write_prompt $func "Dropped table t${j}"
+        let j=j+1
+    done
+    $CDB2SQL_EXE --tabs --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "select * from comdb2_tables" | while read x ; do
+        write_prompt $func "Found table $x"
+    done
+}
+
+function pushnext
+{
+    typeset master=$(get_master)
+    write_prompt pushnext "Running pushnext"
+    ${CDB2SQL_EXE} ${CDB2_OPTIONS} --host $master $DBNAME "exec procedure sys.cmd.send('pushnext')" >/dev/null 2>&1
+}
+
+function downgrade
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="downgrade"
+    typeset node=$(get_master)
+    typeset count=0
+    typeset foundmaster=0
+    typeset maxcount=600
+    typeset initialmaster=0
+    write_prompt $func "Running $func $node"
+
+    x=$(get_master)
+    while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+        sleep 1
+        x=$(get_master)
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not find master"
+    initialmaster=$x
+
+    while [[ "$x" == "$initialmaster" && "$count" -lt $maxcount ]]; do
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+            let count=count+1
+        done
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS --host $x $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
+        sleep 1
+        x=$(get_master)
+        while [[ "$CLUSTER" != *"$x"* && "$count" -lt "$maxcount" ]]; do
+            sleep 1
+            x=$(get_master)
+        done
+
+        [[ "$x" != "$node" ]] && foundmaster=1
+        let count=count+1
+    done
+
+    [[ "$count" -ge "$maxcount" ]] && failexit "Could not downgrade master"
+}
+
+function run_test
+{
+    typeset maxtime=`echo "(${TEST_TIMEOUT%%m}-2)*60" | bc`
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset func=run_test
+    typeset count=0
+    rm -f $stopfile >/dev/null 2>&1
+
+    if [[ "$TESTCASE" == "delfile_block_reproleak_generated" ]]; then
+        create_tables
+    fi
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        let count=count+1
+        if [[ "$TESTCASE" == "delfile_block_reproleak_generated" ]]; then
+            truncate_tables
+        else
+            create_tables
+            drop_tables
+        fi
+        pushnext
+        if [[ "$TESTCASE" == "delfile_block_reproleak_generated" ]]; then
+            x=$(( count % 6 ))
+            if [[ "$x" == "0" ]]; then
+                write_prompt $func "Downgrading master"
+                downgrade
+            fi
+        fi
+        write_prompt $func "Sleeping for 10"
+        sleep 10
+    done
+    
+    write_prompt $func "Verify the checkpoint lsn"
+
+    master=$(get_master)
+    txnstat=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} --host $master $DBNAME "exec procedure sys.cmd.send('bdb txnstat')")
+
+    lstckp_ln=$(echo "$txnstat" | grep "st_last_ckp")
+    ckplsn_ln=$(echo "$txnstat" | grep "st_ckp_lsn")
+
+    lstckp=$(echo ${lstckp_ln#*: })
+    ckplsn=$(echo ${ckplsn_ln#*: })
+
+    lstfl=$(echo ${lstckp%:*})
+    ckpfl=$(echo ${ckplsn%:*})
+
+    write_prompt $func "Last-checkpoint is $lstckp, Checkpoint-LSN is $ckplsn"
+
+    diff=$(( lstfl - ckpfl ))
+
+    if [[ "$diff" -gt 1 ]]; then
+        echo "Failing test: Checkpoint-LSN is TOO OLD"
+        exit -1
+    fi
+}
+
+run_test
+echo "Success!"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -244,6 +244,7 @@
 (name='dohsql_pool_thread_slack', description='Forbid parallel sql coordinators from running on this many sql engines (if 0, defaults to 1).', type='INTEGER', value='1', read_only='N')
 (name='dohsql_verbose', description='Run distributed queries in verbose/debug mode', type='BOOLEAN', value='OFF', read_only='N')
 (name='dont_abort_on_in_use_rqid', description='Disable 'abort_on_in_use_rqid'', type='BOOLEAN', value='OFF', read_only='Y')
+(name='dont_block_delete_files_thread', description='Ignore files that would block delete-files thread.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='dont_forbid_ulonglong', description='Disables 'forbid_ulonglong'', type='BOOLEAN', value='OFF', read_only='N')
 (name='dont_init_queue_with_persistent_sequence', description='Disables 'init_queue_with_persistent_sequence'', type='BOOLEAN', value='ON', read_only='Y')
 (name='dont_init_with_inplace_updates', description='Disables 'init_with_inplace_updates'', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
This branch introduces a workaround for the "leaked-handle-lock" scenario that we've observed a few times against 8.0, where the delete-files thread is blocked for a significant time while holding an open-transaction.  It turns out that this operation is completely safe to attempt optimistically.  The changes in this PR provide the 'dont_block_delete_files_thread' tunable which do exactly that.

The 'delfile_block' test verifies this behavior by intentionally leaking handle-locks which subsequently block the delete-files thread.  We verify our success by comparing the most recent checkpoint with its checkpoint LSN.  Running this test with 'dont_block_delete_files_thread' enabled will always show these to be within a short-range of each other.  If this tunable is disabled, the delete-files transaction will remain open indefinitely.  The 'failure' test case I ran showed the last-ckp and ckp-lsn differing by more than 20 log files.

This is 'part 1' of this work.  Part 2 will provide a way to audit cases where handle-locks are leaked.

Signed-off-by: Mark Hannum <mhannum72@gmail.com>