### PR TITLE
block creating a partition with shards matching existing shards

### DIFF
--- a/db/views.c
+++ b/db/views.c
@@ -966,6 +966,14 @@ void *_view_cron_phase1(struct cron_event *event, struct errstat *err)
 
 done:
     if (run) {
+        /* view might go away after unlock */
+        cron_sched_t *sched = NULL;
+        uuid_t u;
+        if (rc == VIEW_NOERR) {
+            sched = _get_sched_byname(view->period, view->name);
+            comdb2uuidcpy(u, view->source_id);
+        }
+
         Pthread_rwlock_unlock(&views_lk);
         /* commit_adaptive unlocks the schema-lk */
         if (rc != VIEW_NOERR)
@@ -981,10 +989,9 @@ done:
                               "Adding phase 2 at %d for %s\n",
                               shardChangeTime, pShardName);
 
-            if (cron_add_event(_get_sched_byname(view->period, view->name),
-                               NULL, shardChangeTime, _view_cron_phase2,
+            if (cron_add_event(sched, NULL, shardChangeTime, _view_cron_phase2,
                                tmp_str = strdup(name), pShardName, NULL,
-                               NULL, &view->source_id, err, NULL) == NULL) {
+                               NULL, &u, err, NULL) == NULL) {
                 logmsg(LOGMSG_ERROR, "%s: failed rc=%d errstr=%s\n", __func__,
                         err->errval, err->errstr);
                 if (tmp_str)
@@ -2954,6 +2961,12 @@ int timepart_populate_shards(timepart_view_t *view, struct errstat *err)
         if (!view->shards[i].tblname) {
             errstat_set_rcstrf(err, rc = VIEW_ERR_GENERIC,
                                "malloc shard %i name", i);
+            goto error;
+        }
+        /* do we have a table with the same name */
+        if (get_dbtable_by_name(view->shards[i].tblname)) {
+            errstat_set_rcstrf(err, rc = VIEW_ERR_EXIST,
+                               "shard %s %d exists", view->shards[i].tblname, i);
             goto error;
         }
         old_name = new_name;

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -1109,5 +1109,7 @@ cdb2sql ${CDB2_OPTIONS} --host MASTER dorintdb default select name, arg1, arg2, 
 TEST 17
 Test block alter
 TEST 18
+Test check for partition new over old shards
+TEST 19
 Test block put retention
 [put time partition t17 retention 20] failed with rc -3 Cannot find partition

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -565,9 +565,51 @@ if (( $? != 0 )) ; then
    exit 1
 fi
 
-header 18 "Test block put retention"
+header 18 "Test check for partition new over old shards"
+echo $cmd "create table t19(a int)"
+$cmd "create table t19(a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create t19"
+   exit 1
+fi
+
+starttime=`perl -MPOSIX -le 'local $ENV{TZ}=":/usr/share/zoneinfo/UTC"; print strftime "%Y-%m-%dT%H%M%S UTC", localtime(time()-3*24*3600-60)'`
+echo $cmd "CREATE TIME PARTITION ON t19 as tv19 PERIOD 'daily' RETENTION 2 START '${starttime}'"
+$cmd "CREATE TIME PARTITION ON t19 as tv19 PERIOD 'daily' RETENTION 2 START '${starttime}'"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create time partition tv19"
+   exit 1
+fi
+
+sleep 30
+
+echo $cmd "drop time partition tv19"
+$cmd "drop time partition tv19"
+if (( $? != 0 )) ; then
+   echo "FAILURE to drop time partition tv19"
+   exit 1
+fi
+
+sleep 10
+
+echo $cmd "create table t19(a int)"
+$cmd "create table t19(a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to recreate t19"
+   exit 1
+fi
+
+echo $cmd "alter table t19 partitioned by time period 'daily' retention 2 start '20240901T'"
+$cmd "alter table t19 partitioned by time period 'daily' retention 2 start '20240901T'"
+if (( $? == 0 )) ; then
+   echo "FAILURE to block creating overlapping shards"
+   exit 1
+fi
+
+header 19 "Test block put retention"
 echo $cmd "put time partition t17 retention 20"
 $cmd "put time partition t17 retention 20" >> $OUT 2>&1
+
 
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual


### PR DESCRIPTION
It only happens if we drop a legacy type time partition (which preserves its shards), then recreate the original table with the same name, and then finally altering that to match the configuration of the initial partition.   It is a fast fail, breaking sql.