### PR TITLE
reuse field to remove an extra sc member

### DIFF
--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -307,7 +307,7 @@ int finalize_add_table(struct ireq *iq, struct schema_change_type *s,
         sc_errf(s, "Failed to add db to thedb->dbs, rc %d\n", rc);
         return rc;
     }
-    s->add_state = SC_DONE_ADD; /* done adding to thedb->dbs */
+    s->already_finalized = 1; /* done adding to thedb->dbs */
 
     if ((rc = set_header_and_properties(tran, db, s, 0, gbl_init_with_bthash)))
         return rc;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -848,7 +848,7 @@ void *sc_resuming_watchdog(void *p)
         mark_schemachange_over(iq.sc->tablename);
         if (iq.sc->kind == SC_ADDTABLE) {
             delete_temp_table(&iq, iq.sc->db);
-            if (iq.sc->add_state == SC_DONE_ADD) {
+            if (iq.sc->already_finalized) {
                 rem_dbtable_from_thedb_dbs(iq.sc->db);
             }
         }
@@ -1575,7 +1575,7 @@ int backout_schema_changes(struct ireq *iq, tran_type *tran)
             poll(NULL, 0, 100);
         }
         if (s->kind == SC_ADDTABLE) {
-            if (s->add_state == SC_DONE_ADD) {
+            if (s->already_finalized) {
                 rem_dbtable_from_thedb_dbs(s->db);
             }
             if (s->newdb) {

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -33,7 +33,6 @@ struct schema_change_type *init_schemachange_type(struct schema_change_type *sc)
     sc->onstack = 0;
     sc->live = 0;
     sc->use_plan = 0;
-    sc->add_state = SC_NOT_ADD;
     /* default values: no change */
     sc->headers = -1;
     sc->compress = -1;

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -60,9 +60,6 @@ struct dest {
     LINKC_T(struct dest) lnk;
 };
 
-/* status for add table process, stored in sc->add_status */
-enum add_state { SC_NOT_ADD = 0, SC_TO_ADD = 1, SC_DONE_ADD = 2 };
-
 enum comdb2_partition_type {
     PARTITION_NONE = 0,
     PARTITION_REMOVE = 1,
@@ -213,7 +210,6 @@ struct schema_change_type {
     SBUF2 *sb; /* socket to sponsoring program */
     int must_close_sb;
     int use_old_blobs_on_rebuild;
-    enum add_state add_state;
     int partialuprecs; /* count updated records in partial table upgrade */
 
     int resume;           /* if we are trying to resume a schema change,


### PR DESCRIPTION
One less field  for sc (removing ADD table dedicated status); we already have "already_finalize" that is used with the other sc types.
