### PR TITLE
{176060832}: Ensuring non-negative from Java random number generator

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -1957,7 +1957,8 @@ readloop:
         if (max - min < 2)
             return min;
         for (int i = 0; i < 10; i++) {
-            val = rnd.nextInt() % (max - min) + min;
+            /* nextInt(N) ensures non-negative */
+            val = rnd.nextInt(max - min) + min;
             if (val != exclude)
                 return val;
         }


### PR DESCRIPTION
Cdb2jdbc applications may run into java.lang.IndexOutOfBoundsException. This patch fixes it.
