### PR TITLE
[8.0]{177402625}: Verifying dbstore inline

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -12944,10 +12944,15 @@ int verify_dbstore_client_function(const char *dbstore)
     sql = strbuf_new();
     strbuf_appendf(sql, "TESTDEFAULT (%s)", dbstore);
 
-    rc = run_verify_dbstore_function((char *)strbuf_buf(sql));
+    struct errstat err = {0};
+    run_sql_return_ll((char *)strbuf_buf(sql), &err);
+    if (err.errval != 0) {
+        logmsg(LOGMSG_ERROR, "error verifying dbstore expression (%s): %s\n", dbstore, err.errstr);
+        rc = -1;
+    }
 
     strbuf_free(sql);
-    return rc ? -1 : 0;
+    return rc;
 }
 
 /* Verify all CHECK constraints against this record.


### PR DESCRIPTION
The dbstore verify code dispatches the test query to an SQL thread, which can deadlock itself with in llmeta, as seen below:

```
0  in pthread_cond_wait@@GLIBC_2.3.2
1  in wait_for_sql_query (clnt=clnt@entry=0x7f2effcf98d0)
2  in dispatch_sql_query
3  in run_verify_dbstore_function (sql=0x2b99358 "TESTDEFAULT ((now()))")
4  in verify_dbstore_client_function (dbstore=0x7f2f040697a8 "(now())")
5  in rec_c_add
6  in yyparse
7  in dyns_load_schema_int
8  in dyns_load_schema_string
9  in create_new_dbtable
10 in reload_csc2_schema
11 in reload_schema
12 in _reload_schema
13 in scdone_alter
14 in bdb_scdone_int
15 in handle_scdone

0  in pthread_cond_wait@@GLIBC_2.3.2
1  in __db_pthread_mutex_lock
2  in __lock_get_internal_int
3  in __lock_get_internal
5  in __db_lget
6  in __bam_search
7  in __bam_c_search
8  in __bam_c_get
10 in __db_c_get_dup
11 in __db_c_get
12 in __db_c_get_pp
13 in comdb2__db_c_get_pp
14 in bdb_lite_exact_var_fetch_int
15 in bdb_lite_exact_var_fetch_tran
16 in llmeta_get_blob
18 in bdb_get_table_parameter_tran
19 in get_disable_skipscan
21 in sqlite3AnalysisLoad
22 in reload_analyze
25 in sqlengine_prepare_engine
27 in get_prepared_stmt
28 in get_prepared_bound_stmt
30 in execute_sql_query (clnt=0x7f2effcf98d0)
```
