### PR TITLE
Make cluster script work on Mac

### DIFF
--- a/contrib/dev-util/cluster
+++ b/contrib/dev-util/cluster
@@ -423,7 +423,7 @@ function cfg {
 function setup {
     local isdocker
     isdocker=$(cat /proc/self/cgroup | cut -d/ -f2 | head -1)
-    if [[ "$isdocker" != "docker" ]]; then
+    if [[ "$isdocker" != "docker" && ! -f /.dockerenv ]]; then
         check-containers-ready || exit 1
         docker exec --user $(id -u) $(container-name 0) ${HOME}/bin/cluster setup $*
         return $?


### PR DESCRIPTION
The current way of checking if in a docker container does not work for containers created from docker on mac

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
