### PR TITLE
Minor changes in presentation of compression stats 

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -428,6 +428,28 @@ int bdb_dump_dta_file_n(bdb_state_type *bdb_state, int dtanum, FILE *out)
 #endif
     return 0;
 }
+char *bdb_get_type_str(bdb_state_type *bdb_state)
+{
+    if (!bdb_state) {
+        return NULL;
+    }
+    switch (bdb_state->bdbtype) {
+        case BDBTYPE_NONE: 
+            return strdup("NONE");
+        case BDBTYPE_ENV:
+            return strdup("ENV");
+        case BDBTYPE_TABLE:
+            return strdup("TABLE");
+        case BDBTYPE_LITE:
+            return strdup("LITE");
+        case BDBTYPE_QUEUE:
+            return strdup("OLDQUEUE");
+        case BDBTYPE_QUEUEDB:
+            return strdup("QUEUE");
+        default:
+            return strdup("UNKNOWN");
+    }
+}
 
 bdbtype_t bdb_get_type(bdb_state_type *bdb_state)
 {

--- a/db/glue.c
+++ b/db/glue.c
@@ -5566,12 +5566,16 @@ uint64_t calc_table_size(struct dbtable *db, int skip_blobs)
     return calc_table_size_tran(NULL, db, skip_blobs);
 }
 
-void compr_print_stats_int(struct dbtable **dbs, int num_dbs){
+void compr_print_stats()
+{
     int ii;
     int odh, compr, blob_compr;
 
-    for (ii = 0; ii < num_dbs; ii++) {
-        struct dbtable *db = dbs[ii];
+    logmsg(LOGMSG_USER, "COMPRESSION FLAGS\n");
+    logmsg(LOGMSG_USER, "These apply to new records only!\n");
+
+    for (ii = 0; ii < thedb->num_dbs; ii++) {
+        struct dbtable *db = thedb->dbs[ii];
         bdb_get_compr_flags(db->handle, &odh, &compr, &blob_compr);
 
         logmsg(LOGMSG_USER, "[%-16s] ", db->tablename);
@@ -5580,24 +5584,7 @@ void compr_print_stats_int(struct dbtable **dbs, int num_dbs){
                odh ? "yes" : "no", bdb_algo2compr(compr),
                bdb_algo2compr(blob_compr), db->inplace_updates ? "yes" : "no",
                db->instant_schema_change ? "yes" : "no");
-
         logmsg(LOGMSG_USER, "\n");
-    }
-}
-void compr_print_stats()
-{
-    if (thedb->num_dbs == 0 && thedb->num_qdbs == 0) {
-        return;
-    }
-    logmsg(LOGMSG_USER, "COMPRESSION FLAGS\n");
-    logmsg(LOGMSG_USER, "These apply to new records only!\n");
-
-    if (thedb->num_dbs) {
-        compr_print_stats_int(thedb->dbs, thedb->num_dbs);
-    }
-
-    if (thedb->num_qdbs) {
-        compr_print_stats_int(thedb->qdbs, thedb->num_qdbs);
     }
 }
 

--- a/tests/ddl_no_csc2.test/t13_alter_table_properties.expected
+++ b/tests/ddl_no_csc2.test/t13_alter_table_properties.expected
@@ -1,19 +1,19 @@
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
 [ALTER TABLE t1 ALTER OPTIONS (ODH OFF)] failed with rc 240 a schema change error occurred
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='N', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='N')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='N', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='N')
 [ALTER TABLE t1 ALTER OPTIONS (ODH OFF, IPU OFF, ISC OFF)] failed with rc 240 a schema change error occurred
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='N')
-(table_name='t1', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='crle', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='rle8', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='N')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='lz4', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='crle', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='rle8', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
 [ALTER TABLE t1 ALTER OPTIONS (REC ZLIB, BLOBFIELD CRLE)] failed with rc -3 near "CRLE": syntax error
-(table_name='t1', odh='Y', compress='rle8', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='none', blob_compress='none', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='Y', compress='none', blob_compress='none', in_place_updates='Y', instant_schema_change='Y')
-(table_name='t1', odh='N', compress='none', blob_compress='none', in_place_updates='N', instant_schema_change='N')
+(table_name='t1', type='TABLE', odh='Y', compress='rle8', blob_compress='rle8', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='none', blob_compress='none', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='Y', compress='none', blob_compress='none', in_place_updates='Y', instant_schema_change='Y')
+(table_name='t1', type='TABLE', odh='N', compress='none', blob_compress='none', in_place_updates='N', instant_schema_change='N')
 [ALTER TABLE t1 ALTER OPTIONS ODH ON] failed with rc -3 near "ODH": syntax error
 [ALTER TABLE t1 ALTER OPTIONS (ODH ON, ODH OFF)] failed with rc -3 Conflicting 'ODH' options
 [ALTER TABLE t1 ALTER OPTIONS (BLOBFIELD LZ4, BLOBFIELD ZLIB)] failed with rc -3 Conflicting 'BLOB COMPRESSION' options
-(table_name='t1', odh='N', compress='none', blob_compress='none', in_place_updates='N', instant_schema_change='N')
+(table_name='t1', type='TABLE', odh='N', compress='none', blob_compress='none', in_place_updates='N', instant_schema_change='N')


### PR DESCRIPTION
This patch :
1.) remove queues from 'stat compr' output
2.) Adds a new field 'type' which displays the type of the bdb object 
