### PR TITLE
179053900: Abort if reload fails during import scdone

### DIFF
--- a/schemachange/sc_callbacks.c
+++ b/schemachange/sc_callbacks.c
@@ -979,7 +979,11 @@ static int scdone_bulkimport(const char tablename[], void *arg, scdone_t type)
         goto done;
 
     logmsg(LOGMSG_INFO, "Replicant bulkimporting table:%s\n", tablename);
-    reload_after_bulkimport(db, tran);
+    rc = reload_after_bulkimport(db, tran);
+    if (rc) {
+        logmsg(LOGMSG_FATAL, "%s: Failed to reload\n", __func__);
+        abort();
+    }
 
     _master_recs(tran, tablename, type);
 


### PR DESCRIPTION
I've seen import scdones segfaulting in various places after `reload_after_bulkimport` fails. The changes in this PR log a message and abort if `reload_after_bulkimport` fails.