### PR TITLE
Fixing local replicant edge case

### DIFF
--- a/db/localrep.c
+++ b/db/localrep.c
@@ -255,8 +255,8 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
-                    /* null terminate if 0-length */
-                    if (inline_len == 0)
+                    /* null terminate if 0-length and has an inline len */
+                    if (inline_len == 0 && fields[i].len > 0)
                         p[0] = 0;
 
                     p += server_schema->member[i].len - 5;
@@ -602,8 +602,8 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                         rc = OP_FAILED_INTERNAL;
                         goto err;
                     }
-                    /* null terminate if 0-length */
-                    if (inline_len == 0)
+                    /* null terminate if 0-length and has an inline len */
+                    if (inline_len == 0 && fields[i].len > 0)
                         p[0] = 0;
 
                     p += server_schema->member[i].len - 5;


### PR DESCRIPTION
If the last column of a replicated table is vutf8 without an inline size hint, and the new ondisk data for the column is an empty string, we mistakenly write 1 byte after what's allocated for its comdb2_oplog entry, e.g.:

```
==134601== Invalid write of size 1
==134601==    at 0x50163B: local_replicant_log_add (localrep.c:260)
==134601==    by 0x552790: add_record (record.c:618)
==134601==    by 0x51A23A: osql_process_packet (osqlcomm.c:6509)
==134601==    by 0x506FFE: process_this_session (osqlblockproc.c:987)
==134601==    by 0x5075A6: apply_changes (osqlblockproc.c:1092)
==134601==    by 0x505C0A: osql_bplog_commit (osqlblockproc.c:348)
==134601==    by 0x603669: toblock_main_int (toblock.c:4637)
==134601==    by 0x6071F5: toblock_main (toblock.c:5866)
==134601==    by 0x5FC65D: toblock_outer (toblock.c:2266)
==134601==    by 0x5FB9DF: toblock (toblock.c:2011)
==134601==    by 0x5687F0: handle_op_local (sltdbt.c:167)
==134601==    by 0x568C72: handle_op_block (sltdbt.c:254)
==134601==  Address 0x14999624 is 0 bytes after a block of size 308 alloc'd
==134601==    at 0x40397BB: malloc (vg_replace_malloc.c:393)
==134601==    by 0x500FB7: local_replicant_log_add (localrep.c:150)
==134601==    by 0x552790: add_record (record.c:618)
==134601==    by 0x51A23A: osql_process_packet (osqlcomm.c:6509)
==134601==    by 0x506FFE: process_this_session (osqlblockproc.c:987)
==134601==    by 0x5075A6: apply_changes (osqlblockproc.c:1092)
==134601==    by 0x505C0A: osql_bplog_commit (osqlblockproc.c:348)
==134601==    by 0x603669: toblock_main_int (toblock.c:4637)
==134601==    by 0x6071F5: toblock_main (toblock.c:5866)
==134601==    by 0x5FC65D: toblock_outer (toblock.c:2266)
==134601==    by 0x5FB9DF: toblock (toblock.c:2011)
==134601==    by 0x5687F0: handle_op_local (sltdbt.c:167)
```

This patch fixes it.