### PR TITLE
all dbs have llmeta today, remove old code

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1419,9 +1419,8 @@ void bdb_register_rtoff_callback(bdb_state_type *bdb_state, void (*func)(void));
  * for, or 0 if no checkpoint is currently running. */
 int bdb_get_checkpoint_time(bdb_state_type *bdb_state);
 
-int bdb_have_llmeta();
 int bdb_llmeta_open(char name[], char dir[], bdb_state_type *parent_bdb_handle,
-                    int create_override, int *bdberr);
+                    int *bdberr);
 int bdb_llmeta_set_tables(tran_type *input_trans, char **tblnames,
                           const int *dbnums, int numdbs, int *bdberr);
 int bdb_llmeta_get_tables(tran_type *input_trans, char **tblnames, int *dbnums,

--- a/bdb/rowlocks.c
+++ b/bdb/rowlocks.c
@@ -1768,8 +1768,6 @@ static int cancel_all_logical_transactions(bdb_state_type *bdb_state)
     return 0;
 }
 
-int llmeta_open(void);
-
 /* XXX
  * Have to think about how logical recovery is going to look on the replicants -
  * now, all of the replicant rowlocks are acquired strictly in

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -2969,7 +2969,7 @@ int llmeta_open(void)
 
     /*open the table*/
     if (bdb_llmeta_open(llmetaname, thedb->basedir, thedb->bdb_env,
-                        0 /*create_override*/, &bdberr) ||
+                        &bdberr) ||
         bdberr != BDBERR_NOERROR) {
         logmsg(LOGMSG_FATAL, "Failed to open low level meta table, rc: %d\n",
                bdberr);

--- a/db/tag.c
+++ b/db/tag.c
@@ -4534,21 +4534,12 @@ void fix_lrl_ixlen_tran(tran_type *tran)
             db->csc2_schema = NULL;
         }
 
-        if (bdb_have_llmeta()) {
-            int ver;
-            ver = get_csc2_version_tran(db->tablename, tran);
-            if (ver > 0) {
-                get_csc2_file_tran(db->tablename, ver, &db->csc2_schema,
-                                   &db->csc2_schema_len, tran);
-            }
-        } else {
-            if (!db->csc2_schema)  
-                db->csc2_schema = load_text_file(db->lrlfname);
-            if (db->csc2_schema)
-                db->csc2_schema_len = strlen(db->csc2_schema);
+        int ver = get_csc2_version_tran(db->tablename, tran);
+        if (ver > 0) {
+            get_csc2_file_tran(db->tablename, ver, &db->csc2_schema,
+                    &db->csc2_schema_len, tran);
         }
     }
-    /* TODO: schema information for foreign tables */
 }
 
 void fix_lrl_ixlen()

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -732,7 +732,6 @@ static int do_merge_table(struct ireq *iq, struct schema_change_type *s,
      * later on
      */
     if (!newdb->csc2_schema) {
-        assert(bdb_have_llmeta() && s->kind == SC_ALTERTABLE);
         int ver;
         ver = get_csc2_version_tran(db->tablename, tran);
         if (ver > 0) {


### PR DESCRIPTION
This check dates before we had llmeta (more exactly, 2008, 8c81e0a57a).  We do not have anymore dbs like that.   Remove code.