### PR TITLE
{174092326}: Fixing double-abort

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -75,6 +75,7 @@ int debug_switch_convert_record_sleep(void);             /* 0 */
 int debug_switch_abort_ufid_open(void);                  /* 0 */
 int debug_switch_bdb_handle_reset_delay(void);           /* 0 */
 int debug_switch_recover_ddlk_sp_delay(void);
+int debug_switch_force_file_version_to_fail(void); /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -34,6 +34,7 @@
 #include <sys/time.h>
 #include "lockmacros.h"
 #include <sys/poll.h>
+#include "debug_switches.h"
 
 extern int gbl_maxretries;
 extern int gbl_disable_access_controls;
@@ -2433,6 +2434,12 @@ int bdb_new_file_version_all(bdb_state_type *bdb_state, tran_type *input_tran,
     int dtanum, ixnum, retries = 0;
     unsigned long long version_num;
     tran_type *tran;
+
+    if (debug_switch_force_file_version_to_fail()) {
+        logmsg(LOGMSG_WARN, "%s: debug_switch_force_file_version_to_fail is ON, faling this call\n", __func__);
+        *bdberr = BDBERR_DEADLOCK;
+        return -1;
+    }
 
     /*stop here if the db isn't open*/
     if (!llmeta_bdb_state) {

--- a/tests/sc_tableversion.test/runit
+++ b/tests/sc_tableversion.test/runit
@@ -148,6 +148,7 @@ assert_vers nonexistent_table "NULL"
 assert_vers $tbl 0
 
 #fastinit does not increase counter
+cdb2sql -m ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('force_file_version_to_fail 1')"
 cdb2sql ${CDB2_OPTIONS} $dbnm default "truncate $tbl"
 assert_vers $tbl 0
 

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -82,6 +82,7 @@ static struct debug_switches {
     int abort_ufid_open;
     int bdb_handle_reset_delay;
     int recover_ddlk_sp_delay;
+    int force_file_version_to_fail;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -261,6 +262,8 @@ int init_debug_switches(void)
     register_int_switch("bdb_handle_reset_delay",
                         "Force a 5-second delay in bdb_handle_reset between closing and opening",
                         &debug_switches.bdb_handle_reset_delay);
+
+    register_debug_switch("force_file_version_to_fail", &debug_switches.force_file_version_to_fail);
     return 0;
 }
 
@@ -491,4 +494,11 @@ int debug_switch_bdb_handle_reset_delay(void)
 int debug_switch_recover_ddlk_sp_delay(void)
 {
     return debug_switches.recover_ddlk_sp_delay;
+}
+int debug_switch_force_file_version_to_fail(void)
+{
+    /* one-off */
+    int ret = debug_switches.force_file_version_to_fail;
+    debug_switches.force_file_version_to_fail = 0;
+    return ret;
 }


### PR DESCRIPTION
#4143 attempts to fix double-abort by setting the berkdb txn struct passed in by caller to NULL in `open_dbs()`, so that it'll become no-op if caller aborts the transaction again. But instead of modifying the actual DB_TXN struct, the PR ends up modifying the argument to the function. This patch corrects this mistake.

The fastinit/truncate code is also modified to retry on deadlock from llmeta. A test is added to reproduce the crash and to verifiy that it works correctly with the bug fix.