### PR TITLE
Don't run full recovery for snapshot

### DIFF
--- a/bdb/bdbglue.h
+++ b/bdb/bdbglue.h
@@ -20,6 +20,8 @@
 struct bdb_state_tag;
 extern struct bdb_state_tag *gbl_bdb_state;
 
+int bdb_recovery_timestamp_fulfills_log_age_requirement(int32_t timestamp);
+
 /* Acquire the write lock.  If the current thread already holds the bdb read
  * lock then it is upgraded to a write lock.  If it already holds the write
  * lock then we just increase our reference count. */

--- a/tests/siasofbounce.test/lrl.options
+++ b/tests/siasofbounce.test/lrl.options
@@ -1,1 +1,2 @@
 enable_snapshot_isolation
+min_keep_logs_age 400


### PR DESCRIPTION
Snapshot databases run through **all** of the logs on startup to populate structures needed for point in time (PIT) snapshots to run correctly. This is overkill, since snapshot databases only actually need to look at the logs written in a fixed time interval. The changes in this PR cause snapshot databases to only run through the logs written in this interval.