### PR TITLE
Make sure that the writer thread waiting list is bound to 25msec

### DIFF
--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -199,7 +199,14 @@ retry:
             iq->usedb = iq->origdb;
 
             n_retries++;
-            deadlocksleepus = (rand() % gbl_maxwthreads * avg_toblock_us);
+            
+            /* avg_tolock_us is updated without a lock; make sure it stays in [0..25msec]
+             * re:177309919
+             */
+            int localwait = avg_toblock_us;
+            if (localwait < 0 || localwait > 25000)
+                localwait = 25000;
+            deadlocksleepus = (rand() % gbl_maxwthreads * localwait);
             /* usleep(0) will likely give up the CPU. Avoid it. */
             if (deadlocksleepus != 0)
                 usleep(deadlocksleepus);


### PR DESCRIPTION
Per title: quick patch for avg_toblock_us (static variable can become negative and we wait forever)
Re: 177309919