### PR TITLE
[8.0] Making logc->get(DB_FIRST) less racy with log-deletion

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -3962,8 +3962,8 @@ low_headroom:
                         ctrace("deleting log %s %d\n", logname, filenum);
                     }
 
-                    rc = unlink(logname);
                     __log_invalidate(filenum);
+                    rc = unlink(logname);
                     if (rc) {
                         logmsg(LOGMSG_ERROR,
                                "delete_log_files: unlink for <%s> returned %d %d\n",


### PR DESCRIPTION
This is an 8.0 port of https://github.com/bloomberg/comdb2/pull/4344.