### PR TITLE
Show shard size in tablesizes systable

### DIFF
--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -57,6 +57,8 @@ struct systbl_tblsize_cursor {
   sqlite3_int64 iRowid;      /* The rowid */
 };
 
+extern int comdb2_next_allowed_table_or_shard(sqlite3_int64 *, int);
+
 static int systblTblSizeConnect(
   sqlite3 *db,
   void *pAux,
@@ -101,7 +103,7 @@ static int systblTblSizeOpen(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor){
   memset(pCur, 0, sizeof(*pCur));
   *ppCursor = &pCur->base;
 
-  comdb2_next_allowed_table(&pCur->iRowid);
+  comdb2_next_allowed_table_or_shard(&pCur->iRowid, 0);
 
   return SQLITE_OK;
 }
@@ -120,7 +122,7 @@ static int systblTblSizeClose(sqlite3_vtab_cursor *cur){
 static int systblTblSizeNext(sqlite3_vtab_cursor *cur){
   systbl_tblsize_cursor *pCur = (systbl_tblsize_cursor*)cur;
   pCur->iRowid++;
-  comdb2_next_allowed_table(&pCur->iRowid);
+  comdb2_next_allowed_table_or_shard(&pCur->iRowid, 0);
   return SQLITE_OK;
 }
 
@@ -187,7 +189,7 @@ static int systblTblSizeFilter(
 ){
   systbl_tblsize_cursor *pCur = (systbl_tblsize_cursor*)pVtabCursor;
   pCur->iRowid = 0;
-  comdb2_next_allowed_table(&pCur->iRowid);
+  comdb2_next_allowed_table_or_shard(&pCur->iRowid, 0);
   return SQLITE_OK;
 }
 

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -417,3 +417,8 @@
 (name='comdb2_users')
 (name='comdb2_views')
 [SELECT * FROM comdb2_systables ORDER BY name] rc 0
+[DROP TABLE IF EXISTS base_tbl] rc 0
+[CREATE TABLE base_tbl (i INTEGER)] rc 0
+[CREATE TIME PARTITION ON base_tbl AS tbl_v PERIOD 'YEARLY' RETENTION 1 START '2038-01-01T00:00:00 UTC'] rc 0
+(COUNT(*)=1)
+[SELECT COUNT(*) FROM comdb2_timepartshards m JOIN comdb2_tablesizes n WHERE m.shardname = n.tablename] rc 0

--- a/tests/comdb2sys.test/comdb2sys.req
+++ b/tests/comdb2sys.test/comdb2sys.req
@@ -16,3 +16,7 @@ SELECT COUNT(*)=1 FROM comdb2_appsock_handlers WHERE name = 'newsql';
 SELECT COUNT(*)=1 FROM comdb2_opcode_handlers WHERE name = 'blockop';
 SELECT type FROM comdb2_temporary_file_sizes ORDER BY type;
 SELECT * FROM comdb2_systables ORDER BY name;
+DROP TABLE IF EXISTS base_tbl;
+CREATE TABLE base_tbl (i INTEGER);$$
+CREATE TIME PARTITION ON base_tbl AS tbl_v PERIOD 'YEARLY' RETENTION 1 START '2038-01-01T00:00:00 UTC'
+SELECT COUNT(*) FROM comdb2_timepartshards m JOIN comdb2_tablesizes n WHERE m.shardname = n.tablename


### PR DESCRIPTION
While time partition shards are excluded from most of the comdb2_table* tables, I do think it makes sense to display their sizes in the comdb2_tablesizes table. This patch adds them back.
