### PR TITLE
Address flakiness in snapshot_during_truncate test

### DIFF
--- a/tests/snapshot_during_truncate.test/Makefile
+++ b/tests/snapshot_during_truncate.test/Makefile
@@ -4,5 +4,6 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=5m
+	export TEST_TIMEOUT=1m
 endif
+unexport CLUSTER

--- a/tests/snapshot_during_truncate.test/runit
+++ b/tests/snapshot_during_truncate.test/runit
@@ -1,91 +1,23 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
-source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/runstepper.sh
 
-TIER="default"
-master=$(cdb2sql ${CDB2_OPTIONS} -tabs "${DBNAME}" "${TIER}" "select host from comdb2_cluster where is_master='Y'")
-readonly master
+readonly test_dir=$(dirname "$0")
 
-set -e
-export SHELLOPTS
+readonly testcase="t00.req"
+readonly expected_output="t00.req.exp"
+readonly actual_output="t00.req.res"
 
-error() {
-	err "Failed at line $1"
+runstepper ${DBNAME} ${testcase} ${actual_output} 1
+
+if diff ${expected_output} ${actual_output};
+then
+	echo "Test passed"
+	exit 0
+else
+	echo "Test failed"
+	echo "see diff: 'diff ${test_dir}/${expected_output} ${test_dir}/${actual_output}'"
 	exit 1
-}
+fi
 
-insert_in_loop() {
-	while true;
-	do
-		cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values(1)" &> /dev/null
-	done
-}
-
-test_snapshot_query() {
-	local -r snapshot_sleep_seconds=$1
-
-	set +e
-query_results=$(cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default - 2>&1 <<EOF
-set transaction snapshot
-begin
-select count(*) from t
-select sleep(${snapshot_sleep_seconds})
-select count(*) from t
-commit
-EOF
-)
-	local -r query_rc=$?
-
-	set -e
-	trap 'error $LINENO' ERR
-
-	# Assert that the txn failed
-	(( query_rc != 0 )) 
-
-	local num_count_results
-	num_count_results=$(echo "$query_results" | sed -nr 's/count.*=([0-9]+)/\1/p' | wc -l)
-	readonly num_count_results
-
-	# Assert that we do not have any results for the second count stmt
-	(( num_count_results == 1));
-}
-
-main() {
-	trap 'error $LINENO' ERR
-
-	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "create table t(i int)"
-
-	# force a checkpoint
-	local -r flush_itrs=3
-	for (( i=0; i<flush_itrs; ++i ));
-	do
-		cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("flush")'
-	done
-
-	local trunc_lsn
-	trunc_lsn=$(cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("bdb cluster")' \
-		| grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
-	readonly trunc_lsn
-
-	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("pushlogs 2")'
-	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values(1)"
-
-	local -r snapshot_sleep_seconds=5
-	test_snapshot_query "${snapshot_sleep_seconds}" &
-
-	local -r snapshot_pid=$!
-	trap "kill -9 $snapshot_pid" EXIT
-
-	sleep 1
-
-	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" "exec procedure sys.cmd.truncate_log(\"{"${trunc_lsn}"}\");" &
-
-	insert_in_loop &
-	local -r insert_pid=$!
-	trap "kill -9 $insert_pid" EXIT
-
-	wait "${snapshot_pid}"
-}
-
-main

--- a/tests/snapshot_during_truncate.test/t00.req
+++ b/tests/snapshot_during_truncate.test/t00.req
@@ -1,0 +1,10 @@
+# Verify that we can't open a cursor after a generation change
+# during a snapshot transaction.
+# 
+# It doesn't matter what LSN we truncate to since any truncate
+# will change the generation.
+#
+2 set transaction snapshot isolation
+2 begin
+1 exec procedure sys.cmd.truncate_log('{3:1}')
+2 select count(*) from t

--- a/tests/snapshot_during_truncate.test/t00.req.exp
+++ b/tests/snapshot_during_truncate.test/t00.req.exp
@@ -1,0 +1,5 @@
+done
+done
+done
+[select count(*) from t] failed with rc 402 Client api should change nodes
+done


### PR DESCRIPTION
The changes in this PR simplify the `snapshot_during_truncate` test to address flakiness by using `stepper.c` for multi-client coordination and by removing other extraneous test code.