### PR TITLE
schema change does not stop threads anymore

### DIFF
--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -1505,8 +1505,4 @@ void change_schemas_recover(char *table)
     }
     backout_schemas(table);
     live_sc_off(db);
-
-    if (db_is_stopped()) {
-        resume_threads(thedb);
-    }
 }


### PR DESCRIPTION
Left-over from the time when we stopped threads during schema changes.  Removing since it might collide with a pending exit.