### PR TITLE
Fix test flakiness from downgrade timing

### DIFF
--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -33,49 +33,6 @@ function insert_records
     assertres $? 0
 }
 
-function wait_till_ready
-{
-    node=$1
-    out=0
-    # wait until we can query it
-    echo "$DBNAME: waiting until ready"
-    while [[ "$out" != "1" ]]; do
-        sleep 2
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-    done
-}
-
-kill_restart_cluster()
-{
-    delay=$1
-    for node in $cluster ; do
-        echo "killrestart nodes $node"
-        kill_restart_node $node $delay &
-    done
-    sleep $delay
-    # select 1 all nodes
-    for node in $cluster ; do
-        out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-        # wait until we can query it
-        echo "$DBNAME: waiting until ready"
-        while [[ "$out" != "1" ]]; do
-            sleep 2
-            out=$(cdb2sql ${CDB2_OPTIONS} --tabs --host $node $DBNAME  'select 1' 2>/dev/null)
-        done
-    done
-}
-
-cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
-
-function flushall 
-{
-    for node in $cluster; do
-        cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "exec procedure sys.cmd.send('flush')"
-    done
-}
-
-
-
 PRFIX=my_table_name_
 master=`cdb2sql -tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep MASTER | cut -f1 -d":" | tr -d '[:space:]'`
 

--- a/tests/sc_lotsoftables.test/runit
+++ b/tests/sc_lotsoftables.test/runit
@@ -129,11 +129,10 @@ test_create_tbls() {
 test_create_tbls
 
 if [[ -n "$CLUSTER" ]] ; then
-    cdb2sql ${CDB2_OPTIONS} $dbnm --host $master 'exec procedure sys.cmd.send("downgrade")'
-    for node in "$CLUSTER" ; do
-        wait_till_ready $node
-    done
+    if ! downgrade_master; then
+        echo "Failed to downgrade master"
+        exit 1
+    fi
 fi
-
 
 echo "Success"

--- a/tests/sc_truncate.test/runit
+++ b/tests/sc_truncate.test/runit
@@ -128,9 +128,7 @@ function run_test
         sleep $downgrade_sleep
         if [[ $downgrade != 0 ]]; then
             if [[ $dgcount == 0 || $downgrades -lt $dgcount ]]; then
-                for node in $CLUSTER ; do
-                    $CDB2SQL_EXE -tabs $CDB2_OPTIONS --host $node $DBNAME "EXEC PROCEDURE sys.cmd.send('downgrade')"
-                done
+                downgrade_master
                 let downgrades=downgrades+1
             fi
         fi
@@ -141,26 +139,6 @@ function run_test
     # OKAY .. add a sleep here ..
     echo "Sleeping for 10 in case schema-change resumes"
     sleep 10
-
-    upcnt=0
-    r=1
-    maxu=30
-
-    # The master could have just downgraded - make sure we can select against every node
-    while [[ "$r" == 1 && "$upcnt" -lt $maxu ]]; do
-        r=0
-        for node in $CLUSTER ; do
-            $CDB2SQL_EXE --admin -tabs $CDB2_OPTIONS --host $node $DBNAME "select 1" > /dev/null 2>&1
-            if [[ "$?" != "0" ]] ; then
-                echo "Error selecing against $node"
-            fi
-        done
-        let upcnt=upcnt+1
-        [[ "$r" == "1" ]] && sleep 1
-    done
-    if [[ $upcnt -ge "$maxu" ]]; then
-        echo "Failed to access all nodes after $maxu second"
-    fi
 
     # Re-enable checkpoints
     for node in $CLUSTER ; do


### PR DESCRIPTION
sc_lotsoftables and sc_truncate are frequently failing because they don't wait for all downgrades to complete before exiting, and therefore the test infrastructure can't reach the db at finish.

The changes in this PR aim to provide a downgrade function that waits until election completes and verifies that all nodes are coherent and reachable before returning.