### PR TITLE
Fix deadlock when sc running during downgrade

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -53,6 +53,7 @@
 #include "logmsg.h"
 #include "comdb2_atomic.h"
 
+extern int gbl_debug_downgrade_during_sc_deadlock;
 extern int sc_ready(void);
 extern int gbl_debug_systable_locks;
 extern int32_t gbl_rep_lockid;
@@ -279,6 +280,9 @@ retry:
         return -1;
     }
     uint64_t transize;
+    if (gbl_debug_downgrade_during_sc_deadlock) {
+        sleep(10);
+    }
     seqnum_type seqnum;
     rc = bdb_tran_commit_with_seqnum_size(bdb_state, ltran, &seqnum,
                                           &transize, bdberr);
@@ -352,10 +356,6 @@ int bdb_llog_partition(bdb_state_type *bdb_state, tran_type *tran, char *name,
     ++gbl_views_gen;
     return bdb_llog_scdone_tran(bdb_state, views, tran, name, strlen(name) + 1,
                                 bdberr);
-}
-int bdb_llog_luareload(bdb_state_type *bdb_state, int wait, int *bdberr)
-{
-    return bdb_llog_scdone(bdb_state, luareload, NULL, 0, wait, bdberr);
 }
 
 int bdb_llog_luafunc(bdb_state_type *bdb_state, scdone_t type, int wait,

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -67,7 +67,6 @@ int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
                          tran_type *tran, const char *tbl, int tbllen, int *bdberr);
 int bdb_llog_scdone(bdb_state_type *, scdone_t, const char *tablename, 
                     int tablenamelen, int wait, int *bdberr);
-int bdb_llog_luareload(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_analyze(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_views(bdb_state_type *bdb_state, char *name, int wait,
                    int *bdberr);

--- a/bdb/file.c
+++ b/bdb/file.c
@@ -134,6 +134,7 @@ extern int get_commit_lsn_map_switch_value();
 extern int is_db_roomsync();
 extern int get_schema_change_in_progress(const char *func, int line);
 
+int gbl_debug_downgrade_during_sc_deadlock = 0;
 int gbl_debug_children_lock = 0;
 int gbl_queuedb_genid_filename = 1;
 int gbl_queuedb_file_threshold = 0;
@@ -5393,6 +5394,9 @@ static int bdb_upgrade_downgrade_reopen_wrap(bdb_state_type *bdb_state, int op,
     }
 
     if (op != UPGRADE) {
+        if (gbl_debug_downgrade_during_sc_deadlock) {
+            sleep(10);
+        }
         wait_for_sc_to_stop("downgrade", __func__, __LINE__);
         bdb_set_read_only(bdb_state);
     }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -74,6 +74,7 @@ extern int gbl_logmsg_epochms;
 extern int gbl_2pc;
 char *gbl_allowed_coordinators;
 extern int gbl_all_waitdie;
+extern int gbl_debug_downgrade_during_sc_deadlock;
 extern int gbl_debug_disable_waitdie_deadlock_detection;
 extern int gbl_coordinator_sync_on_commit;
 extern int gbl_coordinator_wait_propagate;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1943,6 +1943,10 @@ REGISTER_TUNABLE("forbid_incoherent_writes",
                  "transaction start.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_forbid_incoherent_writes, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_downgrade_during_sc_deadlock",
+                 "Cause downgrading node to wait for sc to finish.  (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_debug_downgrade_during_sc_deadlock, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("debug_downgrade_cluster_at_open",
                  "Sleep on open to allow testsuite to downgrade master.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_downgrade_cluster_at_open, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -520,8 +520,6 @@ static int do_add_sp_int(struct schema_change_type *sc, struct ireq *iq)
     }
     if (rc == 0) {
         ++gbl_lua_version;
-        int bdberr;
-        bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
         if (iq) {
             if (sc->fname[0] == 0) {
                 sprintf(sc->fname, "%d", version);
@@ -543,10 +541,6 @@ static int do_del_sp_int(struct schema_change_type *sc, struct ireq *iq)
     } else {
         rc = del_sp(sc);
     }
-    if (rc == 0) {
-        int bdberr;
-        bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
-    }
     free(sc->newcsc2);
     sc->newcsc2 = NULL;
     return rc;
@@ -558,10 +552,6 @@ static int do_default_sp_int(struct schema_change_type *sc, struct ireq *iq)
         rc = default_versioned_sp(sc, iq);
     } else {
         rc = default_sp(sc);
-    }
-    if (rc == 0) {
-        int bdberr;
-        bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
     }
     free(sc->newcsc2);
     sc->newcsc2 = NULL;

--- a/tests/partition_sc.test/Makefile
+++ b/tests/partition_sc.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/partition_sc.test/lrl.options
+++ b/tests/partition_sc.test/lrl.options
@@ -1,0 +1,1 @@
+debug_downgrade_during_sc_deadlock on

--- a/tests/partition_sc.test/runit
+++ b/tests/partition_sc.test/runit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -ex
+
+send_signal_to_node() {
+	local -r signal=$1 node=$2
+	echo "sending $signal to $node"
+
+	if [[ "${node}" == "$(hostname)" ]];
+	then
+		cat "${TMPDIR}"/"${DBNAME}"."${node}".pid | xargs kill -"${signal}"
+	else
+		ssh "${node}" "cat "${TMPDIR}"/"${DBNAME}".pid | xargs kill -"${signal}""
+	fi
+}
+
+main() {
+	if [ -z "${CLUSTER}" ]; then
+		return 0
+	fi
+
+	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default "create table t(i int)"
+
+	local old_master
+	old_master=$(cdb2sql --tabs ${CDB2_OPTIONS} "${DBNAME}" default "select host from comdb2_cluster where is_master='Y'")
+	readonly old_master
+
+	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default "exec procedure sys.cmd.send('downgrade')" &
+	sleep 2
+	cdb2sql ${CDB2_OPTIONS} "${DBNAME}" default "create default lua consumer t_cons on (table t for insert and update and delete)" &
+	sleep 2
+
+	# Stop master while SC and downgrade are running so that someone else gets elected
+	send_signal_to_node "SIGSTOP" "${old_master}"
+
+	sleep 20 # Let cluster run election
+
+	# Start old master. Bug is that it won't be able to finish its downgrade because its seqno
+	# is behind the rest of the cluster.
+	send_signal_to_node "SIGCONT" "${old_master}"
+
+	sleep 70 # Give time for old master to hit timeout waiting for sc to finish and abort
+
+	# We're testing that the downgrading node doesn't abort. Should be available at finish when bug is fixed.
+}
+
+main


### PR DESCRIPTION
The following deadlock can occur when an sc is running during a master downgrade:

1. node can't increase its generation until it finishes downgrade
2. downgrade is blocked on schema change
3. schema change is blocked on getting next sequence number
4. getting the next sequence number is blocked waiting for a higher generation (loop to step 1)

The changes in this PR fix this deadlock by modifying the lua schema change process to not request new sequence numbers.