### PR TITLE
{173871120}: Allowing cold-started replicants to participate in election

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -76,8 +76,11 @@ int debug_switch_abort_ufid_open(void);                  /* 0 */
 int debug_switch_bdb_handle_reset_delay(void);           /* 0 */
 int debug_switch_recover_ddlk_sp_delay(void);
 int debug_switch_force_file_version_to_fail(void); /* 0 */
+int debug_switch_rep_verify_req_delay(void);       /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */
 
+/* setters */
+void debug_switch_set_rep_verify_req_delay(int);
 #endif

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3937,8 +3937,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
     if ((!bdb_state->caught_up) || (bdb_state->exiting))
         make_lsn(&permlsn, INT_MAX, INT_MAX);
 
-    if ((force_election) && (bdb_state->caught_up) &&
-        (host == bdb_state->repinfo->master_host)) {
+    if ((force_election) && (host == bdb_state->repinfo->master_host)) {
         logmsg(LOGMSG_WARN, "master %s requested election\n", host);
         r = DB_REP_HOLDELECTION;
         master_confused = 1;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5617,6 +5617,17 @@ int main(int argc, char **argv)
 
     start_physrep_threads();
 
+    if (debug_switch_rep_verify_req_delay()) {
+        extern int gbl_rep_newmaster_processed_on_replicant;
+        while (!gbl_rep_newmaster_processed_on_replicant) {
+            /* spin till my REP_NEWMASTER is processed by replicants */
+            sleep(1);
+        }
+        /* downgrade leader before other nodes catch up.
+         * see code in __rep_process_message */
+        bdb_transfermaster(thedb->static_table.handle);
+    }
+
     if (!gbl_perform_full_clean_exit) {
         void *ret;
         rc = pthread_join(timer_tid, &ret);

--- a/tests/electbug2.test/Makefile
+++ b/tests/electbug2.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/electbug2.test/lrl.options
+++ b/tests/electbug2.test/lrl.options
@@ -1,0 +1,1 @@
+rep_verify_req_delay 1

--- a/tests/electbug2.test/runit
+++ b/tests/electbug2.test/runit
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# We get here only if election works correctly
+echo "Passed."
+exit 0

--- a/tests/setup
+++ b/tests/setup
@@ -301,8 +301,13 @@ setup_db() {
                 out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' 2>&1)
                 $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select 1' &> $LOGDIR/${DBNAME}.${node}.conn
             done
-            $CDB2SQL_EXE -v ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $LOGDIR/${DBNAME}.${node}.conn
-            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)
+            if [[ $TESTCASE == "electbug2" ]]; then
+                # The electbug2 test deliberately downgrades the leader as soon as one is elected.
+                # Nodes may switch between a coherent and an incoherent state because of that. Use admin mode.
+                use_admin_mode="--admin"
+            fi
+            $CDB2SQL_EXE -v ${CDB2_OPTIONS} ${use_admin_mode} --tabs --host $node $DBNAME 'select comdb2_host()' &>> $LOGDIR/${DBNAME}.${node}.conn
+            out=$($CDB2SQL_EXE ${CDB2_OPTIONS} ${use_admin_mode} --tabs --host $node $DBNAME 'select comdb2_host()' 2>&1)
             if [ "$out" != "$node" ] ; then
                 sleep 1
                 failexit "comdb2_host() '$out' != expected '$node'"

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -83,6 +83,7 @@ static struct debug_switches {
     int bdb_handle_reset_delay;
     int recover_ddlk_sp_delay;
     int force_file_version_to_fail;
+    int rep_verify_req_delay;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -264,6 +265,7 @@ int init_debug_switches(void)
                         &debug_switches.bdb_handle_reset_delay);
 
     register_debug_switch("force_file_version_to_fail", &debug_switches.force_file_version_to_fail);
+    register_debug_switch("rep_verify_req_delay", &debug_switches.rep_verify_req_delay);
     return 0;
 }
 
@@ -501,4 +503,12 @@ int debug_switch_force_file_version_to_fail(void)
     int ret = debug_switches.force_file_version_to_fail;
     debug_switches.force_file_version_to_fail = 0;
     return ret;
+}
+int debug_switch_rep_verify_req_delay(void)
+{
+    return debug_switches.rep_verify_req_delay;
+}
+void debug_switch_set_rep_verify_req_delay(int val)
+{
+    debug_switches.rep_verify_req_delay = val;
 }


### PR DESCRIPTION
Currently replicants brought up afresh do not participate in election unless they are marked 'caught up' after the global bdb_env is initialized. However when half or more of the cluster are in this state, and the leader downgrades the cluster will then not be able to elect because of lack of quorum, as seen below

```
3333 2024/01/24 14:21:20 0x0x7fc1954f9700: calling for election with cluster of 3 nodes (3 connected) : c2btda-pw-053 c2btda-pw-928 c2btda-pw-922 ,  2.388000 secs timeout and priority 100
3343 2024/01/24 14:21:20 __rep_elect line 1453 not enough vote1s, failing
3344 2024/01/24 14:21:20 __rep_elect line 1533 ret is -30979
3345 2024/01/24 14:21:20 __rep_elect_done line 846 clearing PHASE1/PHASE2/TALLY, inelect is 1
3346 2024/01/24 14:21:20 __rep_elect_done called from __rep_elect line 1536
3347 2024/01/24 14:21:20 __rep_elect_done line 856 setting rep->egen from 168 to 169
3348 2024/01/24 14:21:20 __rep_elect line 1544 returning -30979 master .invalid egen is 168
3349 2024/01/24 14:21:20 failed to reach consensus in election with 2.388000 secs timeout. network timeout or received votes of a different egen

```

This patch gets rid of the 'caught-up' check. As long as a replicant is connected to the leader, and the leader requests election, the replicant should always respond to that request.

A new test electbug2 is added to reproduce this bug.
