### PR TITLE
Handling misused rte in evbuffer

### DIFF
--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/BadRte.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/BadRte.java
@@ -1,0 +1,17 @@
+package com.bloomberg.comdb2.jdbc;
+
+import java.sql.*;
+import org.junit.*;
+import org.junit.Assert.*;
+
+public class BadRte {
+    @Test public void testBadRteClient() throws SQLException {
+        String db = System.getProperty("cdb2jdbc.test.database");
+        String cluster = System.getProperty("cdb2jdbc.test.cluster");
+        Connection conn = DriverManager.getConnection(String.format("jdbc:comdb2://%s/%s?allow_pmux_route=1&portmuxport=19000", cluster, db));
+        Statement stmt = conn.createStatement();
+        stmt.executeQuery("SELECT 1");
+        stmt.close();
+        conn.close();
+    }
+}

--- a/net/net_appsock.h
+++ b/net/net_appsock.h
@@ -15,6 +15,7 @@ struct appsock_handler_arg {
     int fd;
     int is_readonly;
     int secure; /* whether connection is routed from a secure pmux port */
+    int badrte;
     int admin;
     struct sockaddr_in addr;
     struct evbuffer *rd_buf;

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -1142,6 +1142,8 @@ static void newsql_setup_clnt_evbuffer(int fd, short what, void *data)
     reset_clnt(clnt, 1);
     char *origin = arg->origin;
     clnt->origin = origin ? origin : intern("???");
+    if (arg->badrte)
+        logmsg(LOGMSG_ERROR, "misused rte from host %s\n", clnt->origin);
     clnt->appdata = appdata;
     clnt->done_cb = newsql_done_cb;
 


### PR DESCRIPTION
If we see an "rte", write a response and wait for the next "newsql".