### PR TITLE
need to disable live sc upon error before freeing stuff; 173695058

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1263,52 +1263,48 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
 
 
     if (rc) {
-        if (rc == ERR_NOMASTER) {
-            /* IFF the schema changes are NOT aborted, clean in-mem structures but
-             * leave persistent and replicated changes (llmeta, new btree-s) so
-             * that a new master/resume will pick it up later
-             * NOTE: this clears iq->sc_pending, obviously (sc-s are freed), so
-             * the rest of schema change code -finalize, callback hooks- do NOT
-             * trigger anymore (they should not, they will do it when future resume
-             * finishes)
-             * NOTE2: if sc_should_abort is set, the bplog writer will call 
-             * backout_schema_change and sc_abort callback, which they will 
-             * clear any persistent and in-mem structures 
-             */
-            struct schema_change_type *next;
-            sc = iq->sc_pending;
-            while (sc != NULL) {
-                next = sc->sc_next;
-                if (sc->newdb && sc->newdb->handle) {
-                    int bdberr = 0;
-                    live_sc_off(sc->db);
-                    while (sc->logical_livesc) {
-                        usleep(200);
-                    }
-                    if (sc->db->sc_live_logical) {
-                        bdb_clear_logical_live_sc(sc->db->handle, 1);
-                        sc->db->sc_live_logical = 0;
-                    }
-                    if (rc == ERR_NOMASTER)
-                        sc_set_downgrading(sc);
-                    bdb_close_only(sc->newdb->handle, &bdberr);
-                    freedb(sc->newdb);
-                    sc->newdb = NULL;
+        /* IFF the schema changes are NOT aborted, clean in-mem structures but
+         * leave persistent and replicated changes (llmeta, new btree-s) so
+         * that a new master/resume will pick it up later
+         * NOTE: this clears iq->sc_pending, obviously (sc-s are freed), so
+         * the rest of schema change code -finalize, callback hooks- do NOT
+         * trigger anymore (they should not, they will do it when future resume
+         * finishes)
+         * NOTE2: if sc_should_abort is set, the bplog writer will call 
+         * backout_schema_change and sc_abort callback, which they will 
+         * clear any persistent and in-mem structures 
+         */
+        struct schema_change_type *next;
+        sc = iq->sc_pending;
+        while (sc != NULL) {
+            next = sc->sc_next;
+            if (sc->newdb && sc->newdb->handle) {
+                int bdberr = 0;
+                live_sc_off(sc->db);
+                while (sc->logical_livesc) {
+                    usleep(200);
+                }
+                if (sc->db->sc_live_logical) {
+                    bdb_clear_logical_live_sc(sc->db->handle, 1);
+                    sc->db->sc_live_logical = 0;
                 }
                 sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, 0, __func__,
-                           __LINE__);
-                free_schema_change_type(sc);
-                sc = next;
-            }
-            iq->sc_pending = NULL;
-        } else {
-            sc = iq->sc_pending;
-            while (sc != NULL) {
+                               __LINE__);
+                if (rc == ERR_NOMASTER) {
+                        sc_set_downgrading(sc);
+                        bdb_close_only(sc->newdb->handle, &bdberr);
+                        freedb(sc->newdb);
+                        sc->newdb = NULL;
+                        free_schema_change_type(sc);
+                }
+            } else {
                 sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, 0, __func__,
-                           __LINE__);
-                sc = sc->sc_next;
+                               __LINE__);
             }
+            sc = next;
         }
+        if (rc == ERR_NOMASTER)
+            iq->sc_pending = NULL;
     }
     logmsg(LOGMSG_INFO, ">>> DDL SCHEMA CHANGE RC %d <<<\n", rc);
 

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2502,7 +2502,6 @@ void handle_postabort_bpfunc(struct ireq *iq)
     }
 }
 
-int backout_schema_changes(struct ireq *iq, tran_type *tran);
 static void backout_and_abort_tranddl(struct ireq *iq, tran_type *parent,
                                       int rowlocks)
 {


### PR DESCRIPTION
173695058; live_sc_off is not called until too late, at which point schema changes are freed and concurrent live writes crash