### PR TITLE
Allow specific physrep fanouts from metadb

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1403,6 +1403,22 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
             logmsg(LOGMSG_INFO, "Physrep ignoring table %s\n", table);
             physrep_add_ignore_table(table);
         }
+    } else if (tokcmp(tok, ltok, "physrep_fanout_override") == 0) {
+        tok = segtok(line, len, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_FATAL, "physrep_fanout_override requires dbname & fanout value\n");
+            return -1;
+        }
+        char *dbname = alloca(ltok + 1);
+        tokcpy(tok, ltok, dbname);
+
+        tok = segtok(line, len, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_FATAL, "physrep_fanout_override requires dbname & fanout value\n");
+            return -1;
+        }
+        int fanout = toknum(tok, ltok);
+        physrep_fanout_override(dbname, fanout);
     } else if (tokcmp(tok, ltok, "replicate_wait") == 0) {
         tok = segtok(line, len, &st, &ltok);
 

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -110,6 +110,62 @@ int sc_ready(void);
 int is_commit(u_int32_t rectype);
 int physrep_bdb_wait_for_seqnum(bdb_state_type *bdb_state, DB_LSN *lsn, void *data);
 
+static hash_t *physrep_fanout = NULL;
+static pthread_mutex_t fanout_lk = PTHREAD_MUTEX_INITIALIZER;
+
+struct fanout_override {
+    char *dbname;
+    int fanout;
+};
+
+void physrep_fanout_override(const char *dbname, int fanout)
+{
+    Pthread_mutex_lock(&fanout_lk);
+    if (!physrep_fanout) {
+        physrep_fanout = hash_init_strptr(offsetof(struct fanout_override, dbname));
+    }
+    struct fanout_override *fo = hash_find(physrep_fanout, &dbname);
+    if (!fo) {
+        fo = malloc(sizeof(struct fanout_override));
+        fo->dbname = strdup(dbname);
+        hash_add(physrep_fanout, fo);
+    }
+    fo->fanout = fanout;
+    Pthread_mutex_unlock(&fanout_lk);
+}
+
+int physrep_fanout_get(const char *dbname)
+{
+    int fanout = gbl_physrep_fanout;
+    Pthread_mutex_lock(&fanout_lk);
+    if (physrep_fanout) {
+        struct fanout_override *fo = hash_find(physrep_fanout, &dbname);
+        if (fo) {
+            fanout = fo->fanout;
+        }
+    }
+    Pthread_mutex_unlock(&fanout_lk);
+    return fanout;
+}
+
+static int physrep_fanout_print(void *obj, void *arg)
+{
+    struct fanout_override *fo = (struct fanout_override *)obj;
+    physrep_logmsg(LOGMSG_USER, "dbname %s fanout %d\n", fo->dbname, fo->fanout);
+    return 0;
+}
+
+void physrep_fanout_dump(void)
+{
+    Pthread_mutex_lock(&fanout_lk);
+    if (physrep_fanout) {
+        hash_for(physrep_fanout, physrep_fanout_print, NULL);
+    } else {
+        physrep_logmsg(LOGMSG_USER, "no fanout overrides\n");
+    }
+    Pthread_mutex_unlock(&fanout_lk);
+}
+
 void cleanup_hosts()
 {
     DB_Connection *cnct;

--- a/db/phys_rep.h
+++ b/db/phys_rep.h
@@ -37,5 +37,8 @@ int physrep_exited();
 int physrep_get_metadb_or_local_hndl(cdb2_hndl_tp**);
 void physrep_cleanup(void);
 void physrep_update_low_file_num(int*, int*);
+void physrep_fanout_override(const char *dbname, int fanout);
+int physrep_fanout_get(const char *dbname);
+void physrep_fanout_dump(void);
 
 #endif /* PHYS_REP_H */

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2148,6 +2148,24 @@ clipper_usage:
         gbl_who = toknum(tok, ltok);
         gbl_debug = gbl_sdebug = 0;
         logmsg(LOGMSG_USER, "Set who to %d\n", gbl_who);
+    } else if (tokcmp(tok, ltok, "physrep_fanout_override") == 0) {
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_FATAL, "physrep_fanout_override requires dbname & fanout value\n");
+            return -1;
+        }
+        char *dbname = alloca(ltok + 1);
+        tokcpy(tok, ltok, dbname);
+
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_FATAL, "physrep_fanout_override requires dbname & fanout value\n");
+            return -1;
+        }
+        int fanout = toknum(tok, ltok);
+        physrep_fanout_override(dbname, fanout);
+    } else if (tokcmp(tok, ltok, "physrep_fanout_dump") == 0) {
+        physrep_fanout_dump();
     } else if (tokcmp(tok, ltok, "leaktxn") == 0) {
         bdb_trans_leak(thedb->bdb_env);
     } else if (tokcmp(tok, ltok, "unleaktxn") == 0) {

--- a/lua/lib/physrep_register_replicant.lua
+++ b/lua/lib/physrep_register_replicant.lua
@@ -8,7 +8,7 @@ local function main(dbname, hostname, lsn, source_dbname, source_hosts)
     db:begin()
 
     -- Retrieve physrep tunables
-    local tunables = sys.physrep_tunables()
+    local tunables = sys.physrep_tunables(source_dbname)
 
     -- The physical replicant is attempting a fresh registration; remove it
     -- from the comdb2_physrep_connections table.

--- a/lua/syssp.c
+++ b/lua/syssp.c
@@ -532,12 +532,22 @@ extern int gbl_physrep_max_candidates;
 
 static int db_comdb_physrep_tunables(Lua L)
 {
+    int fanout = gbl_physrep_fanout;
+    if (lua_isstring(L, 1)) {
+        char *sourcedb = (char*) lua_tostring(L, -1);
+        fanout = physrep_fanout_get(sourcedb);
+        logmsg(LOGMSG_DEBUG, "%s: fanout for %s is %d\n", __func__, sourcedb, fanout);
+    }
+    else {
+        return luaL_error(L, "Requires sourcedb");
+    }
+
     int tunables_count = 3;
 
     lua_createtable(L, tunables_count, 0);
 
     lua_pushstring(L, "physrep_fanout");
-    lua_pushinteger(L, gbl_physrep_fanout);
+    lua_pushinteger(L, fanout);
     lua_settable(L, -3);
 
     lua_pushstring(L, "physrep_max_candidates");

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -92,6 +92,36 @@ function wait_for_catchup()
     fi
 }
 
+function verify_fanout_overrides()
+{
+    local repl_metadb_name=$1
+    local repl_metadb_host=$2
+    local parent_db=$3
+
+    # Add a fanout override live
+    cdb2sql ${CDB2_OPTIONS} --host $repl_metadb_host $repl_metadb_name "exec procedure sys.cmd.send('physrep_fanout_override livetst 99')"
+
+    # Grab all of the fanout overrides
+    x=$(cdb2sql ${CDB2_OPTIONS} --host $repl_metadb_host $repl_metadb_name "exec procedure sys.cmd.send('physrep_fanout_dump')")
+
+    # Verify the 2 fanout lrl configurations
+    if [[ $x != *"fanouttest fanout 100"* ]]; then
+        cleanFailExit "fanouttest not set to 100"
+    fi
+
+    if [[ $x != *"fanouttest2 fanout 50"* ]]; then
+        cleanFailExit "fanouttest2 not set to 50"
+    fi
+
+    if [[ $x != *"$DBNAME fanout 3"* ]]; then
+        cleanFailExit "$DBNAME not set to 3"
+    fi
+
+    if [[ $x != *"livetst fanout 99"* ]]; then
+        cleanFailExit "livetst not set to 99"
+    fi
+}
+
 function create_physrep_tables()
 {
     local repl_metadb_name=$1
@@ -230,6 +260,33 @@ function kill_source_nodes()
     popd
 }
 
+function verify_fanout_myoverride()
+{
+    echo "== Verify fanout myoverride =="
+    local _dbname=$1
+    local _dbdir=$2
+
+    if [[ -z "$CLUSTER" ]]; then # Standalone
+        logFile=$TESTDIR/logs/${_dbname}.${node}.log
+        egrep "db_comdb_physrep_tunables: fanout for $DBNAME is 3" $logFile
+        if [[ $? -ne 0 ]]; then
+            cleanFailExit "fanout for $DBNAME is not 1"
+        fi
+    else
+        found=0
+        for node in $CLUSTER ; do
+            logFile=$TESTDIR/logs/${_dbname}.${node}.log
+            egrep "db_comdb_physrep_tunables: fanout for $DBNAME is 3" $logFile
+            if [[ $? -eq 0 ]]; then
+                found=1
+            fi
+        done
+        if [[ $found -ne 1 ]]; then
+            cleanFailExit "fanout for $DBNAME is not 3"
+        fi
+    fi
+}
+
 function setup_physrep_metadb()
 {
     echo "== Setting up replication metadb cluster =="
@@ -246,6 +303,9 @@ function setup_physrep_metadb()
         cat <<END >> ${_dbdir}/${_dbname}.lrl
 name ${_dbname}
 dir ${_dbdir}
+physrep_fanout_override fanouttest 100
+physrep_fanout_override fanouttest2 50
+physrep_fanout_override $DBNAME 3
 logmsg level debug
 END
 
@@ -264,6 +324,7 @@ END
         PIDs="${PIDs} $(cat ${_dbdir}/${_dbname}.pid)"
 
         create_physrep_tables ${_dbname} ${node}
+        verify_fanout_overrides ${_dbname} ${node}
 
     # Cluster
     else
@@ -279,6 +340,9 @@ END
 name ${_dbname}
 dir ${_dbdir}
 cluster nodes ${CLUSTER}
+physrep_fanout_override fanouttest 100
+physrep_fanout_override fanouttest2 50
+physrep_fanout_override $DBNAME 3
 logmsg level debug
 END
                 scp ${tmpdir}/${_dbname}.lrl ${node}:${_dbdir}/${_dbname}.lrl
@@ -312,6 +376,7 @@ END
         done
 
         create_physrep_tables ${_dbname} ${firstNode}
+        verify_fanout_overrides ${_dbname} ${firstNode}
     fi
     echo "Physrep replication metadb cluster/node started!"
 }
@@ -714,6 +779,7 @@ generate_tests
 run_tests
 verify_blkseq
 compare_end_lsns
+verify_fanout_myoverride ${REPL_META_DBNAME} ${REPL_META_HOST}
 cleanup
 
 exit 0


### PR DESCRIPTION
Allow db-specific overrides in physrep-metadb for physrep-fanout.  This is the 8.0 version of https://github.com/bloomberg/comdb2/pull/4684.
