### PR TITLE
{172584364}: Honoring gbl_ssl_allow_remsql

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -4968,7 +4968,7 @@ static int _get_protocol_flags(struct sqlclntstate *clnt, fdb_t *fdb,
         }
     } else {
         *flags = FDB_MSG_CURSOR_OPEN_SQL_SSL;
-        if (clnt->plugin.has_ssl(clnt) || fdb->ssl >= SSL_REQUIRE) {
+        if ((clnt->plugin.has_ssl(clnt) || fdb->ssl >= SSL_REQUIRE) && gbl_ssl_allow_remsql) {
             *flags |= FDB_MSG_CURSOR_OPEN_FLG_SSL;
         }
     }

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8017,6 +8017,7 @@ sqlite3BtreeCursor_remote(Btree *pBt,      /* The btree */
                           BtCursor *cur,   /* Write new cursor here */
                           struct sql_thread *thd)
 {
+    extern int gbl_ssl_allow_remsql;
     struct sqlclntstate *clnt = thd->clnt;
     fdb_tran_t *trans;
     fdb_t *fdb;
@@ -8067,7 +8068,7 @@ sqlite3BtreeCursor_remote(Btree *pBt,      /* The btree */
     if (trans)
         Pthread_mutex_lock(&clnt->dtran_mtx);
 
-    int usessl = clnt->plugin.has_ssl(clnt);
+    int usessl = clnt->plugin.has_ssl(clnt) && gbl_ssl_allow_remsql;
     cur->fdbc =
         fdb_cursor_open(clnt, cur, cur->rootpage, trans, &cur->ixnum, usessl);
     if (!cur->fdbc) {


### PR DESCRIPTION
This gives us an option to disable remote-sql over SSL.