### PR TITLE
Use ReentrantLock instead of synchronized for JDK 21 compatibility

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -17,6 +17,7 @@ import java.io.*;
 import java.sql.*;
 import java.util.*;
 import java.util.concurrent.*;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.*;
 
 /**
@@ -43,7 +44,7 @@ public class Comdb2Connection implements Connection {
     private boolean autoCommit = true;
     private boolean txnModeChanged = false;
 
-    private Object lock = new Object();
+    private final ReentrantLock lock = new ReentrantLock();
     private boolean opened = false;
 
     private Comdb2DatabaseMetaData md = null;
@@ -408,7 +409,9 @@ public class Comdb2Connection implements Connection {
 
     @Override
     public void close() throws SQLException {
-        synchronized (lock) {
+        lock.lock();
+
+        try {
             if (opened == true) {
 
                 for(Comdb2Statement stmt : stmts)
@@ -431,6 +434,8 @@ public class Comdb2Connection implements Connection {
                 md.conn.close();
                 md = null;
             }
+        } finally {
+            lock.unlock();
         }
     }
 


### PR DESCRIPTION
**Feature type:**

Enhancement.

**Motivation:**

JDK 21 has introduced official support for virtual threads. It is a framework for efficient processing of blocking tasks in the simple thread-per-request style. Behind the scenes, the JVM runtime maintains a relatively small number of platform threads. A virtual thread is mounted onto a platform thread for execution. When the virtual thread blocks (e.g. on I/O) it is unmounted, and the platform thread is then free to execute a different task. See https://openjdk.org/jeps/444 for more details.

The current virtual threads implementation, however, does not play nicely with `synchronized` blocks and methods, especially when blocking operations are performed inside of them. In these situations the platform threads cannot be freed, and the JEP recommends using `ReentrantLock` instead. This PR replaces all usages of `synchronized` in `cdb2jdbc` with the recommended lock type.

**Current behaviour:**

The `cdb2jdbc` driver frequently causes pinning of the platform threads due to I/O under `synchronized` blocks (confirmed by running my service with the `-Djdk.tracePinnedThreads=full` flag).

**New behaviour:**

The pinning doesn't happen any longer as the driver uses the recommended synchronisation primitives.

Note:

https://github.com/bloomberg/comdb2/pull/4174 must be merged first to ensure that the build of the library succeeds.
