### PR TITLE
faster inserts during tpt schema change

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2057,7 +2057,7 @@ inline static void update_node_acks(bdb_state_type *bdb_state, struct interned_s
     if (h->expected_udp_count > 1 &&
         delta > bdb_state->attr->udp_drop_delta_threshold &&
         rate > bdb_state->attr->udp_drop_warn_percent) {
-        logmsg(LOGMSG_USER,
+        logmsg(LOGMSG_DEBUG,
                "update_node_acks: host %s, expected_udp_count = %d, delta = "
                "%.1f, loss = %f percent\n", host->str, h->expected_udp_count, delta, rate);
     }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -483,6 +483,7 @@ extern int gbl_timer_warn_interval;
 int gbl_incoherent_clnt_wait = 10;
 int gbl_new_leader_duration = 3;
 extern int gbl_transaction_grace_period;
+extern int gbl_partition_sc_reorder;
 extern int gbl_dohsql_joins;
 
 /*

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2491,6 +2491,10 @@ REGISTER_TUNABLE("transaction_grace_period",
                  "Time to wait for connections with pending transactions to go away on exit. (Default: 60)",
                  TUNABLE_INTEGER, &gbl_transaction_grace_period, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("partition_sc_reorder",
+                 "If the schema change is serialized for a partition, run current shard last",
+                 TUNABLE_BOOLEAN, &gbl_partition_sc_reorder, 0, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("dohsql_joins",
                  "Enable to support joins in parallel sql execution (default: on)",
                  TUNABLE_BOOLEAN, &gbl_dohsql_joins, 0, NULL, NULL, NULL, NULL);

--- a/db/views.h
+++ b/db/views.h
@@ -79,6 +79,7 @@ typedef struct timepart_sc_arg {
     int nshards;
     int rc;
     void *tran; /*remove?*/
+    int last;
 } timepart_sc_arg_t;
 
 extern int gbl_partitioned_table_enabled;
@@ -288,7 +289,7 @@ int comdb2_partition_check_name_reuse(const char *tblname, char **partname, int 
  */
 int timepart_foreach_shard(const char *view_name,
                            int func(const char *, timepart_sc_arg_t *),
-                           timepart_sc_arg_t *arg, int first_shard);
+                           timepart_sc_arg_t *arg, int first_shard, int reorder);
 
 /**
  * Run "func" for each shard of a partition
@@ -298,7 +299,7 @@ int timepart_foreach_shard(const char *view_name,
  */
 int timepart_foreach_shard_lockless(timepart_view_t *view,
                                     int func(const char *, timepart_sc_arg_t *),
-                                    timepart_sc_arg_t *arg);
+                                    timepart_sc_arg_t *arg, int reorder);
 
 /**
  * Queue up the necessary events to rollout time partitions 

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -942,7 +942,7 @@ static int verify_sc_resumed_for_all_shards(void *obj, void *arg)
     sc_arg.s = tpt_sc->s;
     /* start new sc for shards that were not resumed */
     timepart_foreach_shard(tpt_sc->viewname, verify_sc_resumed_for_shard,
-                           &sc_arg, -1);
+                           &sc_arg, -1, 0);
     assert(sc_arg.s != tpt_sc->s);
     tpt_sc->s = sc_arg.s;
     return 0;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -663,6 +663,7 @@
 (name='parallel_recovery', description='', type='INTEGER', value='0', read_only='Y')
 (name='parallel_sync', description='Run checkpoint/memptrickle code with parallel writes', type='BOOLEAN', value='ON', read_only='N')
 (name='participantid_bits', description='Number of bits allocated for the participant stripe ID (remaining bits are used for the update ID).', type='INTEGER', value='0', read_only='N')
+(name='partition_sc_reorder', description='If the schema change is serialized for a partition, run current shard last', type='BOOLEAN', value='ON', read_only='N')
 (name='partitioned_table_enabled', description='Allow syntax create/alter table ... partitioned by ...', type='BOOLEAN', value='ON', read_only='N')
 (name='pause_moveto', description='pause_moveto', type='BOOLEAN', value='OFF', read_only='N')
 (name='pbkdf2_iterations', description='Number of iterations of PBKDF2 algorithm for password hashing.', type='INTEGER', value='4096', read_only='N')


### PR DESCRIPTION
Leave the current shard for tpt last, to eliminate double writes for inserts.
