### PR TITLE
Log abbreviated hint statements in eventlog in their full form.

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -366,6 +366,7 @@ extern int gbl_sequence_feature;
 extern int gbl_reproduce_sequence_corruption;
 extern int gbl_permissive_sequence_sc;
 extern int gbl_view_feature;
+extern int gbl_eventlog_fullhintsql;
 
 extern char *gbl_kafka_topic;
 extern char *gbl_kafka_brokers;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -576,6 +576,9 @@ REGISTER_TUNABLE("fullrecovery",
                  "recovery from the beginning of "
                  "available logs. (Default : off)",
                  TUNABLE_BOOLEAN, &gbl_fullrecovery, READONLY | NOARG, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("eventlog_fullhintsql",
+                 "Log full sql statement in the event log for hint abbreviated sql. (Default : on)",
+                 TUNABLE_BOOLEAN, &gbl_eventlog_fullhintsql, NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("gbl_exit_on_pthread_create_fail",
                  "If set, database will exit if thread pools aren't able to "
                  "create threads. (Default: 1)",

--- a/db/sql.h
+++ b/db/sql.h
@@ -726,6 +726,7 @@ struct sqlclntstate {
     pthread_mutex_t sql_lk;
     char *sql;
     struct string_ref *sql_ref;
+    struct string_ref *hint_sql_ref;
     int recno;
     int client_understands_query_stats;
     char tzname[CDB2_MAX_TZNAME];

--- a/tests/eventlog.test/runit
+++ b/tests/eventlog.test/runit
@@ -189,6 +189,8 @@ cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t2(a int)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "create table t3(b int)"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select distinct t2.a from t2 left join t3 on t2.a = t3.b"
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "select distinct t2.a from t2 left join comdb2_tables on t2.a = comdb2_tables.tablename"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "select /*+ RUNCOMDB2SQL -403612579.49152.261521527 */ * from t2 limit 1"
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "select /*+ RUNCOMDB2SQL -403612579.49152.261521527 */"
 
 # need to flush to get correct stmts in logfile
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "exec procedure sys.cmd.send('reql events flush')"
@@ -213,6 +215,12 @@ res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
     zcat $f | jq -c 'if (.type == "sql") and (.sql == "select * from t1 where i = 10001") then .id else empty end'
 done )
 assertres $res "null"
+
+echo "make sure that hint query is log in full"
+res=$(for f in $(ls -1t $TESTDIR/var/log/cdb2/$DBNAME.events.* | head -2); do
+    zcat $f | jq -c 'if (.type == "sql") and (.sql == "select /*+ RUNCOMDB2SQL -403612579.49152.261521527 */ * from t2 limit 1") then . else empty end'
+done | wc -l)
+assertres $res 2
 
 echo "Test whether all tables referenced in query are present in event log even if not needed to execute query"
 echo "make sure string 'select distinct t2.a from t2 left join t3 on t2.a = t3.b' is in the last 2 eventlog files:"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -349,6 +349,7 @@
 (name='epochms_repts', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='erroff', description='Disables 'erron'', type='BOOLEAN', value='OFF', read_only='Y')
 (name='erron', description='', type='BOOLEAN', value='ON', read_only='Y')
+(name='eventlog_fullhintsql', description='Log full sql statement in the event log for hint abbreviated sql. (Default : on)', type='BOOLEAN', value='ON', read_only='N')
 (name='eventlog_nkeep', description='Keep this many eventlog files (Default: 2)', type='INTEGER', value='0', read_only='N')
 (name='exclusive_blockop_qconsume', description='Enables serialization of blockops and queue consumes. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='exit_on_internal_failure', description='', type='BOOLEAN', value='ON', read_only='Y')


### PR DESCRIPTION
Per title.  
Queries:
SELECT /*+ RUNCOMDB2SQL ... */
This is trigger for an api&server bug that crashes in QA testing.
RE: 177199209