### PR TITLE
Making logc->get(DB_FIRST) less racy with log-deletion

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3960,8 +3960,8 @@ low_headroom:
                         ctrace("deleting log %s %d\n", logname, filenum);
                     }
 
-                    rc = unlink(logname);
                     __log_invalidate(filenum);
+                    rc = unlink(logname);
                     if (rc) {
                         logmsg(LOGMSG_ERROR,
                                "delete_log_files: unlink for <%s> returned %d %d\n",


### PR DESCRIPTION
log-deletion should invalidate a log file from the log-file-validity cache before unlinking it.