### PR TITLE
Enable 'stack-at-get-lock' by default & expose in locks table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ if(DEBUG_STACK_AT_DB_OPEN_CLOSE)
     add_definitions(-DDEBUG_STACK_AT_DB_OPEN_CLOSE)
 endif()
 
-option(STACK_AT_GET_LOCK "Store a cheapstack at every get-lock" OFF)
+option(STACK_AT_GET_LOCK "Store a cheapstack at every get-lock" ON)
 mark_as_advanced(STACK_AT_GET_LOCK)
 if(STACK_AT_GET_LOCK)
     add_definitions(-DSTACK_AT_GET_LOCK)

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -58,6 +58,7 @@
 
 #include "tunables.h"
 #include "dbinc/trigger_subscription.h"
+#include <dbinc/maxstackframes.h>
 
 #if defined(__cplusplus)
 extern "C" {
@@ -2189,7 +2190,11 @@ struct __ufid_to_db_t {
 
 typedef int (*collect_locks_f)(void *args, int64_t threadid, int32_t lockerid,
 		const char *mode, const char *status, const char *table,
-		int64_t page, const char *rectype);
+		int64_t page, const char *rectype
+#if defined (STACK_AT_LOCK_GEN_INCREMENT) || defined (STACK_AT_GET_LOCK)
+        ,int frames, void *buf[MAX_BERK_STACK_FRAMES]
+#endif
+        );
 
 /* Database Environment handle. */
 struct __db_env {

--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -20,7 +20,7 @@ extern size_t gbl_lkr_hash;
 
 #define	DB_LOCK_DEFAULT_N	1000	/* Default # of locks in region. */
 
-#define MAX_BERK_STACK_FRAMES 32
+#include <dbinc/maxstackframes.h>
 
 /*
  * The locker id space is divided between the transaction manager and the lock
@@ -360,9 +360,6 @@ struct __db_lock {
 #if defined (STACK_AT_LOCK_GEN_INCREMENT) || defined (STACK_AT_GET_LOCK)
 	int			frames;
 	void		*buf[MAX_BERK_STACK_FRAMES];
-	int 		stack_gen;
-	DB_LOCK		*lock;
-	pthread_t	tid;
 #endif
 };
 

--- a/berkdb/dbinc/maxstackframes.h
+++ b/berkdb/dbinc/maxstackframes.h
@@ -1,0 +1,15 @@
+/*-
+ * See the file LICENSE for redistribution information.
+ *
+ * Copyright (c) 1996-2003
+ *	Sleepycat Software.  All rights reserved.
+ *
+ * $Id: lock.h,v 11.47 2003/04/16 18:23:27 ubell Exp $
+ */
+
+#ifndef	_DB_MAXSTACKFRAMES_H_
+#define	_DB_MAXSTACKFRAMES_H_
+
+#define MAX_BERK_STACK_FRAMES 32
+
+#endif /* !_DB_MAXSTACKFRAMES_H_ */

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -1933,13 +1933,6 @@ static void inline
 get_stack(struct __db_lock *lockp, DB_LOCK *lock, int checkgen)
 {
 	lockp->frames = backtrace(lockp->buf, MAX_BERK_STACK_FRAMES);
-
-	if (checkgen && lockp->gen != lockp->stack_gen + 1) {
-		abort();
-	}
-	lockp->stack_gen = lockp->gen;
-	lockp->tid = pthread_self();
-	lockp->lock = lock;
 }
 #endif
 

--- a/berkdb/lock/lock_stat.c
+++ b/berkdb/lock/lock_stat.c
@@ -735,7 +735,11 @@ __collect_lock(DB_LOCKTAB *lt, DB_LOCKER *lip, struct __db_lock *lp,
 	if (namep && memcmp(namep, "XXX.", 4) == 0)
 		namep += 4;
 
-	(*func)(arg, (uint64_t)lip->tid, lip->id, mode, status, namep, page, rectype);
+	(*func)(arg, (uint64_t)lip->tid, lip->id, mode, status, namep, page, rectype
+#if defined (STACK_AT_LOCK_GEN_INCREMENT) || defined (STACK_AT_GET_LOCK)
+        ,lp->frames, lp->buf
+#endif
+    );
 	if (hexdump)
 		free(hexdump);
 	return 0;


### PR DESCRIPTION
Signed-off-by: Mark Hannum <mhannum72@gmail.com>

"Different" take on stack-on-get-lock code being studied.  This version enables code that was originally written by Akshat for the 'segmented-lkmgr' project.  The downside to this approach is that it doubles the size of an individual lock.  Upside is that there doesn't seem to be a performance penalty (my benchmark was simply to time the lkmgr test in single-node mode).

Submitting this only as a point-of-reference: my guess is that we'll probably end up combining the two schemes, storing a single integer in each lock and keeping the corresponding stacks in a hash.