### PR TITLE
{170477625}: Fixing dbstore function

### DIFF
--- a/tests/sc_dbstore_func.test/Makefile
+++ b/tests/sc_dbstore_func.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sc_dbstore_func.test/output.expected
+++ b/tests/sc_dbstore_func.test/output.expected
@@ -1,0 +1,4 @@
+(rows inserted=1)
+(COUNT(*)=0)
+(rows inserted=1)
+(COUNT(*)=0)

--- a/tests/sc_dbstore_func.test/runit
+++ b/tests/sc_dbstore_func.test/runit
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+cat << EOF | cdb2sql ${CDB2_OPTIONS} -s $dbnm default - >output.actual 2>&1
+CREATE TABLE t1 { tag ondisk { int i } }\$\$
+INSERT INTO t1 VALUES (1)
+ALTER TABLE t1 { tag ondisk { int i datetime t dbstore={now()} } }\$\$
+SELECT COUNT(*) FROM t1 WHERE t IS NULL -- rebuild; t should be evaluated
+CREATE TABLE t2 { tag ondisk { int i } }\$\$
+INSERT INTO t2 VALUES (1)
+ALTER TABLE t2 { tag ondisk { int i byte b[16] dbstore={guid()} } }\$\$
+SELECT COUNT(*) FROM t2 WHERE b IS NULL -- rebuild; b should be evaluated
+EOF
+
+diff output.actual output.expected


### PR DESCRIPTION
Rebuilding a new field with a dbstore function crashes the database, as there's no `SERVER_to_SERVER` routine for the `SERVER_FUNCTION` datatype. This patch fixes it.

There're a few places where such a dbstore function can be evaluated for existing records. 

1) It can be evaluated per record at sc-convert-record time. This approach obviously requires a rebuild.

2) It can be evaluated once at sc-commit-time. The advantage of this is that it works with both instant and non-instant schema change. The disadvantage is that all existing rows get the same value, which may cause other problems down the line (uniqueness violation, for instance).

3) It can be evaluated per bdb-cursor move (this is where a literal dbstore is processed). The problem with this approach is that selecting the same row at different times may produce different values for this field (`now()`, `guid()`, etc.).

4) It can be not evaluated at all, leaving the new field for all existing rows NULL. This may cause other problems down the line (nullability violation, for instance).

None of these are perfect but option 1 seems to make the most sense. This patch also implements that.
