### PR TITLE
{173891382}: Capturing remote queries and their fingerprints

### DIFF
--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -2290,6 +2290,16 @@ static void _fdb_extract_source_id(struct sqlclntstate *clnt, SBUF2 *sb, fdb_msg
         strncpy(clnt->conninfo.pename, "UNKNOWN", sizeof(clnt->conninfo.pename));
     clnt->conninfo.pename[sizeof(clnt->conninfo.pename) - 1] = '\0';
     clnt->conninfo.pid = msg->co.srcpid;
+
+    /* set up reqlog */
+    clnt->argv0 = strdup(clnt->conninfo.pename); /* reset_clnt frees argv0 and stack */
+    clnt->stack = strdup("fdb");
+    clnt->origin = get_origin_mach_by_buf(sb);
+    if (clnt->origin == NULL)
+        clnt->origin = intern("???");
+
+    if (clnt->rawnodestats == NULL)
+        clnt->rawnodestats = get_raw_node_stats(clnt->argv0, clnt->stack, clnt->origin, sbuf2fileno(sb), msg->co.ssl);
 }
 
 int fdb_bend_cursor_open(SBUF2 *sb, fdb_msg_t *msg, svc_callback_arg_t *arg)

--- a/tests/remsql.test/runit
+++ b/tests/remsql.test/runit
@@ -149,7 +149,21 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
 
    successful=0
 else
-   successful=1
+   # Additionally, verify remote queries are captured in the comdb2_sql_client_stats table
+   if [[ $dbname == *"generated"* ]]; then
+      # don't perform check for redirect
+      successful=1
+   else
+      successful=0
+      # since we do not know which remote node src's connected to, check all remote nodes
+      for h in $(cdb2sql --tabs --cdb2cfg ${cdb2config} ${dbname} default "SELECT host FROM comdb2_cluster"); do
+         # the 'task' field is only 8 bytes. just search for the "srcdb" prefix
+         remcnt=$(cdb2sql --tabs --host ${h} ${dbname} "SELECT COUNT(*) FROM comdb2_sql_client_stats WHERE task LIKE \"srcdb%\"")
+         if [[ $remcnt -gt 0 ]]; then
+            successful=1
+         fi
+      done
+   fi
 fi
 
 $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup


### PR DESCRIPTION
The fdb module may internally generate helper queries to run on the remote database. These queries are not captured by the comdb2_sql_clientstats table, and show ??? as task and origin in longreqs. This patch fixes it.