### PR TITLE
select the last used shard so that we properly rollout if db is down

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -2935,8 +2935,8 @@ static void _view_find_current_shard(timepart_view_t *view)
                 return;
             }
         }
-        if (newest_earlier_shard < 0 ||
-            view->shards[newest_earlier_shard].low < view->shards[i].low)
+        if (newest_earlier_shard < 0 || (view->shards[i].low != INT_MAX && 
+            view->shards[newest_earlier_shard].low < view->shards[i].low))
             newest_earlier_shard = i;
     }
     assert(newest_earlier_shard >= 0 && newest_earlier_shard < view->nshards);


### PR DESCRIPTION
If the db is live, we always find a proper shard; if the db is down, we might miss a few rollouts.  This patch skips the unused shards when determining the last used shard (they have low == INT_MAX, which breaks the rollout).

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>

