### PR TITLE
Recover_blkseq fix & blkseq_race test

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -82,6 +82,7 @@ extern int gbl_largepages;
 extern int gbl_loghist;
 extern int gbl_loghist_verbose;
 extern int gbl_master_retry_poll_ms;
+extern int gbl_debug_blkseq_race;
 extern int gbl_master_swing_osql_verbose;
 extern int gbl_master_swing_sock_restart_sleep;
 extern int gbl_max_lua_instructions;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -664,6 +664,8 @@ REGISTER_TUNABLE("master_retry_poll_ms",
                  "retrying a transaction. (Default: 100ms)",
                  TUNABLE_INTEGER, &gbl_master_retry_poll_ms, READONLY, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_blkseq_race", "Pause after adding blkseq to reproduce blkseq race.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_blkseq_race, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("master_swing_osql_verbose",
                  "Produce verbose trace for SQL handlers detecting a master "
                  "change. (Default: off)",

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -102,6 +102,7 @@ extern int gbl_print_blockp_stats;
 extern int gbl_dump_blkseq;
 extern __thread int send_prefault_udp;
 extern unsigned int gbl_delayed_skip;
+int gbl_debug_blkseq_race = 0;
 
 extern void delay_if_sc_resuming(struct ireq *iq);
 extern void clear_pfk(struct dbenv *dbenv, int i, int numops);
@@ -5417,6 +5418,10 @@ add_blkseq:
                                        &replay_data, &replay_len);
                 if (debug_switch_test_ddl_backout_blkseq())
                     rc = -1;
+                if (!rc && gbl_debug_blkseq_race && !(rand() % 5)) {
+                    logmsg(LOGMSG_INFO, "Sleep 10 to debug blkseq\n");
+                    sleep(10);
+                }
             }
 
             if (rc == 0 && have_blkseq) {

--- a/tests/blkseq_race.test/Makefile
+++ b/tests/blkseq_race.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=12m
+endif

--- a/tests/blkseq_race.test/lrl.options
+++ b/tests/blkseq_race.test/lrl.options
@@ -1,0 +1,13 @@
+#on cause_random_blkseq_replays
+master_swing_osql_verbose
+
+dtastripe 16
+
+# Apply & sync log before acking
+early 0
+
+# Flush log on commit
+setattr SYNCTRANSACTIONS 1
+
+# Sleep after writing blkseq, before writing commit
+debug_blkseq_race on

--- a/tests/blkseq_race.test/runit
+++ b/tests/blkseq_race.test/runit
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export maxrecord=0
+
+function failexit
+{
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function stop_cluster
+{
+    [[ $debug == "1" ]] && set -x
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE -admin $CDB2_OPTIONS --tabs $DBNAME --host $node "exec procedure sys.cmd.send(\"exit\")"
+    done
+    sleep 5
+    for node in $CLUSTER ; do
+        if [ $node == $(hostname) ] ; then
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+        else
+            kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+        fi
+    done
+}
+
+function verify_up
+{
+    typeset func="verify_up"
+    typeset node=$1
+    typeset count=0
+    typeset r=1
+    while [[ ! -f $stopfile && "$r" -ne "0" && "$count" -lt 100 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null 2>&1
+        r=$?
+        [[ $r != 0 ]] && sleep 1
+        let count=count+1
+    done
+
+    if [[ ! -f $stopfile && $r != 0 ]] ; then
+        failexit "node $node did not recover in time"
+    fi
+}
+
+function bounce_master_thread
+{
+    typeset func="bounce_master_thread"
+    typeset node=""
+    while [[ ! -f $stopfile ]]; do
+        sleep $(( 10 + ( RANDOM % 5 ) ))
+        node=$(get_master)
+        bounce_node $node 1
+        verify_up $node
+    done
+    write_prompt $func "Exiting"
+}
+
+function check_results
+{
+    typeset func="check_results"
+    typeset j=0
+
+    while [[ $j -le $maxrecord && ! -f $stopfile ]]; do
+
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "select count(*) from t1 where a=$j")
+        r=$?
+
+        while [[ "$r" -ne 0 && ! -f $stopfile ]]; do
+            x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "select count(*) from t1 where a=$j")
+            r=$?
+        done
+
+        if [[ "$x" == "0" ]]; then 
+            echo "Reproduced blkseq missing record a=$j"
+            touch $stopfile
+        fi
+        let j=j+1
+    done
+}
+
+function insert_thread
+{
+    typeset func="insert_thread"
+    typeset count=0
+
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "insert into t1(a) values($count)" >/dev/null 2>&1
+        r=$?
+        if [[ "$r" == 0 && "$debug" == "1" ]]; then echo "Insert succeeded" ; fi
+        while [[ "$r" -ne 0 && ! -f $stopfile ]]; do
+            $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "insert into t1(a) values($count)" >/dev/null 2>&1
+            r=$?
+            if [[ "$r" == 0 && "$debug" == "1" ]]; then echo "Insert succeeded" ; fi
+        done
+        export maxrecord=count
+        check_results
+        let count=count+1
+    done
+    write_prompt $func "Exiting"
+    #export maxrecord=count
+}
+
+function create_table
+{
+    typeset func="create_table"
+    $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "create table t1(a int)" >/dev/null 2>&1
+}
+
+function run_test
+{
+    typeset func="run_test"
+    typeset maxtime=600
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset failed=0
+
+    create_table
+    rm $stopfile >/dev/null 2>&1
+    bounce_master_thread &
+    insert_thread &
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt $endtime ]]; do
+        sleep 1
+    done
+
+    # Different thread failed the test
+    if [[ -f "$stopfile" ]] ; then
+        failed=1
+        echo "Testcase failed"
+    fi
+    touch "$stopfile"
+
+    write_prompt $func "Sleeping 10"
+    sleep 10
+
+    write_prompt $func "Stopping cluster"
+    stop_cluster
+
+    write_prompt $func "Waiting for spawned processes"
+    wait
+    write_prompt $func "Finished waiting for spawned processes"
+    if [[ "$failed" == 1 ]]; then
+        failexit $func "Testcase failed"
+    fi
+}
+
+run_test
+echo "Success"


### PR DESCRIPTION
Only add committed-blkseqs to the blkseq temp-tables.  A new test, blkseq_race, failed prior to this change because a new master would incorrectly add an uncommitted transaction to it's blkseq tables.
