### PR TITLE
[fix test flakiness]: Allow parallel do_verify calls

### DIFF
--- a/tests/tools/runit_common.sh
+++ b/tests/tools/runit_common.sh
@@ -72,12 +72,13 @@ sendtocluster()
 
 do_verify()
 {
-    tbl=$1
-    $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.verify('$tbl', 'parallel')" &> verify_$tbl.out
+    local -r tbl=$1
+    local verify_output
+    verify_output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} default "exec procedure sys.cmd.verify('${tbl}', 'parallel')")
 
-    if ! grep succeeded verify_$tbl.out > /dev/null ; then
-        grep succeeded verify_$tbl.out | head -10
-        failexit "verify $tbl had errors"
+    if ! echo "${verify_output}" | grep -q "succeeded" ; then
+        echo "Verify output for ${tbl}: '${verify_output}'"
+        failexit "verify ${tbl} had errors"
     fi
 }
 


### PR DESCRIPTION
sc_repeated_updates failed recently because `do_verify` failed. Looking at the db logs, no verify actually failed, but the test ran verify on the same table 13 times in the minute that the failure happened. Calling the `do_verify` function in parallel like this isn't reliable because the `do_verify` function redirects verify results to a file and then checks the value written to the file: One process can open the file with truncation in between the time that another process writes to it and checks it. The changes in this PR fix this race condition by having `do_verify` operate on private data.