### PR TITLE
Fix memory leak in sys-table overrides

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -1803,6 +1803,11 @@ static char *load_src(char *spname, struct spversion_t *spversion,
             return src;
         }
 
+        if (*err) {
+            free(*err);
+            *err = NULL;
+        }
+
         size = strlen(sys_src) + 1;
         if (bootstrap) {
             char *bsrc = malloc(size + sizeof(bootstrap_src));

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1722,6 +1722,22 @@ if [[ "$NOSOURCE" == "1" ]]; then
     restart_source_nodes
 fi
 
+# Enable memstats on the metadb
+$CDB2SQL_EXE $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "exec procedure sys.cmd.send(\"memstat debug on util\")"
+$CDB2SQL_EXE $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "exec procedure sys.cmd.send(\"memstat debug start\")"
+
+function check_metadb_memstat
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "exec procedure sys.cmd.send(\"memstat debug stop\")"
+    leaks=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "exec procedure sys.cmd.send(\"memstat debug dump util\")" | sort | uniq -c | sort -nr | head -1)
+    # Before the leak was fixed, the first was more than 1700 ..
+    cnt=$(echo $leaks | awk '{print $1}')
+    if [[ $cnt -gt 100 ]]; then
+        echo "Metadb memory leaks detected: $leaks"
+        failexit "Metadb memory leaks detected: $leaks"
+    fi
+}
+
 function announce
 {
     typeset text=$1
@@ -1837,8 +1853,13 @@ function run_tests
     testcase_finish $testcase
 
     testcase="multimeta"
-    testcase_preamble $multimeta
+    testcase_preamble $testcase
     multimetadb
+    testcase_finish $testcase
+
+    testcase="check_metadb_memstat"
+    testcase_preamble $testcase
+    check_metadb_memstat
     testcase_finish $testcase
 }
 


### PR DESCRIPTION
Fixes this leak:

strbuf_new at strbuf.c:46 (discriminator 1)
no_such_procedure at sp.c:1710
load_user_src at sp.c:1765 (discriminator 1)
load_src at sp.c:1801 (discriminator 1)
setup_sp_int at sp.c:6358
exec_procedure_int at sp.c:7226 (discriminator 1)
reset_clnt_after_sp at sp.c:4021
handle_stored_proc at sqlinterfaces.c:4055
sqlengine_work_appsock_pp at sqlinterfaces.c:4813
