### PR TITLE
Fixing build

### DIFF
--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -721,7 +721,7 @@ static void osql_scdone_commit_callback(struct ireq *iq)
 
                 /* If another schemachange thread is deleting files,
                    we can't safely free the bdb state. Let it leak. */
-                if (iq->sc->drop_table && !bdb_is_delfiles_in_progress()) {
+                if (iq->sc->kind == SC_DROPTABLE && !bdb_is_delfiles_in_progress()) {
                     bdb_free(iq->sc->db->handle, &bdberr);
                     freedb(iq->sc->db);
                 }

--- a/schemachange/sc_queues.c
+++ b/schemachange/sc_queues.c
@@ -703,7 +703,7 @@ done:
 
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s rc:%d\n", __func__, rc);
-    } else if (sc->drop_table) {
+    } else if (sc->kind == SC_DROPTABLE) {
         bdb_free(db->handle, &bdberr);
         freedb(db);
     }


### PR DESCRIPTION
Schemachange actions (`addonly`, `alteronly`, `drop_table`, `fastinit`, etc.) no longer exist. They are replaced by the `kind` enum.