### PR TITLE
Update options for sicountbug tool

### DIFF
--- a/tests/tools/sicountbug.c
+++ b/tests/tools/sicountbug.c
@@ -550,7 +550,7 @@ int main(int argc,char *argv[])
     c = default_config();
 
     /* char *optarg=argument, int optind = argv index  */
-    while ((opt = getopt(argc,argv,"d:hr:i:tsoD"))!=EOF)
+    while ((opt = getopt(argc,argv,"d:hr:i:g:tsoD"))!=EOF)
     {
         switch(opt)
         {


### PR DESCRIPTION
The changes in this PR allow the user to specify their target tier with `-g` while invoking `sicountbug`.