### PR TITLE
Allow cdb2api policy configuration

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -816,6 +816,8 @@ int gbl_hostname_refresh_time = 60;
 
 int gbl_pstack_self = 1;
 
+char *gbl_cdb2api_policy_override = NULL;
+
 int close_all_dbs_tran(tran_type *tran);
 
 int open_all_dbs_tran(void *tran);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -461,6 +461,9 @@ extern int gbl_unexpected_last_type_warn;
 extern int gbl_unexpected_last_type_abort;
 extern int gbl_pstack_self;
 
+/* For fdb connections using cdb2api */
+extern char *gbl_cdb2api_policy_override;
+
 /*
   =========================================================
   Value/Update/Verify functions for some tunables that need

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2459,6 +2459,6 @@ REGISTER_TUNABLE("noleader_retry_poll_ms",
                  "Wait this long before retrying on no-leader. (Default: 10)",
                  TUNABLE_INTEGER, &gbl_noleader_retry_poll_ms, INTERNAL, NULL,
                  NULL, NULL, NULL);
-
-
+REGISTER_TUNABLE("cdb2api_policy_override", "Use this policy override with cdb2api. (Default: none)",
+                TUNABLE_STRING, &gbl_cdb2api_policy_override, 0, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -98,6 +98,7 @@
 (name='catchup_on_commit', description='Replicant to INCOHERENT_WAIT rather than INCOHERENT on commit if within CATCHUP_WINDOW.', type='BOOLEAN', value='OFF', read_only='N')
 (name='catchup_window', description='Start waiting in waitforseqnum if replicant is within this many bytes of master.', type='INTEGER', value='40000000', read_only='N')
 (name='cause_random_blkseq_replays', description='Cause random blkseq replays from replicant', type='BOOLEAN', value='OFF', read_only='N')
+(name='cdb2api_policy_override', description='Use this policy override with cdb2api. (Default: none)', type='STRING', value=NULL, read_only='N')
 (name='check_applied_lsns', description='Check transaction that its LSNs have been applied', type='BOOLEAN', value='OFF', read_only='N')
 (name='check_applied_lsns_debug', description='Lots of verbose trace for debugging applied LSNs.', type='BOOLEAN', value='OFF', read_only='N')
 (name='check_applied_lsns_fatal', description='Abort if check_applied_lsns fails', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
The changes in this PR provide database operators with a tunable that allows them to configure the cdb2api policy used when pushing a query to a foreign db.

The name of the tunable is 'cdb2api_policy_override' and it can take the values 'CDB2_RANDOM' for cdb2api's CDB2_RANDOM policy, 'CDB2_RANDOMROOM' for cdb2api's CDB2_RANDOMROOM policy, and 'CDB2_ROOM' for cdb2api's CDB2_ROOM policy.