### PR TITLE
manual partition updates

### DIFF
--- a/db/logical_cron.c
+++ b/db/logical_cron.c
@@ -105,7 +105,6 @@ static char *logical_cron_describe(sched_if_t *impl)
     return strdup(msg);
 }
 
-#define LOGICAL_CRON_SYSTABLE "comdb2_logical_cron"
 #define LOGICAL_CRON_THREAD_MEMORY 1048576
 
 static void *logical_cron_kickoff(struct cron_event *event, struct errstat *err)

--- a/db/logical_cron.h
+++ b/db/logical_cron.h
@@ -19,6 +19,8 @@
 
 #include "cron.h"
 
+#define LOGICAL_CRON_SYSTABLE "comdb2_logical_cron"
+
 /**
  * Move logical clock one step forward
  *

--- a/db/views.h
+++ b/db/views.h
@@ -492,4 +492,7 @@ void partition_unpublish(struct schema_change_type *sc);
 /* called for a truncate rollout before finalize commits the tran */
 int partition_truncate_callback(tran_type *tran, struct schema_change_type *s);
 
+/* return the default value for a manual partition */
+int logical_partition_next_rollout(const char *name);
+
 #endif

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -1421,7 +1421,9 @@ static int comdb2GetManualPartitionParams(Parse* pParse, Token *retention,
         setError(pParse, SQLITE_MISUSE, "Invalid manual retention");
         return -1;
     }
-    if (_get_integer(start, oStart)) {
+    if (!start)  {
+        *oStart = 0;
+    } else if (_get_integer(start, oStart)) {
         setError(pParse, SQLITE_MISUSE, "Invalid manual start");
         return -1;
     }
@@ -2611,6 +2613,9 @@ static void comdb2CounterInt(Parse *pParse, Token *nm, Token *lnm,
 
     if (chkAndCopyPartitionTokens(pParse, name, nm, lnm))
         goto err;
+
+    if (isset == 0)
+        value = logical_partition_next_rollout(name);
 
     query = logical_cron_update_sql(name, value, isset==0);
 

--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -247,6 +247,9 @@ partition_options ::= NONE. {
 partition_options ::= MANUAL RETENTION INTEGER(R) START INTEGER(S). {
     comdb2CreateManualPartition(pParse, &R, &S);
 }
+partition_options ::= MANUAL RETENTION INTEGER(R). {
+    comdb2CreateManualPartition(pParse, &R, 0);
+}
 merge ::= .
 merge ::= merge_with.
 merge_with ::= MERGE nm(Y) dbnm(Z). {

--- a/tests/manual_partition.test/run.log.exp
+++ b/tests/manual_partition.test/run.log.exp
@@ -1,4 +1,3 @@
-Creating comdb2_logical_cron table
 Creating partition 1 and 2
 XXXXX we should see to empty partitions with no counters
 [
@@ -116,11 +115,11 @@ XXXXX we should see the data in part1, and the counter, no rollout yet
 (name='testpart2', shardname='$1_4580E96D')
 (name='timepart_cron', type='WALLTIME', running=0, nevents=0, description='Time partition scheduler')
 (name='Global Job Scheduler', type='WALLTIME', running=0, nevents=1, description='Default cron scheduler')
-(name='testpart1', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart1 clock 0')
+(name='testpart1', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart1 clock 1')
 (name='testpart2', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart2 clock 0')
-(name='Truncate', type='testpart1', epoch=1, arg1='testpart1', arg2=NULL, arg3=NULL)
+(name='Truncate', type='testpart1', epoch=2, arg1='testpart1', arg2=NULL, arg3=NULL)
 (name='Truncate', type='testpart2', epoch=10, arg1='testpart2', arg2=NULL, arg3=NULL)
-(name='testpart1', value=0)
+(name='testpart1', value=1)
 XXXXX we should see additional counter for part2
 (a=1, alltypes_vutf8='hi')
 (a=2, alltypes_vutf8='ho')
@@ -141,8 +140,8 @@ XXXXX we should see additional counter for part2
   },
   {
    "TABLENAME"    : "$1_7DA96DB",
-   "LOW"          : 2147483647,
-   "HIGH"         : 2147483647
+   "LOW"          : 1,
+   "HIGH"         : 2
   }
   ]
  }
@@ -177,11 +176,11 @@ XXXXX we should see additional counter for part2
 (name='testpart2', shardname='$1_4580E96D')
 (name='timepart_cron', type='WALLTIME', running=0, nevents=0, description='Time partition scheduler')
 (name='Global Job Scheduler', type='WALLTIME', running=0, nevents=1, description='Default cron scheduler')
-(name='testpart1', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart1 clock 0')
+(name='testpart1', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart1 clock 1')
 (name='testpart2', type='LOGICAL', running=0, nevents=1, description='Logical cron testpart2 clock 0')
-(name='Truncate', type='testpart1', epoch=1, arg1='testpart1', arg2=NULL, arg3=NULL)
+(name='Truncate', type='testpart1', epoch=2, arg1='testpart1', arg2=NULL, arg3=NULL)
 (name='Truncate', type='testpart2', epoch=10, arg1='testpart2', arg2=NULL, arg3=NULL)
-(name='testpart1', value=0)
+(name='testpart1', value=1)
 (name='testpart2', value=0)
 sleeping
 (a=1, alltypes_vutf8='hi')

--- a/tests/manual_partition.test/runit
+++ b/tests/manual_partition.test/runit
@@ -51,11 +51,6 @@ function timepart_stats
 
 master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
 
-echo "Creating comdb2_logical_cron table"
-echo "Creating comdb2_logical_cron table" > $output
-gorun "create table comdb2_logical_cron (name cstring(128) primary key, value int)"
-gorun "select * from comdb2_logical_cron"
-
 echo "Creating partition 1 and 2"
 echo "Creating partition 1 and 2" >> $output
 gorun "create table testpart1(a int, alltypes_vutf8 text) partitioned by manual retention 2 start 1"


### PR DESCRIPTION
Updates:
- the backend table "comdb2_logical_cron" is automatically created when first manual partition is created, if it does not exist
- the start value for a counter is optional, and defaults to 0 if missing in the statement
- rollout increment fix: now it starts properly from start value + 1, rather that default to 0

RDSICOMDB2-267