### PR TITLE
RDSICOMDB2-447: Fix return code handling

### DIFF
--- a/db/osqlshadtbl.c
+++ b/db/osqlshadtbl.c
@@ -1868,12 +1868,12 @@ static int process_local_shadtbl_qblob(struct sqlclntstate *clnt,
         tmptblkey = bdb_temp_table_key(tbl->blb_cur);
         idx = i;
         if (rc == IX_EMPTY || rc == IX_NOTFND ||
-            (key.seq != tmptblkey->seq || key.id != tmptblkey->id)) {
+            (tmptblkey && (key.seq != tmptblkey->seq || key.id != tmptblkey->id))) {
             /* null blob */
             data = NULL;
             ldata = -1;
         } else if (rc == IX_FND) {
-            tmptblkey = bdb_temp_table_key(tbl->blb_cur);
+            assert(tmptblkey);
             if (tmptblkey->odh)
                 idx |= OSQL_BLOB_ODH_BIT;
             data = bdb_temp_table_data(tbl->blb_cur);


### PR DESCRIPTION
If `bdb_temp_table_find` has an error, it marks the cursor invalid.

`bdb_temp_table_key` will always return NULL when passed an invalid cursor.

The error handling code in `process_local_shadtbl_qblob` tries to dereference the pointer returned by `bdb_temp_table_key` without checking if it is null first.

The changes in this PR check whether the pointer is null before dereferencing it.