### PR TITLE
Fix morestripe test

### DIFF
--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -77,7 +77,7 @@ static int reload_rename_table_alias(tran_type *tran, const char *name,
     return 0;
 }
 
-static int reload_stripe_info(tran_type *tran, uint8_t lid)
+static int reload_stripe_info(tran_type *tran, uint32_t lid)
 {
     int rc;
     int bdberr = 0;


### PR DESCRIPTION
This fixes 2 crashes which occur occasionally in the morestripe test.  'reload_stripe_info' was quietly chopping off 24-bits of the transaction's original lockid by taking a uint8 argument rather than uint32.  This causes the code to later destroy a different (possibly in-use) lockid rather than the original transaction-id.  In this test, the truncated lockid consistently mapped to repdb-cursor's lockid.  So an out-of-order log-record then causes the replication thread to crash, because that lockid has been destroyed.

The second fix addresses a parallel-rep issue when the database is exiting.  If we fail to dispatch a recovery-processor thread because the thread pool has stopped, then we we should remove this from the list of in-flight transactions.  The exit-crash occurs when later code is blocked waiting for the inflight-transactions counter to drop to zero.