### PR TITLE
do not treat all schema changes errors as downgrades

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -393,9 +393,18 @@ int osql_bplog_schemachange(struct ireq *iq)
     if (rc)
         csc2_free_all();
 
-    if (rc) {
-        /* free schema changes that have finished without marking schema change
-         * over in llmeta so new master can resume properly */
+    if (rc && !iq->sc_should_abort) {
+        /* IFF the schema changes are NOT aborted, clean in-mem structures but
+         * leave persistent and replicated changes (llmeta, new btree-s) so
+         * that a new master/resume will pick it up later
+         * NOTE: this clears iq->sc_pending, obviously (sc-s are freed), so
+         * the rest of schema change code -finalize, callback hooks- do NOT
+         * trigger anymore (they should not, they will do it when future resume
+         * finishes)
+         * NOTE2: if sc_should_abort is set, the bplog writer will call 
+         * backout_schema_change and sc_abort callback, which they will 
+         * clear any persistent and in-mem structures 
+         */
         struct schema_change_type *next;
         sc = iq->sc_pending;
         while (sc != NULL) {

--- a/tests/sc_multitable.test/Makefile
+++ b/tests/sc_multitable.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/sc_multitable.test/README
+++ b/tests/sc_multitable.test/README
@@ -1,0 +1,1 @@
+Test a failed (aborted) schema change part of a partition alter.

--- a/tests/sc_multitable.test/lrl.options
+++ b/tests/sc_multitable.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/sc_multitable.test/new.csc2
+++ b/tests/sc_multitable.test/new.csc2
@@ -1,0 +1,9 @@
+schema
+{
+    int a
+}
+
+keys
+{
+    dup "a" = a
+}

--- a/tests/sc_multitable.test/run.log.alpha
+++ b/tests/sc_multitable.test/run.log.alpha
@@ -1,0 +1,4 @@
+[set transaction chunk 10000] rc 0
+[begin] rc 0
+[insert into testview1 select * from  generate_series(1,100000)] rc 0
+[commit] rc 0

--- a/tests/sc_multitable.test/runit
+++ b/tests/sc_multitable.test/runit
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+
+dbname=$1
+VIEW1="testview1"
+OUT="run.log"
+
+rm $OUT 2>/dev/null
+touch $OUT
+
+
+# create the partition
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-3600)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'"
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >>    \$OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE create time partition"
+   exit 1
+fi
+
+# check the current partitions
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID"
+cdb2sql -tabs ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >>    \$OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE partinfo"
+   exit 1
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbname default >> $OUT <<EOF
+set transaction chunk 10000
+begin
+insert into ${VIEW1} select * from  generate_series(1,100000)
+commit
+EOF
+if (( $? != 0 )) ; then
+   echo "FAILURE insert"
+   exit 1
+fi
+
+master=$(get_master)
+
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat new.csc2`}"
+cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat new.csc2`}" &
+
+sleep 3
+
+echo cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"
+cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"
+if (( $? != 0 )) ; then
+   echo "FAILURE scabort"
+   exit 1
+fi
+
+sleep 5
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('llmeta list')" | grep IN >> $OUT
+
+# we need to scrub dbname from alpha
+sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
+
+difs=`diff $OUT $OUT.alpha.actual`
+if [[ ! -z "${difs}" ]] ; then
+   echo "diff $OUT $OUT.alpha.actual"
+   echo ${difs}
+   echo "FAILURE diff"
+   exit 1
+fi
+
+echo "Success"

--- a/tests/sc_multitable.test/t.csc2
+++ b/tests/sc_multitable.test/t.csc2
@@ -1,0 +1,4 @@
+schema
+{
+    int a
+}


### PR DESCRIPTION
Currently, if two or more tables are schema changed in the same transaction, and:
- one table schema change fails (for example, by receiving a scabort trap during row conversion), and
- the other schema changes are done with the asynchronous execution before the above failure,
the error handling will treat this as a master downgrade.  
The llmeta entries for the other schema changes will be left in place and a master swing will resume and execute those schema changes as individual transactions (even though the original transaction was cancelled).   If the multiple tables are shards in a partition, the master swing will resume and apply the schema change as one transaction.
Luckily, typing this is way longer than the fix.