### PR TITLE
Lighten-up maxtables test

### DIFF
--- a/tests/maxtable.test/lrl.options
+++ b/tests/maxtable.test/lrl.options
@@ -1,0 +1,1 @@
+dtastripe 1


### PR DESCRIPTION
This test creates the maximum number of tables permissible. For each of these tables, an fd is kept open for each of its 8 btree files. This causes the db to run out of file descriptors on some of my machines. The changes in this PR cause each table to just have 1 btree file to lighten up this test. This change also seems to make the test duration 12 minutes shorter.