### PR TITLE
Clear message when a schema change starts.

### DIFF
--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -477,4 +477,6 @@ int llog_scdone_rename_wrapper(bdb_state_type *bdb_state,
                                struct schema_change_type *s, tran_type *tran,
                                int *bdberr);
 
+const char *schema_change_kind(struct schema_change_type *s);
+
 #endif


### PR DESCRIPTION
When we start a schema change on a master we should clearly print the name of the table and the kind of schema change, like:
"Starting schema change: table t kind SC_ADDTABLE new seed 0x2d2785000000"
"Starting schema change: table t kind SC_ALTERTABLE new seed 0x352785000000"
"Starting schema change: table t kind SC_DROPTABLE new seed 0x282785000000"

This PR addresses this.

Also, make sure this is printed with the default logmsg level.

NOTE: this is a resubmit of https://github.com/bloomberg/comdb2/pull/4231 with a shorter branch name, since it breaks a PATH_MAX limit in the internal regression tester.