### PR TITLE
Option to disallow Anonymous ID over pmux secure port

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -81,6 +81,7 @@ int debug_switch_test_trigger_deadlock(void);      /* 0 */
 int debug_switch_is_dbq_get_delayed(void);         /* 0 */
 int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
+int debug_switch_ignore_null_auth_func(void);      /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -41,6 +41,7 @@
 #define COMPOSITE_TUNABLE_SEP '.'
 
 extern int gbl_waitalive_iterations;
+extern int gbl_allow_anon_id_for_spmux;
 extern int gbl_allow_lua_print;
 extern int gbl_allow_lua_dynamic_libs;
 extern int gbl_allow_pragma;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -32,6 +32,9 @@ REGISTER_TUNABLE("allow_lua_print", "Enable to allow stored "
                                     "DB's stdout. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_allow_lua_print, READONLY | NOARG, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("allow_anon_id_for_spmux",
+                 "Allow anonymous identities over connections routed from the secure pmux port", TUNABLE_INTEGER,
+                 &gbl_allow_anon_id_for_spmux, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("allow_lua_dynamic_libs",
                  "Enable to allow use of dynamic "
                  "libraries (Default: off)",

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -2146,7 +2146,6 @@ static int _fdb_send_open_retries(struct sqlclntstate *clnt, fdb_t *fdb,
     int tran_flags = 0;
     sqlite3 *db;
     const char *sql;
-
     if (clnt->thd != NULL && (db = clnt->thd->sqldb) != NULL && db->pVdbe != NULL && db->pVdbe->fdb_warn_this_op != 0) {
         /* we only need one trace */
         sql = clnt->sql ? clnt->sql : "unavailable";

--- a/db/sql.h
+++ b/db/sql.h
@@ -858,6 +858,7 @@ struct sqlclntstate {
     uint8_t queue_me;
     uint8_t fail_dispatch;
     uint8_t in_sqlite_init; /* clnt is in sqlite init phase when this is set */
+    uint8_t secure;         /* clnt is forwarded from pmux over the secure port, */
 
     int where_trace_flags;
 

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -89,7 +89,6 @@ struct newsql_appdata_evbuffer {
 
     unsigned initial : 1; /* New connection or called newsql_reset */
     unsigned local : 1;
-    unsigned secure : 1;
 
     struct sqlwriter *writer;
     struct ssl_data *ssl_data;
@@ -589,7 +588,7 @@ static void process_query(struct newsql_appdata_evbuffer *appdata)
 
     /* If the connection is forwarded from a secure pmux port,
      * both IAM and TLS must be enabled on the database. */
-    if (appdata->secure) {
+    if (clnt->secure) {
         int has_externalauth = gbl_uses_externalauth || gbl_uses_externalauth_connect;
         int ssl_able = SSL_IS_ABLE(gbl_client_ssl_mode);
         if (!has_externalauth || !ssl_able) {
@@ -599,7 +598,7 @@ static void process_query(struct newsql_appdata_evbuffer *appdata)
         }
     }
 
-    if (appdata->secure || SSL_IS_PREFERRED(gbl_client_ssl_mode)) {
+    if (clnt->secure || SSL_IS_PREFERRED(gbl_client_ssl_mode)) {
         switch(ssl_check(appdata, have_ssl)) {
         case 1: goto read;
         case 2: goto err;
@@ -1102,10 +1101,10 @@ static void newsql_setup_clnt_evbuffer(struct appsock_handler_arg *arg, int admi
 
     clnt->admin = admin;
     clnt->force_readonly = arg->is_readonly;
+    clnt->secure = arg->secure;
     appdata->base = arg->base;
     appdata->initial = 1;
     appdata->local = local;
-    appdata->secure = arg->secure;
     appdata->fd = arg->fd;
     appdata->rd_buf = arg->rd_buf;
     appdata->rd_hdr_ev = event_new(appdata->base, arg->fd, EV_READ, rd_hdr, appdata);

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -385,6 +385,8 @@ int comdb2PrepareSC(Vdbe *v, Parse *pParse, int int_arg,
     return comdb2prepareNoRows(v, pParse, int_arg, arg, func, freeFunc);
 }
 
+extern int gbl_allow_anon_id_for_spmux;
+int reject_anon_id(struct sqlclntstate *);
 int (*externalComdb2AuthenticateUserDDL)(void*, const char *tablename) = NULL;
 int (*externalComdb2CheckOpAccess)(void *) = 0;
 
@@ -394,10 +396,15 @@ static int comdb2AuthenticateUserDDL(const char *tablename)
 
      if (gbl_uses_externalauth && externalComdb2AuthenticateUserDDL && !clnt->admin) {
          clnt->authdata = get_authdata(clnt);
-         if (gbl_externalauth_warn && !clnt->authdata)
-            logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",
-                   clnt->argv0 ? clnt->argv0 : "???", clnt->conninfo.pid, clnt->conninfo.node);
-         else if (externalComdb2AuthenticateUserDDL(clnt->authdata, tablename)) {
+         if (!clnt->authdata) {
+             if (clnt->secure && !gbl_allow_anon_id_for_spmux) {
+                 return reject_anon_id(clnt);
+             }
+             if (gbl_externalauth_warn) {
+                logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",
+                       clnt->argv0 ? clnt->argv0 : "???", clnt->conninfo.pid, clnt->conninfo.node);
+             }
+         } else if (externalComdb2AuthenticateUserDDL(clnt->authdata, tablename)) {
              ATOMIC_ADD64(gbl_num_auth_denied, 1);
              return SQLITE_AUTH;
          }
@@ -437,10 +444,15 @@ static int comdb2CheckOpAccess(void) {
     struct sqlclntstate *clnt = get_sql_clnt();
     if (gbl_uses_externalauth && externalComdb2CheckOpAccess && !clnt->admin) {
          clnt->authdata = get_authdata(clnt);
-         if (gbl_externalauth_warn && !clnt->authdata) {
-            logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",
-                   clnt->argv0 ? clnt->argv0 : "???", clnt->conninfo.pid, clnt->conninfo.node);
-            return SQLITE_OK;
+         if (!clnt->authdata) {
+             if (clnt->secure && !gbl_allow_anon_id_for_spmux) {
+                 return reject_anon_id(clnt);
+             }
+             if (gbl_externalauth_warn) {
+                logmsg(LOGMSG_INFO, "Client %s pid:%d mach:%d is missing authentication data\n",
+                       clnt->argv0 ? clnt->argv0 : "???", clnt->conninfo.pid, clnt->conninfo.node);
+                return SQLITE_OK;
+             }
          } else if (externalComdb2CheckOpAccess(clnt->authdata)) {
              ATOMIC_ADD64(gbl_num_auth_denied, 1);
              return SQLITE_AUTH;

--- a/tests/pmux_secure_route.test/expected
+++ b/tests/pmux_secure_route.test/expected
@@ -1,2 +1,5 @@
 [select 1] failed with rc -1 cdb2_run_statement_typed_int: Cannot connect to db
 (2=2)
+(name='sqlite_stat1')
+(name='sqlite_stat4')
+[SELECT name FROM sqlite_master ORDER BY name] failed with rc -106 authentication data not found

--- a/tests/pmux_secure_route.test/runit
+++ b/tests/pmux_secure_route.test/runit
@@ -27,6 +27,15 @@ cdb2sql --cdb2cfg $DBDIR/5106.cfg $dbnm --host localhost "exec procedure sys.cmd
 # externalauth is enabled. connections routed from 5104 should be accepted
 cdb2sql --cdb2cfg $DBDIR/5104.cfg $dbnm --host localhost "select 2" >>output 2>&1
 
+# turn on this debug tunable since we do not have an authentication plugin in the open source build
+cdb2sql --cdb2cfg $DBDIR/5106.cfg $dbnm --host localhost "exec procedure sys.cmd.send('ignore_null_auth_func 1')"
+# turn on anonymous id. verify that we're accepted
+cdb2sql --cdb2cfg $DBDIR/5106.cfg $dbnm --host localhost "exec procedure sys.cmd.send('allow_anon_id_for_spmux 1')"
+cdb2sql --cdb2cfg $DBDIR/5104.cfg $dbnm --host localhost "SELECT name FROM sqlite_master ORDER BY name" >>output 2>&1
+# now turn off anonymous id. verify that we're rejected
+cdb2sql --cdb2cfg $DBDIR/5106.cfg $dbnm --host localhost "exec procedure sys.cmd.send('allow_anon_id_for_spmux 0')"
+cdb2sql --cdb2cfg $DBDIR/5104.cfg $dbnm --host localhost "SELECT name FROM sqlite_master ORDER BY name" >>output 2>&1
+
 kill -9 $dbpid
 kill -9 $pmuxpid
 diff expected output

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -20,6 +20,7 @@
 (name='additional_deferms', description='Wait-fudge to ensure that a replicant has gone incoherent.', type='INTEGER', value='0', read_only='N')
 (name='admin_mode', description='Fail non-admin client requests (Default: False)', type='BOOLEAN', value='OFF', read_only='N')
 (name='all_incoherent', description='Master pretends nodes are incoherent.', type='BOOLEAN', value='OFF', read_only='N')
+(name='allow_anon_id_for_spmux', description='Allow anonymous identities over connections routed from the secure pmux port', type='INTEGER', value='0', read_only='N')
 (name='allow_broken_datetimes', description='Allow broken datetimes', type='BOOLEAN', value='ON', read_only='N')
 (name='allow_key_typechange', description='allow_key_typechange', type='BOOLEAN', value='OFF', read_only='N')
 (name='allow_lua_dynamic_libs', description='Enable to allow use of dynamic libraries (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -88,6 +88,7 @@ static struct debug_switches {
     int dbq_get_is_delayed;
     int rep_rec_is_delayed;
     int get_tmp_dir_sleep;
+    int ignore_null_auth_func;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -272,6 +273,7 @@ int init_debug_switches(void)
     register_debug_switch("rep_verify_req_delay", &debug_switches.rep_verify_req_delay);
     register_debug_switch("test_trigger_deadlock", &debug_switches.test_trigger_deadlock);
     register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
+    register_debug_switch("ignore_null_auth_func", &debug_switches.ignore_null_auth_func);
     return 0;
 }
 
@@ -545,4 +547,8 @@ int debug_switch_get_tmp_dir_sleep(void)
 void debug_switch_set_tmp_dir_sleep(int val)
 {
     debug_switches.get_tmp_dir_sleep = val;
+}
+int debug_switch_ignore_null_auth_func(void)
+{
+    return debug_switches.ignore_null_auth_func;
 }


### PR DESCRIPTION
This patch adds options to disallow foreign-db queries and the Anonymous Identity, over client connections forwarded from the pmux secure port.