### PR TITLE
{171141266}: Ensure that heartbeat is stopped before sending last row

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2181,10 +2181,10 @@ static int try_ssl(cdb2_hndl_tp *hndl, SBUF2 *sb)
 
     /* The node does not agree with dbinfo. This usually happens
        during the downgrade from SSL to non-SSL. */
-    if (rc == 'N') {
+    if (rc != 'Y') {
         if (SSL_IS_OPTIONAL(hndl->c_sslmode)) {
             hndl->c_sslmode = SSL_ALLOW;
-            return 0;
+            return (rc == 'N') ? 0 : -1;
         }
 
         /* We reach here only if the server is mistakenly downgraded

--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1940,6 +1940,7 @@ void explain_distribution(dohsql_node_t *node)
         }
     }
 
+    NO_HEARTBEAT(clnt);
     write_response(clnt, RESPONSE_ROW_LAST, NULL, 0);
 }
 

--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -260,6 +260,7 @@ send_error:
     }
 
     /* send last row */
+    NO_HEARTBEAT(clnt);
     if (first_row) {
         irc = write_response(clnt, RESPONSE_ROW_LAST_DUMMY, NULL, 0);
     } else {

--- a/db/sql.h
+++ b/db/sql.h
@@ -932,6 +932,13 @@ struct sqlclntstate {
     int disable_fdb_push;
 };
 
+#define NO_HEARTBEAT(c)                     \
+do {                                        \
+    Pthread_mutex_lock(&(c)->wait_mutex);   \
+    (c)->ready_for_heartbeats = 0;          \
+    Pthread_mutex_unlock(&(c)->wait_mutex); \
+} while (0)                                 \
+
 /* Query stats. */
 struct query_path_component {
     char lcl_tbl_name[MAXTABLELEN];

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -1320,6 +1320,7 @@ int newsql_dump_query_plan(struct sqlclntstate *clnt, sqlite3 *hndl)
     out = NULL;
 
     sqlite3_finalize(stmt);
+    NO_HEARTBEAT(clnt);
     write_response(clnt, RESPONSE_ROW_LAST, NULL, 0);
     return 0;
 }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2244,9 +2244,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
         sql_set_sqlengine_state(clnt, __FILE__, __LINE__,
                                 SQLENG_NORMAL_PROCESS);
         outrc = CDB2ERR_VERIFY_ERROR;
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
+        NO_HEARTBEAT(clnt);
         if (do_send_commitrollback_response(clnt, sideeffects)) {
             write_response(clnt, RESPONSE_ERROR, clnt->osql.xerr.errstr, outrc);
         }
@@ -2369,9 +2367,7 @@ int handle_sql_commitrollback(struct sqlthdstate *thd,
             rc = CDB2__ERROR_CODE__TRAN_TOO_BIG;
         }
 
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
+        NO_HEARTBEAT(clnt);
 
         outrc = rc;
 
@@ -2879,9 +2875,7 @@ static void _prepare_error(struct sqlthdstate *thd,
 
 static int send_run_error(struct sqlclntstate *clnt, const char *err, int rc)
 {
-    Pthread_mutex_lock(&clnt->wait_mutex);
-    clnt->ready_for_heartbeats = 0;
-    Pthread_mutex_unlock(&clnt->wait_mutex);
+    NO_HEARTBEAT(clnt);
     return write_response(clnt, RESPONSE_ERROR, (void *)err, rc);
 }
 
@@ -3679,9 +3673,7 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
         }
         clnt->had_errors = 1;
     } else {
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
+        NO_HEARTBEAT(clnt);
         if (!skip_response(clnt)) {
             if (postponed_write)
                 send_row(clnt, NULL, row_id, 0, NULL);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -6820,6 +6820,7 @@ static int flush_sp(SP sp, char **err)
 {
     int rc;
     struct sqlclntstate *clnt = sp->clnt;
+    NO_HEARTBEAT(clnt);
     if (clnt->osql.sent_column_data) {
         rc = write_response(clnt, RESPONSE_ROW_LAST, NULL, 0);
     } else {

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -403,9 +403,7 @@ retry_read:
         }
 
     if (pre_enabled) {
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
+        NO_HEARTBEAT(clnt);
         pre_enabled = 0;
     }
 
@@ -445,9 +443,7 @@ retry_read:
     free(p);
 
     if (pre_enabled) {
-        Pthread_mutex_lock(&clnt->wait_mutex);
-        clnt->ready_for_heartbeats = 0;
-        Pthread_mutex_unlock(&clnt->wait_mutex);
+        NO_HEARTBEAT(clnt);
     }
 
     if (!query) {


### PR DESCRIPTION
A stored procedure may send a heartbeat after the last row, which can break the SSL protocol when sockpool is present, as shown below.

|    | SERVER               |     CLIENT-1                                 |     CLIENT-2                            |
|----|----------------------|----------------------------------------------|-----------------------------------------|
| T0 | send ROW_LAST        |//////////////////////////////////////////////|/////////////////////////////////////////|
| T1 |//////////////////////| recv ROW_LAST, this is considered an OK_DONE |/////////////////////////////////////////|
| T2 | send HEARTBEAT       |//////////////////////////////////////////////|/////////////////////////////////////////|
| T3 |//////////////////////| cdb2_close; connection returned to sockpool  |/////////////////////////////////////////|
| T4 |//////////////////////|//////////////////////////////////////////////| cdb2_open; reuse the connection from T3; start SSL protocol; send SSLCONN packet |
| T5 | recv SSLCONN; call SSL_accept           |//////////////////////////////////////////////|/////////////////////////////////////////|
| T6 |//////////////////////|//////////////////////////////////////////////| read 1st byte of the HEARTBEAT from T2; since it's not 'N', call SSL_connect.   now read the remainder of the heartbeat, which isn't part of SSL negotiation. SSL_connect fails.                      |
| T8 | SSL_accept fails     |//////////////////////////////////////////////|/////////////////////////////////////////|

This patch fixes it by switching off the ready_for_heartbeats flag before sending ROW_LAST, so that no heartbeats will go out after ROW_LAST and potentially be read by the next process that reuses the connection. The SSL-ability byte check in the API is also changed from `rc == 'N'` to `rc != 'Y'`, to avoid mishandling of a heartbeat packet (as shown at T6 in the table above).