### PR TITLE
{172614039}: Fixing start time for old-style TPT rollouts

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -2156,6 +2156,10 @@ static int _view_get_next_rollout_epoch(enum view_partition_period period,
     int cast_val = 0;
     struct errstat err = {0};
 
+    struct tm tm_start, tm_adjusted;
+    time_t timecopy = startTime, currentepoch = 0;
+    char *first_shard_time = "SELECT MAX(%d, CAST((CAST(%d AS DATETIME) - CAST((%d - 1)*%d AS %s)) AS INT))";
+
     fmt = (back_in_time) ? fmt_backward : fmt_forward;
 
     /* time reference */
@@ -2163,8 +2167,23 @@ static int _view_get_next_rollout_epoch(enum view_partition_period period,
         /* if this is the first shard incompassing all records, starttime tells
            us where we shard this in two */
         assert(nshards == 1);
+        time(&currentepoch);
+        if (startTime >= currentepoch) /* short-circuit if it starts now or in the future */
+            return startTime;
 
-        return startTime;
+        /* If start time is in the past, advance it if needed. The 1st
+           shard should happen at the start time or the oldest shard time,
+           whichever occurs later. (eg for a TPT that rolls out monthly, retains
+           6 months of data, and is configured to start on 1970-01-01, we really
+           only need to partition from 5 months ago. */
+        localtime_r(&timecopy, &tm_start);
+        localtime_r(&currentepoch, &tm_adjusted);
+        tm_start.tm_year = tm_adjusted.tm_year;
+        tm_start.tm_mon = tm_adjusted.tm_mon;
+        tm_start.tm_mday = tm_adjusted.tm_mday;
+        mktime(&tm_start);
+        /* Take yyyy-mm-dd from today and HH:MM:SS from the start time, and form a new time */
+        currentepoch = mktime(&tm_start);
     } else if (retention == 1) {
         /* for retention 1, the startTime moves forward, since there is no other
         persistent info about rollouts */
@@ -2204,7 +2223,10 @@ static int _view_get_next_rollout_epoch(enum view_partition_period period,
         return INT_MAX;
     }
 
-    snprintf(query, sizeof(query), fmt, crtTime, cast_val, cast_str);
+    if (crtTime == INT_MIN && retention > 1)
+        snprintf(query, sizeof(query), first_shard_time, startTime, currentepoch, retention, cast_val, cast_str);
+    else
+        snprintf(query, sizeof(query), fmt, crtTime, cast_val, cast_str);
 
     /* note: this is run when a new rollout is decided.  It doesn't have
     to be fast, or highly optimized (like running directly datetime functions */

--- a/tests/simple_timepart.test/runit
+++ b/tests/simple_timepart.test/runit
@@ -211,11 +211,14 @@ cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE table tbl3 (a int)"
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl3 select value from generate_series(1,$CNT)"
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE table tbl4 (a int)"
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl4 select value from generate_series(1,$CNT)"
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE table tbl5 (a int)"
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl5 select value from generate_series(1,$CNT)"
 
 assertcnt tbl1 $CNT
 assertcnt tbl2 $CNT
 assertcnt tbl3 $CNT
 assertcnt tbl4 $CNT
+assertcnt tbl5 $CNT
 
 adayago=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-(24*3600 + 3600))'`
 cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl1 as tbl1v1 PERIOD 'DAILY' RETENTION 3 START '${adayago}'" >> $OUT
@@ -245,6 +248,12 @@ if (( $? != 0 )) ; then
    exit 1
 fi
 
+alongtimeago="1970-01-01T000000.000 UTC"
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON tbl5 as tbl5v1 PERIOD 'DAILY' RETENTION 3 START '${alongtimeago}'" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE"
+   exit 1
+fi
 
 sleep 60
 timepart_stats
@@ -253,21 +262,25 @@ cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl1v1 select value from ge
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl2v1 select value from generate_series($CNT+1,2*$CNT)"
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl3v1 select value from generate_series($CNT+1,2*$CNT)"
 cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl4v1 select value from generate_series($CNT+1,2*$CNT)"
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into tbl5v1 select value from generate_series($CNT+1,2*$CNT)"
 
 assertcnt tbl1v1 $((2*CNT))
 assertcnt tbl2v1 $((2*CNT))
 assertcnt tbl3v1 $((2*CNT))
 assertcnt tbl4v1 $((2*CNT))
+assertcnt tbl5v1 $((2*CNT))
 
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop time partition tbl1v1"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop time partition tbl2v1"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop time partition tbl3v1"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop time partition tbl4v1"
+cdb2sql ${CDB2_OPTIONS} $dbname default "drop time partition tbl5v1"
 
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop table tbl1"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop table tbl2"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop table tbl3"
 cdb2sql ${CDB2_OPTIONS} $dbname default "drop table tbl4"
+cdb2sql ${CDB2_OPTIONS} $dbname default "drop table tbl5"
 
 
 # we need to scrub dbname from alpha


### PR DESCRIPTION
Advance the start time of a time partition to avoid unnecessary fake rollouts.