### PR TITLE
{171098261}: fixing inco_slow check

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2728,7 +2728,7 @@ static void bdb_slow_replicant_check(bdb_state_type *bdb_state,
         for (int i = 0; i < numnodes; i++) {
             //const char *host = hosts[i];
             struct interned_string *host = hosts[i];
-            struct hostinfo *h = retrieve_hostinfo(worst_node);
+            struct hostinfo *h = retrieve_hostinfo(host);
             double avg = averager_avg(h->time_minute);
             print_message = 0;
 


### PR DESCRIPTION
Ensure that we check all nodes to see if there's any incoherent_slow node that can be marked back to incoherent.