### PR TITLE
workaround stock sqlite token count limit

### DIFF
--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -2799,11 +2799,13 @@ filter_opt(A) ::= FILTER LP WHERE expr(X) RP.  { A = X; }
 ** number that TK_SPAN is no more than 255, or else the new tokens must
 ** appear after this line.
 */
+%ifndef SQLITE_BUILDING_FOR_COMDB2
 %include {
 #if TK_SPAN>255
 # error too many tokens in the grammar
 #endif
 }
+%endif
 
 /*
 ** The TK_SPACE and TK_ILLEGAL tokens must be the last two tokens.  The

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -2594,7 +2594,11 @@ typedef int ynVar;
 ** allocated, regardless of whether or not EP_Reduced is set.
 */
 struct Expr {
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  u16 op;                 /* Operation performed by this node */
+#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   u8 op;                 /* Operation performed by this node */
+#endif 
   char affinity;         /* The affinity of the column or 0 if not a column */
   u32 flags;             /* Various flags.  EP_* See below */
   union {


### PR DESCRIPTION
exclude token count check as we've hit stock sqlite limit. Also expand Expr.op field to u16 since we now have more than 255 tokens

