### PR TITLE
Add max_wr_logbytes_per_txn & warn_wr_logbytes_per_txn

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1464,6 +1464,7 @@ struct ireq {
     int tptlock; /* need to know if we need to wrap whole txn in a view_lock */
     uint32_t written_row_count;
     uint32_t cascaded_row_count;
+    uint64_t written_logbytes_count;
 
     /* Client endian flags. */
     uint8_t client_endian;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -211,6 +211,8 @@ extern int gbl_verbose_send_coherency_lease;
 extern int gbl_reset_on_unelectable_cluster;
 extern int gbl_rep_verify_always_grab_writelock;
 extern int gbl_rep_verify_will_recover_trace;
+extern uint64_t gbl_warn_wr_logbytes_per_txn;
+extern uint64_t gbl_max_wr_logbytes_per_txn;
 extern uint32_t gbl_written_rows_warn;
 extern uint32_t gbl_max_wr_rows_per_txn;
 extern uint32_t gbl_max_cascaded_rows_per_txn;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1448,6 +1448,12 @@ REGISTER_TUNABLE("written_rows_warn",
                  "Set warning threshold for rows written in a transaction.  "
                  "(Default: 0)",
                  TUNABLE_INTEGER, &gbl_written_rows_warn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("max_wr_logbytes_per_txn", "Set the maximum number of log-bytes written per transaction.",
+                 TUNABLE_INTEGER, &gbl_max_wr_logbytes_per_txn, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("warn_wr_logbytes_per_txn",
+                 "Set warning threshold for log-bytes written in a transaction.  "
+                 "(Default: 0)",
+                 TUNABLE_INTEGER, &gbl_warn_wr_logbytes_per_txn, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_cascaded_rows_per_txn", "Set the max cascaded rows updated per transaction.", TUNABLE_INTEGER,
                  &gbl_max_cascaded_rows_per_txn, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_time_per_txn_ms", "Set the max time allowed for transaction to finish", TUNABLE_INTEGER,

--- a/db/glue.c
+++ b/db/glue.c
@@ -786,6 +786,7 @@ int trans_commit_logical_tran(void *trans, int *bdberr)
 int gbl_javasp_early_release = 1;
 int gbl_debug_add_replication_latency = 0;
 uint32_t gbl_written_rows_warn = 0;
+uint64_t gbl_warn_wr_logbytes_per_txn = 0;
 extern int gbl_debug_disttxn_trace;
 
 static int trans_commit_int(struct ireq *iq, void *trans, char *source_host, int timeoutms, int adaptive, int logical,
@@ -799,10 +800,17 @@ static int trans_commit_int(struct ireq *iq, void *trans, char *source_host, int
 
     memset(&ss, -1, sizeof(ss));
 
-    if (release_schema_lk && gbl_written_rows_warn > 0 && iq->written_row_count >= gbl_written_rows_warn) {
-        uuidstr_t us;
-        logmsg(LOGMSG_USER, "transaction-audit [%llu:%s] modified %u rows\n", iq->sorese->rqid,
-               comdb2uuidstr(iq->sorese->uuid, us), iq->written_row_count);
+    if (release_schema_lk) {
+        if (gbl_written_rows_warn > 0 && iq->written_row_count > gbl_written_rows_warn) {
+            uuidstr_t us;
+            logmsg(LOGMSG_USER, "transaction-audit [%llu:%s] modified %u rows\n", iq->sorese->rqid,
+                   comdb2uuidstr(iq->sorese->uuid, us), iq->written_row_count);
+        }
+        if (gbl_warn_wr_logbytes_per_txn > 0 && iq->written_logbytes_count > gbl_warn_wr_logbytes_per_txn) {
+            uuidstr_t us;
+            logmsg(LOGMSG_USER, "transaction-audit [%llu:%s] wrote %" PRIu64 " logbytes\n", iq->sorese->rqid,
+                   comdb2uuidstr(iq->sorese->uuid, us), iq->written_logbytes_count);
+        }
     }
 
     int startms = comdb2_time_epochms();

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -2870,6 +2870,8 @@ void abort_disttxn(struct ireq *iq, int rc, int outrc)
         } \
     } while(0)
 
+__thread uint64_t *txn_logbytes = NULL;
+
 static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, struct ireq *iq, block_state_t *p_blkstate)
 {
     int rowlocks = gbl_rowlocks;
@@ -3153,6 +3155,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
     }
 
     iq->blkstate->pos = 0;
+    txn_logbytes = &iq->written_logbytes_count;
+    iq->written_logbytes_count = 0;
 
     if (!rowlocks) {
         /* start parent transaction */
@@ -6372,6 +6376,7 @@ static int toblock_main(struct javasp_trans_state *javasp_trans_handle, struct i
 done:
 
     assert(iq->sc_running == 0);
+    txn_logbytes = NULL;
 
     Pthread_mutex_lock(&blklk);
     blkcnt--;

--- a/tests/max_wr_rows.test/Makefile
+++ b/tests/max_wr_rows.test/Makefile
@@ -4,7 +4,7 @@ else
 	include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=1m
+	export TEST_TIMEOUT=2m
 endif
 
 unexport CLUSTER

--- a/tests/max_wr_rows.test/runit
+++ b/tests/max_wr_rows.test/runit
@@ -25,6 +25,7 @@ function createtables
     cdb2sql ${CDB2_OPTIONS} $db $stage "create table t1 {schema{int id} keys{ \"id\" = id }}"
     cdb2sql ${CDB2_OPTIONS} $db $stage "create table t2 {schema{int id} keys{ dup \"id\" = id } constraints { \"id\" -> \"t1\":\"id\" on delete cascade on update cascade }}"
     cdb2sql ${CDB2_OPTIONS} $db $stage "create table t3 (i int)"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "create table t4 (i int)"
 }
 
 function insert_records
@@ -274,11 +275,27 @@ function runtest_max_ttl
     # also assert that the last insert did not succeed
     local cnt=`cdb2sql ${CDB2_OPTIONS} --tabs $db $stage "select count(i) from t3"`
     assertres $cnt 2
+    cdb2sql ${CDB2_OPTIONS} $db $stage "exec procedure sys.cmd.send('bdb setattr DELAY_WRITES_IN_RECORD_C 0')"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "put tunable max_time_per_txn_ms 0"
+}
+
+function runtest_max_logbytes
+{
+    cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t4 (i) values (1)"
+    cdb2sql ${CDB2_OPTIONS} $db $stage "put tunable max_wr_logbytes_per_txn 1"
+    local x=$(cdb2sql ${CDB2_OPTIONS} $db $stage "insert into t4 (i) values (2)" 2>&1)
+    if [[ "$x" != *"Transaction exceeds max log-bytes limit"* ]]; then
+        failexit "Expected: Transaction exceeds max log-bytes limit"
+    fi
+    local cnt=`cdb2sql ${CDB2_OPTIONS} --tabs $db $stage "select count(i) from t4"`
+    assertres $cnt 1
+    cdb2sql ${CDB2_OPTIONS} $db $stage "put tunable max_wr_logbytes_per_txn 0"
 }
 
 createtables
 runtest
 runtest_max_cascades
 runtest_max_ttl
+runtest_max_logbytes
 
 echo "Success"


### PR DESCRIPTION
These warn and fail transactions which produce log-traffic beyond the threshold.