### PR TITLE
fix table scan in a join when inner loop is remote and a table scan 

### DIFF
--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -1535,8 +1535,6 @@ void fdb_msg_print_message(SBUF2 *sb, fdb_msg_t *msg, char *prefix)
              (prefix) ? " " : "", (prefix) ? prefix : "");
     prefix = prf;
 
-    assert(msg->hd.type & FD_MSG_FLAGS_ISUUID);
-
     switch (msg->hd.type & FD_MSG_TYPE) {
     case FDB_MSG_TRAN_BEGIN:
     case FDB_MSG_TRAN_PREPARE:


### PR DESCRIPTION
When inner join loop is a remote table scan, make sure a Rewind (i.e. a move to first row) returns at least one row if there is a predicate for the join.  Since we pass the predicate remotely for optimized filtering, returning no rows for a move to first row will be interpreted by sqlite as an empty table and it will stop the join prematurely.
We fix this by making sure a move to first row in table scan always return a row unless the remote table is empty.
I.e 
we change the remote query from 
SELECT *, rowid FROM remtable WHERE predicate
to 
SELECT *, rowid FROM remtable WHERE predicate union SELECT * from (SELECT *, rowid FROM remtable limit 1)

This is a corner case that is best to be avoided in general, since a inner loop that does a remote table scan will perform terrible in general, with or without remote filtering.