### PR TITLE
net: accept-thd (main event_base) tracks appsock count

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,6 +218,8 @@ if (${CMAKE_C_COMPILER_ID} STREQUAL GNU OR ${CMAKE_C_COMPILER_ID} STREQUAL Clang
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function")
   if (${CMAKE_C_COMPILER_ID} STREQUAL GNU)
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-stringop-truncation")
+  else()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-typedef-redefinition")
   endif()
   set(COMMON_FLAGS "${COMMON_FLAGS} -pthread")
   set(COMMON_FLAGS "${COMMON_FLAGS} -fno-strict-aliasing")

--- a/db/sql.h
+++ b/db/sql.h
@@ -998,6 +998,8 @@ struct sqlclntstate {
     unsigned force_fdb_push_remote : 1;
     unsigned return_long_column_names : 1; // if 0 then tunable decides
     unsigned in_local_cache : 1;
+    unsigned evicted_appsock : 1;
+
     unsigned num_adjusted_column_name_length; // does not consider fastsql
     char **adjusted_column_names;
 
@@ -1680,9 +1682,7 @@ void add_lru_evbuffer(struct sqlclntstate *);
 void rem_lru_evbuffer(struct sqlclntstate *);
 void add_sql_evbuffer(struct sqlclntstate *);
 void rem_sql_evbuffer(struct sqlclntstate *);
-int add_appsock_connection_evbuffer(struct sqlclntstate *);
 void rem_appsock_connection_evbuffer(struct sqlclntstate *);
-void exhausted_appsock_connections(struct sqlclntstate *);
 void update_col_info(struct sql_col_info *info, int);
 void sqlengine_work_appsock(struct sqlthdstate *, struct sqlclntstate *);
 const char *sqlite3ErrStr(int);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6805,7 +6805,9 @@ static int close_lru_evbuffer_int(struct sqlclntstate *self)
         return -1;
     }
     rem_lru_evbuffer_int(clnt);
-    clnt->plugin.close(clnt); /* newsql_close_evbuffer */
+    int fd = get_fileno(clnt);
+    if (fd != -1) shutdown(fd, SHUT_RDWR);
+    if (self == NULL) clnt->evicted_appsock = 1;
     return 0;
 }
 
@@ -6817,42 +6819,36 @@ static int close_lru_evbuffer(struct sqlclntstate *self)
     return ret;
 }
 
-int add_appsock_connection_evbuffer(struct sqlclntstate *clnt)
+int check_appsock_limit(int pending)
 {
-    extern unsigned long long total_appsock_conns;
-    if (clnt->admin) {
-       return 0;
-    }
+    ++total_appsock_conns;
     int max = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_MAXAPPSOCKSLIMIT);
     int warn = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_APPSOCKSLIMIT);
-    int lim = warn < max ? warn : max;
-    total_appsock_conns++;
-    int current = ATOMIC_ADD32(active_appsock_conns, 1);
-    time_metric_add(thedb->connections, current);
-    if (current > lim) {
-        static time_t last_trace = 0;
+    int current = pending + ATOMIC_ADD32(active_appsock_conns, 1);
+    if (warn > max) warn = max;
+    if (current <= warn) return 0;
+    if (current > max) {
+        if (close_lru_evbuffer(NULL) == 0) return 0;
+        ATOMIC_ADD32(active_appsock_conns, -1);
+        ++gbl_denied_appsock_connection_count;
+        static time_t last = 0;
         time_t now = time(NULL);
-        if (current > max) {
-            if (close_lru_evbuffer(clnt) != 0) {
-                return -1;
-            }
-        } else if (now - last_trace) {
-            last_trace = now;
-            logmsg(LOGMSG_WARN, "%s: SQL connection limit approaching (%d/%d)\n", __func__, current, max);
+        if (now != last) {
+            logmsg(LOGMSG_USER,
+                   "Exhausted appsock connections, total %d connections denied-connection count=%" PRId64 "\n",
+                   current, gbl_denied_appsock_connection_count);
+            last = now;
+        }
+        return -1;
+    } else if (current > warn) {
+        static time_t last = 0;
+        time_t now = time(NULL);
+        if (now != last) {
+            logmsg(LOGMSG_USER, "SQL connection limit approaching (%d/%d)\n", current, max);
+            last = now;
         }
     }
     return 0;
-}
-
-int check_appsock_limit(int pending)
-{
-    int max = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_MAXAPPSOCKSLIMIT);
-    int current = pending + ATOMIC_LOAD32(active_appsock_conns);
-    if (current <= max) return 0;
-    if (close_lru_evbuffer(NULL) == 0) {
-        return 0;
-    }
-    return current;
 }
 
 void rem_appsock_connection_evbuffer(struct sqlclntstate *clnt)
@@ -7177,20 +7173,6 @@ void clnt_plugin_reset(struct sqlclntstate *clnt)
     clnt->plugin.param_count = backup->param_count;
     clnt->plugin.param_value = backup->param_value;
     clnt->plugin.param_index = backup->param_index;
-}
-
-void exhausted_appsock_connections(struct sqlclntstate *clnt)
-{
-    write_response(clnt, RESPONSE_ERROR_APPSOCK_LIMIT, "Exhausted appsock connections.", 0);
-    gbl_denied_appsock_connection_count++;
-    static time_t last = 0;
-    time_t now = time(NULL);
-    if (now != last) {
-        logmsg(LOGMSG_USER,
-               "%s: Exhausted appsock connections, total %d connections denied-connection count=%" PRId64 "\n",
-               __func__, active_appsock_conns, gbl_denied_appsock_connection_count);
-        last = now;
-    }
 }
 
 int maxquerytime_cb(struct sqlclntstate *clnt)

--- a/net/net_appsock.h
+++ b/net/net_appsock.h
@@ -39,6 +39,7 @@ void do_revconn_evbuffer(int fd, short what, void *data);
 typedef void(*run_on_base_fn)(void *);
 void run_on_base(struct event_base *, run_on_base_fn, void *);
 
+extern unsigned long long total_appsock_conns;
 extern int32_t active_appsock_conns;
 extern int64_t gbl_denied_appsock_connection_count;
 

--- a/net/net_int.h
+++ b/net/net_int.h
@@ -336,7 +336,7 @@ uint8_t *net_wire_header_put(const wire_header_type *, uint8_t *, const uint8_t 
 
 void add_host(host_node_type *);
 void dispatch_decom(char *);
-void do_appsock(netinfo_type *, struct sockaddr_in *, SBUF2 *, uint8_t);
+int do_appsock(netinfo_type *, struct sockaddr_in *, SBUF2 *, uint8_t);
 int findpeer(int, char *, int);
 int get_dedicated_conhost(host_node_type *, struct in_addr *);
 host_node_type *get_host_node_by_name_ll(netinfo_type *, const char *);
@@ -359,8 +359,6 @@ enum net_metric_type {
     MAX_QUEUE_SIZE = 2
 };
 int get_hosts_metric(const char *netname, enum net_metric_type type);
-
-int should_reject_request(void);
 
 int dist_heartbeats(dist_hbeats_type *);
 


### PR DESCRIPTION
@markhannum Reported this while running `sqlqueries` test.

This fixes race in closing an evicted connection. Also fixes active connection accounting.