### PR TITLE
Add selecting types test for typessql. Check declared types

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -265,7 +265,7 @@ static int inner_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
     conn->ncols = ncols;
 
     for (i = 0; i < ncols; i++) {
-        conn->cols[i].type = get_sqlite3_column_type(clnt, stmt, i, 0, 0);
+        conn->cols[i].type = get_sqlite3_column_type(clnt, stmt, i, 0);
     }
     return 0;
 }

--- a/db/sql.h
+++ b/db/sql.h
@@ -1385,7 +1385,7 @@ int sqlite3_is_success(int);
 int sqlite3_is_prepare_only(struct sqlclntstate *);
 int sqlite3_maybe_step(struct sqlclntstate *, sqlite3_stmt *);
 int get_sqlite3_column_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                            int col, int skip_decltype, int non_null_type);
+                            int col, int skip_decltype);
 int is_column_type_null(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col);
 
 int column_type(struct sqlclntstate *, sqlite3_stmt *, int);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -968,14 +968,14 @@ int validate_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
 }
 
 int get_sqlite3_column_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
-                            int col, int skip_decltype, int non_null_type)
+                            int col, int skip_decltype)
 {
     int type = SQLITE_NULL;
     int ncols = column_count(clnt, stmt);
 
     if (sqlite3_can_get_column_type_and_data(clnt, stmt)) {
         int colNum = col;
-        if (clnt->typessql_state && non_null_type)
+        if (clnt->typessql_state && !skip_decltype)
             colNum += ncols;
         type = column_type(clnt, stmt, colNum);
         if (type == SQLITE_NULL && !skip_decltype) {
@@ -991,7 +991,7 @@ int get_sqlite3_column_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt,
 int is_column_type_null(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col)
 {
     if (!clnt->fdb_push) {
-        return get_sqlite3_column_type(clnt, stmt, col, 1, 0) == SQLITE_NULL ||
+        return get_sqlite3_column_type(clnt, stmt, col, 1) == SQLITE_NULL ||
                column_type(clnt, stmt, col) == SQLITE_NULL;
     }
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -341,7 +341,7 @@ static int newsql_send_hdr(struct sqlclntstate *clnt, int h, int s)
 }
 
 static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col,
-                        int check_protocol_version, int non_null_type)
+                        int check_protocol_version)
 {
     struct newsql_appdata *appdata = clnt->appdata;
     CDB2SQLQUERY *sql_query = appdata->sqlquery;
@@ -352,7 +352,7 @@ static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col,
             type = SQLITE_TEXT;
         }
     } else if (stmt) {
-        type = get_sqlite3_column_type(clnt, stmt, col, 0, non_null_type);
+        type = get_sqlite3_column_type(clnt, stmt, col, 0);
         if ((check_protocol_version == 1 && appdata->protocol_version == 1 /* fastsql */) ||
             type == SQLITE_NULL) {
             type = typestr_to_type(sqlite3_column_decltype(stmt, col));
@@ -389,7 +389,7 @@ static int newsql_columns(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
         cols[i].value.data = (uint8_t *)name;
         cols[i].value.len = len;
         cols[i].has_type = 1;
-        cols[i].type = appdata->col_info.type[i] = get_col_type(clnt, stmt, i, 1, clnt->typessql_state != NULL);
+        cols[i].type = appdata->col_info.type[i] = get_col_type(clnt, stmt, i, 1);
     }
     CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;
     resp.response_type = RESPONSE_TYPE__COLUMN_NAMES;
@@ -446,7 +446,7 @@ static int newsql_columns_lua(struct sqlclntstate *clnt,
         cols[i].value.len = len;
         cols[i].has_type = 1;
         cols[i].type = appdata->col_info.type[i] =
-            sp_column_type(arg, i, n_types, get_col_type(clnt, stmt, i, 0, 0));
+            sp_column_type(arg, i, n_types, get_col_type(clnt, stmt, i, 0));
     }
     clnt->osql.sent_column_data = 1;
     CDB2SQLRESPONSE resp = CDB2__SQLRESPONSE__INIT;

--- a/tests/typessql.test/lrl.options
+++ b/tests/typessql.test/lrl.options
@@ -1,1 +1,2 @@
 typessql on
+table t2 t2.csc2

--- a/tests/typessql.test/t02.sql
+++ b/tests/typessql.test/t02.sql
@@ -1,2 +1,3 @@
 put tunable typessql_records_max 1
 SELECT NULL AS a UNION ALL SELECT 1 ORDER BY a; -- test traversing the max number of records allowed
+put tunable typessql_records_max 1000

--- a/tests/typessql.test/t04.expected
+++ b/tests/typessql.test/t04.expected
@@ -1,0 +1,7 @@
+(rows inserted=1)
+(i=NULL, r=NULL, s=NULL, v=NULL, byt=NULL, b=NULL, d=NULL, d2=NULL)
+(i=1, r=1.000000, s='hi', v='hello', byt=x'deadbeef', b=x'deadbeef', d="2023-09-13T000000.000 America/New_York", d2="2023-09-13T000000.000001 America/New_York")
+(interval=NULL)
+(interval="0 00:00:00.000001")
+(i=NULL, r=NULL, s=NULL, v=NULL, byt=NULL, b=NULL, d=NULL, d2=NULL)
+(i=1, r=1.000000, s='hi', v='hello', byt=x'deadbeef', b=x'deadbeef', d="2023-09-13T130000.000 Asia/Tokyo", d2="2023-09-13T130000.000001 Asia/Tokyo")

--- a/tests/typessql.test/t04.sql
+++ b/tests/typessql.test/t04.sql
@@ -1,0 +1,5 @@
+INSERT INTO t2 VALUES (1, 1.0, 'hi', 'hello', x'deadbeef', x'deadbeef', '20230913T', '2023-09-13T00:00:00.000001');
+SELECT NULL AS i, NULL as r, NULL as s, NULL as v, NULL as byt, NULL as b, NULL as d, NULL as d2 UNION ALL SELECT * FROM t2 ORDER BY i; -- test returning all types from queue
+SELECT NULL AS interval UNION ALL SELECT d2 - d FROM t2;
+set timezone Asia/Tokyo;
+SELECT NULL AS i, NULL as r, NULL as s, NULL as v, NULL as byt, NULL as b, NULL as d, NULL as d2 UNION ALL SELECT * FROM t2 ORDER BY i; -- make sure timezone is correct

--- a/tests/typessql.test/t2.csc2
+++ b/tests/typessql.test/t2.csc2
@@ -1,0 +1,11 @@
+tag ondisk
+{
+    int i null=yes
+    float r null=yes
+    cstring s[10] null=yes
+    vutf8 v[2] null=yes
+    byte byt[4] null=yes
+    blob b null=yes
+    datetime d null=yes
+    datetimeus d2 null=yes
+}


### PR DESCRIPTION
Types. Tests. Typessql.

Tests to make sure that each type is returned correctly with typessql
Also remove non_null_type var since this is used the same as skip_decl_type
And check declared types in typessql to avoid searching more rows if don't need to