### PR TITLE
Fixing fingerprinting of table arguments

### DIFF
--- a/sqlite/src/tokenize.c
+++ b/sqlite/src/tokenize.c
@@ -835,13 +835,14 @@ static int isLeftOperand(int tokenType){
 ** This function should return non-zero if the specified token type is
 ** a keyword that requires the next token to be a table identifier.
 */
-static int requiresTableId(int tokenType){
+static int requiresTableId(int tokenType, int useStrId){
   switch( tokenType ){
     case TK_FROM:
     case TK_JOIN:
     case TK_INTO:
     case TK_UPDATE:
     case TK_TABLE:    return 1;
+    case TK_SPACE:    return useStrId;
     default:          return 0;
   }
 }
@@ -964,7 +965,6 @@ char *sqlite3Normalize_alternate(
         /* fall through */
       }
       default: {
-        useStrId = requiresTableId(tokenType);
         if( sqlite3IsIdChar(zSql[i]) ) addSpaceSeparator(pStr);
         j = pStr->nChar;
         sqlite3_str_append(pStr, zSql+i, n);
@@ -975,6 +975,7 @@ char *sqlite3Normalize_alternate(
         break;
       }
     }
+    useStrId = requiresTableId(tokenType, useStrId);
   }
   if( tokenType!=TK_SEMI ) sqlite3_str_append(pStr, ";", 1);
   return sqlite3_str_finish(pStr);

--- a/tests/fingerprints.test/t08.req
+++ b/tests/fingerprints.test/t08.req
@@ -1,0 +1,4 @@
+SELECT * FROM 'sqlite_stat1' LIMIT 0 -- should show table name
+SELECT * FROM comdb2_transaction_logs('{1:0}') LIMIT 0 -- should not show arguments for hidden columns
+SELECT fingerprint, normalized_sql FROM comdb2_fingerprints WHERE fingerprint='002dcfc6d511a5d625fa142f7f0df9f4'
+SELECT fingerprint, normalized_sql FROM comdb2_fingerprints WHERE fingerprint='c30b0528f036eab64a7953ed7c55af40'

--- a/tests/fingerprints.test/t08.req.out
+++ b/tests/fingerprints.test/t08.req.out
@@ -1,0 +1,2 @@
+(fingerprint='002dcfc6d511a5d625fa142f7f0df9f4', normalized_sql='SELECT*FROM sqlite_stat1 LIMIT?;')
+(fingerprint='c30b0528f036eab64a7953ed7c55af40', normalized_sql='SELECT*FROM comdb2_transaction_logs(?)LIMIT?;')


### PR DESCRIPTION
Queries that select from the same table but with different arguments for hidden columns (most notably `SELECT * FROM comdb2_transaction_logs('{file:offset}')`) are fingerprinted uniquely. This patch fixes it.