### PR TITLE
block new query requests in remsql if incoherent

### DIFF
--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -3415,6 +3415,16 @@ static int handle_remsql_session(SBUF2 *sb, struct dbenv *dbenv)
 
     memcpy(&open_msg, &msg, sizeof open_msg);
 
+    /* let transactional cursors go through */ 
+    if (!bdb_am_i_coherent(thedb->bdb_env)) {
+        if (((flags & FD_MSG_FLAGS_ISUUID) && comdb2uuid_is_zero((unsigned char*)open_msg.tid)) ||
+                (*(unsigned long long *)open_msg.tid == 0ULL)) {
+            logmsg(LOGMSG_ERROR, "Rejecting standalong remsql, node incoherent\n");
+            return -1;
+        }
+    }
+
+
     /* check and protect against newer versions */
     if (_check_code_release(sb, open_msg.cid, open_msg.rootpage,
                             flags & FD_MSG_FLAGS_ISUUID)) {


### PR DESCRIPTION
More upgrades to remsql, if node is incoherent, and the cursor is not part of a transaction, block it.