### PR TITLE
Fix regop-rowlocks logic in txn-log systable

### DIFF
--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -439,14 +439,21 @@ static u_int64_t get_timestamp_from_regop_rowlocks_record(char *data)
 
 static u_int32_t get_generation_from_regop_rowlocks_record(char *data)
 {
-    u_int32_t generation;
+    u_int32_t generation = 0;
+    off_t loff;
+    u_int32_t lflags;
     u_int32_t rectype;
     LOGCOPY_32(&rectype, data); 
     if ((rectype < 10000 && rectype > 2000) || rectype > 12000) {
-        LOGCOPY_32( &generation, &data[4 + 4 + 8 + 8 + 4 + 8 + 8 + 8 + 8 + 8 + 4] );
+        loff = 4 + 4 + 8 + 8 + 4 + 8 + 8 + 8 + 8 + 8;
     } else {
-        LOGCOPY_32( &generation, &data[4 + 4 + 8 + 4 + 8 + 8 + 8 + 8 + 8 + 4] );
+        loff = 4 + 4 + 8 + 4 + 8 + 8 + 8 + 8 + 8;
     }
+    LOGCOPY_32( &lflags, &data[loff] );
+    if (lflags & DB_TXN_LOGICAL_GEN) {
+        LOGCOPY_32(&generation, &data[loff + 4]);
+    }
+
     return generation;
 }
 

--- a/tests/nogensc.test/Makefile
+++ b/tests/nogensc.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/nogensc.test/lrl.options
+++ b/tests/nogensc.test/lrl.options
@@ -1,0 +1,3 @@
+nowatch
+logmsg level info
+berkattr elect_highest_committed_gen 0

--- a/tests/nogensc.test/runit
+++ b/tests/nogensc.test/runit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+export debug=1
+
+$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1(a int)"
+
+g=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select generation from comdb2_transaction_logs where rectype=2015")
+
+if [[ "$DBNAME" == *"usegen"* ]]; then
+    if [[ "$g" == "NULL" ]]; then
+        echo "Committed-gen database should have non-NULL for generation"
+        exit 1
+    fi
+else
+    if [[ "$g" != "NULL" ]]; then
+        echo "No-gen database should have NULL for generation in regop_rowlocks record"
+        exit 1
+    fi
+fi
+
+echo "Success"

--- a/tests/nogensc.test/usegen.testopts
+++ b/tests/nogensc.test/usegen.testopts
@@ -1,0 +1,1 @@
+berkattr elect_highest_committed_gen 1


### PR DESCRIPTION
txnregop_rowlocks records only contain generation if TXN_LOGICAL_GEN flag is lit in flags.