### PR TITLE
{175997346}: Fixing race between systable and sc

### DIFF
--- a/sqlite/ext/comdb2/metrics.c
+++ b/sqlite/ext/comdb2/metrics.c
@@ -195,6 +195,8 @@ const sqlite3_module systblMetricsModule = {
     0,                       /* xRollbackTo */
     0,                       /* xShadowName */
     .access_flag = CDB2_ALLOW_USER,
+    /* this system table calculates table sizes. grab the 'comdb2_table' lock */
+    .systable_lock = "comdb2_tables"
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2))       \


### PR DESCRIPTION
The comdb2_metrics table calculates table sizes and thus needs to be protected under the 'comdb2_tables' lock.
