### PR TITLE
{175017306} enable bypass_auth flag for triggers

### DIFF
--- a/db/db_access.c
+++ b/db/db_access.c
@@ -203,7 +203,7 @@ int access_control_check_sql_write(struct BtCursor *pCur,
                                                   : pCur->db->tablename;
 
     if (gbl_uses_externalauth && !clnt->admin && (thd->clnt->in_sqlite_init == 0) &&
-        externalComdb2AuthenticateUserWrite) {
+        externalComdb2AuthenticateUserWrite && !clnt->current_user.bypass_auth) {
         clnt->authdata = get_authdata(clnt);
         char client_info[1024];
         snprintf(client_info, sizeof(client_info),

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -7334,6 +7334,7 @@ void *exec_trigger(char *spname)
     clnt.dbtran.mode = TRANLEVEL_SOSQL;
     clnt.sql = sql;
     clnt.dbtran.trans_has_sp = 1;
+    clnt.current_user.bypass_auth = 1;
 
     thread_memcreate(128 * 1024);
     struct sqlthdstate thd = {0};


### PR DESCRIPTION
We currently had it enabled only for auto analyze (for table reads), bypass for writes too.
