### PR TITLE
ufid-open should return DB_DELETED if fails to open

### DIFF
--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -494,7 +494,7 @@ __ufid_open(dbenv, txn, dbpp, inufid, name, lsnp)
 		logmsg(LOGMSG_INFO, "__dbreg_fid_to_fname error opening db:%s\n", name);
 		ret = ENOENT;
 	}
-	(*dbpp) = dbp;
+	if (!ret) (*dbpp) = dbp;
 	return ret;
 }
 
@@ -526,6 +526,12 @@ __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, create)
 			} else if (ufid->dbp != dbp) {
 				close_dbp = dbp;
 			}
+		}
+		if (ret == ENOENT) {
+			if (gbl_abort_on_missing_ufid) {
+				abort();
+			}
+			ret = DB_DELETED;
 		}
 		ret = ret ? ret : (ufid->ignore ? DB_IGNORED : 0);
 		(*dbpp) = ufid->dbp;

--- a/tests/truncatesc.test/lrl.options
+++ b/tests/truncatesc.test/lrl.options
@@ -12,3 +12,4 @@ verbose_physrep on
 #setattr REP_WORKERS 0
 online_recovery on
 ack_trace
+ufid_log on

--- a/tests/truncatesc.test/ufid_on.testopts
+++ b/tests/truncatesc.test/ufid_on.testopts
@@ -1,0 +1,1 @@
+ufid_log on


### PR DESCRIPTION
The issue can be reproduced by running the truncatesc test with ufid_log enabled.  I've added the ufid_log testopt to the truncatesc test.
