### PR TITLE
Test and fix for abort-in-election issue

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -2411,6 +2411,7 @@ rep_verify_err:if ((t_ret = __log_c_close(logc)) != 0 &&
 #endif
 			egen = rep->egen;
 			committed_gen = rep->committed_gen;
+			logmsg(LOGMSG_DEBUG, "%s line %d Setting PHASE2 clearing PHASE1\n", __func__, __LINE__);
 			F_SET(rep, REP_F_EPHASE2);
 			F_CLR(rep, REP_F_EPHASE1);
 			if (master == rep->eid) {
@@ -6946,7 +6947,7 @@ __rep_cmp_vote2(dbenv, rep, eid, egen)
 	}
 #ifdef DIAGNOSTIC
 	if (FLD_ISSET(dbenv->verbose, DB_VERB_REPLICATION))
-		__db_err(dbenv, "Did not find vote1 for eid %d, egen %lu",
+		__db_err(dbenv, "Did not find vote2 for eid %d, egen %lu",
 			eid, (u_long)egen);
 #endif
 	logmsg(LOGMSG_DEBUG,

--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -842,6 +842,8 @@ __rep_elect_done(dbenv, rep, egen, func, line)
 	int inelect;
 
 	inelect = IN_ELECTION_TALLY(rep);
+	logmsg(LOGMSG_DEBUG, "%s line %d clearing PHASE1/PHASE2/TALLY, inelect is %d\n",
+		__func__, __LINE__, inelect);
 	F_CLR(rep, REP_F_EPHASE1 | REP_F_EPHASE2 | REP_F_TALLY);
 	rep->sites = 0;
 	rep->votes = 0;

--- a/tests/downgrade_loop.test/Makefile
+++ b/tests/downgrade_loop.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=8m
+endif

--- a/tests/downgrade_loop.test/README
+++ b/tests/downgrade_loop.test/README
@@ -1,0 +1,1 @@
+Make sure that we can downgrade in a loop without crashing

--- a/tests/downgrade_loop.test/lrl.options
+++ b/tests/downgrade_loop.test/lrl.options
@@ -1,0 +1,1 @@
+logmsg level debug

--- a/tests/downgrade_loop.test/runit
+++ b/tests/downgrade_loop.test/runit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+function run_test
+{
+    typeset iters=300
+    typeset i=0
+    while [[ "$i" -lt "$iters" ]]; do
+        let i=i+1
+        echo "Downgrade iteration $i / $iters"
+        for n in $CLUSTER ; do
+            $CDB2SQL_EXE --admin $CDB2_OPTIONS --host $n $DBNAME "exec procedure sys.cmd.send('downgrade')" >/dev/null
+        done
+        sleep 1
+    done
+}
+
+function check_all_nodes
+{
+    typeset err=1
+    typeset iter=0
+    while [[ "$err" == 1 ]]; do
+        let iter=iter+1
+        err=0
+        echo "check_all_nodes iteration $iter"
+        for n in $CLUSTER; do
+            $CDB2SQL_EXE $CDB2_OPTIONS --host $n $DBNAME "select 1" >/dev/null 2>&1
+            e=$?
+            if [[ "$e" -ne "0" ]]; then err=1 ; fi
+        done
+        if [[ "$err" == "1" ]]; then
+            sleep 2
+        fi
+    done
+    [[ "$err" -ne "0" ]] && failexit "cluster not up"
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+
+run_test
+check_all_nodes
+echo "Success"
+
+exit 0 


### PR DESCRIPTION
I'm still re-reading this code to refresh my understanding of election logic.  I believe this fixes the issue.  The abort is in place to prevent the elect thread from sending more than a single vote for the same election-generation.  Calling rep-elect-done after discovering a master increments the election generation.