### PR TITLE
sc_resume fix

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1263,7 +1263,7 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
 
 
     if (rc) {
-        if (!iq->sc_should_abort) {
+        if (rc == ERR_NOMASTER) {
             /* IFF the schema changes are NOT aborted, clean in-mem structures but
              * leave persistent and replicated changes (llmeta, new btree-s) so
              * that a new master/resume will pick it up later


### PR DESCRIPTION
While cleaning the llmeta persistent leaks for multi-table schema changes, I have broken downgrades in certain fail scenarios.  This is because iq->sc_should_abort is set also for downgrading in those cases.  This should fix sc_resume regression.