### PR TITLE
Set newmaster and generation under rep_mutexp

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3829,7 +3829,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control, D
 {
     int rc;
     int r;
-    char *master;
+    char *master, *newmaster = NULL;
     uint32_t gen, egen;
     DB_LSN permlsn;
     uint32_t generation, commit_generation;
@@ -3889,6 +3889,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control, D
     rm.starttime = time1;
     rm.type = rectype;
     add_rep_mon(&rm);
+    uint32_t newgen = 0;
 
     bdb_state->repinfo->repstats.rep_process_message++;
 
@@ -3936,13 +3937,15 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control, D
     } else {
         r = bdb_state->dbenv->rep_process_message(bdb_state->dbenv, control, rec,
                                                   &host, &permlsn,
-                                                  &commit_generation, online);
+                                                  &commit_generation, &newgen, &newmaster, online);
     }
 
     if (got_vote2lock) {
         if (bdb_get_rep_master(bdb_state, &master, &gen, &egen) != 0) {
             abort();
         }
+        master = newmaster;
+        egen = newgen;
         Pthread_mutex_unlock(&vote2_lock);
     }
 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2590,7 +2590,7 @@ struct __db_env {
 	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, int *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
-		char **, DB_LSN *, uint32_t *, int));
+		char **, DB_LSN *, uint32_t *, uint32_t *, char **, int));
 	int  (*rep_verify_will_recover) __P((DB_ENV *, DBT *, DBT *));
 	int  (*rep_truncate_repdb) __P((DB_ENV *));
 	int  (*rep_start) __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -1068,16 +1068,18 @@ done:
  *	(respectively).
  *
  * PUBLIC: int __rep_process_message __P((DB_ENV *, DBT *, DBT *, char**,
- * PUBLIC:	 DB_LSN *, uint32_t *,int));
+ * PUBLIC:	 DB_LSN *, uint32_t *,uint32_t *, char **, int));
  */
 
 int
-__rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen, online)
+__rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen, newgen, newmaster, online)
 	DB_ENV *dbenv;
 	DBT *control, *rec;
 	char **eidp;
 	DB_LSN *ret_lsnp;
 	uint32_t *commit_gen;
+	uint32_t *newgen;
+	char **newmaster;
 	int online;
 {
 	int fromline = 0;
@@ -1280,6 +1282,8 @@ __rep_process_message(dbenv, control, rec, eidp, ret_lsnp, commit_gen, online)
 		if (rp->rectype == REP_VOTE1 || rp->rectype == REP_VOTE2 ||
 			rp->rectype == REP_GEN_VOTE1 ||
 			rp->rectype == REP_GEN_VOTE2) {
+			if (newgen) *newgen = 0;
+			if (newmaster) *newmaster = NULL;
 			MUTEX_LOCK(dbenv, db_rep->rep_mutexp);
 #ifdef DIAGNOSTIC
 			if (FLD_ISSET(dbenv->verbose, DB_VERB_REPLICATION))
@@ -2525,9 +2529,11 @@ rep_verify_err:if ((t_ret = __log_c_close(logc)) != 0 &&
 			__db_err(dbenv, "Counted vote %d", rep->votes);
 #endif
 		if (done) {
-			logmsg(LOGMSG_DEBUG, "%s line %d elected master %s for egen %d\n",
+			logmsg(LOGMSG_USER, "%s line %d elected master %s for egen %d\n",
 					__func__, __LINE__, rep->eid, vi_egen);
 			__rep_elect_master(dbenv, rep, eidp);
+			if (newgen) *newgen = vi_egen;
+			if (newmaster) *newmaster = *eidp;
 			ret = (rep->votes > rep->nsites / 2 + 1) ? DB_HAS_MAJORITY : DB_REP_NEWMASTER;
 			goto errunlock;
 		} else {


### PR DESCRIPTION
Simplifies election code by retrieving the new generation and master under rep_mutexp rather than doing a separate lookup later.