### PR TITLE
free the dropped table db instead of leaking it

### DIFF
--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -159,5 +159,9 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
     if (gbl_replicate_local)
         local_replicant_write_clear(iq, tran, db);
 
+    /* lets not forget to free db */
+    freedb(s->db);
+    s->db = NULL;
+
     return 0;
 }


### PR DESCRIPTION
We need to free the dbtable object once the table drop is finalized.