### PR TITLE
Add integration tier to the list of environments

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -470,6 +470,7 @@ public class DatabaseDiscovery {
             hndl.myDbPorts.add(hndl.overriddenPort);
         } else if ( hndl.myDbCluster.equalsIgnoreCase("default")
                 || hndl.myDbCluster.equalsIgnoreCase("dev")
+                || hndl.myDbCluster.equalsIgnoreCase("integration")
                 || hndl.myDbCluster.equalsIgnoreCase("uat")
                 || hndl.myDbCluster.equalsIgnoreCase("alpha")
                 || hndl.myDbCluster.equalsIgnoreCase("beta")


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
Add a new entry to the list of recognized environments so support the `integration` tier

* What are the current behavior and expected behavior, if this is a bugfix ?
Using a connection string such as `jdbc:comdb2://integration/<dbname>?comdb2dbname=comdb3db` should work (it doesn't today)

* What are the steps required to reproduce the bug, if this is a bugfix ?
Try connecting to any database in the `integration` tier - it shouldn't be possible without this change.

* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
