### PR TITLE
Add atomic truncate test

### DIFF
--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -65,6 +65,7 @@ extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN*);
 #include <bdbglue.h>
 extern int gbl_is_physical_replicant;
 int gbl_apprec_gen;
+int gbl_debug_sleep_during_truncate = 0;
 
 #else
 
@@ -1367,6 +1368,9 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 
 	log_recovery_progress(1, -1);
 	dbenv->recovery_pass = DB_TXN_BACKWARD_ROLL;
+	if (trunclsn && gbl_debug_sleep_during_truncate) {
+		sleep(5);
+	}
 
 	/*
 	 * Pass #2.

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -89,6 +89,7 @@ extern int gbl_debug_sleep_coordinator_before_commit;
 extern int gbl_debug_sleep_on_set_read_only;
 extern int gbl_debug_wait_on_verify_off;
 extern int gbl_debug_disttxn_trace;
+extern int gbl_debug_sleep_during_truncate;
 extern int gbl_sparse_lockerid_map;
 extern int gbl_spstrictassignments;
 extern int gbl_early;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -290,6 +290,9 @@ REGISTER_TUNABLE("debug_sleep_coordinator_before_commit", "Coordinator sleeps be
 REGISTER_TUNABLE("debug_coordinator_dispatch_failure", "Fake failed dispatch in coordinator.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_debug_coordinator_dispatch_failure, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("debug_sleep_during_truncate", "Sleeps during the backward pass of a truncate.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_debug_sleep_during_truncate, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL,
+                 NULL);
 REGISTER_TUNABLE("debug_sleep_on_set_read_only", "Sleep before setting to readonly.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_sleep_on_set_read_only, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug_wait_on_verify_off", "Wait for particpant when verify is disabled.  (Default: off)",

--- a/tests/atomic_truncate.test/Makefile
+++ b/tests/atomic_truncate.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/atomic_truncate.test/lrl.options
+++ b/tests/atomic_truncate.test/lrl.options
@@ -1,0 +1,1 @@
+debug_sleep_truncate on

--- a/tests/atomic_truncate.test/runit
+++ b/tests/atomic_truncate.test/runit
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+TIER="default"
+
+query_replicant_in_loop() {
+	set +e
+
+	local prev_count=-1
+	while true;
+	do
+		local count
+		count=$(cdb2sql -tabs ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "select count(*) from t")
+		if (( $? ));
+		then
+			exit 0
+		elif (( prev_count != -1 && count != prev_count ));
+		then
+			echo "count mismatch count: "${count}". prev_count: "${prev_count}"."
+			exit 1
+		fi
+		prev_count=$count
+	done
+}
+
+main() {
+	set -e
+
+	local master
+	master=$(cdb2sql ${CDB2_OPTIONS} -tabs "${DBNAME}" "${TIER}" "select host from comdb2_cluster where is_master='Y'")
+	readonly master
+
+	local trunc_lsn
+	trunc_lsn=$(cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("bdb cluster")' \
+		| grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
+	readonly trunc_lsn
+
+	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "create table t(i int)"
+	for ((i=0; i<1000; ++i ));
+	do
+		cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values("${i}")" &> /dev/null
+	done
+
+	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" "exec procedure sys.cmd.truncate_log(\"{"${trunc_lsn}"}\");" &
+	query_replicant_in_loop
+}
+
+main


### PR DESCRIPTION
We shouldn't be able to see intermediate state during truncation.

The changes in this PR add a test that exposes a bug where this expectation is violated.

Fails with `count mismatch count: 0. prev_count: 1000.`
