### PR TITLE
[8.0] {174899913}: Fixing sporadic ENOENT errors

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -80,6 +80,7 @@ int debug_switch_rep_verify_req_delay(void);       /* 0 */
 int debug_switch_test_trigger_deadlock(void);      /* 0 */
 int debug_switch_is_dbq_get_delayed(void);         /* 0 */
 int debug_switch_is_rep_rec_delayed(void);         /* 0 */
+int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */
@@ -88,4 +89,5 @@ int debug_switch_net_delay(void); /* 0 */
 void debug_switch_set_rep_verify_req_delay(int);
 void debug_switch_set_dbq_get_delayed(int);
 void debug_switch_set_rep_rec_delayed(int);
+int debug_switch_set_tmp_dir_sleep(int);
 #endif

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1401,21 +1401,45 @@ static int clear_csc2_files(void)
     return 0;
 }
 
-/* gets called single threaded during startup to initialize */
+/* gets called single threaded from init() during startup to initialize.
+   subsequent calls are thread-safe. */
 char *comdb2_get_tmp_dir(void)
 {
-    static char path[256];
+    static char path[PATH_MAX];
     static int once = 0;
+
+    if (debug_switch_get_tmp_dir_sleep()) {
+        once = 0;
+    }
 
     if (!once) {
         bzero(path, sizeof(path));
 
+        if (debug_switch_get_tmp_dir_sleep()) {
+            /* The line below partially copies the file path. The sorter will not
+               be able to use the incomplete path */
+            snprintf(path, PATH_MAX, "%s/t", thedb->basedir);
+            logmsg(LOGMSG_WARN, "partially copied path. waiting to copy full path\n");
+            sleep(5);
+            logmsg(LOGMSG_WARN, "copying full path\n");
+        }
+
         if (gbl_nonames)
-            snprintf(path, 256, "%s/tmp", thedb->basedir);
+            snprintf(path, PATH_MAX, "%s/tmp", thedb->basedir);
         else
-            snprintf(path, 256, "%s/%s.tmpdbs", thedb->basedir, thedb->envname);
+            snprintf(path, PATH_MAX, "%s/%s.tmpdbs", thedb->basedir, thedb->envname);
+
+        once = 1;
     }
 
+    while (debug_switch_get_tmp_dir_sleep() && path[strlen(path) - 1] != 't') {
+        logmsg(LOGMSG_WARN, "waiting for the other query to partially copy the path\n");
+        sleep(1);
+    }
+
+    if (debug_switch_get_tmp_dir_sleep()) {
+        debug_switch_set_tmp_dir_sleep(0);
+    }
     return path;
 }
 

--- a/tests/sorter_tmpdir_race.test/Makefile
+++ b/tests/sorter_tmpdir_race.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/sorter_tmpdir_race.test/expected
+++ b/tests/sorter_tmpdir_race.test/expected
@@ -1,0 +1,1 @@
+[SELECT randomblob(1024*512) AS b FROM generate_series(1,1024) ORDER BY b] failed with rc -5 unable to open database file

--- a/tests/sorter_tmpdir_race.test/runit
+++ b/tests/sorter_tmpdir_race.test/runit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+# Know where we'll be connecting to
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT comdb2_host()'`
+echo "host is $host"
+# Turn on test switch
+cdb2sql $dbnm --host $host 'EXEC PROCEDURE sys.cmd.send("get_tmp_dir_sleep 1")'
+cdb2sql $dbnm --host $host 'SELECT randomblob(1024*512) AS b FROM generate_series(1,1024) ORDER BY b' >/dev/null 2>actual &
+sleep 6
+cdb2sql $dbnm --host $host 'SELECT randomblob(1024*512) AS b FROM generate_series(1,1024) ORDER BY b' >/dev/null 2>actual
+diff actual expected

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -87,6 +87,7 @@ static struct debug_switches {
     int test_trigger_deadlock;
     int dbq_get_is_delayed;
     int rep_rec_is_delayed;
+    int get_tmp_dir_sleep;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -270,6 +271,7 @@ int init_debug_switches(void)
     register_debug_switch("force_file_version_to_fail", &debug_switches.force_file_version_to_fail);
     register_debug_switch("rep_verify_req_delay", &debug_switches.rep_verify_req_delay);
     register_debug_switch("test_trigger_deadlock", &debug_switches.test_trigger_deadlock);
+    register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
     return 0;
 }
 
@@ -535,4 +537,12 @@ void debug_switch_set_rep_rec_delayed(int val)
 int debug_switch_is_rep_rec_delayed(void)
 {
     return debug_switches.rep_rec_is_delayed;
+}
+int debug_switch_get_tmp_dir_sleep(void)
+{
+    return debug_switches.get_tmp_dir_sleep;
+}
+void debug_switch_set_tmp_dir_sleep(int val)
+{
+    debug_switches.get_tmp_dir_sleep = val;
 }


### PR DESCRIPTION
`comdb2_get_tmp_dir()` isn't thread-safe and may return an empty string. This causes the sqlite sorter to fail with ENOENT intermittently, when opening a temporary file.

This patch correctly sets the `once` flag in `comdb2_get_tmp_dir()`, to make it thread-safe for calls after the very first call.