### PR TITLE
Re-enable non-jvm linearizable tests

### DIFF
--- a/tests/TODO
+++ b/tests/TODO
@@ -59,7 +59,6 @@ sc_resume
 
 DISABLED TESTS:
 async_sc_bench.test       -- benchmark for paper
-cinsert_linearizable.test
 halt_processor_tds.test   -- requires a cluster
 jepsen_a6.test            -- jepsen tests require java & root access
 jepsen_a6_nemesis.test
@@ -75,7 +74,6 @@ jepsen_sets.test
 killcluster.test
 netloss.test              -- does not pass most of the time; requires kernel 4.x & docker 17.x
 overflowblobs.test        -- timesout
-register_linearizable.test
 repeated_downgrades.test  -- we get lost writes from the downgrades
 incremental_backup_load.test -- times out on rr- we have other tests
 rootpagememleak.test


### PR DESCRIPTION
Re-enable linearizable tests that do not require clojure