### PR TITLE
check for error code in comdb2sc schema changes before setting the sql tables

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -502,7 +502,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
             local_lock = 1;
         }
         rc = do_finalize(post, iq, s, tran);
-        if (!s->is_osql) {
+        if (!rc && !s->is_osql) {
             create_sqlmaster_records(tran);
             create_sqlite_master();
         }

--- a/schemachange/sc_schema.c
+++ b/schemachange/sc_schema.c
@@ -391,11 +391,11 @@ int mark_schemachange_over_tran(const char *table, tran_type *tran)
                                  0 /*schema_change_data_len*/, &bdberr) ||
         bdberr != BDBERR_NOERROR) {
         logmsg(LOGMSG_WARN,
-               "POSSIBLY RESUMABLE: Could not mark schema change "
+               "POSSIBLY RESUMABLE: bdberr %d Could not mark schema change "
                "done in the low level meta table.  This usually means "
                "that the schema change failed in a potentially "
                "resumable way (ie there is a new master) if this is "
-               "the case, the new master will try to resume\n");
+               "the case, the new master will try to resume\n", bdberr);
 
         return SC_BDB_ERROR;
     }


### PR DESCRIPTION
This is a recent regression.   Check for error code before updating the sql table records.