### PR TITLE
Tweak generating pstack

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -118,6 +118,7 @@ extern struct interned_string *gbl_myhostname_interned;
 extern size_t gbl_blobmem_cap;
 extern int gbl_backup_logfiles;
 extern int gbl_commit_lsn_map;
+struct timeval last_timer_pstack;
 
 #define FILENAMELEN 100
 
@@ -2215,6 +2216,7 @@ void pstack_self(void)
     gbl_logmsg_ctrace = old;
     fclose(out);
     unlink(output);
+    gettimeofday(&last_timer_pstack, NULL);
 }
 
 static void panic_func(DB_ENV *dbenv, int errval)

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -458,8 +458,8 @@ static void *do_pstack(void *arg)
 #define timeval_to_ms(x) x.tv_sec * 1000 + x.tv_usec / 1000
 int gbl_timer_warn_interval = 1500; //msec
 int gbl_timer_pstack_interval =  5 * 60; //sec
+extern struct timeval last_timer_pstack;
 static struct timeval last_timer_check;
-static struct timeval last_timer_pstack;
 static struct event *check_timers_ev;
 static void check_timers(int dummyfd, short what, void *arg)
 {
@@ -504,7 +504,6 @@ static void check_timers(int dummyfd, short what, void *arg)
     if (!need_pstack) return;
     timersub(&now, &last_timer_pstack, &diff);
     if (diff.tv_sec < gbl_timer_pstack_interval) return;
-    last_timer_pstack = now;
     logmsg(LOGMSG_WARN, "%s: Generating pstack\n", __func__);
     pthread_t t;
     Pthread_create(&t, NULL, do_pstack, NULL);


### PR DESCRIPTION
Long rep-process-message generates a pstack. This suspends execution which triggers a long-timer-tick, which generates another pstack. Keep track of time when last pstack was generated to prevent the second pstack described above.