### PR TITLE
Fix file descriptor leak in offload net

### DIFF
--- a/net/net.c
+++ b/net/net.c
@@ -2702,6 +2702,7 @@ int do_appsock(netinfo_type *netinfo_ptr, struct sockaddr_in *cliaddr,
         rtn(netinfo_ptr, sb);
         return 0;
     }
+    sbuf2close(sb);
     return -1;
 }
 


### PR DESCRIPTION
Exhausted appsock connections, total 17 connections denied-connection count=852
Exhausted appsock connections, total 27 connections denied-connection count=949
accept_error_cb err:24 [Too many open files] [outstanding fds:1] [appsock fds:0]
Aborted (core dumped)