### PR TITLE
Fix scalar-functions for initcomdb2

### DIFF
--- a/bbinc/util.h
+++ b/bbinc/util.h
@@ -43,11 +43,9 @@ char *load_text_file(const char *filename);
 int rewrite_lrl_table(const char *lrlname, const char *tablename,
                       const char *csc2path);
 /* Create an external lrl file with the db's table defs */
-int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
-                          const char *p_lrl_fname_out, char *p_table_names[],
-                          char *p_csc2_paths[], int table_nums[],
-                          size_t num_tables, char *out_lrl_dir, int has_sp,
-                          int has_timepartitions);
+int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in, const char *p_lrl_fname_out, char *p_table_names[],
+                          char *p_csc2_paths[], int table_nums[], size_t num_tables, char *out_lrl_dir, int has_sp,
+                          int has_user_vers_sp, int has_timepartitions);
 /* Remove all table definitions from the lrl file and append use_llmeta */
 int rewrite_lrl_remove_tables(const char *lrlname);
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -396,6 +396,7 @@ int gbl_allowbrokendatetime = 1;
 int gbl_sort_nulls_correctly = 1;
 int gbl_check_client_tags = 1;
 char *gbl_spfile_name = NULL;
+char *gbl_user_vers_spfile_name = NULL;
 char *gbl_timepart_file_name = NULL;
 int gbl_max_lua_instructions = 10000;
 int gbl_check_wrong_cmd = 1;
@@ -1959,23 +1960,23 @@ size_t gbl_lkr_hash = 16;
 char **sfuncs = NULL;
 char **afuncs = NULL;
 
-#define llmeta_set_lua_funcs(pfx)                                              \
-    do {                                                                       \
-        if (pfx##funcs == NULL)                                                \
-            break;                                                             \
-        char **func = &pfx##funcs[0];                                          \
-        while (*func) {                                                        \
-            int bdberr;                                                        \
-            int rc = bdb_llmeta_add_lua_##pfx##func(*func, NULL, &bdberr);     \
-            if (rc) {                                                          \
-               logmsg(LOGMSG_ERROR, "could not add sql lua " #pfx "func:%s to llmeta\n",\
-                       *func);                                                 \
-                return -1;                                                     \
-            } else {                                                           \
-               logmsg(LOGMSG_INFO, "Added Lua SQL " #pfx "func:%s\n", *func);  \
-            }                                                                  \
-            ++func;                                                            \
-        }                                                                      \
+#define llmeta_set_lua_funcs(pfx)                                                                                      \
+    do {                                                                                                               \
+        if (pfx##funcs == NULL)                                                                                        \
+            break;                                                                                                     \
+        char **func = &pfx##funcs[0];                                                                                  \
+        while (*func) {                                                                                                \
+            int bdberr;                                                                                                \
+            int flags = 0;                                                                                             \
+            int rc = bdb_llmeta_add_lua_##pfx##func(*func, &flags, &bdberr);                                           \
+            if (rc) {                                                                                                  \
+                logmsg(LOGMSG_ERROR, "could not add sql lua " #pfx "func:%s to llmeta\n", *func);                      \
+                return -1;                                                                                             \
+            } else {                                                                                                   \
+                logmsg(LOGMSG_INFO, "Added Lua SQL " #pfx "func:%s\n", *func);                                         \
+            }                                                                                                          \
+            ++func;                                                                                                    \
+        }                                                                                                              \
     } while (0)
 
 #define llmeta_load_lua_funcs(pfx)                                             \
@@ -2955,8 +2956,11 @@ int repopulate_lrl(const char *p_lrl_fname_out)
         p_data->table_nums[i] = thedb->dbs[i]->dbnum;
     }
 
-    int has_sp =
-        dump_spfile(p_data->lrl_fname_out_dir, thedb->envname, SP_FILE_NAME);
+    char file[1024];
+    snprintf(file, sizeof(file), "%s/%s_%s", p_data->lrl_fname_out_dir, thedb->envname, SP_FILE_NAME);
+    int has_sp = dump_spfile(file);
+    snprintf(file, sizeof(file), "%s/%s_%s", p_data->lrl_fname_out_dir, thedb->envname, SP_VERS_FILE_NAME);
+    int has_user_vers_sp = dump_user_version_spfile(file);
 
     if (dump_queuedbs(p_data->lrl_fname_out_dir) != 0) {
         free(p_data);
@@ -2971,10 +2975,9 @@ int repopulate_lrl(const char *p_lrl_fname_out)
     }
 
     /* write out the lrl */
-    if (rewrite_lrl_un_llmeta(getresourcepath("lrl"), p_lrl_fname_out,
-                              p_data->p_table_names, p_data->p_csc2_paths,
-                              p_data->table_nums, thedb->num_dbs,
-                              p_data->lrl_fname_out_dir, has_sp, has_tp)) {
+    if (rewrite_lrl_un_llmeta(getresourcepath("lrl"), p_lrl_fname_out, p_data->p_table_names, p_data->p_csc2_paths,
+                              p_data->table_nums, thedb->num_dbs, p_data->lrl_fname_out_dir, has_sp, has_user_vers_sp,
+                              has_tp)) {
         logmsg(LOGMSG_ERROR, "%s: rewrite_lrl_un_llmeta failed\n", __func__);
 
         free(p_data);
@@ -4116,6 +4119,10 @@ static int init(int argc, char **argv)
 
         if (gbl_spfile_name) {
             read_spfile(gbl_spfile_name);
+        }
+
+        if (gbl_user_vers_spfile_name) {
+            read_user_version_spfile(gbl_user_vers_spfile_name);
         }
 
         if (gbl_timepart_file_name) {

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -25,6 +25,7 @@
 #define MAXVER 255
 
 #define SP_FILE_NAME "stored_procedures.sp"
+#define SP_VERS_FILE_NAME "vers_stored_procedures.sp"
 #define TIMEPART_FILE_NAME "time_partitions.tp"
 #define REPOP_QDB_FMT "%s/%s.%d.queuedb" /* /dir/dbname.num.ext */
 
@@ -3381,8 +3382,10 @@ int get_max_reclen(struct dbenv *);
 
 void testrep(int niter, int recsz);
 int sc_request_disallowed(SBUF2 *sb);
-int dump_spfile(char *path, const char *dblrl, char *file_name);
-int read_spfile(char *file);
+int dump_spfile(const char *file);
+int dump_user_version_spfile(const char *file);
+int read_spfile(const char *file);
+int read_user_version_spfile(const char *file);
 
 struct bdb_cursor_ifn;
 

--- a/db/config.c
+++ b/db/config.c
@@ -685,17 +685,17 @@ static int new_table_from_schema(struct dbenv *dbenv, char *tblname,
     return 0;
 }
 
-#define parse_lua_funcs(pfx)                                                   \
-    do {                                                                       \
-        tok = segtok(line, sizeof(line), &st, &ltok);                          \
-        int num = toknum(tok, ltok);                                           \
-        pfx##funcs = malloc(sizeof(char *) * (num + 1));                       \
-        int i;                                                                 \
-        for (i = 0; i < num; ++i) {                                            \
-            tok = segtok(line, sizeof(line), &st, &ltok);                      \
-            pfx##funcs[i] = tokdup(tok, ltok);                                 \
-        }                                                                      \
-        pfx##funcs[i] = NULL;                                                  \
+#define parse_lua_funcs(pfx)                                                                                           \
+    do {                                                                                                               \
+        tok = segtok(line, strlen(line), &st, &ltok);                                                                  \
+        int num = toknum(tok, ltok);                                                                                   \
+        pfx##funcs = malloc(sizeof(char *) * (num + 1));                                                               \
+        int i;                                                                                                         \
+        for (i = 0; i < num; ++i) {                                                                                    \
+            tok = segtok(line, strlen(line), &st, &ltok);                                                              \
+            pfx##funcs[i] = tokdup(tok, ltok);                                                                         \
+        }                                                                                                              \
+        pfx##funcs[i] = NULL;                                                                                          \
     } while (0)
 
 static int read_lrl_option(struct dbenv *dbenv, char *line,

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -303,6 +303,7 @@ extern uint8_t _non_dedicated_subnet;
 
 extern char *gbl_crypto;
 extern char *gbl_spfile_name;
+extern char *gbl_user_vers_spfile_name;
 extern char *gbl_timepart_file_name;
 extern char *gbl_test_log_file;
 extern pthread_mutex_t gbl_test_log_file_mtx;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1115,6 +1115,8 @@ REGISTER_TUNABLE("sort_nulls_with_header",
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("spfile", NULL, TUNABLE_STRING, &gbl_spfile_name, READONLY,
                  NULL, NULL, file_update, NULL);
+REGISTER_TUNABLE("version_spfile", NULL, TUNABLE_STRING, &gbl_user_vers_spfile_name, READONLY, NULL, NULL, file_update,
+                 NULL);
 REGISTER_TUNABLE("timepartitions", NULL, TUNABLE_STRING,
                  &gbl_timepart_file_name, READONLY, NULL, NULL, file_update,
                  NULL);

--- a/db/db_util.c
+++ b/db/db_util.c
@@ -305,11 +305,9 @@ int rewrite_lrl_remove_tables(const char *lrlname)
 
 /* Create a new lrl file with the table defs added back in (the reverse of
  * llmeta'ing an lrl file */
-int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
-                          const char *p_lrl_fname_out, char *p_table_names[],
-                          char *p_csc2_paths[], int table_nums[],
-                          size_t num_tables, char *out_lrl_dir, int has_sp,
-                          int has_timepartitions)
+int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in, const char *p_lrl_fname_out, char *p_table_names[],
+                          char *p_csc2_paths[], int table_nums[], size_t num_tables, char *out_lrl_dir, int has_sp,
+                          int has_user_vers_sp, int has_timepartitions)
 {
     unsigned i;
     int fd_out;
@@ -375,9 +373,13 @@ int rewrite_lrl_un_llmeta(const char *p_lrl_fname_in,
         sbuf2printf(sb_out, "\n");
     }
 
+    if (has_user_vers_sp) {
+        sbuf2printf(sb_out, "version_spfile %s/%s_%s", out_lrl_dir, thedb->envname, SP_VERS_FILE_NAME);
+        sbuf2printf(sb_out, "\n");
+    }
+
     if (has_timepartitions) {
-        sbuf2printf(sb_out, "timepartitions %s/%s_%s", out_lrl_dir,
-                    thedb->envname, TIMEPART_FILE_NAME);
+        sbuf2printf(sb_out, "timepartitions %s/%s_%s", out_lrl_dir, thedb->envname, TIMEPART_FILE_NAME);
         sbuf2printf(sb_out, "\n");
     }
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -5921,24 +5921,20 @@ static int _process_single_table_sc_merge(struct ireq *iq)
  * otherwise, it will return an error.
  *
  */
-static int _process_shards_serially(const char *partname,
-                                    int func(const char *, timepart_sc_arg_t *),
+static int _process_shards_serially(const char *partname, int func(const char *, timepart_sc_arg_t *),
                                     timepart_sc_arg_t *arg)
 {
-    char shardname[MAXTABLELEN+1];
+    char shardname[MAXTABLELEN + 1];
     int rc = VIEW_NOERR;
     int irc = 0;
 
     while (rc == VIEW_NOERR) {
-        rc = timepart_foreach_shardname(partname, shardname, sizeof(shardname),
-                                        arg);
+        rc = timepart_foreach_shardname(partname, shardname, sizeof(shardname), arg);
         if (rc == VIEW_NOERR) {
-            logmsg(LOGMSG_USER, "%s Applying %p to %s [%d]\n",
-                   __func__, arg->s, shardname, arg->indx);
+            logmsg(LOGMSG_USER, "%s Applying %p to %s [%d]\n", __func__, arg->s, shardname, arg->indx);
             irc = func(shardname, arg);
             if (irc) {
-                logmsg(LOGMSG_ERROR, "%s failed shard %s [%d] rc %d\n",
-                       partname, shardname, arg->indx, irc);
+                logmsg(LOGMSG_ERROR, "%s failed shard %s [%d] rc %d\n", partname, shardname, arg->indx, irc);
                 return -1;
             }
         }
@@ -5960,7 +5956,7 @@ static int _process_partitioned_table_merge(struct ireq *iq)
     /* if this was a CREATE & ALTER, first shart is an aliased
      * table with the same name as the partition
      * use that as the destination for merging
-     * OTHERWISE, create a new table with the same name as 
+     * OTHERWISE, create a new table with the same name as
      * the partition
      */
     char *first_shard_name = timepart_shard_name(sc->tablename, 0, 0, NULL);
@@ -6009,7 +6005,7 @@ static int _process_partitioned_table_merge(struct ireq *iq)
         }
         arg.check_extra_shard = 1;
         strncpy(sc->newtable, sc->tablename, sizeof(sc->newtable)); /* piggyback a rename with alter */
-        arg.indx = 0; /* see timepart_foreach_shardname NOTE */
+        arg.indx = 0;                                               /* see timepart_foreach_shardname NOTE */
     }
 
     /* at this point we have created the future btree, launch an alter
@@ -6017,18 +6013,14 @@ static int _process_partitioned_table_merge(struct ireq *iq)
      */
     arg.s = sc;
     arg.s->iq = iq;
-    char *partname = strdup(sc->tablename);  /*sc->tablename gets rewritten*/
+    char *partname = strdup(sc->tablename); /*sc->tablename gets rewritten*/
     if (!partname)
         return VIEW_ERR_MALLOC;
     /* note: we have already set nothrevent depending on the number of shards */
     if (arg.s->nothrevent) {
-        rc = _process_shards_serially(partname,
-                                      start_schema_change_tran_wrapper_merge,
-                                      &arg);
+        rc = _process_shards_serially(partname, start_schema_change_tran_wrapper_merge, &arg);
     } else {
-        rc = timepart_foreach_shard(partname,
-                                    start_schema_change_tran_wrapper_merge,
-                                    &arg);
+        rc = timepart_foreach_shard(partname, start_schema_change_tran_wrapper_merge, &arg);
     }
     free(partname);
 
@@ -6210,18 +6202,14 @@ static int _process_partition_alter_and_drop(struct ireq *iq)
     arg.s = sc;
     arg.s->iq = iq;
     arg.check_extra_shard = 1;
-    char *partname = strdup(sc->tablename);  /*sc->tablename gets rewritten*/
+    char *partname = strdup(sc->tablename); /*sc->tablename gets rewritten*/
     if (!partname)
         return VIEW_ERR_MALLOC;
     if (sc->nothrevent) {
         arg.indx = -1; /* see timepart_foreach_shardname NOTE */
-        rc = _process_shards_serially(partname,
-                                      start_schema_change_tran_wrapper,
-                                      &arg);
+        rc = _process_shards_serially(partname, start_schema_change_tran_wrapper, &arg);
     } else {
-        rc = timepart_foreach_shard(partname,
-                                    start_schema_change_tran_wrapper,
-                                    &arg);
+        rc = timepart_foreach_shard(partname, start_schema_change_tran_wrapper, &arg);
     }
     free(partname);
 
@@ -6229,9 +6217,7 @@ out:
     return rc;
 }
 
-
-static const uint8_t *_get_txn_info(char *msg, unsigned long long rqid,
-                                    uuid_t uuid,  int *type)
+static const uint8_t *_get_txn_info(char *msg, unsigned long long rqid, uuid_t uuid, int *type)
 {
     const uint8_t *p_buf;
     const uint8_t *p_buf_end;
@@ -6262,7 +6248,6 @@ static const uint8_t *_get_txn_info(char *msg, unsigned long long rqid,
 
     return p_buf;
 }
-
 
 /**
  * Handles each packet and start schema change

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2158,6 +2158,24 @@ clipper_usage:
             return -1;
     } else if (tokcmp(tok, ltok, "bdbrem") == 0) {
         backend_cmd(dbenv, line, llinesav, stsav);
+    } else if (tokcmp(tok, ltok, "dumpversp") == 0) {
+        char filename[PATH_MAX];
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "dumpversp requires path\n");
+            return -1;
+        }
+        tokcpy(tok, ltok, filename);
+        dump_user_version_spfile(filename);
+    } else if (tokcmp(tok, ltok, "loadversp") == 0) {
+        char filename[PATH_MAX];
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "dumpversp requires path\n");
+            return -1;
+        }
+        tokcpy(tok, ltok, filename);
+        read_user_version_spfile(filename);
     } else if (tokcmp(tok, ltok, "electtime") == 0) {
         int num;
 

--- a/db/views.c
+++ b/db/views.c
@@ -2431,16 +2431,14 @@ static void _setup_arg(timepart_view_t *view, timepart_sc_arg_t *arg)
  *
  * NOTE: arg->indx starts at -1
  */
-int timepart_foreach_shardname(const char *view_name,
-                               char *next_shard, int next_shard_len,
-                               timepart_sc_arg_t *arg)
+int timepart_foreach_shardname(const char *view_name, char *next_shard, int next_shard_len, timepart_sc_arg_t *arg)
 {
     timepart_views_t *views;
     timepart_view_t *view;
     int rc = VIEW_NOERR;
 
     /* code relies on this to point to the current shard,
-     * so we have to start the shard walk by setting 
+     * so we have to start the shard walk by setting
      * indx to -1
      */
     arg->indx++;
@@ -2456,7 +2454,7 @@ int timepart_foreach_shardname(const char *view_name,
 
     _setup_arg(view, arg);
 
-    assert(arg->indx>=0);
+    assert(arg->indx >= 0);
 
     if (arg->indx < view->nshards) {
         strncpy(next_shard, view->shards[arg->indx].tblname, next_shard_len);
@@ -2477,7 +2475,6 @@ done:
     return rc;
 }
 
-
 /**
  * Run "func" for each shard, starting with "first_shard".
  * Callback receives the name of the shard and argument struct
@@ -2485,9 +2482,7 @@ done:
  * already created
  *
  */
-int timepart_foreach_shard(const char *view_name,
-                           int func(const char *, timepart_sc_arg_t *),
-                           timepart_sc_arg_t *arg)
+int timepart_foreach_shard(const char *view_name, int func(const char *, timepart_sc_arg_t *), timepart_sc_arg_t *arg)
 {
     timepart_views_t *views;
     timepart_view_t *view;

--- a/db/views.h
+++ b/db/views.h
@@ -289,9 +289,7 @@ int comdb2_partition_check_name_reuse(const char *tblname, char **partname, int 
  * already created
  *
  */
-int timepart_foreach_shard(const char *view_name,
-                           int func(const char *, timepart_sc_arg_t *),
-                           timepart_sc_arg_t *arg);
+int timepart_foreach_shard(const char *view_name, int func(const char *, timepart_sc_arg_t *), timepart_sc_arg_t *arg);
 
 /**
  * Run "func" for each shard of a partition
@@ -509,8 +507,6 @@ int logical_partition_next_rollout(const char *name);
  * Returns whatever VIEW_ERR_ otherwise.
  *
  */
-int timepart_foreach_shardname(const char *view_name,
-                               char *next_shard, int next_shard_len,
-                               timepart_sc_arg_t *arg);
+int timepart_foreach_shardname(const char *view_name, char *next_shard, int next_shard_len, timepart_sc_arg_t *arg);
 
 #endif

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -950,8 +950,7 @@ static int verify_sc_resumed_for_all_shards(void *obj, void *arg)
     sc_arg.s = tpt_sc->s;
     /* start new sc for shards that were not resumed */
     sc_arg.check_extra_shard = 1;
-    timepart_foreach_shard(tpt_sc->viewname, verify_sc_resumed_for_shard,
-                           &sc_arg);
+    timepart_foreach_shard(tpt_sc->viewname, verify_sc_resumed_for_shard, &sc_arg);
     assert(sc_arg.s != tpt_sc->s);
     tpt_sc->s = sc_arg.s;
     return 0;

--- a/schemachange/sc_lua.h
+++ b/schemachange/sc_lua.h
@@ -17,8 +17,8 @@
 #ifndef INCLUDE_SC_LUA_H
 #define INCLUDE_SC_LUA_H
 
-int dump_spfile(char *path, const char *dblrl, char *file_name);
-int read_spfile(char *file);
+int dump_spfile(const char *file);
+int read_spfile(const char *file);
 struct ireq;
 int do_add_sp(struct schema_change_type *, struct ireq *);
 int do_del_sp(struct schema_change_type *sc, struct ireq *);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1052,6 +1052,7 @@
 (name='verify_thread_stacksz', description='Size of the verify thread stack.', type='INTEGER', value='2097152', read_only='N')
 (name='verifycheckpoints', description='Highly paranoid checkpoint validity checks', type='BOOLEAN', value='OFF', read_only='N')
 (name='verifylsn', description='Verify if LSN written before writing page', type='BOOLEAN', value='OFF', read_only='N')
+(name='version_spfile', description='', type='STRING', value=NULL, read_only='Y')
 (name='view_feature', description='Enables support for VIEWs (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='views_dft_preempt_roll_secs', description='Amount of seconds to run phase 1 of time partition rollout before phase 2', type='INTEGER', value='1800', read_only='N')
 (name='views_dft_roll_delete_lag_secs', description='Amount of seconds to run phase 3 of time partition rollout after phase 2', type='INTEGER', value='5', read_only='N')


### PR DESCRIPTION
Fixes ability to specify a Lua-sp scalar function via initcomdb2.  This is the 8.0 version of https://github.com/bloomberg/comdb2/pull/4514
