### PR TITLE
[8.0] Querying comdb2db for physrep source db number

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1665,12 +1665,13 @@ static int read_available_comdb2db_configs(cdb2_hndl_tp *hndl, char comdb2db_hos
     return 0;
 }
 
-int cdb2_get_comdb2db(char **comdb2dbname)
+int cdb2_get_comdb2db(char **comdb2dbname, char **comdb2dbclass)
 {
     if (!strlen(cdb2_comdb2dbname)) {
         read_available_comdb2db_configs(NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, 0, 0);
     }
     (*comdb2dbname) = strdup(cdb2_comdb2dbname);
+    (*comdb2dbclass) = strdup((strcmp(cdb2_comdb2dbname, "comdb3db") == 0) ? "dev" : "prod");
     return 0;
 }
 

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -205,7 +205,7 @@ typedef struct cdb2_effects_type effects_tp;
 
 void cdb2_set_comdb2db_config(const char *cfg_file);
 void cdb2_set_comdb2db_info(const char *cfg_info);
-int cdb2_get_comdb2db(char **comdb2db_name);
+int cdb2_get_comdb2db(char **comdb2db_name, char **comdb2db_class);
 
 int cdb2_open(cdb2_hndl_tp **hndl, const char *dbname, const char *type,
               int flags);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -466,6 +466,7 @@ extern int gbl_physrep_max_rollback;
 /* source-name / host is from lrl */
 extern char *gbl_physrep_source_dbname;
 extern int gbl_physrep_source_dbnum;
+extern int gbl_query_comdb2db_for_absent_physrep_source_dbnum;
 extern char *gbl_physrep_source_host;
 
 /* meta-name / host is from lrl */

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1949,6 +1949,9 @@ REGISTER_TUNABLE("physrep_source_host", "List of physical replication source clu
                  &gbl_physrep_source_host, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_source_dbnum", "Physical replication source cluster db number.", TUNABLE_INTEGER,
                  &gbl_physrep_source_dbnum, READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("query_comdb2db_for_absent_physrep_source_dbnum",
+                 "If only physrep source name is specified, query comdb2db for its db number", TUNABLE_INTEGER,
+                 &gbl_query_comdb2db_for_absent_physrep_source_dbnum, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_ignore_queues", "Don't replicate queues.", TUNABLE_BOOLEAN, &gbl_physrep_ignore_queues,
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_max_rollback", "Maximum logs physrep can rollback. (Default: 0)", TUNABLE_INTEGER,

--- a/db/machcache.c
+++ b/db/machcache.c
@@ -70,8 +70,7 @@ static char *comdb2dbname = NULL;
 void class_machs_init()
 {
     class_machs_hash = hash_init_user((hashfunc_t *)class_machs_hash_func, (cmpfunc_t *)class_machs_cmp, 0, 0);
-    cdb2_get_comdb2db(&comdb2dbname);
-    comdb2dbclass = (strcmp(comdb2dbname, "comdb3db") == 0) ? "dev" : "prod";
+    cdb2_get_comdb2db(&comdb2dbname, &comdb2dbclass);
 }
 
 int gbl_class_machs_refresh = 300;

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -78,6 +78,7 @@ unsigned int gbl_deferred_phys_update;
 
 char *gbl_physrep_source_dbname;
 int gbl_physrep_source_dbnum;
+int gbl_query_comdb2db_for_absent_physrep_source_dbnum = 1;
 char *gbl_physrep_source_host;
 char *gbl_physrep_metadb_name;
 char *gbl_physrep_metadb_host;
@@ -290,8 +291,7 @@ static int append_quoted_source_hosts(char *buf, int buf_len, int *rc) {
     static char *comdb2dbname = NULL;
 
     if (!comdb2dbname) {
-        cdb2_get_comdb2db(&comdb2dbname);
-        comdb2dbclass = (strcmp(comdb2dbname, "comdb3db") == 0) ? "dev" : "prod";
+        cdb2_get_comdb2db(&comdb2dbname, &comdb2dbclass);
     }
 
     *rc = cdb2_open(&comdb2db, comdb2dbname, comdb2dbclass, 0);


### PR DESCRIPTION
If physrep source db number isn't specified in the LRL, let's try to get it from comdb2db.
