### PR TITLE
Allow alternate metadbs for physrep revconns

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1570,6 +1570,27 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
             exit(1);
         }
         gbl_physrep_metadb_host = tokdup(tok, ltok);
+    } else if (tokcmp(tok, ltok, "alternate_metadb") == 0) {
+        tok = segtok(line, len, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "Must specify an alternate database to replicate from\n");
+            return -1;
+        }
+        char *dbname = tokdup(tok, ltok);
+
+        tok = segtok(line, len, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "Must specify an alternate metadb host\n");
+            free(dbname);
+            return -1;
+        }
+        char *host = tokdup(tok, ltok);
+        if (physrep_add_alternate_metadb(dbname, host) != 0) {
+            logmsg(LOGMSG_ERROR, "Failed to add alternate metadb %s@%s\n", dbname, host);
+            free(dbname);
+            free(host);
+            return -1;
+        }
     } else if (tokcmp(tok, ltok, "physrep_ignore") == 0) {
         /* Tables that should ignore replication */
         while ((tok = segtok(line, len, &st, &ltok)) != NULL && ltok > 0) {

--- a/db/phys_rep.h
+++ b/db/phys_rep.h
@@ -40,5 +40,6 @@ void physrep_update_low_file_num(int*, int*);
 void physrep_fanout_override(const char *dbname, int fanout);
 int physrep_fanout_get(const char *dbname);
 void physrep_fanout_dump(void);
+int physrep_add_alternate_metadb(char *dbname, char *host);
 
 #endif /* PHYS_REP_H */

--- a/tests/phys_rep_tiered.test/lrl.options
+++ b/tests/phys_rep_tiered.test/lrl.options
@@ -1,4 +1,5 @@
 logmsg level debug
+dtastripe 1
 debug_drop_nth_rep_message 10000
 incoherent_slow_inactive_timeout 0
 revsql_fake_connect_failure 1

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -749,11 +749,15 @@ function fix_lrl_and_restart_source_nodes()
     local _source_dbdir=$3
     local _meta_dbname=$4
     local _meta_host=$5
-    local _meta_dbdir=$6
+    local _altmeta_dbname=$6
+    local _altmeta_host=$7
 
     if [[ -z "$CLUSTER" ]]; then
         node=$(hostname)
         echo "physrep_metadb ${_meta_dbname} ${_meta_host}" >> ${_source_dbdir}/${_source_dbname}.lrl
+
+        echo "alternate_metadb ${_altmeta_dbname} ${_altmeta_host}" >> ${_source_dbdir}/${_source_dbname}.lrl
+
         #echo "blocking_physrep 0" >> ${_source_dbdir}/${_source_dbname}.lrl
         echo "physrep_debug 1" >> ${_source_dbdir}/${_source_dbname}.lrl
         echo "killrestart node $node"
@@ -772,6 +776,7 @@ function fix_lrl_and_restart_source_nodes()
 
         for node in $CLUSTER ; do
             ssh ${node} "echo \"physrep_metadb ${_meta_dbname} ${_meta_host}\" >> ${_source_dbdir}/${_source_dbname}.lrl" < /dev/null
+            ssh ${node} "echo \"alternate_metadb ${_altmeta_dbname} ${_altmeta_host}\" >> ${_source_dbdir}/${_source_dbname}.lrl" < /dev/null
             ssh ${node} "echo \"physrep_debug 1\" >> ${_source_dbdir}/${_source_dbname}.lrl" < /dev/null
             #ssh ${node} "echo \"physrep_register_interval 5\" >> ${_source_dbdir}/${_source_dbname}.lrl"
             echo "killrestart node $node"
@@ -804,6 +809,9 @@ function setup_physrep_cluster()
     local _meta_dbname=$6
     local _meta_host=$7
     local _meta_dbdir=$8
+    local _altmeta_dbname=$9
+    local _altmeta_host=${10}
+    local _altmeta_dbdir=${11}
 
     tmpdir=${TMPDIR:-/tmp}
 
@@ -875,8 +883,8 @@ function setup_physrep_cluster()
         # 2. Start instances
         for node in ${CLUSTER}; do
             logFile=$TESTDIR/logs/${_dbname}.${node}.log
-        ssh ${node} "$COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null & 
-        PIDs="${PIDs} $!"
+            ssh ${node} "$COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+            PIDs="${PIDs} $!"
         done
 
         # 3. Wait for instances to come online
@@ -894,9 +902,58 @@ function setup_physrep_cluster()
     echo "Physrep replication cluster/node started!"
 }
 
+function setup_alt_replicant()
+{
+    echo "== Setting alternate replicant =="
+
+    local _alt_dbname=$1
+    local _alt_host=$2
+    local _repl_dbdir_prefix=$3
+    local _cluster_dbname=$4
+    local _cluster_host=$5
+    local _cluster_dbdir=$6
+    local _altmeta_dbname=$7
+    local _altmeta_host=$8
+    local _altmeta_dbdir=$9
+    local _repl_dbname=${_alt_dbname}
+    local _repl_dbdir=${_repl_dbdir_prefix}/${_repl_dbname}
+    local tmpdir=${TMPDIR:-/tmp}
+
+    logFile=$TESTDIR/logs/${_repl_dbname}.log
+
+    ssh ${_alt_host} "${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H ${_repl_dbname} -y @${_cluster_host} ${_cluster_host}:${_cluster_dbdir}/${_cluster_dbname}.lrl ${_repl_dbdir} ${_repl_dbdir}" >> ${logFile} 2>&1 < /dev/null
+
+    if [ ! $? -eq 0 ]; then
+        cleanFailExit "copycomdb2 failed"
+    fi
+
+    # Comment out both physrep_metadb and alternate_metadb
+    ssh ${_alt_host} "sed -i -E 's/^(physrep_metadb|alternate_metadb)/# \1/' ${_repl_dbdir}/${_repl_dbname}.lrl" < /dev/null
+
+    # This replicant's metadb will be the alternate metadb
+    ssh ${_alt_host} "echo "physrep_metadb ${_altmeta_dbname} ${_altmeta_host}" >> ${_repl_dbdir}/${_repl_dbname}.lrl" < /dev/null
+
+    # Ask the physrep cluster to start a reverse-connection to this replicant
+    # through the alternate metadb
+    add_to_physrep_sources ${_altmeta_dbname} ${_altmeta_host} ${_cluster_dbname} ${_cluster_host} ${_alt_dbname} ${_alt_host}
+
+    # Start the alt-replicant
+    ssh ${_alt_host} "$COMDB2_EXE ${_alt_dbname} --lrl ${_repl_dbdir}/${_alt_dbname}.lrl --pidfile ${_repl_dbdir}/${_alt_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+    PIDs="${PIDs} $!"
+
+    out=0
+    while [[ "$out" != "1" ]];  do 
+        echo "${_alt_dbname}: waiting until ready"
+        sleep $SLEEP_BETWEEN_CHECKS
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host ${_alt_host} ${_repl_dbname} 'select 1' 2>/dev/null)
+    done
+    echo "Setup $_alt_dbname replicant on ${_alt_host} complete"
+}
+
 function setup_physrep_replicants()
 {
     echo "== Setting up standalone replicants =="
+
     local _dbname_prefix=$1
     local _dbdir_prefix=$2
     local _source_dbname=$3
@@ -905,6 +962,9 @@ function setup_physrep_replicants()
     local _meta_dbname=$6
     local _meta_host=$7
     local _meta_dbdir=$8
+    local _altmeta_dbname=$9
+    local _altmeta_host=${10}
+    local _altmeta_dbdir=${11}
 
     local tmpdir=${TMPDIR:-/tmp}
 
@@ -917,10 +977,9 @@ function setup_physrep_replicants()
         logFile=$TESTDIR/logs/${_repl_dbname}.log
 
         # Add this node to comdb2_physrep_sources table to test for 'reverse connection'
-        add_to_physrep_sources ${_meta_dbname} ${_meta_host} ${_source_dbname} ${_source_host} ${_repl_dbname} ${node}
+        add_to_physrep_sources ${_meta_dbname} ${_meta_host} ${_source_dbname} ${_source_host} ${_alt_dbname} ${_alt_host}
 
         # use copycomdb2 to create a physical replicant
-
         ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H ${_repl_dbname} -y @${_source_host} ${_source_host}:${_source_dbdir}/${_source_dbname}.lrl ${_repl_dbdir} ${_repl_dbdir} >> ${logFile} 2>&1
         if [ ! $? -eq 0 ]; then
             cleanFailExit "copycomdb2 failed"
@@ -1189,12 +1248,19 @@ function cleanup_internal()
 
     REPL_META_DBNAME=${TESTCASE}_${TESTID}_META
     REPL_META_DBDIR=${DBDIR}/${REPL_META_DBNAME}
+    
+    REPL_ALTMETA_DBNAME=${TESTCASE}_${TESTID}_ALT
+    REPL_ALTMETA_DBDIR=${DBDIR}/${REPL_ALTMETA_DBNAME}
 
     REPL_CLUS_DBNAME=${TESTCASE}_${TESTID}_CLUS
     REPL_CLUS_DBDIR=${DBDIR}/${REPL_CLUS_DBNAME}
 
     REPL_DBNAME_PREFIX=${TESTCASE}_${TESTID}_REPL
     REPL_DBDIR_PREFIX=${DBDIR}/${REPL_DBNAME_PREFIX}
+
+    REPL_ALT_DBNAME=${REPL_DBNAME_PREFIX}_${TESTID}_${REPL_ALT_HOST}_ALT
+    REPL_ALT_DBDIR=${REPL_DBDIR_PREFIX}/${REPL_ALT_DBNAME}
+    REPL_ALT_PIDFILE=${REPL_ALT_DBDIR}/${REPL_ALT_DBNAME}.pid
 
     if [[ -n "$CLUSTER" ]]; then
         for node in $CLUSTER ; do
@@ -1203,8 +1269,11 @@ function cleanup_internal()
             ssh ${node} "kill -$sig \$(cat ${_repl_dbdir}/${_repl_dbname}.pid)" < /dev/null
             ssh ${node} "kill -$sig \$(cat ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.pid)" < /dev/null 
             ssh ${node} "kill -$sig \$(cat ${REPL_META_DBDIR}/${REPL_META_DBNAME}.pid)" < /dev/null
+            ssh ${node} "kill -$sig \$(cat ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.pid)" < /dev/null
         done
     fi
+    ssh ${first} "kill -$sig \$(cat ${REPL_CLUS_DBDIR}/${REPL_ALT_DBNAME}.pid)" < /dev/null
+    ssh ${REPL_ALT_HOST} "kill -$sig \$(cat ${REPL_ALT_PIDFILE})" < /dev/null
 }
 
 function cleanup()
@@ -1275,6 +1344,32 @@ function verify_revconn_fix
     if [[ "$x" -gt 80 ]]; then
         cleanFailExit "Reverse connection loop in $logFile"
     fi
+}
+
+# All physreps are aware of the emply alternate metadb
+function multimetadb
+{
+    echo "Alternate metadb physrep should be replicating"
+    echo "Just create a table, and make sure that it replicates"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table multimetadb(a int)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into multimetadb select * from generate_series(1, 1000)"
+    found=0
+    while [[ "$found" != "1" ]]; do
+        sleep 1
+        # ${REPL_ALT_DBNAME} ${REPL_ALT_HOST}
+        found=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${REPL_ALT_DBNAME} --host $REPL_ALT_HOST "select count(*) from comdb2_tables where tablename='multimetadb'")
+    done
+    cnt=0
+    while [[ $cnt != 1000 ]]; do
+        sleep 1
+        cnt=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_ALT_DBNAME --host $REPL_ALT_HOST "select count(*) from multimetadb")
+    done
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table multimetadb"
+    while [[ "$found" != "0" ]]; do
+        sleep 1
+        found=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_ALT_DBNAME --host $REPL_ALT_HOST "select count(*) from comdb2_tables where tablename='multimetadb'")
+    done
 }
 
 # Use message traps to verify overlap logic
@@ -1563,8 +1658,13 @@ REPL_META_DBNAME=${TESTCASE}_${TESTID}_META
 REPL_META_DBDIR=${DBDIR}/${REPL_META_DBNAME}
 REPL_META_HOST=""
 
+REPL_ALTMETA_DBNAME=${TESTCASE}_${TESTID}_ALT
+REPL_ALTMETA_DBDIR=${DBDIR}/${REPL_ALTMETA_DBNAME}
+REPL_ALTMETA_HOST=""
+
 if [[ -z "$CLUSTER" ]]; then # Standalone
     REPL_META_HOST=$(hostname)
+    REPL_ALTMETA_HOST=$(hostname)
 else                         # Cluster
     for node in ${CLUSTER}; do
         let cluster_count=cluster_count+1
@@ -1572,20 +1672,23 @@ else                         # Cluster
     for node in ${CLUSTER}; do
         first=${node}
         REPL_META_HOST=${node}
+        REPL_ALTMETA_HOST=${node}
         # Downgrade now - we want to test incoherent later
         cdb2sql ${CDB2_OPTIONS} ${DBNAME} --host $node "exec procedure sys.cmd.send('downgrade')"
         break
     done
 fi
 
+# Setup both metadb and altmeta
 setup_physrep_metadb ${REPL_META_DBNAME} ${REPL_META_DBDIR}
+setup_physrep_metadb ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_DBDIR}
 
 # 2. Update source cluster lrl to point to the replication metadata cluster
 SOURCE_DBNAME=${DBNAME}
 SOURCE_DBDIR=${DBDIR}
 SOURCE_HOST=${REPL_META_HOST}
 
-fix_lrl_and_restart_source_nodes ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_META_DBDIR}
+fix_lrl_and_restart_source_nodes ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_HOST}
 
 # 2.5 No-source ensures physrep cluster can start if parent is not running
 if [[ "$NOSOURCE" == "1" ]]; then
@@ -1596,12 +1699,21 @@ fi
 REPL_CLUS_DBNAME=${TESTCASE}_${TESTID}_CLUS
 REPL_CLUS_DBDIR=${DBDIR}/${REPL_CLUS_DBNAME}
 REPL_CLUS_HOST=${REPL_META_HOST}
-setup_physrep_cluster ${REPL_CLUS_DBNAME} ${REPL_CLUS_DBDIR} ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_META_DBDIR}
+setup_physrep_cluster ${REPL_CLUS_DBNAME} ${REPL_CLUS_DBDIR} ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_META_DBDIR} ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_HOST} ${REPL_ALTMETA_DBDIR}
 
 # 4. Setup physical replicants
 REPL_DBNAME_PREFIX=${TESTCASE}_${TESTID}_REPL
+REPL_ALT_HOST=$first
 REPL_DBDIR_PREFIX=${DBDIR}/${REPL_DBNAME_PREFIX}
-setup_physrep_replicants ${REPL_DBNAME_PREFIX} ${REPL_DBDIR_PREFIX} ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_META_DBDIR}
+
+REPL_ALT_DBNAME=${REPL_DBNAME_PREFIX}_${TESTID}_${REPL_ALT_HOST}_ALT
+REPL_ALT_DBDIR=${REPL_DBDIR_PREFIX}/${REPL_ALT_DBNAME}
+REPL_ALT_PIDFILE=${REPL_ALT_DBDIR}/${REPL_ALT_DBNAME}.pid
+
+setup_alt_replicant ${REPL_ALT_DBNAME} ${REPL_ALT_HOST} ${REPL_DBDIR_PREFIX} ${REPL_CLUS_DBNAME} ${REPL_CLUS_HOST} ${REPL_CLUS_DBDIR} ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_HOST} ${REPL_ALTMETA_DBDIR}
+
+
+setup_physrep_replicants ${REPL_DBNAME_PREFIX} ${REPL_DBDIR_PREFIX} ${SOURCE_DBNAME} ${SOURCE_HOST} ${SOURCE_DBDIR} ${REPL_META_DBNAME} ${REPL_META_HOST} ${REPL_META_DBDIR} ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_HOST} ${REPL_ALTMETA_DBDIR}
 
 # Verify LSNS whether or not NOSOURCE is lit 
 verify_physrep_lsns ${REPL_DBNAME_PREFIX} ${REPL_CLUS_DBNAME}
@@ -1722,6 +1834,11 @@ function run_tests
     testcase="verify_revconn_fix"
     testcase_preamble $testcase
     verify_revconn_fix
+    testcase_finish $testcase
+
+    testcase="multimeta"
+    testcase_preamble $multimeta
+    multimetadb
     testcase_finish $testcase
 }
 


### PR DESCRIPTION
alternate_metadb <dbname> <location> allows you to specify alternate metadbs for reverse connections.
