### PR TITLE
{176307598}: Fixing recursive logmsg calls from ctrace

### DIFF
--- a/util/ctrace.c
+++ b/util/ctrace.c
@@ -81,6 +81,28 @@ static int g_mutex_enabled = 1;
  * I suspect is not all that slow, as it is usually a fast system call). */
 static int ctrace_time_epoch(void) { return time(NULL); }
 
+static int __logmsg(loglvl lvl, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int ret = logmsgv(lvl, fmt, args);
+    va_end(args);
+    return ret;
+}
+
+static int __logmsgf(loglvl lvl, FILE *f, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    int ret = logmsgvf(lvl, f, fmt, args);
+    va_end(args);
+    return ret;
+}
+
+/* Ensure that ctrace isn't redirected to itself. Otherwise it would self-block on g_mutex */
+#define logmsg __logmsg
+#define logmsgf __logmsgf
+
 #define CTRACE_TIMER_START(THRESHOLD)                                          \
     do {                                                                       \
         bbhrtime_t timer_start;                                                \


### PR DESCRIPTION
When `gbl_logmsg_ctrace` is on, `logmsg()` is redirected to `ctrace()`, which acquires `g_mutex`. However `ctrace()` may also call back into `logmsg()`, and gets redirected again back to itself. It will then unfortunately block on `g_mutex`, as seen below.

```
#0  __lll_lock_wait ()
#1  in __GI___pthread_mutex_lock
#2  in ctracev
#3  in logmsg
#4  in ctracev
#5  in logmsg
#6  in pstack_self
#7  in do_pstack
```

This patch fixes it.