### PR TITLE
clear table if comdb2sc add table fails after finalizing

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -224,6 +224,13 @@ static void stop_and_free_sc(struct ireq *iq, int rc,
             sbuf2printf(s->sb, "SUCCESS\n");
         }
     }
+    if (rc && iq->sc->kind == SC_ADDTABLE) {
+        delete_temp_table(iq, iq->sc->db);
+        if (iq->sc->already_finalized) {
+            rem_dbtable_from_thedb_dbs(iq->sc->db);
+        }
+    }
+
     sc_set_running(iq, s, s->tablename, 0, NULL, 0, 0, __func__, __LINE__);
     if (do_free) {
         free_sc(s);


### PR DESCRIPTION
Currently, issue reproduceable with comdb2sc, if an error is forced during mark_schemachange_over_tran() call in do_finalize() stage.  At this point a table is added to the list of tables, under global schema lock.   The ddl schema change common code (i.e. common with comdb2sc) does its job and abort the transaction, which removes all llmeta entries added during finalize_add_table().  But the legacy comdb2sc fails early and does not clear the in-memory table from the list of tables.
Everything goes unnoticed until a new schema change arrives and commits successfully.  Because we construct LLMETA_TABLES list of tables in llmeta based on the list of tables in memory, this commit wrongly adds the failed/non-persistent table to the list.  At this point the db is corrupted and cannot restart (unless ignore_bad_table lrl option is used).
Fix the comdb2sc add by clearing properly on error.
