### PR TITLE
Verify default value functions with sqlite

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -51,6 +51,7 @@ int compute_all_data(int tidx);
 int comdb2_iam_master();
 
 extern int gbl_ready;
+extern int gbl_create_mode;
 
 char *revision = "$Revision: 1.24 $";
 int unionflag = 0;
@@ -97,6 +98,7 @@ static int dyns_field_depth_comn(char *tag, int fidx, dpth_t *dpthinfo,
 int gbl_legacy_schema = 0;
 int gbl_check_constraint_feature = 1;
 int gbl_default_function_feature = 1;
+int gbl_verify_default_function = 1;
 int gbl_on_del_set_null_feature = 1;
 int gbl_sequence_feature = 1;
 
@@ -1381,6 +1383,7 @@ void datakey_piece_add(char *buf) {
 }
 
 extern int is_valid_datetime(const char *str, const char *tz);
+extern void create_verify_dbstore_clientfunc(const char *str);
 
 void rec_c_add(int typ, int size, char *name, char *cmnt)
 {
@@ -1576,7 +1579,21 @@ void rec_c_add(int typ, int size, char *name, char *cmnt)
                 any_errors++;
                 return;
             }
-        } else
+        } else {
+            int verify_dbstore_client_function(const char *dbstore);
+            if (fopt->valtype == CLIENT_FUNCTION && fopt->opttype != FLDOPT_NULL && gbl_verify_default_function) {
+                if (gbl_ready) {
+                    if (verify_dbstore_client_function(fopt->value.strval) != 0) {
+                        csc2_error("Error at line %3d: INVALID DBSTORE FUNCTION FOR %s\n", current_line, name);
+                        csc2_syntax_error("Error at line %3d: INVALID DBSTORE FUNCTION FOR %s\n", current_line, name);
+                        any_errors++;
+                        return;
+                    }
+                } else if (gbl_create_mode) {
+                    create_verify_dbstore_clientfunc(fopt->value.strval);
+                }
+                /* Otherwise assume it was verified when it was created */
+            }
             switch (typ) {
             case T_LOGICAL:
             case T_UINTEGER2:
@@ -1708,6 +1725,7 @@ void rec_c_add(int typ, int size, char *name, char *cmnt)
                 any_errors++;
                 return;
             }
+        }
 
         for (j = 0; j < nfieldopt; j++) {
             if (j == i)

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3649,6 +3649,7 @@ void dump_client_sql_data(struct reqlogger *logger, int do_snapshot);
 
 int backout_schema_changes(struct ireq *iq, tran_type *tran);
 int bplog_schemachange(struct ireq *iq, blocksql_tran_t *tran, void *err);
+int verify_dbstore_client_function(const char *dbstore);
 
 extern int gbl_abort_invalid_query_info_key;
 extern int gbl_is_physical_replicant;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -318,6 +318,7 @@ extern int gbl_sc_pause_at_end;
 extern int gbl_sc_is_at_end;
 extern int gbl_max_password_cache_size;
 extern int gbl_check_constraint_feature;
+extern int gbl_verify_default_function;
 extern int gbl_default_function_feature;
 extern int gbl_on_del_set_null_feature;
 extern int gbl_sequence_feature;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -175,6 +175,8 @@ REGISTER_TUNABLE("default_datetime_precision", NULL,
 */
 REGISTER_TUNABLE("default_function_feature", "Enables support for SQL function as default value in column definitions (Default: ON)",
                  TUNABLE_BOOLEAN, &gbl_default_function_feature, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("verify_default_function", "Verify default function at schema-change.  (Default: on)", TUNABLE_BOOLEAN,
+                 &gbl_verify_default_function, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("dir",
                  "Database directory. (Default: $COMDB2_ROOT/var/cdb2/$DBNAME)",
                  TUNABLE_STRING, &db->basedir, READONLY, NULL, NULL, NULL,

--- a/db/sql.h
+++ b/db/sql.h
@@ -955,6 +955,8 @@ struct sqlclntstate {
 
     int lastresptype;
     char *externalAuthUser;
+
+    unsigned verify_dbstore : 1;
 };
 
 /* Query stats. */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12551,6 +12551,26 @@ static int run_verify_indexes_query(char *sql, struct schema *sc, Mem *min,
     return rc;
 }
 
+static int run_verify_dbstore_function(char *sql)
+{
+    struct schema_mem sm = {0};
+
+    struct sqlclntstate clnt;
+    start_internal_sql_clnt(&clnt);
+    clnt.dbtran.mode = TRANLEVEL_SOSQL;
+    clnt.sql = sql;
+    clnt.admin = gbl_force_writesql;
+    clnt.schema_mems = &sm;
+    clnt.verify_dbstore = 1;
+
+    int rc = dispatch_sql_query(&clnt);
+    rc = rc ? rc : clnt.had_errors;
+
+    end_internal_sql_clnt(&clnt);
+
+    return rc;
+}
+
 unsigned long long verify_indexes(struct dbtable *db, uint8_t *rec,
                                   blob_buffer_t *blobs, size_t maxblobs,
                                   int is_alter)
@@ -12909,6 +12929,25 @@ struct temptable get_tbl_by_rootpg(const sqlite3 *db, int i)
     hash_t *h = db->aDb[1].pBt[0].temp_tables;
     struct temptable *t = hash_find(h, &i);
     return *t;
+}
+
+/* Verify dbstore client function
+ * @return
+ *     0  : Success
+ *    -1  : Failed
+ */
+int verify_dbstore_client_function(const char *dbstore)
+{
+    int rc = 0;
+    strbuf *sql;
+
+    sql = strbuf_new();
+    strbuf_appendf(sql, "TESTDEFAULT (%s)", dbstore);
+
+    rc = run_verify_dbstore_function((char *)strbuf_buf(sql));
+
+    strbuf_free(sql);
+    return rc ? -1 : 0;
 }
 
 /* Verify all CHECK constraints against this record.

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3182,11 +3182,16 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
 int get_prepared_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                       struct sql_state *rec, struct errstat *err, int flags)
 {
-    curtran_assert_nolocks();
-    rdlock_schema_lk();
+    /* sc-thread holds schema-lk in verify_dbstore */
+    if (!clnt->verify_dbstore) {
+        curtran_assert_nolocks();
+        rdlock_schema_lk();
+    }
     int rc = get_prepared_stmt_int(thd, clnt, rec, err,
                                    flags | PREPARE_RECREATE);
-    unlock_schema_lk();
+    if (!clnt->verify_dbstore) {
+        unlock_schema_lk();
+    }
     if (gbl_stable_rootpages_test) {
         static int skip = 0;
         if (!skip) {
@@ -4330,7 +4335,7 @@ check_version:
 
     if (!thd->sqldb || (rc == SQLITE_SCHEMA_REMOTE)) {
         /* need to refresh things; we need to grab views lock */
-        if (!got_views_lock) {
+        if (!got_views_lock && !clnt->verify_dbstore) {
             unlock_schema_lk();
 
             if (!clnt->dbtran.cursor_tran) {

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -5153,6 +5153,21 @@ oom:
     return;
 }
 
+void comdb2TestDefault(
+    Parse *pParse,      /* Parsing context */
+    Expr *pExpr,        /* The parsed expression of the default value */
+    const char *zStart, /* Start of the default value text */
+    const char *zEnd    /* First character past end of defaut value text */
+)
+{
+    sqlite3 *db = pParse->db;
+    if( !sqlite3ExprIsConstantOrFunction(pExpr, db->init.busy) ){
+        sqlite3ErrorMsg(pParse, "default value is not constant");
+        return;
+    }
+    return;
+}
+
 void comdb2AddDefaultValue(
     Parse *pParse,      /* Parsing context */
     Expr *pExpr,        /* The parsed expression of the default value */

--- a/sqlite/src/comdb2build.h
+++ b/sqlite/src/comdb2build.h
@@ -69,6 +69,7 @@ void comdb2CreateTableEnd(Parse *, Token *, Token *, u8, int);
 void comdb2CreateTableLikeEnd(Parse *, Token *, Token *);
 void comdb2AddColumn(Parse *, Token *, Token *);
 void comdb2AddDefaultValue(Parse *, Expr *, const char *, const char *);
+void comdb2TestDefault(Parse *, Expr *, const char *, const char *);
 void comdb2AddNull(Parse *);
 void comdb2SetAutoIncrement(Parse *);
 void comdb2AddNotNull(Parse *, int);

--- a/sqlite/src/parse.y
+++ b/sqlite/src/parse.y
@@ -351,7 +351,7 @@ columnname(A) ::= nm(A) typetoken(Y). {sqlite3AddColumn(pParse,&A,&Y);}
   PAGEORDER PARTITIONED PASSWORD PAUSE PERIOD PENDING PROCEDURE PUT
   REBUILD READ READONLY REC RESERVED RESUME RETENTION REVOKE RLE ROWLOCKS
   SCALAR SCHEMACHANGE SKIPSCAN START SUMMARIZE
-  THREADS THRESHOLD TIME TRUNCATE TUNABLE TYPE
+  TESTDEFAULT THREADS THRESHOLD TIME TRUNCATE TUNABLE TYPE
   VERSION WRITE DDL USERSCHEMA ZLIB
 %endif SQLITE_BUILDING_FOR_COMDB2
   .
@@ -2464,6 +2464,13 @@ analyze_sumthds(A) ::= SUMMARIZE INTEGER(X). {
     SET_ANALYZE_SUMTHREAD(A,tmp);
 }
 
+//////////////////////////////// TESTDEFAULT //////////////////////////////////
+//
+%ifdef SQLITE_BUILDING_FOR_COMDB2
+cmd ::= TESTDEFAULT LP(A) expr(X) RP(Z). {
+                            {comdb2TestDefault(pParse,X,A.z+1,Z.z);}
+}
+%endif SQLITE_BUILDING_FOR_COMDB2
 //////////////////////////////// REBUILD TABLE ////////////////////////////////
 
 %type comdb2opt {int}

--- a/sqlite/tool/mkkeywordhash.c
+++ b/sqlite/tool/mkkeywordhash.c
@@ -400,6 +400,7 @@ static Keyword aKeywordTable[] = {
   { "SKIPSCAN",          "TK_SKIPSCAN",          ALWAYS           },
   { "START",             "TK_START",             ALWAYS           },
   { "SUMMARIZE",         "TK_SUMMARIZE",         ALWAYS           },
+  { "TESTDEFAULT",       "TK_TESTDEFAULT",       ALWAYS           },
   { "THREADS",           "TK_THREADS",           ALWAYS           },
   { "THRESHOLD",         "TK_THRESHOLD",         ALWAYS           },
   { "TIME",              "TK_TIME",              ALWAYS           },

--- a/tests/auth.test/t09.expected
+++ b/tests/auth.test/t09.expected
@@ -192,6 +192,7 @@
 (candidate='TABLE')
 (candidate='TEMP')
 (candidate='TEMPORARY')
+(candidate='TESTDEFAULT')
 (candidate='THEN')
 (candidate='THREADS')
 (candidate='THRESHOLD')

--- a/tests/comdb2sys.test/comdb2sys.expected
+++ b/tests/comdb2sys.test/comdb2sys.expected
@@ -81,11 +81,11 @@
 (tablename='t3', bytes=73728)
 (tablename='t4', bytes=73728)
 [select * from comdb2_tablesizes order by tablename] rc 0
-(KEYWORDS_COUNT=222)
+(KEYWORDS_COUNT=223)
 [SELECT COUNT(*) AS KEYWORDS_COUNT FROM comdb2_keywords] rc 0
 (RESERVED_KW=66)
 [SELECT COUNT(*) AS RESERVED_KW FROM comdb2_keywords WHERE reserved = 'Y'] rc 0
-(NONRESERVED_KW=156)
+(NONRESERVED_KW=157)
 [SELECT COUNT(*) AS NONRESERVED_KW FROM comdb2_keywords WHERE reserved = 'N'] rc 0
 (name='ALL', reserved='Y')
 (name='ALTER', reserved='Y')
@@ -292,6 +292,7 @@
 (name='SUMMARIZE', reserved='N')
 (name='TEMP', reserved='N')
 (name='TEMPORARY', reserved='N')
+(name='TESTDEFAULT', reserved='N')
 (name='THREADS', reserved='N')
 (name='THRESHOLD', reserved='N')
 (name='TIES', reserved='N')

--- a/tests/sc_dbstore_func.test/output.expected
+++ b/tests/sc_dbstore_func.test/output.expected
@@ -17,3 +17,10 @@
 1
 -- Verify records again after full rebuild --
 1
+-- This schema change should fail on invalid default value --
+[CREATE TABLE t1 { schema { cstring s[33] dbstore={bogus} } }] failed with rc 240 Error at line   0: INVALID DBSTORE FUNCTION FOR s
+
+-- The following schema change should succeed --
+-- This verifies that alter also fails on an invalid default value --
+[ALTER TABLE t1 { schema { cstring s[33] dbstore={bogus} } }] failed with rc 240 Error at line   0: INVALID DBSTORE FUNCTION FOR s
+

--- a/tests/sc_dbstore_func.test/runit
+++ b/tests/sc_dbstore_func.test/runit
@@ -29,6 +29,67 @@ SELECT COUNT(*) FROM t1 WHERE b IS NOT NULL
 SELECT "-- Verify records again after full rebuild --"
 REBUILD t1
 SELECT COUNT(*) FROM t1 WHERE b IS NOT NULL
+DROP TABLE t1
+SELECT "-- This schema change should fail on invalid default value --"
+CREATE TABLE t1 { schema { cstring s[33] dbstore={bogus} } }\$\$
+SELECT "-- The following schema change should succeed --"
+CREATE TABLE t1 { schema { cstring s[33] dbstore={hex(GUID())} } }\$\$
+SELECT "-- This verifies that alter also fails on an invalid default value --"
+ALTER TABLE t1 { schema { cstring s[33] dbstore={bogus} } }\$\$
 EOF
 
 diff output.actual output.expected
+
+# Make sure we can create a new db which specifies a client-function dbstore, 
+# but that we fail to create a new db which has an invalid dbstore function.
+function create_database_with_table()
+{
+    DB=$1
+    CSC2=$2
+    GREPTRACE=$3
+    NEWDBDIR=${DBDIR}/${DB}
+    mkdir -p $NEWDBDIR >/dev/null 2>&1
+    cp ${CSC2}.csc2 $NEWDBDIR
+    echo "name $DB" > $NEWDBDIR/$DB.lrl
+    echo "dir ${NEWDBDIR}" >> $NEWDBDIR/$DB.lrl
+    echo "table $CSC2 $NEWDBDIR/${CSC2}.csc2" >> $NEWDBDIR/$DB.lrl
+    ${COMDB2_EXE} ${DB} --create --dir ${NEWDBDIR} --lrl $NEWDBDIR/$DB.lrl &> out
+    egrep "$GREPTRACE" out
+    if [[ $? -ne 0 ]]; then
+        cat out
+        echo "Failed to find $GREPTRACE in output"
+        exit 1
+    fi
+}
+
+function start_and_stop_db()
+{
+    DB=$1
+    NEWDBDIR=${DBDIR}/${DB}
+    ${COMDB2_EXE} ${DB} --dir ${NEWDBDIR} --lrl $NEWDBDIR/$DB.lrl &> out &
+    PID=$!
+
+    # Wait for "I AM READY", or timeout
+    ready=0
+    while [[ "$ready" == "0" ]]; do
+        grep "I AM READY" out &> /dev/null
+        if [[ $? == 0 ]]; then
+            ready=1
+        else
+            sleep 1
+        fi
+    done
+
+    echo "Database could start successfully"
+    kill -9 $PID
+}
+
+# Verify that a bad dbstore client function fails on create
+create_database_with_table bad${DBNAME} t1_bad "Failed to verify dbstore client function"
+
+# Verify that a good dbstore client function succeeds on create
+create_database_with_table good${DBNAME} t1_good "Created database" 
+
+# Verify that good-dbstore client function can start
+start_and_stop_db good${DBNAME}
+

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1057,6 +1057,7 @@
 (name='verbose_waiter_flag', description='Print trace setting the waiter flag in lock code', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_all_pools', description='verify objects are returned to the correct pools', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_dbreg', description='Periodically check if dbreg entries are correct', type='BOOLEAN', value='OFF', read_only='N')
+(name='verify_default_function', description='Verify default function at schema-change.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='verify_directio', description='Run expensive checks on directio calls', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_master_lease_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='verify_pool_maxt', description='Max Number of verify threads in the thrd pool.', type='INTEGER', value='8', read_only='N')


### PR DESCRIPTION
Schemachange utilizes 'TESTDEFAULT' command to verify that the client-function is valid.  This is the 8.0 version of https://github.com/bloomberg/comdb2/pull/4837
