### PR TITLE
Revert "{179084052}: Closing inactive in-process cached connections"

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -379,7 +379,6 @@ extern int gbl_noleader_retry_duration_ms;
 extern int gbl_noleader_retry_poll_ms;
 
 extern char *gbl_iam_dbname;
-extern int gbl_inproc_conn_ttl;
 
 /* util/ctrace.c */
 extern int nlogs;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2554,8 +2554,6 @@ REGISTER_TUNABLE("iam_dbname",
                  "override dbname for IAM",
                  TUNABLE_STRING, &gbl_iam_dbname, READEARLY | READONLY, NULL,
                  NULL, NULL, NULL);
-REGISTER_TUNABLE("inproc_conn_ttl", "Close in-process cached connections after this many seconds of inactivity (Default: 10s)",
-                 TUNABLE_INTEGER, &gbl_inproc_conn_ttl, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("comdb2_oplog_preserve_seqno", "Preserve max value of the seqno in llmeta", TUNABLE_BOOLEAN, &gbl_comdb2_oplog_preserve_seqno, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("queue_nonodh_scan_limit", "For comdb2_queues, stop queue scan at this depth (Default: 10000)", TUNABLE_INTEGER, &gbl_nonodh_queue_scan_limit, 0, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -448,7 +448,6 @@
 (name='init_with_time_based_genids', description='Enables time-based GENIDs', type='BOOLEAN', value='OFF', read_only='Y')
 (name='inline_mtraps', description='inline_mtraps', type='BOOLEAN', value='OFF', read_only='N')
 (name='inmem_repdb_memory', description='Current memory usage of in-memory repdb.  (Default: 0)', type='INTEGER', value='0', read_only='Y')
-(name='inproc_conn_ttl', description='Close in-process cached connections after this many seconds of inactivity (Default: 10s)', type='INTEGER', value='10', read_only='N')
 (name='instant_schema_change', description='When possible (eg: when just adding fields) schema change will not rebuild the underlying tables. (Default: on)', type='BOOLEAN', value='ON', read_only='Y')
 (name='iomap_enabled', description='Map file that tells comdb2ar to pause while we fsync', type='BOOLEAN', value='ON', read_only='N')
 (name='ioqueue', description='Maximum depth of the I/O prefaulting queue. (Default: 0)', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
This reverts commit 6235d86d578978986f3989be2649107a472509cb.

# Conflicts:
#	db/db_tunables.h