### PR TITLE
Add continue on verify error mode for chunk stmts

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1010,6 +1010,8 @@ struct sqlclntstate {
     unsigned return_long_column_names : 1; // if 0 then tunable decides
     unsigned in_local_cache : 1;
     unsigned evicted_appsock : 1;
+    unsigned set_continue_on_chunk_verify_error : 1; // set stmt enabled
+    unsigned continued_on_chunk_verify_error : 1;    // did we continue on verify error?
 
     unsigned num_adjusted_column_name_length; // does not consider fastsql
     char **adjusted_column_names;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8886,6 +8886,7 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
 
         sql_set_sqlengine_state(clnt, __FILE__, __LINE__, SQLENG_FNSH_STATE);
         rc = handle_sql_commitrollback(clnt->thd, clnt, TRANS_CLNTCOMM_CHUNK);
+        int continued_on_chunk_verify_error = (clnt->set_continue_on_chunk_verify_error && rc == CDB2ERR_VERIFY_ERROR);
         if (rc) {
             comdb2_sqlite3VdbeError(pCur->vdbe,
                                     errstat_get_str(&clnt->osql.xerr));
@@ -8894,6 +8895,12 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
             /* we need to recreate the transaction in any case
                goto done;
              */
+            if (continued_on_chunk_verify_error) {
+                logmsg(LOGMSG_ERROR, "Continuing on verify error for sql %.*s\n", 100, clnt->sql);
+                rc = SQLITE_OK;
+                commit_rc = SQLITE_OK;
+                clnt->continued_on_chunk_verify_error = 1;
+            }
         }
 
         // clnt takes priority for throttle time

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2220,6 +2220,14 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
                 } else {
                     clnt->multiline = 1;
                 }
+            } else if (strncasecmp(sqlstr, "continue_on_verify_error", 24) == 0) {
+                sqlstr += 24;
+                sqlstr = skipws(sqlstr);
+                if (strncasecmp(sqlstr, "off", 3) == 0) {
+                    clnt->set_continue_on_chunk_verify_error = 0;
+                } else {
+                    clnt->set_continue_on_chunk_verify_error = 1;
+                }
             } else {
                 rc = ii + 1;
             }
@@ -2398,6 +2406,7 @@ newsql_loop_result newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_quer
         bzero(&clnt->log_effects, sizeof(clnt->log_effects));
         bzero(&clnt->chunk_effects, sizeof(clnt->chunk_effects));
         clnt->had_errors = 0;
+        clnt->continued_on_chunk_verify_error = 0;
         clnt->ctrl_sqlengine = SQLENG_NORMAL_PROCESS;
     }
     if (clnt->dbtran.mode < TRANLEVEL_SOSQL) {


### PR DESCRIPTION
Add mode via set stmt where a chunk transaction continues to run even if a verify error is encountered in some chunk. Return the verify error at commit.

Made continued on verify error variable because clnt->had_errors variable would rollback last chunk even if that chunk specifically didn't have any errors