### PR TITLE
Change snprintf overflow value in conditional to size - off

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -74,8 +74,8 @@
     {                                                                          \
         int ret;                                                               \
         ret = snprintf(str + off, size - off, fmt, __VA_ARGS__);               \
-        if (ret >= size) {                                                     \
-            off += size;                                                       \
+        if (ret >= size - off) {                                               \
+            off += size - off;                                                 \
             goto done;                                                         \
         }                                                                      \
         off += ret;                                                            \


### PR DESCRIPTION
We are writing at most `size - off` bytes in snprintf, so should check `ret` against this value

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
