### PR TITLE
RFC: PRAGMA CHUNK

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -747,6 +747,7 @@ struct sqlclntstate {
     struct query_effects effects;
     struct query_effects log_effects;
     struct query_effects chunk_effects;
+    int chunk_pragma; /* is it a chunk pragma? */
     int64_t nsteps;
 
     struct user current_user;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -13194,4 +13194,3 @@ int comdb2_is_field_indexable(const char *table_name, int fld_idx) {
     }
     return 1;
 }
-

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1243,6 +1243,7 @@ static int newsql_upd_snapshot(struct sqlclntstate *clnt)
        send_intrans_response by setting INTRANSRESULTS to ON. */
     if (appdata->send_intrans_response != -1 && sqlquery->n_features > 0 &&
         gbl_disable_skip_rows == 0) {
+        appdata->send_intrans_response = 1;
         for (int ii = 0; ii < sqlquery->n_features; ii++) {
             if (CDB2_CLIENT_FEATURES__SKIP_INTRANS_RESULTS !=
                 sqlquery->features[ii])

--- a/sqlite/src/pragma.c
+++ b/sqlite/src/pragma.c
@@ -30,6 +30,12 @@
 ** ../tool/mkpragmatab.tcl. */
 #include "pragma.h"
 
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+int handle_sql_pragma_chunk_on(Parse *pParse);
+int handle_sql_pragma_chunk_off(Parse *pParse);
+int handle_sql_pragma_chunk_cancel(Parse *pParse);
+#endif
+
 /*
 ** Interpret the given string as a safety level.  Return 0 for OFF,
 ** 1 for ON or NORMAL, 2 for FULL, and 3 for EXTRA.  Return 1 for an empty or 
@@ -2167,6 +2173,26 @@ void sqlite3Pragma(
       sqlite3_activate_cerod(&zRight[6]);
     }
 #endif
+  }
+  break;
+#endif
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  case PragTyp_CHUNK: {
+    if( zRight ){
+      if( sqlite3StrNICmp(zRight, "on", 2)==0 ){ /* begin chunking */
+        handle_sql_pragma_chunk_on(pParse);
+        break;
+      }
+      if( sqlite3StrNICmp(zRight, "off", 3)==0 ){ /* end chunking */
+        handle_sql_pragma_chunk_off(pParse);
+        break;
+      }
+      if( sqlite3StrNICmp(zRight, "cancel", 3)==0 ){ /* cancel current chunk */
+        handle_sql_pragma_chunk_cancel(pParse);
+        break;
+      }
+    }
+    sqlite3ErrorMsg(pParse, "expects on/off/cancel");
   }
   break;
 #endif

--- a/sqlite/src/pragma.h
+++ b/sqlite/src/pragma.h
@@ -50,6 +50,9 @@
 #define PragTyp_KEY                           42
 #define PragTyp_LOCK_STATUS                   43
 #define PragTyp_STATS                         44
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+#define PragTyp_CHUNK                         45
+#endif
 
 /* Property flags associated with various pragma. */
 #define PragFlg_NeedSchema 0x01 /* Force schema load before running */
@@ -194,6 +197,13 @@ static const PragmaName aPragmaName[] = {
   /* ePragFlg:  */ PragFlg_Result0|PragFlg_NoColumns1,
   /* ColNames:  */ 0, 0,
   /* iArg:      */ SQLITE_CkptFullFSync },
+#endif
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+ {/* zName:     */ "chunk",
+  /* ePragTyp:  */ PragTyp_CHUNK,
+  /* ePragFlg:  */ PragFlg_NoColumns,
+  /* ColNames:  */ 0, 0,
+  /* iArg:      */ 0 },
 #endif
 #if !defined(SQLITE_OMIT_SCHEMA_PRAGMAS)
  {/* zName:     */ "collation_list",

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -41,12 +41,12 @@ EOF
 
 echo "Inserting chunks of 99 rows"
 echo "Inserting chunks of 99 rows" >> $outlog
-$r >> $outlog << "EOF" 
+$r 2>> $outlog << "EOF"
 set transaction blocksql
 set transaction chunk 99 
-begin 
+pragma chunk = on
 insert into t select * from t2
-commit
+pragma chunk = off
 EOF
 
 check_done
@@ -65,12 +65,12 @@ check_done
 
 echo "Inserting chunks of 1 row"
 echo "Inserting chunks of 1 row" >> $outlog
-$r >> $outlog << "EOF" 
+$r 2>> $outlog << "EOF" 
 set transaction blocksql
 set transaction chunk 1 
-begin
+pragma chunk = on
 insert into t select * from t2
-commit
+pragma chunk = off
 EOF
 
 check_done
@@ -89,17 +89,17 @@ check_done
 
 echo "Multiple inserts in a transaction chunks of 1"
 echo "Multiple inserts in a transaction chunks of 1" >> $outlog
-$r >> $outlog << "EOF"
+$r 2>> $outlog << "EOF"
 set transaction blocksql
 set transaction chunk 1
-begin
+pragma chunk = on
 insert into t values (1)
 insert into t values (2)
 insert into t values (3)
 insert into t values (4)
 insert into t values (5)
 insert into t values (6)
-commit
+pragma chunk = off
 EOF
 
 check_done


### PR DESCRIPTION
A chunk "transaction" requires to be wrapped in a transaction explicitly using BEGIN and COMMIT, though it's not atomic. This usage has caused a lot of confusion. This patch proposes a new syntax for chunk transactions, using SQLite's PRAGMA:

```
SET TRANSACTION CHUNK N
PRAGMA CHUNK=ON -- begin a chunk tran
INSERT INTO T VALUES(...)
PRAGMA CHUNK=OFF -- finish a chunk tran
```

The CHUNK pragma and `BEGIN..COMMIT` behave mostly identically, except that the CHUNK pragma disables the skip-row optimization. To make these two work together, it would require the client to recognize the pragma and treat it as a BEGIN, and that means client-side parsing and a new client feature to be backwards compatible. Since chunk is mostly used in scheduled jobs that run only periodically where performance isn't the greatest concern, I think I'm okay with this tradeoff.