### PR TITLE
{176316843}: Adding local-cache flag to clnt

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2162,10 +2162,21 @@ static inline int cdb2_hostid()
     return _MACHINE_ID;
 }
 
+typedef enum {
+    NEWSQL_STATE_NONE = 0,
+    /* Query is making progress. Applicable only when type is HEARTBEAT */
+    NEWSQL_STATE_ADVANCING,
+    /* RESET from in-process cache. Applicable only when type is RESET */
+    NEWSQL_STATE_LOCALCACHE
+} newsql_state;
+
 static int send_reset(SBUF2 *sb)
 {
     int rc = 0;
-    struct newsqlheader hdr = {.type = ntohl(CDB2_REQUEST_TYPE__RESET)};
+    struct newsqlheader hdr = {
+        .type = ntohl(CDB2_REQUEST_TYPE__RESET),
+        .state = ntohl(NEWSQL_STATE_NONE)
+    };
     rc = sbuf2fwrite((char *)&hdr, sizeof(hdr), 1, sb);
     if (rc != 1) {
         return -1;

--- a/db/sql.h
+++ b/db/sql.h
@@ -940,6 +940,7 @@ struct sqlclntstate {
     unsigned force_fdb_push_redirect : 1; // this should only be set if can_redirect_fdb is true
     unsigned force_fdb_push_remote : 1;
     unsigned return_long_column_names : 1; // if 0 then tunable decides
+    unsigned in_local_cache : 1;
 
     char *sqlengine_state_file;
     int sqlengine_state_line;
@@ -1245,6 +1246,7 @@ struct connection_info {
     int time_in_state_int;
     enum connection_state state_int;
     int64_t in_transaction;
+    int64_t in_local_cache;
 };
 
 /* makes master swing verbose */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6687,6 +6687,7 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
         c->fingerprint = NULL;
     }
     c->in_transaction = clnt->in_client_trans;
+    c->in_local_cache = clnt->in_local_cache;
     Pthread_mutex_unlock(&clnt->state_lk);
 }
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2008,7 +2008,7 @@ int forward_set_commands(struct sqlclntstate *clnt, cdb2_hndl_tp *hndl,
 
 int newsql_heartbeat(struct sqlclntstate *clnt)
 {
-    int state;
+    int state = NEWSQL_STATE_NONE;
 
     if (!clnt->heartbeat)
         return 0;
@@ -2017,9 +2017,10 @@ int newsql_heartbeat(struct sqlclntstate *clnt)
 
     /* We're still in a good state if we're just waiting for the client to consume an event. */
     if (is_pingpong(clnt))
-        state = 1;
+        state = NEWSQL_STATE_ADVANCING;
     else {
-        state = (clnt->sqltick > clnt->sqltick_last_seen);
+        if (clnt->sqltick > clnt->sqltick_last_seen)
+            state = NEWSQL_STATE_ADVANCING;
         clnt->sqltick_last_seen = clnt->sqltick;
     }
 

--- a/plugins/newsql/newsql.h
+++ b/plugins/newsql/newsql.h
@@ -28,6 +28,14 @@ struct newsql_stmt {
     char tzname[CDB2_MAX_TZNAME];
 };
 
+typedef enum {
+    NEWSQL_STATE_NONE,
+    /* Query is making progress. Applicable only when type is HEARTBEAT */
+    NEWSQL_STATE_ADVANCING,
+    /* RESET from in-process cache. Applicable only when type is RESET */
+    NEWSQL_STATE_LOCALCACHE
+} newsql_state;
+
 struct newsqlheader {
     int type;        /*  newsql request/response type */
     int compression; /*  Some sort of compression done? */

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -161,6 +161,7 @@ static int newsql_flush_evbuffer(struct sqlclntstate *clnt)
 static void newsql_reset_evbuffer(struct newsql_appdata_evbuffer *appdata)
 {
     appdata->initial = 1;
+    appdata->clnt.in_local_cache = (appdata->hdr.state == NEWSQL_STATE_LOCALCACHE);
     newsql_reset(&appdata->clnt);
 }
 

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -97,5 +97,6 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_INTEGER, "is_ssl", -1, offsetof(struct connection_info, is_ssl),
             CDB2_INTEGER, "has_cert", -1, offsetof(struct connection_info, has_cert),
             CDB2_CSTRING, "common_name", -1, offsetof(struct connection_info, common_name),
+            CDB2_INTEGER, "in_local_cache", -1, offsetof(struct connection_info, in_local_cache),
             SYSTABLE_END_OF_FIELDS);
 }


### PR DESCRIPTION
These changes would help us identify whether a connection is truly leaked, or is being cached in the client process.
