### PR TITLE
Increase precision of modsnap truncate failure

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1418,6 +1418,8 @@ void bdb_unregister_modsnap(bdb_state_type *bdb_state, void * registration);
  * Register a new modsnap transaction.
  *
  * bdb_state: Caller's bdb state.
+ * modsnap_start_lsn_file: File of the modsnap start lsn
+ * modsnap_start_lsn_offset: Offset of the modsnap start lsn
  * last_checkpoint_lsn_file: File of the checkpoint lsn preceding the modsnap start point.
  * last_checkpoint_lsn_offset: Offset of the checkpoint lsn preceding the modsnap start point.
  * registration: This gets set to point to a berkdb structure that holds registration state. 
@@ -1427,9 +1429,16 @@ void bdb_unregister_modsnap(bdb_state_type *bdb_state, void * registration);
  * Returns 0 on success and non-0 on failure.
  */
 int bdb_register_modsnap(bdb_state_type *bdb_state,
+                        unsigned int modsnap_start_lsn_file,
+                        unsigned int modsnap_start_lsn_offset,
                         unsigned int last_checkpoint_lsn_file,
                         unsigned int last_checkpoint_lsn_offset,
                         void ** registration);
+
+/* 
+ * Returns 1 if this registered modsnap txn is allowed to open cursors; 0 otherwise
+ */
+int bdb_is_modsnap_txn_allowed_to_open_cursors(void * registration);
 
 /* bdb_get_modsnap_start_state --
  * Get the start state for a new modsnap transaction. A modsnap transaction's start state includes 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2855,6 +2855,8 @@ struct __db_env {
 
 struct __modsnap_txn
 {
+	int is_allowed_to_open_cursors;
+	DB_LSN modsnap_start_lsn;
 	DB_LSN prior_checkpoint_lsn;
 	LINKC_T(struct __modsnap_txn) lnk;
 };

--- a/berkdb/env/env_recover.c
+++ b/berkdb/env/env_recover.c
@@ -56,6 +56,8 @@ static const char revid[] =
 #include "list.h"
 #include "logmsg.h"
 
+extern void invalidate_modsnap_txns_starting_at_lsn_geq_cutoff_lsn(DB_ENV *dbenv, DB_LSN cutoff_lsn);
+extern int __txn_commit_map_set_modsnap_start_lsn(DB_ENV *, DB_LSN);
 extern int __txn_commit_map_add(DB_ENV *, u_int64_t, DB_LSN);
 extern int __txn_commit_map_get(DB_ENV *, u_int64_t, DB_LSN*);
 
@@ -1606,6 +1608,8 @@ done:
 				goto err;
 
 			__log_vtruncate(dbenv, max_lsn, &region->last_ckp, trunclsn);
+
+			invalidate_modsnap_txns_starting_at_lsn_geq_cutoff_lsn(dbenv, *trunclsn);
 
 			logmsg(LOGMSG_WARN, "TRUNCATED TO is %u:%u \n", trunclsn->file,
 				trunclsn->offset);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4882,7 +4882,8 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
                 goto done;
             }
 
-            if (bdb_register_modsnap(db->handle, clnt->last_checkpoint_lsn_file, clnt->last_checkpoint_lsn_offset, &clnt->modsnap_registration)) {
+            if (bdb_register_modsnap(db->handle, clnt->modsnap_start_lsn_file, clnt->modsnap_start_lsn_offset,
+                    clnt->last_checkpoint_lsn_file, clnt->last_checkpoint_lsn_offset, &clnt->modsnap_registration)) {
                 logmsg(LOGMSG_ERROR, "%s: Failed to register modsnap txn\n", __func__);
                 rc = SQLITE_INTERNAL;
                 goto done;
@@ -9666,15 +9667,11 @@ int osql_check_shadtbls(bdb_state_type *bdb_env, struct sqlclntstate *clnt,
 int gbl_random_get_curtran_failures;
 extern int gbl_test_curtran_change_code;
 
-static int should_fail_with_gen_change(const uint32_t curgen, const struct sqlclntstate * const clnt) {
-    const int tranlevel_is_modsnap = clnt->dbtran.mode == TRANLEVEL_MODSNAP;
+static int should_fail_due_to_gen_change(const uint32_t curgen, const struct sqlclntstate * const clnt) {
     const int tranlevel_is_snapserial = (clnt->dbtran.mode == TRANLEVEL_SNAPISOL || clnt->dbtran.mode == TRANLEVEL_SERIAL);
+    if (!tranlevel_is_snapserial) { return 0; }
 
-    if (!tranlevel_is_modsnap && !tranlevel_is_snapserial) { return 0; }
-
-    // We only want to fail tranlevel_snapisol/tranlevel_serializable if durable lsns are enabled.
-    // We want to fail tranlevel_modsnap even if durable lsns are disabled.
-    if (tranlevel_is_snapserial && !bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS)) { return 0; }
+    if (!bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS)) { return 0; }
 
     if (!clnt->init_gen) { return 0; }
 
@@ -9738,7 +9735,7 @@ retry:
      * master (which means that our shadow-tables will be incorrect).  */
 
     curgen = bdb_get_rep_gen(bdb_state);
-    if (should_fail_with_gen_change(curgen, clnt)) {
+    if (should_fail_due_to_gen_change(curgen, clnt)) {
         bdb_put_cursortran(bdb_state, curtran_out, curtran_flags, &bdberr);
         curtran_out = NULL;
         clnt->gen_changed = 1;
@@ -9746,6 +9743,17 @@ retry:
                "td %p %s: failing because generation has changed: "
                "orig-gen=%u, cur-gen=%u\n",
                (void *)pthread_self(), __func__, clnt->init_gen, curgen);
+        return -1;
+    }
+    
+    const int tran_is_registered_modsnap = clnt->dbtran.mode == TRANLEVEL_MODSNAP
+        && clnt->modsnap_registration;
+    if (tran_is_registered_modsnap && !bdb_is_modsnap_txn_allowed_to_open_cursors(clnt->modsnap_registration)) {
+        bdb_put_cursortran(bdb_state, curtran_out, curtran_flags, &bdberr);
+        curtran_out = NULL;
+        logmsg(LOGMSG_DEBUG,
+               "td %p %s: failing because modsnap txn is no longer valid",
+               (void *)pthread_self(), __func__);
         return -1;
     }
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1735,7 +1735,8 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
             goto done;
         }
 
-        if (bdb_register_modsnap(db->handle, clnt->last_checkpoint_lsn_file, clnt->last_checkpoint_lsn_offset, &clnt->modsnap_registration)) {
+        if (bdb_register_modsnap(db->handle, clnt->modsnap_start_lsn_file, clnt->modsnap_start_lsn_offset,
+                   clnt->last_checkpoint_lsn_file, clnt->last_checkpoint_lsn_offset, &clnt->modsnap_registration)) {
             logmsg(LOGMSG_ERROR, "%s: Failed to register modsnap txn\n", __func__);
             rc = SQLITE_INTERNAL;
             goto done;

--- a/tests/snapshot_during_truncate.test/Makefile
+++ b/tests/snapshot_during_truncate.test/Makefile
@@ -4,5 +4,6 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=5m
+	export TEST_TIMEOUT=1m
 endif
+unexport CLUSTER

--- a/tests/snapshot_during_truncate.test/lrl.options
+++ b/tests/snapshot_during_truncate.test/lrl.options
@@ -1,1 +1,2 @@
 enable_snapshot_isolation
+table t t.csc2

--- a/tests/snapshot_during_truncate.test/runit
+++ b/tests/snapshot_during_truncate.test/runit
@@ -1,91 +1,23 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
-source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/runstepper.sh
 
-TIER="default"
-master=$(cdb2sql ${CDB2_OPTIONS} -tabs "${DBNAME}" "${TIER}" "select host from comdb2_cluster where is_master='Y'")
-readonly master
+readonly test_dir=$(dirname "$0")
 
-set -e
-export SHELLOPTS
+readonly testcase="t00.req"
+readonly expected_output="t00.req.exp"
+readonly actual_output="t00.req.res"
 
-error() {
-	err "Failed at line $1"
+runstepper ${DBNAME} ${testcase} ${actual_output} 1
+
+if diff ${expected_output} ${actual_output};
+then
+	echo "Test passed"
+	exit 0
+else
+	echo "Test failed"
+	echo "see diff: 'diff ${test_dir}/${expected_output} ${test_dir}/${actual_output}'"
 	exit 1
-}
+fi
 
-insert_in_loop() {
-	while true;
-	do
-		cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values(1)" &> /dev/null
-	done
-}
-
-test_snapshot_query() {
-	local -r snapshot_sleep_seconds=$1
-
-	set +e
-query_results=$(cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default - 2>&1 <<EOF
-set transaction snapshot
-begin
-select count(*) from t
-select sleep(${snapshot_sleep_seconds})
-select count(*) from t
-commit
-EOF
-)
-	local -r query_rc=$?
-
-	set -e
-	trap 'error $LINENO' ERR
-
-	# Assert that the txn failed
-	(( query_rc != 0 )) 
-
-	local num_count_results
-	num_count_results=$(echo "$query_results" | sed -nr 's/count.*=([0-9]+)/\1/p' | wc -l)
-	readonly num_count_results
-
-	# Assert that we do not have any results for the second count stmt
-	(( num_count_results == 1));
-}
-
-main() {
-	trap 'error $LINENO' ERR
-
-	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "create table t(i int)"
-
-	# force a checkpoint
-	local -r flush_itrs=3
-	for (( i=0; i<flush_itrs; ++i ));
-	do
-		cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("flush")'
-	done
-
-	local trunc_lsn
-	trunc_lsn=$(cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("bdb cluster")' \
-		| grep MASTER | sed 's/.*lsn //g ; s/ .*//g')
-	readonly trunc_lsn
-
-	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" 'exec procedure sys.cmd.send("pushlogs 2")'
-	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" "${TIER}" "insert into t values(1)"
-
-	local -r snapshot_sleep_seconds=5
-	test_snapshot_query "${snapshot_sleep_seconds}" &
-
-	local -r snapshot_pid=$!
-	trap "kill -9 $snapshot_pid" EXIT
-
-	sleep 1
-
-	cdb2sql ${CDB2_OPTIONS} --host "${master}" "${DBNAME}" "exec procedure sys.cmd.truncate_log(\"{"${trunc_lsn}"}\");" &
-
-	insert_in_loop &
-	local -r insert_pid=$!
-	trap "kill -9 $insert_pid" EXIT
-
-	wait "${snapshot_pid}"
-}
-
-main

--- a/tests/snapshot_during_truncate.test/runit
+++ b/tests/snapshot_during_truncate.test/runit
@@ -2,22 +2,48 @@
 bash -n "$0" | exit 1
 
 source ${TESTSROOTDIR}/tools/runstepper.sh
+source setup.sh
 
-readonly test_dir=$(dirname "$0")
+set -e
 
-readonly testcase="t00.req"
-readonly expected_output="t00.req.exp"
-readonly actual_output="t00.req.res"
+test_dir=$(dirname "$0")
+readonly test_dir
 
-runstepper ${DBNAME} ${testcase} ${actual_output} 1
+run_test() {
+	local -r test_name=$1
+	local -r test_input="${test_name}.req"
+	local -r expected_output="${test_name}.req.exp"
+	local -r actual_output="${test_name}.req.res"
 
-if diff ${expected_output} ${actual_output};
-then
-	echo "Test passed"
-	exit 0
-else
-	echo "Test failed"
-	echo "see diff: 'diff ${test_dir}/${expected_output} ${test_dir}/${actual_output}'"
-	exit 1
-fi
+	runstepper ${DBNAME} ${test_input} ${actual_output} 1
 
+	if diff ${expected_output} ${actual_output}
+	then
+		echo "Test ${test_name} passed"
+
+		return 0
+	else
+		echo "Test ${test_name} failed"
+		echo "see diff: 'diff ${test_dir}/${expected_output} ${test_dir}/${actual_output}'"
+
+		return 1
+	fi
+}
+
+main() {
+	local rc=0
+
+	for test_name in t00 t01;
+	do
+		setup_${test_name}
+
+		if ! run_test ${test_name};
+		then
+			rc=1
+		fi
+	done
+
+	return ${rc}
+}
+
+main

--- a/tests/snapshot_during_truncate.test/setup.sh
+++ b/tests/snapshot_during_truncate.test/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+setup_t00() {
+	local trunc_lsn_file
+	trunc_lsn_file=$(( $(cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "select logfile from comdb2_cluster") + 2 ))
+	readonly trunc_lsn_file
+
+	sed -i -e "s/<trunc_lsn>/$(( trunc_lsn_file )):0/g" t00.req
+}
+
+setup_t01() {
+	local trunc_lsn trunc_lsn_file trunc_lsn_offset
+	trunc_lsn=$(cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default "select logfile, logoffset from comdb2_cluster")
+	trunc_lsn_file=$(cut -f 1 <<< ${trunc_lsn})
+	trunc_lsn_offset=$(cut -f 2 <<< ${trunc_lsn})
+	readonly trunc_lsn trunc_lsn_file trunc_lsn_offset
+
+	sed -i -e "s/<trunc_lsn>/${trunc_lsn_file}:${trunc_lsn_offset}/g" t01.req
+}

--- a/tests/snapshot_during_truncate.test/t.csc2
+++ b/tests/snapshot_during_truncate.test/t.csc2
@@ -1,0 +1,4 @@
+schema
+{
+   int  i
+}

--- a/tests/snapshot_during_truncate.test/t00.req
+++ b/tests/snapshot_during_truncate.test/t00.req
@@ -1,10 +1,8 @@
-# Verify that we can't open a cursor after a generation change
-# during a snapshot transaction.
-# 
-# It doesn't matter what LSN we truncate to since any truncate
-# will change the generation.
+# Verify a snapshot txn does not fail to open a cursor
+# if we truncate to an lsn above its start lsn
 #
 2 set transaction snapshot isolation
 2 begin
-1 exec procedure sys.cmd.truncate_log('{3:1}')
+# `setup.sh` populates `trunc_lsn`
+1 exec procedure sys.cmd.truncate_log('{<trunc_lsn>}')
 2 select count(*) from t

--- a/tests/snapshot_during_truncate.test/t00.req
+++ b/tests/snapshot_during_truncate.test/t00.req
@@ -1,0 +1,10 @@
+# Verify that we can't open a cursor after a generation change
+# during a snapshot transaction.
+# 
+# It doesn't matter what LSN we truncate to since any truncate
+# will change the generation.
+#
+2 set transaction snapshot isolation
+2 begin
+1 exec procedure sys.cmd.truncate_log('{3:1}')
+2 select count(*) from t

--- a/tests/snapshot_during_truncate.test/t00.req.exp
+++ b/tests/snapshot_during_truncate.test/t00.req.exp
@@ -1,5 +1,5 @@
 done
 done
 done
-[select count(*) from t] failed with rc 402 Client api should change nodes
+(count(*)=0)
 done

--- a/tests/snapshot_during_truncate.test/t00.req.exp
+++ b/tests/snapshot_during_truncate.test/t00.req.exp
@@ -1,0 +1,5 @@
+done
+done
+done
+[select count(*) from t] failed with rc 402 Client api should change nodes
+done

--- a/tests/snapshot_during_truncate.test/t01.req
+++ b/tests/snapshot_during_truncate.test/t01.req
@@ -1,0 +1,11 @@
+# Verify that a snapshot txn fails if we truncate
+# to an lsn before its start lsn
+#
+# pushnext to make sure that the snapshot definitely starts
+# at an lsn above the truncate lsn
+2 exec procedure sys.cmd.send('pushnext')
+2 set transaction snapshot isolation
+2 begin
+# `setup.sh` populates `trunc_lsn`
+1 exec procedure sys.cmd.truncate_log('{<trunc_lsn>}')
+2 select count(*) from t

--- a/tests/snapshot_during_truncate.test/t01.req.exp
+++ b/tests/snapshot_during_truncate.test/t01.req.exp
@@ -1,0 +1,7 @@
+(out='pushing to logfile 2')
+done
+done
+done
+done
+[select count(*) from t] failed with rc 402 Client api should change nodes
+done


### PR DESCRIPTION
The changes in this PR improve upon the failure implemented in #4755: 

The changes in #4755 disallow a  modsnap transaction from opening a cursor whenever there's a gen change. This is a catch-all method that can unnecessarily fail transactions.

The changes in this PR remove these unnecessary failures by only disallowing a modsnap transaction from opening a cursor if we truncate to an lsn below its start lsn.