### PR TITLE
Prevent initial slowness on node startup

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -1683,7 +1683,7 @@ void net_newnode_rtn(netinfo_type *netinfo_ptr, struct interned_string *host, in
     if (bdb_state->repinfo->master_host == bdb_state->repinfo->myhost) {
         Pthread_mutex_lock(&(bdb_state->coherent_state_lock));
 
-        set_coherent_state(bdb_state, host, STATE_INCOHERENT_WAIT, __func__,
+        set_coherent_state(bdb_state, host, STATE_INCOHERENT, __func__,
                            __LINE__);
         Pthread_mutex_unlock(&(bdb_state->coherent_state_lock));
 
@@ -1948,7 +1948,7 @@ void bdb_all_incoherent(bdb_state_type *bdb_state)
     struct hostinfo *h = NULL;
     LISTC_FOR_EACH(&hostinfo_list, h, lnk)
     {
-        h->coherent_state = STATE_INCOHERENT_WAIT;
+        h->coherent_state = STATE_INCOHERENT;
     }
     hostinfo_unlock();
 

--- a/tests/incoherent_startup.test/Makefile
+++ b/tests/incoherent_startup.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=10m
+endif

--- a/tests/incoherent_startup.test/lrl.options
+++ b/tests/incoherent_startup.test/lrl.options
@@ -1,0 +1,3 @@
+noearly
+rep_processors 0
+rep_workers 0

--- a/tests/incoherent_startup.test/runit
+++ b/tests/incoherent_startup.test/runit
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+
+if [ "x$dbnm" == "x" ] ; then
+    failexit "need a DB name"
+fi
+
+wait_for_db ${DBNAME}
+if [[ $? != 0 ]] ; then
+    failexit "DB $DBNAME not ready"
+fi
+
+$CDB2SQL_EXE ${CDB2_OPTIONS} ${DBNAME} default "create table t(a int);"
+host=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "select host from comdb2_cluster where is_master='N' and coherent_state='coherent' limit 1")
+master=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "select host from comdb2_cluster where is_master='Y'")
+$CDB2SQL_EXE --host $host ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.send('exit')"
+sleep 30
+$CDB2SQL_EXE ${CDB2_OPTIONS} ${DBNAME} default -<<'EOF'
+set maxtransize 1000000
+insert into t select value from generate_series(1,1000000);
+EOF
+
+cluster=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "select host from comdb2_cluster where host!='$host'")
+
+ssh -n -o StrictHostKeyChecking=no $host /opt/bb/bin/comdb2 ${DBNAME} --lrl ${DBDIR}/${DBNAME}.lrl >dbout 2>&1 &
+
+failed=0
+
+while :; do
+    start=$(date +%s)
+    ${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} ${DBNAME} default "insert into t values(1)"
+    end=$(date +%s)
+    if [[ $(($end - $start)) -gt 2 ]]; then
+        echo "Slow write: $(($end - $start)) seconds"
+        failed=1
+        break
+    fi
+    sleep 0.1
+    # keep running until the node is coherent or we had a long event
+    ${CDB2SQL_EXE} --tabs --host ${master} ${CDB2_OPTIONS} ${DBNAME} "select * from comdb2_cluster"
+    state=$(${CDB2SQL_EXE} --tabs --host ${master} ${CDB2_OPTIONS} ${DBNAME} "select coherent_state from comdb2_cluster where host='$host'")
+    if [[ "$state" == "coherent" ]]; then
+        echo "Node is coherent, stopping test"
+        ${CDB2SQL_EXE} --tabs --host ${master} ${CDB2_OPTIONS} ${DBNAME} "select * from comdb2_cluster"
+        break
+    fi
+done
+
+if [[ $failed -ne 0 ]]; then
+    echo "Failed"
+    exit 1
+fi
+
+wait_for_db ${DBNAME}
+
+echo "Success"

--- a/tests/testcase.mk
+++ b/tests/testcase.mk
@@ -8,12 +8,13 @@ ifeq ($(TESTSROOTDIR),)
   # TESTSROOTDIR is not set when make is issued from within a test directory 
   # (will check assumption few lines later)
   # needs to expand to a full path, otherwise it propagates as '../'
-  export TESTSROOTDIR=$(shell readlink -f $(PWD)/.. 2> /dev/null || realpath $(PWD)/..)
+  export TESTSROOTDIR=$(shell readlink -f $(shell pwd)/.. 2> /dev/null || realpath $(shell pwd)/..)
   export SKIPSSL=1   #force SKIPSSL for local test -- easier to debug
   export INSETUP=yes
 else
   export INSETUP=
 endif
+
 
 # check that we indeed have the correct dir in TESTSROOTDIR
 ifeq ($(wildcard ${TESTSROOTDIR}/setup),)
@@ -29,8 +30,9 @@ include $(TESTSROOTDIR)/Makefile.common
 
 $(shell [ ! -f ${TESTDIR} ] &&  mkdir -p ${TESTDIR}/ )
 
-export CURRDIR?=$(shell pwd)
-export TESTCASE=$(patsubst %.test,%,$(shell basename $(CURRDIR)))
+export CURRDIR:=$(shell pwd)
+export TESTCASE:=$(patsubst %.test,%,$(shell basename $(CURRDIR)))
+
 #comdb2 does not allow db names with '_' underscore in them
 export DBNAME=$(subst _,,$(TESTCASE))$(TESTID)
 export DBDIR=$(TESTDIR)/$(DBNAME)

--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -106,3 +106,19 @@ retry_in_loop()
 
     return 1
 }
+
+wait_for_db()
+{
+    local -r dbname=$1
+    hosts=""
+    while [[ -z "$hosts" ]]; do
+        hosts=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} $dbname default "select host from comdb2_cluster")
+    done
+    for host in $hosts; do
+        check=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} --host $host $dbname "select comdb2_host()")
+        if [[ "$check" != "$host" ]]; then
+            return 1
+        fi
+    done
+    return 0
+}


### PR DESCRIPTION
Nodes used to start with INCOHERENT_WAIT which would make the first transaction block until it switched to INCOHERENT.