### PR TITLE
Free fdb push in sqlite_done so doesn't show up in next stmt

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3848,6 +3848,8 @@ static void sqlite_done(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         dohsql_end_distribute(clnt, thd->logger);
         distributed = 1;
     }
+    if (clnt->fdb_push)
+        fdb_push_free(&clnt->fdb_push);
 
     sql_statement_done(thd->sqlthd, thd->logger, clnt, stmt, outrc);
 

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -604,8 +604,6 @@ int osql_clean_sqlclntstate(struct sqlclntstate *clnt)
         free(clnt->saved_errstr);
         clnt->saved_errstr = NULL;
     }
-    if (clnt->fdb_push)
-        fdb_push_free(&clnt->fdb_push);
 
     if (clnt->dbtran.shadow_tran) {
         /* for some reason the clnt contains an unfinished

--- a/tests/fdb_push.test/output.log
+++ b/tests/fdb_push.test/output.log
@@ -10,3 +10,8 @@ Table "sqlite_stat1" Rootp 1073741828 Remrootp 4 Version=0
 Table "sqlite_stat4" Rootp 1073741829 Remrootp 5 Version=0
 Index "$ID_52596C31" for table "t" Rootp 1073741827 Remrootp 3 Version=0
 Table "t" Rootp 1073741826 Remrootp 2 Version=0
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+(rows inserted=1)

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -32,6 +32,12 @@ cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remd
 # get the version V2
 cdb2sql ${SRC_CDB2_OPTIONS} --tabs --host $mach $a_dbname "exec procedure sys.cmd.send(\"fdb info db\")" 2>&1 | cut -f 5- -d ' ' >> $output
 
+# make sure clnt->fdb_push is cleared when running local stmt after foreign stmt (insert stmt will fail if clnt->fdb_push is not cleared)
+cdb2sql -s ${SRC_CDB2_OPTIONS} --host $mach $a_dbname - >> $output 2>&1 << EOF
+select * from LOCAL_${a_remdbname}.t order by id
+insert into t values (10, "hi")
+EOF
+
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
 


### PR DESCRIPTION
See test for where this breaks

This also seems like a memory leak if you run multiple foreign queries. fdb_push_run would override clnt->fdb_push but not clear memory of older clnt->fdb_push. So this should be cleared in sqlite_done

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
