### PR TITLE
Test modsnap txns running during truncate

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1446,6 +1446,7 @@ int bdb_register_modsnap(bdb_state_type *bdb_state,
  *                         then this should be set by the caller to the retry start lsn offset.
  * last_checkpoint_lsn_file: This gets set to the preceding checkpoint lsn file.
  * last_checkpoint_lsn_offset: This gets set to the preceding checkpoint lsn offset.
+ * trunc_gen: This gets set to the current truncate generation
  *
  * Returns 0 on success and non-0 on failure.
  */
@@ -1455,7 +1456,8 @@ int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
                         unsigned int *last_commit_lsn_file,
                         unsigned int *last_commit_lsn_offset,
                         unsigned int *last_checkpoint_lsn_file,
-                        unsigned int *last_checkpoint_lsn_offset);
+                        unsigned int *last_checkpoint_lsn_offset,
+                        uint32_t *trunc_gen);
 
 void bdb_set_tran_verify_updateid(tran_type *tran);
 

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2793,7 +2793,8 @@ int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
                         unsigned int *modsnap_start_lsn_file,
                         unsigned int *modsnap_start_lsn_offset,
                         unsigned int *last_checkpoint_lsn_file,
-                        unsigned int *last_checkpoint_lsn_offset)
+                        unsigned int *last_checkpoint_lsn_offset,
+                        uint32_t *trunc_gen)
 {
     DB_ENV *dbenv;
     DB_LSN modsnap_start_lsn;
@@ -2836,6 +2837,7 @@ int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
     *modsnap_start_lsn_offset = modsnap_start_lsn.offset;
     *last_checkpoint_lsn_file = last_checkpoint_lsn.file;
     *last_checkpoint_lsn_offset = last_checkpoint_lsn.offset;
+    *trunc_gen = dbenv->trunc_gen;
 
     logmsg(LOGMSG_DEBUG, "Starting a new modsnap transaction with last commit lsn "
             "%"PRIu32":%"PRIu32" and last checkpoint %"PRIu32":%"PRIu32"\n",

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2799,6 +2799,7 @@ struct __db_env {
 	DB_LSN durable_lsn;
 	uint32_t durable_generation;
     uint32_t rep_gen;
+	uint32_t trunc_gen;
 
 	void (*set_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t));
 	void (*get_durable_lsn) __P((DB_ENV *, DB_LSN *, uint32_t *));

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -934,8 +934,6 @@ void log_recovery_progress(int stage, int progress)
 }
 
 
-
-
 /*
  * __db_apprec --
  *	Perform recovery.  If max_lsn is non-NULL, then we are trying
@@ -979,8 +977,10 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	hi_txn = TXN_MAXIMUM;
 	txninfo = NULL;
 
-	if (trunclsn)
+	if (trunclsn) {
 		(*trunclsn) = (*max_lsn);
+		dbenv->trunc_gen += 1;
+	}
 
 	pass = "initial";
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -854,6 +854,7 @@ struct sqlclntstate {
     uint8_t is_analyze;
     uint8_t is_overlapping;
     uint32_t init_gen;
+    uint32_t init_trunc_gen; /* Only set for modsnap txns */
     int8_t gen_changed;
     uint8_t skip_peer_chk; /* 1 if this is a temp table operation from an SP,
                               where peer check and the dbopen_gen check at commit time are skipped. */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1737,7 +1737,8 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         }
         if (bdb_get_modsnap_start_state(db->handle, clnt->is_hasql_retry, clnt->snapshot,
                     &clnt->modsnap_start_lsn_file, &clnt->modsnap_start_lsn_offset, 
-                    &clnt->last_checkpoint_lsn_file, &clnt->last_checkpoint_lsn_offset)) {
+                    &clnt->last_checkpoint_lsn_file, &clnt->last_checkpoint_lsn_offset,
+                    &clnt->init_trunc_gen)) {
             logmsg(LOGMSG_ERROR, "%s: Failed to get modsnap txn start state\n", __func__);
             rc = SQLITE_INTERNAL;
             goto done;
@@ -5439,6 +5440,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     clnt->verify_indexes = 0;
     clnt->schema_mems = NULL;
     clnt->init_gen = 0;
+    clnt->init_trunc_gen = 0;
     for (int i = 0; i < clnt->ncontext; i++) {
         free(clnt->context[i]);
     }

--- a/tests/snapshot_during_truncate.test/Makefile
+++ b/tests/snapshot_during_truncate.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/snapshot_during_truncate.test/lrl.options
+++ b/tests/snapshot_during_truncate.test/lrl.options
@@ -1,0 +1,1 @@
+enable_snapshot_isolation

--- a/tests/snapshot_during_truncate.test/runit
+++ b/tests/snapshot_during_truncate.test/runit
@@ -3,17 +3,6 @@ bash -n "$0" | exit 1
 
 TIER="default"
 
-# Returns zero if all counts in the output are equal; nonzero otherwise
-verify_consistent_count_in_output() {
-	local -r results=$1
-
-	local num_distinct_counts
-	num_distinct_counts=$(echo "$results" | sed -nr 's/count.*=([0-9]+)/\1/p' | uniq | wc -l)
-	readonly num_distinct_counts
-
-	(( num_distinct_counts == 1 ))
-}
-
 insert_in_loop() {
 	while true;
 	do
@@ -24,6 +13,7 @@ insert_in_loop() {
 run_snapshot_query() {
 	local -r snapshot_sleep_seconds=$1 
 
+	set +e
 query_results=$(cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default - <<EOF
 set transaction snapshot
 begin
@@ -34,8 +24,17 @@ select count(*) from t
 commit
 EOF
 )
+	if (( $? == 0 ));
+	then
+		echo "Expected query to fail but got success"
+		exit 1
+	fi
 
-	if ! verify_consistent_count_in_output "${query_results}";
+	local num_distinct_counts
+	num_distinct_counts=$(echo "$results" | sed -nr 's/count.*=([0-9]+)/\1/p' | wc -l)
+	readonly num_distinct_counts
+
+	if (( num_distinct_counts != 0 ));
 	then
 		echo "Bad snapshot"
 		echo "${query_results}"

--- a/tests/snapshot_during_truncate.test/runit
+++ b/tests/snapshot_during_truncate.test/runit
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+TIER="default"
+
+# Returns zero if all counts in the output are equal; nonzero otherwise
+verify_consistent_count_in_output() {
+	local -r results=$1
+
+	local num_distinct_counts
+	num_distinct_counts=$(echo "$results" | sed -nr 's/count.*=([0-9]+)/\1/p' | uniq | wc -l)
+	readonly num_distinct_counts
+
+	(( num_distinct_counts == 1 ))
+}
+
+insert_in_loop() {
+	while true;
+	do
+		cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values(1)" &> /dev/null
+	done
+}
+
+run_snapshot_query() {
+	local -r snapshot_sleep_seconds=$1 
+
+query_results=$(cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default - <<EOF
+set transaction snapshot
+begin
+select sleep(${snapshot_sleep_seconds})
+select count(*) from t
+select sleep(${snapshot_sleep_seconds})
+select count(*) from t
+commit
+EOF
+)
+
+	if ! verify_consistent_count_in_output "${query_results}";
+	then
+		echo "Bad snapshot"
+		echo "${query_results}"
+		exit 1
+	fi
+
+	exit 0
+}
+
+main() {
+	set -e
+
+	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "create table t(i int)"
+
+	local master
+	master=$(cdb2sql ${CDB2_OPTIONS} -tabs "${DBNAME}" "${TIER}" "select host from comdb2_cluster where is_master='Y'")
+	readonly master
+
+	# force a checkpoint
+	local -r flush_itrs=3
+	for (( i=0; i<flush_itrs; ++i ));
+	do
+		cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("flush")'
+	done
+
+	local trunc_lsn
+	trunc_lsn=$(cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("bdb cluster")' \
+		| grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
+	readonly trunc_lsn
+
+	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("pushlogs 2")'
+
+	local -r snapshot_sleep_seconds=5
+	run_snapshot_query "${snapshot_sleep_seconds}" &
+	local -r snapshot_pid=$!
+	trap "kill -9 $snapshot_pid" EXIT
+
+	sleep 1
+
+	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" "exec procedure sys.cmd.truncate_log(\"{"${trunc_lsn}"}\");" &
+
+	insert_in_loop &
+	local -r insert_pid=$!
+	trap "kill -9 $insert_pid" EXIT
+
+	wait "${snapshot_pid}"
+}
+
+main


### PR DESCRIPTION
The changes in this PR expose the following bug:
1. a snapshot transaction latches its start LSN
2. truncate runs
3. the snapshot transaction sees new updates in its selects since these updates have commit LSNs lower than the latched snapshot start LSN

This is a draft. Finished PR will include fix