### PR TITLE
{173038130}: Fixing clnt race

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -228,6 +228,13 @@ static void sqlengine_work_shard(struct thdpool *pool, void *work,
         handle_child_error(clnt, clnt->query_rc);
     }
 
+    /* clear the child clnt from this sql thread */
+    if (thd->sqlthd) {
+        Pthread_mutex_lock(&gbl_sql_lock);
+        thd->sqlthd->clnt = NULL;
+        Pthread_mutex_unlock(&gbl_sql_lock);
+    }
+
     if (put_curtran(thedb->bdb_env, clnt)) {
         logmsg(LOGMSG_ERROR, "%s: unable to destroy a CURSOR transaction!\n",
                __func__);


### PR DESCRIPTION
This is a regression from #3778. The idea of that pull request was to clear `sqlthd->clnt` in `signal_clnt_as_done()`, while holding the global `gbl_sql_lock` mutex. But dohsql child worker does not call `signal_clnt_as_done()`.

This patch adds back the code to clear `sqlthd->clnt`, in `sqlengine_work_shard()`.
