### PR TITLE
Test and simple-fix for revconn close bug

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2384,8 +2384,7 @@ static int newsql_connect_via_fd(cdb2_hndl_tp *hndl)
         || (errno != 0 && fd == 0)) {
         debugprint("ERROR: %s:%d invalid fd", __func__, __LINE__);
     } else {
-        if ((sb = sbuf2open(fd, 0)) == 0) {
-            close(fd);
+        if ((sb = sbuf2open(fd, SBUF2_NO_CLOSE_FD)) == 0) {
             rc = -1;
             goto after_callback;
         }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -454,7 +454,9 @@ extern int gbl_revsql_cdb2_debug;
 extern int gbl_revsql_host_refresh_freq_sec;
 extern int gbl_revsql_connect_freq_sec;
 extern int gbl_revsql_force_rte;
+extern int gbl_revsql_fake_connect_failure;
 extern int gbl_connect_remote_rte;
+extern int gbl_abort_on_invalid_close;
 
 int gbl_debug_tmptbl_corrupt_mem;
 int gbl_group_concat_mem_limit; /* 0 implies allow upto SQLITE_MAX_LENGTH,

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1947,6 +1947,10 @@ REGISTER_TUNABLE("revsql_connect_freq_sec", "This node will attempt to (reverse)
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("revsql_force_rte", "Force reverse sql connections to use rte. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_revsql_force_rte, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("revsql_fake_connect_failure", "Fake a connect-failure on a new revsql connection.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_revsql_fake_connect_failure, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("abort_on_invalid_close", "Abort in sbufclose if the fd is invalid.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_abort_on_invalid_close, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("connect_remote_rte", "Connect to remote nodes using rte. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_connect_remote_rte, 0, 0, 0, 0, 0);
 REGISTER_TUNABLE("revsql_debug",

--- a/tests/phys_rep_tiered.test/lrl.options
+++ b/tests/phys_rep_tiered.test/lrl.options
@@ -1,2 +1,5 @@
 debug_drop_nth_rep_message 10000
 incoherent_slow_inactive_timeout 0
+revsql_fake_connect_failure 1
+abort_on_invalid_close 1
+revsql_debug 1


### PR DESCRIPTION
This is the 8.0 code which fixes the reverse-connection double-close bug.(https://github.com/bloomberg/comdb2/pull/4579)