### PR TITLE
dbs_idx is used only for writes reordering; simplify

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2415,9 +2415,9 @@ struct dbtable *newqdb(struct dbenv *env, const char *name, int avgsz, int pages
 int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
 void stop_threads(struct dbenv *env);
 void resume_threads(struct dbenv *env);
-void replace_db_idx(struct dbtable *p_db, int idx);
 int add_dbtable_to_thedb_dbs(dbtable *table);
 void rem_dbtable_from_thedb_dbs(dbtable *table);
+void re_add_dbtable_to_thedb_dbs(dbtable *table);
 void hash_sqlalias_db(dbtable *db, const char *newname);
 int rename_db(struct dbtable *db, const char *newname);
 int ix_find_rnum_by_recnum(struct ireq *iq, int recnum_in, int ixnum,
@@ -3548,7 +3548,6 @@ int compare_tag_int(struct schema *old, struct schema *new, FILE *out,
                     int strict);
 int cmp_index_int(struct schema *oldix, struct schema *newix, char *descr,
                   size_t descrlen);
-int getdbidxbyname_ll(const char *p_name);
 int get_dbtable_idx_by_name(const char *tablename);
 int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *prefix, int resume,
                         int temp, tran_type *tran);

--- a/db/config.c
+++ b/db/config.c
@@ -664,8 +664,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
     }
 
     struct errstat err = {0};
-    db = create_new_dbtable(dbenv, tblname, csc2, dbnum, dbenv->num_dbs, 0, 0,
-                            0, &err);
+    db = create_new_dbtable(dbenv, tblname, csc2, dbnum, 0, 0, 0, &err);
     if (!db) {
         logmsg(LOGMSG_ERROR, "%s\ncsc2:\"%s\"\n", err.errstr, csc2);
         free(csc2);

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -19,16 +19,15 @@
 #include "dynschematypes.h"
 #include "dynschemaload.h"
 
-static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum,
-                                  int dbix);
+static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum);
 static int init_check_constraints(dbtable *tbl);
 static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
                           int no_side_effects, struct errstat *err);
 
 struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
-                                   char *csc2, int dbnum, int indx,
-                                   int sc_alt_tablename, int allow_ull,
-                                   int no_side_effects, struct errstat *err)
+                                   char *csc2, int dbnum, int sc_alt_tablename,
+                                   int allow_ull, int no_side_effects,
+                                   struct errstat *err)
 {
     struct dbtable *newtable = NULL;
     int rc;
@@ -47,7 +46,7 @@ struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
         goto err;
     }
 
-    newtable = newdb_from_schema(dbenv, tablename, dbnum, indx);
+    newtable = newdb_from_schema(dbenv, tablename, dbnum);
     if (!newtable) {
         errstat_set_rcstrf(err, -1, "newdb_from_schema failed for %s",
                            tablename);
@@ -111,8 +110,7 @@ done:
     return rc;
 }
 
-static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum,
-                                  int dbix)
+static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum)
 {
     dbtable *tbl;
     int ii;
@@ -124,8 +122,6 @@ static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum,
         logmsg(LOGMSG_FATAL, "%s: Memory allocation error\n", __func__);
         return NULL;
     }
-
-    tbl->dbs_idx = dbix;
 
     tbl->dbtype = DBTYPE_TAGGED_TABLE;
     tbl->tablename = strdup(tblname);

--- a/db/macc_glue.h
+++ b/db/macc_glue.h
@@ -21,9 +21,9 @@
 
 /* create a dbtable with the provided schema "csc2" */
 struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
-                                   char *csc2, int dbnum, int indx,
-                                   int sc_alt_tablename, int allow_ull,
-                                   int no_sideeffects, struct errstat *err);
+                                   char *csc2, int dbnum, int sc_alt_tablename,
+                                   int allow_ull, int no_sideeffects,
+                                   struct errstat *err);
 
 /* populate an existing db with .NEW tags for provided schema "csc2" */
 int populate_db_with_alt_schema(struct dbenv *dbenv, struct dbtable *db,

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1790,7 +1790,7 @@ int osql_schemachange_logic(struct schema_change_type *sc,
     sc->usedbtablevers = comdb2_table_version(sc->tablename);
 
     if (thd->clnt->dbtran.mode == TRANLEVEL_SOSQL) {
-        if (usedb && getdbidxbyname_ll(sc->tablename) < 0) {
+        if (usedb && !get_dbtable_by_name(sc->tablename)) {
             unsigned long long version;
             char *first_shardname =
                 timepart_shard_name(sc->tablename, 0, 1, &version);

--- a/db/tag.c
+++ b/db/tag.c
@@ -6053,7 +6053,7 @@ struct schema *create_version_schema(char *csc2, int version,
 
     ver_db = create_new_dbtable(
         thedb, gbl_ver_temp_table, csc2, 0 /* no altname */, 0 /* fake dbnum */,
-        0 /* fake dbs_idx */, 1 /* allow ull */, 1 /* no side effects */, &err);
+        1 /* allow ull */, 1 /* no side effects */, &err);
     if (!ver_db) {
         logmsg(LOGMSG_ERROR, "%s\ncsc2: \"%s\"\n", err.errstr, csc2);
         goto done;
@@ -6127,7 +6127,6 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
 {
     int rc;
     int bdberr;
-    int foundix = db->dbs_idx;
     int version = get_csc2_version_tran(db->tablename, tran);
     int len;
     void *old_bdb_handle, *new_bdb_handle;
@@ -6143,7 +6142,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
 
     struct errstat err = {0};
     dbtable *newdb = create_new_dbtable(thedb, db->tablename, csc2, db->dbnum,
-                                        foundix, 0, 1, 0, &err);
+                                        0, 1, 0, &err);
     if (!newdb) {
         logmsg(LOGMSG_ERROR, "%s (%s:%d)\n", err.errstr, __FILE__, __LINE__);
         goto err;
@@ -6188,7 +6187,7 @@ static int load_new_ondisk(dbtable *db, tran_type *tran)
                 bdberr);
     db->handle = old_bdb_handle;
 
-    replace_db_idx(db, foundix);
+    re_add_dbtable_to_thedb_dbs(db);
     fix_constraint_pointers(db, newdb);
 
     memset(newdb, 0xff, sizeof(dbtable));

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -116,8 +116,8 @@ int add_table_to_environment(char *table, const char *csc2,
 
     struct errstat err = {0};
     newdb = create_new_dbtable(thedb, table, (char *)csc2, 0 /*dbnum*/,
-                               thedb->num_dbs, 0 /*no altname*/,
-                               timepartition_name ? 1 : 0 /* allow null if tpt rollout */, 
+                               0 /*no altname*/,
+                               timepartition_name ? 1 : 0 /* allow null if tpt rollout */,
                                0 /* side effects */, &err);
     if (!newdb) {
         sc_client_error(s, "%s", err.errstr);

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -384,7 +384,6 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     int changed;
     int i;
     char new_prefix[32];
-    int foundix;
     struct scinfo scinfo;
     struct errstat err = {0};
 
@@ -441,14 +440,8 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     }
     Pthread_mutex_lock(&csc2_subsystem_mtx);
 
-    /* find which db has a matching name */
-    if ((foundix = getdbidxbyname_ll(s->tablename)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
-        exit(1);
-    }
-
     newdb = create_new_dbtable(thedb, s->tablename, s->newcsc2, db->dbnum,
-                               foundix, 1 /* sc_alt_name */,
+                               1 /* sc_alt_name */,
                                (s->same_schema) ? 1 : 0, 0, &err);
 
     if (!newdb) {

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -59,7 +59,6 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
     int bdberr = 0;
     int datacopy_odh = 0;
     char new_prefix[32];
-    int foundix;
     struct scinfo scinfo;
     struct errstat err = {0};
 
@@ -81,15 +80,9 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
 
     Pthread_mutex_lock(&csc2_subsystem_mtx);
 
-    /* find which db has a matching name */
-    if ((foundix = getdbidxbyname_ll(s->tablename)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
-        exit(1);
-    }
-
     int saved_broken_max_rec_sz = fix_broken_max_rec_sz(s->db->lrl);
     newdb = s->newdb =
-        create_new_dbtable(thedb, s->tablename, s->newcsc2, db->dbnum, foundix,
+        create_new_dbtable(thedb, s->tablename, s->newcsc2, db->dbnum,
                            1 /* sc_alt_name */, 1 /* allow ull */, 0, &err);
     gbl_broken_max_rec_sz = saved_broken_max_rec_sz;
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1029,15 +1029,9 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
     int changed = 0;
     int rc;
 
-    int foundix = getdbidxbyname_ll(table);
-    if (foundix == -1) {
-        logmsg(LOGMSG_FATAL, "Couldn't find table <%s>\n", table);
-        exit(1);
-    }
-
     struct errstat err = {0};
-    newdb = create_new_dbtable(thedb, table, (char *)csc2, db->dbnum, foundix,
-                               1, 1, 0, &err);
+    newdb = create_new_dbtable(thedb, table, (char *)csc2, db->dbnum, 1, 1, 0,
+                               &err);
 
     if (newdb == NULL) {
         /* shouldn't happen */

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -558,7 +558,7 @@ int do_dryrun(struct schema_change_type *s)
     }
 
     struct errstat err = {0};
-    newdb = create_new_dbtable(thedb, s->tablename, s->newcsc2, 0, 0, 1, s->same_schema, 0,
+    newdb = create_new_dbtable(thedb, s->tablename, s->newcsc2, 0, 1, s->same_schema, 0,
                                &err);
     if (!newdb) {
         sc_client_error(s, "%s", err.errstr);
@@ -937,21 +937,14 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
     }
 
     char new_prefix[32];
-    int foundix;
 
     if (s->headers != db->odh) {
         s->header_change = s->force_dta_rebuild = s->force_blob_rebuild = 1;
     }
 
-    if ((foundix = getdbidxbyname_ll(s->tablename)) < 0) {
-        logmsg(LOGMSG_FATAL, "couldnt find table <%s>\n", s->tablename);
-        abort();
-    }
-
     struct errstat err = {0};
     newdb = create_new_dbtable(thedb, s->tablename, s->newcsc2,
-                               (s->dbnum != -1) ? s->dbnum : 0, foundix, 1, 1,
-                               0, &err);
+                               (s->dbnum != -1) ? s->dbnum : 0, 1, 1, 0, &err);
     if (!newdb) {
         logmsg(LOGMSG_FATAL, "Shouldn't happen in this piece of code %s:%d.\n",
                __FILE__, __LINE__);


### PR DESCRIPTION
NOTE: reordering writes on master based on table name could be done without the need to use a table index value.  Eliminating a bunch of confusing code and set dbs_idx upon indexing in thedb table array only.