### PR TITLE
[8.0] {174676593}: Fixing trigger lock inversion

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -77,10 +77,15 @@ int debug_switch_bdb_handle_reset_delay(void);           /* 0 */
 int debug_switch_recover_ddlk_sp_delay(void);
 int debug_switch_force_file_version_to_fail(void); /* 0 */
 int debug_switch_rep_verify_req_delay(void);       /* 0 */
+int debug_switch_test_trigger_deadlock(void);      /* 0 */
+int debug_switch_is_dbq_get_delayed(void);         /* 0 */
+int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */
 
 /* setters */
 void debug_switch_set_rep_verify_req_delay(int);
+void debug_switch_set_dbq_get_delayed(int);
+void debug_switch_set_rep_rec_delayed(int);
 #endif

--- a/bdb/bdb_queuedb.h
+++ b/bdb/bdb_queuedb.h
@@ -51,6 +51,8 @@ const struct bdb_queue_stats *bdb_queuedb_get_stats(bdb_state_type *bdb_state);
 int bdb_trigger_subscribe(bdb_state_type *, pthread_cond_t **,
                           pthread_mutex_t **, const uint8_t **status);
 int bdb_trigger_unsubscribe(bdb_state_type *);
+int bdb_trigger_lock(bdb_state_type *, const uint8_t **status, void **);
+int bdb_trigger_unlock(bdb_state_type *, void *);
 int bdb_trigger_open(bdb_state_type *);
 int bdb_trigger_close(bdb_state_type *);
 int bdb_trigger_ispaused(bdb_state_type *);

--- a/bdb/phys_rep_lsn.c
+++ b/bdb/phys_rep_lsn.c
@@ -225,6 +225,7 @@ int truncate_log_lock(bdb_state_type *bdb_state, unsigned int file,
         return send_truncate_to_master(bdb_state, file, offset);
     }
 
+    bdb_state->dbenv->trigger_pause_all(bdb_state->dbenv);
     if (online) {
         BDB_READLOCK(msg);
     } else {
@@ -234,6 +235,7 @@ int truncate_log_lock(bdb_state_type *bdb_state, unsigned int file,
 
     /* have to get lock for recovery */
     BDB_RELLOCK();
+    bdb_state->dbenv->trigger_unpause_all(bdb_state->dbenv);
 
     return 0;
 }

--- a/bdb/queuedb.c
+++ b/bdb/queuedb.c
@@ -1392,6 +1392,18 @@ int bdb_trigger_unsubscribe(bdb_state_type *bdb_state)
     return dbenv->trigger_unsubscribe(dbenv, bdb_state->name);
 }
 
+int bdb_trigger_lock(bdb_state_type *bdb_state, const uint8_t **status, void **retp)
+{
+    DB_ENV *dbenv = bdb_state->dbenv;
+    return dbenv->trigger_lock(dbenv, bdb_state->name, status, retp);
+}
+
+int bdb_trigger_unlock(bdb_state_type *bdb_state, void *ret)
+{
+    DB_ENV *dbenv = bdb_state->dbenv;
+    return dbenv->trigger_unlock(dbenv, ret);
+}
+
 int bdb_trigger_open(bdb_state_type *bdb_state)
 {
     DB_ENV *dbenv = bdb_state->dbenv;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2805,11 +2805,15 @@ struct __db_env {
 	int(*trigger_subscribe) __P((DB_ENV *, const char *, pthread_cond_t **,
 					 pthread_mutex_t **, const uint8_t **));
 	int(*trigger_unsubscribe) __P((DB_ENV *, const char *));
+	int(*trigger_lock) __P((DB_ENV *, const char *, const uint8_t **, void **));
+	int(*trigger_unlock) __P((DB_ENV *, void *));
 	int(*trigger_open) __P((DB_ENV *, const char *));
 	int(*trigger_close) __P((DB_ENV *, const char *));
 	int(*trigger_ispaused) __P((DB_ENV *, const char *));
 	int(*trigger_pause) __P((DB_ENV *, const char *));
 	int(*trigger_unpause) __P((DB_ENV *, const char *));
+	int(*trigger_pause_all) __P((DB_ENV *));
+	int(*trigger_unpause_all) __P((DB_ENV *));
 
 	int (*pgin[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));
 	int (*pgout[DB_TYPE_MAX]) __P((DB_ENV *, db_pgno_t, void *, DBT *));

--- a/berkdb/db/trigger_subscription.c
+++ b/berkdb/db/trigger_subscription.c
@@ -32,3 +32,12 @@ struct __db_trigger_subscription *__db_get_trigger_subscription(const char *name
 	Pthread_mutex_unlock(&subscription_lk);
 	return s;
 }
+
+int __db_for_each_trigger_subscription(hashforfunc_t *func, int lock_it)
+{
+	Pthread_mutex_lock(&subscription_lk);
+	if (htab != NULL)
+		hash_for(htab, func, (void *)(intptr_t)lock_it);
+	Pthread_mutex_unlock(&subscription_lk);
+	return 0;
+}

--- a/berkdb/dbinc/trigger_subscription.h
+++ b/berkdb/dbinc/trigger_subscription.h
@@ -6,6 +6,7 @@
 
 struct __db_trigger_subscription {
 	char *name;
+	int was_open; /* 1 if recovery should change it back to open */
 	int active;
 	uint8_t status;
 	pthread_cond_t cond;
@@ -13,5 +14,6 @@ struct __db_trigger_subscription {
 };
 
 struct __db_trigger_subscription *__db_get_trigger_subscription(const char *);
+int __db_for_each_trigger_subscription(hashforfunc_t *, int);
 
 #endif //TRIGGER_SUBSCRIPTION_H

--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -48,6 +48,7 @@ static const char revid[] =
 #include "logmsg.h"
 #include "locks_wrap.h"
 #include "trigger_sub_status.h"
+#include "debug_switches.h"
 
 static int __dbenv_init __P((DB_ENV *));
 static void __dbenv_err __P((const DB_ENV *, int, const char *, ...));
@@ -91,11 +92,15 @@ static int __dbenv_set_use_sys_malloc __P((DB_ENV *, int));
 static int __dbenv_trigger_subscribe __P((DB_ENV *, const char *,
 	pthread_cond_t **, pthread_mutex_t **, const uint8_t **));
 static int __dbenv_trigger_unsubscribe __P((DB_ENV *, const char *));
+static int __dbenv_trigger_lock __P((DB_ENV *, const char *, const uint8_t **, void **));
+static int __dbenv_trigger_unlock __P((DB_ENV *, void *));
 static int __dbenv_trigger_open __P((DB_ENV *, const char *));
 static int __dbenv_trigger_close __P((DB_ENV *, const char *));
 static int __dbenv_trigger_ispaused __P((DB_ENV *, const char *));
 static int __dbenv_trigger_pause __P((DB_ENV *, const char *));
 static int __dbenv_trigger_unpause __P((DB_ENV *, const char *));
+static int __dbenv_trigger_pause_all __P((DB_ENV *));
+static int __dbenv_trigger_unpause_all __P((DB_ENV *));
 int __dbenv_apply_log __P((DB_ENV *, unsigned int, unsigned int, int64_t,
             void*, int));
 size_t __dbenv_get_log_header_size __P((DB_ENV*)); 
@@ -336,11 +341,15 @@ __dbenv_init(dbenv)
 
 	dbenv->trigger_subscribe = __dbenv_trigger_subscribe;
 	dbenv->trigger_unsubscribe = __dbenv_trigger_unsubscribe;
+	dbenv->trigger_lock = __dbenv_trigger_lock;
+	dbenv->trigger_unlock = __dbenv_trigger_unlock;
 	dbenv->trigger_open = __dbenv_trigger_open;
 	dbenv->trigger_close = __dbenv_trigger_close;
 	dbenv->trigger_ispaused = __dbenv_trigger_ispaused;
 	dbenv->trigger_pause = __dbenv_trigger_pause;
 	dbenv->trigger_unpause = __dbenv_trigger_unpause;
+	dbenv->trigger_pause_all = __dbenv_trigger_pause_all;
+	dbenv->trigger_unpause_all = __dbenv_trigger_unpause_all;
 
 	Pthread_mutex_init(&dbenv->utxnid_lock, NULL);
 	dbenv->next_utxnid = 0;
@@ -1372,6 +1381,42 @@ __dbenv_get_durable_lsn(dbenv, lsnp, generation)
 	Pthread_mutex_unlock(&gbl_durable_lsn_lk);
 }
 
+
+static int
+__dbenv_lock_or_unlock_a_trigger_subscription(void *obj, void *action)
+{
+	intptr_t pause_it = (intptr_t)action;
+	struct __db_trigger_subscription *t = obj;
+	Pthread_mutex_lock(&t->lock);
+	if (pause_it && t->status == TRIGGER_SUBSCRIPTION_OPEN) {
+		/* pause it if not already paused */
+		t->status = TRIGGER_SUBSCRIPTION_PAUSED;
+		t->was_open = 1;
+	} else if (!pause_it && t->was_open) {
+		/* unpause it if we paused it */
+		t->status = TRIGGER_SUBSCRIPTION_OPEN;
+		t->was_open = 0;
+	}
+	Pthread_mutex_unlock(&t->lock);
+	return 0;
+}
+
+static int
+__dbenv_trigger_pause_all(dbenv)
+	DB_ENV *dbenv;
+{
+	__db_for_each_trigger_subscription(__dbenv_lock_or_unlock_a_trigger_subscription, 1);
+	return 0;
+}
+
+static int
+__dbenv_trigger_unpause_all(dbenv)
+	DB_ENV *dbenv;
+{
+	__db_for_each_trigger_subscription(__dbenv_lock_or_unlock_a_trigger_subscription, 0);
+	return 0;
+}
+
 static int
 __dbenv_trigger_subscribe(dbenv, fname, cond, lock, status)
 	DB_ENV *dbenv;
@@ -1407,6 +1452,42 @@ __dbenv_trigger_unsubscribe(dbenv, fname)
 	return 0;
 }
 
+/*
+ * just like __dbenv_trigger_subscribe(), but retain the trigger
+ * subscription lock till __dbenv_trigger_unlock() is called.
+ */
+static int
+__dbenv_trigger_lock(dbenv, fname, status, retp)
+	DB_ENV *dbenv;
+	const char *fname;
+	const uint8_t **status;
+	void **retp;
+{
+	int rc = 1;
+	struct __db_trigger_subscription *t;
+	*retp = t = __db_get_trigger_subscription(fname);
+	Pthread_mutex_lock(&t->lock);
+	if (t->status != TRIGGER_SUBSCRIPTION_CLOSED) {
+		++t->active;
+		*status = &t->status;
+		rc = 0;
+	}
+	return rc;
+}
+
+static int
+__dbenv_trigger_unlock(dbenv, ret)
+	DB_ENV *dbenv;
+	void *ret;
+{
+	struct __db_trigger_subscription *t = ret;
+	if (t != NULL) {
+		--t->active;
+		Pthread_mutex_unlock(&t->lock);
+	}
+	return 0;
+}
+
 static int
 __dbenv_trigger_open(dbenv, fname)
 	DB_ENV *dbenv;
@@ -1414,11 +1495,20 @@ __dbenv_trigger_open(dbenv, fname)
 {
 	struct __db_trigger_subscription *t;
 	t = __db_get_trigger_subscription(fname);
+	if (debug_switch_test_trigger_deadlock()) {
+		logmsg(LOGMSG_WARN, "%s: acquiring t->lock\n", __func__);
+	}
 	Pthread_mutex_lock(&t->lock);
+	if (debug_switch_test_trigger_deadlock()) {
+		logmsg(LOGMSG_WARN, "%s: acquired t->lock\n", __func__);
+	}
 	DB_ASSERT(t->status == TRIGGER_SUBSCRIPTION_CLOSED);
 	t->status = TRIGGER_SUBSCRIPTION_OPEN;
 	Pthread_cond_signal(&t->cond);
 	Pthread_mutex_unlock(&t->lock);
+	if (debug_switch_test_trigger_deadlock()) {
+		logmsg(LOGMSG_WARN, "%s: released t->lock\n", __func__);
+	}
 	return 0;
 }
 

--- a/tests/trigger_lock_inversion.test/Makefile
+++ b/tests/trigger_lock_inversion.test/Makefile
@@ -1,0 +1,10 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif
+export VERIFY_DB_AT_FINISH=0
+export CHECK_DB_AT_FINISH=0

--- a/tests/trigger_lock_inversion.test/lrl.options
+++ b/tests/trigger_lock_inversion.test/lrl.options
@@ -1,0 +1,5 @@
+logmsg level warn
+# to make wait_for_seqnum timeout faster (default is 10 seconds)
+setattr REPTIMEOUT_MINMS 2000
+# allow replicant to be marked back coherent faster (default is 10 seocnds)
+setattr DOWNGRADE_PENALTY 2000

--- a/tests/trigger_lock_inversion.test/runit
+++ b/tests/trigger_lock_inversion.test/runit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'DROP TABLE IF EXISTS t'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t (i INTEGER)'
+cdb2sql ${CDB2_OPTIONS} $dbnm default 'CREATE DEFAULT LUA CONSUMER watcher ON (TABLE t FOR INSERT AND UPDATE AND DELETE)'
+
+# Know where we'll be connecting to
+leader=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT host FROM comdb2_cluster WHERE is_master="Y"'`
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+peer=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT host FROM comdb2_cluster WHERE host != \"$host\" AND is_master=\"N\" LIMIT 1"`
+
+echo leader is $leader host is $host will upgrade leader to $peer
+cdb2sql $dbnm --host $leader 'EXEC PROCEDURE sys.cmd.send("flush")'
+
+# Turn on test switch
+cdb2sql $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("test_trigger_deadlock 1")'
+cdb2sql $dbnm --host $host 'EXEC PROCEDURE watcher()' &
+wpid=$!
+
+cdb2sql $dbnm --host $leader 'INSERT INTO t VALUES(1)'
+cdb2sql $dbnm --host $leader 'UPDATE t set i = 0 WHERE 1'
+cdb2sql $dbnm --host $leader default 'DELETE FROM t'
+cdb2sql $dbnm --host $leader 'EXEC PROCEDURE sys.cmd.send("flush")'
+cdb2sql $dbnm --host $leader "EXEC PROCEDURE sys.cmd.send(\"upgrade $peer\")"
+
+sleep 10 # allow leader-change to complete
+
+leader=`cdb2sql --tabs $dbnm --host $leader 'SELECT host FROM comdb2_cluster WHERE is_master="Y"'`
+echo new leader is $leader
+# Push LSN a iittle so wait_for_seqnum will mark this node incoherent
+cdb2sql $dbnm --host $leader 'INSERT INTO t VALUES(1)'
+
+sleep 5 # sleep a bit over (REPTIMEOUT_MINMS + DOWNGRADE_PENALTY) so we can be marked back coherent
+
+echo can I query this node?
+cdb2sql $dbnm --host $host 'SELECT 1'
+if [ $? != 0 ]; then
+    echo No >&2
+    kill $wpid
+    exit 1
+fi
+
+kill $wpid
+echo Yes

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -84,6 +84,9 @@ static struct debug_switches {
     int recover_ddlk_sp_delay;
     int force_file_version_to_fail;
     int rep_verify_req_delay;
+    int test_trigger_deadlock;
+    int dbq_get_is_delayed;
+    int rep_rec_is_delayed;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -266,6 +269,7 @@ int init_debug_switches(void)
 
     register_debug_switch("force_file_version_to_fail", &debug_switches.force_file_version_to_fail);
     register_debug_switch("rep_verify_req_delay", &debug_switches.rep_verify_req_delay);
+    register_debug_switch("test_trigger_deadlock", &debug_switches.test_trigger_deadlock);
     return 0;
 }
 
@@ -511,4 +515,24 @@ int debug_switch_rep_verify_req_delay(void)
 void debug_switch_set_rep_verify_req_delay(int val)
 {
     debug_switches.rep_verify_req_delay = val;
+}
+int debug_switch_test_trigger_deadlock(void)
+{
+    return debug_switches.test_trigger_deadlock;
+}
+void debug_switch_set_dbq_get_delayed(int val)
+{
+    debug_switches.dbq_get_is_delayed = val;
+}
+int debug_switch_is_dbq_get_delayed(void)
+{
+    return debug_switches.dbq_get_is_delayed;
+}
+void debug_switch_set_rep_rec_delayed(int val)
+{
+    debug_switches.rep_rec_is_delayed = val;
+}
+int debug_switch_is_rep_rec_delayed(void)
+{
+    return debug_switches.rep_rec_is_delayed;
 }


### PR DESCRIPTION
dbq_poll() acquires trigger-subscription-lock first, and bdb-read-lock/recovery-write-lock second. On the other hand, rep_verify_match(), when matching a dbreg_register log record on a queue file, acquires bdb-write-lock/recovery-write-lock first, and trigger-subscription-lock second. Therefore it can deadlock.

This patch fixes the lock inversion.