### PR TITLE
Adding test for the views_lk issue

### DIFF
--- a/tests/systable_locking.test/runit
+++ b/tests/systable_locking.test/runit
@@ -316,11 +316,38 @@ function read_systable_from_consumer {
     if [[ $? -ne 0 ]]; then failexit "consumer failed"; fi
 }
 
+function do_not_hold_onto_viewslk_from_consumer {
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<-'EOF'
+	DROP TABLE IF EXISTS t1
+	CREATE TABLE t1(i INTEGER)$$
+	CREATE PROCEDURE baz VERSION 'bar' {
+	local function main()
+		local stmt = db:exec("SELECT * FROM COMDB2_COLUMNS")
+		stmt:close()
+		db:consumer():get()
+		return 0
+	end
+	}$$
+	CREATE LUA CONSUMER baz ON (TABLE t1 FOR INSERT)
+	EOF
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "CREATE TABLE t2 (i INT) PARTITIONED BY MANUAL"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "EXEC PROCEDURE baz()" &
+    sleep 1
+    # rollout a shard; this would acquire views_lk
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "PUT COUNTER t2 INCREMENT"
+    # make sure that we aren't blocked on anything
+    timeout 3s $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "EXEC PROCEDURE sys.info.cluster()"
+    if [[ $? -ne 0 ]]; then failexit "could not get sys.info.cluster"; fi
+    wait
+}
+
 function run_test
 {
     splock_test
     alltables_test
     read_systable_from_consumer
+    do_not_hold_onto_viewslk_from_consumer
 }
 
 setup


### PR DESCRIPTION
This patch adds a test which would reproduce the views_lk issue without the ez-systable rewriting for comdb2_columns.