### PR TITLE
{171159124} Improving SSL error handling

### DIFF
--- a/bbinc/ssl_io.h
+++ b/bbinc/ssl_io.h
@@ -22,8 +22,13 @@
 
 /* Gracefully shutdown an SSL connection. The fd remains resuable.
    Return 0 upon success. */
-int SBUF2_FUNC(sslio_close)(SBUF2 *, int reuse);
+int SBUF2_FUNC(sslio_close)(SBUF2 *, int wait_for_peer);
 #define sslio_close SBUF2_FUNC(sslio_close)
+
+/* Free the SSL struct, without calling SSL_shutdown(). This should be called
+   only on a non-recoverable SSL error (ie SSL_ERROR_SYSCALL or SSL_ERROR_SSL). */
+void SBUF2_FUNC(sslio_free)(SBUF2 *);
+#define sslio_free SBUF2_FUNC(sslio_free)
 
 int SBUF2_FUNC(sslio_read)(SBUF2 *, char *cc, int len);
 #define sslio_read SBUF2_FUNC(sslio_read)

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2208,6 +2208,9 @@ static int try_ssl(cdb2_hndl_tp *hndl, SBUF2 *sb)
     SSL_CTX_free(ctx);
     if (rc != 1) {
         hndl->sslerr = sbuf2lasterror(sb, hndl->errstr, sizeof(hndl->errstr));
+        /* Shut it down and reset sbuf. Caller will reconnect upon a null `hndl->sb'. */
+        sbuf2close(sb);
+        hndl->sb = NULL;
         /* If SSL_connect() fails, invalidate the session. */
         if (p != NULL)
             p->sessobj = NULL;
@@ -2363,7 +2366,6 @@ static int newsql_connect(cdb2_hndl_tp *hndl, int node_indx)
     sbuf2settimeout(sb, hndl->socket_timeout, hndl->socket_timeout);
 
     if (try_ssl(hndl, sb) != 0) {
-        sbuf2close(sb);
         rc = -1;
         goto after_callback;
     }

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -349,7 +349,7 @@ retry_read:
             /* Print the error message in the sbuf2. */
             char err[256];
             sbuf2lasterror(sb, err, sizeof(err));
-            logmsg(LOGMSG_ERROR, "%s\n", err);
+            logmsg(LOGMSG_ERROR, "SSL_accept: %s\n", err);
             return NULL;
         }
 

--- a/util/sbuf2.c
+++ b/util/sbuf2.c
@@ -96,7 +96,7 @@ struct sbuf2 {
     SSL *ssl;
     X509 *cert;
     int protocolerr;
-    char sslerr[120];
+    char sslerr[SSL_ERRSTR_LENGTH];
 };
 
 int SBUF2_FUNC(sbuf2fileno)(SBUF2 *sb)
@@ -582,13 +582,7 @@ ssl_downgrade:
                 break;
             case SSL_ERROR_ZERO_RETURN:
                 /* Peer has done a clean shutdown. */
-                SSL_shutdown(sb->ssl);
-                SSL_free(sb->ssl);
-                sb->ssl = NULL;
-                if (sb->cert) {
-                    X509_free(sb->cert);
-                    sb->cert = NULL;
-                }
+                sslio_close(sb, 0);
                 goto ssl_downgrade;
             case SSL_ERROR_SYSCALL:
                 sb->protocolerr = 0;
@@ -600,6 +594,7 @@ ssl_downgrade:
                     ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr),
                                  my_ssl_eprintln, "IO error. errno %d.", errno);
                 }
+                sslio_free(sb);
                 break;
             case SSL_ERROR_SSL:
                 errno = EIO;
@@ -607,6 +602,7 @@ ssl_downgrade:
                 ssl_sfliberrprint(sb->sslerr, sizeof(sb->sslerr),
                                   my_ssl_eprintln,
                                   "A failure in SSL library occured");
+                sslio_free(sb);
                 break;
             default:
                 errno = EIO;
@@ -676,13 +672,7 @@ ssl_downgrade:
                 break;
             case SSL_ERROR_ZERO_RETURN:
                 /* Peer has done a clean shutdown. */
-                SSL_shutdown(sb->ssl);
-                SSL_free(sb->ssl);
-                sb->ssl = NULL;
-                if (sb->cert) {
-                    X509_free(sb->cert);
-                    sb->cert = NULL;
-                }
+                sslio_close(sb, 0);
                 goto ssl_downgrade;
             case SSL_ERROR_SYSCALL:
                 sb->protocolerr = 0;
@@ -694,6 +684,7 @@ ssl_downgrade:
                     ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr),
                                  my_ssl_eprintln, "IO error. errno %d.", errno);
                 }
+                sslio_free(sb);
                 break;
             case SSL_ERROR_SSL:
                 errno = EIO;
@@ -701,6 +692,7 @@ ssl_downgrade:
                 ssl_sfliberrprint(sb->sslerr, sizeof(sb->sslerr),
                                   my_ssl_eprintln,
                                   "A failure in SSL library occured");
+                sslio_free(sb);
                 break;
             default:
                 errno = EIO;

--- a/util/ssl_support.c
+++ b/util/ssl_support.c
@@ -254,7 +254,7 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
     if (myctx == NULL) {
         ssl_sfliberrprint(err, n, my_ssl_eprintln,
                           "Failed to create SSL context");
-        rc = ERR_get_error();
+        rc = -1;
         goto error;
     }
 
@@ -298,7 +298,7 @@ int SBUF2_FUNC(ssl_new_ctx)(SSL_CTX **pctx, ssl_mode mode, const char *dir,
         if (RAND_bytes(sid_ctx, sizeof(sid_ctx)) != 1) {
             ssl_sfliberrprint(err, n, my_ssl_eprintln,
                               "Failed to get random bytes");
-            rc = ERR_get_error();
+            rc = -1;
             goto error;
         }
         SSL_CTX_set_session_id_context(myctx, sid_ctx, sizeof(sid_ctx));


### PR DESCRIPTION
This patch improves error handling for SSL. SSL_shutdown() must not be called on SSL_ERROR_SYSCALL/SSL_ERROR_SSL. This patch fixes it, too.

(DRQS 171159124)
(JIRA RDSICDBDBA-914)