### PR TITLE
Only add DB_AM_RECOVER to ufid-hash, enable ufid-logging by default

### DIFF
--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -237,8 +237,9 @@ __db_open(dbp, txn, fname, dname, type, flags, mode, meta_pgno)
 			goto err;
 	}
 
-	__ufid_add_dbp(dbp->dbenv, dbp);
-
+	if (F_ISSET(dbp, DB_AM_RECOVER)) {
+		__ufid_add_dbp(dbp->dbenv, dbp);
+	}
 
 	if (dbp->pgsize > 65536) {
 		/* If we have large pages, we need a bias factor for accessing entries. */

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -87,7 +87,7 @@ static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
 static int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
 int gbl_ufid_dbreg_test = 0;
-int gbl_ufid_log = 0;
+int gbl_ufid_log = 1;
 
 /* Get the recovery LSN. */
 int

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2167,7 +2167,7 @@ REGISTER_TUNABLE("disable_ckp", "Disable checkpoints to debug.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_disable_ckp, EXPERIMENTAL | INTERNAL,
                  NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: off)", TUNABLE_BOOLEAN, &gbl_ufid_log,
+REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: on)", TUNABLE_BOOLEAN, &gbl_ufid_log,
                  EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("utxnid_log", "Generate utxnid logs. (Default: on)", TUNABLE_BOOLEAN, &gbl_utxnid_log,


### PR DESCRIPTION
Only allow DB_AM_RECOVER dbps to be added to the ufid-hash.
