### PR TITLE
cdb2api does not send or retry abbreviated hint queries

### DIFF
--- a/plugins/newsql/newsql.h
+++ b/plugins/newsql/newsql.h
@@ -88,6 +88,7 @@ void newsql_reset(struct sqlclntstate *);
 void free_newsql_appdata(struct sqlclntstate *);
 void newsql_effects(CDB2SQLRESPONSE *, CDB2EFFECTS *, struct sqlclntstate *);
 void newsql_set_client_info(struct sqlclntstate *, CDB2SQLQUERY *, int initial);
+int newsql_is_newsql(struct sqlclntstate *clnt);
 
 #define plugin_set_callbacks_newsql(name)                                      \
     clnt->plugin.close = newsql_close##_##name;                                \

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -1310,6 +1310,11 @@ static int newsql_init(void *arg)
     return 0;
 }
 
+int newsql_is_newsql(struct sqlclntstate *clnt)
+{
+    return clnt && clnt->plugin.close == newsql_close_evbuffer;
+}
+
 comdb2_appsock_t newsql_plugin = {
     "newsql",             /* Name */
     "",                   /* Usage info */


### PR DESCRIPTION
Sql hint queries that do not have full statement are only sent by legacy comdbapi sql.  For newsql interface, do not try to retry, since the api will not handle it.

RE: 177199209
