### PR TITLE
Usleep macro that sleeps no more than 1 second

### DIFF
--- a/bdb/berktest.c
+++ b/bdb/berktest.c
@@ -12,6 +12,7 @@
 #include <gettimeofday_ms.h>
 #include <errno.h>
 #include <logmsg.h>
+#include <sys_wrap.h>
 
 static DB_ENV *dbenv = NULL;
 static u_int32_t commit_delay_ms = 2;
@@ -218,7 +219,7 @@ static void run_test(berktable_t *tables, int tablecount, int txnsize,
         }
 
         if (commit_delay_ms) {
-            usleep(commit_delay_ms * 1000);
+            Usleep(commit_delay_ms * 1000);
         }
     }
 

--- a/bdb/fstdump.c
+++ b/bdb/fstdump.c
@@ -1204,7 +1204,7 @@ static int close_retry(DBC *dbcp, fstdump_t *common)
         if (rc != DB_LOCK_DEADLOCK)
             break;
         if (++retries > deadlock_sleep_start)
-            usleep(deadlock_sleep_amt);
+            Usleep(deadlock_sleep_amt);
     }
     if (retries == gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "ERROR - TOO MUCH CONTENTION (dbcp->c_close)\n");
@@ -1240,7 +1240,7 @@ static int get_retry(DBC *dbcp, fstdump_t *common, DBT *key, DBT *data,
             break;
 
         if (++retries > deadlock_sleep_start)
-            usleep(deadlock_sleep_amt);
+            Usleep(deadlock_sleep_amt);
     }
     if (retries == gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "ERROR - TOO MUCH CONTENTION (dbcp->c_get)\n");
@@ -1287,7 +1287,7 @@ static int open_retry(DBC **dbcp, fstdump_per_thread_t *fstdump,
             break;
 
         if (++retries > deadlock_sleep_start)
-            usleep(deadlock_sleep_amt);
+            Usleep(deadlock_sleep_amt);
     }
     if (retries == gbl_maxretries) {
         logmsg(LOGMSG_ERROR, "ERROR - TOO MUCH CONTENTION (dbp->cursor)\n");

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3965,7 +3965,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control, D
         poll(NULL, 0, (bdb_state->attr->repsleep));
 
     if (bdb_state->attr->rep_debug_delay > 0)
-        usleep(bdb_state->attr->rep_debug_delay * 1000);
+        Usleep(bdb_state->attr->rep_debug_delay * 1000);
 
     rem_rep_mon(&rm);
     time2 = comdb2_time_epoch();

--- a/bdb/threads.c
+++ b/bdb/threads.c
@@ -142,7 +142,7 @@ void *memp_trickle_thread(void *arg)
 
         if (db_is_exiting())
             break;
-        usleep(time);
+        Usleep(time);
     }
 
     bdb_thread_event(bdb_state, 0);

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -1224,7 +1224,7 @@ __get_page_latch_int(lt, locker, flags, obj, lock_mode, lock)
 				while (pollcnt++ < latch_max_poll &&
 				    ((ret = pthread_mutex_trylock(&latch->
 						lock)) != 0))
-					usleep(latch_poll_us);
+					Usleep(latch_poll_us);
 			}
 
 			if (ret) {

--- a/berkdb/mp/mp_fget.c
+++ b/berkdb/mp/mp_fget.c
@@ -1052,7 +1052,7 @@ __memp_send_sparse_page_thread(_)
                     pgno, &dbt, gbl_pg_compact_thresh) == 0) {
 			send_pg_compact_req(bdb_state, fileid, dbt.size, dbt.data);
 			if (gbl_pg_compact_latency_ms > 0)
-				usleep(gbl_pg_compact_latency_ms * 1000LL);
+				Usleep(gbl_pg_compact_latency_ms * 1000LL);
 		}
 		__os_free(dbenv, dbt.data);
 	}

--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -2932,7 +2932,7 @@ do_ckp:
 		ckp_lsn = prepared;
 	}
 	if (unlikely(gbl_ckp_sleep_before_sync > 0))
-		usleep(gbl_ckp_sleep_before_sync * 1000LL);
+		Usleep(gbl_ckp_sleep_before_sync * 1000LL);
 
 	ckp_lsn_sav = ckp_lsn;
 	/* If flag is DB_FORCE, don't run perfect checkpoints. */

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1355,7 +1355,7 @@ int bplog_schemachange_wait(struct ireq *iq, int rc)
                 int bdberr = 0;
                 live_sc_off(sc->db);
                 while (sc->logical_livesc) {
-                    usleep(200);
+                    Usleep(200);
                 }
                 if (sc->db->sc_live_logical) {
                     bdb_clear_logical_live_sc(sc->db->handle, 1);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -4090,7 +4090,7 @@ int osql_send_usedb(osql_target_t *target, unsigned long long rqid, uuid_t uuid,
     if (d_ms) {
         logmsg(LOGMSG_DEBUG, "Sleeping for DELAY_AFTER_SAVEOP_USEDB (%dms)\n",
                d_ms);
-        usleep(1000 * d_ms);
+        Usleep(1000 * d_ms);
     }
 
     return rc;

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -887,7 +887,7 @@ static int osql_sock_restart(struct sqlclntstate *clnt, int maxretries,
         retries++;
         /* if we're shaking really badly, back off */
         if (retries > 1)
-            usleep(retries * 10000); // sleep for a multiple of 10ms
+            Usleep(retries * 10000); // sleep for a multiple of 10ms
 
         sentops = 0;
 
@@ -1754,7 +1754,7 @@ static int osql_send_recordgenid_logic(struct BtCursor *pCur,
             rc = osql_send_recordgenid(&osql->target, osql->rqid, osql->uuid,
                                        genid, nettype);
             if (gbl_master_swing_sock_restart_sleep) {
-                usleep(gbl_master_swing_sock_restart_sleep * 1000);
+                Usleep(gbl_master_swing_sock_restart_sleep * 1000);
             }
         }
         RESTART_SOCKSQL;

--- a/db/pushlogs.c
+++ b/db/pushlogs.c
@@ -149,7 +149,7 @@ static void *pushlogs_thread(void *voidarg)
 
         /* throttle this */
         if (delayms)
-            usleep(delayms * 1000);
+            Usleep(delayms * 1000);
     }
 
     if (nwrites > 0) {

--- a/db/record.c
+++ b/db/record.c
@@ -193,7 +193,7 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
             if (iq->debug)
                 reqprintf(iq, "Sleeping for DELAY_WRITES_IN_RECORD_C (%dms)",
                           d_ms);
-            int lrc = usleep(1000 * d_ms);
+            int lrc = Usleep(1000 * d_ms);
             if (lrc)
                 reqprintf(iq, "usleep error rc %d errno %d\n", rc, errno);
         }
@@ -884,7 +884,7 @@ int upd_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (d_ms) {
         if (iq->debug)
             reqprintf(iq, "Sleeping for %d ms", d_ms);
-        usleep(1000 * d_ms);
+        Usleep(1000 * d_ms);
     }
 
     if (!(flags & RECFLAGS_DONT_LOCK_TBL)) {
@@ -1715,7 +1715,7 @@ int del_record(struct ireq *iq, void *trans, void *primkey, int rrn,
     if (d_ms) {
         if (iq->debug)
             reqprintf(iq, "Sleeping for %d ms", d_ms);
-        usleep(1000 * d_ms);
+        Usleep(1000 * d_ms);
     }
 
     if (!is_event_from_sc(flags)) {

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -231,7 +231,7 @@ retry:
             deadlocksleepus = (rand() % gbl_maxwthreads * localwait);
             /* usleep(0) will likely give up the CPU. Avoid it. */
             if (deadlocksleepus != 0)
-                usleep(deadlocksleepus);
+                Usleep(deadlocksleepus);
             goto retry;
         }
 

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -4501,7 +4501,7 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
             if (d_ms) {
                 logmsg(LOGMSG_DEBUG,
                        "Sleeping for DELAY_AFTER_SAVEOP_DONE (%dms)\n", d_ms);
-                usleep(1000 * d_ms);
+                Usleep(1000 * d_ms);
             }
 
             if (!(iq->p_buf_in = packedreq_sql_get(

--- a/net/net.c
+++ b/net/net.c
@@ -2900,7 +2900,7 @@ int net_init(netinfo_type *netinfo_ptr)
         const char *hostlist[REPMAX];
         int retry = 100;
         while (--retry >= 0 && (rc = net_get_all_nodes_connected(netinfo_ptr, hostlist)) < (num - 1)) {
-            usleep(10 * 1000); //10ms
+            Usleep(10 * 1000); //10ms
         }
         gettimeofday(&b, NULL);
         timersub(&b, &a, &c);

--- a/net/testnet.c
+++ b/net/testnet.c
@@ -179,7 +179,7 @@ static void *generator_thd(void *voidarg)
             sleep(1);
         } else {
             dest->send_seqn++;
-            usleep(gbl_usleep);
+            Usleep(gbl_usleep);
         }
     }
 

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -686,7 +686,7 @@ errout:
         }
 
         while (s->logical_livesc) {
-            usleep(200);
+            Usleep(200);
         }
 
         if (db->sc_live_logical) {
@@ -853,7 +853,7 @@ convert_records:
         }
 
         while (s->logical_livesc) {
-            usleep(200);
+            Usleep(200);
         }
 
         if (db->sc_live_logical) {
@@ -921,7 +921,7 @@ int finalize_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     /* wait for logical redo thread to stop */
     while (s->logical_livesc) {
-        usleep(200);
+        Usleep(200);
     }
 
     db->sc_to = newdb;

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -398,7 +398,7 @@ static void delay_sc_if_needed(struct convert_record_data *data,
     if (delay != 0)
         poll(NULL, 0, delay * 5);
     else if (BDB_ATTR_GET(thedb->bdb_attr, SC_FORCE_DELAY))
-        usleep(gbl_sc_usleep);
+        Usleep(gbl_sc_usleep);
 
     /* if sanc list is not ok, snooze for 100 ms */
     if (!net_sanctioned_list_ok(data->from->dbenv->handle_sibling))
@@ -648,12 +648,12 @@ static int convert_record(struct convert_record_data *data)
     }
     if (tbl_had_writes(data)) {
         /* NB: if we return here, writes could block SC forever, so lets not */
-        usleep(gbl_sc_usleep);
+        Usleep(gbl_sc_usleep);
     }
 
     /* if master queue latency increased, slow down*/
     if (gbl_altersc_latency && gbl_altersc_delay_usec > 0)
-        usleep(gbl_altersc_delay_usec);
+        Usleep(gbl_altersc_delay_usec);
 
     if (data->trans == NULL) {
         /* Schema-change writes are always page-lock, not rowlock */
@@ -1240,7 +1240,7 @@ static void *convert_records_thd(struct convert_record_data *data)
             use_rebuild_thr(&data->cmembers->thrcount,
                             &data->cmembers->maxthreads)) {
             /* num thread at max, sleep few microsec then try again */
-            usleep(bdb_attr_get(data->from->dbenv->bdb_attr,
+            Usleep(bdb_attr_get(data->from->dbenv->bdb_attr,
                                 BDB_ATTR_SC_NO_REBUILD_THR_SLEEP));
             continue;
         }
@@ -1846,7 +1846,7 @@ static int upgrade_records(struct convert_record_data *data)
 
         /* snooze for a bit if writes have been coming in */
         if (gbl_sc_last_writer_time >= comdb2_time_epoch() - 5)
-            usleep(gbl_sc_usleep);
+            Usleep(gbl_sc_usleep);
         break;
     } // end of rc check
 

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -424,7 +424,7 @@ void delay_if_sc_resuming(struct ireq *iq)
                    diff);
             printerr = 1; // avoid spew
         }
-        usleep(10000); // 10ms
+        Usleep(10000); // 10ms
     }
 }
 

--- a/sqlite/src/func.c
+++ b/sqlite/src/func.c
@@ -472,7 +472,7 @@ static void usleepFunc(sqlite3_context *context, int argc, sqlite3_value *argv[]
   while( remain > 0 ){
     us = ( remain > 1000000 ) ? 1000000 : remain;
     remain -= us;
-    usleep(us);
+    Usleep(us);
     if( comdb2_sql_tick() )
       break;
   }

--- a/util/sys_wrap.h
+++ b/util/sys_wrap.h
@@ -61,6 +61,19 @@
         rc;                                                                                                            \
     })
 
+#define Usleep(usec)                                                                                                   \
+    ({                                                                                                                 \
+        int rc;                                                                                                        \
+        if ((unsigned int)(usec) <= 1000000) {                                                                         \
+            rc = usleep((usec));                                                                                       \
+        } else {                                                                                                       \
+            logmsg(LOGMSG_ERROR, "usleep argument out of range: %u, capping the value at 1000000\n",                   \
+                   (unsigned int)(usec));                                                                              \
+            rc = usleep(1000000);                                                                                      \
+        }                                                                                                              \
+        rc;                                                                                                            \
+    })
+
 #define Pthread_attr_destroy(...) WRAP_SYSFUNC(pthread_attr_destroy, __VA_ARGS__)
 #define Pthread_attr_init(...) WRAP_SYSFUNC(pthread_attr_init, __VA_ARGS__)
 #define Pthread_attr_setdetachstate(...) WRAP_SYSFUNC(pthread_attr_setdetachstate, __VA_ARGS__)

--- a/util/thdpool.c
+++ b/util/thdpool.c
@@ -294,7 +294,7 @@ int thdpool_destroy(struct thdpool **pool_p, int coopWaitUs)
         unsigned int elapsedUs = 0;
         thdpool_stop(pool);
         while (ATOMIC_LOAD32(pool->nactthd) > 0) {
-            usleep(waitUs);
+            Usleep(waitUs);
             elapsedUs += waitUs;
             if ((coopWaitUs > 0) && (elapsedUs >= (unsigned int)coopWaitUs)) {
                 logmsg(LOGMSG_ERROR,


### PR DESCRIPTION
(Addendum to #4836) This patch adds a Usleep macro to replace usleep(), that ensures we do not sleep more than 1 second.