### PR TITLE
Update appsock exhausted error code

### DIFF
--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -72,6 +72,7 @@ enum cdb2_errors {
 
     CDB2ERR_THREADPOOL_INTERNAL = -20, /* some error in threadpool code */
     CDB2ERR_ANALYZE_ALREADY_RUNNING = -22,
+    CDB2ERR_APPSOCK_LIMIT = -23,
 
     CDB2ERR_NOMASTER = -101,
     CDB2ERR_UNTAGGED_DATABASE = -102,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -7154,7 +7154,7 @@ void clnt_plugin_reset(struct sqlclntstate *clnt)
 
 void exhausted_appsock_connections(struct sqlclntstate *clnt)
 {
-    write_response(clnt, RESPONSE_ERROR, "Exhausted appsock connections.", CDB2__ERROR_CODE__APPSOCK_LIMIT);
+    write_response(clnt, RESPONSE_ERROR, "Exhausted appsock connections.", CDB2ERR_APPSOCK_LIMIT);
     gbl_denied_appsock_connection_count++;
     static time_t last = 0;
     time_t now = time(NULL);

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -17,7 +17,6 @@
 #ifndef __SQLINTERFACES_H__
 #define __SQLINTERFACES_H__
 
-#define SQLHERR_APPSOCK_LIMIT -110
 #define SQLHERR_WRONG_DB -111
 
 #include <stdlib.h>

--- a/docs/pages/programming/c_api.md
+++ b/docs/pages/programming/c_api.md
@@ -718,6 +718,7 @@ These return codes can be found in ```cdb2api.h```
 | -20  |```CDB2ERR_THREADPOOL_INTERNAL``` | <a id="CDB2ERR_THREADPOOL_INTERNAL"/>Some error in threadpool code. 
 | -21  |```CDB2ERR_READONLY``` | <a id="CDB2ERR_READONLY"/>Database is readonly (possible because a schema change operation is in progress). 
 | -22  |```CDB2ERR_ANALYZE_ALREADY_RUNNING``` | <a id="CDB2ERR_ANALYZE_ALREADY_RUNNING"/>Analyze is already running on some table. 
+| -23  |```CDB2ERR_APPSOCK_LIMIT``` | <a id="CDB2ERR_APPSOCK_LIMIT"/>Exhausted appsock connections.
 | -101 |```CDB2ERR_NOMASTER``` | <a id="CDB2ERR_NOMASTER"/>Database has no master node - try again later. 
 | -103 |```CDB2ERR_CONSTRAINTS``` | <a id="CDB2ERR_CONSTRAINTS"/>Some constraint violation. 
 | 203  |```CDB2ERR_DEADLOCK``` | <a id="CDB2ERR_DEADLOCK"/>Deadlock detected. 

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -42,6 +42,7 @@ enum CDB2_ErrorCode {
 
     THREADPOOL_INTERNAL     = -20;  /* some error in threadpool code */
     READONLY                = -21;
+    APPSOCK_LIMIT           = -23;
 
     NOMASTER                = -101;
     NOTSERIAL               =  230;
@@ -55,7 +56,6 @@ enum CDB2_ErrorCode {
 
     QUERYLIMIT              = -107;
     MASTER_TIMEOUT          = -109;
-    APPSOCK_LIMIT           = -110;
     WRONG_DB                = -111;
 
     VERIFY_ERROR            = 2;

--- a/tests/osql_cleanup.test/README
+++ b/tests/osql_cleanup.test/README
@@ -8,7 +8,7 @@ to masternode without waiting for commit. This test only exercises newsql querie
 NB: due to the high number of threads that dont close, the db will run out of appsock
 connections and client will see error:
 
-12:50:49> Error: cdb2_run_statement failed: -110 Exhausted appsock connections.
+12:50:49> Error: cdb2_run_statement failed: -23 Exhausted appsock connections.
 
 server will have these errors:
 


### PR DESCRIPTION
Problem: return code to client -110 is already taken by CDB2ERR_SCHEMA
Replace CDB2__ERROR_CODE__APPSOCK_LIMIT (-110) with CDB2ERR_APPSOCK_LIMIT (-23) so it is distinct from CDB2ERR_SCHEMA

This will be used by cdb2api in the future to fix exhausted appsock bug (currently doesn't retry on other nodes when reaches limit)

Don't think code -110 is parsed anywhere currently