### PR TITLE
Port SQLite changes from 7.0 to main, add testcase

### DIFF
--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -1887,9 +1887,6 @@ static void generateColumnNames(
   sqlite3 *db = pParse->db;
   int fullName;    /* TABLE.COLUMN if no AS clause and is a direct table ref */
   int srcName;     /* COLUMN or TABLE.COLUMN if no AS clause and is direct */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  int isCompound = 0; /* Will be >0 for compound SELECT statements */
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #ifndef SQLITE_OMIT_EXPLAIN
   /* If this is an EXPLAIN, skip this step */
@@ -1900,18 +1897,9 @@ static void generateColumnNames(
 
   if( pParse->colNamesSet ) return;
   /* Column names are determined by the left-most term of a compound select */
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  /* COMPAT: column types of compound SELECTs are assumed to be 'text'. */
-  while( pSelect->pPrior ){ isCompound++; pSelect = pSelect->pPrior; }
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   while( pSelect->pPrior ) pSelect = pSelect->pPrior;
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   SELECTTRACE(1,pParse,pSelect,("generating column names\n"));
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  pTabList = isCompound>0 ? 0 : pSelect->pSrc;
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pTabList = pSelect->pSrc;
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pEList = pSelect->pEList;
   assert( v!=0 );
 #if !defined(SQLITE_BUILDING_FOR_COMDB2)

--- a/tests/yast.test/types.test
+++ b/tests/yast.test/types.test
@@ -1,0 +1,15 @@
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+# Build some test data
+#
+do_test types-1.0 {
+  execsql {
+    CREATE TABLE t(a int, b blob);
+    INSERT INTO t(a, b) VALUES(1, null),(2, x'0011')
+  }
+} {}
+
+do_execsql_test types-1.1.1 {
+  select a, quote(b) from t where a=1 union all select a, quote(b) from t where a=2;
+} {1 {} 2 X'0011'}


### PR DESCRIPTION
Fixes the case where the column value of the first result of a UNION ALL is NULL and we can't determine the type - fall back to decltype.