### PR TITLE
Make rebuild work for partitions that are created using "create .. partitioned" syntax.

### DIFF
--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -1121,3 +1121,5 @@ cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, 
 (out='table  $1_45259338 sz      64.00KB   1% (dta 64.00KB) partition teststatsize')
 (out='table  $2_91201505 sz      64.00KB   1% (dta 64.00KB) partition teststatsize')
 (out='temp files         sz     128.00KB   2% (tmptbls 0B, sqlsorters 0B, blkseqs 128.00KB, others 0B)')
+TEST 17
+Test REBUILD partition

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -534,6 +534,21 @@ $cmd "alter table teststatsize partitioned by time period 'daily' retention 3 st
 echo $cmd "exec procedure sys.cmd.send('stat size')"
 $cmd "exec procedure sys.cmd.send('stat size')" | egrep -v "GRAND|FILESYSTEM|log files" >> $OUT 2>&1
 
+header 17 "Test REBUILD partition"
+echo $cmd "create table t18(a int) partitioned by time period 'daily' retention 2 start '20240101T'"
+$cmd "create table t18(a int) partitioned by time period 'daily' retention 2 start '20240101T'"
+if (( $? != 0 )) ; then
+    echo "FAILURE to create partition t18"
+    exit 1
+fi
+
+echo $cmd "rebuild t18"
+$cmd "rebuild t18"
+if (( $? != 0 )) ; then
+    echo "FAILURE to rebuild partition t18"
+    exit 1
+fi
+
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual
 


### PR DESCRIPTION
Simple patch, use one shard to retrieve csc2 and make rebuild work.  
NOTE: rebuild work for partitions added to existing tables, because first tables are aliased and share the same name as the partition.