### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+#Use the official Debian-based image
+FROM debian:bullseye
+
+# Set the non-interactive mode for apt environment variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install prerequisites
+RUN apt-get update && apt-get install -y \
+    bison \
+    build-essential \
+    cmake \
+    flex \
+    libevent-dev \
+    liblz4-dev \
+    libprotobuf-c-dev \
+    libreadline-dev \
+    libsqlite3-dev \
+    libssl-dev \
+    libunwind-dev \
+    ncurses-dev \
+    protobuf-c-compiler \
+    tcl \
+    uuid-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Add /opt/bb/bin to PATH
+ENV PATH="${PATH}:/opt/bb/bin"
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the project source code to the container
+COPY . /app
+
+# Build and install Comdb2
+RUN mkdir build && cd build && cmake .. && make && make install
+
+# Start pmux
+CMD ["pmux", "-n"]
+
+# Expose any necessary ports
+EXPOSE 80


### PR DESCRIPTION
**Type of Change:** Feature
**Current Behavior:** The project currently does not include a Dockerfile.
**Explanation:** We have developed an automated tool for generating Dockerfiles and have successfully created one for your project. Our local tests confirm that the image can be built successfully. However, we recognize a potential limitation in our Dockerfile: the final open port specified may not fully align with what developers actually need. Developers are encouraged to make minor adjustments to suit their specific requirements.
**Usage:**
1. Place the Dockerfile in the root directory of the project;
2. Run the following command in the root directory of the project to build the image: docker build -t <image_name> . ;
3. Run the following command to run the container: docker run -it <image_name> bash;

Should you identify any shortcomings in the generated Dockerfile, we would greatly appreciate and welcome your suggestions.
