### PR TITLE
More SSL metrics

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -374,6 +374,7 @@ uint32_t gbl_nsql;
 long long gbl_nsql_steps;
 
 uint32_t gbl_nnewsql;
+uint32_t gbl_nnewsql_ssl;
 long long gbl_nnewsql_steps;
 
 uint32_t gbl_masterrejects = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -508,6 +508,7 @@ struct summary_nodestats {
     char *task;
     char *stack;
     int ref;
+    int is_ssl;
 
     unsigned finds;
     unsigned rngexts;
@@ -1707,6 +1708,7 @@ extern uint32_t gbl_nsql;
 extern long long gbl_nsql_steps;
 
 extern unsigned int gbl_nnewsql;
+extern unsigned int gbl_nnewsql_ssl;
 extern long long gbl_nnewsql_steps;
 
 extern unsigned int gbl_masterrejects;
@@ -2901,7 +2903,7 @@ void nodestats_report(FILE *fh, const char *prefix, int disp_rates);
 void nodestats_node_report(FILE *fh, const char *prefix, int disp_rates,
                            char *host);
 struct rawnodestats *get_raw_node_stats(const char *task, const char *stack,
-                                        char *host, int fd);
+                                        char *host, int fd, int is_ssl);
 int release_node_stats(const char *task, const char *stack, char *host);
 struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
                                                 int disp_rates);

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -53,6 +53,7 @@ struct comdb2_metrics_store {
     int64_t retries;
     int64_t sql_cost;
     int64_t sql_count;
+    int64_t sql_ssl_count;
     int64_t start_time;
     int64_t threads;
     int64_t current_connections;
@@ -174,6 +175,8 @@ comdb2_metric gbl_metrics[] = {
      STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.sql_cost, NULL},
     {"sql_count", "Number of sql queries executed", STATISTIC_INTEGER,
      STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.sql_count, NULL},
+    {"sql_ssl_count", "Number of sql queries executed, via SSL", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.sql_ssl_count, NULL},
     {"start_time", "Server start time", STATISTIC_INTEGER,
      STATISTIC_COLLECTION_TYPE_LATEST, &stats.start_time, NULL},
     {"threads", "Number of threads", STATISTIC_INTEGER,
@@ -419,6 +422,7 @@ int refresh_metrics(void)
     stats.retries = n_retries;
     stats.sql_cost = gbl_nsql_steps + gbl_nnewsql_steps;
     stats.sql_count = gbl_nsql + gbl_nnewsql;
+    stats.sql_ssl_count = gbl_nnewsql_ssl;
     stats.current_connections = net_get_num_current_non_appsock_accepts(thedb->handle_sibling) + active_appsock_conns;
 
     rc = bdb_get_lock_counters(thedb->bdb_env, &stats.deadlocks,

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1836,6 +1836,7 @@ clipper_usage:
             logmsg(LOGMSG_USER, "readonly                %c\n", gbl_readonly ? 'Y' : 'N');
             logmsg(LOGMSG_USER, "num sql queries         %u\n", gbl_nsql);
             logmsg(LOGMSG_USER, "num new sql queries     %u\n", gbl_nnewsql);
+            logmsg(LOGMSG_USER, "num ssl sql queries     %u\n", gbl_nnewsql_ssl);
             logmsg(LOGMSG_USER, "num master rejects      %u\n",
                    gbl_masterrejects);
             logmsg(LOGMSG_USER, "sql ticks               %llu\n", gbl_sqltick);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2500,7 +2500,7 @@ static int release_clientstats(unsigned checksum, int node)
 }
 
 struct rawnodestats *get_raw_node_stats(const char *task, const char *stack,
-                                        char *host, int fd)
+                                        char *host, int fd, int is_ssl)
 {
     struct nodestats *nodestats = NULL;
     unsigned checksum;
@@ -2535,6 +2535,11 @@ struct rawnodestats *get_raw_node_stats(const char *task, const char *stack,
                 __func__, task, stack, node);
         }
     }
+
+    /* The same task name from the same node may switch from plaintext to SSL
+     * on a config change; it may also fall back from SSL to plaintext, on an SSL
+     * error. Always get its latest SSL status from clnt. */
+    nodestats->is_ssl = is_ssl;
 
     if (tmp && namelen >= 1024)
         free(tmp);
@@ -2742,6 +2747,7 @@ struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
                                   ? strdup(nodestats->stack)
                                   : NULL;
         summaries[ii].ref = nodestats->ref;
+        summaries[ii].is_ssl = nodestats->is_ssl;
 
         summaries[ii].sql_queries = snap.sql_queries;
         summaries[ii].sql_steps = snap.sql_steps;

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -215,6 +215,7 @@ struct nodestats {
     struct in_addr addr;
     char *task;
     char *stack;
+    int is_ssl;
 
     int ref;
     pthread_mutex_t mtx;

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -378,7 +378,7 @@ int handle_ireq(struct ireq *iq)
                        req2a(iq->opcode));
 
     iq->rawnodestats =
-        get_raw_node_stats(NULL, NULL, iq->frommach, sbuf2fileno(iq->sb));
+        get_raw_node_stats(NULL, NULL, iq->frommach, sbuf2fileno(iq->sb), 0 /* tag does not support ssl */);
     if (iq->rawnodestats && iq->opcode >= 0 && iq->opcode < MAXTYPCNT)
         iq->rawnodestats->opcode_counts[iq->opcode]++;
     if (gbl_print_deadlock_cycles && IQ_HAS_SNAPINFO(iq))

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2074,7 +2074,7 @@ int newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
     if (clnt->rawnodestats == NULL) {
         clnt->rawnodestats =
             get_raw_node_stats(clnt->argv0, clnt->stack, clnt->origin,
-                               clnt->plugin.get_fileno(clnt));
+                               clnt->plugin.get_fileno(clnt), clnt->plugin.has_ssl(clnt));
     }
     if (process_set_commands(clnt, sql_query)) {
         return -1;
@@ -2101,6 +2101,9 @@ int newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
         return -1;
     }
     ATOMIC_ADD32(gbl_nnewsql, 1);
+    if (clnt->plugin.has_ssl(clnt))
+        ATOMIC_ADD32(gbl_nnewsql_ssl, 1);
+
     return 0;
 }
 

--- a/sqlite/ext/comdb2/clientstats.c
+++ b/sqlite/ext/comdb2/clientstats.c
@@ -55,7 +55,8 @@ enum {
     COLUMN_SQL_QUERIES,
     COLUMN_SQL_STEPS,
     COLUMN_SQL_ROWS,
-    COLUMN_SVC_TIME
+    COLUMN_SVC_TIME,
+    COLUMN_IS_SSL
 };
 
 static int systblClientStatsConnect(sqlite3 *db, void *pAux, int argc,
@@ -71,7 +72,7 @@ static int systblClientStatsConnect(sqlite3 *db, void *pAux, int argc,
             "\"upds\" INTEGER, \"dels\" INTEGER, \"bsql\" INTEGER, \"recom\" "
             "INTEGER, \"snapisol\" INTEGER, \"serial\" INTEGER, "
             "\"sql_queries\" INTEGER, \"sql_steps\" INTEGER, \"sql_rows\" "
-            "INTEGER, \"svc_time\" DOUBLE)");
+            "INTEGER, \"svc_time\" DOUBLE, \"is_ssl\" INTEGER)");
 
     if (rc == SQLITE_OK) {
         if ((*ppVtab = sqlite3_malloc(sizeof(sqlite3_vtab))) == 0) {
@@ -216,6 +217,9 @@ static int systblClientStatsColumn(sqlite3_vtab_cursor *cur,
         break;
     case COLUMN_SVC_TIME:
         sqlite3_result_double(ctx, summaries[ii].svc_time);
+        break;
+    case COLUMN_IS_SSL:
+        sqlite3_result_int(ctx, summaries[ii].is_ssl);
         break;
     default: assert(0);
     };


### PR DESCRIPTION
Twe new metrics are added in this patch:

1. A "sql_ssl_count" row is added to the comdb2_metrics system table, which keeps track of the number of SQL statements over SSL;

2. An "is_ssl" column is added to the comdb2_clientstats table, which is a boolean flag for whether a client uses SSL