### PR TITLE
Increase selectv_rcode test timeout

### DIFF
--- a/tests/selectv_rcode.test/Makefile
+++ b/tests/selectv_rcode.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=5m
+	export TEST_TIMEOUT=7m
 endif


### PR DESCRIPTION
/skipbuild

This test is guaranteed to take at least 4 minutes because of `sleep` statements. After sleeping, this test waits for threads to finish executing their most recent query. This is typically fast, but snapshot PIT updates can take ~20 seconds to complete. Since snapshot PIT writers are waited-on multiple times in the test, it can put the test over the time limit of 5 minutes.

The short term fix is to raise the test timeout. The long term fix is to use modsnap for this test (which requires a few logical changes to the test) and then hopefully lower the timeout again.