### PR TITLE
Add missing dependency on `libunwind`

### DIFF
--- a/cdb2api/cdb2api.pc
+++ b/cdb2api/cdb2api.pc
@@ -8,4 +8,4 @@ Description: C API to talk to Comdb2
 Version: 1.0
 Libs: -L${libdir} -lcdb2api
 Cflags: -I${includedir} 
-Requires: libprotobuf-c libssl libcrypto
+Requires: libprotobuf-c libssl libcrypto libunwind


### PR DESCRIPTION
`libcdb2api.a` declares its dependencies here, unlike `libcdb2api.so`
which uses `cmake` instead.

Signed-off-by: Gus Monod <gmonod1@bloomberg.net>
