### PR TITLE
Don't acquire queue lk unless db:consumer is successful

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -907,34 +907,6 @@ dbtable *get_dbtable_by_name(const char *p_name)
     return p_db;
 }
 
-dbtable *get_dbtable_by_name_locked(tran_type *tran, const char *p_name)
-{
-    dbtable *p_db = NULL;
-    int rc = 0;
-
-    if (!tran)
-        return get_dbtable_by_name(p_name);
-
-    Pthread_rwlock_rdlock(&thedb_lock);
-    p_db = _db_hash_find(p_name);
-    if (!p_db && !strcmp(p_name, COMDB2_STATIC_TABLE))
-        p_db = &thedb->static_table;
-    if (!p_db) {
-        rc = bdb_lock_tablename_read(thedb->bdb_env, p_db->tablename, tran);
-    } else {
-        rc = bdb_lock_tablename_write(thedb->bdb_env, p_db->tablename, tran);
-    }
-    Pthread_rwlock_unlock(&thedb_lock);
-
-    if (rc) {
-        logmsg(LOGMSG_ERROR, "%s Failed to lock table by name rc=%d!\n",
-               __func__, rc);
-        return NULL;
-    }
-
-    return p_db;
-}
-
 dbtable *getqueuebyname(const char *name)
 {
     return hash_find_readonly(thedb->qdb_hash, &name);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1974,10 +1974,6 @@ struct dbtable *get_dbtable_by_name(const char *name);
 struct dbview *get_view_by_name(const char *view_name);
 /* Load all views from llmeta */
 int llmeta_load_views(struct dbenv *, void *);
-/* lookup a table by name; if it exists, lock table readonly
-   if there is no table, lock table in write mode
-   NOTE: if there is no tran object, this behaves like get_dbtable_by_name */
-struct dbtable *get_dbtable_by_name_locked(tran_type *tran, const char *name);
 /*look up managed queue db's by name*/
 struct dbtable *getqueuebyname(const char *name);
 struct dbtable *getfdbbyrmtnameenv(struct dbenv *dbenv, const char *tblname);

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -57,7 +57,6 @@ typedef struct trigger_reg {
     int node;
     int elect_cookie;
     genid_t trigger_cookie;
-    char qdb_locked;
     int spname_len;
     char spname[0]; // spname_len + 1
     // hostname[]
@@ -82,19 +81,6 @@ void trigger_reg_to_cpu(trigger_reg_t *);
 
 #define trigger_reg_sz(sp_name)                                                \
     sizeof(trigger_reg_t) + strlen(sp_name) + 1 + strlen(gbl_myhostname) + 1
-
-#define trigger_reg_init(dest, sp_name, have_lock)                             \
-    do {                                                                       \
-        dest = alloca(trigger_reg_sz(sp_name));                                \
-        dest->node = 0;                                                        \
-        dest->elect_cookie = ATOMIC_LOAD32(gbl_master_changes);                \
-        dest->trigger_cookie = get_id(thedb->bdb_env);                         \
-        dest->qdb_locked = have_lock;                                          \
-        dest->spname_len = strlen(sp_name);                                    \
-        memcpy(dest->spname, sp_name, dest->spname_len + 1);                   \
-        int hostname_len = strlen(gbl_myhostname);                             \
-        memcpy(trigger_hostname(dest), gbl_myhostname, hostname_len + 1);      \
-    } while (0)
 
 #define Q4SP(var, spname)                                                      \
     char var[sizeof("__q") + strlen(spname)];                                  \

--- a/tests/sp.test/t01.req.out
+++ b/tests/sp.test/t01.req.out
@@ -274,7 +274,7 @@ SP: exec procedure bound(@i, @u, @ll, @ull, @s, @us, @f, @d, @dt, @cstr, @ba, @b
 (version='sptest')
 (version='sptest')
 (version='sptest')
-[exec procedure cons0(true)] failed with rc -3 [local consumer = db:consumer()...]:2: trigger/consumer is only supported under default transaction mode
+[exec procedure cons0(true)] failed with rc -3 [local consumer = db:consumer()...]:2: consumer is only supported under default transaction mode
 (rows deleted=500)
 (name='audit', type='trigger', tbl_name='foraudit', event='add', col='i', seq='N')
 (name='audit', type='trigger', tbl_name='foraudit', event='del', col='i', seq='N')

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -67,6 +67,10 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL GNU)
   set_source_files_properties(sltpck.c PROPERTIES COMPILE_FLAGS "-Wno-return-local-addr")
 endif()
 
+if (${CMAKE_C_COMPILER_ID} STREQUAL GNU)
+  set_source_files_properties(schema_lk.c PROPERTIES COMPILE_FLAGS "-O0")
+endif()
+
 add_library(util ${src})
 include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}

--- a/util/schema_lk.h
+++ b/util/schema_lk.h
@@ -33,20 +33,16 @@ void unlock_schema_int(const char *file, const char *func, int line);
 #define wrlock_schema_lk() wrlock_schema_int(__FILE__, __func__, __LINE__)
 void wrlock_schema_int(const char *file, const char *func, int line);
 
-#define assert_wrlock_schema_lk()                                              \
-    assert_wrlock_schema_int(__FILE__, __func__, __LINE__);
+#define assert_wrlock_schema_lk() assert_wrlock_schema_int(__FILE__, __func__, __LINE__)
 void assert_wrlock_schema_int(const char *file, const char *func, int line);
 
-#define assert_rdlock_schema_lk()                                              \
-    assert_rdlock_schema_int(__FILE__, __func__, __LINE__);
+#define assert_rdlock_schema_lk() assert_rdlock_schema_int(__FILE__, __func__, __LINE__)
 void assert_rdlock_schema_int(const char *file, const char *func, int line);
 
-#define assert_lock_schema_lk()                                                \
-    assert_lock_schema_int(__FILE__, __func__, __LINE__);
+#define assert_lock_schema_lk() assert_lock_schema_int(__FILE__, __func__, __LINE__)
 void assert_lock_schema_int(const char *file, const char *func, int line);
 
-#define assert_no_schema_lk()                                                  \
-    assert_no_schema_lock_int(__FILE__, __func__, __LINE__);
+#define assert_no_schema_lk() assert_no_schema_lock_int(__FILE__, __func__, __LINE__)
 void assert_no_schema_lock_int(const char *file, const char *func, int line);
 
 #endif


### PR DESCRIPTION
1. Get table-lock only when `db:consumer()` succeeds in registering with master.
2. Delete code to track schema-lk and table-lock (`have_schema_lock, got_lock, have_lock, qdb_locked.`)
3. Make `recover_deadlock` reacquire the table-lock for queuedb (like it does for regular tables.)
4. Fix unprotected hash lookup in `can_consume`.
5. Remove some dead code.