### PR TITLE
Create default lua consumer atomically

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -85,7 +85,9 @@ static const char *const bdb_scdone_type_names[] = {
     "user_view",               // 21
     "add_queue_file",          // 22
     "del_queue_file",          // 23
-    "alias_table"              // 24
+    "alias_table",             // 24
+    "alias",                   // 25
+    "default_cons",            // 26
 };
 
 const char *bdb_get_scdone_str(scdone_t type)
@@ -93,17 +95,13 @@ const char *bdb_get_scdone_str(scdone_t type)
     int maxIndex = sizeof(bdb_scdone_type_names) /
                    sizeof(bdb_scdone_type_names[0]);
     static __thread char buf[100];
-    if (type >= invalid && type <= del_queue_file) {
-        int index = ((int)type) + 1; // -1 ==> 0
-        if (index >= 0 && index <= maxIndex) {
-            snprintf(buf, sizeof(buf), "\"%s\" (%d)",
-                     bdb_scdone_type_names[index], (int)type);
-        } else {
-            snprintf(buf, sizeof(buf), "BAD_INDEX %d (%d)",
-                     index, (int)type);
-        }
+    int index = ((int)type) + 1; // -1 ==> 0
+    if (index >= 0 && index <= maxIndex) {
+        snprintf(buf, sizeof(buf), "\"%s\" (%d)",
+                 bdb_scdone_type_names[index], (int)type);
     } else {
-        snprintf(buf, sizeof(buf), "UNKNOWN (%d)", (int)type);
+        snprintf(buf, sizeof(buf), "BAD_INDEX %d (%d)",
+                 index, (int)type);
     }
     return buf;
 }

--- a/bdb/bdb_schemachange.h
+++ b/bdb/bdb_schemachange.h
@@ -51,7 +51,8 @@ typedef enum scdone {
     add_queue_file,          // 22
     del_queue_file,          // 23
     alias_table,             // 24
-    alias                    // 25
+    alias,                   // 25
+    default_cons,            // 26
 } scdone_t;
 
 #define BDB_BUMP_DBOPEN_GEN(type, msg) \
@@ -65,7 +66,7 @@ void bdb_bump_dbopen_gen(scdone_t type, const char *message,
 
 int bdb_llog_scdone_tran(bdb_state_type *bdb_state, scdone_t type,
                          tran_type *tran, const char *tbl, int tbllen, int *bdberr);
-int bdb_llog_scdone(bdb_state_type *, scdone_t, const char *tablename, 
+int bdb_llog_scdone(bdb_state_type *, scdone_t, const char *tablename,
                     int tablenamelen, int wait, int *bdberr);
 int bdb_llog_luareload(bdb_state_type *, int wait, int *bdberr);
 int bdb_llog_analyze(bdb_state_type *, int wait, int *bdberr);
@@ -87,5 +88,5 @@ typedef void (*SCABORTFP)(void);
 void bdb_replace_cached_data_version(bdb_state_type *target, bdb_state_type *new);
 void bdb_replace_cached_blob_version(bdb_state_type *target, int targetnum, bdb_state_type *new, int newnum);
 void bdb_replace_cached_index_version(bdb_state_type *target, int targetnum, bdb_state_type *new, int newnum);
-int bdb_llog_alias(bdb_state_type *bdb_state, int wait, int *bdberr); 
+int bdb_llog_alias(bdb_state_type *bdb_state, int wait, int *bdberr);
 #endif

--- a/db/config.c
+++ b/db/config.c
@@ -461,7 +461,8 @@ static char *legacy_options[] = {
     "sc_protobuf 0",
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
-    "endianize_locklist 0"
+    "endianize_locklist 0",
+    "create_default_consumers_atomically 0"
 };
 // clang-format on
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -54,6 +54,7 @@ extern int gbl_test_badwrite_intvl;
 extern int gbl_broken_max_rec_sz;
 extern int gbl_broken_num_parser;
 extern int gbl_crc32c;
+extern int gbl_create_default_consumer_atomically;
 extern int gbl_decom;
 extern int gbl_disable_rowlocks;
 extern int gbl_disable_rowlocks_logging;
@@ -69,6 +70,7 @@ extern int gbl_disable_skip_rows;
 extern int gbl_enable_berkdb_retry_deadlock_bias;
 extern int gbl_enable_cache_internal_nodes;
 extern int gbl_partial_indexes;
+extern int gbl_fail_to_create_default_cons;
 extern int gbl_force_writesql;
 extern int gbl_logmsg_epochms;
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -76,6 +76,10 @@ REGISTER_TUNABLE("archive_on_init",
                  "at the time of init. (Default: ON)",
                  TUNABLE_BOOLEAN, &gbl_archive_on_init, READONLY, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("create_default_consumer_atomically",
+                 "Create default consumers atomically (default on)",
+                 TUNABLE_BOOLEAN, &gbl_create_default_consumer_atomically, 1, NULL,
+                 NULL, NULL, NULL);
 REGISTER_TUNABLE("badwrite_intvl", NULL, TUNABLE_INTEGER,
                  &gbl_test_badwrite_intvl, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("bbenv", NULL, TUNABLE_BOOLEAN, &gbl_bbenv,
@@ -1933,6 +1937,11 @@ REGISTER_TUNABLE("logdelete_lock_trace",
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_logdelete_lock_trace, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("fail_to_create_default_cons",
+                 "Fail in the middle of creating a default consumer to test that it happens atomically.  "
+                 "(Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_fail_to_create_default_cons,
+                 INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("flush_log_at_checkpoint",
                  "Replicants flush the log at checkpoint records.  "
                  "(Default: on)",

--- a/protobuf/schemachange.proto
+++ b/protobuf/schemachange.proto
@@ -55,4 +55,6 @@ message CDB2_Schemachange {
   repeated string genshardshardnames = 52;
   optional string import_src_tablename = 53;
   optional string import_src_dbname = 54;
+  optional string tablename_for_default_cons_q = 55;
+  optional bytes newcsc2_for_default_cons_q = 56;
 }

--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -520,7 +520,7 @@ void sc_del_unused_files_tran(struct dbtable *db, tran_type *tran)
 
     if (bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DELAYED_OLDFILE_CLEANUP)) {
         if (bdb_list_unused_files_tran(
-                db->handle, tran, &bdberr, 
+                db->handle, tran, &bdberr,
                 "schemachange") || bdberr != BDBERR_NOERROR)
             logmsg(LOGMSG_WARN, "%s: errors listing old files\n", __func__);
     } else {
@@ -1152,6 +1152,13 @@ static int scdone_llmeta_queue(const char table[], void *arg, scdone_t type)
     return rc;
 }
 
+static int scdone_default_cons(const char table[], void *arg, scdone_t type)
+{
+    logmsg(LOGMSG_DEBUG, "Replicant invalidating Lua machines\n");
+    ++gbl_lua_version;
+    return scdone_llmeta_queue(table, arg, llmeta_queue_add);
+}
+
 static int scdone_genid48(const char tablename[], void *arg, scdone_t type)
 {
     switch (type) {
@@ -1284,7 +1291,8 @@ int (*SCDONE_CALLBACKS[])(const char *, void *, scdone_t) = {
     &scdone_llmeta_queue,  &scdone_genid48,        &scdone_genid48,
     &scdone_lua_sfunc,     &scdone_lua_afunc,      &scdone_rename_table,
     &scdone_change_stripe, &scdone_user_view,      &scdone_queue_file,
-    &scdone_queue_file,    &scdone_rename_table,   &scdone_alias};
+    &scdone_queue_file,    &scdone_rename_table,   &scdone_alias,
+    &scdone_default_cons};
 
 /* TODO fail gracefully now that inline? */
 /* called by bdb layer through a callback as a detached thread,

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -647,6 +647,7 @@ struct {
     {1, alter, do_alter_table, finalize_alter_table, NULL, NULL},
     {1, alter, do_alter_table, finalize_alter_table, NULL, NULL},
     {1, bulkimport, do_import, finalize_import, NULL, NULL},
+    {0, 0, NULL, NULL, do_default_cons, finalize_default_cons},
 };
 
 static int do_schema_change_tran_int(sc_arg_t *arg)

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -6,10 +6,15 @@
 #include "comdb2.h"
 #include "schemachange.h"
 #include "sc_lua.h"
+#include "sc_queues.h"
 #include "sqlglue.h"
 #include "translistener.h"
+#include "bdb_int.h"
 
 #include "logmsg.h"
+
+int gbl_fail_to_create_default_cons = 0;
+int gbl_create_default_consumer_atomically = 1;
 
 struct sp_file_t {
     char name[128]; // MAX_SPNAME
@@ -319,7 +324,7 @@ static int show_versioned_sp_src(struct schema_change_type *sc)
     free(src);
     return 0;
 }
-static int add_versioned_sp(struct schema_change_type *sc)
+static int add_versioned_sp(struct schema_change_type *sc, tran_type *tran)
 {
     int rc, bdberr;
     char *spname = sc->tablename;
@@ -329,7 +334,6 @@ static int add_versioned_sp(struct schema_change_type *sc)
     bdb_get_default_versioned_sp(spname, &default_ver_str);
     free(default_ver_str);
 
-    tran_type *tran = sc->tran;
     rc = bdb_add_versioned_sp(tran, spname, version, sc->newcsc2);
     if (default_ver_num <= 0 && default_ver_str == NULL) {
         // first version - set it default as well
@@ -337,10 +341,10 @@ static int add_versioned_sp(struct schema_change_type *sc)
     }
     return rc;
 }
-static int chk_versioned_sp(char *name, char *version, struct ireq *iq)
+static int chk_versioned_sp_tran(char *name, char *version, struct ireq *iq, tran_type *tran)
 {
     char *src = NULL;
-    int rc = bdb_get_versioned_sp(name, version, &src);
+    int rc = bdb_get_versioned_sp_tran(tran, name, version, &src);
     if (rc != 0) {
         if (iq) {
             errstat_cat_strf(&iq->errstat, "no such procedure %s:%s", name,
@@ -350,6 +354,10 @@ static int chk_versioned_sp(char *name, char *version, struct ireq *iq)
     free(src);
     return rc;
 }
+static int chk_versioned_sp(char *name, char *version, struct ireq *iq)
+{
+    return chk_versioned_sp_tran(name, version, iq, NULL);
+}
 static int del_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
 {
     int rc;
@@ -357,12 +365,12 @@ static int del_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
         return rc;
     return bdb_del_versioned_sp(sc->tablename, sc->fname);
 }
-static int default_versioned_sp(struct schema_change_type *sc, struct ireq *iq)
+static int default_versioned_sp(struct schema_change_type *sc, struct ireq *iq, tran_type *tran)
 {
     int rc;
-    if ((rc = chk_versioned_sp(sc->tablename, sc->fname, iq)) != 0)
+    if ((rc = chk_versioned_sp_tran(sc->tablename, sc->fname, iq, tran)) != 0)
         return rc;
-    return bdb_set_default_versioned_sp(sc->tran, sc->tablename, sc->fname);
+    return bdb_set_default_versioned_sp(tran, sc->tablename, sc->fname);
 }
 
 // ----------------
@@ -441,18 +449,18 @@ static int show_sp_src(struct schema_change_type *sc)
 // ---------------------------
 // ADD/DEL/DEFAULT REGULAR SPs
 // ---------------------------
-static int add_sp(struct schema_change_type *sc, int *version)
+static int add_sp(struct schema_change_type *sc, int *version, tran_type *tran)
 {
     SBUF2 *sb = sc->sb;
     char *schemabuf = sc->newcsc2;
     int rc, bdberr;
-    if ((rc = bdb_set_sp_lua_source(NULL, NULL, sc->tablename, schemabuf,
+    if ((rc = bdb_set_sp_lua_source(NULL, tran, sc->tablename, schemabuf,
                                     strlen(schemabuf) + 1, 0, &bdberr)) != 0) {
         sbuf2printf(sb, "!Unable to add lua source. \n");
         sbuf2printf(sb, "FAILED\n");
         return rc;
     }
-    bdb_get_lua_highest(NULL, sc->tablename, version, INT_MAX, &bdberr);
+    bdb_get_lua_highest(tran, sc->tablename, version, INT_MAX, &bdberr);
     sbuf2printf(sb, "!Added stored procedure: %s \t version %d.\n",
                 sc->tablename, *version);
     sbuf2printf(sb, "SUCCESS\n");
@@ -480,7 +488,7 @@ fail:
     sbuf2printf(sb, "FAILED\n");
     return -1;
 }
-static int default_sp(struct schema_change_type *sc)
+static int default_sp(struct schema_change_type *sc, tran_type *tran)
 {
     SBUF2 *sb = sc->sb;
     if (sc->newcsc2 == NULL) {
@@ -495,7 +503,7 @@ static int default_sp(struct schema_change_type *sc)
         goto fail;
     }
     int bdberr;
-    if (bdb_set_sp_lua_default(NULL, NULL, sc->tablename, version, &bdberr)) {
+    if (bdb_set_sp_lua_default(NULL, tran, sc->tablename, version, &bdberr)) {
         sbuf2printf(sb, "!version not found number %d\n", version);
         goto fail;
     }
@@ -510,18 +518,20 @@ fail:
 // ---------------------------------------------------
 // Decide whether to call regular or versioned or both
 // ---------------------------------------------------
-static int do_add_sp_int(struct schema_change_type *sc, struct ireq *iq)
+static int do_add_sp_int(struct schema_change_type *sc, struct ireq *iq, tran_type *tran)
 {
     int rc, version;
     if (sc->fname[0] != 0) {
-        rc = add_versioned_sp(sc);
+        rc = add_versioned_sp(sc, tran);
     } else {
-        rc = add_sp(sc, &version);
+        rc = add_sp(sc, &version, tran);
     }
     if (rc == 0) {
         ++gbl_lua_version;
-        int bdberr;
-        bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
+        if (sc->kind != SC_DEFAULTCONS) {
+            int bdberr;
+            bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
+        }
         if (iq) {
             if (sc->fname[0] == 0) {
                 sprintf(sc->fname, "%d", version);
@@ -551,15 +561,15 @@ static int do_del_sp_int(struct schema_change_type *sc, struct ireq *iq)
     sc->newcsc2 = NULL;
     return rc;
 }
-static int do_default_sp_int(struct schema_change_type *sc, struct ireq *iq)
+static int do_default_sp_int(struct schema_change_type *sc, struct ireq *iq, tran_type *tran)
 {
     int rc;
     if (sc->fname[0] != 0) {
-        rc = default_versioned_sp(sc, iq);
+        rc = default_versioned_sp(sc, iq, tran);
     } else {
-        rc = default_sp(sc);
+        rc = default_sp(sc, tran);
     }
-    if (rc == 0) {
+    if (rc == 0 && sc->kind != SC_DEFAULTCONS) {
         int bdberr;
         bdb_llog_luareload(thedb->bdb_env, 1, &bdberr);
     }
@@ -608,13 +618,19 @@ int do_show_sp(struct schema_change_type *sc, struct ireq *unused)
     sbuf2printf(sb, "SUCCESS\n");
     return 0;
 }
+
+int do_add_sp_tran(struct schema_change_type *sc, struct ireq *iq, tran_type *tran, int lock_schema_lk)
+{
+    if (lock_schema_lk) { wrlock_schema_lk(); }
+    int rc = do_add_sp_int(sc, iq, tran);
+    ++gbl_lua_version;
+    if (lock_schema_lk) { unlock_schema_lk(); }
+    return !rc && !sc->finalize ? SC_COMMIT_PENDING : rc;
+}
+
 int do_add_sp(struct schema_change_type *sc, struct ireq *iq)
 {
-    wrlock_schema_lk();
-    int rc = do_add_sp_int(sc, iq);
-    ++gbl_lua_version;
-    unlock_schema_lk();
-    return !rc && !sc->finalize ? SC_COMMIT_PENDING : rc;
+    return do_add_sp_tran(sc, iq, NULL, /* lock_schema_lk */ 1);
 }
 
 int finalize_add_sp(struct schema_change_type *sc)
@@ -649,16 +665,82 @@ int finalize_del_sp(struct schema_change_type *sc)
     return 0;
 }
 
+int do_default_sp_tran(struct schema_change_type *sc, struct ireq *iq, tran_type *tran, int lock_schema_lk)
+{
+    if (lock_schema_lk) { wrlock_schema_lk(); }
+    int rc = do_default_sp_int(sc, iq, tran);
+    ++gbl_lua_version;
+    if (lock_schema_lk) { unlock_schema_lk(); }
+    return !rc && !sc->finalize ? SC_COMMIT_PENDING : rc;
+}
+
 int do_default_sp(struct schema_change_type *sc, struct ireq *iq)
 {
+    return do_default_sp_tran(sc, iq, NULL, /* lock_schema_lk */ 1);
+}
+
+int do_default_cons(struct schema_change_type *sc, struct ireq *iq)
+{
     wrlock_schema_lk();
-    int rc = do_default_sp_int(sc, iq);
-    ++gbl_lua_version;
+    javasp_splock_wrlock();
+    
+    tran_type *ltran = NULL;
+    int rc = trans_start_logical_sc(iq, &ltran);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "%s: Failed to start logical transaction\n", __func__);
+        goto done;
+    }
+
+    bdb_ltran_get_schema_lock(ltran);
+
+    tran_type *tran = NULL;
+    rc = get_physical_transaction(thedb->bdb_env, ltran, &tran, 0);
+    if (rc != 0 || tran == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: Failed to start physical transaction\n", __func__);
+        goto done;
+    }
+
+    rc = do_add_sp_tran(sc, iq, tran, /* lock_schema_lk */ 0);
+    if (rc && rc != SC_COMMIT_PENDING) {
+        logmsg(LOGMSG_ERROR, "%s: Failed to add procedure. rc %d\n", __func__, rc);
+        goto done;
+    }
+    rc = do_default_sp_tran(sc, iq, tran, /* lock_schema_lk */ 0);
+    if (rc && rc != SC_COMMIT_PENDING) {
+        logmsg(LOGMSG_ERROR, "%s: Failed to make procedure default\n", __func__);
+        goto done;
+    }
+
+    if (gbl_fail_to_create_default_cons) {
+        rc = SC_ABORTED;
+        goto done;
+    }
+
+    // This will commit/abort our transaction:
+    rc = perform_trigger_update_tran(sc, iq, ltran, /* lock_schema_and_sp_lk */ 0);
+    ltran = NULL;
+    tran = NULL;
+    if (rc && rc != SC_COMMIT_PENDING) {
+        logmsg(LOGMSG_ERROR, "%s: Failed to create queue\n", __func__);
+        goto done;
+    }
+
+done:
+    if (ltran) { trans_abort(iq, ltran); }
+    else if (tran) { trans_abort(iq, tran); }
+
     unlock_schema_lk();
+    javasp_splock_unlock();
+
     return !rc && !sc->finalize ? SC_COMMIT_PENDING : rc;
 }
 
 int finalize_default_sp(struct schema_change_type *sc)
+{
+    return 0;
+}
+
+int finalize_default_cons(struct schema_change_type *sc)
 {
     return 0;
 }

--- a/schemachange/sc_lua.h
+++ b/schemachange/sc_lua.h
@@ -24,10 +24,12 @@ int do_add_sp(struct schema_change_type *, struct ireq *);
 int do_del_sp(struct schema_change_type *sc, struct ireq *);
 int do_default_sp(struct schema_change_type *, struct ireq *);
 int do_show_sp(struct schema_change_type *sc, struct ireq *);
+int do_default_cons(struct schema_change_type *sc, struct ireq *iq);
 
 int finalize_add_sp(struct schema_change_type *sc);
 int finalize_del_sp(struct schema_change_type *sc);
 int finalize_default_sp(struct schema_change_type *sc);
+int finalize_default_cons(struct schema_change_type *sc);
 int do_lua_sfunc(struct schema_change_type *, struct ireq *iq);
 int do_lua_afunc(struct schema_change_type *, struct ireq *iq);
 

--- a/schemachange/sc_queues.h
+++ b/schemachange/sc_queues.h
@@ -21,6 +21,7 @@ int do_alter_queues_int(struct schema_change_type *);
 int consumer_change(const char *queuename, int consumern, const char *method);
 int add_queue_to_environment(char *table, int avgitemsz, int pagesize);
 int perform_trigger_update(struct schema_change_type *, struct ireq *);
+int perform_trigger_update_tran(struct schema_change_type *, struct ireq *, tran_type *ltran, int lock_schema_and_sp_lk);
 int perform_trigger_update_replicant(tran_type *, const char *queue_name,
                                      scdone_t);
 int finalize_trigger(struct schema_change_type *);

--- a/schemachange/sc_struct.c
+++ b/schemachange/sc_struct.c
@@ -55,6 +55,7 @@ struct schema_change_type *init_schemachange_type(struct schema_change_type *sc)
     Pthread_mutex_init(&sc->livesc_mtx, NULL);
     Pthread_mutex_init(&sc->mtxStart, NULL);
     Pthread_cond_init(&sc->condStart, NULL);
+    sc->newcsc2_for_default_cons_q = NULL;
     return sc;
 }
 
@@ -115,6 +116,10 @@ void free_schema_change_type(struct schema_change_type *s)
     if (s->import_src_table_data) {
         import_data__free_unpacked(s->import_src_table_data, &pb_alloc);
         s->import_src_table_data = NULL;
+    }
+    if (s->newcsc2_for_default_cons_q) {
+        free(s->newcsc2_for_default_cons_q);
+        s->newcsc2_for_default_cons_q = NULL;
     }
 
     free_dests(s);
@@ -250,6 +255,8 @@ int pack_schema_change_protobuf(struct schema_change_type *s, void **packed_sc, 
     s->spname_len = strlen(s->spname) + 1;
     s->newcsc2_len = (s->newcsc2) ? strlen(s->newcsc2) + 1 : 0;
     s->sc_version = sc.version = sc_version;
+    s->tablename_for_default_cons_q_len = strlen(s->tablename_for_default_cons_q) + 1;
+    s->newcsc2_for_default_cons_q_len = (s->newcsc2_for_default_cons_q) ? strlen(s->newcsc2_for_default_cons_q) + 1 : 0;
 
     sc.kind = s->kind;
     sc.rqid = s->rqid;
@@ -289,6 +296,13 @@ int pack_schema_change_protobuf(struct schema_change_type *s, void **packed_sc, 
 
     sc.import_src_tablename = s->import_src_tablename;
     sc.import_src_dbname = s->import_src_dbname;
+
+    sc.tablename_for_default_cons_q = s->tablename_for_default_cons_q;
+    if (s->newcsc2_for_default_cons_q) {
+        sc.has_newcsc2_for_default_cons_q = 1;
+        sc.newcsc2_for_default_cons_q.data = (uint8_t *) s->newcsc2_for_default_cons_q;
+        sc.newcsc2_for_default_cons_q.len = s->newcsc2_for_default_cons_q_len;
+    }
 
     sc.dests = malloc(sizeof(char *) * s->dests.count);
     if (!sc.dests) {
@@ -392,6 +406,23 @@ int pack_schema_change_protobuf(struct schema_change_type *s, void **packed_sc, 
     return 0;
 }
 
+static int unpack_newcsc2_field(const ProtobufCBinaryData *src, char **dest, size_t *dest_len)
+{
+    if (src->len) {
+        *dest_len = src->len;
+        *dest = malloc(*dest_len);
+        if (!*dest) {
+            logmsg(LOGMSG_ERROR, "unpack_newcsc2_field: malloc failed\n");
+            return -1;
+        }
+        memcpy(*dest, src->data, *dest_len);
+    } else {
+        *dest_len = 0;
+        *dest = NULL;
+    }
+    return 0;
+}
+
 int unpack_schema_change_protobuf(struct schema_change_type *s, void *packed_sc, size_t *plen)
 {
     int32_t *ibuf = (int32_t *)packed_sc;
@@ -432,14 +463,12 @@ int unpack_schema_change_protobuf(struct schema_change_type *s, void *packed_sc,
     s->newdtastripe = sc->newdtastripe;
     s->blobstripe = sc->blobstripe;
     s->live = sc->live;
-    if (sc->newcsc2.len) {
-        s->newcsc2_len = sc->newcsc2.len;
-        s->newcsc2 = malloc(s->newcsc2_len);
-        memcpy(s->newcsc2, sc->newcsc2.data, s->newcsc2_len);
-    } else {
-        s->newcsc2_len = 0;
-        s->newcsc2 = NULL;
+
+    if (unpack_newcsc2_field(&sc->newcsc2, &s->newcsc2, &s->newcsc2_len) != 0) {
+        cdb2__schemachange__free_unpacked(sc, NULL);
+        return -1;
     }
+
     s->scanmode = sc->scanmode;
     s->force_rebuild = sc->force_rebuild;
     s->force_dta_rebuild = sc->force_dta_rebuild;
@@ -490,6 +519,23 @@ int unpack_schema_change_protobuf(struct schema_change_type *s, void *packed_sc,
         strncpy(s->import_src_dbname, sc->import_src_dbname, sizeof(s->import_src_dbname));
         s->import_src_dbname_len = strlen(s->import_src_dbname) + 1;
     }
+
+    if (sc->tablename_for_default_cons_q) {
+        strncpy0(s->tablename_for_default_cons_q, sc->tablename_for_default_cons_q, sizeof(s->tablename_for_default_cons_q));
+        s->tablename_for_default_cons_q_len = strlen(s->tablename_for_default_cons_q) + 1;
+    } else {
+        s->tablename_for_default_cons_q[0] = '\0';
+        s->tablename_for_default_cons_q_len = 1;
+    }
+
+    if (!sc->has_newcsc2_for_default_cons_q) {
+        s->newcsc2_for_default_cons_q_len = 0;
+        s->newcsc2_for_default_cons_q = NULL;
+    } else if (unpack_newcsc2_field(&sc->newcsc2_for_default_cons_q, &s->newcsc2_for_default_cons_q, &s->newcsc2_for_default_cons_q_len) != 0) {
+        cdb2__schemachange__free_unpacked(sc, NULL);
+        return -1;
+    }
+
     switch (sc->partition_type) {
     case PARTITION_ADD_TIMED:
     case PARTITION_ADD_MANUAL: {

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -1525,6 +1525,7 @@ const char *schema_change_kind(struct schema_change_type *s)
     case SC_DELSP: return "SC_DELSP";
     case SC_DEFAULTSP: return "SC_DEFAULTSP";
     case SC_SHOWSP: return "SC_SHOWSP";
+    case SC_DEFAULTCONS: return "SC_DEFAULTCONS";
     case SC_ADD_TRIGGER: return "SC_ADD_TRIGGER";
     case SC_DEL_TRIGGER: return "SC_DEL_TRIGGER";
     case SC_ADD_SFUNC: return "SC_ADD_SFUNC";

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -136,6 +136,7 @@ enum schema_change_kind {
     SC_DROPTABLE_INDEX = 28,
     SC_REBUILDTABLE_INDEX = 29,
     SC_BULK_IMPORT = 30,
+    SC_DEFAULTCONS = 31, 
     SC_LAST /* End marker */
 };
 
@@ -315,6 +316,11 @@ struct schema_change_type {
     unsigned long long import_dst_data_genid;
     unsigned long long import_dst_index_genids[MAXINDEX];
     unsigned long long import_dst_blob_genids[MAXBLOBS];
+
+    char tablename_for_default_cons_q[MAXTABLELEN];
+    size_t tablename_for_default_cons_q_len;
+    char * newcsc2_for_default_cons_q;
+    size_t newcsc2_for_default_cons_q_len;
 };
 
 typedef int (*ddl_t)(struct ireq *, struct schema_change_type *, tran_type *);

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -7964,5 +7964,23 @@ void create_default_consumer_sp(Parse *p, char *spname)
     strcpy(sc->tablename, spname);
     strcpy(sc->fname, version);
     comdb2prepareNoRows(v, p, 0, sc, &comdb2SqlSchemaChange, (vdbeFuncArgFree)&free_schema_change_type);
+}
 
+void create_default_consumer_sp_atomic(Parse *p, char *spname, const char * tablename_for_q, const char * newcsc2_for_q, int seq_for_q, char dest_for_q[64])
+{
+    Vdbe *v = sqlite3GetVdbe(p);
+    const char *version = "comdb2 default consumer 1.1";
+
+    struct schema_change_type *sc = new_schemachange_type();
+    sc->kind = SC_DEFAULTCONS;
+    strcpy(sc->tablename, spname);
+    strcpy(sc->fname, version);
+    sc->newcsc2 = strdup(default_consumer);
+    sc->persistent_seq = seq_for_q;
+    struct dest *d = malloc(sizeof(struct dest));
+    d->dest = strdup(dest_for_q);
+    listc_abl(&sc->dests, d);
+    sc->newcsc2_for_default_cons_q = strdup(newcsc2_for_q);
+    strcpy(sc->tablename_for_default_cons_q, tablename_for_q);
+    comdb2PrepareSC(v, p, 0, sc, &comdb2SqlSchemaChange, (vdbeFuncArgFree)&free_schema_change_type);
 }

--- a/sqlite/src/comdb2build.h
+++ b/sqlite/src/comdb2build.h
@@ -160,6 +160,7 @@ int comdb2TokenToStr(Token *nm, char *buf, size_t len);
 int comdb2IsPrepareOnly(Parse* pParse);
 int comdb2AuthenticateUserOp(Parse* pParse);
 
-void create_default_consumer_sp(Parse *, char *);
+void create_default_consumer_sp_atomic(Parse *p, char *spname, const char * tablename_for_q, const char * newcsc2_for_q, int seq_for_q, char dest_for_q[64]);
+void create_default_consumer_sp(Parse *p, char *spname);
 
 #endif // COMDB2BUILD_H

--- a/sqlite/src/comdb2lua.c
+++ b/sqlite/src/comdb2lua.c
@@ -20,6 +20,8 @@
 struct dbtable;
 struct dbtable *getqueuebyname(const char *);
 int bdb_get_sp_get_default_version(const char *, int *);
+extern int gbl_create_default_consumer_atomically;
+extern int gbl_sc_protobuf;
 
 #define MAX_SPNAME_FOR_TRIGGER MAX_SPNAME-strlen(Q_TAG) // includes null terminator
 #define COMDB2_DEFAULT_CONSUMER 2
@@ -132,6 +134,11 @@ Cdb2TrigTables *comdb2AddTriggerTable(Parse *parse, Cdb2TrigTables *tables, SrcL
     return tmp;
 }
 
+static int can_create_default_consumer_atomically()
+{
+    return gbl_create_default_consumer_atomically && gbl_sc_protobuf;
+}
+
 void comdb2CreateTrigger(Parse *parse, int consumer, int seq, Token *proc, Cdb2TrigTables *tbl)
 {
     if (comdb2IsPrepareOnly(parse))
@@ -223,24 +230,28 @@ void comdb2CreateTrigger(Parse *parse, int consumer, int seq, Token *proc, Cdb2T
     char method[64];
     sprintf(method, "dest:%s:%s", consumer ? "dynlua" : "lua", spname);
 
-    // trigger add table:qname dest:method
-    struct schema_change_type *sc = new_schemachange_type();
-    sc->kind = SC_ADD_TRIGGER;
-    sc->persistent_seq = seq;
-    strcpy(sc->tablename, qname);
-    struct dest *d = malloc(sizeof(struct dest));
-    d->dest = strdup(method);
-    listc_abl(&sc->dests, d);
-    sc->newcsc2 = strbuf_disown(s);
-    strbuf_free(s);
-    Vdbe *v = sqlite3GetVdbe(parse);
-
-    if (consumer == COMDB2_DEFAULT_CONSUMER) {
-        create_default_consumer_sp(parse, spname);
-        comdb2prepareNoRows(v, parse, 0, sc, comdb2SqlSchemaChange, (vdbeFuncArgFree)&free_schema_change_type);
+    if (consumer == COMDB2_DEFAULT_CONSUMER && can_create_default_consumer_atomically()) {
+        create_default_consumer_sp_atomic(parse, spname, qname, strbuf_disown(s), seq, method);
     } else {
-        comdb2prepareNoRows(v, parse, 0, sc, &comdb2SqlSchemaChange_tran, (vdbeFuncArgFree)&free_schema_change_type);
+        // trigger add table:qname dest:method
+        struct schema_change_type *sc = new_schemachange_type();
+        sc->kind = SC_ADD_TRIGGER;
+        sc->persistent_seq = seq;
+        strcpy(sc->tablename, qname);
+        struct dest *d = malloc(sizeof(struct dest));
+        d->dest = strdup(method);
+        listc_abl(&sc->dests, d);
+        sc->newcsc2 = strbuf_disown(s);
+        Vdbe *v = sqlite3GetVdbe(parse);
+
+        if (consumer == COMDB2_DEFAULT_CONSUMER) {
+            create_default_consumer_sp(parse, spname);
+            comdb2prepareNoRows(v, parse, 0, sc, comdb2SqlSchemaChange, (vdbeFuncArgFree)&free_schema_change_type);
+        } else {
+            comdb2prepareNoRows(v, parse, 0, sc, &comdb2SqlSchemaChange_tran, (vdbeFuncArgFree)&free_schema_change_type);
+        }
     }
+    strbuf_free(s);
     return;
 }
 

--- a/tests/consumer.test/non_atomic_default_consumer.testopts
+++ b/tests/consumer.test/non_atomic_default_consumer.testopts
@@ -1,0 +1,1 @@
+create_default_consumer_atomically 0

--- a/tests/consumer.test/runit
+++ b/tests/consumer.test/runit
@@ -3,4 +3,7 @@ bash -n "$0" | exit 1
 
 set -e
 ./t00.sh
+if [ "$TESTCASE" == "consumer" ]; then
+	./t06.sh
+fi
 ${TESTSROOTDIR}/tools/compare_results.sh -s -d $1

--- a/tests/consumer.test/t06.sh
+++ b/tests/consumer.test/t06.sh
@@ -1,0 +1,36 @@
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+tier="default"
+
+set -ex
+
+main() {
+	cdb2sql ${CDB2_OPTIONS} ${DBNAME} ${tier} "drop table if exists t"
+	cdb2sql ${CDB2_OPTIONS} ${DBNAME} ${tier} "create table t(i int)"
+
+	sendtocluster "exec procedure sys.cmd.send('fail_to_create_default_cons 1')"
+	if cdb2sql ${CDB2_OPTIONS} ${DBNAME} ${tier} "create default lua consumer t_cons on (table t for insert and update and delete)";
+	then
+		echo "FAIL: Should have failed to create consumer. Test may be buggy."
+		return 1
+	fi
+
+	local proc_exists=$(cdb2sql ${CDB2_OPTIONS} --tabs ${DBNAME} ${tier} "select 1 from comdb2_procedures where name='t_cons' limit 1")
+	if (( proc_exists == 1 ));
+	then
+		echo "FAIL: Procedure should not exist"
+		return 1
+	fi
+
+	sendtocluster "exec procedure sys.cmd.send('fail_to_create_default_cons 0')"
+	cdb2sql ${CDB2_OPTIONS} ${DBNAME} ${tier} "create default lua consumer t_cons on (table t for insert and update and delete)"
+
+	proc_exists=$(cdb2sql ${CDB2_OPTIONS} --tabs ${DBNAME} ${tier} "select 1 from comdb2_procedures where name='t_cons' limit 1")
+	if (( proc_exists != 1 ));
+	then
+		echo "FAIL: Procedure should exist."
+		return 1
+	fi
+}
+
+main

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -155,6 +155,7 @@
 (name='core_on_sparse_file', description='Generate a core if we catch berkeley creating a sparse file', type='BOOLEAN', value='OFF', read_only='N')
 (name='crc32c', description='Use crc32c (alternate faster implementation of CRC32, different checksums) for page checksums. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='create_dba_user', description='Automatically create 'dba' user if it does not exist already (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
+(name='create_default_consumer_atomically', description='Create default consumers atomically (default on)', type='BOOLEAN', value='ON', read_only='N')
 (name='create_default_user', description='Automatically create 'default' user when authentication is enabled. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='createdbs', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='cron_idle_secs', description='Set the default sleep time before the cron scheduler checks again the queue for events', type='INTEGER', value='30', read_only='N')


### PR DESCRIPTION
Default consumers are currently created in 3 transactions. The changes in this PR make the db use just 1 transaction.