### PR TITLE
collect blobs during check constraints validation in sc

### DIFF
--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -484,7 +484,7 @@ static int prepare_and_verify_newdb_record(struct convert_record_data *data,
     /* map old blobs to new blobs */
     if (!data->s->force_rebuild && !data->s->use_old_blobs_on_rebuild &&
         ((gbl_partial_indexes && data->to->ix_partial) || data->to->ix_expr ||
-         !gbl_use_plan || !data->to->plan || !data->to->plan->plan_blobs)) {
+         !gbl_use_plan || !data->to->plan || !data->to->plan->plan_blobs || data->to->n_check_constraints)) {
         if (!leakcheck)
             bzero(data->wrblb, sizeof(data->wrblb));
         for (int ii = 0; ii < data->to->numblobs; ii++) {
@@ -885,7 +885,7 @@ static int convert_record(struct convert_record_data *data)
     if (data->from->numblobs != 0 &&
         ((gbl_partial_indexes && data->to->ix_partial) || data->to->ix_expr ||
          !gbl_use_plan || !data->to->plan || !data->to->plan->plan_blobs ||
-         data->s->force_rebuild || data->s->use_old_blobs_on_rebuild)) {
+         data->s->force_rebuild || data->s->use_old_blobs_on_rebuild || data->to->n_check_constraints)) {
         int bdberr;
         free_blob_status_data(&data->blb);
         bdb_fetch_args_t args = {0};

--- a/tests/checkconstr.test/Makefile
+++ b/tests/checkconstr.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/checkconstr.test/README
+++ b/tests/checkconstr.test/README
@@ -1,0 +1,1 @@
+Test check constraints, more specifically, test that blobs are collected and used during sc validation.

--- a/tests/checkconstr.test/lrl.options
+++ b/tests/checkconstr.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/checkconstr.test/runit
+++ b/tests/checkconstr.test/runit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbname=$1
+if [[ -z $dbname ]] ; then
+    echo dbname missing
+    exit 1
+fi
+
+SQLT="cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default"
+SQL="cdb2sql ${CDB2_OPTIONS} ${DBNAME} default"
+
+
+$SQL "insert into t values (1, '{""hey"": 1}')"
+$SQL - <<EOF
+insert into t values (2, '{"cats":123,"cats2":"woah","more cats": 1234, "so much cat": 4321 ,"why cat": 1,"all you need is a cat":0}')
+EOF
+
+$SQL "alter table t {`cat t2.csc2`}"
+if (( $? != 0 )) ; then
+    echo "Failure to alter"
+    exit 1
+fi
+
+echo "Testcase passed."
+exit 0

--- a/tests/checkconstr.test/t.csc2
+++ b/tests/checkconstr.test/t.csc2
@@ -1,0 +1,20 @@
+schema 
+{
+        int a
+        vutf8 config[10]
+}
+
+keys 
+{
+        "a" = a
+}
+
+constraints
+{
+    check "JSON_CHECK" = { where JSON_VALID(config) }
+}
+
+
+
+
+

--- a/tests/checkconstr.test/t2.csc2
+++ b/tests/checkconstr.test/t2.csc2
@@ -1,0 +1,21 @@
+//this is a new comment
+schema 
+{
+        int a
+        vutf8 config[10]
+}
+
+keys 
+{
+        "a" = a
+}
+
+constraints
+{
+    check "JSON_CHECK" = { where JSON_VALID(config) }
+}
+
+
+
+
+


### PR DESCRIPTION
Right now, any schema change for a table with check constraints that requires blobs for validation (long vutf8 fields for example, used with a json function, re: 178413697) will fail the check since the blob shows empty.