### PR TITLE
Fix queuedb_rollover test

### DIFF
--- a/tests/queuedb_rollover.test/qdb1.sh
+++ b/tests/queuedb_rollover.test/qdb1.sh
@@ -21,7 +21,7 @@ for ((i=1;i<9600;++i)); do
 done | cdb2sql $SP_OPTIONS - >/dev/null
 
 ./qdb_cons.sh nop0 1 9600
-./qdb_cons.sh log1 1 9600
+./qdb_cons.sh log1 1 9600 $SP_HOST
 
 for ((i=1;i<96;++i)); do
     cdb2sql ${SP_OPTIONS} "exec procedure dml2($i)" 2> /dev/null

--- a/tests/queuedb_rollover.test/qdb_cons.sh
+++ b/tests/queuedb_rollover.test/qdb_cons.sh
@@ -3,16 +3,24 @@
 sp=$1
 from=$2
 to=$3
+host=$4
 logfile="/tmp/queuedb_rollover.$sp"
+
+if [ -z "$host" ];
+then
+    OPTIONS=$SP_OPTIONS
+else
+    OPTIONS="--host $host $SP_OPTIONS"
+fi
 
 rm -f $logfile $logfile.rerun
 
 for ((i = $from; i < $to; ++i)); do
     echo "exec procedure $sp()"
-done | cdb2sql $SP_OPTIONS - > /dev/null 2> $logfile
+done | cdb2sql $OPTIONS - > /dev/null 2> $logfile
 
 #Rerun to compensate for failure due to schemachange
 n=$(cat $logfile | wc -l)
 for ((i = 0; i < $n; ++i)); do
     echo "exec procedure $sp()"
-done | tee $logfile.rerun | cdb2sql $SP_OPTIONS - > /dev/null
+done | tee $logfile.rerun | cdb2sql $OPTIONS - > /dev/null


### PR DESCRIPTION
Addresses #4388 

The test was failing because a stored procedure was getting executed on the wrong node. The changes in this PR run the stored procedure on the correct node.