### PR TITLE
Truncate ignored queuedbs

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -4488,6 +4488,17 @@ deadlock_again:
             } else {
                 pagesize = bdb_state->attr->pagesizedta;
             }
+
+            extern int gbl_physrep_ignore_queues;
+            if (gbl_is_physical_replicant && gbl_physrep_ignore_queues) {
+                char new[PATH_MAX];
+                print(bdb_state, "truncating ignored queuedb %s\n", bdb_trans(tmpname, new));
+                rc = truncate(bdb_trans(tmpname, new), pagesize * 2);
+                if (rc != 0) {
+                    logmsg(LOGMSG_ERROR, "truncate %s error %d\n", bdb_trans(tmpname, new), errno);
+                }
+            }
+
             rc = dbp->set_pagesize(dbp, pagesize);
             if (rc != 0) {
                 logmsg(LOGMSG_ERROR, "unable to set pagesize on qdb to %d\n",

--- a/tests/physrep_ignore_table.test/consumer.lua
+++ b/tests/physrep_ignore_table.test/consumer.lua
@@ -1,0 +1,10 @@
+local function main(event)
+    local consumer = db:consumer()
+    while true do
+        local event = consumer:get()
+        local tp = event.type
+        print("Event type: " .. tp)
+        consumer:consume()
+    end
+end
+    

--- a/tests/physrep_ignore_table.test/runit
+++ b/tests/physrep_ignore_table.test/runit
@@ -33,6 +33,18 @@ function create_tables
 
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t4(a int, b blob)"
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create index t4a on t4(a)"
+
+    # Consumer queues should be truncated in physrep
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create procedure const1 version 'v1' {$(cat consumer.lua)}\$\$
+create procedure const2 version 'v1' {$(cat consumer.lua)}\$\$
+create procedure const3 version 'v1' {$(cat consumer.lua)}\$\$
+create procedure const4 version 'v1' {$(cat consumer.lua)}\$\$
+create lua consumer const1 on (table t1 for insert and update and delete)
+create lua consumer const2 on (table t1 for insert and update and delete)
+create lua consumer const3 on (table t1 for insert and update and delete)
+create lua consumer const4 on (table t1 for insert and update and delete)
+EOF
 }
 
 function fill_tables
@@ -126,6 +138,10 @@ function check_physrep_file_sizes
         [[ "$fl" == *"datas"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
         [[ "$fl" == *"blobs"* ]] && [[ "$sz" != 131072 ]] && failexit "$fl was not truncated"
         [[ "$fl" == *"index"* ]] && [[ "$sz" != 8192 ]] && failexit "$fl was not truncated"
+    done
+
+    ls -l $DEST_DBDIR/__qconst* | while read perm i1 own grp sz mon day tm fl ; do
+        [[ "$fl" == *"queuedb"* ]] && [[ "$sz" != 131072 ]] && failexit "$fl was not truncated"
     done
 }
 


### PR DESCRIPTION
Physical replicants should truncate any queuedb's on startup if physrep_ignore_queues is set.  This is the 8.0 port of https://github.com/bloomberg/comdb2/pull/4661.