### PR TITLE
we already have a views lock

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -257,7 +257,7 @@ retry:
         return -1;
     }
 
-    if ((sctype == alter || sctype == fastinit || sctype == bulkimport || sctype == drop || sctype == views) &&
+    if ((sctype == alter || sctype == fastinit || sctype == bulkimport || sctype == drop) &&
         (strncmp(tbl, "sqlite_stat", sizeof("sqlite_stat") - 1) != 0)) {
         bdb_lock_tablename_write(bdb_state, tbl, tran);
     }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7749,13 +7749,6 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
             return rc;
         }
 
-        if (db->timepartition_name != NULL &&
-            (rc = bdb_lock_tablename_read_fromlid(thedb->bdb_env, db->timepartition_name,
-                                                  bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran))) != 0) {
-            logmsg(LOGMSG_ERROR, "%s lock %s returns %d\n", __func__, db->timepartition_name, rc);
-            return rc;
-        }
-
         /* BIG NOTE:
          * A sqlite engine can safely access a dbtable once it acquires the read lock
          * for the table. This is done under schema change lock, and after that the


### PR DESCRIPTION
Views are accessed during prepare stage by sql threads, during rollout by cron thread on master, and by recover callbacks following rollbacks on the replicants.  We get a read lock in the first case, and a write one during the second event.  I fail to see an issue and a need for an additional persistent berkdb lock.


Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
