### PR TITLE
{175173722}: Fixing file-version-cache after RENAME

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -591,9 +591,9 @@ static int form_file_name_ex(
         buflen -= offset;
     }
 
-    if (is_data_file && bdb_state->dtavers[file_num] == 0)
+    if (is_data_file)
         bdb_state->dtavers[file_num] = version_num;
-    else if (!is_data_file && bdb_state->ixvers[file_num] == 0)
+    else
         bdb_state->ixvers[file_num] = version_num;
 
     return orig_buflen - buflen;

--- a/tests/diskspace_nollmeta.test/expected
+++ b/tests/diskspace_nollmeta.test/expected
@@ -9,3 +9,4 @@
 (name='tbl1', shardname='$0_828B7B36', sizemb=17)
 (name='tbl1', shardname='$1_AABB76F6', sizemb=3)
 (name='tbl1', shardname='$2_13E6EE2D', sizemb=3)
+(out='table         tbl2 sz      16.68MB   5% (dta 2.83MB, ix0 1.57MB, ix1 1.78MB, blob0 1024.00KB, blob1 1024.00KB, blob2 8.50MB)')

--- a/tests/diskspace_nollmeta.test/runit
+++ b/tests/diskspace_nollmeta.test/runit
@@ -67,4 +67,10 @@ cdb2sql -m ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('stat size
 cdb2sql -m ${CDB2_OPTIONS} $dbnm default "ALTER TABLE tbl1 PARTITIONED BY TIME PERIOD 'daily' RETENTION 3 start '2024-01-01'"
 cdb2sql -m ${CDB2_OPTIONS} $dbnm default "SELECT name, shardname, size/1000000 as sizemb FROM comdb2_timepartshards" | grep tbl1 >>actual
 
+#### Test 9: rename
+cdb2sql -m ${CDB2_OPTIONS} $dbnm default "ALTER TABLE tbl1 PARTITIONED BY NONE"
+cdb2sql -m ${CDB2_OPTIONS} $dbnm default "ALTER TABLE tbl1 RENAME TO tbl2"
+sleep 5
+cdb2sql -m ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('stat size')" | grep 'tbl1\|tbl2' >>actual
+
 diff actual expected


### PR DESCRIPTION
The file-version cache would not update after a rename. This patch fixes it.