### PR TITLE
Adding auto increment on existing col should not require NULL

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -3968,14 +3968,6 @@ int compare_tag_int(struct schema *old, struct schema *new, FILE *out,
                          fold->in_default_type != fnew->in_default_type) {
                     snprintf(buf, sizeof(buf), "dbstore");
                     change = SC_DBSTORE_CHANGE;
-                    if (fnew->in_default_type == SERVER_SEQUENCE && fold->in_default_type != SERVER_SEQUENCE &&
-                        (fnew->flags & NO_NULL)) {
-                        if (out) {
-                            logmsg(LOGMSG_INFO, "tag %s field %s new sequence requires null\n", old->tag, fold->name);
-                        }
-                        return SC_BAD_NEW_FIELD;
-                    }
-
                     if (fnew->in_default_type == SERVER_FUNCTION && fold->in_default_type != SERVER_FUNCTION &&
                         (fnew->flags & NO_NULL)) {
                         if (out)


### PR DESCRIPTION
8.0 version of https://github.com/bloomberg/comdb2/commit/a9cdca7fe9f65f0f8e5adeb226200d6aedda86fd

Support for adding autoincrement on existing col in 8.1. This will just change the error message since adding autoinc on existing col should not require NULL

nextsequence.test checks for error in this case

```
@testdb> create table t3 { schema { longlong a longlong b } }$$
[create table t3 { schema { longlong a longlong b } }] rc 0
```

Old:
```
@testdb> alter table t3 { schema { longlong a longlong b dbstore=nextsequence } }$$
[alter table t3 { schema { longlong a longlong b dbstore=nextsequence } }] failed with rc 240 cannot add new field without dbstore or null
@testdb> 
```

New:
```
@testdb> alter table t3 { schema { longlong a longlong b dbstore=nextsequence } }$$
[alter table t3 { schema { longlong a longlong b dbstore=nextsequence } }] failed with rc 240 cannot set sequence for existing column
@testdb> 
```