### PR TITLE
Don't hardcode db prefix during cluster setup

### DIFF
--- a/contrib/dev-util/cluster
+++ b/contrib/dev-util/cluster
@@ -234,7 +234,7 @@ function build {
 	ssh-keygen -q -t rsa -N '' -f $PWD/id_rsa
 	cat > config <<- EOF
 		LogLevel=quiet
-		HOST m*
+		HOST $(get mach-prefix)*
 			StrictHostKeyChecking no
 	EOF
 	cat >> Dockerfile <<- EOF


### PR DESCRIPTION
The cluster script supports using a custom prefix for db names, but the default prefix is hardcoded in the cluster setup stage. The changes in this PR use the true prefix instead of the default during setup.