### PR TITLE
Do not keep views lock for the duration of a serial tpt schema change.

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -949,8 +949,9 @@ static int verify_sc_resumed_for_all_shards(void *obj, void *arg)
     sc_arg.view_name = tpt_sc->viewname;
     sc_arg.s = tpt_sc->s;
     /* start new sc for shards that were not resumed */
+    sc_arg.check_extra_shard = 1;
     timepart_foreach_shard(tpt_sc->viewname, verify_sc_resumed_for_shard,
-                           &sc_arg, -1);
+                           &sc_arg);
     assert(sc_arg.s != tpt_sc->s);
     tpt_sc->s = sc_arg.s;
     return 0;

--- a/tests/timepart_trunc.test/serialsc.testopts
+++ b/tests/timepart_trunc.test/serialsc.testopts
@@ -1,0 +1,1 @@
+dohsql_sc_max_threads 1


### PR DESCRIPTION
Currently the master node cannot create new sqlite engines during a partition schema change if there are too many shards (tunable dohsql_sc_max_threads, default 8).  There is a lock reversal (views lock read mode, running inline alter schema change which requires exclusive schema lock; this is opposite an sql thread that gets a read schema lock followed by a read views lock),
It impacts large partitions running an alter schema change the same time with rollout.

Re: 175478973