### PR TITLE
Add comdb2_notifications queue to schedule analyze

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -665,7 +665,7 @@ DEF_ATTR(
     "Amount of seconds to run phase 3 of time partition rollout after phase 2")
 DEF_ATTR(
     AA_REQUEST_MODE, aa_request_mode, BOOLEAN, 0,
-    "Print a message to stdout instead of performing auto-analyze ourselves")
+    "Add a message to comdb2_notifications instead of performing auto-analyze ourselves")
 DEF_ATTR(TEST_IO_TIME, test_io_time, SECS, 10, "Check I/O in watchdog this often")
 DEF_ATTR(TEST_SQL_TIME, test_sql_time, SECS, 0, "Check SQL in watchdog this often")
 DEF_ATTR(DELETE_OLD_FILE_DEBUG, delete_old_file_debug, BOOLEAN, 0,

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -105,6 +105,7 @@
 #include <schema_lk.h>
 #include <tohex.h>
 #include <timer_util.h>
+#include <notifications_queue.h>
 
 #include <phys_rep.h>
 #include <phys_rep_lsn.h>

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -36,6 +36,7 @@ set(src
   lrucache.c
   marshal.c
   memdebug.c
+  notifications_queue.c
   osql_srs.c
   osqlblkseq.c
   osqlblockproc.c

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -662,6 +662,7 @@ typedef struct dbtable {
     time_t aa_lastepoch;
     unsigned aa_counter_upd;   // counter which includes updates
     unsigned aa_counter_noupd; // does not include updates
+    unsigned aa_added_to_queue; // update when schedule autoanalyze added to comdb2_notifications
 
     /* Foreign key constraints */
     constraint_t *constraints;

--- a/db/notifications_queue.c
+++ b/db/notifications_queue.c
@@ -1,0 +1,136 @@
+#include <notifications_queue.h>
+#include <cdb2api.h>
+#include <logmsg.h>
+#include <cdb2_constants.h>
+#include <comdb2.h>
+#include <time.h>
+
+extern char gbl_dbname[MAX_DBNAME_LENGTH];
+time_t gbl_notifications_queue_last_truncated = 0;
+
+static int create_notifications_queue() {
+    cdb2_hndl_tp *db;
+    int rc = 0;
+    int rc2;
+
+    if (getqueuebyname("__qcomdb2_notifications")) {
+        return 0;
+    }
+
+    rc = cdb2_open(&db, gbl_dbname, "local", 0);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto done;
+    }
+
+    char *sql;
+    if (get_dbtable_by_name("comdb2_notifications_table") == NULL) {
+        sql = "CREATE TABLE comdb2_notifications_table(tablename cstring(100), timestamp datetime, json vutf8(100));";
+        rc = cdb2_run_statement(db, sql);
+        if (rc != CDB2_OK) {
+            logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+            goto done;
+        }
+    }
+
+    sql = "CREATE PROCEDURE comdb2_notifications VERSION 'v1' {\n"
+          "local function define_emit_columns()\n"
+          "db:num_columns(3)\n"
+          "db:column_name('tablename', 1)\n"
+          "db:column_type('cstring', 1)\n"
+          "db:column_name('timestamp', 2)\n"
+          "db:column_type('datetime', 2)\n"
+          "db:column_name('json', 3)\n"
+          "db:column_type('vutf8', 3)\n"
+          "end\n"
+          "local function main()\n"
+          "define_emit_columns()\n"
+          "-- get handle to consumer associated with stored procedure\n"
+          "local consumer = db:consumer()\n"
+          "local row\n"
+          "local change = consumer:get() -- blocking call\n"
+          "if change then\n"
+          "row = change.new\n"
+          "end\n"
+          "if row == nil then\n"
+          "row = {}\n"
+          "end\n"
+          "consumer:emit(row) -- blocking call\n"
+          "consumer:consume()\n"
+          "end\n"
+          "}";
+    rc = cdb2_run_statement(db, sql);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto done;
+    }
+
+    sql = "CREATE LUA CONSUMER comdb2_notifications ON (TABLE comdb2_notifications_table FOR INSERT)";
+    rc = cdb2_run_statement(db, sql);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto done;
+    }
+
+done:
+    rc2 = cdb2_close(db);
+    if (rc2 != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc2, cdb2_errstr(db));
+        return rc2;
+    }
+    return rc;
+}
+
+void *add_to_notifications_queue(void *arg) {
+    cdb2_hndl_tp *db;
+    int rc;
+    struct notifications_queue_item *item = (struct notifications_queue_item *)arg;
+
+    if (create_notifications_queue()) {
+        goto free_memory;
+    }
+
+    rc = cdb2_open(&db, gbl_dbname, "local", 0);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto close;
+    }
+
+    char *sql = "insert into comdb2_notifications_table values(@tablename, NOW(), @json);";
+    rc = cdb2_bind_param(db, "tablename", CDB2_CSTRING, item->tablename, strlen(item->tablename));
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto clear;
+    }
+
+    rc = cdb2_bind_param(db, "json", CDB2_CSTRING, item->json, strlen(item->json));
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto clear;
+    }
+
+    rc = cdb2_run_statement(db, sql);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+        goto clear;
+    }
+
+clear:
+    rc = cdb2_clearbindings(db);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+    }
+
+close:
+    rc = cdb2_close(db);
+    if (rc != CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s: rc = %d, %s\n", __func__, rc, cdb2_errstr(db));
+    }
+
+free_memory:
+    free(item->tablename);
+    free(item->json);
+    free(item);
+
+    return NULL;
+}

--- a/db/notifications_queue.h
+++ b/db/notifications_queue.h
@@ -1,0 +1,29 @@
+/*
+   Copyright 2023, Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef INCLUDED_NOTIFICATIONS_QUEUE_H
+#define INCLUDED_NOTIFICATIONS_QUEUE_H
+
+#include "comdb2.h"
+
+struct notifications_queue_item {
+    char *tablename;
+    char *json;
+};
+
+void *add_to_notifications_queue(void *arg);
+
+#endif /* !INCLUDED_NOTIFICATIONS_QUEUE_H */

--- a/tests/autoanalyze.test/runit
+++ b/tests/autoanalyze.test/runit
@@ -124,7 +124,7 @@ get_autoanalyze_stat()
     cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm  'exec procedure sys.cmd.send("stat autoanalyze")' | grep "Table t1" > $fl
 
     sCnt=`cat $fl | cut -d= -f2 | awk '{print $1}'`
-    lRun=`cat $fl | cut -d= -f3 | sed 's/[^(]*(\([^)]*\))/\1/' `
+    lRun=`cat $fl | cut -d= -f3 | sed 's/[^(]*(\([^)]*\))/\1/' | cut -d, -f1 `
     echo "count $sCnt, lastrun $lRun" >&2
     echo $sCnt $lRun > $TMPDIR/$$.out
     read savedCnt lastRun < $TMPDIR/$$.out
@@ -400,5 +400,39 @@ if [[ $lastRun != $prevDate || $savedCnt -eq 0 ]] ; then
     exit -1
 fi
 
+echo ""
+echo "Testing comdb2_notifications queue"
+
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr autoanalyze 1")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr aa_count_upd 1")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr min_aa_ops 50")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr chk_aa_time 6")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr min_aa_time 10")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr aa_llmeta_save_freq 1")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr aa_min_percent 20")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr aa_min_percent_jitter 300")'
+cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb setattr aa_request_mode 1")'
+
+sleep 5
+
+update_records 100
+sleep $T_TO_SLEEP
+
+tablename=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure comdb2_notifications()' | awk '{print $1}'`
+if [[ ! $tablename || $tablename != "t1" ]] ; then
+    echo "Expected table t1 from comdb2_notifications consumer, got $tablename instead"
+    echo "Failed"
+    exit -1
+fi
+
+# make sure it only shows up in the queue one time (cheat by just checking table)
+sleep $T_TO_SLEEP
+
+count=`cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'select count(*) from comdb2_notifications_table'`
+if [[ $count -ne 1 ]] ; then
+    echo "Expected one row in comdb2_notifications_table, got $count"
+    echo "Failed"
+    exit -1
+fi
 
 echo "Success"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -2,7 +2,7 @@
 (name='aa_llmeta_save_freq', description='Persist change counters per table on every Nth iteration (called every CHK_AA_TIME seconds).', type='INTEGER', value='1', read_only='N')
 (name='aa_min_percent', description='Percent change above which we kick off analyze.', type='INTEGER', value='20', read_only='N')
 (name='aa_min_percent_jitter', description='Additional jitter factor for determining percent change.', type='INTEGER', value='300', read_only='N')
-(name='aa_request_mode', description='Print a message to stdout instead of performing auto-analyze ourselves', type='BOOLEAN', value='OFF', read_only='N')
+(name='aa_request_mode', description='Add a message to comdb2_notifications instead of performing auto-analyze ourselves', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_invalid_query_info_key', description='Abort in thread-teardown for invalid query_info_key', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_on_in_use_rqid', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='abort_on_invalid_context', description='abort_on_invalid_context', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Replace AA_REQUEST_MODE to add to lua queue instead of printing to stdout

comdb2_notifications_table may manually need to be cleared out

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
