### PR TITLE
Add child transactions to the commit LSN map during PIT recovery

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1264,7 +1264,7 @@ void delete_log_files(bdb_state_type *bdb_state);
 void delete_log_files_list(bdb_state_type *bdb_state, char **list);
 void delete_log_files_chkpt(bdb_state_type *bdb_state);
 void bdb_checkpoint_list_init();
-int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp);
+int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp, int push_top);
 void bdb_checkpoint_list_get_ckplsn_before_lsn(DB_LSN lsn, DB_LSN *lsnout);
 
 /* rep.c */

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -192,7 +192,7 @@ void bdb_checkpoint_list_init()
     ckp_lst_ready = 1;
 }
 
-int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp)
+int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp, int push_top)
 {
     struct checkpoint_list *ckp = NULL;
     if (!ckp_lst_ready)
@@ -204,7 +204,11 @@ int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp)
     ckp->ckp_lsn = ckp_lsn;
     ckp->timestamp = timestamp;
     Pthread_mutex_lock(&ckp_lst_mtx);
-    listc_abl(&ckp_lst, ckp);
+    if (push_top) {
+        listc_atl(&ckp_lst, ckp);
+    } else {
+        listc_abl(&ckp_lst, ckp);
+    }
     Pthread_mutex_unlock(&ckp_lst_mtx);
 
     return 0;

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -2885,7 +2885,7 @@ err:
 }
 #undef ERR
 
-int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp);
+int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp, int push_top);
 
 static inline int is_commit(int rectype)
 {
@@ -3728,7 +3728,7 @@ gap_check:		max_lsn_dbtp = NULL;
 
 		ret =
 			bdb_checkpoint_list_push(rp->lsn, ckp_args->ckp_lsn,
-			ckp_args->timestamp);
+			ckp_args->timestamp, 0);
 		if (ret) {
 			logmsg(LOGMSG_ERROR, "%s: failed to push to checkpoint list, ret %d\n",
 				__func__, ret);

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2804,7 +2804,7 @@ void collect_txnids(DB_ENV *dbenv, u_int32_t *txnarray, int max, int *count)
 	(*count) = idx;
 }
 
-int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp);
+int bdb_checkpoint_list_push(DB_LSN lsn, DB_LSN ckp_lsn, int32_t timestamp, int push_top);
 
 /* Configure txn_checkpoint() to sleep this much time before memp_sync() */
 int gbl_ckp_sleep_before_sync = 0;
@@ -3080,7 +3080,7 @@ do_ckp:
 		}
 		Pthread_mutex_unlock(&dbenv->mintruncate_lk);
 
-		ret = bdb_checkpoint_list_push(ckp_lsn, ckp_lsn_sav, timestamp);
+		ret = bdb_checkpoint_list_push(ckp_lsn, ckp_lsn_sav, timestamp, 0);
 		if (ret) {
 			logmsg(LOGMSG_ERROR, 
 				"%s: failed to push to checkpoint list, ret %d\n",

--- a/tests/siasofbounce.test/Makefile
+++ b/tests/siasofbounce.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif
+unexport CLUSTER

--- a/tests/siasofbounce.test/lrl.options
+++ b/tests/siasofbounce.test/lrl.options
@@ -1,0 +1,1 @@
+enable_snapshot_isolation

--- a/tests/siasofbounce.test/runit
+++ b/tests/siasofbounce.test/runit
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+insert() {
+	local itr=1
+	while cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "insert into t values("${itr}")";
+	do
+		(( itr++ ))
+		sleep .1
+	done
+	return 1
+}
+
+run_asof_snapshot_query() {
+	local -r asof_time=$1 
+
+cdb2sql --tabs ${CDB2_OPTIONS} "${DBNAME}" default - <<EOF
+set transaction snapshot
+begin transaction as of datetime ${asof_time}
+select count(*) from t
+commit
+EOF
+}
+
+main() {
+	set -e
+
+	cdb2sql --tabs ${CDB2_OPTIONS} "${DBNAME}" default "create table t(i int)"
+
+	insert > /dev/null &
+	local -r pid=$!
+
+	sleep 1
+	local asof_time
+	asof_time=$(date +%FT%T.%N)
+	readonly asof_time
+	sleep 1
+
+	local results_before_bounce
+	results_before_bounce=$(run_asof_snapshot_query "${asof_time}") 
+	readonly results_before_bounce
+
+	local -r MAX_FLUSH_ITRS=3
+	local flush_itr
+	for (( flush_itr=0; flush_itr<MAX_FLUSH_ITRS; flush_itr++ )); do
+		cdb2sql --tabs ${CDB2_OPTIONS} "${DBNAME}" default "exec procedure sys.cmd.send('flush')"
+		sleep 1
+	done
+
+	kill -9 "${pid}"
+
+	set +e
+	local -r KILL_WAIT_TIME=5
+	kill_restart_node $(hostname) "${KILL_WAIT_TIME}"
+	set -e
+
+	local results_after_bounce
+	results_after_bounce=$(run_asof_snapshot_query "${asof_time}")
+	readonly results_after_bounce
+
+	if [[ "${results_before_bounce}" != "${results_after_bounce}" ]]; then
+		err "PIT snapshot results before bounce and after bounce do not match!"
+		err "Before bounce:"
+		err "${results_before_bounce}"
+		err "After bounce:"
+		err "${results_after_bounce}"
+		exit 1
+	else
+		echo "Passed test"
+		exit 0
+	fi
+}
+
+main

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -9,6 +9,9 @@ failexit()
     exit -1
 }
 
+err() {
+  echo "[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $*" >&2
+}
 
 # assert result value in $1 is the same as expected value in $2, optional comment in $3
 # assertres (result, expected, comment)


### PR DESCRIPTION
The changes in this PR fix a bug where the database wrongly does not add child transactions to the commit LSN map when doing the full scan of the logs required to support point-in-time transactions (PIT recovery).

The changes in this PR reverse the direction of the PIT recovery log scan (from forward to backward). That way, when a child transaction is encountered, its parent's commit LSN already exists in the map. After looking up the parent's commit LSN, the child can immediately be added to the map with the same LSN.