### PR TITLE
Fix bug with upserts+fk constraints

### DIFF
--- a/tests/upsert.test/t00_upsert.expected
+++ b/tests/upsert.test/t00_upsert.expected
@@ -238,4 +238,4 @@ keys
 (i=1, j=1)
 (i=2, j=1)
 ('---- uncommittable + constraints ----'='---- uncommittable + constraints ----')
-[COMMIT] failed with rc 2 Transaction is uncommittable: Duplicate insert on key 'KEY' in table 'c' index 0
+[COMMIT] failed with rc 299 add key constraint duplicate key 'KEY' on table 'c' index 0

--- a/tests/upsert.test/t05.expected
+++ b/tests/upsert.test/t05.expected
@@ -1,0 +1,7 @@
+(rows inserted=1)
+[insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be dup error] failed with rc 299 add key constraint duplicate key 'A_K' on table 'a' index 1
+(rows inserted=1)
+[insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be either fk error or dup error] failed with rc 299 add key constraint duplicate key 'A_K' on table 'a' index 1
+[insert into a(i, j, k) values(2, 1, 0) ON CONFLICT (i, j) do update set k = 1 -- should be fk error] failed with rc 3 Transaction violates foreign key constraint a(i, j) -> b(i): key value does not exist in parent table
+(rows inserted=1)
+[insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be dup error] failed with rc 299 add key constraint duplicate key 'A_K' on table 'a' index 1

--- a/tests/upsert.test/t05.sql
+++ b/tests/upsert.test/t05.sql
@@ -1,0 +1,22 @@
+drop table if exists a
+drop table if exists b
+
+create table a(i int, j int, k int)$$
+create unique index a_ij on a(i, j)
+create unique index a_k on a(k)
+
+insert into a(i, j, k) values(1, 1, 1)
+insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be dup error
+
+create table b(i int)$$
+create unique index b_i on b(i)
+insert into b values(1)
+
+alter table a add foreign key (i) references b(i)$$
+insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be either fk error or dup error
+insert into a(i, j, k) values(2, 1, 0) ON CONFLICT (i, j) do update set k = 1 -- should be fk error
+
+insert into b values(2)
+insert into a(i, j, k) values(2, 1, 1) ON CONFLICT (i, j) do update set k = 1 -- should be dup error
+
+SELECT 1 FROM comdb2_metrics m, comdb2_tunables t WHERE m.name LIKE 'verify_replays' AND t.name='osql_verify_retry_max' AND m.value >= CAST(t.value AS int)

--- a/tests/upsert.test/t06.expected
+++ b/tests/upsert.test/t06.expected
@@ -1,0 +1,13 @@
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+done
+done
+(rows inserted=1)
+done
+done
+done

--- a/tests/upsert.test/t06.trans
+++ b/tests/upsert.test/t06.trans
@@ -1,0 +1,11 @@
+1 drop table if exists a
+1 drop table if exists b
+1 create table a(i int unique)
+1 create table b(i int unique, j int unique, constraint fk foreign key (i) references a(i))
+1 insert into a values(1)
+1 set transaction read committed isolation
+1 begin
+1 replace into b values(1, 1)
+2 insert into b values(1, 0)
+1 commit
+1 select 1 FROM comdb2_metrics m, comdb2_tunables t WHERE m.name LIKE 'verify_replays' AND t.name='osql_verify_retry_max' AND m.value >= cast(t.value AS int)


### PR DESCRIPTION
If an upsert-insert gets a duplicate key violation, then it should only retry if the colliding key is the one specified in the upsert 'on conflict' clause. We do not check this and instead blindly retry any inserts with collisions when we're doing a delayed key add, which is what happens if there is a foreign key. The changes in this PR have the db only retry if the colliding key is the one from the 'on conflict' clause.