### PR TITLE
Address compiler warning

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -2025,7 +2025,7 @@ struct params_info *dohsql_params_append(struct params_info **pparams,
     return *pparams = params;
 }
 
-int dohsql_clone_params(int nparams, struct param_data * params,
+int dohsql_clone_params(unsigned int nparams, struct param_data * params,
                         int *pnparams, struct param_data **pparams)
 {
     struct param_data *pout;

--- a/db/dohsql.h
+++ b/db/dohsql.h
@@ -118,7 +118,7 @@ struct params_info *dohsql_params_append(struct params_info **pparams,
  * Clone bound parameters; deep-copy pointers
  *
  */
-int dohsql_clone_params(int nparams, struct param_data * params,
+int dohsql_clone_params(unsigned int nparams, struct param_data * params,
                         int *pnparams, struct param_data **pparams);
 
 /**


### PR DESCRIPTION
When `COMDB2_PER_THREAD_MALLOC=OFF` gcc 8.5.0 produces the following warning:

```
comdb2/db/dohsql.c:2041:12: error: argument 1 range [18446744071562067968, 18446744073709551615] exceeds maximum object size 9223372036854775807 -Werror=alloc-size-larger-than=]
     pout = calloc(nparams, sizeof(struct param_data));
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
`nparams` is an `int`. If `nparams` is negative and is then cast to a `size_t` when it is passed to `calloc`, then the object size that `calloc` calculates could be out of range. `nparams` should never be negative so I changed it from an `int` to an `unsigned int`.