### PR TITLE
comdb2_files: skip watchdog and tmpdir contents

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1457,6 +1457,15 @@ char *comdb2_get_tmp_dir(void)
     return path;
 }
 
+char *comdb2_get_tmp_dir_name(void) {
+    char *full_path = comdb2_get_tmp_dir();
+
+    char *last_slash_pos = strrchr(full_path, '/');
+    assert(last_slash_pos != NULL);
+
+    return ++last_slash_pos;
+}
+
 /* check space similar to bdb/summarize.c: check_free_space()
  * dir is fetched from comdb2_get_tmp_dir()
  */

--- a/sqlite/ext/comdb2/files.c
+++ b/sqlite/ext/comdb2/files.c
@@ -36,7 +36,7 @@
 
 typedef unsigned char u_int8_t;
 
-char *comdb2_get_tmp_dir(void);
+char *comdb2_get_tmp_dir_name(void);
 int endianness_mismatch(struct sqlclntstate *clnt);
 void berk_fix_checkpoint_endianness(u_int8_t *buffer);
 
@@ -315,6 +315,30 @@ static int read_next_chunk(systbl_files_cursor *pCur)
     return SQLITE_OK;
 }
 
+/*
+ * Returns 1 if dirent should be skipped on the basis of its name; otherwise, returns 0.
+ *
+ * d_name: The name of the dirent to be checked
+ */
+static int should_skip_dirent(const char *d_name) {
+    const char *excluded_dirents[] = {".", "..", "watchdog", comdb2_get_tmp_dir_name(), "" /* sentinel */};
+    const char *excluded;
+    int rc;
+
+    rc = 0;
+
+    for (int i=0; (excluded = excluded_dirents[i]), excluded[0] != '\0'; ++i) {
+        rc = (strcmp(d_name, excluded) == 0);
+
+        if (rc) {
+            goto err;
+        }
+    }
+
+err:
+    return rc;
+}
+
 static int read_dir(const char *dirname, db_file_t **files, int *count, char *file_pattern, size_t chunk_size)
 {
     struct dirent buf;
@@ -330,7 +354,7 @@ static int read_dir(const char *dirname, db_file_t **files, int *count, char *fi
     }
 
     while (bb_readdir(d, &buf, &de) == 0 && de) {
-        if ((strcmp(de->d_name, ".") == 0) || (strcmp(de->d_name, "..") == 0)) {
+        if (should_skip_dirent(de->d_name)) {
             continue;
         }
 

--- a/tests/comdb2_files.test/lrl.options
+++ b/tests/comdb2_files.test/lrl.options
@@ -1,0 +1,1 @@
+nowatch

--- a/tests/comdb2_files.test/runit
+++ b/tests/comdb2_files.test/runit
@@ -103,6 +103,47 @@ function test_comdb2_files_broken_symlink() {
 	)
 }
 
+function test_comdb2_files_skips_file_on_excluded_list() {
+	(
+		# Given
+		local dbname=$1 dbdir=$2 excluded_file="watchdog"
+		echo "borkbork" > $dbdir/$excluded_file
+		trap "rm $dbdir/$excluded_file" EXIT
+
+		# When
+		num_files=$(cdb2sql -tabs $dbname local "select count(*) from comdb2_files where filename like '%$excluded_file%'")
+
+		# Then
+		query_rc=$?
+		if (( query_rc == 0 && num_files == 0 ));
+		then
+			return 0
+		else
+			return 1
+		fi
+	)
+}
+
+function test_comdb2_files_skips_dir_on_excluded_list() {
+	(
+		# Given
+		local dbname=$1 dbdir=$2 excluded_dir="tmp" file="foo"
+		echo "restrictedBlahBlah" > $dbdir/$excluded_dir/$file
+
+		# When
+		num_files=$(cdb2sql -tabs $dbname local "select count(*) from comdb2_files where filename like '%$file%'")
+
+		# Then
+		query_rc=$?
+		if (( query_rc == 0 && num_files == 0 ));
+		then
+			return 0
+		else
+			return 1
+		fi
+	)
+}
+
 function runtest {
 	local dbname=$1 dbdir=$2
 	local tests=$(compgen -A function | grep -oh "test_\w*")


### PR DESCRIPTION
Because it is not important that clients have the ability to see `tmp` directory contents and `watchdog` using `comdb2_files`, the changes in this PR cause the `comdb2_files` processor to unconditionally skip these files.