### PR TITLE
RDSICDBDBA-1409 - specific recovery LSN implies exit

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -239,7 +239,10 @@ int handle_cmdline_options(int argc, char **argv, char **lrlname)
                    gbl_recovery_lsn_file, gbl_recovery_lsn_offset);
             gbl_fullrecovery = 1;
             break;
-        case 4: /* recovery_lsn */ gbl_recovery_options = optarg; break;
+        case 4: /* recovery_lsn */
+            gbl_recovery_options = optarg;
+            gbl_exit = 1;
+            break;
         case 5: /* pidfile */ write_pidfile(optarg); break;
         case 10: /* dir */ set_dbdir(optarg); break;
         case 11: /* tunable */ add_cmd_line_tunable(optarg); break;


### PR DESCRIPTION
This is to allow comdb2ar to run comdb2 without full recovery on a copy if the recovery LSN is known.