### PR TITLE
Run physical verify after db-exit, fix sc_truncate

### DIFF
--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -420,7 +420,6 @@ if [ $CHECK_DB_AT_FINISH -eq 1 ] ; then
         if [[ -z "${verify_ret}" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
             verify_ret=`verify_db_at_finish ${SECONDARY_DBNAME} $SECONDARY_CDB2_CONFIG`
         fi
-        verify_phys=`verify_physical_at_finish ${DBNAME} $CDB2_CONFIG`
     fi
 fi
 
@@ -448,12 +447,6 @@ elif [[ -n "$verify_ret" ]] && [[ $rc -ne 0 ]] ; then
     echo "!$TESTCASE: failed" >> ${TEST_LOG}
     echo -e "!$TESTCASE: also ${RED}failed${NEUTRAL} verify ($verify_ret)"
     echo "!$TESTCASE: also failed verify ($verify_ret)" >> ${TEST_LOG}
-elif [[ -n "$verify_phys" ]] && [[ $rc -ne 0 ]]; then
-    echo "!$TESTCASE: failed rc=$rc (logs in ${TESTDIR}/logs/${DBNAME}.testcase)"
-    echo "!$TESTCASE: failed" >> ${TEST_LOG}
-    echo "!$TESTCASE: also failed physical-verify ($verify_phys)" | tee -a ${TEST_LOG}
-elif [[ -n "$verify_phys" ]]; then
-    echo "!$TESTCASE: failed physical-verify ($verify_phys)" | tee -a ${TEST_LOG}
 elif [[ -f "${DBNAME}.failexit" ]] ; then
     echo -e "!$TESTCASE: ${RED}failed${NEUTRAL} (found ${DBNAME}.failexit, logs in ${TESTDIR}/logs/${DBNAME}.testcase)"
     echo "!$TESTCASE: failed (found ${DBNAME}.failexit)" >> ${TEST_LOG}
@@ -493,6 +486,19 @@ if [[ -z "$cr" ]] ; then
 
     if [[ -n "$cr" ]] ; then
         echo "!$TESTCASE: at unsetup found core ($cr)" | tee -a ${TEST_LOG}
+        exit 1
+    fi
+fi
+
+# Do this after unsetup to prevent false-positives
+if [ $CHECK_DB_AT_FINISH -eq 1 ] ; then
+    verify_phys=`verify_physical_at_finish ${DBNAME} $CDB2_CONFIG`
+    if [[ -z "$verify_phys" ]] && [[ -n "${SECONDARY_DBNAME}" ]]; then
+        verify_phys=`verify_physical_at_finish ${SECONDARY_DBNAME} $CDB2_CONFIG`
+    fi
+
+    if [[ -n "$verify_phys" ]]; then
+        echo "!$TESTCASE: at unsetup failed physical-verify ($verify_phys)" | tee -a ${TEST_LOG}
         exit 1
     fi
 fi

--- a/tests/sc_truncate.test/runit
+++ b/tests/sc_truncate.test/runit
@@ -77,6 +77,32 @@ function insert_thread
     done
 }
 
+function check_up
+{
+    [[ $debug == "1" ]] && set -x
+    typeset func="check_up"
+    typeset max=60
+    typeset i=0
+    typeset error=1
+    while [[ "$i" -lt "$max" && "$error" -ne "0" ]]; do
+        error=0
+        for node in $CLUSTER ; do
+            $CDB2SQL_EXE -tabs $CDB2_OPTIONS --host $node $DBNAME "select 1" > /dev/null 2>&1 
+            if [[ "$?" -ne "0" ]] ; then 
+                error=1
+            fi
+        done
+        if [[ "$error" -ne "0" ]]; then
+            sleep 1
+        fi
+    let i=i+1
+    done
+    if [[ "$error" -ne "0" ]]; then
+        write_prompt $func "Database not up at finish"
+        echo "Database not up at finish" >> $failfile
+    fi
+}
+
 function run_test
 {
     [[ $debug == "1" ]] && set -x
@@ -137,6 +163,7 @@ function run_test
     done
     touch $stopfile
     wait
+    check_up
 }
 
 # Globals
@@ -166,6 +193,7 @@ else
 fi
 
 run_test $truncaters $truncate_sleep $downgrade_sleep $inserters $insertrecs $nocheckpoint $dgcount $maxtruncatefail
+
 if [[ -f $failfile ]]; then
     echo "Failed test"
     cat $failfile


### PR DESCRIPTION
This fixes the spurious sc_truncate failures.
