### PR TITLE
Repro & fix lrl-init corruption issue

### DIFF
--- a/bdb/bdb_verify.c
+++ b/bdb/bdb_verify.c
@@ -39,7 +39,7 @@ extern void fsnapf(FILE *, void *, int);
 extern int __bam_defcmp(DB *dbp, const DBT *a, const DBT *b);
 int gbl_debug_sleep_on_verify = 0;
 
-static int locprint(verify_common_t *par, char *fmt, ...)
+int locprint(verify_common_t *par, char *fmt, ...)
 {
     char buf[LINE_MAX];
     va_list ap;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5893,6 +5893,8 @@ void epoch2a(int epoch, char *buf, size_t buflen)
     }
 }
 
+int gbl_reproduce_sequence_corruption = 0;
+
 /* store our schemas in meta */
 static int put_all_csc2()
 {
@@ -5914,7 +5916,11 @@ static int put_all_csc2()
                 return -1;
             }
 
-            rc = init_table_sequences(NULL, NULL, thedb->dbs[ii]);
+            if (gbl_reproduce_sequence_corruption) {
+                logmsg(LOGMSG_USER, "%s reproducing table sequence corruption\n", __func__);
+            } else {
+                rc = init_table_sequences(NULL, NULL, thedb->dbs[ii]);
+            }
         }
     }
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -312,6 +312,8 @@ extern int gbl_check_constraint_feature;
 extern int gbl_default_function_feature;
 extern int gbl_on_del_set_null_feature;
 extern int gbl_sequence_feature;
+extern int gbl_reproduce_sequence_corruption;
+extern int gbl_permissive_sequence_sc;
 extern int gbl_view_feature;
 
 extern char *gbl_kafka_topic;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1074,6 +1074,10 @@ REGISTER_TUNABLE("sbuftimeout", NULL, TUNABLE_INTEGER, &gbl_sbuftimeout,
 REGISTER_TUNABLE("sc_del_unused_files_threshold", NULL, TUNABLE_INTEGER,
                  &gbl_sc_del_unused_files_threshold_ms, READONLY | NOZERO, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_repro_seq_corruption", "Reproduce init-sequence corruption (Default: OFF)", TUNABLE_BOOLEAN,
+                 &gbl_reproduce_sequence_corruption, EXPERIMENTAL | INTERNAL | READEARLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("permissive_sequence_sc", "Allow schema-changes on corrupt sequences (Default: ON)", TUNABLE_BOOLEAN,
+                 &gbl_permissive_sequence_sc, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sequence_feature", "Enables support for SEQUENCES in column definitions (Default: ON)",
                  TUNABLE_BOOLEAN, &gbl_sequence_feature, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("simulate_rowlock_deadlock", NULL, TUNABLE_INTEGER,

--- a/tests/nextsequence.test/lrl.options
+++ b/tests/nextsequence.test/lrl.options
@@ -1,6 +1,10 @@
 nowatch
 logmsg level info
 permit_small_sequences on
+
+# Test drop/alter/rename against 3 different tables
 table lrlsequence seqlonglong.csc2
+table lrlsequence2 seqlonglong.csc2
+table lrlsequence3 seqlonglong.csc2
 #setattr REP_PROCESSORS 0
 #setattr REP_WORKERS 0

--- a/tests/nextsequence.test/runit
+++ b/tests/nextsequence.test/runit
@@ -190,6 +190,22 @@ function max_sequence_ddl
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table t1"
 }
 
+function reset_sequence
+{
+    typeset master=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default 'select host from comdb2_cluster where is_master="Y"')
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1 (a int, b longlong autoincrement)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('setseq t1 b 999')"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1)"
+    x=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select b from t1")
+    [[ "$x" != "1000" ]] && failexit "Failed to reset sequence"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "delete from t1 where 1"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('setseq t1 b 99')"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1(a) values(1)"
+    x=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select b from t1")
+    [[ "$x" != "100" ]] && failexit "Failed to reset sequence"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table t1"
+}
+
 function max_sequence_csc2
 {
     disable_strict_mode
@@ -381,6 +397,71 @@ function lrl_sequence
     [[ $? != 0 ]] && failexit "Failed to drop lrlsequence table"
 }
 
+function allow_permissive_sequence_sc
+{
+    if [[ -n $CLUSTER ]]; then
+        for n in $CLUSTER ; do
+            $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $n "put tunable 'permissive_sequence_sc' 1"
+        done
+    else
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "put tunable 'permissive_sequence_sc' 1"
+    fi
+}
+
+function verify_and_fix_corruption
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into lrlsequence(a) select * from generate_series (1,100)"
+    [[ $? == 0 ]] && failexit "lrlsequence table should have been corrupt"
+
+    # Drop table should fail
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table lrlsequence"
+    [[ $? == 0 ]] && failexit "lrlsequence table should have been corrupt for drop"
+
+    # Rename table should fail
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "alter table lrlsequence2 rename to newlrlsequence2"
+    [[ $? == 0 ]] && failexit "lrlsequence2 table should have been corrupt for rename"
+
+    # Alter table should fail
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "alter table lrlsequence3 drop column b"
+    [[ $? == 0 ]] && failexit "lrlsequence3 table should have been corrupt for alter"
+
+    # Make sure that verify returns a bad rcode for each of these
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('lrlsequence')")
+    [[ $? == 0 ]] && failexit "lrlsequence table should have failed verify"
+    echo "$x" 
+
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('lrlsequence2')")
+    [[ $? == 0 ]] && failexit "lrlsequencee2table should have failed verify"
+    echo "$x"
+
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('lrlsequence3')")
+    [[ $? == 0 ]] && failexit "lrlsequencee3 table should have failed verify"
+    echo "$x"
+
+    allow_permissive_sequence_sc
+
+    # Drop table should succeed
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table lrlsequence"
+    [[ $? != 0 ]] && failexit "lrlsequence table should have been allowed to drop"
+
+    # Rename table should succeed
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "alter table lrlsequence2 rename to newlrlsequence2"
+    [[ $? != 0 ]] && failexit "lrlsequence2 table should have been renamed"
+
+    # Alter table should succeed
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "alter table lrlsequence3 drop column b"
+    [[ $? != 0 ]] && failexit "lrlsequence3 table should have been allowed to alter"
+
+    # Verify on the new table should succeed
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('newlrlsequence2')")
+    [[ $? != 0 ]] && failexit "newlrlsequencee2table should have succeeded verify"
+    echo "$x"
+
+    x=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('lrlsequence3')")
+    [[ $? != 0 ]] && failexit "lrlsequencee3 table should have succeeded verify"
+    echo "$x"
+}
+
 function run_test
 {
     set_output_files
@@ -404,7 +485,12 @@ function run_test
     strict_csc2
     validate_type_ddl
     validate_type_csc2
-    lrl_sequence
+    reset_sequence
+    if [[ "$DBNAME" == *"nextsequencereprocorruptiongenerated"* ]]; then
+        verify_and_fix_corruption
+    else
+        lrl_sequence
+    fi
 }
 
 run_test


### PR DESCRIPTION
Workaround for clients bit by lrl-init sequence bug allows 'permissive' schema-changes which do not fail if the underlying llmeta record does not exist.
