### PR TITLE
Only enable commit LSN map if a dependent is enabled

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -452,7 +452,7 @@ snap_impl_enum gbl_snap_impl = SNAP_IMPL_MODSNAP;
 int gbl_use_appsock_as_sqlthread = 0;
 int gbl_rep_process_txn_time = 0;
 int gbl_utxnid_log = 1;
-int gbl_commit_lsn_map = 1;
+int gbl_test_commit_lsn_map = 0;
 
 /* how many times we retry osql for verify */
 int gbl_osql_verify_retries_max = 499;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -220,7 +220,7 @@ extern int gbl_catchup_window_trace;
 extern int gbl_early_ack_trace;
 extern int gbl_commit_delay_timeout;
 extern int gbl_commit_delay_copy_ms;
-extern int gbl_commit_lsn_map;
+extern int gbl_test_commit_lsn_map;
 extern int gbl_throttle_logput_trace;
 extern int gbl_fills_waitms;
 extern int gbl_finish_fill_threshold;
@@ -1097,9 +1097,17 @@ static int fdb_default_ver_update(void *context, void *value)
 /* Forward declaration */
 int ctrace_set_rollat(void *unused, void *value);
 
+/*
+ * The map is enabled if all of its dependencies are enabled and
+ * any enabled feature depends on it.
+ */
 int get_commit_lsn_map_switch_value()
 {
-    return gbl_utxnid_log && gbl_commit_lsn_map;
+    const int dependencies_are_enabled = gbl_utxnid_log;
+    const int enabled_dependent_exists = 
+        gbl_test_commit_lsn_map || gbl_use_modsnap_for_snapshot;
+    
+    return dependencies_are_enabled && enabled_dependent_exists;
 }
 
 /* Return the value for sql_tranlevel_default. */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1528,9 +1528,9 @@ REGISTER_TUNABLE("commit_delay_on_copy_ms",
 REGISTER_TUNABLE("commit_delay_trace", "Verbose commit-delays.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_commit_delay_trace,
                  EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("commit_lsn_map", "Maintain a map of transaction commit LSNs. (Default: on)",
-                 TUNABLE_BOOLEAN, &gbl_commit_lsn_map,
-                 NOARG, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("test_commit_lsn_map", "Maintain a map of transaction commit LSNs. (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_test_commit_lsn_map,
+                 NOARG | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("incoherent_slow_inactive_timeout", "Periodically reset slow-nodes to incoherent.  (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_incoherent_slow_inactive_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("set_coherent_state_trace", "Verbose coherency trace.  (Default: off)", TUNABLE_BOOLEAN,

--- a/tests/commit_lsn_map.test/lrl.options
+++ b/tests/commit_lsn_map.test/lrl.options
@@ -1,2 +1,3 @@
 utxnid_log on
+test_commit_lsn_map 1
 berkattr commit_map_debug 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -136,7 +136,6 @@
 (name='collect_before_locking', description='Collect a transaction from the log before acquiring locks.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='commit_delay_on_copy_ms', description='Set automatic delay-ms for commit-delay on copy.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='commit_delay_timeout_seconds', description='Set timeout for commit-delay on copy.  (Default: 10)', type='INTEGER', value='10', read_only='N')
-(name='commit_lsn_map', description='Maintain a map of transaction commit LSNs. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='commit_map_debug', description='Produce debug output in commit lsn map', type='BOOLEAN', value='OFF', read_only='N')
 (name='commitdelay', description='Add a delay after every commit. This is occasionally useful to throttle the transaction rate.', type='INTEGER', value='0', read_only='N')
 (name='commitdelaybehindthresh', description='Call for election again and ask the master to delay commits if we are further than this far behind on startup.', type='INTEGER', value='1048576', read_only='N')


### PR DESCRIPTION
The changes in this PR cause the commit LSN map to be enabled only if a dependent feature is enabled.