### PR TITLE
[8.0] Reducing cdb2api compatibility spew

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -379,6 +379,8 @@ uint32_t gbl_nnewsql;
 uint32_t gbl_nnewsql_ssl;
 long long gbl_nnewsql_steps;
 
+uint32_t gbl_nnewsql_compat;
+
 uint32_t gbl_masterrejects = 0;
 
 volatile uint32_t gbl_analyze_gen = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1718,6 +1718,8 @@ extern unsigned int gbl_nnewsql;
 extern unsigned int gbl_nnewsql_ssl;
 extern long long gbl_nnewsql_steps;
 
+extern unsigned int gbl_nnewsql_compat;
+
 /* Legacy request metrics */
 extern int64_t gbl_fastsql_execute_inline_params;
 extern int64_t gbl_fastsql_set_isolation_level;

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1901,6 +1901,7 @@ clipper_usage:
             logmsg(LOGMSG_USER, "num sql queries         %u\n", gbl_nsql);
             logmsg(LOGMSG_USER, "num new sql queries     %u\n", gbl_nnewsql);
             logmsg(LOGMSG_USER, "num ssl sql queries     %u\n", gbl_nnewsql_ssl);
+            logmsg(LOGMSG_USER, "num sql compat queries  %u\n", gbl_nnewsql_compat);
             logmsg(LOGMSG_USER, "num master rejects      %u\n",
                    gbl_masterrejects);
             logmsg(LOGMSG_USER, "sql ticks               %llu\n", gbl_sqltick);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -356,7 +356,7 @@ static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col,
         }
     } else if (stmt) {
         type = get_sqlite3_column_type(clnt, stmt, col, 0);
-        if ((check_protocol_version == 1 && appdata->protocol_version == 1 /* fastsql */) ||
+        if ((check_protocol_version && appdata->protocol_version == NEWSQL_PROTOCOL_COMPAT /* fastsql */) ||
             type == SQLITE_NULL) {
             type = typestr_to_type(sqlite3_column_decltype(stmt, col));
         }
@@ -368,7 +368,7 @@ static int get_col_type(struct sqlclntstate *clnt, sqlite3_stmt *stmt, int col,
 #define ADJUST_LONG_COL_NAME(clnt_return_long_column_names, appdata, n, l)                                             \
     do {                                                                                                               \
         if ((l > MAX_COL_NAME_LEN) && ((!clnt_return_long_column_names && gbl_return_long_column_names == 0) ||        \
-                                       (appdata->protocol_version == 1 /* fastsql */))) {                              \
+                                       (appdata->protocol_version == NEWSQL_PROTOCOL_COMPAT /* fastsql */))) {         \
             l = MAX_COL_NAME_LEN + 1;                                                                                  \
             char *namebuf = alloca(l);                                                                                 \
             n = strncpy0(namebuf, n, l);                                                                               \
@@ -2051,6 +2051,7 @@ int is_commit_rollback(struct sqlclntstate *clnt)
 int newsql_first_run(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
 {
     struct newsql_appdata *appdata = clnt->appdata;
+    appdata->protocol_version = NEWSQL_PROTOCOL_ORIGINAL;
     for (int ii = 0; ii < sql_query->n_features; ++ii) {
         switch(sql_query->features[ii]) {
         case CDB2_CLIENT_FEATURES__FLAT_COL_VALS:
@@ -2060,9 +2061,7 @@ int newsql_first_run(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
             clnt->request_fp = 1;
             break;
         case CDB2_CLIENT_FEATURES__REQUIRE_FASTSQL:
-            logmsg(LOGMSG_USER, "%s:%d cdb2api requested for 'fastsql' protocol\n",
-                   __func__, __LINE__);
-            appdata->protocol_version = 1; // FASTSQL's protocol version = 1
+            appdata->protocol_version = NEWSQL_PROTOCOL_COMPAT;
             break;
         case CDB2_CLIENT_FEATURES__CAN_REDIRECT_FDB:
             clnt->can_redirect_fdb = 1;
@@ -2189,6 +2188,9 @@ newsql_loop_result newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_quer
     }
 
     ATOMIC_ADD32(gbl_nnewsql, 1);
+    struct newsql_appdata *appdata = clnt->appdata;
+    if (appdata->protocol_version == NEWSQL_PROTOCOL_COMPAT)
+        ATOMIC_ADD32(gbl_nnewsql_compat, 1);
     if (clnt->plugin.has_ssl(clnt)) ATOMIC_ADD32(gbl_nnewsql_ssl, 1);
 
     /* coherent  _or_ in middle of transaction */

--- a/plugins/newsql/newsql.h
+++ b/plugins/newsql/newsql.h
@@ -49,6 +49,11 @@ struct newsql_postponed_data {
     uint8_t *row;
 };
 
+typedef enum {
+    NEWSQL_PROTOCOL_ORIGINAL,
+    NEWSQL_PROTOCOL_COMPAT
+} newsql_protocol_ver;
+
 #define NEWSQL_APPDATA_COMMON                                                  \
     int (*ping_pong)(struct sqlclntstate *);                                   \
     int (*read)(struct sqlclntstate *, void *, int len, int nitems);           \


### PR DESCRIPTION
This patch also fixes a bug that a cdb2api client may see "odd" behaviors from a sockpool connection donated by a compatibility client.
