### PR TITLE
Fall back to complete drain

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4453,6 +4453,9 @@ static int process_set_command(cdb2_hndl_tp *hndl, const char *sql)
 
 static inline void consume_previous_query(cdb2_hndl_tp *hndl)
 {
+    while (cdb2_next_record_int(hndl, 0) == CDB2_OK)
+        ;
+/*
     int hardbound = 0;
     while (cdb2_next_record_int(hndl, 0) == CDB2_OK) {
         hardbound++;
@@ -4461,6 +4464,7 @@ static inline void consume_previous_query(cdb2_hndl_tp *hndl)
             break;
         }
     }
+*/
 
     clear_responses(hndl);
     hndl->rows_read = 0;


### PR DESCRIPTION
Drain-cursor completely rather than closing.
