### PR TITLE
ignore failed indexes for default tag, per 7.0 behaviour

### DIFF
--- a/tests/ddl_csc2.test/t3.csc2
+++ b/tests/ddl_csc2.test/t3.csc2
@@ -1,0 +1,16 @@
+schema
+{
+    int      a
+    int      b
+}
+
+tag default
+{
+    int a
+}
+
+keys
+{
+    "b" =  b
+}
+


### PR DESCRIPTION
For default tag, when building keys, we need to ignore errors if there is an index with a column that is not in the default tag.