### PR TITLE
Fix max col name length off by 1 err

### DIFF
--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -3141,10 +3141,8 @@ static int dyns_get_field_info_comn(char *tag, int fidx, char *name,
     if (type != NULL) {
         *type = field_type(tables[tidx].sym[fidx].type, use_server_types);
     }
-    if (name != NULL) {
-        bzero(name, namelen);
-        strncpy(name, tables[tidx].sym[fidx].nm, namelen);
-    }
+    if (name != NULL)
+        snprintf(name, namelen, "%s", tables[tidx].sym[fidx].nm);
     if (offset != NULL) {
         *offset = tables[tidx].sym[fidx].off;
     }

--- a/tests/column_names_length.test/t01.expected
+++ b/tests/column_names_length.test/t01.expected
@@ -1,0 +1,4 @@
+(version='v1')
+(rows inserted=1)
+(thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthel=1)
+(thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthel=1)

--- a/tests/column_names_length.test/t01.sql
+++ b/tests/column_names_length.test/t01.sql
@@ -1,0 +1,13 @@
+create procedure col_names_func version 'v1' {
+local function main()
+    local dbtable, rc = db:prepare("SELECT * from t;")
+    dbtable:emit()
+end
+}$$
+
+PUT TUNABLE return_long_column_names 1;
+CREATE TABLE t(thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydog108 int)$$
+INSERT INTO t VALUES(1);
+-- should truncate column name to 99 chars
+SELECT * FROM t;
+EXEC PROCEDURE col_names_func();


### PR DESCRIPTION
namelen is size of buf. Since strncpy adds \0 at end should be namelen - 1

Current behavior truncates long col names to 100 chars with no NULL
This fix truncates to 99 chars with NULL at end

Previously had buffer overflow
```
@testdb> select * from top
(thequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthelazydogthequickbrownfoxjumpsoverthela�=1)
```