### PR TITLE
Optimize read-only modsnap transactions

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -62,6 +62,9 @@ typedef struct bdb_callback_tag bdb_callback_type;
 struct tran_tag;
 typedef struct tran_tag tran_type;
 
+struct table_version_cache;
+typedef struct table_version_cache table_version_cache;
+
 struct bdb_attr_tag;
 typedef struct bdb_attr_tag bdb_attr_type;
 
@@ -2056,8 +2059,10 @@ int bdb_llmeta_list_records(bdb_state_type *bdb_state, int *bdberr);
 int bdb_have_ipu(bdb_state_type *bdb_state);
 
 bdb_state_type *bdb_get_table_by_name(bdb_state_type *bdb_state, char *table);
-int bdb_osql_check_table_version(bdb_state_type *bdb_state, tran_type *tran,
-                                 int trak, int *bdberr);
+int bdb_osql_check_table_version(bdb_state_type *bdb_state, table_version_cache *cache);
+
+int bdb_init_table_version_cache(table_version_cache **cache);
+void bdb_free_table_version_cache(table_version_cache *cache);
 
 int bdb_get_myseqnum(bdb_state_type *bdb_state, seqnum_type *seqnum);
 

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -445,9 +445,6 @@ struct tran_tag {
     /* Tables that this tran touches (for logical redo sc) */
     hash_t *dirty_table_hash;
 
-    /* cache the versions of dta files to catch schema changes and fastinits */
-    int table_version_cache_sz;
-    unsigned long long *table_version_cache;
     bdb_state_type *parent_state;
 
     /* Send the master periodic 'acks' after this many physical commits */
@@ -765,6 +762,12 @@ typedef struct {
     int should_reject_timestamp;
     int should_reject;
 } repinfo_type;
+
+typedef struct table_version_cache
+{
+    int sz;
+    unsigned long long *entries;
+} table_version_cache;
 
 struct hostinfo
 {
@@ -1842,8 +1845,8 @@ int bdb_lite_list_records(bdb_state_type *bdb_state,
                                           int *bdberr),
                           int *bdberr);
 
-int bdb_osql_cache_table_versions(bdb_state_type *bdb_state, tran_type *tran,
-                                  int trak, int *bdberr);
+int bdb_osql_cache_table_versions(bdb_state_type *bdb_state, table_version_cache *cache,
+                                  int *bdberr);
 int bdb_temp_table_destroy_lru(struct temp_table *tbl,
                                bdb_state_type *bdb_state, int *last,
                                int *bdberr);

--- a/db/sql.h
+++ b/db/sql.h
@@ -275,6 +275,9 @@ typedef struct {
     int maxchunksize;     /* multi-transaction bulk mode */
     int crtchunksize;     /* how many rows are processed already */
     int nchunks;          /* number of chunks. 0 for a non-chunked transaction. */
+
+    /* cache the versions of dta files to catch schema changes and fastinits */
+    table_version_cache *table_version_cache;
 } dbtran_type;
 typedef dbtran_type trans_t;
 

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4859,6 +4859,49 @@ int start_new_transaction(struct sqlclntstate *clnt)
     return 0;
 }
 
+static int cache_table_versions(struct sqlclntstate *clnt)
+{
+    if (clnt->dbtran.table_version_cache) {
+        bdb_free_table_version_cache(clnt->dbtran.table_version_cache);
+        clnt->dbtran.table_version_cache = NULL;
+    }
+
+    int rc = bdb_init_table_version_cache(&clnt->dbtran.table_version_cache);
+    if (rc) {
+        logmsg(LOGMSG_ERROR,
+               "%s failed initialize table verison cache rc=%d\n",
+               __func__, rc);
+        return rc;
+    }
+
+    int bdberr;
+    rc = bdb_osql_cache_table_versions(thedb->bdb_env,
+        clnt->dbtran.table_version_cache, &bdberr);
+    if (rc) {
+        logmsg(LOGMSG_ERROR,
+               "%s failed to cache table versions rc=%d bdberr=%d\n",
+               __func__, rc, bdberr);
+        return rc;
+    }
+
+    return 0;
+}
+
+static int must_start_new_transaction(const struct sqlclntstate *clnt, int is_writer)
+{
+    if (is_writer) { return 1; }
+
+    const int tran_mode_must_open_shadows =
+        clnt->dbtran.mode > TRANLEVEL_RECOM && clnt->dbtran.mode != TRANLEVEL_MODSNAP;
+    if (tran_mode_must_open_shadows) { return 1; }
+
+    const int is_selectv = clnt->has_recording;
+    const int is_singular_request = clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS;
+    if (is_selectv && !is_singular_request) { return 1; }
+
+    return 0;
+}
+
 /*
  ** Attempt to start a new transaction. A write-transaction
  ** is started if the second argument is nonzero, otherwise a read-
@@ -4958,17 +5001,20 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
         goto done;
     }
 
-    // TODO: Don't open shadows for read-only modsnap txns.
-    // In order to make this optimization work, we still need to latch
-    // the initial versions of tables and use these latched versions to 
-    // fail on schema changes. This is currently handled in the shadow code
-    // but can be refactored out.
-    if ((clnt->dbtran.mode <= TRANLEVEL_RECOM) && wrflag == 0) { // read-only
-        if (clnt->has_recording == 0 ||                        // not selectv
-            clnt->ctrl_sqlengine == SQLENG_NORMAL_PROCESS) { // singular selectv
-            rc = SQLITE_OK;
+    if (clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
+        clnt->dbtran.mode == TRANLEVEL_SERIAL ||
+        clnt->dbtran.mode == TRANLEVEL_MODSNAP) {
+        rc = cache_table_versions(clnt);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s: Failed to cache table versions\n", __func__);
+            rc = SQLITE_ERROR;
             goto done;
         }
+    }
+
+    if (!must_start_new_transaction(clnt, wrflag)) {
+        rc = SQLITE_OK;
+        goto done;
     }
 
     /* UPSERT: If we were asked to perform some action on conflict
@@ -5239,6 +5285,11 @@ int sqlite3BtreeCommit(Btree *pBt)
         clnt->selectv_arr = NULL;
     }
 
+    if (clnt->dbtran.table_version_cache) {
+        bdb_free_table_version_cache(clnt->dbtran.table_version_cache);
+        clnt->dbtran.table_version_cache = NULL;
+    }
+
     reset_clnt_flags(clnt);
 
 done:
@@ -5355,6 +5406,11 @@ int sqlite3BtreeRollback(Btree *pBt, int dummy, int writeOnlyDummy)
     if (clnt->selectv_arr) {
         currangearr_free(clnt->selectv_arr);
         clnt->selectv_arr = NULL;
+    }
+
+    if (clnt->dbtran.table_version_cache) {
+        bdb_free_table_version_cache(clnt->dbtran.table_version_cache);
+        clnt->dbtran.table_version_cache = NULL;
     }
 
     reset_clnt_flags(clnt);
@@ -7937,19 +7993,15 @@ static int sqlite3LockStmtTables_int(sqlite3_stmt *pStmt, int after_recovery)
         }
 
         /* in snapshot and stronger isolations, check cached table versions */
-        if (clnt->dbtran.shadow_tran &&
-            (clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
-             clnt->dbtran.mode == TRANLEVEL_SERIAL ||
-             clnt->dbtran.mode == TRANLEVEL_MODSNAP)) {
+        if (clnt->dbtran.table_version_cache &&
+            (clnt->dbtran.mode == TRANLEVEL_SERIAL ||
+            clnt->dbtran.mode == TRANLEVEL_SNAPISOL ||
+            clnt->dbtran.mode == TRANLEVEL_MODSNAP)) {
             /* make sure btrees have not changed since the transaction started
              */
-            int bdberr = 0;
-            rc = bdb_osql_check_table_version(
-                db->handle, clnt->dbtran.shadow_tran, 0, &bdberr);
+            rc = bdb_osql_check_table_version(db->handle, clnt->dbtran.table_version_cache);
             if (rc != 0) {
-                /* fprintf(stderr, "bdb_osql_check_table_version failed rc=%d
-                   bdberr=%d\n",
-                   rc, bdberr);*/
+                /* fprintf(stderr, "bdb_osql_check_table_version failed rc=%d\n", rc);*/
                 sqlite3_mutex_enter(sqlite3_db_mutex(p->db));
                 sqlite3VdbeError(p, "table \"%s\" was schema changed",
                                  db->tablename);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2254,6 +2254,11 @@ static int do_commitrollback(struct sqlthdstate *thd, struct sqlclntstate *clnt,
         }
     }
 
+    if (clnt->dbtran.table_version_cache) {
+        bdb_free_table_version_cache(clnt->dbtran.table_version_cache);
+        clnt->dbtran.table_version_cache = NULL;
+    }
+
     return rc;
 }
 

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -609,6 +609,11 @@ int osql_clean_sqlclntstate(struct sqlclntstate *clnt)
         clnt->saved_errstr = NULL;
     }
 
+    if (clnt->dbtran.table_version_cache) {
+        bdb_free_table_version_cache(clnt->dbtran.table_version_cache);
+        clnt->dbtran.table_version_cache = NULL;
+    }
+
     if (clnt->dbtran.shadow_tran) {
         /* for some reason the clnt contains an unfinished
            shadow transaction, that could have allocated structures


### PR DESCRIPTION
The changes in #4902 forced all modsnap transactions to open shadow btrees. It did this because the table version cache, which is necessary for all snapshot transactions, was coupled to the shadow code; therefore, even though some read-only modsnap transactions don't require shadow btrees, they still needed to open them just to use the table version cache.

The changes in this PR decouple the table version cache from shadow code so that eligible read-only modsnap transactions can skip opening shadows, which can be expensive.