### PR TITLE
Fix segfault on partitioned merge sc failure

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6468,13 +6468,14 @@ static int _process_partitioned_table_merge(struct ireq *iq)
 
         rc = start_schema_change_tran(iq, NULL);
 
-        iq->sc->sc_next = iq->sc_pending;
-        iq->sc_pending = iq->sc;
         if (rc) {
             if (rc != SC_MASTER_DOWNGRADE)
                 iq->osql_flags |= OSQL_FLAGS_SCDONE;
             return ERR_SC;
         }
+
+        iq->sc->sc_next = iq->sc_pending;
+        iq->sc_pending = iq->sc;
     } else {
         /*
          * use the fast shard as the destination, after first altering it
@@ -6488,14 +6489,16 @@ static int _process_partitioned_table_merge(struct ireq *iq)
 
         rc = start_schema_change_tran(iq, NULL);
 
-        sc->partition.type = tt;
-        iq->sc->sc_next = iq->sc_pending;
-        iq->sc_pending = iq->sc;
         if (rc) {
             if (rc != SC_MASTER_DOWNGRADE)
                 iq->osql_flags |= OSQL_FLAGS_SCDONE;
             return ERR_SC;
         }
+
+        sc->partition.type = tt;
+        iq->sc->sc_next = iq->sc_pending;
+        iq->sc_pending = iq->sc;
+
         arg.check_extra_shard = 1;
         strncpy(sc->newtable, sc->tablename, sizeof(sc->newtable)); /* piggyback a rename with alter */
         arg.start = 1;

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -419,12 +419,25 @@ $cmd "select * from t14 order by 1" >> $OUT
 
 timepart_stats 0
 
-echo $cmd "ALTER TABLE t14 PARTITIONED BY NONE"
-$cmd "ALTER TABLE t14 PARTITIONED BY NONE"
-if (( $? != 0 )) ; then
-   echo "FAILURE to remote partitioning for t14"
+$cmdm "exec procedure sys.cmd.send('convert_record_sleep 1')"
+
+echo $cmd "ALTER TABLE t14 PARTITIONED BY NONE &"
+$cmd "ALTER TABLE t14 PARTITIONED BY NONE" &
+waitpid=$!
+
+sleep 1
+
+if $cmd "ALTER TABLE t14 PARTITIONED BY NONE"; then
+   echo "FAILURE to block concurrent schema change"
    exit 1
 fi
+
+if ! wait $waitpid; then
+   echo "FAILURE to remove partitioning for t14"
+   exit 1
+fi
+
+$cmdm "exec procedure sys.cmd.send('convert_record_sleep 0')"
 
 echo $cmd "select * from t14 order by 1"
 echo $cmd "select * from t14 order by 1" >> $OUT


### PR DESCRIPTION
After failing to start a schema change, `start_schema_change_tran()` [frees the associated schema change object before returning](https://github.com/bloomberg/comdb2/blob/63967d698d8a7710cecca80c7f2e32444e9866b7/schemachange/schemachange.c#L54). 

Partitioned table merge code links failed scs into the `sc_pending` list, which is later accessed in [`bplog_schemachange_wait()`](https://github.com/bloomberg/comdb2/blob/63967d698d8a7710cecca80c7f2e32444e9866b7/db/osqlblockproc.c#L1304). Since failed schema changes have already been freed at this point, it segfaults.

The changes in this PR do not link failed scs into the `sc_pending` list.