### PR TITLE
Default logbyte warn threshold -> 512Mb

### DIFF
--- a/db/glue.c
+++ b/db/glue.c
@@ -786,7 +786,7 @@ int trans_commit_logical_tran(void *trans, int *bdberr)
 int gbl_javasp_early_release = 1;
 int gbl_debug_add_replication_latency = 0;
 uint32_t gbl_written_rows_warn = 0;
-int64_t gbl_warn_wr_logbytes_per_txn = 0;
+int64_t gbl_warn_wr_logbytes_per_txn = 1024 * 1024 * 512;
 extern int gbl_debug_disttxn_trace;
 
 static int trans_commit_int(struct ireq *iq, void *trans, char *source_host, int timeoutms, int adaptive, int logical,

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1117,7 +1117,7 @@
 (name='warn_nondbreg_records', description='warn on non-dbreg records before checkpoint', type='BOOLEAN', value='OFF', read_only='N')
 (name='warn_on_replicant_log_write', description='Warn if replicant is writing to logs', type='BOOLEAN', value='ON', read_only='N')
 (name='warn_slow_replicants', description='Warn if any replicant's average response times over the last 10 seconds are significantly worse than the second worst replicant's.', type='BOOLEAN', value='ON', read_only='N')
-(name='warn_wr_logbytes_per_txn', description='Set warning threshold for log-bytes written in a transaction.  (Default: 0)', type='INT64', value='0', read_only='N')
+(name='warn_wr_logbytes_per_txn', description='Set warning threshold for log-bytes written in a transaction.  (Default: 0)', type='INT64', value='536870912', read_only='N')
 (name='watchthreshold', description='Panic if node has been unhealthy (unresponsive, out of resources, etc.) for more than this many seconds. The default value is 60.', type='INTEGER', value='60', read_only='N')
 (name='written_rows_warn', description='Set warning threshold for rows written in a transaction.  (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='zliblevel', description='If zlib compression is enabled, this determines the compression level.', type='INTEGER', value='6', read_only='N')


### PR DESCRIPTION
Audit customers which do large commits.