### PR TITLE
limit maximum number of parallel schema changes for partitioned tables

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1609,6 +1609,7 @@ extern int gbl_sqlreadaheadthresh;
 extern int gbl_iothreads;
 extern int gbl_ioqueue;
 extern int gbl_prefaulthelperthreads;
+extern int gbl_max_parallel_partition_sc_threads;
 
 extern int gbl_osqlpfault_threads;
 extern osqlpf_step *gbl_osqlpf_step;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2432,4 +2432,7 @@ REGISTER_TUNABLE("unexpected_last_type_warn",
 REGISTER_TUNABLE("unexpected_last_type_abort",
                  "Panic if the last response server sent before sockpool reset isn't LAST_ROW",
                  TUNABLE_INTEGER, &gbl_unexpected_last_type_abort, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("max_parallel_partition_sc_threads",
+                 "If partition has more than this amount of shards, run each schema change alter serial",
+                 TUNABLE_INTEGER, &gbl_max_parallel_partition_sc_threads, 0, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -489,6 +489,7 @@
 (name='max_latch_lockerid', description='Size of latch lockerid array', type='INTEGER', value='10000', read_only='N')
 (name='max_lua_instructions', description='Maximum lua opcodes to execute before we assume the stored procedure is looping and kill it. (Default: 10000)', type='INTEGER', value='10000', read_only='Y')
 (name='max_num_compact_pages_per_txn', description='', type='INTEGER', value='-1', read_only='N')
+(name='max_parallel_partition_sc_threads', description='If partition has more than this amount of shards, run each schema change alter serial', type='INTEGER', value='10', read_only='N')
 (name='max_password_cache_size', description='Password cache size, set to <=0 to turn off caching (Default: 100)', type='INTEGER', value='100', read_only='N')
 (name='max_plan_query_plans', description='Maximum number of plans to be placed into the query plan hash for each fingerprint (Default: 20)', type='INTEGER', value='20', read_only='N')
 (name='max_query_fingerprints', description='Maximum number of queries to be placed into the fingerprint hash (Default: 1000)', type='INTEGER', value='1000', read_only='N')


### PR DESCRIPTION
Found in the wild, 365 shards partition blowing up memory limits on alter.   This patch adds a configurable limit for the maximum number of shards that can be run in parallel (default 10).  Wider partitions run each alter in parallel.
