### PR TITLE
{176747440}: correctly handling dbinfo under single-port

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -270,6 +270,7 @@ public class Comdb2Connection implements Connection {
     }
 
     public void setAllowPmuxRoute(boolean rte) {
+        hndl.hasAllowPmuxRoute = true;
         hndl.setAllowPmuxRoute(rte);
     }
 
@@ -296,6 +297,7 @@ public class Comdb2Connection implements Connection {
     }
 
     public void setUseIdentity(boolean useIdentity) {
+        hndl.hasUseIdentity = true;
         hndl.setUseIdentity(useIdentity);
     }
 

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -351,6 +351,8 @@ public class Comdb2Handle extends AbstractConnection {
 
     void addHosts(List<String> hosts) {
         myDbHosts.addAll(hosts);
+        /* This should be considered direct-cpu (ie no discovery) */
+        isDirectCpu = true;
     }
 
     void addPorts(List<Integer> ports) {
@@ -1986,7 +1988,8 @@ readloop:
            we're not on it, connect to it. */
         if (prefIdx != -1 && dbHostIdx != prefIdx) {
             io = new SockIO(myDbHosts.get(prefIdx),
-                    myDbPorts.get(prefIdx), tcpbufsz, pmuxrte ? myDbName : null,
+                    pmuxrte ? portMuxPort : myDbPorts.get(prefIdx),
+                    tcpbufsz, pmuxrte ? myDbName : null,
                     soTimeout, connectTimeout);
             if (io.open()) {
                 try {
@@ -2023,7 +2026,7 @@ readloop:
                         || try_node == dbHostConnected)
                     continue;
 
-                io = new SockIO(myDbHosts.get(try_node), myDbPorts.get(try_node),
+                io = new SockIO(myDbHosts.get(try_node), pmuxrte ? portMuxPort : myDbPorts.get(try_node),
                                 tcpbufsz, pmuxrte ? myDbName : null,
                                 soTimeout, connectTimeout);
                 if (io.open()) {
@@ -2066,7 +2069,7 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx),
+            io = new SockIO(myDbHosts.get(dbHostIdx), pmuxrte ? portMuxPort : myDbPorts.get(dbHostIdx),
                             tcpbufsz, pmuxrte ? myDbName : null,
                             soTimeout, connectTimeout);
             if (io.open()) {
@@ -2097,7 +2100,7 @@ readloop:
                     || dbHostIdx == dbHostConnected)
                 continue;
 
-            io = new SockIO(myDbHosts.get(dbHostIdx), myDbPorts.get(dbHostIdx),
+            io = new SockIO(myDbHosts.get(dbHostIdx), pmuxrte ? portMuxPort : myDbPorts.get(dbHostIdx),
                             tcpbufsz, pmuxrte ? myDbName : null, 
                             soTimeout, connectTimeout);
             if (io.open()) {
@@ -2126,7 +2129,7 @@ readloop:
          */
         if (masterIndexInMyDbHosts >= 0) {
             io = new SockIO(myDbHosts.get(masterIndexInMyDbHosts),
-                            myDbPorts.get(masterIndexInMyDbHosts),
+                            pmuxrte ? portMuxPort : myDbPorts.get(masterIndexInMyDbHosts),
                             tcpbufsz, pmuxrte ? myDbName : null,
                             soTimeout, connectTimeout);
             if (io.open()) {
@@ -2155,7 +2158,9 @@ readloop:
         if (!isDirectCpu && refresh_dbinfo_if_failed) {
             try {
                 DatabaseDiscovery.getDbHosts(this, true);
-                reopen(false);
+                /* reset random policy */
+                dbHostIdx = -1;
+                return reopen(false);
             } catch (NoDbHostFoundException e) {
                 logger.log(Level.SEVERE, "Failed to refresh dbinfo", e);
             }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -65,7 +65,8 @@ public class Comdb2Handle extends AbstractConnection {
     boolean hasUserTcpSz;
     int tcpbufsz;
     int age = 180; /* default max age 180 seconds */
-    boolean pmuxrte = false;
+    boolean hasAllowPmuxRoute;
+    boolean pmuxrte = true;
     boolean verifyretry = true;
     boolean stmteffects = true;
     int soTimeout = 5000;
@@ -96,7 +97,8 @@ public class Comdb2Handle extends AbstractConnection {
     private boolean ack = false;
     private boolean skipDrain = false;
     private boolean clearAckOnClose = true;
-    private boolean useIdentity = false;
+    boolean hasUseIdentity;
+    boolean useIdentity = true;
 
     private boolean isRead;
     private String lastSql;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -52,6 +52,31 @@ public class DatabaseDiscovery {
 
     private static final Map<String, TimeAndHosts> comdb2lcldb = new ConcurrentHashMap<>();
 
+    private static boolean value_on_off(String val) {
+        if (val == null)
+            return false;
+
+        if (val.equalsIgnoreCase("on"))
+            return true;
+        if (val.equalsIgnoreCase("true"))
+            return true;
+        if (val.equalsIgnoreCase("yes"))
+            return true;
+        if (val.equalsIgnoreCase("1"))
+            return true;
+
+        if (val.equalsIgnoreCase("off"))
+            return false;
+        if (val.equalsIgnoreCase("false"))
+            return false;
+        if (val.equalsIgnoreCase("no"))
+            return false;
+        if (val.equalsIgnoreCase("0"))
+            return true;
+
+        return false;
+    }
+
     /**
      * Reads information from comdb2db cfg file. Returns true if the minimal
      * necessary information has been gathered. Otherwise, returns false.
@@ -84,6 +109,10 @@ public class DatabaseDiscovery {
                         hndl.myDbHosts.add(tokens[i]);
                         hndl.myDbPorts.add(hndl.overriddenPort);
                     }
+                } else if (tokens[0].equalsIgnoreCase("comdb2_feature")) {
+                    if (tokens[1].equalsIgnoreCase("iam_identity_v6")
+                            && !hndl.hasUseIdentity)
+                        hndl.useIdentity = value_on_off(tokens[2]);
                 } else if (tokens[0].equalsIgnoreCase("comdb2_config")) {
 
                     if (tokens[1].equalsIgnoreCase("default_type")
@@ -128,7 +157,11 @@ public class DatabaseDiscovery {
                     }
                     else if (tokens[1].equalsIgnoreCase("stack_at_open")
                             && !hndl.hasSendStack) {
-                        hndl.sendStack = tokens[2].equalsIgnoreCase("true");
+                        hndl.sendStack = value_on_off(tokens[2]);
+                    }
+                    else if (tokens[1].equalsIgnoreCase("allow_pmux_route")
+                            && !hndl.hasAllowPmuxRoute) {
+                        hndl.pmuxrte = value_on_off(tokens[2]);
                     }
                 } else if (tokens[0].equalsIgnoreCase(hndl.comdb2dbName)) {
                     /**

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -97,15 +97,22 @@ public class DatabaseDiscovery {
 
                 String[] tokens = line.split(":\\s*|=\\s*|,\\s*|\\s+");
 
-                if (tokens.length < 3)
+                if (tokens.length < 2)
                     continue;
 
                 if (tokens[0].equalsIgnoreCase(hndl.myDbName)) {
                     /**
                      * Gets dunumber and hosts of the actual database.
                      */
-                    hndl.myDbNum = Integer.parseInt(tokens[1]);
-                    for (int i = 2; i < tokens.length; ++i) {
+                    int i = 1;
+                    try {
+                        /* db number is only optional */
+                        hndl.myDbNum = Integer.parseInt(tokens[i]);
+                        ++i;
+                    } catch (NumberFormatException e) {
+                        hndl.myDbNum = -1;
+                    }
+                    for (; i < tokens.length; ++i) {
                         hndl.myDbHosts.add(tokens[i]);
                         hndl.myDbPorts.add(hndl.overriddenPort);
                     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/SockIO.java
@@ -154,7 +154,10 @@ public class SockIO implements IO {
                 /* Errors are handled by the catch block below. */
                 out.write(rtepacket.getBytes());
                 out.flush();
-                readLine(32);
+                /* empty string: success */
+                String ret = readLine(32);
+                if (!ret.equals("0"))
+                    throw new IOException("could not route connection");
             }
         } catch (IOException e) {
             opened = false;


### PR DESCRIPTION
Even when configured single-port, the jdbc driver would start using database ports after receiving a dbinfo response which contains those port numbers. This patch fixes it.