### PR TITLE
Disable parallel rep for yast

### DIFF
--- a/tests/yast.test/lrl.options
+++ b/tests/yast.test/lrl.options
@@ -2,3 +2,7 @@ update_delete_limit
 dtastripe 1
 ssl_client_mode OPTIONAL
 exec_sql_on_new_connect PRAGMA automatic_index = 0;
+
+# Disable parallel rep: reload-analyze isn't a serialization point
+REP_WORKERS 0
+REP_PROCESSORS 0


### PR DESCRIPTION
The yast test requires that new stats will be applied and used immediately, which won't necessarily be true if parallel rep is enabled.