### PR TITLE
A few simple fixes for physical replicants

### DIFF
--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -39,6 +39,7 @@ const char *aa_lastepoch_str = "autoanalyze_lastepoch";
 const char *aa_needs_analyze_time_str = "autoanalyze_needs_analyze_time";
 static volatile int auto_analyze_running = 0;
 int gbl_debug_aa;
+extern int gbl_is_physical_replicant;
 
 /* ctime_r no-new-line */
 static char *ctime_r_nnl(time_t *t, char *out)
@@ -501,7 +502,7 @@ void *auto_analyze_main(void *unused)
 
 void autoanalyze_after_fastinit(char *table)
 {
-    if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_AUTOANALYZE) == 0)
+    if (gbl_is_physical_replicant || bdb_attr_get(thedb->bdb_attr, BDB_ATTR_AUTOANALYZE) == 0)
         return;
     pthread_t analyze;
     char *tblname = strdup(table); // will be freed in auto_analyze_table()

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -156,6 +156,7 @@ extern int gbl_all_prepare_leak;
 extern int gbl_flush_on_prepare;
 extern int gbl_abort_on_unset_ha_flag;
 extern int gbl_abort_on_unfound_txn;
+extern int gbl_abort_on_ufid_mismatch;
 extern int gbl_write_dummy_trace;
 extern int gbl_abort_on_incorrect_upgrade;
 extern int gbl_poll_in_pg_free_recover;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1420,10 +1420,10 @@ REGISTER_TUNABLE("abort_on_unset_ha_flag",
                  "Abort in snap_uid_retry if ha is unset. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_abort_on_unset_ha_flag, INTERNAL, NULL,
                  NULL, NULL, NULL);
-REGISTER_TUNABLE("write_dummy_trace",
-                 "Print trace when doing a dummy write. (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_write_dummy_trace, INTERNAL, NULL, NULL,
-                 NULL, NULL);
+REGISTER_TUNABLE("abort_on_ufid_mismatch", "Abort in dbreg-open on ufid mismatch. (Default: on)", TUNABLE_BOOLEAN,
+                 &gbl_abort_on_ufid_mismatch, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("write_dummy_trace", "Print trace when doing a dummy write. (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_write_dummy_trace, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("seed_genid", "Set genid-seed in hex for genid48 test.",
                  TUNABLE_STRING, NULL, EXPERIMENTAL | INTERNAL,
                  next_genid_value, NULL, genid_seed_update, NULL);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2210,7 +2210,8 @@ void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc,
             if (last_long_request_epoch != comdb2_time_epoch()) {
                 last_long_request_epoch = comdb2_time_epoch();
 
-                if (long_request_out != default_out && long_request_thresh && logger->clnt && !can_consume(logger->clnt)) {
+                if (long_request_out != default_out && long_request_thresh && logger->clnt &&
+                    !can_consume(logger->clnt) && !logger->clnt->force_readonly) {
 
                     if (logger->iq && logger->iq->sorese) {
                         char *sqlinfo = osql_sess_info(logger->iq->sorese);

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -1073,11 +1073,17 @@ int get_analyze_abort_requested()
     return analyze_abort_requested;
 }
 
+extern int gbl_is_physical_replicant;
 
 /* analyze 'table' */
 int analyze_table(char *table, SBUF2 *sb, int scale, int override_llmeta,
                   int bypass_auth)
 {
+    if (gbl_is_physical_replicant) {
+        logmsg(LOGMSG_ERROR, "%s: Analyze invalid on physical replicant\n", __func__);
+        return -1;
+    }
+
     if (check_stat1(sb))
         return -1;
 

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -317,6 +317,7 @@ rowlocks_deadlock_trace|off |Prints deadlock trace in phys.c
 mask_internal_tunables|on|When enabled, comdb2_tunables system table would not list INTERNAL tunables
 lightweight_rename|off|When enabled, rename will add an alias instead of completely changing the table name
 utxnid_log|on|When enabled, 8-byte transaction IDs will be written to log records.
+abort_on_ufid_mismatch|on|Abort on open if the on-disk ufid doesn't match the ufid in the transaction log.
 
 #### `sqllogger` commands
 

--- a/plugins/reversesql/reversesql.c
+++ b/plugins/reversesql/reversesql.c
@@ -209,8 +209,9 @@ static int handle_reversesql_request(comdb2_appsock_arg_t *arg) {
         if (gbl_revsql_allow_command_exec == 0) {
             logmsg(LOGMSG_USER, "%s:%d Command execution over reverse connection is prohibited!\n",
                    __func__, __LINE__);
+        } else {
+            execute_rev_command(remote_dbname, fd_str, command);
         }
-        execute_rev_command(remote_dbname, fd_str, command);
         goto done;
     }
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -8,6 +8,7 @@
 (name='abort_on_in_use_rqid', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='abort_on_invalid_context', description='abort_on_invalid_context', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_on_replicant_log_write', description='Abort if replicant is writing to logs', type='BOOLEAN', value='OFF', read_only='N')
+(name='abort_on_ufid_mismatch', description='Abort in dbreg-open on ufid mismatch. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='abort_on_unfound_txn', description='Abort if we cannot find a txn for a thread.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='abort_ufid_open', description='Abort ufid_open when applying a transaction', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_zero_lsn_memp_put', description='Abort on memp_fput pages with zero headers', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
* Abort in open if file-ufid is different from log-ufid
* Disable analyze up-front for physical replicants
* Force-readonly handles ignored for long-requests