### PR TITLE
Removing unused structure & fixing leak

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1023,7 +1023,6 @@ struct thread_info {
     void *ct_add_table;
     void *ct_del_table;
     void *ct_add_index;
-    void *stmt_cache;
     hash_t *ct_add_table_genid_hash; // for quick lookups
     pool_t *ct_add_table_genid_pool; // provides memory for the above hash
 };

--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -556,13 +556,6 @@ void *thd_req(void *vthd)
         thdinfo->ct_add_table_genid_pool =
             pool_setalloc_init(sizeof(unsigned long long), 0, malloc, free);
 
-        /* Initialize the sql statement cache */
-        thdinfo->stmt_cache = stmt_cache_new(NULL);
-        if (thdinfo->stmt_cache == NULL) {
-            logmsg(LOGMSG_ERROR, "%s:%d failed to create sql statement cache\n",
-                    __func__, __LINE__);
-        }
-
         Pthread_setspecific(thd_info_key, thdinfo);
         thd->inited = 1;
     }


### PR DESCRIPTION
The thread_info.stmt_cache structure is neither used nor freed on thread exit. This patch removes it.