### PR TITLE
feat: correct location of the workflow to publish cdb2hibernatedialect

### DIFF
--- a/.github/workflows/publication_cdb2hibernatedialect.yaml
+++ b/.github/workflows/publication_cdb2hibernatedialect.yaml
@@ -1,0 +1,59 @@
+name: 'Publication cdb2hibernatedialect'
+
+on:
+  push:
+    paths:
+      - 'contrib/cdb2hibernatedialect/**'
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: 'Publish'
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 11
+      - name: 'Gradle'
+        run: |
+          echo 'org.gradle.caching=false' >> gradle.properties
+          echo 'org.gradle.configuration-cache=false' >> gradle.properties
+        working-directory: ./contrib/cdb2hibernatedialect
+      - name: 'Build cdb2hibernatedialect'
+        run: |
+          ./gradlew build
+        working-directory: ./contrib/cdb2hibernatedialect
+      - name: 'Publish snapshot to OSSRH'
+        if: github.event_name == 'push'
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
+        run: |
+          ./gradlew \
+            publishMavenPublicationToSonatypeRepository \
+            closeSonatypeStagingRepository
+        working-directory: ./contrib/cdb2hibernatedialect
+      - name: 'Publish release to OSSRH'
+        if: github.event_name == 'release' && github.event.action == 'published'
+        env:
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_KEY_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.OSSRH_USERNAME }}
+        run: |
+          ./gradlew \
+            -Prelease \
+            publishMavenPublicationToSonatypeRepository \
+            closeAndReleaseSonatypeStagingRepository
+        working-directory: ./contrib/cdb2hibernatedialect

--- a/contrib/cdb2hibernatedialect/build.gradle
+++ b/contrib/cdb2hibernatedialect/build.gradle
@@ -11,10 +11,14 @@
  * limitations under the License.
  */
 
+import java.time.Duration
+
 plugins {
     id "java"
     id "maven-publish"
+    id "signing"
     id "org.jetbrains.gradle.plugin.idea-ext" version "1.1.8"
+    id "io.github.gradle-nexus.publish-plugin" version "1.3.0"
 }
 
 group = "com.bloomberg.comdb2"
@@ -67,4 +71,19 @@ publishing {
             from components.java
         }
     }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype()
+    }
+    transitionCheckOptions {
+        maxRetries = 180
+        delayBetween = Duration.ofSeconds(10L)
+    }
+}
+
+signing {
+    sign(publishing.publications["maven"])
+    required = project.hasProperty("release")
 }


### PR DESCRIPTION
Correct location of the workflow to publish `cdb2hibernatedialect`
- adding a condition for a workflow to run when changes are in the path `contrib/cdb2hibernatedialect/**` (https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-including-paths)
  - ❗ I've removed original condition to run on push to the `main` branch, to avoid situation when the workflow could be run on non-cdb2hibernatedialect changes (https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#using-multiple-events) , but instead of add an `if` condition to prevent job to be running if `github.ref` is not `main`. (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution)
- for tasks which are building the binary and publishing it, the working directory is added - `./contrib/cdb2hibernatedialect` (https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#defaultsrunworking-directory)