### PR TITLE
Fixing incorrect rcode in longreqs

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3713,7 +3713,7 @@ static int post_sqlite_processing(struct sqlthdstate *thd,
 static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                     struct sql_state *rec, int *fast_error, struct errstat *err)
 {
-    int rc;
+    int rc, t_rc;
     uint64_t row_id = 0;
     int rowcount = 0;
     int postponed_write = 0;
@@ -3818,8 +3818,12 @@ postprocessing:
        and we must reset the state */
     if (rc == SQLITE_EARLYSTOP_DOHSQL)
         sqlite3_reset(stmt);
+    if (rc == SQLITE_DONE || rc == SQLITE_OK) /* good rcodes */
+        rc = 0;
     /* closing: error codes, postponed write result and so on*/
-    rc = post_sqlite_processing(thd, clnt, rec, postponed_write, row_id);
+    t_rc = post_sqlite_processing(thd, clnt, rec, postponed_write, row_id);
+    if (t_rc != 0 && rc == 0)
+        rc = t_rc;
 
     return rc;
 }


### PR DESCRIPTION
reqlog may log a good rcode for an error. The example below shows that a failed query is recorded with a "rc 0" in the longreqs.

```
osql_sock_commit line 1066 setting rcout to (210) from -6
LONG REQUEST (240025 ms) finished (see mydb.longreqs for details)

10/20 14:03:57: LONG REQUEST 240025 msec for fingerprint 4c9553ff0390f309285ce1e210f7457e pid 236623 task cdb2sql rqid 74d1c790-03b0-422f-9750-a65b1f2eaade from localhost rc 0
```

This patch fixes it.
