### PR TITLE
178222599: Limit len of sp name for triggers/consumers to 28

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1505,7 +1505,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         char *queue = alloca(ltok + 1);
         tokcpy(tok, ltok, queue);
         char *bdbq = alloca(ltok + 4);
-        sprintf(bdbq, "__q%s", queue);
+        sprintf(bdbq, "%s%s", Q_TAG, queue);
 
         if ((tok = segtok(line, len, &st, &ltok)) == NULL || ltok == 0) {
             logmsg(LOGMSG_ERROR, "Expected dump-queue filename\n");
@@ -1531,7 +1531,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         char *queue = alloca(ltok + 1);
         tokcpy(tok, ltok, queue);
         char *bdbq = alloca(ltok + 4);
-        sprintf(bdbq, "__q%s", queue);
+        sprintf(bdbq, "%s%s", Q_TAG, queue);
 
         if ((tok = segtok(line, len, &st, &ltok)) == NULL || ltok <= 0) {
             logmsg(LOGMSG_ERROR, "Expected kafka topic\n");

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3820,7 +3820,7 @@ static int osql_net_type_to_net_uuid_type(int type)
 int is_tablename_queue(const char *name)
 {
     /* See also, __db_open @ /berkdb/db/db_open.c for register_qdb */
-    return strncmp(name, "__q", 3) == 0;
+    return strncmp(name, Q_TAG, 3) == 0;
 }
 
 int osql_send_prepare(osql_target_t *target, unsigned long long rqid, uuid_t uuid, const char *dist_txnid,

--- a/db/translistener.c
+++ b/db/translistener.c
@@ -865,7 +865,7 @@ done:
 static int sp_trigger_skip(struct stored_proc *sp)
 {
     int rc = 0;
-    const char *prefix = "__q__m";   // identifier for migrated queues
+    const char *prefix = Q_TAG "__m";   // identifier for migrated queues
     size_t prefix_len = strlen(prefix);
     const char *qname = sp->qname;
     size_t qname_len = strlen(qname);
@@ -1461,7 +1461,7 @@ int gather_triggers(struct gather_triggers_arg *arg)
     struct stored_proc *sp;
     LISTC_FOR_EACH(&stored_procs, sp, lnk) {
         e.name = sp->name;
-        if (strncmp(e.name, "__q", 3) == 0) e.name += 3;
+        if (strncmp(e.name, Q_TAG, 3) == 0) e.name += 3;
         struct dbtable *qdb = getqueuebyname(sp->name);
         if (!qdb) continue;
         if (qdb->consumers[0] == NULL) continue;

--- a/db/trigger.h
+++ b/db/trigger.h
@@ -82,11 +82,12 @@ void trigger_reg_to_cpu(trigger_reg_t *);
 #define trigger_reg_sz(sp_name)                                                \
     sizeof(trigger_reg_t) + strlen(sp_name) + 1 + strlen(gbl_myhostname) + 1
 
+#define Q_TAG "__q"
 #define Q4SP(var, spname)                                                      \
-    char var[sizeof("__q") + strlen(spname)];                                  \
-    sprintf(var, "__q%s", spname);
+    char var[sizeof(Q_TAG) + strlen(spname)];                                  \
+    sprintf(var, "%s%s", Q_TAG, spname);
 
-#define SP4Q(q) ((q) + (sizeof("__q") - 1))
+#define SP4Q(q) ((q) + (sizeof(Q_TAG) - 1))
 
 struct lua_State;
 void force_unregister(struct lua_State *, trigger_reg_t *);

--- a/docs/pages/programming/sql.md
+++ b/docs/pages/programming/sql.md
@@ -283,6 +283,9 @@ as new SQL functions with the
 [CREATE LUA FUNCTION](#create-lua-function) statement, or as triggers with ```CREATE LUA TRIGGER```/
 ```CREATE LUA CONSUMER``` statements.
 
+The maximum procedure name length is 31 chars 
+**unless the procedure will be used by a trigger or a consumer, in which case the limit is 28 chars**.
+
 All procedures have versions.  If a version is not provided by the user
 then the database will give the procedure a numeric version. Versioning allows a more
 compartmentalized development model.  For instance, users may have "beta" and "prod" versions of a procedure

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -1231,7 +1231,9 @@ void comdb2CreateProcedure(Parse* pParse, Token* nm, Token* ver, Token* proc)
     Vdbe *v  = sqlite3GetVdbe(pParse);
 
     if (comdb2TokenToStr(nm, spname, sizeof(spname))) {
-        setError(pParse, SQLITE_MISUSE, "Procedure name is too long");
+        char *errMsg = comdb2_asprintf("procedure name must not exceed %d characters", sizeof(spname)-1);
+        setError(pParse, SQLITE_MISUSE, errMsg);
+        free(errMsg);
         return;
     }
 
@@ -1249,7 +1251,9 @@ void comdb2CreateProcedure(Parse* pParse, Token* nm, Token* ver, Token* proc)
     }
     if (ver) {
         if (comdb2TokenToStr(ver, sp_version, sizeof(sp_version))) {
-            setError(pParse, SQLITE_MISUSE, "Procedure version is too long");
+            char *errMsg = comdb2_asprintf("procedure version must not exceed %d characters", sizeof(sp_version)-1);
+            setError(pParse, SQLITE_MISUSE, errMsg);
+            free(errMsg);
             goto cleanup;
         }
         strcpy(sc->fname, sp_version);
@@ -1290,7 +1294,9 @@ void comdb2DefaultProcedure(Parse *pParse, Token *nm, Token *ver, int str)
     Vdbe *v = sqlite3GetVdbe(pParse);
 
     if (comdb2TokenToStr(nm, spname, sizeof(spname))) {
-        setError(pParse, SQLITE_MISUSE, "Procedure name is too long");
+        char *errMsg = comdb2_asprintf("procedure name must not exceed %d characters", sizeof(spname)-1);
+        setError(pParse, SQLITE_MISUSE, errMsg);
+        free(errMsg);
         return;
     }
 
@@ -1299,7 +1305,9 @@ void comdb2DefaultProcedure(Parse *pParse, Token *nm, Token *ver, int str)
 
     if (str) {
         if (comdb2TokenToStr(ver, sp_version, sizeof(sp_version))) {
-            setError(pParse, SQLITE_MISUSE, "Procedure version is too long");
+            char *errMsg = comdb2_asprintf("procedure version must not exceed %d characters", sizeof(sp_version)-1);
+            setError(pParse, SQLITE_MISUSE, errMsg);
+            free(errMsg);
             goto cleanup;
         }
         strcpy(sc->fname, sp_version);
@@ -1342,7 +1350,9 @@ void comdb2DropProcedure(Parse *pParse, Token *nm, Token *ver, int str)
     Vdbe *v = sqlite3GetVdbe(pParse);
 
     if (comdb2TokenToStr(nm, spname, sizeof(spname))) {
-        setError(pParse, SQLITE_MISUSE, "Procedure name is too long");
+        char *errMsg = comdb2_asprintf("procedure name must not exceed %d characters", sizeof(spname)-1);
+        setError(pParse, SQLITE_MISUSE, errMsg);
+        free(errMsg);
         return;
     }
 
@@ -1368,7 +1378,9 @@ void comdb2DropProcedure(Parse *pParse, Token *nm, Token *ver, int str)
 
     if (str) {
         if (comdb2TokenToStr(ver, sp_version, sizeof(sp_version))) {
-            setError(pParse, SQLITE_MISUSE, "Procedure version is too long");
+            char *errMsg = comdb2_asprintf("procedure version must not exceed %d characters", sizeof(sp_version)-1);
+            setError(pParse, SQLITE_MISUSE, errMsg);
+            free(errMsg);
             goto cleanup;
         }
         strcpy(sc->fname, sp_version);

--- a/tests/consumer.test/t05.expected
+++ b/tests/consumer.test/t05.expected
@@ -1,0 +1,9 @@
+(version='sample')
+(version='sample')
+(version='sample')
+[create procedure len_is_32_______________________ version 'sample' {
+        local function main()
+        end
+}] failed with rc -3 procedure name must not exceed 31 characters
+[create lua consumer len_is_29____________________ on (table t for update of i)] failed with rc -3 procedure name must not exceed 28 characters
+(name='len_is_28___________________', type='consumer', tbl_name='t', event='upd', col='i', seq='N')

--- a/tests/consumer.test/t05.sql
+++ b/tests/consumer.test/t05.sql
@@ -1,0 +1,20 @@
+create table t(i int)$$
+create procedure len_is_28___________________ version 'sample' {
+        local function main()
+        end
+}$$
+create procedure len_is_29____________________ version 'sample' {
+        local function main()
+        end
+}$$
+create procedure len_is_31______________________ version 'sample' {
+        local function main()
+        end
+}$$
+create procedure len_is_32_______________________ version 'sample' {
+        local function main()
+        end
+}$$
+create lua consumer len_is_28___________________ on (table t for update of i)
+create lua consumer len_is_29____________________ on (table t for update of i)
+select * from comdb2_triggers where name like 'len_is_%'


### PR DESCRIPTION
You can create a procedure with a name having a maximum of 31 characters; however, creating a consumer or a trigger on a procedure with a name of over 28 characters fails. This is probably because `__q` is internally added to the name of the consumer/trigger. The changes in this PR cause `create consumer/trigger` to error out if the procedure name has more than 28 characters.