### PR TITLE
Add schema versions systable

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1610,6 +1610,41 @@ typedef struct {
 int bdb_llmeta_get_sc_history(tran_type *t, sc_hist_row **hist_out, int *num,
                               int *bdberr, const char *tablename);
 
+typedef struct schema_version_row {
+    char *db_name;
+    int vers;
+    char *csc2;
+} schema_version_row;
+
+/*
+ * bdb_llmeta_free_schema_versions --
+ *
+ * Frees list of schema versions allocated by `bdb_llmeta_get_schema_versions`
+ * `data` is the list of schema versions to be freed 
+ * and `n` is the number of elements in this list.
+ */ 
+void bdb_llmeta_free_schema_versions(schema_version_row *data, int n);
+
+/*
+ * bdb_llmeta_get_schema_versions --
+ *
+ * Gets all schema versions stored in llmeta.
+ * 
+ * On success: 
+ * - returns zero
+ * - `data` points to a list of versions.
+ * Elements in this list are of type `schema_version_row`.
+ * *** This list must be freed with a call to `bdb_llmeta_free_schema_versions`***
+ * - `num` points to the number of entries in this list
+ *
+ * On failure:
+ * - returns nonzero
+ * - `data` points to NULL
+ * - `num` points to zero
+ */
+int bdb_llmeta_get_schema_versions(tran_type *t, schema_version_row **data, int *num,
+                                    int *bdberr);
+
 int bdb_del_schema_change_history(tran_type *t, const char *tablename,
                                   uint64_t seed);
 

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -721,6 +721,16 @@ Information about current/most recent schema change per table.
 * `converted` - Number of records converted.
 * `error` - Error message of the schema change.
 
+## comdb2_schemaversions
+
+List of all versions of table schemas stored in llmeta.
+
+    comdb2_schemaversions(name, csc2, version)
+
+* `tablename` - Name of the table.
+* `csc2` - Schema in csc2 format.
+* `version` - Numeric version associated with this schema version in llmeta.
+
 ## comdb2_views
 
 List of views in the database.

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -62,6 +62,7 @@ add_library(sqlite
   ext/comdb2/users.c
   ext/comdb2/views.c
   ext/comdb2/fdb.c
+  ext/comdb2/schemaversions.c
   ext/misc/carray.c
   ext/misc/completion.c
   ext/misc/regexp.c

--- a/sqlite/ext/comdb2/comdb2systblInt.h
+++ b/sqlite/ext/comdb2/comdb2systblInt.h
@@ -51,6 +51,7 @@ extern const sqlite3_module systblLogicalOpsModule;
 extern const sqlite3_module systblSystabsModule;
 extern const sqlite3_module systblFdbInfoModule;
 extern const sqlite3_module systblFilesModule;
+extern sqlite3_module systblSchemaVersionsModule;
 extern sqlite3_module systblTablePermissionsModule;
 extern sqlite3_module systblSystabPermissionsModule;
 extern sqlite3_module systblTimepartPermissionsModule;
@@ -96,6 +97,7 @@ int systblTransactionStateInit(sqlite3 *db);
 int systblMemstatsInit(sqlite3 *db);
 int systblStacks(sqlite3 *db);
 int systblPreparedInit(sqlite3 *db);
+int systblSchemaVersionsInit(sqlite3 *db);
 
 /* Simple yes/no answer for booleans */
 #define YESNO(x) ((x) ? "Y" : "N")

--- a/sqlite/ext/comdb2/schemaversions.c
+++ b/sqlite/ext/comdb2/schemaversions.c
@@ -1,0 +1,79 @@
+/*
+   Copyright 2020 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+#include "comdb2.h"
+#include "comdb2systbl.h"
+#include "comdb2systblInt.h"
+#include "sql.h"
+#include "ezsystables.h"
+#include "cdb2api.h"
+
+static int get_versions(void **data, int *npoints)
+{
+    int rc, bdberr, nvers;
+
+    nvers = 0;
+    schema_version_row *vers = NULL;
+    tran_type *trans = curtran_gettran();
+
+    if (trans == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: cannot create transaction object\n", __func__);
+        rc = SQLITE_INTERNAL;
+        goto cleanup;
+    }
+
+    rc = bdb_llmeta_get_schema_versions(trans, &vers, &nvers, &bdberr);
+    if (rc || bdberr) {
+        logmsg(LOGMSG_ERROR, "%s: failed to get all schema versions\n",
+               __func__);
+        rc = SQLITE_INTERNAL;
+        goto cleanup;
+    }
+
+    *npoints = nvers;
+    *data = vers;
+
+cleanup:
+    curtran_puttran(trans);
+
+    return rc;
+}
+
+static void free_versions(void *p, int n)
+{
+    bdb_llmeta_free_schema_versions((schema_version_row *) p, n);
+}
+
+sqlite3_module systblSchemaVersionsModule = {
+    .access_flag = CDB2_ALLOW_USER,
+    .systable_lock = "comdb2_tables",
+};
+
+int systblSchemaVersionsInit(sqlite3 *db)
+{
+    return create_system_table(
+        db, "comdb2_schemaversions", &systblSchemaVersionsModule,
+        get_versions, free_versions, sizeof(struct schema_version_row),
+        CDB2_CSTRING, "tablename", -1, offsetof(struct schema_version_row, db_name),
+        CDB2_CSTRING, "csc2", -1, offsetof(struct schema_version_row, csc2),
+        CDB2_INTEGER, "version", -1, offsetof(struct schema_version_row, vers),
+        SYSTABLE_END_OF_FIELDS);
+}

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -236,6 +236,8 @@ int comdb2SystblInit(
 #endif
   if (rc == SQLITE_OK)  
     rc = systblPreparedInit(db);
+  if (rc == SQLITE_OK)
+    rc = systblSchemaVersionsInit(db);
 #endif
   return rc;
 }

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -259,6 +259,7 @@
 (candidate='comdb2_replication_netqueue')
 (candidate='comdb2_sc_history')
 (candidate='comdb2_sc_status')
+(candidate='comdb2_schemaversions')
 (candidate='comdb2_sql_client_stats')
 (candidate='comdb2_sqlpool_queue')
 (candidate='comdb2_stacks')

--- a/tests/cdb2sql.test/t00.expected
+++ b/tests/cdb2sql.test/t00.expected
@@ -54,6 +54,7 @@ unknown @ls sub-command foo
 (name='comdb2_replication_netqueue')
 (name='comdb2_sc_history')
 (name='comdb2_sc_status')
+(name='comdb2_schemaversions')
 (name='comdb2_sql_client_stats')
 (name='comdb2_sqlpool_queue')
 (name='comdb2_stacks')

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -397,6 +397,7 @@
 (name='comdb2_replication_netqueue')
 (name='comdb2_sc_history')
 (name='comdb2_sc_status')
+(name='comdb2_schemaversions')
 (name='comdb2_sql_client_stats')
 (name='comdb2_sqlpool_queue')
 (name='comdb2_stacks')

--- a/tests/schemaversions.test/Makefile
+++ b/tests/schemaversions.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/schemaversions.test/runit
+++ b/tests/schemaversions.test/runit
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+a_dbn=$1
+
+### Verify comdb2_schemaversions state after table create
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "create table t(i int)"
+
+count=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select count(*) from comdb2_schemaversions where tablename='t'")
+
+if (( count != 1 ));
+then
+	echo "Wrong version count after table create"
+	exit 1
+fi
+
+version=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(version) from comdb2_schemaversions where tablename='t'")
+
+if (( version != 1 ));
+then
+	echo "Wrong max schema version found after alter"
+	exit 1
+fi
+
+csc2=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select csc2 from comdb2_schemaversions where tablename='t'")
+
+### Verify copy of a table created from comdb2_schemaversions csc2
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "create table t_cpy {${csc2}}"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t values(1)"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t_cpy select * from t"
+res=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(i) from t_cpy")
+
+if (( res != 1 ));
+then
+	echo "Unexpected result after schema change + insert"
+	exit 1
+fi
+
+### Verify comdb2_schemaversions state after 1st table alter
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "alter table t add j int"
+count=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select count(*) from comdb2_schemaversions where tablename='t'")
+
+if (( count != 2 ));
+then
+	echo "Count of versions did not increase after table alter"
+	exit 1
+fi
+
+version=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(version) from comdb2_schemaversions where tablename='t'")
+
+if (( version != 2 ));
+then
+	echo "Wrong max schema version found after alter"
+	exit 1
+fi
+
+### Verify copy of a table altered from new comdb2_schemaversions csc2
+
+csc2=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select csc2 from comdb2_schemaversions where tablename='t' and version=2")
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "alter table t_cpy {${csc2}}"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "delete from t"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t values(1, 2)"
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t_cpy select * from t"
+res=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(j) from t_cpy")
+
+if (( res != 2 ));
+then
+	echo "Unexpected result after schema change + insert"
+	exit 1
+fi
+
+### Verify comdb2_schemaversions state after 2nd table alter
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "alter table t add l int"
+count=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select count(*) from comdb2_schemaversions where tablename='t'")
+
+if (( count != 3 ));
+then
+	echo "Count of versions did not increase after table alter"
+	exit 1
+fi
+
+version=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(version) from comdb2_schemaversions where tablename='t'")
+
+if (( version != 3 ));
+then
+	echo "Wrong max schema version found after alter"
+	exit 1
+fi
+
+### Verify comdb2_schemaversions state after rebuild.
+
+cdb2sql ${CDB2_OPTIONS} $a_dbn default "rebuild t"
+count=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select count(*) from comdb2_schemaversions where tablename='t'")
+
+if (( count != 1 ));
+then
+	echo "Count of versions did not decrease after table truncate"
+	exit 1
+fi
+
+version=$(cdb2sql ${CDB2_OPTIONS} --tabs $a_dbn default "select max(version) from comdb2_schemaversions where tablename='t'")
+
+if (( version != 1 ));
+then
+	echo "Highest verison not 1 after rebuild"
+	exit 1
+fi

--- a/tests/userschema.test/t00.expected
+++ b/tests/userschema.test/t00.expected
@@ -41,6 +41,7 @@
 (tablename='comdb2_replication_netqueue', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_sc_history', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_sc_status', username='mohit', READ='Y', WRITE='Y', DDL='Y')
+(tablename='comdb2_schemaversions', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_sql_client_stats', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_sqlpool_queue', username='mohit', READ='Y', WRITE='Y', DDL='Y')
 (tablename='comdb2_stacks', username='mohit', READ='Y', WRITE='Y', DDL='Y')


### PR DESCRIPTION
The changes in this PR add a system table called `comdb2_schemaversions` that exposes all versions of table schemas stored in llmeta.

For example, if a table is added and altered as such
```
create table test(i int)
alter table test add j int
```

Then `comdb2_schemaversions` will contain one record for each of these versions, as shown:

```
testdb> select * from comdb2_schemaversions where tablename='test'
(tablename='test', csc2='schema
        {
                int i null = yes
        }
', version=1)
(tablename='test', csc2='schema
        {
                int i null = yes
                int j null = yes
        }
', version=2)
```

