### PR TITLE
8.0 Add set statement to force fdb_push_redirect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ plugins/.gitignore
 plugins/bb-plugins
 /.idea/*
 /cmake-build*
+/.vscode/*
+.clang-format
+/.devcontainer/*

--- a/db/dohast.c
+++ b/db/dohast.c
@@ -955,7 +955,8 @@ int comdb2_check_push_remote(Parse *pParse)
     ast_t *ast = pParse->ast;
     dohsql_node_t *node;
 
-    if (!gbl_fdb_push_remote)
+    GET_CLNT;
+    if (!gbl_fdb_push_remote && !clnt->force_fdb_push_remote && !clnt->force_fdb_push_redirect)
         return 0;
 
     if (ast && ast->unsupported)

--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -65,8 +65,12 @@ int fdb_push_run(Parse *pParse, dohsql_node_t *node)
     fdb_push_connector_t *push = NULL;
     struct Db *pDb = &pParse->db->aDb[node->remotedb];
 
-    logmsg(LOGMSG_DEBUG, "CALLING FDB PUSH RUN on query %s (gbl_fdb_push_remote=%d)\n", clnt->sql, gbl_fdb_push_remote);
-    if (!gbl_fdb_push_remote)
+    logmsg(LOGMSG_DEBUG,
+           "CALLING FDB PUSH RUN on query %s (gbl_fdb_push_remote=%d) (clnt force remote? %d) (clnt force redirect? "
+           "%d) (clnt can redirect? %d)\n",
+           clnt->sql, gbl_fdb_push_remote, clnt->force_fdb_push_remote, clnt->force_fdb_push_redirect,
+           clnt->can_redirect_fdb);
+    if (!gbl_fdb_push_remote && !clnt->force_fdb_push_remote && !clnt->force_fdb_push_redirect)
         return -1;
 
     if (clnt->disable_fdb_push)
@@ -228,8 +232,12 @@ int handle_fdb_push(struct sqlclntstate *clnt, struct errstat *err)
         assert(class);
     }
 
-    if (gbl_fdb_push_redirect_foreign && clnt->can_redirect_fdb) {
-        logmsg(LOGMSG_DEBUG, "CALLING FDB PUSH REDIRECT on query %s\n", clnt->sql);
+    if ((gbl_fdb_push_redirect_foreign || clnt->force_fdb_push_redirect) && clnt->can_redirect_fdb &&
+        !clnt->force_fdb_push_remote) {
+        logmsg(LOGMSG_DEBUG,
+               "CALLING FDB PUSH REDIRECT on query %s (redirect tunable on %d) (clnt force remote? %d) (clnt force "
+               "redirect? %d)\n",
+               clnt->sql, gbl_fdb_push_redirect_foreign, clnt->force_fdb_push_remote, clnt->force_fdb_push_redirect);
         // tell cdb2api to run query directly on foreign db
         // send back db, tier, flag
         // NOTE: Cost will not work for this
@@ -244,7 +252,11 @@ int handle_fdb_push(struct sqlclntstate *clnt, struct errstat *err)
         write_response(clnt, RESPONSE_REDIRECT_FOREIGN, foreign_db, cdb2api_policy_flag);
         goto reset;
     }
-    logmsg(LOGMSG_DEBUG, "CALLING FDB PUSH on query %s (redirect tunable on? %d) (clnt can redirect? %d)\n", clnt->sql, gbl_fdb_push_redirect_foreign, clnt->can_redirect_fdb);
+    logmsg(LOGMSG_DEBUG,
+           "CALLING FDB PUSH on query %s (redirect tunable on? %d) (clnt force remote? %d) (clnt force redirect? %d) "
+           "(clnt can redirect? %d)\n",
+           clnt->sql, gbl_fdb_push_redirect_foreign, clnt->force_fdb_push_remote, clnt->force_fdb_push_redirect,
+           clnt->can_redirect_fdb);
 
     char *conf = getenv("CDB2_CONFIG");
     if (conf)

--- a/db/sql.h
+++ b/db/sql.h
@@ -930,6 +930,8 @@ struct sqlclntstate {
     unsigned request_fp: 1;
     unsigned dohsql_disable: 1;
     unsigned can_redirect_fdb: 1;
+    unsigned force_fdb_push_redirect : 1; // this should only be set if can_redirect_fdb is true
+    unsigned force_fdb_push_remote : 1;
 
     char *sqlengine_state_file;
     int sqlengine_state_line;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5432,6 +5432,8 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     clnt->flat_col_vals = 0;
     clnt->request_fp = 0;
     clnt->can_redirect_fdb = 0;
+    clnt->force_fdb_push_redirect = 0;
+    clnt->force_fdb_push_remote = 0;
     free(clnt->prev_cost_string);
     clnt->prev_cost_string = NULL;
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1912,6 +1912,26 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
             } else if (strncasecmp(sqlstr, "sockbplog", 10) == 0) {
                 init_bplog_socket(clnt);
                 rc = 0;
+            } else if (strncasecmp(sqlstr, "force_fdb_push", 14) == 0) {
+                sqlstr += 14;
+                sqlstr = skipws(sqlstr);
+                if (strncasecmp(sqlstr, "off", 3) == 0) {
+                    clnt->force_fdb_push_redirect = 0;
+                    clnt->force_fdb_push_remote = 0;
+                } else if (strncasecmp(sqlstr, "redirect", 8) == 0) {
+                    if (!clnt->can_redirect_fdb) {
+                        snprintf(err, sizeof(err), "client does not support fdb push redirect");
+                        rc = ii + 1;
+                    } else {
+                        clnt->force_fdb_push_redirect = 1;
+                        clnt->force_fdb_push_remote = 0;
+                    }
+                } else if (strncasecmp(sqlstr, "remote", 6) == 0) {
+                    clnt->force_fdb_push_remote = 1;
+                    clnt->force_fdb_push_redirect = 0;
+                } else {
+                    rc = ii + 1;
+                }
             } else {
                 rc = ii + 1;
             }

--- a/tests/fdb_push.test/output.log
+++ b/tests/fdb_push.test/output.log
@@ -43,3 +43,18 @@ Make sure disabled for client transactions
 (id=3, b1='Hello3')
 (id=4, b1='Hello4')
 (1=1)
+Test set force_fdb_push redirect
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+Test set force_fdb_push remote
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+Test set force_fdb_push off
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')

--- a/tests/fdb_push.test/output.log.fdbpushredirect
+++ b/tests/fdb_push.test/output.log.fdbpushredirect
@@ -45,3 +45,18 @@ Make sure disabled for client transactions
 (id=3, b1='Hello3')
 (id=4, b1='Hello4')
 (1=1)
+Test set force_fdb_push redirect
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+Test set force_fdb_push remote
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')
+Test set force_fdb_push off
+(id=1, b1='Hello1')
+(id=2, b1='Hello2')
+(id=3, b1='Hello3')
+(id=4, b1='Hello4')

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -115,6 +115,25 @@ select 1
 commit
 EOF
 
+# test set options
+echo "Test set force_fdb_push redirect" >> $output
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+set force_fdb_push redirect
+select * from LOCAL_${a_remdbname}.t order by id
+EOF
+
+echo "Test set force_fdb_push remote" >> $output
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+set force_fdb_push remote
+select * from LOCAL_${a_remdbname}.t order by id
+EOF
+
+echo "Test set force_fdb_push off" >> $output
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+set force_fdb_push off
+select * from LOCAL_${a_remdbname}.t order by id
+EOF
+
 if [[ $a_dbname == "srcdbfdbpushredirectgenerated"* ]]; then
     active_output=output.log.fdbpushredirect
 else


### PR DESCRIPTION
Add option set force_fdb_push with options redirect, remote, off to force one of these to be used, even if tunable is off

Note that if fdb push redirect + remote tunables are on, but set force_fdb_push off is run, the tunable still takes precedence and runs with the option on

8.0 version of https://github.com/bloomberg/comdb2/pull/4440