### PR TITLE
Enforce commit LSN map dependency on utxnids

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1596,7 +1596,7 @@ REGISTER_TUNABLE("commit_delay_trace", "Verbose commit-delays.  (Default: off)",
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("commit_lsn_map", "Maintain a map of transaction commit LSNs. (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_commit_lsn_map,
-                 NOARG, NULL, NULL, NULL, NULL);
+                 NOARG, NULL, NULL, commit_lsn_map_update, NULL);
 REGISTER_TUNABLE("incoherent_slow_inactive_timeout", "Periodically reset slow-nodes to incoherent.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_incoherent_slow_inactive_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("set_coherent_state_trace", "Verbose coherency trace.  (Default: off)", TUNABLE_BOOLEAN,
@@ -2162,7 +2162,7 @@ REGISTER_TUNABLE("ufid_log", "Generate ufid logs.  (Default: on)", TUNABLE_BOOLE
                  EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("utxnid_log", "Generate utxnid logs. (Default: on)", TUNABLE_BOOLEAN, &gbl_utxnid_log,
-                 NOARG|READEARLY, NULL, NULL, NULL, NULL);
+                 NOARG|READEARLY, NULL, NULL, utxnid_log_update, NULL);
 
 REGISTER_TUNABLE("ufid_add_on_collect", "Add to ufid-hash on collect.  (Default: off)", TUNABLE_BOOLEAN, 
                  &gbl_ufid_add_on_collect, EXPERIMENTAL | INTERNAL | READONLY, NULL, NULL, NULL, NULL);

--- a/tests/commit_lsn_map.test/lrl.options
+++ b/tests/commit_lsn_map.test/lrl.options
@@ -1,2 +1,1 @@
-utxnid_log on
 berkattr commit_map_debug 1

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -259,5 +259,60 @@ function test_delete
 	done
 }
 
+verify_tunable_value() {
+	local -r tunable=$1 exp_on_off=$2 node=$3
+	local res_on_off
+
+	res_on_off=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "select value from comdb2_tunables where name='$tunable'")
+	readonly res_on_off
+
+	if ! (echo $res_on_off | grep --ignore-case "$exp_on_off" > /dev/null);
+	then
+		echo "$tunable='$res_on_off' but should be $exp_on_off"
+		return 1
+	fi
+}
+
+test_tunables() {
+	set -e
+	local node
+	node=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()")
+	readonly node
+	
+	verify_tunable_value "commit_lsn_map" "on" $node
+	verify_tunable_value "utxnid_log" "on" $node
+
+	# Verify disabling utxnid logging disables the commit LSN map
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('utxnid_log off')"
+	verify_tunable_value "commit_lsn_map" "off" $node
+	verify_tunable_value "utxnid_log" "off" $node
+
+	# Verify that the commit LSN map cannot be enabled when utxnid logging is disabled
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('commit_lsn_map on')"
+	verify_tunable_value "commit_lsn_map" "off" $node
+	verify_tunable_value "utxnid_log" "off" $node
+
+	# Verify that re-enabling utxnid logging re-enables the commit LSN map
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('utxnid_log on')"
+	verify_tunable_value "commit_lsn_map" "on" $node
+	verify_tunable_value "utxnid_log" "on" $node
+
+	# Verify that re-enabling utxnid logging *does not* re-enable the commit LSN map if the map
+	# was turned off explicitly
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('utxnid_log off')"
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('commit_lsn_map off')"
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('utxnid_log on')"
+	verify_tunable_value "commit_lsn_map" "off" $node
+	verify_tunable_value "utxnid_log" "on" $node
+
+	# Verify that the commit LSN map can be enabled when utxnid logging is enabled
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('commit_lsn_map on')"
+	verify_tunable_value "commit_lsn_map" "on" $node
+	verify_tunable_value "utxnid_log" "on" $node
+
+	set +e
+}
+
 test_delete
 test_add
+test_tunables


### PR DESCRIPTION
The changes in this PR block commit_lsn_map from being enabled if utxnid logging is disabled.