### PR TITLE
fix crash during group by sorting involving datetimes and strings

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -5145,6 +5145,9 @@ int sqlite3VdbeRecordCompareWithSkip(
 
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   memset(&mem1, 0, sizeof(Mem));
+  /* pass tzname to Mem1 as well, in case it is a datetime that needs conversion */
+  mem1.tz = pRhs->tz;
+  mem1.enc = pPKey2->pKeyInfo->enc;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   /* If bSkip is true, then the caller has already determined that the first
   ** two elements in the keys are equal. Fix the various stack variables so

--- a/sqlite/src/vdbemem.c
+++ b/sqlite/src/vdbemem.c
@@ -482,8 +482,9 @@ int sqlite3VdbeMemStringify(Mem *pMem, u8 enc, u8 bForce){
 
     if( convMem2ClientDatetimeStr(pMem, tmp, sizeof(tmp), &outdtsz) ){ 
       char *z;
-      sqlite3ErrorWithMsg(pMem->db, SQLITE_CONV_ERROR,
-            "can't convert datetime value to string");
+      if (pMem->db)
+          sqlite3ErrorWithMsg(pMem->db, SQLITE_CONV_ERROR,
+                              "can't convert datetime value to string");
       pMem->n = strlen("conv_error");
       z = sqlite3GlobalConfig.m.xMalloc(pMem->n+2);
       if( !z ) return SQLITE_NOMEM;

--- a/sqlite/src/vdbesort.c
+++ b/sqlite/src/vdbesort.c
@@ -785,6 +785,12 @@ static int vdbeSorterCompareTail(
     sqlite3VdbeRecordUnpack(pTask->pSorter->pKeyInfo, nKey2, pKey2, r2);
     *pbKey2Cached = 1;
   }
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  /* pass tzname, just in case one of the keys turn out a datetime */
+  if (pTask->pSorter->db && pTask->pSorter->db->pVdbe) {
+    r2->aMem->tz = pTask->pSorter->db->pVdbe->tzname;
+  }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   return sqlite3VdbeRecordCompareWithSkip(nKey1, pKey1, r2, 1);
 }
 
@@ -812,6 +818,12 @@ static int vdbeSorterCompare(
     sqlite3VdbeRecordUnpack(pTask->pSorter->pKeyInfo, nKey2, pKey2, r2);
     *pbKey2Cached = 1;
   }
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  /* pass tzname, just in case one of the keys turn out a datetime */
+  if (pTask->pSorter->db && pTask->pSorter->db->pVdbe) {
+    r2->aMem->tz = pTask->pSorter->db->pVdbe->tzname;
+  }
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
   return sqlite3VdbeRecordCompare(nKey1, pKey1, r2);
 }
 

--- a/tests/datetime.test/t24.expected
+++ b/tests/datetime.test/t24.expected
@@ -1,0 +1,4 @@
+(rows inserted=1)
+(rows inserted=1)
+(mixes='2020 and change')
+(mixes='2025-10-01T000000.000 US/Eastern')

--- a/tests/datetime.test/t24.sql
+++ b/tests/datetime.test/t24.sql
@@ -1,0 +1,6 @@
+set timezone US/Eastern
+create table t(d datetime)$$
+insert into t (d) values (cast("2007-10-01T" as datetime))
+insert into t (d) values (cast("2025-10-01T" as datetime))
+select case when d <= '2020-10-01T' then "2020 and change" else d end as mixes from t group by mixes
+drop table t


### PR DESCRIPTION
We need to pass the proper timezone  to Mem objects that are processed by the sorter engine.

It is possible for a query to pass values that require a datetime conversion to string, which in turn requires a timezone.

Example:
select case when d <= '2020-10-01T' then "2020 and change" else d end as mixes from t group by mixes

re: 180106112
