### PR TITLE
Showing shard disk size in comdb2_timepartshards

### DIFF
--- a/db/timepart_systable.h
+++ b/db/timepart_systable.h
@@ -33,6 +33,7 @@ typedef struct systable_timepartshard {
     char *shardname;
     int64_t low;
     int64_t high;
+    int64_t size_in_bytes;
 } systable_timepartshard_t;
 
 /**

--- a/db/views_systable.c
+++ b/db/views_systable.c
@@ -89,6 +89,7 @@ int timepart_systable_timepartshards_collect(void **data, int *nrecords)
     int narr = 0;
     int nview;
     int rc = 0;
+    struct dbtable *db;
 
     Pthread_rwlock_rdlock(&views_lk);
 
@@ -113,6 +114,9 @@ int timepart_systable_timepartshards_collect(void **data, int *nrecords)
             arr[narr].shardname = strdup(view->shards[nshard].tblname);
             arr[narr].low = view->shards[nshard].low;
             arr[narr].high = view->shards[nshard].high;
+            db = get_dbtable_by_name(view->shards[nshard].tblname);
+            if (db != NULL)
+                arr[narr].size_in_bytes = calc_table_size(db, 0);
             if (!arr[narr].name || !arr[narr].shardname) {
                 logmsg(LOGMSG_ERROR, "%s OOM\n", __func__);
                 timepart_systable_timepartshards_free(arr, narr);

--- a/sqlite/ext/comdb2/timepartitions.c
+++ b/sqlite/ext/comdb2/timepartitions.c
@@ -83,6 +83,7 @@ static int systblTimepartitionsShardsInit(sqlite3 *db)
         CDB2_CSTRING, "shardname", -1, offsetof(systable_timepartshard_t, shardname),
         CDB2_INTEGER, "low", -1, offsetof(systable_timepartshard_t, low),
         CDB2_INTEGER, "high", -1, offsetof(systable_timepartshard_t, high),
+        CDB2_INTEGER, "size", -1, offsetof(systable_timepartshard_t, size_in_bytes),
         SYSTABLE_END_OF_FIELDS);
 }
 

--- a/tests/simple_timepart.test/runit
+++ b/tests/simple_timepart.test/runit
@@ -36,6 +36,12 @@ function timepart_stats
         exit 1
     fi
 
+    cdb2sql ${CDB2_OPTIONS} $dbname default  "select shardname, size from comdb2_timepartshards"
+    if (( $? != 0 )) ; then
+        echo "FAILURE"
+        exit 1
+    fi
+
     echo cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, shardname from comdb2_timepartshards" >> $OUT
     cdb2sql ${CDB2_OPTIONS} $dbname default  "select name, shardname from comdb2_timepartshards" >> $OUT
     if (( $? != 0 )) ; then


### PR DESCRIPTION
This patch adds a `size' column to the `comdb2_timepartshards' system table. The value of the new column is the shard's disk size in bytes.