### PR TITLE
Fixing misuse of nonames in non-singlemeta code

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3531,13 +3531,8 @@ int open_auxdbs(struct dbtable *db, int force_create)
     /* meta information dbs.  we need to make sure that lite meta tables
      * are named differently to heavy meta tables otherwise we can't tell
      * them apart at startup.. */
-    if (gbl_nonames) {
-        snprintf(name, sizeof(name), "comdb2_meta");
-        snprintf(litename, sizeof(litename), "comdb2_metalite");
-    } else {
-        snprintf(name, sizeof(name), "%s.meta", db->tablename);
-        snprintf(litename, sizeof(litename), "%s.metalite", db->tablename);
-    }
+    snprintf(name, sizeof(name), "%s.meta", db->tablename);
+    snprintf(litename, sizeof(litename), "%s.metalite", db->tablename);
 
     ctrace("bdb_open_more: opening <%s>\n", name);
     numdtafiles = 1;


### PR DESCRIPTION
The combination of non-singlemeta and nonames are problematic: When nonames is on, we use the name "comdb2_meta" to open all meta's. As a result, all tables end up sharing a common meta. The example below demonstrates the problem:

```
$ cdb2sql -tabs nonsinglemeta local "exec procedure sys.cmd.send('stat compr')"
COMPRESSION FLAGS
These apply to new records only!
[sqlite_stat1    ] ODH: yes Compress: lz4      Blob compress: lz4       in-place updates: yes  instant schema change: yes
[sqlite_stat4    ] ODH: yes Compress: lz4      Blob compress: lz4       in-place updates: yes  instant schema change: yes
[t1              ] ODH: yes Compress: lz4      Blob compress: lz4       in-place updates: yes  instant schema change: yes

$ cdb2sql nonsinglemeta local "create table t2 (i int) OPTIONS rec none, blobfield zlib"

$ cdb2sql -tabs nonsinglemeta local "exec procedure sys.cmd.send('stat compr')"
COMPRESSION FLAGS
These apply to new records only!
[sqlite_stat1    ] ODH: yes Compress: none     Blob compress: zlib      in-place updates: yes  instant schema change: yes
[sqlite_stat4    ] ODH: yes Compress: none     Blob compress: zlib      in-place updates: yes  instant schema change: yes
[t1              ] ODH: yes Compress: none     Blob compress: zlib      in-place updates: yes  instant schema change: yes
[t2              ] ODH: yes Compress: none     Blob compress: zlib      in-place updates: yes  instant schema change: yes
```

The database has 3 tables which are all compressed using lz4. A fourth table is added with no compression for data and zlib for blob. All 4 tables now have the same compression settings.
