### PR TITLE
add support for table alias in dohsql

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -266,10 +266,14 @@ char *sqlite_struct_to_string(Vdbe *v, Select *p, Expr *extraRows,
         /* is it a subquery? */
         if (p->pSrc->a[i].zName) {
             if (p->pSrc->a[i].zDatabase)
-                tbl = sqlite3_mprintf("%s\"%w\".\"%w\"", tmp,
-                        p->pSrc->a[i].zDatabase, p->pSrc->a[i].zName);
+                tbl = sqlite3_mprintf("%s\"%w\".\"%w\"%s%s", tmp,
+                        p->pSrc->a[i].zDatabase, p->pSrc->a[i].zName,
+                        p->pSrc->a[i].zAlias ? " " : "",
+                        p->pSrc->a[i].zAlias ? p->pSrc->a[i].zAlias : "");
             else
-                tbl = sqlite3_mprintf("%s\"%w\"", tmp, p->pSrc->a[i].zName);
+                tbl = sqlite3_mprintf("%s\"%w\"%s%s", tmp, p->pSrc->a[i].zName,
+                        p->pSrc->a[i].zAlias ? " " : "",
+                        p->pSrc->a[i].zAlias ? p->pSrc->a[i].zAlias : "");
         } else {
             /* subquery */
             dohsql_node_t *subnode = gen_select(v, p->pSrc->a[i].pSelect);
@@ -280,7 +284,9 @@ char *sqlite_struct_to_string(Vdbe *v, Select *p, Expr *extraRows,
                 sqlite3_free(where);
                 return NULL;
             }
-            tbl = sqlite3_mprintf("%s(%s)", tmp, subnode->sql);
+            tbl = sqlite3_mprintf("%s(%s)%s%s", tmp, subnode->sql,
+                    p->pSrc->a[i].zAlias ? " " : "",
+                    p->pSrc->a[i].zAlias ? p->pSrc->a[i].zAlias : "");
             node_free(&subnode, v->db);
         }
         sqlite3_free(tmp);

--- a/tests/union_parallel.test/10_1_join.req
+++ b/tests/union_parallel.test/10_1_join.req
@@ -32,6 +32,7 @@ select t.a, t.b, t2.c from t left outer join t2 on t.a = t2.c union all select t
 #explain distribution select count(*) from t, t2 where t.a > 0 union all select count(t3.e) from t3, t4  where t3.e == t4.h
 select count(*) from t, t2 where t.a > 0 union all select count(t3.e) from t3, t4  where t3.e == t4.h
 select 1 from t left join (select a from t) union all  select 1 from t left join (select a from t) limit 2
+select t.a from t left join (select a from t) tt where tt.a = t.a union all  select 1 from t left join (select a from t) limit 2
 delete from t
 delete from t2
 delete from t3

--- a/tests/union_parallel.test/10_1_join.req.exp
+++ b/tests/union_parallel.test/10_1_join.req.exp
@@ -68,6 +68,8 @@
 (count(*)=3)
 (1=1)
 (1=1)
+(a=1)
+(a=1)
 (rows deleted=6)
 (rows deleted=6)
 (rows deleted=6)


### PR DESCRIPTION
Per title; example:
Before:
 c "select t.a from t left join (select a from t) tt where tt.a = t.a union all  select 1 from t left join (select a from t) limit 2"
[select t.a from t left join (select a from t) tt where tt.a = t.a union all  select 1 from t left join (select a from t) limit 2] failed with rc -3 no such column: tt.a
Now:
 c "select t.a from t left join (select a from t) tt where tt.a = t.a union all  select 1 from t left join (select a from t) limit 2"
(a=1)
(a=1)
