### PR TITLE
Tranlog timeouts protect heavily written physreps

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -460,6 +460,7 @@ extern int gbl_debug_invalid_genid;
 
 /* Tranlog */
 extern int gbl_tranlog_incoherent_timeout;
+extern int gbl_tranlog_default_timeout;
 extern int gbl_tranlog_maxpoll;
 
 /* Physical replication */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1780,6 +1780,8 @@ REGISTER_TUNABLE("blocking_physrep",
                  "Physical replicant blocks on select. (Default: false)",
                  TUNABLE_BOOLEAN, &gbl_blocking_physrep, 0, NULL, NULL, NULL,
                  NULL);
+REGISTER_TUNABLE("tranlog_default_timeout", "Default timeout for tranlog queries.  (Default: 30)", TUNABLE_INTEGER,
+                 &gbl_tranlog_default_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("tranlog_incoherent_timeout", "Timeout in seconds for incoherent tranlog. (Default: 10)",
                  TUNABLE_INTEGER, &gbl_tranlog_incoherent_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("tranlog_maxpoll", "Tranlog timeout in seconds for blocking poll. (Default: 60)", TUNABLE_INTEGER,

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1064,6 +1064,32 @@ function run_tests()
     done
 }
 
+function tranlog_timeout()
+{
+    typeset begin
+    typeset end
+    echo "== tranlog timeout test"
+
+    # Set timeout for 5 seconds - this should succeed if total time is between 5 and 7 seconds
+    echo "Testing timeout of 5 seconds"
+    begin=$(date +%s)
+    cdb2sql ${CDB2_OPTIONS} $DBNAME default "select * from comdb2_transaction_logs(NULL, NULL, 1, 5)" > /dev/null
+    end=$(date +%s)
+    total=$(( end - begin ))
+    if [[ $total -lt 5 || $total -gt 7 ]]; then
+        cleanFailExit "tranlog timeout test failed, total time $total wanted 5"
+    fi
+
+    echo "Testing default timeout - should be 30 seconds"
+    begin=$(date +%s)
+    cdb2sql ${CDB2_OPTIONS} $DBNAME default "select * from comdb2_transaction_logs(NULL, NULL, 1)" > /dev/null
+    end=$(date +%s)
+    total=$(( end - begin ))
+    if [[ $total -lt 29 || $total -gt 35 ]]; then
+        cleanFailExit "tranlog timeout test failed, total time $total wanted 30"
+    fi
+}
+
 function revconn_latency()
 {
     typeset now=$(date +%s)
@@ -1211,6 +1237,7 @@ if [[ "$NOSOURCE" == "1" ]]; then
     restart_source_nodes
 fi
 
+tranlog_timeout
 revconn_latency $lastNode
 revconn_latency $firstNode
 generate_tests

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1006,6 +1006,7 @@
 (name='track_replication_times', description='Track how long each replicant takes to ack all transactions.', type='BOOLEAN', value='ON', read_only='N')
 (name='track_replication_times_max_lsns', description='Track replication times for up to this many transactions.', type='INTEGER', value='50', read_only='N')
 (name='tracked_locklist_init', description='Initial allocation count for tracked locks', type='INTEGER', value='10', read_only='N')
+(name='tranlog_default_timeout', description='Default timeout for tranlog queries.  (Default: 30)', type='INTEGER', value='30', read_only='N')
 (name='tranlog_incoherent_timeout', description='Timeout in seconds for incoherent tranlog. (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='tranlog_maxpoll', description='Tranlog timeout in seconds for blocking poll. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='transaction_grace_period', description='Time to wait for connections with pending transactions to go away on exit. (Default: 60)', type='INTEGER', value='60', read_only='N')


### PR DESCRIPTION
Heavily written physical replicants can fall into the 'drain-cursor' case without hitting the incoherent or no-record timeouts.  This PR addresses the issue by providing a timeout argument and default value of 30 seconds.