### PR TITLE
Toggle tagged-writes for tests which require them

### DIFF
--- a/tests/comdb2sys.test/lrl.options
+++ b/tests/comdb2sys.test/lrl.options
@@ -5,3 +5,4 @@ table t2 t2.csc2
 table t3 t3.csc2
 table t4 t4.csc2
 enable_partial_indexes
+disable_tagged_api_writes 1

--- a/tests/diskspace_nollmeta.test/lrl.options
+++ b/tests/diskspace_nollmeta.test/lrl.options
@@ -1,1 +1,2 @@
 nokeycompr
+disable_tagged_api_writes 1

--- a/tests/timepart_trunc.test/lrl.options
+++ b/tests/timepart_trunc.test/lrl.options
@@ -1,1 +1,2 @@
 setattr DEBUG_TIMEPART_CRON 1
+disable_tagged_api_writes 1

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -533,7 +533,13 @@ if (( $? != 0 )) ; then
 fi
 
 echo $cmd "put tunable disable_tagged_api_writes 0"
-$cmd "put tunable disable_tagged_api_writes 0"
+if [[ -n "$CLUSTER" ]]; then
+    for node in $CLUSTER; do
+        cdb2sql --host $node $dbname --host $node "put tunable disable_tagged_api_writes 0"
+    done
+else
+    $cmd "put tunable disable_tagged_api_writes 0"
+fi
 if (( $? != 0 )) ; then
    echo "FAILURE to put tunable to 0"
    exit 1
@@ -547,7 +553,13 @@ if (( $? == 0 )) ; then
 fi
 
 echo $cmd "put tunable disable_tagged_api_writes 1"
-$cmd "put tunable disable_tagged_api_writes 1"
+if [[ -n "$CLUSTER" ]]; then
+    for node in $CLUSTER; do
+        cdb2sql --host $node $dbname --host $node "put tunable disable_tagged_api_writes 1"
+    done
+else
+    $cmd "put tunable disable_tagged_api_writes 1"
+fi
 if (( $? != 0 )) ; then
    echo "FAILURE to put tunable to 1"
    exit 1


### PR DESCRIPTION
Fixes for timepart_trunc, diskspace_nollmeta, and comdb2sys tests
