### PR TITLE
use the openssl EVP API for SHA1 and AES instead of the deprecated lo…

### DIFF
--- a/berkdb/dbinc/crypto.h
+++ b/berkdb/dbinc/crypto.h
@@ -70,8 +70,8 @@ typedef struct __cipher {
 #define	DB_AES_CHUNK	16	/* AES byte unit size */
 
 typedef struct __aes_cipher {
-	AES_KEY	decrypt_key;	/* Decryption key instance */
-	AES_KEY	encrypt_key;	/* Encryption key instance */
+    EVP_CIPHER_CTX *encrypt_ctx;
+    EVP_CIPHER_CTX *decrypt_ctx;
 } AES_CIPHER;
 
 #include "dbinc_auto/crypto_ext.h"


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?

This is sort of a bug-fix, but also improves security

* What are the current behavior and expected behavior, if this is a bugfix ?

Current behaviour is that you use a `#pragma` to remove warnings about using deprecated openssl features. This fix implements non-deprecated usage of the EVP APIs of openssl.

* What are the steps required to reproduce the bug, if this is a bugfix ?

Try building and testing with the new code. Behaviour should be unchanged (still using AES and SHA-1 for encryption and key stretching) but the build should work correctly while not using the `#pragma`.

* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?

This new behaviour is better as it is more future-proof use of openssl, and is a more secure way to use the openssl APIs.
