### PR TITLE
{176398616}: Fixing race between sc and load-cache

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -81,6 +81,7 @@ int debug_switch_is_dbq_get_delayed(void);         /* 0 */
 int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
 int debug_switch_ignore_null_auth_func(void);      /* 0 */
+int debug_switch_load_cache_delay(void);           /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/berkdb/mp/mp_fopen.c
+++ b/berkdb/mp/mp_fopen.c
@@ -1379,6 +1379,7 @@ done:	/* Discard the DB_MPOOLFILE structure. */
 		__os_free(dbenv, dbmfp->pgcookie->data);
 		__os_free(dbenv, dbmfp->pgcookie);
 	}
+	memset(dbmfp, CLEAR_BYTE, sizeof(DB_MPOOLFILE));
 	__os_free(dbenv, dbmfp);
 
 	return (ret);

--- a/tests/sc_load_cache_race.test/Makefile
+++ b/tests/sc_load_cache_race.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/sc_load_cache_race.test/lrl.options
+++ b/tests/sc_load_cache_race.test/lrl.options
@@ -1,0 +1,3 @@
+dtastripe 1
+load_cache_threads 1
+logmsg level info

--- a/tests/sc_load_cache_race.test/runit
+++ b/tests/sc_load_cache_race.test/runit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+
+db=$1
+echo $db
+leader=`cdb2sql --tabs ${CDB2_OPTIONS} $db default 'SELECT host FROM comdb2_cluster WHERE is_master="Y"'`
+
+cdb2sql $db --host $leader "CREATE TABLE t_load_cache_race (i INT)"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('dump_cache')"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('load_cache_delay 1')"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('load_cache')" &
+sleep 2
+cdb2sql $db --host $leader "TRUNCATE TABLE t_load_cache_race"
+wait

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -88,6 +88,7 @@ static struct debug_switches {
     int rep_rec_is_delayed;
     int get_tmp_dir_sleep;
     int ignore_null_auth_func;
+    int load_cache_delay;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -270,6 +271,7 @@ int init_debug_switches(void)
     register_debug_switch("test_trigger_deadlock", &debug_switches.test_trigger_deadlock);
     register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
     register_debug_switch("ignore_null_auth_func", &debug_switches.ignore_null_auth_func);
+    register_debug_switch("load_cache_delay", &debug_switches.load_cache_delay);
     return 0;
 }
 
@@ -543,4 +545,8 @@ void debug_switch_set_tmp_dir_sleep(int val)
 int debug_switch_ignore_null_auth_func(void)
 {
     return debug_switches.ignore_null_auth_func;
+}
+int debug_switch_load_cache_delay(void)
+{
+    return debug_switches.load_cache_delay;
 }


### PR DESCRIPTION
Load-cache needs to hold schema-lk while loading pages into bufferpool, to prevent a schamechange from closing its mpool structure in another thread of control.