### PR TITLE
fix(build): avoid redefining typedefs

### DIFF
--- a/db/comdb2uuid.c
+++ b/db/comdb2uuid.c
@@ -14,7 +14,7 @@
    limitations under the License.
  */
 
-#include <uuid/uuid.h>
+#include "comdb2uuid.h"
 
 void comdb2uuid(uuid_t u) { uuid_generate(u); }
 

--- a/db/comdb2uuid.h
+++ b/db/comdb2uuid.h
@@ -17,7 +17,8 @@
 #ifndef INCLUDED_COMDB2_UUID_H
 #define INCLUDED_COMDB2_UUID_H
 
-typedef unsigned char uuid_t[16];
+#include <uuid/uuid.h>
+
 typedef char uuidstr_t[37];
 
 void comdb2uuid(uuid_t u);

--- a/schemachange/sc_util.c
+++ b/schemachange/sc_util.c
@@ -225,7 +225,7 @@ static int seed_qsort_cmpfunc(const void *key1, const void *key2)
 }
 
 // keep only last N sc history entries
-int trim_sc_history_entries(tran_type *tran, const char *tablename)
+int trim_sc_history_entries(struct tran_tag *tran, const char *tablename)
 {
     int rc = 0, bdberr, nkeys;
     sc_hist_row *hist = NULL;

--- a/schemachange/sc_util.h
+++ b/schemachange/sc_util.h
@@ -21,7 +21,6 @@
 
 struct dbtable;
 struct tran_tag;
-typedef struct tran_tag tran_type;
 
 int close_all_dbs(void);
 int open_all_dbs(void);
@@ -54,6 +53,6 @@ int sc_via_ddl_only();
 void set_schema_change_in_progress(const char *func, int line, int val);
 
 int get_schema_change_in_progress(const char *func, int line);
-int trim_sc_history_entries(tran_type *tran, const char *tablename);
+int trim_sc_history_entries(struct tran_tag *tran, const char *tablename);
 
 #endif


### PR DESCRIPTION
@morgando found that 8f5cdab prevents clang from compiling the project because `tran_type` is redefined (interestingly, gcc did not complain about this). Avoid redefining typedefs by including the necessary headers and do the same for `uuid_t`.
