### PR TITLE
If a schema change fails while processing a partition, mark scdone flag 

### DIFF
--- a/tests/sc_multitable.test/lrl.options
+++ b/tests/sc_multitable.test/lrl.options
@@ -1,1 +1,3 @@
 table t t.csc2
+table t2 t2.csc2
+logmsg level info

--- a/tests/sc_multitable.test/run.log.alpha
+++ b/tests/sc_multitable.test/run.log.alpha
@@ -1,4 +1,99 @@
+[
+ {
+  "NAME"      : "testview1",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$1_E5EE49E6",
+  },
+  {
+   "TABLENAME"    : "t",
+  }
+  ]
+ }
+]
 [set transaction chunk 10000] rc 0
 [begin] rc 0
 [insert into testview1 select * from  generate_series(1,100000)] rc 0
+[commit] rc 0
+[
+ {
+  "NAME"      : "testview1",
+  "PERIOD"    : "daily",
+  "RETENTION" : 2,
+  "SHARD0NAME": "t",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$1_E5EE49E6",
+  },
+  {
+   "TABLENAME"    : "t",
+  }
+  ]
+ }
+],
+ {
+  "NAME"      : "tv2",
+  "PERIOD"    : "daily",
+  "RETENTION" : 15,
+  "SHARD0NAME": "t2",
+  "TABLES"    :
+  [
+  {
+   "TABLENAME"    : "$0_B1ED0A83",
+  },
+  {
+   "TABLENAME"    : "$15_697633E9",
+  },
+  {
+   "TABLENAME"    : "$14_CC37A197",
+  },
+  {
+   "TABLENAME"    : "$13_B8C7C5FE",
+  },
+  {
+   "TABLENAME"    : "$12_1D865780",
+  },
+  {
+   "TABLENAME"    : "$11_F7A897F3",
+  },
+  {
+   "TABLENAME"    : "$10_52E9058D",
+  },
+  {
+   "TABLENAME"    : "$9_2CFDA638",
+  },
+  {
+   "TABLENAME"    : "$8_89BC3446",
+  },
+  {
+   "TABLENAME"    : "$7_C51D6EEA",
+  },
+  {
+   "TABLENAME"    : "$6_605CFC94",
+  },
+  {
+   "TABLENAME"    : "$5_8A723CE7",
+  },
+  {
+   "TABLENAME"    : "$4_2F33AE99",
+  },
+  {
+   "TABLENAME"    : "$3_5BC3CAF0",
+  },
+  {
+   "TABLENAME"    : "$2_FE82588E",
+  }
+  ]
+ }
+]
+(rows inserted=10)
+(rows inserted=10)
+[set transaction chunk 1000] rc 0
+[begin] rc 0
+[insert into '$14_CC37A197' (a) select * from  generate_series(1,1000000)] rc 0
 [commit] rc 0

--- a/tests/sc_multitable.test/runit
+++ b/tests/sc_multitable.test/runit
@@ -18,15 +18,18 @@ touch $OUT
 # create the partition
 starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-3600)'`
 echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'"
-cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >>    \$OUT
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t as ${VIEW1} PERIOD 'daily' RETENTION 2 START '${starttime}'" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE create time partition"
    exit 1
 fi
 
+# time to do a rollout
+sleep 10
+
 # check the current partitions
 echo cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID"
-cdb2sql -tabs ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >>    \$OUT
+cdb2sql -tabs ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >> $OUT
 if (( $? != 0 )) ; then
    echo "FAILURE partinfo"
    exit 1
@@ -49,6 +52,66 @@ echo cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat new.csc
 cdb2sql ${CDB2_OPTIONS} $dbname default "alter table ${VIEW1} {`cat new.csc2`}" &
 
 sleep 3
+
+echo cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"
+cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"
+if (( $? != 0 )) ; then
+   echo "FAILURE scabort"
+   exit 1
+fi
+
+sleep 5
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('llmeta list')" | grep IN >> $OUT
+
+
+# create a large partition past limit
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()- 15*24*3600)'`
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t2 as tv2 PERIOD 'daily' RETENTION 15 START '${starttime}'"
+cdb2sql ${CDB2_OPTIONS} $dbname default "CREATE TIME PARTITION ON t2 as tv2 PERIOD 'daily' RETENTION 15 START '${starttime}'" >>  $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE create time partition tv2"
+   exit 1
+fi
+
+# give time to do 15 rollouts
+sleep 30
+
+# check the current partitions
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID"
+cdb2sql -tabs ${CDB2_OPTIONS} $dbname default "exec procedure sys.cmd.send('partitions')" | egrep -v "STARTTIME|LOW|HIGH|SOURCE_ID" >> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE partinfo tv2"
+   exit 1
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into '\$0_B1ED0A83' (a) select * from generate_series(1,10)" >> $OUT 
+if (( $? != 0 )) ; then
+   echo "FAILURE insert tv2 shard 0"
+   exit 1
+fi
+cdb2sql ${CDB2_OPTIONS} $dbname default "insert into '\$15_697633E9' (a) select * from generate_series(101,110)" >> $OUT 
+if (( $? != 0 )) ; then
+   echo "FAILURE insert tv2 shard 1"
+   exit 1
+fi
+cdb2sql ${CDB2_OPTIONS} $dbname default >> $OUT <<EOF
+set transaction chunk 1000
+begin
+insert into '\$14_CC37A197' (a) select * from  generate_series(1,1000000)
+commit
+EOF
+if (( $? != 0 )) ; then
+   echo "FAILURE insert shard 3"
+   exit 1
+fi
+
+master=$(get_master)
+
+echo cdb2sql ${CDB2_OPTIONS} $dbname default "alter table tv2 drop column b"
+cdb2sql ${CDB2_OPTIONS} $dbname default "alter table tv2 drop column b" &
+
+sleep 10
 
 echo cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"
 cdb2sql ${CDB2_OPTIONS} $dbname --host ${master} "exec procedure sys.cmd.send('scabort')"

--- a/tests/sc_multitable.test/t2.csc2
+++ b/tests/sc_multitable.test/t2.csc2
@@ -1,0 +1,5 @@
+schema
+{
+    int a
+    int b null=yes
+}


### PR DESCRIPTION
This allows toblock abort callback to go through schema changes that finished the async phase and remove IN_SCHEMA_CHANGE llmeta entries.
Re: 174764815
