### PR TITLE
{171755293}: fixing race on clnt->appdata

### DIFF
--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -96,6 +96,13 @@ static void free_newsql_appdata_evbuffer(int dummyfd, short what, void *arg)
     struct newsql_appdata_evbuffer *appdata = arg;
     struct sqlclntstate *clnt = &appdata->clnt;
     int fd = appdata->fd;
+    pthread_mutex_t *lk = (clnt->thd && clnt->thd->sqlthd) ? clnt->thd->sqlthd->lk : NULL;
+
+    /* grab the mutex on the associated sql thread to prevent other threads
+       (eg sql_dump_running_statements()) from reading a stale clnt */
+    if (lk)
+        Pthread_mutex_lock(lk);
+
     rem_sql_evbuffer(clnt);
     rem_appsock_connection_evbuffer(clnt);
     if (appdata->ping) {
@@ -126,6 +133,9 @@ static void free_newsql_appdata_evbuffer(int dummyfd, short what, void *arg)
     free(appdata);
     shutdown(fd, SHUT_RDWR);
     close(fd);
+
+    if (lk)
+        Pthread_mutex_unlock(lk);
 }
 
 static void newsql_cleanup(struct newsql_appdata_evbuffer *appdata)

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -526,10 +526,18 @@ retry_read:
 static void free_newsql_appdata_sbuf(struct sqlclntstate *clnt)
 {
     struct newsql_appdata_sbuf *appdata = clnt->appdata;
+    pthread_mutex_t *lk = (clnt->thd && clnt->thd->sqlthd) ? clnt->thd->sqlthd->lk : NULL;
+
+    if (lk)
+        Pthread_mutex_lock(lk);
+
     clnt_unregister(clnt);
     free_newsql_appdata(clnt);
     newsql_protobuf_destroy(&appdata->newsql_protobuf_allocator);
     free(appdata);
+
+    if (lk)
+        Pthread_mutex_unlock(lk);
 }
 
 static int handle_newsql_request(comdb2_appsock_arg_t *arg)


### PR DESCRIPTION
After being freed by an appsock thread or a libevent event-loop, clnt->appdata may still be read from another thread of control.  This patch fixes it.

/plugin-branch exit_race
