### PR TITLE
Flag to allow SQL on incoherent nodes

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -3167,7 +3167,7 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl,
     }
 
     int n_features = 0;
-    int features[10]; // Max 10 client features??
+    int features[20]; // Max 20 client features??
     CDB2QUERY query = CDB2__QUERY__INIT;
     CDB2SQLQUERY sqlquery = CDB2__SQLQUERY__INIT;
     CDB2SQLQUERY__Snapshotinfo snapshotinfo;
@@ -3276,6 +3276,9 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl,
 
     if (hndl && (hndl->flags & CDB2_REQUIRE_FASTSQL) != 0) {
         features[n_features++] = CDB2_CLIENT_FEATURES__REQUIRE_FASTSQL;
+    }
+    if (hndl && (hndl->flags & CDB2_ALLOW_INCOHERENT) != 0) {
+        features[n_features++] = CDB2_CLIENT_FEATURES__ALLOW_INCOHERENT;
     }
 
     if (n_features) {

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -40,6 +40,7 @@ enum cdb2_hndl_alloc_flags {
     CDB2_TYPE_IS_FD = 256,
     CDB2_REQUIRE_FASTSQL = 512,
     CDB2_MASTER = 1024,
+    CDB2_ALLOW_INCOHERENT = 2048
 };
 
 enum cdb2_request_type {

--- a/db/sql.h
+++ b/db/sql.h
@@ -673,6 +673,20 @@ void clear_session_tbls(struct sqlclntstate *);
 void clear_participants(struct sqlclntstate *);
 int add_participant(struct sqlclntstate *, const char *dbname, const char *tier);
 
+struct features {
+    unsigned have_ssl : 1;
+    unsigned have_sqlite_fmt : 1;
+    unsigned allow_master_exec : 1;
+    unsigned allow_master_dbinfo : 1;
+    unsigned queue_me : 1;
+    unsigned allow_incoherent : 1;
+    unsigned skip_intrans_results : 1;
+    unsigned flat_col_vals : 1;
+    unsigned request_fp : 1;
+    unsigned require_fastsql : 1;
+    unsigned can_redirect_fdb : 1;
+};
+
 /* Client specific sql state */
 struct sqlclntstate {
     struct thdpool *pPool;     /* When null, the default SQL thread pool is
@@ -1036,6 +1050,8 @@ struct sqlclntstate {
     unsigned verify_dbstore : 1;
     unsigned multiline : 1;
     int tail_offset;
+
+    struct features features;
 };
 typedef struct sqlclntstate sqlclntstate;
 

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1,5 +1,4 @@
 /*
- *  return newsql_row_remtran(c, a, i);
    Copyright 2017, 2023 Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -31,6 +31,8 @@ enum CDB2ClientFeatures {
     REQUIRE_FASTSQL        = 10;
     /* To tell the server that the client can redirect an fdb query */
     CAN_REDIRECT_FDB       = 11;
+    /* Useful for utilities - allow queries on incoherent nodes. */
+    ALLOW_INCOHERENT       = 12;
 }
 
 message CDB2_FLAG {

--- a/tests/incoherent_sql.test/Makefile
+++ b/tests/incoherent_sql.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/incoherent_sql.test/README
+++ b/tests/incoherent_sql.test/README
@@ -1,0 +1,4 @@
+Tests cdb2api mode to allow SQL on incoherent nodes
+
+Generally a bad idea, but useful for tools that need to
+get the status of all the nodes, etc.

--- a/tests/incoherent_sql.test/lrl.options
+++ b/tests/incoherent_sql.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/incoherent_sql.test/runit
+++ b/tests/incoherent_sql.test/runit
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+db=$1
+export CDB2_LOG_CALLS=1
+
+host=$(cdb2sql --tabs ${CDB2_OPTIONS} $db default "select host from comdb2_cluster where is_master='N' limit 1")
+leader=$(cdb2sql --tabs ${CDB2_OPTIONS} $db default "select host from comdb2_cluster where is_master='Y'")
+cdb2sql --host ${host} --tabs ${CDB2_OPTIONS} $db "put tunable rep_debug_delay 11000"
+for i in $(seq 1 100); do
+    cdb2sql ${CDB2_OPTIONS} --host ${leader} $db  "insert into t values(1)" >/dev/null &
+done
+wait
+state=$(cdb2sql --tabs --host ${leader} ${CDB2_OPTIONS} $db "select coherent_state from comdb2_cluster where host='${host}'")
+if [[ !"$state" =~ ^INCOHERENT* ]]; then
+    echo "Expected host to be incoherent!"
+    exit 1
+fi
+checkhost=$(cdb2sql --tabs --allow-incoherent --host ${host} ${CDB2_OPTIONS} $db 'select comdb2_host()')
+if [[ "$checkhost" != "$host" ]]; then
+    echo "Couldn't run query on incoherent host with --allow-incoherent option"
+    exit 1
+fi
+
+checkerr=$(cdb2sql --host ${host} ${CDB2_OPTIONS} $db 'select comdb2_host()' 2>&1)
+if [[ ! "$checkerr" =~ .*Cannot\ connect\ to\ db.* ]]; then
+    echo "Able to run query on incoherent node?"
+    exit 1
+fi
+
+# remove debug delay so unsetup can successfully query all the nodes
+cdb2sql --tabs --allow-incoherent --host ${host} ${CDB2_OPTIONS} $db 'put tunable rep_debug_delay 0'
+cdb2sql ${CDB2_OPTIONS} --host ${leader} $db  "insert into t values(1)" >/dev/null
+cdb2sql ${CDB2_OPTIONS} --host ${leader} $db  "insert into t values(1)" >/dev/null
+
+sleep 20
+
+
+echo "Testcase passed."
+exit 0

--- a/tests/incoherent_sql.test/t.csc2
+++ b/tests/incoherent_sql.test/t.csc2
@@ -1,0 +1,3 @@
+schema {
+    int a
+}


### PR DESCRIPTION
Useful for tooling that wants to check metrics/liveness of a database on an incoherent node.