### PR TITLE
when a table is partitioned, name is aliased; needs special handling during unpartitioning

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -54,6 +54,7 @@
 #include "osqlsqlsocket.h"
 #include "sc_global.h"
 #include "logical_cron.h"
+#include "sc_logic.h"
 
 
 #define MAX_CLUSTER REPMAX
@@ -5880,19 +5881,54 @@ static int _process_partitioned_table_merge(struct ireq *iq)
 {
     struct schema_change_type *sc = iq->sc;
     int rc;
+    int start_shard = 0;
 
     assert(sc->kind == SC_ALTERTABLE);
 
-    /* create a table with the same name as the partition */
-    sc->nothrevent = 1; /* we need do_add_table to run first */
-    sc->finalize = 0;   /* make sure */
-    sc->kind = SC_ADDTABLE;
+    /* if this was a CREATE & ALTER, first shart is an aliased
+     * table with the same name as the partition
+     * use that as the destination for merging
+     * OTHERWISE, create a new table with the same name as 
+     * the partition
+     */
+    char *first_shard_name = timepart_shard_name(sc->tablename, 0, 0, NULL);
+    struct dbtable *first_shard = get_dbtable_by_name(first_shard_name);
+    free(first_shard_name);
 
-    rc = start_schema_change_tran(iq, NULL);
-    iq->sc->sc_next = iq->sc_pending;
-    iq->sc_pending = iq->sc;
-    if (rc != SC_COMMIT_PENDING) {
-        return ERR_SC;
+    if (!first_shard->sqlaliasname) {
+        /*
+         * create a table with the same name as the partition
+         */
+        sc->nothrevent = 1; /* we need do_add_table to run first */
+        sc->finalize = 0;   /* make sure */
+        sc->kind = SC_ADDTABLE;
+
+        rc = start_schema_change_tran(iq, NULL);
+        iq->sc->sc_next = iq->sc_pending;
+        iq->sc_pending = iq->sc;
+        if (rc != SC_COMMIT_PENDING) {
+            return ERR_SC;
+        }
+    } else {
+        /*
+         * use the fast shard as the destination, after first altering it
+         */
+        sc->nothrevent = 1; /* we need do_alter_table to run first */
+        sc->finalize = 0;
+        enum comdb2_partition_type tt = sc->partition.type;
+        sc->partition.type = PARTITION_NONE;
+
+        strncpy(sc->tablename, first_shard->tablename, sizeof(sc->tablename));
+
+        rc = start_schema_change_tran(iq, NULL);
+        sc->partition.type = tt;
+        iq->sc->sc_next = iq->sc_pending;
+        iq->sc_pending = iq->sc;
+        if (rc != SC_COMMIT_PENDING) {
+            return ERR_SC;
+        }
+        start_shard = 1;
+        strncpy(sc->newtable, sc->tablename, sizeof(sc->newtable)); /* piggyback a rename with alter */
     }
 
     /* at this point we have created the future btree, launch an alter
@@ -5901,9 +5937,16 @@ static int _process_partitioned_table_merge(struct ireq *iq)
     timepart_sc_arg_t arg = {0};
     arg.s = sc;
     arg.s->iq = iq;
+    arg.indx = start_shard;
     /* note: we have already set nothrevent depending on the number of shards */
     rc = timepart_foreach_shard(
-        sc->tablename, start_schema_change_tran_wrapper_merge, &arg, 0);
+        sc->tablename, start_schema_change_tran_wrapper_merge, &arg, start_shard);
+
+    if (first_shard->sqlaliasname) {
+        sc->partition.type = PARTITION_REMOVE; /* first shard is the collapsed table */
+        sc->publish = partition_publish;
+        sc->unpublish = partition_unpublish;
+    }
     return rc;
 }
 

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -978,3 +978,127 @@ Test ALTER table MERGE
 (a=100)
 (a=200)
 [select * from t16 order by a] failed with rc -3 no such table: t16
+cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "t",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_F64CD191",
+  },
+  {
+   "TABLENAME"    : "$1_A2620AE4",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t3",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_43868980",
+  },
+  {
+   "TABLENAME"    : "$2_CE9DB8D",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='t', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+(name='t2', period='daily', retention=2, nshards=2, version=0, shard0name='t3')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='t', shardname='$0_F64CD191')
+(name='t', shardname='$1_A2620AE4')
+(name='t2', shardname='$0_43868980')
+(name='t2', shardname='$2_CE9DB8D')
+cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
+(name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+TEST 16
+Test PARTITION NONE on ALIASED table
+cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
+[
+ {
+  "NAME"      : "t",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_F64CD191",
+  },
+  {
+   "TABLENAME"    : "$1_A2620AE4",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t3",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_43868980",
+  },
+  {
+   "TABLENAME"    : "$2_CE9DB8D",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "t17",
+  "PERIOD"    : "daily",
+  "RETENTION" : 3,
+  "SHARD0NAME": "<none>",
+  "ROLLOUT"   : "TRUNCATE",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_41D9A045",
+  },
+  {
+   "TABLENAME"    : "$1_E76B54BE",
+  },
+  {
+   "TABLENAME"    : "$2_B9E973E6",
+  }
+  ]
+ }
+]
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, period, retention, nshards, version,shard0name from comdb2_timepartitions 
+(name='t', period='daily', retention=2, nshards=2, version=0, shard0name='<none>')
+(name='t2', period='daily', retention=2, nshards=2, version=0, shard0name='t3')
+(name='t17', period='daily', retention=3, nshards=3, version=1, shard0name='<none>')
+cdb2sql ${CDB2_OPTIONS} dorintdb default select name, shardname from comdb2_timepartshards
+(name='t', shardname='$0_F64CD191')
+(name='t', shardname='$1_A2620AE4')
+(name='t2', shardname='$0_43868980')
+(name='t2', shardname='$2_CE9DB8D')
+(name='t17', shardname='$0_41D9A045')
+(name='t17', shardname='$1_E76B54BE')
+(name='t17', shardname='$2_B9E973E6')
+cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, arg3 from comdb2_timepartevents order by 1, 2
+(name='AddShard', arg1='t2', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t', arg2=NULL, arg3=NULL)
+(name='Truncate', arg1='t17', arg2=NULL, arg3=NULL)
+(a=1000)
+(a=2000)
+(a=3000)
+(a=4000)
+(tablename='t17')

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -458,6 +458,57 @@ $cmd "select * from t15 order by a" >> $OUT
 echo $cmd "select * from t16 order by a"
 $cmd "select * from t16 order by a" >> $OUT 2>&1
 
+timepart_stats 0
+
+header 16 "Test PARTITION NONE on ALIASED table"
+echo $cmd "CREATE TABLE t17(a int)"
+$cmd "CREATE TABLE t17(a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create t17"
+   exit 1
+fi
+
+
+echo $cmd "insert into t17 values (1000), (2000)"
+$cmd "insert into t17 values (1000), (2000)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t17"
+   exit 1
+fi
+
+echo $cmd "ALTER TABLE t17 PARTITIONED BY TIME PERIOD 'daily' RETENTION 3 start '2023-01-01T'"
+$cmd "ALTER TABLE t17 PARTITIONED BY TIME PERIOD 'daily' RETENTION 3 start '2023-01-01T'"
+if (( $? != 0 )) ; then
+   echo "FAILURE to partition t17"
+   exit 1
+fi
+
+echo $cmd "insert into t17 values (3000), (4000)"
+$cmd "insert into t17 values (3000), (4000)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into partition t17"
+   exit 1
+fi
+
+timepart_stats 0
+
+echo $cmd "ALTER TABLE t17 PARTITIONED BY NONE"
+$cmd "ALTER TABLE t17 PARTITIONED BY NONE"
+if (( $? != 0 )) ; then
+   echo "FAILURE to UNpartition t17"
+   exit 1
+fi
+
+echo $cmd "select * from t17 order by a"
+$cmd "select * from t17 order by a" >> $OUT 2>&1
+
+
+echo $cmd "select * from comdb2_tables where tablename='t17'"
+$cmd "select * from comdb2_tables where tablename='t17'" >> $OUT 2>&1
+
+echo $cmd "select * from comdb2_timepartshards where name='t17'"
+$cmd "select * from comdb2_timepartshards where name='t17'" >> $OUT 2>&1
+
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
 


### PR DESCRIPTION
Partitioning an existing table creates an alias for it to serve as first shard; if the partition is merged back to the original table, special code is required to remove the alias.