### PR TITLE
Print client API type in reqlog

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -1591,6 +1591,10 @@ static void log_header_ll(struct reqlogger *logger, struct output *out,
 
     dumpf(logger, out, " rqid %s from %s", logger->id, reqorigin(logger));
 
+    if (logger->api_type) {
+        dumpf(logger, out, " clntapi %s", logger->api_type);
+    }
+
     if (out == long_request_out && is_running) {
         /* No need to include 'rc' if the request is still running. */
         dumpf(logger, out, " **running**\n");
@@ -1939,6 +1943,7 @@ void reqlog_long_running_clnt(struct sqlclntstate *clnt)
     logger.mask = logger.event_mask | logger.dump_mask;
 
     reqlog_set_clnt(&logger, clnt);
+    reqlog_set_api_type(&logger, clnt->plugin.api_type(clnt));
     reqlog_set_origin(&logger, "%s", clnt->origin);
     reqlog_set_vreplays(&logger, clnt->verify_retries);
     reqlog_set_sql(&logger, sql);
@@ -3066,6 +3071,11 @@ inline void reqlog_set_error(struct reqlogger *logger, const char *error,
     free(logger->error);
     logger->error = strdup(error);
     logger->error_code = error_code;
+}
+
+inline void reqlog_set_api_type(struct reqlogger *logger, const char *api_type)
+{
+    if (logger) logger->api_type = api_type;
 }
 
 inline int reqlog_get_error_code(const struct reqlogger *logger)

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -96,6 +96,7 @@ void reqlog_set_context(struct reqlogger *logger, int ncontext, char **context);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
 void reqlog_set_clnt(struct reqlogger *, struct sqlclntstate *);
 void reqlog_set_nwrites(struct reqlogger *logger, int nwrites, int cascaded_nwrites);
+void reqlog_set_api_type(struct reqlogger *logger, const char *api_type);
 
 void reqlog_long_running_clnt(struct sqlclntstate *);
 void reqlog_long_running_sql_statements(void);

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -124,6 +124,8 @@ struct reqlogger {
     char *error;
     char error_code;
 
+    const char *api_type;
+
     struct client_query_stats *path;
     int ncontext;
     char **context;

--- a/db/sql.h
+++ b/db/sql.h
@@ -400,6 +400,7 @@ int sp_column_val(struct response_data *, int, int, void *);
 void *sp_column_ptr(struct response_data *, int, int, size_t *);
 
 typedef int(plugin_func)(struct sqlclntstate *);
+typedef const char *(api_type_func)(struct sqlclntstate *);
 typedef int(response_func)(struct sqlclntstate *, int, void *, int);
 typedef void *(replay_func)(struct sqlclntstate *, void *);
 typedef int(param_index_func)(struct sqlclntstate *, const char *, int64_t *);
@@ -470,6 +471,7 @@ struct plugin_callbacks {
     plugin_func *peer_check; /* newsql_peer_check_evbuffer */
     auth_func *get_authdata; /* newsql_get_authdata */
     override_type_func *set_timeout; /* newsql_set_timeout_sbuf */
+    api_type_func *api_type; /* newsql_api_type */
 
     /* Optional */
     void *state;
@@ -536,6 +538,7 @@ struct plugin_callbacks {
         make_plugin_callback(clnt, name, peer_check);                          \
         make_plugin_callback(clnt, name, get_authdata);                        \
         make_plugin_callback(clnt, name, set_timeout);                         \
+        make_plugin_callback(clnt, name, api_type);                            \
         make_plugin_optional_null(clnt, count);                                \
         make_plugin_optional_null(clnt, type);                                 \
         make_plugin_optional_null(clnt, int64);                                \

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2779,6 +2779,7 @@ void query_stats_setup(struct sqlthdstate *thd, struct sqlclntstate *clnt)
         logmsg(LOGMSG_USER, "SQL mode=%d [%s]\n", clnt->dbtran.mode, clnt->sql);
 
     reqlog_set_clnt(thd->logger, clnt);
+    reqlog_set_api_type(thd->logger, clnt->plugin.api_type(clnt));
 }
 
 int param_count(struct sqlclntstate *clnt)
@@ -7025,6 +7026,10 @@ static int internal_get_x509_attr(struct sqlclntstate *a, int b, void *c, int d)
 static int internal_set_timeout(struct sqlclntstate *clnt, int timeout_ms)
 {
     return -1;
+}
+static const char * internal_api_type(struct sqlclntstate *clnt)
+{
+    return "internal";
 }
 
 void start_internal_sql_clnt(struct sqlclntstate *clnt)

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1462,6 +1462,11 @@ static int newsql_set_timeout(struct sqlclntstate *clnt, int timeout_ms)
     return 0;
 }
 
+static const char * newsql_api_type(struct sqlclntstate *clnt)
+{
+    return "cdb2api";
+}
+
 int handle_set_querylimits(char *sqlstr, struct sqlclntstate *clnt)
 {
     int iswarn = 0;


### PR DESCRIPTION
The changes in this PR add the client API to the information printed about each request in the request log.