### PR TITLE
Try to fix rr build

### DIFF
--- a/tests/tools/localrep.c
+++ b/tests/tools/localrep.c
@@ -414,7 +414,7 @@ int apply_add(cdb2_hndl_tp *db, void *opsp, int opsz) {
     strbuf_append(sql, ")");
 
     cdb2_clearbindings(db);
-    bound_values = calloc(nfields, sizeof(void*));
+    bound_values = calloc((size_t)nfields, sizeof(void*));
     for (int i = 0; i < nfields; i++) {
         fld[i].type = htonl(fld[i].type);
         fld[i].len = htonl(fld[i].len);


### PR DESCRIPTION
RR failing builds:

/bb/comdb2a/roborivers/branches/master/tests/tools/localrep.c: In function ‘apply_add’:
/bb/comdb2a/roborivers/branches/master/tests/tools/localrep.c:417:20: error: argument 1 range [18446744071562067968, 18446744073709551615] exceeds maximum object size 9223372036854775807 [-Werror=alloc-size-larger-than=]
  417 |     bound_values = calloc(nfields, sizeof(void*));
      |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /bb/comdb2a/roborivers/branches/master/tests/tools/localrep.c:1:
/usr/include/stdlib.h:541:14: note: in a call to allocation function ‘calloc’ declared here
  541 | extern void *calloc (size_t __nmemb, size_t __size)
      |              ^~~~~~
cc1: all warnings being treated as errors
make[2]: *** [tests/tools/CMakeFiles/localrep.dir/build.make:76: tests/tools/CMakeFiles/localrep.dir/localrep.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2242: tests/tools/CMakeFiles/localrep.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:156: all] Error 2
