### PR TITLE
only generate index tag schemas for ONDISK and DEFAULT

### DIFF
--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -934,8 +934,11 @@ static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
                 }
             }
         }
-        if (create_key_schema(db, schema, alt, err) > 0)
-            return -1;
+        if (is_disk_schema || !strcasecmp(rtag, ".DEFAULT")) {
+            /* we really only use .ONDISK_IX tag names */
+            if (create_key_schema(db, schema, alt, err) > 0)
+                return -1;
+        }
         if (is_disk_schema) {
             int i, rc;
             /* csc2 doesn't have the correct recsize for ondisk schema - use


### PR DESCRIPTION
Currently, for a schema like:
ondisk
{ 
int a
}
tag "t"
{
int a
}
keys
{
"a" = a
}
We generate tag schema for ONDISK_IX_0, but also for t_IX_0, which we do not use.  Patch removes the extra tag schemas.