### PR TITLE
Single-quote table name before using it in bash cmd

### DIFF
--- a/schemachange/sc_import.c
+++ b/schemachange/sc_import.c
@@ -1846,7 +1846,7 @@ int do_import(struct ireq *iq, struct schema_change_type *sc, tran_type *tran)
 
     const char *my_tier = get_my_mach_class_str();
     const int cmd_size = snprintf(NULL, 0,
-        "%s --import --lrl %s/import.lrl --dir %s --tables %s --src %s --my-tier %s",
+        "%s --import --lrl %s/import.lrl --dir %s --tables '%s' --src %s --my-tier %s",
         exe, tmp_db_dir, tmp_db_dir, src_tablename, srcdb, my_tier)
         + 1;
     command = malloc(cmd_size);
@@ -1857,7 +1857,7 @@ int do_import(struct ireq *iq, struct schema_change_type *sc, tran_type *tran)
     }
 
     sprintf(command,
-        "%s --import --lrl %s/import.lrl --dir %s --tables %s --src %s --my-tier %s",
+        "%s --import --lrl %s/import.lrl --dir %s --tables '%s' --src %s --my-tier %s",
          exe, tmp_db_dir, tmp_db_dir, src_tablename, srcdb, my_tier);
 
     rc = system(command);

--- a/tests/bulkimport.test/runit
+++ b/tests/bulkimport.test/runit
@@ -299,6 +299,23 @@ function test_feature_tunable() {
 	)
 }
 
+function test_import_against_table_with_dollar_char() {
+	(
+		# Given
+		local dst_tbl=foo src_tbl='$table'
+		query_dst_db "create table $dst_tbl(i int)"
+		query_src_db "create table '"$src_tbl"'(i int)"
+		trap "query_dst_db 'drop table $dst_tbl';
+			  query_src_db 'drop table '\''$src_tbl'\'" EXIT
+
+		# When
+		query_dst_db "replace table $dst_tbl with LOCAL_$SRC_DBNAME.'"$src_tbl"'"
+
+		# Then
+		(( $? == 0 ))
+	)
+}
+
 function test_resume_is_blocked() {
 	(
 		# Given


### PR DESCRIPTION
Bulk import runs a shell command that takes a table name as an argument. A table with '$' in its name will not be imported properly since the characters following the '$' will be interpreted as an environment variable when the shell command is executed. The changes in this PR fix this bug by single-quoting the table name before passing it to the shell.