### PR TITLE
track comdb2fastseed users; dump counters on exit

### DIFF
--- a/bbinc/util.h
+++ b/bbinc/util.h
@@ -55,7 +55,8 @@ char *fmt_size(char *buf, size_t bufsz, uint64_t bytes);
 
 int getroom_callback(void *dummy, const char *host);
 
-uint64_t comdb2fastseed(void);
+uint64_t comdb2fastseed(int srcid);
+void report_fastseed_users(int lvl);
 
 char *inet_ntoa_r(in_addr_t addr, char out[16]);
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1648,6 +1648,8 @@ static void begin_clean_exit(void)
  */
 void clean_exit(void)
 {
+    report_fastseed_users(LOGMSG_ERROR);
+
     if(gbl_perform_full_clean_exit) {
         begin_clean_exit();
         return;

--- a/db/envstubs.c
+++ b/db/envstubs.c
@@ -58,14 +58,18 @@ extern int gbl_mynodeid;
 
 uint64_t (*external_fastseed)(void) = NULL;
 
+static void _track(int srcid);
+
 /* TODO: fastseed - compatibility mode only - remove */
-uint64_t comdb2fastseed(void)
+uint64_t comdb2fastseed(int srcid)
 {
     int epoch, node, dup;
     int firstepoch = 0;
     int retries;
     int seed[2];
     uint64_t out;
+
+    _track(srcid);
 
     if (external_fastseed)
         return external_fastseed();
@@ -139,4 +143,27 @@ uint64_t comdb2fastseed(void)
 
     memcpy(&out, seed, 8);
     return flibc_ntohll(out);
+}
+
+/* hack alert: this is indexed by sources, which gets their own next available
+ * int id good enough to track this code that is going away
+ */
+static int track[5];
+const char *track_names[5] = {"osql", "remsql", "remtran", "seqno", "sqlfunc"};
+
+static void _track(int srcid)
+{
+    if (srcid < 0 || srcid >= sizeof(track) / sizeof(track[0]))
+        srcid = 0;
+    track[srcid]++;
+}
+
+void report_fastseed_users(int lvl)
+{
+    int i;
+    for (i = 0; i < sizeof(track) / sizeof(track[0]); i++) {
+        if (track[i])
+            logmsg(lvl, "COMDB2FASTSEED \"%s\" count %d\n", track_names[i],
+                   track[i]);
+    }
 }

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -2389,7 +2389,7 @@ static fdb_cursor_if_t *_fdb_cursor_open_remote(struct sqlclntstate *clnt,
         comdb2uuid(fdbc->ciduuid);
         memcpy(fdbc->tid, tid, sizeof(uuid_t));
     } else {
-        *((unsigned long long *)fdbc->cid) = comdb2fastseed();
+        *((unsigned long long *)fdbc->cid) = comdb2fastseed(1);
         memcpy(fdbc->tid, tid, sizeof(unsigned long long));
     }
     fdbc->flags = flags;
@@ -3766,7 +3766,7 @@ static fdb_tran_t *fdb_trans_dtran_get_subtran(struct sqlclntstate *clnt,
         if (tran->isuuid) {
             comdb2uuid((unsigned char *)tran->tid);
         } else
-            *(unsigned long long *)tran->tid = comdb2fastseed();
+            *(unsigned long long *)tran->tid = comdb2fastseed(2);
 
         tran->fdb = fdb;
 

--- a/db/glue.c
+++ b/db/glue.c
@@ -5703,7 +5703,7 @@ long long get_unique_longlong(struct dbenv *env)
     if (gbl_use_fastseed_for_comdb2_seqno) {
         uint64_t uid;
 
-        uid = comdb2fastseed();
+        uid = comdb2fastseed(3);
         uid = flibc_htonll(uid);
         memcpy(&id, &uid, sizeof(uid));
     } else {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -236,7 +236,7 @@ static int osql_sock_start_int(struct sqlclntstate *clnt, int type,
             osql->rqid = OSQL_RQID_USE_UUID;
             comdb2uuid(osql->uuid);
         } else {
-            osql->rqid = comdb2fastseed();
+            osql->rqid = comdb2fastseed(0);
             comdb2uuid_clear(osql->uuid);
             assert(osql->rqid);
         }

--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -2622,8 +2622,8 @@ static void dbglogCookieFunc(
   sqlite3_value **NotUsed2
 ){
   UNUSED_PARAMETER2(NotUsed, NotUsed2);
-  uint64_t comdb2fastseed(void);
-  sqlite3_result_int64(context, (i64)comdb2fastseed());
+  uint64_t comdb2fastseed(int);
+  sqlite3_result_int64(context, (i64)comdb2fastseed(4));
 }
 
 static void dbglogBeginFunc(


### PR DESCRIPTION
Simple hack to track users before starting to remove rqid code (based on fastseed).

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
