### PR TITLE
Don't verify-at-finish the recovery-pages test

### DIFF
--- a/tests/recovery_pages.test/Makefile
+++ b/tests/recovery_pages.test/Makefile
@@ -3,3 +3,7 @@ ifeq ($(TESTSROOTDIR),)
 else
   include $(TESTSROOTDIR)/testcase.mk
 endif
+export VERIFY_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif


### PR DESCRIPTION
Disable physical-verify: this test purposely corrupts btrees