### PR TITLE
Abort in unlock if rwlock is not held

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -5185,6 +5185,11 @@ clipper_usage:
         }
     } else if (tokcmp(tok, ltok, "panic") == 0) {
         bdb_panic(thedb->bdb_env);
+    } else if (tokcmp(tok, ltok, "test_abort_rwlock") == 0) {
+        pthread_rwlock_t testlk = PTHREAD_RWLOCK_INITIALIZER;
+        logmsg(LOGMSG_USER, "Unlocking a rwlock which isn't held\n");
+        Pthread_rwlock_unlock(&testlk);
+        logmsg(LOGMSG_USER, "Test failed: the process should have aborted\n");
     } else if (tokcmp(tok, ltok, "debug_logreq") == 0) {
         int file, offset;
         tok = segtok(line, lline, &st, &ltok);

--- a/tests/rwlock_unlock.test/Makefile
+++ b/tests/rwlock_unlock.test/Makefile
@@ -1,0 +1,9 @@
+export COMDB2_UNITTEST=1
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/rwlock_unlock.test/README
+++ b/tests/rwlock_unlock.test/README
@@ -1,0 +1,1 @@
+Verify that we abort if we try to unlock a rwlock which is not locked

--- a/tests/rwlock_unlock.test/runit
+++ b/tests/rwlock_unlock.test/runit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#set -e
+debug=1
+[[ "$debug" != 0 ]] && set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+# Testcase variables
+unset CLUSTER
+DBNAME=ttsz$TESTID
+DBDIR=$TESTDIR/$DBNAME
+CDB2_CONFIG=$DBDIR/comdb2db.cfg
+CDB2_OPTIONS="--cdb2cfg $CDB2_CONFIG"
+export dbpid=""
+
+function call_unsetup()
+{
+    local successful=$1
+    COMDB2_UNITTEST=0 $TESTSROOTDIR/unsetup $successful &> $TESTDIR/logs/$DBNAME.unsetup
+}
+
+function setup_db()
+{
+    COMDB2_UNITTEST=0 $TESTSROOTDIR/setup &> $TESTDIR/logs/$DBNAME.setup
+}
+
+
+# Trap to call_unsetup if the test exits
+trap "call_unsetup \"0\"" INT EXIT
+
+echo "Setting core ulimit to 0"
+ulimit -c 0
+
+echo "Setting up database $DBNAME"
+setup_db
+dbpid=$(cat ${TMPDIR}/${DBNAME}.pid)
+
+kill -0 $dbpid
+[[ $? != 0 ]] && failexit "Database is not running"
+
+echo "Telling database to unlock a rwlock which is not locked- this should abort"
+$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME "exec procedure sys.cmd.send('test_abort_rwlock')"
+
+sleep 5
+kill -0 $dbpid
+[[ $? == 0 ]] && failexit "Unlocking an unlocked rwlock did not abort the database"
+
+echo "Success"


### PR DESCRIPTION
Abort immediately if a thread attempts to unlock a rwlock which is not held.
