### PR TITLE
Force dbopen on analyze if using old-style stats

### DIFF
--- a/bdb/bdb_schemachange.c
+++ b/bdb/bdb_schemachange.c
@@ -266,8 +266,11 @@ retry:
         bdb_lock_tablename_write(bdb_state, tbl, tran);
     }
     /* analyze does NOT need schema_lk */
+    /* Acquire schema-lk for single prod move: analyze can force a dbopen */
+    /*
     if (sctype == sc_analyze)
         ltran->get_schema_lock = 0;
+    */
 
     rc = bdb_llog_scdone_tran(bdb_state, sctype, tran, tbl, tbllen, bdberr);
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -184,6 +184,7 @@ extern int reqltruncate;
 extern int analyze_max_comp_threads;
 extern int analyze_max_table_threads;
 extern int gbl_always_reload_analyze;
+extern int gbl_recreate_master_recs_on_analyze;
 extern int gbl_block_set_commit_genid_trace;
 extern int gbl_random_prepare_commit;
 extern int gbl_all_prepare_commit;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -71,6 +71,8 @@ REGISTER_TUNABLE("analyze_tbl_threads",
                  NULL, analyze_set_max_table_threads, NULL);
 REGISTER_TUNABLE("always_reload_analyze", "Reload analyze data on every query. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_always_reload_analyze, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("recreate_master_records_on_analyze", "On if analyze will force a dbopen.", TUNABLE_BOOLEAN,
+                 &gbl_recreate_master_recs_on_analyze, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("archive_on_init",
                  "Archive files with database extensions in the database directory "
                  "at the time of init. (Default: ON)",

--- a/db/sql.h
+++ b/db/sql.h
@@ -989,6 +989,7 @@ struct sqlclntstate {
     int flat_col_vals;
     plugin_func *recover_ddlk;
     replay_func *recover_ddlk_fail;
+    unsigned loading_stat: 1;
     unsigned skip_eventlog: 1;
     unsigned request_fp: 1;
     unsigned dohsql_disable: 1;

--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -794,6 +794,29 @@ static int analyze_table_int(table_descriptor_t *td, struct thr_handle *thr_self
                 sqlite3_free(sql); sql = NULL;
                 goto error;
             }
+        } else {
+            logmsg(LOGMSG_USER, "%s: have idx:%s cloning into:%s\n", __func__, ix->sqlitetag, namebuf);
+            sql = sqlite3_mprintf("INSERT INTO sqlite_stat1(tbl, idx, stat) "
+                                  "SELECT tbl, '%q', stat FROM sqlite_stat1 "
+                                  "WHERE tbl='%q' AND idx='%q'",
+                                  namebuf, tbl->tablename, ix->sqlitetag);
+            rc = run_internal_sql_clnt(&clnt, sql);
+            if (rc) {
+                snprintf(zErrTab, sizeof(zErrTab), "failed:%s", sql);
+                sqlite3_free(sql); sql = NULL;
+                goto error;
+            }
+            if (!get_dbtable_by_name("sqlite_stat4")) continue;
+            sql = sqlite3_mprintf("INSERT INTO sqlite_stat4(tbl, idx, neq, nlt, ndlt, sample) "
+                                  "SELECT tbl, '%q', neq, nlt, ndlt, sample FROM sqlite_stat4 "
+                                  "WHERE tbl='%q' AND idx='%q'",
+                                  namebuf, tbl->tablename, ix->sqlitetag);
+            rc = run_internal_sql_clnt(&clnt, sql);
+            if (rc) {
+                snprintf(zErrTab, sizeof(zErrTab), "failed:%s", sql);
+                sqlite3_free(sql); sql = NULL;
+                goto error;
+            }
         }
     }
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2661,8 +2661,7 @@ static void compare_estimate_cost(sqlite3_stmt *stmt)
         logmsg(LOGMSG_USER, "---------------------------\n");
 }
 
-static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt,
-                          int analyze_gen)
+static int reload_analyze(struct sqlthdstate *thd, struct sqlclntstate *clnt, int analyze_gen)
 {
     // if analyze is running, don't reload
     extern volatile int analyze_running_flag;
@@ -2727,7 +2726,9 @@ static int check_thd_gen(struct sqlthdstate *thd, struct sqlclntstate *clnt, int
         int ret;
         TRK;
         stmt_cache_reset(thd->stmt_cache);
+        clnt->loading_stat = 1;
         ret = reload_analyze(thd, clnt, cached_analyze_gen);
+        clnt->loading_stat = 0;
         return ret;
     }
 

--- a/tests/dbopen_oldstats.test/Makefile
+++ b/tests/dbopen_oldstats.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/dbopen_oldstats.test/README
+++ b/tests/dbopen_oldstats.test/README
@@ -1,0 +1,1 @@
+Analyze will force a dbopen if it sees old-style stats

--- a/tests/dbopen_oldstats.test/lrl.options
+++ b/tests/dbopen_oldstats.test/lrl.options
@@ -1,0 +1,3 @@
+always_reload_analyze 1
+sqlenginepool linger 0
+sqlenginepool mint 0

--- a/tests/dbopen_oldstats.test/runit
+++ b/tests/dbopen_oldstats.test/runit
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+function prefer_new_index
+{
+    # Make sure that if both indexes exist, the client prefers the new index
+    master=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y'")
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master - <<'EOF'
+create table tt(a int index, b int index, c int index, d int index, e int index)$$
+insert into tt select value, value, value, value, value from generate_series(1, 10000)$$
+analyze tt
+EOF
+    # Verify that this produces both old and new stats
+
+}
+
+# This version creates both stats, so this test should succeed trivially
+function verify_map
+{
+    # Avoid dumb races by always going to the master
+    master=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select host from comdb2_cluster where is_master='Y'")
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master - <<'EOF'
+create table t(i int index)$$
+insert into t select value from generate_series(1, 1000)
+analyze t
+delete from sqlite_stat1 where tbl = 't' and idx != 't_ix_0'
+delete from sqlite_stat4 where tbl = 't' and idx != 't_ix_0'
+create table u(i int index)$$
+insert into u select value from generate_series(1, 1000)
+delete from sqlite_stat1 where tbl = 'u' and idx = 't_ix_0'
+delete from sqlite_stat4 where tbl = 'u' and idx = 't_ix_0'
+analyze u
+EOF
+
+#     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master - <<'EOF'
+# create table t(i int index)$$
+# insert into t select value from generate_series(1, 1000)
+# analyze t
+# update sqlite_stat1 set idx='t_ix_0'
+# update sqlite_stat4 set idx='t_ix_0'
+# create table u(i int index)$$
+# insert into u select value from generate_series(1, 1000)
+# update sqlite_stat1 set idx='$$KEY_3AA4168B_3AA4168B' where idx = 't_ix_0'
+# update sqlite_stat4 set idx='$$KEY_3AA4168B_3AA4168B' where idx = 't_ix_0'
+# analyze u
+# EOF
+# 
+    # before analyze->dbopen this stat4dump would fail to find any records
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "exec procedure sys.cmd.send('stat4dump')")
+    echo "$x"
+
+    # This needs both 'idx:u' and 'idx:t'
+    y=$(echo "$x" | grep "idx:u")
+    if [[ -z "$y" ]]; then
+        echo "Testcase failed - no idx:u"
+        exit 1
+    fi
+
+    y=$(echo "$x" | grep "idx:t")
+    if [[ -z "$y" ]]; then
+        echo "Testcase failed - no idx:t"
+        exit 1
+    fi
+    
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "drop table t"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "drop table u"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "truncate sqlite_stat1"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "truncate sqlite_stat4"
+}
+
+function run_test
+{
+    echo "verify_map"
+    verify_map
+
+    echo "Success!"
+}
+
+run_test

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -812,6 +812,7 @@
 (name='recovery_workers.maxt', description='Maximum number of threads in the pool.', type='INTEGER', value='16', read_only='N')
 (name='recovery_workers.mint', description='Minimum number of threads in the pool.', type='INTEGER', value='0', read_only='N')
 (name='recovery_workers.stacksz', description='Thread stack size.', type='INTEGER', value='1048576', read_only='N')
+(name='recreate_master_records_on_analyze', description='On if analyze will force a dbopen.', type='BOOLEAN', value='OFF', read_only='Y')
 (name='reject_osql_mismatch', description='(Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='reject_writes_on_rtcpu', description='reject_writes_on_rtcpu', type='BOOLEAN', value='ON', read_only='N')
 (name='release_locks_trace', description='Print trace if we release locks', type='BOOLEAN', value='OFF', read_only='N')

--- a/tests/yast.test/analyze1.test
+++ b/tests/yast.test/analyze1.test
@@ -147,7 +147,7 @@ do_test analyze-3.1 {
     ANALYZE t1;
     SELECT idx, stat FROM sqlite_stat1 ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {2 2} {$T1I2_DA360153} {2 1} {$T1I3_A82B8A75} {2 2 1}}
+} {{$T1I1_433F50E9} {2 2} {$T1I2_DA360153} {2 1} {$T1I3_A82B8A75} {2 2 1} t1_ix_0 {2 2} t1_ix_1 {2 1} t1_ix_2 {2 2 1}}
 #} {t1i1 {2 2} t1i2 {2 1} t1i3 {2 2 1}}
 do_test analyze-3.2 {
   execsql {
@@ -156,7 +156,7 @@ do_test analyze-3.2 {
     ANALYZE t1;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {4 4} {$T1I2_DA360153} {4 1} {$T1I3_A82B8A75} {4 4 1}}
+} {{$T1I1_433F50E9} {4 4} {$T1I2_DA360153} {4 1} {$T1I3_A82B8A75} {4 4 1} t1_ix_0 {4 4} t1_ix_1 {4 1} t1_ix_2 {4 4 1}}
 #} {t1i1 {4 4} t1i2 {4 1} t1i3 {4 4 1}}
 do_test analyze-3.3 {
   execsql {
@@ -164,7 +164,7 @@ do_test analyze-3.3 {
     ANALYZE;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1}}
 #} {t1i1 {5 3} t1i2 {5 2} t1i3 {5 3 1}}
 do_test analyze-3.4 {
   execsql {
@@ -175,7 +175,7 @@ do_test analyze-3.4 {
     ANALYZE;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2} {$T2I3_2EBFF8DB} {5 3 1}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2} {$T2I3_2EBFF8DB} {5 3 1} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1} t2_ix_0 {5 3} t2_ix_1 {5 2} t2_ix_2 {5 3 1}}
 do_test analyze-3.5.1 {
   execsql {
     DROP INDEX t2i3;
@@ -190,20 +190,20 @@ do_test analyze-3.5.3 {
   execsql {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2} {$T2I3_2EBFF8DB} {5 3 1}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2} {$T2I3_2EBFF8DB} {5 3 1} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1} t2_ix_0 {5 3} t2_ix_1 {5 2} t2_ix_2 {5 3 1}}
 do_test analyze-3.6 {
   execsql {
     ANALYZE t2;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} {$T2I2_9D967B83} {5 2} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1} t2_ix_0 {5 3} t2_ix_1 {5 2}}
 do_test analyze-3.7 {
   execsql {
     DROP INDEX t2i2;
     ANALYZE t2;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1} t2_ix_0 {5 3}}
 do_test analyze-3.8 {
   execsql {
     CREATE TABLE t3 (a,b,c,d);
@@ -215,13 +215,13 @@ do_test analyze-3.8 {
     DROP TABLE t2;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3}}
+} {{$T1I1_433F50E9} {5 3} {$T1I2_DA360153} {5 2} {$T1I3_A82B8A75} {5 3 1} {$T2I1_49F2A39} {5 3} t1_ix_0 {5 3} t1_ix_1 {5 2} t1_ix_2 {5 3 1} t2_ix_0 {5 3}}
 do_test analyze-3.9 {
   execsql {
     ANALYZE;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1}}
+} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} t3_ix_0 {5 3} t3_ix_1 {5 3 1 1 1} t3_ix_2 {5 5 2 2 1}}
 
 do_test analyze-3.10 {
   execsql {
@@ -233,26 +233,26 @@ do_test analyze-3.10 {
     ANALYZE;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {1 {Table not found} {$ANOTHERFOOLISHNAME_6DBDCA38} {2 1} {$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1}}
+} {1 {Table not found} {$ANOTHERFOOLISHNAME_6DBDCA38} {2 1} {$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} sillyname_ix_0 {2 1} t3_ix_0 {5 3} t3_ix_1 {5 3 1 1 1} t3_ix_2 {5 5 2 2 1}}
 do_test analyze-3.11 {
   execsql {
     DROP INDEX foolishname;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$ANOTHERFOOLISHNAME_6DBDCA38} {2 1} {$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1}}
+} {{$ANOTHERFOOLISHNAME_6DBDCA38} {2 1} {$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} sillyname_ix_0 {2 1} t3_ix_0 {5 3} t3_ix_1 {5 3 1 1 1} t3_ix_2 {5 5 2 2 1}}
 do_test analyze-3.12 {
   execsql {
     DROP TABLE sillyname;
     analyze;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1}}
+} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} t3_ix_0 {5 3} t3_ix_1 {5 3 1 1 1} t3_ix_2 {5 5 2 2 1}}
 
 do_test analyze-3.13 {
   execsql {
     SELECT idx,count() FROM sqlite_stat4 WHERE tbl in (select name from sqlite_master where type='table') group by idx;
   }
-} {{$T3I1_39FF0389} 5 {$T3I2_58D6C701} 5 {$T3I3_1F62C3BC} 5}
+} {{$T3I1_39FF0389} 5 {$T3I2_58D6C701} 5 {$T3I3_1F62C3BC} 5 t3_ix_0 5 t3_ix_1 5 t3_ix_2 5}
 
 
 # Try corrupting the sqlite_stat1 table and make sure the
@@ -267,7 +267,7 @@ do_test analyze-4.0 {
     ANALYZE;
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} {$T4I1_EFB47759} {5 3} {$T4I2_98B347CF} {5 2}}
+} {{$T3I1_39FF0389} {5 3} {$T3I2_58D6C701} {5 3 1 1 1} {$T3I3_1F62C3BC} {5 5 2 2 1} {$T4I1_EFB47759} {5 3} {$T4I2_98B347CF} {5 2} t3_ix_0 {5 3} t3_ix_1 {5 3 1 1 1} t3_ix_2 {5 5 2 2 1} t4_ix_0 {5 3} t4_ix_1 {5 2}}
 comdb2_omit_test do_test analyze-4.1 {
   execsql {
     PRAGMA writable_schema=on;
@@ -309,28 +309,28 @@ do_test analyze-5.0 {
     SELECT DISTINCT idx FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
     SELECT DISTINCT tbl FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
   }
-} {{$T3I1_39FF0389} {$T3I2_58D6C701} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3 t4}
+} {{$T3I1_39FF0389} {$T3I2_58D6C701} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3_ix_0 t3_ix_1 t3_ix_2 t4_ix_0 t4_ix_1 t3 t4}
 set stat sqlite_stat4
 do_test analyze-5.1 {
     execsql "
       SELECT DISTINCT idx FROM $stat WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
       SELECT DISTINCT tbl FROM $stat WHERE tbl in (select name from sqlite_master where type='table') ORDER BY 1;
     "
-} {{$T3I1_39FF0389} {$T3I2_58D6C701} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3 t4}
+} {{$T3I1_39FF0389} {$T3I2_58D6C701} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3_ix_0 t3_ix_1 t3_ix_2 t4_ix_0 t4_ix_1 t3 t4}
 do_test analyze-5.2 {
   execsql {
     DROP INDEX t3i2;
     ANALYZE;
-    SELECT DISTINCT idx FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
-    SELECT DISTINCT tbl FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
+    SELECT DISTINCT idx FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
+    SELECT DISTINCT tbl FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
   }
-} {{$T3I1_39FF0389} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3 t4}
+} {{$T3I1_39FF0389} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3_ix_0 t3_ix_1 t4_ix_0 t4_ix_1 t3 t4}
 do_test analyze-5.3 {
     execsql "
       SELECT DISTINCT idx FROM $stat WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
       SELECT DISTINCT tbl FROM $stat WHERE tbl in (select name from sqlite_master where type='table') ORDER BY 1;
     "
-  } {{$T3I1_39FF0389} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3 t4}
+  } {{$T3I1_39FF0389} {$T3I3_1F62C3BC} {$T4I1_EFB47759} {$T4I2_98B347CF} t3_ix_0 t3_ix_1 t4_ix_0 t4_ix_1 t3 t4}
 do_test analyze-5.4 {
   execsql {
     DROP TABLE t3;
@@ -338,13 +338,13 @@ do_test analyze-5.4 {
     SELECT DISTINCT idx FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
     SELECT DISTINCT tbl FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
   }
-} {{$T4I1_EFB47759} {$T4I2_98B347CF} t4}
+} {{$T4I1_EFB47759} {$T4I2_98B347CF} t4_ix_0 t4_ix_1 t4}
 do_test analyze-5.5 {
     execsql "
       SELECT DISTINCT idx FROM $stat WHERE tbl not like 'cdb2.%.sav' ORDER BY 1;
       SELECT DISTINCT tbl FROM $stat WHERE tbl in (select name from sqlite_master where type='table') ORDER BY 1;
     "
-} {{$T4I1_EFB47759} {$T4I2_98B347CF} t4}
+} {{$T4I1_EFB47759} {$T4I2_98B347CF} t4_ix_0 t4_ix_1 t4}
 
 # Ticket [cfa2c908f218254d7be64aa4b8fa55ba4df20853] 2017-06-13
 # Assertion fault in STAT4 on a double-negation.
@@ -381,7 +381,7 @@ do_test analyze-98.1.3 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {{$I_3AA4168B} t {$I_3AA4168B} {1000 1}}
+} {{$I_3AA4168B} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
 do_test analyze-98.1.4 {
   execsql {
     EXPLAIN QUERY PLAN SELECT * FROM t;
@@ -392,7 +392,7 @@ do_test analyze-98.1.4 {
 # Force system to use old style names
 do_test analyze-98.2.1 {
   execsql {
-    UPDATE sqlite_stat1 SET idx = 't_ix_0' where idx = '$I_3AA4168B';
+    DELETE from sqlite_stat1 where idx = '$I_3AA4168B';
     REBUILD t;
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
@@ -412,13 +412,13 @@ do_test analyze-98.3.1 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {t_ix_0 cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
 do_test analyze-98.3.2 {
   execsql {
     EXPLAIN QUERY PLAN SELECT * FROM t;
     EXPLAIN QUERY PLAN SELECT * FROM t ORDER BY i;
   }
-} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX t_ix_0 (~960 rows)}}
+} {3 0 0 {SCAN TABLE t (~960 rows)} 4 0 0 {SCAN TABLE t USING COVERING INDEX $I_3AA4168B (~960 rows)}}
 #
 # System switches to new style names
 do_test analyze-98.4.1 {
@@ -442,7 +442,7 @@ do_test analyze-98.5 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
 # Finally, old style names are purged from the system
 do_test analyze-98.6 {
   execsql {
@@ -450,7 +450,7 @@ do_test analyze-98.6 {
     SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 't';
     SELECT * FROM sqlite_stat1 WHERE tbl IN ('t', 'cdb2.t.sav') ORDER BY tbl, idx;
   }
-} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} t {$I_3AA4168B} {1000 1}}
+} {{$I_3AA4168B} cdb2.t.sav {$I_3AA4168B} {1000 1} cdb2.t.sav t_ix_0 {1000 1} t {$I_3AA4168B} {1000 1} t t_ix_0 {1000 1}}
 
 #
 # This test corrupts the database file so it must be the last test

--- a/tests/yast.test/index6.test
+++ b/tests/yast.test/index6.test
@@ -112,7 +112,7 @@ do_test index6-1.10 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {14 1} {$T1B_DA360153} {10 1}}
+} {{$T1A_433F50E9} {14 1} {$T1B_DA360153} {10 1} t1_ix_0 {14 1} t1_ix_1 {10 1}}
 #{{} 20 t1a {14 1} t1b {10 1} ok}
 
 # STAT1 shows the partial indices have a reduced number of
@@ -125,7 +125,7 @@ do_test index6-1.11 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {20 1} {$T1B_DA360153} {10 1}}
+} {{$T1A_433F50E9} {20 1} {$T1B_DA360153} {10 1} t1_ix_0 {20 1} t1_ix_1 {10 1}}
 #{{} 20 t1a {20 1} t1b {10 1} ok}
 
 do_test index6-1.11 {
@@ -136,7 +136,7 @@ do_test index6-1.11 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {6 1} {$T1B_DA360153} {20 1}}
+} {{$T1A_433F50E9} {6 1} {$T1B_DA360153} {20 1} t1_ix_0 {6 1} t1_ix_1 {20 1}}
 #{{} 20 t1a {6 1} t1b {20 1} ok}
 
 do_test index6-1.12 {
@@ -147,7 +147,7 @@ do_test index6-1.12 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {13 1} {$T1B_DA360153} {10 1}}
+} {{$T1A_433F50E9} {13 1} {$T1B_DA360153} {10 1} t1_ix_0 {13 1} t1_ix_1 {10 1}}
 #{{} 20 t1a {13 1} t1b {10 1} ok}
 
 do_test index6-1.13 {
@@ -157,7 +157,7 @@ do_test index6-1.13 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1}}
+} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} t1_ix_0 {10 1} t1_ix_1 {8 1}}
 #{{} 15 t1a {10 1} t1b {8 1} ok}
 
 do_test index6-1.14 {
@@ -167,7 +167,7 @@ do_test index6-1.14 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1}}
+} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} t1_ix_0 {10 1} t1_ix_1 {8 1}}
 #{{} 15 t1a {10 1} t1b {8 1} ok}
 
 do_test index6-1.15 {
@@ -177,7 +177,7 @@ do_test index6-1.15 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} {$T1C_AD3131C5} {15 1}}
+} {{$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} {$T1C_AD3131C5} {15 1} t1_ix_0 {10 1} t1_ix_1 {8 1} t1_ix_2 {15 1}}
 #{t1a {10 1} t1b {8 1} t1c {15 1} ok}
 
 # Queries use partial indices as appropriate times.
@@ -256,7 +256,7 @@ do_execsql_test index6-2.103 {
 do_execsql_test index6-2.103eqp {
   EXPLAIN QUERY PLAN
   SELECT b FROM t2 WHERE a=15 AND a<100;
-} {5 0 0 {SEARCH TABLE t2 USING INDEX $T2A2_49F2A39 (a=?) (~9 rows)}}
+} {5 0 0 {SEARCH TABLE t2 USING INDEX t2_ix_0 (a=?) (~9 rows)}}
 #{/.*INDEX t2a2.*/}
 do_execsql_test index6-2.104 {
   SELECT b FROM t2 WHERE a=515 AND a>200;
@@ -264,7 +264,7 @@ do_execsql_test index6-2.104 {
 do_execsql_test index6-2.104eqp {
   EXPLAIN QUERY PLAN
   SELECT b FROM t2 WHERE a=515 AND a>200;
-} {5 0 0 {SEARCH TABLE t2 USING INDEX $T2A2_49F2A39 (a=?) (~9 rows)}}
+} {5 0 0 {SEARCH TABLE t2 USING INDEX t2_ix_0 (a=?) (~9 rows)}}
 #{/.*INDEX t2a2.*/}
 
 # Partial UNIQUE indices

--- a/tests/yast.test/index7.test
+++ b/tests/yast.test/index7.test
@@ -159,7 +159,7 @@ do_test index7-1.10 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {14 1} {$T1B_DA360153} {10 1}}
+} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {14 1} {$T1B_DA360153} {10 1} t1_ix_0 {20 1} t1_ix_1 {14 1} t1_ix_2 {10 1}}
 #{t1 {20 1} t1a {14 1} t1b {10 1} ok}
 
 # STAT1 shows the partial indices have a reduced number of
@@ -172,7 +172,7 @@ do_test index7-1.11 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {20 1} {$T1B_DA360153} {10 1}}
+} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {20 1} {$T1B_DA360153} {10 1} t1_ix_0 {20 1} t1_ix_1 {20 1} t1_ix_2 {10 1}}
 #{t1 {20 1} t1a {20 1} t1b {10 1} ok}
 
 do_test index7-1.11b {
@@ -183,7 +183,7 @@ do_test index7-1.11b {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {6 1} {$T1B_DA360153} {20 1}}
+} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {6 1} {$T1B_DA360153} {20 1} t1_ix_0 {20 1} t1_ix_1 {6 1} t1_ix_2 {20 1}}
 #{t1 {20 1} t1a {6 1} t1b {20 1} ok}
 
 do_test index7-1.12 {
@@ -194,7 +194,7 @@ do_test index7-1.12 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {13 1} {$T1B_DA360153} {10 1}}
+} {{$PRIMARY_BE5F2ECE} {20 1} {$T1A_433F50E9} {13 1} {$T1B_DA360153} {10 1} t1_ix_0 {20 1} t1_ix_1 {13 1} t1_ix_2 {10 1}}
 #{t1 {20 1} t1a {13 1} t1b {10 1} ok}
 
 do_test index7-1.13 {
@@ -204,7 +204,7 @@ do_test index7-1.13 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {15 1} {$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1}}
+} {{$PRIMARY_BE5F2ECE} {15 1} {$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} t1_ix_0 {15 1} t1_ix_1 {10 1} t1_ix_2 {8 1}}
 #{t1 {15 1} t1a {10 1} t1b {8 1} ok}
 
 ifcapable comdb2_skip {
@@ -226,7 +226,7 @@ do_test index7-1.15 {
     SELECT idx, stat FROM sqlite_stat1 WHERE tbl not like 'cdb2.%.sav' ORDER BY idx;
     #PRAGMA integrity_check;
   }
-} {{$PRIMARY_BE5F2ECE} {15 1} {$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} {$T1C_AD3131C5} {15 1}}
+} {{$PRIMARY_BE5F2ECE} {15 1} {$T1A_433F50E9} {10 1} {$T1B_DA360153} {8 1} {$T1C_AD3131C5} {15 1} t1_ix_0 {15 1} t1_ix_1 {10 1} t1_ix_2 {8 1} t1_ix_3 {15 1}}
 #{t1 {15 1} t1a {10 1} t1b {8 1} t1c {15 1} ok}
 
 # Queries use partial indices as appropriate times.
@@ -304,7 +304,7 @@ do_execsql_test index7-2.103 {
 do_execsql_test index7-2.103eqp {
   EXPLAIN QUERY PLAN
   SELECT b FROM t2 WHERE a=15 AND a<100;
-} {5 0 0 {SEARCH TABLE t2 USING INDEX $T2A2_49F2A39 (a=?) (~9 rows)}}
+} {5 0 0 {SEARCH TABLE t2 USING INDEX t2_ix_1 (a=?) (~9 rows)}}
 #{/.*INDEX t2a2.*/}
 do_execsql_test index7-2.104 {
   SELECT b FROM t2 WHERE a=515 AND a>200;
@@ -312,7 +312,7 @@ do_execsql_test index7-2.104 {
 do_execsql_test index7-2.104eqp {
   EXPLAIN QUERY PLAN
   SELECT b FROM t2 WHERE a=515 AND a>200;
-} {5 0 0 {SEARCH TABLE t2 USING INDEX $T2A2_49F2A39 (a=?) (~9 rows)}}
+} {5 0 0 {SEARCH TABLE t2 USING INDEX t2_ix_1 (a=?) (~9 rows}}
 #{/.*INDEX t2a2.*/}
 
 # Partial UNIQUE indices


### PR DESCRIPTION
Analyze could force sqlite machines to recreate sqlite master, so allow it to acquire the schema-lk temporarily.