### PR TITLE
Add partial datacopy tunable, disable by default

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -51,6 +51,7 @@ int compute_all_data(int tidx);
 int comdb2_iam_master();
 
 extern int gbl_ready;
+extern int gbl_partial_datacopies;
 
 char *revision = "$Revision: 1.24 $";
 int unionflag = 0;
@@ -922,7 +923,14 @@ void key_setdatakey(void)
 
 void key_setpartialdatakey(void)
 {
-    if (macc_globals->workkeyflag & DATAKEY) {
+    if (!gbl_partial_datacopies) {
+        csc2_error("Error at line %3d: PARTIAL DATACOPY DISABLED.\n",
+                    current_line);
+        csc2_syntax_error("Error at line %3d: PARTIAL DATACOPY DISABLED.",
+                          current_line);
+        any_errors++;
+        return;
+    } else if (macc_globals->workkeyflag & DATAKEY) {
         csc2_error("Error at line %3d: CANNOT HAVE DATACOPY AND PARTIAL DATACOPY.\n",
                     current_line);
         csc2_syntax_error("Error at line %3d: CANNOT HAVE DATACOPY AND PARTIAL DATACOPY.",

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -559,6 +559,7 @@ int gbl_key_updates = 1;
 int gbl_partial_indexes = 1;
 int gbl_expressions_indexes = 1;
 int gbl_new_indexes = 0;
+int gbl_partial_datacopies = 0;
 
 int gbl_optimize_truncate_repdb = 1;
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -63,6 +63,7 @@ extern int gbl_disable_sql_dlmalloc;
 extern int gbl_enable_berkdb_retry_deadlock_bias;
 extern int gbl_enable_cache_internal_nodes;
 extern int gbl_partial_indexes;
+extern int gbl_partial_datacopies;
 extern int gbl_sparse_lockerid_map;
 extern int gbl_spstrictassignments;
 extern int gbl_early;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -965,6 +965,8 @@ REGISTER_TUNABLE("pagesize", NULL, TUNABLE_INTEGER,
 REGISTER_TUNABLE("parallel_recovery", NULL, TUNABLE_INTEGER,
                  &gbl_parallel_recovery_threads, READONLY, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("partial_datacopies", "If set, allows partial datacopy definitions in table schema. (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_partial_datacopies, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("penaltyincpercent", NULL, TUNABLE_INTEGER,
                  &gbl_penaltyincpercent, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("perfect_ckp", NULL, TUNABLE_INTEGER, &gbl_use_perfect_ckp,

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -38,6 +38,7 @@ extern int gbl_ddl_cascade_drop;
 extern int gbl_legacy_schema;
 extern int gbl_permit_small_sequences;
 extern int gbl_lightweight_rename;
+extern int gbl_partial_datacopies;
 
 int gbl_view_feature = 1;
 
@@ -5366,6 +5367,10 @@ static void comdb2AddIndexInt(
     }
 
     if (pdList) { // partial datacopy
+        if (!gbl_partial_datacopies) {
+            sqlite3ErrorMsg(pParse, "Partial datacopy disabled.");
+            goto cleanup;
+        }
         if (key->flags & KEY_DATACOPY) {
             pParse->rc = SQLITE_ERROR;
             sqlite3ErrorMsg(pParse, "Cannot have datacopy and partial datacopy.");

--- a/tests/instant_sc.test/lrl.options
+++ b/tests/instant_sc.test/lrl.options
@@ -2,3 +2,4 @@ table   t   t.csc2
 dtastripe 1
 init_with_compr none
 init_with_compr_blobs none
+partial_datacopies on

--- a/tests/partial_datacopy.test/lrl.options
+++ b/tests/partial_datacopy.test/lrl.options
@@ -1,2 +1,1 @@
-dont_forbid_ulonglong
 partial_datacopies on

--- a/tests/sc_partial_datacopy.test/lrl.options
+++ b/tests/sc_partial_datacopy.test/lrl.options
@@ -1,3 +1,4 @@
 maxosqltransfer 500000
 logmsg level info
 dont_forbid_ulonglong
+partial_datacopies on

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -647,6 +647,7 @@
 (name='parallel_count', description='When 'direct_count' is on, enable thread-per-stripe', type='BOOLEAN', value='OFF', read_only='N')
 (name='parallel_recovery', description='', type='INTEGER', value='0', read_only='Y')
 (name='parallel_sync', description='Run checkpoint/memptrickle code with parallel writes', type='BOOLEAN', value='ON', read_only='N')
+(name='partial_datacopies', description='If set, allows partial datacopy definitions in table schema. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='participantid_bits', description='Number of bits allocated for the participant stripe ID (remaining bits are used for the update ID).', type='INTEGER', value='0', read_only='N')
 (name='partitioned_table_enabled', description='Allow syntax create/alter table ... partitioned by ...', type='BOOLEAN', value='ON', read_only='N')
 (name='pause_moveto', description='pause_moveto', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
If a table in 8.0 has an index with partial datacopy enabled and the node needs to be reverted back to 7.0 then we will not be able to restart comdb2 bc of schema errors. So add tunable to disable functionality until 8.0 is stable

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
