### PR TITLE
Cleanup modsnap code

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1433,27 +1433,27 @@ int bdb_register_modsnap(bdb_state_type *bdb_state,
 
 /* bdb_get_modsnap_start_state --
  * Get the start state for a new modsnap transaction. A modsnap transaction's start state includes 
- * the the preceding commit lsn (its target lsn) and the preceding checkpoint lsn.
+ * its start lsn and the checkpoint lsn preceding its start lsn.
  *
  * bdb_state: Caller's bdb state.
  * is_ha_retry: 1 if transaction is a hasql retry. 0 otherwise.
  * snapshot_epoch: Snapshot epoch if a PIT snapshot or 0 if not a PIT snapshot.
- * last_commit_lsn_file: This gets set to the preceding commit lsn file.
- *                       If transaction is a hasql retry, 
+ * modsnap_start_lsn_file: If transaction is a hasql retry, 
  *                       then this should be set by the caller to the retry start lsn file.
- * last_commit_lsn_offset: This gets set to the preceding commit lsn offset.
- *                         If transaction is a hasql retry, 
- *                         then this should be set by the caller to the retry start lsn offset.
- * last_checkpoint_lsn_file: This gets set to the preceding checkpoint lsn file.
- * last_checkpoint_lsn_offset: This gets set to the preceding checkpoint lsn offset.
+ *                       Otherwise, this gets set to the modsnap start lsn file.
+ * modsnap_start_lsn_offset: If transaction is a hasql retry, 
+ *                         then this should be set by the caller to the retry start lsn offset;
+ *                         Otherwise, this gets set to the modsnap start lsn offset.
+ * last_checkpoint_lsn_file: This gets set to the checkpoint lsn file preceding the start lsn.
+ * last_checkpoint_lsn_offset: This gets set to the checkpoint lsn offset preceding the start lsn.
  *
  * Returns 0 on success and non-0 on failure.
  */
 int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
                         int is_hasql_retry,
                         int snapshot_epoch,
-                        unsigned int *last_commit_lsn_file,
-                        unsigned int *last_commit_lsn_offset,
+                        unsigned int *modsnap_start_lsn_file,
+                        unsigned int *modsnap_start_lsn_offset,
                         unsigned int *last_checkpoint_lsn_file,
                         unsigned int *last_checkpoint_lsn_offset);
 
@@ -2433,7 +2433,6 @@ int bdb_rep_deadlocks(bdb_state_type *bdb_state, int64_t *nrep_deadlocks);
 int bdb_run_logical_recovery(bdb_state_type *bdb_state, int locks_only);
 
 int delete_logfile_txns_commit_lsn_map(bdb_state_type *bdb_state, int file);
-int truncate_commit_lsn_map(bdb_state_type *bdb_state, int file);
 int truncate_asof_pglogs(bdb_state_type *bdb_state, int file, int offset);
 
 int bdb_set_logical_live_sc(bdb_state_type *bdb_state, int lock);

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -2013,23 +2013,6 @@ int delete_logfile_txns_commit_lsn_map(bdb_state_type *bdb_state, int file)
     return __txn_commit_map_delete_logfile_txns(bdb_state->dbenv, file);
 }
 
-int truncate_commit_lsn_map(bdb_state_type *bdb_state, int file)
-{
-    int del_log;
-
-    del_log = file + 1;
-
-    if (bdb_state == NULL) {
-        return 0;
-    }
-
-    while (__txn_commit_map_delete_logfile_txns(bdb_state->dbenv, del_log) == 0) {
-        ++del_log;
-    }
-
-    return 0;
-}
-
 /* Remove pglogs & clear queues for anything larger than LSN.
  * Called while holding recoverlk in write mode. */
 int truncate_asof_pglogs(bdb_state_type *bdb_state, int file, int offset)

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -69,8 +69,6 @@ int gbl_debug_sleep_before_prepare = 0;
 extern int gbl_debug_txn_sleep;
 extern int gbl_debug_disttxn_trace;
 extern int __txn_getpriority(DB_TXN *txnp, int *priority);
-extern int __txn_commit_map_get_highest_checkpoint_lsn(DB_ENV *dbenv, DB_LSN *out_highest_checkpoint_lsn, int lock); 
-extern int __txn_commit_map_get_modsnap_start_lsn(DB_ENV *dbenv, DB_LSN *out_modsnap_start_lsn, int lock); 
 
 #if 0
 int __lock_dump_region_lockerid __P((DB_ENV *, const char *, FILE *, u_int32_t lockerid));
@@ -2787,63 +2785,6 @@ void bdb_unregister_modsnap(bdb_state_type *bdb_state, void * registration)
     free(outstanding_modsnap);
 }
 
-int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
-                        int is_ha_retry,
-                        int snapshot_epoch,
-                        unsigned int *modsnap_start_lsn_file,
-                        unsigned int *modsnap_start_lsn_offset,
-                        unsigned int *last_checkpoint_lsn_file,
-                        unsigned int *last_checkpoint_lsn_offset)
-{
-    DB_ENV *dbenv;
-    DB_LSN modsnap_start_lsn;
-    DB_LSN last_checkpoint_lsn;
-    DB_TXN_COMMIT_MAP *txmap;
-    int rc;
-
-    rc = 0;
-    dbenv = bdb_state->dbenv;
-    txmap = dbenv->txmap;
-
-    if (is_ha_retry) {
-        modsnap_start_lsn.file = *modsnap_start_lsn_file;
-        modsnap_start_lsn.offset = *modsnap_start_lsn_offset;
-
-        bdb_checkpoint_list_get_ckplsn_before_lsn(modsnap_start_lsn, &last_checkpoint_lsn);
-    } else if (snapshot_epoch) {
-        // This LSN is not necessarily a commit LSN but this is okay --
-        // it can still serve as our start point.
-        bdb_get_lsn_context_from_timestamp(bdb_state, snapshot_epoch, &modsnap_start_lsn, 0, &rc); 
-        if (rc != 0) {
-            return rc;
-        }
-
-        bdb_checkpoint_list_get_ckplsn_before_lsn(modsnap_start_lsn, &last_checkpoint_lsn);
-    } else {
-        Pthread_mutex_lock(&txmap->txmap_mutexp);
-        if ((rc = __txn_commit_map_get_highest_checkpoint_lsn(dbenv, &last_checkpoint_lsn, 0)) != 0) {
-            Pthread_mutex_unlock(&txmap->txmap_mutexp);
-            return rc;
-        }
-        if ((rc = __txn_commit_map_get_modsnap_start_lsn(dbenv, &modsnap_start_lsn, 0)) != 0) {
-            Pthread_mutex_unlock(&txmap->txmap_mutexp);
-            return rc;
-        }
-        Pthread_mutex_unlock(&txmap->txmap_mutexp);
-    }
-
-    *modsnap_start_lsn_file = modsnap_start_lsn.file;
-    *modsnap_start_lsn_offset = modsnap_start_lsn.offset;
-    *last_checkpoint_lsn_file = last_checkpoint_lsn.file;
-    *last_checkpoint_lsn_offset = last_checkpoint_lsn.offset;
-
-    logmsg(LOGMSG_DEBUG, "Starting a new modsnap transaction with last commit lsn "
-            "%"PRIu32":%"PRIu32" and last checkpoint %"PRIu32":%"PRIu32"\n",
-            modsnap_start_lsn.file, modsnap_start_lsn.offset, last_checkpoint_lsn.file, last_checkpoint_lsn.offset);
-
-    return rc;
-}
-
 int bdb_register_modsnap(bdb_state_type *bdb_state,
                         unsigned int last_checkpoint_lsn_file,
                         unsigned int last_checkpoint_lsn_offset,
@@ -2870,6 +2811,72 @@ int bdb_register_modsnap(bdb_state_type *bdb_state,
     * (void **)registration = (void *) outstanding_modsnap;
     
     return rc;
+}
+
+static int get_modsnap_start_lsn(bdb_state_type *bdb_state, int snapshot_epoch,
+    unsigned int *p_modsnap_start_lsn_file, unsigned int *p_modsnap_start_lsn_offset)
+{
+    const int is_pit_snapshot = snapshot_epoch != 0;
+
+    if (is_pit_snapshot)
+    {
+        DB_LSN modsnap_start_lsn;
+        int bdberr = 0;
+        const int rc = bdb_get_lsn_context_from_timestamp(bdb_state, snapshot_epoch,
+            &modsnap_start_lsn, 0, &bdberr); 
+
+        if (rc || bdberr) {
+            logmsg(LOGMSG_ERROR, "%s: Failed to get LSN from timestamp with rc %d and bdberr %d\n",
+                __func__, rc, bdberr);
+            return rc | bdberr;
+        }
+
+        *p_modsnap_start_lsn_file = modsnap_start_lsn.file;
+        *p_modsnap_start_lsn_offset = modsnap_start_lsn.offset;
+    } else
+    {
+        (void)bdb_get_current_lsn(bdb_state, p_modsnap_start_lsn_file, p_modsnap_start_lsn_offset);
+    }
+
+    return 0;
+}
+
+int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
+                        int is_ha_retry,
+                        int snapshot_epoch,
+                        unsigned int *modsnap_start_lsn_file,
+                        unsigned int *modsnap_start_lsn_offset,
+                        unsigned int *last_checkpoint_lsn_file,
+                        unsigned int *last_checkpoint_lsn_offset)
+{
+    // If this is a ha-sql retry, then the retry snapshot is provided as input.
+    if (!is_ha_retry) {
+        const int rc = get_modsnap_start_lsn(bdb_state, snapshot_epoch,
+            modsnap_start_lsn_file, modsnap_start_lsn_offset);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s: Failed to get modsnap start LSN\n", __func__);
+            return rc;
+        }
+    }
+
+    const DB_LSN modsnap_start_lsn = {*modsnap_start_lsn_file, *modsnap_start_lsn_offset};
+
+    DB_LSN last_checkpoint_lsn;
+    bdb_checkpoint_list_get_ckplsn_before_lsn(modsnap_start_lsn, &last_checkpoint_lsn);
+
+    *last_checkpoint_lsn_file = last_checkpoint_lsn.file;
+    *last_checkpoint_lsn_offset = last_checkpoint_lsn.offset;
+
+    logmsg(LOGMSG_DEBUG, "Starting a new modsnap transaction:\n"
+            "Is ha retry? %s\n"
+            "Snapshot epoch %d\n"
+            "Last commit LSN %"PRIu32":%"PRIu32"\n"
+            "Last checkpoint LSN %"PRIu32":%"PRIu32"\n",
+            is_ha_retry ? "Yes" : "No", snapshot_epoch,
+            modsnap_start_lsn.file, modsnap_start_lsn.offset,
+            last_checkpoint_lsn.file, last_checkpoint_lsn.offset);
+
+    return 0;
 }
 
 void bdb_upgrade_all_prepared(bdb_state_type *bdb_state)

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2878,8 +2878,6 @@ struct __txn_commit_map {
 	pthread_mutex_t txmap_mutexp;
 	int64_t highest_logfile;
 	int64_t smallest_logfile;
-	DB_LSN modsnap_start_lsn;
-	DB_LSN highest_checkpoint_lsn;
 	hash_t *transactions;
 	hash_t *logfile_lists;
 };

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -56,7 +56,6 @@ static const char revid[] =
 #include "list.h"
 #include "logmsg.h"
 
-extern int __txn_commit_map_set_modsnap_start_lsn(DB_ENV *, DB_LSN);
 extern int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
 extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN*);
 
@@ -1480,8 +1479,6 @@ __db_apprec(dbenv, max_lsn, trunclsn, update, flags)
 	if (ret != 0 && ret != DB_NOTFOUND)
 		goto err;
 	dbenv->recovery_pass = DB_TXN_NOT_IN_RECOVERY;
-
-	__txn_commit_map_set_modsnap_start_lsn(dbenv, stop_lsn);
 
 	/*
 	 * Process any pages that were on the limbo list and move them to

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -3089,12 +3089,6 @@ do_ckp:
 			return ret;
 		}
 
-		if (dbenv->txmap != NULL) {
-			Pthread_mutex_lock(&dbenv->txmap->txmap_mutexp);
-			dbenv->txmap->highest_checkpoint_lsn = ckp_lsn; 
-			Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
-		}
-
 		ret = __log_flush_pp(dbenv, NULL);
 		if (ret == 0)
 			__txn_updateckp(dbenv, &ckp_lsn);	/* this is the output lsn from txn_ckp_log */

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -367,8 +367,6 @@ int __txn_commit_map_init(dbenv)
 		goto err;
 	}
 
-	ZERO_LSN(txmap->highest_checkpoint_lsn);
-	ZERO_LSN(txmap->modsnap_start_lsn);
 	txmap->smallest_logfile = -1;
 	txmap->highest_logfile = -1;
 	Pthread_mutex_init(&txmap->txmap_mutexp, NULL);
@@ -457,14 +455,14 @@ static void __txn_commit_map_delete_logfile_list(DB_ENV *dbenv, LOGFILE_TXN_LIST
 		logmsg(LOGMSG_WARN, "%s: Deleting the highest logfile (%"PRIu32") in txmap\n", __func__, del_log);
 
 		LOGFILE_TXN_LIST *successor = NULL;
-		while ((successor == NULL) && (--txmap->highest_logfile >= 0)) {
-			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
+		while ((successor == NULL) && (--txmap->highest_logfile >= txmap->smallest_logfile)) {
+			successor = hash_find(txmap->logfile_lists, &txmap->highest_logfile);
 		}
 		assert(successor);
 	} else if (i_am_smallest_logfile)
 	{
 		LOGFILE_TXN_LIST *successor = NULL;
-		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->modsnap_start_lsn.file)) {
+		while ((successor == NULL) && (++txmap->smallest_logfile <= txmap->highest_logfile)) {
 			successor = hash_find(txmap->logfile_lists, &txmap->smallest_logfile);
 		}
 		assert(successor);
@@ -541,12 +539,7 @@ static int __txn_commit_map_remove_nolock_foreach_wrapper(void *obj, void *arg) 
  * __txn_commit_map_remove --
  *	Removes a transaction from the commit LSN map
  *
- *	*If this function deletes the transaction with the highest commit LSN, 
- * then it is the caller's responsibility to call 
- * `__txn_commit_map_set_modsnap_start_lsn` with the next highest
- * commit LSN*
- *
- * PUBLIC: int __txn_commit_map_get_highest_checkpoint_lsn
+ * PUBLIC: int __txn_commit_map_remove
  * PUBLIC:	   __P((DB_ENV *, u_int64_t));
  */
 int __txn_commit_map_remove(dbenv, utxnid)
@@ -563,56 +556,6 @@ int __txn_commit_map_remove(dbenv, utxnid)
 }
 
 /*
- * __txn_commit_map_get_highest_checkpoint_lsn --
- *	Get the highest checkpoint lsn
- *	from the commit LSN map. If `lock` neq 0 then will acquire lock over data access.
- *
- * PUBLIC: int __txn_commit_map_get_highest_checkpoint_lsn
- * PUBLIC:	   __P((DB_ENV *, DB_LSN *, int));
- */
-int __txn_commit_map_get_highest_checkpoint_lsn(dbenv, highest_checkpoint_lsn, lock)
-	DB_ENV *dbenv;
-	DB_LSN *highest_checkpoint_lsn;
-	int lock;
-{
-	DB_TXN_COMMIT_MAP *txmap;
-
-	txmap = dbenv->txmap;
-
-	if (lock) { Pthread_mutex_lock(&txmap->txmap_mutexp); }
-
-	*highest_checkpoint_lsn = txmap->highest_checkpoint_lsn;
-
-	if (lock) { Pthread_mutex_unlock(&txmap->txmap_mutexp); }
-	return 0;
-}
-
-/*
- * __txn_commit_map_get_modsnap_start_lsn --
- *	Get the highest commit lsn
- *	from the commit LSN map. If `lock` neq 0 then will acquire lock over data access.
- *
- * PUBLIC: int __txn_commit_map_get_modsnap_start_lsn
- * PUBLIC:	   __P((DB_ENV *, DB_LSN *, int));
- */
-int __txn_commit_map_get_modsnap_start_lsn(dbenv, modsnap_start_lsn, lock)
-	DB_ENV *dbenv;
-	DB_LSN *modsnap_start_lsn;
-	int lock;
-{
-	DB_TXN_COMMIT_MAP *txmap;
-
-	txmap = dbenv->txmap;
-
-	if (lock) { Pthread_mutex_lock(&txmap->txmap_mutexp); }
-
-	*modsnap_start_lsn = txmap->modsnap_start_lsn;
-
-	if (lock) { Pthread_mutex_unlock(&txmap->txmap_mutexp); }
-	return 0;
-}
-
-/*
  * __txn_commit_map_print_info --
  *	Prints the internal state of the commit LSN map.
  */
@@ -621,16 +564,8 @@ void __txn_commit_map_print_info(DB_ENV *dbenv, loglvl lvl, int should_lock) {
 
 	if (should_lock) { Pthread_mutex_lock(&txmap->txmap_mutexp); }
 
-	logmsg(lvl, "Modsnap start lsn file: %"PRIu32"; "
-					"Modsnap start lsn offset: %"PRIu32"; "
-					"Highest checkpoint lsn file: %"PRIu32"; "
-					"Highest checkpoint lsn offset: %"PRIu32"; "
-					"Highest logfile: %"PRId64"; "
+	logmsg(lvl, "Highest logfile: %"PRId64"; "
 					"Smallest logfile: %"PRId64"\n",
-					txmap->modsnap_start_lsn.file,
-					txmap->modsnap_start_lsn.offset,
-					txmap->highest_checkpoint_lsn.file,
-					txmap->highest_checkpoint_lsn.offset,
 					txmap->highest_logfile,
 					txmap->smallest_logfile);
 
@@ -641,11 +576,6 @@ void __txn_commit_map_print_info(DB_ENV *dbenv, loglvl lvl, int should_lock) {
  * __txn_commit_map_delete_logfile_txns --
  *	Remove all transactions that committed in a specific logfile 
  *	from the commit LSN map.	
- *
- *	*If this function deletes the transaction with the highest commit LSN, 
- * then it is the caller's responsibility to call 
- * `__txn_commit_map_set_modsnap_start_lsn` with the next highest
- * commit LSN*
  *
  * PUBLIC: int __txn_commit_map_delete_logfile_txns
  * PUBLIC:	   __P((DB_ENV *, u_int32_t));
@@ -785,10 +715,7 @@ int __txn_commit_map_add_nolock(dbenv, utxnid, commit_lsn)
 		}
 	}
 
-	if (log_compare(&txmap->modsnap_start_lsn, &commit_lsn) <= 0) {
-		txmap->modsnap_start_lsn = commit_lsn;
-		txmap->highest_logfile = commit_lsn.file;
-	}
+	if (commit_lsn.file > txmap->highest_logfile) { txmap->highest_logfile = commit_lsn.file; }
 
 	txn->utxnid = utxnid;
 	txn->commit_lsn = commit_lsn;
@@ -828,24 +755,6 @@ int __txn_commit_map_add(dbenv, utxnid, commit_lsn)
 
 	Pthread_mutex_unlock(&dbenv->txmap->txmap_mutexp);
 	return ret;
-}
-
-/*
- * __txn_commit_map_set_modsnap_start_lsn --
- *	Set the highest commit LSN.
- *
- * PUBLIC: int __txn_commit_map_set_modsnap_start_lsn
- * PUBLIC:	   __P((DB_ENV *, DB_LSN));
- */
-void __txn_commit_map_set_modsnap_start_lsn(dbenv, modsnap_start_lsn)
-	DB_ENV *dbenv;
-	DB_LSN modsnap_start_lsn;
-{
-	DB_TXN_COMMIT_MAP * const txmap = dbenv->txmap;
-
-	Pthread_mutex_lock(&txmap->txmap_mutexp);
-	txmap->modsnap_start_lsn = modsnap_start_lsn;
-	Pthread_mutex_unlock(&txmap->txmap_mutexp);
 }
 
 static inline void __free_prepared_children(DB_ENV *dbenv, DB_TXN_PREPARED *p)

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -6161,7 +6161,6 @@ int thdpool_alarm_on_queing(int len)
 
 int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
 {
-    int commit_lsn_map = get_commit_lsn_map_switch_value();
     int *file = &(((int *)(inlsn))[0]);
     int *offset = &(((int *)(inlsn))[1]);
     int rc;
@@ -6170,9 +6169,6 @@ int comdb2_recovery_cleanup(void *dbenv, void *inlsn, int is_master)
     logmsg(LOGMSG_INFO, "%s starting for [%d:%d] as %s\n", __func__, *file,
            *offset, is_master ? "MASTER" : "REPLICANT");
 
-    if (commit_lsn_map) {
-        rc = truncate_commit_lsn_map(thedb->bdb_env, *file);
-    }
     rc = truncate_asof_pglogs(thedb->bdb_env, *file, *offset);
 
     logmsg(LOGMSG_INFO, "%s complete [%d:%d] rc=%d\n", __func__, *file, *offset,

--- a/tests/commit_lsn_map.test/runit
+++ b/tests/commit_lsn_map.test/runit
@@ -253,14 +253,6 @@ get_clminfo() {
 	cdb2sql ${CDB2_OPTIONS} --host $1 $dbnm "exec procedure sys.cmd.send('bdb clminfo')"
 }
 
-extract_modsnap_start_lsn_offset_from_clminfo() {
-	grep -oP '(?<=Modsnap start lsn offset: )[0-9]+' <<<"$1"
-}
-
-extract_modsnap_start_lsn_file_from_clminfo() {
-	grep -oP '(?<=Modsnap start lsn file: )[0-9]+' <<<"$1"
-}
-
 extract_smallest_logfile_from_clminfo() {
 	grep -oP '(?<=Smallest logfile: )[-]?[0-9]+' <<<"$1"
 }
@@ -325,42 +317,6 @@ test_delete() {
 
 	# Verify that txmap handles request to delete non-existing file
 	verify_txmap_deletes_records 1 $node
-}
-
-verify_cached_modsnap_start_lsn_after_recovery() {
-	trap 'error $LINENO' ERR
-
-	local -r node=$1
-
-	local clminfo_after_recovery
-	clminfo_after_recovery=$(get_clminfo $node)
-	readonly clminfo_after_recovery
-
-	local cached_modsnap_start_lsn_file_after_recovery
-	cached_modsnap_start_lsn_file_after_recovery=$(extract_modsnap_start_lsn_file_from_clminfo "$clminfo_after_recovery")
-	readonly cached_modsnap_start_lsn_file_after_recovery
-
-	local cached_modsnap_start_lsn_offset_after_recovery
-	cached_modsnap_start_lsn_offset_after_recovery=$(extract_modsnap_start_lsn_offset_from_clminfo "$clminfo_after_recovery")
-	readonly cached_modsnap_start_lsn_offset_after_recovery
-
-	local modsnap_start_lsn_after_recovery
-	modsnap_start_lsn_after_recovery=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbnm \
-		"select commitlsnfile, max(commitlsnoffset) from comdb2_transaction_commit \
-		where commitlsnfile in (select max(commitlsnfile) from comdb2_transaction_commit)")
-	readonly modsnap_start_lsn_after_recovery
-
-	local modsnap_start_lsn_file_after_recovery
-	modsnap_start_lsn_file_after_recovery=$(echo "$modsnap_start_lsn_after_recovery" | cut -f 1)
-	readonly modsnap_start_lsn_file_after_recovery
-
-	local modsnap_start_lsn_offset_after_recovery
-	modsnap_start_lsn_offset_after_recovery=$(echo "$modsnap_start_lsn_after_recovery" | cut -f 2)
-	readonly modsnap_start_lsn_offset_after_recovery
-
-	(( cached_modsnap_start_lsn_file_after_recovery <= modsnap_start_lsn_file_after_recovery ))
-	(( cached_modsnap_start_lsn_file_after_recovery < modsnap_start_lsn_file_after_recovery \
-	|| cached_modsnap_start_lsn_offset_after_recovery <= modsnap_start_lsn_offset_after_recovery ))
 }
 
 verify_correct_utxnids_in_map() {
@@ -441,7 +397,6 @@ test_recover_to_lsn() {
 	# Then
 
 	verify_txmap_has_expected_min_max_files 1 1 "$master"
-	verify_cached_modsnap_start_lsn_after_recovery "$master"
 	verify_correct_utxnids_in_map "$utxnids_to_recover" "$utxnids_to_be_deleted_during_recovery" "$master"
 }
 


### PR DESCRIPTION
The changes in this PR

1. Remove redundant code: I had written new modsnap code to keep track of the last commit lsn and the last checkpoint lsn to provide state for new modsnap transactions to start with. It turns out that there was already code to track the last commit lsn, and there was also already code to get the checkpoint prior to any given lsn. The changes in this PR get rid of the new modsnap code and just use the old functions.
2. Refactor `bdb_get_modsnap_start_state`
3. Update out of date comments / variable names
4. Fix bug in `__txn_commit_map_delete_logfile_list`