### PR TITLE
Remove unused var if use sys alloc

### DIFF
--- a/berkdb/env/env_method.c
+++ b/berkdb/env/env_method.c
@@ -160,7 +160,9 @@ static pthread_once_t berkdb_blobmem_once = PTHREAD_ONCE_INIT;
 static void
 __berkdb_blobmem_init_once(void)
 {
+#ifndef USE_SYS_ALLOC
 	extern size_t gbl_blobmem_cap;
+#endif
 	berkdb_blobmem = comdb2bma_create(0, gbl_blobmem_cap, "berkdb/blob", NULL);
 	if (berkdb_blobmem == NULL) {
 		__db_err(dbenv_being_initialized,


### PR DESCRIPTION
Would error otherwise if compile with -DCOMDB2_PER_THREAD_MALLOC=OFF