### PR TITLE
Validate database directory on --create

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -538,7 +538,7 @@ static struct dbenv *read_lrl_file_int(struct dbenv *dbenv, const char *lrlname,
                                        int required)
 {
     FILE *ff;
-    char line[512] = {0}; // valgrind doesn't like sse42 instructions
+    char line[2048] = {0}; // valgrind doesn't like sse42 instructions
     struct lrlfile *lrlfile;
     struct read_lrl_option_type options = {
         .lineno = 0, .lrlname = lrlname, .dbname = dbenv->envname,

--- a/db/config.c
+++ b/db/config.c
@@ -57,6 +57,8 @@ extern const char *gbl_repoplrl_fname;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern char **sfuncs;
 extern char **afuncs;
+extern char **gbl_extra_dirents;
+extern int gbl_num_extra_dirents;
 static int gbl_nogbllrl; /* don't load /bb/bin/comdb2*.lrl */
 
 static int pre_read_option(char *, int);
@@ -1241,6 +1243,14 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_snapisol = 1;
         gbl_selectv_rangechk = 1;
+    } else if (tokcmp(tok, ltok, "extra_dirents") == 0) {
+        char *rest = tok + strlen("extra_dirents");
+        // Size passed to malloc is an upper bound on the number of tokens.
+        gbl_extra_dirents = malloc(sizeof(char *) * (strlen(rest)/2+1));
+
+        while ((tok = segtok(line, len, &st, &ltok)) != NULL && ltok > 0) {
+            gbl_extra_dirents[gbl_num_extra_dirents++] = tokdup(tok, ltok);
+        }
     } else if (tokcmp(tok, ltok, "mallocregions") == 0) {
         if ((strcmp(COMDB2_VERSION, "2") == 0) ||
             (strcmp(COMDB2_VERSION, "old") == 0)) {

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -62,6 +62,7 @@ extern int gbl_disable_skip_rows;
 extern int gbl_disable_sql_dlmalloc;
 extern int gbl_enable_berkdb_retry_deadlock_bias;
 extern int gbl_enable_cache_internal_nodes;
+extern char *gbl_extra_dirents_str;
 extern int gbl_partial_indexes;
 extern int gbl_sparse_lockerid_map;
 extern int gbl_spstrictassignments;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2145,6 +2145,10 @@ REGISTER_TUNABLE("longreq_log_freq_sec",
 REGISTER_TUNABLE("eventlog_nkeep", "Keep this many eventlog files (Default: 2)",
                  TUNABLE_INTEGER, &eventlog_nkeep, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("extra_direntries", "Ignore these entries in the db directory"
+                 " during initialization", TUNABLE_STRING, &gbl_extra_dirents_str,
+                 READONLY | READEARLY, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("waitalive_iterations",
                  "Wait this many iterations for a "
                  "socket to be usable.  (Default: 3)",

--- a/tests/dbcreate.test/Makefile
+++ b/tests/dbcreate.test/Makefile
@@ -5,6 +5,6 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=2m
 endif
 

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -47,6 +47,13 @@ ${COMDB2_EXE} --no-global-lrl $DB --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "No such file or directory" out | grep "logs:" || failexit "expected 'No such file or directory'"
 
 echo "Check 7"
+touch $TSTDBDIR/${DB}.lrl
+touch $TSTDBDIR/illegalfile
+${COMDB2_EXE} --no-global-lrl ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
+grep "Database directory failed validation" out || failexit "expected 'Database directory failed validation'"
+rm -rf $TSTDBDIR/*
+
+echo "Check 8"
 # for tables with current timestamp in them there was a bug where create db stmt will fail if nullsort comes after table in lrl
 # normally in_default for dt field should be null if table has current timestamp
 # but in this bug stype_is_null() (called from sql_field_default_trans) will not recognize null of in_default for dt field in table
@@ -58,15 +65,17 @@ echo "nullsort high" >> $TSTDBDIR/${DB}.lrl
 echo "schema { datetime dt dbstore=\"CURRENT_TIMESTAMP\" }" > $TSTDBDIR/t.csc2
 ${COMDB2_EXE} ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "Created database" out || failexit "expected 'Created database'"
+rm -rf $TSTDBDIR/*
 
-echo "Check 7.5"
+echo "Check 8.5"
 echo "table t t.csc2" > $TSTDBDIR/${DB}.lrl # this has to come before setting nullsort
 echo "nullsort low" >> $TSTDBDIR/${DB}.lrl # depending on machine this might fail instead of above
 echo "schema { datetime dt dbstore=\"CURRENT_TIMESTAMP\" }" > $TSTDBDIR/t.csc2
 ${COMDB2_EXE} ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
 grep "Created database" out || failexit "expected 'Created database'"
+rm -rf $TSTDBDIR/*
 
-echo "Check 8"
+echo "Check 9"
 touch $TSTDBDIR/${DB}.lrl
 df $TSTDBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" > $TSTDBDIR/${DB}.lrl 
 ${COMDB2_EXE} --no-global-lrl ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
@@ -77,7 +86,7 @@ echo "dir     $TSTDBDIR" >> $TSTDBDIR/${DB}.lrl
 mkdir -p $TSTDBDIR/var/log/cdb2
 mkdir -p $TMPDIR
 
-echo "Check 9, bring up db and query it"
+echo "Check 10, bring up db and query it"
 if [[ -n "$CLUSTER" ]]; then
     echo "Use comdb2makecluster --nocreate to copy to cluster"
 

--- a/tests/repopulate_queues.test/runit
+++ b/tests/repopulate_queues.test/runit
@@ -27,6 +27,7 @@ for i in `seq 1 5`; do
     rm -rf $DBDIR/$db.repop
     mkdir -p $DBDIR/$db.repop
     $COMDB2_EXE $db --repopnewlrl $DBDIR/$db.repop/$db.lrl --lrl $DBDIR/$db/$db.lrl
+    echo "extra_dirents $(ls $DBDIR/$db | tr "\n" " ")" >> $DBDIR/$db.repop/$db.lrl
     $COMDB2_EXE $db --create --lrl $DBDIR/$db.repop/$db.lrl
     $COMDB2_EXE $db --lrl $DBDIR/$db.repop/$db.lrl &
     sleep 10

--- a/tests/setup
+++ b/tests/setup
@@ -155,6 +155,7 @@ setup_db() {
     done >> ${LRL}
 
     mkdir -p $DBDIR/rulesets
+    echo "extra_dirents rulesets" >> ${LRL}
     for ruleset in $(ls *.ruleset 2>/dev/null); do
         cp $PWD/$ruleset $DBDIR/rulesets/
     done

--- a/tests/tools/comdb2makecluster
+++ b/tests/tools/comdb2makecluster
@@ -113,9 +113,9 @@ if [ $CREATEDB == 1 ] ; then
     cat >> $DBDIR/$DBNAME.lrl <<EOPTIONS
 name    $DBNAME
 dir     $DBDIR
+extra_dirents   tmp var
 
 EOPTIONS
-
 
     pmux_port=5105
     pmux_cmd='pmux -n'

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -331,6 +331,7 @@
 (name='externalauth', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='externalauth_connect', description='Check for externalauth only once on connect', type='BOOLEAN', value='OFF', read_only='N')
 (name='externalauth_warn', description='Warn instead of returning error in case of missing authdata', type='BOOLEAN', value='OFF', read_only='N')
+(name='extra_direntries', description='Ignore these entries in the db directory during initialization', type='STRING', value=NULL, read_only='Y')
 (name='fake_sc_replication_timeout', description='Fake a replication timeout on finalize schemachange. ', type='BOOLEAN', value='OFF', read_only='N')
 (name='fdb_io_error_retries', description='Number of retries for io error remsql', type='INTEGER', value='16', read_only='N')
 (name='fdb_io_error_retries_phase_1', description='Number of immediate retries; capped by fdb_io_error_retries', type='INTEGER', value='6', read_only='N')


### PR DESCRIPTION
The changes in this PR fail a `--create` if the database directory has an entry that does not fall into one of these categories:
1. Has a name ending with an [accepted extension](https://github.com/bloomberg/comdb2/pull/4376/files#diff-91454b1e6e0271e4ab1900d4829d866b37f219f943ed9864fe0f2f23e4cc91e2R265).
2. Has a name that was explicitly whitelisted with the [`extra_direntries` tunable](https://github.com/bloomberg/comdb2/pull/4376/files#diff-c6ffbd9fb3d6b94c5143be665b399991db0791d8b00bf2c3209a3d210daf2c7aR2148)
3. Has a name that is one of '.' or '..'

The motivation for disallowing preexisting direntries on initialization is to remove ambiguity as to whether files in a database directory were created by the running db or by a previous db that lived in the same directory.