### PR TITLE
Acquire write-ref to blkseq-lk on blkseq-insert

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -702,7 +702,7 @@ int bdb_tran_get_start_file_offset(bdb_state_type *bdb_state, tran_type *tran,
    units */
 int bdb_tran_commit_with_seqnum_size(bdb_state_type *bdb_state, tran_type *tran,
                                      seqnum_type *seqnum, uint64_t *out_txnsize,
-                                     int *bdberr);
+                                     int holdlock, int *rellock, int *bdberr);
 
 /* abort the transaction referenced by the tran handle */
 int bdb_tran_abort(bdb_state_type *bdb_handle, tran_type *tran, int *bdberr);
@@ -1021,6 +1021,10 @@ int bdb_wait_for_seqnum_from_all_adaptive_newcoh(bdb_state_type *bdb_state,
                                                  seqnum_type *seqnum,
                                                  uint64_t txnsize,
                                                  int *timeoutms);
+
+int bdb_wait_for_seqnum_from_all_adaptive_checklock(bdb_state_type *bdb_state,
+                                                    seqnum_type *seqnum, uint64_t txnsize, 
+                                                    int ignore_lock_desired, int *timeoutms);
 
 int bdb_wait_for_seqnum_from_n(bdb_state_type *bdb_state, seqnum_type *seqnum,
                                int n);

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -338,6 +338,8 @@ int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key,
     return IX_NOTFND;
 }
 
+int gbl_debug_reproduce_blkseq_race = 0;
+
 int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key,
                       int klen, void *data, int datalen, void **dtaout,
                       int *lenout)
@@ -352,7 +354,8 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key,
     if (!bdb_state->attr->private_blkseq_enabled)
         return 0;
 
-    if (tran != NULL && (rc = bdb_lock_blkseq_write(bdb_state, key, klen, tran)) != 0) {
+    if (!gbl_debug_reproduce_blkseq_race && tran != NULL &&
+        (rc = bdb_lock_blkseq_write(bdb_state, key, klen, tran)) != 0) {
         return rc;
     }
 

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -20,6 +20,7 @@
 
 #include <build/db_int.h>
 #include "llog_auto.h"
+#include "dbinc_auto/txn_auto.h"
 #include "llog_ext.h"
 #include "printformats.h"
 
@@ -677,63 +678,81 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
     last_log_filenum = lsn.file;
     while (rc == 0) {
         u_int32_t rectype;
-        if (logdta.size > sizeof(u_int32_t)) {
+        if (logdta.size > (sizeof(u_int32_t) + sizeof(u_int32_t) + sizeof(DB_LSN))) {
             LOGCOPY_32(&rectype, logdta.data);
             normalize_rectype(&rectype);
-            if (rectype == DB_llog_blkseq) {
-                rc = llog_blkseq_read(bdb_state->dbenv, logdta.data, &blkseq);
-                if (rc) {
-                    logmsg(LOGMSG_ERROR, "at " PR_LSN " llog_blkseq_read rc %d\n",
-                            PARM_LSN(lsn), rc);
-                    goto err;
-                }
-                int *k;
-                k = (int *)blkseq->key.data;
-                if ((now - blkseq->time) >
-                    bdb_state->attr->private_blkseq_maxage) {
-                    logmsg(LOGMSG_INFO,
-                           "Stopping at " PR_LSN ", blkseq age %" PRId64
-                           " > max %d\n",
-                           PARM_LSN(lsn), now - blkseq->time,
-                           bdb_state->attr->private_blkseq_maxage);
-                    break;
-                }
 
-                /* TODO: these should always run back in time, so the if may be
-                 * unnecessary? Right? */
-                if (blkseq->time < oldest_blkseq)
-                    oldest_blkseq = blkseq->time;
+            /* blkseq-record is previous */
+            if (rectype == DB___txn_regop || rectype == DB___txn_regop_gen ||
+                rectype == DB___txn_regop_rowlocks) {
 
-                if (lsn.file != last_log_filenum && oldest_blkseq != INT_MAX) {
-                    /* if we just switched a file, remember the oldest blkseq we
-                     * saw in the current file */
-                    for (int i = 0; i < bdb_state->pvt_blkseq_stripes; i++) {
-                        logseq = malloc(sizeof(struct seen_blkseq));
-                        logseq->logfile = lsn.file;
-                        logseq->timestamp = oldest_blkseq;
+                /* Skip past rectype & txnid */
+                char *bp = (logdta.data + sizeof(u_int32_t) + sizeof(u_int32_t));
+                DB_LSN prevlsn = {0};
 
-                        /* we are running backwards here, so add to the start of
-                         * the list */
-                        listc_atl(&bdb_state->blkseq_log_list[i], logseq);
+                LOGCOPY_FROMLSN(bp, &prevlsn);
+                rc = logc->get(logc, &prevlsn, &logdta, DB_SET);
+                if (rc == 0) {
+                    LOGCOPY_32(&rectype, logdta.data);
+                    if (rectype == DB_llog_blkseq) {
+                        rc = llog_blkseq_read(bdb_state->dbenv, logdta.data, &blkseq);
+                        if (rc) {
+                            logmsg(LOGMSG_ERROR, "at " PR_LSN " llog_blkseq_read rc %d\n",
+                                    PARM_LSN(lsn), rc);
+                            goto err;
+                        }
+                        int *k;
+                        k = (int *)blkseq->key.data;
+                        if ((now - blkseq->time) >
+                                bdb_state->attr->private_blkseq_maxage) {
+                            logmsg(LOGMSG_INFO,
+                                    "Stopping at " PR_LSN ", blkseq age %" PRId64
+                                    " > max %d\n",
+                                    PARM_LSN(lsn), now - blkseq->time,
+                                    bdb_state->attr->private_blkseq_maxage);
+                            break;
+                        }
+
+                        /* TODO: these should always run back in time, so the if may be
+                         * unnecessary? Right? */
+                        if (blkseq->time < oldest_blkseq)
+                            oldest_blkseq = blkseq->time;
+
+                        if (lsn.file != last_log_filenum && oldest_blkseq != INT_MAX) {
+                            /* if we just switched a file, remember the oldest blkseq we
+                             * saw in the current file */
+                            for (int i = 0; i < bdb_state->pvt_blkseq_stripes; i++) {
+                                logseq = malloc(sizeof(struct seen_blkseq));
+                                logseq->logfile = lsn.file;
+                                logseq->timestamp = oldest_blkseq;
+
+                                /* we are running backwards here, so add to the start of
+                                 * the list */
+                                listc_atl(&bdb_state->blkseq_log_list[i], logseq);
+                            }
+
+                            oldest_blkseq = INT_MAX;
+                            last_log_filenum = lsn.file;
+                        }
+
+                        rc = bdb_blkseq_insert(bdb_state, NULL, blkseq->key.data,
+                                blkseq->key.size, blkseq->data.data,
+                                blkseq->data.size, NULL, NULL);
+                        if (rc == IX_DUP)
+                            ndupes++;
+                        else if (rc) {
+                            logmsg(LOGMSG_ERROR, "at " PR_LSN " bdb_blkseq_insert %x %x %x rc %d\n",
+                                    PARM_LSN(lsn), k[0], k[1], k[2], rc);
+                            goto err;
+                        } else
+                            nblkseq++;
+                        free(blkseq);
+                        blkseq = NULL;
                     }
 
-                    oldest_blkseq = INT_MAX;
-                    last_log_filenum = lsn.file;
                 }
-
-                rc = bdb_blkseq_insert(bdb_state, NULL, blkseq->key.data,
-                                       blkseq->key.size, blkseq->data.data,
-                                       blkseq->data.size, NULL, NULL);
-                if (rc == IX_DUP)
-                    ndupes++;
-                else if (rc) {
-                    logmsg(LOGMSG_ERROR, "at " PR_LSN " bdb_blkseq_insert %x %x %x rc %d\n",
-                           PARM_LSN(lsn), k[0], k[1], k[2], rc);
-                    goto err;
-                } else
-                    nblkseq++;
-                free(blkseq);
-                blkseq = NULL;
+                /* Reset to commit record */
+                rc = logc->get(logc, &lsn, &logdta, DB_SET);
             }
         }
 

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -16,6 +16,7 @@
 
 #include "bdb_api.h"
 #include "bdb_int.h"
+#include "locks.h"
 
 #include <build/db_int.h>
 #include "llog_auto.h"
@@ -350,6 +351,10 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key,
 
     if (!bdb_state->attr->private_blkseq_enabled)
         return 0;
+
+    if (tran != NULL && (rc = bdb_lock_blkseq_write(bdb_state, key, klen, tran)) != 0) {
+        return rc;
+    }
 
     ddata.flags = DB_DBT_REALLOC;
 

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -275,7 +275,7 @@ retry:
     uint64_t transize;
     seqnum_type seqnum;
     rc = bdb_tran_commit_with_seqnum_size(bdb_state, ltran, &seqnum,
-                                          &transize, bdberr);
+                                          &transize, 0, NULL, bdberr);
     if (rc || *bdberr != BDBERR_NOERROR) {
         if (*bdberr == BDBERR_DEADLOCK)
             goto retry;

--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -157,7 +157,7 @@ done:
         if (rc == 0) {
             seqnum_type seqnum;
             rc = bdb_tran_commit_with_seqnum_size(bdb_state, t, &seqnum, NULL,
-                                                  &bdberr);
+                                                  0, NULL, &bdberr);
             if (rc)
                 goto ret;
             rc = bdb_wait_for_seqnum_from_all(bdb_state, &seqnum);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -2918,7 +2918,7 @@ retry:
 
     seqnum_type ss;
     rc = bdb_tran_commit_with_seqnum_size(llmeta_bdb_state, tran, &ss, NULL,
-                                          &bdberr);
+                                          0, NULL, &bdberr);
 
     if (rc == 0 && wait_for_seqnum) {
         int timeoutms;

--- a/bdb/locks.h
+++ b/bdb/locks.h
@@ -60,6 +60,7 @@ void bdb_dump_my_lock_state(FILE *out);
 #define MINMAXFLUFF_LEN 10
 #define KEYFLUFF_LEN 12
 #define SHORT_TABLENAME_LEN 28
+#define BLKSEQ_KEY_LEN 56
 #define TABLE_CRC_LEN 4
 #define ROWLOCK_FLUFF_LEN 2
 
@@ -69,6 +70,7 @@ void bdb_dump_my_lock_state(FILE *out);
 #define IXHASH_KEY_SIZE (FILEID_LEN + ROWLOCK_FLUFF_LEN + 8)
 #define STRIPELOCK_KEY_SIZE (FILEID_LEN)
 #define TABLELOCK_KEY_SIZE (SHORT_TABLENAME_LEN + TABLE_CRC_LEN)
+#define BLKSEQLOCK_KEY_SIZE (BLKSEQ_KEY_LEN + TABLE_CRC_LEN)
 
 /* Make sure these are different */
 BB_COMPILE_TIME_ASSERT(rowlock_sizes_row_minmax,
@@ -96,5 +98,11 @@ int berkdb_lock_random_rowlock(bdb_state_type *bdb_state, int lid, int flags,
                                void *lkname, int mode, void *lk);
 int berkdb_lock_rowlock(bdb_state_type *bdb_state, int lid, int flags,
                         void *lkname, int mode, void *lk);
+
+int bdb_lock_blkseq_read(bdb_state_type *, const uint8_t *blkseq, int blkseq_len,
+        tran_type *tran);
+int bdb_lock_blkseq_write(bdb_state_type *, const uint8_t *blkseq, int blkseq_len,
+        tran_type *tran);
+
 
 #endif

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -5827,6 +5827,14 @@ __lock_list_parse_pglogs_int(dbenv, locker, flags, lock_mode, list, maxlsn,
 						else
 							logmsg(LOGMSG_USER, "\n");
 						break;
+					case(60):
+						if (fp)
+							fprintf(fp, "\t\tBLKSEQLOCK: ");
+						else
+							logmsg(LOGMSG_USER, "\t\tBLKSEQLOCK: ");
+						hexdumpfp(fp, obj_dbt.data, obj_dbt.size);
+						break;
+
 					default:
 						if (fp)
 							fprintf(fp, "\t\tUNKNOWN-SIZE-%d: ", obj_dbt.size);
@@ -6022,7 +6030,14 @@ __lock_get_list_int_int(dbenv, locker, flags, lock_mode, list, pcontext, maxlsn,
 							else
 								logmsg(LOGMSG_USER, "\n");
 							break;
-
+						case(60):
+							if (fp)
+								fprintf(fp, "\t\tBLKSEQLOCK: ");
+							else
+								logmsg(LOGMSG_USER, "\t\tBLKSEQLOCK: ");
+							hexdumpfp(fp, obj_dbt.data, obj_dbt.size);
+							break;
+	
 						default:
 							if (fp)
 								fprintf(fp, "\t\tUNKNOWN-SIZE-%d: ", obj_dbt.size);

--- a/berkdb/lock/lock_stat.c
+++ b/berkdb/lock/lock_stat.c
@@ -638,7 +638,7 @@ __collect_lock(DB_LOCKTAB *lt, DB_LOCKER *lip, struct __db_lock *lp,
 	char minmax = 0;
 	char *hexdump = NULL;
 	char *namep = NULL;
-	char rectype[80]={0};
+	char rectype[132]={0};
 	unsigned long long genid;
 	char fileid[DB_FILE_ID_LEN];
 	char tablename[64] = {0};
@@ -711,6 +711,15 @@ __collect_lock(DB_LOCKTAB *lt, DB_LOCKER *lip, struct __db_lock *lp,
 			snprintf(rectype, sizeof(rectype), "STRIPELOCK");
 			break;
 
+        case (60):
+        {
+            int len = snprintf(rectype, sizeof(rectype), "BLKSEQLOCK ");
+            /* Increased rectype to 11 + (60 * 2) + 1 */
+            assert(len == 11);
+            util_tohex(&rectype[len], (const char *)ptr, 60);
+            namep = NULL;
+            break;
+        }
 		/* LSN LOCK .. REALLY?? */
 		case (8):
 			memcpy(&lsn, ptr, sizeof(DB_LSN));

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -82,6 +82,8 @@ extern int gbl_largepages;
 extern int gbl_loghist;
 extern int gbl_loghist_verbose;
 extern int gbl_master_retry_poll_ms;
+extern int gbl_debug_blkseq_race;
+extern int gbl_debug_reproduce_blkseq_race;
 extern int gbl_master_swing_osql_verbose;
 extern int gbl_master_swing_sock_restart_sleep;
 extern int gbl_max_lua_instructions;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -664,6 +664,14 @@ REGISTER_TUNABLE("master_retry_poll_ms",
                  "retrying a transaction. (Default: 100ms)",
                  TUNABLE_INTEGER, &gbl_master_retry_poll_ms, READONLY, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_blkseq_race",
+                 "Pause after adding blkseq to reproduce blkseq race.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_blkseq_race,
+                 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_reproduce_blkseq_race",
+                 "Reproduce blkseq-race by not locking.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_blkseq_race,
+                 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("master_swing_osql_verbose",
                  "Produce verbose trace for SQL handlers detecting a master "
                  "change. (Default: off)",

--- a/db/glue.c
+++ b/db/glue.c
@@ -531,7 +531,8 @@ static int trans_commit_seqnum_int(void *bdb_handle, struct dbenv *dbenv,
     iq->gluewhere = "bdb_tran_commit_with_seqnum_size";
     if (!logical)
         bdb_tran_commit_with_seqnum_size(
-            bdb_handle, trans, (seqnum_type *)seqnum, &iq->txnsize, 0, NULL, &bdberr);
+            bdb_handle, trans, (seqnum_type *)seqnum, &iq->txnsize, repblk,
+            rellock, &bdberr);
     else {
         bdb_tran_commit_logical_with_seqnum_size(
             bdb_handle, trans, blkseq, blklen, blkkey, blkkeylen,

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -227,6 +227,11 @@ int thd_init(void)
     return 0;
 }
 
+int write_thread_count()
+{
+    return write_thd_count;
+}
+
 void thd_stats(void)
 {
     int ii, jj;

--- a/db/osqlblkseq.c
+++ b/db/osqlblkseq.c
@@ -57,6 +57,15 @@ int cnonce_hashcmpfunc(const void *key1, const void *key2, int len)
     return -1;
 }
 
+int osql_blkseq_is_inflight(const void *key)
+{
+    void *iq_src = NULL;
+    Pthread_mutex_lock(&hmtx);
+    iq_src = hash_find(hiqs_cnonce, key);
+    Pthread_mutex_unlock(&hmtx);
+    return (iq_src != NULL);
+}
+
 int osql_blkseq_register_cnonce(struct ireq *iq)
 {
     void *iq_src = NULL;

--- a/db/osqlblkseq.c
+++ b/db/osqlblkseq.c
@@ -80,7 +80,7 @@ int osql_blkseq_register_cnonce(struct ireq *iq)
 
     /* rc == 0 means we need to wait for it to go away */
     while (rc == 0) {
-        logmsg(LOGMSG_DEBUG, "Already in blkseq %*s, stalling...\n",
+        logmsg(LOGMSG_USER, "Already in blkseq %*s, stalling...\n",
                IQ_SNAPINFO(iq)->keylen - 3, IQ_SNAPINFO(iq)->key);
         poll(NULL, 0, gbl_block_blkseq_poll);
 

--- a/db/osqlblkseq.h
+++ b/db/osqlblkseq.h
@@ -48,6 +48,13 @@ int osql_blkseq_init(void);
 int osql_blkseq_register_cnonce(struct ireq *iq);
 
 /**
+ * This closes the race between writing blkseq to a temp-table and commit.
+ * - Check to see if a cnonce is in flight
+ *
+ */
+int osql_blkseq_is_inflight(const void *key);
+
+/**
  * Main function
  * - check to see if the seq exists
  * - if this is a replay, return OSQL_BLOCKSEQ_REPLAY

--- a/db/osqlcheckboard.c
+++ b/db/osqlcheckboard.c
@@ -290,12 +290,32 @@ int osql_chkboard_sqlsession_exists(unsigned long long rqid, uuid_t uuid)
     return (osql_chkboard_fetch_entry(rqid, uuid, 1) != NULL);
 }
 
+void trace_osql_checkboard(unsigned long long rqid, uuid_t uuid, int nops, void *data, struct errstat *errstat,
+                                struct query_effects *effects, const char *from, const char *func)
+{
+    uuidstr_t uuidstr;
+    comdb2uuidstr((unsigned char *)uuid, uuidstr);
+    logmsg(LOGMSG_USER, "checkboard rqid=%llx uuid=%s nops=%d data=%p errstat=%p errval=%d "
+                        "effects=%p affected=%d selected=%d updated=%d deleted=%d inserted=%d from=%s "
+                        "func=%s\n",
+                        rqid, uuidstr, nops, data, errstat, errstat ? errstat->errval : -1, effects,
+                        effects ? effects->num_affected : -1,
+                        effects ? effects->num_selected : -1,
+                        effects ? effects->num_updated : -1,
+                        effects ? effects->num_deleted : -1,
+                        effects ? effects->num_inserted : -1, 
+                        from, func);
+}
+
+
+
 int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops, void *data, struct errstat *errstat,
-                                struct query_effects *effects, const char *from)
+                                struct query_effects *effects, const char *from, const char *func)
 {
     if (!checkboard)
         return 0;
 
+    trace_osql_checkboard(rqid, uuid, nops, data, errstat, effects, from, func);
     Pthread_mutex_lock(&checkboard->mtx);
 
     osql_sqlthr_t *entry = osql_chkboard_fetch_entry(rqid, uuid, 0);

--- a/db/osqlcheckboard.h
+++ b/db/osqlcheckboard.h
@@ -106,7 +106,7 @@ int osql_unregister_sqlthr(struct sqlclntstate *clnt);
  *
  */
 int osql_chkboard_sqlsession_rc(unsigned long long rqid, uuid_t uuid, int nops, void *data, struct errstat *errstat,
-                                struct query_effects *effects, const char *from);
+                                struct query_effects *effects, const char *from, const char *func);
 
 /**
  * Wait the default time for the session to complete

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1078,7 +1078,7 @@ retry:
                     __func__, __LINE__, rcout, rc);
         } else {
 
-            if (gbl_random_blkseq_replays && ((rand() % 50) == 0)) {
+            if (gbl_random_blkseq_replays && ((rand() % 2) == 0)) {
                 logmsg(LOGMSG_ERROR, "%s line %d forcing random blkseq retry\n",
                        __func__, __LINE__);
                 osql->xerr.errval = ERR_NOMASTER;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -595,12 +595,23 @@ void bdb_osql_trn_clients_status();
 void bdb_newsi_mempool_stat();
 
 static pthread_mutex_t exiting_lock = PTHREAD_MUTEX_INITIALIZER;
+int write_thread_count(void);
+
 void *clean_exit_thd(void *unused)
 {
     comdb2_name_thread(__func__);
     if (!gbl_ready)
         return NULL;
 
+/*
+    bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START_RDWR);
+    thrman_register(THRTYPE_CLEANEXIT);
+    thread_started("clean_exit");
+    int wr = write_thread_count();
+
+    logmsg(LOGMSG_USER, "%s write-thread-count is %d\n", __func__, wr);
+    bdb_get_writelock(thedb->bdb_env, "clean_exit", __func__, __LINE__);
+    */
     Pthread_mutex_lock(&exiting_lock);
     if (gbl_exit) {
         Pthread_mutex_unlock(&exiting_lock);
@@ -612,6 +623,7 @@ void *clean_exit_thd(void *unused)
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START_RDWR);
     thrman_register(THRTYPE_CLEANEXIT);
     thread_started("clean_exit");
+    logmsg(LOGMSG_USER, "%s write-thread-count is %d\n", __func__, write_thread_count());
 
     clean_exit();
     return NULL;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -102,6 +102,7 @@ extern int gbl_print_blockp_stats;
 extern int gbl_dump_blkseq;
 extern __thread int send_prefault_udp;
 extern unsigned int gbl_delayed_skip;
+int gbl_debug_blkseq_race = 0;
 
 extern void delay_if_sc_resuming(struct ireq *iq);
 extern void clear_pfk(struct dbenv *dbenv, int i, int numops);
@@ -5418,6 +5419,10 @@ add_blkseq:
                 rc = (rc == BDBERR_DEADLOCK ? RC_INTERNAL_RETRY : rc);
                 if (debug_switch_test_ddl_backout_blkseq())
                     rc = -1;
+                if (!rc && gbl_debug_blkseq_race && !(rand() % 5)) {
+                    logmsg(LOGMSG_USER, "Sleeping to show blkseq race causes lost writes\n");
+                    sleep(10);
+                }
             }
 
             if (rc == 0 && have_blkseq) {

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5415,6 +5415,7 @@ add_blkseq:
                                        bskeylen, buf_fstblk,
                                        p_buf_fstblk - buf_fstblk + sizeof(int),
                                        &replay_data, &replay_len);
+                rc = (rc == BDBERR_DEADLOCK ? RC_INTERNAL_RETRY : rc);
                 if (debug_switch_test_ddl_backout_blkseq())
                     rc = -1;
             }

--- a/tests/blkseq_race.test/Makefile
+++ b/tests/blkseq_race.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=12m
+endif

--- a/tests/blkseq_race.test/lrl.options
+++ b/tests/blkseq_race.test/lrl.options
@@ -1,0 +1,16 @@
+#on cause_random_blkseq_replays
+master_swing_osql_verbose
+
+dtastripe 16
+
+# Apply & sync log before acking
+early 0
+
+# Flush log on commit
+setattr SYNCTRANSACTIONS 1
+
+# Sleep after writing blkseq, before writing commit
+debug_blkseq_race on
+
+# Don't acquire blkseq-lock to reproduce blkseq-bug
+#debug_reproduce_blkseq_race on

--- a/tests/blkseq_race.test/runit
+++ b/tests/blkseq_race.test/runit
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export maxrecord=0
+
+function failexit
+{
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function stop_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+    done
+    sleep 5
+}
+
+function verify_up
+{
+    typeset func="verify_up"
+    typeset node=$1
+    typeset count=0
+    typeset r=1
+    while [[ ! -f $stopfile && "$r" -ne "0" && "$count" -lt 100 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+
+    if [[ ! -f $stopfile && $r != 0 ]] ; then
+        failexit "node $node did not recover in time"
+    fi
+}
+
+function bounce_master_thread
+{
+    typeset func="bounce_master_thread"
+    typeset node=""
+    while [[ ! -f $stopfile ]]; do
+        sleep $(( 10 + ( RANDOM % 5 ) ))
+        node=$(get_master)
+        bounce_node $node 1
+        verify_up $node
+    done
+    write_prompt $func "Exiting"
+}
+
+function check_results
+{
+    typeset func="check_results"
+    typeset j=0
+
+    while [[ $j -le $maxrecord && ! -f $stopfile ]]; do
+
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "select count(*) from t1 where a=$j")
+        r=$?
+
+        while [[ "$r" -ne 0 && ! -f $stopfile ]]; do
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "select count(*) from t1 where a=$j")
+            r=$?
+        done
+
+        if [[ "$x" == "0" ]]; then 
+            echo "Reproduced blkseq missing record a=$j"
+            touch $stopfile
+        fi
+        let j=j+1
+    done
+}
+
+function insert_thread
+{
+    typeset func="insert_thread"
+    typeset count=0
+
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "insert into t1(a) values($count)" >/dev/null 2>&1
+        r=$?
+        if [[ "$r" == 0 ]]; then echo "Insert succeeded" ; fi
+        while [[ "$r" -ne 0 && ! -f $stopfile ]]; do
+            $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "insert into t1(a) values($count)" >/dev/null 2>&1
+            r=$?
+            if [[ "$r" == 0 ]]; then echo "Insert succeeded" ; fi
+        done
+        export maxrecord=count
+        check_results
+        let count=count+1
+    done
+    write_prompt $func "Exiting"
+    #export maxrecord=count
+}
+
+function create_table
+{
+    typeset func="create_table"
+    $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "create table t1(a int)" >/dev/null 2>&1
+}
+
+function run_test
+{
+    typeset func="run_test"
+    typeset maxtime=600
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+
+    create_table
+    rm $stopfile
+    bounce_master_thread &
+    insert_thread &
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        sleep 1
+    done
+
+    # Different thread failed the test
+    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    touch "$stopfile"
+    echo "Waiting for spawned processes"
+    wait
+    echo "Finished waiting for spawned processes"
+    check_results
+}
+
+run_test
+stop_cluster
+wait
+echo "Success"

--- a/tests/blkseq_race.test/runit
+++ b/tests/blkseq_race.test/runit
@@ -22,9 +22,16 @@ function stop_cluster
 {
     [[ $debug == "1" ]] && set -x
     for node in $CLUSTER ; do
-        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+        $CDB2SQL_EXE -admin $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
     done
     sleep 5
+    for node in $CLUSTER ; do
+        if [ $node == $(hostname) ] ; then
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+        else
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+        fi
+    done
 }
 
 function verify_up
@@ -115,6 +122,7 @@ function run_test
     typeset maxtime=600
     typeset now=$(date +%s)
     typeset endtime=$(( now + maxtime ))
+    typeset failed=0
 
     create_table
     rm $stopfile
@@ -126,15 +134,25 @@ function run_test
     done
 
     # Different thread failed the test
-    [[ -f "$stopfile" ]] && failexit "testcase failed"
+    if [[ -f "$stopfile" ]] ; then
+        failed=1
+        echo "Testcase failed"
+    fi
     touch "$stopfile"
+
+    echo "Sleeping 10"
+    sleep 10
+
+    echo "Stopping cluster"
+    stop_cluster
+
     echo "Waiting for spawned processes"
     wait
     echo "Finished waiting for spawned processes"
-    check_results
+    if [[ "$failed" == 1 ]]; then
+        failexit $func "Testcase failed"
+    fi
 }
 
 run_test
-stop_cluster
-wait
 echo "Success"


### PR DESCRIPTION
This solves a race condition in our tmptable-blkseq scheme where a competing block-processor attempting to commit the same transaction can read the blkseq and return replay-information prior to the transaction writing a commit record.  This PR solves the issue by creating a Berkley blkseq-lock using the blkseq key, which will force the second (replay) transaction to block until the transaction is actually committed.

This additionally solves a race condition for 'recovered prepares' which haven't yet added blkseq information to the blkseq structures.  Because this solution uses a Berkley lock, a recovered prepare will automatically block a replay by acquiring the blkseq lock after it upgrades from rep-start.