### PR TITLE
Fix fdb access on IAM enable databases in 7.0

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1795,7 +1795,7 @@ static int access_control_check_sql_write(struct BtCursor *pCur,
     }
 
      if (gbl_uses_externalauth && clnt->no_transaction == 0 &&
-        externalComdb2AuthenticateUserWrite && !clnt->admin) {
+        externalComdb2AuthenticateUserWrite && !clnt->admin && pCur->db) {
          clnt->authdata = get_authdata(clnt);
          if(externalComdb2AuthenticateUserWrite(clnt->authdata, pCur->db->tablename)) {
              char msg[1024];
@@ -1868,7 +1868,7 @@ int access_control_check_sql_read(struct BtCursor *pCur, struct sql_thread *thd)
 
     if (gbl_uses_externalauth && clnt->no_transaction == 0 &&
         externalComdb2AuthenticateUserRead && !clnt->admin /* not admin connection */
-        && !clnt->current_user.bypass_auth /* not analyze */) {
+        && !clnt->current_user.bypass_auth /* not analyze */ && pCur->db) {
          clnt->authdata = get_authdata(clnt);
          if(externalComdb2AuthenticateUserRead(clnt->authdata, pCur->db->tablename)) {
              char msg[1024];


### PR DESCRIPTION
already works in 8.0 because table name is NULL if pCur->db is NULL

https://github.com/bloomberg/comdb2/pull/2982/files#diff-83540c17a36c15a7d6dd5f64a0e92bfe342e371a59b37ff2db2bed85395172a5R282