### PR TITLE
Reverting #5138

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2943,8 +2943,7 @@ static void _prepare_error(struct sqlthdstate *thd,
         errstr = (char *)sqlite3_errmsg(thd->sqldb);
         reqlog_logf(thd->logger, REQL_TRACE, "sqlite3_prepare failed %d: %s\n",
                     rc, errstr);
-        /* this is not retriable; api will retry unless ha or only begin was sent */
-        errstat_set_rcstrf(err, ERR_PREPARE, "%s", errstr);
+        errstat_set_rcstrf(err, ERR_PREPARE_RETRY, "%s", errstr);
 
         //srs_tran_del_last_query(clnt);
         return;


### PR DESCRIPTION
Revert "A hint query that has NO full statement and is part of a transactio  is NOT retryable."

This reverts commit c9c76eeb8b4382059ee0f53b63b8cf177052f745.

This commit ends up breaking sql-hint: if a query isn't found for a hint string, server needs to return a retryable error so that client can re-send the query in its full form. It should not be treated as a fatal error, even if the client has begun a transaction.
