### PR TITLE
Change physrep to poll by default

### DIFF
--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -56,7 +56,7 @@ typedef struct DB_Connection {
 int gbl_physrep_debug = 0;
 int gbl_physrep_register_interval = 600; // force re-registration every 10 mins
 int gbl_physrep_reconnect_penalty = 0;
-int gbl_blocking_physrep = 1;
+int gbl_blocking_physrep = 0;
 int gbl_physrep_fanout = 8;
 int gbl_physrep_max_candidates = 6;
 int gbl_physrep_max_pending_replicants = 10;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -69,7 +69,7 @@
 (name='blobmem_sz_thresh_kb', description='Sets the threshold (in KB) above which blobs are allocated by the blob allocator. (Default: 0)', type='INTEGER', value='-1', read_only='Y')
 (name='blobstripe', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='blocking_latches', description='Block on latch rather than deadlock', type='BOOLEAN', value='OFF', read_only='N')
-(name='blocking_physrep', description='Physical replicant blocks on select. (Default: false)', type='BOOLEAN', value='ON', read_only='N')
+(name='blocking_physrep', description='Physical replicant blocks on select. (Default: false)', type='BOOLEAN', value='OFF', read_only='N')
 (name='broadcast_check_rmtpol', description='Check rmtpol before sending triggers', type='BOOLEAN', value='ON', read_only='N')
 (name='broken_max_rec_sz', description='', type='INTEGER', value='0', read_only='Y')
 (name='broken_num_parser', description='', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
Quick-fix for physical replicants attempting to drain result sets.