### PR TITLE
Fixing lock inversion

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -513,9 +513,7 @@ static char *last_master = NULL;
 
 static void reset_rep_all_req_dedup_counters()
 {
-	Pthread_mutex_lock(&rep_all_lk);
-	ZERO_LSN(last_lsn);
-	Pthread_mutex_unlock(&rep_all_lk);
+	last_master = db_eid_invalid;
 }
 
 static int send_rep_all_req_dedup(DB_ENV *dbenv, char *master_eid, DB_LSN *lsn, int flags, const char *func, int line)


### PR DESCRIPTION
A lock inversion is introduced in https://github.com/bloomberg/comdb2/pull/4022:

```
REP_VOTE1 -> lock rep-mutex -> reset_rep_all_req_dedup_counters() -> lock rep_all_lk
send_rep_all_req_dedup() -> lock rep_all_lk -> __rep_send_message() -> lock rep->mutex
```

This stack trace below demonstrates such a case on production:

```
0  0x00007ff143a9881d in __lll_lock_wait () from /usr/lib64/libpthread.so.0
1  0x00007ff143a91ac9 in pthread_mutex_lock () from /usr/lib64/libpthread.so.0
2  0x0000000000aa5793 in reset_rep_all_req_dedup_counters ()
3  0x0000000000ab4c2d in __rep_process_message ()
4  0x0000000000d206ca in process_berkdb ()
5  berkdb_receive_rtn_int ()
6  berkdb_receive_rtn ()
7  0x0000000000dc18a7 in process_user_msg ()
8  0x0000000000dc3763 in process_payload ()
9  0x0000000000dc397e in process_net_msgs ()
10 0x0000000000dc3fcb in rd_worker ()
11 0x00007ff143a8f1cf in start_thread () from /usr/lib64/libpthread.so.0
12 0x00007ff142bc8dd3 in clone () from /usr/lib64/libc.so.6

0  0x00007ff143a9881d in __lll_lock_wait ()
1  0x00007ff143a91ac9 in pthread_mutex_lock ()
2  0x0000000000a94098 in __db_pthread_mutex_lock ()
3  0x0000000000ab8390 in __rep_send_message ()
4  0x0000000000aa6f8e in send_rep_all_req_dedup ()
5  send_rep_all_req ()
6  0x0000000000ab9103 in __rep_new_master ()
7  0x0000000000ab4276 in __rep_process_message ()
8  0x0000000000d206ca in process_berkdb ()
9  berkdb_receive_rtn_int ()
10 berkdb_receive_rtn ()
11 0x0000000000dc18a7 in process_user_msg ()
12 0x0000000000dc3763 in process_payload ()
13 0x0000000000dc397e in process_net_msgs ()
14 0x0000000000dc3fcb in rd_worker ()
15 0x00007ff143a8f1cf in start_thread () from /usr/lib64/libpthread.so.0
16 0x00007ff142bc8dd3 in clone () from /usr/lib64/libc.so.6
```

The patch fixes it, by resetting `last_master` which is a pointer type, without holding
any locks.