### PR TITLE
Avoid deadlocking between partition rollout and queries accessing schema system tables

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -7702,6 +7702,13 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         return 0;
     }
 
+    /* do we need views lock? get it here before getting "comdb2_table" lock */
+    if (p->numPartitionLocks) {
+        p->crtPartitionLocks = p->numPartitionLocks;
+        extern void views_lock(void);
+        views_lock();
+    }
+
     for (int i = 0; i < p->numVTableLocks; i++) {
         if ((rc = bdb_lock_tablename_read_fromlid(thedb->bdb_env, p->vTableLocks[i],
                                                   bdb_get_lid_from_cursortran(clnt->dbtran.cursor_tran))) != 0) {

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -48,8 +48,6 @@
 #include "timepart_systable.h"
 #include "ezsystables.h"
 
-extern pthread_rwlock_t views_lk;
-
 struct systable_column {
     char *tablename;
     char *columnname;
@@ -74,8 +72,6 @@ static int collect_columns(void **pd, int *pn)
     struct field *pField = NULL;
     struct systable_column *data = NULL, *p = NULL;
     int ncols = 0;
-
-    Pthread_rwlock_rdlock(&views_lk);
 
     ntables = timepart_systable_num_tables_and_views();
 
@@ -138,8 +134,6 @@ static int collect_columns(void **pd, int *pn)
             ++ncols;
         }
     }
-
-    Pthread_rwlock_unlock(&views_lk);
 
     *pn = ncols;
     *pd = data;

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -47,8 +47,6 @@
 #include "timepart_systable.h"
 #include "ezsystables.h"
 
-extern pthread_rwlock_t views_lk;
-
 struct systable_keycomponent {
     char *table;
     char *key;
@@ -68,8 +66,6 @@ static int collect_keycomponents(void **pd, int *pn)
     struct field *pField = NULL;
     struct systable_keycomponent *data = NULL, *p = NULL;
     int ncols = 0;
-
-    Pthread_rwlock_rdlock(&views_lk);
 
     ntables = timepart_systable_num_tables_and_views();
     for (; comdb2_next_allowed_table(&tableid) == SQLITE_OK && tableid < ntables; ++tableid) {
@@ -91,8 +87,6 @@ static int collect_keycomponents(void **pd, int *pn)
             }
         }
     }
-
-    Pthread_rwlock_unlock(&views_lk);
 
     *pn = ncols;
     *pd = data;

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -48,8 +48,6 @@
 #include "timepart_systable.h"
 #include "ezsystables.h"
 
-extern pthread_rwlock_t views_lk;
-
 struct systable_key {
     char *table;
     char *key;
@@ -72,8 +70,6 @@ static int collect_keys(void **pd, int *pn)
     struct systable_key *data = NULL, *p = NULL;
     int ncols = 0;
 
-    Pthread_rwlock_rdlock(&views_lk);
-
     ntables = timepart_systable_num_tables_and_views();
     for (; comdb2_next_allowed_table(&tableid) == SQLITE_OK && tableid < ntables; ++tableid) {
         pDb = comdb2_get_dbtable_or_shard0(tableid);
@@ -95,8 +91,6 @@ static int collect_keys(void **pd, int *pn)
             ++ncols;
         }
     }
-
-    Pthread_rwlock_unlock(&views_lk);
 
     *pn = ncols;
     *pd = data;

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -46,8 +46,6 @@
 #include "timepart_systable.h"
 #include "ezsystables.h"
 
-extern pthread_rwlock_t views_lk;
-
 sqlite3_module systblTablesModule = {
     .access_flag = CDB2_ALLOW_ALL,
     .systable_lock = "comdb2_tables"
@@ -61,8 +59,6 @@ static int collect_tables(void **pd, int *pn)
     int nviewable = 0;
     char **data = NULL;
 
-    Pthread_rwlock_rdlock(&views_lk);
-
     ntables = timepart_systable_num_tables_and_views();
     data = calloc(ntables, sizeof(char *));
     for (; comdb2_next_allowed_table(&tableid) == SQLITE_OK && tableid < ntables; ++tableid, ++nviewable) {
@@ -73,8 +69,6 @@ static int collect_tables(void **pd, int *pn)
             data[nviewable] = strdup(pDb->sqlaliasname ? pDb->sqlaliasname : pDb->tablename);
         }
     }
-
-    Pthread_rwlock_unlock(&views_lk);
 
     *pn = nviewable;
     *pd = data;

--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -8047,6 +8047,20 @@ case OP_VOpen: {
   if( rc ) goto abort_due_to_error;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   rc = pModule->xOpen(pVtab, &pVCur);
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  extern int views_needs_comdb2_tables_lock(const char *);
+  if( p->crtPartitionLocks>0 && pModule->systable_lock &&
+      !strncasecmp(pModule->systable_lock, "comdb2_tables", strlen("comdb2_tables")+1 )){
+    p->crtPartitionLocks--;
+    if( p->crtPartitionLocks==0 ){
+        /* done collecting all schema, release the views lock for the rest
+         * of execution
+         */
+        extern void views_unlock(void);
+        views_unlock();
+    }
+  }
+#endif
   sqlite3VtabImportErrmsg(p, pVtab);
   if( rc ) goto abort_due_to_error;
 

--- a/sqlite/src/vdbeInt.h
+++ b/sqlite/src/vdbeInt.h
@@ -588,6 +588,8 @@ struct Vdbe {
   u16 numTables;
   u16 vTableFlags;        /* Pre-acquire rwlocks / mutexes for certain vtables */
   u16 numVTableLocks;
+  int numPartitionLocks;  /* how many system tables require views lock */
+  int crtPartitionLocks;  /* same as above, but decremented upon "collect" call */
   char **vTableLocks;
   u16 hasVTables;
   u8 hasScalarFunc;

--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -5235,6 +5235,11 @@ WhereInfo *sqlite3WhereBegin(
       const char *pVTab = (const char *)sqlite3GetVTable(db, pTab);
       int iCur = pTabItem->iCursor;
       sqlite3VdbeAddOp4(v, OP_VOpen, iCur, 0, 0, pVTab, P4_VTAB);
+#ifdef SQLITE_BUILDING_FOR_COMDB2
+      const char *lockname = ((VTable*)pVTab)->pVtab->pModule->systable_lock;
+      if( lockname && !strncasecmp(lockname, "comdb2_tables", sizeof("comdb2_tables")) )
+        v->numPartitionLocks++;
+#endif
     }else if( IsVirtual(pTab) ){
       /* noop */
     }else


### PR DESCRIPTION
We record how many system tables a query needs, which requires "comdb2_tables" systable_lock.  If any, we get the views lock before getting table locks on those system tables.  The views lock is kept until the last of those system tables is collected, which happens at the beginning at the vdbe execution.   For the client driven next_record run, the views lock is available.