### PR TITLE
Reproduce newsi-on-master bug, disable newsi by default

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1206,10 +1206,14 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
     } else if (tokcmp(tok, ltok, "enable_snapshot_isolation") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_snapisol = 1;
+        /* Disable- will circle back to fix */
+/*
         gbl_new_snapisol = 1;
         gbl_new_snapisol_asof = 1;
         gbl_new_snapisol_logging = 1;
         logmsg(LOGMSG_INFO, "Enabled snapshot isolation (default newsi)\n");
+*/
+        logmsg(LOGMSG_INFO, "Enabled snapshot isolation\n");
     } else if (tokcmp(tok, ltok, "enable_new_snapshot") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_snapisol = 1;

--- a/tests/newsi_on_master.test/Makefile
+++ b/tests/newsi_on_master.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+unexport CLUSTER
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/newsi_on_master.test/README
+++ b/tests/newsi_on_master.test/README
@@ -1,0 +1,2 @@
+Reproduces bug Morgan found when newsi runs directly on master
+Immediate fix is to disable newsi

--- a/tests/newsi_on_master.test/lrl.options
+++ b/tests/newsi_on_master.test/lrl.options
@@ -1,0 +1,4 @@
+enable_snapshot_isolation
+
+# To reproduce newsi-on-master bug, uncomment this line
+#enable_new_snapshot

--- a/tests/newsi_on_master.test/results.expected
+++ b/tests/newsi_on_master.test/results.expected
@@ -1,0 +1,10 @@
+[@redirect ./results.txt] rc 0
+[set transaction snapshot] rc 0
+[begin] rc 0
+1000
+[select count(*) from t1] rc 0
+5
+[select sleep(5)] rc 0
+1000
+[select count(*) from t1] rc 0
+[commit] rc 0

--- a/tests/newsi_on_master.test/runit
+++ b/tests/newsi_on_master.test/runit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+results=./results.txt
+expected=./results.expected
+
+$CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "create table t1(a int)" 
+$CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, 1000)"
+$CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default - <<EOF &
+@redirect $results
+set transaction snapshot
+begin
+select count(*) from t1
+select sleep(5)
+select count(*) from t1
+commit
+EOF
+
+$CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default - <<EOF
+select sleep(2)
+delete from t1 where 1
+EOF
+
+sleep 5
+
+diff $results $expected
+if [[ $? != 0 ]]; then
+    echo "Testcase failed"
+    exit 1
+fi
+
+echo "Testcase succeeded"


### PR DESCRIPTION
Reproduce the news-on-master bug that Morgan discovered.  Disable newsi as the default-- I will circle back to fix.