### PR TITLE
Block resuming a partition merge schema change

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1471,8 +1471,9 @@ void *resume_sc_multiddl_txn_finalize(void *p)
         } else {
             logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__,
                    sc->tablename, sc->sc_rc);
-            sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__,
-                           __LINE__);
+            if (sc->set_running)
+                sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__,
+                               __LINE__);
             free_schema_change_type(sc);
             error = 1;
         }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6482,20 +6482,16 @@ static int _process_partitioned_table_merge(struct ireq *iq)
          */
         sc->nothrevent = 1; /* we need do_alter_table to run first */
         sc->finalize = 0;
-        enum comdb2_partition_type tt = sc->partition.type;
-        sc->partition.type = PARTITION_NONE;
 
         strncpy(sc->tablename, first_shard->tablename, sizeof(sc->tablename));
 
         rc = start_schema_change_tran(iq, NULL);
-
         if (rc) {
             if (rc != SC_MASTER_DOWNGRADE)
                 iq->osql_flags |= OSQL_FLAGS_SCDONE;
             return ERR_SC;
         }
 
-        sc->partition.type = tt;
         iq->sc->sc_next = iq->sc_pending;
         iq->sc_pending = iq->sc;
 

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -403,7 +403,17 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     struct scinfo scinfo;
     struct errstat err = {0};
 
-    if (s->partition.type == PARTITION_MERGE)
+    db = get_dbtable_by_name(s->tablename);
+    if (db == NULL) {
+        sc_errf(s, "Table not found:%s\n", s->tablename);
+        return SC_TABLE_DOESNOT_EXIST;
+    }
+
+
+    /* note for a partition merge, if we reuse the first shard (i.e. it is aliased),
+     * we need to alter it here instead of running do_merge_table
+     */
+    if (s->partition.type == PARTITION_MERGE && !db->sqlaliasname)
         return do_merge_table(iq, s, tran);
 
 #ifdef DEBUG_SC
@@ -412,12 +422,6 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     gbl_use_plan = 1;
     gbl_sc_last_writer_time = 0;
-
-    db = get_dbtable_by_name(s->tablename);
-    if (db == NULL) {
-        sc_errf(s, "Table not found:%s\n", s->tablename);
-        return SC_TABLE_DOESNOT_EXIST;
-    }
 
     if (s->resume == SC_PREEMPT_RESUME) {
         newdb = db->sc_to;

--- a/tests/TODO
+++ b/tests/TODO
@@ -83,6 +83,6 @@ rowlocks_blkseq.test
 sc_async_constraints.test
 sigstopcluster.test
 weighted_standing_queue.test -- failing in rhel8 + podman
-sc_resume_partition.test -- Pending PR #5073
+sc_resume_partition.test
 
 # vim: set sw=4 ts=4 et:


### PR DESCRIPTION
The actual fix to survive master swings requires more time at this point, so lets block resume for now (matching 8.0) behavior.

The 8.0 patch was merged here:
https://github.com/bloomberg/comdb2/pull/4936
