### PR TITLE
Physrep: Fix an error connecting to replication metadb

### DIFF
--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -357,7 +357,7 @@ static int get_metadb_hndl(cdb2_hndl_tp **hndl) {
         return 1;
     }
 
-    int rc = cdb2_open(hndl, dbname, host, CDB2_DIRECT_CPU);
+    int rc = cdb2_open(hndl, dbname, host, 0);
     if (rc != 0) {
         physrep_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (rc: %d)\n",
                        __func__, __LINE__, dbname, host, rc);


### PR DESCRIPTION
In order to locate replication metadb, its lrl option takes either hostname(s) or a valid `tier/zone`. The attempt to connect using zone was, however, broken as the cdb2_open() call erroneously used `CDB2_DIRECT_CPU` flag. This flag is specifically meant for connecting to specific hosts.