### PR TITLE
Reducing cdb2api compatibility spew

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -369,6 +369,8 @@ int64_t gbl_nnewsql;
 int64_t gbl_nnewsql_ssl;
 long long gbl_nnewsql_steps;
 
+int64_t gbl_nnewsql_compat;
+
 uint32_t gbl_masterrejects = 0;
 
 volatile uint32_t gbl_analyze_gen = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1746,6 +1746,8 @@ extern int64_t gbl_nnewsql;
 extern int64_t gbl_nnewsql_ssl;
 extern long long gbl_nnewsql_steps;
 
+extern int64_t gbl_nnewsql_compat;
+
 /* Legacy request metrics */
 extern int64_t gbl_fastsql_execute_inline_params;
 extern int64_t gbl_fastsql_set_isolation_level;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1897,6 +1897,7 @@ clipper_usage:
             logmsg(LOGMSG_USER, "num sql queries         %"PRId64"\n", gbl_nsql);
             logmsg(LOGMSG_USER, "num new sql queries     %"PRId64"\n", gbl_nnewsql);
             logmsg(LOGMSG_USER, "num ssl sql queries     %"PRId64"\n", gbl_nnewsql_ssl);
+            logmsg(LOGMSG_USER, "num sql compat queries %"PRId64"\n", gbl_nnewsql_compat);
             logmsg(LOGMSG_USER, "num master rejects      %u\n",
                    gbl_masterrejects);
             logmsg(LOGMSG_USER, "sql ticks               %llu\n", gbl_sqltick);

--- a/plugins/newsql/newsql.h
+++ b/plugins/newsql/newsql.h
@@ -49,6 +49,11 @@ struct newsql_postponed_data {
     uint8_t *row;
 };
 
+typedef enum {
+    NEWSQL_PROTOCOL_ORIGINAL,
+    NEWSQL_PROTOCOL_COMPAT
+} newsql_protocol_ver;
+
 #define NEWSQL_APPDATA_COMMON                                                  \
     int (*ping_pong)(struct sqlclntstate *);                                   \
     int (*read)(struct sqlclntstate *, void *, int len, int nitems);           \


### PR DESCRIPTION
This patch also fixes a bug that a cdb2api client may see "odd" behaviors from a sockpool connection donated by a compatibility client.