### PR TITLE
Address log delete races

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -3187,11 +3187,15 @@ void backend_sync_stat(struct dbenv *dbenv)
     }
 }
 
-/*just update the sync config */
+/* just update the sync config */
+/* *This function acquires the log delete lock */
 void backend_update_sync(struct dbenv *dbenv)
 {
     if (dbenv->bdb_attr == 0)
         return; /*skip */
+
+    logdelete_lock(__func__, __LINE__);
+
     bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SYNCTRANSACTIONS, dbenv->log_sync);
     bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_LOGDELETEAGE,
                  dbenv->log_delete
@@ -3201,6 +3205,8 @@ void backend_update_sync(struct dbenv *dbenv)
     bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_LOGDELETELOWFILENUM,
                  dbenv->log_delete_filenum);
     backend_sync_stat(dbenv);
+
+    logdelete_unlock(__func__, __LINE__);
 }
 
 static void net_close_all_dbs(void *hndl, void *uptr, char *fromnode,

--- a/plugins/logdelete/logdelete.c
+++ b/plugins/logdelete/logdelete.c
@@ -54,9 +54,7 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
     log_delete_add_state(thedb, &log_delete_state);
     log_delete_counter_change(thedb, LOG_DEL_REFRESH);
 
-    logdelete_lock(__func__, __LINE__);
     backend_update_sync(thedb);
-    logdelete_unlock(__func__, __LINE__);
 
     /* check for after commented out below as well
     int before_count = bdb_get_low_headroom_count(thedb->bdb_env);

--- a/sqlite/ext/comdb2/files_util.c
+++ b/sqlite/ext/comdb2/files_util.c
@@ -284,9 +284,7 @@ int files_util_open(sqlite3_vtab *p, sqlite3_vtab_cursor **ppCursor)
     log_delete_counter_change(thedb, LOG_DEL_REFRESH);
     logmsg(LOGMSG_INFO, "disabling log file deletion\n");
 
-    logdelete_lock(__func__, __LINE__);
     backend_update_sync(thedb);
-    logdelete_unlock(__func__, __LINE__);
 
     return SQLITE_OK;
 }
@@ -298,6 +296,7 @@ int files_util_close(sqlite3_vtab_cursor *cur)
     logmsg(LOGMSG_INFO, "re-enabling log file deletion\n");
     log_delete_rem_state(thedb, &(pCur->log_delete_state));
     log_delete_counter_change(thedb, LOG_DEL_REFRESH);
+
     backend_update_sync(thedb);
 
     release_files(pCur->files, pCur->nfiles);


### PR DESCRIPTION
There are a few places where the log deletion lock isn't held over `backend_update_sync`. The changes in this PR update the implementation of `backend_update_sync` to acquire the lock for the duration of the call instead of requiring the caller to hold the lock.