### PR TITLE
Send authdata to fdb even if auth is not enabled on local db

### DIFF
--- a/db/db_access.c
+++ b/db/db_access.c
@@ -71,10 +71,10 @@ static int check_user_password(struct sqlclntstate *clnt)
     int password_rc = 0;
     int valid_user;
 
+    clnt->authdata = get_authdata(clnt);
     if ((gbl_uses_externalauth || gbl_uses_externalauth_connect) &&
             (externalComdb2AuthenticateUserMakeRequest || debug_switch_ignore_null_auth_func()) &&
             !clnt->admin && !clnt->current_user.bypass_auth) {
-        clnt->authdata = get_authdata(clnt);
         if (!clnt->authdata && clnt->secure && !gbl_allow_anon_id_for_spmux)
             return reject_anon_id(clnt);
         if (gbl_externalauth_warn && !clnt->authdata) {

--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -284,7 +284,7 @@ int handle_fdb_push(struct sqlclntstate *clnt, struct errstat *err)
         return -1;
     }
 
-    if (gbl_uses_externalauth && gbl_fdb_auth_enabled && externalComdb2getAuthIdBlob)
+    if (gbl_fdb_auth_enabled && externalComdb2getAuthIdBlob)
         cdb2_setIdentityBlob(hndl, externalComdb2getAuthIdBlob(clnt->authdata));
 
     rc = cdb2_run_statement(hndl, clnt->sql);

--- a/plugins/remsql/fdb_comm.c
+++ b/plugins/remsql/fdb_comm.c
@@ -41,7 +41,7 @@ extern int gbl_fdb_auth_enabled;
 
 static int fdb_auth_enabled()
 {
-    return (gbl_fdb_auth_enabled && gbl_uses_externalauth);
+    return gbl_fdb_auth_enabled;
 }
 
 void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);


### PR DESCRIPTION
Send authdata to fdb even if auth is not enabled on local db

fdbauth is already enabled by default, however it works only if local db has auth enabled