### PR TITLE
Do not keep views lock for the duration of a serial tpt schema change.

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -6112,8 +6112,7 @@ void freedb_int(dbtable *db, dbtable *replace)
         db->dbs_idx = dbs_idx;
         db->sqlaliasname = sqlaliasname;
         db->timepartition_name = timepartition_name;
-    } else
-        free(db);
+    }
 }
 
 void free_db_and_replace(dbtable *db, dbtable *newdb)

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -81,14 +81,8 @@ void free_schema_change_type(struct schema_change_type *s)
 {
     if (!s)
         return;
-    if (s->newcsc2) {
-        free(s->newcsc2);
-        s->newcsc2 = NULL;
-    }
-    if (s->sc_convert_done) {
-        free(s->sc_convert_done);
-        s->sc_convert_done = NULL;
-    }
+    free(s->newcsc2);
+    free(s->sc_convert_done);
 
     free_dests(s);
     Pthread_mutex_destroy(&s->mtx);

--- a/tests/timepart_trunc.test/serialsc.testopts
+++ b/tests/timepart_trunc.test/serialsc.testopts
@@ -1,0 +1,1 @@
+dohsql_sc_max_threads 1


### PR DESCRIPTION
This is a rework of https://github.com/bloomberg/comdb2/pull/4472 for main branch.  It is more aggressive in releasing the view lock for every shard schema change.  

Re: 175478973