### PR TITLE
ci: check that project compiles with GCC and Clang

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,117 @@
+name: Build
+
+on:
+  # Run anytime a new commit is pushed to main.
+  push:
+    branches: [main]
+
+  # Run on every PR that is opened against main.
+  pull_request:
+    branches: [main]
+
+  # Run on a schedule (daily @ 6am Eastern time).
+  schedule:
+    - cron: "0 11 * * *"
+
+  # Enable manually triggering jobs.
+  workflow_dispatch:
+
+# If someone pushes a new commit to a branch, ensure that only the latest commit
+# is built to avoid wasting runner minutes. Treat "main" as an exception,
+# probably best to test all commits to it.
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+# We can have multiple jobs. Jobs run in parallel unless they explicitly declare
+# dependencies on other jobs.
+jobs:
+  build_ubuntu:
+    # This is the name of the check as it will appear on the PR.
+    name: Build [${{ matrix.os }}] [${{ matrix.compiler }}]
+
+    # TODO: When we want to make a job failure block a PR, we must set
+    # "continue-on-error" to "false" or omit it, *and* mark the check as
+    # required under branch protection rules.
+    continue-on-error: true
+
+    # Strategies can be used to run the same job with different configurations.
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        compiler: [gcc, clang]
+        include:
+          - compiler: gcc
+            cc: gcc
+            cxx: g++
+          - compiler: clang
+            cc: clang
+            cxx: clang++
+
+    # These environment variables will be set for every step in the job.
+    env:
+      # Tell CMake to configure the build system with the desired compilers for
+      # the current job configuration selected from the matrix.
+      CC: ${{ matrix.cc }}
+      CXX: ${{ matrix.cxx }}
+
+    # This specifies the "runner" to use for this job. Runners can be either
+    # GitHub-hosted or self-hosted. All repos in the `bloomberg` org that use
+    # Actions use GitHub-hosted runners. See the GitHub docs for how runner time
+    # is billed: https://docs.github.com/en/billing/concepts/product-billing/github-actions.
+    runs-on: ${{ matrix.os }}
+
+    defaults:
+      run:
+        # Make sure to fail any "run" step early on so that steps don't silently
+        # pass even when errors may have occurred.
+        shell: bash -o errexit -o nounset -o pipefail {0}
+
+    # Steps in a job are executed serially.
+    steps:
+      # "actions/checkout" is an official action supported by GitHub.
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # In addition to using official and community actions, we can run our own
+      # shell scripts. If the last executed process in a "run" step ends with a
+      # non-zero exit code, the step fails.
+      #
+      # Note: gcc and clang are pre-installed on Ubuntu runners. 
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y  \
+            bison                \
+            build-essential      \
+            cmake                \
+            flex                 \
+            libevent-dev         \
+            liblz4-dev           \
+            libprotobuf-c-dev    \
+            libreadline-dev      \
+            libsqlite3-dev       \
+            libssl-dev           \
+            libunwind-dev        \
+            ncurses-dev          \
+            protobuf-c-compiler  \
+            tcl                  \
+            uuid-dev             \
+            zlib1g-dev
+
+      - name: Generate build system
+        run: |
+          mkdir -p build
+          cd build
+
+          echo "Running CMake"
+          cmake ..
+
+      - name: Build [all]
+        working-directory: build
+        run: |
+          make -j $(nproc)
+
+      - name: Build [test-tools]
+        working-directory: build
+        run: |
+          make -j $(nproc) test-tools


### PR DESCRIPTION
/skipbuild

8f5cdab inadvertently broke Clang builds, which was subsequently fixed in 7b1c452. Some developers on the team use Clang as it provides better diagnostics than GCC. To avoid disrupting developers who use Clang, it would be good to proactively check that project changes compile with Clang. Ensure this by compiling the project with Clang in CI. For completeness, do the same for GCC.