### PR TITLE
{174371954}: Fixing memory leaks

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5249,6 +5249,10 @@ void cleanup_clnt(struct sqlclntstate *clnt)
     memset(&clnt->work.rec, 0, sizeof(struct sql_state));
     memset(clnt->work.aFingerprint, 0, FINGERPRINTSZ);
 
+    clear_session_tbls(clnt);
+    free(clnt->authdata);
+    clnt->authdata = NULL;
+
     destroy_hash(clnt->ddl_tables, free_it);
     destroy_hash(clnt->dml_tables, free_it);
     clnt->ddl_tables = NULL;

--- a/mem/mem.h
+++ b/mem/mem.h
@@ -41,6 +41,7 @@ XMACRO_COMDB2MA(COMDB2MA_STATIC_DFP_DECNUMBER,  "dfp_decNumber",    0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_PROTOBUF,       "protobuf",         0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_SCHEMACHANGE,   "schemachange",     0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_STATIC_LUA,            "lua",              0, 0) \
+XMACRO_COMDB2MA(COMDB2MA_STATIC_PLUGINS,        "plugins",          0, 0) \
 XMACRO_COMDB2MA(COMDB2MA_COUNT,                 NULL,               0, 0)
 
 #define XMACRO_COMDB2MA(idx, name, size, cap) idx,

--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -14,6 +14,10 @@ set(PLUGIN_BASE_DIR "${PROJECT_SOURCE_DIR}/plugins")
 # Clear the list of static plugin libraries from cache.
 unset(PLUGIN_LIBRARIES CACHE)
 
+set(module plugins)
+set(MODULE PLUGINS)
+configure_file(${PROJECT_SOURCE_DIR}/mem/mem.h.in mem_plugins.h @ONLY)
+
 add_subdirectory(dbqueuedb)
 add_subdirectory(logdelete)
 add_subdirectory(newsql)


### PR DESCRIPTION
An unterminated transaction (e.g., client executes "BEGIN", and disconnects without issuing a "COMMIT" or "ROLLBACK") may leak memory in a few places. This patch fixes it.