### PR TITLE
{172590922}: dumping tables on exit

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1660,6 +1660,8 @@ void clean_exit(void)
 
     stop_threads(thedb);
     flush_db();
+    if (gbl_backend_opened)
+        llmeta_dump_mapping(thedb);
 
 #   if 0
     /* TODO: (NC) Instead of sleep(), maintain a counter of threads and wait for


### PR DESCRIPTION
Quick fix: have database dump tables on exit, so that `copycomdb2 -m` won't miss any newly created tables since startup.