### PR TITLE
{172683652}: Wait less for a new leader

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -311,6 +311,8 @@ extern int gbl_view_feature;
 
 extern char *gbl_kafka_topic;
 extern char *gbl_kafka_brokers;
+extern int gbl_noleader_retry_duration_ms;
+extern int gbl_noleader_retry_poll_ms;
 
 /* util/ctrace.c */
 extern int nlogs;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2445,5 +2445,12 @@ REGISTER_TUNABLE("unexpected_last_type_abort",
 REGISTER_TUNABLE("pstack_self",
                  "Dump stack traces on certain slow events.",
                  TUNABLE_BOOLEAN, &gbl_pstack_self, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-
+REGISTER_TUNABLE("noleader_retry_duration_ms",
+                 "The amount of time in milliseconds that a replicant retries if there isn't a leader. (Default: 50,000)",
+                 TUNABLE_INTEGER, &gbl_noleader_retry_duration_ms, INTERNAL, NULL,
+                 NULL, NULL, NULL);
+REGISTER_TUNABLE("noleader_retry_poll_ms",
+                 "Wait this long before retrying on no-leader. (Default: 10)",
+                 TUNABLE_INTEGER, &gbl_noleader_retry_poll_ms, INTERNAL, NULL,
+                 NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
`osql_sock_restart()` calls into `osql_sock_start()` with the same rqid. However both functions have their own retry mechanism: `osql_sock_restart()` retries up to 600 times, and `osql_sock_start()` waits up to 50 seconds. In total, this would be more than 8 hours wait time.
