### PR TITLE
Disabling queue-odh for multimeta

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -4101,6 +4101,11 @@ int backend_open_tran(struct dbenv *dbenv, tran_type *tran, uint32_t flags)
                 logmsg(LOGMSG_ERROR, "meta database not available\n");
             }
         }
+
+        /* disable these queuedb tunables that require singlemeta */
+        gbl_init_with_queue_odh = 0;
+        gbl_init_with_queue_compr = 0;
+        gbl_init_with_queue_persistent_seq = 0;
     }
 
     /* now that meta is open, get the blobstripe conversion genids for each

--- a/tests/queuedb_multimeta.test/Makefile
+++ b/tests/queuedb_multimeta.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/queuedb_multimeta.test/expected
+++ b/tests/queuedb_multimeta.test/expected
@@ -1,0 +1,9 @@
+[CREATE TABLE t1 (a INTEGER)] rc 0
+(filename='_comdb2_static_table.metalite.dta')
+(filename='sqlite_stat1.metalite.dta')
+(filename='sqlite_stat4.metalite.dta')
+(filename='t1.metalite.dta')
+[SELECT DISTINCT filename FROM comdb2_files WHERE filename LIKE '%metalite%'] rc 0
+[CREATE DEFAULT LUA CONSUMER q1 ON (TABLE t1 FOR INSERT)] rc 0
+(name='q1')
+[SELECT name FROM comdb2_procedures] rc 0

--- a/tests/queuedb_multimeta.test/lrl.options
+++ b/tests/queuedb_multimeta.test/lrl.options
@@ -1,0 +1,2 @@
+logmsg level info
+singlemeta 0

--- a/tests/queuedb_multimeta.test/runit
+++ b/tests/queuedb_multimeta.test/runit
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+dbnm=$1
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - >actual <<EOF
+CREATE TABLE t1 (a INTEGER)\$\$
+SELECT DISTINCT filename FROM comdb2_files WHERE filename LIKE '%metalite%'
+CREATE DEFAULT LUA CONSUMER q1 ON (TABLE t1 FOR INSERT)
+SELECT name FROM comdb2_procedures
+EOF
+
+diff actual expected


### PR DESCRIPTION
Ultimately we want to get rid of meta completely, meanwhile this patch will allow multimeta databases that have queues to get on 8.1.