### PR TITLE
jdbc: Supporting per-connection identity

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Connection.java
@@ -296,7 +296,7 @@ public class Comdb2Connection implements Connection {
         hndl.setClearAck(clearAck);
     }
 
-    public void setUseIdentity(boolean useIdentity) {
+    public void setUseIdentity(String useIdentity) {
         hndl.hasUseIdentity = true;
         hndl.setUseIdentity(useIdentity);
     }

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -98,7 +98,8 @@ public class Comdb2Handle extends AbstractConnection {
     private boolean skipDrain = false;
     private boolean clearAckOnClose = true;
     boolean hasUseIdentity;
-    boolean useIdentity = true;
+    String useIdentity = null;
+    IdentityCreator ic = null;
 
     private boolean isRead;
     private String lastSql;
@@ -408,7 +409,7 @@ public class Comdb2Handle extends AbstractConnection {
         this.clearAckOnClose = val;
     }
 
-    public void setUseIdentity(boolean val){
+    public void setUseIdentity(String val){
         this.useIdentity = val;
     }
 
@@ -684,7 +685,7 @@ public class Comdb2Handle extends AbstractConnection {
         Cdb2Query query = new Cdb2Query();
         Cdb2SqlQuery sqlQuery = new Cdb2SqlQuery();
         query.cdb2SqlQuery = sqlQuery;
-        IdentityCreator ic;
+        IdentityCreatorFactory icf;
         Cdb2IdentityBlob idblob;
 
         if (!sentClientInfo) {
@@ -696,9 +697,10 @@ public class Comdb2Handle extends AbstractConnection {
             sentClientInfo = true;
         }
 
-        if (useIdentity && (ic = Driver.getIdentityCreator()) != null) {
+        if (ic == null && (icf = Driver.getIdentityCreatorFactory()) != null)
+            ic = icf.build(useIdentity);
+        if (ic != null)
             sqlQuery.identity = ic.create();
-        }
 
         sqlQuery.dbName = myDbName;
         sqlQuery.sqlQuery = sql;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/DatabaseDiscovery.java
@@ -65,15 +65,6 @@ public class DatabaseDiscovery {
         if (val.equalsIgnoreCase("1"))
             return true;
 
-        if (val.equalsIgnoreCase("off"))
-            return false;
-        if (val.equalsIgnoreCase("false"))
-            return false;
-        if (val.equalsIgnoreCase("no"))
-            return false;
-        if (val.equalsIgnoreCase("0"))
-            return true;
-
         return false;
     }
 
@@ -119,7 +110,7 @@ public class DatabaseDiscovery {
                 } else if (tokens[0].equalsIgnoreCase("comdb2_feature")) {
                     if (tokens[1].equalsIgnoreCase("iam_identity_v6")
                             && !hndl.hasUseIdentity)
-                        hndl.useIdentity = value_on_off(tokens[2]);
+                        hndl.useIdentity = String.valueOf(value_on_off(tokens[2]));
                 } else if (tokens[0].equalsIgnoreCase("comdb2_config")) {
 
                     if (tokens[1].equalsIgnoreCase("default_type")

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Driver.java
@@ -27,7 +27,7 @@ public class Driver implements java.sql.Driver {
     public static final String PREFIX = "jdbc:comdb2:";
     protected HashMap<String, Option> options = new HashMap<String, Option>();
     private static HealthChecker healthChecker;
-    private static IdentityCreator identityCreator;
+    private static IdentityCreatorFactory identityCreatorFactory;
 
     public Driver() throws SQLException {
         populateOptions();
@@ -126,7 +126,7 @@ public class Driver implements java.sql.Driver {
             options.put("stack_at_open", new BooleanOption("stack_at_open", "StackAtOpen"));
             options.put("skip_rs_drain", new BooleanOption("skip_rs_drain", "SkipResultSetDrain"));
             options.put("clear_ack", new BooleanOption("clear_ack", "ClearAck"));
-            options.put("use_identity", new BooleanOption("use_identity", "UseIdentity"));
+            options.put("use_identity", new StringOption("use_identity", "UseIdentity"));
             options.put("use_txn_for_batch", new BooleanOption("use_txn_for_batch", "UseTxnForBatch"));
         } catch (Throwable e) {
             throw new SQLException(e);
@@ -344,12 +344,12 @@ public class Driver implements java.sql.Driver {
         return healthChecker;
     }
 
-    public static void setIdentityCreator(IdentityCreator ic) {
-        identityCreator = ic;
+    public static void setIdentityCreatorFactory(IdentityCreatorFactory icf) {
+        identityCreatorFactory = icf;
     }
 
-    public static IdentityCreator getIdentityCreator() {
-        return identityCreator;
+    public static IdentityCreatorFactory getIdentityCreatorFactory() {
+        return identityCreatorFactory;
     }
 }
 /* vim: set sw=4 ts=4 et: */

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/IdentityCreatorFactory.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/IdentityCreatorFactory.java
@@ -1,4 +1,4 @@
-/* Copyright 2023 Bloomberg Finance L.P.
+/* Copyright 2025 Bloomberg Finance L.P.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -13,9 +13,7 @@
    limitations under the License. */
 package com.bloomberg.comdb2.jdbc;
 
-import com.bloomberg.comdb2.jdbc.Cdb2Query.*;
-
-/* per connection identity creator */
-public interface IdentityCreator {
-    Cdb2IdentityBlob create();
+/* identity creator factory */
+public interface IdentityCreatorFactory {
+    IdentityCreator build(String spec);
 }


### PR DESCRIPTION
This patch adds a new interface to support per-connection identities.