### PR TITLE
Fix duplicated bound param

### DIFF
--- a/tests/union_parallel.test/9_3_params.req
+++ b/tests/union_parallel.test/9_3_params.req
@@ -1,0 +1,2 @@
+@bind CDB2_INTEGER p 1
+select 'one' as c1, comdb2_ctxinfo('parallel'), a from t where a=@p and a=@p union all select 'two' as c1, comdb2_ctxinfo('parallel'), a from t where a=@p and a=@p union all select 'three' as c1 , comdb2_ctxinfo('parallel'), a from t where a=@p order by c1;

--- a/tests/union_parallel.test/9_3_params.req.exp
+++ b/tests/union_parallel.test/9_3_params.req.exp
@@ -1,0 +1,3 @@
+(c1='one', comdb2_ctxinfo ( 'parallel' )=1, a=1)
+(c1='three', comdb2_ctxinfo ( 'parallel' )=0, a=1)
+(c1='two', comdb2_ctxinfo ( 'parallel' )=0, a=1)

--- a/tests/union_parallel.test/9_4_params.req
+++ b/tests/union_parallel.test/9_4_params.req
@@ -1,0 +1,5 @@
+@bind CDB2_INTEGER 1 1
+@bind CDB2_INTEGER 2 2
+@bind CDB2_INTEGER 3 1
+@bind CDB2_INTEGER 4 1
+select 'one' as c1, comdb2_ctxinfo('parallel'), a from t where a=? or  a=? union all select 'two' as c1, comdb2_ctxinfo('parallel'), a from t where a=? and a=? order by c1

--- a/tests/union_parallel.test/9_4_params.req.exp
+++ b/tests/union_parallel.test/9_4_params.req.exp
@@ -1,0 +1,3 @@
+(c1='one', comdb2_ctxinfo ( 'parallel' )=1, a=1)
+(c1='one', comdb2_ctxinfo ( 'parallel' )=1, a=2)
+(c1='two', comdb2_ctxinfo ( 'parallel' )=0, a=1)


### PR DESCRIPTION
sqlite Expr name still has the prefix @ for named bound parameters; make sure we skip that when we checked for reused named parameters.  This is a bug impacting queries that are parallelized and use named parameters multiple times
Re: 174620650