### PR TITLE
Ensuring each dohsql clnt has its own authdata

### DIFF
--- a/db/dohsql.c
+++ b/db/dohsql.c
@@ -1032,7 +1032,7 @@ static int _shard_connect(struct sqlclntstate *clnt, dohsql_connector_t *conn,
     conn->clnt->origin = clnt->origin;
     conn->clnt->current_user = clnt->current_user;
     conn->clnt->sql = strdup(sql);
-    conn->clnt->authdata = get_authdata(clnt);
+    conn->clnt->authdata = clnt->authdata = get_authdata(clnt);
     conn->clnt->argv0 = clnt->argv0;
     memcpy(conn->clnt->tzname, clnt->tzname, sizeof(clnt->tzname));
     make_dohsql_plugin(conn->clnt);
@@ -1074,7 +1074,6 @@ static void _shard_disconnect(dohsql_connector_t *conn)
     free(conn->params);
     free(clnt->sql);
     clnt->sql = NULL;
-    free(clnt->authdata);
     clnt->authdata = NULL;
     clnt->argv0 = NULL;
     cleanup_clnt(clnt);


### PR DESCRIPTION
The changes in #5146 may double free the authdata on the parent clnt. This pull request ensures that each dohsql clnt has its own authdata which can be freed independently by `reset_clnt()`.