### PR TITLE
Remote Table Aliases

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2468,4 +2468,5 @@ int release_locks_int(const char *trace, const char *func, int line, struct sqlc
 
 int bdb_keylen(bdb_state_type *bdb_state, int ixnum);
 
+void llmeta_collect_tablename_alias(void);
 #endif

--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -353,7 +353,6 @@ int bdb_llog_partition(bdb_state_type *bdb_state, tran_type *tran, char *name,
     return bdb_llog_scdone_tran(bdb_state, views, tran, name, strlen(name) + 1,
                                 bdberr);
 }
-
 int bdb_llog_luareload(bdb_state_type *bdb_state, int wait, int *bdberr)
 {
     return bdb_llog_scdone(bdb_state, luareload, NULL, 0, wait, bdberr);
@@ -524,4 +523,9 @@ int bdb_clear_logical_live_sc(bdb_state_type *bdb_state, int lock)
     }
 
     return 0;
+}
+
+int bdb_llog_alias(bdb_state_type *bdb_state, int wait, int *bdberr) 
+{
+    return bdb_llog_scdone(bdb_state, alias, NULL, 0, wait, bdberr);
 }

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -50,7 +50,8 @@ typedef enum scdone {
     user_view,               // 21
     add_queue_file,          // 22
     del_queue_file,          // 23
-    alias_table              // 24
+    alias_table,             // 24
+    alias                    // 25
 } scdone_t;
 
 #define BDB_BUMP_DBOPEN_GEN(type, msg) \
@@ -86,4 +87,5 @@ typedef void (*SCABORTFP)(void);
 void bdb_replace_cached_data_version(bdb_state_type *target, bdb_state_type *new);
 void bdb_replace_cached_blob_version(bdb_state_type *target, int targetnum, bdb_state_type *new, int newnum);
 void bdb_replace_cached_index_version(bdb_state_type *target, int targetnum, bdb_state_type *new, int newnum);
+int bdb_llog_alias(bdb_state_type *bdb_state, int wait, int *bdberr); 
 #endif

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(src
+  alias.c
   api_history.c
   appsock_handler.c
   autoanalyze.c

--- a/db/alias.c
+++ b/db/alias.c
@@ -1,0 +1,135 @@
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+#include <string.h>
+#include <pthread.h>
+#include <memory_sync.h>
+
+#include "comdb2.h"
+#include "sql.h"
+#include "schemachange.h"
+#include "bdb_schemachange.h"
+#include "str0.h"
+#include "logmsg.h"
+#include "cron.h"
+#include "cron_systable.h"
+#include "timepart_systable.h"
+#include "logical_cron.h"
+#include "sc_util.h"
+#include "bdb_int.h"
+#include "util.h"
+
+static hash_t *alias_tbl_hash = NULL;
+static pthread_mutex_t alias_tbl_hash_lk = PTHREAD_MUTEX_INITIALIZER;
+struct table_alias {
+    char *alias;
+    char *tablename;
+};
+
+void load_aliases_from_llmeta() {
+    if (!alias_tbl_hash) {
+        alias_tbl_hash = hash_init_strptr(0);
+    }
+    llmeta_collect_tablename_alias();
+}
+
+static int free_alias(void *obj, void *arg)
+{
+    struct table_alias *t = (struct table_alias *)obj;
+    if (t != NULL) {
+        free(t->alias);
+        free(t->tablename);
+        free(t);
+    }
+    return 0;
+}
+
+void clear_aliases() {
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    hash_for(alias_tbl_hash, free_alias, NULL);
+    hash_clear(alias_tbl_hash);
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+}
+
+void reload_aliases() {
+    clear_aliases();
+    load_aliases_from_llmeta();
+}
+
+char *get_tablename(const char *alias) {
+    struct table_alias *t = NULL;
+    char *result = NULL;
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    t = hash_find(alias_tbl_hash, &alias);
+    if (t) {
+        result = strdup(t->tablename);
+    }
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+    return result;
+}
+
+int add_alias(const char *alias, const char *tablename){
+    struct table_alias *t = calloc(1, sizeof(struct table_alias));
+    if (!t) {
+        logmsg(LOGMSG_ERROR, "%s:%d : OOM\n", __func__, __LINE__);
+        return -1;
+    }
+    logmsg(LOGMSG_USER, "Adding ALIAS %s for table %s\n", alias, tablename);
+    t->alias = strdup(alias);
+    t->tablename = strdup(tablename);
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    if (hash_find(alias_tbl_hash, &alias)) {
+        logmsg(LOGMSG_ERROR, "Alias %s already exists\n", alias);
+        Pthread_mutex_unlock(&alias_tbl_hash_lk);
+        return -1;
+    }
+    hash_add(alias_tbl_hash, t);
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+    return 0;
+}
+
+void remove_alias(const char *alias) {
+    struct table_alias *t = NULL;
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    t = hash_find(alias_tbl_hash, &alias);
+    if(!t) {
+        logmsg(LOGMSG_WARN, "Couldn't find alias %s\n", alias);
+    } else {
+        hash_del(alias_tbl_hash, t);
+    }
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+}
+
+char *get_alias(const char *tablename){
+    struct table_alias *t = NULL;
+    void *ent;
+    unsigned int bkt;
+    char *result = NULL;
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    for (t = (struct table_alias *)hash_first(alias_tbl_hash, &ent, &bkt); t;
+         t = (struct table_alias *)hash_next(alias_tbl_hash, &ent, &bkt)) {
+        if (strcmp(t->tablename, tablename)==0) {
+            result = strdup(t->alias);
+            break;
+        }
+    }
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+    return result;
+}
+
+
+static int print_alias_info(void *obj, void *arg)
+{
+    struct table_alias *t = (struct table_alias *)obj;
+    if (t != NULL) {
+        logmsg(LOGMSG_USER, "\"%s\" -> \"%s\"\n", t->alias, t->tablename);
+    }
+    return 0;
+}
+void dump_alias_info() {
+    Pthread_mutex_lock(&alias_tbl_hash_lk);
+    hash_for(alias_tbl_hash, print_alias_info, NULL);
+    Pthread_mutex_unlock(&alias_tbl_hash_lk);
+}
+
+

--- a/db/alias.h
+++ b/db/alias.h
@@ -1,0 +1,11 @@
+#ifndef ALIAS_H
+#define ALIAS_H
+typedef struct table_alias table_alias_t;
+void load_aliases_from_llmeta();
+void reload_aliases();
+int add_alias(const char *, const char *);
+void remove_alias(const char *);
+char *get_alias(const char *);
+char *get_tablename(const char *);
+void dump_alias_info();
+#endif 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -142,7 +142,7 @@ void berk_memp_sync_alarm_ms(int);
 #include <net_appsock.h>
 #include "sc_csc2.h"
 #include "reverse_conn.h"
-
+#include "alias.h"
 #define tokdup strndup
 
 int gbl_thedb_stopped = 0;
@@ -4125,6 +4125,7 @@ static int init(int argc, char **argv)
             return -1;
         }
 
+        load_aliases_from_llmeta();
         /* if we are repopulating the .lrl with the table definitions */
         if (gbl_repoplrl_fname) {
             /* print all the schemas to disk ie /data/dir/tablename.csc2 */

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -56,6 +56,7 @@
 #include "ssl_io.h"
 #include "ssl_bend.h"
 #include "comdb2_query_preparer.h"
+#include "alias.h"
 
 extern int gbl_fdb_resolve_local;
 extern int gbl_fdb_allow_cross_classes;
@@ -4110,11 +4111,7 @@ char *fdb_get_alias(const char **p_tablename)
     char *errstr = NULL;
     char *alias = NULL;
     const char *tablename = *p_tablename;
-    tran_type *trans;
-
-    trans = curtran_gettran();
-    alias = llmeta_get_tablename_alias_tran(trans, tablename, &errstr);
-    curtran_puttran(trans);
+    alias = get_tablename(tablename);
     if (!alias) {
         if (errstr) {
             logmsg(LOGMSG_ERROR, "%s: error retrieving fdb alias for %s\n", __func__,
@@ -4135,7 +4132,7 @@ char *fdb_get_alias(const char **p_tablename)
     return alias;
 }
 
-void fdb_stat_alias(void) { llmeta_list_tablename_alias(); }
+void fdb_stat_alias(void) { dump_alias_info(); }
 
 /**
 * This function will check some critical regions

--- a/protobuf/bpfunc.proto
+++ b/protobuf/bpfunc.proto
@@ -1,6 +1,11 @@
 //package com.bloomberg.comdb2.bpfunc;
 syntax = "proto2";
 
+enum alias_op {
+    CREATE = 0;
+    DROP   = 1;
+}
+
 message bpfunc_create_timepart {
   required string tablename = 1;
   required string partition_name = 2;
@@ -35,6 +40,7 @@ message bpfunc_authentication {
 message bpfunc_alias {
     required string remote = 1;
     required string name = 2;
+    required alias_op op = 3;
 }
 
 message bpfunc_analyze_threshold

--- a/tests/alias.test/Makefile
+++ b/tests/alias.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=remdb
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=1m
+endif

--- a/tests/alias.test/README
+++ b/tests/alias.test/README
@@ -1,0 +1,1 @@
+ Simple test to verify creating, deleting and resolving table aliases

--- a/tests/alias.test/output.log.actual
+++ b/tests/alias.test/output.log.actual
@@ -1,0 +1,59 @@
+Populating remote database
+[create table t1(a int)] rc 0
+10
+[insert into t1 select * from generate_series(1,10)] rc 0
+Creating aliases
+[put alias t1_alias1 'LOCAL_remdb.t1'] rc 0
+[put alias t1_alias2 'LOCAL_remdb.t1'] rc 0
+[put alias t1_alias3 'LOCAL_remdb.t1'] rc 0
+"t1_alias1" -> "LOCAL_remdb.t1"
+"t1_alias2" -> "LOCAL_remdb.t1"
+"t1_alias3" -> "LOCAL_remdb.t1"
+[exec procedure sys.cmd.send('stat alias')] rc 0
+Trying to overwrite alias should fail
+[put alias t1_alias1 'LOCAL_remdb.blah'] failed with rc 203 tablename alias already exists
+Create alias to non-existent remote table should succeed
+[select * from invalid_alias] failed with rc -3 no such table "blah" for db "remdb"
+[put alias invalid_alias 'LOCAL_remdb.blah'] rc 0
+Select using alias name
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+[select * from t1_alias1] rc 0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+[select * from t1_alias2] rc 0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+[select * from t1_alias3] rc 0
+Dropping an alias
+[put alias t1_alias1 ''] rc 0
+"t1_alias2" -> "LOCAL_remdb.t1"
+"t1_alias3" -> "LOCAL_remdb.t1"
+"invalid_alias" -> "LOCAL_remdb.blah"
+[exec procedure sys.cmd.send('stat alias')] rc 0
+Select using deleted alias
+[select * from t1_alias1] failed with rc -3 no such table: t1_alias1

--- a/tests/alias.test/runit
+++ b/tests/alias.test/runit
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# remote db config
+REM_CDB2_OPTIONS="--cdb2cfg ${SECONDARY_CDB2_CONFIG}"
+
+output=run.log
+echo "Populating remote database" >> $output 
+cdb2sql --tabs ${REM_CDB2_OPTIONS} $SECONDARY_DBNAME default - >> $output 2>&1 << EOF
+create table t1(a int)\$\$
+insert into t1 select * from generate_series(1,10)
+EOF
+
+echo "Creating aliases" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+put alias t1_alias1 'LOCAL_${SECONDARY_DBNAME}.t1'
+put alias t1_alias2 'LOCAL_${SECONDARY_DBNAME}.t1'
+put alias t1_alias3 'LOCAL_${SECONDARY_DBNAME}.t1'
+exec procedure sys.cmd.send('stat alias')
+EOF
+
+echo "Trying to overwrite alias should fail" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+put alias t1_alias1 'LOCAL_${SECONDARY_DBNAME}.blah'
+EOF
+
+echo "Create alias to non-existent remote table should succeed" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+put alias invalid_alias 'LOCAL_${SECONDARY_DBNAME}.blah'
+select * from invalid_alias
+EOF
+
+echo "Select using alias name" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+select * from t1_alias1
+select * from t1_alias2
+select * from t1_alias3
+EOF
+
+
+echo "Dropping an alias" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+put alias t1_alias1 ''
+exec procedure sys.cmd.send('stat alias')
+EOF
+
+echo "Select using deleted alias" >> $output
+cdb2sql --tabs ${CDB2_OPTIONS} $DBNAME default - >> $output 2>&1 << EOF
+select * from t1_alias1
+EOF
+
+#get rid of remdb name
+sed "s/${SECONDARY_DBNAME}/remdb/g" $output > run.log.actual
+
+testcase_output=$(cat run.log.actual)
+expected_output=$(cat output.log.actual)
+if [[ "$testcase_output" != "$expected_output" ]]; then
+
+   # print message 
+   echo "  ^^^^^^^^^^^^"
+   echo "The above testcase (${testcase}) has failed!!!" 
+   echo " "
+   echo "Use 'diff <expected-output> <my-output>' to see why:"
+   echo "> diff ${PWD}/{output.log.actual,run.log.actual}"
+   echo " "
+   diff output.log.actual run.log.actual
+   echo " "
+
+   # quit
+   exit 1
+fi
+
+echo "Testcase passed."


### PR DESCRIPTION
Get alias as advertised [here](https://tutti.prod.bloomberg.com/comdb2/programming/sql#get) is unimplemented. Additionally there doesn't seem to be a way to drop an alias once created. Furthermore, all alias operations currently seem to read and write directly from llmeta which can prove to be expensive in scenarios where resolving an alias name to a remote tablename occurs frequently . 

This patch addresses the above three : 
1.) Fetch the local alias for a remote table
2.) Delete an alias -> PUT ALIAS <aliasname> ""
3.) Maintain alias information in an in-memory hash table