### PR TITLE
replace thread based fdb heartbeats with libevent

### DIFF
--- a/db/fdb_fend.h
+++ b/db/fdb_fend.h
@@ -33,6 +33,7 @@
 #include "sqliteInt.h"
 #include "vdbeInt.h"
 #include "comdb2uuid.h"
+#include "net_int.h"
 
 /**
  * REMOTE SQL VERSIONING
@@ -189,6 +190,11 @@ struct fdb_tran {
     struct temp_table *dedup_tbl;
     struct temp_cursor *dedup_cur;
     int nwrites; /* number of writes (ins/upd/del) issues on the fdb tran */
+
+    /**
+     * libevent heartbeats
+     */
+    fdb_hbeats_type hbeats;
 };
 typedef struct fdb_tran fdb_tran_t;
 
@@ -402,7 +408,7 @@ int fdb_unlock_table(fdb_tbl_ent_t *ent);
  * Send heartbeats to remote dbs in a distributed transaction
  *
  */
-int fdb_heartbeats(struct sqlclntstate *clnt);
+int fdb_heartbeats(fdb_hbeats_type *hbeats);
 
 /**
  * Change association of a cursor to a table (see body note)

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5062,12 +5062,6 @@ static int wait_for_sql_query(struct sqlclntstate *clnt)
                 if (diff.tv_sec >= clnt->heartbeat) {
                     last = st;
                     send_heartbeat(clnt);
-                    rc = fdb_heartbeats(clnt);
-                    if (rc) {
-                        logmsg(LOGMSG_ERROR, "%s: fdb_heartbeats, rc=%d\n",
-                               __func__, rc);
-                        return -1;
-                    }
                 }
                 if (clnt->query_timeout > 0 && !clnt->statement_timedout) {
                     TIMESPEC_SUB(st, first, diff);

--- a/net/net.h
+++ b/net/net.h
@@ -462,6 +462,9 @@ int db_is_stopped(void);
 int db_is_exiting(void);
 void stop_event_net(void);
 int sync_state_to_protobuf(int);
+struct fdb_hbeats;
 void increase_net_buf(void);
+int enable_fdb_heartbeats(struct fdb_hbeats*);
+int disable_fdb_heartbeats(struct fdb_hbeats*);
 
 #endif

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -415,6 +415,14 @@ typedef struct ack_state_struct {
     netinfo_type *netinfo;
 } ack_state_type;
 
+struct fdb_tran;
+typedef struct fdb_hbeats {
+    struct fdb_tran *tran;
+    struct event *ev_hbeats;
+    pthread_mutex_t sb_mtx;
+    struct timeval tv;
+} fdb_hbeats_type;
+
 /* Trace functions */
 void host_node_printf(loglvl lvl, host_node_type *host_node_ptr, const char *fmt, ...);
 void host_node_errf(loglvl lvl, host_node_type *host_node_ptr, const char *fmt, ...);

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -400,7 +400,6 @@ retry_read:
                 clnt->ready_for_heartbeats = 1;
             }
             newsql_heartbeat(clnt);
-            fdb_heartbeats(clnt);
             Pthread_mutex_unlock(&clnt->wait_mutex);
         }
 
@@ -441,7 +440,6 @@ retry_read:
             clnt->ready_for_heartbeats = 1;
         }
         newsql_heartbeat(clnt);
-        fdb_heartbeats(clnt);
         Pthread_mutex_unlock(&clnt->wait_mutex);
     }
     free(p);

--- a/tests/writes_remsql_names.test/output.8.log
+++ b/tests/writes_remsql_names.test/output.8.log
@@ -1,0 +1,36 @@
+[begin] rc 0
+(sleep(10)=10)
+[select sleep(10)] rc 0
+[commit] rc 0
+(a=-90, b=-910, c=-9100)
+(a=2, b=1, c=1)
+(a=3, b=2, c=2)
+(a=4, b=3, c=3)
+(a=5, b=4, c=4)
+(a=6, b=5, c=5)
+(a=7, b=6, c=6)
+(a=8, b=7, c=7)
+(a=9, b=8, c=8)
+(a=10, b=9, c=9)
+(a=11, b=10, c=10)
+(a=12, b=11, c=11)
+(a=13, b=12, c=12)
+(a=14, b=13, c=13)
+(a=15, b=14, c=14)
+(a=16, b=15, c=15)
+(a=91, b=0, c=900)
+(a=92, b=10, c=100)
+(a=93, b=20, c=200)
+(a=96, b=50, c=500)
+(a=97, b=60, c=600)
+(a=911, b=100, c=1000)
+(a=924, b=230, c=2300)
+(a=9124, b=1230, c=12300)
+(a=123456, b=123456, c=123456)
+(a=911116, b=9111150, c=91111500)
+Table "sqlite_stat1" Rootp 1073741828 Remrootp 8 Version=0
+Table "sqlite_stat4" Rootp 1073741829 Remrootp 9 Version=0
+Index "$A_7B7C1C21" for table "t2" Rootp 1073741831 Remrootp 7 Version=0
+Index "$ID_1E5012DF" for table "t1" Rootp 1073741827 Remrootp 5 Version=0
+Table "t1" Rootp 1073741826 Remrootp 4 Version=0
+Table "t2" Rootp 1073741830 Remrootp 6 Version=0

--- a/tests/writes_remsql_names.test/pausedtxn.req
+++ b/tests/writes_remsql_names.test/pausedtxn.req
@@ -1,0 +1,5 @@
+begin
+insert into t values (123456, 123456, 123456)
+select sleep(10)
+commit
+select * from t

--- a/tests/writes_remsql_names.test/writes_remsql_names.sh
+++ b/tests/writes_remsql_names.test/writes_remsql_names.sh
@@ -182,6 +182,13 @@ if [[ -z $opt || "$opt" == "7" ]]; then
    run_test rollbackupdates.req output.7.log $output t2 a
 fi
 
+if [[ -z $opt || "$opt" == "8" ]]; then
+
+    output=./run.8.out
+    run_test pausedtxn.req output.8.log $output t2 a
+fi
+
+
 
 echo "Testcase passed."
 


### PR DESCRIPTION
8.0 timeouts when longer sql runs during a cross-db transaction.  This adds libevent heartbeats to prevent it.