### PR TITLE
{173263890}: Speeding up logc->get(DB_FIRST)

### DIFF
--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -463,9 +463,14 @@ int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe)
             goto done;
         }
 
+        Pthread_mutex_unlock(&bdb_state->blkseq_lk[stripe]);
+        /* DB_FIRST on many log files can be expensive. Do it without
+         * holding the blkseq mutex so that we do not block replication
+         * for too long */
         logdta.flags = DB_DBT_MALLOC;
         rc = logc->get(logc, &lsn, &logdta, DB_FIRST);
         logc->close(logc, 0);
+        Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
 
         if (rc) {
             logmsg(LOGMSG_ERROR, "%s: couldn't retrieve first log-record, rc=%d\n",

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3945,6 +3945,7 @@ low_headroom:
                     }
 
                     rc = unlink(logname);
+                    __log_invalidate(filenum);
                     if (rc) {
                         logmsg(LOGMSG_ERROR,
                                "delete_log_files: unlink for <%s> returned %d %d\n",


### PR DESCRIPTION
This patch adds a simple cache inside the berkdb layer to avoid opening and reading all log files for every `logc->get(DB_FIRST)` call.

The blkseq code is also tweaked to avoid blocking replication while getting the very first log record.
