### PR TITLE
we already have a field tracking this case, remove

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -433,7 +433,7 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
 {
     int rc, bdberr = 0;
 
-    if (s->finalize_only) {
+    if (s->resume == SC_OSQL_RESUME) {
         return s->sc_rc;
     }
     if (s->done_type != user_view) {

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -1239,7 +1239,6 @@ clone_schemachange_type(struct schema_change_type *sc)
     newsc->dryrun = sc->dryrun;
     newsc->use_new_genids = newsc->use_new_genids;
     newsc->finalize = sc->finalize;
-    newsc->finalize_only = sc->finalize_only;
     newsc->is_osql = sc->is_osql;
     newsc->timepartition_name = sc->timepartition_name;
     newsc->timepartition_version = sc->timepartition_version;

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -154,7 +154,6 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             s = stored_sc;
             iq->sc = s;
             Pthread_mutex_lock(&s->mtx);
-            s->finalize_only = 1;
             s->nothrevent = 1;
             s->resume = SC_OSQL_RESUME;
             Pthread_mutex_unlock(&s->mtx);
@@ -163,10 +162,10 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
             logmsg(LOGMSG_INFO,
                    "Resuming schema change: rqid [%llx %s] "
                    "table %s, add %d, drop %d, fastinit %d, alter "
-                   "%d, finalize_only %d\n",
+                   "%d resume %d\n",
                    s->rqid, us, s->tablename, s->kind == SC_ADDTABLE,
                    s->kind == SC_DROPTABLE, IS_FASTINIT(s), IS_ALTERTABLE(s),
-                   s->finalize_only);
+                   s->resume);
 
         } else {
             int bdberr;
@@ -314,7 +313,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     arg->sc = iq->sc;
     s->started = 0;
 
-    if (s->resume && IS_ALTERTABLE(s) && !s->finalize_only) {
+    if (s->resume && s->resume != SC_OSQL_RESUME && IS_ALTERTABLE(s)) {
         if (gbl_test_sc_resume_race) {
             logmsg(LOGMSG_INFO, "%s:%d sleeping 5s for sc_resume test\n",
                    __func__, __LINE__);

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -222,7 +222,6 @@ struct schema_change_type {
     int use_new_genids;   /* rebuilding old genids needs to
                              get new genids to avoid name collission */
     int finalize;      /* Whether the schema change should be committed */
-    int finalize_only; /* only commit the schema change */
 
     pthread_mutex_t mtx; /* mutex for thread sync */
     pthread_mutex_t mtxStart; /* mutex for thread start */


### PR DESCRIPTION
finalize_only is set only iff resume = SC_OSQL_RESUME; since resume serves a more general purpose, we can get rid of finalize_only and simplify the code.