### PR TITLE
8.0 Fix potential analyze segfault

### DIFF
--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -404,6 +404,8 @@ static int cleanup_sampled_indicies(struct sqlclntstate *client)
 {
     int i;
 
+    if (!clnt->sampled_idx_tbl) { return 0; }
+
     /* delete sampled temptables */
     for (i = 0; i < client->n_cmp_idx; i++) {
         sampled_idx_t *s_ix = &client->sampled_idx_tbl[i];


### PR DESCRIPTION
If we fail to `calloc()` [here](https://github.com/bloomberg/comdb2/blob/3ba5238f7d15e0b0eff44555f4007cf99cd84a3d/db/sqlanalyze.c#L362), we will still try to free the null pointer that it returns. The changes in this PR check that the pointer is not null before freeing it.