### PR TITLE
mark initial schema change as forced rebuild, otherwise it can be ignored

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5924,6 +5924,9 @@ static int _process_partitioned_table_merge(struct ireq *iq)
     struct dbtable *first_shard = get_dbtable_by_name(first_shard_name);
     free(first_shard_name);
 
+    /* we need to move data */
+    sc->force_rebuild = 1;
+
     if (!first_shard->sqlaliasname) {
         /*
          * create a table with the same name as the partition

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -853,6 +853,8 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default select * from t14 order by 1
 (a=10, b=20)
 (a=30, b=40)
 (a=50, b=60)
+(a=111, b=111)
+(a=222, b=222)
 cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
 [
  {
@@ -924,6 +926,8 @@ cdb2sql ${CDB2_OPTIONS} dorintdb default select * from t14 order by 1
 (a=10, b=20)
 (a=30, b=40)
 (a=50, b=60)
+(a=111, b=111)
+(a=222, b=222)
 cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
 [
  {

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -398,6 +398,21 @@ if (( $? != 0 )) ; then
    exit 1
 fi
 
+echo $cmd "insert into '\$1_9ABA178A' values (111,111)"
+$cmd "insert into '\$1_9ABA178A' values (111,111)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t14i shard 1"
+   exit 1
+fi
+
+echo $cmd "insert into '\$0_528953B1' values (222,222)"
+$cmd "insert into '\$0_528953B1' values (222,222)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t14i shard 0"
+   exit 1
+fi
+
+
 echo $cmd "select * from t14 order by 1"
 echo $cmd "select * from t14 order by 1" >> $OUT
 $cmd "select * from t14 order by 1" >> $OUT


### PR DESCRIPTION
 174008613; currently only the shard 0 data is collapsed into a table when we remove the partition.  When doing a simple collapse, schema does not change and there is no data transfer.  After removing the partition, we are left with the original data in the shard 0 (which happened to be the original shard).