### PR TITLE
Address out-of-date types in hatest.c

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -6366,6 +6366,10 @@ static int set_up_ssl_params(cdb2_hndl_tp *hndl)
     return 0;
 }
 
+#ifdef my_ssl_eprintln
+#undef my_ssl_eprintln
+#endif
+
 #define my_ssl_eprintln(fmt, ...)                                              \
     ssl_eprintln("cdb2api", "%s: " fmt, __func__, ##__VA_ARGS__)
 

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ include_directories(
   ${PROJECT_SOURCE_DIR}/datetime
   ${PROJECT_SOURCE_DIR}/mem
   ${PROJECT_BINARY_DIR}/protobuf
+  ${PROJECT_SOURCE_DIR}/util
   ${PROTOBUF-C_INCLUDE_DIR}
   ${SQLite3_INCLUDE_DIRS}
   ${OPENSSL_INCLUDE_DIR}


### PR DESCRIPTION
`hatest.c` was using a copy of the definitions of `cdb2_hndl` and `sbuf2`. The real definition of `cdb2_hndl` changed, which broke the hatest tool since it would cast `cdb2_hndl` structs to its own out-of-date type.

The changes in this PR make `hatest.c` use the real definitions of `cdb2_hndl` and `sbuf2` instead of dummy definitions.