### PR TITLE
remove useless argument for sc_set_running

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1300,7 +1300,7 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
                     bdb_clear_logical_live_sc(sc->db->handle, 1);
                     sc->db->sc_live_logical = 0;
                 }
-                sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, 0, __func__,
+                sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__,
                                __LINE__);
                 if (rc == ERR_NOMASTER) {
                         sc_set_downgrading(sc);
@@ -1310,7 +1310,7 @@ int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err)
                         free_schema_change_type(sc);
                 }
             } else {
-                sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, 0, __func__,
+                sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__,
                                __LINE__);
             }
             sc = next;
@@ -1360,7 +1360,7 @@ void *bplog_commit_timepart_resuming_sc(void *p)
         } else {
             logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__,
                    sc->tablename, sc->sc_rc);
-            sc_set_running(&iq, sc, sc->tablename, 0, NULL, 0, 0, __func__,
+            sc_set_running(&iq, sc, sc->tablename, 0, NULL, 0, __func__,
                            __LINE__);
             free_schema_change_type(sc);
             error = 1;

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6435,7 +6435,7 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         /* Success: reset the table counters */
         iq->sc = iq->sc_pending;
         while (iq->sc != NULL) {
-            sc_set_running(iq, iq->sc, iq->sc->tablename, 0, NULL, 0, 0,
+            sc_set_running(iq, iq->sc, iq->sc->tablename, 0, NULL, 0,
                            __func__, __LINE__);
             iq->sc = iq->sc->sc_next;
         }

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -65,7 +65,7 @@ const char *get_sc_to_name();
 void wait_for_sc_to_stop(const char *operation, const char *func, int line);
 void allow_sc_to_run();
 int sc_set_running(struct ireq *iq, struct schema_change_type *s, char *table,
-                   int running, const char *host, time_t time, int replicant,
+                   int running, const char *host, time_t time,
                    const char *func, int line);
 void sc_assert_clear(const char *func, int line);
 void sc_status(struct dbenv *dbenv);

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -231,7 +231,7 @@ static void stop_and_free_sc(struct ireq *iq, int rc,
         }
     }
 
-    sc_set_running(iq, s, s->tablename, 0, NULL, 0, 0, __func__, __LINE__);
+    sc_set_running(iq, s, s->tablename, 0, NULL, 0, __func__, __LINE__);
     if (do_free) {
         free_sc(s);
     }
@@ -737,7 +737,7 @@ downgraded:
     Pthread_mutex_unlock(&s->mtx);
     if (!s->is_osql) {
         if (rc == SC_MASTER_DOWNGRADE) {
-            sc_set_running(iq, s, s->tablename, 0, NULL, 0, 0, __func__,
+            sc_set_running(iq, s, s->tablename, 0, NULL, 0, __func__,
                            __LINE__);
             free_sc(s);
         } else {
@@ -1622,7 +1622,7 @@ int scdone_abort_cleanup(struct ireq *iq)
     struct schema_change_type *s = iq->sc;
     mark_schemachange_over(s->tablename);
     if (s->set_running)
-        sc_set_running(iq, s, s->tablename, 0, gbl_myhostname, time(NULL), 0,
+        sc_set_running(iq, s, s->tablename, 0, gbl_myhostname, time(NULL),
                        __func__, __LINE__);
     if (s->db && s->db->handle) {
         if (s->kind == SC_ADDTABLE) {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -264,7 +264,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
     comdb2uuidstr(s->uuid, us);
     s->seed = seed;
     rc = sc_set_running(iq, s, s->tablename, s->preempted ? 2 : 1, node,
-                        time(NULL), 0, __func__, __LINE__);
+                        time(NULL), __func__, __LINE__);
     if (rc != 0) {
         logmsg(LOGMSG_INFO, "Failed sc_set_running [%llx %s] rc %d\n", s->rqid,
                us, rc);
@@ -377,7 +377,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
                 free(arg);
             if (!s->is_osql) {
                 sc_set_running(iq, s, s->tablename, 0, gbl_myhostname,
-                               time(NULL), 0, __func__, __LINE__);
+                               time(NULL), __func__, __LINE__);
                 free_schema_change_type(s);
             }
             rc = SC_ASYNC_FAILED;
@@ -1147,7 +1147,7 @@ int sc_timepart_add_table(const char *existingTableName,
     }
 
     if (sc_set_running(NULL, &sc, sc.tablename, 1, gbl_myhostname, time(NULL),
-                       0, __func__, __LINE__) != 0) {
+                       __func__, __LINE__) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;
@@ -1221,7 +1221,7 @@ int sc_timepart_drop_table(const char *tableName, struct errstat *xerr)
     }
 
     if (sc_set_running(NULL, &sc, sc.tablename, 1, gbl_myhostname, time(NULL),
-                       0, __func__, __LINE__) != 0) {
+                       __func__, __LINE__) != 0) {
         xerr->errval = SC_VIEW_ERR_EXIST;
         snprintf(xerr->errstr, sizeof(xerr->errstr), "schema change running");
         goto error;


### PR DESCRIPTION
Once upon a time (i.e. around 2007AD) sc_set_running was being called on a replicant. Never more.

/plugin-branch sc_set_running_not_on_replicant