### PR TITLE
Fix clang build warning

### DIFF
--- a/sqlite/src/comdb2lua.c
+++ b/sqlite/src/comdb2lua.c
@@ -24,7 +24,7 @@ int bdb_get_sp_get_default_version(const char *, int *);
 extern int gbl_create_default_consumer_atomically;
 extern int gbl_sc_protobuf;
 
-#define MAX_SPNAME_FOR_TRIGGER MAX_SPNAME-strlen(Q_TAG) // includes null terminator
+#define MAX_SPNAME_FOR_TRIGGER (MAX_SPNAME-(sizeof(Q_TAG)-1)) // includes null terminator
 #define COMDB2_DEFAULT_CONSUMER 2
 
 static int comdb2LocateSP(Parse *p, char *sp)


### PR DESCRIPTION
```
comdb2/sqlite/src/comdb2lua.c:172:17: error: variable length array folded to constant array as an extension [-Werror,-Wgnu-folding-constant]
  172 |     char spname[MAX_SPNAME_FOR_TRIGGER];
      |                 ^~~~~~~~~~~~~~~~~~~~~~
comdb2/sqlite/src/comdb2lua.c:27:43: note: expanded from macro 'MAX_SPNAME_FOR_TRIGGER'
   27 | #define MAX_SPNAME_FOR_TRIGGER MAX_SPNAME-strlen(Q_TAG) // includes null terminator
```

The changes in this PR fix this warning by using `sizeof` instead of `strlen`. This fixes the error because `sizeof` is evaluated at compile time.