### PR TITLE
{172914411} Fix an issue with partial index in chunked transactions (Backport from main branch)

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8496,12 +8496,17 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
     int bdberr = 0;
 
     uint8_t **pIdxInsert = NULL, **pIdxDelete = NULL;
+    unsigned long long ins_keys_saved = 0ULL;
+    unsigned long long del_keys_saved = 0ULL;
 
     if (clnt->dbtran.crtchunksize >= clnt->dbtran.maxchunksize) {
-
-        /* Latch expressional index keys. We do not want them to be
-           cleaned up by the micro transaction we are about to commit. */
-        if (gbl_expressions_indexes && pCur->db->ix_expr) {
+        /* Latch partial index/index on expression related data. We do not want
+           them to be cleaned up by the micro transaction we are about to commit. */
+        if (gbl_partial_indexes && pCur->db && pCur->db->ix_partial) {
+            ins_keys_saved = clnt->ins_keys;
+            del_keys_saved = clnt->del_keys;
+        }
+        if (gbl_expressions_indexes && pCur->db && pCur->db->ix_expr) {
             pIdxInsert = clnt->idxInsert;
             pIdxDelete = clnt->idxDelete;
             clnt->idxInsert = clnt->idxDelete = NULL;
@@ -8603,7 +8608,12 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
         clnt->dbtran.crtchunksize++;
     }
 done:
-    /* Restore the expressional index keys onto clnt for the next OP_Insert/OP_Delete. */
+    /* Restore the partial index/index on expression data onto clnt for the next
+       OP_Insert/OP_Delete. */
+    if (ins_keys_saved != 0 || del_keys_saved != 0) {
+        clnt->ins_keys = ins_keys_saved;
+        clnt->del_keys = del_keys_saved;
+    }
     if (pIdxInsert != NULL || pIdxDelete != NULL) {
         clnt->idxInsert = pIdxInsert;
         clnt->idxDelete = pIdxDelete;

--- a/tests/transchunk.test/runit
+++ b/tests/transchunk.test/runit
@@ -282,5 +282,8 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
 
 fi
 
-echo "Testcase passed."
+# Run rest of the tests
+${TESTSROOTDIR}/tools/compare_results.sh -s -d $1
+[ $? -eq 0 ] || exit 1
 
+echo "Testcase passed."

--- a/tests/transchunk.test/t1.expected
+++ b/tests/transchunk.test/t1.expected
@@ -1,0 +1,8 @@
+[commit] failed with rc 299 add key constraint duplicate key 'KEY' on table 't1' index 0
+(count(*) = 1=1)
+(out='Verify succeeded.')
+(rows deleted=1)
+(rows inserted=10000)
+(count(*) = 0=1)
+(out='Verify succeeded.')
+(rows deleted=0)

--- a/tests/transchunk.test/t1.sql
+++ b/tests/transchunk.test/t1.sql
@@ -1,0 +1,61 @@
+-- DRQS-172914411
+
+drop table if exists t1;
+
+create table t1 {
+    schema {
+        int c1
+        int c2
+    }
+    keys {
+        "key" = c1 + c2 {where c1 = 1}
+    }
+}$$
+
+set transaction blocksql
+set transaction chunk 1
+begin;
+delete from t1;
+insert into t1 values (1, 1);
+insert into t1 values (1, 1);
+commit;
+
+-- Since the above transaction ran in chunk-mode, only the first INSERT
+-- should have succeeded.
+select count(*) = 1 from t1;
+
+exec procedure sys.cmd.verify('t1')
+
+delete from t1;
+
+# Cleanup
+drop table t1
+
+# Additionally, we also test that chunked-deletes work fine with
+# partial-index.
+
+create table t1 {
+    schema {
+        int c1
+        int c2
+    }
+    keys {
+        "key" = c1 + c2 {where c1 = 1}
+    }
+}$$
+
+insert into t1 select 1, value from generate_series(1, 10000);
+
+set transaction chunk 100
+begin;
+delete from t1;
+commit;
+
+select count(*) = 0 from t1;
+
+exec procedure sys.cmd.verify('t1')
+
+delete from t1;
+
+# Cleanup
+drop table t1


### PR DESCRIPTION
Chunked transactions over partial index could cause index corruption. The fix was to save/restore the 'affected keys' flags on the replicant during implicit rollover of the chunked transactions.