### PR TITLE
async phase also needs write locks, and a txn

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3550,8 +3550,8 @@ int cmp_index_int(struct schema *oldix, struct schema *newix, char *descr,
                   size_t descrlen);
 int getdbidxbyname_ll(const char *p_name);
 int get_dbtable_idx_by_name(const char *tablename);
-int open_temp_db_resume(struct dbtable *db, char *prefix, int resume, int temp,
-                        tran_type *tran);
+int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *prefix, int resume,
+                        int temp, tran_type *tran);
 int find_constraint(struct dbtable *db, constraint_t *ct);
 
 /* END OF SCHEMACHANGE DECLARATIONS*/

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -522,7 +522,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
      * truncated prefix anyway */
     bdb_get_new_prefix(new_prefix, sizeof(new_prefix), &bdberr);
 
-    rc = open_temp_db_resume(newdb, new_prefix, s->resume, 0, tran);
+    rc = open_temp_db_resume(iq, newdb, new_prefix, s->resume, 0, tran);
     if (rc) {
         /* todo: clean up db */
         sc_errf(s, "failed opening new db\n");

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -126,7 +126,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
         local_lock = 1;
         wrlock_schema_lk();
     }
-    rc = open_temp_db_resume(newdb, new_prefix, 0, 0, tran);
+    rc = open_temp_db_resume(iq, newdb, new_prefix, 0, 0, tran);
     if (local_lock)
         unlock_schema_lk();
     if (rc) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -975,7 +975,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
 
     bdb_get_new_prefix(new_prefix, sizeof(new_prefix), &bdberr);
 
-    rc = open_temp_db_resume(newdb, new_prefix, 1, 0, NULL);
+    rc = open_temp_db_resume(iq, newdb, new_prefix, 1, 0, NULL);
     if (rc) {
         backout_schemas(newdb->tablename);
         abort();


### PR DESCRIPTION
Adding and truncating a table needs to create a newdb table during the async phase, but that requires to write llmeta and therefore needs a proper txn (for that matter open_dbs have an infinite retry loop for deadlocks, to be reviewed in a future PR).
