### PR TITLE
{172886541}

### DIFF
--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -3086,9 +3086,6 @@ static int whereLoopAddBtree(
 #else
       pNew->rRun = rSize + 16;
 #endif
-      if( (pTab->tabFlags & TF_Ephemeral)!=0 ){
-        pNew->wsFlags |= WHERE_VIEWSCAN;
-      }
       ApplyCostMultiplier(pNew->rRun, pTab->costMult);
       whereLoopOutputAdjust(pWC, pNew, rSize);
       rc = whereLoopInsert(pBuilder, pNew);
@@ -4269,13 +4266,6 @@ static int wherePathSolver(WhereInfo *pWInfo, LogEst nRowEst){
         }else{
           rCost = rUnsorted;
           rUnsorted -= 2;  /* TUNING:  Slight bias in favor of no-sort plans */
-        }
-
-        /* TUNING:  A full-scan of a VIEW or subquery in the outer loop
-        ** is not so bad. */
-        if( iLoop==0 && (pWLoop->wsFlags & WHERE_VIEWSCAN)!=0 ){
-          rCost += -10;
-          nOut += -30;
         }
 
         /* Check to see if pWLoop should be added to the set of

--- a/sqlite/src/whereInt.h
+++ b/sqlite/src/whereInt.h
@@ -593,4 +593,3 @@ void sqlite3WhereTabFuncArgs(Parse*, struct SrcList_item*, WhereClause*);
 #define WHERE_PARTIALIDX   0x00020000  /* The automatic index is partial */
 #define WHERE_IN_EARLYOUT  0x00040000  /* Perhaps quit IN loops early */
 #define WHERE_IN_SEEKSCAN  0x00100000  /* Seek-scan optimization for IN */
-#define WHERE_VIEWSCAN     0x02000000  /* A full-scan of a VIEW or subquery */


### PR DESCRIPTION
This PR reverts an [upstream sqlite patch](https://www.sqlite.org/src/info/e3754cc18824aad4) introduced in https://github.com/bloomberg/comdb2/pull/3415, that has caused a query performance regression in R8. 
