### PR TITLE
Only use directIO in summarize on AIX

### DIFF
--- a/bdb/summarize.c
+++ b/bdb/summarize.c
@@ -345,8 +345,6 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
         // Don't want to call into __os_open_extend here, so use the same flags.
 #if defined(_AIX)
 		oflags |= O_CIO;
-#else
-		oflags |= O_DIRECT;
 #endif
     }
 


### PR DESCRIPTION
On AIX it's a requirement when open with this flag elsewhere. Everywhere else is a bigger change -- not sure it's a good default