### PR TITLE
Change chunking logic in comdb2_files

### DIFF
--- a/sqlite/ext/comdb2/files.c
+++ b/sqlite/ext/comdb2/files.c
@@ -182,6 +182,8 @@ static void set_chunk_size(db_file_t *f, size_t chunk_size)
             chunk_size /= page_size;
             chunk_size *= page_size;
         }
+    } else if (chunk_size == 0) {
+        chunk_size = MAX_BUFFER_SIZE;
     }
 
     dbfile_set_chunk_size(f->info, chunk_size);

--- a/tests/comdb2_files.test/runit
+++ b/tests/comdb2_files.test/runit
@@ -28,6 +28,17 @@ function runtest {
 		exit $rc
 	fi
 
+	echo "Verifying that comdb2_files handles large files"
+	exp_size=$(( 24 * 1024*1024))
+	truncate -s $exp_size $dir/largefile
+	res_size=$(cdb2sql -tabs $dbnm local "select sum(size) from comdb2_files where filename like '%largefile%'")
+	rc=$?
+	if (( (rc != 0) || (res_size != exp_size) ));
+	then
+		echo "Exiting"
+		exit 1
+	fi
+
 	echo "Verifying that comdb2_files fails on a broken symlink"
 	ln -s idonutexist $dir/link
 	! cdb2sql $dbnm local 'select count(*) from comdb2_files' > /dev/null


### PR DESCRIPTION
When the size of a file chunk is greater than the [maximum buffer size](https://github.com/bloomberg/comdb2/blob/759c61366f3f31cc152cc4f5ac96be5a9546b864/archive/ar_wrap.c#L66) used by the `comdb2_files`, then [this buffer writer function](https://github.com/bloomberg/comdb2/blob/759c61366f3f31cc152cc4f5ac96be5a9546b864/archive/ar_wrap.c#L442) is called multiple times (the call occurs [here](https://github.com/bloomberg/comdb2/blob/759c61366f3f31cc152cc4f5ac96be5a9546b864/archive/ar_wrap.c#L442)). Each of these calls overwrites the chunk's output buffer with the partial write value, so only the last partial write is visible to the client.

The changes in this PR make the maximum chunk size equal to the maximum buffer size so that a chunk is always written in one go. This removes the issue with partial writes described above.