### PR TITLE
no crashing for no curtran nolock check

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11961,6 +11961,9 @@ void curtran_assert_nolocks(void)
     struct sql_thread *thd = pthread_getspecific(query_info_key);
     if (!thd)
         return;
+    /* not all requests have curtran, like, comdb2api over cdb2sql gets it after this call */
+    if (!thd->clnt->dbtran.cursor_tran)
+        return;
     uint32_t lockid = bdb_get_lid_from_cursortran(thd->clnt->dbtran.cursor_tran);
     if (!lockid)
         return;


### PR DESCRIPTION
Regression. No all sql requests have a curtran at the start of the prepare process. Do not dereference a NULL curtran.

Re: 178686148
