### PR TITLE
Auth: Remove OP permissions on user/table drop (backported from main)

### DIFF
--- a/bdb/bdb_access.c
+++ b/bdb/bdb_access.c
@@ -276,6 +276,15 @@ static int bdb_del_user_tbl_access(bdb_state_type *bdb_state, tran_type *tran,
     int rc = 0;
     int bdberr;
 
+    if ((rc = bdb_tbl_op_access_delete(bdb_state, tran, 0, table_name,
+                                       user, &bdberr)) != 0) {
+        logmsg(LOGMSG_ERROR,
+               "error deleting user access information (user: %s, table: %s, "
+               "rc: %d, bdberr: %d)\n",
+               user, table_name, rc, bdberr);
+        return rc;
+    }
+
     if ((rc = bdb_tbl_access_read_delete(bdb_state, tran, table_name, user,
                                          &bdberr)) != 0) {
         logmsg(LOGMSG_ERROR,

--- a/tests/auth.test/lrl.options
+++ b/tests/auth.test/lrl.options
@@ -1,4 +1,2 @@
 table   dummy   dummy.csc2
-
-allow_user_schema
 create_dba_user off

--- a/tests/auth.test/queueodh.testopts
+++ b/tests/auth.test/queueodh.testopts
@@ -1,0 +1,4 @@
+init_with_queue_ondisk_header off
+init_with_queue_compr off
+init_with_queue_persistent_sequence off
+debug_queuedb on

--- a/tests/auth.test/t14.expected
+++ b/tests/auth.test/t14.expected
@@ -1,5 +1,5 @@
 [create table t1(i int)] failed with rc -106 access denied
-[create table t2(i int, i int)] failed with rc -106 access denied
+[create table t2(i int, j int)] failed with rc -106 access denied
 [create table t3{schema { int i }}] failed with rc -106 access denied
 [select * from comdb2_tables] failed with rc -106 access denied
 (username='lua', isOP='N')
@@ -10,16 +10,14 @@
 (username='user1', isOP='Y')
 (username='user2', isOP='N')
 (username='user3', isOP='N')
-[create table t2(i int, i int)] failed with rc -3 Duplicate column name 'i'.
-(tablename='t1@user2')
-(tablename='t3@user2')
-[drop table t2] failed with rc -3 no such table: t2@user2
-[create table t2(i int, i int)] failed with rc -3 Duplicate column name 'i'.
+[create table t1(i int)] failed with rc -3 User does not have OP credentials
+[create table t2(i int, j int)] failed with rc -3 User does not have OP credentials
+[create table t3{schema { int i }}] failed with rc -3 User does not have OP credentials
 (tablename='dummy')
 (tablename='sqlite_stat1')
 (tablename='sqlite_stat4')
-(tablename='foraudit@user1')
-(tablename='audit@user1')
-(tablename='t1@user1')
-(tablename='t3@user1')
-[drop table t2] failed with rc -3 no such table: t2@user1
+(tablename='foraudit')
+(tablename='audit')
+(tablename='t1')
+(tablename='t2')
+(tablename='t3')

--- a/tests/auth.test/t14.req
+++ b/tests/auth.test/t14.req
@@ -1,6 +1,6 @@
 # unauthenticated user
 create table t1(i int)$$
-create table t2(i int, i int)$$
+create table t2(i int, j int)$$
 create table t3{schema { int i }}$$
 select * from comdb2_tables;
 
@@ -9,18 +9,15 @@ set user 'user2'
 set password 'new_password'
 select * from comdb2_users;
 create table t1(i int)$$
-create table t2(i int, i int)$$
+create table t2(i int, j int)$$
 create table t3{schema { int i }}$$
 select * from comdb2_tables;
-drop table t1;
-drop table t2;
-drop table t3;
 
 # OP user
 set user 'user1'
 set password 'password1'
 create table t1(i int)$$
-create table t2(i int, i int)$$
+create table t2(i int, j int)$$
 create table t3{schema { int i }}$$
 select * from comdb2_tables;
 drop table t1;

--- a/tests/auth.test/t15.expected
+++ b/tests/auth.test/t15.expected
@@ -3,6 +3,6 @@
 (i=1)
 (count(*)=1)
 (user='---------- non-OP user ----------')
-[select * from 't1@user1'] failed with rc -106 Read access denied to t1@user1 for user user2 bdberr=15
-[select count(*) from 't1@user1'] failed with rc -106 Read access denied to t1@user1 for user user2 bdberr=15
+[select * from 't1'] failed with rc -106 Read access denied to t1 for user user2 bdberr=15
+[select count(*) from 't1'] failed with rc -106 Read access denied to t1 for user user2 bdberr=15
 (user='---------- OP user ----------')

--- a/tests/auth.test/t15.req
+++ b/tests/auth.test/t15.req
@@ -12,8 +12,8 @@ set user 'user2'
 set password 'new_password'
 select '---------- non-OP user ----------' as user;
 # Both the following requests must be denied
-select * from 't1@user1';
-select count(*) from 't1@user1';
+select * from 't1';
+select count(*) from 't1';
 
 # Cleanup (OP user)
 set user 'user1'

--- a/tests/auth.test/t17.expected
+++ b/tests/auth.test/t17.expected
@@ -1,0 +1,7 @@
+(user='---------- OP user ----------')
+(rows inserted=1)
+(user='---------- anonymous user ----------')
+(i=1=1)
+[insert into t1 values(2)] failed with rc -106 Write access denied to t1 for user  bdberr=15
+[drop table t1] failed with rc -3 User does not have OP credentials
+(user='---------- OP user ----------')

--- a/tests/auth.test/t17.req
+++ b/tests/auth.test/t17.req
@@ -1,0 +1,25 @@
+# OP user
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+# create an anonymous user
+put password '' for ''
+
+# create a table and grant read to the anonymous user
+create table t1(i int)$$
+insert into t1 values(1);
+grant read on t1 to ''
+
+set user ''
+set password ''
+select '---------- anonymous user ----------' as user;
+select i=1 from t1;
+# the following commands must fail
+insert into t1 values(2);
+drop table t1;
+
+# Cleanup
+set user 'user1'
+set password 'password1'
+select '---------- OP user ----------' as user;
+drop table t1;

--- a/tests/auth.test/t18.expected
+++ b/tests/auth.test/t18.expected
@@ -1,0 +1,7 @@
+(user='---------- user1: OP user ----------')
+(rows inserted=1)
+(user='---------- user2: non-OP user ----------')
+(i=1)
+(user='---------- user1: OP user ----------')
+(user='---------- user2: non-OP user ----------')
+[select * from t1] failed with rc -106 Read access denied to t1 for user user2 bdberr=15

--- a/tests/auth.test/t18.req
+++ b/tests/auth.test/t18.req
@@ -1,0 +1,35 @@
+# This test is to ensure that the user's OP privilege must also be dropped
+# along with user.
+
+# OP user: create a table and grant read to 'user2'
+set user 'user1'
+set password 'password1'
+select '---------- user1: OP user ----------' as user;
+create table t1(i int unique)$$
+insert into t1 values(1);
+# grant OP to 'user2'
+grant OP to 'user2';
+
+# 'user2' now should be able to read from t1
+set user 'user2'
+set password 'new_password'
+select '---------- user2: non-OP user ----------' as user;
+select * from t1;
+
+# Recreate 'user2'
+set user 'user1'
+set password 'password1'
+select '---------- user1: OP user ----------' as user;
+put password off for 'user2'
+put password 'new_password' for 'user2'
+
+# 'user2' now must not have read permission on t1
+set user 'user2'
+set password 'new_password'
+select '---------- user2: non-OP user ----------' as user;
+select * from t1;
+
+# Cleanup
+set user 'user1'
+set password 'password1'
+drop table t1;

--- a/tests/auth.test/twofiles.testopts
+++ b/tests/auth.test/twofiles.testopts
@@ -1,0 +1,2 @@
+queuedb_file_threshold 1
+queuedb_file_interval 5000


### PR DESCRIPTION
Also backported all tests from auth.test.

(https://github.com/bloomberg/comdb2/pull/3060)