### PR TITLE
Fix mac build

### DIFF
--- a/db/autoanalyze.c
+++ b/db/autoanalyze.c
@@ -356,7 +356,7 @@ void stat_auto_analyze(void)
         logmsg(LOGMSG_USER,
                "Table %s, aa counter=%"PRId64" (saved %"PRId64", new %d, percent of tbl %.2f), last run time=%s, needs analyze time=%s\n",
                tbl->tablename, newautoanalyze_counter, saved_counter, delta, new_aa_percnt,
-               loc_print_date(&lastepoch, lastepoch_str), loc_print_date(&needs_analyze_time, needs_analyze_time_str));
+               loc_print_date((time_t *) &lastepoch, lastepoch_str), loc_print_date((time_t *) &needs_analyze_time, needs_analyze_time_str));
     }
 }
 

--- a/protobuf/CMakeLists.txt
+++ b/protobuf/CMakeLists.txt
@@ -1,6 +1,10 @@
-find_program(protoc-c NAMES protoc-c)
-if(NOT protoc-c)
-  message(FATAL_ERROR "protoc-c not found!")
+if(${CMAKE_SYSTEM_NAME} STREQUAL Darwin)
+    find_program(protobuf-generator NAMES protoc)
+else()
+    find_program(protobuf-generator NAMES protoc-c)
+endif()
+if(NOT protobuf-generator)
+    message(FATAL_ERROR "protobuf generator not found!")
 endif()
 list(APPEND proto bpfunc.proto  connectmsg.proto  sqlquery.proto  sqlresponse.proto) 
 foreach(p ${proto})
@@ -11,7 +15,7 @@ foreach(p ${proto})
   add_custom_command(
     OUTPUT ${h} ${c}
     DEPENDS ${p}
-    COMMAND ${protoc-c} -I${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${p} --c_out=${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${protobuf-generator} -I${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/${p} --c_out=${CMAKE_CURRENT_BINARY_DIR}
   )
 endforeach()
 add_custom_target(proto DEPENDS ${dot_c} ${dot_h})

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -98,6 +98,11 @@ list(APPEND common-deps
   crc32c
 )
 
+if (NOT COMDB2_SKIP_CDB2API_SO)
+  add_library(api_hello_world_lib SHARED api_hello_world_lib.c)
+  list(APPEND test-tools api_hello_world_lib)
+endif()
+
 foreach(executable ${test-tools})
   if (COMDB2_BBCMAKE)
     target_link_libraries(${executable} opencdb2api ${common-deps})
@@ -107,9 +112,6 @@ foreach(executable ${test-tools})
 endforeach()
 
 if(NOT COMDB2_SKIP_CDB2API_SO)
-  add_library(api_hello_world_lib SHARED api_hello_world_lib.c)
-  list(APPEND test-tools api_hello_world_lib)
-
   add_exe(api_libs api_libs.c)
   target_link_libraries(api_libs cdb2api_shared ${common-deps})
 

--- a/tests/tools/cdb2bind.c
+++ b/tests/tools/cdb2bind.c
@@ -588,7 +588,7 @@ static void test_pass_array_to_sp()
         i32s[i] = i;
         i64s[i] = i * 10;
         ds[i] = i * 100;
-        char s[64]; sprintf(s, "%zd", i64s[i] * 100);
+        char s[64]; sprintf(s, "%" PRId64 "", i64s[i] * 100);
         ss[i] = strdup(s);
         bs[i].len = i;
         bs[i].data = blob;
@@ -607,12 +607,12 @@ static void test_pass_array_to_sp()
                 int64_t val = *(int64_t *)cdb2_column_value(hndl, i);
                 if (i == 0) {
                     if (val != i32s[n]) {
-                        fprintf(stderr, "row:%d i32 col:%d val:%zd vs exp:%d\n", n, i, val, i32s[n]);
+                        fprintf(stderr, "row:%d i32 col:%d val:%" PRId64 " vs exp:%d\n", n, i, val, i32s[n]);
                         abort();
                     }
                 } else if (i == 1) {
                     if (val != i64s[n]) {
-                        fprintf(stderr, "row:%d i64 col:%d %zd vs exp:%zd\n", n, i, val, i64s[n]);
+                        fprintf(stderr, "row:%d i64 col:%d %" PRId64 " vs exp:%" PRId64 "\n", n, i, val, i64s[n]);
                         abort();
                     }
                 } else {

--- a/tests/tools/insert.c
+++ b/tests/tools/insert.c
@@ -474,13 +474,11 @@ int prepare_select_bug(void)
         return rc;
     }
 
-    int iteration = 0;
     cdb2_effects_tp effects;
     char sql[64];
 
     // First erase everything larger
     do {
-        iteration++;
         rc = cdb2_run_statement(db, "begin");
         if (rc) {
             tdprintf(stderr, db, __func__, __LINE__, "XXX %s: begin rc %d %s\n",
@@ -648,13 +646,11 @@ int prepare_select_test(void)
         return rc;
     }
 
-    int iteration = 0;
     cdb2_effects_tp effects;
     char sql[64];
 
     // First erase everything larger
     do {
-        iteration++;
         rc = cdb2_run_statement(db, "begin");
         if (rc) {
             tdprintf(stderr, db, __func__, __LINE__, "XXX %s: begin rc %d %s\n",

--- a/tests/tools/recom.c
+++ b/tests/tools/recom.c
@@ -35,7 +35,7 @@ void usage(FILE *f)
 /* Run and discard results */
 static inline int run_statement(cdb2_hndl_tp *sqlh, const char *sql, int iter)
 {
-    int rc, cnt=0;
+    int rc;
 
     rc = cdb2_run_statement(sqlh, sql);
     if(verbose && CDB2ERR_VERIFY_ERROR == rc) {
@@ -54,7 +54,6 @@ static inline int run_statement(cdb2_hndl_tp *sqlh, const char *sql, int iter)
     do
     {
         rc = cdb2_next_record(sqlh);
-        cnt++;
     } 
     while(CDB2_OK == rc);
 


### PR DESCRIPTION
1. Addresses protobuf-c compatibility issue: The version of protobuf-c that is available on homebrew has a compatibility issue with protobuf. This is addressed by using protoc with the protobuf-c plugin instead of using protoc-c, per [this comment](https://github.com/Homebrew/homebrew-core/issues/168501#issuecomment-2063611013).
2. Addresses warnings in builds.
3. Addresses this failure in the test tooling build:
```
Undefined symbols for architecture arm64:
  "_cdb2_register_event", referenced from:
      _cdb2_lib_init in api_hello_world_lib.c.o
ld: symbol(s) not found for architecture arm64
```