### PR TITLE
Don't use fdb push in client transactions

### DIFF
--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -71,7 +71,7 @@ int fdb_push_run(Parse *pParse, dohsql_node_t *node)
     if (clnt->disable_fdb_push)
         return -1;
 
-    if (clnt->intrans)
+    if (clnt->intrans || clnt->in_client_trans)
         return -1;
 
     if (pDb->version < FDB_VER_PROXY)

--- a/tests/fdb_push.test/lrl.options
+++ b/tests/fdb_push.test/lrl.options
@@ -1,3 +1,4 @@
 table t t.csc2
 table t2 t2.csc2
 ssl_allow_remsql 1
+foreign_db_push_remote 1

--- a/tests/fdb_push.test/output.log
+++ b/tests/fdb_push.test/output.log
@@ -34,3 +34,9 @@ Test running with no sqlite_stat1
 (rows inserted=1)
 (rows inserted=1)
 (rows inserted=1)
+Make sure disabled for client transactions
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+(1=1)

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -91,6 +91,15 @@ cdb2sql ${REM_CDB2_OPTIONS2} $a_remdbname2 default "drop table if exists sqlite_
 # for now just make sure db doesn't seg fault when this stmt is run
 cdb2sql ${SRC_CDB2_OPTIONS} --host $mach $a_dbname "select * from LOCAL_${a_remdbname2}.t order by id" # >> $output 2>&1
 
+# problem when running fdb stmt followed by local stmt in client transaction
+echo "Make sure disabled for client transactions" >> $output
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+begin
+select * from LOCAL_${a_remdbname}.t order by id
+select 1
+commit
+EOF
+
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
 


### PR DESCRIPTION
If you do then select 1 fails in test I added

```
[select 1] failed with rc -105 Database disconnected while in transaction.
[commit] failed with rc -105 Database disconnected while in transaction.
```
