### PR TITLE
{178494086}: Fixing miscalculation of query runtime from SP

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2226,7 +2226,7 @@ static int dbstmt_bind_int(Lua lua, dbstmt_t *dbstmt)
     return stmt_bind(lua, dbstmt->stmt);
 }
 
-static int lua_prepare_sql_int(SP sp, const char *sql, sqlite3_stmt **stmt,
+static int lua_prepare_sql_int(SP sp, const char *sql, sqlite3_stmt **pstmt,
                                struct sql_state *rec, int flags)
 {
     Lua L = sp->lua;
@@ -2235,6 +2235,7 @@ static int lua_prepare_sql_int(SP sp, const char *sql, sqlite3_stmt **stmt,
     struct errstat err;
     struct sql_state rec_lcl = {0};
     struct sql_state *rec_ptr = rec ? rec : &rec_lcl;
+    sqlite3_stmt *stmt;
     rec_ptr->sql = sql;
 
     /* Reset logger. This clears table names (see reqlog_add_table) and
@@ -2261,8 +2262,10 @@ retry:
     }
     if (sp->rc == SQLITE_PERM) sp->rc = SQLITE_SCHEMA; /* R7 compat */
     if (sp->rc == 0) {
-        *stmt = rec_ptr->stmt;
-        rec_ptr->sql = sqlite3_sql(*stmt);
+        stmt = rec_ptr->stmt;
+        rec_ptr->sql = sqlite3_sql(stmt);
+        ((Vdbe*)stmt)->luaStartTime = -1;
+        *pstmt = stmt;
     } else if (sp->rc == SQLITE_SCHEMA) {
         return luaL_error(L, sqlite3ErrStr(sp->rc));
     } else {
@@ -2310,7 +2313,7 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
         return;
     }
 
-    if (sp != NULL) {
+    if (sp != NULL && pVdbe->luaStartTime >= 0) {
         const char *zNormSql = sqlite3_normalized_sql(pStmt);
         logger = sp->thd->logger;
 

--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -169,6 +169,10 @@ void sqlite3VdbeSwap(Vdbe *pA, Vdbe *pB){
     SWAP(int, pA->oldColCount, pB->oldColCount);
     SWAP(char **, pA->oldColNames, pB->oldColNames);
     SWAP(char **, pA->oldColDeclTypes, pB->oldColDeclTypes);
+    SWAP(i64, pA->luaStartTime, pB->luaStartTime);
+    SWAP(i64, pA->luaRows, pB->luaRows);
+    SWAP(double, pA->luaSavedCost, pB->luaSavedCost);
+    SWAP(u8, pA->fingerprint_added, pB->fingerprint_added);
   }
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   pB->expmask = pA->expmask;

--- a/tests/sp.test/lrl.options
+++ b/tests/sp.test/lrl.options
@@ -1,2 +1,3 @@
 dtastripe 1
 enable_snapshot_isolation
+max_query_fingerprints 10000

--- a/tests/sp.test/t18.req
+++ b/tests/sp.test/t18.req
@@ -1,0 +1,28 @@
+DROP TABLE IF EXISTS t18
+CREATE TABLE t18 (i INTEGER)$$
+CREATE INDEX t18_i ON t18(i)
+INSERT INTO t18 VALUES(1)
+ANALYZE t18
+CREATE PROCEDURE sp18_1 {
+local function main()
+    local dbstmt
+    dbstmt = db:prepare("SELECT i FROM t18")
+    dbstmt = db:prepare("SELECT i FROM t18")
+    dbstmt:exec()
+    dbstmt:emit()
+end }$$
+EXEC PROCEDURE sp18_1()
+SELECT total_time < 10 FROM comdb2_fingerprints WHERE UPPER(normalized_sql) LIKE '%EXEC PROCEDURE SP18_1()%'
+CREATE PROCEDURE sp18_2 {
+local function main()
+    local dbstmt
+    dbstmt = db:prepare("SELECT i FROM t18 WHERE i=@i");
+    db:bind("i", 1)
+    dbstmt:exec()
+    dbstmt:emit()
+    db:bind("i", 3)
+    dbstmt:exec()
+    dbstmt:emit()
+end }$$
+EXEC PROCEDURE sp18_2()
+SELECT total_time < 10 FROM comdb2_fingerprints WHERE UPPER(normalized_sql) LIKE '%EXEC PROCEDURE SP18_2()%'

--- a/tests/sp.test/t18.req.out
+++ b/tests/sp.test/t18.req.out
@@ -1,0 +1,7 @@
+(rows inserted=1)
+(version='1')
+(i=1)
+(total_time < 10=1)
+(version='1')
+(i=1)
+(total_time < 10=1)


### PR DESCRIPTION
Inside a stored procedure, if a query is 1) prepared but never executed, or 2) reprepared (parameters changed, schema changed, etc.), its execution time will be miscalculated. This patch fixes these cases.