### PR TITLE
{172914411} Fix an issue with partial index in chunked transactions

### DIFF
--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -282,5 +282,8 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
 
 fi
 
-echo "Testcase passed."
+# Run rest of the tests
+${TESTSROOTDIR}/tools/compare_results.sh -s -d $1
+[ $? -eq 0 ] || exit 1
 
+echo "Testcase passed."

--- a/tests/transchunk.test/t1.expected
+++ b/tests/transchunk.test/t1.expected
@@ -1,0 +1,8 @@
+[commit] failed with rc 299 add key constraint duplicate key 'KEY' on table 't1' index 0
+(count(*) = 1=1)
+(out='Verify succeeded.')
+(rows deleted=1)
+(rows inserted=10000)
+(count(*) = 0=1)
+(out='Verify succeeded.')
+(rows deleted=0)

--- a/tests/transchunk.test/t1.sql
+++ b/tests/transchunk.test/t1.sql
@@ -1,0 +1,61 @@
+-- DRQS-172914411
+
+drop table if exists t1;
+
+create table t1 {
+    schema {
+        int c1
+        int c2
+    }
+    keys {
+        "key" = c1 + c2 {where c1 = 1}
+    }
+}$$
+
+set transaction blocksql
+set transaction chunk 1
+begin;
+delete from t1;
+insert into t1 values (1, 1);
+insert into t1 values (1, 1);
+commit;
+
+-- Since the above transaction ran in chunk-mode, only the first INSERT
+-- should have succeeded.
+select count(*) = 1 from t1;
+
+exec procedure sys.cmd.verify('t1')
+
+delete from t1;
+
+# Cleanup
+drop table t1
+
+# Additionally, we also test that chunked-deletes work fine with
+# partial-index.
+
+create table t1 {
+    schema {
+        int c1
+        int c2
+    }
+    keys {
+        "key" = c1 + c2 {where c1 = 1}
+    }
+}$$
+
+insert into t1 select 1, value from generate_series(1, 10000);
+
+set transaction chunk 100
+begin;
+delete from t1;
+commit;
+
+select count(*) = 0 from t1;
+
+exec procedure sys.cmd.verify('t1')
+
+delete from t1;
+
+# Cleanup
+drop table t1


### PR DESCRIPTION
Chunked transactions over partial index could cause index corruption. The fix was to save/restore the 'affected keys' flags on the replicant during implicit rollover of the chunked transactions.