### PR TITLE
reinit event base after fork

### DIFF
--- a/tools/pmux/pmux.cpp
+++ b/tools/pmux/pmux.cpp
@@ -968,6 +968,7 @@ int main(int argc, char **argv)
 
     if (!foreground_mode) {
         bb_daemon();
+        event_reinit(base);
     }
 
     set_max_active_connections();


### PR DESCRIPTION
pmux in daemon mode fails silently on macOS sonoma. It works only in foreground mode. 

The error seems to be : 

% Jul 22 13:03:05  pmux[71874] <Debug>: set_max_active_connections:192
Jul 22 13:03:05  pmux[71874] <Info>: READY
[warn] kevent: Bad file descriptor
Jul 22 13:03:05  pmux[71874] <Info>: GOODBYE

Turns out some event mechanisms do not survive across fork boundaries. Libevent [suggests](https://libevent.org/doc/event_8h.html#a7f05aabb4fbcd2ba676bb6ba92f21630) to reinit the event base following a fork call. 