### PR TITLE
Fix double-closes discovered under https://github.com/bloomberg/comdb2/pulls/4585

### DIFF
--- a/berkdb/os/os_region.c
+++ b/berkdb/os/os_region.c
@@ -182,10 +182,11 @@ __os_r_detach(dbenv, infop, destroy)
 		char name[MAXPATHLEN];
 
 		snprintf(name, sizeof(name) - 1, "/mnt/hugetlbfs/%s.%u",
-		    gbl_dbname, infop->id);
-        if (rp->size)
-            munmap(infop->addr, rp->size);
-		close(infop->fd);
+			gbl_dbname, infop->id);
+		if (rp->size)
+			munmap(infop->addr, rp->size);
+		if (infop->fd >= 0)
+			close(infop->fd);
 		unlink(name);
 	}
 

--- a/db/comdb2_ruleset.c
+++ b/db/comdb2_ruleset.c
@@ -1354,8 +1354,10 @@ failure:
   if( rc==0 ) rc = EINVAL;
 
 done:
-  if( sb!=NULL ) sbuf2close(sb);
-  if( fd!=-1 ) close(fd);
+  if( sb!=NULL )
+    sbuf2close(sb);
+  else if( fd!=-1 )
+    close(fd);
   return rc;
 }
 
@@ -1459,7 +1461,9 @@ failure:
   rc = 1;
 
 done:
-  if( sb!=NULL ) sbuf2close(sb);
-  if( fd!=-1 ) close(fd);
+  if( sb!=NULL ) 
+    sbuf2close(sb);
+  else if( fd!=-1 )
+    close(fd);
   return rc;
 }


### PR DESCRIPTION
This fixes 2 additional cases where comdb2 was closing invalid file descriptors.