### PR TITLE
{171377006}: Fixing spurious 402 error during leader-swing

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -4164,6 +4164,10 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
 
         break;
 
+    case DB_HAS_MAJORITY:
+        logmsg(LOGMSG_WARN, "%s: received another vote for leader %s\n", __func__, host);
+        break;
+
     case DB_REP_NEWMASTER:
         bdb_state->repinfo->repstats.rep_newmaster++;
 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1328,6 +1328,7 @@ typedef enum {
 #define	DB_VERIFY_BAD		(-30976)/* Verify failed; bad format. */
 #define	DB_CUR_STALE		(-30975)/* Cursor deserialization failed since 
 					 * something had changed. comdb2 add */
+#define	DB_HAS_MAJORITY		(-30974)/* have enough votes to become a majority */
 #define DB_LOCK_DESIRED		(-31000)/* BDB needs  a long running operation
 					 *  out of the library */
 #define DB_LOCK_DEADLOCK_CUSTOM	(-31001)/* Deadlock on custom log record.  */

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -2437,7 +2437,7 @@ rep_verify_err:if ((t_ret = __log_c_close(logc)) != 0 &&
 			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s for egen %d\n",
 					__func__, __LINE__, rep->eid, vi_egen);
 			__rep_elect_master(dbenv, rep, eidp);
-			ret = DB_REP_NEWMASTER;
+			ret = (rep->votes > rep->nsites / 2 + 1) ? DB_HAS_MAJORITY : DB_REP_NEWMASTER;
 			goto errunlock;
 		} else {
 			MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);


### PR DESCRIPTION
The osql repo is cleared in bdb_upgrade(). However currently bdb_upgrade() may be called more than once, for instance, when a machine has more votes than needed to become a majority. This would lead to the following race condition:

```
machine-1                                      machine-2
----------------------------------------------------------------------------------
received a vote and has majority (N/2+1)
|
bdb_upgrade()
 \
  clean up osql-repo
  boardcast new leader
----------------------------------------------------------------------------------
                                               session restarted against machine-1
----------------------------------------------------------------------------------
received 1 more vote past majority (N/2+2)
|
bdb_upgrade()
 \
  clean up osql-repo
  boardcast new leader
----------------------------------------------------------------------------------
                                               session lost
```

To fix this, a new `HAS_MAJORITY` message type is introduced. The type is returned when a node has more than enough votes to become a leader, and is treated as a no-op subsequently. The leader would then call `bdb_upgrade()` only once during a single generation of election.