### PR TITLE
Recreate rather than truncate large temptables

### DIFF
--- a/bdb/temptable.c
+++ b/bdb/temptable.c
@@ -1391,12 +1391,15 @@ static int bdb_temp_table_truncate_temp_db(bdb_state_type *bdb_state,
     return bdb_temp_table_reset_cursors(bdb_state, tbl, bdberr);
 }
 
+int gbl_temptable_recreate_size = 1048576;
+
 int bdb_temp_table_truncate(bdb_state_type *bdb_state, struct temp_table *tbl,
                             int *bdberr)
 {
     if (tbl == NULL)
         return 0;
     int rc = 0;
+    off_t sz;
     unsigned long long int ii = 0;
     arr_elem_t *elem;
 
@@ -1428,7 +1431,8 @@ int bdb_temp_table_truncate(bdb_state_type *bdb_state, struct temp_table *tbl,
         break;
 
     case TEMP_TABLE_TYPE_BTREE:
-        if (tbl->num_mem_entries < 100)
+        rc = tbl->tmpdb->size(tbl->tmpdb, &sz);
+        if (tbl->num_mem_entries < 100 && (rc == 0 && sz < gbl_temptable_recreate_size))
             rc = bdb_temp_table_truncate_temp_db(bdb_state, tbl, bdberr);
         else
             rc = bdb_temp_table_init_temp_db(bdb_state, tbl, bdberr);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1758,6 +1758,7 @@ struct __db {
 	int  (*set_pagesize) __P((DB *, u_int32_t));
 	int  (*set_paniccall) __P((DB *, void (*)(DB_ENV *, int)));
 	int  (*stat) __P((DB *, void *, u_int32_t));
+	int  (*size) __P((DB *, off_t *));
 	int  (*sync) __P((DB *, u_int32_t));
 	int  (*upgrade) __P((DB *, const char *, u_int32_t));
 	int  (*verify) __P((DB *,

--- a/berkdb/db/db_method.c
+++ b/berkdb/db/db_method.c
@@ -272,6 +272,7 @@ __db_init(dbp, flags)
 	dbp->set_pagesize = __db_set_pagesize;
 	dbp->set_paniccall = __db_set_paniccall;
 	dbp->stat = __db_stat_pp;
+    dbp->size = __db_size_pp;
 	dbp->sync = __db_sync_pp;
 	dbp->upgrade = __db_upgrade_pp;
 	dbp->verify = __db_verify_pp;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -460,6 +460,7 @@ extern int gbl_replicant_retry_on_not_durable;
 extern int gbl_enable_internal_sql_stmt_caching;
 extern int gbl_longreq_log_freq_sec;
 extern int gbl_disable_seekscan_optimization;
+extern int gbl_temptable_recreate_size;
 extern int gbl_pgcomp_dryrun;
 extern int gbl_pgcomp_dbg_stdout;
 extern int gbl_pgcomp_dbg_ctrace;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -346,6 +346,8 @@ REGISTER_TUNABLE("disable_tagged_api", "Disables 'enable_tagged_api'",
 REGISTER_TUNABLE("disable_tagged_api_writes", "Disables tag api writes",
                  TUNABLE_BOOLEAN, &gbl_disable_tagged_api_writes, NOARG, NULL, NULL,
                  NULL, NULL);
+REGISTER_TUNABLE("temptable_recreate_size", "Sets temptable re-create size threshold.  (Default: 1048576).",
+                 TUNABLE_INTEGER, &gbl_temptable_recreate_size, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("disable_temptable_pool", "Sets 'temptable_limit' to 0.",
                  TUNABLE_BOOLEAN, &gbl_temptable_pool_capacity,
                  INVERSE_VALUE | READONLY | NOARG, NULL, NULL, NULL, NULL);

--- a/tests/docker/Dockerfile.install
+++ b/tests/docker/Dockerfile.install
@@ -27,6 +27,7 @@ RUN apt-get update && \
     libuuid1 \
     libz1 \
     libz-dev \
+    lsof \
     make \
     ncurses-dev \
     netcat-openbsd \

--- a/tests/temptable_size.test/Makefile
+++ b/tests/temptable_size.test/Makefile
@@ -1,0 +1,9 @@
+export COMDB2_UNITTEST=1
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/temptable_size.test/runit
+++ b/tests/temptable_size.test/runit
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#set -e
+debug=1
+[[ "$debug" != 0 ]] && set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+# Testcase variables
+unset CLUSTER
+DBNAME=ttsz$TESTID
+DBDIR=$TESTDIR/$DBNAME
+CDB2_CONFIG=$DBDIR/comdb2db.cfg
+CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
+export dbpid=""
+
+function call_unsetup()
+{
+    local successful=$1
+    COMDB2_UNITTEST=0 $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
+}
+
+function setup_db()
+{
+    COMDB2_UNITTEST=0 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
+}
+
+function create_table()
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "create table if not exists t1(a int, b blob)"
+    [[ $? != 0 ]] && failexit "Failed to create table t1"
+}
+
+function low_size()
+{
+    echo "Creating an osql/bplog schedule which will allow the temptable to be recycled"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "insert into t1 (a, b) values(1, randomblob(1024*256)), (1, randomblob(1024*256))"
+    [[ $? != 0 ]] && failexit "Failed to insert into table t1"
+
+    lsofout=$(lsof -p $dbpid | egrep deleted | awk '{print $7}')
+    for sz in $lsofout ; do
+        [[ "$sz" -eq "65536" ]] && failexit "recreated small temptable"
+        [[ "$sz" -gt "1048576" ]] && failexit "large temptable persisted"
+    done
+    echo "Temptable system correctly retained small temptables"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "exec procedure sys.cmd.send('temptable_clear')"
+}
+
+function high_size()
+{
+    echo "Creating an osql/bplog schedule which will recreate the temptable"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "insert into t1 (a, b) values(1, randomblob(1024*1024)), (1, randomblob(1024*1024))"
+    [[ $? != 0 ]] && failexit "Failed to insert into table t1"
+
+    lsofout=$(lsof -p $dbpid | egrep deleted | awk '{print $7}')
+    for sz in $lsofout ; do
+        [[ "$sz" -gt "1048576" ]] && failexit "large temptable persisted"
+        [[ "$sz" -ne "65536" ]] && failexit "Failed to recreate temptable"
+    done
+    echo "Temptable system correctly recreated large temptables"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "exec procedure sys.cmd.send('temptable_clear')"
+}
+
+function run_test()
+{
+    low_size
+    high_size
+}
+
+# Trap to call_unsetup if the test exits
+trap "call_unsetup \"0\"" INT EXIT
+
+setup_db
+dbpid=$(cat ${TMPDIR}/${DBNAME}.pid)
+create_table
+run_test
+call_unsetup 1
+
+echo "Success"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1001,6 +1001,7 @@
 (name='temptable_cachesz', description='Cache size for temporary tables. Temp tables do not share the database's main buffer pool.', type='INTEGER', value='262144', read_only='N')
 (name='temptable_limit', description='Set the maximum number of temporary tables the database can create. (Default: 8192)', type='INTEGER', value='8192', read_only='Y')
 (name='temptable_mem_threshold', description='If in-memory temp tables contain more than this many entries, spill them to disk.', type='INTEGER', value='512', read_only='N')
+(name='temptable_recreate_size', description='Sets temptable re-create size threshold.  (Default: 1048576).', type='INTEGER', value='1048576', read_only='N')
 (name='test_auth_time', description='Check auth in watchdog this often', type='INTEGER', value='60', read_only='N')
 (name='test_blkseq_replay', description='Test blkseq replay codepath (for debugging only)', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_blob_race', description='', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
Force temptable to recreate themselves if they are larger than 1 mb
