### PR TITLE
Fix `ar_compress` and `ar_decompress` not set bug

### DIFF
--- a/db/copycomdb2
+++ b/db/copycomdb2
@@ -144,21 +144,23 @@ lz4_rmt=
 do_recovery=yes
 
 [ -z "$comdb2ar" ] && comdb2ar="${PREFIX}/bin/comdb2ar"
-[ -z "$lz4" ] && lz4="${PREFIX}/bin/lz4"
+[ -z "$lz4" ] && lz4="${PREFIX}/bin/lz4"  # set default lz4 path
 
 if [[ ! -x $comdb2ar ]]; then
-   comdb2ar=$(which comdb2ar 2>/dev/null)
+    comdb2ar=$(which comdb2ar 2>/dev/null)
 fi
 
+# if the lz4 executable is not on default path, use the one avaiable in PATH
 if [[ ! -x $lz4 ]]; then
-   lz4=$(which lz4 2>/dev/null)
-   if [[ -z "$lz4" ]]; then
-       ar_compress="cat"
-       ar_decompress="cat"
-   else
-       ar_compress="$lz4 stdin stdout"
-       ar_decompress="$lz4 -d stdin stdout"
-   fi
+    lz4=$(which lz4 2>/dev/null)
+fi
+
+if [[ -z "$lz4" ]]; then  # lz4 does not exist in the system
+    ar_compress="cat"
+    ar_decompress="cat"
+else                      # lz4 does exist in the system
+    ar_compress="$lz4 stdin stdout"
+    ar_decompress="$lz4 -d stdin stdout"
 fi
 
 set - `getopt "LC:ht:l:rdsSx:fmaZu:bpH:y:P:z:R" "$@"` || die


### PR DESCRIPTION
## Issue (Bug)
The **current behavior** is that if `lz4` exists on the default path (`/opt/bb/bin/lz4`), `[[ ! -x $lz4 ]]` would evaluate to `false`, and `ar_compress` and `ar_decompress` wouldn't be set to correct value and therefore undefined.

The **expected behavior** is that `ar_compress` and `ar_decompress` should be set in all circumstances.

## Reproduce the bug
Run `copycomdb2` on a host where `/opt/bb/bin/lz4` does exist.