### PR TITLE
Use modsnap when snapshot is the default isolation level

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -147,6 +147,7 @@ extern pthread_mutex_t gbl_fingerprint_hash_mu;
 extern int gbl_alternate_normalize;
 extern int gbl_typessql;
 extern int gbl_modsnap_asof;
+extern int gbl_use_modsnap_for_snapshot;
 
 /* Once and for all:
 
@@ -5240,7 +5241,8 @@ int tdef_to_tranlevel(int tdef)
         return TRANLEVEL_SERIAL;
 
     case SQL_TDEF_SNAPISOL:
-        return TRANLEVEL_SNAPISOL;
+        return gbl_use_modsnap_for_snapshot ?
+               TRANLEVEL_MODSNAP : TRANLEVEL_SNAPISOL;
 
     default:
         logmsg(LOGMSG_FATAL, "%s: line %d Unknown modedef: %d", __func__, __LINE__,

--- a/tests/sp.test/sp.sh
+++ b/tests/sp.test/sp.sh
@@ -344,7 +344,9 @@ local function main(t)
   th1:join()
   th2:join()
   th3:join()
+  db:begin()
   db:exec("select * from t order by i"):emit()
+  db:commit()
 end}$$
 put default procedure test11 'sptest11'
 exec procedure test11()


### PR DESCRIPTION
The changes in this PR cause default transactions to run using the new snapshot implementation (modsnap) when `sql_tranlevel_default snapshot` and `use_modsnap_for_snapshot` are both set.