### PR TITLE
do not forget to update schema records

### DIFF
--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1313,6 +1313,9 @@ int sc_timepart_truncate_table(const char *tableName, struct errstat *xerr,
         return xerr->errval;
     }
 
+    create_sqlmaster_records(NULL);
+    create_sqlite_master();
+
     bzero(xerr, sizeof(*xerr));
     return 0;
 }


### PR DESCRIPTION
Regression in c0a16eb3ee7707a76a0d9c0cc1edb600ad86064c for partition truncate rollout.
