### PR TITLE
Fix for Dockerfile smell DL3007

### DIFF
--- a/tests/netloss.test/Dockerfile.dev
+++ b/tests/netloss.test/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 RUN apt-get update && \
   apt-get install -y \


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:

* What is the type of the change (bug fix, feature, documentation and etc.) ?
Refactoring of Dockerfile for writing best practices

* What are the current behavior and expected behavior, if this is a bugfix ?
None

* What are the steps required to reproduce the bug, if this is a bugfix ?
None

* What is the current behavior and new behavior, if this is a feature change or enhancement ?
The Dockerfile contains a best practice violation (smell) that could lead to reliability issues

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
Setting a specific version tag ensures the build reproducibility

* Description:

Hi!
The Dockerfile placed at "tests/netloss.test/Dockerfile.dev" contains the best practice violation [DL3007](https://github.com/hadolint/hadolint/wiki/DL3007) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3007 occurs when the tag "latest" is used instead of a specific version tag for the base image.
In this pull request, we propose a fix for that smell generated by our fixing tool. We have verified that the patch is correct before opening the pull request.
To fix this smell, specifically, we use a heuristic approach that selects the most probable version tag for the base image in order to replace the "latest" tag. In detail, it selects the most recent image tag which corresponds to the same image digest that currently corresponds to the "latest" tag.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
