### PR TITLE
Add Commit LSN Map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,13 @@ else()
   add_definitions(-DWITH_TCL=0)
 endif()
 
+option(INCLUDE_DEBUG_ONLY_SYSTABLES "Turn ON to compile with debug-only systables" OFF)
+if(INCLUDE_DEBUG_ONLY_SYSTABLES)
+	add_definitions(-DINCLUDE_DEBUG_ONLY_SYSTABLES=1)
+else()
+	add_definitions(-DINCLUDE_DEBUG_ONLY_SYSTABLES=0)
+endif()
+
 option(WITH_TINFO "Turn ON on platforms where tinfo library is required for cdb2sql" OFF)
 if(WITH_TINFO)
   add_definitions(-DWITH_TINFO=1)

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2331,6 +2331,7 @@ int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks);
 
 int bdb_run_logical_recovery(bdb_state_type *bdb_state, int locks_only);
 
+int truncate_commit_lsn_map(bdb_state_type *bdb_state, int file);
 int truncate_asof_pglogs(bdb_state_type *bdb_state, int file, int offset);
 
 int bdb_set_logical_live_sc(bdb_state_type *bdb_state, int lock);

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3507,6 +3507,7 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
     int filenum;
     int delete_adjacent;
     int ctrace_info = 0;
+    int commit_lsn_map = gbl_commit_lsn_map;
 
     filenums_str[0] = 0;
 
@@ -3852,7 +3853,9 @@ low_headroom:
                 bdb_snapshot_asof_delete_log(bdb_state, filenum, sb.st_mtime);
 
             /* Delete transactions that committed in this file from the commit LSN map. */
-            __txn_commit_map_delete_logfile_txns(bdb_state->dbenv, filenum);
+            if (commit_lsn_map) {
+                __txn_commit_map_delete_logfile_txns(bdb_state->dbenv, filenum);
+            }
 
             if ((filenum <= lowfilenum && delete_adjacent) || is_low_headroom) {
                 /* delete this file if we got this far AND it's under the

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -158,6 +158,8 @@ static int close_dbs_txn(bdb_state_type *bdb_state, DB_TXN *tid);
 static int close_dbs_flush(bdb_state_type *bdb_state);
 static int bdb_watchdog_test_io_dir(bdb_state_type *bdb_state, char *dir);
 
+int __txn_commit_map_delete_logfile_txns(DB_ENV *, int);
+
 void berkdb_set_recovery(DB_ENV *dbenv);
 void watchdog_set_alarm(int seconds);
 void watchdog_cancel_alarm(void);
@@ -3848,6 +3850,9 @@ low_headroom:
              */
             if (filenum <= local_lowfilenum && gbl_new_snapisol_asof)
                 bdb_snapshot_asof_delete_log(bdb_state, filenum, sb.st_mtime);
+
+            /* Delete transactions that committed in this file from the commit LSN map. */
+            __txn_commit_map_delete_logfile_txns(bdb_state->dbenv, filenum);
 
             if ((filenum <= lowfilenum && delete_adjacent) || is_low_headroom) {
                 /* delete this file if we got this far AND it's under the

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -324,3 +324,307 @@ dofree:
 
 	return (ret);
 }
+
+/*
+ * __txn_commit_map_init --
+ * 	Initialize commit LSN map.
+ *
+ * PUBLIC: int __txn_commit_map_init
+ * PUBLIC:     __P((DB_ENV *));
+ */
+int __txn_commit_map_init(dbenv) 
+	DB_ENV *dbenv;
+{
+	int ret;
+	DB_TXN_COMMIT_MAP *txmap;
+
+	ret = __os_calloc(dbenv, 1, sizeof(DB_TXN_COMMIT_MAP), &txmap);
+
+	if (ret) {
+		goto err;
+	}
+
+	txmap->transactions = hash_init_o(offsetof(UTXNID_TRACK, utxnid), sizeof(u_int64_t));
+	txmap->logfile_lists = hash_init_o(offsetof(LOGFILE_TXN_LIST, file_num), sizeof(u_int32_t));
+
+	if (txmap->transactions == NULL || txmap->logfile_lists == NULL) {
+		ret = ENOMEM;
+		goto err;
+	}
+
+	Pthread_mutex_init(&txmap->txmap_mutexp, NULL);
+	dbenv->txmap = txmap;
+
+	return 0;
+err:
+	logmsg(LOGMSG_ERROR, "Failed to initialize commit LSN map\n");
+	return ret;
+}
+
+static int free_logfile_list_elt(obj, arg)
+        void *obj;
+        void *arg;
+{
+        LOGFILE_TXN_LIST *llist;
+        UTXNID *elt, *tmp_elt;
+        DB_ENV *dbenv;
+
+        llist = (LOGFILE_TXN_LIST *) obj;
+        dbenv = (DB_ENV *) arg;
+
+        LISTC_FOR_EACH_SAFE(&llist->commit_utxnids, elt, tmp_elt, lnk)
+        {
+                __os_free(dbenv, elt);
+        }
+	__os_free(dbenv, llist);
+        return 0;
+}
+
+static int free_transactions(obj, arg)
+        void *obj;
+        void *arg;
+{
+        UTXNID_TRACK *elt;
+        DB_ENV *dbenv;
+
+        elt = (UTXNID_TRACK *) obj;
+        dbenv = (DB_ENV *) arg;
+
+        __os_free(dbenv, elt);
+        return 0;
+}
+
+/*
+ * __commit_map_destroy --
+ *      Destroy commit LSN map.
+ *
+ * PUBLIC: int __commit_map_destroy
+ * PUBLIC:     __P((DB_ENV *));
+ */
+int __txn_commit_map_destroy(dbenv)
+        DB_ENV *dbenv;
+{
+        if (dbenv->txmap) {
+                hash_for(dbenv->txmap->transactions, &free_transactions, (void *) dbenv);
+                hash_clear(dbenv->txmap->transactions);
+                hash_free(dbenv->txmap->transactions);
+
+                hash_for(dbenv->txmap->logfile_lists, &free_logfile_list_elt, (void *) dbenv);
+                hash_clear(dbenv->txmap->logfile_lists);
+                hash_free(dbenv->txmap->logfile_lists);
+
+                Pthread_mutex_destroy(&dbenv->txmap->txmap_mutexp);
+                __os_free(dbenv, dbenv->txmap);
+        }
+
+        return 0;
+}
+
+/*
+ * __txn_commit_map_remove_nolock --
+ *  Remove a transaction from the commit LSN map without locking.
+ *
+ * PUBLIC: static int __txn_commit_map_remove_nolock
+ * PUBLIC:     __P((DB_ENV *, u_int64_t));
+ */
+static int __txn_commit_map_remove_nolock(dbenv, utxnid)
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+{
+	DB_TXN_COMMIT_MAP *txmap;
+	UTXNID_TRACK *txn;
+	int ret;
+
+	txmap = dbenv->txmap;
+	ret = 0;
+
+	txn = hash_find(txmap->transactions, &utxnid);
+
+	if (txn) {
+		hash_del(txmap->transactions, txn);
+		__os_free(dbenv, txn); 
+	} else {
+		ret = 1;
+	}
+
+	return ret;
+}
+
+/*
+ * __txn_commit_map_remove --
+ *  Remove a transaction from the commit LSN map.	
+ *
+ * PUBLIC: int __txn_commit_map_remove
+ * PUBLIC:     __P((DB_ENV *, u_int64_t));
+ */
+int __txn_commit_map_remove(dbenv, utxnid) 
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+{
+	int ret;
+
+	Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
+	ret = __txn_commit_map_remove_nolock(dbenv, utxnid);
+	Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
+
+	return ret;
+}
+
+/*
+ * __txn_commit_map_delete_logfile_txns --
+ *  Remove all transactions that committed in a specific logfile 
+ *  from the commit LSN map.	
+ *
+ * PUBLIC: int __txn_commit_map_delete_logfile_txns
+ * PUBLIC:     __P((DB_ENV *, u_int32_t));
+ */
+int __txn_commit_map_delete_logfile_txns(dbenv, del_log) 
+	DB_ENV *dbenv;
+	u_int32_t del_log;
+{
+	DB_TXN_COMMIT_MAP *txmap;
+	LOGFILE_TXN_LIST *to_delete;
+	UTXNID *elt, *tmpp;
+	int ret;
+
+	txmap = dbenv->txmap;
+	to_delete = hash_find(txmap->logfile_lists, &del_log);
+	ret = 0;
+
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+
+	if (to_delete) {
+		LISTC_FOR_EACH_SAFE(&to_delete->commit_utxnids, elt, tmpp, lnk)
+		{
+			__txn_commit_map_remove_nolock(dbenv, elt->utxnid);
+			__os_free(dbenv, elt);
+		}
+
+		hash_del(txmap->logfile_lists, &del_log);
+		__os_free(dbenv, to_delete);
+	} else {
+		ret = 1;
+	}
+
+	Pthread_mutex_unlock(&txmap->txmap_mutexp);
+	return ret;
+}
+ 
+/*
+ * __txn_commit_map_get --
+ *  Get the commit LSN of a transaction.
+ *
+ * PUBLIC: int __txn_commit_map_get
+ * PUBLIC:     __P((DB_ENV *, u_int64_t, DB_LSN*));
+ */
+int __txn_commit_map_get(dbenv, utxnid, commit_lsn) 
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+	DB_LSN *commit_lsn;
+{
+	DB_TXN_COMMIT_MAP *txmap;
+	UTXNID_TRACK *txn;
+	int ret;
+   
+	txmap = dbenv->txmap;
+	ret = 0;
+
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+	txn = hash_find(txmap->transactions, &utxnid);
+
+	if (txn == NULL) {
+		ret = DB_NOTFOUND;
+	} else {
+		*commit_lsn = txn->commit_lsn;
+	}
+
+	Pthread_mutex_unlock(&txmap->txmap_mutexp);
+	return ret;
+}
+
+/*
+ * __txn_commit_map_add --
+ *  Store the commit LSN of a transaction.
+ *
+ * PUBLIC: int __txn_commit_map_add
+ * PUBLIC:     __P((DB_ENV *, u_int64_t, DB_LSN));
+ */
+int __txn_commit_map_add(dbenv, utxnid, commit_lsn) 
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+	DB_LSN commit_lsn;
+{
+	DB_TXN_COMMIT_MAP *txmap;
+	LOGFILE_TXN_LIST *to_delete;
+	UTXNID_TRACK *txn;
+	UTXNID* elt;
+	int ret, alloc_txn, alloc_delete_list;
+
+	txmap = dbenv->txmap;
+	alloc_txn = 0;
+	alloc_delete_list = 0;
+	ret = 0;
+
+	/* Don't add transactions that commit at the zero LSN */
+	if (IS_ZERO_LSN(commit_lsn)) {
+		return ret;
+	}
+
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+
+	txn = hash_find(txmap->transactions, &utxnid);
+
+	if (txn != NULL) { 
+		/* Don't add transactions that already exist in the map */
+		Pthread_mutex_unlock(&txmap->txmap_mutexp);
+		return ret;
+	}
+
+	to_delete = hash_find(txmap->logfile_lists, &commit_lsn.file);
+
+	if (!to_delete) {
+		if ((ret = __os_malloc(dbenv, sizeof(LOGFILE_TXN_LIST), &to_delete) != 0)) {
+			ret = ENOMEM;
+			goto err;
+		} else {
+			alloc_delete_list = 1;
+		}
+	}
+
+        if ((ret = __os_malloc(dbenv, sizeof(UTXNID_TRACK), &txn)) != 0) {
+                ret = ENOMEM;
+                goto err;
+        }
+        alloc_txn = 1;
+
+        if ((ret = __os_malloc(dbenv, sizeof(UTXNID), &elt)) != 0) {
+                ret = ENOMEM;
+                goto err;
+        }
+
+        if (alloc_delete_list) {
+                to_delete->file_num = commit_lsn.file;
+                listc_init(&to_delete->commit_utxnids, offsetof(UTXNID, lnk));
+                hash_add(txmap->logfile_lists, to_delete);
+        }
+
+        txn->utxnid = utxnid;
+        txn->commit_lsn = commit_lsn;
+        hash_add(txmap->transactions, txn);
+
+        elt->utxnid = utxnid;
+        listc_atl(&to_delete->commit_utxnids, elt);
+
+        Pthread_mutex_unlock(&txmap->txmap_mutexp);
+        return ret;
+err:
+        Pthread_mutex_unlock(&txmap->txmap_mutexp);
+        if (alloc_delete_list) {
+                __os_free(dbenv, to_delete);
+        }
+        if (alloc_txn) {
+                __os_free(dbenv, txn);
+        }
+        return ret;
+}
+

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -451,26 +451,6 @@ static int __txn_commit_map_remove_nolock(dbenv, utxnid)
 }
 
 /*
- * __txn_commit_map_remove --
- *  Remove a transaction from the commit LSN map.	
- *
- * PUBLIC: int __txn_commit_map_remove
- * PUBLIC:     __P((DB_ENV *, u_int64_t));
- */
-int __txn_commit_map_remove(dbenv, utxnid) 
-	DB_ENV *dbenv;
-	u_int64_t utxnid;
-{
-	int ret;
-
-	Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
-	ret = __txn_commit_map_remove_nolock(dbenv, utxnid);
-	Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
-
-	return ret;
-}
-
-/*
  * __txn_commit_map_delete_logfile_txns --
  *  Remove all transactions that committed in a specific logfile 
  *  from the commit LSN map.	

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -6002,6 +6002,7 @@ int thdpool_alarm_on_queing(int len)
 
 int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
 {
+    int commit_lsn_map = gbl_commit_lsn_map;
     int *file = &(((int *)(inlsn))[0]);
     int *offset = &(((int *)(inlsn))[1]);
     int rc;
@@ -6010,7 +6011,9 @@ int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
     logmsg(LOGMSG_INFO, "%s starting for [%d:%d] as %s\n", __func__, *file,
            *offset, is_master ? "MASTER" : "REPLICANT");
 
-	rc = truncate_commit_lsn_map(thedb->bdb_env, *file);
+    if (commit_lsn_map) {
+        rc = truncate_commit_lsn_map(thedb->bdb_env, *file);
+    }
     rc = truncate_asof_pglogs(thedb->bdb_env, *file, *offset);
 
     logmsg(LOGMSG_INFO, "%s complete [%d:%d] rc=%d\n", __func__, *file, *offset,

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -447,6 +447,7 @@ int gbl_enable_cache_internal_nodes = 1;
 int gbl_use_appsock_as_sqlthread = 0;
 int gbl_rep_process_txn_time = 0;
 int gbl_utxnid_log = 1; 
+int gbl_commit_lsn_map = 1;
 
 /* how many times we retry osql for verify */
 int gbl_osql_verify_retries_max = 499;
@@ -6004,10 +6005,14 @@ int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
     int *file = &(((int *)(inlsn))[0]);
     int *offset = &(((int *)(inlsn))[1]);
     int rc;
+
     assert(*file >= 0 && *offset >= 0);
     logmsg(LOGMSG_INFO, "%s starting for [%d:%d] as %s\n", __func__, *file,
            *offset, is_master ? "MASTER" : "REPLICANT");
+
+	rc = truncate_commit_lsn_map(thedb->bdb_env, *file);
     rc = truncate_asof_pglogs(thedb->bdb_env, *file, *offset);
+
     logmsg(LOGMSG_INFO, "%s complete [%d:%d] rc=%d\n", __func__, *file, *offset,
            rc);
     return rc;

--- a/db/config.c
+++ b/db/config.c
@@ -428,6 +428,7 @@ static char *legacy_options[] = {
     "usenames",
     "setattr max_sql_idle_time 864000",
     "utxnid_log off"
+    "commit_lsn_map off"
 };
 int gbl_legacy_defaults = 0;
 int pre_read_legacy_defaults(void *_, void *__)

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -177,6 +177,7 @@ extern int gbl_catchup_window_trace;
 extern int gbl_early_ack_trace;
 extern int gbl_commit_delay_timeout;
 extern int gbl_commit_delay_copy_ms;
+extern int gbl_commit_lsn_map;
 extern int gbl_throttle_logput_trace;
 extern int gbl_fills_waitms;
 extern int gbl_finish_fill_threshold;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1571,6 +1571,9 @@ REGISTER_TUNABLE("commit_delay_on_copy_ms",
 REGISTER_TUNABLE("commit_delay_trace", "Verbose commit-delays.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_commit_delay_trace,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("commit_lsn_map", "Maintain a map of transaction commit LSNs. (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_commit_lsn_map,
+                 NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("set_coherent_state_trace",
                  "Verbose coherency trace.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_set_coherent_state_trace, EXPERIMENTAL | INTERNAL, NULL,

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(sqlite
   ext/comdb2/threadpools.c
   ext/comdb2/timepartitions.c
   ext/comdb2/timeseries.c
+  ext/comdb2/trancommit.c
   ext/comdb2/tranlog.c
   ext/comdb2/transactionstate.c
   ext/comdb2/triggers.c

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -88,6 +88,7 @@ int systblTablePermissionsInit(sqlite3 *db);
 int systblSystabPermissionsInit(sqlite3 *db);
 int systblTimepartPermissionsInit(sqlite3 *db);
 int systblFdbInfoInit(sqlite3 *db);
+int systblTranCommitInit(sqlite3 *db);
 int systblTransactionStateInit(sqlite3 *db);
 int systblMemstatsInit(sqlite3 *db);
 int systblStacks(sqlite3 *db);

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -340,6 +340,10 @@ int comdb2SystblInit(
     rc = systblTransactionStateInit(db);
   if (rc == SQLITE_OK)  
     rc = systblStacks(db);
+#ifdef INCLUDE_DEBUG_ONLY_SYSTABLES
+  if (rc == SQLITE_OK)
+    rc = systblTranCommitInit(db);
+#endif
 #endif
   return rc;
 }

--- a/sqlite/ext/comdb2/trancommit.c
+++ b/sqlite/ext/comdb2/trancommit.c
@@ -1,0 +1,103 @@
+/*
+   Copyright 2018-2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <stddef.h>
+#include <stdlib.h>
+#include <plhash.h>
+#include <bdb/bdb_int.h>
+
+#include "comdb2.h"
+#include "sql.h"
+#include "build/db.h"
+#include "comdb2systblInt.h"
+#include "ezsystables.h"
+#include "types.h"
+
+extern int gbl_commit_lsn_map;
+
+sqlite3_module systblTransactionCommitModule =
+{
+	.access_flag = CDB2_ALLOW_USER,
+};
+
+typedef struct txn_commit_info {
+	u_int64_t utxnid;
+	u_int64_t commit_lsn_file;
+	u_int64_t commit_lsn_offset;
+} txn_commit_info;
+
+typedef struct add_tran_commit_args {
+	txn_commit_info **data;
+	int *npoints;
+} add_tran_commit_args;
+
+int add_tran_commit(void *obj, void *arg) {
+	UTXNID_TRACK* ritem = (UTXNID_TRACK*) obj;
+	add_tran_commit_args* info = (add_tran_commit_args *) arg;
+	txn_commit_info** data = info->data;
+	txn_commit_info* litem = (txn_commit_info *) (((txn_commit_info *) *data)+(*info->npoints));
+
+	litem->utxnid = ritem->utxnid;
+	litem->commit_lsn_file = ritem->commit_lsn.file;
+	litem->commit_lsn_offset = ritem->commit_lsn.offset;
+	(*(info->npoints))++;
+
+	return 0;
+}
+
+int get_tran_commits(void **data, int *npoints) {
+	int ret = 0;
+
+	if (!gbl_commit_lsn_map) {
+            *data = NULL;
+            *npoints = 0;
+            return ret;
+        }
+
+	bdb_state_type *bdb_state = thedb->bdb_env;
+
+	Pthread_mutex_lock(&bdb_state->dbenv->txmap->txmap_mutexp);
+	*npoints = hash_get_num_entries(bdb_state->dbenv->txmap->transactions);
+	*data = malloc((*npoints)*sizeof(txn_commit_info));
+	add_tran_commit_args* args = malloc(sizeof(add_tran_commit_args));
+	args->data = (txn_commit_info**) data;
+	*npoints = 0;
+	args->npoints = npoints;
+
+	ret = hash_for(bdb_state->dbenv->txmap->transactions, add_tran_commit, args);
+	Pthread_mutex_unlock(&bdb_state->dbenv->txmap->txmap_mutexp);
+
+	free(args);
+	return ret;
+}
+
+void free_tran_commits(void *data, int npoints) {
+	txn_commit_info * info = (txn_commit_info *) data;
+	if (info != NULL) {
+            free(info);
+        }
+}
+
+int systblTranCommitInit(sqlite3 *db) {
+	return create_system_table(
+		db, "comdb2_transaction_commit", &systblTransactionCommitModule,
+		get_tran_commits, free_tran_commits, sizeof(txn_commit_info),
+		CDB2_INTEGER, "utxnid", -1, offsetof(txn_commit_info, utxnid),
+		CDB2_INTEGER, "commitlsnfile", -1, offsetof(txn_commit_info, commit_lsn_file),
+		CDB2_INTEGER, "commitlsnoffset", -1, offsetof(txn_commit_info, commit_lsn_offset),
+		SYSTABLE_END_OF_FIELDS
+	);
+}

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -38,6 +38,9 @@
 #define TRANLOG_COLUMN_TXNID        8
 #define TRANLOG_COLUMN_UTXNID       9
 #define TRANLOG_COLUMN_MAXUTXNID    10
+#define TRANLOG_COLUMN_CHILDUTXNID  11
+#define TRANLOG_COLUMN_LSN_FILE     12 /* Useful for sorting records by LSN */
+#define TRANLOG_COLUMN_LSN_OFFSET   13
 
 
 /* Modeled after generate_series */
@@ -71,7 +74,7 @@ static int tranlogConnect(
   int rc;
 
   rc = sqlite3_declare_vtab(db,
-     "CREATE TABLE x(minlsn hidden,maxlsn hidden,flags hidden,lsn,rectype integer,generation integer,timestamp integer,payload,txnid integer,utxnid integer,maxutxnid hidden)");
+     "CREATE TABLE x(minlsn hidden,maxlsn hidden,flags hidden,lsn,rectype integer,generation integer,timestamp integer,payload,txnid integer,utxnid integer,maxutxnid hidden, childutxnid hidden, lsnfile hidden, lsnoffset hidden)");
   if( rc==SQLITE_OK ){
     pNew = *ppVtab = sqlite3_malloc( sizeof(*pNew) );
     if( pNew==0 ) return SQLITE_NOMEM;
@@ -418,6 +421,7 @@ static int tranlogColumn(
   u_int32_t txnid = 0;
   u_int64_t utxnid = 0;
   u_int64_t maxutxnid = 0;
+  u_int64_t childutxnid = 0;
 
   switch( i ){
     case TRANLOG_COLUMN_START:
@@ -526,6 +530,27 @@ static int tranlogColumn(
         break;
     case TRANLOG_COLUMN_LOG:
         sqlite3_result_blob(ctx, pCur->data.data, pCur->data.size, NULL);
+        break;
+    case TRANLOG_COLUMN_CHILDUTXNID:
+        if (pCur->data.data)
+                LOGCOPY_32(&rectype, pCur->data.data);
+
+        if (rectype == DB___txn_child+2000 || rectype == DB___txn_child+3000)
+        { 
+                LOGCOPY_64(&childutxnid, &((char *) pCur->data.data)[4 + 4 + 8 + 8 + 4]); 
+        }
+
+        if (childutxnid > 0) {
+                sqlite3_result_int64(ctx, childutxnid);
+        } else {
+                sqlite3_result_null(ctx);
+        }
+        break;
+    case TRANLOG_COLUMN_LSN_FILE:
+        sqlite3_result_int(ctx, pCur->curLsn.file);
+        break;
+    case TRANLOG_COLUMN_LSN_OFFSET:
+        sqlite3_result_int(ctx, pCur->curLsn.offset);
         break;
   }
   return SQLITE_OK;

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -271,6 +271,7 @@
 (candidate='comdb2_timepartpermissions')
 (candidate='comdb2_timepartshards')
 (candidate='comdb2_timeseries')
+(candidate='comdb2_transaction_commit')
 (candidate='comdb2_transaction_logs')
 (candidate='comdb2_transaction_state')
 (candidate='comdb2_triggers')

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -67,6 +67,7 @@ unknown @ls sub-command foo
 (name='comdb2_timepartpermissions')
 (name='comdb2_timepartshards')
 (name='comdb2_timeseries')
+(name='comdb2_transaction_commit')
 (name='comdb2_transaction_logs')
 (name='comdb2_transaction_state')
 (name='comdb2_triggers')

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -409,6 +409,7 @@
 (name='comdb2_timepartpermissions')
 (name='comdb2_timepartshards')
 (name='comdb2_timeseries')
+(name='comdb2_transaction_commit')
 (name='comdb2_transaction_logs')
 (name='comdb2_transaction_state')
 (name='comdb2_triggers')

--- a/tests/commit_lsn_map.test/Makefile
+++ b/tests/commit_lsn_map.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+# Grab my database name.
+dbnm=$1
+
+# Try this many times to see an archive 
+seen_iter=${2:-300}
+
+# Try this many times to see an archive 
+clean_iter=${3:-10}
+
+# Let the testcase timeout fail us
+target=5
+
+seen_count=0
+seen_archives=0
+seen_clear=0
+
+kill_wait_time=10
+
+CKP_RECTYPE=11
+CKP_UTXNID_RECTYPE=2011
+
+count=0
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'select comdb2_dbname()'
+
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | xargs echo`
+
+kill_restart_cluster()
+{
+    for node in $CLUSTER ; do
+        echo "killrestart nodes $node"
+        kill_restart_node $node $kill_wait_time
+    done
+}
+
+function failif
+{
+	if [[ $1 -ne 0 ]]; then
+		exit 1
+	fi
+}
+
+function bounce {
+	if [[ -n "$CLUSTER" ]] ; then
+		kill_restart_cluster 
+	else
+		kill_restart_node $(hostname) $kill_wait_time
+	fi
+}
+
+# Count the number of logs that are ready to archive
+function count_archive
+{
+    typeset dbnm=$1
+    cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb log_archive")' | egrep 'log.00000' | wc -l
+}
+
+function insert_values
+{
+	for (( i=0; i<$1; i++))
+	do
+		cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into "$2" values($3)"
+	done
+}
+
+function update_tranlog_copy
+{
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into tranlog_copy select utxnid, childutxnid, lsnfile, lsnoffset from comdb2_transaction_logs where childutxnid is not null on conflict do nothing'
+}
+
+function verify_child_commit_lsn_is_parent_commit_lsn
+{
+	update_tranlog_copy
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(*) from comdb2_transaction_commit parent, comdb2_transaction_commit child, tranlog_copy logs where logs.utxnid=parent.utxnid and logs.childutxnid=child.utxnid and (parent.commitlsnfile!=child.commitlsnfile or parent.commitlsnoffset!=child.commitlsnoffset)')
+	numinvalidchildren=$(echo $res | grep -oP "[0-9]+\)$")
+	numinvalidchildren=${numinvalidchildren:0:-1}
+	failif numinvalidchildren
+}
+
+function num_children
+{
+	update_tranlog_copy &>/dev/null
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(*) from tranlog_copy where childutxnid is not null')
+	numchildren=$(echo $res | grep -oP "[0-9]+\)$")
+	numchildren=${numchildren:0:-1}
+	echo $numchildren
+}
+
+function test_add_basic
+{
+	# Verify that transactions that commit are reflected in the map. 
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table data(i int)'
+
+	insert_values 100 data 1
+
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(*) from comdb2_transaction_commit')
+	num_entries_in_map=$(echo $res | grep -oP "[0-9]+\)$")
+	num_entries_in_map=${num_entries_in_map:0:-1}
+	if [ $num_entries_in_map -lt 100 ]; then
+		echo "FAIL test_add_basic"
+		exit 1
+	fi
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table data'
+}
+
+function test_add_children
+{
+	# Verify that transaction children are reflected in the map with their
+	# parent's commit lsn.
+
+	max_itrs=10
+	num_itrs=0
+	num=$(num_children)
+	
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table data(i int)'
+
+	while [[ "$num" -eq "0" ]]; do
+		if (( $num_itrs == $max_itrs )); then
+			echo "FAIL test_add_children"
+			exit 1
+		fi 
+
+		insert_values 10 data 1
+
+		num_itrs=$((num_itrs+1))
+		num=$(num_children)
+	done
+
+	verify_child_commit_lsn_is_parent_commit_lsn
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table data'
+}
+
+function test_add_recovery
+{
+	# Verify that recovered transactions that are reflected in the map. 
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table data(i int)'
+
+	# Send checkpoint
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb setattr CHECKPOINTTIME 10000")'
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb checkpoint")'
+	sleep 10
+
+	insert_values 100 data 1
+	verify_child_commit_lsn_is_parent_commit_lsn
+
+	# Get checkpoint lsn file/offset
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select lsnfile, max(lsnoffset) from comdb2_transaction_logs where (rectype='$CKP_RECTYPE' or rectype='$CKP_UTXNID_RECTYPE') and lsnfile=(select max(lsnfile) from comdb2_transaction_logs where (rectype='$CKP_RECTYPE' or rectype='$CKP_UTXNID_RECTYPE'))')
+	recoverylsnfile=$(echo $res | grep -oP "[0-9]+\,")
+	recoverylsnfile=${recoverylsnfile:0:-1}
+	recoverylsnoffset=$(echo $res | grep -oP "[0-9]+\)$")
+	recoverylsnoffset=${recoverylsnoffset:0:-1}
+
+	# Get max lsn file/offset before bounce
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select max(lsnfile) from comdb2_transaction_logs')
+	maxlsnfilebeforebounce=$(echo $res | grep -oP "[0-9]+\)$")
+	maxlsnfilebeforebounce=${maxlsnfilebeforebounce:0:-1}
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select max(lsnoffset) from comdb2_transaction_logs where lsnfile='$maxlsnfilebeforebounce'')
+	maxlsnoffsetbeforebounce=$(echo $res | grep -oP "[0-9]+\)$")
+	maxlsnoffsetbeforebounce=${maxlsnoffsetbeforebounce:0:-1}
+
+	bounce
+
+	update_tranlog_copy
+
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(*) from comdb2_transaction_commit commits, tranlog_copy logs where commits.utxnid=logs.utxnid and (logs.lsnfile>'$recoverylsnfile' or (logs.lsnfile='$recoverylsnfile' and logs.lsnoffset>'$recoverylsnoffset'))')
+	numrecoveredtxns=$(echo $res | grep -oP "[0-9]+\)$")
+	numrecoveredtxns=${numrecoveredtxns:0:-1}
+
+	# Verify that we recovered txns in the recovery range.
+	if [[ "$numrecoveredtxns" -eq "0" ]]; then
+		echo "FAIL test_add_recovery"
+		exit 1
+	fi
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table data'
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb setattr CHECKPOINTTIME 60")'
+}
+
+function test_add_replicant
+{
+        cdb2sql ${CDB2_OPTIONS} $dbnm default "create table data(i int)"
+
+        # Run txns
+        for (( i=0; i<100; i++))
+        do
+                cdb2sql ${CDB2_OPTIONS} --host $master $dbnm default "insert into data values(1)"
+        done
+
+        # Do ckp
+
+        cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb checkpoint")'
+        sleep 10
+
+        # Make sure that replicant has map entries from txns
+        for node in $CLUSTER ; do
+                if [ $node != $master ]; then
+                        res=$(cdb2sql ${CDB2_OPTIONS} --host $node $dbnm default 'select COUNT(*) from comdb2_transaction_commit')
+                        num_entries_in_map=$(echo $res | grep -oP "[0-9]+\)$")
+                        num_entries_in_map=${num_entries_in_map:0:-1}
+                        if [ $num_entries_in_map -lt 100 ]; then
+                                echo "FAIL test_add_replicant"
+                                exit 1
+                        fi
+                        break
+                fi
+        done
+
+
+        cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table data"
+}
+
+function test_add
+{
+	# Test adding to the commit LSN map
+
+	# A mirror of the transaction log systable is needed to use it for joins.
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table tranlog_copy(utxnid int, childutxnid int, lsnfile int, lsnoffset int)'
+
+	test_add_basic
+	test_add_children
+	test_add_recovery
+	test_add_replicant
+
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'drop table tranlog_copy'
+}
+
+function test_delete
+{
+	# Test that deleting log files deletes relevant records 
+	# from the commit LSN map.
+
+	while [[ "$seen_archives" -eq "0" && "$count" -lt "$seen_iter" ]]
+	do
+	    #comdb2sc -m $dbnm send pushlogs $target
+	    cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm "exec procedure sys.cmd.send('pushlogs $target')"
+	    sleep 3
+
+	    res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(DISTINCT commitlsnfile), MAX(commitlsnfile) from comdb2_transaction_commit')
+	    numfilesinmap=$(echo $res | grep -oP "[0-9]+\,")
+	    numfilesinmap=${numfilesinmap:0:-1}
+	    maxfileinmap=$(echo $res | grep -oP "[0-9]+\)$")
+	    maxfileinmap=${maxfileinmap:0:-1}
+
+	    seen_count="$(count_archive $dbnm)"
+
+	    # Didn't see anything that needed to be archived: try again
+	    if [[ "$seen_count" == "0" ]]; then
+
+		let target=target+1
+		let count=count+1
+
+	    # Saw something that needed to be archived: break out of loop
+	    else
+
+		# Break out of this loop
+		seen_archives=1
+
+	    fi
+
+	done
+
+
+	if [[ "$seen_archives" == "0" ]]; then
+
+	    echo "Never saw any archives, failing testcase"
+	    exit 1
+
+	fi
+
+	echo "$dbnm has accrued $seen_count logfiles."
+
+	seencountsave=$seen_count
+
+	cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
+	for node in $cluster ; do 
+	    cdb2sql ${CDB2_OPTIONS} --host $node $dbnm 'exec procedure sys.cmd.send("bdb setattr MIN_KEEP_LOGS 1")'
+	    cdb2sql ${CDB2_OPTIONS} --host $node $dbnm 'exec procedure sys.cmd.send("flush")'
+	done
+
+
+	# Sleep a bit
+	sleep 10
+
+	count=0
+
+	while [[ "$seen_clear" == "0" && "$count" -lt "$clean_iter" ]]; do
+
+	    seen_count="$(count_archive $dbnm)"
+
+	    if [ "$seen_count" -eq "0" ]; then
+
+		seen_clear=1
+
+	    else
+
+		echo "Waiting for $seen_count logfiles to be deleted."
+
+		for node in $cluster ; do 
+		    cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('flush')"
+		done
+
+		sleep 30
+		let count=count+1
+
+	    fi
+
+	done
+
+	if [[ "$seen_clear" == "0" ]]; then
+
+	    echo "Archives were never cleared, failing testcase"
+	    exit 1
+
+	fi
+
+	res=$(cdb2sql ${CDB2_OPTIONS} $dbnm default 'select COUNT(DISTINCT commitlsnfile) from comdb2_transaction_commit where commitlsnfile<="$maxfileinmap"')
+	numremainingfiles=$(echo $res | grep -oP "[0-9]+\)$")
+	numremainingfiles=${numremainingfiles:0:-1}
+
+	if ((numfilesinmap - numremainingfiles < seencountsave)); then
+	    exit 1
+	fi
+}
+
+test_delete
+test_add

--- a/tests/docker/Dockerfile.install
+++ b/tests/docker/Dockerfile.install
@@ -51,7 +51,7 @@ RUN cd /comdb2 &&  \
     rm -rf build && \
     mkdir build && \
     cd build && \
-    cmake -DWITH_TCL=1 .. && \
+    cmake -DWITH_TCL=1 -DINCLUDE_DEBUG_ONLY_SYSTABLES=1 .. && \
     make -j4 && \
     make -j4 test-tools && \
     make install &&  \

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -125,6 +125,7 @@
 (name='collect_before_locking', description='Collect a transaction from the log before acquiring locks.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='commit_delay_on_copy_ms', description='Set automatic delay-ms for commit-delay on copy.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='commit_delay_timeout_seconds', description='Set timeout for commit-delay on copy.  (Default: 10)', type='INTEGER', value='10', read_only='N')
+(name='commit_lsn_map', description='Maintain a map of transaction commit LSNs. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')
 (name='commitdelaybehindthresh', description='Call for election again and ask the master to delay commits if we are further than this far behind on startup.', type='INTEGER', value='1048576', read_only='N')
 (name='commitdelaymax', description='Introduce a delay after each transaction before returning control to the application. Occasionally useful to allow replicants to catch up on startup with a very busy system.', type='INTEGER', value='0', read_only='N')

--- a/tests/userschema.test/t00.expected
+++ b/tests/userschema.test/t00.expected
@@ -54,6 +54,7 @@
 (tablename='comdb2_timepartpermissions', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_timepartshards', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_timeseries', username='mohit', READ='Y', WRITE='Y', DDL='Y')
+(tablename='comdb2_transaction_commit', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_transaction_logs', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_transaction_state', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_triggers', username='mohit', READ='Y', WRITE='Y', DDL='Y')


### PR DESCRIPTION
**Context**

This PR is part of a larger project to reimplement snapshot isolation without using logical logs. This implementation requires a structure that maps a transaction to its commit LSN. The changes in this PR add a component that provides this mapping.

**Implementation**


*Adding transactions to the map*

A running transaction is added to the map [when it commits](https://github.com/bloomberg/comdb2/pull/3803/files#diff-bf04707b376550c402355a1dc5ba543c3d459d99630b7c364cb66862874088a7R1394). Child transactions are not added to the transaction map when they commit but rather when their parent commits. They are added with their own utxnid but their parent's commit LSN. This required maintaining [a list of committed children](https://github.com/bloomberg/comdb2/pull/3803/files#diff-fb9f5c855be885e551d31c68861135fc7e41e6909a8b41b3e7ce6e5d7d870b5cR1058) in the parent. When a child commits, [it adds itself to its parent's list of committed children](https://github.com/bloomberg/comdb2/pull/3803/files#diff-bf04707b376550c402355a1dc5ba543c3d459d99630b7c364cb66862874088a7R1362), and, when the parent commits, [it iterates through the list of committed children and adds each of them to the commit map with its own commit LSN](https://github.com/bloomberg/comdb2/pull/3803/files#diff-bf04707b376550c402355a1dc5ba543c3d459d99630b7c364cb66862874088a7R1400).

During recovery, committed transactions are added during the backward pass (see [`txn_rec.c`](https://github.com/bloomberg/comdb2/pull/3803/files#diff-5471205d1ef3462f89e624a326ff37c30da5c3f234617693f8b672d25610588dR165)). Adding transactions during the backward pass instead of the forward pass made it easier to deal with child transactions: Once a child commit is reached, its parent's commit must already exist in the map, if it ocurred -- [so the child can be added to the map with its parent's commit LSN immediately](https://github.com/bloomberg/comdb2/pull/3803/files#diff-5471205d1ef3462f89e624a326ff37c30da5c3f234617693f8b672d25610588dR823). 

When a replicant processes a committed parent transaction, [it adds it to the map](https://github.com/bloomberg/comdb2/pull/3803/files#diff-ec57e659bd52da1fac41087fbe2907e44ad664e1c593477769caa537a482a07fR4688). After processing a transaction, the replicant finds all of the records associated with that transaction by walking back in the log. [Child transactions are added as they are encountered during this walkback.](https://github.com/bloomberg/comdb2/pull/3803/files#diff-ec57e659bd52da1fac41087fbe2907e44ad664e1c593477769caa537a482a07fR5993)

*Removing transactions from the map*

Transactions are removed from the map in tandem with [log deletion](https://github.com/bloomberg/comdb2/pull/3803/files#diff-c0e18238b2ba144f0dc79e0113312bcb85d62c3f90cf59892afef4292b8b9382R3855) and [log truncation](https://github.com/bloomberg/comdb2/pull/3803/files#diff-91454b1e6e0271e4ab1900d4829d866b37f219f943ed9864fe0f2f23e4cc91e2R6041).

**Future work**

A future PR will add past transactions to the map as needed to support point in time transactions.

**Testing**

This PR adds `commit_lsn_map.test` (see [`tests/commit_lsn_map.test/runit`](https://github.com/bloomberg/comdb2/pull/3803/files#diff-0b56a3a7130865b68d3a76c83862e6b981abfc1166a551c7969b40d27dc64673R308)). See function-level comments for more details.
