### PR TITLE
Abort on commit if this lockid previously received deadlock

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2527,6 +2527,7 @@ struct __db_env {
 	int  (*lock_id) __P((DB_ENV *, u_int32_t *));
 	int  (*lock_id_flags) __P((DB_ENV *, u_int32_t *, u_int32_t));
 	int  (*lock_id_free) __P((DB_ENV *, u_int32_t));
+	int  (*locker_had_deadlock) __P((DB_ENV *, u_int32_t, u_int32_t *));
 	int  (*lock_id_has_waiters) __P((DB_ENV *, u_int32_t));
 	int  (*lock_id_set_logical_abort) __P((DB_ENV *, u_int32_t));
 	int  (*lock_stat) __P((DB_ENV *, DB_LOCK_STAT **, u_int32_t));

--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -293,7 +293,8 @@ typedef struct __db_locker {
 #define DB_LOCKER_TRACK         	0x0100
 #define DB_LOCKER_READONLY      	0x0200
 #define DB_LOCKER_IN_LOGICAL_ABORT 	0x0800
-#define DB_LOCKER_TRACK_WRITELOCKS      0x8000
+#define DB_LOCKER_HAD_DEADLOCK		0x1000
+#define DB_LOCKER_TRACK_WRITELOCKS	  0x8000
 	u_int8_t has_waiters;
 	u_int32_t flags;
 	u_int8_t has_pglk_lsn;

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -156,6 +156,69 @@ __lock_id_pp(dbenv, idp)
 	return __lock_id_flags_pp(dbenv, idp, 0);
 }
 
+static int
+__locker_had_deadlock(dbenv, locker, had_deadlock)
+	DB_ENV *dbenv;
+	u_int32_t locker;
+	u_int32_t *had_deadlock;
+{
+	DB_LOCKREGION *region;
+	DB_LOCKTAB *lt;
+	u_int32_t partition;
+	struct __db_lock *lp, *wlp;
+	DB_LOCKER *sh_locker;
+	u_int32_t locker_ndx;
+	int ret;
+
+	(*had_deadlock) = 0;
+
+	lt = dbenv->lk_handle;
+	region = lt->reginfo.primary;
+
+	if (F_ISSET(dbenv, DB_ENV_NOLOCKING))
+		return (0);
+
+	LOCKREGION(dbenv, lt);
+	LOCKER_INDX(lt, region, locker, locker_ndx);
+
+	if ((ret = __lock_getlocker(lt, locker, locker_ndx,
+			GETLOCKER_KEEP_PART, &sh_locker)) != 0 || NULL == sh_locker) {
+		UNLOCKREGION(dbenv, lt);
+		return EINVAL;
+	}
+
+	partition = sh_locker->partition;
+	(*had_deadlock) = F_ISSET(sh_locker, DB_LOCKER_HAD_DEADLOCK);;
+	unlock_locker_partition(region, partition);
+
+	return ret;
+}
+
+/*
+ * __locker_had_deadlock_pp --
+ *
+ * PUBLIC: int  __locker_had_deadlock_pp __P((DB_ENV *, u_int32_t, u_int32_t *));
+ */
+int
+__locker_had_deadlock_pp(dbenv, locker, had_deadlock)
+	DB_ENV *dbenv;
+	u_int32_t locker;
+	u_int32_t *had_deadlock;
+{
+	int rep_check, ret;
+	PANIC_CHECK(dbenv);
+	ENV_REQUIRES_CONFIG(dbenv,
+		dbenv->lk_handle, "DB_LOCK->locker_set_track", DB_INIT_LOCK);
+
+	rep_check = IS_ENV_REPLICATED(dbenv) ? 1 : 0;
+	if (rep_check)
+		__env_rep_enter(dbenv);
+	ret = __locker_had_deadlock(dbenv, locker, had_deadlock);
+	if (rep_check)
+		__env_rep_exit(dbenv);
+	return ret;
+}
+
 /*
  * __lock_id_flags_pp --
  *	DB_ENV->lock_id_flags pre/post processing.
@@ -2979,6 +3042,9 @@ expired:			obj_ndx = sh_obj->index;
 done:
 	ret = 0;
 err:
+	if (ret == DB_LOCK_DEADLOCK) {
+		F_SET(sh_locker, DB_LOCKER_HAD_DEADLOCK);
+	}
 	if (newl != NULL &&
 	    (t_ret = __lock_freelock(lt, newl, sh_locker,
 		    DB_LOCK_FREE | DB_LOCK_UNLINK)) != 0 && ret == 0) {

--- a/berkdb/lock/lock_method.c
+++ b/berkdb/lock/lock_method.c
@@ -107,6 +107,7 @@ __lock_dbenv_create(dbenv)
 		dbenv->lock_add_child_locker = __lock_add_child_locker_pp;
 		dbenv->lock_id = __lock_id_pp;
 		dbenv->lock_id_flags = __lock_id_flags_pp;
+		dbenv->locker_had_deadlock = __locker_had_deadlock_pp;
 		dbenv->lock_id_free = __lock_id_free_pp;
 		dbenv->lock_id_has_waiters = __lock_id_has_waiters_pp;
 		dbenv->lock_id_set_logical_abort =

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -281,6 +281,7 @@ extern int gbl_ufid_log;
 extern int gbl_utxnid_log;
 extern int gbl_ufid_add_on_collect;
 extern int gbl_collect_before_locking;
+extern int gbl_abort_on_deadlock_commit;
 extern unsigned gbl_ddlk;
 extern int gbl_abort_on_missing_ufid;
 extern int gbl_ufid_dbreg_test;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2166,6 +2166,10 @@ REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default:
 REGISTER_TUNABLE("collect_before_locking", "Collect a transaction from the log before acquiring locks.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_collect_before_locking, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("abort_on_deadlock_commit", "Abort if a transaction attempts to commit after deadlock.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_abort_on_deadlock_commit, 0, NULL, NULL, NULL, NULL);
+
+
 REGISTER_TUNABLE("debug_ddlk", "Generate random deadlocks.  (Default: 0)", TUNABLE_INTEGER, &gbl_ddlk,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -4,6 +4,7 @@
 (name='aa_min_percent_jitter', description='Additional jitter factor for determining percent change.', type='INTEGER', value='300', read_only='N')
 (name='aa_request_mode', description='Mark table in comdb2_auto_analyze_tables instead of performing auto-analyze ourselves', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_invalid_query_info_key', description='Abort in thread-teardown for invalid query_info_key', type='BOOLEAN', value='OFF', read_only='N')
+(name='abort_on_deadlock_commit', description='Abort if a transaction attempts to commit after deadlock.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='abort_on_in_use_rqid', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='abort_on_invalid_context', description='abort_on_invalid_context', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_on_replicant_log_write', description='Abort if replicant is writing to logs', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Simple idea from Mike .. if a lockid has gotten a DEADLOCK, and then subsequently attempts to commit, then abort the database rather than possibly corrupting it.  I've defaulted this to ON to test under RR.