### PR TITLE
Detect uncommitable upserts

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1352,6 +1352,12 @@ struct ireq {
     /* Support for //DBSTATS. */
     SBUF2 *dbglog_file;
     int *nwrites;
+
+    /* List of indices that we've written to detect uncommitable upsert txns */
+    hash_t *vfy_idx_hash; 
+
+    int dup_key_insert;
+
     /* List of genids that we've written to detect uncommitable txn's */
     hash_t *vfy_genid_hash;
     pool_t *vfy_genid_pool;
@@ -1419,6 +1425,7 @@ struct ireq {
 
     unsigned errstrused : 1;
     unsigned vfy_genid_track : 1;
+    unsigned vfy_idx_track : 1;
     unsigned have_blkseq : 1;
 
     unsigned sc_locked : 1;

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -52,6 +52,9 @@
 #include "comdb2_pthread_create.h"
 #endif
 
+extern int free_it(void *obj, void *arg);
+extern void destroy_hash(hash_t *h, int (*free_func)(void *, void *));
+
 pthread_key_t thd_info_key;
 
 void (*comdb2_ipc_sndbak)(int *, int) = 0;
@@ -631,6 +634,12 @@ static void *thd_req(void *vthd)
                 thd->iq->vfy_genid_pool = NULL;
             }
             thd->iq->vfy_genid_track = 0;
+            if (thd->iq->vfy_idx_hash) {
+                destroy_hash(thd->iq->vfy_idx_hash, free_it);
+                thd->iq->vfy_idx_hash = NULL;
+            }
+            thd->iq->vfy_idx_track = 0;
+            thd->iq->dup_key_insert = 0;
 #if 0
             fprintf(stderr, "%s:%d: THD=%p relablk iq=%p\n", __func__, __LINE__, pthread_self(), thd->iq);
 #endif

--- a/db/indices.h
+++ b/db/indices.h
@@ -17,6 +17,8 @@
 #ifndef INCLUDED_INDICES_H
 #define INCLUDED_INDICES_H
 
+int track_record_index(struct ireq *iq, int ixnum, void *key, int ixkeylen);
+
 int check_for_upsert(struct ireq *iq, void *trans, blob_buffer_t *blobs, size_t maxblobs, int *opfailcode,
                      int *ixfailnum, int *retrc, void *od_dta, size_t od_len, unsigned long long ins_keys,
                      int rec_flags);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6677,6 +6677,17 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
 
         if (rc != 0) {
             if (err->errcode == OP_FAILED_UNIQ) {
+                if (iq->vfy_idx_track == 1 && iq->dup_key_insert == 1) {
+                    rc = ERR_UNCOMMITABLE_TXN;
+                    reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "add key constraint "
+                                                   "duplicate key '%s' on "
+                                                   "table '%s' index %d",
+                          get_keynm_from_db_idx(iq->usedb, err->ixnum),
+                          iq->usedb->tablename, err->ixnum);
+                    err->errcode = ERR_UNCOMMITABLE_TXN;
+                    return rc;
+                }
+
                 int upsert_idx = dt.upsert_flags >> 8;
                 if ((dt.upsert_flags & OSQL_FORCE_VERIFY) != 0) {
                     if (upsert_idx == err->ixnum) {

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1862,12 +1862,12 @@ static int free_clnt_ddl_context(void *obj, void *arg)
     free(ctx);
     return 0;
 }
-static int free_it(void *obj, void *arg)
+int free_it(void *obj, void *arg)
 {
     free(obj);
     return 0;
 }
-static inline void destroy_hash(hash_t *h, int (*free_func)(void *, void *))
+void destroy_hash(hash_t *h, int (*free_func)(void *, void *))
 {
     if (!h)
         return;

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -4792,7 +4792,16 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
             reqpopprefixes(iq, 1);
 
         if (rc != 0) {
-            check_serializability = 1;
+            if (iq->vfy_idx_track == 1 && iq->dup_key_insert == 1) {
+                rc = ERR_UNCOMMITABLE_TXN;
+                reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "add key constraint "
+                                               "duplicate key '%s' on "
+                                               "table '%s' index %d",
+                      get_keynm_from_db_idx(iq->usedb, ixout),
+                      iq->usedb->tablename, ixout);
+            } else {
+                check_serializability = 1;
+            }
             opnum = blkpos; /* so we report the failed blockop accurately */
             err.blockop_num = blkpos;
             err.errcode = errout;

--- a/tests/upsert.test/t00_upsert.expected
+++ b/tests/upsert.test/t00_upsert.expected
@@ -237,3 +237,5 @@ keys
 (COUNT(*)=2=1)
 (i=1, j=1)
 (i=2, j=1)
+('---- uncommittable + constraints ----'='---- uncommittable + constraints ----')
+[COMMIT] failed with rc 2 add key constraint duplicate key 'KEY' on table 'c' index 0

--- a/tests/upsert.test/t00_upsert.sql
+++ b/tests/upsert.test/t00_upsert.sql
@@ -362,3 +362,18 @@ INSERT OR REPLACE INTO t1 VALUES(2,1);
 SELECT COUNT(*)=2 FROM t1;
 SELECT * FROM t1 ORDER BY 1;
 DROP TABLE t1;
+
+SELECT '---- uncommittable + constraints ----';
+CREATE TABLE m {schema{int i} keys{"pk" = i}}$$
+CREATE TABLE c {schema{int i} keys{"key" = i} constraints{"key" -> <"m" : "pk">}}$$
+BEGIN;
+INSERT INTO m(i) VALUES(1);
+INSERT INTO m(i) VALUES(2);
+COMMIT;
+BEGIN;
+INSERT INTO c(i) VALUES(1) ON CONFLICT(i) DO UPDATE SET i=2;
+INSERT INTO c(i) VALUES(1) ON CONFLICT(i) DO UPDATE SET i=2;
+COMMIT;
+SELECT 1 FROM comdb2_metrics m, comdb2_tunables t WHERE m.name LIKE 'verify_replays' AND t.name='osql_verify_retry_max' AND m.value >= CAST(t.value AS int)
+DROP TABLE c;
+DROP TABLE m;

--- a/tests/upsert.test/t01_upsert.expected
+++ b/tests/upsert.test/t01_upsert.expected
@@ -143,3 +143,61 @@ done
 done
 done
 done
+(part='---------------------------------- PART #07 ----------------------------------')
+done
+done
+done
+done
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+(i=1)
+done
+(i=2)
+done
+(part='---------------------------------- PART #08 ----------------------------------')
+done
+done
+done
+done
+done
+done
+done
+done
+done
+done
+[commit] failed with rc 2 add key constraint duplicate key 'COMDB2_PK' on table 't1' index 0
+done
+done
+done
+(part='---------------------------------- PART #09 ----------------------------------')
+done
+done
+done
+done
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+(i=1, j=1)
+(i=2, j=1)
+(i=4, j=1)
+done
+done
+done
+done
+done
+done
+[commit] failed with rc 2 add key constraint duplicate key '$KEY_877B2989' on table 't1' index 0
+done
+(i=1, j=1)
+(i=2, j=1)
+(i=4, j=1)
+done

--- a/tests/upsert.test/t01_upsert.trans
+++ b/tests/upsert.test/t01_upsert.trans
@@ -106,3 +106,48 @@
 1 SET TRANSACTION BLOCKSQL
 2 SET TRANSACTION BLOCKSQL
 
+1 SELECT '---------------------------------- PART #07 ----------------------------------' AS part;
+1 drop table if exists t1
+2 drop table if exists t2
+1 create table t1(i int primary key)
+1 create table t2(i int primary key)
+1 begin
+1 insert into t1(i) values(1) on conflict (i) do update set i=2
+1 insert into t2(i) values(1) on conflict (i) do update set i=2
+2 insert into t2(i) values(1)
+1 commit
+1 select * from t1
+1 select * from t2
+
+1 SELECT '---------------------------------- PART #08 ----------------------------------' AS part;
+1 drop table if exists t1
+1 create table t1(i int primary key)
+1 begin
+1 insert into t1(i) values(1) on conflict (i) do update set i=2
+1 insert into t1(i) values(100) on conflict (i) do update set i=101
+1 insert into t1(i) values(1) on conflict (i) do update set i=2
+1 insert into t1(i) values(10) on conflict (i) do update set i=11
+1 insert into t1(i) values(10) on conflict (i) do update set i=11
+1 insert into t1(i) values(10) on conflict (i) do update set i=11
+1 commit
+1 select 1 from comdb2_metrics m, comdb2_tunables t where m.name like 'verify_replays' and t.name='osql_verify_retry_max' and m.value >= CAST(t.value AS int)
+1 select * from t1
+
+1 SELECT '---------------------------------- PART #09 ----------------------------------' AS part;
+1 drop table if exists t1
+1 create table t1(i int unique, j int)
+1 create index t1_j on t1(j)
+1 begin
+1 insert into t1 values(1, 1)
+1 insert into t1 values(2, 1)
+1 insert into t1 values(3, 1) on conflict (i) do update set i=4
+2 insert into t1 values(3, 1)
+1 commit -- will retry because of 2's insert and then should succeed as update
+1 select * from t1 order by i
+1 begin
+1 insert into t1 values(5, 1)
+1 insert into t1 values(6, 1)
+1 insert into t1 values(7, 1) on conflict (i) do update set i=4
+1 insert into t1 values(7, 1) on conflict (i) do update set i=4
+1 commit
+1 select * from t1 order by i


### PR DESCRIPTION
A blocksql transaction that inserts the same key multiple times with upsert statements is not detected as uncommittable. So it retries the maximum number of times before failing.

The following is an example of such a transaction:
```
create table t(i int primary key)
begin
insert into t(i) values(1) on conflict (i) do update set i=2
insert into t(i) values(1) on conflict (i) do update set i=2
commit
```

The changes in this PR cause this type of transaction to fail as soon as extended checking kicks in: A hash structure tracks the keys that the running transaction has inserted. Once the running transaction has tried to insert the same key twice, the transaction is considered uncommittable and is failed.