### PR TITLE
{171621407} fix index reorder bug

### DIFF
--- a/bbinc/cdb2_constants.h
+++ b/bbinc/cdb2_constants.h
@@ -61,7 +61,7 @@
 #define MAX_USERNAME_LEN 16
 #define MAX_PASSWORD_LEN 19
 #define MAXBBNODENUM 32768 /* Legacy: maximum number assigned to a machine in BBENV */
-
+#define GENIDLEN sizeof(unsigned long long)
 /* moved here from csc2, better place */
 /*max length of index name, its char[64] in stat1 - 10 for $_12345678*/
 #define MAXIDXNAMELEN 54

--- a/db/indices.c
+++ b/db/indices.c
@@ -22,6 +22,7 @@
 #include "indices.h"
 #include "sqloffload.h"
 
+
 extern int gbl_partial_indexes;
 static __thread void *defered_index_tbl = NULL;
 static __thread void *defered_index_tbl_cursor = NULL;
@@ -47,7 +48,7 @@ typedef struct {
                            // usedb separately
     short ixnum;
     short ixlen;
-    char ixkey[MAXKEYLEN]; // consider storing up to the largest key
+    char ixkey[MAXKEYLEN + GENIDLEN]; // consider storing up to the largest key
                            // for dups genid is appended to end of key
     dit_t type;
     unsigned long long genid;

--- a/tests/reorder_deletes.test/runit
+++ b/tests/reorder_deletes.test/runit
@@ -65,6 +65,29 @@ insert_records()
     echo "done inserting round $nout"
 }
 
+populate_t2() {
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "DROP TABLE IF EXISTS t2" > t2.out
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t2 {`cat t2.csc2`}" >> t2.out
+    echo "begin" > t2.ins
+    local j=0
+    while [[ $j -lt 10 ]] ; do
+        echo "insert into t2 values('1','${j}')" >> t2.ins
+	let j=j+1
+    done
+    echo "commit" >> t2.ins
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default -f t2.ins >> t2.out 
+    assertcnt t2 10
+}
+
+basic_deletes() {
+    populate_t2
+    echo "begin" > t2.ins
+    echo "delete from t2 where text1='1'" >> t2.ins
+    echo "commit" >> t2.ins
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default -f t2.ins >> t2.out
+    count=`cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "select count(*) from t2 where text1='1'"` >> t2.out
+    assertres $count 0
+}
 
 
 do_deletes()
@@ -99,6 +122,7 @@ do_deletes()
     echo "done updater $updater"
 }
 
+basic_deletes
 NUM=10000
 TRANSZ=15
 CONCURRENT=20

--- a/tests/reorder_deletes.test/t2.csc2
+++ b/tests/reorder_deletes.test/t2.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    cstring text1[512]
+    cstring text2[512]
+}
+
+keys {
+    dup "PK1"=text1
+    datacopy "PK2"=text2
+}

--- a/tests/reorder_inserts.test/runit
+++ b/tests/reorder_inserts.test/runit
@@ -75,10 +75,29 @@ do_inserts()
     echo "done inserter $item"
 }
 
+
+# {171621407} simple inserts were failing for key lengths >= 512
+# this function exercises simple inserts in a transaction
+basic_inserts() {
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "DROP TABLE IF EXISTS t2" > t2.out
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t2 {`cat t2.csc2`}" >> t2.out
+    echo "begin" > t2.ins
+    local j=0
+    while [[ $j -lt 10 ]] ; do
+        echo "insert into t2 values('1','${j}')" >> t2.ins
+	let j=j+1
+    done
+    echo "commit" >> t2.ins
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default -f t2.ins >> t2.out 
+    assertcnt t2 10
+}
+
 #cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "INSERT INTO t1 (a,b,c,d) WITH i(x) AS ( VALUES(1) UNION ALL SELECT x+1 FROM i where x < $NUM) SELECT x,(x+1)%100,(x+2)%100,(x+3)%100 FROM i" > ins1.out
 
 tun=`cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "select value from comdb2_tunables where name='print_deadlock_cycles'"`
 assertres $tun 1 # Tunable needs to be set to 1
+
+basic_inserts
 
 i=0
 while [[ $i -lt $INSERTERS ]] ; do 

--- a/tests/reorder_inserts.test/t2.csc2
+++ b/tests/reorder_inserts.test/t2.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    cstring text1[512]
+    cstring text2[512]
+}
+
+keys {
+    dup "PK1"=text1
+    datacopy "PK2"=text2
+}

--- a/tests/reorder_updates.test/runit
+++ b/tests/reorder_updates.test/runit
@@ -48,6 +48,30 @@ assert_schema()
     fi
 }
 
+populate_t2() {
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "DROP TABLE IF EXISTS t2" > t2.out
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t2 {`cat t2.csc2`}" >> t2.out
+    echo "begin" > t2.ins
+    local j=0
+    while [[ $j -lt 10 ]] ; do
+        echo "insert into t2 values('1','${j}')" >> t2.ins
+	let j=j+1
+    done
+    echo "commit" >> t2.ins
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default -f t2.ins >> t2.out 
+    assertcnt t2 10
+}
+
+basic_updates() {
+    populate_t2
+    echo "begin" > t2.ins
+    echo "update t2 set text1='2' where text1='1'" >> t2.ins
+    echo "commit" >> t2.ins
+    cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default -f t2.ins >> t2.out
+    count=`cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "select count(*) from t2 where text1='2'"` >> t2.out
+    assertres $count 10
+}
+
 
 do_updates()
 {
@@ -83,6 +107,7 @@ NUM=10000
 TRANSZ=20
 UPDATERS=20
 
+basic_updates
 cdb2sql -s --tabs ${CDB2_OPTIONS} $dbnm default "INSERT INTO t1 (a,b,c,d) WITH i(x) AS ( VALUES(1) UNION ALL SELECT x+1 FROM i where x < $NUM) SELECT x,(random()+1)%100000,(random()+2)%100000,(random()+3)%100000 FROM i" > ins1.out
 
 assertcnt t1 $NUM

--- a/tests/reorder_updates.test/t2.csc2
+++ b/tests/reorder_updates.test/t2.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    cstring text1[512]
+    cstring text2[512]
+}
+
+keys {
+    dup "PK1"=text1
+    datacopy "PK2"=text2
+}


### PR DESCRIPTION
While collecting and reordering index operations in the defered index table, we don't allocate sufficient memory for keys into the table. Specifically for dup indexes of length >= 512, we end up overwriting memory and corrupting fields in the dti key structure. This patch fixes the bug and updates the test cases to exercise the edge case.
