### PR TITLE
Reproduce and fix time-partition crash

### DIFF
--- a/db/sqlmaster.c
+++ b/db/sqlmaster.c
@@ -147,6 +147,7 @@ master_entry_t *create_master_entry_array(struct dbtable **dbs, int num_dbs,
  */
 void create_sqlite_master()
 {
+    assert_wrlock_schema_lk();
     master_entry_t *new_arr = NULL;
     int local_nentries = 0;
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1096,6 +1096,8 @@ int sc_timepart_add_table(const char *existingTableName,
     sc.kind = SC_ADDTABLE;
     sc.finalize = 1;
 
+    sc.keep_locked = 1;
+
     /* get new schema */
     db = get_dbtable_by_name(existingTableName);
     if (db == NULL) {
@@ -1168,6 +1170,8 @@ int sc_timepart_add_table(const char *existingTableName,
     create_sqlmaster_records(NULL);
     create_sqlite_master();
 
+    unlock_schema_lk();
+
     return xerr->errval;
 
 error:
@@ -1197,6 +1201,8 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     /* this is a table add */
     sc.kind = SC_DROPTABLE;
     sc.finalize = 1;
+
+    sc.keep_locked = 1;
 
     /* get new schema */
     db = get_dbtable_by_name(tableName);
@@ -1254,6 +1260,8 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     create_sqlmaster_records(NULL);
     create_sqlite_master();
 
+    unlock_schema_lk();
+
     return xerr->errval;
 
 error:
@@ -1276,6 +1284,7 @@ int sc_timepart_truncate_table(const char *tableName, struct errstat *xerr,
     sc.is_osql = 1;
     sc.newpartition = partition;
 
+    sc.keep_locked = 1;
 
     /* use real table name, not the sql alias */
     struct dbtable *table = get_dbtable_by_name(tableName);
@@ -1308,6 +1317,8 @@ int sc_timepart_truncate_table(const char *tableName, struct errstat *xerr,
 
     create_sqlmaster_records(NULL);
     create_sqlite_master();
+
+    unlock_schema_lk();
 
     bzero(xerr, sizeof(*xerr));
     return 0;

--- a/tests/tpcrash.test/Makefile
+++ b/tests/tpcrash.test/Makefile
@@ -1,0 +1,11 @@
+unexport CLUSTER
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+# TODO this causes lock-inversion .. i will fix that later
+export VERIFY_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/tpcrash.test/lrl.options
+++ b/tests/tpcrash.test/lrl.options
@@ -1,0 +1,3 @@
+nowatch
+logmsg level info
+

--- a/tests/tpcrash.test/runit
+++ b/tests/tpcrash.test/runit
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export maxtable=20
+
+function failexit
+{
+    [[ $debug == "1" ]] && set -x
+    touch $stopfile
+    echo "Failed: $1"
+    exit -1
+}
+
+function create_tables
+{
+    typeset count=${1:-20}
+    typeset j=0
+    while [[ $j -lt $count ]]; do
+        t="t${j}"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "create table $t(a int)"
+        let j=j+1
+    done
+}
+
+function create_partitions
+{
+    typeset count=${1:-20}
+    typeset j=0
+    while [[ $j -lt $count ]]; do
+        t="t${j}"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "create time partition on $t as ${t}part period 'weekly' retention 2 start '2024-01-01T000000.000'"
+        let j=j+1
+    done
+}
+
+function create_procedures
+{
+    typeset count=${1:-20}
+    typeset j=0
+    while [[ $j -lt $count ]]; do
+        p="p${j}"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME - <<EOF
+create procedure $p version 'test' {
+local function main()
+    db:column_type("string", 1);
+    db:column_type("string", 2);
+    db:emit("123", "456");
+    return 0
+end}\$\$
+EOF
+        let j=j+1
+    done
+}
+
+function run_test
+{
+    create_tables $maxtable
+    create_partitions $maxtable
+    create_procedures $maxtable
+}
+
+run_test
+echo "Success"


### PR DESCRIPTION
Assert we hold schema-lk in create_sqlite_master, fix places where we don't have it.  The tpcrash test reproduces the issue.