### PR TITLE
Change analyze to always sample if enabled

### DIFF
--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -826,8 +826,11 @@ static int analyze_table_int(table_descriptor_t *td,
     if (sampled_tables_enabled)
         get_sampling_threshold(td->table, &sampling_threshold);
 
-    /* sample if enabled & large */
-    if (sampled_tables_enabled && totsiz > sampling_threshold) {
+    /* sample if enabled */
+    if (sampled_tables_enabled) {
+        if (totsiz <= sampling_threshold) {
+            td->scale = 100;
+        }
         logmsg(LOGMSG_INFO, "Sampling table '%s' at %d%% coverage\n", td->table, td->scale);
         sampled_table = 1;
         rc = sample_indicies(td, &clnt, tbl, td->scale, td->sb);


### PR DESCRIPTION
Analyze grabs locks, & uses other berkley resources inline if the size of the table being analyzed is below a certain threshold.  This PR changes the logic so that every analyze is executed from temp-tables- but those tables are compressed only if they are beyond the size threshold.