### PR TITLE
Implement modsnap durable LSN support

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1445,6 +1445,7 @@ int bdb_is_modsnap_txn_allowed_to_open_cursors(void * registration);
  * its start lsn and the checkpoint lsn preceding its start lsn.
  *
  * bdb_state: Caller's bdb state.
+ * bdb_attr: Caller's bdb attr.
  * is_ha_retry: 1 if transaction is a hasql retry. 0 otherwise.
  * snapshot_epoch: Snapshot epoch if a PIT snapshot or 0 if not a PIT snapshot.
  * modsnap_start_lsn_file: If transaction is a hasql retry, 
@@ -1459,6 +1460,7 @@ int bdb_is_modsnap_txn_allowed_to_open_cursors(void * registration);
  * Returns 0 on success and non-0 on failure.
  */
 int bdb_get_modsnap_start_state(bdb_state_type *bdb_state,
+                        bdb_attr_type *bdb_attr,
                         int is_hasql_retry,
                         int snapshot_epoch,
                         unsigned int *modsnap_start_lsn_file,

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4874,7 +4874,7 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
             if (clnt->is_hasql_retry) {
                 get_snapshot(clnt, (int *) &clnt->modsnap_start_lsn_file, (int *) &clnt->modsnap_start_lsn_offset);
             }
-            if (bdb_get_modsnap_start_state(db->handle, clnt->is_hasql_retry, clnt->snapshot, 
+            if (bdb_get_modsnap_start_state(db->handle, thedb->bdb_attr, clnt->is_hasql_retry, clnt->snapshot, 
                     &clnt->modsnap_start_lsn_file, &clnt->modsnap_start_lsn_offset, &clnt->last_checkpoint_lsn_file, 
                     &clnt->last_checkpoint_lsn_offset)) {
                 logmsg(LOGMSG_ERROR, "%s: Failed to get modsnap txn start state\n", __func__);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1727,7 +1727,7 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         if (clnt->is_hasql_retry) {
             get_snapshot(clnt, (int *) &clnt->modsnap_start_lsn_file, (int *) &clnt->modsnap_start_lsn_offset);
         }
-        if (bdb_get_modsnap_start_state(db->handle, clnt->is_hasql_retry, clnt->snapshot,
+        if (bdb_get_modsnap_start_state(db->handle, thedb->bdb_attr, clnt->is_hasql_retry, clnt->snapshot,
                     &clnt->modsnap_start_lsn_file, &clnt->modsnap_start_lsn_offset, 
                     &clnt->last_checkpoint_lsn_file, &clnt->last_checkpoint_lsn_offset)) {
             logmsg(LOGMSG_ERROR, "%s: Failed to get modsnap txn start state\n", __func__);


### PR DESCRIPTION
If the database is running with durable LSNs, then start snapshots as of the latest durable LSN.