### PR TITLE
do not unlock views lock twice in explain schema system table queries

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -3308,6 +3308,11 @@ int sqlite3VdbeReset(Vdbe *p){
      */
     extern void views_unlock(void);
     views_unlock();
+    /* any statement that is not cached (like an explain query), will call
+     * sqlite3VdbeReset twice, first time when we check sqlite rc code,
+     * and second when we finalize the stmt, since we do not cache it
+     */
+    p->crtPartitionLocks = 0;
   }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 


### PR DESCRIPTION
When we do not cache a statement that uses schema system tables that are not collected (like, if this is an explain), we call sqlite3VdbeReset twice, once when we get the sqlite return code, and second when we finalize the statement.  Reset the counter to avoid unlocking the views lock twice.
