### PR TITLE
From 7.0 - give transactions some time to finish

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1586,6 +1586,8 @@ static void begin_clean_exit(void)
        here in a second, so letting new reads in would be bad. */
     block_new_requests(thedb);
 
+    wait_for_transactions();
+
     print_all_time_accounting();
     wait_for_sc_to_stop("exit", __func__, __LINE__);
 
@@ -1642,6 +1644,8 @@ void clean_exit(void)
     /* dont let any new requests come in.  we're going to go non-coherent
        here in a second, so letting new reads in would be bad. */
     block_new_requests(thedb);
+
+    wait_for_transactions();
 
     print_all_time_accounting();
     wait_for_sc_to_stop("exit", __func__, __LINE__);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -478,6 +478,7 @@ extern int gbl_timer_warn_interval;
 
 int gbl_incoherent_clnt_wait = 0;
 int gbl_new_leader_duration = 3;
+extern int gbl_transaction_grace_period;
 
 /*
   =========================================================

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2489,4 +2489,9 @@ REGISTER_TUNABLE("timer_pstack_interval", "Skip pstack if last one was within sp
 REGISTER_TUNABLE("timer_warn_interval", "Flag timer thds which tick longer than specified interval in msec. To disable, set to 0 (Default: 1500ms)",
                  TUNABLE_INTEGER, &gbl_timer_warn_interval, INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("transaction_grace_period",
+                 "Time to wait for connections with pending transactions to go away on exit.  (Default: 60)",
+                 TUNABLE_INTEGER, &gbl_transaction_grace_period, 0, NULL, NULL, NULL, NULL);
+
+
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -1207,6 +1207,7 @@ struct connection_info {
     int node_int;
     int time_in_state_int;
     enum connection_state state_int;
+    int64_t in_transaction;
 };
 
 /* makes master swing verbose */
@@ -1549,5 +1550,7 @@ int comdb2_sql_tick(void);
 int comdb2_sql_tick_no_recover_deadlock(void);
 int forward_set_commands(struct sqlclntstate *clnt, cdb2_hndl_tp *hndl,
                          struct errstat *err);
+
+void wait_for_transactions(void);
 
 #endif /* _SQL_H_ */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6681,6 +6681,7 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
         c->sql = NULL;
         c->fingerprint = NULL;
     }
+    c->in_transaction = clnt->in_client_trans;
     Pthread_mutex_unlock(&clnt->state_lk);
 }
 
@@ -7162,4 +7163,45 @@ char *clnt_tzname(struct sqlclntstate *clnt, sqlite3_stmt *stmt)
         return clnt->plugin.tzname(clnt, stmt);
 
     return stmt_tzname(stmt);
+}
+
+int gbl_transaction_grace_period = 60;
+void wait_for_transactions(void) {
+    int ntrans;
+    int nwaits = 0;
+
+
+    for (nwaits = 0; nwaits < gbl_transaction_grace_period; nwaits++) {
+        ntrans = 0;
+        struct connection_info *connections;
+        int nconnections;
+
+        int rc = gather_connection_info(&connections, &nconnections);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "failed to get connection info\n");
+            return;
+        }
+        for (int i = 0; i < nconnections; i++) {
+            struct connection_info *c = &connections[i];
+            if (c->in_transaction) {
+                ntrans++;
+                if (nwaits > 10) {
+                    if (ntrans == 1)
+                        logmsg(LOGMSG_INFO, "waiting for transactions:\n------------------------\n");
+                    logmsg(LOGMSG_INFO, "open transaction on connection from %s pid %d\n", c->host, (int) c->pid);
+                }
+            }
+        }
+        free_connection_info(connections, nconnections);
+        if (ntrans) {
+            if (nwaits > 10)
+                logmsg(LOGMSG_INFO, "------------------------\n");
+            sleep(1);
+            nwaits++;
+        }
+        else
+            break;
+    }
+    if (ntrans && nwaits)
+        logmsg(LOGMSG_INFO, "giving up and exiting with pending transactions\n");
 }

--- a/tests/trangrace.test/Makefile
+++ b/tests/trangrace.test/Makefile
@@ -1,0 +1,9 @@
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/trangrace.test/lrl
+++ b/tests/trangrace.test/lrl
@@ -1,0 +1,3 @@
+# we're trying to prevent the db from exiting with pending transactions
+# so set "shutdown no matter what" higher than the grace period
+exitalarmsec 60

--- a/tests/trangrace.test/runit
+++ b/tests/trangrace.test/runit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+if [[ -z "$CLUSTER" ]]; then
+    echo "Skipping for non-clustered"
+    exit 0
+fi
+
+if [[ $# -ne 1 ]]; then
+    echo Usage: dbname
+    exit 1
+fi
+
+TMPDIR=${TMPDIR:-/tmp}
+dbname=$1
+
+host=$(cdb2sql -tabs -s ${CDB2_OPTIONS} $dbname default "select host from comdb2_cluster where is_master='N' limit 1")
+
+
+(
+sleep 5
+if [[ $myhost = $host ]]; then
+    cdb2sql -s ${CDB2_OPTIONS} $dbname local "exec procedure sys.cmd.send('exit')" >/dev/null
+else
+    ssh $host "$(which cdb2sql) -s ${CDB2_OPTIONS} $dbname local \"exec procedure sys.cmd.send('exit')\"" >/dev/null
+fi
+) &
+
+cdb2sql --host $host -s ${CDB2_OPTIONS} $dbname default <<'EOF'
+drop table if exists t;
+create table t(a int);$$
+begin;
+insert into t values(1);
+select sleep(15);
+insert into t values(1);
+commit;
+EOF
+
+count=$(cdb2sql -s ${CDB2_OPTIONS} -tabs $dbname default "select count(*) from t")
+if [[ $count -eq 2 ]]; then
+    echo Passed
+    exit 0
+else
+    echo "Failed: count $count, expected 2"
+    exit 1
+fi

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -986,6 +986,7 @@
 (name='track_replication_times', description='Track how long each replicant takes to ack all transactions.', type='BOOLEAN', value='ON', read_only='N')
 (name='track_replication_times_max_lsns', description='Track replication times for up to this many transactions.', type='INTEGER', value='50', read_only='N')
 (name='tracked_locklist_init', description='Initial allocation count for tracked locks', type='INTEGER', value='10', read_only='N')
+(name='transaction_grace_period', description='Time to wait for connections with pending transactions to go away on exit. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='transient_page_reallocation', description='Orphaned pages are maintained locally', type='BOOLEAN', value='OFF', read_only='N')
 (name='typessql', description='Use typessql to attempt to buffer results until all columns are non-null. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='typessql_records_max', description='The maximum number of records for typessql to buffer and find non-null types before giving up. (Default: 1000)', type='INTEGER', value='1000', read_only='N')


### PR DESCRIPTION
When we're asked to exit, give running transactions a small grace period to let them try to finish.
