### PR TITLE
Allow all socksql, recom, snapisol & serial

### DIFF
--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2981,6 +2981,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
         const uint8_t *p_buf_in_saved;
         int got_blockseq = 0;
         int got_osql = 0;
+        int is_tagged = 1;
 
         /* this is a pre-loop, we want to jump back to the begining after it's
          * done */
@@ -3044,6 +3045,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
                 /* fall-through */
             case BLOCK2_SNAPISOL:
             case BLOCK2_SERIAL:
+                is_tagged = 0;
                 if (gbl_use_blkseq) {
                     have_blkseq = 1;
                     osql_bplog_set_blkseq(iq->sorese, iq);
@@ -3125,7 +3127,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
                             gbl_blockop_name_xrefs[opnum]);
             }
         }
-        if (!got_osql && gbl_disable_tagged_api_writes) {
+        if (is_tagged && gbl_disable_tagged_api_writes) {
             logmsg(LOGMSG_ERROR, "Rejecting tagged api request\n");
             outrc = ERR_BADREQ;
             fromline = __LINE__;


### PR DESCRIPTION
Consider all socksql, read-committed, snapshot, and serializable as non-tagged requests.