### PR TITLE
{RDSICOMDB2-371}: Cherrypick of [40739c793b] from upstream SQLite trunk.

### DIFF
--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -2334,7 +2334,9 @@ static void whereLoopOutputAdjust(
         /* In the absence of explicit truth probabilities, use heuristics to
         ** guess a reasonable truth probability. */
         pLoop->nOut--;
-        if( pTerm->eOperator&(WO_EQ|WO_IS) ){
+        if( (pTerm->eOperator&(WO_EQ|WO_IS))!=0
+         && (pTerm->wtFlags & TERM_HIGHTRUTH)==0  /* tag-20200224-1 */
+        ){
           Expr *pRight = pTerm->pExpr->pRight;
           testcase( pTerm->pExpr->op==TK_IS );
           if( sqlite3ExprIsInteger(pRight, &k, 0) && k>=(-1) && k<=1 ){
@@ -2342,7 +2344,10 @@ static void whereLoopOutputAdjust(
           }else{
             k = 20;
           }
-          if( iReduce<k ) iReduce = k;
+          if( iReduce<k ){
+            pTerm->wtFlags |= TERM_HEURTRUTH;
+            iReduce = k;
+          }
         }
       }
     }
@@ -2523,9 +2528,9 @@ static int whereLoopAddBtreeIndex(
     }
 
     if( IsUniqueIndex(pProbe) && saved_nEq==pProbe->nKeyCol-1 ){
-      pBuilder->bldFlags |= SQLITE_BLDF_UNIQUE;
+      pBuilder->bldFlags1 |= SQLITE_BLDF1_UNIQUE;
     }else{
-      pBuilder->bldFlags |= SQLITE_BLDF_INDEXED;
+      pBuilder->bldFlags1 |= SQLITE_BLDF1_INDEXED;
     }
     pNew->wsFlags = saved_wsFlags;
     pNew->u.btree.nEq = saved_nEq;
@@ -2708,6 +2713,27 @@ static int whereLoopAddBtreeIndex(
           if( rc!=SQLITE_OK ) break;          /* Jump out of the pTerm loop */
           if( nOut ){
             pNew->nOut = sqlite3LogEst(nOut);
+            if( nEq==1
+             /* TUNING: Mark terms as "low selectivity" if they seem likely
+             ** to be true for half or more of the rows in the table.
+             ** See tag-202002240-1 */
+             && pNew->nOut+10 > pProbe->aiRowLogEst[0]
+            ){
+#if WHERETRACE_ENABLED /* 0x01 */
+              if( sqlite3WhereTrace & 0x01 ){
+                sqlite3DebugPrintf(
+                   "STAT4 determines term has low selectivity:\n");
+                whereTermPrint(pTerm, 999);
+              }
+#endif
+              pTerm->wtFlags |= TERM_HIGHTRUTH;
+              if( pTerm->wtFlags & TERM_HEURTRUTH ){
+                /* If the term has previously been used with an assumption of
+                ** higher selectivity, then set the flag to rerun the
+                ** loop computations. */
+                pBuilder->bldFlags2 |= SQLITE_BLDF2_2NDPASS;
+              }
+            }
             if( pNew->nOut>saved_nOut ) pNew->nOut = saved_nOut;
             pNew->nOut -= nIn;
           }
@@ -3154,9 +3180,9 @@ static int whereLoopAddBtree(
       }
     }
 
-    pBuilder->bldFlags = 0;
+    pBuilder->bldFlags1 = 0;
     rc = whereLoopAddBtreeIndex(pBuilder, pSrc, pProbe, 0);
-    if( pBuilder->bldFlags==SQLITE_BLDF_INDEXED ){
+    if( pBuilder->bldFlags1==SQLITE_BLDF1_INDEXED ){
       /* If a non-unique index is used, or if a prefix of the key for
       ** unique index is used (making the index functionally non-unique)
       ** then the sqlite_stat1 data becomes important for scoring the
@@ -4692,6 +4718,28 @@ static int exprIsDeterministic(Expr *p){
   return w.eCode;
 }
 
+  
+#ifdef WHERETRACE_ENABLED
+/*
+** Display all WhereLoops in pWInfo
+*/
+static void showAllWhereLoops(WhereInfo *pWInfo, WhereClause *pWC){
+  if( sqlite3WhereTrace ){    /* Display all of the WhereLoop objects */
+    WhereLoop *p;
+    int i;
+    static const char zLabel[] = "0123456789abcdefghijklmnopqrstuvwyxz"
+                                           "ABCDEFGHIJKLMNOPQRSTUVWYXZ";
+    for(p=pWInfo->pLoops, i=0; p; p=p->pNextLoop, i++){
+      p->cId = zLabel[i%(sizeof(zLabel)-1)];
+      whereLoopPrint(p, pWC);
+    }
+  }
+}
+# define WHERETRACE_ALL_LOOPS(W,C) showAllWhereLoops(W,C)
+#else
+# define WHERETRACE_ALL_LOOPS(W,C)
+#endif
+
 /*
 ** The index pIdx is used by a query and contains one or more expressions.
 ** In other words pIdx is an index on an expression.  iIdxCur is the cursor
@@ -5034,19 +5082,28 @@ WhereInfo *sqlite3WhereBegin(
   if( nTabList!=1 || whereShortCut(&sWLB)==0 ){
     rc = whereLoopAddAll(&sWLB);
     if( rc ) goto whereBeginError;
-  
-#ifdef WHERETRACE_ENABLED
-    if( sqlite3WhereTrace ){    /* Display all of the WhereLoop objects */
-      WhereLoop *p;
-      int i;
-      static const char zLabel[] = "0123456789abcdefghijklmnopqrstuvwyxz"
-                                             "ABCDEFGHIJKLMNOPQRSTUVWYXZ";
-      for(p=pWInfo->pLoops, i=0; p; p=p->pNextLoop, i++){
-        p->cId = zLabel[i%(sizeof(zLabel)-1)];
-        whereLoopPrint(p, sWLB.pWC);
+
+#ifdef SQLITE_ENABLE_STAT4
+    /* If one or more WhereTerm.truthProb values were used in estimating
+    ** loop parameters, but then those truthProb values were subsequently
+    ** changed based on STAT4 information while computing subsequent loops,
+    ** then we need to rerun the whole loop building process so that all
+    ** loops will be built using the revised truthProb values. */
+    if( sWLB.bldFlags2 & SQLITE_BLDF2_2NDPASS ){
+      WHERETRACE_ALL_LOOPS(pWInfo, sWLB.pWC);
+      WHERETRACE(0xffff, 
+           ("**** Redo all loop computations due to"
+            " TERM_HIGHTRUTH changes ****\n"));
+      while( pWInfo->pLoops ){
+        WhereLoop *p = pWInfo->pLoops;
+        pWInfo->pLoops = p->pNextLoop;
+        whereLoopDelete(db, p);
       }
+      rc = whereLoopAddAll(&sWLB);
+      if( rc ) goto whereBeginError;
     }
 #endif
+    WHERETRACE_ALL_LOOPS(pWInfo, sWLB.pWC);
   
     wherePathSolver(pWInfo, 0);
     if( db->mallocFailed ) goto whereBeginError;

--- a/sqlite/src/whereInt.h
+++ b/sqlite/src/whereInt.h
@@ -293,6 +293,12 @@ struct WhereTerm {
 #define TERM_LIKE       0x400  /* The original LIKE operator */
 #define TERM_IS         0x800  /* Term.pExpr is an IS operator */
 #define TERM_VARSELECT  0x1000 /* Term.pExpr contains a correlated sub-query */
+#define TERM_HEURTRUTH  0x2000 /* Heuristic truthProb used */
+#ifdef SQLITE_ENABLE_STAT4
+#  define TERM_HIGHTRUTH  0x4000 /* Term excludes few rows */
+#else
+#  define TERM_HIGHTRUTH  0      /* Only used with STAT4 */
+#endif
 
 /*
 ** An instance of the WhereScan object is used as an iterator for locating
@@ -407,13 +413,16 @@ struct WhereLoopBuilder {
   UnpackedRecord *pRec;     /* Probe for stat4 (if required) */
   int nRecValid;            /* Number of valid fields currently in pRec */
 #endif
-  unsigned int bldFlags;    /* SQLITE_BLDF_* flags */
+  unsigned char bldFlags1;  /* First set of SQLITE_BLDF_* flags */
+  unsigned char bldFlags2;  /* Second set of SQLITE_BLDF_* flags */
   unsigned int iPlanLimit;  /* Search limiter */
 };
 
 /* Allowed values for WhereLoopBuider.bldFlags */
-#define SQLITE_BLDF_INDEXED  0x0001   /* An index is used */
-#define SQLITE_BLDF_UNIQUE   0x0002   /* All keys of a UNIQUE index used */
+#define SQLITE_BLDF1_INDEXED  0x0001   /* An index is used */
+#define SQLITE_BLDF1_UNIQUE   0x0002   /* All keys of a UNIQUE index used */
+
+#define SQLITE_BLDF2_2NDPASS  0x0004   /* Second builder pass needed */
 
 /* The WhereLoopBuilder.iPlanLimit is used to limit the number of
 ** index+constraint combinations the query planner will consider for a

--- a/tests/yast.test/analyzeG.test
+++ b/tests/yast.test/analyzeG.test
@@ -1,0 +1,88 @@
+# 2020-02-23
+#
+# The author disclaims copyright to this source code.  In place of
+# a legal notice, here is a blessing:
+#
+#    May you do good and not evil.
+#    May you find forgiveness for yourself and forgive others.
+#    May you share freely, never taking more than you give.
+#
+#***********************************************************************
+# Tests for functionality related to ANALYZE.
+#
+
+set testdir [file dirname $argv0]
+source $testdir/tester.tcl
+
+ifcapable !stat4 {
+  finish_test
+  return
+}
+set testprefix analyzeG
+
+proc do_scan_order_test {tn sql expect} {
+  uplevel [list do_test $tn [subst -nocommands -nobackslashes {
+    set res ""
+    db eval "explain query plan $sql" {
+      regsub { \(.*?$} [set detail] "" detail
+      lappend res [set detail]
+    }
+    set res
+  }] [list {*}$expect]]
+}
+
+#-------------------------------------------------------------------------
+# Test cases 1.* seek to verify that even if an index is not used, its
+# stat4 data may be used by the planner to estimate the number of
+# rows that match an unindexed constraint on the same column.
+#
+do_execsql_test 1.0 {
+  CREATE TABLE t1(a, x);
+  CREATE TABLE t2(b, y);
+  WITH s(i) AS (
+    SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i<100
+  )
+  INSERT INTO t1 SELECT (i%50), NULL FROM s;
+  WITH s(i) AS (
+    SELECT 1 UNION ALL SELECT i+1 FROM s WHERE i<100
+  )
+  INSERT INTO t2 SELECT (CASE WHEN i<95 THEN 44 ELSE i END), NULL FROM s;
+} {100 100}; # rows inserted
+
+# Join tables t1 and t2. Both contain 100 rows. (a=44) matches 2 rows
+# in "t1", (b=44) matches 95 rows in table "t2". But the planner doesn't
+# know this, so it has no preference as to which order the tables are
+# scanned in. In practice this means that tables are scanned in the order
+# they are specified in in the FROM clause.
+do_scan_order_test 1.1.1 {
+  SELECT * FROM t1, t2 WHERE a=44 AND b=44;
+} {
+  {SCAN TABLE t1} {SCAN TABLE t2}
+}
+do_scan_order_test 1.1.2 {
+  SELECT * FROM t2, t1 WHERE a=44 AND b=44 
+} {
+  {SCAN TABLE t2} {SCAN TABLE t1} 
+}
+
+do_execsql_test 1.2 {
+  CREATE INDEX t2b ON t2(b);
+  ANALYZE;
+}
+
+# Now, with the ANALYZE data, the planner knows that (b=44) matches a 
+# large number of rows. So it elects to scan table "t1" first, regardless
+# of the order in which the tables are specified in the FROM clause.
+do_scan_order_test 1.3.1 {
+  SELECT * FROM t1, t2 WHERE a=44 AND b=44;
+} {
+  {SCAN TABLE t1} {SCAN TABLE t2}
+}
+do_scan_order_test 1.3.2 {
+  SELECT * FROM t2, t1 WHERE a=44 AND b=44 
+} {
+  {SCAN TABLE t1} {SCAN TABLE t2} 
+}
+
+
+finish_test

--- a/tests/yast.test/lrl.options
+++ b/tests/yast.test/lrl.options
@@ -6,3 +6,4 @@ ssl_client_mode OPTIONAL
 REP_WORKERS 0
 REP_PROCESSORS 0
 early 0
+exec_sql_on_new_connect PRAGMA automatic_index = 0;

--- a/tests/yast.test/tester.tcl
+++ b/tests/yast.test/tester.tcl
@@ -192,7 +192,8 @@ proc maybe_quote_value { db index format } {
                     set value [string map [list \" \\\"] $value]
                     set wrap \"
                 }
-                list {
+                list -
+                list2 {
                     # do nothing, handled below.
                 }
                 default {
@@ -214,7 +215,8 @@ proc maybe_quote_value { db index format } {
                 }
                 tabs -
                 tabs2 -
-                list {
+                list -
+                list2 {
                     # do nothing, handled below.
                 }
                 default {
@@ -275,6 +277,7 @@ proc maybe_trace { message } {
 
 proc grab_cdb2_results { db varName {format csv} } {
     set list [expr {$format eq "list"}]
+    set list2 [expr {$format eq "list2"}]
     set csv [expr {$format eq "csv"}]
     set tabs [expr {$format eq "tabs"}]
     # This one emulates upstream's execsql2 output which includes column
@@ -283,9 +286,10 @@ proc grab_cdb2_results { db varName {format csv} } {
     if {[string length $varName] > 0} {upvar 1 $varName result}
     set once false
     while {[cdb2 next $db]} {
-        if {$list} {
+        if {$list || $list2} {
             set row [list]
             for {set index 0} {$index < [cdb2 colcount $db]} {incr index} {
+                if {$list2} {lappend row [cdb2 colname $db $index]}
                 lappend row [maybe_quote_value $db $index $format]
             }
             lappend result $row
@@ -374,7 +378,7 @@ proc do_cdb2_query { dbName sql {tier default} {format csv} {costVarName ""} {pa
     set lastCost [string equal $costVarName lastcost]
     if { $lastCost } { set doCost 0 }
 
-    if {[info exists ::cdb2_config]} then {
+    if {[info exists ::cdb2_config]} {
       cdb2 configure $::cdb2_config true
     }
 
@@ -618,9 +622,27 @@ proc execsql_status2 {sql} {
   return "$r $gbl_scan $gbl_sort $gbl_count"
 }
 
-proc db {e sql} {
-  execsql $sql list_results
+proc db {args} {
+  if {[llength $args] != 2 && [llength $args] != 3} {
+    error {wrong # args: should be "db eval sql ?script?"}
+  }
+  if {[lindex $args 0] ni [list "eval" "one"]} {
+    error "only db \"eval\" and \"one\" are supported"
+  }
+  set sql [lindex $args 1]
+  set script [lindex $args 2]
+  if {[string length $script] > 0} {
+    set r [execsql $sql {list_results list_with_col_name verbatim}]
+    foreach row $r {
+      foreach {name value} $row {uplevel 1 [list set $name $value]}
+      uplevel 1 $script
+    }
+    return ""
+  } else {
+    return [execsql $sql list_results]
+  }
 }
+
 proc execpresql {handle args} {
   trace remove execution $handle enter [list execpresql $handle]
   if {[info exists ::G(perm:presql)]} {
@@ -1650,10 +1672,14 @@ proc execsql {sql {options ""} {params {}}} {
     if {[lsearch -exact $options tabs_with_col_name] != -1} {
       # execsql2
       set format tabs2
+    } elseif {[lsearch -exact $options list_with_col_name] != -1} {
+      # db eval
+      set format list2
     } else {
       set format tabs
     }
 
+    if {$format ne "list2" && [lsearch -exact $options list_results] != -1} {set format list}
     if {[lsearch -exact $options list_results] != -1} {set format list}
 
     #
@@ -1702,14 +1728,22 @@ proc execsql {sql {options ""} {params {}}} {
     #}
 
     if {[lsearch -exact $options list_results] != -1} {
-      #
-      # NOTE: The list format is being used.  Treat the resulting output as
-      #       a list of rows, where each row is a list of column values.
-      #
-      foreach output $outputs {
-        foreach o $output {
-          if {[string equal $o NULL]} {set o ""}
-          lappend r $o
+      if {[lsearch -exact $options verbatim] != -1} {
+        #
+        # NOTE: Return the outputs verbatim.  They should already have any
+        #       necessary list formatting.
+        #
+        set r $outputs
+      } else {
+        #
+        # NOTE: The list format is being used.  Treat the resulting output as
+        #       a list of rows, where each row is a list of column values.
+        #
+        foreach output $outputs {
+          foreach o $output {
+            if {[string equal $o NULL]} {set o ""}
+            lappend r $o
+          }
         }
       }
     } else {


### PR DESCRIPTION
This check-in was cherry-picked onto 7.0, but is never ported to 8.0 or later. This pull request adds it.