### PR TITLE
fix read_committed test

### DIFF
--- a/tests/read_committed.test/q22_1.sql
+++ b/tests/read_committed.test/q22_1.sql
@@ -4,6 +4,7 @@ create index t_ij on t(i, j)
 insert into t(i, j) values(1,1),(2,2)
 
 set transaction read committed
+begin
 delete from t where i = 1
 select max(j) from t where i = 1
 commit

--- a/tests/read_committed.test/q22_1.sql.exp
+++ b/tests/read_committed.test/q22_1.sql.exp
@@ -4,9 +4,10 @@
 (rows inserted=2)
 [insert into t(i, j) values(1,1),(2,2)] rc 0
 [set transaction read committed] rc 0
-(rows deleted=1)
+[begin] rc 0
 [delete from t where i = 1] rc 0
 (max(j)=NULL)
 [select max(j) from t where i = 1] rc 0
+[commit] rc 0
 (max(j)=NULL)
 [select max(j) from t where i = 1] rc 0

--- a/tests/read_committed.test/runit
+++ b/tests/read_committed.test/runit
@@ -28,11 +28,12 @@ tbl=t1
 function run_test 
 {
     for i in `ls *.sql`; do
-        cmd="cdb2sql -f ${i} ${CDB2_OPTIONS} $dbname default > ${i}.res"
+        cmd="cdb2sql -f ${i} ${CDB2_OPTIONS} $dbname default > ${i}.res 2>&1"
         echo $cmd
         eval $cmd
         if ! `diff ${i}.exp ${i}.res > /dev/null`; then
             echo "${i}.exp ${i}.res differ..."
+            diff ${i}.exp ${i}.res
             echo "Test FAILED"
             exit 1
         fi


### PR DESCRIPTION
This patch fixes a few things in read_committed test: 
1.) We weren't redirecting stderr to stdout
2.) Print diff incase of failure to make it easier to inspect the failures
3.) Fix q22 test 
