### PR TITLE
Protect fdb writes with mutex if hbeats are enabled

### DIFF
--- a/db/fdb_fend.h
+++ b/db/fdb_fend.h
@@ -160,6 +160,7 @@ typedef struct fdb_sqlstat_table fdb_sqlstat_table_t;
 typedef struct fdb_sqlstat_cursor fdb_sqlstat_cursor_t;
 
 struct fdb_tran {
+    char magic[4];
     char *tid; /* transaction id */
     char *
         host; /* what is the remote replicant this transaction is submitted to
@@ -409,6 +410,12 @@ int fdb_unlock_table(fdb_tbl_ent_t *ent);
  *
  */
 int fdb_heartbeats(fdb_hbeats_type *hbeats);
+
+/**
+ * Close sbuf2, destroy mutex and free fdb-tran
+ *
+ */
+void fdb_heartbeat_free_tran(fdb_hbeats_type *hbeats);
 
 /**
  * Change association of a cursor to a table (see body note)

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -1827,10 +1827,8 @@ static void fdb_heartbeat(int dummyfd, short what, void *data)
     check_fdb_thd();
 
     fdb_hbeats_type *hb = data; 
-    Pthread_mutex_lock(&hb->sb_mtx);
     logmsg(LOGMSG_INFO, "Sending fdb heartbeat for tran %p\n", hb);
     fdb_heartbeats(hb);
-    Pthread_mutex_unlock(&hb->sb_mtx);
 }
 
 static void do_enable_fdb_heartbeats(int dummyfd, short what, void *data)
@@ -1858,6 +1856,7 @@ int enable_fdb_heartbeats(fdb_hbeats_type  *hb)
                            hb, NULL);
 }
 
+extern void fdb_heartbeat_free_tran(fdb_hbeats_type *hb);
 static void do_disable_fdb_heartbeats_and_free(int dummyfd, short what, void *data)
 {
     fdb_hbeats_type *hb= data;
@@ -1868,7 +1867,7 @@ static void do_disable_fdb_heartbeats_and_free(int dummyfd, short what, void *da
         event_free(hb->ev_hbeats);
         hb->ev_hbeats = NULL;
     }
-    free(hb->tran);
+    fdb_heartbeat_free_tran(hb);
 }
 
 int disable_fdb_heartbeats_and_free(fdb_hbeats_type *hb)


### PR DESCRIPTION
Lock around the fdb-write functions if heartbeats are enabled.