### PR TITLE
{171419822} net: Check gbl_appsock_thdpool instead of gbl_ready to sk…

### DIFF
--- a/db/appsock_handler.c
+++ b/db/appsock_handler.c
@@ -338,7 +338,7 @@ int appsock_handler_start(struct dbenv *dbenv, SBUF2 *sb, struct sockaddr_in cli
     now = time(NULL);
 
     /* reject requests if we're not up, going down, or not interested */
-    if (dbenv->stopped || gbl_exit || !gbl_ready) {
+    if (dbenv->stopped || gbl_exit || !gbl_appsock_thdpool) {
         if (header_read) {
             total_appsock_rejections++;
             sbuf2close(sb);

--- a/net/net.c
+++ b/net/net.c
@@ -113,6 +113,7 @@ static int curr_udp_cnt = 0;
 
 extern int gbl_pmux_route_enabled;
 extern int gbl_exit;
+extern int gbl_ready;
 extern int gbl_net_portmux_register_interval;
 
 int gbl_verbose_net = 0;
@@ -5619,6 +5620,10 @@ int handle_accepted_socket(SBUF2 *sb, netinfo_type *netinfo_ptr, int is_inline, 
       /* appsock reqs have a non-0 first byte */
       if (firstbyte > 0)
       {
+         if (!gbl_ready) {
+             sbuf2close(sb);
+             return -1;
+         }
          APPSOCKFP *rtn = NULL;
 
          *is_admin = 0;


### PR DESCRIPTION
/silent