### PR TITLE
Increase autoanalyze sleep amount in test

### DIFF
--- a/tests/autoanalyze.test/runit
+++ b/tests/autoanalyze.test/runit
@@ -171,7 +171,7 @@ master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.sen
 
 #cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb setattr aa_min_percent 0")'
 T_TO_SLEEP=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master 'exec procedure sys.cmd.send("bdb attr")' | grep -i min_aa_time | awk '{print $3}')
-T_TO_SLEEP=$((T_TO_SLEEP+1))
+T_TO_SLEEP=$((T_TO_SLEEP+3))
 #T_TO_SLEEP=26
 
 echo "Testing adding num records that exceeds the threshold"


### PR DESCRIPTION
Autoanalyze test fails rarely, this might fix those cases?

Failure ex:

```
76 00:20:18> Testing Percent based insert
 77 00:20:18> Attribute set
 78 00:20:18> Attribute set
 79 00:20:18> Attribute set
 80 00:20:19> Inserting 200 records as one transaction.
 81 00:20:19> count 200, lastrun 1749269995
 82 00:20:19>
 83 00:20:19> Table t1, aa counter=200 (saved 0, new 200, percent of tbl 100.00), last run time=2025-06-07 00:19:55 (1749269995), needs analyze time=1969-12-31 19:00:00 (0)
 84 00:20:19> Turn on autoanalyze
 85 00:20:19> Attribute set
 86 00:20:40> Sat Jun  7 00:20:40 EDT 2025
 87 00:20:40> count 200, lastrun 1749269995
 88 00:20:40>
 89 00:20:40> Table t1, aa counter=200 (saved 200, new 0, percent of tbl 100.00), last run time=2025-06-07 00:19:55 (1749269995), needs analyze time=1969-12-31 19:00:00 (0)
 90 00:20:40> Failed lastRun 1749269995 is eq to 1749269995 -- insert should have triggered autoanalyze
 ```