### PR TITLE
{176689231}: Porting SQLite fix for LEFT-JOIN using OR that matches no rows

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -3637,7 +3637,7 @@ int sqlite3VdbeCursorMoveto(VdbeCursor **pp, int *piCol){
   assert( p->eCurType==CURTYPE_BTREE || p->eCurType==CURTYPE_PSEUDO );
   if( p->deferredMoveto ){
     int iMap;
-    if( p->aAltMap && (iMap = p->aAltMap[1+*piCol])>0 ){
+    if( p->aAltMap && (iMap = p->aAltMap[1+*piCol])>0 && !p->nullRow ){
       *pp = p->pAltCursor;
       *piCol = iMap - 1;
       return SQLITE_OK;

--- a/tests/yast.test/whereD.test
+++ b/tests/yast.test/whereD.test
@@ -337,4 +337,18 @@ do_searchcount_test 6.6.4 {
   SELECT c FROM x1 WHERE b=6 OR c=11 OR a=1
 } {7 11 3 search 0}
 
+# 2020-02-22 ticket aa4378693018aa99
+# In the OP_Column opcode, if a cursor is marked with OP_NullRow
+# (because it is the right table of a LEFT JOIN that does not match)
+# then do not substitute index cursors, as the index cursors do not
+# have the VdbeCursor.nullRow flag set.
+#
+do_execsql_test 6.7 {
+  DROP TABLE IF EXISTS t1;
+  DROP TABLE IF EXISTS t2;
+  CREATE TABLE t1(a UNIQUE, b UNIQUE);
+  INSERT INTO t1(a,b) VALUES(null,2);
+  CREATE VIEW t2 AS SELECT * FROM t1 WHERE b<10 OR a<7 ORDER BY b;
+  SELECT t1.* FROM t1 LEFT JOIN t2 ON abs(t1.a)=abs(t2.b);
+} {{} 2}
 finish_test


### PR DESCRIPTION
This patch backports https://www.sqlite.org/src/info/f02030b3403d6773
