### PR TITLE
Address commit LSN map recovery bug

### DIFF
--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1702,7 +1702,7 @@ int bdb_lock_row_fromlid_int(bdb_state_type *bdb_state, int lid, int idx,
 struct cursor_tran {
     uint32_t lockerid;
     uint32_t flags;
-    DB_LSN last_commit_lsn; /* Commit LSN prior to modsnap start point */
+    DB_LSN modsnap_start_lsn; /* Modsnap start point */
     DB_LSN last_checkpoint_lsn; /* Checkpoint LSN prior to modsnap start point */
     int id; /* debugging */
 };

--- a/bdb/cursor_ll.c
+++ b/bdb/cursor_ll.c
@@ -1669,7 +1669,7 @@ DBC *get_cursor_for_cursortran_flags(cursor_tran_t *curtran, DB *db,
     } else
         assert(dbc != NULL);
 
-    dbc->last_commit_lsn = curtran->last_commit_lsn;
+    dbc->modsnap_start_lsn = curtran->modsnap_start_lsn;
     dbc->last_checkpoint_lsn = curtran->last_checkpoint_lsn;
     return dbc;
 }

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2073,7 +2073,7 @@ struct __dbc {
 	char*	   pf; // Added by Fabio for prefaulting the index pages
 	db_pgno_t   lastpage; // pgno of last move
 
-	DB_LSN last_commit_lsn; /* Commit LSN prior to modsnap start point */
+	DB_LSN modsnap_start_lsn; /* Modsnap start point */
 	DB_LSN last_checkpoint_lsn; /* Checkpoint LSN prior to modsnap start point */
 };
 extern pthread_key_t DBG_FREE_CURSOR;
@@ -2871,7 +2871,7 @@ struct __txn_commit_map {
 	pthread_mutex_t txmap_mutexp;
 	int64_t highest_logfile;
 	int64_t smallest_logfile;
-	DB_LSN highest_commit_lsn;
+	DB_LSN modsnap_start_lsn;
 	DB_LSN highest_checkpoint_lsn;
 	hash_t *transactions;
 	hash_t *logfile_lists;

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2859,8 +2859,7 @@ struct __utxnid {
 
 struct __logfile_txn_list {
 	u_int32_t file_num;
-	DB_LSN highest_commit_lsn;
-	LISTC_T(struct __utxnid) commit_utxnids;
+	hash_t *commit_utxnids;
 };
 
 struct __utxnid_track {
@@ -2870,6 +2869,7 @@ struct __utxnid_track {
 
 struct __txn_commit_map {
 	pthread_mutex_t txmap_mutexp;
+	int64_t highest_logfile;
 	int64_t smallest_logfile;
 	DB_LSN highest_commit_lsn;
 	DB_LSN highest_checkpoint_lsn;

--- a/berkdb/build/db_int.h
+++ b/berkdb/build/db_int.h
@@ -545,7 +545,7 @@ extern pthread_key_t txn_key;
 
 extern int __mempv_fget(DB_MPOOLFILE *, DB *, db_pgno_t, DB_LSN, DB_LSN, void *, u_int32_t);
 
-#define PAGEGET(dbc, mpf, pgno, flags, page) (dbc != NULL && F_ISSET(dbc, DBC_SNAPSHOT)) ? __mempv_fget(mpf, dbc->dbp, *pgno, dbc->last_commit_lsn, dbc->last_checkpoint_lsn, page, flags) : __memp_fget(mpf, pgno, flags, page)
+#define PAGEGET(dbc, mpf, pgno, flags, page) (dbc != NULL && F_ISSET(dbc, DBC_SNAPSHOT)) ? __mempv_fget(mpf, dbc->dbp, *pgno, dbc->modsnap_start_lsn, dbc->last_checkpoint_lsn, page, flags) : __memp_fget(mpf, pgno, flags, page)
 
 #define PAGEPUT(dbc, mpf, page, flags) (dbc != NULL && F_ISSET(dbc, DBC_SNAPSHOT)) ? __mempv_fput(mpf, page, flags) : __memp_fput(mpf, page, flags)
 

--- a/berkdb/db/db_cam.c
+++ b/berkdb/db/db_cam.c
@@ -762,7 +762,7 @@ __db_c_idup(dbc_orig, dbcp, flags)
 
 	// Flag should be set before cursor is positioned.
 	F_SET(dbc_n, F_ISSET(dbc_orig, DBC_SNAPSHOT));
-	dbc_n->last_commit_lsn = dbc_orig->last_commit_lsn;
+	dbc_n->modsnap_start_lsn = dbc_orig->modsnap_start_lsn;
 	dbc_n->last_checkpoint_lsn = dbc_orig->last_checkpoint_lsn;
 
 	/* If the user wants the cursor positioned, do it here.  */

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -56,7 +56,7 @@ static const char revid[] =
 #include "list.h"
 #include "logmsg.h"
 
-extern int __txn_commit_map_set_highest_commit_lsn(DB_ENV *, DB_LSN);
+extern int __txn_commit_map_set_modsnap_start_lsn(DB_ENV *, DB_LSN);
 extern int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
 extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN*);
 
@@ -1481,7 +1481,7 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 		goto err;
 	dbenv->recovery_pass = DB_TXN_NOT_IN_RECOVERY;
 
-	__txn_commit_map_set_highest_commit_lsn(dbenv, stop_lsn);
+	__txn_commit_map_set_modsnap_start_lsn(dbenv, stop_lsn);
 
 	/*
 	 * Process any pages that were on the limbo list and move them to

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -56,6 +56,7 @@ static const char revid[] =
 #include "list.h"
 #include "logmsg.h"
 
+extern int __txn_commit_map_set_highest_commit_lsn(DB_ENV *, DB_LSN);
 extern int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
 extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN*);
 
@@ -1479,6 +1480,8 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	if (ret != 0 && ret != DB_NOTFOUND)
 		goto err;
 	dbenv->recovery_pass = DB_TXN_NOT_IN_RECOVERY;
+
+	__txn_commit_map_set_highest_commit_lsn(dbenv, stop_lsn);
 
 	/*
 	 * Process any pages that were on the limbo list and move them to

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -370,6 +370,7 @@ int __txn_commit_map_init(dbenv)
 	ZERO_LSN(txmap->highest_checkpoint_lsn);
 	ZERO_LSN(txmap->highest_commit_lsn);
 	txmap->smallest_logfile = -1;
+	txmap->highest_logfile = -1;
 	Pthread_mutex_init(&txmap->txmap_mutexp, NULL);
 	dbenv->txmap = txmap;
 
@@ -383,19 +384,13 @@ static int free_logfile_list_elt(obj, arg)
         void *obj;
         void *arg;
 {
-        LOGFILE_TXN_LIST *llist;
-        UTXNID *elt, *tmp_elt;
-        DB_ENV *dbenv;
+	LOGFILE_TXN_LIST * const to_delete = (LOGFILE_TXN_LIST * const) obj;
+	DB_ENV * const dbenv = (DB_ENV * const) arg;
 
-        llist = (LOGFILE_TXN_LIST *) obj;
-        dbenv = (DB_ENV *) arg;
-
-        LISTC_FOR_EACH_SAFE(&llist->commit_utxnids, elt, tmp_elt, lnk)
-        {
-                __os_free(dbenv, elt);
-        }
-	__os_free(dbenv, llist);
-        return 0;
+	hash_clear(to_delete->commit_utxnids);
+	hash_free(to_delete->commit_utxnids);
+	__os_free(dbenv, to_delete);
+	return 0;
 }
 
 static int free_transactions(obj, arg)
@@ -438,32 +433,124 @@ int __txn_commit_map_destroy(dbenv)
         return 0;
 }
 
+
+/*
+ * __txn_commit_map_delete_logfile_list --
+ *
+ * PUBLIC: static int __txn_commit_map_delete_logfile_list
+ * PUBLIC:     __P((DB_ENV *, LOGFILE_TXN_LIST * const));
+ */
+static void __txn_commit_map_delete_logfile_list(DB_ENV *dbenv, LOGFILE_TXN_LIST * const to_delete) {
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
+	const u_int32_t del_log = to_delete->file_num;
+	const int i_am_highest_logfile = del_log == txmap->highest_logfile;
+	const int i_am_smallest_logfile = del_log == txmap->smallest_logfile;
+
+	if (i_am_highest_logfile && i_am_smallest_logfile)
+	{
+		logmsg(LOGMSG_WARN, "%s: Deleting the only logfile (%"PRIu32") in txmap\n", __func__, del_log);
+
+		txmap->highest_logfile = -1;
+		txmap->smallest_logfile = -1;
+	} else if (i_am_highest_logfile)
+	{
+		logmsg(LOGMSG_WARN, "%s: Deleting the highest logfile (%"PRIu32") in txmap\n", __func__, del_log);
+
+		LOGFILE_TXN_LIST *successor = NULL;
+		while ((successor == NULL) && (--txmap->highest_logfile >= 0)) {
+			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
+		}
+		assert(successor);
+	} else if (i_am_smallest_logfile)
+	{
+		LOGFILE_TXN_LIST *successor = NULL;
+		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->highest_commit_lsn.file)) {
+			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
+		}
+		assert(successor);
+	}
+
+	hash_del(txmap->logfile_lists, to_delete);
+	hash_clear(to_delete->commit_utxnids);
+	hash_free(to_delete->commit_utxnids);
+	__os_free(dbenv, to_delete);
+}
+
+
 /*
  * __txn_commit_map_remove_nolock --
  *  Remove a transaction from the commit LSN map without locking.
  *
  * PUBLIC: static int __txn_commit_map_remove_nolock
+ * PUBLIC:     __P((DB_ENV *, u_int64_t, int));
+ */
+static int __txn_commit_map_remove_nolock(dbenv, utxnid, delete_from_logfile_lists)
+	DB_ENV *dbenv;
+	u_int64_t utxnid;
+	int delete_from_logfile_lists;
+{
+	if (dbenv->attr.commit_map_debug) {
+		logmsg(LOGMSG_DEBUG, "%s: Deleting utxnid %"PRIu64"\n",
+				__func__, utxnid);
+	}
+
+	int ret = 0;
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
+
+	UTXNID_TRACK * const txn = hash_find(txmap->transactions, &utxnid);
+	if (!txn) {
+		logmsg(LOGMSG_ERROR, "%s: Could not find transaction %"PRIu64" in the map\n", __func__, utxnid);
+		ret = 1;
+		goto err;
+	}
+
+	LOGFILE_TXN_LIST * const logfile_list = hash_find(txmap->logfile_lists, &(txn->commit_lsn.file));
+	if (!logfile_list) {
+		logmsg(LOGMSG_ERROR, "%s: Could not find logfile list for file %d\n", __func__, txn->commit_lsn.file);
+		ret = 1;
+		goto err;
+	}
+
+	if (delete_from_logfile_lists) {
+		hash_del(logfile_list->commit_utxnids, txn);
+	}
+
+	if (hash_get_num_entries(logfile_list->commit_utxnids) == 0) {
+		__txn_commit_map_delete_logfile_list(dbenv, logfile_list);
+	}
+
+	hash_del(txmap->transactions, txn);
+	__os_free(dbenv, txn); 
+
+err:
+	return ret;
+}
+
+static int __txn_commit_map_remove_nolock_foreach_wrapper(void *obj, void *arg) {
+	return __txn_commit_map_remove_nolock((DB_ENV *) arg, ((UTXNID_TRACK *) obj)->utxnid, 0);
+}
+
+/*
+ * __txn_commit_map_remove --
+ *  Removes a transaction from the commit LSN map
+ *
+ *  *If this function deletes the transaction with the highest commit LSN, 
+ * then it is the caller's responsibility to call 
+ * `__txn_commit_map_set_highest_commit_lsn` with the next highest
+ * commit LSN*
+ *
+ * PUBLIC: int __txn_commit_map_get_highest_checkpoint_lsn
  * PUBLIC:     __P((DB_ENV *, u_int64_t));
  */
-static int __txn_commit_map_remove_nolock(dbenv, utxnid)
+int __txn_commit_map_remove(dbenv, utxnid)
 	DB_ENV *dbenv;
 	u_int64_t utxnid;
 {
-	DB_TXN_COMMIT_MAP *txmap;
-	UTXNID_TRACK *txn;
-	int ret;
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
 
-	txmap = dbenv->txmap;
-	ret = 0;
-
-	txn = hash_find(txmap->transactions, &utxnid);
-
-	if (txn) {
-		hash_del(txmap->transactions, txn);
-		__os_free(dbenv, txn); 
-	} else {
-		ret = 1;
-	}
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+	int ret = __txn_commit_map_remove_nolock(dbenv, utxnid, 1);
+	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 
 	return ret;
 }
@@ -531,11 +618,13 @@ void __txn_commit_map_print_info(DB_ENV *dbenv, loglvl lvl, int should_lock) {
 					"Highest commit lsn offset: %"PRIu32"; "
 					"Highest checkpoint lsn file: %"PRIu32"; "
 					"Highest checkpoint lsn offset: %"PRIu32"; "
+					"Highest logfile: %"PRId64"; "
 					"Smallest logfile: %"PRId64"\n",
 					txmap->highest_commit_lsn.file,
 					txmap->highest_commit_lsn.offset,
 					txmap->highest_checkpoint_lsn.file,
 					txmap->highest_checkpoint_lsn.offset,
+					txmap->highest_logfile,
 					txmap->smallest_logfile);
 
 	if (should_lock) { Pthread_mutex_unlock(&txmap->txmap_mutexp); }
@@ -545,6 +634,11 @@ void __txn_commit_map_print_info(DB_ENV *dbenv, loglvl lvl, int should_lock) {
  * __txn_commit_map_delete_logfile_txns --
  *  Remove all transactions that committed in a specific logfile 
  *  from the commit LSN map.	
+ *
+ *  *If this function deletes the transaction with the highest commit LSN, 
+ * then it is the caller's responsibility to call 
+ * `__txn_commit_map_set_highest_commit_lsn` with the next highest
+ * commit LSN*
  *
  * PUBLIC: int __txn_commit_map_delete_logfile_txns
  * PUBLIC:     __P((DB_ENV *, u_int32_t));
@@ -570,44 +664,12 @@ int __txn_commit_map_delete_logfile_txns(dbenv, del_log)
 		goto err;
 	}
 
-	UTXNID *elt, *tmpp;
-	LISTC_FOR_EACH_SAFE(&to_delete->commit_utxnids, elt, tmpp, lnk)
-	{
-		__txn_commit_map_remove_nolock(dbenv, elt->utxnid);
-		__os_free(dbenv, elt);
+	ret = hash_for(to_delete->commit_utxnids, (hashforfunc_t *const) __txn_commit_map_remove_nolock_foreach_wrapper, (void *) dbenv);
+	if (ret) {
+		goto err;
 	}
 
-	const int i_am_highest_logfile = del_log == txmap->highest_commit_lsn.file;
-	const int i_am_smallest_logfile = del_log == txmap->smallest_logfile;
-
-	if (i_am_highest_logfile && i_am_smallest_logfile)
-	{
-		logmsg(LOGMSG_WARN, "%s: Deleting the only logfile (%"PRIu32") in txmap\n", __func__, del_log);
-
-		ZERO_LSN(txmap->highest_commit_lsn);
-		txmap->smallest_logfile = -1;
-	} else if (i_am_highest_logfile)
-	{
-		logmsg(LOGMSG_WARN, "%s: Deleting the highest logfile (%"PRIu32") in txmap\n", __func__, del_log);
-
-		LOGFILE_TXN_LIST *successor = NULL;
-		for (int prev_log=del_log-1; successor == NULL && prev_log >= 0; --prev_log) {
-			successor = hash_find(txmap->logfile_lists, &prev_log);
-		}
-		assert(successor);
-		txmap->highest_commit_lsn = successor->highest_commit_lsn;
-	} else if (i_am_smallest_logfile)
-	{
-		LOGFILE_TXN_LIST *successor = NULL;
-		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->highest_commit_lsn.file)) {
-			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
-		}
-		assert(successor);
-	}
-
-	hash_del(txmap->logfile_lists, to_delete);
-	__os_free(dbenv, to_delete);
-
+	__txn_commit_map_delete_logfile_list(dbenv, to_delete);
 err:
 	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 
@@ -661,7 +723,6 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 	DB_TXN_COMMIT_MAP *txmap;
 	LOGFILE_TXN_LIST *to_delete;
 	UTXNID_TRACK *txn;
-	UTXNID* elt;
 	int ret, alloc_txn, alloc_delete_list, commit_map_debug;
 
 	txmap = dbenv->txmap;
@@ -707,15 +768,9 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 	}
 	alloc_txn = 1;
 
-	if ((ret = __os_malloc(dbenv, sizeof(UTXNID), &elt)) != 0) {
-		ret = ENOMEM;
-		goto err;
-	}
-
 	if (alloc_delete_list) {
-		ZERO_LSN(to_delete->highest_commit_lsn);
 		to_delete->file_num = commit_lsn.file;
-		listc_init(&to_delete->commit_utxnids, offsetof(UTXNID, lnk));
+		to_delete->commit_utxnids = hash_init_o(offsetof(UTXNID_TRACK, utxnid), sizeof(u_int64_t));
 		hash_add(txmap->logfile_lists, to_delete);
 
 		if (commit_lsn.file < txmap->smallest_logfile || txmap->smallest_logfile == -1) {
@@ -725,18 +780,13 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 
 	if (log_compare(&txmap->highest_commit_lsn, &commit_lsn) <= 0) {
 		txmap->highest_commit_lsn = commit_lsn;
-	}
-
-	if (log_compare(&to_delete->highest_commit_lsn, &commit_lsn) <= 0) {
-		to_delete->highest_commit_lsn = commit_lsn;
+		txmap->highest_logfile = commit_lsn.file;
 	}
 
 	txn->utxnid = utxnid;
 	txn->commit_lsn = commit_lsn;
 	hash_add(txmap->transactions, txn);
-
-	elt->utxnid = utxnid;
-	listc_atl(&to_delete->commit_utxnids, elt);
+	hash_add(to_delete->commit_utxnids, txn);
 	
 	return ret;
 err:
@@ -771,6 +821,24 @@ int __txn_commit_map_add(dbenv, utxnid, commit_lsn)
 
 	Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
 	return ret;
+}
+
+/*
+ * __txn_commit_map_set_highest_commit_lsn --
+ *  Set the highest commit LSN.
+ *
+ * PUBLIC: int __txn_commit_map_set_highest_commit_lsn
+ * PUBLIC:     __P((DB_ENV *, DB_LSN));
+ */
+void __txn_commit_map_set_highest_commit_lsn(dbenv, highest_commit_lsn)
+	DB_ENV *dbenv;
+	DB_LSN highest_commit_lsn;
+{
+	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
+
+	Pthread_mutex_lock(&txmap->txmap_mutexp);
+	txmap->highest_commit_lsn = highest_commit_lsn;
+	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 }
 
 static inline void __free_prepared_children(DB_ENV *dbenv, DB_TXN_PREPARED *p)

--- a/db/sql.h
+++ b/db/sql.h
@@ -949,9 +949,9 @@ struct sqlclntstate {
     int64_t last_cost;
     int disable_fdb_push;
 
-    /* Commit LSN prior to modsnap start point */
-    uint32_t last_commit_lsn_file; 
-    uint32_t last_commit_lsn_offset;
+    /* Modsnap start point */
+    uint32_t modsnap_start_lsn_file; 
+    uint32_t modsnap_start_lsn_offset;
 
     /* Checkpoint LSN prior to modsnap start point */
     uint32_t last_checkpoint_lsn_file;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1739,10 +1739,10 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     assert(db->handle);
     if (clnt->dbtran.mode == TRANLEVEL_MODSNAP) {
         if (clnt->is_hasql_retry) {
-            get_snapshot(clnt, (int *) &clnt->last_commit_lsn_file, (int *) &clnt->last_commit_lsn_offset);
+            get_snapshot(clnt, (int *) &clnt->modsnap_start_lsn_file, (int *) &clnt->modsnap_start_lsn_offset);
         }
         if (bdb_get_modsnap_start_state(db->handle, clnt->is_hasql_retry, clnt->snapshot,
-                    &clnt->last_commit_lsn_file, &clnt->last_commit_lsn_offset, 
+                    &clnt->modsnap_start_lsn_file, &clnt->modsnap_start_lsn_offset, 
                     &clnt->last_checkpoint_lsn_file, &clnt->last_checkpoint_lsn_offset)) {
             logmsg(LOGMSG_ERROR, "%s: Failed to get modsnap txn start state\n", __func__);
             rc = SQLITE_INTERNAL;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -227,8 +227,8 @@ static struct query_effects *newsql_get_query_effects(struct sqlclntstate *clnt)
     if (newsql_has_high_availability(clnt)) {                                  \
         int file = 0, offset = 0;                                              \
         if (clnt->modsnap_in_progress) {                                       \
-            file = clnt->last_commit_lsn_file;                                 \
-            offset = clnt->last_commit_lsn_offset;                             \
+            file = clnt->modsnap_start_lsn_file;                                 \
+            offset = clnt->modsnap_start_lsn_offset;                             \
         } else if (fill_snapinfo(clnt, &file, &offset)) {                      \
             sql_response.error_code = (char)CDB2ERR_CHANGENODE;                \
         }                                                                      \

--- a/tests/commit_lsn_map.test/error.sh
+++ b/tests/commit_lsn_map.test/error.sh
@@ -1,0 +1,11 @@
+error() {
+	err "Failed at line $1"
+	exit 1
+}
+
+function failif {
+	if [[ $1 -ne 0 ]]; then
+		exit 1
+	fi
+}
+

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/cluster_utils.sh
+source ${TESTSROOTDIR}/tools/runit_common.sh
+source ./error.sh
 
 # Grab my database name.
 dbnm=$1
@@ -34,13 +36,6 @@ kill_restart_cluster()
         echo "killrestart nodes $node"
         kill_restart_node $node $kill_wait_time
     done
-}
-
-function failif
-{
-	if [[ $1 -ne 0 ]]; then
-		exit 1
-	fi
 }
 
 function bounce {
@@ -244,7 +239,8 @@ verify_txmap_deletes_records() {
 		"select COUNT(*) from comdb2_transaction_commit")
 	readonly initial_num_records_for_file initial_num_records
 
-	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('clm_delete_logfile $logfile_to_delete')"
+	cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
+		"exec procedure sys.cmd.send('clm_delete_logfile $logfile_to_delete')" > /dev/null
 
 	final_num_records=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm "select COUNT(*) from comdb2_transaction_commit")
 	readonly final_num_records
@@ -253,17 +249,39 @@ verify_txmap_deletes_records() {
 	fi
 }
 
+get_clminfo() {
+	cdb2sql ${CDB2_OPTIONS} --host $1 $dbnm "exec procedure sys.cmd.send('bdb clminfo')"
+}
+
+extract_highest_commit_lsn_offset_from_clminfo() {
+	grep -oP '(?<=Highest commit lsn offset: )[0-9]+' <<<"$1"
+}
+
+extract_highest_commit_lsn_file_from_clminfo() {
+	grep -oP '(?<=Highest commit lsn file: )[0-9]+' <<<"$1"
+}
+
+extract_smallest_logfile_from_clminfo() {
+	grep -oP '(?<=Smallest logfile: )[-]?[0-9]+' <<<"$1"
+}
+
+extract_highest_logfile_from_clminfo() {
+	grep -oP '(?<=Highest logfile: )[-]?[0-9]+' <<<"$1"
+}
+
 verify_txmap_has_expected_min_max_files() {
+	trap 'error $LINENO' ERR
+
 	local -r exp_min_file=$1 exp_max_file=$2 node=$3
-	local final_state records_outside_of_expected_window
+	local highest_logfile smallest_logfile records_outside_of_expected_window
 
 	# Check that window stored in internal structure is correct
-	final_state=$(cdb2sql ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('bdb clminfo')")
-	readonly final_state
-	if !(echo "$final_state" | grep "Highest commit lsn file: $exp_max_file" > /dev/null) ||
-		!(echo "$final_state" | grep "Smallest logfile: $exp_min_file" > /dev/null); then
+	highest_logfile=$(extract_highest_logfile_from_clminfo "$(get_clminfo $node)")
+	smallest_logfile=$(extract_smallest_logfile_from_clminfo "$(get_clminfo $node)")
+	readonly highest_logfile smallest_logfile
+	if (( highest_logfile != exp_max_file || smallest_logfile != exp_min_file )); then
 		echo "Expected max file to be $exp_max_file and min file to be $exp_min_file. Got:"
-		echo "$final_state"
+		echo "highest commit lsn file: $highest_logfile; smallest logfile: $smallest_logfile"
 		exit 1
 	fi
 
@@ -279,6 +297,8 @@ verify_txmap_has_expected_min_max_files() {
 }
 
 test_delete() {
+	trap 'error $LINENO' ERR
+
 	local node
 	node=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()")
 	readonly node
@@ -297,7 +317,7 @@ test_delete() {
 	verify_txmap_has_expected_min_max_files 3 3 $node
 
 	verify_txmap_deletes_records 3 $node
-	verify_txmap_has_expected_min_max_files -1 0 $node
+	verify_txmap_has_expected_min_max_files -1 -1 $node
 
 	# Verify that txmap handles adding new files after deletes
 	pushlogs 5
@@ -307,9 +327,133 @@ test_delete() {
 	verify_txmap_deletes_records 1 $node
 }
 
+verify_cached_highest_commit_lsn_after_recovery() {
+	trap 'error $LINENO' ERR
+
+	local -r node=$1
+
+	local clminfo_after_recovery
+	clminfo_after_recovery=$(get_clminfo $node)
+	readonly clminfo_after_recovery
+
+	local cached_highest_commit_lsn_file_after_recovery
+	cached_highest_commit_lsn_file_after_recovery=$(extract_highest_commit_lsn_file_from_clminfo "$clminfo_after_recovery")
+	readonly cached_highest_commit_lsn_file_after_recovery
+
+	local cached_highest_commit_lsn_offset_after_recovery
+	cached_highest_commit_lsn_offset_after_recovery=$(extract_highest_commit_lsn_offset_from_clminfo "$clminfo_after_recovery")
+	readonly cached_highest_commit_lsn_offset_after_recovery
+
+	local highest_commit_lsn_after_recovery
+	highest_commit_lsn_after_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
+		"select commitlsnfile, max(commitlsnoffset) from comdb2_transaction_commit \
+		where commitlsnfile in (select max(commitlsnfile) from comdb2_transaction_commit)")
+	readonly highest_commit_lsn_after_recovery
+
+	local highest_commit_lsn_file_after_recovery
+	highest_commit_lsn_file_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 1)
+	readonly highest_commit_lsn_file_after_recovery
+
+	local highest_commit_lsn_offset_after_recovery
+	highest_commit_lsn_offset_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 2)
+	readonly highest_commit_lsn_offset_after_recovery
+
+	(( cached_highest_commit_lsn_file_after_recovery <= highest_commit_lsn_file_after_recovery ))
+	(( cached_highest_commit_lsn_file_after_recovery < highest_commit_lsn_file_after_recovery \
+	|| cached_highest_commit_lsn_offset_after_recovery <= highest_commit_lsn_offset_after_recovery ))
+}
+
+verify_correct_utxnids_in_map() {
+	trap 'error $LINENO' ERR
+
+	local -r utxnids_to_recover=$1 utxnids_to_be_deleted_during_recovery=$2 host=$3
+
+	local recovered_utxnids
+	recovered_utxnids=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $host $dbnm \
+		'select distinct utxnid from comdb2_transaction_commit order by utxnid' \
+		| sed 's/ /\n/g')
+	readonly recovered_utxnids 
+
+	local present_unexpected_utxnids
+	present_unexpected_utxnids=$(comm -12 \
+		<(sort <<<$(echo "$recovered_utxnids")) \
+		<(sort <<<$(echo "$utxnids_to_be_deleted_during_recovery")))
+	readonly present_unexpected_utxnids
+	[[ -z $present_unexpected_utxnids ]] # Assert that we have no unexpected utxnids
+
+	local absent_expected_utxnids
+	absent_expected_utxnids=$(comm -23 \
+		<(sort <<<$(echo "$utxnids_to_recover")) \
+		<(sort <<<$(echo "$recovered_utxnids")))
+	readonly absent_expected_utxnids
+	[[ -z $absent_expected_utxnids ]] # Assert that we have all expected utxnids
+}
+
+test_recover_to_lsn() {
+	trap 'error $LINENO' ERR
+
+	local host
+	host=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select comdb2_host()")
+	readonly host
+
+	# Given
+
+		# Run some initial traffic 
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'create table t(i int)' > /dev/null
+	cdb2sql ${CDB2_OPTIONS} $dbnm default 'insert into t values(1)' > /dev/null
+
+	local -r flush_itrs=2
+	local itr
+	for (( itr=0; itr<flush_itrs; itr++ )); do
+		cdb2sql ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("flush")' > /dev/null
+	done
+
+	local utxnids_to_recover
+	utxnids_to_recover=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $host $dbnm \
+		'select distinct utxnid from comdb2_transaction_commit order by utxnid' \
+		| sed 's/ /\n/g')
+	readonly utxnids_to_recover
+
+	local recovery_lsn
+	recovery_lsn=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm default \
+		'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
+	readonly recovery_lsn
+
+	local recovery_lsn_file
+	recovery_lsn_file=$(echo "$recovery_lsn" | cut -d: -f 1)
+	readonly recovery_lsn_file
+
+	local recovery_lsn_offset
+	recovery_lsn_offset=$(echo "$recovery_lsn" | cut -d: -f 2)
+	readonly recovery_lsn_offset
+
+		# Run more traffic that will be undone during recovery
+	insert_values 10 t 1 # Need to do this because pushlogs doesn't seem to generate child txns
+	pushlogs 3
+
+	local utxnids_to_be_deleted_during_recovery
+	utxnids_to_be_deleted_during_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $host $dbnm \
+		"select distinct utxnid from comdb2_transaction_commit where commitlsnfile > $recovery_lsn_file or commitlsnfile = $recovery_lsn_file and commitlsnoffset > $recovery_lsn_offset order by utxnid" \
+		| sed 's/ /\n/g')
+	readonly utxnids_to_be_deleted_during_recovery
+
+	# When
+
+	cdb2sql ${CDB2_OPTIONS} --host $master $dbnm \
+		"exec procedure sys.cmd.truncate_log(\"{$recovery_lsn}\")"
+	sleep 5 # Wait for cluster to run recovery
+	
+	# Then
+
+	verify_txmap_has_expected_min_max_files 1 1 "$host"
+	verify_cached_highest_commit_lsn_after_recovery "$host"
+	verify_correct_utxnids_in_map "$utxnids_to_recover" "$utxnids_to_be_deleted_during_recovery" "$host"
+}
+
 if [ "$TESTCASE" == "commit_lsn_map_delete_generated" ];
 then
-	set -e
+	set -o pipefail
+	test_recover_to_lsn
 	test_delete
 else
 	test_add

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -253,12 +253,12 @@ get_clminfo() {
 	cdb2sql ${CDB2_OPTIONS} --host $1 $dbnm "exec procedure sys.cmd.send('bdb clminfo')"
 }
 
-extract_highest_commit_lsn_offset_from_clminfo() {
-	grep -oP '(?<=Highest commit lsn offset: )[0-9]+' <<<"$1"
+extract_modsnap_start_lsn_offset_from_clminfo() {
+	grep -oP '(?<=Modsnap start lsn offset: )[0-9]+' <<<"$1"
 }
 
-extract_highest_commit_lsn_file_from_clminfo() {
-	grep -oP '(?<=Highest commit lsn file: )[0-9]+' <<<"$1"
+extract_modsnap_start_lsn_file_from_clminfo() {
+	grep -oP '(?<=Modsnap start lsn file: )[0-9]+' <<<"$1"
 }
 
 extract_smallest_logfile_from_clminfo() {
@@ -327,7 +327,7 @@ test_delete() {
 	verify_txmap_deletes_records 1 $node
 }
 
-verify_cached_highest_commit_lsn_after_recovery() {
+verify_cached_modsnap_start_lsn_after_recovery() {
 	trap 'error $LINENO' ERR
 
 	local -r node=$1
@@ -336,31 +336,31 @@ verify_cached_highest_commit_lsn_after_recovery() {
 	clminfo_after_recovery=$(get_clminfo $node)
 	readonly clminfo_after_recovery
 
-	local cached_highest_commit_lsn_file_after_recovery
-	cached_highest_commit_lsn_file_after_recovery=$(extract_highest_commit_lsn_file_from_clminfo "$clminfo_after_recovery")
-	readonly cached_highest_commit_lsn_file_after_recovery
+	local cached_modsnap_start_lsn_file_after_recovery
+	cached_modsnap_start_lsn_file_after_recovery=$(extract_modsnap_start_lsn_file_from_clminfo "$clminfo_after_recovery")
+	readonly cached_modsnap_start_lsn_file_after_recovery
 
-	local cached_highest_commit_lsn_offset_after_recovery
-	cached_highest_commit_lsn_offset_after_recovery=$(extract_highest_commit_lsn_offset_from_clminfo "$clminfo_after_recovery")
-	readonly cached_highest_commit_lsn_offset_after_recovery
+	local cached_modsnap_start_lsn_offset_after_recovery
+	cached_modsnap_start_lsn_offset_after_recovery=$(extract_modsnap_start_lsn_offset_from_clminfo "$clminfo_after_recovery")
+	readonly cached_modsnap_start_lsn_offset_after_recovery
 
-	local highest_commit_lsn_after_recovery
-	highest_commit_lsn_after_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
+	local modsnap_start_lsn_after_recovery
+	modsnap_start_lsn_after_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
 		"select commitlsnfile, max(commitlsnoffset) from comdb2_transaction_commit \
 		where commitlsnfile in (select max(commitlsnfile) from comdb2_transaction_commit)")
-	readonly highest_commit_lsn_after_recovery
+	readonly modsnap_start_lsn_after_recovery
 
-	local highest_commit_lsn_file_after_recovery
-	highest_commit_lsn_file_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 1)
-	readonly highest_commit_lsn_file_after_recovery
+	local modsnap_start_lsn_file_after_recovery
+	modsnap_start_lsn_file_after_recovery=$(echo "$modsnap_start_lsn_after_recovery" | cut -f 1)
+	readonly modsnap_start_lsn_file_after_recovery
 
-	local highest_commit_lsn_offset_after_recovery
-	highest_commit_lsn_offset_after_recovery=$(echo "$highest_commit_lsn_after_recovery" | cut -f 2)
-	readonly highest_commit_lsn_offset_after_recovery
+	local modsnap_start_lsn_offset_after_recovery
+	modsnap_start_lsn_offset_after_recovery=$(echo "$modsnap_start_lsn_after_recovery" | cut -f 2)
+	readonly modsnap_start_lsn_offset_after_recovery
 
-	(( cached_highest_commit_lsn_file_after_recovery <= highest_commit_lsn_file_after_recovery ))
-	(( cached_highest_commit_lsn_file_after_recovery < highest_commit_lsn_file_after_recovery \
-	|| cached_highest_commit_lsn_offset_after_recovery <= highest_commit_lsn_offset_after_recovery ))
+	(( cached_modsnap_start_lsn_file_after_recovery <= modsnap_start_lsn_file_after_recovery ))
+	(( cached_modsnap_start_lsn_file_after_recovery < modsnap_start_lsn_file_after_recovery \
+	|| cached_modsnap_start_lsn_offset_after_recovery <= modsnap_start_lsn_offset_after_recovery ))
 }
 
 verify_correct_utxnids_in_map() {
@@ -446,7 +446,7 @@ test_recover_to_lsn() {
 	# Then
 
 	verify_txmap_has_expected_min_max_files 1 1 "$host"
-	verify_cached_highest_commit_lsn_after_recovery "$host"
+	verify_cached_modsnap_start_lsn_after_recovery "$host"
 	verify_correct_utxnids_in_map "$utxnids_to_recover" "$utxnids_to_be_deleted_during_recovery" "$host"
 }
 


### PR DESCRIPTION
The database recovers to a point prior to the end of the log in the case of log truncation and in the case of point-in-time recovery. Therefore, it may unroll transactions that were formerly committed if they committed after that recovery point. These transactions are not currently removed from the commit LSN map: This is a bug. The changes in this PR fix this bug.