### PR TITLE
Fix snapshot replication bug

### DIFF
--- a/tests/snapisol.test/noearly.testopts
+++ b/tests/snapisol.test/noearly.testopts
@@ -1,0 +1,1 @@
+noearly


### PR DESCRIPTION
The changes in this PR fix these 2 bugs related to the new snapshot-isolation implementation (aka modsnap):

1. Replicants do not add transactions to the commit LSN map when early acks are disabled.
2. A replicant can early ack a commit LSN before it puts that LSN in the commit LSN map: A commit LSN is passed to `__rep_set_last_locked` before it is added to the commit LSN map, and a commit LSN can be early acked as soon as it is passed to `__rep_set_last_locked`.

Both of these bugs are fixed in this PR by unconditionally adding a transaction's commit LSN to the commit LSN map just before calling `__rep_set_last_locked`.

The changes in this PR also cause the `snapisol` test to run an iteration with early acks disabled.