### PR TITLE
Fix disable-fdb-heartbeat race

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -3866,8 +3866,6 @@ static void _free_fdb_tran(fdb_distributed_tran_t *dtran, fdb_tran_t *tran)
 {
     int rc, bdberr;
 
-    disable_fdb_heartbeats(&tran->hbeats);
-
     listc_rfl(&dtran->fdb_trans, tran);
 
     if (tran->sb)
@@ -3882,7 +3880,7 @@ static void _free_fdb_tran(fdb_distributed_tran_t *dtran, fdb_tran_t *tran)
                    __func__, rc, bdberr);
     }
     Pthread_mutex_destroy(&tran->hbeats.sb_mtx);
-    free(tran);
+    disable_fdb_heartbeats_and_free(&tran->hbeats);
 }
 
 int fdb_trans_commit(struct sqlclntstate *clnt, enum trans_clntcomm sideeffects)

--- a/net/net.h
+++ b/net/net.h
@@ -465,6 +465,6 @@ int sync_state_to_protobuf(int);
 struct fdb_hbeats;
 void increase_net_buf(void);
 int enable_fdb_heartbeats(struct fdb_hbeats*);
-int disable_fdb_heartbeats(struct fdb_hbeats*);
+int disable_fdb_heartbeats_and_free(struct fdb_hbeats *);
 
 #endif

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -1858,7 +1858,7 @@ int enable_fdb_heartbeats(fdb_hbeats_type  *hb)
                            hb, NULL);
 }
 
-static void do_disable_fdb_heartbeats(int dummyfd, short what, void *data)
+static void do_disable_fdb_heartbeats_and_free(int dummyfd, short what, void *data)
 {
     fdb_hbeats_type *hb= data;
 
@@ -1868,12 +1868,12 @@ static void do_disable_fdb_heartbeats(int dummyfd, short what, void *data)
         event_free(hb->ev_hbeats);
         hb->ev_hbeats = NULL;
     }
+    free(hb->tran);
 }
 
-int disable_fdb_heartbeats(fdb_hbeats_type *hb)
+int disable_fdb_heartbeats_and_free(fdb_hbeats_type *hb)
 {
-    return event_base_once(fdb_base, -1, EV_TIMEOUT, do_disable_fdb_heartbeats,
-                           hb, NULL);
+    return event_base_once(fdb_base, -1, EV_TIMEOUT, do_disable_fdb_heartbeats_and_free, hb, NULL);
 }
 
 static void enable_read(int dummyfd, short what, void *data)


### PR DESCRIPTION
_free_fdb_tran tells eventlib to disable heartbeats, and frees the fdb_tran which contains the heartbeat information.  This PR frees the fdb_tran after the heartbeat has been disabled.
