### PR TITLE
Do not send intrans results during replays (cherry-picked from main)

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -417,6 +417,7 @@ extern int gbl_fdb_incoherence_percentage;
 extern int gbl_fdb_io_error_retries;
 extern int gbl_fdb_io_error_retries_phase_1;
 extern int gbl_fdb_io_error_retries_phase_2_poll;
+extern int gbl_debug_invalid_genid;
 
 /* Physical replication */
 extern int gbl_blocking_physrep;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1352,6 +1352,10 @@ REGISTER_TUNABLE("debug.txn_sleep",
                  "Sleep during a transaction to test transaction state systable", TUNABLE_INTEGER,
                  &gbl_debug_txn_sleep, INTERNAL, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("debug.invalid_genid",
+                 "Deliberately introduce an invalid genid, FOR TESTING PURPOSE (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_invalid_genid,
+                 NOARG | EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE(
     "query_plan_percentage",
     "Alarm if the average cost per row of current query plan is n percent above the cost for different query plan."

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -74,6 +74,7 @@ extern int gbl_partial_indexes;
 int gbl_master_sends_query_effects = 1;
 int gbl_toblock_random_deadlock_trans;
 int gbl_selectv_writelock = 0;
+int gbl_debug_invalid_genid;
 
 extern int db_is_exiting();
 
@@ -6786,6 +6787,10 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
             dt.del_keys = -1ULL;
         }
         genid = dt.genid;
+
+        if (gbl_debug_invalid_genid == 1) {
+            genid++;
+        }
 
         if (gbl_enable_osql_logging) {
             int jj = 0;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3527,7 +3527,7 @@ static int handle_non_sqlite_requests(struct sqlthdstate *thd,
 
 static int skip_response_int(struct sqlclntstate *clnt, int from_error)
 {
-    if (clnt->osql.replay == OSQL_RETRY_DO)
+    if (clnt->osql.replay == OSQL_RETRY_DO || clnt->osql.replay == OSQL_RETRY_LAST)
         return 1;
     if (clnt->isselect || is_with_statement(clnt->sql))
         return 0;

--- a/tests/replay_trans.test/Makefile
+++ b/tests/replay_trans.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/replay_trans.test/README
+++ b/tests/replay_trans.test/README
@@ -1,0 +1,1 @@
+Test the behavior of transactions when they are replayed on verify error.

--- a/tests/replay_trans.test/runit
+++ b/tests/replay_trans.test/runit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+
+if [ "x$dbnm" == "x" ] ; then
+    echo "need a DB name"
+    exit 1
+fi
+
+function verify() {
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify.out
+    if ! grep succeeded verify.out > /dev/null ; then
+	failexit "Verify did not succeed, see verify3.out"
+    fi
+}
+
+function init() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t1(i INT UNIQUE, j DATETIME)"
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "INSERT INTO t1 VALUES(1, NOW())"
+
+    master=`getmaster`
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master "PUT TUNABLE 'debug.invalid_genid' 1"
+}
+
+function cleanup() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default "DROP TABLE t1"
+}
+
+function assert_fail() {
+    if [[ $1 -eq 0 ]]; then
+        failexit "transaction succeeded, expected it to fail"
+    fi
+}
+
+function run_bad_tx_with_intransres() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default - <<EOF
+SET INTRANSRESULTS ON
+BEGIN
+UPDATE t1 SET j = NOW() WHERE i = 1;
+COMMIT
+EOF
+    assert_fail $?
+}
+
+function run_bad_tx_without_intransres() {
+    cdb2sql ${CDB2_OPTIONS} $dbnm default - <<EOF
+SET INTRANSRESULTS OFF
+BEGIN
+UPDATE t1 SET j = NOW() WHERE i = 1;
+COMMIT
+EOF
+    assert_fail $?
+}
+
+init
+run_bad_tx_with_intransres
+run_bad_tx_without_intransres
+verify
+cleanup


### PR DESCRIPTION
When client has 'intransresults' enabled, comdb2 should avoid sending results while replaying transaction statements.