### PR TITLE
Flag to allow clients to run on incoherent nodes.

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3272,6 +3272,9 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl,
     if (hndl && (hndl->flags & CDB2_REQUIRE_FASTSQL) != 0) {
         features[n_features++] = CDB2_CLIENT_FEATURES__REQUIRE_FASTSQL;
     }
+    if (hndl && (hndl->flags & CDB2_ALLOW_INCOHERENT) != 0) {
+        features[n_features++] = CDB2_CLIENT_FEATURES__ALLOW_INCOHERENT;
+    }
 
     if (n_features) {
         sqlquery.n_features = n_features;

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -39,6 +39,7 @@ enum cdb2_hndl_alloc_flags {
     CDB2_TYPE_IS_FD = 256,
     CDB2_REQUIRE_FASTSQL = 512,
     CDB2_MASTER = 1024,
+    CDB2_ALLOW_INCOHERENT = 2048,
 };
 
 enum cdb2_request_type {

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2338,8 +2338,16 @@ newsql_loop_result newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_quer
         ATOMIC_ADD64(gbl_nnewsql_compat, 1);
     if (clnt->plugin.has_ssl(clnt)) ATOMIC_ADD64(gbl_nnewsql_ssl, 1);
 
+    int allow_incoherent = 0;
+    for (int i = 0; i < sql_query->n_features; i++) {
+        if (sql_query->features[i] == CDB2_CLIENT_FEATURES__ALLOW_INCOHERENT) {
+            allow_incoherent = 1;
+            break;
+        }
+    }
+
     /* coherent  _or_ in middle of transaction */
-    if (!incoh_reject(clnt->admin, thedb->bdb_env) || clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS) {
+    if (allow_incoherent || !incoh_reject(clnt->admin, thedb->bdb_env) || clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS) {
         return NEWSQL_SUCCESS;
     }
     if (gbl_incoherent_clnt_wait > 0) {

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -31,6 +31,8 @@ enum CDB2ClientFeatures {
     REQUIRE_FASTSQL        = 10;
     /* To tell the server that the client can redirect an fdb query */
     CAN_REDIRECT_FDB       = 11;
+    /* Useful for utilities - allow queries on incoherent nodes. */
+    ALLOW_INCOHERENT       = 12;
 }
 
 message CDB2_FLAG {


### PR DESCRIPTION
Useful for utilities that check db health, for example.