### PR TITLE
Supporting new JDBC URL

### DIFF
--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -16,7 +16,7 @@ limitations under the License. -->
   <groupId>com.bloomberg.comdb2</groupId>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>cdb2jdbc</artifactId>
-  <version>2.7.0</version>
+  <version>2.8.0</version>
   <packaging>jar</packaging>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -281,6 +281,10 @@ public class Comdb2Connection implements Connection {
         hndl.setClearAck(clearAck);
     }
 
+    public void setForceDirectcpu(boolean directcpu) {
+        hndl.setForceDirectcpu(directcpu);
+    }
+
     public ArrayList<String> getDbHosts() throws NoDbHostFoundException{
         return hndl.getDbHosts();
     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -74,6 +74,12 @@ public class Comdb2Handle extends AbstractConnection {
     int connectTimeout = 100;
     int dbinfoTimeout = 500;
 
+    /* ternary:
+       null:  let driver figure out
+       true:  directcpu
+       false: cluster */
+    Boolean forceDirectcpu = null;
+
     private boolean in_retry = false;
     private boolean temp_trans = false;
     private boolean debug = false;
@@ -192,6 +198,8 @@ public class Comdb2Handle extends AbstractConnection {
         ret.sentClientInfo = sentClientInfo;
         ret.hasSendStack = hasSendStack;
         ret.sendStack = sendStack;
+
+        ret.forceDirectcpu = forceDirectcpu;
 
         return ret;
     }
@@ -485,6 +493,10 @@ public class Comdb2Handle extends AbstractConnection {
 
     public void setCluster(String cluster) {
         myDbCluster = cluster;
+    }
+
+    public void setForceDirectcpu(boolean val) {
+        forceDirectcpu = val;
     }
 
     private int retryQueries(int nretry, boolean runlast) {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -444,6 +444,17 @@ public class DatabaseDiscovery {
         }
     }
 
+    static boolean isTier(String str) {
+        return (
+               str.equalsIgnoreCase("default")
+            || str.equalsIgnoreCase("dev")
+            || str.equalsIgnoreCase("uat")
+            || str.equalsIgnoreCase("alpha")
+            || str.equalsIgnoreCase("beta")
+            || str.equalsIgnoreCase("prod")
+        );
+    }
+
     /**
      * Gets the database server host(s) and port(s) of @hndl.
      * 
@@ -463,17 +474,15 @@ public class DatabaseDiscovery {
             comdb2lcldb.remove(hndl.myDbName + "/" + hndl.myDbCluster);
         }
 
-        if (hndl.myDbCluster.equalsIgnoreCase("local")) {
+        if (hndl.myDbCluster.equalsIgnoreCase("local") && hndl.forceDirectcpu == null) {
 			/* type is local */
             hndl.isDirectCpu = true;
             hndl.myDbHosts.add("localhost");
             hndl.myDbPorts.add(hndl.overriddenPort);
-        } else if ( hndl.myDbCluster.equalsIgnoreCase("default")
-                || hndl.myDbCluster.equalsIgnoreCase("dev")
-                || hndl.myDbCluster.equalsIgnoreCase("uat")
-                || hndl.myDbCluster.equalsIgnoreCase("alpha")
-                || hndl.myDbCluster.equalsIgnoreCase("beta")
-                || hndl.myDbCluster.equalsIgnoreCase("prod")) {
+        } else if ((isTier(hndl.myDbCluster) && hndl.forceDirectcpu == null) ||
+                (hndl.forceDirectcpu != null && hndl.forceDirectcpu == false)) {
+            /* This is a pre-defined tier (eg jdbc:comdb2://dev);
+             * or is defined as a tier from the URL (eg jdbc:comdb2:tier//fuzz) */
             hndl.isDirectCpu = false;
 
             /* if the handle asks for cache, do it now. */

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/DatabaseDiscoveryTest.java
@@ -24,7 +24,8 @@ public class DatabaseDiscoveryTest {
     public void testDNSDown() throws IOException, SQLException {
         try {
             LogManager.getLogManager().reset();
-            Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db");
+            /* The URL below would inquire dev-comdb2db.example.com */
+            Connection conn = DriverManager.getConnection("jdbc:comdb2://dev/db?dnssuffix=example.com");
             Assert.assertTrue("Should not reach here", false);
         } catch (SQLException sqle) {
             Assert.assertTrue("Should see correct error message.",


### PR DESCRIPTION
Our JDBC URL accepts a list of pre-defined tier names ("dev", "beta", "prod", etc.), and obviously does not work very well with a new or custom tier. This patch adds support for a new JDBC URL variation that allows specifying a tier name explicitly:

jdbc:comdb2:tier//abc/xyz, that would connect to database `xyz' on tier `abc'

The smoketest has been failing since a new DNS entry for dev-comdb2db was added ( test assumes that this DNS record does not exist). This patch also fixes the test.