### PR TITLE
Change nodeix-indexed arrays into hash-tables

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -704,21 +704,53 @@ struct waiting_for_lsn {
 
 typedef LISTC_T(struct waiting_for_lsn) wait_for_lsn_list;
 
+struct seqnum_strptr {
+    const char *host;
+    struct seqnum_t seqnum;
+}; 
+
+struct wait_for_lsn_list_strptr {
+    const char *host;
+    wait_for_lsn_list *waitlist;
+};
+
+struct averager_strptr {
+    const char *host;
+    struct averager *av;
+};
+
+struct short_strptr {
+    const char *host;
+    short s;
+};
+
+struct uint64_strptr {
+    const char *host;
+    uint64_t u;
+};
+
+struct int_strptr {
+    const char *host;
+    int i;
+};
+
 typedef struct {
-    seqnum_type *seqnums; /* 1 per node num */
+    hash_t *seqnums; /* 1 per node num */
+    pthread_mutex_t seqnum_hash_lk; /* 1 per node num */
     pthread_mutex_t lock;
     pthread_cond_t cond;
     pthread_key_t key;
-    wait_for_lsn_list **waitlist;
-    short *expected_udp_count;
-    short *incomming_udp_count;
-    short *udp_average_counter;
-    int *filenum;
+    hash_t *waitlist;
+    pthread_mutex_t waitlist_hash_lk;
+    hash_t *expected_udp_count;
+    hash_t *incoming_udp_count;
+    hash_t *udp_average_counter;
+    hash_t *filenum;
 
     pool_t *trackpool;
-    /* need to do a bit better here... */
-    struct averager **time_10seconds;
-    struct averager **time_minute;
+    hash_t *time_10seconds;
+    hash_t *time_minute;
+    pthread_mutex_t time_lk;
 } seqnum_info_type;
 
 typedef struct {
@@ -745,7 +777,7 @@ typedef struct {
     char *myhost;
 
     pthread_mutex_t elect_mutex;
-    int *appseqnum; /* application level (bdb lib) sequencing */
+    hash_t *appseqnum; /* application level (bdb lib) sequencing */
     pthread_mutex_t appseqnum_lock;
     pthread_mutex_t upgrade_lock; /* ensure only 1 upgrade at a time */
     pthread_mutex_t send_lock;
@@ -988,8 +1020,8 @@ struct bdb_state_tag {
     signed char low_headroom_count;
 
     signed char pending_seqnum_broadcast;
-    int *coherent_state;
-    uint64_t *master_lease;
+    hash_t *coherent_state;
+    hash_t *master_lease;
     pthread_mutex_t master_lease_lk;
 
     signed char after_llmeta_init_done;
@@ -1000,7 +1032,7 @@ struct bdb_state_tag {
         not_coherent; /*master sets this if it knows were not coherent */
     int not_coherent_time;
 
-    uint64_t *last_downgrade_time;
+    hash_t *last_downgrade_time;
 
     /* old databases with datacopy don't have odh in index */
     signed char datacopy_odh;
@@ -1149,6 +1181,16 @@ int bdb_downgrade(bdb_state_type *bdb_state, uint32_t newgen, int *done);
 int bdb_downgrade_noelect(bdb_state_type *bdb_state);
 int get_seqnum(bdb_state_type *bdb_state, const char *host);
 void bdb_set_key(bdb_state_type *bdb_state);
+
+seqnum_type *retrieve_seqnum(bdb_state_type *bdb_state, const char *host);
+int *retrieve_coherent_state(bdb_state_type *bdb_state, const char *host);
+int *retrieve_filenum(bdb_state_type *bdb_state, const char *host);
+int *retrieve_appseqnum(bdb_state_type *bdb_state, const char *host);
+int *retrieve_last_downgrade_time(bdb_state_type *bdb_state, const char *host);
+uint64_t *retrieve_master_lease(bdb_state_type *bdb_state, const char *host);
+struct averager **retrieve_time_10seconds(bdb_state_type *bdb_state, const char *host);
+struct averager **retrieve_time_minute(bdb_state_type *bdb_state, const char *host);
+wait_for_lsn_list **retrieve_waitlist(bdb_state_type *bdb_state, const char *host);
 
 uint64_t subtract_lsn(bdb_state_type *bdb_state, DB_LSN *lsn1, DB_LSN *lsn2);
 void get_my_lsn(bdb_state_type *bdb_state, DB_LSN *lsnout);

--- a/bdb/bdb_net.c
+++ b/bdb/bdb_net.c
@@ -846,13 +846,12 @@ void send_coherency_leases(bdb_state_type *bdb_state, int lease_time,
 
     for (i = 0; i < count; i++) {
         Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
+        int *coherent_state = retrieve_coherent_state(bdb_state, hostlist[i]);
 
-        if (!master_is_coherent || bdb_state->coherent_state[
-                nodeix(hostlist[i])] != STATE_COHERENT) {
+        if (!master_is_coherent || (*coherent_state) != STATE_COHERENT) {
             *inc_wait = 1;
         }
-        do_send = master_is_coherent && (bdb_state->coherent_state[
-                nodeix(hostlist[i])] == STATE_COHERENT);
+        do_send = master_is_coherent && (*coherent_state) == STATE_COHERENT;
         Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
 
         if (do_send) {

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -3502,7 +3502,8 @@ static inline void set_seqnum_host(void *in_bdb_state, char *host, DB_LSN lsn,
                                    const char *func, int line)
 {
     bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
-    bdb_state->seqnum_info->seqnums[nodeix(host)].lsn = lsn;
+    seqnum_type *seqnum = retrieve_seqnum(bdb_state, host);
+    seqnum->lsn = lsn;
     if (gbl_set_seqnum_trace) {
         logmsg(LOGMSG_USER, "%s line %d setting host %s lsn to %d:%d\n", func,
                line, host, lsn.file, lsn.offset);
@@ -3562,9 +3563,8 @@ int bdb_push_pglogs_commit(void *in_bdb_state, DB_LSN commit_lsn, uint32_t gen,
             abort();
 
         set_seqnum_host(bdb_state, master, commit_lsn, __func__, __LINE__);
-        bdb_state->seqnum_info->seqnums[nodeix(master)].generation =
-            bdb_state->seqnum_info->seqnums[nodeix(master)].commit_generation =
-                gen;
+        seqnum_type *seqnum = retrieve_seqnum(bdb_state, master);
+        (*seqnum).generation = (*seqnum).commit_generation = gen;
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         bdb_set_commit_lsn_gen(bdb_state, &commit_lsn, gen);
         master_cnt++;
@@ -3572,9 +3572,8 @@ int bdb_push_pglogs_commit(void *in_bdb_state, DB_LSN commit_lsn, uint32_t gen,
             logmsg(LOGMSG_USER,
                    "%s: setting seqnum_info ptr %p on master to [%d][%d] gen "
                    "[%d] master-count=%llu not-master-count=%llu\n",
-                   __func__, &bdb_state->seqnum_info->seqnums[nodeix(master)],
-                   commit_lsn.file, commit_lsn.offset, gen, master_cnt,
-                   notmaster_cnt);
+                   __func__, seqnum, commit_lsn.file, commit_lsn.offset, gen,
+                   master_cnt, notmaster_cnt);
         }
     }
     else {

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -450,8 +450,9 @@ static inline void set_coherent_state(bdb_state_type *bdb_state,
                                       const char *hostname, int state,
                                       const char *func, int line)
 {
-    if (bdb_state->coherent_state[nodeix(hostname)] != state) {
-        bdb_state->coherent_state[nodeix(hostname)] = state;
+    int *coherent_state = retrieve_coherent_state(bdb_state, hostname);
+    if ((*coherent_state) != state) {
+        (*coherent_state) = state;
         if (gbl_set_coherent_state_trace) {
             logmsg(LOGMSG_USER, "%s line %d setting %s coherent state to %s\n",
                    func, line, hostname, coherent_state_to_str(state));
@@ -517,8 +518,11 @@ void bdb_transfermaster_tonode(bdb_state_type *bdb_state, char *tohost)
     bdb_downgrade_noelect(bdb_state);
 
     numsleeps = 0;
-    DB_LSN tohost_lsn = bdb_state->seqnum_info->seqnums[nodeix(tohost)].lsn;
-    DB_LSN myhost_lsn = bdb_state->seqnum_info->seqnums[nodeix(myhost)].lsn;
+    seqnum_type *toh = retrieve_seqnum(bdb_state, tohost);
+    seqnum_type *myh = retrieve_seqnum(bdb_state, myhost);
+
+    DB_LSN tohost_lsn = toh->lsn;
+    DB_LSN myhost_lsn = myh->lsn;
 again:
     if (((tohost_lsn.file > myhost_lsn.file) ||
          (tohost_lsn.file == myhost_lsn.file &&
@@ -607,7 +611,8 @@ static inline int is_incoherent_complete(bdb_state_type *bdb_state,
         *incohwait = 0;
 
     Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-    state = bdb_state->coherent_state[nodeix(host)];
+    int *coherent_state = retrieve_coherent_state(bdb_state, host);
+    state = (*coherent_state);
     Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
 
     /* STATE_COHERENT and STATE_INCOHERENT_LOCAL return COHERENT. */
@@ -651,9 +656,10 @@ static int throttle_updates_incoherent_nodes(netinfo_type *netinfo_ptr, const ch
     if (is_incoherent(bdb_state, host)) {
 
         DB_LSN *lsnp, *masterlsn;
-
-        lsnp = &bdb_state->seqnum_info->seqnums[nodeix(host)].lsn;
-        masterlsn = &bdb_state->seqnum_info->seqnums[nodeix(bdb_state->repinfo->master_host)].lsn;
+        seqnum_type *seq = retrieve_seqnum(bdb_state, host);
+        seqnum_type *master_seq = retrieve_seqnum(bdb_state, bdb_state->repinfo->master_host);
+        lsnp = &seq->lsn;
+        masterlsn = &master_seq->lsn;
         cntbytes = subtract_lsn(bdb_state, masterlsn, lsnp);
         if (cntbytes > window) {
             ret = 1;
@@ -1825,8 +1831,9 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host)
         /* clobber his state blindly.  we have no lsn here, just keep the last
            one in place.  */
         Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
+        int *coherent_state = retrieve_coherent_state(bdb_state, host);
 
-        if (bdb_state->coherent_state[nodeix(host)] == STATE_COHERENT) {
+        if ((*coherent_state) == STATE_COHERENT) {
             /*
              * We defer waits, making sure the coherency lease expires for
              * the disconnected replicant;  the node needs to be incoherent,
@@ -1841,7 +1848,8 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host)
         }
 
         /* hostdown can defer commits */
-        bdb_state->last_downgrade_time[nodeix(host)] = gettimeofday_ms();
+        int *last_downgrade_time = retrieve_last_downgrade_time(bdb_state, host);
+        (*last_downgrade_time) = gettimeofday_ms();
         Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
         trigger_unregister_node(host);
     } 
@@ -1887,21 +1895,23 @@ int net_hostdown_rtn(netinfo_type *netinfo_ptr, char *host)
     return 0;
 }
 
+static int set_incoherent_wait(void *obj, void *arg)
+{
+    struct int_strptr *incoherent_state = (struct int_strptr *)obj;
+    incoherent_state->i = STATE_INCOHERENT_WAIT;
+    return 0;
+}
+
 void bdb_all_incoherent(bdb_state_type *bdb_state)
 {
-    int i;
     if (gbl_set_coherent_state_trace) {
         logmsg(LOGMSG_USER, "%s line %d setting all nodes to INCOHERENT_WAIT\n",
                __func__, __LINE__);
     }
     Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-    for (i = 0; i < MAXNODES; i++) {
-        bdb_state->coherent_state[i] = STATE_INCOHERENT_WAIT;
-    }
-
+    hash_for(bdb_state->coherent_state, set_incoherent_wait, NULL);
     set_coherent_state(bdb_state, bdb_state->repinfo->myhost, STATE_COHERENT,
                        __func__, __LINE__);
-
     Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
 }
 
@@ -1954,29 +1964,82 @@ void bdb_get_notcoherent_list(bdb_state_type *bdb_state,
     }
 }
 
+static int purge_averager(void *obj, void *arg)
+{
+    struct averager_strptr *a = (struct averager_strptr *)obj;
+    if (a->av != NULL) averager_purge_old(a->av, INT_MAX);
+    return 0;
+}
+
+static int clear_waitlists(void *obj, void *arg)
+{
+    struct wait_for_lsn_list_strptr *w = (struct wait_for_lsn_list_strptr *)obj;
+    bdb_state_type *bdb_state = (bdb_state_type *)arg;
+    if (w->waitlist == NULL) {
+        return 0;
+    } struct wait_for_lsn *waitforlsn = listc_rtl(w->waitlist);
+    while (waitforlsn) {
+        pool_relablk(bdb_state->seqnum_info->trackpool, waitforlsn);
+        waitforlsn = listc_rtl(w->waitlist);
+    }
+    return 0;
+}
+
 void bdb_disable_replication_time_tracking(bdb_state_type *bdb_state)
 {
-    Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
+    Pthread_mutex_lock(&(bdb_state->seqnum_info->waitlist_hash_lk));
+    hash_for(bdb_state->seqnum_info->waitlist, clear_waitlists, bdb_state);
+    Pthread_mutex_unlock(&(bdb_state->seqnum_info->waitlist_hash_lk));
 
-    for (int node = 0; node < MAXNODES; node++) {
-        if (bdb_state->seqnum_info->waitlist[node]) {
-            struct wait_for_lsn *waitforlsn;
-            waitforlsn = listc_rtl(bdb_state->seqnum_info->waitlist[node]);
-            while (waitforlsn) {
-                pool_relablk(bdb_state->seqnum_info->trackpool, waitforlsn);
-                waitforlsn = listc_rtl(bdb_state->seqnum_info->waitlist[node]);
-            }
+    Pthread_mutex_lock(&bdb_state->seqnum_info->time_lk);
+    hash_for(bdb_state->seqnum_info->time_10seconds, purge_averager, NULL);
+    hash_for(bdb_state->seqnum_info->time_minute, purge_averager, NULL);
+    Pthread_mutex_unlock(&bdb_state->seqnum_info->time_lk);
+}
 
-            if (bdb_state->seqnum_info->time_10seconds) {
-                averager_purge_old(bdb_state->seqnum_info->time_10seconds[node],
-                                   INT_MAX);
-                averager_purge_old(bdb_state->seqnum_info->time_minute[node],
-                                   INT_MAX);
-            }
-        }
+static short *retrieve_incoming_udp_count(bdb_state_type *bdb_state, const char *host)
+{
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    struct short_strptr *s;
+    const char *h = intern(host);
+    Pthread_mutex_lock(&lk);
+    if ((s = hash_find(bdb_state->seqnum_info->incoming_udp_count, &h)) == NULL) {
+        s = calloc(sizeof(struct short_strptr), 1);
+        s->host = h;
+        hash_add(bdb_state->seqnum_info->incoming_udp_count, s);
     }
+    Pthread_mutex_unlock(&lk);
+    return &s->s;
+}
 
-    Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
+static short *retrieve_expected_udp_count(bdb_state_type *bdb_state, const char *host)
+{
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    struct short_strptr *s;
+    const char *h = intern(host);
+    Pthread_mutex_lock(&lk);
+    if ((s = hash_find(bdb_state->seqnum_info->expected_udp_count, &h)) == NULL) {
+        s = calloc(sizeof(struct short_strptr), 1);
+        s->host = h;
+        hash_add(bdb_state->seqnum_info->expected_udp_count, s);
+    }
+    Pthread_mutex_unlock(&lk);
+    return &s->s;
+}
+
+static short *retrieve_udp_average_counter(bdb_state_type *bdb_state, const char *host)
+{
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    struct short_strptr *s;
+    const char *h = intern(host);
+    Pthread_mutex_lock(&lk);
+    if ((s = hash_find(bdb_state->seqnum_info->udp_average_counter, &h)) == NULL) {
+        s = calloc(sizeof(struct short_strptr), 1);
+        s->host = h;
+        hash_add(bdb_state->seqnum_info->udp_average_counter, s);
+    }
+    Pthread_mutex_unlock(&lk);
+    return &s->s;
 }
 
 /* when packet is udp, increase counter
@@ -1985,34 +2048,32 @@ void bdb_disable_replication_time_tracking(bdb_state_type *bdb_state)
 inline static void update_node_acks(bdb_state_type *bdb_state, char *host,
                                     int is_tcp)
 {
-    int node_ix = nodeix(host);
+    short *incoming, *expected, *average;
     if (is_tcp == 0) {
-        bdb_state->seqnum_info->incomming_udp_count[node_ix]++;
+        incoming = retrieve_incoming_udp_count(bdb_state, host);
+        (*incoming)++;
         return;
     }
 
-    if (++bdb_state->seqnum_info->udp_average_counter[node_ix] <
-        bdb_state->attr->udp_average_over_epochs) {
+    average = retrieve_udp_average_counter(bdb_state, host);
+
+    if (++(*average) < bdb_state->attr->udp_average_over_epochs) {
         return;
     }
 
-    float delta = (bdb_state->seqnum_info->expected_udp_count[node_ix] -
-                   bdb_state->seqnum_info->incomming_udp_count[node_ix]);
-    float rate =
-        100 * delta / bdb_state->seqnum_info->expected_udp_count[node_ix];
+    expected = retrieve_expected_udp_count(bdb_state, host);
+    incoming = retrieve_incoming_udp_count(bdb_state, host);
 
-    if (bdb_state->seqnum_info->expected_udp_count[node_ix] > 1 &&
+    float delta = (*expected) - (*incoming);
+    float rate = 100 * delta / (*expected);
+
+    if ((*expected) > 1 &&
         delta > bdb_state->attr->udp_drop_delta_threshold &&
         rate > bdb_state->attr->udp_drop_warn_percent) {
-        logmsg(LOGMSG_USER,
-               "update_node_acks: host %s, expected_udp_count = %d, delta = "
-               "%.1f, loss = %f percent\n",
-               host, bdb_state->seqnum_info->expected_udp_count[node_ix], delta,
-               rate);
+        logmsg(LOGMSG_USER, "update_node_acks: host %s, expected_udp_count = %d, delta = "
+               "%.1f, loss = %f percent\n", host, (*expected), delta, rate);
     }
-    bdb_state->seqnum_info->incomming_udp_count[node_ix] = 0;
-    bdb_state->seqnum_info->expected_udp_count[node_ix] = 0;
-    bdb_state->seqnum_info->udp_average_counter[node_ix] = 0;
+    (*incoming) = (*expected) = (*average) = 0;
 }
 
 static int lsncmp(const void *lsn1, const void *lsn2)
@@ -2081,14 +2142,10 @@ static void calculate_durable_lsn(bdb_state_type *bdb_state, DB_LSN *dlsn,
 
     Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
     for (j = 0; j < nodecount; j++) {
-        int node_ix = nodeix(nodelist[j]);
-        memcpy(&nodelsns[index], &bdb_state->seqnum_info->seqnums[node_ix].lsn,
-               sizeof(DB_LSN));
+        seqnum_type *seqnum = retrieve_seqnum(bdb_state, nodelist[j]);
+        memcpy(&nodelsns[index], &seqnum->lsn, sizeof(DB_LSN));
         /* Consider only generation matches that aren't in catch-up mode */
-        if ((mygen ==
-             (nodegens[index] =
-                  bdb_state->seqnum_info->seqnums[node_ix].generation)) &&
-            (bdb_state->seqnum_info->seqnums[node_ix].lsn.file != 2147483647)) {
+        if ((mygen == (nodegens[index] = seqnum->generation)) && (seqnum->lsn.file != 2147483647)) {
             index++;
         }
     }
@@ -2162,7 +2219,8 @@ int verify_master_leases_int(bdb_state_type *bdb_state, const char **comlist,
 
     Pthread_mutex_lock(&(bdb_state->master_lease_lk));
     for (i = 0; i < comcount; i++) {
-        if (ctime < bdb_state->master_lease[nodeix(comlist[i])])
+        uint64_t *master_lease = retrieve_master_lease(bdb_state, comlist[i]); 
+        if (ctime < (*master_lease))
             current_leases++;
     }
     Pthread_mutex_unlock(&(bdb_state->master_lease_lk));
@@ -2266,7 +2324,6 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     struct waiting_for_lsn *waitforlsn = NULL;
     int now;
     int track_times;
-    int node_ix = nodeix(host);
     int seqnum_trace = bdb_state->attr->wait_for_seqnum_trace;
 
     track_times = bdb_state->attr->track_replication_times;
@@ -2330,7 +2387,8 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
             else
                 lease_time = issue_time + seqnum->lease_ms;
             Pthread_mutex_lock(&(bdb_state->master_lease_lk));
-            bdb_state->master_lease[node_ix] = lease_time;
+            uint64_t *master_lease = retrieve_master_lease(bdb_state, host); 
+            (*master_lease) = lease_time;
             Pthread_mutex_unlock(&(bdb_state->master_lease_lk));
 
             if (bdb_state->attr->master_lease_set_trace && (now = time(NULL)) > lastpr)
@@ -2367,14 +2425,14 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
      * give nodes a chance to dig themselves out if there's no activity (eg: if
      * they went incoherent because of a
      * read spike, but there's nomore reads or writes). */
-    if (change_coherency &&
-        bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_SLOW) {
+    int *cstate = retrieve_coherent_state(bdb_state, host);
+    if (change_coherency && (*cstate) == STATE_INCOHERENT_SLOW) {
         Pthread_mutex_lock(&slow_node_check_lk);
         if ((comdb2_time_epochms() - last_slow_node_check_time) >
                 bdb_state->attr->slowrep_inactive_timeout &&
-            bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_SLOW) {
+            (*cstate) == STATE_INCOHERENT_SLOW) {
             Pthread_mutex_lock(&bdb_state->coherent_state_lock);
-            if (bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_SLOW) {
+            if ((*cstate) == STATE_INCOHERENT_SLOW) {
                 set_coherent_state(bdb_state, host, STATE_INCOHERENT, __func__,
                                    __LINE__);
             }
@@ -2387,8 +2445,8 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     bzero(&zero_seq, sizeof(seqnum_type));
 
     /* make a note of the first time we see a seqnum for a node */
-    if (memcmp(&(bdb_state->seqnum_info->seqnums[node_ix]), &zero_seq,
-               sizeof(seqnum_type)) == 0) {
+    seqnum_type *host_seqnum = retrieve_seqnum(bdb_state, host);
+    if (memcmp(host_seqnum, &zero_seq, sizeof(seqnum_type)) == 0) {
         logmsg(LOGMSG_INFO, "got first seqnum from host %s: <%s>\n", host,
                lsn_to_str(str, &(seqnum->lsn)));
     }
@@ -2402,32 +2460,29 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     /* Completely possible .. it just means that the durable lsn will trail a
      * bit */
     if (bdb_state->attr->wait_for_seqnum_trace &&
-        log_compare(&bdb_state->seqnum_info->seqnums[node_ix].lsn,
-                    &seqnum->lsn) > 0) {
+        log_compare(&host_seqnum->lsn, &seqnum->lsn) > 0) {
         logmsg(LOGMSG_USER,
                "%s seqnum from %s moving backwards from [%d][%d] gen %d to "
                "[%d][%d] gen %d\n",
                __func__, host,
-               bdb_state->seqnum_info->seqnums[node_ix].lsn.file,
-               bdb_state->seqnum_info->seqnums[node_ix].lsn.offset,
-               bdb_state->seqnum_info->seqnums[node_ix].generation,
+               host_seqnum->lsn.file, 
+               host_seqnum->lsn.offset, 
+               host_seqnum->generation, 
                seqnum->lsn.file, seqnum->lsn.offset, seqnum->generation);
     } else if (bdb_state->attr->wait_for_seqnum_trace) {
         logmsg(LOGMSG_USER,
                "%s seqnum from %s moving from [%d][%d] gen %d to "
                "[%d][%d] gen %d commit_gen %d mygen %d change_coherency %d\n",
                __func__, host,
-               bdb_state->seqnum_info->seqnums[node_ix].lsn.file,
-               bdb_state->seqnum_info->seqnums[node_ix].lsn.offset,
-               bdb_state->seqnum_info->seqnums[node_ix].generation,
+               host_seqnum->lsn.file, 
+               host_seqnum->lsn.offset, 
+               host_seqnum->generation, 
                seqnum->lsn.file, seqnum->lsn.offset, seqnum->generation,
                seqnum->commit_generation, mygen, change_coherency);
     }
 
-    if (should_copy_seqnum(bdb_state, seqnum,
-                &bdb_state->seqnum_info->seqnums[node_ix])) {
-        memcpy(&(bdb_state->seqnum_info->seqnums[node_ix]), seqnum,
-               sizeof(seqnum_type));
+    if (should_copy_seqnum(bdb_state, seqnum, host_seqnum)) {
+        memcpy(host_seqnum, seqnum, sizeof(seqnum_type));
     }
 
     if (gbl_set_seqnum_trace) {
@@ -2436,22 +2491,21 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     }
 
     if (change_coherency && track_times) {
-        if (bdb_state->seqnum_info->time_10seconds[node_ix] == NULL) {
-            if (bdb_state->seqnum_info->waitlist[node_ix] == NULL) {
-                bdb_state->seqnum_info->waitlist[node_ix] =
-                    malloc(sizeof(wait_for_lsn_list));
-                listc_init(bdb_state->seqnum_info->waitlist[node_ix],
-                           offsetof(struct waiting_for_lsn, lnk));
-            }
 
-            bdb_state->seqnum_info->time_10seconds[node_ix] =
-                averager_new(10000, 100000);
-            bdb_state->seqnum_info->time_minute[node_ix] =
-                averager_new(60000, 100000);
+        struct averager **time_10seconds = retrieve_time_10seconds(bdb_state, host);
+        struct averager **time_minute = retrieve_time_minute(bdb_state, host);
+        wait_for_lsn_list **waitlist = retrieve_waitlist(bdb_state, host);
+
+        if ((*time_10seconds) == NULL) {
+            if ((*waitlist) == NULL) {
+                (*waitlist) = malloc(sizeof(wait_for_lsn_list));
+                listc_init((*waitlist), offsetof(struct waiting_for_lsn, lnk));
+            }
+            (*time_10seconds) = averager_new(10000, 10000);
+            (*time_minute) = averager_new(10000, 10000);
         }
-        waitforlsn =
-            (struct waiting_for_lsn *)bdb_state->seqnum_info->waitlist[node_ix]
-                ->top;
+        waitforlsn = (struct waiting_for_lsn *)(*waitlist)->top;
+
         while (waitforlsn) {
             if (log_compare(&seqnum->lsn, &waitforlsn->lsn) >= 0) {
                 struct waiting_for_lsn *next;
@@ -2460,13 +2514,10 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
                 diff = now - waitforlsn->start;
                 next = waitforlsn->lnk.next;
 
-                listc_rfl(bdb_state->seqnum_info->waitlist[node_ix],
-                          waitforlsn);
+                listc_rfl((*waitlist), waitforlsn);
 
-                averager_add(bdb_state->seqnum_info->time_10seconds[node_ix],
-                             diff, now);
-                averager_add(bdb_state->seqnum_info->time_minute[node_ix], diff,
-                             now);
+                averager_add((*time_10seconds), diff, now);
+                averager_add((*time_minute), diff, now);
 
                 pool_relablk(bdb_state->seqnum_info->trackpool, waitforlsn);
                 waitforlsn = next;
@@ -2496,21 +2547,18 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
     Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
 
     if (change_coherency) {
-        if (bdb_state->coherent_state[node_ix] == STATE_INCOHERENT ||
-            bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_WAIT) {
+        int *cstate = retrieve_coherent_state(bdb_state, host);
+        if ((*cstate) == STATE_INCOHERENT || (*cstate) == STATE_INCOHERENT_WAIT) {
             if (bdb_state->callback->nodeup_rtn) {
                 if ((bdb_state->callback->nodeup_rtn(bdb_state, host))) {
-                    rc = bdb_wait_for_seqnum_from_node_nowait_int(
-                        bdb_state, &(bdb_state->seqnum_info->seqnums[nodeix(
-                                       bdb_state->repinfo->master_host)]),
-                        host);
+                    seqnum_type *master_seqnum = retrieve_seqnum(bdb_state, bdb_state->repinfo->master_host);
+                    rc = bdb_wait_for_seqnum_from_node_nowait_int(bdb_state, master_seqnum, host);
                     if (rc == 0) {
                         /* prevent a node from becoming coherent for at least
                          * downgrade_penalty seconds after an event that would
                          * delay commits (the last downgrade) */
-                        if (downgrade_penalty &&
-                            (gettimeofday_ms() -
-                             bdb_state->last_downgrade_time[node_ix]) <=
+                        int *last_downgrade_time = retrieve_last_downgrade_time(bdb_state, host);
+                        if (downgrade_penalty && (gettimeofday_ms() - (*last_downgrade_time)) <=
                                 downgrade_penalty) {
                             set_coherent_state(bdb_state, host,
                                                STATE_INCOHERENT_WAIT, __func__,
@@ -2539,14 +2587,10 @@ static void got_new_seqnum_from_node(bdb_state_type *bdb_state,
 
                     /* INCOHERENT_WAIT if this node is within the catchup_window
                      */
-                    if (catchup_window && bdb_state->coherent_state[node_ix] ==
-                                              STATE_INCOHERENT) {
-                        masterlsn = &(bdb_state->seqnum_info
-                                          ->seqnums[nodeix(
-                                              bdb_state->repinfo->master_host)]
-                                          .lsn);
-                        cntbytes =
-                            subtract_lsn(bdb_state, masterlsn, &seqnum->lsn);
+                    int *cstate = retrieve_coherent_state(bdb_state, host);
+                    if (catchup_window && (*cstate) == STATE_INCOHERENT) {
+                        masterlsn = &(master_seqnum->lsn);
+                        cntbytes = subtract_lsn(bdb_state, masterlsn, &seqnum->lsn);
                         if (cntbytes < catchup_window) {
                             set_coherent_state(bdb_state, host,
                                                STATE_INCOHERENT_WAIT, __func__,
@@ -2568,7 +2612,7 @@ static int bdb_wait_for_seqnum_from_node_nowait_int(bdb_state_type *bdb_state,
 {
     seqnum_type *host_seqnum;
     Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-    host_seqnum = &bdb_state->seqnum_info->seqnums[nodeix(host)];
+    host_seqnum = retrieve_seqnum(bdb_state, host);
 
     /*fprintf(stderr, "calling bdb_seqnum_compare\n");*/
     if (bdb_seqnum_compare(bdb_state, host_seqnum, master_seqnum) >= 0) {
@@ -2585,6 +2629,17 @@ static int bdb_wait_for_seqnum_from_node_nowait_int(bdb_state_type *bdb_state,
         }
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         return 0;
+    } else {
+        if (gbl_set_coherent_state_trace) {
+            logmsg(LOGMSG_USER,
+                   "%s line %d returning INCOHERENT for %s, "
+                   "master_seqnum=%d:%d generation %d ptr %p, incoming "
+                   "seqnum=%d:%d generation %d\n",
+                   __func__, __LINE__, host, master_seqnum->lsn.file,
+                   master_seqnum->lsn.offset, master_seqnum->generation,
+                   master_seqnum, host_seqnum->lsn.file,
+                   host_seqnum->lsn.offset, host_seqnum->generation);
+        }
     }
     Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
     return -999;
@@ -2594,23 +2649,23 @@ static void bdb_zap_lsn_waitlist(bdb_state_type *bdb_state, const char *host) {
     if (bdb_state == NULL)
         return;
 
+    struct averager **time_10seconds = retrieve_time_10seconds(bdb_state, host);
+    struct averager **time_minute = retrieve_time_minute(bdb_state, host);
+    wait_for_lsn_list **waitlist = retrieve_waitlist(bdb_state, host);
+
     /* clear statistics */
     Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-    int node_ix = nodeix(host);
-    if (bdb_state->seqnum_info->time_minute[node_ix])
-        averager_clear(bdb_state->seqnum_info->time_minute[node_ix]);
-    if (bdb_state->seqnum_info->time_10seconds[node_ix])
-        averager_clear(bdb_state->seqnum_info->time_10seconds[node_ix]);
+    if ((*time_minute))
+        averager_clear((*time_minute));
+    if ((*time_10seconds))
+        averager_clear((*time_10seconds));
 
-    /* clear any lsns we were waiting for */
     struct waiting_for_lsn *waitforlsn;
-    if (bdb_state->seqnum_info->waitlist[node_ix]) {
-        waitforlsn = (struct waiting_for_lsn *)listc_rtl(
-            bdb_state->seqnum_info->waitlist[node_ix]);
+    if ((*waitlist)) {
+        waitforlsn = (struct waiting_for_lsn *)listc_rtl((*waitlist));
         while (waitforlsn) {
             pool_relablk(bdb_state->seqnum_info->trackpool, waitforlsn);
-            waitforlsn = (struct waiting_for_lsn *)listc_rtl(
-                bdb_state->seqnum_info->waitlist[node_ix]);
+            waitforlsn = (struct waiting_for_lsn *)listc_rtl((*waitlist));
         }
     }
 
@@ -2620,84 +2675,58 @@ static void bdb_zap_lsn_waitlist(bdb_state_type *bdb_state, const char *host) {
 static void bdb_slow_replicant_check(bdb_state_type *bdb_state,
                                      seqnum_type *seqnum)
 {
-    double *proctime;
     const char *worst_node = NULL, *second_worst_node = NULL;
     int numnodes;
     const char *hosts[REPMAX];
-    int state;
     int print_message;
     int made_incoherent_slow = 0;
 
     /* this used to be allocated on stack, but that can overflow if called from
      * the appsock thread */
-    proctime = malloc(sizeof(double) * MAXNODES);
-    if (proctime == NULL)
-        return;
-
-    proctime[0] = 0;
 
     numnodes =
         net_get_all_commissioned_nodes(bdb_state->repinfo->netinfo, hosts);
  
     if (numnodes < 2) {
-        free(proctime);
         return;
     }
 
     Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
     double worst_time = 0;
-    /* find the slowest and second slowest nodes */
-    for (int i = 0; i < numnodes; i++) {
-        const char *host = hosts[i];
-        int node_ix = nodeix(host);
-
-        if (bdb_state->seqnum_info->time_minute[node_ix])
-            proctime[node_ix] =
-                averager_avg(bdb_state->seqnum_info->time_minute[node_ix]);
-        else
-            proctime[node_ix] = 0;
-
-        /* We're just checking, not checking & setting */
-        state = bdb_state->coherent_state[node_ix];
-
-        if (state != STATE_COHERENT)
-            continue;
-
-        if (proctime[node_ix] > worst_time) {
-            worst_time = proctime[node_ix];
-            worst_node = host;
-        }
-    }
     double second_worst_time = 0;
+
     for (int i = 0; i < numnodes; i++) {
         const char *host = hosts[i];
-        int node_ix = nodeix(host);
-        state = bdb_state->coherent_state[node_ix];
-        if (state != STATE_COHERENT)
+        int *cstate = retrieve_coherent_state(bdb_state, host);
+
+        if ((*cstate) != STATE_COHERENT)
             continue;
 
-        if (proctime[node_ix] > second_worst_time && host != worst_node) {
-            second_worst_node = host;
-            second_worst_time = proctime[node_ix];
-        }
+        struct averager **time_minute = retrieve_time_minute(bdb_state, host);
+        if ((*time_minute)) {
+            double avg = averager_avg((*time_minute));
+            if (avg > worst_time) {
+                second_worst_time = worst_time;
+                second_worst_node = worst_node;
+                worst_time = avg;
+                worst_node = host;
+
+            } else if (avg > second_worst_time) {
+                second_worst_time = avg;
+                second_worst_node = host;
+            }
+        } 
     }
     Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
-#if 0
-    printf("bdb_slow_replicant_check worst is %d at %.2fms, second worst is %d at %.2fms, going to start marking incoherent at %.2fs\n",
-            worst_node, proctime[worst_node], second_worst_node, proctime[second_worst_node], 
-            proctime[second_worst_node] * bdb_state->attr->slowrep_incoherent_factor + bdb_state->attr->slowrep_incoherent_mintime);
-#endif
     print_message = 0;
     if (worst_node && second_worst_node && worst_node != second_worst_node) {
         /* weigh time, to account for inter-datacenter delays */
         Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-        int worst_node_ix = nodeix(worst_node);
-        state = bdb_state->coherent_state[worst_node_ix];
+        int *cstate = retrieve_coherent_state(bdb_state, worst_node);
 
-        if (state == STATE_COHERENT &&
-                    worst_time >
-                    (second_worst_time *
+        if ((*cstate) == STATE_COHERENT &&
+                    worst_time > (second_worst_time *
                     bdb_state->attr->slowrep_incoherent_factor +
                     bdb_state->attr->slowrep_incoherent_mintime)) {
             /* if a node is worse then twice slower than other nodes, mark it
@@ -2706,13 +2735,11 @@ static void bdb_slow_replicant_check(bdb_state_type *bdb_state,
                     bdb_state->attr->make_slow_replicants_incoherent) {
                 print_message = 1;
                 if (bdb_state->attr->make_slow_replicants_incoherent) {
-                    if (bdb_state->coherent_state[worst_node_ix] ==
-                        STATE_COHERENT)
-                        defer_commits(bdb_state, worst_node, __func__);
+                    defer_commits(bdb_state, worst_node, __func__);
+                    int *dtime = retrieve_last_downgrade_time(bdb_state, worst_node);
                     set_coherent_state(bdb_state, worst_node, STATE_INCOHERENT_SLOW,
                             __func__, __LINE__);
-                    bdb_state->last_downgrade_time[worst_node_ix] =
-                        gettimeofday_ms();
+                    (*dtime) = gettimeofday_ms();
                     made_incoherent_slow = 1;
                 }
             }
@@ -2737,15 +2764,16 @@ static void bdb_slow_replicant_check(bdb_state_type *bdb_state,
          * they are up to the master's LSN. */
         for (int i = 0; i < numnodes; i++) {
             const char *host = hosts[i];
-            int node_ix = nodeix(host);
-            if (proctime[node_ix] == 0)
-                continue;
-            if (bdb_state->coherent_state[node_ix] != STATE_INCOHERENT_SLOW)
-                continue;
             Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-            if (bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_SLOW &&
-                (proctime[node_ix] <
-                 (worst_time * bdb_state->attr->slowrep_incoherent_factor +
+            int *cstate = retrieve_coherent_state(bdb_state, host);
+            struct averager **time_minute = retrieve_time_minute(bdb_state, host);
+            double avg = 0.0F;
+            if ((*time_minute)) {
+                avg = averager_avg((*time_minute));
+            }
+
+            if ((*cstate) == STATE_INCOHERENT_SLOW &&
+                (avg < (worst_time * bdb_state->attr->slowrep_incoherent_factor +
                   bdb_state->attr->slowrep_incoherent_mintime))) {
                 print_message = 1;
                 set_coherent_state(bdb_state, host, STATE_INCOHERENT, __func__,
@@ -2756,10 +2784,9 @@ static void bdb_slow_replicant_check(bdb_state_type *bdb_state,
                 logmsg(LOGMSG_USER,
                        "replication time for %s (%.2fms) is within "
                        "bounds of second-worst node %s (%.2fms)\n",
-                       host, proctime[node_ix], worst_node, worst_time);
+                       host, avg, worst_node, worst_time);
         }
     }
-    free(proctime);
 }
 
 /* expects seqnum_info lock held */
@@ -2769,22 +2796,17 @@ static int bdb_track_replication_time(bdb_state_type *bdb_state,
     if (!bdb_state->attr->track_replication_times)
         return 0;
 
-    struct waiting_for_lsn *waitforlsn;
-    int node_ix = nodeix(host);
-    if (bdb_state->seqnum_info->waitlist[node_ix] == NULL) {
-        bdb_state->seqnum_info->waitlist[node_ix] =
-            malloc(sizeof(wait_for_lsn_list));
-        listc_init(bdb_state->seqnum_info->waitlist[node_ix],
-                   offsetof(struct waiting_for_lsn, lnk));
+    wait_for_lsn_list **waitlist = retrieve_waitlist(bdb_state, host);;
+    if ((*waitlist) == NULL) {
+        (*waitlist) = malloc(sizeof(wait_for_lsn_list));
+        listc_init((*waitlist), offsetof(struct waiting_for_lsn, lnk));
     }
 
-    if (bdb_state->seqnum_info->waitlist[node_ix]->count <
-        bdb_state->attr->track_replication_times_max_lsns) {
-        waitforlsn = pool_getablk(bdb_state->seqnum_info->trackpool);
-        waitforlsn->lsn = seqnum->lsn;
-        waitforlsn->start = comdb2_time_epochms();
-        /* printf("waiting for %s\n", lsn_to_str(str, &seqnum->lsn)); */
-        listc_abl(bdb_state->seqnum_info->waitlist[node_ix], waitforlsn);
+    if ((*waitlist)->count < bdb_state->attr->track_replication_times_max_lsns) {
+        struct waiting_for_lsn *w = pool_getablk(bdb_state->seqnum_info->trackpool);
+        w->lsn = seqnum->lsn;
+        w->start = comdb2_time_epochms();
+        listc_abl((*waitlist), w);
     }
 
     return 0;
@@ -2834,7 +2856,6 @@ static int bdb_wait_for_seqnum_from_node_int(bdb_state_type *bdb_state,
     int node_is_rtcpu = 0;
     DB_LSN got_lsn;
     uint32_t got_gen;
-    int node_ix = nodeix(host);
     /* if we were passed a child, find his parent */
     if (bdb_state->parent)
         bdb_state = bdb_state->parent;
@@ -2848,8 +2869,9 @@ static int bdb_wait_for_seqnum_from_node_int(bdb_state_type *bdb_state,
 
     /* dont wait if it's in a skipped state */
     Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-    if ((coherent_state = bdb_state->coherent_state[node_ix]) ==
-        STATE_INCOHERENT) {
+    int *cstate = retrieve_coherent_state(bdb_state, host);
+    seqnum_type *host_seqnum = retrieve_seqnum(bdb_state, host);
+    if ((coherent_state = (*cstate)) == STATE_INCOHERENT) {
         Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
         if (bdb_state->attr->wait_for_seqnum_trace) {
             logmsg(LOGMSG_USER, PR_LSN " %s is incoherent, not waiting\n",
@@ -2863,11 +2885,11 @@ static int bdb_wait_for_seqnum_from_node_int(bdb_state_type *bdb_state,
     /* node is rtcpued off:  we may need to make the node incoherent */
     if (node_is_rtcpu) {
         Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
-        if (bdb_state->coherent_state[node_ix] == STATE_COHERENT ||
-            bdb_state->coherent_state[node_ix] == STATE_INCOHERENT_WAIT) {
-            if (bdb_state->coherent_state[node_ix] == STATE_COHERENT)
+        if ((*cstate) == STATE_COHERENT || (*cstate) == STATE_INCOHERENT_WAIT) {
+            if ((*cstate) == STATE_COHERENT)
                 defer_commits(bdb_state, host, __func__);
-            bdb_state->last_downgrade_time[node_ix] = gettimeofday_ms();
+            int *dtime = retrieve_last_downgrade_time(bdb_state, host);
+            (*dtime) = gettimeofday_ms();
             set_coherent_state(bdb_state, host, STATE_INCOHERENT, __func__,
                                __LINE__);
             bdb_state->repinfo->skipsinceepoch = comdb2_time_epoch();
@@ -2884,13 +2906,14 @@ static int bdb_wait_for_seqnum_from_node_int(bdb_state_type *bdb_state,
 
     Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
 
-    if (gbl_udp)
-        bdb_state->seqnum_info->expected_udp_count[node_ix]++;
+    if (gbl_udp) {
+        short *eudp = retrieve_expected_udp_count(bdb_state, host);
+        (*eudp)++;
+    }
 
 again:
 
-    if (bdb_state->seqnum_info->seqnums[node_ix].lsn.file == INT_MAX ||
-        bdb_lock_desired(bdb_state)) {
+    if (host_seqnum->lsn.file == INT_MAX || bdb_lock_desired(bdb_state)) {
         /* add 1 ms of latency if we have someone catching up */
         poll(NULL, 0, 1);
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
@@ -2902,7 +2925,7 @@ again:
         return 1;
     }
 
-    uint32_t gen = bdb_state->seqnum_info->seqnums[node_ix].generation;
+    uint32_t gen = host_seqnum->generation;
     if (bdb_state->attr->enable_seqnum_generations &&
         gen > seqnum->generation) {
         static unsigned long long higher_generation_reject = 0;
@@ -2922,8 +2945,7 @@ again:
         return -10;
     }
 
-    if (bdb_state->attr->enable_seqnum_generations &&
-        gen < seqnum->generation) {
+    if (bdb_state->attr->enable_seqnum_generations && gen < seqnum->generation) {
         static time_t pr = 0;
         time_t now;
 
@@ -2935,11 +2957,9 @@ again:
     }
 
     got_gen = gen;
-    got_lsn = bdb_state->seqnum_info->seqnums[node_ix].lsn;
+    got_lsn = host_seqnum->lsn;
 
-    if (bdb_seqnum_compare(bdb_state,
-                           &(bdb_state->seqnum_info->seqnums[node_ix]),
-                           seqnum) >= 0) {
+    if (bdb_seqnum_compare(bdb_state, host_seqnum, seqnum) >= 0) {
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         if (bdb_state->attr->wait_for_seqnum_trace) {
             logmsg(LOGMSG_USER, "%s line %d called from %d %s good rcode mach-gen %u mach_lsn %d:%d waiting for %u %d:%d\n", 
@@ -3339,11 +3359,11 @@ got_ack:
 
         /* replication timeout: we may need to make the node incoherent */
         if (rc != 0 && rc != -2) {
-            int node_ix = nodeix(nodelist[i]);
             // Extract seqnum
             Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-            nodegen = bdb_state->seqnum_info->seqnums[node_ix].generation;
-            nodelsn = bdb_state->seqnum_info->seqnums[node_ix].lsn;
+            seqnum_type *host_seqnum = retrieve_seqnum(bdb_state, nodelist[i]);
+            nodegen = host_seqnum->generation; 
+            nodelsn = host_seqnum->lsn; 
             Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
             Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
@@ -3353,15 +3373,15 @@ got_ack:
                  * decide to stop sending leases).  For role-change the new
                  * master marks every node as INCOHERENT_WAIT and then sleeps
                  * for the lease interval. */
-                if (bdb_state->coherent_state[node_ix] == STATE_COHERENT)
+                int *cstate = retrieve_coherent_state(bdb_state, nodelist[i]);
+                if ((*cstate) == STATE_COHERENT)
                     defer_commits(bdb_state, nodelist[i], __func__);
 
                 /* Change to INCOHERENT_WAIT if we allow catchup on commit */
                 if (bdb_state->attr->catchup_on_commit && catchup_window) {
-                    masterlsn =
-                        &(bdb_state->seqnum_info
-                              ->seqnums[nodeix(bdb_state->repinfo->master_host)]
-                              .lsn);
+                    seqnum_type *master_seqnum = retrieve_seqnum(bdb_state, 
+                        bdb_state->repinfo->master_host);
+                    masterlsn = &master_seqnum->lsn;
                     cntbytes = subtract_lsn(bdb_state, masterlsn, &nodelsn);
 
                     set_coherent_state(bdb_state, nodelist[i],
@@ -3374,7 +3394,8 @@ got_ack:
                                        __func__, __LINE__);
 
                 /* Record the downgrade time */
-                bdb_state->last_downgrade_time[node_ix] = gettimeofday_ms();
+                int *dtime = retrieve_last_downgrade_time(bdb_state, nodelist[i]);
+                (*dtime) = gettimeofday_ms();
 
                 bdb_state->repinfo->skipsinceepoch = comdb2_time_epoch();
             }
@@ -3570,10 +3591,8 @@ int bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum)
 
         Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
 
-        int myhost_ix = nodeix(bdb_state->repinfo->myhost);
-        memcpy(seqnum, &(bdb_state->seqnum_info->seqnums[myhost_ix]),
-               sizeof(seqnum_type));
-
+        seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+        memcpy(seqnum, s, sizeof(seqnum_type));
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         seqnum->generation = rep_gen;
     }
@@ -3595,11 +3614,8 @@ int get_myseqnum(bdb_state_type *bdb_state, uint8_t *p_net_seqnum)
         memcpy(&seqnum.lsn, &our_lsn, sizeof(DB_LSN));
     } else {
         Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-
-        int myhost_ix = nodeix(bdb_state->repinfo->myhost);
-        memcpy(&seqnum, &(bdb_state->seqnum_info->seqnums[myhost_ix]),
-               sizeof(seqnum_type));
-
+        seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+        memcpy(&seqnum, s, sizeof(seqnum_type));
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
         if ((bdb_state->attr->enable_seqnum_generations &&
@@ -3704,9 +3720,9 @@ void bdb_set_seqnum(void *in_bdb_state)
 
     if (lastlsn.file > 0) {
         Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-        int myhost_ix = nodeix(bdb_state->repinfo->myhost);
-        bdb_state->seqnum_info->seqnums[myhost_ix].lsn = lastlsn;
-        bdb_state->seqnum_info->seqnums[myhost_ix].generation = mygen;
+        seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+        s->lsn = lastlsn;
+        s->generation = mygen;
 
         if (gbl_set_seqnum_trace && (now = time(NULL)) - lastpr) {
             logmsg(LOGMSG_USER, "%s line %d set %s seqnum to %d:%d gen %d\n",
@@ -4061,9 +4077,9 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
         bdb_state->repinfo->repstats.rep_isperm++;
 
         Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
-        int myhost_ix = nodeix(bdb_state->repinfo->myhost);
-        bdb_state->seqnum_info->seqnums[myhost_ix].lsn = permlsn;
-        bdb_state->seqnum_info->seqnums[myhost_ix].generation = generation;
+        seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+        s->lsn = permlsn;
+        s->generation = generation;
         Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
 
         /*
@@ -5143,7 +5159,8 @@ static int berkdb_receive_rtn_int(void *ack_handle, void *usr_ptr,
         p_buf_end = ((uint8_t *)dta + dtalen);
 
         p_buf = (uint8_t *)buf_get(&filenum, sizeof(filenum), p_buf, p_buf_end);
-        bdb_state->seqnum_info->filenum[nodeix(from_node)] = filenum;
+        int *fnum = retrieve_filenum(bdb_state, from_node);
+        (*fnum) = filenum;
         break;
 
     case USER_TYPE_BERKDB_NEWSEQ:
@@ -5500,18 +5517,14 @@ void *watcher_thread(void *arg)
                 now = comdb2_time_epochms();
                 Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
                 for (i = 0; i < count; i++) {
-                    if (bdb_state->seqnum_info
-                            ->time_10seconds[nodeix(hostlist[i])])
-                        averager_purge_old(
-                            bdb_state->seqnum_info
-                                ->time_10seconds[nodeix(hostlist[i])],
-                            now);
-                    if (bdb_state->seqnum_info
-                            ->time_minute[nodeix(hostlist[i])])
-                        averager_purge_old(
-                            bdb_state->seqnum_info
-                                ->time_minute[nodeix(hostlist[i])],
-                            now);
+
+                    struct averager **time_10seconds = retrieve_time_10seconds(bdb_state, hostlist[i]);
+                    struct averager **time_minute = retrieve_time_minute(bdb_state, hostlist[i]);
+
+                    if ((*time_10seconds))
+                        averager_purge_old((*time_10seconds), now);
+                    if ((*time_minute))
+                        averager_purge_old((*time_minute), now);
                 }
                 Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
             }
@@ -5837,10 +5850,8 @@ int bdb_wait_for_seqnum_from_n(bdb_state_type *bdb_state, seqnum_type *seqnum,
             net_get_all_nodes_connected(bdb_state->repinfo->netinfo, connlist);
         Pthread_mutex_lock(&bdb_state->seqnum_info->lock);
         for (i = 0; i < numnodes; i++) {
-            if (bdb_seqnum_compare(
-                    bdb_state,
-                    &bdb_state->seqnum_info->seqnums[nodeix(connlist[i])],
-                    seqnum) >= 0) {
+            seqnum_type *s = retrieve_seqnum(bdb_state, connlist[i]);
+            if (bdb_seqnum_compare(bdb_state, s, seqnum) >= 0) {
                 num_acks++;
             }
         }

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -865,15 +865,14 @@ static inline unsigned long long lag_bytes(bdb_state_type *bdb_state)
         return 0;
 
     for (i = 0; i < count; i++) {
-        if (!is_incoherent(bdb_state, connlist[i]) &&
-            log_compare(
-                &bdb_state->seqnum_info->seqnums[nodeix(connlist[i])].lsn,
-                &minlsn) < 0) {
-            minlsn = bdb_state->seqnum_info->seqnums[nodeix(connlist[i])].lsn;
+        seqnum_type *s = retrieve_seqnum(bdb_state, connlist[i]);
+        if (!is_incoherent(bdb_state, connlist[i]) && log_compare(&s->lsn, &minlsn) < 0) {
+            minlsn = s->lsn;
         }
     }
 
-    masterlsn = bdb_state->seqnum_info->seqnums[nodeix(master_host)].lsn;
+    seqnum_type *master_seq = retrieve_seqnum(bdb_state, master_host);
+    masterlsn = master_seq->lsn;
     if (log_compare(&minlsn, &masterlsn) >= 0)
         return 0;
 
@@ -1598,10 +1597,8 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
             /* successful physical commit, lets increment our seqnum */
             Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
             /* dont let our global lsn go backwards */
-            memcpy(&old_lsn,
-                   &(bdb_state->seqnum_info
-                         ->seqnums[nodeix(bdb_state->repinfo->myhost)]),
-                   sizeof(DB_LSN));
+            seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+            memcpy(&old_lsn, &s->lsn, sizeof(DB_LSN));
 
             if (log_compare(&lsn, &old_lsn) > 0) {
                 /*fprintf(stderr, "%s:%d 2 updating my seqnum to %d:%d\n",
@@ -1609,12 +1606,8 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
 
                 // TODO not sure if this is necessary anymore 
                 // I should be setting this from a hook in log-put
-                memcpy(&(bdb_state->seqnum_info
-                             ->seqnums[nodeix(bdb_state->repinfo->myhost)]),
-                       &lsn, sizeof(DB_LSN));
-                bdb_state->seqnum_info
-                    ->seqnums[nodeix(bdb_state->repinfo->myhost)]
-                    .generation = generation;
+                memcpy(&(s->lsn), &lsn, sizeof(DB_LSN));
+                s->generation = generation;
             }
             Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         }
@@ -1880,26 +1873,21 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
         assert(!rc);
 
         if (seqnum) {
-            memcpy(seqnum, &lsn, sizeof(DB_LSN));
+            memcpy(&seqnum->lsn, &lsn, sizeof(DB_LSN));
             seqnum->generation = generation;
             set_seqnum = 1;
 
             Pthread_mutex_lock(&(bdb_state->seqnum_info->lock));
             /* dont let our global lsn go backwards */
-            memcpy(&old_lsn,
-                   &(bdb_state->seqnum_info
-                         ->seqnums[nodeix(bdb_state->repinfo->myhost)]),
-                   sizeof(DB_LSN));
+            seqnum_type *s = retrieve_seqnum(bdb_state, bdb_state->repinfo->myhost);
+            memcpy(&old_lsn, &s->lsn, sizeof(DB_LSN));
 
             if (log_compare(&lsn, &old_lsn) > 0) {
                 /*fprintf(stderr, "%s:%d 2 updating my seqnum to %d:%d\n",
                   __func__, __LINE__, lsn.file, lsn.offset);*/
-                memcpy(&(bdb_state->seqnum_info
-                             ->seqnums[nodeix(bdb_state->repinfo->myhost)]),
-                       &lsn, sizeof(DB_LSN));
-                bdb_state->seqnum_info
-                    ->seqnums[nodeix(bdb_state->repinfo->myhost)]
-                    .generation = generation;
+
+                memcpy(&(s->lsn), &lsn, sizeof(DB_LSN));
+                s->generation = generation;
             }
             Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
         }
@@ -1933,7 +1921,7 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
         free(log_stats);
 
         if (seqnum) {
-            memcpy(seqnum, &our_lsn, sizeof(DB_LSN));
+            memcpy(&seqnum->lsn, &our_lsn, sizeof(DB_LSN));
             seqnum->generation = generation;
         }
 
@@ -1959,7 +1947,7 @@ int bdb_tran_commit_with_seqnum_int(bdb_state_type *bdb_state, tran_type *tran,
         else if (seqnum) {
             bzero(seqnum, sizeof(seqnum_type));
             // TODO: NC: copy lsn instead of tran->savelsn instead?
-            memcpy(seqnum, &(tran->savelsn), sizeof(DB_LSN));
+            memcpy(&seqnum->lsn, &(tran->savelsn), sizeof(DB_LSN));
             seqnum->generation = generation;
         }
 

--- a/db/db_access.c
+++ b/db/db_access.c
@@ -212,6 +212,7 @@ int access_control_check_sql_write(struct BtCursor *pCur,
     }
 
     if (gbl_uses_accesscontrol_tableXnode) {
+        /* Using nodeix here is wrong: I will handle in different PR */
         rc = bdb_access_tbl_write_by_mach_get(
             pCur->db->dbenv->bdb_env, NULL, pCur->db->tablename,
             nodeix(thd->clnt->origin), &bdberr);

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/datetime
   ${PROJECT_SOURCE_DIR}/mem
   ${PROJECT_BINARY_DIR}/protobuf
+  ${PROJECT_BINARY_DIR}/bbinc
   ${PROTOBUF-C_INCLUDE_DIR}
   ${SQLite3_INCLUDE_DIRS}
   ${OPENSSL_INCLUDE_DIR}
@@ -71,10 +72,12 @@ add_exe(utf8 utf8.c)
 add_exe(verify_atomics_work verify_atomics_work.c)
 add_exe(makerecord_timer makerecord_timer.c)
 add_exe(sqlite_clnt sqlite_clnt.c)
+add_exe(hashbench hashbench.c testutil.c)
 
 target_link_libraries(cson_test cson)
 target_link_libraries(stepper util mem dlmalloc util)
 target_link_libraries(test_threadpool util mem dlmalloc util)
+target_link_libraries(hashbench util mem dlmalloc util)
 
 list(APPEND common-deps
   ${READLINE_LIBRARIES}

--- a/tests/tools/hashbench.c
+++ b/tests/tools/hashbench.c
@@ -1,0 +1,252 @@
+#include <stdio.h>
+#include <inttypes.h>
+#include <nodemap.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <intern_strings.h>
+#include <time.h>
+#include <plhash.h>
+#include "mem.h"
+#include <pthread.h>
+#include "testutil.h"
+
+static char *argv0=NULL;
+
+enum
+{
+    MODE_NODEIX     = 1,
+    MODE_STRING     = 2,
+    MODE_ALLOC      = 3,
+    MODE_NODEIXIX   = 4
+};
+
+void usage(FILE *f)
+{
+    fprintf(stderr, "Usage: %s <cmd-line>\n", argv0);
+    fprintf(stderr, " -i <iterations>       - iterations\n");
+    fprintf(stderr, " -c <host-count>       - hostname count\n");
+    fprintf(stderr, " -m <host-min>         - hostname min-string\n");
+    fprintf(stderr, " -x <host-max>         - hostname max-string\n");
+    fprintf(stderr, " -n                    - nodeix-hash mode\n");
+    fprintf(stderr, " -s                    - string-hash mode\n");
+    fprintf(stderr, " -a                    - string-hash-alloc mode\n");
+    fprintf(stderr, " -e                    - nodeix-index mode\n");
+    fprintf(stderr, " -h                    - help\n");
+}
+
+static char randc(void)
+{
+    const char *characters="abcdefghijklmnopqrstuvwxyz0123456789";
+    static int len = 0;
+    if (len == 0) len = strlen(characters);
+    return characters[random() % len];
+}
+
+static char *randstring(int minsz, int maxsz)
+{
+    int sz = (minsz == maxsz) ? minsz: minsz + (random() % (maxsz - minsz));
+    char *r = (char *)malloc(sz + 1);
+    for (int i = 0; i < sz; i++) {
+        r[i] = randc();
+    }
+    r[sz] = '\0';
+    return r;
+}
+
+static char **create_random_strings(int count, int minsz, int maxsz)
+{
+    char **r = (char **)malloc(count * sizeof(char *));
+    for (int i = 0; i < count; i++) {
+        r[i] = intern(randstring(minsz, maxsz));
+    }
+    return r;
+}
+
+struct int_nodeix {
+    int nodeix;
+    int i;
+};
+
+struct int_strptr {
+    const char *host;
+    int i;
+};
+
+hash_t *nodex_hash;
+hash_t *str_hash;
+int *nodeix_index;
+
+int *retrieve_strp_alloc(const char *host)
+{
+    struct int_strptr *n;
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+    if ((n = hash_find(str_hash, &host)) == NULL) {
+        n = calloc(sizeof(struct int_strptr), 1);
+        n->host = strdup(host);
+        hash_add(str_hash, n);
+    }
+    pthread_mutex_unlock(&lk);
+    return &n->i;
+}
+
+int *retrieve_strp(const char *host)
+{
+    struct int_strptr *n;
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+    if ((n = hash_find(str_hash, &host)) == NULL) {
+        n = calloc(sizeof(struct int_strptr), 1);
+        n->host = host;
+        hash_add(str_hash, n);
+    }
+    pthread_mutex_unlock(&lk);
+    return &n->i;
+}
+
+int *retrieve_nodex(const char *host)
+{
+    int nix = nodeix(host);
+    struct int_nodeix *n;
+    static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+    pthread_mutex_lock(&lk);
+    if ((n = hash_find(nodex_hash, &nix)) == NULL) {
+        n = calloc(sizeof(struct int_nodeix), 1);
+        n->nodeix = nix;
+        hash_add(nodex_hash, n);
+    }
+    pthread_mutex_unlock(&lk);
+    return &n->i;
+}
+
+int *retrieve_nodex_index(const char *host)
+{
+    int nix = nodeix(host);
+    return &nodeix_index[nix];
+}
+
+char *mode_to_str(int mode)
+{
+    switch(mode) {
+        case MODE_STRING:
+            return "string-hash";
+            break;
+        case MODE_ALLOC:
+            return "string-alloc-hash";
+            break;
+        case MODE_NODEIX:
+            return "nodex-hash";
+            break;
+        case MODE_NODEIXIX:
+            return "nodex-index";
+            break;
+        default:
+            return "unknown";
+    }
+}
+
+/* Simple benchmark for different hash-ing algorithms */
+int main(int argc, char *argv[])
+{
+    int c, hostcount=64, minsz=16, maxsz=32, iterations=1000000, mode=MODE_NODEIX, *n;
+    uint64_t startms, endms;
+    argv0=argv[0];
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    setvbuf(stderr, NULL, _IOLBF, 0);
+    srandom(time(NULL) ^ getpid());
+    comdb2ma_init(0, 0);
+
+    while ((c = getopt(argc, argv, "hc:m:x:i:nsaeh"))!=EOF) {
+        switch(c) {
+            case 'i':
+                iterations = atoi(optarg);
+                fprintf(stderr, "Set iterations to %d\n", iterations);
+                break;
+
+            case 'c':
+                hostcount = atoi(optarg);
+                fprintf(stderr, "Set hostcount to %d\n", hostcount);
+                break;
+
+            case 'm':
+                minsz = atoi(optarg);
+                fprintf(stderr, "Set minsz to %d\n", minsz);
+                break;
+
+            case 'x':
+                maxsz = atoi(optarg);
+                fprintf(stderr, "Set maxsz to %d\n", maxsz);
+                break;
+
+            case 'n':
+                mode = MODE_NODEIX;
+                fprintf(stderr, "Set mode to NODEIX-HASH\n");
+                break;
+
+            case 's':
+                mode = MODE_STRING;
+                fprintf(stderr, "Set mode to STRING-HASH\n");
+                break;
+
+            case 'a':
+                mode = MODE_ALLOC;
+                fprintf(stderr, "Set mode to STRING-ALLOC-HASH\n");
+                break;
+
+            case 'e':
+                mode = MODE_NODEIXIX;
+                fprintf(stderr, "Set mode to NODEIX-INDEX\n");
+                break;
+
+
+            case 'h':
+                usage(stdout);
+                exit(0);
+                break;
+
+            default:
+                usage(stderr);
+                exit(1);
+                break;
+        }
+    }
+
+    if (minsz > maxsz || minsz <= 0) {
+        fprintf(stderr, "Invalid minsz\n");
+        usage(stderr);
+        exit(1);
+    }
+
+    char **r = create_random_strings(hostcount, minsz, maxsz);
+
+    if (mode == MODE_STRING || mode == MODE_ALLOC) {
+        str_hash = hash_init_strptr(0);
+    } else if (mode == MODE_NODEIX) {
+        nodex_hash = hash_init(sizeof(int));
+    } else if (mode == MODE_NODEIXIX) {
+        nodeix_index = calloc(sizeof(int), hostcount);
+    }
+
+    startms = timems();
+
+    for (int i = 0; i < iterations; i++) {
+        if (mode == MODE_STRING) {
+            n = retrieve_strp(r[random() % hostcount]);
+            (*n) = random();
+        } else if (mode == MODE_ALLOC){
+            n = retrieve_strp_alloc(r[random() % hostcount]);
+            (*n) = random();
+        } else if (mode == MODE_NODEIX){
+            n = retrieve_nodex(r[random() % hostcount]);
+            (*n) = random();
+        } else if (mode == MODE_NODEIXIX) {
+            n = retrieve_nodex_index(r[random() % hostcount]);
+            (*n) = random();
+        }
+    }
+    endms = timems();
+    fprintf(stderr, "%s test %d iterations in %"PRIu64"ms %f/s\n", mode_to_str(mode),
+        iterations, endms - startms, (double)(((double)iterations * (double)1000) / (double)(endms - startms)));
+    return 0;
+}


### PR DESCRIPTION
Change arrays which are sized by MAXNODES to hash-tables so that the nodeix value isn't forced to be less than MAXNODES.  This is a WIP- I'm submitting a PR early to allow RR to run it, and to open discussions about this or other approaches.