### PR TITLE
block put retention for truncate partitions

### DIFF
--- a/db/views.h
+++ b/db/views.h
@@ -508,4 +508,20 @@ int logical_partition_next_rollout(const char *name);
  */
 timepart_view_t *timepart_reaquire_view(const char *partname);
 
+enum {
+    ROLLOUT_INVALID = -1,
+    ROLLOUT_TRUNC = 0,
+    ROLLOUT_LEG_PART = 1,
+    ROLLOUT_LEG_FULL = 2
+};
+
+/**
+ * Return ROLLOUT_LEG_FULL for legacy full
+ * Return ROLLOUT_LEG_PART for legacy partial
+ * Return ROLLOUT_TRUNC if truncate rollout
+ * Return ROLLOUT_INVALID if not existing
+ *
+ */
+int timepart_rollout(const char *partname);
+
 #endif

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -2871,6 +2871,15 @@ void comdb2timepartRetention(Parse *pParse, Token *nm, Token *lnm, int retention
                               ERROR_ON_TBL_NOT_FOUND, 1, 0, NULL))
         goto clean_arg;
 
+    int rc = timepart_rollout(tp_retention->timepartname);
+    if (rc == ROLLOUT_INVALID) {
+        setError(pParse, SQLITE_ERROR, "Partition does not exist");
+        goto clean_arg;
+    } else if (rc == ROLLOUT_TRUNC) {
+        setError(pParse, SQLITE_ERROR, "Use alter to change partition config");
+        goto clean_arg;
+    }
+
     tp_retention->newvalue = retention;
 
     comdb2prepareNoRows(v, pParse, 0, arg, &comdb2SendBpfunc, 

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -1131,3 +1131,5 @@ Test block alter of a constraint target table
 TEST 21
 Test table_version for a partition name for a create table partitioned case
 0
+TEST 22
+Test put retention block for truncate partitions

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -665,6 +665,12 @@ if (( $? != 0 )) ; then
    exit 1
 fi
 
+header 22 "Test put retention block for truncate partitions"
+$cmdt "put time partition t retention 1"
+if (( $? == 0 )) ; then
+   echo "FAILURE to block put retention"
+   exit 1
+fi
 
 # we need to scrub dbname from alpha
 sed "s/dorintdb/$dbname/g; s#\${CDB2_OPTIONS}#${CDB2_OPTIONS}#g" $OUT.alpha > $OUT.alpha.actual


### PR DESCRIPTION
Highly specific case covering on;ly retention.  Better to collapse and recreate with new format. Blocking for truncate partition, it never worked.
re:  178501853