### PR TITLE
Fix flakiness in queuedb_rollover test

### DIFF
--- a/tests/queuedb_rollover.test/qdb_cons.sh
+++ b/tests/queuedb_rollover.test/qdb_cons.sh
@@ -14,6 +14,7 @@ else
 fi
 
 rm -f $logfile $logfile.rerun
+touch $logfile
 
 for ((i = $from; i < $to; ++i)); do
     echo "exec procedure $sp()"


### PR DESCRIPTION
The queuedb_rollover test is sometimes failing because `cat: /tmp/queuedb_rollover.nop2: No such file or directory` is showing up in the output, and that line is not in the expected output.

This line is showing up because none of [these schema changes](https://github.com/bloomberg/comdb2/blob/7b1c4524ca6382a1e43bf357fff1c851f14251cb/tests/queuedb_rollover.test/qdb_cons.sh#L19) fail, and therefore there is no stderr to redirect to the file.

The changes in this PR fix the flakiness by creating the file before executing the schema change loop. If none of the schema changes fail, then the file will exist but have zero lines.