### PR TITLE
Implement set_snapshot_impl getter

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -715,7 +715,7 @@ static void toggle_new_snapisol(int switch_val) {
  *
  * impl: The value to output as a string.
  */
-static const char *snap_impl_str(snap_impl_enum impl) {
+const char *snap_impl_str(snap_impl_enum impl) {
     switch (impl) {
     case SNAP_IMPL_ORIG:
         return "ORIGINAL";

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -508,6 +508,7 @@ extern int gbl_sc_status_max_rows;
 extern int gbl_rep_process_pstack_time;
 
 extern void set_snapshot_impl(snap_impl_enum impl);
+extern const char *snap_impl_str(snap_impl_enum impl);
 
 /*
   =========================================================
@@ -603,6 +604,13 @@ static int snapshot_impl_update(void *context, void *value) {
 
 found:
     return rc;
+}
+
+static void *snapshot_impl_value(void *context)
+{
+    comdb2_tunable *tunable = (comdb2_tunable *)context;
+
+    return (void *) snap_impl_str(*(int *)tunable->var);
 }
 
 struct enable_sql_stmt_caching_st {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -429,8 +429,8 @@ REGISTER_TUNABLE("enable_snapshot_isolation",
 REGISTER_TUNABLE("set_snapshot_impl",
                  "Changes the default snapshot implementation "
                  "*without enabling snapshot* (default 'original')",
-                 TUNABLE_STRING, &gbl_snap_impl, READEARLY | READONLY, NULL, NULL,
-                 snapshot_impl_update, NULL);
+                 TUNABLE_ENUM, &gbl_snap_impl, READEARLY | READONLY,
+                 snapshot_impl_value, NULL, snapshot_impl_update, NULL);
 REGISTER_TUNABLE("enable_sparse_lockerid_map",
                  "If set, allocates a sparse map of lockers for deadlock "
                  "resolution. (Default: on)",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -880,7 +880,7 @@
 (name='serialize_reads_like_writes', description='Send read-only multi-statement schedules to the master.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='set_abort_flag_in_locker', description='', type='BOOLEAN', value='ON', read_only='N')
 (name='set_repinfo_master_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
-(name='set_snapshot_impl', description='Changes the default snapshot implementation *without enabling snapshot* (default 'original')', type='STRING', value=NULL, read_only='Y')
+(name='set_snapshot_impl', description='Changes the default snapshot implementation *without enabling snapshot* (default 'original')', type='ENUM', value='ORIGINAL', read_only='Y')
 (name='sgio_enabled', description='Do scatter gather I/O', type='BOOLEAN', value='OFF', read_only='N')
 (name='sgio_max', description='Max scatter gather I/O to do at one time', type='INTEGER', value='10485760', read_only='N')
 (name='shadows_nonblocking', description='', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
The changes in this PR change the type of `set_snapshot_impl` to `ENUM` and implement a getter method for it.