### PR TITLE
Support per-rank configuration in multi-db tests

### DIFF
--- a/tests/setup
+++ b/tests/setup
@@ -79,6 +79,20 @@ check_db_port_running_node() {
 
 
 setup_db() {
+    if [[ $# -ne 1 ]]; then
+        failexit "$FUNCNAME: Expected 1 argument. Got $#"
+    fi
+
+    dbrank=$1 # 1 for primary db, 2 for secondary, and 3 for tertiary.
+
+    case $dbrank in
+        1|2|3)
+            ;;
+        *)
+            failexit "$FUNCNAME: Expected db rank to be 1, 2, or 3. \
+                     Got $dbrank"
+    esac
+
     # TESTDIR looks like this: tests/test_12758
     # DBDIR looks like this: tests/test_12758/analyzenew12758
     mkdir -p $DBDIR $TMPDIR
@@ -144,9 +158,16 @@ setup_db() {
     if [[ -f lrl ]]; then
         cat lrl >> ${LRL}
     fi
+
+    # Substitute test specific variables into lrl
     if [[ -f lrl.options ]]; then
-        # use sed to substitute in test specific variables into lrl
+        # lrl.options provides common options to all db ranks
+
         cat lrl.options | sed "s#\${TESTDIR}#${TESTDIR}#" >> ${LRL}
+    fi
+
+    if [[ -f lrl_${dbrank}.options ]]; then
+        cat lrl_${dbrank}.options | sed "s#\${TESTDIR}#${TESTDIR}#" >> ${LRL}
     fi
 
     SSH_OPT="-o StrictHostKeyChecking=no "
@@ -323,7 +344,7 @@ setup_db() {
 }
 
 # setup primary db for the test
-setup_db
+setup_db 1
 
 if [ -n "${SECONDARY_DB_PREFIX}" ] ; then
     cd -
@@ -339,7 +360,7 @@ if [ -n "${SECONDARY_DB_PREFIX}" ] ; then
 
 
     # setup secondary db for the test, if specified
-    DBNAME="${SECONDARY_DBNAME}" DBDIR="${SECONDARY_DBDIR}" CDB2_CONFIG="$SECONDARY_CDB2_CONFIG" CDB2_OPTIONS="${SECONDARY_CDB2_OPTIONS}" setup_db
+    DBNAME="${SECONDARY_DBNAME}" DBDIR="${SECONDARY_DBDIR}" CDB2_CONFIG="$SECONDARY_CDB2_CONFIG" CDB2_OPTIONS="${SECONDARY_CDB2_OPTIONS}" setup_db 2
     cd -
 fi
 
@@ -356,7 +377,7 @@ if [ -n "${TERTIARY_DB_PREFIX}" ] ; then
 
 
     # setup tertiary db for the test, if specified
-    DBNAME="${TERTIARY_DBNAME}" DBDIR="${TERTIARY_DBDIR}" CDB2_CONFIG="$TERTIARY_CDB2_CONFIG" CDB2_OPTIONS="${TERTIARY_CDB2_OPTIONS}" setup_db
+    DBNAME="${TERTIARY_DBNAME}" DBDIR="${TERTIARY_DBDIR}" CDB2_CONFIG="$TERTIARY_CDB2_CONFIG" CDB2_OPTIONS="${TERTIARY_CDB2_OPTIONS}" setup_db 3
     cd -
 fi
 

--- a/tests/tools/create_generated_tests.sh
+++ b/tests/tools/create_generated_tests.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
-# will be called by tests makefile to create all the generated tests:
-# for every .testopts file in a test directory, will generate a new test
-# with those features (in the .testopts file) appended to the lrl.options
-# of the test in question into destination directory passed in $2.
+# This script is called by the test suite's Makefile to create generated tests.
+# This is what it does:
+#
+# For each <fileprefix> with the .testopts extension in a test directory, 
+# it generates a new test in the directory passed in $2 with
+#
+# - the options in the <fileprefix>.testopts file appended to lrl.options
+# - the options in the <fileprefix>.testopts${rank} file appended to lrl_${rank}.options
+#
+# If <fileprefix>.testopts${rank} doesn't exist for some rank, 
+# then lrl_${rank}.options is untouched.
 
 DEST=$PWD
-
+DB_RANKS=(1 2 3)
 
 # generate a single test by running $0 basic.test/snapshot.testopts
 generate_test()
@@ -21,7 +28,13 @@ generate_test()
     NDIR=${TST}_${OPTFL}_generated.test
     mkdir -p $DEST/$NDIR/
     cp ${TST}.test/* $DEST/$NDIR/
+
     cat $gtst >> $DEST/$NDIR/lrl.options
+
+    for rank in "${DB_RANKS[@]}"; do
+        test -f "${gtst}${rank}" && \
+        cat "${gtst}${rank}" >> $DEST/$NDIR/lrl_${rank}.options
+    done
 }
 
 


### PR DESCRIPTION
In multi-database tests, each database is assigned a rank (currently, primary, secondary, or tertiary). The changes in this PR add support for per-rank database configuration in multi-database tests.

After these changes are merged, developers will be able to

- Use `lrl_<rank>.options` to specify unique options for a rank of database.
- Use files with the `.testopts<rank>` extension to specify unique options for a rank of database in generated tests.

`lrl.options` and files with the `.testopts` extension will continue to be applied to all test databases. 