### PR TITLE
do not forget to transfer blob info from old to new blob arrays

### DIFF
--- a/db/record.c
+++ b/db/record.c
@@ -1195,9 +1195,9 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
                     retrc = ERR_INTERNAL;
                 goto err;
             }
-            blob_status_to_blob_buffer(&oldblobs, del_blobs_buf);
-            blob_status_to_blob_buffer(&oldblobs, add_blobs_buf);
         }
+        blob_status_to_blob_buffer(&oldblobs, del_blobs_buf);
+        blob_status_to_blob_buffer(&oldblobs, add_blobs_buf);
         for (blobno = 0;
              blobno < maxblobs && blobno < iq->usedb->schema->numblobs;
              blobno++) {


### PR DESCRIPTION
Regression in 402517945e90a7c98a59e240884d58c4e72577a1.  Add and delete blob arrays need info from original blob array.
Fixes scindex test case.