### PR TITLE
remove set -e for reorder_inserts test

### DIFF
--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
-set -e
 set -x
 
 source ${TESTSROOTDIR}/tools/runit_common.sh


### PR DESCRIPTION
grep returns 1 if it can't find any matches. This makes the test fail if there are no deadlocks. 