### PR TITLE
watchdog: Check timers every second

### DIFF
--- a/db/watchdog.c
+++ b/db/watchdog.c
@@ -417,8 +417,11 @@ static void *watchdog_watcher_thread(void *arg)
 
     while (!db_is_exiting()) {
         int ss = 10; /* sleep for these many seconds */
-        for (int i = 0; i < ss && !db_is_exiting(); i++)
+        for (int i = 0; i < ss && !db_is_exiting(); i++) {
             sleep(1);
+            void check_timers(void);
+            check_timers();
+        }
 
         if (gbl_nowatch || db_is_exiting())
             continue;

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -460,12 +460,10 @@ int gbl_timer_warn_interval = 1500; //msec
 int gbl_timer_pstack_interval =  5 * 60; //sec
 extern struct timeval last_timer_pstack;
 static struct timeval last_timer_check;
-static struct event *check_timers_ev;
-static void check_timers(int dummyfd, short what, void *arg)
+void check_timers(void)
 {
     if (gbl_timer_warn_interval == 0) return;
 
-    check_base_thd();
     int ms, need_pstack = 0;
     struct timeval now, diff;
     gettimeofday(&now, NULL);
@@ -3219,11 +3217,6 @@ static void setup_bases(void)
     } else if (reader_policy == POLICY_SINGLE) {
         init_base(&single.rdthd, &single.rdbase, "read");
     }
-
-    gettimeofday(&last_timer_check, NULL);
-    check_timers_ev = event_new(base, -1, EV_PERSIST, check_timers, NULL);
-    struct timeval one = {1, 0};
-    event_add(check_timers_ev, &one);
 
     logmsg(LOGMSG_USER, "Libevent %s with backend method %s\n", event_get_version(), event_base_get_method(base));
 }

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -511,9 +511,7 @@ void check_timers(void)
 static __thread struct event_base *current_base;
 static void *net_dispatch(void *arg)
 {
-    char thdname[32];
     struct net_dispatch_info *n = arg;
-    snprintf(thdname, sizeof(thdname), "net_dispatch %s", n->who);
     comdb2_name_thread(n->who);
 
     current_base = n->base;
@@ -1587,6 +1585,10 @@ static int process_net_msgs(struct event_info *e, struct evbuffer *buf, void **m
 static void *rd_worker(void *data)
 {
     struct event_info *e = data;
+    char thdname[64];
+    snprintf(thdname, sizeof(thdname), "%s - %s", __func__, e->host);
+    comdb2_name_thread(thdname);
+
     netinfo_type *n = e->net_info->netinfo_ptr;
     if (n->start_thread_callback) {
         n->start_thread_callback(n->callback_data);


### PR DESCRIPTION
Check from watchdog-watcher instead of base thread. This allows catching a blocked base-thd.