### PR TITLE
Avoid reading llmeta disableskipscan tunable for all tables during analyze stat load.

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -5601,6 +5601,9 @@ int main(int argc, char **argv)
         exit(1);
     }
 
+    /* read disableskipscan here */
+    get_disable_skipscan_all();
+
     /*
       Place a freeze on tunables' registration. This is done to
       avoid multiple re-registration during the creation of temp

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3673,4 +3673,6 @@ void csc2_allow_bools(void);
 void csc2_disallow_bools(void);
 int csc2_used_bools(void);
 
+void get_disable_skipscan_all();
+
 #endif /* !INCLUDED_COMDB2_H */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2594,6 +2594,13 @@ static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     extern volatile int analyze_running_flag;
     if (analyze_running_flag)
         return 0;
+
+    /* a change in disableskipscan comes on replicant as a sc_analyze scdone log
+     * read here the llmeta entries for that tunable (instead of deep down in
+     * sqlite3AnalysisLoad)
+     */
+    get_disable_skipscan_all();
+
     int rc, got_curtran;
     rc = got_curtran = 0;
     if (!clnt->dbtran.cursor_tran) {

--- a/sqlite/src/analyze.c
+++ b/sqlite/src/analyze.c
@@ -145,7 +145,6 @@
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
 #include <logmsg.h>
 int is_comdb2_index_disableskipscan(const char *);
-void get_disable_skipscan_all();
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 
 #if defined(SQLITE_ENABLE_STAT4)
@@ -2442,10 +2441,6 @@ int sqlite3AnalysisLoad(sqlite3 *db, int iDb){
   assert( iDb>=0 && iDb<db->nDb );
   assert( db->aDb[iDb].pBt!=0 );
 
-#if defined(SQLITE_BUILDING_FOR_COMDB2)
-  /* AZ: put disabler loader here */
-  get_disable_skipscan_all();
-#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   /* Clear any prior statistics */
   assert( sqlite3SchemaMutexHeld(db, iDb, 0) );
   for(i=sqliteHashFirst(&pSchema->tblHash); i; i=sqliteHashNext(i)){


### PR DESCRIPTION
Instead, read at the server start and when that tunable changes for any table (which is signaled by a scdone sc_analyze message).

Ported https://github.com/bloomberg/comdb2/pull/4886 to 8.0