### PR TITLE
[8.0]{176398616}: Fixing race between sc and load-cache

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -82,6 +82,7 @@ int debug_switch_is_dbq_get_delayed(void);         /* 0 */
 int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
 int debug_switch_ignore_null_auth_func(void);      /* 0 */
+int debug_switch_load_cache_delay(void);           /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */

--- a/berkdb/mp/mp_fopen.c
+++ b/berkdb/mp/mp_fopen.c
@@ -1380,6 +1380,7 @@ done:	/* Discard the DB_MPOOLFILE structure. */
 		__os_free(dbenv, dbmfp->pgcookie->data);
 		__os_free(dbenv, dbmfp->pgcookie);
 	}
+	memset(dbmfp, CLEAR_BYTE, sizeof(DB_MPOOLFILE));
 	__os_free(dbenv, dbmfp);
 
 	return (ret);

--- a/berkdb/mp/mp_sync.c
+++ b/berkdb/mp/mp_sync.c
@@ -36,7 +36,8 @@ static const char revid[] = "$Id: mp_sync.c,v 11.80 2003/09/13 19:20:41 bostic E
 #include "ctrace.h"
 #include <pool.h>
 #include "logmsg.h"
-#include "locks_wrap.h"
+#include "debug_switches.h"
+#include "schema_lk.h"
 
 extern int gbl_file_permissions;
 
@@ -1987,6 +1988,7 @@ load_fileids(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 	dbmp = dbenv->mp_handle;
 	dbmfp = NULL;
 
+	rdlock_schema_lk();
 	MUTEX_THREAD_LOCK(dbenv, dbmp->mutexp);
 	for (dbmfp = TAILQ_FIRST(&dbmp->dbmfq); dbmfp != NULL;
 			dbmfp = TAILQ_NEXT(dbmfp, q)) {
@@ -1996,10 +1998,18 @@ load_fileids(struct thdpool *thdpool, void *work, void *thddata, int thd_op)
 	MUTEX_THREAD_UNLOCK(dbenv, dbmp->mutexp);
 
 	if (dbmfp) {
+		if (debug_switch_load_cache_delay()) {
+			char *fname = (char *)R_ADDR(dbmp->reginfo, dbmfp->mfp->path_off);
+			if (strncmp(fname, "XXX.t_load_cache_race_", strlen("XXX.t_load_cache_race_")) == 0) {
+				sleep(5);
+			}
+		}
+
 		for(int pages = 0 ; pages < pagelist->cnt; pages++) {
 			touch_page(dbmfp, pagelist->pages[pages]);
 		}
-	} 
+	}
+	unlock_schema_lk();
 
 	Pthread_mutex_lock(fileid_env->lk);
 	(*fileid_env->active_threads)--;

--- a/tests/sc_load_cache_race.test/Makefile
+++ b/tests/sc_load_cache_race.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/sc_load_cache_race.test/lrl.options
+++ b/tests/sc_load_cache_race.test/lrl.options
@@ -1,0 +1,3 @@
+dtastripe 1
+load_cache_threads 1
+logmsg level info

--- a/tests/sc_load_cache_race.test/runit
+++ b/tests/sc_load_cache_race.test/runit
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+
+db=$1
+echo $db
+leader=`cdb2sql --tabs ${CDB2_OPTIONS} $db default 'SELECT host FROM comdb2_cluster WHERE is_master="Y"'`
+
+cdb2sql $db --host $leader "CREATE TABLE t_load_cache_race (i INT)"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('dump_cache')"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('load_cache_delay 1')"
+cdb2sql $db --host $leader "EXEC PROCEDURE sys.cmd.send('load_cache')" &
+sleep 2
+cdb2sql $db --host $leader "TRUNCATE TABLE t_load_cache_race"
+wait

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -89,6 +89,7 @@ static struct debug_switches {
     int rep_rec_is_delayed;
     int get_tmp_dir_sleep;
     int ignore_null_auth_func;
+    int load_cache_delay;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -274,6 +275,7 @@ int init_debug_switches(void)
     register_debug_switch("test_trigger_deadlock", &debug_switches.test_trigger_deadlock);
     register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
     register_debug_switch("ignore_null_auth_func", &debug_switches.ignore_null_auth_func);
+    register_debug_switch("load_cache_delay", &debug_switches.load_cache_delay);
     return 0;
 }
 
@@ -551,4 +553,8 @@ void debug_switch_set_tmp_dir_sleep(int val)
 int debug_switch_ignore_null_auth_func(void)
 {
     return debug_switches.ignore_null_auth_func;
+}
+int debug_switch_load_cache_delay(void)
+{
+    return debug_switches.load_cache_delay;
 }


### PR DESCRIPTION
Load-cache needs to hold schema-lk while loading pages into bufferpool, to prevent a schamechange from closing its mpool structure in another thread of control.