### PR TITLE
RDSICOMDB2-280: pmux secure port routing

### DIFF
--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -247,7 +247,7 @@ int send_reversesql_request(const char *dbname, const char *host,
         if (gbl_revsql_debug == 1) {
             revconn_logmsg(LOGMSG_USER, "%s:%d Received 'newsql' request over 'reversesql' connection\n", __func__, __LINE__);
         }
-        (void) do_appsock_evbuffer(buf, &cliaddr, new_fd, 1);
+        (void)do_appsock_evbuffer(buf, &cliaddr, new_fd, 1, 0);
 
     } else {
         uint8_t firstbyte;

--- a/net/net.h
+++ b/net/net.h
@@ -452,7 +452,7 @@ void net_queue_stat_iterate(netinfo_type *, QSTATITERFP, struct net_get_records 
 void net_queue_stat_iterate_evbuffer(netinfo_type *, QSTATITERFP, struct net_get_records *);
 void net_userfunc_iterate(netinfo_type *netinfo_ptr, UFUNCITERFP *uf_iter, void *arg);
 
-int do_appsock_evbuffer(struct evbuffer *buf, struct sockaddr_in *ss, int fd, int is_readonly);
+int do_appsock_evbuffer(struct evbuffer *buf, struct sockaddr_in *ss, int fd, int is_readonly, int secure);
 
 /* Blocks until the net-queue is X% full or less */
 int net_throttle_wait(netinfo_type *netinfo_ptr);

--- a/net/net_appsock.h
+++ b/net/net_appsock.h
@@ -12,6 +12,7 @@ struct sqlclntstate;
 struct appsock_handler_arg {
     int fd;
     int is_readonly;
+    int secure; /* whether connection is routed from a secure pmux port */
     struct sockaddr_in addr;
     struct evbuffer *rd_buf;
     struct event_base *base;

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -89,6 +89,7 @@ struct newsql_appdata_evbuffer {
 
     unsigned initial : 1; /* New connection or called newsql_reset */
     unsigned local : 1;
+    unsigned secure : 1;
 
     struct sqlwriter *writer;
     struct ssl_data *ssl_data;
@@ -585,7 +586,20 @@ static void process_query(struct newsql_appdata_evbuffer *appdata)
         }
     }
     clnt->sqlite_row_format = have_sqlite_fmt;
-    if (SSL_IS_PREFERRED(gbl_client_ssl_mode)) {
+
+    /* If the connection is forwarded from a secure pmux port,
+     * both IAM and TLS must be enabled on the database. */
+    if (appdata->secure) {
+        int has_externalauth = gbl_uses_externalauth || gbl_uses_externalauth_connect;
+        int ssl_able = SSL_IS_ABLE(gbl_client_ssl_mode);
+        if (!has_externalauth || !ssl_able) {
+            logmsg(LOGMSG_ERROR, "can't handle a secure connection: externalauth %d ssl %d\n", has_externalauth,
+                   ssl_able);
+            goto err;
+        }
+    }
+
+    if (appdata->secure || SSL_IS_PREFERRED(gbl_client_ssl_mode)) {
         switch(ssl_check(appdata, have_ssl)) {
         case 1: goto read;
         case 2: goto err;
@@ -1091,6 +1105,7 @@ static void newsql_setup_clnt_evbuffer(struct appsock_handler_arg *arg, int admi
     appdata->base = arg->base;
     appdata->initial = 1;
     appdata->local = local;
+    appdata->secure = arg->secure;
     appdata->fd = arg->fd;
     appdata->rd_buf = arg->rd_buf;
     appdata->rd_hdr_ev = event_new(appdata->base, arg->fd, EV_READ, rd_hdr, appdata);

--- a/tests/pmux_secure_route.test/Makefile
+++ b/tests/pmux_secure_route.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/pmux_secure_route.test/expected
+++ b/tests/pmux_secure_route.test/expected
@@ -1,0 +1,2 @@
+[select 1] failed with rc -1 cdb2_run_statement_typed_int: Cannot connect to db
+(2=2)

--- a/tests/pmux_secure_route.test/runit
+++ b/tests/pmux_secure_route.test/runit
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=pmuxsecure
+
+# Use our own pmux in this test
+${COMDB2_EXE} ${dbnm} --create --dir $TESTDIR/${dbnm} --tunable 'portmux_bind_path /tmp/pmux.secure.socket' --tunable 'portmux_port 5106' --tunable "ssl_cert_path $TESTDIR"
+${PMUX_EXE} -f -b /tmp/pmux.secure.socket -p 5106 -s 5104 -r 20000:20001 &
+pmuxpid=$!
+
+${COMDB2_EXE} ${dbnm} --lrl $TESTDIR/${dbnm}/${dbnm}.lrl &
+dbpid=$!
+sleep 10;
+
+cp $DBDIR/comdb2db.cfg $DBDIR/5104.cfg
+echo 'comdb2_config:allow_pmux_route:true' >>$DBDIR/5104.cfg
+echo 'comdb2_config:portmuxport=5104' >> $DBDIR/5104.cfg
+
+cp $DBDIR/comdb2db.cfg $DBDIR/5106.cfg
+echo 'comdb2_config:allow_pmux_route:true' >>$DBDIR/5106.cfg
+echo 'comdb2_config:portmuxport=5106' >> $DBDIR/5106.cfg
+
+# externalauth is disabled. connections routed from 5104 should be rejected
+cdb2sql --cdb2cfg $DBDIR/5104.cfg $dbnm --host localhost "select 1" >output 2>&1
+# now turn on externalauth, through the "insecure" pmux port
+cdb2sql --cdb2cfg $DBDIR/5106.cfg $dbnm --host localhost "exec procedure sys.cmd.send('externalauth 1')"
+# externalauth is enabled. connections routed from 5104 should be accepted
+cdb2sql --cdb2cfg $DBDIR/5104.cfg $dbnm --host localhost "select 2" >>output 2>&1
+
+kill -9 $dbpid
+kill -9 $pmuxpid
+diff expected output


### PR DESCRIPTION
In addition to routing connections to databases on 5105, listen on an additional port. Connections on this port should be routed to databases just like 5105, except:

1) They must be TLS-enabled
2) They must have a valid IAM token
3) Database must have IAM enabled
