### PR TITLE
Update log4j version to stop warnings

### DIFF
--- a/tests/tools/linearizable/jdbctest/pom.xml
+++ b/tests/tools/linearizable/jdbctest/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
         <groupId>com.bloomberg.comdb2</groupId>
         <artifactId>cdb2jdbc</artifactId>
-        <version>2.0.0</version>
+        <version>2.7.0</version>
     </dependency>
     <dependency>
         <groupId>com.jcraft</groupId>
@@ -36,7 +36,7 @@
     <dependency>
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
-        <version>1.2.17</version>
+        <version>2.17.2</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Update the log4j versions to stop GitHub security warnings.  I would love to update these and retest linearizable at some point- but not today.