### PR TITLE
Quiet compiler re. intentionally unused variable

### DIFF
--- a/dlmalloc/dlmalloc.c
+++ b/dlmalloc/dlmalloc.c
@@ -3405,6 +3405,8 @@ static void add_segment(mstate m, char* tbase, size_t tsize, flag_t mmapped) {
   }
 
   check_top_chunk(m, m->top);
+
+  (void)(nfences);
 }
 
 /* -------------------------- System allocation -------------------------- */


### PR DESCRIPTION
The osx build warns that `nfences` is unused since it is only used in an assert. The changes in this PR quiet the compiler by casting it to void at the end of the function.