### PR TITLE
Fix lostwrite testcase

### DIFF
--- a/tests/lostwrite.test/Makefile
+++ b/tests/lostwrite.test/Makefile
@@ -6,5 +6,5 @@ endif
 
 export CHECK_DB_AT_FINISH=0
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=23m
+	export TEST_TIMEOUT=30m
 endif

--- a/tests/lostwrite.test/lrl.options
+++ b/tests/lostwrite.test/lrl.options
@@ -1,5 +1,5 @@
-all_incoherent on
 decoupled_logputs off
 setattr REP_PROCESSORS 0
 setattr REP_WORKERS 0
 replicant_retry_on_not_durable on
+forbid_remote_admin 0

--- a/tests/lostwrite.test/runit
+++ b/tests/lostwrite.test/runit
@@ -58,6 +58,7 @@ function inserter
             let count=count+1
         fi
     done
+    sleep 5
     checkdata $1
 }
 
@@ -79,11 +80,21 @@ function bouncemaster
     $ssh $node ${DEBUG_PREFIX} ${CMD} >> $TESTDIR/logs/${DBNAME}.${node}.db 2>&1 &
 }
 
+function unsettunables
+{
+    sleep 5
+    for node in $CLUSTER ; do
+        $CDB2SQL_EXE --admin $DBNAME --host $node 'PUT TUNABLE replicant_latency 0' &
+        $CDB2SQL_EXE --admin $DBNAME --host $node 'PUT TUNABLE all_incoherent 0' &
+    done
+}
+
 function settunables
 {
     sleep 5
     for node in $CLUSTER ; do
-        $ssh $node "$CDB2SQL_EXE --admin $DBNAME --host $node 'PUT TUNABLE replicant_latency 1'" &
+        $CDB2SQL_EXE --admin $DBNAME --host $node 'PUT TUNABLE replicant_latency 1' &
+        $CDB2SQL_EXE --admin $DBNAME --host $node 'PUT TUNABLE all_incoherent 1' &
     done
 }
 
@@ -91,7 +102,6 @@ function setup
 {
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "DROP TABLE IF EXISTS t1"
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "CREATE TABLE t1(t int,a int)"
-    #sleep 7
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "CREATE INDEX ix1 ON t1(t,a)"
 }
 
@@ -141,6 +151,9 @@ function run_test
         echo "BOUNCE COUNT $i"
         bouncemaster
     done
+    unsettunables
+    unsettunables
+    unsettunables
     touch $stopfile
     waitforinserters $threads
     if [[ "$keepalive" != "1" ]] ; then 


### PR DESCRIPTION
The lostwrite test case was failing to set tunables on replicants because cdb2sql is not guaranteed to be available.  Simple fix is to allow-remote-admin, and change the tunable directly from the client.
