### PR TITLE
{175182248}: Fixing sbuf2free race

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11280,13 +11280,12 @@ void disconnect_remote_db(const char *protocol, const char *dbname, const char *
         logmsg(LOGMSG_ERROR, "%p: Donating socket for %s\n", (void *)pthread_self(), socket_type);
 
     /* this is used by fdb sql for now */
-    socket_pool_donate_ext(socket_type, fd, IOTIMEOUTMS / 1000, 0,
-                           0, NULL, NULL);
+    if (sbuf2free(sb) == 0)
+        socket_pool_donate_ext(socket_type, fd, IOTIMEOUTMS / 1000, 0, 0, NULL, NULL);
 
     /*fprintf(stderr, "%s: donated socket %d to sockpool %s\n", __func__, fd,
      * socket_type);*/
 
-    sbuf2free(sb);
     *psb = NULL;
 }
 


### PR DESCRIPTION
An SSL connection must be shut down before its underlying TCP socket can be donated to the sockpool. Otherwise another sockpool user could attempt to reuse the socket, while SSL_shutdown is in progress, causing the function to hang.

cdb2api already handles it correctly. This patch implements the same logic in the fdb subsystem.