### PR TITLE
forgot to add sc to sc_pending; less verbose spewing

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5756,6 +5756,13 @@ static int start_schema_change_tran_wrapper(const char *tblname,
         sc->preempted == SC_ACTION_RESUME ||
         sc->kind == SC_ALTERTABLE_PENDING) {
         iq->sc = NULL;
+        if (rc != SC_ASYNC && rc != SC_COMMIT_PENDING && sc->nothrevent) {
+            /* we need to link the sc into sc_pending so that backout
+             * picks it up
+             */
+            sc->sc_next = iq->sc_pending;
+            iq->sc_pending = sc;
+        }
     } else {
         iq->sc->sc_next = iq->sc_pending;
         iq->sc_pending = iq->sc;

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -98,8 +98,12 @@ int get_stopsc(const char *func, int line)
     ret = stopsc;
     Pthread_mutex_unlock(&gbl_sc_progress_lk);
     if (gbl_verbose_set_sc_in_progress) {
-        logmsg(LOGMSG_USER, "%s line %d %s returning %d\n", func, line,
-               __func__, ret);
+        static int once = -1;
+        if (once != ret) {
+            logmsg(LOGMSG_USER, "%s line %d %s returning %d\n", func, line,
+                   __func__, ret);
+            once = ret;
+        }
     }
     return ret;
 }
@@ -160,8 +164,12 @@ int get_schema_change_in_progress(const char *func, int line)
     }
     Pthread_mutex_unlock(&gbl_sc_progress_lk);
     if (gbl_verbose_set_sc_in_progress) {
-        logmsg(LOGMSG_USER, "%s line %d %s returning %d stopsc is %d\n", func,
-               line, __func__, val, stopped);
+        static int once = -1;
+        if (once != val) {
+            logmsg(LOGMSG_USER, "%s line %d %s returning %d stopsc is %d\n", func,
+                   line, __func__, val, stopped);
+            once = val;
+        }
     }
     return val;
 }


### PR DESCRIPTION
Inline schema changes do not get added to sc_pending; make sure we do that so cleanup picks it up.
Also reduce the verbose spew (only spew on state changes).