### PR TITLE
Broadcast newmaster from watcher-thread

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -68,6 +68,7 @@ int gbl_prefault_latency = 0;
 int gbl_long_log_truncation_warn_thresh_sec = INT_MAX;
 int gbl_long_log_truncation_abort_thresh_sec = INT_MAX;
 int gbl_debug_drop_nth_rep_message = 0;
+int gbl_broadcast_newmaster = 1;
 extern int gbl_debug_stat4dump_loop;
 
 extern struct thdpool *gbl_udppfault_thdpool;
@@ -4837,6 +4838,10 @@ void berkdb_receive_msg(void *ack_handle, void *usr_ptr, char *from_host,
         }
 
         bdb_state->dbenv->rep_flush(bdb_state->dbenv);
+
+        if (gbl_broadcast_newmaster) {
+            bdb_state->dbenv->rep_newmaster(bdb_state->dbenv);
+        }
 
         logmsg(LOGMSG_INFO, "USER_TYPE_LSNCMP %d %d    %d %d host:%s\n", lsn_cmp.lsn.file,
                 cur_lsn.file, lsn_cmp.lsn.offset, cur_lsn.offset, from_host);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2592,6 +2592,7 @@ struct __db_env {
 	void *rep_handle;		/* Replication handle and methods. */
 	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, int *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
+	int  (*rep_newmaster) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
 		char **, DB_LSN *, uint32_t *, uint32_t *, char **, int));
 	int  (*rep_verify_will_recover) __P((DB_ENV *, DBT *, DBT *));

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -345,6 +345,7 @@ extern int gbl_ufid_dbreg_test;
 extern int gbl_debug_add_replication_latency;
 extern int gbl_javasp_early_release;
 extern int gbl_debug_drop_nth_rep_message;
+extern int gbl_broadcast_newmaster;
 extern int gbl_fdb_emulate_old;
 
 extern long long sampling_threshold;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1498,6 +1498,10 @@ REGISTER_TUNABLE("debug_drop_nth_rep_message", "Drop the Nth replication message
                  "for testing purposes (Default: 0)", TUNABLE_INTEGER,
                  &gbl_debug_drop_nth_rep_message, EXPERIMENTAL | INTERNAL, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("broadcast_newmaster",
+                 "Broadcast new-master periodically.  "
+                 "(Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_broadcast_newmaster, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE(
     "max_clientstats",
     "Max number of client stats stored in comdb2_clientstats. (Default: 10000)",


### PR DESCRIPTION
Fixes a case where incoherent physical replicants request log-records on a lower generation than the current master's generation.
