### PR TITLE
handle case when partition alias has also auto analyze

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -9022,6 +9022,12 @@ int bdb_set_table_parameter(void *parent_tran, const char *table,
 #endif
             cson_value_free(rootV);
             free(blob);
+            if (value == NULL) {
+                /* blob does not contain this param, and we are trying to 
+                 * delete it; we are done here 
+                 */
+                return 0;
+            }
             return 1;
         }
 


### PR DESCRIPTION
Partitioning an existing table creates a light table alias; there is a corner case when removing a partition still fails (when other table/partition parameters are set, like auto analyze).  Straightforward fix.