### PR TITLE
Clean up uncommittable txn error handling

### DIFF
--- a/db/block_internal.c
+++ b/db/block_internal.c
@@ -2007,7 +2007,7 @@ int blkseq_get_rcode(void *data, int datalen)
                 case ERR_NULL_CONSTRAINT:
                 case ERR_SQL_PREP:
                 case ERR_CONSTR:
-                case ERR_UNCOMMITABLE_TXN:
+                case ERR_UNCOMMITTABLE_TXN:
                 case ERR_DIST_ABORT:
                 case ERR_NOMASTER:
                 case ERR_NOTSERIAL:
@@ -2027,7 +2027,7 @@ int blkseq_get_rcode(void *data, int datalen)
                 case ERR_NULL_CONSTRAINT:
                 case ERR_SQL_PREP:
                 case ERR_CONSTR:
-                case ERR_UNCOMMITABLE_TXN:
+                case ERR_UNCOMMITTABLE_TXN:
                 case ERR_DIST_ABORT:
                 case ERR_NOMASTER:
                 case ERR_NOTSERIAL:

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -351,7 +351,7 @@ enum RCODES {
     ERR_VERIFY_PI = 319,
     ERR_CHECK_CONSTRAINT = 320,
     ERR_INDEX_CONFLICT = 330,
-    ERR_UNCOMMITABLE_TXN = 404, /* txn is uncommitable, returns ERR_VERIFY
+    ERR_UNCOMMITTABLE_TXN = 404, /* txn is uncommittable, returns ERR_VERIFY
                                    rather than retry */
     ERR_DIST_ABORT = 430,       /* Prepared txn has been aborted */
     ERR_QUERY_REJECTED = 451,
@@ -1355,12 +1355,12 @@ struct ireq {
     SBUF2 *dbglog_file;
     int *nwrites;
 
-    /* List of indices that we've written to detect uncommitable upsert txns */
+    /* List of indices that we've written to detect uncommittable upsert txns */
     hash_t *vfy_idx_hash; 
 
     int dup_key_insert;
 
-    /* List of genids that we've written to detect uncommitable txn's */
+    /* List of genids that we've written to detect uncommittable txn's */
     hash_t *vfy_genid_hash;
     pool_t *vfy_genid_pool;
 

--- a/db/glue.c
+++ b/db/glue.c
@@ -5224,7 +5224,7 @@ int dbq_consume(struct ireq *iq, void *trans, int consumer, const struct bdb_que
     if (bdberr == BDBERR_READONLY)
         return ERR_NOMASTER;
     if (bdberr == BDBERR_DELNOTFOUND)
-        return  bdb_get_type(bdb_handle) == BDBTYPE_QUEUEDB ? ERR_UNCOMMITABLE_TXN: IX_NOTFND;
+        return  bdb_get_type(bdb_handle) == BDBTYPE_QUEUEDB ? ERR_UNCOMMITTABLE_TXN: IX_NOTFND;
     return map_unhandled_bdb_wr_rcode("bdb_queue_consume", bdberr);
 }
 

--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -344,7 +344,7 @@ static int srs_tran_replay_int(struct sqlclntstate *clnt, int(dispatch_fn)(struc
                __func__);
     }
     if (rc && clnt->verify_retries < gbl_osql_verify_retries_max) {
-        logmsg(LOGMSG_ERROR, "Uncommitable transaction %d retried %d times,  "
+        logmsg(LOGMSG_ERROR, "Uncommittable transaction %d retried %d times,  "
                "rc=%d [global retr=%lld] nq=%d tnq=%d\n", clnt->queryid,
                clnt->verify_retries, rc, gbl_verify_tran_replays, nq, tnq);
     }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6619,15 +6619,15 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         if (iq->vfy_genid_track) {
             unsigned long long *g = hash_find(iq->vfy_genid_hash, &dt.genid);
 
-            /* punt immediately with uncommitable txn */
+            /* punt immediately with uncommittable txn */
             if (g) {
-                rc = ERR_UNCOMMITABLE_TXN;
+                rc = ERR_UNCOMMITTABLE_TXN;
                 reqerrstr(iq, COMDB2_DEL_RC_INVL_KEY,
-                          "uncommitable txn on del genid=%llx rc=%d",
+                          "uncommittable txn on del genid=%llx rc=%d",
                           bdb_genid_to_host_order(dt.genid), rc);
                 err->blockop_num = step;
                 err->ixnum = 0;
-                err->errcode = ERR_UNCOMMITABLE_TXN;
+                err->errcode = ERR_UNCOMMITTABLE_TXN;
                 return rc;
             }
 
@@ -6736,13 +6736,13 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         if (rc != 0) {
             if (err->errcode == OP_FAILED_UNIQ) {
                 if (iq->vfy_idx_track == 1 && iq->dup_key_insert == 1) {
-                    rc = ERR_UNCOMMITABLE_TXN;
-                    reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "add key constraint "
-                                                   "duplicate key '%s' on "
-                                                   "table '%s' index %d",
+                    rc = ERR_UNCOMMITTABLE_TXN;
+                    reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "Transaction is uncommittable: "
+                                                       "Duplicate insert on key '%s' "
+                                                       "in table '%s' index %d",
                           get_keynm_from_db_idx(iq->usedb, err->ixnum),
                           iq->usedb->tablename, err->ixnum);
-                    err->errcode = ERR_UNCOMMITABLE_TXN;
+                    err->errcode = ERR_UNCOMMITTABLE_TXN;
                     return rc;
                 }
 
@@ -6865,15 +6865,15 @@ int osql_process_packet(struct ireq *iq, unsigned long long rqid, uuid_t uuid,
         if (iq->vfy_genid_track) {
             unsigned long long *g = hash_find(iq->vfy_genid_hash, &genid);
 
-            /* punt immediately with uncommitable txn */
+            /* punt immediately with uncommittable txn */
             if (g) {
-                rc = ERR_UNCOMMITABLE_TXN;
+                rc = ERR_UNCOMMITTABLE_TXN;
                 reqerrstr(iq, COMDB2_UPD_RC_INVL_KEY,
-                          "uncommitable txn on upd genid=%llx rc=%d",
+                          "uncommittable txn on upd genid=%llx rc=%d",
                           bdb_genid_to_host_order(genid), rc);
                 err->blockop_num = step;
                 err->ixnum = 0;
-                err->errcode = ERR_UNCOMMITABLE_TXN;
+                err->errcode = ERR_UNCOMMITTABLE_TXN;
                 return rc;
             }
 

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -235,7 +235,7 @@ done:
         rc != ERR_RMTDB_NESTED && rc != ERR_NESTED && rc != ERR_NOMASTER && rc != ERR_READONLY && rc != ERR_VERIFY &&
         rc != RC_TRAN_CLIENT_RETRY && rc != RC_INTERNAL_FORWARD && rc != RC_INTERNAL_RETRY &&
         rc != ERR_TRAN_TOO_BIG && /* THIS IS SENT BY BLOCKSQL WHEN TOOBIG */
-        rc != 999 && rc != ERR_ACCESS && rc != ERR_UNCOMMITABLE_TXN && rc != ERR_DIST_ABORT &&
+        rc != 999 && rc != ERR_ACCESS && rc != ERR_UNCOMMITTABLE_TXN && rc != ERR_DIST_ABORT &&
         (rc != ERR_NOT_DURABLE || !iq->sorese)) {
         /* XXX CLIENT_RETRY DOESNT ACTUALLY CAUSE A RETRY USUALLY, just
            a bad rc to the client! */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2199,7 +2199,7 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                     /* convert this to user code */
                     rc = blockproc2sql_error(clnt->osql.xerr.errval, __func__,
                                              __LINE__);
-                    if (clnt->osql.xerr.errval == ERR_UNCOMMITABLE_TXN) {
+                    if (clnt->osql.xerr.errval == ERR_UNCOMMITTABLE_TXN) {
                         osql_set_replay(__FILE__, __LINE__, clnt,
                                         OSQL_RETRY_LAST);
                     }
@@ -3685,8 +3685,8 @@ static int rc_sqlite_to_client(struct sqlthdstate *thd,
         irc = errstat_get_rc(&clnt->osql.xerr);
         if (irc) {
             *perrstr = (char *)errstat_get_str(&clnt->osql.xerr);
-            /* Do not retry on ERR_UNCOMMITABLE_TXN. */
-            if (irc == ERR_UNCOMMITABLE_TXN) {
+            /* Do not retry on ERR_UNCOMMITTABLE_TXN. */
+            if (irc == ERR_UNCOMMITTABLE_TXN) {
                 osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_LAST);
             } else if ((irc == ERR_SC) && (*perrstr == NULL || (*perrstr)[0] == '\0')) {
                 *perrstr = "a schema change error occurred";
@@ -6484,7 +6484,7 @@ int blockproc2sql_error(int rc, const char *func, int line)
     case 1229: /* ERR_BLOCK_FAILED + OP_FAILED_INTERNAL + ERR_FIND_CONSTRAINT */
         return CDB2ERR_FKEY_VIOLATION;
 
-    case ERR_UNCOMMITABLE_TXN:
+    case ERR_UNCOMMITTABLE_TXN:
         return CDB2ERR_VERIFY_ERROR;
 
     case ERR_REJECTED:

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -1111,7 +1111,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
                     case ERR_NULL_CONSTRAINT:
                     case ERR_SQL_PREP:
                     case ERR_CONSTR:
-                    case ERR_UNCOMMITABLE_TXN:
+                    case ERR_UNCOMMITTABLE_TXN:
                     case ERR_NOMASTER:
                     case ERR_DIST_ABORT:
                     case ERR_NOTSERIAL:
@@ -1132,7 +1132,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
                         case ERR_NULL_CONSTRAINT:
                         case ERR_SQL_PREP:
                         case ERR_CONSTR:
-                        case ERR_UNCOMMITABLE_TXN:
+                        case ERR_UNCOMMITTABLE_TXN:
                         case ERR_NOMASTER:
                         case ERR_NOTSERIAL:
                         case ERR_DIST_ABORT:
@@ -4791,10 +4791,11 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle,
 
         if (rc != 0) {
             if (iq->vfy_idx_track == 1 && iq->dup_key_insert == 1) {
-                rc = ERR_UNCOMMITABLE_TXN;
-                reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "add key constraint "
-                                               "duplicate key '%s' on "
-                                               "table '%s' index %d",
+                rc = ERR_UNCOMMITTABLE_TXN;
+                errout = ERR_UNCOMMITTABLE_TXN;
+                reqerrstr(iq, COMDB2_CSTRT_RC_DUP, "Transaction is uncommittable: "
+                                                   "Duplicate insert on key '%s' "
+                                                   "in table '%s' index %d",
                       get_keynm_from_db_idx(iq->usedb, ixout),
                       iq->usedb->tablename, ixout);
             } else {
@@ -5229,12 +5230,12 @@ backout:
             }
         }
 
-        if (rc == ERR_UNCOMMITABLE_TXN) {
+        if (rc == ERR_UNCOMMITTABLE_TXN) {
             logmsg(
                 LOGMSG_ERROR,
-                "Forced VERIFY-FAIL for uncommitable blocksql transaction\n");
-            err.errcode = ERR_UNCOMMITABLE_TXN;
-            rc = ERR_UNCOMMITABLE_TXN;
+                "Forced VERIFY-FAIL for uncommittable blocksql transaction\n");
+            err.errcode = ERR_UNCOMMITTABLE_TXN;
+            rc = ERR_UNCOMMITTABLE_TXN;
         }
 
         if (rc == RC_INTERNAL_RETRY) {
@@ -5280,7 +5281,7 @@ backout:
     case ERR_NULL_CONSTRAINT:
     case ERR_SQL_PREP:
     case ERR_CONSTR:
-    case ERR_UNCOMMITABLE_TXN:
+    case ERR_UNCOMMITTABLE_TXN:
     case ERR_NOMASTER:
     case ERR_NOTSERIAL:
     case ERR_DIST_ABORT:

--- a/tests/reorder_deletes.test/runit
+++ b/tests/reorder_deletes.test/runit
@@ -111,10 +111,10 @@ do_deletes()
         done
         echo "commit" >> $sqlfl
 
-        # the following may fail with "[commit] failed with rc 2 uncommitable txn on del genid=5270003 rc=404"
+        # the following may fail with "[commit] failed with rc 2 uncommittable txn on del genid=5270003 rc=404"
         cdb2sql ${CDB2_OPTIONS} $dbnm default -f $sqlfl  &> $updfl
         res=`grep '\[commit\]' $updfl`
-        if [[ $res != "[commit] rc 0" && $res != "[commit] failed with rc 2 uncommitable"* ]] ; then
+        if [[ $res != "[commit] rc 0" && $res != "[commit] failed with rc 2 uncommittable"* ]] ; then
             failexit "update failed with unexpected error"
         fi
 

--- a/tests/upsert.test/t00_upsert.expected
+++ b/tests/upsert.test/t00_upsert.expected
@@ -238,4 +238,4 @@ keys
 (i=1, j=1)
 (i=2, j=1)
 ('---- uncommittable + constraints ----'='---- uncommittable + constraints ----')
-[COMMIT] failed with rc 2 add key constraint duplicate key 'KEY' on table 'c' index 0
+[COMMIT] failed with rc 2 Transaction is uncommittable: Duplicate insert on key 'KEY' in table 'c' index 0

--- a/tests/upsert.test/t01_upsert.expected
+++ b/tests/upsert.test/t01_upsert.expected
@@ -64,7 +64,7 @@ done
 (a='three', b=1)
 (a='two', b=1)
 done
-[COMMIT] failed with rc 2 uncommitable txn on upd genid=xxxx rc=404
+[COMMIT] failed with rc 2 uncommittable txn on upd genid=xxxx rc=404
 done
 (a='one', b=1)
 (a='three', b=1)
@@ -102,7 +102,7 @@ done
 (a=1, b=2, c=0, 'x'='x')
 (a=3, b=4, c=0, 'x'='x')
 done
-[COMMIT] failed with rc 2 uncommitable txn on upd genid=xxxx rc=404
+[COMMIT] failed with rc 2 uncommittable txn on upd genid=xxxx rc=404
 done
 (a=1, b=2, c=0, 'x'='x')
 (a=3, b=4, c=0, 'x'='x')
@@ -170,7 +170,7 @@ done
 done
 done
 done
-[commit] failed with rc 2 add key constraint duplicate key 'COMDB2_PK' on table 't1' index 0
+[commit] failed with rc 2 Transaction is uncommittable: Duplicate insert on key 'COMDB2_PK' in table 't1' index 0
 done
 done
 done
@@ -195,7 +195,7 @@ done
 done
 done
 done
-[commit] failed with rc 2 add key constraint duplicate key '$KEY_877B2989' on table 't1' index 0
+[commit] failed with rc 2 Transaction is uncommittable: Duplicate insert on key '$KEY_877B2989' in table 't1' index 0
 done
 (i=1, j=1)
 (i=2, j=1)


### PR DESCRIPTION
- Make the error message more descriptive for transactions that are uncommittable due to a duplicate key violation.
- Fix the spelling of "uncommittable" throughout the codebase -- it is currently spelled "uncommitable".