### PR TITLE
[8.0]{176316843}: Adding local-cache flag to clnt

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2165,10 +2165,21 @@ static inline int cdb2_hostid()
     return _MACHINE_ID;
 }
 
+typedef enum {
+    NEWSQL_STATE_NONE = 0,
+    /* Query is making progress. Applicable only when type is HEARTBEAT */
+    NEWSQL_STATE_ADVANCING,
+    /* RESET from in-process cache. Applicable only when type is RESET */
+    NEWSQL_STATE_LOCALCACHE
+} newsql_state;
+
 static int send_reset(SBUF2 *sb)
 {
     int rc = 0;
-    struct newsqlheader hdr = {.type = ntohl(CDB2_REQUEST_TYPE__RESET)};
+    struct newsqlheader hdr = {
+        .type = ntohl(CDB2_REQUEST_TYPE__RESET),
+        .state = ntohl(NEWSQL_STATE_NONE)
+    };
     rc = sbuf2fwrite((char *)&hdr, sizeof(hdr), 1, sb);
     if (rc != 1) {
         return -1;

--- a/db/sql.h
+++ b/db/sql.h
@@ -940,6 +940,7 @@ struct sqlclntstate {
     unsigned force_fdb_push_redirect : 1; // this should only be set if can_redirect_fdb is true
     unsigned force_fdb_push_remote : 1;
     unsigned return_long_column_names : 1; // if 0 then tunable decides
+    unsigned in_local_cache : 1;
 
     char *sqlengine_state_file;
     int sqlengine_state_line;
@@ -1219,6 +1220,7 @@ struct connection_info {
     int time_in_state_int;
     enum connection_state state_int;
     int64_t in_transaction;
+    int64_t in_local_cache;
 };
 
 /* makes master swing verbose */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6566,6 +6566,7 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
         c->fingerprint = NULL;
     }
     c->in_transaction = clnt->in_client_trans;
+    c->in_local_cache = clnt->in_local_cache;
     Pthread_mutex_unlock(&clnt->state_lk);
 }
 
@@ -7095,6 +7096,7 @@ void print_idle_clnt(struct sqlclntstate *clnt)
     struct timeval now, elapsed;
     gettimeofday(&now, NULL);
     timersub(&now, &clnt->wait_for_rd_since, &elapsed);
-    logmsg(LOGMSG_USER, "fd:%d  idle:%ldmins  origin:%s  [prev=> process:%s pid:%d sql:%s]  [process:%s pid:%d sql:%s] opcode:%s\n",
-           get_fileno(clnt), elapsed.tv_sec / 60, clnt->origin, clnt->prev_argv0, clnt->prev_pid, clnt->second_last_sql, clnt->argv0, clnt->conninfo.pid, clnt->last_sql, clnt->prev_opcode);
+    logmsg(LOGMSG_USER, "fd:%d  idle:%ldmins  origin:%s  [prev=> process:%s pid:%d sql:%s]  [process:%s pid:%d sql:%s] opcode:%s local-cache:%c\n",
+           get_fileno(clnt), elapsed.tv_sec / 60, clnt->origin, clnt->prev_argv0, clnt->prev_pid, clnt->second_last_sql, clnt->argv0, clnt->conninfo.pid, clnt->last_sql, clnt->prev_opcode,
+           clnt->in_local_cache ? 'Y' : 'N');
 }

--- a/plugins/newsql/newsql.h
+++ b/plugins/newsql/newsql.h
@@ -35,6 +35,14 @@ struct newsqlheader {
     int length;      /*  length of response */
 };
 
+typedef enum {
+    NEWSQL_STATE_NONE,
+    /* Query is making progress. Applicable only when type is HEARTBEAT */
+    NEWSQL_STATE_ADVANCING,
+    /* RESET from in-process cache. Applicable only when type is RESET */
+    NEWSQL_STATE_LOCALCACHE
+} newsql_state;
+
 struct newsql_postponed_data {
     size_t len;
     struct newsqlheader hdr;
@@ -72,7 +80,7 @@ typedef enum {
 newsql_loop_result newsql_loop(struct sqlclntstate *, CDB2SQLQUERY *);
 int is_commit_rollback(struct sqlclntstate *);
 int newsql_should_dispatch(struct sqlclntstate *, int *is_commit_rollback);
-void newsql_reset(struct sqlclntstate *);
+void newsql_reset(struct sqlclntstate *, int);
 void free_newsql_appdata(struct sqlclntstate *);
 void newsql_effects(CDB2SQLRESPONSE *, CDB2EFFECTS *, struct sqlclntstate *);
 

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -166,7 +166,7 @@ static int newsql_flush_evbuffer(struct sqlclntstate *clnt)
 static void newsql_reset_evbuffer(struct newsql_appdata_evbuffer *appdata)
 {
     appdata->initial = 1;
-    newsql_reset(&appdata->clnt);
+    newsql_reset(&appdata->clnt, (appdata->hdr.state == NEWSQL_STATE_LOCALCACHE));
 }
 
 static int newsql_done_cb(struct sqlclntstate *clnt)

--- a/plugins/newsql/newsql_sbuf.c
+++ b/plugins/newsql/newsql_sbuf.c
@@ -367,7 +367,7 @@ retry_read:
     } else if (hdr.type == CDB2_REQUEST_TYPE__RESET) {
         struct newsql_appdata_sbuf *appdata = clnt->appdata;
         newsql_protobuf_reset_offset(&appdata->newsql_protobuf_allocator);
-        newsql_reset(clnt);
+        newsql_reset(clnt, (hdr.state == NEWSQL_STATE_LOCALCACHE));
         goto retry_read;
     }
 

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -97,5 +97,6 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_INTEGER, "is_ssl", -1, offsetof(struct connection_info, is_ssl),
             CDB2_INTEGER, "has_cert", -1, offsetof(struct connection_info, has_cert),
             CDB2_CSTRING, "common_name", -1, offsetof(struct connection_info, common_name),
+            CDB2_INTEGER, "in_local_cache", -1, offsetof(struct connection_info, in_local_cache),
             SYSTABLE_END_OF_FIELDS);
 }


### PR DESCRIPTION
These changes would help us identify whether a connection is truly leaked, or is being cached in the client process.