### PR TITLE
avoid lock inversion during partition rollout

### DIFF
--- a/db/views_sqlite.c
+++ b/db/views_sqlite.c
@@ -45,7 +45,7 @@ int views_sqlite_update(timepart_views_t *views, sqlite3 *db,
         view = views->views[i];
 
         /* check if this exists?*/
-        tab = sqlite3FindTableCheckOnly(db, view->name, NULL);
+        tab = sqlite3FindTableCheckOnlyNoAlias(db, view->name, NULL);
         if (tab) {
             /* paranoia */
             if (tab->pSelect == NULL) {

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -4298,6 +4298,7 @@ void sqlite3ExprIfFalseDup(Parse*, Expr*, int, int);
 Table *sqlite3FindTable(sqlite3*,const char*, const char*);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 Table *sqlite3FindTableCheckOnly(sqlite3*,const char*, const char*);
+Table *sqlite3FindTableCheckOnlyNoAlias(sqlite3*,const char*, const char*);
 Table *sqlite3FindTableByAnalysisLoad(sqlite3*,const char*, const char*);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #define LOCATE_VIEW    0x01


### PR DESCRIPTION
Short fix for partition lock inversion: do not read from llmeta during triggers update.

Re: 174791652