### PR TITLE
{174631435}: cdb2jdbc removing redundant bind() call

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
@@ -144,7 +144,6 @@ public class SockIO implements IO {
             if (tcpbufsz > 0)
                 sock.setReceiveBufferSize(tcpbufsz);
 
-            sock.bind(new InetSocketAddress(0));
             sock.connect(new InetSocketAddress(host, port), connectTimeout);
             out = new BufferedOutputStream(sock.getOutputStream());
             in = new BufferedInputStream(sock.getInputStream());


### PR DESCRIPTION
This redundant bind() call before connect() seems to cause sporadic EADDRINUSE errors for our customers. Get rid of it.