### PR TITLE
Implement partition database discovery via comdb2db.cfg

### DIFF
--- a/tests/partitiondb.test/Makefile
+++ b/tests/partitiondb.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=s1
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/partitiondb.test/README
+++ b/tests/partitiondb.test/README
@@ -1,0 +1,1 @@
+Test that a partition database name gets mapped onto a shard via the api.

--- a/tests/partitiondb.test/lrl.options
+++ b/tests/partitiondb.test/lrl.options
@@ -1,0 +1,2 @@
+foreign_db_resolve_local 1
+foreign_db_push_remote_writes 1

--- a/tests/partitiondb.test/runit
+++ b/tests/partitiondb.test/runit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+set -x
+
+SHARDS_LIST="$DBNAME $SECONDARY_DBNAME"
+
+# for pdb discovery to work for this test, we need to add the cluster lines from the extra dbs into the primary db comdb2 config
+# since SECONDARY_CDB2_OPTIONS will not be used when querying partitiondb
+cluster_line=$(head -n 1 $DBDIR/comdb2db.cfg)
+echo "s1$cluster_line" >> $DBDIR/comdb2db.cfg
+
+echo "partition partitiondb:$SHARDS_LIST" >> $DBDIR/comdb2db.cfg
+
+P_SQL="cdb2sql --tabs ${CDB2_OPTIONS} partitiondb default"
+
+shard=$($P_SQL "select comdb2_dbname()")
+if [[ $shard != $DBNAME && $shard != $SECONDARY_DBNAME ]]; then
+	echo "Got dbname $shard but expected one in ($DBNAME, $SECONDARY_DBNAME)"
+	exit 1
+fi;
+
+echo "Success"

--- a/tests/remotecreate.test/runit
+++ b/tests/remotecreate.test/runit
@@ -21,6 +21,17 @@ shards=""
 SHARDS_LIST="$DBNAME $SECONDARY_DBNAME $TERTIARY_DBNAME $QUATERNARY_DBNAME"
 numshards=4
 
+# for pdb discovery to work for this test, we need to add the cluster lines from the extra dbs into the primary db comdb2 config
+# since SECONDARY_CDB2_OPTIONS, TERTIARY_CDB2_OPTIONS, etc. will not be used when querying partitiondb
+cluster_line=$(head -n 1 $DBDIR/comdb2db.cfg)
+echo "s1$cluster_line" >> $DBDIR/comdb2db.cfg
+echo "s2$cluster_line" >> $DBDIR/comdb2db.cfg
+echo "s3$cluster_line" >> $DBDIR/comdb2db.cfg
+
+echo "partition partitiondb:$SHARDS_LIST" >> $DBDIR/comdb2db.cfg
+
+P_SQLT="cdb2sql --tabs ${CDB2_OPTIONS} partitiondb default"
+P_SQL="cdb2sql ${CDB2_OPTIONS} partitiondb default"
 S0_SQLT="cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default"
 S0_SQL="cdb2sql ${CDB2_OPTIONS} ${DBNAME} default"
 S1_SQLT="cdb2sql --tabs ${SECONDARY_CDB2_OPTIONS} ${SECONDARY_DBNAME} default"
@@ -43,7 +54,7 @@ function fail_exit()
 }
 
 function setup_testcase {
-	$S0_SQL "DROP TABLE IF EXISTS t"
+	$P_SQL "DROP TABLE IF EXISTS t"
 }
 
 function verify_table {
@@ -90,24 +101,24 @@ function verify_llmeta {
 }
 
 function test_creation_nonkey {
-	$S0_SQL "create table t(a int , b int) partitioned by columns(a) on (${shards})"
+	$P_SQL "create table t(a int , b int) partitioned by columns(a) on (${shards})"
 	if (( $? == 0 )); then
 		fail_exit "test_creation succeeded. Should have failed creating a sharded table with a non-key sharding key"
 	fi
 }
 
 function test_deletion {
-	$S0_SQL "create table t(a int unique, b int) partitioned by columns(a) on (${shards})"
+	$P_SQL "create table t(a int unique, b int) partitioned by columns(a) on (${shards})"
 	if (( $? != 0 )); then
 		fail_exit "test_creation failed. Could not create table"
 	fi
 	verify_table "t"
-	$S0_SQL "drop table t"
+	$P_SQL "drop table t"
 	verify_llmeta ''
 }
 
 function test_creation {
-	$S0_SQL "create table t(a int unique, b int) partitioned by columns(a) on (${shards})"
+	$P_SQL "create table t(a int unique, b int) partitioned by columns(a) on (${shards})"
 	if (( $? != 0 )); then
 		fail_exit "test_creation failed. Could not create table"
 	fi

--- a/tests/tools/test_get_comdb2db_hosts.c
+++ b/tests/tools/test_get_comdb2db_hosts.c
@@ -24,7 +24,7 @@ int main()
 
     rc = get_comdb2db_hosts(NULL,NULL, NULL, &master,
             NULL, &num_hosts, NULL,NULL,
-            NULL, &num_db_hosts, NULL, 1);
+            NULL, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == -1);
     assert(num_hosts == -1);
@@ -34,7 +34,7 @@ int main()
 
     rc = get_comdb2db_hosts(NULL,NULL, NULL, &master,
             NULL, &num_hosts, NULL,NULL,
-            NULL, &num_db_hosts, NULL, 1); //just get defaults
+            NULL, &num_db_hosts, NULL, 1, NULL, NULL); //just get defaults
 
     assert(rc == 0);
     assert(num_hosts == 0);
@@ -47,7 +47,7 @@ int main()
     char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master,
             NULL, &num_hosts, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 1);
+            db_hosts, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == 0);
     assert(num_db_hosts == 0);
@@ -66,7 +66,7 @@ int main()
     char db_hosts[MAX_NODES][CDB2HOSTNAME_LEN] = {0};
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master,
             NULL, &num_hosts, NULL, NULL,
-            db_hosts, &num_db_hosts, NULL, 1);
+            db_hosts, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == 0);
     assert(num_hosts == 0);
@@ -86,7 +86,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master,
             NULL, &num_hosts, &comdb2db_num, NULL,
-            db_hosts, &num_db_hosts, NULL, 1);
+            db_hosts, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == 0);
     assert(num_hosts == 3);
@@ -106,7 +106,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master,
             NULL, &num_hosts, &comdb2db_num, NULL,
-            db_hosts, &num_db_hosts, NULL, 1);
+            db_hosts, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == -1);
     assert(num_hosts == 0);
@@ -123,7 +123,7 @@ int main()
     int comdb2db_num = 0;
     rc = get_comdb2db_hosts(NULL, comdb2db_hosts, NULL, &master,
             NULL, &num_hosts, &comdb2db_num, NULL,
-            db_hosts, &num_db_hosts, NULL, 1);
+            db_hosts, &num_db_hosts, NULL, 1, NULL, NULL);
 
     assert(rc == 0);
     assert(num_hosts == 3);


### PR DESCRIPTION
Am taking suggestions for different name to specify sharding in comdb2db.cfg as opposed to just `shard`

Note: in testsuite will get logmsg `get_host_by_name:gethostbyname(%s): errno=0 err=Success` because cannot query comdb2db. Code will continue to open shard