### PR TITLE
RDSICOMDB2-495: Fix double-free on downgrade

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1367,14 +1367,15 @@ int bplog_schemachange_wait(struct ireq *iq, int rc)
                             freedb(sc->newdb);
                         }
                         sc->newdb = NULL;
-                        sc_set_running(iq, sc, sc->tablename, 0, gbl_myhostname,
-                                       time(NULL), __func__, __LINE__);
-                        free_schema_change_type(sc);
                 }
-            } else if (rc == ERR_NOMASTER) {
-                /* this can happen if a table was caught by downgrade during
-                 * do_ddl; code will clean sc->newdb, but does not mess with
-                 * sc_set_running
+            }
+            if (rc == ERR_NOMASTER) {
+                /*
+                 * This can happen if
+                 * 1. a table is caught by downgrade during do_ddl
+                 *      (in which case newdb will have been cleaned in do_schema_change_tran_int())
+                 * 2. a table finished do_ddl and another got caught by a downgrade
+                 *      (in which case newdb was freed in the block above)
                  */
                 sc_set_running(iq, sc, sc->tablename, 0, gbl_myhostname,
                                time(NULL), __func__, __LINE__);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1362,8 +1362,10 @@ int bplog_schemachange_wait(struct ireq *iq, int rc)
                 }
                 if (rc == ERR_NOMASTER) {
                         sc_set_downgrading(sc);
-                        bdb_close_only(sc->newdb->handle, &bdberr);
-                        freedb(sc->newdb);
+                        if (!sc->newdb_borrowed) {
+                            bdb_close_only(sc->newdb->handle, &bdberr);
+                            freedb(sc->newdb);
+                        }
                         sc->newdb = NULL;
                         sc_set_running(iq, sc, sc->tablename, 0, gbl_myhostname,
                                        time(NULL), __func__, __LINE__);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6304,6 +6304,7 @@ static int start_schema_change_tran_wrapper_merge(const char *tblname,
 
     struct schema_change_type *alter_sc = clone_schemachange_type(sc);
 
+    alter_sc->newdb_borrowed = 1; 
     /* new target */
     strncpy0(alter_sc->tablename, tblname, sizeof(sc->tablename));
     /*alter_sc->usedbtablevers = sc->partition.u.mergetable.version;*/
@@ -6356,6 +6357,8 @@ static int _process_single_table_sc_merge(struct ireq *iq)
      * if this is an alter .. merge, we still prefer to sequence alters
      * to limit the amount of parallelism in flight
      */
+
+    sc->newdb_borrowed = 0;
     sc->nothrevent = 1;
     sc->finalize = 0; /* make sure */
     if (sc->kind == SC_ALTERTABLE) {
@@ -6410,6 +6413,8 @@ static int _process_partitioned_table_merge(struct ireq *iq)
 
     /* we need to move data */
     sc->force_rebuild = 1;
+
+    sc->newdb_borrowed = 0;
 
     if (!first_shard->sqlaliasname) {
         /*

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -709,8 +709,10 @@ downgraded:
 
             /* return NOMASTER for live schemachange writes */
             sc_set_downgrading(s);
-            bdb_close_only(s->newdb->handle, &bdberr);
-            freedb(s->newdb);
+            if (!s->newdb_borrowed) {
+                bdb_close_only(s->newdb->handle, &bdberr);
+                freedb(s->newdb);
+            }
             s->newdb = NULL;
 
             if (!trans)

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -268,6 +268,11 @@ struct schema_change_type {
 
     struct dbtable *db;
     struct dbtable *newdb;
+
+    // if we are borrowing newdb, then someone else is responsible for freeing it.
+    // This information is useful for avoiding double-frees in schema changes
+    // over partitioned tables where newdb is shared between shards.
+    short newdb_borrowed;
     struct timepart_view *newpartition;
     struct scplan plan; /**** TODO This is an abomination, i know. Yet still
                            much better than on the stack where I found it.

--- a/tests/TODO
+++ b/tests/TODO
@@ -81,6 +81,5 @@ rowlocks_blkseq.test
 sc_async_constraints.test
 sigstopcluster.test
 weighted_standing_queue.test -- failing in rhel8 + podman
-sc_resume_partition.test
 
 # vim: set sw=4 ts=4 et:

--- a/tests/sc_resume_partition.test/runit
+++ b/tests/sc_resume_partition.test/runit
@@ -8,20 +8,21 @@ set -ex
 [ -z "${CLUSTER}" ] && { echo "Test requires a cluster"; exit 0; }
 
 dbnm=$1
+tier="default"
 
 test_partition_merge_resume() {
 	# Given
 	local starttime
 	starttime=$(get_timestamp 120)
 	local master
-	master=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'SELECT host FROM comdb2_cluster WHERE is_master="Y"'`
+	master=$(get_master)
 
-	cdb2sql $dbnm --host $master "EXEC PROCEDURE sys.cmd.send('convert_record_sleep 1')"
-	cdb2sql ${CDB2_OPTIONS} ${dbnm} default "create table t(a int) partitioned by time period 'daily' retention 2 start '${starttime}'"
-	cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t values (1)"
+	cdb2sql $dbnm --host ${master} "EXEC PROCEDURE sys.cmd.send('convert_record_sleep 1')"
+	cdb2sql ${CDB2_OPTIONS} ${dbnm} ${tier} "create table t(a int) partitioned by time period 'daily' retention 2 start '${starttime}'"
+	cdb2sql ${CDB2_OPTIONS} ${dbnm} ${tier} "insert into t values (1)"
 
 	# When
-	cdb2sql ${CDB2_OPTIONS} ${dbnm} default "alter table t partitioned by none" &
+	cdb2sql ${CDB2_OPTIONS} ${dbnm} ${tier} "alter table t partitioned by none" &
 	waitpid=$!
 	sleep 1
 	downgrade_master
@@ -34,7 +35,7 @@ test_partition_merge_resume() {
 	fi
 
 	local timepart
-	timepart=$(cdb2sql --tabs ${CDB2_OPTIONS} ${dbnm} default "select * from comdb2_timepartitions where name='t'")
+	timepart=$(cdb2sql --tabs ${CDB2_OPTIONS} ${dbnm} ${tier} "select * from comdb2_timepartitions where name='t'")
 	if [[ -z ${timepart} ]];
 	then
 		echo "FAIL: Could not find expected time partition"
@@ -42,7 +43,7 @@ test_partition_merge_resume() {
 	fi
 
 	# Cleanup
-	cdb2sql ${CDB2_OPTIONS} ${dbnm} default "drop table t"
+	cdb2sql ${CDB2_OPTIONS} ${dbnm} ${tier} "drop table t"
 }
 
 test_partition_merge_resume

--- a/tests/sc_resume_partition.test/runit
+++ b/tests/sc_resume_partition.test/runit
@@ -9,18 +9,6 @@ set -ex
 
 dbnm=$1
 
-restart_cluster() {
-	set +e
-	for node in ${CLUSTER} ; do
-		kill_restart_node ${node} &
-	done
-	set -e
-
-	sleep 2
-
-	wait_for_cluster
-}
-
 test_partition_merge_resume() {
 	# Given
 	local starttime
@@ -33,10 +21,10 @@ test_partition_merge_resume() {
 	cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t values (1)"
 
 	# When
-	COMDB2_CONFIG_MIN_RETRIES=1 cdb2sql ${CDB2_OPTIONS} ${dbnm} default "alter table t partitioned by none" &
+	cdb2sql ${CDB2_OPTIONS} ${dbnm} default "alter table t partitioned by none" &
 	waitpid=$!
 	sleep 1
-	restart_cluster &> /dev/null
+	downgrade_master
 
 	# Then
 	if wait ${waitpid};

--- a/tests/tools/waitmach.sh
+++ b/tests/tools/waitmach.sh
@@ -24,8 +24,7 @@ function waitmach
         cfg=""
     fi
 
-    while [[ "$out" != "1" ]]; do
-        out=$($CDB2SQL_EXE $cfg --tabs $dbname $mach 'select 1' 2> /dev/null)
+    while ! $CDB2SQL_EXE $cfg --tabs $dbname $mach 'select 1' &> /dev/null; do
         sleep 1
     done
 }


### PR DESCRIPTION
If a downgrade runs while a merge of a partitioned table is happening, then the scs for multiple shards will try to free the `newdb` that is shared between the shards. The changes in this PR explicitly assign ownership of `newdb` to one sc so that only that sc frees `newdb` during a downgrade.