### PR TITLE
Reduce snapshot recovery spew

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -2125,6 +2125,8 @@ __scan_logfiles_for_asof_modsnap(dbenv)
 		GOTOERR;
 	}
 
+	DB_LSN recoverable_lsn;
+	ZERO_LSN(recoverable_lsn);
 	for (ret = __log_c_get(logc, &last_lsn, &data, DB_LAST), lsn =
 		last_lsn; ret == 0;
 		ret = __log_c_get(logc, &lsn, &data, DB_PREV)) {
@@ -2154,7 +2156,8 @@ __scan_logfiles_for_asof_modsnap(dbenv)
 			if (ret >= 0) {
 				bdb_set_gbl_recoverable_lsn(&lsn,
 					ckp_args->timestamp);
-				logmsg(LOGMSG_WARN, "set gbl_recoverable_lsn as [%d][%d]\n",
+				recoverable_lsn = lsn;
+				logmsg(LOGMSG_DEBUG, "set gbl_recoverable_lsn as [%d][%d]\n",
 					lsn.file, lsn.offset);
 			}
 
@@ -2224,6 +2227,10 @@ __scan_logfiles_for_asof_modsnap(dbenv)
 	}
 
 	ret = 0;
+	if (!IS_ZERO_LSN(recoverable_lsn)) {
+		logmsg(LOGMSG_WARN, "set gbl_recoverable_lsn as [%d][%d]\n",
+			recoverable_lsn.file, recoverable_lsn.offset);
+	}
 
 err:
 	if (lineno)


### PR DESCRIPTION
The changes in #4632 reversed the direction of the PIT recovery log scan (from forward to backward). When the log scan was running forward, the global recoverable LSN was set only once, right after the first checkpoint was read. Now that the direction of recovery has been switched, the global recoverable LSN is updated once for every checkpoint in the log. PIT recovery logging code was not updated appropriately in #4632 and this has resulted in alot of spew on startup:

```
set gbl_recoverable_lsn as [1][5344028]
set gbl_recoverable_lsn as [1][5343900]
set gbl_recoverable_lsn as [1][5343684]
set gbl_recoverable_lsn as [1][5343556]
set gbl_recoverable_lsn as [1][5343428]
set gbl_recoverable_lsn as [1][5343212]
set gbl_recoverable_lsn as [1][5343084]
... one line for each checkpoint in the log
```
The changes in this PR only emit one log at WARN level with the actual recoverable LSN once PIT recovery is finished.