### PR TITLE
{179368903}: Adding msgtrap to clear sc history

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1690,6 +1690,8 @@ typedef struct {
 int bdb_llmeta_get_sc_history(tran_type *t, sc_hist_row **hist_out, int *num,
                               int *bdberr, const char *tablename);
 
+void bdb_clear_sc_history();
+
 typedef struct schema_version_row {
     char *db_name;
     int vers;

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -203,6 +203,7 @@ static int kv_del(tran_type *tran, void *k, int *bdberr);
 static int kv_get_kv(tran_type *t, void *k, size_t klen, void ***keys,
                      void ***values, int **valuelens, int *num, int *bdberr);
 static int kv_del_by_value(tran_type *tran, void *k, size_t klen, void *v, size_t vlen, int *bdberr);
+static int kv_del(tran_type *tran, void *k, int *bdberr);
 typedef int kv_for_each_cb(void *k, void *v, void *data);
 static int kv_for_each_pair(tran_type *t, void *sk, size_t sklen, kv_for_each_cb *cb, void *data);
 
@@ -4939,6 +4940,34 @@ int bdb_llmeta_get_all_sc_status(tran_type *tran, llmeta_sc_status_data **status
     *status_out = cb_data.status_ents;
     *sc_data_out = cb_data.sc_data;
     return 0;
+}
+
+
+static int delete_this_entry(void *k, void *v, void *data)
+{
+    int bdberr = BDBERR_NOERROR;
+    int rc = kv_del(NULL, k, &bdberr);
+    if (rc == 0 && bdberr == BDBERR_NOERROR) {
+        (*(int *)data)++;
+        return 0;
+    } else {
+        logmsg(LOGMSG_ERROR, "%s: kv_del rc %d bdberr %d\n", __func__, rc, bdberr);
+        return -1;
+    }
+}
+
+void bdb_clear_sc_history()
+{
+    int i, cnt;
+
+    llmetakey_t k[3] = {htonl(LLMETA_SCHEMACHANGE_STATUS),
+                        htonl(LLMETA_SCHEMACHANGE_STATUS_V2),
+                        htonl(LLMETA_SCHEMACHANGE_HISTORY)};
+
+    for (i = 0, cnt = 0; i != sizeof(k)/sizeof(llmetakey_t); ++i)
+        kv_for_each_pair(NULL, &k[i], sizeof(llmetakey_t), delete_this_entry, &cnt);
+
+    logmsg(LOGMSG_INFO, "%s: %d records removed\n", __func__, cnt);
 }
 
 /* updates the last processed genid for a stripe in the in progress schema

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -5086,6 +5086,8 @@ clipper_usage:
         gbl_use_modsnap_for_snapshot = 0;
     } else if (tokcmp(tok, ltok, "del_llmeta_comdb2_seqno") == 0) {
         bdb_del_seqno(NULL);
+    } else if (tokcmp(tok, ltok, "clear_sc_history") == 0) {
+        bdb_clear_sc_history();
     } else {
         // see if any plugins know how to handle this
         struct message_handler *h;

--- a/tests/comdb2sys_sc_history.test/expected
+++ b/tests/comdb2sys_sc_history.test/expected
@@ -60,3 +60,9 @@
 	}
 ')
 [SELECT name, newcsc2 FROM comdb2_sc_status] rc 0
+(6=6)
+[SELECT 6] rc 0
+(COUNT(*)=0)
+[SELECT COUNT(*) FROM comdb2_sc_history] rc 0
+(COUNT(*)=0)
+[SELECT COUNT(*) FROM comdb2_sc_status] rc 0

--- a/tests/comdb2sys_sc_history.test/runit
+++ b/tests/comdb2sys_sc_history.test/runit
@@ -26,4 +26,11 @@ SELECT name FROM comdb2_sc_history
 SELECT name, newcsc2 FROM comdb2_sc_status
 EOF
 
+master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select host from comdb2_cluster where is_master='Y'"`
+cdb2sql $dbnm --host $master "EXEC PROCEDURE sys.cmd.send('clear_sc_history')"
+cdb2sql $dbnm --host $host - >>actual <<EOF
+SELECT 6
+SELECT COUNT(*) FROM comdb2_sc_history
+SELECT COUNT(*) FROM comdb2_sc_status
+EOF
 diff expected actual


### PR DESCRIPTION
This patch adds a message trap `clear_sc_history` that deletes all sc history and status entries from llmeta.