### PR TITLE
Revconn-latency test and fix

### DIFF
--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -31,6 +31,7 @@
 #include "reverse_conn.h"
 #include "phys_rep.h"
 #include "machclass.h"
+#include "net_appsock.h"
 
 #define revconn_logmsg(lvl, ...)                                               \
     do {                                                                       \
@@ -88,7 +89,6 @@ int send_reversesql_request(const char *dbname, const char *host,
     SBUF2 *sb;
     int new_fd;
     int rc = 0;
-    socklen_t len;
     int polltm;
     struct sockaddr_in cliaddr;
     struct pollfd pol;
@@ -107,6 +107,7 @@ int send_reversesql_request(const char *dbname, const char *host,
 
     netinfo_type *netinfo_ptr = thedb->bdb_env->repinfo->netinfo;
     new_fd = sbuf2fileno(sb);
+    make_server_socket(new_fd);
 
     // NC: Most of the following code has been copied from net/net.c (accept_thread())
 
@@ -117,68 +118,6 @@ int send_reversesql_request(const char *dbname, const char *host,
         rc = 0;
         goto cleanup;
     }
-
-#if defined _SUN_SOURCE
-    wait_alive(new_fd);
-#endif
-
-#ifdef NODELAY
-    flag = 1;
-    len = sizeof(flag);
-    rc = setsockopt(new_fd, IPPROTO_TCP, TCP_NODELAY, (char *)&flag, len);
-    if (rc != 0) {
-        revconn_logmsg(LOGMSG_ERROR, "%s: Couldn't turn off nagel on new_fd %d, flag=%d: %d %s\n",
-                       __func__, new_fd, flag, errno, strerror(errno));
-        rc = -1;
-        goto cleanup;
-    }
-#endif
-
-    int on = 1;
-    len = sizeof(on);
-    rc = setsockopt(new_fd, SOL_SOCKET, SO_KEEPALIVE, (char *)&on, len);
-    if (rc != 0) {
-        revconn_logmsg(LOGMSG_ERROR, "%s: Couldn't turn on keep alive on new fd %d: %d %s\n",
-                       __func__, new_fd, errno, strerror(errno));
-        rc = -1;
-        goto cleanup;
-    }
-
-#ifdef TCPBUFSZ
-    int tcpbfsz = (8 * 1024 * 1024);
-    len = sizeof(tcpbfsz);
-    rc = setsockopt(new_fd, SOL_SOCKET, SO_SNDBUF, &tcpbfsz, len);
-    if (rc < 0) {
-        revconn_logmsg(LOGMSG_ERROR, "%s: Couldn't set tcp sndbuf size on listenfd %d: %d %s\n",
-                       __func__, new_fd, errno, strerror(errno));
-        rc = -1;
-        goto cleanup;
-    }
-
-    tcpbfsz = (8 * 1024 * 1024);
-    len = sizeof(tcpbfsz);
-    rc = setsockopt(new_fd, SOL_SOCKET, SO_RCVBUF, &tcpbfsz, len);
-    if (rc < 0) {
-        revconn_logmsg(LOGMSG_ERROR, "%s: Couldn't set tcp rcvbuf size on listenfd %d: %d %s\n",
-                       __func__, new_fd, errno, strerror(errno));
-        rc = -1;
-        goto cleanup;
-    }
-#endif
-
-#ifdef NOLINGER
-    struct linger linger_data;
-    linger_data.l_onoff = 0;
-    linger_data.l_linger = 1;
-    len = sizeof(linger_data);
-    if (setsockopt(new_fd, SOL_SOCKET, SO_LINGER, (char *)&linger_data,
-                   len) != 0) {
-        revconn_logmsg(LOGMSG_ERROR, "%s: Couldn't turn off linger on new_fd %d: %d %s\n",
-                       __func__, new_fd, errno, strerror(errno));
-        rc = -1;
-        goto cleanup;
-    }
-#endif
 
     sbuf2setbufsize(sb, netinfo_ptr->bufsz);
 

--- a/net/net.h
+++ b/net/net.h
@@ -457,8 +457,6 @@ void net_queue_stat_iterate(netinfo_type *, QSTATITERFP, struct net_get_records 
 void net_queue_stat_iterate_evbuffer(netinfo_type *, QSTATITERFP, struct net_get_records *);
 void net_userfunc_iterate(netinfo_type *netinfo_ptr, UFUNCITERFP *uf_iter, void *arg);
 
-int do_appsock_evbuffer(struct evbuffer *buf, struct sockaddr_in *ss, int fd, int is_readonly, int secure);
-
 /* Blocks until the net-queue is X% full or less */
 int net_throttle_wait(netinfo_type *netinfo_ptr);
 

--- a/net/net_appsock.h
+++ b/net/net_appsock.h
@@ -20,6 +20,8 @@ struct appsock_handler_arg {
 
 int add_appsock_handler(const char *, event_callback_fn);
 int maxquerytime_cb(struct sqlclntstate *);
+void make_server_socket(int fd);
+int do_appsock_evbuffer(struct evbuffer *buf, struct sockaddr_in *ss, int fd, int is_readonly, int secure);
 
 typedef void(*run_on_base_fn)(void *);
 void run_on_base(struct event_base *, run_on_base_fn, void *);

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -284,7 +284,7 @@ static void make_socket_reusable(int fd)
     }
 }
 
-static void make_socket_nonblocking(int fd)
+void make_server_socket(int fd)
 {
     evutil_make_socket_nonblocking(fd);
     make_socket_nolinger(fd);
@@ -299,7 +299,7 @@ static int get_nonblocking_socket(void)
     if (fd == -1) {
         logmsgperror("get_nonblocking_socket socket");
     } else {
-        make_socket_nonblocking(fd);
+        make_server_socket(fd);
     }
     return fd;
 }
@@ -2857,7 +2857,7 @@ static void do_recvfd(int pmux_fd, short what, void *data)
     case -1: reopen_unix(pmux_fd, n); return;
     case -2: close_oldest_pending_connection(); return;
     }
-    make_socket_nonblocking(newfd);
+    make_server_socket(newfd);
     ssize_t rc = write(newfd, "0\n", 2);
     if (rc != 2) {
         logmsg(LOGMSG_ERROR, "%s:write pmux_fd:%d rc:%zd (%s)\n", __func__, pmux_fd, rc, strerror(errno));
@@ -3047,7 +3047,7 @@ static void net_accept(netinfo_type *netinfo_ptr)
     if (fd == -1) {
         return;
     }
-    make_socket_nonblocking(fd);
+    make_server_socket(fd);
     n->listener = evconnlistener_new(base, accept_cb, n, LEV_OPT_CLOSE_ON_FREE,
                                      gbl_net_maxconn ? gbl_net_maxconn : SOMAXCONN, fd);
     evconnlistener_set_error_cb(n->listener, accept_error_cb);
@@ -3279,7 +3279,7 @@ static void add_event(int fd, event_callback_fn func, void *data)
 
 void add_tcp_event(int fd, event_callback_fn func, void *data)
 {
-    make_socket_nonblocking(fd);
+    make_server_socket(fd);
     add_event(fd, func, data);
 }
 

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -13,11 +13,15 @@ dbname=$1
 dgpid=0
 first=""
 cluster_count=0
+do_gcore=0
 NRUNS=100
 SLEEPAMOUNT=300
 KILL_WAIT_TIME=10
 SLEEP_BETWEEN_CHECKS=.5
 PIDs=""
+firstNode=""
+lastNode=""
+
 export NOSOURCE=0
 if [[ $DBNAME == *"nosourcegenerated"* ]]; then
     NOSOURCE=1
@@ -520,6 +524,7 @@ END
                 ssh ${node} "$COMDB2_EXE ${_dbname} --create --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null
                 firstNode=${node}
             else
+                lastNode=${node}
                 ssh $node "${COPYCOMDB2_EXE} -x ${COMDB2_EXE} $firstNode:${_dbdir}/${_dbname}.lrl $_dbdir $_dbdir" >> ${logFile} 2>&1 < /dev/null
                 if [ ! $? -eq 0 ]; then
                     cleanFailExit "copycomdb2 failed"
@@ -858,6 +863,47 @@ function run_tests()
     done
 }
 
+function revconn_latency()
+{
+    typeset now=$(date +%s)
+    typeset end=$((now + 60))
+    typeset tnode=$1
+    typeset failed=0
+    typeset cored=0
+
+    TESTDIR=${TESTDIR:-${PWD}/test_${TESTID}}
+    TMPDIR=${TMPDIR:-${TESTDIR}/tmp}
+    PIDFILE=${TMPDIR}/${DBNAME}.${tnode}.pid
+    tpid=$(ssh $tnode "cat $PIDFILE" < /dev/null)
+
+    while [[ $now -lt $end && $failed == 0 ]]; do
+        cdb2sql ${CDB2_OPTIONS} $DBNAME --host $tnode "select comdb2_host()" >/dev/null 2>&1 &
+        bpid=$!
+        count=0
+        while kill -0 $bpid 2>/dev/null ; do
+            let count=count+1
+            if [[ $do_gcore == 1 && $count -gt 3 && $cored == 0 ]]; then
+                echo "Reached time threshold, gcoring"
+                ssh $tnode "gcore -o /cores/core.comdb2 $tpid" < /dev/null
+                cored=1
+                failed=1
+            fi
+            sleep 0.100
+        done
+        wait $bpid
+
+        if [[ $count -gt 5 ]]; then
+            echo "Took more than 0.5 seconds to return, count is $count"
+            failed=1
+        fi
+        now=$(date +%s)
+    done
+
+    if [[ "$failed" == 1 ]]; then
+        cleanFailExit "revconn_latency took too long to return against $tnode"
+    fi
+}
+
 function cleanup_internal()
 {
     typeset sig=$1
@@ -964,6 +1010,8 @@ if [[ "$NOSOURCE" == "1" ]]; then
     restart_source_nodes
 fi
 
+revconn_latency $lastNode
+revconn_latency $firstNode
 generate_tests
 run_tests
 verify_blkseq


### PR DESCRIPTION
Test reproduces the reverse-connection latency bug which affected us recently. Thanks Akshat for the fix: reverse-connections should be set to non-blocking mode.  This is the 8.0 version of https://github.com/bloomberg/comdb2/pull/4783