### PR TITLE
Increase disttxn setup timeout to 6m

### DIFF
--- a/tests/disttxn.test/Makefile
+++ b/tests/disttxn.test/Makefile
@@ -14,3 +14,7 @@ endif
 ifeq ($(TEST_TIMEOUT),)
 	export TEST_TIMEOUT=20m
 endif
+
+ifeq ($(SETUP_TIMEOUT),)
+	export SETUP_TIMEOUT=6m
+endif


### PR DESCRIPTION
Roborivers times out verifying that each of the clusters has started.  This PR increases the setup-timeout to 6 minutes.
