### PR TITLE
Fix corruption when attempting to add existing table from comdb2sc.tsk

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -224,7 +224,7 @@ static void stop_and_free_sc(struct ireq *iq, int rc,
             sbuf2printf(s->sb, "SUCCESS\n");
         }
     }
-    if (rc && iq->sc->kind == SC_ADDTABLE) {
+    if (rc && iq->sc->kind == SC_ADDTABLE && rc != SC_TABLE_ALREADY_EXIST) {
         if (iq->sc->db) {
             delete_temp_table(iq, iq->sc->db);
         }


### PR DESCRIPTION
Simple fix doesn't remove the table from the environment on a 'table-exists' error.  The test for this is csc2err under robo-mark
