### PR TITLE
Don't emit set-gen messages if gbl_create_mode is set

### DIFF
--- a/berkdb/rep/rep_util.c
+++ b/berkdb/rep/rep_util.c
@@ -46,6 +46,7 @@ int bdb_num_connected_nodes(struct bdb_state_tag *);
 
 int gbl_verbose_master_req = 0;
 int gbl_trace_repmore_reqs = 0;
+extern int gbl_create_mode;
 
 /*
  * rep_util.c:
@@ -407,9 +408,11 @@ __rep_set_gen(dbenv, func, line, gen)
 	egen = rep->egen;
 	if (rep->egen <= gen)
 		egen = gen + 1;
-	logmsg(LOGMSG_USER,
-			"%s line %d setting rep->gen from %d to %d, egen from %d to %d\n",
-			func, line, rep->gen, gen, rep->egen, egen);
+	if (!gbl_create_mode) {
+		logmsg(LOGMSG_USER,
+				"%s line %d setting rep->gen from %d to %d, egen from %d to %d\n",
+				func, line, rep->gen, gen, rep->egen, egen);
+	}
 	rep->gen = gen;
 	rep->egen = egen;
 }
@@ -447,8 +450,10 @@ __rep_set_egen(dbenv, func, line, egen)
 	REP *rep;
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
-	logmsg(LOGMSG_USER, "%s line %d setting rep->egen from %d to %d\n",
-			func, line, rep->egen, egen);
+	if (!gbl_create_mode) {
+		logmsg(LOGMSG_USER, "%s line %d setting rep->egen from %d to %d\n",
+				func, line, rep->egen, egen);
+	}
 	rep->egen = egen;
 }
 
@@ -471,8 +476,10 @@ __rep_set_log_gen(dbenv, func, line, log_gen)
 	REP *rep;
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
-	logmsg(LOGMSG_USER, "%s line %d setting rep->log_gen from %d to %d\n",
-			func, line, rep->log_gen, log_gen);
+	if (!gbl_create_mode) {
+		logmsg(LOGMSG_USER, "%s line %d setting rep->log_gen from %d to %d\n",
+				func, line, rep->log_gen, log_gen);
+	}
 	rep->log_gen = log_gen;
 }
 /*

--- a/berkdb/txn/txn_rec.c
+++ b/berkdb/txn/txn_rec.c
@@ -475,8 +475,6 @@ __txn_regop_gen_recover(dbenv, dbtp, lsnp, op, info)
 			__rep_set_gen(dbenv, __func__, __LINE__, argp->generation);
 			__rep_set_log_gen(dbenv, __func__, __LINE__, rep->gen);
 			gbl_recovery_gen = rep->gen;
-		} else {
-			logmsg(LOGMSG_USER, "%s line %d: rep->gen is %u, not setting to %u\n", __func__, __LINE__, rep->gen, argp->generation);
 		}
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 	} else if ((dbenv->tx_timestamp != 0 &&
@@ -806,8 +804,6 @@ __txn_regop_rowlocks_recover(dbenv, dbtp, lsnp, op, info)
 			__rep_set_gen(dbenv, __func__, __LINE__, argp->generation);
 			__rep_set_log_gen(dbenv, __func__, __LINE__, rep->gen);
 			gbl_recovery_gen = rep->gen;
-		} else {
-			logmsg(LOGMSG_USER, "%s line %d: rep->gen is %u, not setting to %u\n", __func__, __LINE__, rep->gen, argp->generation);
 		}
 		MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 	}
@@ -1101,8 +1097,6 @@ __txn_ckp_recover(dbenv, dbtp, lsnp, op, info)
 					__rep_set_log_gen(dbenv, __func__, __LINE__, rep->gen);
 					gbl_recovery_gen = rep->gen;
 				}
-			} else {
-				logmsg(LOGMSG_USER, "%s line %d: rep->gen is %u, not setting to %u\n", __func__, __LINE__, rep->gen, argp->rep_gen);
 			}
 
 			if (argp->rep_gen > rep->recover_gen)


### PR DESCRIPTION
Don't emit 'setting elect-gen' messages in create mode
