### PR TITLE
Fix incomplete hint statements part of transactions (return -3 not -105).

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2943,7 +2943,8 @@ static void _prepare_error(struct sqlthdstate *thd,
         errstr = (char *)sqlite3_errmsg(thd->sqldb);
         reqlog_logf(thd->logger, REQL_TRACE, "sqlite3_prepare failed %d: %s\n",
                     rc, errstr);
-        errstat_set_rcstrf(err, ERR_PREPARE_RETRY, "%s", errstr);
+        /* this is not retriable; api will retry unless ha or only begin was sent */
+        errstat_set_rcstrf(err, ERR_PREPARE, "%s", errstr);
 
         //srs_tran_del_last_query(clnt);
         return;


### PR DESCRIPTION
A hint query that has NO full statement and is part of a transaction is NOT retriable.

Api will not retry a transaction, not unless this is ha snapshot, or only begin was sent.

Sending ERROR_PREPARE_RETRY makes api retry, fail every time because this is not HA and more than begin ws sent, and finally fail with -105 (disconnected during transaction).

Sending ERROR_PREPARE will return -3 incomplete input as expected by both comdb2api and cdb2api.

Re: 177199209
