### PR TITLE
Set newmaster and generation under rep_mutexp

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3803,7 +3803,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
 {
     int rc;
     int r;
-    char *master;
+    char *master, *newmaster = NULL;
     uint32_t gen, egen;
     DB_LSN permlsn;
     uint32_t generation, commit_generation;
@@ -3859,6 +3859,7 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
     rm.starttime = time1;
     rm.type = rectype;
     add_rep_mon(&rm);
+    uint32_t newgen = 0;
 
     bdb_state->repinfo->repstats.rep_process_message++;
 
@@ -3906,13 +3907,15 @@ static int process_berkdb(bdb_state_type *bdb_state, char *host, DBT *control,
     } else {
         r = bdb_state->dbenv->rep_process_message(bdb_state->dbenv, control, rec,
                                                   &host, &permlsn,
-                                                  &commit_generation, online);
+                                                  &commit_generation, &newgen, &newmaster, online);
     }
 
     if (got_vote2lock) {
         if (bdb_get_rep_master(bdb_state, &master, &gen, &egen) != 0) {
             abort();
         }
+        master = newmaster;
+        egen = newgen;
         Pthread_mutex_unlock(&vote2_lock);
     }
 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2578,7 +2578,7 @@ struct __db_env {
 	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, int *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
-		char **, DB_LSN *, uint32_t *, int));
+		char **, DB_LSN *, uint32_t *, uint32_t *, char **, int));
 	int  (*rep_verify_will_recover) __P((DB_ENV *, DBT *, DBT *));
 	int  (*rep_truncate_repdb) __P((DB_ENV *));
 	int  (*rep_start) __P((DB_ENV *, DBT *, u_int32_t, u_int32_t));


### PR DESCRIPTION
Simplifies election code by retrieving the new generation and master under rep_mutexp rather than doing a separate lookup later.