### PR TITLE
Set filetype after alloc to prevent assert failure

### DIFF
--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -10203,6 +10203,7 @@ static int bdb_process_each_entry_resumable(bdb_state_type *bdb_state, tran_type
         searchkey = key;
         searchkeylen = klen;
         *resume = calloc(1, LLMETA_IXLEN);
+        memcpy((*resume), key, klen);
     } else {
         searchkey = *resume;
         searchkeylen = LLMETA_IXLEN;


### PR DESCRIPTION
This fixes an assert in oldfile cleanup code.