### PR TITLE
need custom flag, cannot use resume for new shard sc-s

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -895,8 +895,8 @@ static int verify_sc_resumed_for_shard(const char *shardname,
     strncpy0(new_sc->tablename, shardname, sizeof(new_sc->tablename));
     new_sc->iq = NULL;
     new_sc->tran = NULL;
-    /*new_sc->resume = 0; ALL RESUMED SC-s HAVE THIS SET, TO PREVENT RESUME DEADLOCK ON BDB LOCK */
-    new_sc->resume = SC_RESUME;
+    new_sc->resume = 0;
+    new_sc->must_resume = 1; /* this is a shard, we cannot complete partition sc without it */
     new_sc->nothrevent = 0;
     new_sc->finalize = 0;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -236,8 +236,10 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             free_schema_change_type(s);
             return rc;
         }
-        if (seed == 0 && host == 0)
+        if (seed == 0 && host == 0) {
+            logmsg(LOGMSG_ERROR, "Failed to determine host and seed!\n");
             return SC_INTERNAL_ERROR; // SC_INVALID_OPTIONS?
+        }
         logmsg(LOGMSG_INFO, "stored seed %016llx, stored host %u\n",
                seed, host);
         logmsg(
@@ -333,7 +335,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         int max_threads =
             bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_ASYNC_MAXTHREADS);
         Pthread_mutex_lock(&sc_async_mtx);
-        while (!s->resume && max_threads > 0 &&
+        while (!s->must_resume && !s->resume && max_threads > 0 &&
                sc_async_threads >= max_threads) {
             logmsg(LOGMSG_INFO, "Waiting for avaiable schema change threads\n");
             Pthread_cond_wait(&sc_async_cond, &sc_async_mtx);

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -217,6 +217,7 @@ struct schema_change_type {
 
     int resume;           /* if we are trying to resume a schema change,
                            * usually because there is a new master */
+    int must_resume;      /* used for partitions, if we generate new shard sc-s upon resume */
     int retry_bad_genids; /* retrying a schema change (with full rebuild)
                              because there are old genids in flight */
     int dryrun;           /* comdb2sc.tsk -y */


### PR DESCRIPTION
When creating new schema changes for missing shards during partition schema change resume, we cannot use the ->resume flag to skip the quota check (since that skips some critical sc initialization code).   Use a custom flag in this case.

Signed-off-by: Dorin Hogea <dhogea@bloomberg.net>
