### PR TITLE
{171428666}: Adding utf8_valid() sql function

### DIFF
--- a/db/types.c
+++ b/db/types.c
@@ -3695,6 +3695,21 @@ TYPES_INLINE int CLIENT_BLOB_to_CLIENT_PSTR2(
     return -1;
 }
 
+static int utf8_validate_trailing_zeros(const char *u, int max)
+{
+    int valid_len;
+
+    if (utf8_validate(u, max, &valid_len) != 0)
+        return -1;
+
+    /* utf8_validate() stops at the 1st NUL character. We want to permit trailing zeros */
+    for (; valid_len < max - 1; ++valid_len) {
+        if (u[valid_len] != '\0')
+            return -1;
+    }
+    return 0;
+}
+
 /**
  * Finds out where the input vutf8 string is stored and then determines where it
  * should be copied and copies it. Doesn't deal with NULLs.
@@ -3717,7 +3732,6 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
                                       blob_buffer_t *inblob,
                                       blob_buffer_t *outblob, int *outdtsz)
 {
-    int valid_len;
     if (out_len > 0)
         memset(out, 0, out_len);
 
@@ -3742,10 +3756,8 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
             /* validate input blob */
             assert(inblob->length == len);
 
-            if (utf8_validate(inblob->data, inblob->length, &valid_len) ||
-                valid_len != len - 1) {
+            if (utf8_validate_trailing_zeros(inblob->data, inblob->length))
                 return -1;
-            }
 
             memcpy(outblob, inblob, sizeof(blob_buffer_t));
             bzero(inblob, sizeof(blob_buffer_t));
@@ -3767,8 +3779,7 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
 
         /* if the string isn't empty, validate the string and make sure its
          * length matches len (minus 1 for the NUL byte) */
-        if (len > 0 &&
-            (utf8_validate(in, len, &valid_len) || valid_len != len - 1))
+        if (len > 0 && utf8_validate_trailing_zeros(in, len))
             return -1;
 
         memcpy(out, in, len);
@@ -3785,7 +3796,6 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
      * fit in the out buffer, then the string needs to be copied from the in
      * buffer to a new out blob */
     else if (len <= in_len) {
-        int valid_len;
 
         if (outblob) {
             if (len > gbl_blob_sz_thresh_bytes)
@@ -3800,8 +3810,7 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
 
             /* if the string isn't empty, validate the string and make sure its
              * length matches len (minus 1 for the NUL byte) */
-            if (len > 0 &&
-                (utf8_validate(in, len, &valid_len) || valid_len != len - 1))
+            if (len > 0 && utf8_validate_trailing_zeros(in, len))
                 return -1;
 
             memcpy(outblob->data, in, len);
@@ -3821,8 +3830,6 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
      * blob to the out buffer */
     else /* len <= out_len */
     {
-        int valid_len;
-
         /* Do not attempt to convert a blob placeholder (i.e., length == -2) */
         if (inblob && inblob->length != -2) {
             if (!inblob->exists || !inblob->data) {
@@ -3832,8 +3839,7 @@ static TYPES_INLINE int vutf8_convert(int len, const void *in, int in_len,
 
             /* if the string isn't empty, validate the string and make sure its
              * length matches len (minus 1 for the NUL byte) */
-            if (len > 0 && (utf8_validate(inblob->data, len, &valid_len) ||
-                            valid_len != len - 1))
+            if (len > 0 && utf8_validate_trailing_zeros(inblob->data, len))
                 return -1;
 
             memcpy(out, inblob->data, len);

--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -1145,6 +1145,36 @@ static void comdb2UserFunc(
                       SQLITE_STATIC);
 }
 
+/* Return 0 if payload is utf8. Return (-N - 1), where N is the index
+ * of the first malformed character */
+int utf8_validate(const char *str, int len, int *valid_len);
+static void comdb2Utf8ValidFunc(
+  sqlite3_context *context,
+  int argc,
+  sqlite3_value **argv
+){
+  int valid_len, rc, len;
+  const char *z;
+  assert(argc == 1);
+  UNUSED_PARAMETER(argc);
+
+  switch( sqlite3_value_type(argv[0]) ){
+    case SQLITE_BLOB:
+      len = sqlite3_value_bytes(argv[0]);
+      z = sqlite3_value_blob(argv[0]);
+      rc = utf8_validate(z, len, &valid_len);
+      break;
+    case SQLITE_TEXT:
+      len = sqlite3_value_bytes(argv[0]) + 1; /* +1 for \0 */
+      z = (const char *)sqlite3_value_text(argv[0]);
+      rc = utf8_validate(z, len, &valid_len);
+      break;
+    default:
+      rc = -1;
+      break;
+  }
+  sqlite3_result_int(context, rc == 0 ? rc : (-valid_len - 1));
+}
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*
@@ -2819,7 +2849,7 @@ void sqlite3RegisterBuiltinFunctions(void){
     FUNCTION(comdb2_starttime,      0, 0, 0, comdb2StartTimeFunc),
     FUNCTION(comdb2_user,           0, 0, 0, comdb2UserFunc),
     FUNCTION(comdb2_last_cost,      0, 0, 0, comdb2LastCostFunc),
-
+    FUNCTION(utf8_valid,            1, 0, 0, comdb2Utf8ValidFunc),
     FUNCTION(checksum_md5,          1, 0, 0, md5Func),
 #if defined(SQLITE_BUILDING_FOR_COMDB2_DBGLOG)
     FUNCTION(dbglog_cookie,         0, 0, 0, dbglogCookieFunc),

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -358,6 +358,7 @@
 (candidate='unlikely()')
 (candidate='upper()')
 (candidate='usleep()')
+(candidate='utf8_valid()')
 (candidate='zeroblob()')
 (username='user1')
 (username='user2')

--- a/tests/func.test/t02_utf8_validate.expected
+++ b/tests/func.test/t02_utf8_validate.expected
@@ -1,0 +1,2 @@
+(utf8_valid('abc')=0)
+(utf8_valid(x'616263FF')=-4)

--- a/tests/func.test/t02_utf8_validate.sql
+++ b/tests/func.test/t02_utf8_validate.sql
@@ -1,0 +1,2 @@
+SELECT utf8_valid('abc')
+SELECT utf8_valid(x'616263FF')


### PR DESCRIPTION
The type system is also tweaked to accept trailing NUL characters in a UTF8 byte sequence.
