### PR TITLE
Update sys_cmd_access output

### DIFF
--- a/tests/sys_cmd_access.test/t00.expected
+++ b/tests/sys_cmd_access.test/t00.expected
@@ -25,6 +25,7 @@
 (out='stat mtrap                 - show mtrap system stats')
 (out='stat dohsql                - show distributed sql stats')
 (out='stat oldfile               - dump oldfile hash')
+(out='stat snapconfig            - print snapshot configuration information')
 (out='dmpl                       - dump threads')
 (out='dmptrn                     - show long transaction stats')
 (out='dmpcts                     - show table constraints')


### PR DESCRIPTION
#4575 adds the command `stat snapconfig`. The changes in this PR add this command to the `sys_cmd_access` test expected output.