### PR TITLE
Do not donate socket if SSL_shutdown fails

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -449,6 +449,9 @@ extern int gbl_seekscan_maxsteps;
 extern int gbl_wal_osync;
 extern uint64_t gbl_sc_headroom;
 
+extern int gbl_unexpected_last_type_warn;
+extern int gbl_unexpected_last_type_abort;
+
 /*
   =========================================================
   Value/Update/Verify functions for some tunables that need

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2422,5 +2422,10 @@ REGISTER_TUNABLE("fdb_incoherence_percentage",
 REGISTER_TUNABLE("fdb_io_error_retries",
                  "Number of retries for io error remsql", TUNABLE_INTEGER,
                  &gbl_fdb_io_error_retries, 0, NULL, NULL, NULL, NULL);
-
+REGISTER_TUNABLE("unexpected_last_type_warn",
+                 "print a line of trace if the last response server sent before sockpool reset isn't LAST_ROW",
+                 TUNABLE_INTEGER, &gbl_unexpected_last_type_warn, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("unexpected_last_type_abort",
+                 "Panic if the last response server sent before sockpool reset isn't LAST_ROW",
+                 TUNABLE_INTEGER, &gbl_unexpected_last_type_abort, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -929,6 +929,8 @@ struct sqlclntstate {
     // Latch last statement's cost for comdb2_last_cost to fetch
     int64_t last_cost;
     int disable_fdb_push;
+
+    int lastresptype;
 };
 
 /* Query stats. */

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -324,6 +324,7 @@ static inline int newsql_to_client_type(int newsql_type)
 static int newsql_response_int(struct sqlclntstate *clnt, const CDB2SQLRESPONSE *r, int h, int flush)
 {
     struct newsql_appdata *appdata = clnt->appdata;
+    clnt->lastresptype = r->response_type;
     return appdata->write(clnt, h, 0, r, flush);
 }
 

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -605,7 +605,7 @@ static void ssl_accept_evbuffer(int dummyfd, short what, void *arg)
         event_base_once(appdata->base, appdata->fd, EV_READ, ssl_accept_evbuffer, appdata, NULL);
         return;
     case SSL_ERROR_WANT_WRITE:
-        event_base_once(appdata->base, appdata->fd, EV_READ, ssl_accept_evbuffer, appdata, NULL);
+        event_base_once(appdata->base, appdata->fd, EV_WRITE, ssl_accept_evbuffer, appdata, NULL);
         return;
     case SSL_ERROR_SYSCALL:
         logmsg(LOGMSG_ERROR, "%s:%d SSL_do_handshake rc:%d err:%d errno:%d [%s]\n",

--- a/util/sbuf2.c
+++ b/util/sbuf2.c
@@ -113,8 +113,11 @@ int SBUF2_FUNC(sbuf2free)(SBUF2 *sb)
         return -1;
 
     /* Gracefully shutdown SSL to make the
-       fd re-usable. */
-    sslio_close(sb, 1);
+       fd re-usable. Close the fd if it fails. */
+    int rc = sslio_close(sb, 1);
+    if (rc)
+        close(sb->fd);
+
     sb->fd = -1;
     if (sb->rbuf) {
         free(sb->rbuf);
@@ -139,7 +142,7 @@ int SBUF2_FUNC(sbuf2free)(SBUF2 *sb)
 #if SBUF2_SERVER
     comdb2ma_destroy(alloc);
 #endif
-    return 0;
+    return rc;
 }
 
 /* flush output, close fd, and free SBUF2.*/


### PR DESCRIPTION
SSL_shutdown() will fail if there is unread data on an SSL connection. The patch changes the API to check the return code from SSL_shutdown(), and to only donate the underlying socket after SSL_shutdown() succeeds.

While #3822 successfully reproduces a case in 7.0 that misleads the API to incorrectly donate a undrained socket to sockpool, I've struggled to get it to happen in 8.0. Therefore, in this patch I've also added instrumentation to catch any protobuf response type other than LAST_ROW and immediately before a RESET from sockpool, as we believe that such a packet causes the behavior in the first place.
