### PR TITLE
sqlwriter flush

### DIFF
--- a/net/sqlwriter.c
+++ b/net/sqlwriter.c
@@ -342,8 +342,11 @@ static int sql_pack_heartbeat(struct sqlwriter *writer)
 
 static void sql_trickle_int(struct sqlwriter *writer, int fd)
 {
-    if (!writer->wr_continue || writer->bad || writer->done) {
+    if (writer->bad || writer->done) {
         sql_disable_heartbeat(writer);
+        return;
+    }
+    if (!writer->wr_continue) {
         return;
     }
     const int outstanding = evbuffer_get_length(writer->wr_buf);
@@ -380,14 +383,15 @@ static void sql_trickle_cb(int fd, short what, void *arg)
 static void sql_heartbeat_cb(int fd, short what, void *arg)
 {
     struct sqlwriter *writer = arg;
-    if (pthread_mutex_trylock(&writer->wr_lock) == 0) {
+    if (pthread_mutex_trylock(&writer->wr_lock)) return;
+    if (writer->wr_continue) {
         int len = evbuffer_get_length(writer->wr_buf);
         time_t now = time(NULL);
         if (len || difftime(now, writer->sent_at) >= min_hb_time) {
             event_add(writer->heartbeat_trickle_ev, NULL);
         }
-        Pthread_mutex_unlock(&writer->wr_lock);
     }
+    Pthread_mutex_unlock(&writer->wr_lock);
 }
 
 void sql_reset(struct sqlwriter *writer)


### PR DESCRIPTION
`sql_flush` clears `wr_continue` flags. Intention is to prevent heartbeat from trying to flush while sql-thread is doing the same. 

Due to the bug, heartbeat is disabled altogether if `sql_trickle_cb` happens to run at the same.

After sql-thread is done flushing it goes back to running the query. If there are no more rows produced in the next 5secs, the client will time out since heartbeats are no longer being sent.