### PR TITLE
slowing down retries when remsql hits incoherent nodes with a dynamic back-off scheme

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -362,6 +362,8 @@ extern int gbl_pgcomp_dbg_ctrace;
 extern int gbl_warn_on_equiv_types;
 extern int gbl_fdb_incoherence_percentage;
 extern int gbl_fdb_io_error_retries;
+extern int gbl_fdb_io_error_retries_phase_1;
+extern int gbl_fdb_io_error_retries_phase_2_poll;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_page_order_table_scan;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2092,8 +2092,14 @@ REGISTER_TUNABLE("fdb_incoherence_percentage",
                  "Generate random incoherent errors in remsql", TUNABLE_INTEGER,
                  &gbl_fdb_incoherence_percentage, INTERNAL, NULL, percent_verify, NULL, NULL);
 REGISTER_TUNABLE("fdb_io_error_retries",
-                 "Number of retries for io error remsql", TUNABLE_INTEGER,
-                 &gbl_fdb_io_error_retries, 0, NULL, NULL, NULL, NULL);
+                 "Number of retries for io error remsql; phase 1 is fast retry, phase 2 is polling",
+                 TUNABLE_INTEGER, &gbl_fdb_io_error_retries, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("fdb_io_error_retries_phase_1",
+                 "Number of immediate retries; capped by fdb_io_error_retries",
+                 TUNABLE_INTEGER, &gbl_fdb_io_error_retries_phase_1, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("fdb_io_error_retries_phase_2_poll",
+                 "Poll initial value for slow retries in phase 2; doubled for each retry", TUNABLE_INTEGER,
+                 &gbl_fdb_io_error_retries_phase_2_poll, 0, NULL, NULL, NULL, NULL);
 
 
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
Currently, if a cross-db sql fails due to the remote server being incoherent, we retry a number of times before failing the request.
Unfortunately, during master swing all the nodes are incoherent and the retries are going too fast, and we end up failing.
Add a slow-start like scheme to slow down the retries; we retry immediately a few times to reduce latency, and then exponentially back-off polling to survive cases when a majority of nodes are incoherent (all configurable).