### PR TITLE
Unregister modsnap txns from crashed clients

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5289,6 +5289,11 @@ void cleanup_clnt(struct sqlclntstate *clnt)
     Pthread_mutex_destroy(&clnt->state_lk);
     Pthread_mutex_destroy(&clnt->sql_tick_lk);
     Pthread_mutex_destroy(&clnt->sql_lk);
+
+    if (clnt->modsnap_registration) {
+        bdb_unregister_modsnap(thedb->bdb_env, clnt->modsnap_registration);
+        clnt->modsnap_registration = NULL;
+    }
 }
 
 int gbl_unexpected_last_type_warn = 1;

--- a/tests/logdelete.test/runit
+++ b/tests/logdelete.test/runit
@@ -32,6 +32,38 @@ function count_archive
     cdb2sql --tabs ${CDB2_OPTIONS} --host $master $dbnm 'exec procedure sys.cmd.send("bdb log_archive")' | egrep 'log.00000' | wc -l
 }
 
+# Runs two snapshot transactions.
+#
+# One of them is killed
+# The other one finishes normally
+#
+# Since both transactions terminate, neither should hold up log deletion.
+function do_snapshot_setup
+{
+    # Create a transaction and kill it
+    cdb2sql ${CDB2_OPTIONS} ${dbnm} default - &> /dev/null <<EOF &
+set transaction snapshot isolation
+begin
+select 1
+select sleep(1000)
+commit
+EOF
+    local -r snapshot_query_to_kill=$!
+    sleep 1
+    kill -9 ${snapshot_query_to_kill}
+
+    # Create a transaction and let it exit normally
+    cdb2sql ${CDB2_OPTIONS} ${dbnm} default - &> /dev/null <<EOF
+set transaction snapshot isolation
+begin
+select 1
+commit
+EOF
+}
+
+if [[ "$TESTCASE" == "logdelete_snapshot_generated" ]]; then
+    do_snapshot_setup
+fi
 
 # Let the test
 while [[ "$seen_archives" -eq "0" && "$count" -lt "$seen_iter" ]]


### PR DESCRIPTION
There is a bug where a modsnap transaction isn't removed from the database's list of outstanding modsnap transactions if the client crashes. This holds up log deletion.

The changes in this PR expose and fix the bug.