### PR TITLE
Change snprintf to strncpy0 to avoid copying whole zStart

### DIFF
--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -5653,7 +5653,7 @@ static void comdb2AddIndexInt(
         if (key->where == 0)
             goto oom;
 
-        snprintf(key->where, where_sz, "%s", zStart);
+        strncpy0(key->where, zStart, where_sz);
     }
 
     /*


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
