### PR TITLE
Reinstate forbid_remote_repopnewlrl

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -299,6 +299,7 @@ extern int gbl_logdelete_lock_trace;
 extern int gbl_flush_log_at_checkpoint;
 extern int gbl_online_recovery;
 extern int gbl_forbid_remote_admin;
+extern int gbl_forbid_remote_repopnewlrl;
 extern int gbl_abort_on_dta_lookup_error;
 extern int gbl_debug_children_lock;
 extern int gbl_serialize_reads_like_writes;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2006,6 +2006,11 @@ REGISTER_TUNABLE("forbid_remote_admin",
                  TUNABLE_BOOLEAN, &gbl_forbid_remote_admin, 0, NULL, NULL, NULL,
                  NULL);
 
+REGISTER_TUNABLE("forbid_remote_repopnewlrl",
+                 "Forbid repopnewlrl requests from remote machines.  (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_forbid_remote_repopnewlrl, 0, NULL, NULL, NULL,
+                 NULL);
+
 REGISTER_TUNABLE("abort_on_dta_lookup_error",
                  "Abort on dta lookup lost the race.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_abort_on_dta_lookup_error,

--- a/net/net.c
+++ b/net/net.c
@@ -2610,14 +2610,13 @@ int is_connection_local(SBUF2 *sb) {
     int rc = getpeername(sbuf2fileno(sb), (struct sockaddr *)&peeraddr, &pl);
     if (rc) {
         // default to not local on error
-        return 1;
+        return 0;
     }
-    char paddr[64];
     char fromaddr[64];
     findpeer(sbuf2fileno(sb), fromaddr, sizeof(fromaddr));
     // allow loopback or same address as us
     if (peeraddr.sin_addr.s_addr == htonl(INADDR_LOOPBACK))
-        return 0;
+        return 1;
 
     // not loopback - see if it came from us
     struct addrinfo *res = NULL, hints = {0}, *r;
@@ -2632,7 +2631,6 @@ int is_connection_local(SBUF2 *sb) {
     int islocal = 0;
     for (r = res; r != NULL; r = r->ai_next) {
         struct in_addr addr = ((struct sockaddr_in *)r->ai_addr)->sin_addr;
-        inet_ntop(((struct sockaddr_in *)r->ai_addr)->sin_family, &addr, paddr, sizeof(paddr));
         if (addr.s_addr == peeraddr.sin_addr.s_addr) {
             islocal = 1;
             break;

--- a/plugins/repopnewlrl/repopnewlrl.c
+++ b/plugins/repopnewlrl/repopnewlrl.c
@@ -17,6 +17,9 @@
 #include "comdb2.h"
 #include "comdb2_plugin.h"
 #include "comdb2_appsock.h"
+#include "net.h"
+
+int gbl_forbid_remote_repopnewlrl = 1;
 
 static int handle_repopnewlrl_request(comdb2_appsock_arg_t *arg)
 {
@@ -25,6 +28,13 @@ static int handle_repopnewlrl_request(comdb2_appsock_arg_t *arg)
     int rc;
 
     sb = arg->sb;
+
+    if (gbl_forbid_remote_repopnewlrl && !is_connection_local(sb)) {
+        logmsg(LOGMSG_ERROR, "%s: rejecting remote repopnewlrl request\n",
+                __func__);
+        arg->error = -1;
+        return APPSOCK_RETURN_ERR;
+    }
 
     if (((rc = sbuf2gets(lrl_fname_out, sizeof(lrl_fname_out), sb)) <= 0) ||
         (lrl_fname_out[rc - 1] != '\n')) {

--- a/tests/forbid_remote_repopnewlrl.test/Makefile
+++ b/tests/forbid_remote_repopnewlrl.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/forbid_remote_repopnewlrl.test/README
+++ b/tests/forbid_remote_repopnewlrl.test/README
@@ -1,0 +1,1 @@
+Verify that forbid_remote_repoplrl works correctly

--- a/tests/forbid_remote_repopnewlrl.test/lrl.options
+++ b/tests/forbid_remote_repopnewlrl.test/lrl.options
@@ -1,0 +1,1 @@
+logmsg level info

--- a/tests/forbid_remote_repopnewlrl.test/runit
+++ b/tests/forbid_remote_repopnewlrl.test/runit
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+[[ $debug == "1" ]] && set -x
+set -x
+
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+function run_test
+{
+    local myhost=$(hostname)
+    local node=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $DBNAME default "select host from comdb2_cluster where host != \"$myhost\" limit 1")
+    local port=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $DBNAME --host $node "select comdb2_port()")
+    local target=$DBDIR/$DBNAME.new.lrl
+
+    echo "Ask $node to repopulate an lrl file"
+    echo -e "repopnewlrl\n$target\n" | nc -w 1 $node $port
+
+    echo "Verify that $node did not create this file"
+    x=$(ssh -o StrictHostKeyChecking=no $node "ls $target")
+    [[ -n "$x" ]] && failexit "Node $node repopulated a new lrl file from a remote connection"
+
+    echo "Search for 'rejecting remote repopnewlrl' in logs"
+    egrep "rejecting remote repopnewlrl request" ${TESTDIR}/logs/${DBNAME}.${node}.db
+    r=$?
+
+    if [[ "$r" != "0" ]]; then
+        failexit "Couldn't find reject remote repopnewlrl message in log"
+    fi
+
+    echo "Tell $db to allow remote repopnewlrl"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "put tunable 'forbid_remote_repopnewlrl' 0"
+
+    echo "Ask $node to repopulate an lrl file"
+    echo -e "repopnewlrl\n$target\n" | nc -w 1 $node $port
+
+    echo "Verify that $node created this file"
+    x=$(ssh -o StrictHostKeyChecking=no $node "ls $target")
+    [[ -z "$x" ]] && failexit "Node $node did not repopulate a new lrl file from a remote connection"
+
+    echo "Success!"
+    exit 0
+}
+
+[ -z "$CLUSTER" ] && failexit "This test requires a cluster"
+run_test

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -382,6 +382,7 @@
 (name='flush_replicant_on_prepare', description='Flush replicant log on prepare. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_scan_dbs_first', description='Don't hold bufpool mutex while opening files for flush', type='BOOLEAN', value='OFF', read_only='N')
 (name='forbid_remote_admin', description='Forbid non-local admin requests.  (Default: on)', type='BOOLEAN', value='OFF', read_only='N')
+(name='forbid_remote_repopnewlrl', description='Forbid repopnewlrl requests from remote machines.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='forbid_ulonglong', description='Disallow u_longlong. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='force_directio', description='Force directio on all file opens if set on environment (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='force_highslot', description='', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
This PR reinstates and fixes the forbid-remote-repopnewlrl logic.  It additionally fixes the broken testcase which should have caught this the first time.
