### PR TITLE
Address commit LSN map recovery bug

### DIFF
--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2860,7 +2860,7 @@ struct __utxnid {
 struct __logfile_txn_list {
 	u_int32_t file_num;
 	DB_LSN highest_commit_lsn;
-	LISTC_T(struct __utxnid) commit_utxnids;
+	hash_t *commit_utxnids;
 };
 
 struct __utxnid_track {

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2875,6 +2875,9 @@ struct __txn_commit_map {
 	DB_LSN highest_checkpoint_lsn;
 	hash_t *transactions;
 	hash_t *logfile_lists;
+
+	hash_t *utxnids_in_limbo;
+	DB_LSN highest_commit_lsn_recovered_so_far;
 };
 
 struct __mempv_cache_page_key

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -383,19 +383,8 @@ static int free_logfile_list_elt(obj, arg)
         void *obj;
         void *arg;
 {
-        LOGFILE_TXN_LIST *llist;
-        UTXNID *elt, *tmp_elt;
-        DB_ENV *dbenv;
-
-        llist = (LOGFILE_TXN_LIST *) obj;
-        dbenv = (DB_ENV *) arg;
-
-        LISTC_FOR_EACH_SAFE(&llist->commit_utxnids, elt, tmp_elt, lnk)
-        {
-                __os_free(dbenv, elt);
-        }
-	__os_free(dbenv, llist);
-        return 0;
+	__os_free((DB_ENV *) arg, (LOGFILE_TXN_LIST *) obj);
+	return 0;
 }
 
 static int free_transactions(obj, arg)
@@ -438,32 +427,106 @@ int __txn_commit_map_destroy(dbenv)
         return 0;
 }
 
+
+/*
+ * __txn_commit_map_delete_logfile_list --
+ *
+ * PUBLIC: static int __txn_commit_map_delete_logfile_list
+ * PUBLIC:     __P((DB_ENV *, LOGFILE_TXN_LIST * const));
+ */
+static void __txn_commit_map_delete_logfile_list(DB_ENV *dbenv, LOGFILE_TXN_LIST * const to_delete) {
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
+	const u_int32_t del_log = to_delete->file_num;
+	const int i_am_highest_logfile = del_log == txmap->highest_commit_lsn.file;
+	const int i_am_smallest_logfile = del_log == txmap->smallest_logfile;
+
+	if (i_am_highest_logfile && i_am_smallest_logfile)
+	{
+		logmsg(LOGMSG_WARN, "%s: Deleting the only logfile (%"PRIu32") in txmap\n", __func__, del_log);
+
+		ZERO_LSN(txmap->highest_commit_lsn);
+		txmap->smallest_logfile = -1;
+	} else if (i_am_highest_logfile)
+	{
+		logmsg(LOGMSG_WARN, "%s: Deleting the highest logfile (%"PRIu32") in txmap\n", __func__, del_log);
+
+		LOGFILE_TXN_LIST *successor = NULL;
+		for (int prev_log=del_log-1; successor == NULL && prev_log >= 0; --prev_log) {
+			successor = hash_find(txmap->logfile_lists, &prev_log);
+		}
+		assert(successor);
+		txmap->highest_commit_lsn = successor->highest_commit_lsn;
+	} else if (i_am_smallest_logfile)
+	{
+		LOGFILE_TXN_LIST *successor = NULL;
+		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->highest_commit_lsn.file)) {
+			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
+		}
+		assert(successor);
+	}
+
+	hash_del(txmap->logfile_lists, to_delete);
+	__os_free(dbenv, to_delete);
+}
+
+
 /*
  * __txn_commit_map_remove_nolock --
  *  Remove a transaction from the commit LSN map without locking.
  *
  * PUBLIC: static int __txn_commit_map_remove_nolock
- * PUBLIC:     __P((DB_ENV *, u_int64_t));
+ * PUBLIC:     __P((DB_ENV *, u_int64_t, int));
  */
-static int __txn_commit_map_remove_nolock(dbenv, utxnid)
+static int __txn_commit_map_remove_nolock(dbenv, utxnid, delete_from_logfile_lists)
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+	int delete_from_logfile_lists;
+{
+	int ret = 0;
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
+
+	UTXNID_TRACK * const txn = hash_find(txmap->transactions, &utxnid);
+	if (!txn) {
+		logmsg(LOGMSG_ERROR, "%s: Could not find transaction %"PRIu64" in the map\n", __func__, utxnid);
+		ret = 1;
+		goto err;
+	}
+
+	LOGFILE_TXN_LIST * const logfile_list = hash_find(txmap->logfile_lists, &(txn->commit_lsn.file));
+	if (!logfile_list) {
+		logmsg(LOGMSG_ERROR, "%s: Could not find logfile list for file %d\n", __func__, txn->commit_lsn.file);
+		ret = 1;
+		goto err;
+	}
+
+	if (delete_from_logfile_lists) {
+		hash_del(logfile_list->commit_utxnids, txn);
+	}
+
+	if (hash_get_num_entries(logfile_list->commit_utxnids) == 0) {
+		__txn_commit_map_delete_logfile_list(dbenv, logfile_list);
+	}
+
+	hash_del(txmap->transactions, txn);
+	__os_free(dbenv, txn); 
+
+err:
+	return ret;
+}
+
+static int __txn_commit_map_remove_nolock_foreach_wrapper(void *obj, void *arg) {
+	return __txn_commit_map_remove_nolock((DB_ENV *) arg, ((UTXNID_TRACK *) obj)->utxnid, 0);
+}
+
+int __txn_commit_map_remove(dbenv, utxnid)
 	DB_ENV *dbenv;
 	u_int64_t utxnid;
 {
-	DB_TXN_COMMIT_MAP *txmap;
-	UTXNID_TRACK *txn;
-	int ret;
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
 
-	txmap = dbenv->txmap;
-	ret = 0;
-
-	txn = hash_find(txmap->transactions, &utxnid);
-
-	if (txn) {
-		hash_del(txmap->transactions, txn);
-		__os_free(dbenv, txn); 
-	} else {
-		ret = 1;
-	}
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+	int ret = __txn_commit_map_remove_nolock(dbenv, utxnid, 1);
+	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 
 	return ret;
 }
@@ -570,44 +633,12 @@ int __txn_commit_map_delete_logfile_txns(dbenv, del_log)
 		goto err;
 	}
 
-	UTXNID *elt, *tmpp;
-	LISTC_FOR_EACH_SAFE(&to_delete->commit_utxnids, elt, tmpp, lnk)
-	{
-		__txn_commit_map_remove_nolock(dbenv, elt->utxnid);
-		__os_free(dbenv, elt);
+	ret = hash_for(to_delete->commit_utxnids, (hashforfunc_t *const) __txn_commit_map_remove_nolock_foreach_wrapper, (void *) dbenv);
+	if (ret) {
+		goto err;
 	}
 
-	const int i_am_highest_logfile = del_log == txmap->highest_commit_lsn.file;
-	const int i_am_smallest_logfile = del_log == txmap->smallest_logfile;
-
-	if (i_am_highest_logfile && i_am_smallest_logfile)
-	{
-		logmsg(LOGMSG_WARN, "%s: Deleting the only logfile (%"PRIu32") in txmap\n", __func__, del_log);
-
-		ZERO_LSN(txmap->highest_commit_lsn);
-		txmap->smallest_logfile = -1;
-	} else if (i_am_highest_logfile)
-	{
-		logmsg(LOGMSG_WARN, "%s: Deleting the highest logfile (%"PRIu32") in txmap\n", __func__, del_log);
-
-		LOGFILE_TXN_LIST *successor = NULL;
-		for (int prev_log=del_log-1; successor == NULL && prev_log >= 0; --prev_log) {
-			successor = hash_find(txmap->logfile_lists, &prev_log);
-		}
-		assert(successor);
-		txmap->highest_commit_lsn = successor->highest_commit_lsn;
-	} else if (i_am_smallest_logfile)
-	{
-		LOGFILE_TXN_LIST *successor = NULL;
-		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->highest_commit_lsn.file)) {
-			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
-		}
-		assert(successor);
-	}
-
-	hash_del(txmap->logfile_lists, to_delete);
-	__os_free(dbenv, to_delete);
-
+	__txn_commit_map_delete_logfile_list(dbenv, to_delete);
 err:
 	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 
@@ -715,7 +746,7 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 	if (alloc_delete_list) {
 		ZERO_LSN(to_delete->highest_commit_lsn);
 		to_delete->file_num = commit_lsn.file;
-		listc_init(&to_delete->commit_utxnids, offsetof(UTXNID, lnk));
+		to_delete->commit_utxnids = hash_init_o(offsetof(UTXNID_TRACK, utxnid), sizeof(u_int64_t));
 		hash_add(txmap->logfile_lists, to_delete);
 
 		if (commit_lsn.file < txmap->smallest_logfile || txmap->smallest_logfile == -1) {
@@ -734,9 +765,7 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 	txn->utxnid = utxnid;
 	txn->commit_lsn = commit_lsn;
 	hash_add(txmap->transactions, txn);
-
-	elt->utxnid = utxnid;
-	listc_atl(&to_delete->commit_utxnids, elt);
+	hash_add(to_delete->commit_utxnids, txn);
 	
 	return ret;
 err:

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1895,12 +1895,21 @@ int free_it(void *obj, void *arg)
     free(obj);
     return 0;
 }
-void destroy_hash(hash_t *h, int (*free_func)(void *, void *))
+void destroy_hash_contents(hash_t *h, int(*free_func)(void *, void *))
 {
-    if (!h)
+    if (!h) {
         return;
+    } 
     hash_for(h, free_func, NULL);
     hash_clear(h);
+
+}
+void destroy_hash(hash_t *h, int (*free_func)(void *, void *))
+{
+    if (!h) {
+        return;
+    }
+    destroy_hash_contents(h, free_func);
     hash_free(h);
 }
 

--- a/tests/commit_lsn_map.test/error.sh
+++ b/tests/commit_lsn_map.test/error.sh
@@ -1,0 +1,11 @@
+error() {
+	err "Failed at line $1"
+	exit 1
+}
+
+function failif {
+	if [[ $1 -ne 0 ]]; then
+		exit 1
+	fi
+}
+

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/cluster_utils.sh
+source ${TESTSROOTDIR}/tools/runit_common.sh
+source ./error.sh
 
 # Grab my database name.
 dbnm=$1
@@ -34,13 +36,6 @@ kill_restart_cluster()
         echo "killrestart nodes $node"
         kill_restart_node $node $kill_wait_time
     done
-}
-
-function failif
-{
-	if [[ $1 -ne 0 ]]; then
-		exit 1
-	fi
 }
 
 function bounce {
@@ -244,7 +239,8 @@ verify_txmap_deletes_records() {
 		"select COUNT(*) from comdb2_transaction_commit")
 	readonly initial_num_records_for_file initial_num_records
 
-	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('clm_delete_logfile $logfile_to_delete')"
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
+		"exec procedure sys.cmd.send('clm_delete_logfile $logfile_to_delete')" > /dev/null
 
 	final_num_records=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "select COUNT(*) from comdb2_transaction_commit")
 	readonly final_num_records
@@ -253,17 +249,33 @@ verify_txmap_deletes_records() {
 	fi
 }
 
+get_clminfo() {
+	cdb2sql ${CDB2_OPTIONS} --host $1 $dbnm "exec procedure sys.cmd.send('bdb clminfo')"
+}
+
+extract_highest_commit_lsn_offset_from_clminfo() {
+	grep -oP '(?<=Highest commit lsn offset: )[0-9]+' <<<"$1"
+}
+
+extract_highest_commit_lsn_file_from_clminfo() {
+	grep -oP '(?<=Highest commit lsn file: )[0-9]+' <<<"$1"
+}
+
+extract_smallest_logfile_from_clminfo() {
+	grep -oP '(?<=Smallest logfile: )[-]?[0-9]+' <<<"$1"
+}
+
 verify_txmap_has_expected_min_max_files() {
 	local -r exp_min_file=$1 exp_max_file=$2 node=$3
-	local final_state records_outside_of_expected_window
+	local highest_commit_lsn_file smallest_logfile records_outside_of_expected_window
 
 	# Check that window stored in internal structure is correct
-	final_state=$(cdb2sql ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('bdb clminfo')")
-	readonly final_state
-	if !(echo "$final_state" | grep "Highest commit lsn file: $exp_max_file" > /dev/null) ||
-		!(echo "$final_state" | grep "Smallest logfile: $exp_min_file" > /dev/null); then
+	highest_commit_lsn_file=$(extract_highest_commit_lsn_file_from_clminfo "$(get_clminfo $node)")
+	smallest_logfile=$(extract_smallest_logfile_from_clminfo "$(get_clminfo $node)")
+	readonly highest_commit_lsn_file smallest_logfile
+	if (( highest_commit_lsn_file != exp_max_file || smallest_logfile != exp_min_file )); then
 		echo "Expected max file to be $exp_max_file and min file to be $exp_min_file. Got:"
-		echo "$final_state"
+		echo "highest commit lsn file: $highest_commit_lsn_file; smallest logfile: $smallest_logfile"
 		exit 1
 	fi
 
@@ -279,6 +291,8 @@ verify_txmap_has_expected_min_max_files() {
 }
 
 test_delete() {
+	trap 'error $LINENO' ERR
+
 	local node
 	node=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()")
 	readonly node
@@ -307,9 +321,118 @@ test_delete() {
 	verify_txmap_deletes_records 1 $node
 }
 
+verify_cached_highest_commit_lsn_after_recovery() {
+	local clminfo_after_recovery
+	clminfo_after_recovery=$(get_clminfo $master)
+	readonly clminfo_after_recovery
+
+	local cached_highest_commit_lsn_file_after_recovery
+	cached_highest_commit_lsn_file_after_recovery=$(extract_highest_commit_lsn_file_from_clminfo "$clminfo_after_recovery")
+	readonly cached_highest_commit_lsn_file_after_recovery
+
+	local cached_highest_commit_lsn_offset_after_recovery
+	cached_highest_commit_lsn_offset_after_recovery=$(extract_highest_commit_lsn_offset_from_clminfo "$clminfo_after_recovery")
+	readonly cached_highest_commit_lsn_offset_after_recovery
+
+
+	local highest_commit_lsn_after_recovery
+	highest_commit_lsn_after_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm \
+		"select commitlsnfile, max(commitlsnoffset) from comdb2_transaction_commit \
+		where commitlsnfile in (select max(commitlsnfile) from comdb2_transaction_commit)")
+	readonly highest_commit_lsn_after_recovery
+
+	local highest_commit_lsn_file_after_recovery
+	highest_commit_lsn_file_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 1)
+	readonly highest_commit_lsn_file_after_recovery
+
+	local highest_commit_lsn_offset_after_recovery
+	highest_commit_lsn_offset_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 2)
+	readonly highest_commit_lsn_offset_after_recovery
+
+	(( cached_highest_commit_lsn_file_after_recovery <= highest_commit_lsn_file_after_recovery \
+		|| cached_highest_commit_lsn_offset_after_recovery <= highest_commit_lsn_offset_after_recovery ))
+}
+
+verify_correct_utxnids_in_map() {
+	local -r utxnids_to_recover=$1 utxnids_before_recovery=$2
+
+	local recovered_utxnids
+	recovered_utxnids=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default \
+		'select distinct utxnid from comdb2_transaction_commit order by utxnid' \
+		| sed 's/ /\n/g')
+	readonly recovered_utxnids 
+
+	local utxnids_to_be_deleted_during_recovery
+	utxnids_to_be_deleted_during_recovery=$(comm -13 \
+		<(sort <<<$(echo "$utxnids_to_recover")) \
+		<(sort <<<$(echo "$utxnids_before_recovery")))
+	readonly utxnids_to_be_deleted_during_recovery
+
+	local present_unexpected_utxnids
+	present_unexpected_utxnids=$(comm -12 \
+		<(sort <<<$(echo "$recovered_utxnids")) \
+		<(sort <<<$(echo "$utxnids_to_be_deleted_during_recovery")))
+	readonly present_unexpected_utxnids
+	[[ -z $present_unexpected_utxnids ]] # Assert that we have no unexpected utxnids
+
+	local absent_expected_utxnids
+	absent_expected_utxnids=$(comm -23 \
+		<(sort <<<$(echo "$utxnids_to_recover")) \
+		<(sort <<<$(echo "$recovered_utxnids")))
+	readonly absent_expected_utxnids
+	[[ -z $absent_expected_utxnids ]] # Assert that we have all expected utxnids
+}
+
+test_recover_to_lsn() {
+	trap 'error $LINENO' ERR
+
+	# Given
+
+		# Run some initial traffic 
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table t(i int)' > /dev/null
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into t values(1)' > /dev/null
+
+	local -r flush_itrs=2
+	local itr
+	for (( itr=0; itr<flush_itrs; itr++ )); do
+		cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("flush")' > /dev/null
+	done
+
+	local utxnids_to_recover
+	utxnids_to_recover=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default \
+		'select distinct utxnid from comdb2_transaction_commit order by utxnid' \
+		| sed 's/ /\n/g')
+	readonly utxnids_to_recover
+
+	local recovery_lsn
+	recovery_lsn=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default \
+		'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
+	readonly recovery_lsn
+
+		# Run more traffic that will be undone during recovery
+	pushlogs 3
+
+	local utxnids_before_recovery
+	utxnids_before_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default \
+		'select distinct utxnid from comdb2_transaction_commit order by utxnid' \
+		| sed 's/ /\n/g')
+	readonly utxnids_before_recovery
+
+	# When
+
+	cdb2sql ${CDB2_OPTIONS} --host $master $dbnm \
+		"exec procedure sys.cmd.truncate_log(\"{$recovery_lsn}\")"
+	
+	# Then
+
+	verify_txmap_has_expected_min_max_files 1 1 $master
+	verify_cached_highest_commit_lsn_after_recovery 
+	verify_correct_utxnids_in_map "$utxnids_to_recover" "$utxnids_before_recovery"
+}
+
 if [ "$TESTCASE" == "commit_lsn_map_delete_generated" ];
 then
-	set -e
+	test_recover_to_lsn
 	test_delete
 else
 	test_add


### PR DESCRIPTION
Transactions are added to the commit LSN map during the backwards pass of recovery. The backward pass undoes transactions. Currently, the commit LSN map code assumes that all transactions undone in the backwards pass will be redone in the forward pass; however, there is no guarantee of this. The changes in this PR address this bug as follows:

When transactions are added to the commit LSN map during the backwards pass they are also marked as "in limbo." This is a way of saying that we are still uncertain about what status these transactions will finally end up in (whether they will be committed or undone).

Each transaction committed in the forward pass is taken out of limbo since we become certain that all of these transactions will be in a committed state once we finish recovery.

After the forward pass, all transactions still in limbo are taken out of limbo and removed from the commit LSN map because they were never committed during the forward pass.