### PR TITLE
{174149262}: Executing JDBC batch in transaction

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -43,6 +43,7 @@ public class Comdb2Connection implements Connection {
     private boolean inTxn = false;
     private boolean autoCommit = true;
     private boolean txnModeChanged = false;
+    private boolean useTxnForBatch = false;
 
     private final ReentrantLock lock = new ReentrantLock();
     private boolean opened = false;
@@ -153,6 +154,14 @@ public class Comdb2Connection implements Connection {
                 || "0".equalsIgnoreCase(v)
                 || "F".equalsIgnoreCase(v))
             usemicrodt = false;
+    }
+
+    public void setUseTxnForBatch(boolean usetxn) {
+        useTxnForBatch = usetxn;
+    }
+
+    public boolean getUseTxnForBatch() {
+        return useTxnForBatch;
     }
 
     /* wrappers to Comdb2Handle */

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -126,6 +126,7 @@ public class Driver implements java.sql.Driver {
             options.put("skip_rs_drain", new BooleanOption("skip_rs_drain", "SkipResultSetDrain"));
             options.put("clear_ack", new BooleanOption("clear_ack", "ClearAck"));
             options.put("use_identity", new BooleanOption("use_identity", "UseIdentity"));
+            options.put("use_txn_for_batch", new BooleanOption("use_txn_for_batch", "UseTxnForBatch"));
         } catch (Throwable e) {
             throw new SQLException(e);
         }

--- a/docs/pages/programming/jdbc_api.md
+++ b/docs/pages/programming/jdbc_api.md
@@ -266,6 +266,10 @@ The parameters are as follows:
 
       Toggle verifyretry. The default is `false`. See also [optimistic concurrency control](transaction_model.html#optimistic-concurrency-control).
 
+    * _use_txn_for_batch_=Boolean
+
+      Set it to true to execute a batch in its own transaction. The default is `false`.
+
         
     \* _To define multiple options, separate them by ampersands._
 


### PR DESCRIPTION
Allow a JDBC batch to be executed in its own transaction. This behavior is toggled by the `use_txn_for_batch` URL parameter.
