### PR TITLE
pstack: Set last pstack time earlier [PORTED #4438]

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2193,8 +2193,9 @@ static void bdb_appsock(netinfo_type *netinfo, SBUF2 *sb)
 extern int gbl_pstack_self;
 void pstack_self(void)
 {
-    if (!gbl_pstack_self)
-        return;
+    if (!gbl_pstack_self) return;
+
+    gettimeofday(&last_timer_pstack, NULL);
 
     char cmd[256];
     char output[20] = "/tmp/pstack.XXXXXX";
@@ -2234,7 +2235,6 @@ void pstack_self(void)
     gbl_logmsg_ctrace = old;
     fclose(out);
     unlink(output);
-    gettimeofday(&last_timer_pstack, NULL);
 }
 
 static void panic_func(DB_ENV *dbenv, int errval)

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -504,7 +504,7 @@ static void check_timers(int dummyfd, short what, void *arg)
     if (!need_pstack) return;
     timersub(&now, &last_timer_pstack, &diff);
     if (diff.tv_sec < gbl_timer_pstack_interval) return;
-    logmsg(LOGMSG_WARN, "%s: Generating pstack\n", __func__);
+    logmsg(LOGMSG_WARN, "%s: Last pstack:%lds. Generating pstack\n", __func__, diff.tv_sec);
     pthread_t t;
     Pthread_create(&t, NULL, do_pstack, NULL);
     Pthread_detach(t);


### PR DESCRIPTION
Should prevent `check_timers` from generating pstack right after long `rep_process_message` does (which suspends process for long enough for check_timers to trigger.)