### PR TITLE
Reduce log spew from commit lsn map

### DIFF
--- a/berkdb/dbinc/db_attr.h
+++ b/berkdb/dbinc/db_attr.h
@@ -43,6 +43,7 @@ BERK_DEF_ATTR(cache_lc_trace_misses, "Print a message on cache miss", BERK_ATTR_
 BERK_DEF_ATTR(cache_lc_check, "Check LC cache system on every transaction", BERK_ATTR_TYPE_BOOLEAN, 0)
 BERK_DEF_ATTR(cache_lc_memlimit, "Limit total memory used by LC cache (0 = unlimited).", BERK_ATTR_TYPE_INTEGER, 2097152)
 BERK_DEF_ATTR(cache_lc_memlimit_tran, "Limit per transaction memory used by LC cache", BERK_ATTR_TYPE_INTEGER, 1048576)
+BERK_DEF_ATTR(commit_map_debug, "Produce debug output in commit lsn map", BERK_ATTR_TYPE_BOOLEAN, 0)
 BERK_DEF_ATTR(consolidate_dbreg_ranges, "Combine adjacent dbreg ranges for same file", BERK_ATTR_TYPE_BOOLEAN, 1)
 BERK_DEF_ATTR(max_latch, "Size of latch array", BERK_ATTR_TYPE_INTEGER, 200000)
 BERK_DEF_ATTR(max_latch_lockerid, "Size of latch lockerid array", BERK_ATTR_TYPE_INTEGER, 10000)

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -630,25 +630,32 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 	LOGFILE_TXN_LIST *to_delete;
 	UTXNID_TRACK *txn;
 	UTXNID* elt;
-	int ret, alloc_txn, alloc_delete_list;
+	int ret, alloc_txn, alloc_delete_list, commit_map_debug;
 
 	txmap = dbenv->txmap;
+	commit_map_debug = dbenv->attr.commit_map_debug;
 	alloc_txn = 0;
 	alloc_delete_list = 0;
 	ret = 0;
 
-	logmsg(LOGMSG_DEBUG, "Trying to add utxnid %"PRIu64" commit lsn %"PRIu32":%"PRIu32" to the map\n", utxnid, commit_lsn.file, commit_lsn.offset);
+	if (commit_map_debug) {
+		logmsg(LOGMSG_DEBUG, "Trying to add utxnid %"PRIu64" commit lsn %"PRIu32":%"PRIu32" to the map\n", utxnid, commit_lsn.file, commit_lsn.offset);
+	}
 
 	/* Don't add transactions that commit at the zero LSN */
 	if (IS_ZERO_LSN(commit_lsn)) {
-		logmsg(LOGMSG_DEBUG, "Transaction %"PRIu64" has a zero commit lsn. Not adding it to the map.\n", utxnid);
+		if (commit_map_debug) {
+			logmsg(LOGMSG_DEBUG, "Transaction %"PRIu64" has a zero commit lsn. Not adding it to the map.\n", utxnid);
+		}
 		return ret;
 	}
 
 	txn = hash_find(txmap->transactions, &utxnid);
 
 	if (txn != NULL) { 
-		logmsg(LOGMSG_DEBUG, "Transaction %"PRIu64" already exists in the map. Not adding it again\n", utxnid);
+		if (commit_map_debug) {
+			logmsg(LOGMSG_DEBUG, "Transaction %"PRIu64" already exists in the map. Not adding it again\n", utxnid);
+		}
 		/* Don't add transactions that already exist in the map */
 		return ret;
 	}

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -467,6 +467,7 @@ log_applied_lsns| 0 |Log applied LSNs to log
 check_applied_lsns| 0 |Check transaction that its LSNs have been applied
 check_applied_lsns_fatal| 0 |Abort if check_applied_lsns fails
 check_applied_lsns_debug| 0 |Lots of verbose trace for debugging applied LSNs
+commit_map_debug| 0 |Produce debug output in commit lsn map
 sgio_enabled| 0 |Do scatter gather I/O
 sgio_max| 10 * MEGABYTE |Max scatter gather I/O to do at one time
 btpf_enabled| 0 |Enables index pages read ahead

--- a/tests/commit_lsn_map.test/lrl.options
+++ b/tests/commit_lsn_map.test/lrl.options
@@ -1,1 +1,2 @@
 utxnid_log on
+berkattr commit_map_debug 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -136,6 +136,7 @@
 (name='commit_delay_on_copy_ms', description='Set automatic delay-ms for commit-delay on copy.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='commit_delay_timeout_seconds', description='Set timeout for commit-delay on copy.  (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='commit_lsn_map', description='Maintain a map of transaction commit LSNs. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='commit_map_debug', description='Produce debug output in commit lsn map', type='BOOLEAN', value='OFF', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')
 (name='commitdelaybehindthresh', description='Call for election again and ask the master to delay commits if we are further than this far behind on startup.', type='INTEGER', value='1048576', read_only='N')
 (name='commitdelaymax', description='Introduce a delay after each transaction before returning control to the application. Occasionally useful to allow replicants to catch up on startup with a very busy system.', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
The changes in this PR protect debug output from the commit LSN map component with a tunable in order to prevent unnecessary spew.