### PR TITLE
{177663687}: Exposing cluster type during lifecycle events

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -7121,6 +7121,7 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
     void *rc;
     int state;
     char *fp;
+    const char *dbtype = (hndl == NULL) ? NULL : hndl->type;
 
     /* Fast return if no arguments need to be passed to the callback. */
     if (e->argc == 0)
@@ -7174,6 +7175,9 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
         case CDB2_FINGERPRINT:
             fp = va_arg(ap, char *);
             break;
+        case CDB2_DBTYPE:
+            dbtype = va_arg(ap, char *);
+            break;
         default:
             (void)va_arg(ap, void *);
             break;
@@ -7201,6 +7205,10 @@ static void *cdb2_invoke_callback(cdb2_hndl_tp *hndl, cdb2_event *e, int argc,
             break;
         case CDB2_FINGERPRINT:
             argv[i] = (void *)fp;
+            break;
+        case CDB2_DBTYPE:
+            argv[i] = (void *)dbtype;
+            break;
         default:
             break;
         }

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -312,7 +312,8 @@ typedef enum cdb2_event_arg {
     CDB2_SQL,
     CDB2_RETURN_VALUE,
     CDB2_QUERY_STATE,
-    CDB2_FINGERPRINT
+    CDB2_FINGERPRINT,
+    CDB2_DBTYPE
 } cdb2_event_arg;
 
 typedef struct cdb2_event cdb2_event;

--- a/docs/pages/programming/c_api.md
+++ b/docs/pages/programming/c_api.md
@@ -660,25 +660,25 @@ where `cb_hndl` is the handle upon which the event is fired.
 
 Besides the user argument, one can request additional arguments by setting `argc` to the number of the arguments, followed by the argument types. The arguments will be passed to `cb` in `argv`. The table below lists the argument types.
 
-|Event Type|`CDB2_HOSTNAME`|`CDB2_PORT`|`CDB2_SQL`|`CDB2_RETURN_VALUE`|`CDB2_FINGERPRINT`|
-|---|---|---|---|---|---|
-| `CDB2_BEFORE_CONNECT` | The hostname to connect to | The port to connect to | N/A | N/A | N/A |
-| `CDB2_AFTER_CONNECT` | The hostname to connect to | The port to connect to | N/A | file descriptor | N/A |
-| `CDB2_BEFORE_PMUX` | The server hostname | The pmux port | N/A | N/A | N/A |
-| `CDB2_AFTER_PMUX` | The server hostname | The pmux port | N/A | The database port | N/A |
-| `CDB2_BEFORE_DBINFO` | The server hostname  | The database port | N/A | N/A | N/A |
-| `CDB2_AFTER_DBINFO` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A |
-| `CDB2_BEFORE_SEND_QUERY` | The server hostname | The database port | The SQL query | N/A | N/A |
-| `CDB2_AFTER_SEND_QUERY` | The server hostname | The database port | The SQL query | 0 on success; Non-zero on failure | N/A |
-| `CDB2_BEFORE_READ_RECORD` | The server hostname | The database port | N/A | N/A | N/A |
-| `CDB2_AFTER_READ_RECORD` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A |
-| `CDB2_AT_ENTER_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | N/A |
-| `CDB2_AT_EXIT_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
-| `CDB2_AT_ENTER_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
-| `CDB2_AT_EXIT_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query |
-| `CDB2_AT_DISCOVERY` | N/A | N/A | N/A | N/A | N/A |
-| `CDB2_AT_OPEN` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A |
-| `CDB2_AT_CLOSE` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A |
+|Event Type|`CDB2_HOSTNAME`|`CDB2_PORT`|`CDB2_SQL`|`CDB2_RETURN_VALUE`|`CDB2_FINGERPRINT`|`CDB2_DBTYPE`|
+|---|---|---|---|---|---|---|
+| `CDB2_BEFORE_CONNECT` | The hostname to connect to | The port to connect to | N/A | N/A | N/A | Resolved dbtype |
+| `CDB2_AFTER_CONNECT` | The hostname to connect to | The port to connect to | N/A | file descriptor | N/A | Resolved dbtype |
+| `CDB2_BEFORE_PMUX` | The server hostname | The pmux port | N/A | N/A | N/A | Resolved dbtype |
+| `CDB2_AFTER_PMUX` | The server hostname | The pmux port | N/A | The database port | N/A | Resolved dbtype |
+| `CDB2_BEFORE_DBINFO` | The server hostname  | The database port | N/A | N/A | N/A | Resolved dbtype |
+| `CDB2_AFTER_DBINFO` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A | Resolved dbtype |
+| `CDB2_BEFORE_SEND_QUERY` | The server hostname | The database port | The SQL query | N/A | N/A | Resolved dbtype |
+| `CDB2_AFTER_SEND_QUERY` | The server hostname | The database port | The SQL query | 0 on success; Non-zero on failure | N/A | Resolved dbtype |
+| `CDB2_BEFORE_READ_RECORD` | The server hostname | The database port | N/A | N/A | N/A | Resolved dbtype |
+| `CDB2_AFTER_READ_RECORD` | The server hostname | The database port | N/A | 0 on success; Non-zero on failure | N/A | Resolved dbtype |
+| `CDB2_AT_ENTER_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | N/A | Resolved dbtype |
+| `CDB2_AT_EXIT_RUN_STATEMENT` | The server hostname | The database port | The SQL query | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query | Resolved dbtype |
+| `CDB2_AT_ENTER_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query | Resolved dbtype |
+| `CDB2_AT_EXIT_NEXT_RECORD` | The server hostname | The database port | N/A | See [cdb2api errors](#cdb2api-errors) | Fingerprint of the SQL query | Resolved dbtype |
+| `CDB2_AT_DISCOVERY` | N/A | N/A | N/A | N/A | N/A | Unresolved dbtype |
+| `CDB2_AT_OPEN` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A | Resolved dbtype |
+| `CDB2_AT_CLOSE` | N/A | N/A | N/A | See [cdb2api errors](#cdb2api-errors) | N/A | Resolved dbtype |
 
 Return Value:
 

--- a/tests/api_events.test/expected
+++ b/tests/api_events.test/expected
@@ -39,3 +39,9 @@ SQL is SELECT "You may say I'm a dreamer, but I'm not the only one."
 FP is 4f16a8ec9db90f803e406659938b2602
 RC is 0
 RC is 1
+====== VERIFYING DBTYPE ARG ======
+DBTYPE is unresolved
+DBTYPE is resolved
+DBTYPE is resolved
+DBTYPE is resolved
+DBTYPE is example.com


### PR DESCRIPTION
This patch makes the cluster type available to API events.