### PR TITLE
Enforce txmap dependency on utxnids

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -118,9 +118,10 @@ extern char *gbl_myhostname;
 extern struct interned_string *gbl_myhostname_interned;
 extern size_t gbl_blobmem_cap;
 extern int gbl_backup_logfiles;
-extern int gbl_commit_lsn_map;
 struct timeval last_timer_pstack;
 extern int gbl_modsnap_asof;
+
+extern int get_commit_lsn_map_switch_value();
 
 #define FILENAMELEN 100
 
@@ -3568,7 +3569,7 @@ static void delete_log_files_int(bdb_state_type *bdb_state)
     int filenum;
     int delete_adjacent;
     int ctrace_info = 0;
-    int commit_lsn_map = gbl_commit_lsn_map;
+    int commit_lsn_map = get_commit_lsn_map_switch_value();
 
     filenums_str[0] = 0;
 

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -67,7 +67,6 @@ int rep_qstat_has_allreq(void);
 extern int db_is_exiting(void);
 
 extern int gbl_exit;
-extern int gbl_commit_lsn_map;
 extern int gbl_rep_printlock;
 extern int gbl_dispatch_rowlocks_bench;
 extern int gbl_rowlocks_bench_logical_rectype;
@@ -141,6 +140,7 @@ extern void wait_for_sc_to_stop(const char *operation, const char *func, int lin
 extern void allow_sc_to_run(void);
 extern int __txn_commit_map_add_nolock(DB_ENV *, u_int64_t, DB_LSN);
 extern int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
+extern int get_commit_lsn_map_switch_value();
 
 int64_t gbl_rep_trans_parallel = 0, gbl_rep_trans_serial =
 	0, gbl_rep_trans_deadlocked = 0, gbl_rep_trans_inline =
@@ -4214,7 +4214,7 @@ processor_thd(struct thdpool *pool, void *work, void *thddata, int op)
 	int i;
 	int inline_worker;
 	int polltm;
-	int commit_lsn_map = gbl_commit_lsn_map;
+	int commit_lsn_map = get_commit_lsn_map_switch_value();
 	DB_LOGC *logc = NULL;
 	DB_ENV *dbenv;
 	int ret, t_ret = 0, last_fileid = -1;
@@ -4753,7 +4753,7 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, lockid, rp,
 	REP *rep;
 	uint32_t lflags = 0;
 	int collect_before_locking = gbl_collect_before_locking;
-	int commit_lsn_map = gbl_commit_lsn_map;
+	int commit_lsn_map = get_commit_lsn_map_switch_value();
 	int td_stats = gbl_bb_berkdb_enable_thread_stats;
 	struct berkdb_thread_stats *t=NULL, *p=NULL;
 	uint64_t x1=0, x2=0, d;
@@ -5617,7 +5617,7 @@ __rep_process_txn_concurrent_int(dbenv, rctl, rec, ltrans, ctrllsn, maxlsn,
 	DBT *lock_dbt, lsn_lock_dbt, lock_dbt_mem = {0};
 	int32_t timestamp = 0;
 	char *dist_txnid = NULL;
-	int commit_lsn_map = gbl_commit_lsn_map;
+	int commit_lsn_map = get_commit_lsn_map_switch_value();
 	int collect_before_locking = gbl_collect_before_locking;
 	DB_LOGC *logc;
 	DB_LSN prev_lsn;

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -93,7 +93,7 @@ void ctrace(char *format, ...);
 int __txn_commit_map_add_nolock(DB_ENV *, u_int64_t, DB_LSN);
 
 extern int gbl_is_physical_replicant;
-extern int gbl_commit_lsn_map;
+extern int get_commit_lsn_map_switch_value();
 
 #else
 
@@ -1070,7 +1070,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 	int ret, t_ret, elect_highest_committed_gen, commit_lsn_map;
 
 	dbenv = txnp->mgrp->dbenv;
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 
 	PANIC_CHECK(dbenv);
 

--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -60,7 +60,7 @@ static const char revid[] = "$Id: txn_rec.c,v 11.54 2003/10/31 23:26:11 ubell Ex
 int set_commit_context(unsigned long long context, uint32_t *generation,
 		void *plsn, void *args, unsigned int rectype);
 
-extern int gbl_commit_lsn_map;
+extern int get_commit_lsn_map_switch_value();
 
 int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN *);
 int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
@@ -161,7 +161,7 @@ __txn_dist_commit_recover(dbenv, dbtp, lsnp, op, info)
 
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 
 	if ((ret = __txn_dist_commit_read(dbenv, dbtp->data, &argp)) != 0)
 		return (ret);
@@ -417,7 +417,7 @@ __txn_regop_gen_recover(dbenv, dbtp, lsnp, op, info)
 
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 
 	if ((ret = __txn_regop_gen_read(dbenv, dbtp->data, &argp)) != 0)
 		return (ret);
@@ -540,7 +540,7 @@ __txn_regop_recover(dbenv, dbtp, lsnp, op, info)
 	(void)__txn_regop_print(dbenv, dbtp, lsnp, op, info);
 #endif
 
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 
 	if ((ret = __txn_regop_read(dbenv, dbtp->data, &argp)) != 0)
 		return (ret);
@@ -679,7 +679,7 @@ __txn_regop_rowlocks_recover(dbenv, dbtp, lsnp, op, info)
 	(void)__txn_regop_rowlocks_print(dbenv, dbtp, lsnp, op, info);
 #endif
 
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
 
@@ -1057,7 +1057,7 @@ __txn_child_recover(dbenv, dbtp, lsnp, op, info)
 	(void)__txn_child_print(dbenv, dbtp, lsnp, op, info);
 #endif
 
-	commit_lsn_map = gbl_commit_lsn_map;
+	commit_lsn_map = get_commit_lsn_map_switch_value();
 
 	if ((ret = __txn_child_read(dbenv, dbtp->data, &argp)) != 0) {
 		abort();

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -1937,7 +1937,7 @@ int __txn_abort_prepared_waiters(dbenv)
 }
 
 extern void lc_free(DB_ENV *dbenv, struct __recovery_processor *rp, LSN_COLLECTION * lc);
-extern int gbl_commit_lsn_map;
+extern int get_commit_lsn_map_switch_value();
 
 /* 
  * __txn_commit_recovered --
@@ -1953,7 +1953,7 @@ int __txn_commit_recovered(dbenv, dist_txnid)
 #if defined (DEBUG_PREPARE)
 	comdb2_cheapstack_sym(stderr, "%s", __func__);
 #endif
-    int commit_lsn_map = gbl_commit_lsn_map;
+    int commit_lsn_map = get_commit_lsn_map_switch_value();
 	DB_TXN_PREPARED *p;
 	Pthread_mutex_lock(&dbenv->prepared_txn_lk);
 	if ((p = hash_find(dbenv->prepared_txn_hash, &dist_txnid)) != NULL) {

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -597,6 +597,8 @@ extern void set_stop_mempsync_thread();
 extern void bdb_prepare_close(bdb_state_type *bdb_state);
 extern void bdb_stop_recover_threads(bdb_state_type *bdb_state);
 
+extern int get_commit_lsn_map_switch_value();
+
 int gbl_use_plan = 1;
 
 double gbl_querylimits_maxcost = 0;
@@ -6172,7 +6174,7 @@ int thdpool_alarm_on_queing(int len)
 
 int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
 {
-    int commit_lsn_map = gbl_commit_lsn_map;
+    int commit_lsn_map = get_commit_lsn_map_switch_value();
     int *file = &(((int *)(inlsn))[0]);
     int *offset = &(((int *)(inlsn))[1]);
     int rc;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -1077,6 +1077,11 @@ static int hostname_update(void *context, void *value)
 /* Forward declaration */
 int ctrace_set_rollat(void *unused, void *value);
 
+int get_commit_lsn_map_switch_value()
+{
+    return gbl_utxnid_log && gbl_commit_lsn_map;
+}
+
 /* Return the value for sql_tranlevel_default. */
 static void *sql_tranlevel_default_value(void *context)
 {

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -88,9 +88,10 @@ extern int gbl_reallyearly;
 extern int gbl_udp;
 extern int gbl_prefault_udp;
 extern int gbl_prefault_latency;
-extern int gbl_commit_lsn_map;
 extern int gbl_use_modsnap_for_snapshot;
 extern struct thdpool *gbl_verify_thdpool;
+
+extern int get_commit_lsn_map_switch_value();
 
 void debug_bulktraverse_data(char *tbl);
 
@@ -5191,7 +5192,7 @@ clipper_usage:
         else
             logmsg(LOGMSG_USER, "Verify threadpool is not active\n");
     } else if (tokcmp(tok, ltok, "clm_delete_logfile") == 0) {
-        if (gbl_commit_lsn_map) {
+        if (get_commit_lsn_map_switch_value()) {
             int del_log;
 
             tok = segtok(line, lline, &st, &ltok);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -121,8 +121,9 @@ extern int gbl_partial_indexes;
 #define SQLITE3BTREE_KEY_SET_DEL(IX) (clnt->del_keys |= (1ULL << (IX)))
 extern int gbl_expressions_indexes;
 extern int gbl_debug_tmptbl_corrupt_mem;
-extern int gbl_commit_lsn_map;
 extern int gbl_utxnid_log;
+
+extern int get_commit_lsn_map_switch_value();
 
 // Lua threads share temp tables.
 // Don't create new btree, use this one (tmptbl_clone)
@@ -3709,7 +3710,7 @@ int sql_set_transaction_mode(sqlite3 *db, struct sqlclntstate *clnt, int mode)
     int i;
 
     /* snapshot/serializable protection */
-    if ((mode == TRANLEVEL_MODSNAP && (!gbl_snapisol || !gbl_commit_lsn_map || !gbl_utxnid_log)) || 
+    if ((mode == TRANLEVEL_MODSNAP && (!gbl_snapisol || !get_commit_lsn_map_switch_value() || !gbl_utxnid_log)) || 
         ((mode == TRANLEVEL_SERIAL || mode == TRANLEVEL_SNAPISOL) &&
         !(gbl_rowlocks || gbl_snapisol))) {
         logmsg(LOGMSG_ERROR, "%s REQUIRES MODIFICATIONS TO THE LRL FILE\n",

--- a/sqlite/ext/comdb2/trancommit.c
+++ b/sqlite/ext/comdb2/trancommit.c
@@ -26,7 +26,7 @@
 #include "ezsystables.h"
 #include "types.h"
 
-extern int gbl_commit_lsn_map;
+extern int get_commit_lsn_map_switch_value();
 
 sqlite3_module systblTransactionCommitModule =
 {
@@ -61,7 +61,7 @@ int add_tran_commit(void *obj, void *arg) {
 int get_tran_commits(void **data, int *npoints) {
     int ret = 0;
 
-    if (!gbl_commit_lsn_map) {
+    if (!get_commit_lsn_map_switch_value()) {
             *data = NULL;
             *npoints = 0;
             return ret;


### PR DESCRIPTION
The changes in this PR block the commit LSN map from being enabled if utxnid logging is disabled.