### PR TITLE
Fixing crashes in net_get_stats and friends while collecting net metrics

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -3232,36 +3232,6 @@ int net_get_conntime_dump_period(netinfo_type *netinfo_ptr) {
     return netinfo_ptr->conntime_dump_period;
 }
 
-int net_get_stats(netinfo_type *netinfo_ptr, struct net_stats *stat) {
-    struct host_node_tag *ptr;
-
-    stat->num_drops = 0;
-
-    Pthread_rwlock_rdlock(&(netinfo_ptr->lock));
-    for (ptr = netinfo_ptr->head; ptr != NULL; ptr = ptr->next)
-        stat->num_drops += ptr->num_queue_full;
-
-    Pthread_rwlock_unlock(&(netinfo_ptr->lock));
-
-    return 0;
-}
-
-int net_get_host_stats(netinfo_type *netinfo_ptr, const char *host, struct net_host_stats *stat) {
-    struct host_node_tag *ptr;
-    stat->queue_size = 0;
-
-    Pthread_rwlock_rdlock(&(netinfo_ptr->lock));
-    for (ptr = netinfo_ptr->head; ptr != NULL; ptr = ptr->next) {
-        if (strcmp(host, ptr->host) == 0) {
-            stat->queue_size = time_metric_max(ptr->metric_queue_size);
-            break;
-        }
-    }
-    Pthread_rwlock_unlock(&(netinfo_ptr->lock));
-
-    return 0;
-}
-
 int net_send_all(netinfo_type *netinfo_ptr, int num, void **data, int *sz,
                  int *type, int *flag)
 {

--- a/net/net.h
+++ b/net/net.h
@@ -332,16 +332,6 @@ struct host_node_info {
 int net_get_nodes_info(netinfo_type *netinfo_ptr, int max_nodes,
                        struct host_node_info *out_nodes);
 
-struct net_host_stats {
-    int queue_size;
-};
-int net_get_host_stats(netinfo_type *netinfo_ptr, const char *host, struct net_host_stats *stat);
-
-struct net_stats {
-    int num_drops;
-};
-int net_get_stats(netinfo_type *netinfo_ptr, struct net_stats *stat);
-
 void net_cmd(netinfo_type *netinfo_ptr, char *line, int lline, int st, int op1);
 
 int net_get_host_network_usage(netinfo_type *netinfo_ptr, const char *host,

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -354,6 +354,12 @@ int net_send_evbuffer(netinfo_type *, const char *, int, void *, int, int, void 
 
 int get_hosts_evbuffer(int n, host_node_type **);
 
+enum net_metric_type {
+    NET_DROPS = 1,
+    MAX_QUEUE_SIZE = 2
+};
+int get_hosts_metric(const char *netname, enum net_metric_type type);
+
 int should_reject_request(void);
 
 int dist_heartbeats(dist_hbeats_type *);


### PR DESCRIPTION
 Getting stats for drops and queue size need to be done by dispatching a net event; walking the host list will race with event lib dropping/adding hosts.

 Re: 178576648
