### PR TITLE
seed last_timer_check, add svc-name to thd-name

### DIFF
--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -475,6 +475,10 @@ static struct timeval last_timer_check;
 void check_timers(void)
 {
     if (gbl_timer_warn_interval == 0) return;
+    if (last_timer_check.tv_sec == 0) {
+        gettimeofday(&last_timer_check, NULL);
+        return;
+    }
 
     int ms, need_pstack = 0;
     struct timeval now, diff;
@@ -1640,7 +1644,7 @@ static void *rd_worker(void *data)
 {
     struct event_info *e = data;
     char thdname[16];
-    snprintf(thdname, sizeof(thdname), "rd:%s", e->host);
+    snprintf(thdname, sizeof(thdname), "%c:%s", e->service[0], e->host);
     comdb2_name_thread(thdname);
 
     netinfo_type *n = e->net_info->netinfo_ptr;


### PR DESCRIPTION
Fixes pstack on startup
Adds r:eplication or o:ffloadsql in thd-names.