### PR TITLE
Multi table ddl should have UUID

### DIFF
--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -477,4 +477,6 @@ int llog_scdone_rename_wrapper(bdb_state_type *bdb_state,
                                struct schema_change_type *s, tran_type *tran,
                                int *bdberr);
 
+const char *schema_change_kind(struct schema_change_type *s);
+
 #endif


### PR DESCRIPTION
Current multi-table ddl implementation uses uuid=0 to mark a standalone table schema change.  It sets uuid=bplog->uuid if more than one table schema change is done in the same transaction.
Nevertheless, bplog->uuid==0 before we call START_SOCKSQL.
While this still does not fixes multi-table ddl resume, it is a pre-requisite to identify schema changes that are part of the same transaction.