### PR TITLE
Increase dbcreate test timeout

### DIFF
--- a/tests/dbcreate.test/Makefile
+++ b/tests/dbcreate.test/Makefile
@@ -5,6 +5,6 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=2m
 endif
 


### PR DESCRIPTION
When I run this test locally it usually finishes just a couple of seconds short of the 1 minute timeout. It has sometimes been hitting the timeout when it runs on our test engine. The changes in this PR increase this test's timeout to 2 minutes since I'm not noticing significant ways to optimize the test.