### PR TITLE
Remove truncatesc_ufid_on_generated test

### DIFF
--- a/tests/truncatesc.test/ufid_on.testopts
+++ b/tests/truncatesc.test/ufid_on.testopts
@@ -1,1 +1,0 @@
-ufid_log on


### PR DESCRIPTION
ufid logging is on by default so this test is redundant.