### PR TITLE
{176911901} -> Read Committed Issue

### DIFF
--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -1702,7 +1702,7 @@ int bdb_temp_table_delete(bdb_state_type *bdb_state, struct temp_cursor *cur,
 {
     int rc;
     arr_elem_t *elem;
-
+    struct temp_cursor *opencur;
     if (!cur->valid) {
         rc = -1;
         goto done;
@@ -1722,6 +1722,13 @@ int bdb_temp_table_delete(bdb_state_type *bdb_state, struct temp_cursor *cur,
         cur->tbl->inmemsz -= (elem->keylen + elem->dtalen);
         memmove(elem, elem + 1,
                 sizeof(arr_elem_t) * (cur->tbl->num_mem_entries - cur->ind));
+        /* Move backward all open cursors to the right of deletion point
+         * by one position */
+        LISTC_FOR_EACH(&cur->tbl->cursors, opencur, lnk)
+        {
+            if (opencur->ind >= cur->ind)
+                --opencur->ind;
+        }
         rc = 0;
         goto done;
     }

--- a/tests/read_committed.test/q23_1.sql
+++ b/tests/read_committed.test/q23_1.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS recom;
+CREATE TABLE recom(a int primary key, b int)$$
+SET TRANSACTION READ COMMITTED;
+BEGIN;
+INSERT INTO recom values (1,2),(2,3),(3,4),(4,5),(5,6),(6,7),(7,8);
+UPDATE recom SET b=99 where b%2=0;
+DELETE FROM recom where b=99;
+SELECT count(*) FROM recom where b=99;
+COMMIT;

--- a/tests/read_committed.test/q23_1.sql.exp
+++ b/tests/read_committed.test/q23_1.sql.exp
@@ -1,0 +1,10 @@
+[DROP TABLE IF EXISTS recom] rc 0
+[CREATE TABLE recom(a int primary key, b int)] rc 0
+[SET TRANSACTION READ COMMITTED] rc 0
+[BEGIN] rc 0
+[INSERT INTO recom values (1,2),(2,3),(3,4),(4,5),(5,6),(6,7),(7,8)] rc 0
+[UPDATE recom SET b=99 where b%2=0] rc 0
+[DELETE FROM recom where b=99] rc 0
+(count(*)=0)
+[SELECT count(*) FROM recom where b=99] rc 0
+[COMMIT] rc 0


### PR DESCRIPTION
Issue: 

DROP TABLE IF EXISTS recom;
CREATE TABLE recom(a int primary key, b int)$$
SET TRANSACTION READ COMMITTED;
BEGIN;
INSERT INTO recom values (1,2),(2,3),(3,4),(4,5),(5,6),(6,7),(7,8);
UPDATE recom SET b=99 where b%2=0;
DELETE FROM recom where b=99;
SELECT count(*) FROM recom where b=99;
COMMIT;

Results in -> 

[DROP TABLE IF EXISTS recom] rc 0
[CREATE TABLE recom(a int primary key, b int)] rc 0
[SET TRANSACTION READ COMMITTED] rc 0
[BEGIN] rc 0
[INSERT INTO recom values (1,2),(2,3),(3,4),(4,5),(5,6),(6,7),(7,8)] rc 0
[UPDATE recom SET b=99 where b%2=0] rc 0
[DELETE FROM recom where b=99] rc 0
**(count(*)=2)
[SELECT count(*) FROM recom where b=99] rc 0**
[COMMIT] rc 0

Cause : 
Shadow tables use temp array version of temp tables which has a bug while deleting array elements. Specifically, after deleting a specific row in the array, we memmove the subsequent elements forward one position, AND we move the cursor ahead one position. This effectively deletes alternate rows (half the number of rows) explaining the behavior seen in the linked ticket -> ln(n) number of deletes being required to delete all the affected rows.

Fix: 
Move the temptable cursor only if the table sequence number recorded before an action is the same as the table sequence after the action. 

Edit: 
@riverszhang89 suggested a better fix : Reposition all open cursors in an adhoc manner rather than a memcmp on every cursor move

