### PR TITLE
Fix a bug in dryrun 

### DIFF
--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -594,12 +594,6 @@ int do_dryrun(struct schema_change_type *s)
             goto done;
         }
     }
-    
-    if (db == NULL) {
-        sbuf2printf(s->sb, ">Table %s will be added.\n", s->tablename);
-        goto done;
-    }
-
 
     struct errstat err = {0};
     newdb = create_new_dbtable(thedb, s->tablename, s->newcsc2, 0, 0, 1, 0, 0,
@@ -610,6 +604,10 @@ int do_dryrun(struct schema_change_type *s)
         goto done;
     }
 
+    if (db == NULL && newdb) {
+        sbuf2printf(s->sb, ">Table %s will be added.\n", s->tablename);
+        goto done;
+    }
     set_schemachange_options(s, db, &scinfo);
     set_sc_flgs(s);
 

--- a/tests/ddl_dryrun.test/Makefile
+++ b/tests/ddl_dryrun.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=1m
+endif

--- a/tests/ddl_dryrun.test/t05.expected
+++ b/tests/ddl_dryrun.test/t05.expected
@@ -1,0 +1,1 @@
+[dryrun create table t3 { schema { int a } keys { "foo" = foo } }] failed with rc 240 Error at line   0: SYMBOL NOT FOUND: foo.

--- a/tests/ddl_dryrun.test/t05.req
+++ b/tests/ddl_dryrun.test/t05.req
@@ -1,0 +1,1 @@
+dryrun create table t3 { schema { int a } keys { "foo" = foo } }


### PR DESCRIPTION
Without patch : 

$ cdb2sql pmuxdb dev 'dryrun create table syntax_check {
schema {
  int a
}

keys {
  "foo" = foo
}
}
'
(Message='Table syntax_check will be added.')

With patch : 

$ cdb2sql pmuxdb dev 'dryrun create table syntax_check {
schema {
  int a
}

keys {
  "foo" = foo
}
}
'
=> failed with rc 240 Error at line   6: SYMBOL NOT FOUND: foo
