### PR TITLE
Modsnap: Use checkpoint LSN instead of LSN of checkpoint record

### DIFF
--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -222,13 +222,6 @@ __checkpoint_save(DB_ENV *dbenv, DB_LSN *lsn, int in_recovery)
 		return EINVAL;
 	}
 
-	if (dbenv->txmap != NULL) {
-		Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
-		// Since checkpoint lsn is lt begin lsn of oldest in-flight txn, any lsn that we get to before the checkpoint lsn was made by a committed txn.
-		dbenv->txmap->highest_checkpoint_lsn = *lsn; 
-		Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
-	}
-
 	return 0;
 }
 

--- a/berkdb/mp/mp_versioned.c
+++ b/berkdb/mp/mp_versioned.c
@@ -12,7 +12,7 @@
 #include "dbinc/hmac.h"
 #include "dbinc_auto/hmac_ext.h"
 
-#define PAGE_VERSION_IS_GUARANTEED_TARGET(highest_checkpoint_lsn, smallest_logfile, target_lsn, pglsn) (log_compare(&highest_checkpoint_lsn, &pglsn) >= 0 || IS_NOT_LOGGED_LSN(pglsn) || (pglsn.file < smallest_logfile))
+#define PAGE_VERSION_IS_GUARANTEED_TARGET(highest_checkpoint_lsn, smallest_logfile, target_lsn, pglsn) (log_compare(&highest_checkpoint_lsn, &pglsn) > 0 || IS_NOT_LOGGED_LSN(pglsn) || (pglsn.file < smallest_logfile))
 
 extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN *);
 

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -3722,6 +3722,13 @@ gap_check:		max_lsn_dbtp = NULL;
 				__func__, ret);
 			goto err;
 		}
+
+		if (dbenv->txmap != NULL) {
+			Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
+			dbenv->txmap->highest_checkpoint_lsn = ckp_args->ckp_lsn; 
+			Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
+		}
+
 		__os_free(dbenv, ckp_args);
 		if (gbl_flush_log_at_checkpoint)
 			__log_flush(dbenv, NULL);

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -3037,6 +3037,12 @@ do_ckp:
 			return ret;
 		}
 
+		if (dbenv->txmap != NULL) {
+			Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
+			dbenv->txmap->highest_checkpoint_lsn = ckp_lsn; 
+			Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
+		}
+
 		ret = __log_flush_pp(dbenv, NULL);
 		if (ret == 0)
 			__txn_updateckp(dbenv, &ckp_lsn);	/* this is the output lsn from txn_ckp_log */


### PR DESCRIPTION
Snapshot transactions using the modsnap implementation judge a Btree page to be at the correct version if its LSN is less than the checkpoint LSN preceding the snapshot start point.

The changes in this PR fix a bug where the LSN of the checkpoint record was being used in place of the actual checkpoint LSN.

This bug was causing occasional failures in the `sicountbug` test.