### PR TITLE
{173319420} load old blobs on update for old translisterner

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3652,7 +3652,6 @@ extern int gbl_throttle_txn_chunks_msec;
 extern int gbl_sql_release_locks_on_slow_reader;
 extern int gbl_fail_client_write_lock;
 extern int gbl_server_admin_mode;
-extern int gbl_always_load_preupd_blobs;
 
 void csc2_free_all(void);
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2475,9 +2475,6 @@ REGISTER_TUNABLE("noleader_retry_poll_ms",
 REGISTER_TUNABLE("cdb2api_policy_override", "Use this policy override with cdb2api. (Default: none)",
                 TUNABLE_STRING, &gbl_cdb2api_policy_override, 0, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("always_load_preupd_blobs", "For update triggers, always load pre-update blob values. (Default: on)", 
-                TUNABLE_BOOLEAN, &gbl_always_load_preupd_blobs, 0, NULL, NULL, NULL, NULL);
-
 REGISTER_TUNABLE("incoherent_clnt_wait", "Delay incoherent reject if without master (Default: 10sec)",
                  TUNABLE_INTEGER, &gbl_incoherent_clnt_wait, 0, NULL, NULL, NULL, NULL);
 

--- a/db/record.c
+++ b/db/record.c
@@ -87,7 +87,6 @@ void free_cached_idx(uint8_t * *cached_idx);
 int gbl_max_wr_rows_per_txn = 0;
 int gbl_max_cascaded_rows_per_txn = 0;
 uint32_t gbl_max_time_per_txn_ms = 0;
-int gbl_always_load_preupd_blobs = 1;
 
 static inline int is_event_from_sc(int flags)
 {
@@ -1112,7 +1111,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
      * If required, remember the old blobs ready for the update trigger.
      * Handle deadlock correctly.
      */
-    if (!(flags & RECFLAGS_NO_TRIGGERS) && (gbl_always_load_preupd_blobs || javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_SAVE_BLOBS_UPD))) {
+    if (!(flags & RECFLAGS_NO_TRIGGERS) && javasp_trans_care_about(iq->jsph, JAVASP_TRANS_LISTEN_SAVE_BLOBS_UPD)) {
         // translistener.c always packs pre, even if the config didn't request it.
         // Always load old blobs.
         rc = save_old_blobs(iq, trans, ".ONDISK", old_dta, rrn, vgenid,

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -1359,8 +1359,11 @@ int javasp_load_procedure_int(const char *name, const char *param,
                     flags |= JAVASP_TRANS_LISTEN_BEFORE_UPD;
                     if (sp_field_is_a_blob(table->name, fieldname))
                         flags |= JAVASP_TRANS_LISTEN_SAVE_BLOBS_UPD;
-                } else if (strcasecmp(flagname, "post_upd") == 0)
+                } else if (strcasecmp(flagname, "post_upd") == 0) {
                     flags |= JAVASP_TRANS_LISTEN_AFTER_UPD;
+                    if (sp_field_is_a_blob(table->name, fieldname))
+                        flags |= JAVASP_TRANS_LISTEN_SAVE_BLOBS_UPD;
+                }
                 else {
                     logmsg(LOGMSG_ERROR, "field %s unknown flag (config file %s)\n",
                             fieldname, argv[0]);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -32,7 +32,6 @@
 (name='allow_user_schema', description='Enable to allow per-user schemas. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='already_aborted_trace', description='Print trace when dd_abort skips an 'already-aborted' locker', type='BOOLEAN', value='OFF', read_only='N')
 (name='alternate_verify_fail', description='alternate_verify_fail', type='BOOLEAN', value='OFF', read_only='N')
-(name='always_load_preupd_blobs', description='For update triggers, always load pre-update blob values. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='always_send_cnonce', description='Always send cnonce to master. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='analyze_comp_threads', description='Number of thread to use when generating samples for computing index statistics. (Default: 10)', type='INTEGER', value='10', read_only='Y')
 (name='analyze_comp_threshold', description='Index file size above which we'll do sampling, rather than scan the entire index. (Default: 104857600)', type='INTEGER', value='104857600', read_only='Y')


### PR DESCRIPTION
Load them even if the code isn't interested in pre_upd events because we always try to fetch them.
