### PR TITLE
Support snapshot-lite isolation level

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -263,6 +263,7 @@ extern int gbl_serialize_reads_like_writes;
 extern int gbl_long_log_truncation_warn_thresh_sec;
 extern int gbl_long_log_truncation_abort_thresh_sec;
 extern int gbl_snapshot_serial_verify_retry;
+extern int gbl_snapshot_lite;
 extern int gbl_cache_flush_interval;
 extern int gbl_load_cache_threads;
 extern int gbl_load_cache_max_pages;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2158,6 +2158,11 @@ REGISTER_TUNABLE("snapshot_serial_verify_retry",
                  TUNABLE_BOOLEAN, &gbl_snapshot_serial_verify_retry, 0, NULL,
                  NULL, NULL, NULL);
 
+REGISTER_TUNABLE("snapshot_lite",
+                 "Use snapshot lite mode (snapshot + retries in new snapshot) (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_snapshot_lite, 0, NULL,
+                 NULL, NULL, NULL);
+
 REGISTER_TUNABLE("strict_double_quotes",
                  "In SQL queries, forbid the use of double-quotes to denote "
                  "a string literal.  Any attempts to do so will result in a "

--- a/tests/snapshot_lite.test/Makefile
+++ b/tests/snapshot_lite.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/snapshot_lite.test/lrl.options
+++ b/tests/snapshot_lite.test/lrl.options
@@ -1,0 +1,3 @@
+enable_snapshot_isolation
+use_modsnap_for_snapshot
+snapshot_lite on

--- a/tests/snapshot_lite.test/runit
+++ b/tests/snapshot_lite.test/runit
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source $TESTSROOTDIR/tools/runstepper.sh
+
+dbname=$1
+if [[ -z $dbname ]] ; then
+    echo dbname missing
+    exit 1
+fi
+
+# verify the result
+function verify
+{
+    # args
+    typeset testname=$1
+
+    cmd="diff ${testname}.expected ${testname}.output"
+    $cmd > /dev/null
+
+    if [[  $? -eq 0 ]]; then
+        echo "passed $testname"
+    else
+        echo "failed $testname"
+        echo "see diffs here: $HOSTNAME"
+        echo "> diff -u ${PWD}/{$testname.expected,$testname.output}"
+        echo
+        exit 1
+    fi
+
+}
+
+for transtest in `ls t*.trans` ; do
+    testname=`echo $transtest | cut -d "." -f 1`
+    output=$testname.output
+
+    runstepper $dbname $transtest $output
+    cat ${testname}.output | perl -pe "s/.n_writeops_done=([0-9]+)/rows inserted='\1'/; s/BLOCK2_SEQV2\(824\)/BLOCK_SEQ(800)/; s/OP #2 BLOCK_SEQ/OP #3 BLOCK_SEQ/; s/genid=\w+/genid=xxxx/;" > tmp
+    mv tmp  ${testname}.output
+
+    verify $testname
+done
+
+echo "Testcase passed."
+exit 0

--- a/tests/snapshot_lite.test/t00.expected
+++ b/tests/snapshot_lite.test/t00.expected
@@ -1,0 +1,12 @@
+(part='---------------------------------- PART #01 ----------------------------------')
+done
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+(i=1, j=2)
+done
+done

--- a/tests/snapshot_lite.test/t00.trans
+++ b/tests/snapshot_lite.test/t00.trans
@@ -1,0 +1,9 @@
+1 SELECT '---------------------------------- PART #01 ----------------------------------' AS part;
+1 CREATE TABLE t1(i INT PRIMARY KEY, j INT)
+1 SET TRANSACTION SNAPSHOT
+1 BEGIN
+1 INSERT INTO t1 VALUES(1, 1) ON CONFLICT(i) DO UPDATE set j=j+1;
+2 INSERT INTO t1 VALUES(1, 1)
+1 COMMIT
+1 SELECT * FROM t1
+1 DROP TABLE t1;


### PR DESCRIPTION
Snapshot-lite is like snapshot but allows for retries on commit failures. Each retry is run in a new snapshot.