### PR TITLE
record-locked-vtable can be passed a null, disable early-ack in yast

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -758,7 +758,7 @@ static int vtable_search(char **vtables, int ntables, const char *table)
 static void record_locked_vtable(struct sql_authorizer_state *pAuthState, const char *table)
 {
     const char *vtable_lock = vtable_lockname(pAuthState->db, table);
-    if ((strcmp(table, "comdb2_triggers") == 0)) {
+    if (table != NULL && (strcmp(table, "comdb2_triggers") == 0)) {
         pAuthState->flags |= PREPARE_ACQUIRE_SPLOCK;
     }
     if (vtable_lock && !vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_lock)) {

--- a/tests/yast.test/lrl.options
+++ b/tests/yast.test/lrl.options
@@ -5,3 +5,4 @@ ssl_client_mode OPTIONAL
 # Disable parallel rep: reload-analyze isn't a serialization point
 REP_WORKERS 0
 REP_PROCESSORS 0
+early 0


### PR DESCRIPTION
Record locked vtable can be called with a NULL table argument.  Disable early-ack in yast.