### PR TITLE
rename unique_tag_key to thd_info_key to properly identify use

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -984,7 +984,7 @@ struct dbenv {
 extern struct dbenv *thedb;
 extern comdb2_tunables *gbl_tunables;
 
-extern pthread_key_t unique_tag_key;
+extern pthread_key_t thd_info_key;
 extern pthread_key_t query_info_key;
 
 struct req_hdr {

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -125,7 +125,7 @@ static int insert_add_index(struct ireq *iq, unsigned long long genid)
     if (iq->idxInsert == NULL)
         return 0;
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "%s: no thdinfo\n", __func__);
         return -1;
@@ -179,7 +179,7 @@ static int cache_delayed_indexes(struct ireq *iq, unsigned long long genid)
         iq->idxInsert = iq->idxDelete = NULL;
     }
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "%s: no thdinfo\n", __func__);
         return -1;
@@ -287,7 +287,7 @@ int insert_add_op(struct ireq *iq, int optype, int rrn, int ixnum,
     int err = 0;
     int rc = 0;
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "insert_add_op: no thdinfo\n");
         rc = -1;
@@ -356,7 +356,7 @@ static int insert_del_op(block_state_t *blkstate, struct dbtable *srcdb,
     cte cte_record;
     int err = 0;
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL)
         return -1;
 
@@ -647,7 +647,7 @@ int verify_del_constraints(struct ireq *iq, void *trans, int *errout)
     int keylen;
     char key[MAXKEYLEN + 1];
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         if (iq->debug)
             reqprintf(iq, "VERKYCNSTRT CANNOT GET DEL LIST CURSOR");
@@ -1165,7 +1165,7 @@ int delayed_key_adds(struct ireq *iq, void *trans, int *blkpos, int *ixout,
         return ERR_INTERNAL;
     }
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         if (iq->debug)
             reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST CURSOR");
@@ -1476,7 +1476,7 @@ int verify_add_constraints(struct ireq *iq, void *trans, int *errout)
         return ERR_INTERNAL;
     }
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         if (iq->debug)
             reqprintf(iq, "VERKYCNSTRT CANNOT GET ADD LIST CURSOR");
@@ -1882,7 +1882,7 @@ int truncate_constraint_table(void *table)
 
 int clear_constraints_tables(void)
 {
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL)
         return -1;
 
@@ -2423,7 +2423,7 @@ int update_constraint_genid(struct ireq *iq, int opcode, int blkpos, int flags,
     int err;
     int rc;
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "%s:%d no thd_info\n", __func__, __LINE__);
         return -1;
@@ -2504,7 +2504,7 @@ int delete_constraint_genid(unsigned long long genid)
     int err;
     int rc;
 
-    struct thread_info *thdinfo = pthread_getspecific(unique_tag_key);
+    struct thread_info *thdinfo = pthread_getspecific(thd_info_key);
     if (thdinfo == NULL) {
         logmsg(LOGMSG_ERROR, "%s:%d no thd_info\n", __func__, __LINE__);
         return -1;

--- a/db/prefault.c
+++ b/db/prefault.c
@@ -450,7 +450,7 @@ static void *prefault_io_thread(void *arg)
 
     Pthread_setspecific(lockmgr_key, &lock_variable);
 
-    /* thdinfo is assigned to thread specific variable unique_tag_key which
+    /* thdinfo is assigned to thread specific variable thd_info_key which
      * will automatically free it when the thread exits. */
     thdinfo = malloc(sizeof(struct thread_info));
     if (thdinfo == NULL) {
@@ -462,7 +462,7 @@ static void *prefault_io_thread(void *arg)
     thdinfo->ct_add_table = NULL;
     thdinfo->ct_del_table = NULL;
     thdinfo->ct_add_index = NULL;
-    Pthread_setspecific(unique_tag_key, thdinfo);
+    Pthread_setspecific(thd_info_key, thdinfo);
 
     while (1) {
         req = NULL;

--- a/db/prefault_helper.c
+++ b/db/prefault_helper.c
@@ -86,7 +86,7 @@ static void *prefault_helper_thread(void *arg)
 
     backend_thread_event(dbenv, COMDB2_THR_EVENT_START_RDWR);
 
-    /* thdinfo is assigned to thread specific variable unique_tag_key which
+    /* thdinfo is assigned to thread specific variable thd_info_key which
      * will automatically free it when the thread exits. */
     thdinfo = malloc(sizeof(struct thread_info));
     if (thdinfo == NULL) {
@@ -99,7 +99,7 @@ static void *prefault_helper_thread(void *arg)
     thdinfo->ct_del_table = NULL;
     thdinfo->ct_add_table = NULL;
     thdinfo->ct_del_table = NULL;
-    Pthread_setspecific(unique_tag_key, thdinfo);
+    Pthread_setspecific(thd_info_key, thdinfo);
 
     while (1) {
         Pthread_mutex_lock(&(dbenv->prefault_helper.mutex));

--- a/db/tag.c
+++ b/db/tag.c
@@ -62,8 +62,6 @@
 extern struct dbenv *thedb;
 extern pthread_mutex_t csc2_subsystem_mtx;
 
-pthread_key_t unique_tag_key;
-
 char gbl_ver_temp_table[] = ".COMDB2.TEMP.VER.";
 char gbl_ondisk_ver[] = ".ONDISK.VER.";
 char gbl_ondisk_ver_fmt[] = ".ONDISK.VER.%d";
@@ -144,7 +142,6 @@ int schema_init(void)
 {
     init_taglock();
     gbl_tag_hash = hash_init_strcaseptr(offsetof(struct dbtag, tblname));
-    Pthread_key_create(&unique_tag_key, free);
 
     logmsg(LOGMSG_INFO, "Schema module init ok\n");
     return 0;
@@ -4615,7 +4612,7 @@ static char *get_unique_tag(void)
     struct thread_info *thd;
     char *tag;
 
-    thd = pthread_getspecific(unique_tag_key);
+    thd = pthread_getspecific(thd_info_key);
     if (thd == NULL)
         return NULL;
 


### PR DESCRIPTION
trivial rename; key maybe was originally used to create unique tag names, but the purpose evolved; new name reflect that.