### PR TITLE
Trigger systable inversion

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1684,12 +1684,15 @@ int bdb_lock_row_fromlid(bdb_state_type *bdb_state, int lid, int idx,
 int bdb_lock_row_fromlid_int(bdb_state_type *bdb_state, int lid, int idx,
                              unsigned long long genid, int how, DB_LOCK *dblk,
                              DBT *lkname, int trylock, int flags);
+enum {
+    CURTRAN_HOLDS_SPLOCK    = 1
+};
 
 /* we use this structure to create a dummy cursor to be used for all
  * non-transactional cursors. it is defined below */
 struct cursor_tran {
     uint32_t lockerid;
-    int flags;
+    uint32_t flags;
     int id; /* debugging */
 };
 

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1689,6 +1689,7 @@ int bdb_lock_row_fromlid_int(bdb_state_type *bdb_state, int lid, int idx,
  * non-transactional cursors. it is defined below */
 struct cursor_tran {
     uint32_t lockerid;
+    int flags;
     int id; /* debugging */
 };
 

--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -137,9 +137,9 @@ static int bdb_queuedb_is_db_full(DB *db)
 
 static int start_qdb_schemachange(struct schema_change_type *sc)
 {
-    javasp_do_procedure_wrlock();
+    javasp_splock_wrlock();
     int rc = start_schema_change(sc);
-    javasp_do_procedure_unlock();
+    javasp_splock_unlock();
     return rc;
 }
 

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2485,6 +2485,8 @@ int bdb_free_curtran_locks(bdb_state_type *bdb_state, cursor_tran_t *curtran,
     return 0;
 }
 
+extern void javasp_splock_unlock(void);
+
 int bdb_put_cursortran(bdb_state_type *bdb_state, cursor_tran_t *curtran,
                        uint32_t flags, int *bdberr)
 {
@@ -2502,6 +2504,11 @@ int bdb_put_cursortran(bdb_state_type *bdb_state, cursor_tran_t *curtran,
         logmsg(LOGMSG_DEBUG, "bdb_put_cursortran called with null curtran\n");
         *bdberr = BDBERR_BADARGS;
         return -1;
+    }
+
+    if (curtran->flags) {
+        javasp_splock_unlock();
+        curtran->flags = 0;
     }
 
     rc = bdb_free_curtran_locks(bdb_state, curtran, bdberr);

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2506,9 +2506,9 @@ int bdb_put_cursortran(bdb_state_type *bdb_state, cursor_tran_t *curtran,
         return -1;
     }
 
-    if (curtran->flags) {
+    if (curtran->flags & CURTRAN_HOLDS_SPLOCK) {
         javasp_splock_unlock();
-        curtran->flags = 0;
+        curtran->flags &= ~CURTRAN_HOLDS_SPLOCK;
     }
 
     rc = bdb_free_curtran_locks(bdb_state, curtran, bdberr);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -388,6 +388,7 @@ extern int gbl_permit_small_sequences;
 extern int gbl_debug_sleep_in_sql_tick;
 extern int gbl_debug_sleep_in_analyze;
 extern int gbl_debug_sleep_in_summarize;
+extern int gbl_debug_sleep_in_trigger_info;
 extern int gbl_protobuf_prealloc_buffer_size;
 extern int gbl_replicant_retry_on_not_durable;
 extern int gbl_enable_internal_sql_stmt_caching;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2224,6 +2224,9 @@ REGISTER_TUNABLE("debug_sleep_in_analyze", "Sleep analyze sql tick.  (Default: o
 REGISTER_TUNABLE("debug_sleep_in_summarize", "Sleep analyze summarize.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_in_summarize, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_sleep_in_trigger_info", "Sleep trigger info.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_sleep_in_trigger_info, INTERNAL | EXPERIMENTAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("debug_consumer_lock",
                  "Enable debug-trace for consumer lock.  "
                  "(Default: off)",

--- a/db/sql.h
+++ b/db/sql.h
@@ -586,6 +586,7 @@ enum prepare_flags {
     PREPARE_NO_NORMALIZE = 32,
     PREPARE_ONLY = 64,
     PREPARE_ALLOW_TEMP_DDL = 128,
+    PREPARE_ACQUIRE_SPLOCK = 256
 };
 
 /* This structure is designed to hold several pieces of data related to

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7639,9 +7639,9 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         return 0;
     }
 
-    if (p->vTableFlags && clnt->dbtran.cursor_tran->flags == 0) {
+    if ((p->vTableFlags & VTABLE_FLAGS_GETSPLOCK) && !(clnt->dbtran.cursor_tran->flags & CURTRAN_HOLDS_SPLOCK)) {
         javasp_splock_rdlock();
-        clnt->dbtran.cursor_tran->flags = 1;
+        clnt->dbtran.cursor_tran->flags |= CURTRAN_HOLDS_SPLOCK;
     }
 
     for (int i = 0; i < p->numVTableLocks; i++) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -107,6 +107,7 @@
 #include "comdb2_query_preparer.h"
 #include <portmuxapi.h>
 #include "cdb2_constants.h"
+#include <translistener.h>
 
 int gbl_delay_sql_lock_release_sec = 5;
 
@@ -7636,6 +7637,11 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
 
     if (NULL == clnt->dbtran.cursor_tran) {
         return 0;
+    }
+
+    if (p->vTableFlags && clnt->dbtran.cursor_tran->flags == 0) {
+        javasp_splock_rdlock();
+        clnt->dbtran.cursor_tran->flags = 1;
     }
 
     for (int i = 0; i < p->numVTableLocks; i++) {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3122,8 +3122,8 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         }
 
         if (rec->stmt) {
-            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks,
-                thd->authState.flags & PREPARE_ACQUIRE_SPLOCK);
+            int flags = (thd->authState.flags & PREPARE_ACQUIRE_SPLOCK) ? VTABLE_FLAGS_GETSPLOCK : 0;
+            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks, flags);
             thd->authState.numVTableLocks = 0;
             thd->authState.vTableLocks = NULL;
         } else {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -758,6 +758,9 @@ static int vtable_search(char **vtables, int ntables, const char *table)
 static void record_locked_vtable(struct sql_authorizer_state *pAuthState, const char *table)
 {
     const char *vtable_lock = vtable_lockname(pAuthState->db, table);
+    if ((strcmp(table, "comdb2_triggers") == 0)) {
+        pAuthState->flags |= PREPARE_ACQUIRE_SPLOCK;
+    }
     if (vtable_lock && !vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_lock)) {
         pAuthState->vTableLocks =
             (char **)realloc(pAuthState->vTableLocks, sizeof(char *) * (pAuthState->numVTableLocks + 1));
@@ -3119,7 +3122,8 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         }
 
         if (rec->stmt) {
-            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks);
+            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks,
+                thd->authState.flags & PREPARE_ACQUIRE_SPLOCK);
             thd->authState.numVTableLocks = 0;
             thd->authState.vTableLocks = NULL;
         } else {

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -959,12 +959,17 @@ int javasp_do_procedure_op(int op, const char *name, const char *param, const ch
     }
 }
 
-void javasp_do_procedure_wrlock(void)
+void javasp_splock_rdlock(void)
+{
+    SP_READLOCK();
+}
+
+void javasp_splock_wrlock(void)
 {
     SP_WRITELOCK();
 }
 
-void javasp_do_procedure_unlock(void)
+void javasp_splock_unlock(void)
 {
     SP_RELLOCK();
 }
@@ -1447,9 +1452,20 @@ static void get_trigger_info_int(const char *name, trigger_info *info)
     }
 }
 
+#include <sys/poll.h>
+int gbl_debug_sleep_in_trigger_info = 0;
+
+void get_trigger_info_lk(const char *name, trigger_info *info)
+{
+    if (gbl_debug_sleep_in_trigger_info && !(rand() % 5)) {
+        poll(NULL, 0, 10);
+    }
+    get_trigger_info_int(name, info);
+}
+
 void get_trigger_info(const char *name, trigger_info *info)
 {
     SP_READLOCK();
-    get_trigger_info_int(name, info);
+    get_trigger_info_lk(name, info);
     SP_RELLOCK();
 }

--- a/db/translistener.h
+++ b/db/translistener.h
@@ -210,8 +210,10 @@ typedef struct {
     LISTC_T(trigger_tbl_info) tbls;
 } trigger_info;
 void get_trigger_info(const char *, trigger_info *);
+void get_trigger_info_lk(const char *, trigger_info *);
 
-void javasp_do_procedure_wrlock(void);
-void javasp_do_procedure_unlock(void);
+void javasp_splock_wrlock(void);
+void javasp_splock_rdlock(void);
+void javasp_splock_unlock(void);
 
 #endif

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -712,9 +712,9 @@ done:
 int perform_trigger_update(struct schema_change_type *sc, struct ireq *unused)
 {
     wrlock_schema_lk();
-    javasp_do_procedure_wrlock();
+    javasp_splock_wrlock();
     int rc = perform_trigger_update_int(sc);
-    javasp_do_procedure_unlock();
+    javasp_splock_unlock();
     unlock_schema_lk();
     return rc;
 }

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -83,7 +83,7 @@ static void get_info(trigger_cursor *cur){
   trigger *t;
 again:
   t = cur->trg;
-  get_trigger_info(t->name, &t->info);
+  get_trigger_info_lk(t->name, &t->info);
   cur->tbl = LISTC_TOP(&t->info.tbls);
   if( cur->tbl ){
     cur->col = LISTC_TOP(&cur->tbl->cols);

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4854,7 +4854,7 @@ char *stmt_column_name(sqlite3_stmt *, int);
 char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
 char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
-void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4854,7 +4854,7 @@ char *stmt_column_name(sqlite3_stmt *, int);
 char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
 char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
-void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -579,6 +579,7 @@ struct Vdbe {
   int *updCols;           /* list of columns modified in this update */
   Table **tbls;           /* list of tables to be open. */ 
   u16 numTables;
+  u16 vTableFlags;        /* Pre-acquire rwlocks / mutexes for certain vtables */
   u16 numVTableLocks;
   char **vTableLocks;
   char tzname[TZNAME_MAX];/* timezone info for datetime support */

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -58,6 +58,7 @@ typedef unsigned Bool;
 enum { VDBESORTER_FIND, VDBESORTER_MOVE, VDBESORTER_WRITE };
 /* moved vdbesorter here because is needed in sqlglue.c */
 /* Opaque type used by code in vdbesort.c */
+enum { VTABLE_FLAGS_GETSPLOCK = 1 };
 typedef struct PmaReader PmaReader;
 typedef struct MergeEngine MergeEngine;
 typedef struct SorterRecord SorterRecord;

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -240,12 +240,7 @@ void stmt_set_vlock_tables(sqlite3_stmt *pStmt, char **vTableLocks,
   stmt_free_vtable_locks(pStmt);
   vdbe->numVTableLocks = numVTableLocks;
   vdbe->vTableLocks = vTableLocks;
-/*
-** Only a single flag so far: acquire the sp-lock prior to any berkley lock.
-*/
-  if (flags) {
-    vdbe->vTableFlags = 1;
-  }
+  vdbe->vTableFlags = flags;
 }
 
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -185,6 +185,7 @@ static void stmt_free_vtable_locks(sqlite3_stmt *pStmt) {
   free(vdbe->vTableLocks);
   vdbe->vTableLocks = 0;
   vdbe->numVTableLocks = 0;
+  vdbe->vTableFlags = 0;
 }
 
 void stmt_set_cached_columns(sqlite3_stmt *pStmt, char **column_names,
@@ -234,11 +235,17 @@ int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt) {
 }
 
 void stmt_set_vlock_tables(sqlite3_stmt *pStmt, char **vTableLocks,
-        int numVTableLocks) {
+        int numVTableLocks, int flags) {
   Vdbe *vdbe = (Vdbe *)pStmt;
   stmt_free_vtable_locks(pStmt);
   vdbe->numVTableLocks = numVTableLocks;
   vdbe->vTableLocks = vTableLocks;
+/*
+** Only a single flag so far: acquire the sp-lock prior to any berkley lock.
+*/
+  if (flags) {
+    vdbe->vTableFlags = 1;
+  }
 }
 
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/tests/systable_locking.test/Makefile
+++ b/tests/systable_locking.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=30m
+	export TEST_TIMEOUT=35m
 endif

--- a/tests/systable_locking.test/runit
+++ b/tests/systable_locking.test/runit
@@ -8,6 +8,7 @@ bash -n "$0" | exit 1
 [[ $debug == "1" ]] && set -x
 
 export TESTITERS=20
+export TESTQUEUEITERS=20
 export MAXTABLES=20
 export MAXVIEWS=20
 export MAXQUEUES=20
@@ -31,6 +32,30 @@ function stat_all_tables
     for x in $t; do
         $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM $x LIMIT 10" >/dev/null 2>&1
     done
+}
+
+function enable_sleep_in_trigger_info
+{
+    [[ $debug == "1" ]] && set -x
+    if [[ -z "$CLUSTER" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "put tunable 'debug_sleep_in_trigger_info' 1" >/dev/null 2>&1
+    else
+        for m in $CLUSTER ; do 
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $m "put tunablel 'debug_sleep_in_trigger_info' 1" >/dev/null 2>&1
+        done
+    fi
+}
+
+function disable_sleep_in_trigger_info
+{
+    [[ $debug == "1" ]] && set -x
+    if [[ -z "$CLUSTER" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "put tunable 'debug_sleep_in_trigger_info' 0" >/dev/null 2>&1
+    else
+        for m in $CLUSTER ; do 
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $m "put tunablel 'debug_sleep_in_trigger_info' 0" >/dev/null 2>&1
+        done
+    fi
 }
 
 # List of systables as of the time this was written
@@ -107,6 +132,29 @@ function write_tables_loop
     done
 }
 
+function select_triggers_loop
+{
+    [[ $debug == "1" ]] && set -x
+    typeset j=0
+    while [[ ! -f $STOP_TABLES_TEST_TOUCHFILE ]];  do
+        let j=j+1
+        if [[ $(( j % 2 )) == 1 ]]; then
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2sys_triggers" >/dev/null 2>&1
+        else
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "SELECT * FROM comdb2_triggers" >/dev/null 2>&1
+        fi
+    done
+}
+
+function start_select_triggers
+{
+    [[ $debug == "1" ]] && set -x
+    typeset cnt=${1:-10}
+    for (( x = 0 ; x < cnt ; ++x )) ; do
+        select_triggers_loop &
+    done
+}
+
 function drop_tables
 {
     [[ $debug == "1" ]] && set -x
@@ -147,6 +195,8 @@ function drop_triggers
         $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop lua trigger audit$x"
     done
 }
+
+
 
 function create_triggers
 {
@@ -197,7 +247,8 @@ function check_all_nodes
     return 0
 }
 
-function run_test
+function alltables_test
+
 {
     [[ $debug == "1" ]] && set -x
     rm -Rf $STOP_TABLES_TEST_TOUCHFILE
@@ -218,6 +269,31 @@ function run_test
     touch $STOP_TABLES_TEST_TOUCHFILE
     wait
     check_all_nodes
+    rm -Rf $STOP_TABLES_TEST_TOUCHFILE
+}
+
+function splock_test
+{
+    [[ $debug == "1" ]] && set -x
+    rm -Rf $STOP_TABLES_TEST_TOUCHFILE
+    enable_sleep_in_trigger_info
+    start_select_triggers
+    for (( i = 0; i < TESTQUEUEITERS; ++i )); do
+        create_triggers
+        drop_triggers
+        [[ $(( i % 10 )) == 0 ]] && echo "Completed $i create and drop triggers"
+    done
+    touch $STOP_TABLES_TEST_TOUCHFILE
+    disable_sleep_in_trigger_info
+    wait
+    check_all_nodes
+    rm -Rf $STOP_TABLES_TEST_TOUCHFILE
+}
+
+function run_test
+{
+    splock_test
+    alltables_test
 }
 
 setup


### PR DESCRIPTION
Reproduces and fixes a lock-inversion bug that occurs when viewing comdb2_triggers table by forcing sql-threads which access comdb2_triggers to acquire the splock prior to any Berkley locks.
