### PR TITLE
Fixing gcc v9.4 warning 'format-truncation'

### DIFF
--- a/db/sigutil.c
+++ b/db/sigutil.c
@@ -137,7 +137,7 @@ void dumpsignalsetupf(FILE *out)
             logmsg(LOGMSG_ERROR, "dumpsignalsetup: sigaction(%d/%s) failed: %d %s\n",
                     signo, unix_signals[ii].name, errno, strerror(errno));
         else {
-            char buf[1024];
+            char buf[2048];
             sprintsigact(buf, sizeof(buf), &act);
             logmsg(LOGMSG_USER, "%8s = %s\n", unix_signals[ii].name, buf);
         }
@@ -155,7 +155,7 @@ void ctracesignalsetup(void)
             logmsg(LOGMSG_ERROR, "dumpsignalsetup: sigaction(%d/%s) failed: %d %s\n",
                     signo, unix_signals[ii].name, errno, strerror(errno));
         else {
-            char buf[1024];
+            char buf[2048];
             sprintsigact(buf, sizeof(buf), &act);
             ctrace("%8s = %s\n", unix_signals[ii].name, buf);
         }

--- a/db/views.c
+++ b/db/views.c
@@ -792,12 +792,16 @@ static int _generate_new_shard_name(const char *oldname, char *newname,
         /* get the length of the number sufix */
         suffix_len = _shard_suffix_str_len(maxshards);
 
-        snprintf(newname, newnamelen, "%s%.*d", oldname, suffix_len, nextnum);
+        if (0 > snprintf(newname, newnamelen, "%s%.*d", oldname, suffix_len, nextnum)) {
+	    return VIEW_ERR_GENERIC;
+	}
     } else {
         char hash[128];
         len = snprintf(hash, sizeof(hash), "%u%s", nextnum, oldname);
         len = crc32c((uint8_t *)hash, len);
-        snprintf(newname, newnamelen, "$%u_%X", nextnum, len);
+        if (0 > snprintf(newname, newnamelen, "$%u_%X", nextnum, len)) {
+	    return VIEW_ERR_GENERIC;
+	}
     }
     newname[newnamelen - 1] = '\0';
 

--- a/db/views.c
+++ b/db/views.c
@@ -792,16 +792,16 @@ static int _generate_new_shard_name(const char *oldname, char *newname,
         /* get the length of the number sufix */
         suffix_len = _shard_suffix_str_len(maxshards);
 
-        if (0 > snprintf(newname, newnamelen, "%s%.*d", oldname, suffix_len, nextnum)) {
-	    return VIEW_ERR_GENERIC;
-	}
+        if (snprintf(newname, newnamelen, "%s%.*d", oldname, suffix_len, nextnum) >= newnamelen) {
+            return VIEW_ERR_GENERIC;
+        }
     } else {
         char hash[128];
         len = snprintf(hash, sizeof(hash), "%u%s", nextnum, oldname);
         len = crc32c((uint8_t *)hash, len);
-        if (0 > snprintf(newname, newnamelen, "$%u_%X", nextnum, len)) {
-	    return VIEW_ERR_GENERIC;
-	}
+        if (snprintf(newname, newnamelen, "$%u_%X", nextnum, len) >= newnamelen) {
+            return VIEW_ERR_GENERIC;
+        }
     }
     newname[newnamelen - 1] = '\0';
 


### PR DESCRIPTION
In both cases we either increase the size of the buffer to be a little more generous or check the error and return an error to the caller

> Warn about calls to formatted input/output functions such as snprintf
> and vsnprintf that might result in output truncation. When the exact
> number of bytes written by a format directive cannot be determined
> at compile-time it is estimated based on heuristics that depend on
> the level argument and on optimization. While enabling optimization
> will in most cases improve the accuracy of the warning, it may also
> result in false positives. Except as noted otherwise,
> the option uses the same logic -Wformat-overflow.
>
> Link: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#:~:text=Wformat%2Dtruncation%20%C2%B6

After the change, the code compiles without warning.

OS: Ubuntu 20.04.5 LTS
