### PR TITLE
{174982521}: Stop leaking the fdb->users counter

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8703,7 +8703,11 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
              */
             rdlock_schema_lk();
             assert(pCur->vdbe == (Vdbe*)clnt->dbtran.pStmt);
-            newlocks_rc = sqlite3LockStmtTables(clnt->dbtran.pStmt);
+            /* remote table locks aren't berkeleydb locks. release them here */
+            if (clnt->dbtran.nLockedRemTables > 0)
+                newlocks_rc = sqlite3UnlockStmtTablesRemotes(clnt);
+            if (newlocks_rc == 0)
+                newlocks_rc = sqlite3LockStmtTables(clnt->dbtran.pStmt);
             unlock_schema_lk();
 
             if (newlocks_rc) {

--- a/tests/remsql.test/runit
+++ b/tests/remsql.test/runit
@@ -132,6 +132,10 @@ SELECT 'inserted 6 records from remote to remote; remote should have 12 records'
 SELECT COUNT(*) FROM LOCAL_${dbname}.chunky
 EOF
 
+###### Verify that we do not leak fdb users counter ######
+cdb2sql --cdb2cfg ${cdb2config} $dbname default "CREATE TABLE yet_another_table(a INTEGER)"
+cdb2sql --cdb2cfg ${CDB2_CONFIG} $srcdbname default "SELECT * FROM LOCAL_${dbname}.yet_another_table"
+
 # validate results
 testcase_output=$(cat output.actual)
 expected_output=$(cat output.expected)


### PR DESCRIPTION
A chunk remote transaction leaks the fdb->users counter, and may block queries against undiscovered remote tables, as shown in the following statements.

```
SET TRANSACTION CHUNK 1
BEGIN
INSERT INTO remote.tbl_1 VALUES (1),(2),(3)
COMMIT -- this transaction would leak the fdb users counter
SELECT * FROM remote.tbl_2 -- never seen tbl_2 before; this query would hang
```