### PR TITLE
Address memory leak

### DIFF
--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -1183,6 +1183,9 @@ static int add_cmacc_stmt(dbtable *tbl, int alt, int allow_ull,
     for(i=0; i < nschs_indx; i++) {
         add_tag_schema(tbl->tablename, schs_indx[i]);
     }
+
+    free(schs);
+    free(schs_indx);
     return 0;
 
 err:


### PR DESCRIPTION
```
==5321== 64 bytes in 3 blocks are definitely lost in loss record 1,440 of 3,163
==5321==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==5321==    by 0x28BBE4: add_cmacc_stmt (macc_glue.c:1040)
==5321==    by 0x28CBFE: create_new_dbtable (macc_glue.c:67)
==5321==    by 0x259D48: create_version_schema.isra.0 (tag.c:6139)
==5321==    by 0x25A048: load_csc2_versions (tag.c:6203)
==5321==    by 0x25A048: load_csc2_versions (tag.c:6190)
==5321==    by 0x13DBC6: llmeta_load_tables_older_versions.part.0 (comdb2.c:2106)
==5321==    by 0x141E9F: llmeta_load_tables_older_versions (comdb2.c:2080)
==5321==    by 0x141E9F: init (comdb2.c:4200)
==5321==    by 0x132321: main (comdb2.c:5728)
```