### PR TITLE
Exit log-get loop if bdb-lock is desired

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -190,6 +190,7 @@ extern int gbl_flush_on_prepare;
 extern int gbl_debug_sleep_before_prepare;
 extern int gbl_wait_for_prepare_seqnum;
 extern int gbl_flush_replicant_on_prepare;
+extern int gbl_slow_rep_log_get_loop;
 extern int gbl_abort_on_unset_ha_flag;
 extern int gbl_abort_on_unfound_txn;
 extern int gbl_abort_on_ufid_mismatch;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -280,6 +280,8 @@ REGISTER_TUNABLE("flush_on_prepare", "Flush master log on prepare. (Default: on)
                  &gbl_flush_on_prepare, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("flush_replicant_on_prepare", "Flush replicant log on prepare. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_flush_replicant_on_prepare, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("slow_rep_log_get_loop", "Add latency to the master's log-get loop for testing.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_slow_rep_log_get_loop, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("wait_for_prepare_seqnum", "Wait-for-seqnum for prepare records. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_wait_for_prepare_seqnum, 0, NULL, NULL, NULL, NULL);
 

--- a/tests/logreq_lock_desired.test/Makefile
+++ b/tests/logreq_lock_desired.test/Makefile
@@ -1,0 +1,9 @@
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/logreq_lock_desired.test/README.md
+++ b/tests/logreq_lock_desired.test/README.md
@@ -1,0 +1,1 @@
+Verify that the master correctly exits the log-get loop on downgrade

--- a/tests/logreq_lock_desired.test/lrl.options
+++ b/tests/logreq_lock_desired.test/lrl.options
@@ -1,0 +1,3 @@
+decoupled_logputs off
+maxosqltransfer 100000000
+req_all_threshold 0

--- a/tests/logreq_lock_desired.test/runit
+++ b/tests/logreq_lock_desired.test/runit
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+export stopfile=./stopfile.txt
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+function create_table
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table if not exists x(a int)"
+}
+
+function insert_loop
+{
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into x select * from generate_series(1, 100000)" >/dev/null 2>&1
+    done
+}
+
+function downgrade
+{
+    master=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y' limit 1")
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('downgrade')" >/dev/null 2>&1
+}
+
+function run_test
+{
+    rm -f $stopfile >/dev/null 2>&1
+
+    create_table
+    insert_loop &
+
+    replicant=""
+    while [[ -z "$replicant" ]]; do
+        replicant=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='N' limit 1")
+        if [[ -z "$replicant" ]]; then
+            sleep 5
+        fi
+    done
+
+    master=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y' limit 1")
+
+    echo "Bringing $replicant down for 120 seconds"
+    kill_restart_node $replicant 120 0
+
+    echo "Sleeping for 20 seconds for recovery"
+    sleep 20
+
+    echo "Toggle sleep-on-long-req-log-request"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "put tunable 'slow_rep_log_get_loop' 1" 
+
+    foundsleep=0
+    echo "Search for 'polling in rep-log-get loop' on master"
+    while [[ "$foundsleep" == "0" ]]; do
+        x=$(grep -c "polling in rep-log-get loop" $TESTDIR/logs/${DBNAME}.${master}.db 2>&1)
+        if [[ "$x" != "0" ]]; then
+            foundsleep=1
+        else
+            sleep 1
+        fi
+    done
+    echo "Found sleep"
+
+    foundtrace=0
+
+    echo "Downgrading"
+    downgrade
+    sleep 1
+
+    cnt=0
+    x=$(grep "exiting log-get loop, lock-is-desired" $TESTDIR/logs/${DBNAME}.${master}.db 2>&1)
+    while [[ "$x" == "" && "$cnt" -le "60" ]]; do
+        sleep 1
+        x=$(grep "exiting log-get loop, lock-is-desired" $TESTDIR/logs/${DBNAME}.${master}.db 2>&1)
+        let cnt=cnt+1
+    done
+
+    if [[ "$x" != "" ]]; then
+        foundtrace=1
+    fi
+
+    touch $stopfile
+
+    # Have seen rr hang for tests which restart nodes
+    # Just kill them from driver
+    echo "Killing all databases"
+    for node in $CLUSTER ; do 
+        kill -9 $(cat ${TMPDIR}/${DBNAME}.${node}.pid)
+    done
+
+    if [[ "$foundtrace" == "1" ]]; then
+        echo "Success!"
+    else
+        failexit "Failed to reproduce lock-is-desired condition in log-get loop"
+    fi
+}
+
+[[ -z "$CLUSTER" ]] && failexit "This test requires a cluster"
+run_test

--- a/tests/tools/cluster_utils.sh
+++ b/tests/tools/cluster_utils.sh
@@ -127,6 +127,10 @@ function kill_restart_node
     if [ -z "$delay" ] ; then # if not set
         delay=0
     fi
+    dowait=$3
+    if [ -z "$dowait" ] ; then
+        dowait=1
+    fi
 
     pushd $DBDIR
     # cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'exec procedure sys.cmd.send("flush")'
@@ -157,7 +161,9 @@ function kill_restart_node
 
     popd
 
-    waitmach $node
+    if [[ "$dowait" == "1" ]]; then
+        waitmach $node
+    fi
 }
 
 function kill_restart_secondary_node

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -926,6 +926,7 @@
 (name='skip_sync_if_direct', description='Don't fsync files if directio enabled', type='BOOLEAN', value='ON', read_only='N')
 (name='skip_table_schema_check', description='skip_table_schema_check', type='BOOLEAN', value='OFF', read_only='N')
 (name='skipdelaybase', description='Delay commits by at least this much if forced to delay by incoherent nodes.', type='INTEGER', value='100', read_only='N')
+(name='slow_rep_log_get_loop', description='Add latency to the master's log-get loop for testing.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='slow_rep_process_txn_freq', description='', type='INTEGER', value='0', read_only='Y')
 (name='slow_rep_process_txn_maxms', description='', type='INTEGER', value='0', read_only='Y')
 (name='slow_rep_process_txn_minms', description='', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
This fixes a watchdog failure that occurred because a master was blocked from downgrading by a thread in this loop.