### PR TITLE
set disable_writer_penalty_deadlock 1 for triggersc_latency test

### DIFF
--- a/tests/triggersc_latency.test/lrl.options
+++ b/tests/triggersc_latency.test/lrl.options
@@ -2,3 +2,10 @@ logmsg level info
 debug_add_replication_latency on
 # uncomment to see bug
 #javasp_early_release off
+
+# The writer-penalty must stay disabled on the master:
+# otherwise deadlocking write-schedules can set the 
+# 'write-penalty' flag, which can prevent a queue-sc 
+# from being dispatched.  This causes spurious & 
+# incorrect failures
+disable_writer_penalty_deadlock 1


### PR DESCRIPTION
The triggersc_latency was failing periodically because the writer-deadlock-penalty would shorten the write-queue, and prevent the schema-change from being dispatched on the master.    Because the other write-sessions are artificially slowed down in this test, the failure case would it to appear as though the schema-change commit was running the 'add_replication_latency' codepath.