### PR TITLE
If we fail to authenticate access to a system table, release views lock.

### DIFF
--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -8047,7 +8047,14 @@ case OP_VOpen: {
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   int comdb2_check_vtab_access(sqlite3*, sqlite3_module*);
   rc = comdb2_check_vtab_access(db, (sqlite3_module*)pModule);
-  if( rc ) goto abort_due_to_error;
+  if( rc ){
+    if (p->crtPartitionLocks>0) {
+      /* release the view lock, if any */
+      extern void views_unlock(void);
+      views_unlock();
+    }
+    goto abort_due_to_error;
+  }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   rc = pModule->xOpen(pVtab, &pVCur);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)


### PR DESCRIPTION
Right now the code leaks a read lock for views.

Fixes auth test timeout (happens only when a failed system table authentication is on the master).