### PR TITLE
dohsql: add support for single-select subqueries in a join

### DIFF
--- a/tests/union_parallel.test/10_1_join.req
+++ b/tests/union_parallel.test/10_1_join.req
@@ -31,6 +31,7 @@ select t.a, t.b, t2.c from t natural inner join t2 where t.a=1 union all select 
 select t.a, t.b, t2.c from t left outer join t2 on t.a = t2.c union all select t3.e, t3.f, t4.h from t3 left join t4 on t3.e == t4.h order by a
 #explain distribution select count(*) from t, t2 where t.a > 0 union all select count(t3.e) from t3, t4  where t3.e == t4.h
 select count(*) from t, t2 where t.a > 0 union all select count(t3.e) from t3, t4  where t3.e == t4.h
+select 1 from t left join (select a from t) union all  select 1 from t left join (select a from t) limit 2
 delete from t
 delete from t2
 delete from t3

--- a/tests/union_parallel.test/10_1_join.req.exp
+++ b/tests/union_parallel.test/10_1_join.req.exp
@@ -66,6 +66,8 @@
 (a=16, b=1600, c=16)
 (count(*)=36)
 (count(*)=3)
+(1=1)
+(1=1)
 (rows deleted=6)
 (rows deleted=6)
 (rows deleted=6)


### PR DESCRIPTION
Per Mike, this fails to properly parse in parallel sql:
create table t(a int); $$
select 1 from t left join (select * from t) union all select 1 from t left join (select * from t)

Subqueries were not supported.   This PR adds support for single select subqueries part of a join.
For other types of subqueries, the statement runs unparalleled. 