### PR TITLE
Don't recover on replicant if we don't unwind any txns

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -82,9 +82,9 @@ int gbl_apprec_gen;
 
 static int __log_earliest __P((DB_ENV *, DB_LOGC *, int32_t *, DB_LSN *));
 static double __lsn_diff __P((DB_LSN *, DB_LSN *, DB_LSN *, u_int32_t, int));
-static int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
+int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *start_lsn);
-static int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
+int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
 	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
 int gbl_ufid_dbreg_test = 0;
 int gbl_ufid_log = 1;
@@ -1765,7 +1765,7 @@ __lsn_diff(low, high, current, max, is_forward)
  * checkpoint (ie: of the checkpoint record), not the LSN IN the checkpoint
  * record.  If I had like 17 more braincells, I'd have __log_backup use
  * this routine, but I'd rather not break things. */
-static int
+int
 __log_find_latest_checkpoint_before_lsn(DB_ENV * dbenv, DB_LOGC * logc,
 	DB_LSN * max_lsn, DB_LSN * start_lsn)
 {
@@ -1814,7 +1814,7 @@ __log_find_latest_checkpoint_before_lsn(DB_ENV * dbenv, DB_LOGC * logc,
  * instead of traversing checkpoints in order, traverses the entire log.  This
  * may be needed if for some reason there's no checkpoint in the log, or if the 
  * checkpoint chain is broken (ie: last_ckp points to 0:0) */
-static int
+int
 __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV * dbenv,
 	DB_LOGC * logc, DB_LSN * max_lsn, DB_LSN * foundlsn)
 {

--- a/berkdb/log/log_put.c
+++ b/berkdb/log/log_put.c
@@ -286,6 +286,9 @@ __log_put_int_int(dbenv, lsnp, contextp, udbt, flags, off_context, usr_ptr)
 	}
 
 	if (IS_REP_MASTER(dbenv)) {
+		if (contextp) {
+			dbenv->prev_commit_lsn = lsn;
+		}
 
 		/*
 		 * Replication masters need to drop the lock to send

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -85,7 +85,7 @@ extern int gbl_physrep_debug;
 extern int gbl_dumptxn_at_commit;
 
 int gbl_rep_badgen_trace;
-int gbl_decoupled_logputs = 1;
+int gbl_decoupled_logputs = 0;
 int gbl_inmem_repdb = 0;
 int gbl_max_apply_dequeue = 100000;
 int gbl_master_req_waitms = 200;
@@ -8246,6 +8246,13 @@ int __dbenv_rep_verify_match(DB_ENV* dbenv, unsigned int file, unsigned int offs
 	return ret;
 }
 
+int gbl_rep_skip_recovery = 1;
+
+int __log_find_latest_checkpoint_before_lsn(DB_ENV *dbenv,
+	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *start_lsn);
+int __log_find_latest_checkpoint_before_lsn_try_harder(DB_ENV *dbenv,
+	DB_LOGC *logc, DB_LSN *max_lsn, DB_LSN *foundlsn);
+
 static int
 __rep_verify_match(dbenv, rp, savetime, online)
 	DB_ENV *dbenv;
@@ -8362,14 +8369,92 @@ __rep_verify_match(dbenv, rp, savetime, online)
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 	}
 
-	if ((ret = __rep_dorecovery(dbenv, &rp->lsn, &trunclsn, online,
-					&undid_schema_change)) != 0) {
-		Pthread_mutex_unlock(&apply_lk);
-		MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
-		if (!online)
-			rep->in_recovery = 0;
-		F_CLR(rep, REP_F_READY);
-		goto errunlock;
+	/* Masters must run full recovery */
+	int i_am_master = F_ISSET(rep, REP_F_MASTER);
+	if (gbl_rep_skip_recovery && !i_am_master && log_compare(&dbenv->prev_commit_lsn, &rp->lsn) <= 0) {
+		DB_TXNREGION *region;
+		region = ((DB_TXNMGR *)dbenv->tx_handle)->reginfo.primary;
+		dbenv->wrlock_recovery_lock(dbenv, __func__, __LINE__);
+
+		DB_LSN last_valid_checkpoint = { 0 }, max_lsn = rp->lsn;
+
+		DB_LOGC *logc;
+
+		if ((ret = __log_cursor(dbenv, &logc)) != 0)
+			abort();
+
+		if ((ret =
+			__log_find_latest_checkpoint_before_lsn(dbenv, logc,
+				&max_lsn, &last_valid_checkpoint)) != 0) {
+			__db_err(dbenv,
+				"can't find last logged checkpoint max_lsn %u:%u",
+				max_lsn.file, max_lsn.offset);
+			ret =
+				__log_find_latest_checkpoint_before_lsn_try_harder
+				(dbenv, logc, &max_lsn, &last_valid_checkpoint);
+			if (ret == 0)
+				logmsg(LOGMSG_DEBUG, "tried harder and found %u:%u\n",
+					last_valid_checkpoint.file,
+					last_valid_checkpoint.offset);
+			else {
+				logmsg(LOGMSG_DEBUG, "tried harder and still failed rc; I'll be good unless I crash %d\n",
+					ret);
+			}
+		}
+
+		/* Save the checkpoint. */
+		if ((ret =
+			__checkpoint_save(dbenv, &last_valid_checkpoint,
+				1)) != 0) {
+			__db_err(dbenv, "can't save checkpoint %u:%u",
+				last_valid_checkpoint.file,
+				last_valid_checkpoint.offset);
+			goto err;
+		}
+
+		logmsg(LOGMSG_WARN, "TRUNCATING to %u:%u checkpoint lsn is %u:%u\n",
+			max_lsn.file, max_lsn.offset,
+			last_valid_checkpoint.file, last_valid_checkpoint.offset);
+
+		region->last_ckp = last_valid_checkpoint;
+
+		/* We are going to truncate, so we'd best close the cursor. */
+		if (logc != NULL && (ret = __log_c_close(logc)) != 0)
+			abort();
+
+		F_SET(region, TXN_IN_RECOVERY);
+		__log_vtruncate(dbenv, &rp->lsn, &region->last_ckp, &trunclsn);
+		F_CLR(region, TXN_IN_RECOVERY);
+
+		/* Recovery cleanup */
+		if (dbenv->rep_recovery_cleanup)
+			dbenv->rep_recovery_cleanup(dbenv, &trunclsn, i_am_master /* 0 */);
+
+		dbenv->unlock_recovery_lock(dbenv, __func__, __LINE__);
+
+		if (dbenv->rep_truncate_callback) {
+			uint32_t rep_truncate_flags = 0;
+			if (online)
+				rep_truncate_flags |= DB_REP_TRUNCATE_ONLINE;
+			dbenv->rep_truncate_callback(dbenv, &trunclsn, rep_truncate_flags);
+		}
+
+		logmsg(LOGMSG_WARN, "skip-recovery truncate log lsn [%d:%d]\n", trunclsn.file,
+				trunclsn.offset);
+	} else {
+		if (gbl_rep_skip_recovery) {
+			logmsg(LOGMSG_WARN, "skip-recovery cannot skip, prev-commit=[%d:%d] trunc-lsn=[%d:%d]\n",
+				dbenv->prev_commit_lsn.file, dbenv->prev_commit_lsn.offset, rp->lsn.file, rp->lsn.offset);
+		}
+		if ((ret = __rep_dorecovery(dbenv, &rp->lsn, &trunclsn, online,
+						&undid_schema_change)) != 0) {
+			Pthread_mutex_unlock(&apply_lk);
+			MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
+			if (!online)
+				rep->in_recovery = 0;
+			F_CLR(rep, REP_F_READY);
+			goto errunlock;
+		}
 	}
 
 	dbenv->rep_gen = rep->gen;

--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -194,6 +194,8 @@ __txn_dist_commit_recover(dbenv, dbtp, lsnp, op, info)
 		 * history with logs that (potentially) were replicated to a majority of nodes.  
 		 */
 	} else if (op == DB_TXN_FORWARD_ROLL) {
+		dbenv->prev_commit_lsn = *lsnp;
+
 		/*
 		 * If this was a 2-phase-commit transaction, then it
 		 * might already have been removed from the list, and
@@ -333,6 +335,7 @@ __txn_dist_prepare_recover(dbenv, dbtp, lsnp, op, info)
 	if (op == DB_TXN_LOGICAL_BACKWARD_ROLL) {
 		abort();
    	} else if (op == DB_TXN_FORWARD_ROLL) {
+		dbenv->prev_commit_lsn = *lsnp;
 		/* If we are here then we already know that this committed. */
 #if 0
 	} else if ((!IS_ZERO_LSN(headp->trunc_lsn) &&
@@ -429,6 +432,7 @@ __txn_regop_gen_recover(dbenv, dbtp, lsnp, op, info)
 		 * history with logs that (potentially) were replicated to a majority of nodes.  
 		 */
 	} else if (op == DB_TXN_FORWARD_ROLL) {
+		dbenv->prev_commit_lsn = *lsnp;
 		/*
 		 * If this was a 2-phase-commit transaction, then it
 		 * might already have been removed from the list, and
@@ -546,6 +550,7 @@ __txn_regop_recover(dbenv, dbtp, lsnp, op, info)
 	if (op == DB_TXN_LOGICAL_BACKWARD_ROLL) {
 		abort();
 	} else if (op == DB_TXN_FORWARD_ROLL) {
+		dbenv->prev_commit_lsn = *lsnp;
 		/*
 		 * If this was a 2-phase-commit transaction, then it
 		 * might already have been removed from the list, and
@@ -694,6 +699,7 @@ __txn_regop_rowlocks_recover(dbenv, dbtp, lsnp, op, info)
 	}
 	else if (op == DB_TXN_FORWARD_ROLL) 
 	{
+		dbenv->prev_commit_lsn = *lsnp;
 		if (argp->lflags & DB_TXN_LOGICAL_BEGIN)
 		{
 			assert(NULL == lt);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -110,6 +110,7 @@ extern int gbl_replicant_latches;
 extern int gbl_return_long_column_names;
 extern int gbl_round_robin_stripes;
 extern int skip_clear_queue_extents;
+extern int gbl_rep_skip_recovery;
 extern int gbl_slow_rep_process_txn_freq;
 extern int gbl_slow_rep_process_txn_minms;
 extern int gbl_slow_rep_process_txn_maxms;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1055,8 +1055,9 @@ REGISTER_TUNABLE("rep_process_txn_trace",
                  "transactions. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_rep_process_txn_time, READONLY | NOARG,
                  NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("reqldiffstat", NULL, TUNABLE_INTEGER, &diffstat_thresh,
-                 READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("rep_skip_recovery", "Skip recovery if truncate won't unwind a transaction.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_rep_skip_recovery, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("reqldiffstat", NULL, TUNABLE_INTEGER, &diffstat_thresh, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("reqltruncate", NULL, TUNABLE_INTEGER, &reqltruncate, READONLY,
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("retry", NULL, TUNABLE_INTEGER, &db->retry, READONLY, NULL,

--- a/tests/nightmare_recovery.test/Makefile
+++ b/tests/nightmare_recovery.test/Makefile
@@ -1,0 +1,12 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=7m
+endif
+
+export DUMPLOCK_ON_TIMEOUT=1
+export CORE_ON_TIMEOUT=1

--- a/tests/nightmare_recovery.test/README
+++ b/tests/nightmare_recovery.test/README
@@ -1,0 +1,1 @@
+Test rep-no-recovery logic

--- a/tests/nightmare_recovery.test/lrl.options
+++ b/tests/nightmare_recovery.test/lrl.options
@@ -1,0 +1,1 @@
+rep_skip_recovery 1

--- a/tests/nightmare_recovery.test/runit
+++ b/tests/nightmare_recovery.test/runit
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ "$debug" == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+export maxtable=50
+export stopfile=./stopfile.txt
+
+function create_table
+{
+    typeset func=create_table
+    write_prompt $func "Creating table"
+    $CDB2SQL_EXE -s --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "create table t1 (a int)" >/dev/null 2>&1
+    [[ "$?" == "0" ]] && write_prompt $func "Created table t1"
+}
+
+function insert_thd
+{
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default "insert into t1 select * from generate_series(1, 1000)" >/dev/null 2>&1
+    done
+}
+
+function findmaster
+{
+    $CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default 'select host from comdb2_cluster where is_master="Y"'
+}
+
+function current_log_file
+{
+    x=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('bdb logstat')" | egrep st_cur_file)
+    echo "${x##* }"
+}
+
+function oldest_txn_file
+{
+    typeset oldest=-1
+    master=$(findmaster)
+    x=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $master  "exec procedure sys.cmd.send('bdb txnstat')"  | egrep -A 1 "active transactions"  2>&1 | egrep -v "active transactions" | awk '{print $NF}')
+    for l in $x ; do
+        f=${l%%:*}
+        if [[ "$oldest" == "-1" || "$f" -lt "$oldest" ]]; then
+            oldest=$f
+        fi 
+    done
+    echo $oldest
+}
+
+function run_test
+{
+    typeset maxtime=`echo "(${TEST_TIMEOUT%%m}-2)*60" | bc`
+    typeset now=$(date +%s)
+    typeset endtime=$(( now + maxtime ))
+    typeset func=run_test
+    typeset logtarget=10
+    rm -f $stopfile >/dev/null 2>&1
+    create_table
+
+    j=0
+    while [[ $j -lt 10 ]]; do
+        insert_thd &
+        let j=j+1
+    done
+
+    while [[ ! -f $stopfile && "$(date +%s)" -lt "$endtime" ]]; do
+        master=$(findmaster)
+        $CDB2SQL_EXE $CDB2_OPTIONS --host $master $DBNAME "exec procedure sys.cmd.send('leaktxn')";
+        oldest=$(oldest_txn_file)
+        clog=$(current_log_file)
+        if [[ $(( clog - oldest )) -gt "$logtarget" ]]; then
+            echo "met log-target, unleak & downgrade"
+            $CDB2SQL_EXE $CDB2_OPTIONS --host $master $DBNAME "exec procedure sys.cmd.send('unleaktxn')";
+            $CDB2SQL_EXE $CDB2_OPTIONS --host $master $DBNAME "exec procedure sys.cmd.send('downgrade')";
+        else
+            echo "oldest txn file is $oldest, current is $clog, logtarget is $logtarget, not downgrading"
+            echo "Need current to be older than $(( oldest + logtarget ))"
+        fi
+        sleep 10
+    done
+
+    touch $stopfile
+    echo "waiting for inserters to stop"
+    wait
+
+    # We succeed if the replicants never run recovery
+    skip=$(egrep skip-recovery ${TESTDIR}/logs/${DBNAME}*db)
+
+    if [[ -z "$skip" ]]; then
+        failexit "skip-recovery messages not found"
+    fi
+    echo "Found skip-recovery"
+    echo "$skip"
+    if [[ $skip == *"skip-recovery cannot skip"* ]]; then
+        failexit "skip-recovery ran recovery"
+    fi
+    echo "Nothing recovered- success!"
+}
+
+run_test
+echo "Success!"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -789,6 +789,7 @@
 (name='rep_processors', description='Try to apply this many transactions in parallel in the replication stream.', type='INTEGER', value='4', read_only='N')
 (name='rep_processors_rowlocks', description='Rowlocks touches 1 file/txn; it's handled by the processor thread.', type='INTEGER', value='0', read_only='N')
 (name='rep_skip_phase_3', description='', type='BOOLEAN', value='OFF', read_only='N')
+(name='rep_skip_recovery', description='Skip recovery if truncate won't unwind a transaction.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='rep_verify_limit_enabled', description='Enable aborting replicant if it doesn't make sufficient progress while rolling back logs to sync up to master.', type='BOOLEAN', value='ON', read_only='N')
 (name='rep_verify_max_time', description='Maximum amount of time we allow a replicant to roll back its logs in an attempt to sync up to the master.', type='INTEGER', value='300', read_only='N')
 (name='rep_verify_min_progress', description='Abort replicant if it doesn't make this much progress while rolling back logs to sync up to master.', type='INTEGER', value='10485760', read_only='N')

--- a/tests/ufid_reopen.test/runit
+++ b/tests/ufid_reopen.test/runit
@@ -5,14 +5,14 @@ bash -n "$0" | exit 1
 
 
 for node in $CLUSTER ; do
-    cdb2sql $dbnm --host $node 'EXEC PROCEDURE sys.cmd.send("abort_ufid_open 1")'
+    cdb2sql $CDB2_OPTIONS $DBNAME --host $node 'EXEC PROCEDURE sys.cmd.send("abort_ufid_open 1")'
 done
 
 set -e
 
 dbnm=$1
 
-master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select host from comdb2_cluster where is_master="Y"'`
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default 'select host from comdb2_cluster where is_master="Y"'`
 echo master is $master
 
 # The test demonstrates that a dbreg entry may be closed and reopened


### PR DESCRIPTION
We think recovery isn't always necessary in rep-verify-match.  I'm submitting this with the feature enabled to see how it fares under robo-rivers.