### PR TITLE
{171830607}: Show time partitions in comdb2_columns, comdb2_keys and comdb2_keycomponents

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -586,7 +586,8 @@ enum prepare_flags {
     PREPARE_NO_NORMALIZE = 32,
     PREPARE_ONLY = 64,
     PREPARE_ALLOW_TEMP_DDL = 128,
-    PREPARE_ACQUIRE_SPLOCK = 256
+    PREPARE_ACQUIRE_SPLOCK = 256,
+    PREPARE_ACQUIRE_VIEWSLK = 512
 };
 
 /* This structure is designed to hold several pieces of data related to

--- a/db/sql.h
+++ b/db/sql.h
@@ -263,6 +263,7 @@ typedef struct {
     int maxchunksize;     /* multi-transaction bulk mode */
     int crtchunksize;     /* how many rows are processed already */
     int nchunks;          /* number of chunks. 0 for a non-chunked transaction. */
+    int views_lk_held;    /* Am I holding views_lk? */
 } dbtran_type;
 typedef dbtran_type trans_t;
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7647,14 +7647,9 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         return 0;
     }
 
-    if (p->numVTableLocks > 0) {
-        /* system table: grab views_lk as long as there's time partitions, so that
-           we can maintain the same lock order as time partion rollout which may
-           happen while we're in the middle of this query */
+    if ((p->vTableFlags & PREPARE_ACQUIRE_VIEWSLK) && !clnt->dbtran.views_lk_held) {
         Pthread_rwlock_rdlock(&views_lk);
         clnt->dbtran.views_lk_held = 1;
-    } else {
-        clnt->dbtran.views_lk_held = 0;
     }
 
     for (int i = 0; i < p->numVTableLocks; i++) {

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7622,6 +7622,7 @@ int gbl_assert_systable_locks = 1;
 #else
 int gbl_assert_systable_locks = 0;
 #endif
+extern pthread_rwlock_t views_lk;
 
 static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
 {
@@ -7644,6 +7645,16 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
 
     if (NULL == clnt->dbtran.cursor_tran) {
         return 0;
+    }
+
+    if (p->numVTableLocks > 0) {
+        /* system table: grab views_lk as long as there's time partitions, so that
+           we can maintain the same lock order as time partion rollout which may
+           happen while we're in the middle of this query */
+        Pthread_rwlock_rdlock(&views_lk);
+        clnt->dbtran.views_lk_held = 1;
+    } else {
+        clnt->dbtran.views_lk_held = 0;
     }
 
     for (int i = 0; i < p->numVTableLocks; i++) {
@@ -9689,6 +9700,12 @@ int put_curtran_flags(bdb_state_type *bdb_state, struct sqlclntstate *clnt,
 
     rc = bdb_put_cursortran(bdb_state, clnt->dbtran.cursor_tran, curtran_flags,
                             &bdberr);
+
+    if (clnt->dbtran.views_lk_held) {
+        Pthread_rwlock_unlock(&views_lk);
+        clnt->dbtran.views_lk_held = 0;
+    }
+
     if (rc) {
         logmsg(LOGMSG_DEBUG, "%s: %p rc %d bdberror %d\n", __func__, (void *)pthread_self(), rc, bdberr);
         ctrace("%s: rc %d bdberror %d\n", __func__, rc, bdberr);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -761,6 +761,18 @@ static void record_locked_vtable(struct sql_authorizer_state *pAuthState, const 
     if (table != NULL && (strcmp(table, "comdb2_triggers") == 0)) {
         pAuthState->flags |= PREPARE_ACQUIRE_SPLOCK;
     }
+    if (table != NULL && (strncasecmp(table, "comdb2_", 7) == 0)) {
+        table += 7;
+        if (strcasecmp(table, "tables") == 0 ||
+            strcasecmp(table, "columns") == 0 ||
+            strcasecmp(table, "keys") == 0 ||
+            strcasecmp(table, "keycomponents") == 0 ||
+            strcasecmp(table, "timepartitions") == 0 ||
+            strcasecmp(table, "timepartshards") == 0 ||
+            strcasecmp(table, "timepartevents") == 0) {
+            pAuthState->flags |= PREPARE_ACQUIRE_VIEWSLK;
+        }
+    }
     if (vtable_lock && !vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_lock)) {
         pAuthState->vTableLocks =
             (char **)realloc(pAuthState->vTableLocks, sizeof(char *) * (pAuthState->numVTableLocks + 1));
@@ -3123,7 +3135,7 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         }
 
         if (rec->stmt) {
-            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks);
+            stmt_set_vlock_tables(rec->stmt, thd->authState.vTableLocks, thd->authState.numVTableLocks, thd->authState.flags);
             thd->authState.numVTableLocks = 0;
             thd->authState.vTableLocks = NULL;
         } else {

--- a/db/timepart_systable.h
+++ b/db/timepart_systable.h
@@ -73,4 +73,13 @@ void timepart_systable_timepartevents_free(void *data, int nrecords);
 
 int timepart_systable_timepartpermissions_collect(void **data, int *nrecords);
 void timepart_systable_timepartpermissions_free(void *arr, int nrecords);
+
+/* return the total number of tables and views */
+int timepart_systable_num_tables_and_views();
+
+/* Given tabId, find the next view that this user is allowed to access. */
+int timepart_systable_next_allowed(sqlite3_int64 *tabId);
+
+/* Given tabId, return this this view's first shard (aka shard0) */
+struct dbtable *timepart_systable_shard0(sqlite3_int64 tabId);
 #endif

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -79,6 +79,7 @@ int systblSQLIndexStatsInit(sqlite3 *);
 int systblTemporaryFileSizesModuleInit(sqlite3 *);
 
 int comdb2_next_allowed_table(sqlite3_int64 *tabId);
+struct dbtable *comdb2_get_dbtable_or_shard0(sqlite3_int64 tabId);
 
 int systblScStatusInit(sqlite3 *db);
 int systblScHistoryInit(sqlite3 *db);

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -43,6 +43,7 @@
 #include "comdb2systblInt.h"
 #include "sql.h"
 #include "views.h"
+#include "timepart_systable.h"
 
 /* systbl_tables_cursor is a subclass of sqlite3_vtab_cursor which serves
 ** as the underlying cursor to enumerate the rows in this vtable. The 
@@ -156,7 +157,7 @@ static int systblTablesRowid(sqlite3_vtab_cursor *cur, sqlite_int64 *pRowid){
 static int systblTablesEof(sqlite3_vtab_cursor *cur){
   systbl_tables_cursor *pCur = (systbl_tables_cursor*)cur;
 
-  return pCur->iRowid >= thedb->num_dbs + timepart_num_views();
+  return pCur->iRowid >= timepart_systable_num_tables_and_views();
 }
 
 /*

--- a/sqlite/ext/comdb2/timepartitions.c
+++ b/sqlite/ext/comdb2/timepartitions.c
@@ -31,12 +31,15 @@ static int systblTimepartitionsEventsInit(sqlite3 *db);
 
 sqlite3_module systblTimepartitionsModule = {
     .access_flag = CDB2_ALLOW_USER,
+    .systable_lock = "comdb2_tables",
 };
 sqlite3_module systblTimepartitionShardsModule = {
     .access_flag = CDB2_ALLOW_USER,
+    .systable_lock = "comdb2_tables",
 };
 sqlite3_module systblTimepartitionEventsModule = {
     .access_flag = CDB2_ALLOW_USER,
+    .systable_lock = "comdb2_tables",
 };
 
 

--- a/sqlite/src/sqlite.h.in
+++ b/sqlite/src/sqlite.h.in
@@ -4854,7 +4854,7 @@ char *stmt_column_name(sqlite3_stmt *, int);
 char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
 char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
-void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -4854,7 +4854,7 @@ char *stmt_column_name(sqlite3_stmt *, int);
 char *stmt_column_decltype(sqlite3_stmt *pStmt, int index);
 char *stmt_cached_column_decltype(sqlite3_stmt *pStmt, int index);
 void stmt_set_cached_columns(sqlite3_stmt *, char **, char **, int);
-void stmt_set_vlock_tables(sqlite3_stmt *, char **, int);
+void stmt_set_vlock_tables(sqlite3_stmt *, char **, int, int);
 int stmt_do_column_names_match(sqlite3_stmt *);
 int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -579,6 +579,7 @@ struct Vdbe {
   int *updCols;           /* list of columns modified in this update */
   Table **tbls;           /* list of tables to be open. */ 
   u16 numTables;
+  u16 vTableFlags;        /* Pre-acquire rwlocks / mutexes for certain vtables */
   u16 numVTableLocks;
   char **vTableLocks;
   char tzname[TZNAME_MAX];/* timezone info for datetime support */

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -233,11 +233,12 @@ int stmt_do_column_decltypes_match(sqlite3_stmt *pStmt) {
   return 1;
 }
 
-void stmt_set_vlock_tables(sqlite3_stmt *pStmt, char **vTableLocks, int numVTableLocks){
+void stmt_set_vlock_tables(sqlite3_stmt *pStmt, char **vTableLocks, int numVTableLocks, int flags){
   Vdbe *vdbe = (Vdbe *)pStmt;
   stmt_free_vtable_locks(pStmt);
   vdbe->numVTableLocks = numVTableLocks;
   vdbe->vTableLocks = vTableLocks;
+  vdbe->vTableFlags = flags;
 }
 
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -419,3 +419,8 @@
 (name='comdb2_users')
 (name='comdb2_views')
 [SELECT * FROM comdb2_systables ORDER BY name] rc 0
+[CREATE TABLE tpt1(a int PRIMARY KEY) PARTITIONED BY TIME PERIOD 'yearly' RETENTION 7 start '2000-01-01T UTC'] rc 0
+(COUNT(*)=1)
+[SELECT COUNT(*) FROM comdb2_keys WHERE tablename = 'tpt1'] rc 0
+(COUNT(*)=1)
+[SELECT COUNT(*) FROM comdb2_keycomponents WHERE tablename = 'tpt1'] rc 0

--- a/tests/comdb2sys.test/comdb2sys.req
+++ b/tests/comdb2sys.test/comdb2sys.req
@@ -16,3 +16,6 @@ SELECT COUNT(*)=1 FROM comdb2_appsock_handlers WHERE name = 'newsql';
 SELECT COUNT(*)=1 FROM comdb2_opcode_handlers WHERE name = 'blockop';
 SELECT type FROM comdb2_temporary_file_sizes ORDER BY type;
 SELECT * FROM comdb2_systables ORDER BY name;
+CREATE TABLE tpt1(a int PRIMARY KEY) PARTITIONED BY TIME PERIOD 'yearly' RETENTION 7 start '2000-01-01T UTC'$$
+SELECT COUNT(*) FROM comdb2_keys WHERE tablename = 'tpt1'
+SELECT COUNT(*) FROM comdb2_keycomponents WHERE tablename = 'tpt1'


### PR DESCRIPTION
This patch also fixes a deadlock between views_lk and the "comdb2_tables" berkdb lock. The solution is simple: don't acquire views_lk from within time partition systable code, but instead rely on the "comdb2_tables" lock to protect the in-memory data structures (similar to #3784).
