### PR TITLE
{175177284}

### DIFF
--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -3485,6 +3485,7 @@ struct AuthContext {
 #define OPFLAG_FORCE_VERIFY   0x100
 #define OPFLAG_IGNORE_FAILURE 0x200
 #define OPFLAG_MKREC_COMDB2   0x400
+#define OPFLAG_SKIPSCAN       0x800
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 /*

--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -4797,7 +4797,6 @@ case OP_SeekGT: {       /* jump, in3, group */
     assert( nField>0 );
     r.pKeyInfo = pC->pKeyInfo;
     r.nField = (u16)nField;
-
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
     /* Reset cooked state that open cursor
      * optimization for 'or' clause would have left us with */
@@ -4830,13 +4829,18 @@ case OP_SeekGT: {       /* jump, in3, group */
       goto abort_due_to_error;
     }
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
-    setCookCol(pC, r.nField);
-#else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+    /* If we're walking an index backwards as part of skip scan
+       don't use the cookFields optimization
+     */
+    if(!(oc==OP_SeekLT && (pOp->p5 & OPFLAG_SKIPSCAN)!=0)) {
+        setCookCol(pC, r.nField);
+    }
+#else //!defined(SQLITE_BUILDING_FOR_COMDB2)
     if( eqOnly && r.eqSeen==0 ){
       assert( res!=0 );
       goto seek_not_found;
     }
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+#endif /* !defined(SQLITE_BUILDING_FOR_COMDB2) */
   }
   pC->deferredMoveto = 0;
   pC->cacheStatus = CACHE_STALE;

--- a/sqlite/src/wherecode.c
+++ b/sqlite/src/wherecode.c
@@ -714,6 +714,9 @@ static int codeAllEqualityTerms(
     j = sqlite3VdbeAddOp0(v, OP_Goto);
     pLevel->addrSkip = sqlite3VdbeAddOp4Int(v, (bRev?OP_SeekLT:OP_SeekGT),
                             iIdxCur, 0, regBase, nSkip);
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    sqlite3VdbeChangeP5(v, OPFLAG_SKIPSCAN);
+#endif
     VdbeCoverageIf(v, bRev==0);
     VdbeCoverageIf(v, bRev!=0);
     sqlite3VdbeJumpHere(v, j);

--- a/tests/skipscan.test/out4.expected
+++ b/tests/skipscan.test/out4.expected
@@ -1,0 +1,9 @@
+[DROP TABLE IF EXISTS t] rc 0
+[CREATE TABLE t(a int, b int, c int)] rc 0
+[CREATE INDEX foo ON t(B,C)] rc 0
+[SET TRANSACTION CHUNK 100] rc 0
+[BEGIN] rc 0
+[INSERT INTO t(a,b,c) select value, value/10000, value from generate_series(1,100000)] rc 0
+[COMMIT] rc 0
+[ANALYZE t] rc 0
+[SELECT c,b,a from t where c > 10000000 ORDER BY B DESC] rc 0

--- a/tests/skipscan.test/runit
+++ b/tests/skipscan.test/runit
@@ -72,3 +72,19 @@ if ! diff out1.txt out3.txt > /dev/null ; then
     failexit "out3 should be same as out1"
 fi
 
+# {175177284}
+cat << EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - >out4.txt 2>&1
+DROP TABLE IF EXISTS t
+CREATE TABLE t(a int, b int, c int)\$\$
+CREATE INDEX foo ON t(B,C)
+SET TRANSACTION CHUNK 100
+BEGIN 
+INSERT INTO t(a,b,c) select value, value/10000, value from generate_series(1,100000)
+COMMIT
+ANALYZE t
+SELECT c,b,a from t where c > 10000000 ORDER BY B DESC
+EOF
+
+if ! diff out4.txt out4.expected > /dev/null ; then
+    failexit "expected empty result set but got rows back!"
+fi


### PR DESCRIPTION
This patch fixes an issue with skipscan when we're walking an index backwards. 

While walking a index backwards (as opposed to walking an index forwards), SkipScan avoids the extra seek step. 

Example plans: 

with " order by desc " clause 
(Plan='  7 [        Last]: Move cursor [2] on index "T_IX" of table "t" to last entry. If no entries exist, go to 21 (cmnt:begin skip-scan on $T_IX_9F1DF81A)')
(Plan='  8 [        Goto]: Go to 10')
(Plan='  9 [      SeekLT]: Move cursor [2] to largest entry < R1. If no such records exist, go to 21')
(Plan=' 10 [      Column]:     R1 = "b" from cursor [2] on index "T_IX" of table "t"  (cmnt:b)')
(Plan=' 11 [    Affinity]:     Convert R1 into integer (affinity: K)')
(Plan=' 12 [     Integer]:     R2 = 10000000')
(Plan=' 13 [       IdxLE]:         Jump to 20 if cursor [2] <= R1..R2')
(Plan=' 14 [DeferredSeek]:         Move cursor [0] to rowid of index cursor [2]')
(Plan=' 15 [      Column]:         R3..R5 ["c", "b",  (from cursor 2)"a" (from cursor 0)] (count:3)')
(Plan=' 18 [   ResultRow]:         Row available at R3..R5')
(Plan=' 19 [        Prev]:     Move cursor [2] to previous entry. If entry exists, go to 13')
(Plan=' 20 [        Goto]: Go to 9 (cmnt:next skip-scan on $T_IX_9F1DF81A)')

versus 

with "order by" clause 
(Plan='  7 [      Rewind]: Move cursor [2] to first entry. If no entries exist, go to 22 (cmnt:begin skip-scan on $T_IX_9F1DF81A)')
(Plan='  8 [        Goto]: Go to 10')
(Plan='  9 [      SeekGT]: Move cursor [2] to smallest entry > R1. If no such records exist, go to 22')
(Plan=' 10 [      Column]:     R1 = "b" from cursor [2] on index "T_IX" of table "t"  (cmnt:b)')
(Plan=' 11 [     Integer]:     R2 = 10000000')
(Plan=' 12 [    Affinity]:     Convert R1 into integer (affinity: K)')
**(Plan=' 13 [      SeekGT]:     Move cursor [2] to smallest entry > R1..R2. If no such records exist, go to 21')**
(Plan=' 14 [       IdxGT]:         Jump to 21 if cursor [2] > R1')
(Plan=' 15 [DeferredSeek]:         Move cursor [0] to rowid of index cursor [2]')
(Plan=' 16 [      Column]:         R3..R5 ["c", "b",  (from cursor 2)"a" (from cursor 0)] (count:3)')
(Plan=' 19 [   ResultRow]:         Row available at R3..R5')
(Plan=' 20 [        Next]:     Move cursor [2] to next entry. If entry exists, go to 14')
(Plan=' 21 [        Goto]: Go to 9 (cmnt:next skip-scan on $T_IX_9F1DF81A)')

The extra Seek step while skip scanning forwards ensures that the cookedFields are set correctly. The lack thereof during a backwards skipscan results in an incorrect optimization which inturn results in a comparison between sqlite and raw format values for a field. This produces incorrect results. 

This patch tracks when we're performing a backwards skipscan on an index and avoids the optimization for this scenario