### PR TITLE
{173291085}: Reducing memory footprint of cascading transaction

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1199,7 +1199,6 @@ struct temp_table;
 struct temp_cursor;
 struct temp_table *bdb_temp_table_create(bdb_state_type *bdb_state,
                                          int *bdberr);
-struct temp_table *bdb_temp_list_create(bdb_state_type *bdb_state, int *bdberr);
 struct temp_table *bdb_temp_hashtable_create(bdb_state_type *bdb_state,
                                              int *bdberr);
 struct temp_table *bdb_temp_array_create(bdb_state_type *bdb_state,


### PR DESCRIPTION
The `list` type of temp-table, used by the constraints subsystem, is incapable of spilling to the disk. This patch changes it to use btree-backed temp-tables. Since the constraints subsystem is the only user of the `temp-list`, the patch gets rid of the implementation all together.