### PR TITLE
Fix serializable tunable bookkeeping

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -42,6 +42,7 @@
 #include "macc_glue.h"
 #include "disttxn.h"
 
+extern int gbl_serializable;
 extern int gbl_import_mode;
 extern char *gbl_import_src;
 extern char *gbl_import_table;
@@ -1384,6 +1385,7 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         gbl_snapisol = 1;
         gbl_selectv_rangechk = 1;
+        gbl_serializable = 1;
     } else if (tokcmp(tok, ltok, "mallocregions") == 0) {
         if ((strcmp(COMDB2_VERSION, "2") == 0) ||
             (strcmp(COMDB2_VERSION, "old") == 0)) {

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -510,7 +510,7 @@ REGISTER_TUNABLE("enable_snapshot_isolation",
 REGISTER_TUNABLE("enable_serial_isolation",
                  "Enable to allow SERIALIZABLE level transactions to run against "
                  "the database. (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_serializable, READONLY, NULL, NULL, NULL,
+                 TUNABLE_BOOLEAN, &gbl_serializable, NOARG | READONLY, NULL, NULL, NULL,
                  NULL);
 REGISTER_TUNABLE("set_snapshot_impl",
                  "Changes the default snapshot implementation "


### PR DESCRIPTION
Incorrect tunable value was showing up in `comdb2_tunables`. Fix is to update the bookkeeping variable when the tunable is processed.