### PR TITLE
Patch partition merge resume test

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -484,6 +484,10 @@ static void do_init_once(void)
     if (cdb2db_dbnum_override) {
         COMDB2DB_NUM_OVERRIDE = atoi(cdb2db_dbnum_override);
     }
+    char *min_retries = getenv("COMDB2_CONFIG_MIN_RETRIES");
+    if (min_retries) {
+        MIN_RETRIES = atoi(min_retries);
+    }
 }
 
 /* if sqlstr is a read stmt will return 1 otherwise return 0

--- a/tests/sc_resume_partition.test/runit
+++ b/tests/sc_resume_partition.test/runit
@@ -33,7 +33,7 @@ test_partition_merge_resume() {
 	cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t values (1)"
 
 	# When
-	cdb2sql ${CDB2_OPTIONS} ${dbnm} default "alter table t partitioned by none" &
+	COMDB2_CONFIG_MIN_RETRIES=1 cdb2sql ${CDB2_OPTIONS} ${dbnm} default "alter table t partitioned by none" &
 	waitpid=$!
 	sleep 1
 	restart_cluster &> /dev/null


### PR DESCRIPTION
This test is flakey: it expects that the api will not retry ddl after the db restarts, but the api *does* retry. The changes in this PR use an environment variable to stop the api from retrying.