### PR TITLE
Only name threads in debug build.

### DIFF
--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -1300,6 +1300,9 @@ void thdpool_set_queued_callback(struct thdpool *pool, void(*callback)(void*))
 }
 
 void comdb2_name_thread(const char *name) {
+#ifndef NDEBUG
+    return;
+#endif
 #ifdef __linux
     pthread_setname_np(pthread_self(), name);
 #elif defined __APPLE__


### PR DESCRIPTION
This breaks lots of tools if enabled, though it's very handy in a debugger.  eg: perf, whatever scans our cores, etc.