### PR TITLE
{172658452}: Speeding up dohast bound parameter processing

### DIFF
--- a/db/ast.h
+++ b/db/ast.h
@@ -36,6 +36,7 @@ struct Parse;
 ast_t *ast_init(struct Parse *pParse, const char *caller);
 int ast_push(ast_t *ast, enum ast_type op, struct Vdbe *v, void *obj);
 void ast_destroy(ast_t **ast, struct sqlite3 *db);
+void ast_make_ready(ast_t *ast);
 void ast_print(ast_t *ast);
 
 #endif

--- a/db/dohsql.h
+++ b/db/dohsql.h
@@ -21,6 +21,7 @@ limitations under the License.
 
 struct params_info {
     struct sqlclntstate *clnt;
+    hash_t *h; /* hash table to dedup bound parameters */
     int nparams;
     struct param_data *params;
 };

--- a/sqlite/src/build.c
+++ b/sqlite/src/build.c
@@ -276,20 +276,23 @@ void sqlite3FinishCoding(Parse *pParse){
     sqlite3VdbeMakeReady(v, pParse);
     pParse->rc = SQLITE_DONE;
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    if( pParse->ast ){
+    if( db->ast ){
       if( comdb2_check_push_remote(pParse) ){
         pParse->rc = SQLITE_SCHEMA_PUSH_REMOTE;
-        return;
-      }
-      if( comdb2_check_parallel(pParse) ){
+      }else if( comdb2_check_parallel(pParse) ){
         pParse->rc = SQLITE_SCHEMA_DOHSQL;
-        return;
       }
     }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   }else{
     pParse->rc = SQLITE_ERROR;
   }
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  if( db->ast && pParse->rc!=SQLITE_DONE ){
+    /* If an error occurred or a dohsql reprepare is needed, reset the AST. */
+    ast_destroy(&db->ast, db);
+  }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 }
 
 /*

--- a/sqlite/src/prepare.c
+++ b/sqlite/src/prepare.c
@@ -666,7 +666,8 @@ int sqlite3SchemaToIndex(sqlite3 *db, Schema *pSchema){
 void sqlite3ParserReset(Parse *pParse){
   sqlite3 *db = pParse->db;
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  if( pParse->ast ) ast_destroy(&pParse->ast, db);
+  /* Done parsing. Mark the AST ready. */
+  if( db->ast ) ast_make_ready(db->ast);
   if( pParse->azSrcListOnly ){
     int i;
     for(i=0; i<pParse->nSrcListOnly; i++){

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -1441,6 +1441,7 @@ void sqlite3CryptFunc(sqlite3_context*,int,sqlite3_value**);
 */
 struct sqlite3 {
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
+  ast_t *ast;
   int isPreparer;               /* Set by preparer plugin - must be first, must be an int. */
 #endif
   sqlite3_vfs *pVfs;            /* OS Interface */
@@ -3310,7 +3311,6 @@ struct Parse {
   u8 eOrconf;          /* Default ON CONFLICT policy for trigger steps */
   u8 disableTriggers;  /* True to disable triggers */
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-  ast_t *ast;
   int preserve_update;    /* statement replacement, preserve flags */
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 

--- a/sqlite/src/vdbeapi.c
+++ b/sqlite/src/vdbeapi.c
@@ -267,6 +267,9 @@ int sqlite3_finalize(sqlite3_stmt *pStmt){
     stmt_free_vtable_locks(pStmt);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     sqlite3 *db = v->db;
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    if( db->ast ) ast_destroy(&db->ast, db);
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     if( vdbeSafety(v) ) return SQLITE_MISUSE_BKPT;
     sqlite3_mutex_enter(db->mutex);
     checkProfileCallback(db, v);


### PR DESCRIPTION
Rebinding parameters may cause SQLite to recompile the statement in the hope of a better query plan. A new yet identical (?) AST is parsed out during the process, as well.

While it makes sense to recode the statement after parameters are changed, it seems a bit wasteful to generate another identical AST. Hence in this patch, the dohast struct is relocated from the parser to the sqlite3 db handle, and is reused whenever possible.

In addition, a lookaside hash table for bound parameter names, is added in this patch, turning an O(N^2) search into an O(1) hash table lookup. This change greatly speeds up AST parsing for a large number of bound parameters.
