### PR TITLE
{174866577}: Fixing libevent stack overflow

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -482,6 +482,13 @@ int gbl_new_leader_duration = 3;
 extern int gbl_transaction_grace_period;
 
 /*
+ * RESET is received on server twice, typically:
+ * sockpool resets once, and the client API resets again.
+ * For now, we need to allow at least 2 resets.
+ */
+int gbl_max_num_consecutive_sql_resets = 2;
+
+/*
   =========================================================
   Value/Update/Verify functions for some tunables that need
   special treatment.

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2490,5 +2490,6 @@ REGISTER_TUNABLE("transaction_grace_period",
                  "Time to wait for connections with pending transactions to go away on exit. (Default: 60)",
                  TUNABLE_INTEGER, &gbl_transaction_grace_period, 0, NULL, NULL, NULL, NULL);
 
-
+REGISTER_TUNABLE("max_num_consecutive_sql_resets", "Tunable to avoid stack overflow from recursive libevent callbacks",
+                 TUNABLE_INTEGER, &gbl_max_num_consecutive_sql_resets, INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/db/sql.h
+++ b/db/sql.h
@@ -905,6 +905,7 @@ struct sqlclntstate {
     int64_t total_sql;
     int64_t sql_since_reset;
     int64_t num_resets;
+    int64_t num_consecutive_sql_resets;
     time_t connect_time;
     time_t last_reset_time;
     int state_start_time;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2187,6 +2187,7 @@ void newsql_reset(struct sqlclntstate *clnt)
     clnt->osql.count_changes = 1;
     clnt->heartbeat = 1;
     clnt->dbtran.mode = tdef_to_tranlevel(gbl_sql_tranlevel_default);
+    ++clnt->num_consecutive_sql_resets;
 }
 
 void free_newsql_appdata(struct sqlclntstate *clnt)


### PR DESCRIPTION
The following pseudo code crashes the server, when sockpool is present

```
while true
  cdb2_open()
  /* do nothing */
  cdb2_close()
end
```

The server will call rd_hdr recursively, and eventually will overflow its call stack, as shown below.

```
12 rd_hdr
13 rd_hdr
14 rd_hdr
...
32672 rd_hdr
32673 rd_hdr
32674 rd_hdr
32675 event_process_active_single_queue
32676 event_process_active
32677 event_base_loop
32678 net_dispatch
32679 start_thread
32680 clone
```

This patch fixes it: after multiple consecutive sql resets are received from the same user, the user will be rescheduled back to the event queue, instead of being processed inline.

Note that open-cdb2api is unaffected by this, as it always does a dbinfo query which will break the server out of the recursion. On the other hand, bb-cdb2api which has the skip-dbinfo optimization is prone to this bug. I have added an internal `donate_ddos` test to demonstrate the bug.
