### PR TITLE
{175900538}: Fixing stat-size misreporting

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -591,11 +591,6 @@ static int form_file_name_ex(
         buflen -= offset;
     }
 
-    if (is_data_file)
-        bdb_state->dtavers[file_num] = version_num;
-    else
-        bdb_state->ixvers[file_num] = version_num;
-
     return orig_buflen - buflen;
 }
 
@@ -711,7 +706,6 @@ static int should_stop_looking_for_queuedb_files(bdb_state_type *bdb_state,
         }
     }
     if (file_version != NULL) *file_version = local_file_version;
-    bdb_state->qvers[file_num] = local_file_version;
     return 0;
 }
 
@@ -748,7 +742,6 @@ static int form_queuedb_name(bdb_state_type *bdb_state, tran_type *tran,
     if (bdb_get_file_version_qdb(bdb_state, tran, file_num, &ver,
                                  &bdberr) == 0) {
         /* success, do nothing yet. */
-        bdb_state->qvers[file_num] = ver;
     } else {
         /* no version -AND- do fallback to versionless */
         ver = 0;

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -2693,18 +2693,22 @@ int bdb_get_file_version_data(bdb_state_type *bdb_state, tran_type *tran,
                               int dtanum, unsigned long long *version_num,
                               int *bdberr)
 {
-    return bdb_get_file_version(tran, bdb_state->name,
-                                LLMETA_FVER_FILE_TYPE_DTA, dtanum, version_num,
-                                bdberr);
+    int rc;
+    rc = bdb_get_file_version(tran, bdb_state->name, LLMETA_FVER_FILE_TYPE_DTA, dtanum, version_num, bdberr);
+    if (rc == 0 && *bdberr == BDBERR_NOERROR)
+        bdb_state->dtavers[dtanum] = *version_num;
+    return rc;
 }
 
 int bdb_get_file_version_index(bdb_state_type *bdb_state, tran_type *tran,
                                int ixnum, unsigned long long *version_num,
                                int *bdberr)
 {
-    return bdb_get_file_version(tran, (bdb_state)->name,
-                                LLMETA_FVER_FILE_TYPE_IX, ixnum, version_num,
-                                bdberr);
+    int rc;
+    rc = bdb_get_file_version(tran, (bdb_state)->name, LLMETA_FVER_FILE_TYPE_IX, ixnum, version_num, bdberr);
+    if (rc == 0 && *bdberr == BDBERR_NOERROR)
+        bdb_state->ixvers[ixnum] = *version_num;
+    return rc;
 }
 
 int bdb_get_file_version_table(bdb_state_type *bdb_state, tran_type *tran,
@@ -2719,9 +2723,11 @@ int bdb_get_file_version_qdb(bdb_state_type *bdb_state, tran_type *tran,
                              int file_num, unsigned long long *version_num,
                              int *bdberr)
 {
-    return bdb_get_file_version(tran, bdb_state->name,
-                                LLMETA_FVER_FILE_TYPE_QDB, file_num,
-                                version_num, bdberr);
+    int rc;
+    rc = bdb_get_file_version(tran, bdb_state->name, LLMETA_FVER_FILE_TYPE_QDB, file_num, version_num, bdberr);
+    if (rc == 0 && *bdberr == BDBERR_NOERROR)
+        bdb_state->qvers[file_num] = *version_num;
+    return rc;
 }
 
 int bdb_get_file_version_data_by_name(tran_type *tran, const char *name,

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -60,6 +60,9 @@ static int reload_rename_table(tran_type *tran, const char *name,
     set_odh_options_tran(db, tran);
     update_dbstore(db);
 
+    llmeta_dump_mapping_tran(tran, thedb);
+    llmeta_dump_mapping_table_tran(tran, thedb, newtable, 1);
+
     return 0;
 }
 
@@ -1167,10 +1170,13 @@ static int scdone_rename_table(const char tablename[], void *arg, scdone_t type)
     if (!tran)
         return bdberr;
 
-    if (type == rename_table)
+    if (type == rename_table) {
+        logmsg(LOGMSG_INFO, "Replicant renaming table %s to %s\n", tablename, (char *)arg);
         rc = reload_rename_table(tran, tablename, arg);
-    else
+    } else {
+        logmsg(LOGMSG_INFO, "Replicant aliasing table %s to %s\n", tablename, (char *)arg);
         rc = reload_rename_table_alias(tran, tablename, arg);
+    }
 
     _master_recs(tran, tablename, type);
     _untran(tran, lid);

--- a/tests/diskspace_nollmeta.test/runit
+++ b/tests/diskspace_nollmeta.test/runit
@@ -71,6 +71,6 @@ cdb2sql -m ${CDB2_OPTIONS} $dbnm default "SELECT name, shardname, size/1000000 a
 cdb2sql -m ${CDB2_OPTIONS} $dbnm default "ALTER TABLE tbl1 PARTITIONED BY NONE"
 cdb2sql -m ${CDB2_OPTIONS} $dbnm default "ALTER TABLE tbl1 RENAME TO tbl2"
 sleep 5
-cdb2sql -m ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('stat size')" | grep 'tbl1\|tbl2' >>actual
+cdb2sql ${CDB2_OPTIONS} $dbnm default "EXEC PROCEDURE sys.cmd.send('stat size')" | grep 'tbl1\|tbl2' >>actual
 
 diff actual expected


### PR DESCRIPTION
After RENAME, the file-version-cache would hold onto the old file versions, which would cause stat-size to misreport the table size. This patch fixes it.
