### PR TITLE
Redefine useless origin_master_node 

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6240,9 +6240,6 @@ int osql_process_schemachange(struct ireq *iq, unsigned long long rqid,
     else
         sc->nothrevent = 1;
     sc->finalize = 0;
-    if (sc->original_master_node[0] != 0 &&
-        strcmp(sc->original_master_node, gbl_myhostname))
-        sc->resume = 1;
 
     iq->sc = sc;
     sc->iq = iq;
@@ -6388,9 +6385,6 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         // TODO (NC): Check why iq->sc_pending is not getting set for views
         iq->sc = iq->sc_pending;
         while (iq->sc != NULL) {
-            if (strcmp(iq->sc->original_master_node, gbl_myhostname) != 0) {
-                return -1;
-            }
             if (!iq->sc_locked) {
                 /* Lock schema from now on before we finalize any schema changes
                  * and hold on to the lock until the transaction commits/aborts.
@@ -7759,7 +7753,8 @@ int osql_send_schemachange(osql_target_t *target, unsigned long long rqid,
     if (check_master(target))
         return OSQL_SEND_ERROR_WRONGMASTER;
 
-    strcpy(sc->original_master_node, target->host);
+    /* we could this field to set the source host */
+    strcpy(sc->source_node, target->host);
 
     if (rqid == OSQL_RQID_USE_UUID) {
         osql_uuid_rpl_t hd_uuid = {0};

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -41,7 +41,7 @@ struct schema_change_type *init_schemachange_type(struct schema_change_type *sc)
     sc->instant_sc = -1;
     sc->persistent_seq = -1;
     sc->dbnum = -1; /* -1 = not changing, anything else = set value */
-    sc->original_master_node[0] = 0;
+    sc->source_node[0] = 0;
     sc->timepartition_name = NULL;
     sc->partition.type = PARTITION_NONE;
     listc_init(&sc->dests, offsetof(struct dest, lnk));
@@ -161,7 +161,7 @@ size_t schemachange_packed_size(struct schema_change_type *s)
         sizeof(s->use_plan) + sizeof(s->commit_sleep) +
         sizeof(s->convert_sleep) + sizeof(s->same_schema) + sizeof(s->dbnum) +
         sizeof(s->flg) + sizeof(s->rebuild_index) +
-        sizeof(s->index_to_rebuild) + sizeof(s->original_master_node) +
+        sizeof(s->index_to_rebuild) + sizeof(s->source_node) +
         dests_field_packed_size(s) + sizeof(s->spname_len) + s->spname_len +
         sizeof(s->lua_func_flags) + sizeof(s->newtable) +
         sizeof(s->usedbtablevers) + sizeof(s->qdb_file_ver) +
@@ -284,8 +284,7 @@ void *buf_put_schemachange(struct schema_change_type *s, void *p_buf, void *p_bu
     p_buf = buf_put(&s->index_to_rebuild, sizeof(s->index_to_rebuild), p_buf,
                     p_buf_end);
 
-    p_buf = buf_put(&s->original_master_node, sizeof(s->original_master_node),
-                    p_buf, p_buf_end);
+    p_buf = buf_put(&s->source_node, sizeof(s->source_node), p_buf, p_buf_end);
 
     p_buf = buf_put_dests(s, p_buf, p_buf_end);
 
@@ -513,8 +512,7 @@ void *buf_get_schemachange_v1(struct schema_change_type *s, void *p_buf,
     p_buf = (uint8_t *)buf_get(&drop_table, sizeof(drop_table), p_buf, p_buf_end); /* s->drop_table */
 
     p_buf =
-        (uint8_t *)buf_get(&s->original_master_node,
-                           sizeof(s->original_master_node), p_buf, p_buf_end);
+        (uint8_t *)buf_get(&s->source_node, sizeof(s->source_node), p_buf, p_buf_end);
 
     p_buf = (uint8_t *)buf_get_dests(s, p_buf, p_buf_end);
 
@@ -699,8 +697,7 @@ void *buf_get_schemachange_v2(struct schema_change_type *s,
                                sizeof(s->index_to_rebuild), p_buf, p_buf_end);
 
     p_buf =
-        (uint8_t *)buf_get(&s->original_master_node,
-                           sizeof(s->original_master_node), p_buf, p_buf_end);
+        (uint8_t *)buf_get(&s->source_node, sizeof(s->source_node), p_buf, p_buf_end);
 
     p_buf = (uint8_t *)buf_get_dests(s, p_buf, p_buf_end);
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -212,7 +212,6 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         }
     }
 
-    strcpy(s->original_master_node, gbl_myhostname);
     unsigned long long seed = 0;
     const char *node = gbl_myhostname;
     if (s->tran == trans && iq->sc_seed) {

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -189,7 +189,7 @@ struct schema_change_type {
     uint8_t rebuild_index;    /* option to rebuild only one index */
     uint8_t index_to_rebuild; /* can use just a short for rebuildindex */
 
-    char original_master_node[256];
+    char source_node[256];
 
     LISTC_T(struct dest) dests;
 


### PR DESCRIPTION
We have used origin_master_node to detect schema change resuming, though this is not how the resume has been working for awhile.   While I cannot remove the 256 bytes useless field from schema change object for now, I am removing the checks, which should make the 256 bytes field available for better usage (like tracking replicant who sent the request).
