### PR TITLE
{177710175}: Keeping track of qdb adds and deletes in statreqs

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4652,6 +4652,22 @@ static inline void log_tbl_item(int64_t curr, int64_t *prev, const char *(*type_
     *prev = curr;
 }
 
+static inline void log_qdb_item(int64_t curr, int64_t *prev, const char *(*type_to_str)(int), int type, char *string,
+                                int *hdr_p, struct reqlogger *statlogger, dbtable *tbl, int first)
+{
+    int diff = curr - *prev;
+    if (diff > 0) {
+        if (*hdr_p == 0) {
+            const char hdr_fmt[] = "DIFF REQUEST STATS FOR QUEUE '%s'\n";
+            reqlog_logf(statlogger, REQL_INFO, hdr_fmt, tbl->tablename);
+            *hdr_p = 1;
+        }
+        reqlog_logf(statlogger, REQL_INFO, "%s%-22s %u\n", (first ? "" : "    "),
+                    (type_to_str ? type_to_str(type) : string), diff);
+    }
+    *prev = curr;
+}
+
 void *statthd(void *p)
 {
     struct dbenv *dbenv;
@@ -4959,6 +4975,15 @@ void *statthd(void *p)
                              &hdr, statlogger, tbl, 0);
                 log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count, NULL, 0, "deadlock count", &hdr,
                              statlogger, tbl, 0);
+            }
+
+            for (ii = 0; ii < dbenv->num_qdbs; ii++) {
+                dbtable *qdb = dbenv->qdbs[ii];
+                int hdr = 0;
+                log_qdb_item(bdb_get_qdb_adds(qdb->handle), &qdb->prev_qdb_adds, NULL, 0, "adds", &hdr, statlogger, qdb,
+                             0);
+                log_qdb_item(bdb_get_qdb_cons(qdb->handle), &qdb->prev_qdb_dels, NULL, 0, "dels", &hdr, statlogger, qdb,
+                             0);
             }
 
             int num_sc = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -664,6 +664,8 @@ typedef struct dbtable {
     int64_t prev_blocktypcnt[BLOCK_MAXOPCODE];
     int64_t prev_blockosqltypcnt[MAX_OSQL_TYPES];
     int64_t prev_nsql;
+    int64_t prev_qdb_adds;
+    int64_t prev_qdb_dels;
     /* counters for writes to this table */
     int64_t write_count[RECORD_WRITE_MAX];
     int64_t saved_write_count[RECORD_WRITE_MAX];


### PR DESCRIPTION
This patch reports consumer's add and delete counters in statreqs, as shown below.

```
12/30 12:19:29:   DIFF REQUEST STATS FOR QUEUE '__qwatcher'
12/30 12:19:29:       adds                   1
12/30 12:19:29:       dels                   1
```