### PR TITLE
{172464778}: Fixing LUA GC race with clean exit

### DIFF
--- a/db/thrman.c
+++ b/db/thrman.c
@@ -473,7 +473,8 @@ static int thrman_check_threads_stopped_ll(void *context)
             thr_type_counts[THRTYPE_SQLENGINEPOOL] +
             thr_type_counts[THRTYPE_VERIFY] + thr_type_counts[THRTYPE_ANALYZE] +
             thr_type_counts[THRTYPE_PURGEBLKSEQ] +
-            thr_type_counts[THRTYPE_PGLOGS_ASOF])
+            thr_type_counts[THRTYPE_PGLOGS_ASOF] +
+            thr_type_counts[THRTYPE_TRIGGER])
         all_gone = 1;
 
     /* if we're exiting then we don't want a schema change thread running */


### PR DESCRIPTION
This patch adds a `db_is_exiting()` check to prevent the following race:

```
Thread 2:
#0  std::ios_base::Init::~Init()
#1  __run_exit_handlers
#2  exit
#3  __libc_start_main
#4  _start

Thread 1:
#0  recover_deadlock_flags_int
#1  recover_deadlock_flags
#2  clnt_check_bdb_lock_desired
#3  sql_tick
#4  comdb2_sql_tick
#5  luabb_trigger_unregister
#6  dbconsumer_free
#7  luaD_precall
#8  luaD_call
#9  GCTM
#10 singlestep
#11 luaC_fullgc
#12 lua_gc
#13 reset_sp
#14 close_sp_int
#15 close_sp_int
#16 close_sp
#17 exec_trigger
#18 trigger_start_int
#19 start_thread
#20 clone
```