### PR TITLE
Use Java 8

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -19,8 +19,8 @@ limitations under the License. -->
   <version>2.5.3</version>
   <packaging>jar</packaging>
   <properties>
-    <maven.compiler.source>1.6</maven.compiler.source>
-    <maven.compiler.target>1.6</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <env.skipTests>true</env.skipTests>
   </properties>
   <dependencies>


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
JDK 6 EOL support [ended on 2017](https://support.oracle.com/knowledge/Middleware/2244851_1.html). Even JDK 8 (the version proposed in this PR) is on its way out. It's well past due time to have the minimum version set to, at the very least, Java 8.

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
JDK 6 was released 16 years ago. I think it's safe to assume that users who  run on such an ancient JDK can continue to use older version of the JDBC driver. 