### PR TITLE
Don't check for options coherency while dropping a queue

### DIFF
--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -455,7 +455,7 @@ static int perform_trigger_update_int(struct schema_change_type *sc)
         }
     }
 
-    if ((rc = check_option_queue_coherency(sc, db)))
+    if (!sc->drop_table && (rc = check_option_queue_coherency(sc, db)))
         goto done;
 
     /* TODO: other checks: procedure with this name must not exist either */


### PR DESCRIPTION
Bug: 

lrl -
init_with_queue_ondisk_header off


create a table, create consumer

then modify lrl . 

lrl -
init_with_queue_ondisk_header on

try to drop consumer, fails with rc -5 "on-disk headers require a rebuild to enable or disable"

Fix : while dropping, don't check any flags.. Just drop