### PR TITLE
pglogs-recovery -> out-of-band

### DIFF
--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -2170,6 +2170,12 @@ static void dump_fileid_queues()
     Pthread_mutex_unlock(&del_queue_lk);
 }
 
+static int my_fileid_free(void *obj, void *arg)
+{
+    free(obj);
+    return 0;
+}
+
 static void *pglogs_asof_thread(void *arg)
 {
     bdb_state_type *bdb_state = (bdb_state_type *)arg;
@@ -2190,6 +2196,32 @@ static void *pglogs_asof_thread(void *arg)
         haslock = 1;
         dbenv->lock_recovery_lock(dbenv, __func__, __LINE__);
     }
+
+    hash_t *fileid_tbl = NULL;
+    fileid_tbl = hash_init_o(0, DB_FILE_ID_LEN);
+    bdb_list_all_fileids_for_newsi(bdb_state, fileid_tbl);
+    int rc = __recover_logfile_pglogs(bdb_state->dbenv, fileid_tbl);
+    if (rc) {
+        logmsg(LOGMSG_ERROR,
+               "%s: failed to bkfill gbl pglogs, new begin-as-of "
+               "snapshot might not work\n",
+               __func__);
+        Pthread_mutex_lock(&bdb_gbl_recoverable_lsn_mutex);
+        bdb_get_current_lsn(bdb_state, &(bdb_gbl_recoverable_lsn.file), &(bdb_gbl_recoverable_lsn.offset));
+        bdb_gbl_recoverable_timestamp = (int32_t)time(NULL);
+        Pthread_mutex_unlock(&bdb_gbl_recoverable_lsn_mutex);
+        logmsg(LOGMSG_ERROR, "set gbl_recoverable_lsn as [%d][%d]\n", bdb_gbl_recoverable_lsn.file,
+               bdb_gbl_recoverable_lsn.offset);
+    }
+    hash_for(fileid_tbl, my_fileid_free, NULL);
+    hash_clear(fileid_tbl);
+    hash_free(fileid_tbl);
+    bdb_get_current_lsn(bdb_state, &bdb_asof_current_lsn.file, &bdb_asof_current_lsn.offset);
+
+    /* Realized this is racy: commit records added right now won't be added to pglogs until this flag is set.
+     * It's not a new race, and long-pglogs-recovery is an issue the dbas are facing right now.
+     * I will address in future PR */
+    bdb_gbl_ltran_pglogs_hash_processed = 1;
 
     while (!db_is_exiting()) {
         // Remove list
@@ -2409,15 +2441,9 @@ void bdb_newsi_stat_init()
 }
 #endif
 
-static int my_fileid_free(void *obj, void *arg)
-{
-    free(obj);
-    return 0;
-}
-
 int bdb_gbl_pglogs_init(bdb_state_type *bdb_state)
 {
-    int rc, bdberr;
+    int bdberr;
     pthread_t thread_id;
 
     if (gbl_new_snapisol_asof) {
@@ -2494,29 +2520,6 @@ int bdb_gbl_pglogs_init(bdb_state_type *bdb_state)
 #       if defined(PTHREAD_STACK_MIN)
         Pthread_attr_setstacksize(&thd_attr, PTHREAD_STACK_MIN + 64 * 1024);
 #       endif
-        hash_t *fileid_tbl = NULL;
-        fileid_tbl = hash_init_o(0, DB_FILE_ID_LEN);
-        bdb_list_all_fileids_for_newsi(bdb_state, fileid_tbl);
-        rc = __recover_logfile_pglogs(bdb_state->dbenv, fileid_tbl);
-        if (rc) {
-            logmsg(LOGMSG_ERROR, "%s: failed to bkfill gbl pglogs, new begin-as-of "
-                            "snapshot might not work\n",
-                    __func__);
-            Pthread_mutex_lock(&bdb_gbl_recoverable_lsn_mutex);
-            bdb_get_current_lsn(bdb_state, &(bdb_gbl_recoverable_lsn.file),
-                                &(bdb_gbl_recoverable_lsn.offset));
-            bdb_gbl_recoverable_timestamp = (int32_t)time(NULL);
-            Pthread_mutex_unlock(&bdb_gbl_recoverable_lsn_mutex);
-            logmsg(LOGMSG_ERROR, "set gbl_recoverable_lsn as [%d][%d]\n",
-                   bdb_gbl_recoverable_lsn.file,
-                   bdb_gbl_recoverable_lsn.offset);
-        }
-        hash_for(fileid_tbl, my_fileid_free, NULL);
-        hash_clear(fileid_tbl);
-        hash_free(fileid_tbl);
-        bdb_get_current_lsn(bdb_state, &bdb_asof_current_lsn.file,
-                            &bdb_asof_current_lsn.offset);
-        bdb_gbl_ltran_pglogs_hash_processed = 1;
 
         Pthread_create(&thread_id, &thd_attr, pglogs_asof_thread, (void *)bdb_state);
     }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -82,6 +82,7 @@ extern int gbl_largepages;
 extern int gbl_loghist;
 extern int gbl_loghist_verbose;
 extern int gbl_master_retry_poll_ms;
+extern int gbl_debug_recover_pglogs_latency;
 extern int gbl_debug_blkseq_race;
 extern int gbl_master_swing_osql_verbose;
 extern int gbl_master_swing_sock_restart_sleep;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -376,6 +376,9 @@ REGISTER_TUNABLE("enable_new_snapshot_logging",
                  TUNABLE_BOOLEAN, &gbl_new_snapisol_logging, READONLY | NOARG,
                  NULL, NULL, NULL, NULL);
 */
+REGISTER_TUNABLE("debug_recover_pglogs_latency", "Add latency to recover pglogs for testing.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_recover_pglogs_latency, INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("enable_osql_blob_optimization",
                  "Replicant tracks which columns are modified in a transaction "
                  "to allow blob updates to be ommitted if possible. (Default: "

--- a/tests/out_of_band_pglogs.test/Makefile
+++ b/tests/out_of_band_pglogs.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=4m
+endif
+export CHECK_DB_AT_FINISH=0

--- a/tests/out_of_band_pglogs.test/README
+++ b/tests/out_of_band_pglogs.test/README
@@ -1,0 +1,1 @@
+"Kick-tires" for new-snapshot PIT startup

--- a/tests/out_of_band_pglogs.test/lrl.options
+++ b/tests/out_of_band_pglogs.test/lrl.options
@@ -1,0 +1,3 @@
+enable_new_snapshot
+enable_new_snapshot_asof
+debug_recover_pglogs_latency 1

--- a/tests/out_of_band_pglogs.test/runit
+++ b/tests/out_of_band_pglogs.test/runit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+export debug=1
+[[ $debug == "1" ]] && set -x
+
+rm ${DBNAME}.failexit >/dev/null 2>&1
+
+function run_test
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1(a int)" >/dev/null
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "truncate t1" >/dev/null >/dev/null
+    j=0
+
+    while [[ $j -lt 100 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, 10)"
+        let j=j+1
+    done
+
+    count=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select count(*) from t1")
+    if [[ $count -ne 1000 ]]; then
+        stopcluster
+        failexit "Should see 1000 records"
+    fi
+
+    bounce_cluster
+
+    # debug_recover_pglogs_latency will cause pglogs to take 100 seconds to recover .. 
+    # we should be available for normal sql after maybe 15 seconds
+    echo "sleeping for 30"
+    sleep 30
+
+    for node in $CLUSTER; do
+        x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "select 1" >/dev/null)
+        r=$?
+        if [[ $r -ne 0 ]]; then
+            echo "Node $node didn't recover in time"
+            stopcluster
+            failexit "Node $node didn't recover in time"
+        fi
+    done
+
+    # insert 10 more records
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, 10)"
+
+    # Verify that point-in-time fails 
+    asoftime=$(date +%s)
+    echo "set transaction snapisol" > sql.txt
+    echo "begin transaction asof datetime $asoftime" >> sql.txt
+    echo "select count(*) from t1" >> sql.txt
+    echo "rollback" 
+
+    for node in $CLUSTER; do
+        x=$($CDB2SQL_EXE --tabs -f ./sql.txt $CDB2_OPTIONS $DBNAME --host $node 2>&1)
+        r=$?
+        if [[ $r == 0 ]]; then
+            stopcluster
+            failexit "Should have failed pit txn against $node while recovering pglogs"
+        fi
+    done
+
+    # Disable 'slow-pglogs' tunable on entire cluster
+    for node in $CLUSTER; do
+        $CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $node "put tunable 'debug_recover_pglogs_latency' '0'"
+    done
+
+    # Now just running it until it succeeds or the testcase times out
+    r=1
+    while [[ $r -ne 0 ]]; do
+        x=$($CDB2SQL_EXE --tabs -f ./sql.txt $CDB2_OPTIONS $DBNAME default 2>&1)
+        r=$?
+        if [[ $r -ne 0 ]]; then 
+            sleep 1
+        fi
+    done
+
+}
+
+if [[ -z "$CLUSTER" ]]; then 
+    echo "This test requires a cluster"
+    exit -1
+fi
+
+run_test
+stopcluster
+
+if [[ -f ${DBNAME}.failexit ]]; then
+    echo "Testcase failed: $(cat ${DBNAME}.failexit)"
+    exit 1
+fi
+
+echo "Success"

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -66,6 +66,13 @@ sendtocluster()
     done
 }
 
+stopcluster()
+{
+    for n in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $n "exec procedure sys.cmd.send(\"exit\")"
+    done
+}
+
 
 do_verify()
 {


### PR DESCRIPTION
Collect new snapshot pglogs from the asof thread.  Fail new-si pit transactions if the pglogs have not been collected.