### PR TITLE
enable proxy remsql

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3218,6 +3218,14 @@ retry_next_record:
     debugprint("hndl->lastresponse->response_type=%d\n",
                hndl->lastresponse->response_type);
 
+    if (hndl->flags & CDB2_SQL_ROWS &&
+        hndl->lastresponse->response_type != RESPONSE_TYPE__LAST_ROW &&
+        !hndl->lastresponse->has_sqlite_row) {
+        debugprint("received regular row when asked for sqlite format\n");
+        sprintf(hndl->errstr, "remote is R7 or lower");
+        return -1;
+    }
+
     if (hndl->lastresponse->snapshot_info &&
         hndl->lastresponse->snapshot_info->file) {
         hndl->snapshot_file = hndl->lastresponse->snapshot_info->file;

--- a/db/fdb_fend.h
+++ b/db/fdb_fend.h
@@ -68,8 +68,10 @@
 #define FDB_VER_SOURCE_ID 2
 #define FDB_VER_WR_NAMES 3
 #define FDB_VER_SSL 4
+#define FDB_VER_PROXY 5
 
-#define FDB_VER FDB_VER_SSL
+
+#define FDB_VER FDB_VER_PROXY
 
 /* cc2 ftw */
 #define fdb_ver_encoded(ver) (-(ver + 1))

--- a/db/sql.h
+++ b/db/sql.h
@@ -929,6 +929,7 @@ struct sqlclntstate {
 
     // Latch last statement's cost for comdb2_last_cost to fetch
     int64_t last_cost;
+    int disable_fdb_push;
 };
 
 /* Query stats. */

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -26,7 +26,7 @@ enum CDB2ClientFeatures {
     /* request server to send back query fingerprint */
     REQUEST_FP           = 7;
     /* rows come in sqlite format */
-    SQLITE_ROW_FORMAT    = 8;
+    SQLITE_ROW_FORMAT    = 9;
 }
 
 message CDB2_FLAG {

--- a/sqlite/src/attach.c
+++ b/sqlite/src/attach.c
@@ -83,7 +83,8 @@ static void attachFunc(
   int version,
   int class,
   int local,
-  int class_override
+  int class_override,
+  int proto_version
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 ){
   int i;
@@ -254,6 +255,7 @@ static void attachFunc(
     pNew->class = class;
     pNew->class_override = class_override;
     pNew->local = local;
+    pNew->version = proto_version;
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     pNew->zDbSName = sqlite3DbStrDup(db, zName);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
@@ -437,7 +439,7 @@ static void attachFunc(
   if( zName==0 ) zName = "";
 
   zErrDyn = NULL;
-  rc = comdb2_dynamic_attach(db, context, 0, argv, zName, zFile, &zErrDyn, 0, 0, 0, 0);
+  rc = comdb2_dynamic_attach(db, context, 0, argv, zName, zFile, &zErrDyn, 0, 0, 0, 0, 0);
   if( zErrDyn ){
     sqlite3_result_error(context, zErrDyn, -1);
     sqlite3DbFree(db, zErrDyn);

--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -532,6 +532,7 @@ retry_after_fdb_creation:
   */
   if( !already_searched_fdb && (db->flags & SQLITE_PrepareOnly)==0 ){
     int        version = 0;
+    int        server_version = 0;
     char       *zErrDyn = NULL;
 
     if( gbl_fdb_track ){
@@ -540,7 +541,7 @@ retry_after_fdb_creation:
 
     int lvl, local, lvl_override;
     rc = sqlite3AddAndLockTable(db, fqDbname, zName, &version,
-          in_analysis_load, &lvl, &local, &lvl_override);
+          in_analysis_load, &lvl, &local, &lvl_override, &server_version);
     if( rc ){
         if( gbl_fdb_track )
             logmsg(LOGMSG_USER, "No foreign table \"%s:%s\"\n", fqDbname, zName);
@@ -560,7 +561,7 @@ retry_after_fdb_creation:
     ** attached from two different databases
     */
     rc = comdb2_dynamic_attach(db, NULL, 0, NULL, uri, dbName,
-        &zErrDyn, version, lvl, local, lvl_override);
+        &zErrDyn, version, lvl, local, lvl_override, server_version);
 
     if( sqlite3UnlockTable(dbName, zName) ){
       logmsg(LOGMSG_ERROR, "%s: failed to unlock %s.%s\n", __func__,

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -1271,6 +1271,7 @@ struct Db {
   int class;           /* what class for this cluster */
   int class_override;  /* was class explicit at the discovery time */
   int local;           /* is this a local db */
+  int version;         /* which protocol it supports */ 
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 
@@ -5016,11 +5017,12 @@ void sqlite3_set_tunable_by_name(char *tname, char *val);
 
 extern int sqlite3AddAndLockTable(sqlite3 *db, const char *dbname,
       const char *table, int *version, int in_analysis_load,
-      int *out_class, int *out_local, int *out_class_override);
+      int *out_class, int *out_local, int *out_class_override,
+      int *proto_version);
 extern int sqlite3UnlockTable(const char *dbname, const char *table);
 extern int comdb2_dynamic_attach(sqlite3 *db, sqlite3_context *context, int argc, sqlite3_value **argv,
       const char *zName, const char *zFile, char **pzErrDyn, int version,
-      int class, int local, int class_override);
+      int class, int local, int class_override, int proto_version);
 extern void comdb2_dynamic_detach(sqlite3 *db, int idx);  
 extern int comdb2_fdb_check_class(const char *dbname);
 int sqlite3InitTable(sqlite3 *db, char **pzErrMsg, const char *zName);


### PR DESCRIPTION
This change takes advantage of versioning in remsql protocol to allow 8.0 servers use the faster proxy mode for remsql; it detects 7.0 or older builds and falls back to unoptimized path in these cases.
It also handles the case when 8.0 server is downgraded to 7.0.