### PR TITLE
{178575361} Fill autoinc value for ireq keys that are not expressions on master

### DIFF
--- a/db/tag.c
+++ b/db/tag.c
@@ -2946,6 +2946,7 @@ int upd_master_columns(struct ireq *iq, void *intrans, void *record, size_t recl
 
 int set_master_columns(struct ireq *iq, void *intrans, void *record, size_t reclen)
 {
+    // also may need to add case to create_key_from_ireq
     tran_type *tran = (tran_type *)intrans;
     char *crec = record;
     int rc = 0, bdberr = 0;
@@ -6699,6 +6700,22 @@ int create_key_from_ireq(struct ireq *iq, int ixnum, int isDelete, char **tail,
         memcpy(outbuf, iq->idxDelete[ixnum], db->ix_keylen[ixnum]);
     else
         memcpy(outbuf, iq->idxInsert[ixnum], db->ix_keylen[ixnum]);
+
+    // autoinc value is not set on replicant, set it now
+    struct schema *idx_schema = get_schema(db, ixnum);
+    struct schema *schema = get_schema(db, -1);
+    for (int nfield = 0; nfield < idx_schema->nmembers; nfield++) {
+        const struct field *idx_field = &idx_schema->member[nfield];
+        // TODO: expression idx
+        if (idx_field->isExpr)
+            continue;
+        if (!(idx_field->in_default_type == SERVER_SEQUENCE && stype_is_resolve_master(outbuf + idx_field->offset)))
+            continue;
+        // grab actual autoinc value from the record
+        const struct field *field = &schema->member[idx_field->idx];
+        assert(idx_field->len == field->len);
+        memcpy(outbuf + idx_field->offset, inbuf + field->offset, idx_field->len);
+    }
 
     if (db->ix_datacopy[ixnum]) {
         assert(db->ix_collattr[ixnum] == 0);

--- a/tests/nextsequence.test/runit
+++ b/tests/nextsequence.test/runit
@@ -883,6 +883,29 @@ function verify_and_fix_corruption
     echo "$x"
 }
 
+function insert_with_idx_and_dummy_expr
+{
+    disable_strict_mode
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table seqwithidxanddummyexpr {$(cat seqwithidxanddummyexpr.csc2)}\$\$
+EOF
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into seqwithidxanddummyexpr(a) values(1)"
+    [[ $? != 0 ]] && failexit "seqwithidxanddummyexpr table should have been allowed to insert"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into seqwithidxanddummyexpr values(2, 2)"
+    [[ $? != 0 ]] && failexit "seqwithidxanddummyexpr table should have been allowed to insert"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into seqwithidxanddummyexpr values(NULL, NULL)"
+    [[ $? != 0 ]] && failexit "seqwithidxanddummyexpr table should have been allowed to insert"
+
+    out=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select b from seqwithidxanddummyexpr order by b")
+    [[ $? != 0 ]] && failexit "seqwithidxanddummyexpr table should have been allowed to select"
+    exp=$'(b=NULL)\n(b=1)\n(b=2)'
+    [[ $out != $exp ]] && failexit "Got $out, Expected $exp"
+
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('seqwithidxanddummyexpr')"
+    [[ $? != 0 ]] && failexit "seqwithidxanddummyexpr should have passed verify"
+}
+
 function run_test
 {
     if [[ "$DBNAME" == *"nextsequencenullsorthighgenerated"* ]]; then
@@ -992,6 +1015,8 @@ function run_test
     else
         lrl_sequence
     fi
+
+    insert_with_idx_and_dummy_expr
 }
 
 run_test

--- a/tests/nextsequence.test/seqwithidxanddummyexpr.csc2
+++ b/tests/nextsequence.test/seqwithidxanddummyexpr.csc2
@@ -1,0 +1,10 @@
+schema
+{
+   int a null=yes
+   int b dbstore=nextsequence null=yes
+}
+keys
+{
+   "b" = b
+   dup "expr" = (int)"1 + 1"
+}


### PR DESCRIPTION
Every key is processed on replicant if there exists even one expr index, but autoinc is only applied on master. If a normal key contains autoinc value and there is an expr index, we need to process the value for the autoinc col of the key on master

Still need to fix case where expression index containing autoinc value does not work