### PR TITLE
removing patch no longer needed to fix lrl and ixlens

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3984,9 +3984,6 @@ static int init(int argc, char **argv)
             unlock_schema_lk();
             return -1;
         }
-
-        fix_lrl_ixlen(); /* set lrl, ix lengths: ignore lrl file, use info from
-                            schema */
     }
 
     /* historical requests */
@@ -5538,9 +5535,6 @@ int main(int argc, char **argv)
 
     handle_resume_sc();
 
-    /* Creating a server context wipes out the db #'s dbcommon entries.
-     * Recreate them. */
-    fix_lrl_ixlen();
     create_marker_file();
 
     create_watchdog_thread(thedb);
@@ -6168,8 +6162,6 @@ retry_tran:
                __func__, rc);
         abort();
     }
-
-    fix_lrl_ixlen_tran(tran);
 
     if ((rc = backend_open_tran(thedb, tran, 0)) != 0) {
         logmsg(LOGMSG_FATAL, "%s: backend_open_tran returns %d\n", __func__,

--- a/db/tag.h
+++ b/db/tag.h
@@ -289,9 +289,7 @@ void replace_tag_schema(struct dbtable *db, struct schema *schema);
 char *sqltype(struct field *f, char *buf, int len);
 char *csc2type(struct field *f);
 void debug_dump_tags(const char *tblname);
-void fix_lrl_ixlen(void);
 struct tran_tag;
-void fix_lrl_ixlen_tran(struct tran_tag *);
 int max_type_size(int type, int len);
 int getidxnumbyname(const struct dbtable *table, const char *tagname, int *ixnum);
 int partial_key_length(struct dbtable *dbname, const char *keyname,

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1046,9 +1046,6 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     if (!have_all_schemas()) sc_errf(s, "Missing schemas (internal error)\n");
 
-    /* kludge: fix lrls */
-    fix_lrl_ixlen_tran(transac);
-
     live_sc_off(db);
 
     /* artificial sleep to aid testing */

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -827,8 +827,6 @@ static int scdone_add(const char tablename[], void *arg, scdone_t type)
     if (rc)
         goto done;
 
-    fix_lrl_ixlen_tran(tran);
-
 done:
     _untran(tran, lid);
 
@@ -891,8 +889,6 @@ static int scdone_fastinit(const char tablename[], void *arg, scdone_t type)
     rc = _db_dbnum(tran, db, &bdberr);
     if (rc)
         goto done;
-
-    fix_lrl_ixlen_tran(tran);
 
 done:
     _untran(tran, lid);
@@ -980,8 +976,6 @@ static int scdone_bulkimport(const char tablename[], void *arg, scdone_t type)
     if (rc)
         goto done;
 
-    fix_lrl_ixlen_tran(tran);
-
 done:
     _untran(tran, lid);
 
@@ -1025,8 +1019,6 @@ static int scdone_setcompr(const char tablename[], void *arg, scdone_t type)
         goto done;
     }
     db->dbnum = dbnum;
-
-    fix_lrl_ixlen_tran(tran);
 
     _master_recs(tran, tablename, type);
 

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1112,7 +1112,6 @@ static int reload_csc2_schema(struct dbtable *db, tran_type *tran,
     free(newdb);
 
     commit_schemas(table);
-    fix_lrl_ixlen_tran(tran);
     update_dbstore(db);
 
     free(new_bdb_handle);


### PR DESCRIPTION
With the recent restructuring in schema change code, we consolidated the creation of a dbtable in a single function.   It is reasonable to set dbtable structure fields at the creation time, if possible.
One of these fields are the length of ondisk row (lrl) and indexes (ix_keylen).  The lengths are different than the sum of the field value lengths, as provided by the csc2 parser, and a conversion is required (as done by fix_lrl_ixlen function in the past).  With the consolidation, we have this conversion done at the time when the dbtable is created.
Another field of dbtable is a cache of csc2 schema (csc2_schema), which is also stored at the time of dbtable creation, instead of being read later on from llmeta.
This structural change has a few benefits:
- whenever a schema change happens; fix_lrl_ixlen used to compute row lengths and collect csc2 string for every single table in the database; this is inefficient, since a schema change only affects one table, the rest of the work is redundant and increases llmeta contention; this does not happen anymore
- we avoid reading transactionally from llmeta to retrieve csc2_schema and table version, for every table, which provides less lock contention
- code is considerably simpler