### PR TITLE
Look for new-name in analysis load

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -989,6 +989,7 @@ struct sqlclntstate {
     int flat_col_vals;
     plugin_func *recover_ddlk;
     replay_func *recover_ddlk_fail;
+    unsigned loading_stat: 1;
     unsigned skip_eventlog: 1;
     unsigned request_fp: 1;
     unsigned dohsql_disable: 1;
@@ -996,9 +997,9 @@ struct sqlclntstate {
     unsigned force_fdb_push_redirect : 1; // this should only be set if can_redirect_fdb is true
     unsigned force_fdb_push_remote : 1;
     unsigned return_long_column_names : 1; // if 0 then tunable decides
+    unsigned in_local_cache : 1;
     unsigned num_adjusted_column_name_length; // does not consider fastsql
     char **adjusted_column_names;
-    unsigned in_local_cache : 1;
 
     char *sqlengine_state_file;
     int sqlengine_state_line;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -839,7 +839,7 @@ static void addCursorCost(BtCursor *pCur, hash_t *h, void *l)
         listc_abl(l, qc);
     }
 
-    if (qc) {
+    if (qc && !pCur->clnt->loading_stat) {
         qc->nfind += pCur->nfind;
         qc->nnext += pCur->nmove;
         /* note: we record writes in record routines on the master */
@@ -1633,6 +1633,49 @@ done:
     snprintf(namebuf, len, "$%s_%X", csctag, crc);
 }
 
+struct ixmap {
+    char *oldname;
+    char *newname;
+};
+
+static hash_t *ixname_map = NULL;
+static pthread_mutex_t ixname_lk = PTHREAD_MUTEX_INITIALIZER;
+
+static void map_index(const char *oldname, const char *newname)
+{
+    Pthread_mutex_lock(&ixname_lk);
+    if (ixname_map == NULL) {
+        ixname_map = hash_init_strptr(offsetof(struct ixmap, oldname));
+    }
+    struct ixmap *m = hash_find(ixname_map, &oldname);
+    if (!m) {
+        m = calloc(sizeof(*m), 1);
+        m->oldname = strdup(oldname);
+        m->newname = strdup(newname);
+        hash_add(ixname_map, m);
+    } else if (strcmp(m->newname, newname) != 0) {
+        free(m->newname);
+        m->newname = strdup(newname);
+    }
+    Pthread_mutex_unlock(&ixname_lk);
+}
+
+char *mapped_index(const char *oldname)
+{
+    char *newname = NULL;
+    Pthread_mutex_lock(&ixname_lk);
+    if (ixname_map == NULL) {
+        Pthread_mutex_unlock(&ixname_lk);
+        return NULL;
+    }
+    struct ixmap *m = hash_find(ixname_map, &oldname);
+    if (m) {
+        newname = m->newname;
+    }
+    Pthread_mutex_unlock(&ixname_lk);
+    return newname;
+}
+
 /*
 ** Given a comdb2 index, this routine will decide whether to
 ** advertise its name as tablename_ix_ixnum or the new style
@@ -1641,15 +1684,19 @@ done:
 ** The index name to be adv. to sqlite is returned in namebuf.
 ** A valid name is always returned.
 */
-void sql_index_name_trans(char *namebuf, int len, struct schema *schema,
-                         struct dbtable *db, int ixnum, void *trans)
+void sql_index_name_trans(char *namebuf, int len, struct schema *schema, struct dbtable *db, int ixnum, void *trans)
 {
     form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename);
     if (stat1_find(namebuf, schema, db, ixnum, trans) > 0) return;
-    snprintf(namebuf, len, "%s_ix_%d", db->tablename, ixnum);
-    if (stat1_find(namebuf, schema, db, ixnum, trans) > 0) return;
-    /* no stats - use new names */
-    form_new_style_name(namebuf, len, schema, schema->csctag, db->tablename);
+
+    char *oldstyle = alloca(len);
+    snprintf(oldstyle, len, "%s_ix_%d", db->tablename, ixnum);
+
+    /* If we find an old-name, use the new name */
+    if (stat1_find(oldstyle, schema, db, ixnum, trans) > 0) {
+        map_index(oldstyle, namebuf);
+    }
+    return;
 }
 
 /*
@@ -2529,6 +2576,7 @@ static inline int i64cmp(const i64 *key1, const i64 *key2)
  */
 static int cursor_move_preprop(BtCursor *pCur, int *pRes, int how, int *done)
 {
+    struct sqlclntstate *clnt = pCur->clnt;
     struct sql_thread *thd = pCur->thd;
     int rc = SQLITE_OK;
 
@@ -2542,22 +2590,22 @@ static int cursor_move_preprop(BtCursor *pCur, int *pRes, int how, int *done)
     }
 
     /* add to cost */
-    switch (how) {
-    case CFIRST:
-    case CLAST:
-        /*printf("tbl %s first/last cost %f\n", pCur->db ? pCur->db->tablename :
-         * "<temp>", pCur->find_cost); */
-        thd->cost += pCur->find_cost;
-        pCur->nfind++;
-        break;
-
-    case CPREV:
-    case CNEXT:
-        /*printf("tbl %s next/prev cost %f\n", pCur->db ? pCur->db->tablename :
-         * "<temp>", pCur->move_cost); */
-        thd->cost += pCur->move_cost;
-        pCur->nmove++;
-        break;
+    if (!clnt->loading_stat) {
+        switch (how) {
+        case CFIRST:
+        case CLAST:
+            thd->cost += pCur->find_cost;
+            pCur->nfind++;
+            break;
+    
+        case CPREV:
+        case CNEXT:
+            /*printf("tbl %s next/prev cost %f\n", pCur->db ? pCur->db->tablename :
+             * "<temp>", pCur->move_cost); */
+            thd->cost += pCur->move_cost;
+            pCur->nmove++;
+            break;
+        }
     }
 
     if (!is_sqlite_db_init(pCur)) {
@@ -2569,7 +2617,7 @@ static int cursor_move_preprop(BtCursor *pCur, int *pRes, int how, int *done)
     }
 
     int inprogress;
-    if (thd->clnt->is_analyze &&
+    if (clnt->is_analyze &&
         ((inprogress = get_schema_change_in_progress(__func__, __LINE__)) ||
                       get_analyze_abort_requested() ||
                       db_is_exiting())) {
@@ -2705,7 +2753,7 @@ static int cursor_move_table(BtCursor *pCur, int *pRes, int how)
 
     outrc = SQLITE_OK;
     *pRes = 0;
-    if (thd)
+    if (thd && !clnt->loading_stat)
         thd->nmove++;
 
     bdberr = 0;
@@ -3930,7 +3978,7 @@ int sqlite3BtreeDelete(BtCursor *pCur, int usage)
 
     /* only record for temp tables - writes for real tables are recorded in
      * block code */
-    if (thd && pCur->db == NULL) {
+    if (thd && pCur->db == NULL && !clnt->loading_stat) {
         thd->nwrite++;
         thd->cost += pCur->write_cost;
         pCur->nwrite++;
@@ -5884,10 +5932,10 @@ int sqlite3BtreeMovetoUnpacked(BtCursor *pCur, /* The cursor to be moved */
         goto done;
     }
 
-    if (thd)
+    if (!clnt->loading_stat) {
         thd->nfind++;
-
-    thd->cost += pCur->find_cost;
+        thd->cost += pCur->find_cost;
+    }
 
     /* assert that this isn't called for sampled (previously misnamed
      * compressed) */
@@ -6556,6 +6604,11 @@ void addVdbeToThdCost(int type, int *data)
     if (thd == NULL)
         return;
 
+    struct sqlclntstate *clnt = thd->clnt;
+    if (clnt->loading_stat) {
+        return;
+    }
+
     switch (type) {
       case VDBESORTER_WRITE:
         thd->cost += CDB2_TEMP_WRITE_COST;
@@ -6578,8 +6631,10 @@ void addVdbeSorterCost(const VdbeSorter *pSorter)
     if (thd == NULL)
         return;
 
-    addSorterCost(pSorter, thd->query_hash, &thd->query_stats);
-    addSorterCost(pSorter, thd->query_hash_subrequest, &thd->query_stats_subrequest);
+    if (!thd->clnt->loading_stat) {
+        addSorterCost(pSorter, thd->query_hash, &thd->query_stats);
+        addSorterCost(pSorter, thd->query_hash_subrequest, &thd->query_stats_subrequest);
+    }
 }
 
 /*
@@ -6650,7 +6705,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
         }
     }
 
-    if (thd) {
+    if (thd && !clnt->loading_stat) {
         addCursorCost(pCur, thd->query_hash, &thd->query_stats);
         addCursorCost(pCur, thd->query_hash_subrequest, &thd->query_stats_subrequest);
     }
@@ -6847,7 +6902,7 @@ static int fetch_blob_into_sqlite_mem(BtCursor *pCur, struct schema *sc,
 
     pCur->nblobs++;
     struct sql_thread *thd = pCur->thd;
-    if (thd) thd->cost += pCur->blob_cost;
+    if (thd && !pCur->clnt->loading_stat) thd->cost += pCur->blob_cost;
 
     if (pCur->rd_blob_buffers) {
         blob = &pCur->rd_blob_buffers[f->blob_index];
@@ -8981,7 +9036,7 @@ int sqlite3BtreeInsert(
         memset(pblobs, 0, sizeof(blob_buffer_t) * MAXBLOBS);
     }
 
-    if (thd && pCur->db == NULL) {
+    if (thd && pCur->db == NULL && !clnt->loading_stat) {
         thd->nwrite++;
         thd->cost += pCur->write_cost;
         pCur->nwrite++;
@@ -10985,10 +11040,12 @@ int sqlite3BtreeCount(BtCursor *pCur, i64 *pnEntry)
             }
         } while (rc == BDBERR_DEADLOCK && nretries++ < max_retries);
         if (rc == 0) {
-            pCur->nfind++;
-            pCur->nmove += count;
-            thd->had_tablescans = 1;
-            thd->cost += pCur->find_cost + (pCur->move_cost * count);
+            if (!clnt->loading_stat) {
+                pCur->nfind++;
+                pCur->nmove += count;
+                thd->had_tablescans = 1;
+                thd->cost += pCur->find_cost + (pCur->move_cost * count);
+            }
         } else if (rc == BDBERR_DEADLOCK) {
             rc = SQLITE_DEADLOCK;
         }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2661,8 +2661,7 @@ static void compare_estimate_cost(sqlite3_stmt *stmt)
         logmsg(LOGMSG_USER, "---------------------------\n");
 }
 
-static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                          int analyze_gen)
+static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt, int analyze_gen)
 {
     // if analyze is running, don't reload
     extern volatile int analyze_running_flag;
@@ -2727,7 +2726,9 @@ static int check_thd_gen(struct sqlthdstate *thd, struct sqlclntstate *clnt, int
         int ret;
         TRK;
         stmt_cache_reset(thd->stmt_cache);
+        clnt->loading_stat = 1;
         ret = reload_analyze(thd, clnt, cached_analyze_gen);
+        clnt->loading_stat = 0;
         return ret;
     }
 

--- a/sqlite/src/analyze.c
+++ b/sqlite/src/analyze.c
@@ -1869,6 +1869,8 @@ static void decodeIntArray(
   }
 }
 
+char *mapped_index(const char *oldname);
+
 /*
 ** This callback is invoked once for each index when reading the
 ** sqlite_stat1 table.  
@@ -1907,6 +1909,14 @@ static int analysisLoader(void *pData, int argc, char **argv, char **NotUsed){
   }else{
     pIndex = sqlite3FindIndex(pInfo->db, argv[1], pInfo->zDatabase);
   }
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  if ( pIndex==0 ) {
+      char *newName = mapped_index(argv[1]);
+      if ( newName!=0 ) {
+          pIndex = sqlite3FindIndex(pInfo->db, newName, pInfo->zDatabase);
+      }
+  }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   z = argv[2];
 
   if( pIndex ){
@@ -2257,6 +2267,14 @@ static int loadStat4(sqlite3 *db, const char *zDb){
     zIndex = (char *)sqlite3_column_text(pStmt, 0);
     if( zIndex==0 ) continue;
     pIdx = findIndexOrPrimaryKey(db, zIndex, zDb);
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+    if( pIdx==0 ) {
+        char *newName = mapped_index(zIndex);
+        if ( newName!=0 ) {
+            pIdx = sqlite3FindIndex(db, newName, zDb);
+        }
+    }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     if( pIdx==0 ) continue;
     if( pIdx->pKeyInfo==0 ){
       Parse parse;

--- a/tests/ixmap.test/Makefile
+++ b/tests/ixmap.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/ixmap.test/README
+++ b/tests/ixmap.test/README
@@ -1,0 +1,1 @@
+Load old-style names if unable to locate new-style names

--- a/tests/ixmap.test/lrl.options
+++ b/tests/ixmap.test/lrl.options
@@ -1,0 +1,3 @@
+always_reload_analyze 1
+sqlenginepool linger 0
+sqlenginepool mint 0

--- a/tests/ixmap.test/runit
+++ b/tests/ixmap.test/runit
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+function verify_map
+{
+    # Avoid dumb races by always going to the master
+    master=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y'")
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master - <<'EOF'
+create table t(i int index)$$
+insert into t select value from generate_series(1, 1000)
+analyze t
+update sqlite_stat1 set idx='t_ix_0'
+update sqlite_stat4 set idx='t_ix_0'
+create table u(i int index)$$
+insert into u select value from generate_series(1, 1000)
+update sqlite_stat1 set idx='$$KEY_3AA4168B_3AA4168B' where idx = 't_ix_0'
+update sqlite_stat4 set idx='$$KEY_3AA4168B_3AA4168B' where idx = 't_ix_0'
+analyze u
+EOF
+
+    # Before ixmap, this stat4dump would fail to find any records
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('stat4dump')")
+    echo "$x"
+
+    # This needs both 'idx:u' and 'idx:t'
+    y=$(echo "$x" | grep "idx:u")
+    if [[ -z "$y" ]]; then
+        echo "Testcase failed - no idx:u"
+        exit 1
+    fi
+
+    y=$(echo "$x" | grep "idx:t")
+    if [[ -z "$y" ]]; then
+        echo "Testcase failed - no idx:t"
+        exit 1
+    fi
+    
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "drop table t"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "drop table u"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "truncate sqlite_stat1"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "truncate sqlite_stat4"
+}
+
+function run_test
+{
+    echo "verify_map"
+    verify_map
+
+    echo "Success!"
+}
+
+run_test

--- a/tests/yast.test/analyze1.test
+++ b/tests/yast.test/analyze1.test
@@ -397,13 +397,13 @@ do_test analyze-98.2.1 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {t_ix_0 t t_ix_0 {1000 1}}
+} {{$I_3AA4168B} t t_ix_0 {1000 1}}
 do_test analyze-98.2.2 {
   execsql {
     EXPLAIN QUERY PLAN SELECT * FROM t;
     EXPLAIN QUERY PLAN SELECT * FROM t ORDER BY i;
   }
-} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX t_ix_0 (~960 rows)}}
+} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX $I_3AA4168B (~960 rows)}}
 #
 # Run analyze to generate stats with new style names
 do_test analyze-98.3.1 {
@@ -412,13 +412,13 @@ do_test analyze-98.3.1 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {t_ix_0 cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1}}
 do_test analyze-98.3.2 {
   execsql {
     EXPLAIN QUERY PLAN SELECT * FROM t;
     EXPLAIN QUERY PLAN SELECT * FROM t ORDER BY i;
   }
-} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX t_ix_0 (~960 rows)}}
+} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX $I_3AA4168B (~960 rows)}}
 #
 # System switches to new style names
 do_test analyze-98.4.1 {
@@ -427,7 +427,7 @@ do_test analyze-98.4.1 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {{$I_3AA4168B} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1}}
 do_test analyze-98.4.2 {
   execsql {
     EXPLAIN QUERY PLAN SELECT * FROM t;
@@ -442,7 +442,7 @@ do_test analyze-98.5 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} t {$I_3AA4168B} {1000 1}}
 # Finally, old style names are purged from the system
 do_test analyze-98.6 {
   execsql {


### PR DESCRIPTION
We are seeing bad plans put in place because long-lived sqlite machines retrieve stats using the incorrect name.  This PR papers over this issue always initializing with new-names, but allowing the load to fallback to old.