### PR TITLE
sp: Check null before deref

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3134,6 +3134,7 @@ static void drop_temp_tables(SP sp)
 // SP ready to run again
 static void reset_sp(SP sp)
 {
+    if (!sp) return;
     if (sp->lua) {
         lua_gc(sp->lua, LUA_GCCOLLECT, 0);
         drop_temp_tables(sp);


### PR DESCRIPTION
Fixes segfault when UDF invokes an invalid procedure.

`(gdb) p err
$9 = 0x7fa90816b580 "no such procedure: json_extract ver:0"
`
