### PR TITLE
Add LSN information to comdb2_cluster

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2309,6 +2309,8 @@ struct cluster_info {
     int64_t port;
     char *is_master;
     char *coherent_state;
+    int64_t logfile;
+    int64_t logoffset;
 };
 
 int bdb_fill_cluster_info(void **data, int *num_nodes);

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -2269,6 +2269,9 @@ int bdb_fill_cluster_info(void **data, int *num_nodes) {
         info[i].coherent_state = bdb_coherent_state_string(nodes[i].host);
         if (info[i].coherent_state[0] == 0)
             info[i].coherent_state = "coherent";
+        DB_LSN *lsnp = &bdb_state->seqnum_info->seqnums[nodeix(nodes[i].host)].lsn;
+        info[i].logfile = lsnp->file;
+        info[i].logoffset = lsnp->offset;
     }
     *data = info;
     return 0;

--- a/sqlite/ext/comdb2/cluster.c
+++ b/sqlite/ext/comdb2/cluster.c
@@ -50,5 +50,7 @@ int systblClusterInit(sqlite3 *db) {
             CDB2_INTEGER, "port",  -1, offsetof(struct cluster_info, port),
             CDB2_CSTRING, "is_master",  -1, offsetof(struct cluster_info, is_master),
             CDB2_CSTRING, "coherent_state",  -1, offsetof(struct cluster_info, coherent_state),
+            CDB2_INTEGER, "logfile",  -1, offsetof(struct cluster_info, logfile),
+            CDB2_INTEGER, "logoffset",  -1, offsetof(struct cluster_info, logoffset),
             SYSTABLE_END_OF_FIELDS);
 }


### PR DESCRIPTION
```
$ cdb2sql mikedb localhost 'select * from comdb2_cluster'
(host='h1', port=19006, is_master='N', coherent_state='coherent', logfile=45, logoffset=17516678)
(host='h2', port=19008, is_master='N', coherent_state='coherent', logfile=45, logoffset=17610950)
(host='h3', port=19008, is_master='N', coherent_state='coherent', logfile=45, logoffset=17610950)
(host='h4', port=19013, is_master='N', coherent_state='coherent', logfile=45, logoffset=17610950)
(host='h5', port=19008, is_master='Y', coherent_state='coherent', logfile=45, logoffset=17610950)
```

RDSICOMDB2-264