### PR TITLE
Add snapshot configuration tests

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -461,6 +461,7 @@ int gbl_enable_cache_internal_nodes = 1;
 int gbl_use_modsnap_for_snapshot = 0;
 int gbl_modsnap_asof = 0;
 const snap_impl_enum gbl_snap_fallback_impl = SNAP_IMPL_MODSNAP;
+const snap_impl_enum gbl_snap_backup_fallback_impl = SNAP_IMPL_MODSNAP;
 snap_impl_enum gbl_snap_impl = SNAP_IMPL_MODSNAP;
 int gbl_use_appsock_as_sqlthread = 0;
 int gbl_rep_process_txn_time = 0;

--- a/tests/siconfig.test/Makefile
+++ b/tests/siconfig.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/siconfig.test/disable_newsi.testopts
+++ b/tests/siconfig.test/disable_newsi.testopts
@@ -1,0 +1,2 @@
+set_snapshot_impl new
+disable_new_snapshot

--- a/tests/siconfig.test/lrl.options
+++ b/tests/siconfig.test/lrl.options
@@ -1,0 +1,1 @@
+enable_snapshot_isolation

--- a/tests/siconfig.test/modsnap.testopts
+++ b/tests/siconfig.test/modsnap.testopts
@@ -1,0 +1,1 @@
+set_snapshot_impl modsnap

--- a/tests/siconfig.test/newsi.testopts
+++ b/tests/siconfig.test/newsi.testopts
@@ -1,0 +1,1 @@
+set_snapshot_impl new

--- a/tests/siconfig.test/orig.testopts
+++ b/tests/siconfig.test/orig.testopts
@@ -1,0 +1,1 @@
+set_snapshot_impl original

--- a/tests/siconfig.test/orig_after_newsi.testopts
+++ b/tests/siconfig.test/orig_after_newsi.testopts
@@ -1,0 +1,3 @@
+# Make sure that the later `set_snapshot_impl` takes precedence
+set_snapshot_impl new
+set_snapshot_impl original

--- a/tests/siconfig.test/runit
+++ b/tests/siconfig.test/runit
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+default_implementation="modsnap" # "original", "newsi", or "modsnap"
+newsi_switches="gbl_new_snapisol gbl_new_snapisol_asof gbl_new_snapisol_logging"
+modsnap_switches="gbl_use_modsnap_for_snapshot gbl_modsnap_asof"
+
+verify_switch_values() {
+	local rc=0 switches=$1 exp_on_off=$2
+	local info=$(cdb2sql $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('stat snapconfig')")
+
+	for switch in $switches;
+	do
+		if ! (echo "$info" | grep --ignore-case "$switch=$exp_on_off" > /dev/null);
+		then
+			echo "$switch does not have expected value ($exp_on_off): $info"
+			rc=1
+			break
+		fi
+	done
+
+	return $rc
+}
+
+verify_implementation() {
+	local rc=0 impl=$1
+	local info=$(cdb2sql $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.send('stat snapconfig')")
+
+	if ! (echo "$info" | grep --ignore-case "Implementation set to '$impl'" > /dev/null); then
+		echo "Snapshot implementation is not expected ('$impl'): $info"
+		rc=1
+	fi
+
+	return $rc
+}
+
+check_original_implementation_is_enabled() {
+	verify_implementation 'original' && \
+	verify_switch_values "$newsi_switches" "off" && \
+	verify_switch_values "$modsnap_switches" "off"
+
+	return $?
+}
+
+check_modsnap_implementation_is_enabled() {
+	verify_implementation 'modsnap' && \
+	verify_switch_values "$newsi_switches" "off" && \
+	verify_switch_values "$modsnap_switches" "on"
+
+	return $?
+}
+
+check_newsi_implementation_is_enabled() {
+	verify_implementation 'new' && \
+	verify_switch_values "$newsi_switches" "on" && \
+	verify_switch_values "$modsnap_switches" "off"
+
+	return $?
+}
+
+main() {
+	if [ "$TESTCASE" == "siconfig" ];
+	then
+		check_${default_implementation}_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_disable_newsi_generated" -a "$default_implementation" != "newsi" ];
+	then
+		check_${default_implementation}_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_newsi_generated" ];
+	then
+		check_newsi_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_modsnap_generated" ];
+	then
+		check_modsnap_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_orig_generated" ];
+	then
+		check_original_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_orig_after_newsi_generated" ];
+	then
+		check_original_implementation_is_enabled
+	elif [ "$TESTCASE" == "siconfig_disable_newsi_generated" && "$default_implementation" == "newsi" ];
+	then
+		check_original_implementation_is_enabled
+	else
+		echo "No test for $TESTCASE"
+		return 1
+	fi
+
+	return $?
+}
+
+main
+exit $?


### PR DESCRIPTION
The changes in this PR add snapshot configuration tests and encapsulate logic for disabling newsi.