### PR TITLE
Fix elect-highest-committed-gen for full-recovery.

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -2414,6 +2414,7 @@ int bdb_is_standalone(void *dbenv, void *in_bdb_state)
 
 extern int gbl_commit_delay_trace;
 int gbl_skip_catchup_logic = 0;
+int gbl_debug_downgrade_cluster_at_open = 0;
 
 static DB_ENV *dbenv_open(bdb_state_type *bdb_state)
 {
@@ -3035,6 +3036,10 @@ if (!is_real_netinfo(bdb_state->repinfo->netinfo))
         print(bdb_state, "dbenv_open: started rep as MASTER\n");
     } else /* we start as a client */
     {
+        if (gbl_debug_downgrade_cluster_at_open) {
+            logmsg(LOGMSG_USER, "%s testcase sleep for 1 on downgrade_cluster_at_open\n", __func__);
+            sleep(1);
+        }
         /*fprintf(stderr, "dbenv_open: starting rep as client\n");*/
         logmsg(LOGMSG_USER,
                "%s line %d calling rep_start as client with egen 0\n", __func__,

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -1029,6 +1029,8 @@ extern pthread_rwlock_t gbl_dbreg_log_lock;
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 #endif
 
+extern int gbl_fullrecovery;
+
 /*
  * __txn_commit --
  *	Commit a transaction.
@@ -1133,7 +1135,8 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 			return __db_panic(dbenv, c_ret);
 	}
 
-	elect_highest_committed_gen = dbenv->attr.elect_highest_committed_gen;
+    /* don't let full recovery write a (higher) generation: it will force this newly-recovered node to be master on the next election */
+	elect_highest_committed_gen = (dbenv->attr.elect_highest_committed_gen && !gbl_fullrecovery);
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -238,6 +238,7 @@ extern int gbl_incoherent_slow_inactive_timeout;
 extern int gbl_force_incoherent;
 extern int gbl_ignore_coherency;
 extern int gbl_skip_catchup_logic;
+extern int gbl_debug_downgrade_cluster_at_open;
 extern int gbl_forbid_incoherent_writes;
 extern int gbl_durable_set_trace;
 extern int gbl_set_seqnum_trace;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1992,6 +1992,10 @@ REGISTER_TUNABLE("forbid_incoherent_writes",
                  TUNABLE_BOOLEAN, &gbl_forbid_incoherent_writes,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_downgrade_cluster_at_open",
+                 "Sleep on open to allow testsuite to downgrade master.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_downgrade_cluster_at_open, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("skip_catchup_logic",
                  "Skip initial catchup logic.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_skip_catchup_logic, EXPERIMENTAL | INTERNAL, NULL, NULL,

--- a/tests/nogen_full_recovery.test/Makefile
+++ b/tests/nogen_full_recovery.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/nogen_full_recovery.test/README
+++ b/tests/nogen_full_recovery.test/README
@@ -1,0 +1,29 @@
+This test makes sure that full-recovery does not write a regop-gen record which
+will incorrectly bias it to win an election when it rejoins the cluster.
+Further, the 'disable' testops examines the behavior when elect-highest-gen is
+disabled.  We believe that there are cases under the original algorithm where
+full-recovery can push the end of the transaction-log beyond that of the
+cluster, which may again incorrectly bias it towards winning an election.
+
+There are 3 different versions of this test:
+
+The default (no-testopts) version has elect-highest-committed-gen enabled, and
+demonstrated the original bug.  It shows how full-recovery writes a regop-gen
+record with a higher-generation than the cluster is running.  When it rejoins,
+it becomes the master, which causes the cluster to unwind any transactions that
+the fully-recovered node has not seen.  To see this failure, undo the fix in
+berkdb/txn.c.
+
+The 'disable' version of this test shows the failure case that occurs if elect-
+highest-committed-gen is disabled.  This is the original issue that this
+tunable was intended to fix.  This version of the test requires that the master
+node downgrade just as the fully-recovered node rejoins the cluster.  The
+fully-recovered node should be guaranteed to win the election because
+full-recovery has pushed it's LSN further than the cluster's LSN.
+
+The 'enableddowngrade' version of this test shows that
+elect-highest-committed-gen will not allow the fully-recovered node to win the
+election despite the fact that it's LSN is larger.  Rather, the election allows
+a node which has the highest written generation to win the election.  So data
+which has replicated to a majority is not lost.  This is the correct behavior.
+

--- a/tests/nogen_full_recovery.test/disable.testopts
+++ b/tests/nogen_full_recovery.test/disable.testopts
@@ -1,0 +1,1 @@
+berkattr elect_highest_committed_gen 0

--- a/tests/nogen_full_recovery.test/enableddowngrade.testopts
+++ b/tests/nogen_full_recovery.test/enableddowngrade.testopts
@@ -1,0 +1,3 @@
+# Just a marker file to run 'downgrade' on original test
+# elect_highest_committed_gen should be enabled with lrl.options
+

--- a/tests/nogen_full_recovery.test/lrl.options
+++ b/tests/nogen_full_recovery.test/lrl.options
@@ -1,0 +1,3 @@
+nowatch
+logmsg level info
+berkattr elect_highest_committed_gen 1

--- a/tests/nogen_full_recovery.test/runit
+++ b/tests/nogen_full_recovery.test/runit
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=1
+
+[[ "$debug" == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+function create_lots_of_btrees
+{
+    j=0
+    while [[ "$j" -lt "100" ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table if not exists x${j}(a int, b blob, c blob, d blob, e blob)"
+        let j=j+1
+    done
+}
+
+function full_recover_node
+{
+    typeset fullrecovery=$1
+    typeset node=$fullrecovery
+
+    kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+    sleep 2 
+    pushd $DBDIR
+
+    export LOGDIR=$TESTDIR/logs
+    export REP_ENV_VARS="${DBDIR}/replicant_env_vars"
+
+    # Run full-recovery
+    if [ $node == `hostname` ] ; then
+    	PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --fullrecovery"
+        $COMDB2_EXE ${DBNAME} ${PARAMS}
+    else
+        PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --fullrecovery"
+        CMD="cd ${DBDIR}; source ${REP_ENV_VARS} ; $COMDB2_EXE ${DBNAME} ${PARAMS}"
+        ssh -n -o StrictHostKeyChecking=no -tt $node "${CMD}" < /dev/null
+    fi
+
+    # While it is down, insert another record .. 
+    # Before fixing the highest-committed-gen fullrecovery bug, you could insert 1000 additional
+    # records here and they would disappear .. inserting 1 record allows the same test to continue 
+    # to fail when elect-highest-committed-gen is disabled
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 (a) values(1)"
+
+    # Verify that the count has replicated (it should but make really, really sure)
+    for n in $CLUSTER ; do
+        if [[ "$n" -ne "$fullrecovery" ]]; then
+            count=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $n "select count(*) from t1")
+            if [[ "$count" -ne $target_records ]] ; then
+                failexit "Count is $count, not $target_records"
+            fi
+        fi
+    done
+
+    # Quickly bring it back up
+	mv --backup=numbered $LOGDIR/${DBNAME}.${node}.db $LOGDIR/${DBNAME}.${node}.db.1
+    if [ $node == `hostname` ] ; then
+        echo "debug_downgrade_cluster_at_open 1" >> $DBDIR/${DBNAME}.lrl
+    	PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
+        $COMDB2_EXE ${DBNAME} ${PARAMS} &> $LOGDIR/${DBNAME}.${node}.db &
+        tail -f $LOGDIR/${DBNAME}.${node}.db | egrep -m 1 "downgrade_cluster_at_open"
+        sleep 1
+    else
+        PARAMS="--no-global-lrl --lrl $DBDIR/${DBNAME}.lrl --pidfile ${TMPDIR}/${DBNAME}.${node}.pid"
+        CMD="cd ${DBDIR}; source ${REP_ENV_VARS} ; echo \"debug_downgrade_cluster_at_open 1\" >> $DBDIR/${DBNAME}.lrl ; $COMDB2_EXE ${DBNAME} ${PARAMS} 2>&1 | tee $TESTDIR/${DBNAME}.db"
+        ssh -n -o StrictHostKeyChecking=no -tt $node ${CMD} &> $LOGDIR/${DBNAME}.${node}.db </dev/null & 
+        echo $! > ${TMPDIR}/${DBNAME}.${node}.pid
+        tail -f $LOGDIR/${DBNAME}.${node}.db | egrep -m 1 "downgrade_cluster_at_open"
+        sleep 1
+    fi
+
+    # The original bug in elect-highest-committed-gen doesn't require a downgrade here
+    # The old version of election requires a downgrade .. 
+    # Downgrade on 'disable' or 'enableddowngrade' (which has elect-highest-committed-gen enabled)
+    if [[ "$DBNAME" == *"enableddowngrade"* || "$DBNAME" == *"disable"* ]]; then
+        echo "Downgrading $master"
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('downgrade')" >/dev/null 2>&1 &
+    fi
+
+    # Wait for entire cluster to be available
+    bad=1
+    while [[ "$bad" == "1" ]]; do
+        bad=0
+        for n in $CLUSTER ; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "select 1"
+            if [[ $? -ne 0 ]] ; then
+                bad=1
+            fi
+        done
+        if [[ "$bad" == "1" ]]; then
+            sleep 1
+        fi
+    done
+
+
+
+}
+
+function run_test
+{
+    typeset target_records=1001
+    typeset fullrecovery=""
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table if not exists t1(a int)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, 1000)"
+
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "exec procedure sys.cmd.send('flush')"
+    done
+
+    fullrecovery=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='N' limit 1")
+    #fullrecovery=$node
+    master=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y' limit 1")
+    node=$fullrecovery
+
+    # Get master again .. if this was the 'disabled' test, the master should be the full-recovered node
+    full_recover_node $fullrecovery
+    master=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y' limit 1")
+
+    # Just repeat until the fully recovered node becomes the master
+    if [[ "$DBNAME" == *"disable"* ]]; then
+        while [[ "$master" != "$fullrecovery" ]]; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "truncate table t1"
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 select * from generate_series(1, 1000)"
+            for node in $CLUSTER ; do
+                $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "exec procedure sys.cmd.send('flush')"
+            done
+
+            fullrecovery=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='N' limit 1")
+            full_recover_node $fullrecovery
+            master=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y' limit 1")
+        done
+    fi
+
+    # Sleep a bit
+    sleep 5
+
+    # Select the count
+    count=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select count(*) from t1")
+
+    if [[ "$count" -ne $target_records ]] ; then
+        
+        # 'FAILURE' is 'SUCCESS' for the disable testcase .. it is attempting to show the failure that
+        # occurs if elect-highest-committed-gen is disabled
+        echo "We got a count of $count, not $target_records"
+        if [[ "$DBNAME" != *"disable"* ]]; then
+            kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+            failexit "Count is not $target_records"
+        else
+            echo "Successfully reproduced bug"
+        fi
+    elif [[ "$DBNAME" == *"disable"* ]]; then
+        echo "FAILURE: disable test failed to reproduce bug"
+        kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+        failexit "Count is correct even though committed-gen is disabled"
+    else
+        echo "Success!"
+    fi
+
+    kill_by_pidfile ${TMPDIR}/${DBNAME}.${node}.pid
+    echo "Success!"
+}
+
+
+[[ -z "$CLUSTER" || $(echo "$CLUSTER" | wc -w) -lt 3 ]] && failexit "This test requires a 3-node cluster"
+
+# This tests both with committed-gen enabled and disabled 
+# When committed_gen is disabled, run-test should fail.
+
+create_lots_of_btrees
+run_test
+


### PR DESCRIPTION
Test and fix for the elect-highest-committed-gen failure.  A new test, 'nogen_full_recovery', shows how the original bug unwound data, how we can lose data when elect-highest-committed-gen is not enabled, and how the non-bugged version of this tunable solves that case.  The README file in the testcase directory describes each test in detail.