### PR TITLE
Archive old files on db --create

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -44,6 +44,7 @@ extern int gbl_waitalive_iterations;
 extern int gbl_allow_lua_print;
 extern int gbl_allow_lua_dynamic_libs;
 extern int gbl_allow_pragma;
+extern int gbl_archive_on_init;
 extern int gbl_berkdb_epochms_repts;
 extern int gbl_pmux_route_enabled;
 extern int gbl_allow_user_schema;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -68,6 +68,11 @@ REGISTER_TUNABLE("analyze_tbl_threads",
                  "generating index statistics. (Default: 5)",
                  TUNABLE_INTEGER, &analyze_max_table_threads, READONLY, NULL,
                  NULL, analyze_set_max_table_threads, NULL);
+REGISTER_TUNABLE("archive_on_init",
+                 "Archive files with database extensions in the database directory "
+                 "at the time of init. (Default: ON)",
+                 TUNABLE_BOOLEAN, &gbl_archive_on_init, READONLY, NULL,
+                 NULL, NULL, NULL);
 REGISTER_TUNABLE("badwrite_intvl", NULL, TUNABLE_INTEGER,
                  &gbl_test_badwrite_intvl, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("bbenv", NULL, TUNABLE_BOOLEAN, &gbl_bbenv,

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -765,6 +765,7 @@ These options are toggable at start time of the server.
 |largepages | 0 | Enables large pages.
 |dedicated_network_suffixes       |            | Suffix to append to node name when server has extra network interfaces that comdb2 is able to use to ensure resiliency when losing one network, example: if eth1 and eth2 are extra network cards on the server and the dns hostnames assigned to the ips of the respective cards are node1_eth1 and node1_eth2, then the option here should be set as: dedicated_network_suffixes _eth1 _eth2
 |remsql_whitelist databases       |            | If this option is set, when another DB makes a connection to this DB, we will only allown processing of that request if that other DB's name is in the whitelist, otherwise it will receive an error, example: `remsql_whitelist databases db1 db2 db3`.
+|archive_on_init                  | ON         | Archive preexisting database files on init.
 
 
 ### Runtime options

--- a/tests/dbcreate.test/runit
+++ b/tests/dbcreate.test/runit
@@ -12,6 +12,7 @@ source ${TESTSROOTDIR}/tools/runit_common.sh
 i=1
 DB=$DBNAME
 TSTDBDIR=$DBDIR
+SAVEDIR=$TSTDBDIR/savs
 
 echo "Check 1"
 ${COMDB2_EXE} --no-global-lrl --create $DB --lrl $TSTDBDIR/${DB}.lrl &> out
@@ -77,7 +78,52 @@ echo "dir     $TSTDBDIR" >> $TSTDBDIR/${DB}.lrl
 mkdir -p $TSTDBDIR/var/log/cdb2
 mkdir -p $TMPDIR
 
-echo "Check 9, bring up db and query it"
+echo "Check 9 -- archive old files on create"
+
+move="oldfile.dta oldfile.index oldfile.datas1 oldfile.blobs1"
+dontmove="oldfile.data oldfile.inde oldfile.indexs1 ${DB}.lrl oldfile.cfg oldfile.blob1"
+
+gohome=$(pwd)
+
+cd $TSTDBDIR
+touch $move
+touch $dontmove
+
+echo "tag ondisk { int i }" >> $TSTDBDIR/q.csc2
+echo "name    $DB" >> $TSTDBDIR/${DB}.lrl
+echo "dir     $TSTDBDIR" >> $TSTDBDIR/${DB}.lrl
+echo "table q q.csc2" >> $TSTDBDIR/${DB}.lrl
+
+${COMDB2_EXE} ${DB} --create --dir $TSTDBDIR --lrl $TSTDBDIR/${DB}.lrl &> out
+
+cd $SAVEDIR
+t_rc=$?
+if (( t_rc != 0 )); then
+    failexit "expected $SAVEDIR to exist"
+fi
+
+ls $move
+t_rc=$?
+if (( t_rc != 0 )); then
+    failexit "expected to find '$move' in $SAVEDIR"
+fi
+
+cd $TSTDBDIR
+ls $dontmove
+t_rc=$?
+if (( t_rc != 0 )); then
+    failexit "Expected to find '$dontmove' in $TSTDBDIR"
+fi
+
+ls q_*.data*
+t_rc=$?
+if (( t_rc != 0 )); then
+    failexit "Expected to find table q's data files"
+fi
+
+cd $gohome
+
+echo "Check 10, bring up db and query it"
 if [[ -n "$CLUSTER" ]]; then
     echo "Use comdb2makecluster --nocreate to copy to cluster"
 
@@ -113,7 +159,7 @@ COMDB2_UNITTEST=0 CLEANUPDBDIR=1 $TESTSROOTDIR/unsetup 1 > $TESTDIR/logs/${DBNAM
 
 
 if [[ -n "$CLUSTER" ]]; then
-    echo "Check 10, Use comdb2makecluster bring up a new db"
+    echo "Check 11, Use comdb2makecluster bring up a new db"
 
     ${TESTSROOTDIR}/tools/comdb2makecluster --dir $TSTDBDIR $DB $CLUSTER
     rc=$?

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -57,6 +57,7 @@
 (name='appsockpool.mint', description='Minimum number of threads in the pool.', type='INTEGER', value='1', read_only='N')
 (name='appsockpool.stacksz', description='Thread stack size.', type='INTEGER', value='***', read_only='N')
 (name='appsockslimit', description='Start warning on this many connections to the database.', type='INTEGER', value='500', read_only='N')
+(name='archive_on_init', description='Archive files with database extensions in the database directory at the time of init. (Default: ON)', type='BOOLEAN', value='ON', read_only='Y')
 (name='asof_thread_drain_limit', description='How many entries at maximum should the BEGIN TRANSACTION AS OF thread drain per run.', type='INTEGER', value='0', read_only='N')
 (name='asof_thread_poll_interval_ms', description='For how long should the BEGIN TRANSACTION AS OF thread sleep after draining its work queue.', type='INTEGER', value='500', read_only='N')
 (name='autoanalyze', description='Set to enable auto-analyze.', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
The changes in this PR archive database files in the database directory at the time of `--create`. A file is a database file if it ends with one of the following extensions: `".dta", ".index", ".datas*", ".blobs*"`. Note that `.datas*` and `.blobs*` contain a wildcard. Files are archived in the directory given by `get_savdir()`.

The motivation for disallowing preexisting direntries on initialization is to remove ambiguity as to whether files in a database directory were created by the running db or by a previous db that lived in the same directory. #4376 contains an alternative approach to solve this problem.