### PR TITLE
set csc2_schema upon creation and remove a bunch of code while doing it

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3280,7 +3280,6 @@ static int init_sqlite_tables(struct dbenv *dbenv)
             logmsg(LOGMSG_ERROR, "%s\n", err.errstr);
             return -1;
         }
-        tbl->csc2_schema = strdup(sqlite_stats_csc2[i]);
 
         /* Add table to the hash. */
         _db_hash_add(tbl);

--- a/db/config.c
+++ b/db/config.c
@@ -671,7 +671,7 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
         return -1;
     }
 
-    db->csc2_schema = csc2;
+    free(csc2);
     db->dbs_idx = dbenv->num_dbs;
     dbenv->dbs[dbenv->num_dbs++] = db;
 

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -54,6 +54,9 @@ struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
         goto err;
     }
 
+    newtable->csc2_schema = strdup(csc2);
+    newtable->csc2_schema_len = strlen(csc2);
+
     rc = add_cmacc_stmt(newtable, sc_alt_tablename, allow_ull, no_side_effects,
                         err);
     if (rc) {

--- a/db/tag.c
+++ b/db/tag.c
@@ -4528,17 +4528,6 @@ void fix_lrl_ixlen_tran(tran_type *tran)
             s = find_tag_schema(db, namebuf);
             db->ix_keylen[ix] = get_size_of_schema(s);
         }
-
-        if (db->csc2_schema) {
-            free(db->csc2_schema);
-            db->csc2_schema = NULL;
-        }
-
-        int ver = get_csc2_version_tran(db->tablename, tran);
-        if (ver > 0) {
-            get_csc2_file_tran(db->tablename, ver, &db->csc2_schema,
-                    &db->csc2_schema_len, tran);
-        }
     }
 }
 

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -35,13 +35,6 @@ static inline int adjust_master_tables(struct dbtable *newdb, const char *csc2,
     int rc;
 
     fix_lrl_ixlen_tran(trans);
-    /* fix_lrl_ixlen() usually sets csc2_schema/csc2_schema_len, but for llmeta
-     * dbs, it grabs this info from llmeta and in the case where we are adding a
-     * table the schema is not yet in llmeta */
-    if (!newdb->csc2_schema && csc2) {
-        newdb->csc2_schema = strdup(csc2);
-        newdb->csc2_schema_len = strlen(newdb->csc2_schema);
-    }
 
     if (newdb->dbenv->master == gbl_myhostname) {
         if ((rc = sql_syntax_check(iq, newdb)))

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -725,29 +725,13 @@ static int do_merge_table(struct ireq *iq, struct schema_change_type *s,
         return SC_TABLE_DOESNOT_EXIST;
     }
 
-    newdb = s->newdb;
-
-    /* NOTE: add prepopulates newdb->csc2_schema, but alter does not
-     * we need this to be able to call populate_db_with_alt_schema
-     * later on
-     */
-    if (!newdb->csc2_schema) {
-        int ver;
-        ver = get_csc2_version_tran(db->tablename, tran);
-        if (ver > 0) {
-            get_csc2_file_tran(db->tablename, ver, &newdb->csc2_schema,
-                               &newdb->csc2_schema_len, tran);
-        } else {
-            sc_client_error(s, "Cannot get csc2 for the table %s",
-                            db->tablename);
-            return -1;
-        }
-    }
 
     if (s->resume == SC_PREEMPT_RESUME) {
         newdb = db->sc_to;
         goto convert_records;
     }
+
+    newdb = s->newdb;
 
     set_schemachange_options_tran(s, db, &scinfo, tran);
 


### PR DESCRIPTION
We can allocate csc2_schema when we create the dbtable, not randomly in various places.  This eliminates some redundant code.