### PR TITLE
Removing code to avoid a roundrip per replicant during schema change

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2543,10 +2543,6 @@ int broadcast_add_new_queue(char *table, int avgitemsz);
 int broadcast_add_consumer(const char *queuename, int consumern,
                            const char *method);
 int broadcast_procedure_op(int op, const char *name, const char *param);
-int broadcast_close_db(char *table);
-int broadcast_close_only_db(char *table);
-int broadcast_close_all_dbs(void);
-int broadcast_sc_end(const char *table, uint64_t seed);
 int broadcast_sc_start(const char *table, uint64_t seed, uint32_t host,
                        time_t t);
 int broadcast_sc_ok(void);

--- a/db/glue.c
+++ b/db/glue.c
@@ -3407,27 +3407,6 @@ int send_forgetmenot(void)
         return -1;
 }
 
-int broadcast_close_all_dbs(void)
-{
-    return send_to_all_nodes(NULL, 0, NET_CLOSE_ALL_DBS, gbl_msgwaittime);
-}
-
-int broadcast_sc_end(const char *table, uint64_t seed)
-{
-    struct net_sc_msg *sc;
-    int len;
-    len = offsetof(struct net_sc_msg, host) + 1;
-
-    sc = alloca(len);
-    if (table)
-        strncpy0(sc->table, table, sizeof(sc->table));
-    else
-        sc->table[0] = '\0';
-    sc->seed = flibc_htonll(seed);
-
-    return send_to_all_nodes(sc, len, NET_STOP_SC, gbl_scwaittime);
-}
-
 const char *get_hostname_with_crc32(bdb_state_type *bdb_state,
                                     unsigned int hash);
 int broadcast_sc_start(const char *table, uint64_t seed, uint32_t host,

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -703,8 +703,6 @@ static void osql_scdone_commit_callback(struct ireq *iq)
                     }
                 }
             }
-
-            broadcast_sc_end(iq->sc->tablename, iq->sc_seed);
             if (iq->sc->db) {
                 int rc;
                 tran_type *lock_trans = NULL;

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -461,8 +461,6 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         s->sc_rc = SC_DETACHED;
     }
 
-    broadcast_sc_start(s->tablename, iq->sc_seed, iq->sc_host,
-                       time(NULL));                   // dont care rcode
     rc = pre(iq, s, NULL);                            // non-tran ??
     if (s->done_type == alter && master_downgrading(s)) {
         s->sc_rc = SC_MASTER_DOWNGRADE;
@@ -489,7 +487,6 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
         if (rc == SC_ABORTED)
             errstat_set_strf(&iq->errstat, "Schema change was aborted");
         mark_schemachange_over_tran(s->tablename, NULL); // non-tran ??
-        broadcast_sc_end(s->tablename, iq->sc_seed);
         if (bdb_set_schema_change_status(
                 NULL, s->tablename, iq->sc_seed, 0, NULL, 0, BDB_SC_ABORTED,
                 errstat_get_str(&iq->errstat), &bdberr) ||
@@ -517,7 +514,6 @@ static int do_ddl(ddl_t pre, ddl_t post, struct ireq *iq,
             unlock_schema_lk();
         if (s->done_type == fastinit && gbl_replicate_local)
             local_replicant_write_clear(iq, tran, s->db);
-        broadcast_sc_end(s->tablename, iq->sc_seed);
     } else {
         rc = SC_COMMIT_PENDING;
     }
@@ -540,8 +536,6 @@ int do_alter_queues(struct schema_change_type *s, struct ireq *unused)
 
     if (master_downgrading(s)) return SC_MASTER_DOWNGRADE;
 
-    broadcast_sc_end(s->tablename, s->iq->sc_seed);
-
     if (gbl_pushlogs_after_sc)
         push_next_log();
 
@@ -559,8 +553,6 @@ int do_alter_stripes(struct schema_change_type *s, struct ireq *unused)
     rc = do_alter_stripes_int(s);
 
     if (master_downgrading(s)) return SC_MASTER_DOWNGRADE;
-
-    broadcast_sc_end(s->tablename, s->iq->sc_seed);
 
     if (gbl_pushlogs_after_sc)
         push_next_log();
@@ -1632,7 +1624,6 @@ int scdone_abort_cleanup(struct ireq *iq)
             sc_del_unused_files(s->db);
         }
     }
-    broadcast_sc_end(s->tablename, iq->sc_seed);
     if (bdb_set_schema_change_status(NULL, s->tablename, iq->sc_seed, 0, NULL,
                                      0, BDB_SC_ABORTED,
                                      errstat_get_str(&iq->errstat), &bdberr) ||


### PR DESCRIPTION
In the early days we have tried to detect schema change collisions on replicants, and that failed shortly.   It used a broadcasting mechanism to let replicants know when schema change started and ended. 
Currently, we still go around and ping each replicant at the start of any schema change.  The callbacks do nothing except to ack back.
This is needed only by the legacy queue alter (in which case we make sure all replicants are up before trying to alter the queue), if any.
Removing code for greater simplicity and speed.
