### PR TITLE
remove sc finalize code that only confuses

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -53,7 +53,7 @@
 #include "ctrace.h"
 #include "intern_strings.h"
 #include "sc_global.h"
-#include "schemachange.h"
+#include "sc_logic.h"
 #include "gettimeofday_ms.h"
 
 extern int gbl_reorder_idx_writes;
@@ -1341,6 +1341,7 @@ void *bplog_commit_timepart_resuming_sc(void *p)
     iq.sc = sc = sc_pending;
     sc_pending = NULL;
     while (sc != NULL) {
+        /* this will block until the asynchronous part finishes */
         Pthread_mutex_lock(&sc->mtx);
         sc->nothrevent = 1;
         Pthread_mutex_unlock(&sc->mtx);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -788,9 +788,10 @@ int do_schema_change_locked(struct schema_change_type *s, void *tran)
     return rc;
 }
 
-int finalize_schema_change_thd(struct ireq *iq, tran_type *trans)
+int finalize_schema_change(struct ireq *iq, tran_type *trans)
 {
     if (iq == NULL || iq->sc == NULL) abort();
+    assert(iq->sc->tran == NULL || iq->sc->tran == trans);
     struct schema_change_type *s = iq->sc;
     Pthread_mutex_lock(&s->mtx);
     enum thrtype oldtype = prepare_sc_thread(s);

--- a/schemachange/sc_logic.h
+++ b/schemachange/sc_logic.h
@@ -22,7 +22,7 @@
 int dryrun_int(struct schema_change_type *, struct dbtable *db, struct dbtable *newdb,
                struct scinfo *);
 int dryrun(struct schema_change_type *s);
-int finalize_schema_change_thd(struct ireq *, tran_type *);
+int finalize_schema_change(struct ireq *, tran_type *);
 int do_setcompr(struct ireq *iq, const char *rec, const char *blob);
 int delete_temp_table(struct ireq *iq, struct dbtable *newdb);
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -429,44 +429,6 @@ void delay_if_sc_resuming(struct ireq *iq)
     }
 }
 
-typedef struct {
-    struct ireq *iq;
-    void *trans;
-} finalize_t;
-
-static void *finalize_schema_change_thd_tran(void *varg)
-{
-    comdb2_name_thread(__func__);
-    finalize_t *arg = varg;
-    void *trans = arg->trans;
-    struct ireq *iq = arg->iq;
-    free(arg);
-    finalize_schema_change_thd(iq, trans);
-    return NULL;
-}
-
-int finalize_schema_change(struct ireq *iq, tran_type *trans)
-{
-    struct schema_change_type *s = iq->sc;
-    int rc;
-    assert(iq->sc->tran == NULL || iq->sc->tran == trans);
-    if (s->nothrevent) {
-        logmsg(LOGMSG_DEBUG, "Executing SYNCHRONOUSLY\n");
-        rc = finalize_schema_change_thd(iq, trans);
-    } else {
-        pthread_t tid;
-        finalize_t *arg = malloc(sizeof(finalize_t));
-        arg->iq = iq;
-        arg->trans = trans;
-        logmsg(LOGMSG_DEBUG, "Executing ASYNCHRONOUSLY\n");
-        Pthread_create(&tid, &gbl_pthread_attr_detached,
-                       finalize_schema_change_thd_tran, arg);
-        rc = SC_ASYNC;
-    }
-
-    return rc;
-}
-
 /* -99 if schema change already in progress */
 int change_schema(char *table, char *fname, int odh, int compress,
                   int compress_blobs)

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -376,7 +376,6 @@ typedef struct llog_scdone {
 size_t schemachange_packed_size(struct schema_change_type *s);
 int start_schema_change_tran(struct ireq *, tran_type *tran);
 int start_schema_change(struct schema_change_type *);
-int finalize_schema_change(struct ireq *, tran_type *);
 int create_queue(struct dbenv *, char *queuename, int avgitem, int pagesize);
 int start_table_upgrade(struct dbenv *dbenv, const char *tbl,
                         unsigned long long genid, int full, int partial,


### PR DESCRIPTION
Probably a leftover, but currently finalizing a schema change always runs synchronous.  Removing some code for clarity.