### PR TITLE
Make Disttxn protobuf field required

### DIFF
--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -658,6 +658,13 @@ static void process_disttxn(struct newsql_appdata_evbuffer *appdata, CDB2DISTTXN
 
     /* Coordinator master tells me (participant master) to prepare */
     case (CDB2_DIST__PREPARE):
+        if (!disttxn->disttxn->name ||
+            !disttxn->disttxn->tier ||
+            !disttxn->disttxn->master) {
+            logmsg(LOGMSG_ERROR, "%s: disttxn prepare missing name, tier or master\n", __func__);
+            rcode = -1;
+            goto sendresponse;
+        }
         rcode = osql_prepare(disttxn->disttxn->txnid, disttxn->disttxn->name, disttxn->disttxn->tier,
                              disttxn->disttxn->master);
         break;
@@ -669,17 +676,38 @@ static void process_disttxn(struct newsql_appdata_evbuffer *appdata, CDB2DISTTXN
 
     /* Participant master sends me (coordinator master) a heartbeat message */
     case (CDB2_DIST__HEARTBEAT):
+        if (!disttxn->disttxn->name ||
+            !disttxn->disttxn->tier) {
+            logmsg(LOGMSG_ERROR, "%s: disttxn malformed heartbeat\n", __func__);
+            rcode = -1;
+            goto sendresponse;
+        }
         rcode = participant_heartbeat(disttxn->disttxn->txnid, disttxn->disttxn->name, disttxn->disttxn->tier);
         break;
 
     /* Participant master tells me (coordinator master) it has prepared */
     case (CDB2_DIST__PREPARED):
+        if (!disttxn->disttxn->name ||
+            !disttxn->disttxn->tier ||
+            !disttxn->disttxn->master) {
+            logmsg(LOGMSG_ERROR, "%s: disttxn prepared missing name, tier or master\n", __func__);
+            rcode = -1;
+            goto sendresponse;
+        }
         rcode = participant_prepared(disttxn->disttxn->txnid, disttxn->disttxn->name, disttxn->disttxn->tier,
                                      disttxn->disttxn->master);
         break;
 
     /* Participant master tells me (coordinator master) it has failed */
     case (CDB2_DIST__FAILED_PREPARE):
+        if (!disttxn->disttxn->name ||
+            !disttxn->disttxn->tier ||
+            !disttxn->disttxn->has_rcode ||
+            !disttxn->disttxn->errmsg) {
+            logmsg(LOGMSG_ERROR, "%s: disttxn failed prepare missing name, tier, rcode or errmsg\n", __func__);
+            rcode = -1;
+            goto sendresponse;
+        }
         rcode = participant_failed(disttxn->disttxn->txnid, disttxn->disttxn->name, disttxn->disttxn->tier,
                                    disttxn->disttxn->rcode, disttxn->disttxn->outrc, disttxn->disttxn->errmsg);
         break;
@@ -696,6 +724,12 @@ static void process_disttxn(struct newsql_appdata_evbuffer *appdata, CDB2DISTTXN
 
     /* Participant master tells me (coordinator master) it has propagated */
     case (CDB2_DIST__PROPAGATED):
+        if (!disttxn->disttxn->name ||
+            !disttxn->disttxn->tier) {
+            logmsg(LOGMSG_ERROR, "%s: disttxn propagated missing name or tier\n", __func__);
+            rcode = -1;
+            goto sendresponse;
+        }
         rcode = participant_propagated(disttxn->disttxn->txnid, disttxn->disttxn->name, disttxn->disttxn->tier);
         break;
     }

--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -137,7 +137,7 @@ message CDB2_DISTTXN {
     optional int32 outrc = 8;
     optional string errmsg = 9;
   }
-  optional Disttxn disttxn = 2;
+  required Disttxn disttxn = 2;
 }
 
 message CDB2_QUERY {


### PR DESCRIPTION
Additionally verifies optional protobuf parameters per request-type.  It is possible to coerce the database into a SEGFAULT.