### PR TITLE
Build HASQL retry list only when HASQL is on

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3122,7 +3122,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl,
         goto after_callback;
     }
 
-    if (trans_append) {
+    if (trans_append && hndl->snapshot_file > 0) {
         /* Retry number of transaction is different from that of query.*/
         cdb2_query_list *item = malloc(sizeof(cdb2_query_list));
         item->buf = buf;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -745,7 +745,7 @@ public class Comdb2Handle extends AbstractConnection {
             byte[] payload = protocol.write(io.getOut());
             io.flush();
 
-            if (inTxn && doAppend) {
+            if (inTxn && doAppend && snapshotFile > 0) {
                 queryList.add(new QueryItem(payload, sql, isRead));
             }
             tdlog(Level.FINEST, "sendQuery returns a good rcode");


### PR DESCRIPTION
Simple fix to address out-of-memory errors with large transactions.