### PR TITLE
Resubmit https://github.com/bloomberg/comdb2/pull/4367 with shorter branch name

### DIFF
--- a/bdb/attr.h
+++ b/bdb/attr.h
@@ -477,8 +477,6 @@ DEF_ATTR(SC_DETACHED, sc_detached, BOOLEAN, 0,
          "Run schema changes in detached mode--just return seed to client.")
 DEF_ATTR(SC_ASYNC_MAXTHREADS, sc_async_maxthreads, QUANTITY, 5,
          "Max number of threads for asynchronous schema changes.")
-DEF_ATTR(SC_DONE_SAME_TRAN, sc_done_same_tran, BOOLEAN, 1,
-         "Write scdone record in the same logical transaction as DDLs.")
 DEF_ATTR(USE_VTAG_ONDISK_VERMAP, use_vtag_ondisk_vermap, BOOLEAN, 1,
          "Use vtag_to_ondisk_vermap conversion function from vtag_to_ondisk.")
 DEF_ATTR(UDP_DROP_DELTA_THRESHOLD, udp_drop_delta_threshold, QUANTITY, 10,

--- a/db/config.c
+++ b/db/config.c
@@ -419,7 +419,6 @@ static char *legacy_options[] = {
     "setattr ENABLE_SEQNUM_GENERATIONS 0",
     "setattr MASTER_LEASE 0",
     "setattr NET_SEND_GBLCONTEXT 1",
-    "setattr SC_DONE_SAME_TRAN 0",
     "sqlsortermaxmmapsize 268435456",
     "unnatural_types 1",
     "wal_osync 1",

--- a/db/views_sqlite.c
+++ b/db/views_sqlite.c
@@ -45,7 +45,7 @@ int views_sqlite_update(timepart_views_t *views, sqlite3 *db,
         view = views->views[i];
 
         /* check if this exists?*/
-        tab = sqlite3FindTableCheckOnly(db, view->name, NULL);
+        tab = sqlite3FindTableCheckOnlyNoAlias(db, view->name, NULL);
         if (tab) {
             /* paranoia */
             if (tab->pSelect == NULL) {

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -1021,7 +1021,6 @@ configurations:
     setattr ENABLE_SEQNUM_GENERATIONS 0
     setattr MASTER_LEASE 0
     setattr NET_SEND_GBLCONTEXT 1
-    setattr SC_DONE_SAME_TRAN 0
     unnatural_types 1
     usenames
 ```

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -1081,9 +1081,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
     bdb_handle_reset_tran(new_bdb_handle, transac, iq->sc_close_tran);
     iq->sc_closed_files = 1;
 
-    if (!s->same_schema ||
-        (!IS_FASTINIT(s) &&
-         BDB_ATTR_GET(thedb->bdb_attr, SC_DONE_SAME_TRAN) == 0)) {
+    if (!s->same_schema) {
         /* reliable per table versioning */
         if (gbl_disable_tpsc_tblvers && s->fix_tp_badvers) {
             rc = table_version_set(transac, db->tablename,

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -329,12 +329,13 @@ static int do_finalize(ddl_t func, struct ireq *iq,
 {
     int rc, bdberr = 0;
     tran_type *tran = input_tran;
+    tran_type *ltran, *ptran;
 
-    if (tran == NULL) {
-        rc = trans_start_sc(iq, NULL, &tran);
+    if (input_tran == NULL) {
+        rc = get_schema_change_txns(iq, &ltran, &ptran, &tran, 1);
         if (rc) {
-            sc_errf(s, "Failed to start finalize transaction\n");
-            return rc;
+            sc_errf(s, "Failed to start finalize transaction %d\n", -rc);
+            return -1;
         }
     }
     uint64_t sc_nrecs = 0;
@@ -344,19 +345,14 @@ static int do_finalize(ddl_t func, struct ireq *iq,
     rc = func(iq, s, tran);
 
     if (rc) {
-        if (input_tran == NULL) {
-            trans_abort(iq, tran);
-            mark_schemachange_over(s->tablename);
-            sc_del_unused_files(s->db);
-        }
+        if (input_tran == NULL)
+            goto abort;
         return rc;
     }
 
     if ((rc = mark_schemachange_over_tran(s->tablename, tran))) {
-        if (input_tran == NULL) {
-            trans_abort(iq, tran);
-            sc_del_unused_files(s->db);
-        }
+        if (input_tran == NULL)
+            goto abort;
         return rc;
     }
 
@@ -377,32 +373,47 @@ static int do_finalize(ddl_t func, struct ireq *iq,
                    "Forcing replication error table %s '%s' for tran %p\n",
                    bdb_get_scdone_str(s->done_type), s->tablename, tran);
         }
-        if (s->keep_locked) {
-            rc = trans_commit(iq, tran, gbl_myhostname);
-        } else {
-            rc = trans_commit_adaptive(iq, tran, gbl_myhostname);
-        }
-        if (debug_switch_fake_sc_replication_timeout())
-            rc = -1;
-        if (rc && !replication_only_error_code(rc)) {
-            sc_errf(s, "Failed to commit finalize transaction\n");
-            return rc;
-        }
 
-        rc = llog_scdone_rename_wrapper(thedb->bdb_env, s, NULL, &bdberr);
+        rc = llog_scdone_rename_wrapper(thedb->bdb_env, s, tran, &bdberr);
         if (rc || bdberr != BDBERR_NOERROR) {
             sc_errf(s, "Failed to send scdone rc=%d bdberr=%d\n", rc, bdberr);
-            return -1;
+            rc = -1;
+            goto abort;
+        } else {
+            if (s->keep_locked) {
+                rc = trans_commit(iq, tran, gbl_myhostname);
+            } else {
+                rc = trans_commit_adaptive(iq, tran, gbl_myhostname);
+            }
+            if (debug_switch_fake_sc_replication_timeout())
+                rc = -1;
+            if (rc && !replication_only_error_code(rc)) {
+                sc_errf(s, "Failed to commit finalize transaction\n");
+                trans_abort_logical(iq, ltran, NULL, 0, NULL, 0);
+                return rc;
+            }
+
+            rc = trans_commit_logical(iq, ltran, gbl_myhostname, 0, 1, NULL, 0, NULL, 0);
+            if (rc) {
+                abort();
+            }
         }
+
         sc_del_unused_files(s->db);
-    } else if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_DONE_SAME_TRAN)) {
+    } else {
         int bdberr = 0;
-        rc = llog_scdone_rename_wrapper(thedb->bdb_env, s, input_tran, &bdberr);
+        rc = llog_scdone_rename_wrapper(thedb->bdb_env, s, tran, &bdberr);
         if (rc || bdberr != BDBERR_NOERROR) {
             sc_errf(s, "Failed to send scdone rc=%d bdberr=%d\n", rc, bdberr);
             return -1;
         }
     }
+    return rc;
+abort:
+    trans_abort(iq, tran);
+    trans_abort_logical(iq, ltran, NULL, 0, NULL, 0);
+    mark_schemachange_over(s->tablename);
+    sc_del_unused_files(s->db);
     return rc;
 }
 

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -479,6 +479,10 @@ int llog_scdone_rename_wrapper(bdb_state_type *bdb_state,
                                struct schema_change_type *s, tran_type *tran,
                                int *bdberr);
 
+int get_schema_change_txns(struct ireq *iq, tran_type **logi,
+                           tran_type **ptran, tran_type **tran,
+                           int force_phys);
+
 const char *schema_change_kind(struct schema_change_type *s);
 
 #endif

--- a/sqlite/src/sqliteInt.h
+++ b/sqlite/src/sqliteInt.h
@@ -4298,6 +4298,7 @@ void sqlite3ExprIfFalseDup(Parse*, Expr*, int, int);
 Table *sqlite3FindTable(sqlite3*,const char*, const char*);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 Table *sqlite3FindTableCheckOnly(sqlite3*,const char*, const char*);
+Table *sqlite3FindTableCheckOnlyNoAlias(sqlite3*,const char*, const char*);
 Table *sqlite3FindTableByAnalysisLoad(sqlite3*,const char*, const char*);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 #define LOCATE_VIEW    0x01

--- a/tests/ddl_no_csc2.test/t08_view.expected
+++ b/tests/ddl_no_csc2.test/t08_view.expected
@@ -16,7 +16,3 @@
 (name='aaa', definition='CREATE VIEW aaa AS SELECT 1')
 (tablename='sqlite_stat1')
 (tablename='sqlite_stat4')
-(test='SC did not work properly with sc_done_same_tran disabled')
-(value='ON')
-(1=1)
-[SELECT * FROM v1] failed with rc -3 no such table: v1

--- a/tests/ddl_no_csc2.test/t08_view.sql
+++ b/tests/ddl_no_csc2.test/t08_view.sql
@@ -28,15 +28,3 @@ DROP VIEW aaa;
 
 SELECT * FROM comdb2_tables;
 SELECT * FROM comdb2_views;
-
-SELECT 'SC did not work properly with sc_done_same_tran disabled' as test;
-# sc_done_same_tran should be enabled by default
-SELECT value FROM comdb2_tunables WHERE name = 'sc_done_same_tran';
-# disable sc_done_same_tran
-PUT TUNABLE sc_done_same_tran 0
-CREATE VIEW v1 AS SELECT 1;
-SELECT * FROM v1;
-DROP VIEW v1;
-SELECT * FROM v1;
-# re-enable sc_done_same_tran
-PUT TUNABLE sc_done_same_tran 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -852,7 +852,6 @@
 (name='sc_del_unused_files_threshold', description='', type='INTEGER', value='30000', read_only='Y')
 (name='sc_delay_verify_error', description='', type='INTEGER', value='100', read_only='N')
 (name='sc_detached', description='Run schema changes in detached mode--just return seed to client.', type='BOOLEAN', value='OFF', read_only='N')
-(name='sc_done_same_tran', description='Write scdone record in the same logical transaction as DDLs.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_force_delay', description='Force schemachange to delay after every record inserted - to have sc backoff.', type='BOOLEAN', value='OFF', read_only='N')
 (name='sc_hist_keep', description='Number of items to keep in llmeta for comdb2_sc_history sys table.', type='INTEGER', value='20', read_only='N')
 (name='sc_history_max_rows', description='Max number of rows returned in comdb2_sc_history (Default: 1000)', type='INTEGER', value='1000', read_only='N')


### PR DESCRIPTION
Breaks rm.

From the original PR:

3 things:
- avoid reading llmeta during views update (lock inversion prevention) (ported https://github.com/bloomberg/comdb2/pull/4365 to main)
- remove code and tunable sc_done_same_tran (only on going forward)
- fix scdone for comdb2sc and partition rollouts, where it is sent outside finalizing txn

