### PR TITLE
Blob cache

### DIFF
--- a/bbinc/blob_buffer.h
+++ b/bbinc/blob_buffer.h
@@ -27,21 +27,15 @@
  * An array of these also supplements */
 typedef struct blob_buffer {
     int exists; /* to differentiate 0 length from null */
-
-    /* blob cache */
-    uint64_t genid;
+    int length;
     char *data;
-    int n; /* SQLite 'n' */
-    int flags; /* SQLite MEM_FLAGS */
-    int length; /* capacity used (might be different from 'n' above) */
-    int capacity; /* allocated */
 
     /* collected has a double life.  on the user side, it is used to
      * track how much blob we've collected from the transaction data.
      * on the server side, it should be non-zero even for a null blob
      * so we know that it's been through the type system (helps us tell
      * which blobs to update on updates) */
-    size_t collected;
+    int collected;
 
     /* The index of the blob.
        An ODH'd blob has OSQL_BLOB_ODH_BIT set,

--- a/bdb/berktest.c
+++ b/bdb/berktest.c
@@ -121,7 +121,6 @@ static berktable_t *create_tables(int *tablecount)
     table->datasize = 8;
     if ((rc = create_and_open(table)) != 0) {
         close_tables(tables, count);
-        free(tables);
         return NULL;
     }
 
@@ -135,7 +134,6 @@ static berktable_t *create_tables(int *tablecount)
     table->datasize = 12;
     if ((rc = create_and_open(table)) != 0) {
         close_tables(tables, count);
-        free(tables);
         return NULL;
     }
 


### PR DESCRIPTION
Premature Optimization claims another victim:
Tried to reuse `ondisk_blobs` in `BtCursor` to cache blob payload in `fetch_blob_into_sqlite_mem`. `MAXBLOBS` number of them were already in that struct, so it seemed natural to use it without inflating the size of all cursors.

Turns out that an update stmt will clear that structure in `sqlite3MakeRecordForComdb2`, and `sqlite3BtreeCloseCursor` won't find any pointers to free.

Fix: Create dedicated buffers for rd and wr operations.