### PR TITLE
Making -cost work for stored procedures

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2276,6 +2276,47 @@ out:
     assert(logger->path == 0);
 }
 
+hash_t *create_query_hash();
+void clear_query_hash(hash_t *h, int destroy);
+void reqlog_begin_subrequest(struct reqlogger *logger)
+{
+    reqlog_set_startprcs(logger, comdb2_time_epochus());
+    struct sql_thread *thd = pthread_getspecific(query_info_key);
+    if (thd != NULL) {
+        thd->in_subrequest = 1;
+        listc_init(&thd->query_stats_subrequest, offsetof(struct query_path_component, lnk));
+        if (thd->query_hash_subrequest == NULL)
+            thd->query_hash_subrequest = create_query_hash();
+    }
+}
+
+void reqlog_end_subrequest(struct reqlogger *logger, int rc, const char *callfunc, int line)
+{
+    const char *request_type = logger->request_type;
+    int opcode = logger->opcode;
+    struct ireq *iq = logger->iq;
+    struct sqlclntstate *clnt = logger->clnt;
+
+    reqlog_end_request(logger, rc, callfunc, line);
+    reqlog_start_request(logger);
+    struct sql_thread *thd = pthread_getspecific(query_info_key);
+    if (thd != NULL) {
+        thd->in_subrequest = 0;
+        listc_init(&thd->query_stats_subrequest, offsetof(struct query_path_component, lnk));
+        clear_query_hash(thd->query_hash_subrequest, 0);
+    }
+
+    if (opcode == OP_SQL && clnt != NULL) {
+        logger->startus = logger->startprcsus = clnt->enque_timeus;
+    } else if (iq != NULL) {
+        logger->startus = logger->startprcsus = iq->nowus;
+    }
+    logger->request_type = request_type;
+    logger->opcode = opcode;
+    logger->iq = iq;
+    logger->clnt = clnt;
+}
+
 /* this is meant to be called by only 1 thread, will need locking if
  * more than one threads were to be involved */
 void reqlog_diffstat_dump(struct reqlogger *logger)

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -69,6 +69,8 @@ void reqlog_set_sql(struct reqlogger *logger, struct string_ref *sr);
 void reqlog_set_startprcs(struct reqlogger *logger, uint64_t start);
 uint64_t reqlog_current_us(struct reqlogger *logger);
 void reqlog_end_request(struct reqlogger *logger, int rc, const char *callfunc, int line);
+void reqlog_begin_subrequest(struct reqlogger *logger);
+void reqlog_end_subrequest(struct reqlogger *logger, int rc, const char *callfunc, int line);
 void reqlog_diffstat_init(struct reqlogger *logger);
 /* this is meant to be called by only 1 thread, will need locking if
  * more than one threads were to be involved */

--- a/db/sql.h
+++ b/db/sql.h
@@ -1243,7 +1243,7 @@ struct sql_hist {
     int64_t txnid;
     struct conninfo conn;
 };
-
+typedef LISTC_T(struct query_path_component) query_path_component_tp;
 struct sql_thread {
     LINKC_T(struct sql_thread) lnk;
     pthread_mutex_t lk;
@@ -1257,8 +1257,11 @@ struct sql_thread {
     int bufsz;
     uint32_t id;
     char *buf;
-    LISTC_T(struct query_path_component) query_stats;
+    int in_subrequest;
+    query_path_component_tp query_stats;
     hash_t *query_hash;
+    query_path_component_tp query_stats_subrequest;
+    hash_t *query_hash_subrequest;
     double cost;
     struct sqlclntstate *clnt;
     /* custom error message to send to client */

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2276,11 +2276,16 @@ static void lua_begin_step(struct sqlclntstate *clnt, SP sp,
 {
     int64_t time = comdb2_time_epochms();
     Vdbe *pVdbe = (Vdbe*)pStmt;
+    struct reqlogger *logger;
 
     if ((sp != NULL) && (pVdbe != NULL)) {
         save_thd_cost_and_reset(sp->thd, pVdbe);
         pVdbe->luaStartTime = time;
         pVdbe->luaRows = 0;
+
+        logger = sp->thd->logger;
+        reqlog_begin_subrequest(logger);
+        reqlog_logf(logger, REQL_INFO, "sp_sql=%s", sqlite3_sql(pStmt));
     }
 }
 
@@ -2298,6 +2303,7 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
                          sqlite3_stmt *pStmt)
 {
     Vdbe *pVdbe = (Vdbe*)pStmt;
+    struct reqlogger *logger;
 
     /* Check whether fingerprint has already been computed. */
     if ((pVdbe == NULL) || (pVdbe->fingerprint_added == 1)) {
@@ -2306,6 +2312,7 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
 
     if (sp != NULL) {
         const char *zNormSql = sqlite3_normalized_sql(pStmt);
+        logger = sp->thd->logger;
 
         if (zNormSql != NULL) {
             double cost = 0.0;
@@ -2332,8 +2339,14 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
             clnt->spcost.rows += pVdbe->luaRows;
 
             pVdbe->fingerprint_added = 1;
+
+            reqlog_set_path(logger, sp->clnt->query_stats);
+            reqlog_set_cost(logger, cost);
+            reqlog_set_rows(logger, pVdbe->luaRows);
         }
 
+        reqlog_end_subrequest(sp->thd->logger, sp->rc, __func__, __LINE__);
+        reqlog_set_sql(logger, clnt->sql_ref);
         restore_thd_cost_and_reset(sp->thd, pVdbe);
     }
 }
@@ -3116,6 +3129,7 @@ static void drop_temp_tables(SP sp)
             expire = 1;
             logmsg(LOGMSG_FATAL, "sqlite3_step rc:%d sql:%s\n", rc, drop_sql);
         }
+        reqlog_end_subrequest(sp->thd->logger, rc, __func__, __LINE__);
     }
     clnt->is_readonly = ro;
     clnt->skip_peer_chk = 0;

--- a/tests/sp.test/t17.req
+++ b/tests/sp.test/t17.req
@@ -1,0 +1,10 @@
+DROP TABLE IF EXISTS t17
+CREATE TABLE t17 (i INTEGER UNIQUE)$$
+INSERT INTO t17 (i) SELECT value FROM generate_series(1, 1000)
+CREATE PROCEDURE sp17 {
+local function main()
+    db:exec("SELECT i FROM t17 WHERE i > 0 AND i <= 10"):emit();
+end }$$
+SET GETCOST ON
+EXEC PROCEDURE sp17()
+SELECT comdb2_prevquerycost()

--- a/tests/sp.test/t17.req.out
+++ b/tests/sp.test/t17.req.out
@@ -1,0 +1,15 @@
+(rows inserted=1000)
+(version='1')
+(i=1)
+(i=2)
+(i=3)
+(i=4)
+(i=5)
+(i=6)
+(i=7)
+(i=8)
+(i=9)
+(i=10)
+(comdb2_prevquerycost()='Cost: 20.00 NRows: 10
+    index 0 on table t17 finds 1 next/prev 10
+')

--- a/tests/sp_longreqs.test/Makefile
+++ b/tests/sp_longreqs.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sp_longreqs.test/runit
+++ b/tests/sp_longreqs.test/runit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+dbnm=$1
+
+# Make sure we talk to the same host
+
+mach=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "SELECT comdb2_host()"`
+
+if [ "$mach" = "" ]; then
+   echo could not retrieve hostname >&2
+   exit 1
+fi
+
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default - >/dev/null <<EOF
+DROP TABLE IF EXISTS t
+CREATE TABLE t (i INTEGER UNIQUE)\$\$
+INSERT INTO t (i) SELECT value FROM generate_series(1, 1000)
+CREATE PROCEDURE sp {
+local function main()
+    db:exec("SELECT i FROM t WHERE i > 0 AND i <= 10"):emit();
+    db:exec("SELECT i FROM t WHERE i > 10 AND i <= 20"):emit();
+end }\$\$
+EXEC PROCEDURE sp()
+EOF
+
+# Redirect longreqs to standard out
+cdb2sql --host $mach $dbnm "EXEC PROCEDURE sys.cmd.send('reql longreqfile <stdout>')" >/dev/null
+cdb2sql --host $mach $dbnm "EXEC PROCEDURE sys.cmd.send('reql longsqlrequest 0')" >/dev/null
+cdb2sql --host $mach $dbnm "EXEC PROCEDURE sp()" >/dev/null
+
+if [ -n "$CLUSTER" ] ; then
+    logfile="$TESTDIR/logs/$dbnm.$mach.db"
+else
+    logfile="$TESTDIR/logs/$dbnm.db"
+fi
+
+# give time for .db file to flush
+sleep 1
+
+# ensure we see individual plans from these 2 queries
+cnt=`grep -c 'index 0 on table t finds 1 next/prev 10' $logfile`
+echo $cnt
+if [ $cnt -ne 2 ]; then
+    echo 'missing cursor stats???' >&2
+    exit 1
+fi
+grep 'sp_sql=SELECT i FROM t WHERE i > 0 AND i <= 10' $logfile
+grep 'sp_sql=SELECT i FROM t WHERE i > 10 AND i <= 20' $logfile
+
+# ensure we have a total plan of the sp
+grep 'index 0 on table t finds 2 next/prev 20' $logfile
+grep 'rowcount=20, cost=40' $logfile
+
+exit 0


### PR DESCRIPTION
This patch makes `comdb2_prevquerycost()` work for stored procedures. Long SQL queries executed from within a store procedure are logged as well.