### PR TITLE
Move where aFingerprint is calculated for sp to get rid of mismatch msg

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3876,13 +3876,6 @@ static void handle_stored_proc(struct sqlthdstate *thd,
     free_original_normalized_sql(clnt);
     normalize_stmt_and_store(clnt, NULL, 1);
 
-    if (clnt->work.zOrigNormSql) {
-        size_t nOrigNormSql = 0;
-
-        calc_fingerprint(clnt->work.zOrigNormSql, &nOrigNormSql,
-                            clnt->work.aFingerprint);
-    }
-
     memset(&clnt->spcost, 0, sizeof(struct sql_hist_cost));
     int rc = exec_procedure(thd, clnt, &errstr);
     if (rc) {
@@ -3900,6 +3893,13 @@ static void handle_stored_proc(struct sqlthdstate *thd,
     if (!in_client_trans(clnt))
         clnt->dbtran.trans_has_sp = 0;
     test_no_btcursors(thd);
+    if (clnt->work.zOrigNormSql) {
+        size_t nOrigNormSql = 0;
+
+        // calculate aFingerprint here since exec_procedure will update aFingerprint to last sql stmt found in stored
+        // procedure
+        calc_fingerprint(clnt->work.zOrigNormSql, &nOrigNormSql, clnt->work.aFingerprint);
+    }
     sqlite_done(thd, clnt, &rec, 0);
 }
 


### PR DESCRIPTION
Update of https://github.com/bloomberg/comdb2/pull/3381
Should get rid of mismatch msg for good

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
