### PR TITLE
Reproduce and fix election bug

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2568,7 +2568,7 @@ struct __db_env {
 	int  (*memp_trickle) __P((DB_ENV *, int, int *, int));
 
 	void *rep_handle;		/* Replication handle and methods. */
-	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, char **));
+	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, int *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
 		char **, DB_LSN *, uint32_t *, int));

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -819,6 +819,10 @@ clipper_usage:
         bdb_transfermaster(dbenv->static_table.handle);
     } else if (tokcmp(tok, ltok, "losemaster") == 0) {
         bdb_losemaster(dbenv->static_table.handle);
+    } else if (tokcmp(tok, ltok, "forceelect") == 0) {
+        call_for_election(thedb->bdb_env, __func__, __LINE__);
+    } else if (tokcmp(tok, ltok, "thedbmaster") == 0) {
+        logmsg(LOGMSG_USER, "%s\n", thedb->master);
     } else if (tokcmp(tok, ltok, "upgrade") == 0) {
         char *newmaster = 0;
         tok = segtok(line, lline, &st, &ltok);
@@ -864,8 +868,7 @@ clipper_usage:
         delete_log_files(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "pushnext") == 0) {
         push_next_log();
-    }
-    else if (tokcmp(tok, ltok, "netpoll") == 0) {
+    } else if (tokcmp(tok, ltok, "netpoll") == 0) {
         int pval;
         tok = segtok(line, lline, &st, &ltok);
         pval = toknum(tok, ltok);

--- a/tests/electbug.test/Makefile
+++ b/tests/electbug.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/electbug.test/README
+++ b/tests/electbug.test/README
@@ -1,0 +1,1 @@
+Reproduces an election bug that occurs when the master requests an election 

--- a/tests/electbug.test/lrl.options
+++ b/tests/electbug.test/lrl.options
@@ -1,0 +1,2 @@
+libevent 1
+libevent_appsock 1

--- a/tests/electbug.test/runit
+++ b/tests/electbug.test/runit
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+export debug=1
+
+[[ $debug == "1" ]] && set -x
+
+master=$(get_master)
+
+function thedbmaster
+{
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $master 'exec procedure sys.cmd.send("thedbmaster")')
+    echo "$x"
+}
+
+function forceelect
+{
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $master 'exec procedure sys.cmd.send("forceelect")')
+}
+
+if [[ -z "$CLUSTER" ]]; then 
+    echo "This test requires a cluster"
+    exit -1
+fi
+
+origtm=$(thedbmaster)
+forceelect
+sleep 30
+newtm=$(thedbmaster)
+
+if [[ "$origtm" != "$newtm" ]] ; then
+    echo "Testcase failed, thedbmaster changed from $origtm to $newtm"
+    exit 1
+fi
+
+echo "Success"


### PR DESCRIPTION
Fix issue we saw on beta recently where an extraneous call for election on the LEADER node will lead to thedb->master being set to '.invalid'.  The 'electbug' demonstrates the issue.  The fix is to relay the 'I-am-already-master' information to the caller, which then resets thedb->master explicitly.  Normal case would expect a NEWMASTER replication message, and set thedb->master in the new-master callback.