### PR TITLE
{174092326}: caching file versions in bdb_state struct

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -553,11 +553,9 @@ int bdb_handle_dbp_hash_stat_reset(bdb_state_type *bdb_state);
 int bdb_close_temp_state(bdb_state_type *bdb_state, int *bdberr);
 
 /* get file sizes for indexes and data files */
-uint64_t bdb_index_size_tran(bdb_state_type *bdb_state, tran_type *tran, int ixnum);
-uint64_t bdb_data_size_tran(bdb_state_type *bdb_state, tran_type *tran, int dtanum);
 uint64_t bdb_data_size(bdb_state_type *bdb_state, int dtanum);
+uint64_t bdb_index_size(bdb_state_type *bdb_state, int dtanum);
 uint64_t bdb_queue_size(bdb_state_type *bdb_state, unsigned *num_extents);
-uint64_t bdb_queue_size_tran(bdb_state_type *bdb_state, tran_type *tran, unsigned *num_extents);
 uint64_t bdb_logs_size(bdb_state_type *bdb_state, unsigned *num_logs);
 uint64_t bdb_tmp_size(bdb_state_type *bdb_state, uint64_t *ptmptbls, uint64_t *psqlsorters, uint64_t *pblkseqs,
                       uint64_t *pothers);

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1060,6 +1060,11 @@ struct bdb_state_tag {
     pthread_mutex_t sc_redo_lk;
     pthread_cond_t sc_redo_wait;
     LISTC_T(struct sc_redo_lsn) sc_redo_list;
+
+    /* cached file versions */
+    unsigned long long dtavers[1 + MAXBLOBS];
+    unsigned long long ixvers[MAXINDEX];
+    unsigned long long qvers[BDB_QUEUEDB_MAX_FILES];
 };
 
 #include <net_types.h>

--- a/db/glue.c
+++ b/db/glue.c
@@ -5553,20 +5553,20 @@ uint64_t calc_table_size_tran(tran_type *tran, struct dbtable *db, int skip_blob
 
     if (db->dbtype == DBTYPE_TAGGED_TABLE) {
         for (ii = 0; ii < db->nix; ii++) {
-            db->ixsizes[ii] = bdb_index_size_tran(db->handle, tran, ii);
+            db->ixsizes[ii] = bdb_index_size(db->handle, ii);
             db->totalsize += db->ixsizes[ii];
         }
 
-        db->dtasize = bdb_data_size_tran(db->handle, tran, 0);
+        db->dtasize = bdb_data_size(db->handle, 0);
         db->totalsize += db->dtasize;
         size_without_blobs = db->totalsize;
 
         for (ii = 0; ii < db->numblobs; ii++) {
-            db->blobsizes[ii] = bdb_data_size_tran(db->handle, tran, ii + 1);
+            db->blobsizes[ii] = bdb_data_size(db->handle, ii + 1);
             db->totalsize += db->blobsizes[ii];
         }
     } else if (db->dbtype == DBTYPE_QUEUE || db->dbtype == DBTYPE_QUEUEDB) {
-        db->totalsize = bdb_queue_size_tran(db->handle, tran, &db->numextents);
+        db->totalsize = bdb_queue_size(db->handle, &db->numextents);
     } else {
         logmsg(LOGMSG_ERROR, "%s: db->dbtype=%d (what the heck is this?)\n",
                 __func__, db->dbtype);

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -136,22 +136,16 @@ static int systblTblSizeColumn(
   struct dbtable *pDb = thedb->dbs[pCur->iRowid];
   char *x = pDb->tablename;
 
-  tran_type *trans = curtran_gettran();
-  if (!trans) {
-      logmsg(LOGMSG_ERROR, "%s cannot create transaction object\n", __func__);
-      return -1;
-  }
   switch( i ){
     case STTS_TABLE: {
       sqlite3_result_text(ctx, x, -1, NULL);
       break;
     }
     case STTS_SIZE: {
-      calc_table_size_tran(trans, pDb, 0);
+      calc_table_size(pDb, 0);
       sqlite3_result_int64(ctx, (sqlite3_int64)pDb->totalsize);
     }
   }
-  curtran_puttran(trans);
   return SQLITE_OK;
 }
 

--- a/tests/diskspace_nollmeta.test/Makefile
+++ b/tests/diskspace_nollmeta.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/diskspace_nollmeta.test/runit
+++ b/tests/diskspace_nollmeta.test/runit
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Verify that we do not get sizes from stale table files
+
+dbnm=$1
+set -e
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t1 (a BYTE(32) PRIMARY KEY, b BLOB)"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "INSERT INTO t1 SELECT randomblob(32), randomblob(128) FROM generate_series(1, 49999)"
+
+# get table size after flushing changes to disk
+cdb2sql -m ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('flush')"
+oldsize=$(cdb2sql -m -tabs ${CDB2_OPTIONS} $dbnm default "SELECT value FROM comdb2_metrics WHERE name = 'diskspace'")
+
+# truncate this table and get the size again. This time size should be smaller.
+cdb2sql ${CDB2_OPTIONS} $dbnm default "TRUNCATE TABLE t1";
+newsize=$(cdb2sql -m -tabs ${CDB2_OPTIONS} $dbnm default "SELECT value FROM comdb2_metrics WHERE name = 'diskspace'")
+
+is_smaller=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default "SELECT ($oldsize > $newsize) AS is_smaller")
+
+echo "diskspace before truncate $oldsize, after truncate $newsize"
+
+if [ "$is_smaller" -ne "1" ]; then
+    echo "diskspace does not come down?" >&2
+    exit 1
+fi

--- a/tests/maxtable.test/runit
+++ b/tests/maxtable.test/runit
@@ -85,14 +85,30 @@ function max_view
     [[ $? == 0 ]] && failexit "should have failed to create view"
 }
 
+function select_diskspace_in_a_loop
+{
+    while true; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default 'SELECT value FROM comdb2_metrics WHERE name = "diskspace"' >/dev/null
+    done &
+    selectpid=$!
+}
+
+
+function kill_the_select_loop
+{
+    kill -9 $selectpid
+}
+
 function run_tests
 {
+    select_diskspace_in_a_loop
     max_table
     rebuild
     max_queue
     rebuild
     max_view
     rebuild
+    kill_the_select_loop
     return 0
 }
 


### PR DESCRIPTION
This patch caches file versions in the bdb_state struct, so that we avoid reading from llmeta next time we need them. Note that it does not fix places where wo do not unroll schemachange states correctly on error from llmeta, but it does make it much less likely for deadlocks to occur.
