### PR TITLE
{174734955} Skip non-readable files in comdb2_files

### DIFF
--- a/tests/comdb2_files.test/Makefile
+++ b/tests/comdb2_files.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/comdb2_files.test/runit
+++ b/tests/comdb2_files.test/runit
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+dir=$DBDIR
+
+function runtest {
+	echo "Verifying that comdb2_files skips read-restricted files"
+	echo "restricted blahblah" > $dir/foo
+	chmod 000 $dir/foo
+	cdb2sql $dbnm local 'select count(*) from comdb2_files' > /dev/null
+	rc=$?
+	if (( rc != 0 ));
+	then
+		echo "Exiting with rc $rc"
+		exit $rc
+	fi
+
+	echo "Verifying that comdb2_files skips read-restricted directories"
+	mkdir $dir/restrictedDir
+	touch $dir/restrictedDir/f
+	chmod 000 $dir/restrictedDir
+	cdb2sql $dbnm local 'select count(*) from comdb2_files' > /dev/null
+	rc=$?
+	if (( rc != 0 ));
+	then
+		echo "Exiting with rc $rc"
+		exit $rc
+	fi
+
+	echo "Verifying that comdb2_files fails on a broken symlink"
+	ln -s idonutexist $dir/link
+	! cdb2sql $dbnm local 'select count(*) from comdb2_files' > /dev/null
+	rc=$?
+	echo "Exiting with rc $rc"
+	exit $rc
+}
+
+if [ -z "$CLUSTER" ];
+then
+	runtest $dbnm $DBDIR
+else
+	node=`echo $CLUSTER | awk '{ print $1}'`
+	ssh $node "export PATH=$PATH; export dir=$DBDIR; export dbnm=$dbnm; $(typeset -f runtest); runtest"
+	rc=$?
+	exit $rc
+fi
+


### PR DESCRIPTION
If there is any file that is read-restricted to the database process in the database directory, then a select from `comdb2_files` will fail when it tries to process a row corresponding to that file. The changes in this PR filter out read-restricted files from the set of files used to generate rows in `comdb2_files`.