### PR TITLE
Flush the log when recovering a checkpoint to avoid an assert failure

### DIFF
--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -652,6 +652,8 @@ __txn_ckp_recover(dbenv, dbtp, lsnp, op, info)
 		data_dbt.ulen = 0;
 
 		if ((ret = __log_c_get(logc, &last_ckp, &data_dbt, DB_SET)) == 0) {
+			/* checkpoint save asserts that this is on-disk */
+			__log_flush(dbenv, NULL);
 			__checkpoint_save(dbenv, &last_ckp, 1);
 			region->last_ckp = argp->last_ckp;
 		} else {


### PR DESCRIPTION
Checkpoints are flushed out-of-band, so this might not have made it to disk yet.
