### PR TITLE
change find_tag_schema prototype to allow refactoring tag subsystem

### DIFF
--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -199,7 +199,7 @@ static long long get_num_rows_from_stat1(struct dbtable *tbldb)
     struct schema *s;
 
     /* Grab the tag schema, or punt. */
-    if (!(s = find_tag_schema(tbldb->tablename, ".ONDISK_ix_0"))) {
+    if (!(s = find_tag_schema(tbldb, ".ONDISK_ix_0"))) {
         /* This is not an error. This just means the table has no indexes. */
         goto abort;
     }

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2620,14 +2620,14 @@ int process_allow_command(char *line, int lline);
 /* blob caching to support find requests */
 int gather_blob_data(struct ireq *iq, const char *tag, blob_status_t *b,
                      const char *to_tag);
-int gather_blob_data_byname(const char *dbname, const char *tag,
+int gather_blob_data_byname(struct dbtable *table, const char *tag,
                             blob_status_t *b, struct schema *pd);
-int check_one_blob_consistency(struct ireq *iq, const char *table,
+int check_one_blob_consistency(struct ireq *iq, struct dbtable *table,
                                const char *tag, blob_status_t *b, void *record,
                                int blob_index, int cblob, struct schema *pd);
-int check_blob_consistency(struct ireq *iq, const char *table, const char *tag,
+int check_blob_consistency(struct ireq *iq, struct dbtable *table, const char *tag,
                            blob_status_t *b, const void *record);
-int check_and_repair_blob_consistency(struct ireq *iq, const char *table,
+int check_and_repair_blob_consistency(struct ireq *iq, struct dbtable *table,
                                       const char *tag, blob_status_t *b,
                                       const void *record);
 void free_blob_status_data(blob_status_t *b);
@@ -2647,7 +2647,7 @@ int getdefaultkeysize(const struct dbtable *tbl, int ixnum);
 int getdefaultdatsize(const struct dbtable *tbl);
 int update_sqlite_stats(struct ireq *iq, void *trans, void *dta);
 void *do_verify(void *);
-void dump_tagged_buf(const char *table, const char *tag,
+void dump_tagged_buf(struct dbtable *table, const char *tag,
                      const unsigned char *buf);
 int ix_find_by_rrn_and_genid_get_curgenid(struct ireq *iq, int rrn,
                                           unsigned long long genid,

--- a/db/constraints.h
+++ b/db/constraints.h
@@ -49,8 +49,8 @@ struct ireq;
 
 int skip_lookup_for_nullfkey(const struct dbtable *db, int ixnum, int nulls);
 int check_single_key_constraint(struct ireq *ruleiq, const constraint_t *ct,
-                                const char *lcl_tag, const char *lcl_key, const char *tblname,
-                                void *trans, int *remote_ri);
+                                const char *lcl_tag, const char *lcl_key, 
+                                const struct dbtable *table, void *trans, int *remote_ri);
 constraint_t *get_constraint_for_ix(struct dbtable *db_table, int ix);
 int convert_key_to_foreign_key(constraint_t *ct, char *lcl_tag, char *lcl_key,
                                char *tblname, bdb_state_type **r_state,

--- a/db/fdb_bend_sql.c
+++ b/db/fdb_bend_sql.c
@@ -630,7 +630,7 @@ _fdb_svc_cursor_start(BtCursor *pCur, struct sqlclntstate *clnt, char *tblname,
             return NULL;
         }
     }
-    pCur->numblobs = get_schema_blob_count(pCur->db->tablename, ".ONDISK");
+    pCur->numblobs = get_schema_blob_count(pCur->db, ".ONDISK");
 
     if (need_bdbcursor) {
         pCur->bdbcur = bdb_cursor_open(

--- a/db/glue.c
+++ b/db/glue.c
@@ -5781,7 +5781,6 @@ int find_record_older_than(struct ireq *iq, void *tran, int timestamp,
 static int ix_find_check_blob_race(struct ireq *iq, char *inbuf, int numblobs,
                                    int *blobnums, void **blobptrs)
 {
-    char *table = iq->usedb->tablename;
     struct schema *sch;
     struct field *fld;
     int i;
@@ -5790,7 +5789,7 @@ static int ix_find_check_blob_race(struct ireq *iq, char *inbuf, int numblobs,
     int blobidx = 0;      /* walk blobnums[numblobs] list for the tag */
     int diskblobidx = -1; /* walk ondisk blobs */
 
-    sch = find_tag_schema(table, ".ONDISK");
+    sch = find_tag_schema(iq->usedb, ".ONDISK");
     if (sch == NULL)
         return -1;
 

--- a/db/indices.c
+++ b/db/indices.c
@@ -912,7 +912,7 @@ done:
 }
 
 // in sc_schema.h
-int verify_record_constraint(struct ireq *iq, struct dbtable *db, void *trans,
+int verify_record_constraint(struct ireq *iq, const struct dbtable *db, void *trans,
                              const void *old_dta, unsigned long long ins_keys,
                              blob_buffer_t *blobs, int maxblobs,
                              const char *from, int rebuild, int convert);
@@ -986,7 +986,7 @@ int upd_new_record_add2indices(struct ireq *iq, void *trans,
                                      mangled_key, partial_datacopy_tail, (char *)new_dta, nd_len, key);
         else {
             rc = create_key_from_schema(
-                iq->usedb, use_new_tag ? NULL : find_tag_schema(iq->usedb->tablename, ".ONDISK"), ixnum, &od_dta_tail,
+                iq->usedb, use_new_tag ? NULL : find_tag_schema(iq->usedb, ".ONDISK"), ixnum, &od_dta_tail,
                 &od_tail_len, mangled_key, partial_datacopy_tail, new_dta, nd_len, key, blobs, MAXBLOBS, NULL);
         }
 
@@ -1078,7 +1078,7 @@ int upd_new_record_indices(
             memcpy(key, iq->idxDelete[ixnum], keysize);
         } else {
             rc = create_key_from_schema_simple(iq->usedb,
-                                               use_new_tag ? NULL : find_tag_schema(iq->usedb->tablename, ".ONDISK"),
+                                               use_new_tag ? NULL : find_tag_schema(iq->usedb, ".ONDISK"),
                                                ixnum, use_new_tag ? sc_old : old_dta, key, del_idx_blobs, MAXBLOBS);
         }
 
@@ -1162,7 +1162,7 @@ int del_new_record_indices(struct ireq *iq, void *trans,
             rc = 0;
         } else {
             rc = create_key_from_schema_simple(iq->usedb,
-                                               use_new_tag ? NULL : find_tag_schema(iq->usedb->tablename, ".ONDISK"),
+                                               use_new_tag ? NULL : find_tag_schema(iq->usedb, ".ONDISK"),
                                                ixnum, use_new_tag ? sc_old : old_dta, key, del_idx_blobs, MAXBLOBS);
         }
 

--- a/db/localrep.c
+++ b/db/localrep.c
@@ -80,7 +80,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }
@@ -91,7 +91,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename, ".ONDISK", od_dta, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb, ".ONDISK", od_dta, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -131,7 +131,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
                                iq->usedb->tablename);
@@ -181,7 +181,7 @@ int local_replicant_log_add(struct ireq *iq, void *trans, void *od_dta,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
                                iq->usedb->tablename);
@@ -409,7 +409,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     if (!iq->usedb->do_local_replication)
         return 0;
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK");
+    s = find_tag_schema(iq->usedb, ".ONDISK");
     if (s == NULL) {
         rc = OP_FAILED_INTERNAL;
         goto done;
@@ -417,7 +417,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     odsz = get_size_of_schema(s);
     server_buf = malloc(odsz);
 
-    s = find_tag_schema(iq->usedb->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(iq->usedb, ".ONDISK_CLIENT");
     if (s == NULL) {
         free(server_buf);
         server_buf = NULL;
@@ -448,7 +448,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
     /* Now get the client version of the record and flush it out
        in a format the client can understand.  It goes out in this format to
        some intermediary machine (gsrv) from where it goes out via rmque. */
-    rc = stag_to_ctag_buf_tz(iq->usedb->tablename, ".ONDISK", server_buf, -1,
+    rc = stag_to_ctag_buf_tz(iq->usedb, ".ONDISK", server_buf, -1,
                              ".ONDISK_CLIENT", client_buf,
                              (unsigned char *)nulls, CONVERT_IGNORE_BLOBS, NULL,
                              NULL, "US/Eastern");
@@ -483,7 +483,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
                      * That necessitates looking up the value in the ondisk
                      * schema. */
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
                                iq->usedb->tablename);
@@ -532,7 +532,7 @@ int local_replicant_log_add_for_update(struct ireq *iq, void *trans, int rrn,
 
                 if (server_schema == NULL) {
                     server_schema =
-                        find_tag_schema(iq->usedb->tablename, ".ONDISK");
+                        find_tag_schema(iq->usedb, ".ONDISK");
                     if (server_schema == NULL) {
                         printf("can't find schema for %s\n",
                                iq->usedb->tablename);
@@ -787,7 +787,7 @@ int local_replicant_write_clear(struct ireq *in_iq, void *in_trans,
     if (gbl_replicate_local == 0 || get_dbtable_by_name("comdb2_oplog") == NULL)
         return 0;
 
-    s = find_tag_schema(db->tablename, ".ONDISK_CLIENT");
+    s = find_tag_schema(db, ".ONDISK_CLIENT");
     if (s == NULL) {
         return OP_FAILED_INTERNAL;
     }

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -355,7 +355,7 @@ static int create_key_schema(dbtable *db, struct schema *schema, int alt,
                 offset = 0;
                 while (temp) {
                     m = &p->member[piece];
-                    m->idx = find_field_idx(dbname, schema->tag, temp->field);
+                    m->idx = find_field_idx(db, schema->tag, temp->field);
                     if (m->idx == -1) {
                         rc = -ix - 1;
                         goto errout;
@@ -479,7 +479,7 @@ static int create_key_schema(dbtable *db, struct schema *schema, int alt,
                 db->ix_expr = 1;
             } else {
                 m->name = strdup(buf);
-                m->idx = find_field_idx(dbname, schema->tag, m->name);
+                m->idx = find_field_idx(db, schema->tag, m->name);
                 if (m->idx == -1) {
                     errstat_set_rcstrf(err, -1, "field %s not found in %s\n",
                                        m->name, schema->tag);
@@ -949,13 +949,12 @@ static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
             if (!alt) {
                 if (!no_side_effects)
                     db->lrl =
-                        get_size_of_schema_by_name(db->tablename, ".ONDISK");
+                        get_size_of_schema_by_name(db, ".ONDISK");
                 rc = clone_server_to_client_tag(db->tablename, ".ONDISK",
                                                 ".ONDISK_CLIENT");
             } else {
                 if (!no_side_effects)
-                    db->lrl = get_size_of_schema_by_name(db->tablename,
-                                                         ".NEW..ONDISK");
+                    db->lrl = get_size_of_schema_by_name(db, ".NEW..ONDISK");
                 rc = clone_server_to_client_tag(db->tablename, ".NEW..ONDISK",
                                                 ".NEW..ONDISK_CLIENT");
             }
@@ -974,7 +973,7 @@ static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
                         snprintf(tmptagname, sizeof(tmptagname),
                                  ".NEW..ONDISK_ix_%d", i);
                     db->ix_keylen[i] =
-                        get_size_of_schema_by_name(db->tablename, tmptagname);
+                        get_size_of_schema_by_name(db, tmptagname);
 
                     if (!alt) {
                         snprintf(sname_buf, sizeof(sname_buf), ".ONDISK_IX_%d",

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6713,8 +6713,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             /* Make sure this is sane before sending to upd_record. */
             for (int ii = 0; ii < MAXBLOBS; ii++) {
                 if (-2 == blobs[ii].length) {
-                    int idx = get_schema_blob_field_idx(iq->usedb->tablename,
-                                                        ".ONDISK", ii);
+                    int idx = get_schema_blob_field_idx(iq->usedb, ".ONDISK", ii);
                     assert(idx < ncols);
                     assert(-1 == (*updCols)[idx + 1]);
                 }

--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -1806,12 +1806,13 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
     int ncols;
     int osql_nettype = tran2netrpl(clnt->dbtran.mode);
     blob_key_t *tmptblkey;
+    struct dbtable *table = get_dbtable_by_name(tbl->tablename);
 
     /* identify the number of blobs */
     for (i = 0; i < tbl->nblobs; i++) {
 
         if (updCols && gbl_osql_blob_optimization) {
-            idx = get_schema_blob_field_idx(tbl->tablename, ".ONDISK", i);
+            idx = get_schema_blob_field_idx(table, ".ONDISK", i);
             ncols = updCols[0];
             if (idx >= 0 && idx < ncols && -1 == updCols[idx + 1]) {
                 rc = osql_send_qblob(&osql->target, osql->rqid, osql->uuid, i,

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1469,9 +1469,9 @@ static int osql_send_qblobs_logic(struct BtCursor *pCur, osqlstate_t *osql,
         /* Send length of -2 if this isn't being used in this update. */
         if (updCols && gbl_osql_blob_optimization && blobs[i].length > 0) {
             int idx =
-                get_schema_blob_field_idx(pCur->db->tablename, ".ONDISK", i);
+                get_schema_blob_field_idx(pCur->db, ".ONDISK", i);
             /* AZ: is pCur->db->schema not set to ondisk so we can instead call
-             * get_schema_blob_field_idx_sc(pCur->db->schema,i); ?? */
+             * get_schema_blob_field_idx_sc(pCur->db,i); ?? */
             int ncols = updCols[0];
             if (idx >= 0 && idx < ncols && -1 == updCols[idx + 1]) {
                 /* Put a token on the network if this isn't going to be used */

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -883,7 +883,7 @@ fprintf(stderr, "opnum %d btst(%x, %d)\n",
                  * old record and the changes.
                  */
                 memcpy(od_dta, fnddta, od_len);
-                rc = ctag_to_stag_buf(iq.usedb->tablename, tag, req->record,
+                rc = ctag_to_stag_buf(iq.usedb, tag, req->record,
                                       WHOLE_BUFFER, fldnullmap, ".ONDISK",
                                       od_dta, CONVERT_UPDATE, &reason);
                 if (rc < 0) {

--- a/db/prefault_toblock.c
+++ b/db/prefault_toblock.c
@@ -92,7 +92,7 @@ static int add_record_prefault(
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,
@@ -112,7 +112,7 @@ static int add_record_prefault(
 
         od_dta = stackbuf;
 
-        rc = ctag_to_stag_buf(iq->usedb->tablename, tag,
+        rc = ctag_to_stag_buf(iq->usedb, tag,
                               (const char *)p_buf_rec, WHOLE_BUFFER, fldnullmap,
                               ondisktag, od_dta, 0, &reason);
         if (rc == -1) {
@@ -147,7 +147,7 @@ static int add_record_prefault(
         }
 
         snprintf(ixtag, sizeof(ixtag), "%s_IX_%d", ondisktag, ixnum);
-        rc = stag_to_stag_buf(iq->usedb->tablename, ondisktag, od_dta, ixtag,
+        rc = stag_to_stag_buf(iq->usedb, ondisktag, od_dta, ixtag,
                               key, NULL);
         if (rc == -1) {
             if (iq->debug)
@@ -253,7 +253,7 @@ upd_record_prefault(struct ireq *iq, void *primkey, int rrn,
         fldnullmap = lclnulls;
     }
 
-    expected_dat_len = get_size_of_schema_by_name(iq->usedb->tablename, tag);
+    expected_dat_len = get_size_of_schema_by_name(iq->usedb, tag);
     if ((size_t)expected_dat_len != reclen) {
         if (iq->debug)
             reqprintf(iq, "BAD DTA LEN %u TAG %s EXPECTS DTALEN %u\n", reclen,

--- a/db/printlog.c
+++ b/db/printlog.c
@@ -94,7 +94,7 @@ void dump_record(DB_ENV *dbenv, __db_addrem_args *args, struct fname *f)
             } else {
                 sprintf(tag, gbl_ondisk_ver_fmt, odh.csc2vers);
             }
-            sc = find_tag_schema(f->table, tag);
+            sc = find_tag_schema(get_dbtable_by_name(f->table), tag);
             if (sc == NULL) {
                 printf("can't find schema for %s ", tag);
                 return;

--- a/db/sqlexplain.c
+++ b/db/sqlexplain.c
@@ -135,7 +135,7 @@ static void print_field(Vdbe *v, struct cursor_info *cinfo, int num, char *buf)
             sc = db->ixschema[cinfo->ix];
         } else {
             snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-            sc = find_tag_schema(db->tablename, scname);
+            sc = find_tag_schema(db, scname);
         }
     } else {
         sc = db->schema;
@@ -199,7 +199,7 @@ static int print_cursor_description(strbuf *out, struct cursor_info *cinfo)
                 sc = db->ixschema[cinfo->ix];
             } else {
                 snprintf(scname, sizeof(scname), ".ONDISK_ix_%d", cinfo->ix);
-                sc = find_tag_schema(db->tablename, scname);
+                sc = find_tag_schema(db, scname);
             }
             strbuf_appendf(out, "index \"%s\" of ",
                            sc ? (sc->csctag ? sc->csctag : sc->tag) : "???");

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -6691,7 +6691,7 @@ static int fetch_blob_into_sqlite_mem(BtCursor *pCur, struct schema *sc,
     }
 
     if (!pCur->have_blob_descriptor) {
-        gather_blob_data_byname(pCur->db->tablename, ".ONDISK",
+        gather_blob_data_byname(pCur->db, ".ONDISK",
                                 &pCur->blob_descriptor, pd);
         pCur->have_blob_descriptor = 1;
     }
@@ -6748,7 +6748,7 @@ again:
     init_fake_ireq(thedb, &iq);
     iq.usedb = pCur->db;
 
-    if (check_one_blob_consistency(&iq, iq.usedb->tablename, ".ONDISK", &blobs,
+    if (check_one_blob_consistency(&iq, iq.usedb, ".ONDISK", &blobs,
                                    dta, f->blob_index, 0, pd)) {
         free_blob_status_data(&blobs);
         nretries++;
@@ -8172,7 +8172,7 @@ sqlite3BtreeCursor_cursor(Btree *pBt,      /* The btree */
     /* check one time if we have blobs when we open the cursor,
      * so we dont need to run this code for every row if we dont even
      * have them */
-    rc = gather_blob_data_byname(cur->db->tablename, ".ONDISK", &cur->blobs, NULL);
+    rc = gather_blob_data_byname(cur->db, ".ONDISK", &cur->blobs, NULL);
     if (rc) {
        logmsg(LOGMSG_ERROR, "sqlite3BtreeCursor: gather_blob_data error rc=%d\n", rc);
         return SQLITE_INTERNAL;
@@ -8530,7 +8530,7 @@ static int make_stat_record(struct sql_thread *thd, BtCursor *pCur,
                             blob_buffer_t blobs[MAXBLOBS])
 {
     int n = is_stat2(pCur->db->tablename) ? 3 : 2;
-    struct schema *sc = find_tag_schema(pCur->db->tablename, ".ONDISK_IX_0");
+    struct schema *sc = find_tag_schema(pCur->db, ".ONDISK_IX_0");
 
     /* extract first n fields from packed record */
     if (sqlite_to_ondisk(sc, pData, nData, pCur->ondisk_buf, pCur->clnt->tzname,

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -3564,7 +3564,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                use record to form and delete other keys */
             snprintf(client_tag, MAXTAGLEN, ".DEFAULT_IX_0");
             snprintf(ondisk_tag, MAXTAGLEN, ".ONDISK_IX_0");
-            rc = ctag_to_stag_buf(iq->usedb->tablename, client_tag,
+            rc = ctag_to_stag_buf(iq->usedb, client_tag,
                                   (const char *)iq->p_buf_in, WHOLE_BUFFER,
                                   nulls, ondisk_tag, key, 0, NULL);
             if (rc == -1) {
@@ -3870,7 +3870,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
             /* convert key */
             bzero(nulls, sizeof(nulls));
-            rc = ctag_to_stag_buf(iq->usedb->tablename, ".DEFAULT_IX_0",
+            rc = ctag_to_stag_buf(iq->usedb, ".DEFAULT_IX_0",
                                   (const char *)p_keydat, WHOLE_BUFFER, nulls,
                                   ".ONDISK_IX_0", key, convert_flags, NULL);
             if (rc == -1) {
@@ -4001,8 +4001,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                    capture comdb clients that are trying to verify
                    only a prefix of the row (size < .default rowsize)
                  */
-                int rowsz = get_size_of_schema_by_name(iq->usedb->tablename,
-                                                       ".DEFAULT");
+                int rowsz = get_size_of_schema_by_name(iq->usedb, ".DEFAULT");
                 if (rowsz != vlen) {
                     logmsg(
                         LOGMSG_ERROR,
@@ -4340,7 +4339,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
                 break;
             }
             dtalen =
-                get_size_of_schema_by_name(iq->usedb->tablename, ".ONDISK");
+                get_size_of_schema_by_name(iq->usedb, ".ONDISK");
 
             MIXED_SQL_DYNTAGS(trans, parent_trans);
 
@@ -6109,7 +6108,7 @@ static int keyless_range_delete_post_delete(void *record, size_t record_len,
         int rc;
         struct javasp_rec *jrec;
         jrec = javasp_alloc_rec(record, record_len,
-                                rngdel_info->iq->usedb->tablename);
+                                rngdel_info->iq->usedb);
         if (rngdel_info->saveblobs)
             javasp_rec_set_blobs(jrec, rngdel_info->oldblobs);
         rc = javasp_trans_tagged_trigger(

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -771,7 +771,7 @@ static int sp_trigger_run(struct javasp_trans_state *javasp_trans_handle,
 
     byte_buffer_init(&bytes);
 
-    s = find_tag_schema(t->name, ".ONDISK");
+    s = find_tag_schema(get_dbtable_by_name(t->name), ".ONDISK");
     if (s == NULL) {
         logmsg(LOGMSG_ERROR, "can't find schema for %s\n", t->name);
         rc = -1;
@@ -885,12 +885,12 @@ int javasp_trans_tagged_trigger(struct javasp_trans_state *javasp_trans_handle,
 }
 
 struct javasp_rec *javasp_alloc_rec(const void *od_dta, size_t od_len,
-                                    const char *tblname)
+                                    struct dbtable *table)
 {
     struct javasp_rec *rec;
     struct schema *schema;
 
-    schema = find_tag_schema(tblname, ".ONDISK");
+    schema = find_tag_schema(table, ".ONDISK");
     if (!schema)
         return NULL;
 
@@ -907,7 +907,7 @@ struct javasp_rec *javasp_alloc_rec(const void *od_dta, size_t od_len,
     }
     bzero(rec, sizeof(struct javasp_rec));
 
-    strncpy0(rec->tablename, tblname, sizeof(rec->tablename));
+    strncpy0(rec->tablename, table->tablename, sizeof(rec->tablename));
     rec->ondisk_dta = od_dta;
     rec->ondisk_dta_len = od_len;
     rec->schema = schema;

--- a/db/translistener.h
+++ b/db/translistener.h
@@ -170,7 +170,7 @@ int javasp_custom_read(struct ireq *iq, const char *opname, const void *indata,
 /* Allocate a javasp_tagged_rec structure for use in communicating record
  * contents to the Java code. */
 struct javasp_rec *javasp_alloc_rec(const void *od_dta, size_t od_len,
-                                    const char *tblname);
+                                    struct dbtable *table);
 
 /* For an allocated record, set the Java transaction handle, rrn and genid.
  * This allows the record to retrieve unknown blobs. */

--- a/db/verify.c
+++ b/db/verify.c
@@ -83,7 +83,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
         return;
     }
     logmsg(LOGMSG_INFO, "rrn %d genid 0x%016llx\n", rrn, genid);
-    dump_tagged_buf(db->tablename, ".ONDISK", (unsigned char *)dta);
+    dump_tagged_buf(db, ".ONDISK", (unsigned char *)dta);
     for (ix = 0; ix < db->nix; ix++) {
         key = malloc(getkeysize(db, ix));
         if (key == NULL) {
@@ -92,7 +92,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             return;
         }
         snprintf(tag, sizeof(tag), ".ONDISK_IX_%d", ix);
-        rc = stag_to_stag_buf(db->tablename, ".ONDISK", dta, tag, key, NULL);
+        rc = stag_to_stag_buf(db, ".ONDISK", dta, tag, key, NULL);
         if (rc) {
             logmsg(LOGMSG_INFO,
                    "dump_record_by_rrn:stag_to_stag_buf rrn %d genid %016llx "
@@ -102,7 +102,7 @@ void dump_record_by_rrn_genid(struct dbtable *db, int rrn, unsigned long long ge
             break;
         }
         logmsg(LOGMSG_INFO, "ix %d:\n", ix);
-        dump_tagged_buf(db->tablename, tag, (unsigned char *)key);
+        dump_tagged_buf(db, tag, (unsigned char *)key);
         free(key);
     }
     free(dta);

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -811,7 +811,7 @@ convert_records:
      *- alter merge: in this case the schema is already populated with NEW tags
      *- create merge: we need to populate schema with NEW tags
      */
-    struct schema *tag = find_tag_schema(newdb->tablename, ".NEW..ONDISK");
+    struct schema *tag = find_tag_schema(newdb, ".NEW..ONDISK");
     if (!tag) {
         struct errstat err = {0};
         rc =

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -288,7 +288,7 @@ int live_sc_post_update_delayed_key_adds_int(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -360,7 +360,7 @@ int live_sc_post_add_record(struct ireq *iq, void *trans,
         return 1;
     }
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK",
+    rc = stag_to_stag_buf_blobs(usedb->sc_to, ".ONDISK",
                                 (const char *)od_dta, ".NEW..ONDISK", new_dta,
                                 &reason, blobs, maxblobs, 1);
     if (rc) {
@@ -799,7 +799,7 @@ static int scdone_add(const char tablename[], void *arg, scdone_t type)
         struct schema *ver_one;
         char tag[MAXTAGLEN];
 
-        ondisk_schema = find_tag_schema(db->tablename, ".ONDISK");
+        ondisk_schema = find_tag_schema(db, ".ONDISK");
         if (NULL == ondisk_schema) {
             logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
                    db->tablename);

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -52,7 +52,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
             rc = ERR_CONSTR;
             goto done;
         }
-        rc = stag_to_stag_buf(db->tablename, from, old_dta, ".NEW..ONDISK",
+        rc = stag_to_stag_buf(db, from, old_dta, ".NEW..ONDISK",
                               new_dta, &reason);
         if (rc) {
             rc = ERR_CONSTR;
@@ -79,7 +79,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         /* Name: .NEW.COLUMNNAME -> .NEW..ONDISK_IX_nn */
         snprintf(lcl_tag, sizeof lcl_tag, ".NEW.%s", ct->lclkeyname);
-        rc = getidxnumbyname(db->tablename, lcl_tag, &lcl_idx);
+        rc = getidxnumbyname(db, lcl_tag, &lcl_idx);
         if (rc) {
             logmsg(LOGMSG_ERROR, "could not get index for %s\n", lcl_tag);
             rc = ERR_CONSTR;
@@ -98,7 +98,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
         if (iq->idxInsert && !convert)
             memcpy(lcl_key, iq->idxInsert[lcl_idx], db->ix_keylen[lcl_idx]);
         else
-            rc = stag_to_stag_buf_blobs(db->tablename, from, od_dta, lcl_tag,
+            rc = stag_to_stag_buf_blobs(db, from, od_dta, lcl_tag,
                                         lcl_key, NULL, blobs, maxblobs, 0);
         if (rc) {
             rc = ERR_CONSTR;
@@ -113,7 +113,7 @@ int verify_record_constraint(const struct ireq *iq, const struct dbtable *db, vo
 
         int ri;
         rc = check_single_key_constraint(&ruleiq, ct, lcl_tag, lcl_key,
-                                         db->tablename, trans, &ri);
+                                         db, trans, &ri);
         if (rc == RC_INTERNAL_RETRY) {
             break;
         } else if (rc && rc != ERR_CONSTR) {
@@ -169,7 +169,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             ldb = newdb;
             snprintf(ondisk_tag, sizeof(ondisk_tag), ".NEW.%s",
                      cnstrt->keynm[j]);
-            rc = getidxnumbyname(cnstrt->table[j], ondisk_tag, &ixnum);
+            rc = getidxnumbyname(ldb, ondisk_tag, &ixnum);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: unknown keytag '%s'\n", __func__,
                        ondisk_tag);
@@ -185,7 +185,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             snprintf(ondisk_tag, sizeof(ondisk_tag), ".NEW..ONDISK_IX_%d",
                      ixnum);
             /* Data -> Key : ONDISK -> .ONDISK_IX_nn */
-            rc = stag_to_stag_buf(newdb->tablename, from, od_dta, ondisk_tag,
+            rc = stag_to_stag_buf(newdb, from, od_dta, ondisk_tag,
                                   lkey, NULL);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: failed to convert to '%s'\n",
@@ -193,7 +193,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
                 return ERR_CONVERT_IX;
             }
             /* here we convert the key into return db format */
-            rc = getidxnumbyname(cnstrt->lcltable->tablename,
+            rc = getidxnumbyname(get_dbtable_by_name(cnstrt->lcltable->tablename),
                                  cnstrt->lclkeyname, &rixnum);
             if (rc) {
                 logmsg(LOGMSG_ERROR, "%s: unknown keytag '%s'\n", __func__,
@@ -206,7 +206,7 @@ int verify_partial_rev_constraint(struct dbtable *to_db, struct dbtable *newdb,
             int nulls = 0;
 
             rixlen = rc = stag_to_stag_buf_ckey(
-                ldb->tablename, ondisk_tag, lkey, cnstrt->lcltable->tablename,
+                ldb, ondisk_tag, lkey, cnstrt->lcltable->tablename,
                 rondisk_tag, rkey, &nulls, PK2FK);
             if (rc == -1) {
                 /* I followed the logic in check_update_constraints */
@@ -438,7 +438,7 @@ int prepare_table_version_one(tran_type *tran, struct dbtable *db,
         exit(1);
     }
 
-    ondisk_schema = find_tag_schema(db->tablename, ".ONDISK");
+    ondisk_schema = find_tag_schema(db, ".ONDISK");
     if (NULL == ondisk_schema) {
         logmsg(LOGMSG_FATAL, ".ONDISK not found in %s! PANIC!!\n",
                db->tablename);
@@ -609,7 +609,7 @@ void verify_schema_change_constraint(struct ireq *iq, void *trans,
     }
 
     struct convert_failure reason;
-    rc = stag_to_stag_buf_blobs(usedb->sc_to->tablename, ".ONDISK", od_dta,
+    rc = stag_to_stag_buf_blobs(usedb->sc_to, ".ONDISK", od_dta,
                                 ".NEW..ONDISK", new_dta, &reason, add_idx_blobs,
                                 add_idx_blobs ? MAXBLOBS : 0, 1);
     if (rc) {
@@ -739,8 +739,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     memset(plan, 0, sizeof(struct scplan));
 
-    oldsc = find_tag_schema(olddb->tablename, ".ONDISK");
-    newsc = find_tag_schema(olddb->tablename, ".NEW..ONDISK");
+    oldsc = find_tag_schema(olddb, ".ONDISK");
+    newsc = find_tag_schema(olddb, ".NEW..ONDISK");
     if (!oldsc || !newsc) {
         sc_errf(s, "%s: can't find both schemas! oldsc=%p newsc=%p\n", __func__,
                 oldsc, newsc);
@@ -816,8 +816,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
 
     for (blobn = 0; blobn < newdb->numblobs; blobn++) {
         int map;
-        map = tbl_blob_no_to_tbl_blob_no(newdb->tablename, ".NEW..ONDISK",
-                                         blobn, olddb->tablename, ".ONDISK");
+        map = tbl_blob_no_to_tbl_blob_no(newdb, ".NEW..ONDISK",
+                                         blobn, olddb, ".ONDISK");
         /* Sanity check, although I don't see how this can possibly
          * happen - make sure we haven't already decided to use this
          * blob file for anything. */
@@ -841,9 +841,8 @@ int create_schema_change_plan(struct schema_change_type *s, struct dbtable *oldd
             plan->blob_plan[blobn] = -1;
         } else if (map >= 0 && map < olddb->numblobs) {
             int oldidx =
-                get_schema_blob_field_idx(olddb->tablename, ".ONDISK", map);
-            int newidx = get_schema_blob_field_idx(newdb->tablename,
-                                                   ".NEW..ONDISK", blobn);
+                get_schema_blob_field_idx(olddb, ".ONDISK", map);
+            int newidx = get_schema_blob_field_idx(newdb, ".NEW..ONDISK", blobn);
 
             /* rebuild if the blob length changed */
             if (oldsc->member[oldidx].len != newsc->member[newidx].len) {
@@ -1324,7 +1323,7 @@ int check_sc_headroom(struct schema_change_type *s, struct dbtable *olddb,
 /* compatible change if type unchanged but get larger in size */
 int compat_chg(struct dbtable *olddb, struct schema *s2, const char *ixname)
 {
-    struct schema *s1 = find_tag_schema(olddb->tablename, ixname);
+    struct schema *s1 = find_tag_schema(olddb, ixname);
     if (s1->nmembers != s2->nmembers) return 1;
     int i;
     for (i = 0; i < s1->nmembers; ++i) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -704,8 +704,8 @@ static int unodhfy_if_necessary(struct ireq *iq, blob_buffer_t *blobs,
     /* Check if we need to unpack vutf8. */
     assert(iq->usedb->sc_from != NULL && iq->usedb->sc_to != NULL);
 
-    from = find_tag_schema(iq->usedb->sc_from->tablename, ".ONDISK");
-    to = find_tag_schema(iq->usedb->sc_to->tablename, ".NEW..ONDISK");
+    from = find_tag_schema(iq->usedb->sc_from, ".ONDISK");
+    to = find_tag_schema(iq->usedb->sc_to, ".NEW..ONDISK");
 
     for (rc = 0, i = 0; i != to->nmembers; ++i) {
         /* If the field in the new schema is new, do nothing. */

--- a/sqlite/ext/comdb2/logicalops.c
+++ b/sqlite/ext/comdb2/logicalops.c
@@ -646,7 +646,7 @@ static int produce_update_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
             goto done;
         }
     } else {
-        int ix = get_schema_blob_field_idx((char *) pCur->table, ".ONDISK", dtafile - 1);
+        int ix = get_schema_blob_field_idx(pCur->db, ".ONDISK", dtafile - 1);
         if ((rc = json_blob(pCur->record, pCur->reclen, pCur->db->schema,
                         ix, pCur->jsonrec)) != 0) {
             logmsg(LOGMSG_ERROR, "%s line %d json_blob returns %d\n", __func__,
@@ -755,7 +755,7 @@ static int produce_add_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
             goto done;
         }
     } else {
-        int ix = get_schema_blob_field_idx((char *) pCur->table, ".ONDISK", dtafile - 1);
+        int ix = get_schema_blob_field_idx(pCur->db, ".ONDISK", dtafile - 1);
         if ((rc = json_blob(pCur->record, pCur->reclen, pCur->db->schema,
                         ix, pCur->jsonrec)) != 0) {
             logmsg(LOGMSG_ERROR, "%s line %d json_blob returns %d\n", __func__,
@@ -863,7 +863,7 @@ static int produce_delete_data_record(logicalops_cursor *pCur, DB_LOGC *logc,
             goto done;
         }
     } else {
-        int ix = get_schema_blob_field_idx((char *) pCur->table, ".ONDISK", dtafile - 1);
+        int ix = get_schema_blob_field_idx(pCur->db, ".ONDISK", dtafile - 1);
         if ((rc = json_blob(pCur->oldrecord, pCur->oldreclen, pCur->db->schema,
                         ix, pCur->oldjsonrec)) != 0) {
             logmsg(LOGMSG_ERROR, "%s line %d json_blob returns %d\n", __func__,

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -1119,7 +1119,7 @@ void comdb2RebuildIndex(Parse* pParse, Token* nm, Token* lnm, Token* index, int 
     if (create_string_from_token(v, pParse, &indexname, index))
         goto out;
 
-    rc = getidxnumbyname(sc->tablename, indexname, &index_num );
+    rc = getidxnumbyname(get_dbtable_by_name(sc->tablename), indexname, &index_num);
     if( rc ){
         logmsg(LOGMSG_ERROR, "!table:index '%s:%s' not found\n", sc->tablename, indexname);
         setError(pParse, SQLITE_ERROR, "Index not found");


### PR DESCRIPTION
A specific tag (a key/value form for an sql view) is only meaningful in the context of a certain table.
Currently tags are stored in a global structure.   This is cut 1 to refactor the global structure into table own structures.