### PR TITLE
 180210883: Fix crash on tpt sc resume

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1029,6 +1029,7 @@ static int verify_sc_resumed_for_all_shards(void *obj, void *arg)
     sc_arg.s = tpt_sc->s;
     sc_arg.check_extra_shard = 1;
     sc_arg.lockless = 1;
+    sc_arg.part_name = tpt_sc->viewname;
     timepart_foreach_shard(verify_sc_resumed_for_shard, &sc_arg);
     tpt_sc->s = sc_arg.s;
     return 0;


### PR DESCRIPTION
`sc_arg.part_name` isn't populated [here](https://github.com/bloomberg/comdb2/blob/a95959e1b24748b450fa691cab384317d16b2b16/schemachange/sc_logic.c#L1028)

and then is passed into `_get_view` here: https://github.com/bloomberg/comdb2/blob/a95959e1b24748b450fa691cab384317d16b2b16/db/views.c#L2484

Crash is happening when strcmp happens on this null pointer.

The changes in this PR populate `sc_arg.part_name`.

This might fix crashes in the `sc_timepart` test