### PR TITLE
Fix schema change race condition

### DIFF
--- a/tests/renametable.test/reqoutput.txt
+++ b/tests/renametable.test/reqoutput.txt
@@ -123,3 +123,7 @@
 [drop table t2] rc 0
 [alter table t2 rename to t] failed with rc 240 New table name exists
 [alter table t2 rename to t2] failed with rc 240 New table name exists
+[begin] rc 0
+[alter table t rename to dummy] rc 0
+[alter table t2 rename to t] rc 0
+[commit] rc 0

--- a/tests/renametable.test/reqoutput_lightweight.txt
+++ b/tests/renametable.test/reqoutput_lightweight.txt
@@ -123,3 +123,7 @@
 [drop table t2] rc 0
 [alter table t2 rename to t] failed with rc -3 New table name already exists
 [alter table t2 rename to t2] failed with rc -3 New table name already exists
+[commit] failed with rc -3 New table name already exists
+[begin] rc 0
+[alter table t rename to dummy] rc 0
+[alter table t2 rename to t] rc 0

--- a/tests/renametable.test/runit
+++ b/tests/renametable.test/runit
@@ -133,6 +133,14 @@ cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t2 rename to t" &>> $OUT
 # Rename to our own name
 cdb2sql ${CDB2_OPTIONS} $dbnm default "alter table t2 rename to t2" &>> $OUT
 
+# Rename after renaming table with target name in txn
+cat <<EOF | cdb2sql ${CDB2_OPTIONS} $dbnm default - >> $OUT 2>&1
+begin
+alter table t rename to dummy\$\$
+alter table t2 rename to t\$\$
+commit
+EOF
+
 df=$(diff $OUT $EXP)
 if [ $? -ne 0 ] ; then
      echo "  ^^^^^^^^^^^^"


### PR DESCRIPTION
Fixes bug introduced in https://github.com/bloomberg/comdb2/pull/5246. Per the changes in that PR, a rename sc checks if its new table name belongs to a table that was dropped earlier in the same transaction. There is a race condition here, because an sc is added to the list of scs in its transaction only [***after*** it starts](https://github.com/bloomberg/comdb2/blob/952c3e0f794e78071af04e4d5c0c4b9fb477f0b9/db/osqlcomm.c#L6283). So at the time that the rename sc checks the other scs in its transaction, it has sometimes not yet been added to the list and therefore incorrectly sees no scs.

The changes in this PR address this race condition by having a rename sc check for collisions during finalize, at which point it has already been linked into the list.

This change fixes `renametable` test failures.