### PR TITLE
bbcmake: make sure to include proprietary cdb2api addons

### DIFF
--- a/cdb2api/CMakeLists.txt
+++ b/cdb2api/CMakeLists.txt
@@ -23,8 +23,8 @@ include_directories(
   ${OPENSSL_INCLUDE_DIR}
 )
 
-if (COMDB2_EXTRA_PLUGINS)
-  include(${COMDB2_EXTRA_PLUGINS}/cdb2api/CMakeLists.txt)
+if (EXTRA_PLUGINS)
+  include(${EXTRA_PLUGINS}/cdb2api/CMakeLists.txt)
 endif()
 
 # common obj files for .so/.dylib and .a


### PR DESCRIPTION
`COMDB2_EXTRA_PLUGINS` is set by `plugins/CMakeLists.txt`, which is processed after `cdb2api/CMakeLists.txt`. This means that a fresh cmake build will not include addons under `COMDB2_EXTRA_PLUGINS` (subsequent builds do get it from `CMakeCache.txt`). This patch fixes it.