### PR TITLE
{171755293}: Fixing race on clnt

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -228,8 +228,6 @@ static void sqlengine_work_shard(struct thdpool *pool, void *work,
         handle_child_error(clnt, clnt->query_rc);
     }
 
-    sql_reset_sqlthread(thd->sqlthd);
-
     if (put_curtran(thedb->bdb_env, clnt)) {
         logmsg(LOGMSG_ERROR, "%s: unable to destroy a CURSOR transaction!\n",
                __func__);

--- a/tests/sql_dump_race.test/Makefile
+++ b/tests/sql_dump_race.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sql_dump_race.test/lrl.options
+++ b/tests/sql_dump_race.test/lrl.options
@@ -1,0 +1,9 @@
+# don't let watchdogs' SELECT-1 intervene
+nowatch
+
+# these settings below make the only sql thread to exit immediately and
+# gets respawned. It makes sure that we don't race with done_sql_thread()
+
+sqlenginepool maxt 1
+sqlenginepool mint 0
+sqlenginepool linger 0

--- a/tests/sql_dump_race.test/runit
+++ b/tests/sql_dump_race.test/runit
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+
+# this triggers cleanup_clnt code path and verifies that it doesn't race with done_sql_thread()
+while true; do cdb2sql $dbnm --host $mach 'SYNTAX-ERROR'; done >/dev/null 2>&1 &
+pid_sql=$!
+
+# this verifies that sql-dump does not race with cleanup_clnt
+while true; do cdb2sql $dbnm --host $mach 'exec procedure sys.cmd.send("sql dump")'; done >/dev/null 2>&1 &
+pid_sql_dump=$!
+
+sleep 60
+
+kill -9 $pid_sql
+kill -9 $pid_sql_dump
+
+cdb2sql $dbnm --host $mach 'SELECT 1'
+if [ $? != 0 ]; then
+    echo "did not get a response from $mach???" >&2
+    exit 1
+fi
+
+# also verifies that sql dump shows replay
+cdb2sql $dbnm --host $mach "EXEC PROCEDURE sys.cmd.send('sqlenginepool maxt 8')"
+cdb2sql $dbnm --host $mach "CREATE TABLE t (i INTEGER)"
+cdb2sql $dbnm --host $mach "INSERT INTO t VALUES (1)"
+
+for i in `seq 1 8`; do
+    while true; do cdb2sql $dbnm --host $mach "UPDATE t SET i = 1 WHERE 1"; done &
+done
+
+while true; do cdb2sql $dbnm --host $mach 'exec procedure sys.cmd.send("sql dump")'; done >sql_dump.out 2>&1 &
+
+sleep 30
+
+jobs -p | xargs kill -9 >/dev/null 2>&1
+
+grep '[replay]' sql_dump.out
+if [ $? = 0 ]; then
+  echo success
+  exit 0
+else
+  echo 'Not seeing any replay in sql-dump???' >&2
+  exit 1
+fi


### PR DESCRIPTION
After being freed by an appsock thread or a libevent event-loop, clnt may still be read from another thread of control. This patch fixes it.

The original patch that attempted to address this issue, unfortunately, triggered a different race condition between sql-thread-exiting and newsql-cleanup. This patch adds a test to verify that both of these 2 races are addressed.
