### PR TITLE
Don't acquire long-term locks in queue walk code.

### DIFF
--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -792,7 +792,9 @@ int bdb_queuedb_walk(bdb_state_type *bdb_state, int flags, void *lastitem,
     DBT dbt_key = {0}, dbt_data = {0};
     DBC *dbcp = NULL;
     uint8_t ver = 0;
+    u_int32_t lockerid;
 
+    bdb_get_tran_lockerid(tran, &lockerid);
     if (gbl_debug_queuedb)
         logmsg(LOGMSG_USER, ">>> bdb_queuedb_walk %s\n", bdb_state->name);
 
@@ -817,8 +819,10 @@ int bdb_queuedb_walk(bdb_state_type *bdb_state, int flags, void *lastitem,
         DB *db = dbs[i]; if (db == NULL) continue;
         dbt_key.flags = dbt_data.flags = DB_DBT_REALLOC;
 
+
+
         /* this API is a little nutty... */
-        rc = db->cursor(db, tran ? tran->tid : NULL, &dbcp, 0);
+        rc = db->paired_cursor_from_lid(db, lockerid, &dbcp, 0);
         if (rc != 0) {
             *bdberr = BDBERR_MISC;
             return -1;

--- a/tests/queuedb_locks.test/Makefile
+++ b/tests/queuedb_locks.test/Makefile
@@ -1,0 +1,6 @@
+export TEST_TIMEOUT=5m
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/queuedb_locks.test/runit
+++ b/tests/queuedb_locks.test/runit
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+
+dbname=$1
+
+set -e
+
+rep=`cdb2sql --tabs ${CDB2_OPTIONS} $dbname default 'select comdb2_host()'`
+
+cdb2sql --host $rep ${CDB2_OPTIONS} $dbname 'create table t(a int)'
+cdb2sql --host $rep ${CDB2_OPTIONS} $dbname 'create default lua consumer test on (table t for insert)'
+
+cdb2sql --host $rep ${CDB2_OPTIONS} $dbname - <<'EOF'
+set transaction chunk 100
+begin
+insert into t select value from generate_series(1, 1000000)
+commit
+EOF
+
+yes "select * from comdb2_queues" | cdb2sql --host $rep ${CDB2_OPTIONS} $dbname - >/dev/null &
+echo $pid
+pid=$!
+sleep 1
+
+maxlocks=0
+
+for i in {1..30}; do
+    locks=$(cdb2sql --host $rep -tabs ${CDB2_OPTIONS} $dbname "select count(*) from comdb2_locks where locktype != 'HANDLE'")
+    [[ $locks -gt $maxlocks ]] && maxlocks=$locks
+    sleep 1
+done
+
+kill -9 $pid
+
+if [[ $maxlocks -gt 10 ]]; then
+    echo "Expected < 10 locks, got $maxlocks"
+    exit 1
+fi
+
+echo maxlocks $maxlocks
+
+exit 0


### PR DESCRIPTION
Current code for comdb2_queues uses a real transaction, which accumulates all the locks it acquires.  This makes it use a paired cursor, like SQL, which releases its locks as it moves.