### PR TITLE
eliminate redundant sqlite master records creation

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6266,7 +6266,11 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
 
     iq->usedb = NULL;
 
-    if (!rc || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
+    /* SC_ASYNC if nothrevent == 0
+     * SC_COMMIT_PENDING if nothrevent == 1 && finalize == 0
+     * SC_OK for everything else except errors
+     */
+    if (rc == SC_OK || rc == SC_ASYNC || rc == SC_COMMIT_PENDING)
         return 0;
 
     return ERR_SC;

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -346,14 +346,6 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
 
     fix_lrl_ixlen_tran(tran);
 
-    if (s->finalize) {
-        if (create_sqlmaster_records(tran)) {
-            sc_errf(s, "create_sqlmaster_records failed\n");
-            return -1;
-        }
-        create_sqlite_master();
-    }
-
     db->sc_to = NULL;
     update_dbstore(db);
     sc_printf(s, "Add table ok\n");

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1073,14 +1073,6 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     /* kludge: fix lrls */
     fix_lrl_ixlen_tran(transac);
 
-    if (s->finalize) {
-        if (create_sqlmaster_records(transac)) {
-            sc_errf(s, "create_sqlmaster_records failed\n");
-            BACKOUT;
-        }
-        create_sqlite_master();
-    }
-
     live_sc_off(db);
 
     /* artificial sleep to aid testing */

--- a/schemachange/sc_drop_table.c
+++ b/schemachange/sc_drop_table.c
@@ -141,14 +141,6 @@ int finalize_drop_table(struct ireq *iq, struct schema_change_type *s,
         }
     }
 
-    if (s->finalize) {
-        if (create_sqlmaster_records(tran)) {
-            sc_errf(s, "create_sqlmaster_records failed\n");
-            return -1;
-        }
-        create_sqlite_master();
-    }
-
     live_sc_off(db);
 
     if (!gbl_create_mode) {

--- a/schemachange/sc_rename_table.c
+++ b/schemachange/sc_rename_table.c
@@ -72,15 +72,6 @@ int finalize_alias_table(struct ireq *iq, struct schema_change_type *s,
         return rc;
     }
 
-    if (s->finalize) {
-        if ((rc = create_sqlmaster_records(tran))) {
-            sc_errf(s, "create_sqlmaster_records failed rc %d\n", rc);
-            hash_sqlalias_db(db, db->tablename);
-            return rc;
-        }
-        create_sqlite_master();
-    }
-
     gbl_sc_commit_count++;
 
     /* TODO: review this, do we need it?*/
@@ -164,14 +155,6 @@ int finalize_rename_table(struct ireq *iq, struct schema_change_type *s,
     if (rc) {
         sc_errf(s, "Failed to set table version for %s\n", db->tablename);
         goto tran_error;
-    }
-
-    if (s->finalize) {
-        if (create_sqlmaster_records(tran)) {
-            sc_errf(s, "create_sqlmaster_records failed\n");
-            goto recover_memory;
-        }
-        create_sqlite_master();
     }
 
     gbl_sc_commit_count++;

--- a/schemachange/sc_view.c
+++ b/schemachange/sc_view.c
@@ -73,12 +73,6 @@ int finalize_add_view(struct ireq *iq, struct schema_change_type *s,
 
     gbl_sc_commit_count++;
 
-    if (create_sqlmaster_records(tran)) {
-        sc_errf(s, "create_sqlmaster_records failed\n");
-        goto err;
-    }
-    create_sqlite_master();
-
     sc_printf(s, "Schema change ok\n");
     return 0;
 
@@ -105,12 +99,6 @@ int finalize_drop_view(struct ireq *iq, struct schema_change_type *s,
     }
 
     delete_view(s->tablename);
-
-    if (create_sqlmaster_records(tran)) {
-        sc_errf(s, "create_sqlmaster_records failed\n");
-        return -1;
-    }
-    create_sqlite_master();
 
     return 0;
 }

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1172,6 +1172,9 @@ int sc_timepart_add_table(const char *existingTableName,
     } else
         xerr->errval = SC_VIEW_NOERR;
 
+    create_sqlmaster_records(NULL);
+    create_sqlite_master();
+
     return xerr->errval;
 
 error:
@@ -1254,6 +1257,10 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
         snprintf(xerr->errstr, sizeof(xerr->errstr), "failed to drop table");
     } else
         xerr->errval = SC_VIEW_NOERR;
+
+    create_sqlmaster_records(NULL);
+    create_sqlite_master();
+
     return xerr->errval;
 
 error:

--- a/tests/ulonglong.test/t00.sql
+++ b/tests/ulonglong.test/t00.sql
@@ -26,7 +26,7 @@ truncate t1;
 select * from t1 order by 1;
 
 # Ensure that time partition rollouts are not affected by 'forbid_ulonglong'
-create time partition on t1 as t1_tp period 'yearly' retention 2 start '2018-01-01';
+create time partition on t1 as t1_tp period 'yearly' retention 2 start '2020-01-01';
 select sleep(5);
 select count(*) from comdb2_timepartshards;
 insert into t1_tp values(3,3), (4,5);


### PR DESCRIPTION
Sql schema records created by create_sqlmaster_records & create_sqlite_master are updated in block processor upon return, we do not need to do it for each of the schema changes in do_X functions.  