### PR TITLE
Improved long-replication stats

### DIFF
--- a/bbinc/thread_stats.h
+++ b/bbinc/thread_stats.h
@@ -20,6 +20,7 @@
 #include <stdint.h>
 
 struct berkdb_thread_stats {
+    uint64_t n_locks;
     unsigned n_lock_waits;
     uint64_t lock_wait_time_us;
     uint64_t worst_lock_wait_time_us;
@@ -43,6 +44,15 @@ struct berkdb_thread_stats {
 
     unsigned n_shalloc_frees;
     uint64_t shalloc_free_time_us;
+
+    uint64_t rep_lock_time_us;
+    uint64_t rep_deadlock_retries;
+
+    uint64_t rep_log_cnt;
+    uint64_t rep_log_bytes;
+
+    uint64_t rep_collect_time_us;
+    uint64_t rep_exec_time_us;
 };
 
 #endif

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2641,6 +2641,14 @@ upgrade:
 	case GRANT:
 		newl->status = DB_LSTAT_HELD;
 		SH_TAILQ_INSERT_TAIL(&sh_obj->holders, newl, links);
+		if (gbl_bb_berkdb_enable_thread_stats) {
+			struct berkdb_thread_stats *t;
+			struct berkdb_thread_stats *p;
+			t = bb_berkdb_get_thread_stats();
+			p = bb_berkdb_get_process_stats();
+			p->n_locks++;
+			t->n_locks++;
+		}
 		break;
 	case HEAD:
 	case TAIL:
@@ -2842,6 +2850,8 @@ upgrade:
 			if (t->worst_lock_wait_time_us < d)
 				t->worst_lock_wait_time_us = d;
 			t->n_lock_waits++;
+			t->n_locks++;
+			p->n_locks++;
 
 			if (gbl_bb_log_lock_waits_fn) {
 				/* We had to wait on this lock - call our

--- a/tests/longreq_stats.test/Makefile
+++ b/tests/longreq_stats.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/longreq_stats.test/lrl.options
+++ b/tests/longreq_stats.test/lrl.options
@@ -1,0 +1,3 @@
+setattr REP_WORKERS 0
+setattr REP_PROCESSORS 0
+decoupled_logputs off

--- a/tests/longreq_stats.test/runit
+++ b/tests/longreq_stats.test/runit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+function setup_longreq
+{
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "exec procedure sys.cmd.send('bdb setattr rep_longreq -1')"
+    done
+}
+
+function create_tables
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1 (a int)"
+}
+
+function write_records
+{
+    typeset SZ=$1
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, $SZ)"
+    [[ $? != 0 ]] && failexit "failed to insert records"
+}
+
+
+function test_logic
+{
+    write_records 100
+    write_records 200
+    write_records 300
+    write_records 400
+    write_records 500
+    write_records 600
+    write_records 700
+    write_records 800
+    write_records 900
+    write_records 1000
+}
+
+function check_log_node
+{
+    typeset node=$1
+    log=$TESTDIR/logs/longreqstats${TESTID}.${node}.db
+    lb=$(egrep "log-records applied" $log)
+
+    # Verify 5 increasingly large transactions
+    lines=$(echo "$lb" | wc -l)
+    [[ "$lines" -ne "10" ]] && failexit "Incorrect number of applied records"
+
+    max=0
+    echo "$lb" | while read ln ; do
+        ll="${ln%% log-records applied*}"
+        x="${ll## }"
+        [ "$x" -le "$max" ] && failexit "log-records got smaller??"
+        max="$x"
+        echo "$node applied $max log records"
+    done
+}
+
+function check_logs
+{
+    master=$(get_master)
+    for node in $CLUSTER ; do
+        if [[ "$node" != "$master" ]]; then
+            check_log_node $node
+        fi
+    done
+}
+
+function run_test
+{
+    create_tables
+    setup_longreq
+    test_logic
+    check_logs
+}
+
+if [[ -z "$CLUSTER" ]]; then 
+    echo "This test requires a cluster"
+    exit -1
+fi
+
+rm ${DBNAME}.failexit
+run_test
+
+if [[ -f ${DBNAME}.failexit ]]; then
+    echo "Testcase failed"
+    exit -1
+fi
+
+echo "Success"


### PR DESCRIPTION
The DBAs requested more insight into how long replication events are spending their time.  The 'longreq_stat' test  does a basic sanity-check.