### PR TITLE
{175603015}: Don't drop upsert flags

### DIFF
--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -922,6 +922,7 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     osqlstate_t *osql = &thd->clnt->osql;
     int rc = 0;
     int bdberr = 0;
+    int upsert_flags_for_add = 0;
     shad_tbl_t *tbl = NULL;
     bdb_state_type *bdbenv = NULL;
     unsigned long long tmp = 0;
@@ -992,6 +993,25 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
                         __func__, tmp, genid, rc, bdberr);
                 return -1;
             }
+        } else {
+            // We are here because the running transaction did an insert followed by an update 
+            // on the same row.
+
+            // We will replace the seqnum used to represent the changes that this transaction
+            // made to the row. We need to latch the upsert flags for the old
+            // seqnum so that we can apply them to the new seqnum.
+
+            // Applying the old flags to the new seqnum is essential for a transaction like
+            // the one below to be sent to master as an upsert:
+            // 
+            // -- recom
+            // begin
+            // upsert on row X
+            // update on row X
+            // commit
+            //
+
+            upsert_flags_for_add = get_rec_flags(thd->clnt, tbl, pCur->genid, 1);
         }
 
         /* delete the original index from add and its indexes */
@@ -1027,6 +1047,12 @@ int osql_save_updrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     /* update add table */
     rc = bdb_temp_table_put(bdbenv, tbl->add_tbl->table, &tmp, sizeof(tmp),
                             (char *)pData, nData, NULL, &bdberr);
+
+    if (upsert_flags_for_add) {
+        // Apply latched upsert flags to the new seqnum.
+        save_rec_flags(thd->clnt, tbl, tmp, upsert_flags_for_add, 1);
+    }
+
     if (rc) {
         logmsg(LOGMSG_ERROR, 
                 "%s: fail to update genid %llx (%lld) rc=%d bdberr=%d (7)\n",

--- a/tests/upsert.test/t01_upsert.expected
+++ b/tests/upsert.test/t01_upsert.expected
@@ -201,3 +201,32 @@ done
 (i=2, j=1)
 (i=4, j=1)
 done
+(part='---------------------------------- PART #10 ----------------------------------')
+done
+done
+done
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+(i=1, j=3)
+done
+(part='---------------------------------- PART #11 ----------------------------------')
+done
+done
+done
+done
+done
+done
+(rows inserted=2)
+done
+done
+done
+(rows inserted=1)
+done
+done
+(i=1, j=3)
+done

--- a/tests/upsert.test/t01_upsert.trans
+++ b/tests/upsert.test/t01_upsert.trans
@@ -151,3 +151,27 @@
 1 insert into t1 values(7, 1) on conflict (i) do update set i=4
 1 commit
 1 select * from t1 order by i
+
+1 SELECT '---------------------------------- PART #10 ----------------------------------' AS part;
+1 drop table if exists t
+1 create table t(i int primary key, j int)
+1 set transaction read committed isolation
+1 begin
+1 insert into t(i, j) values(1, 1) on conflict(i) do update set j=j+1
+1 update t set j=j+1 where i=1
+2 insert into t(i, j) values(1, 1)
+1 commit -- will retry because of 2's insert and then should succeed as update
+1 select * from t
+
+1 SELECT '---------------------------------- PART #11 ----------------------------------' AS part;
+1 drop table if exists t
+1 drop table if exists q
+1 create table t(i int primary key, j int)
+1 create table q(j int)
+1 set transaction read committed isolation
+1 insert into q(j) values(1), (1)
+1 begin
+1 insert into t(i, j) select 1, j from q where j=1 on conflict(i) do update set j=j+1
+2 insert into t(i, j) values(1, 1)
+1 commit -- will retry because of 2's insert and then should succeed as update
+1 select * from t


### PR DESCRIPTION
Upsert flags are dropped when an update follows an insert to the same row in read-committed isolation. 

The changes to (1,1) made in the following transaction should be sent to master as an upsert, but they are not.

```
-- t is empty
begin
insert into t(i, j) values(1, 1) on conflict(i) do update set j=j+1
update t set j=j+1 where i=1
commit
```

This bug causes impossible duplicate key constraint violations to occur.

The changes in this PR fix this bug by applying an inserted row's upsert flags to the new seqnum that it receives on a subsequent update.