### PR TITLE
8.0 - Fix log delete bug that occurs when there's low disk space

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1359,8 +1359,6 @@ int bdb_fetch_last_key_tran(bdb_state_type *bdb_state, tran_type *tran,
 int bdb_rowlock(bdb_state_type *bdb_state, tran_type *tran,
                 unsigned long long genid, int exclusive, int *bdberr);
 
-int bdb_get_low_headroom_count(bdb_state_type *bdb_state);
-
 enum { BDB_LOCK_READ, BDB_LOCK_WRITE };
 
 int bdb_get_locker(bdb_state_type *bdb_state, unsigned int *lid);

--- a/plugins/logdelete/logdelete.c
+++ b/plugins/logdelete/logdelete.c
@@ -58,9 +58,6 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
     backend_update_sync(thedb);
     logdelete_unlock(__func__, __LINE__);
 
-    /* check for after commented out below as well
-    int before_count = bdb_get_low_headroom_count(thedb->bdb_env);
-    */
     before_master = ATOMIC_LOAD32(gbl_master_changes);
     before_sc = gbl_sc_commit_count;
     logmsg(LOGMSG_INFO, "Disabling log file deletion\n");
@@ -136,13 +133,6 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
     if (report_back) {
         /* If we deleted log files during that due to log file deletion
          * then report so */
-        /*
-           int after_count = bdb_get_low_headroom_count(thedb->bdb_env);
-           if(after_count != before_count) {
-           sbuf2printf(sb, "Alert: log files deleted due to low disk
-           headroom\n");
-           }
-         */
         /* (this test is not reliable) */
 
         /* If the master node changed during that then report that too


### PR DESCRIPTION
If nothing can be deleted globally when log deletion is attempted, a node will still calculate what it's willing to delete locally, save it in its memory, and send that out to other cluster nodes [here](https://github.com/bloomberg/comdb2/blob/9dc6829148decaa0b980d79a7e28811bf115874d/bdb/file.c#L4080).

The changes in this PR expose and fix a buggy edge case that occurs when there's nothing that can be deleted globally and a node is low on disk space. In this case, the node will retry log deletion until hitting a retry limit. After hitting the retry limit, the log delete function will exit [here](https://github.com/bloomberg/comdb2/blob/9dc6829148decaa0b980d79a7e28811bf115874d/bdb/file.c#L3714). This exit bypasses the code that saves and sends out the minimum file number that the node is willing to delete locally. Therefore the global low file number may never progress if there's sufficiently low disk space.