### PR TITLE
{180375730}: Keeping track of tagapi comdb2_count call

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2869,6 +2869,7 @@ struct summary_nodestats *get_nodestats_summary(unsigned *nodes_cnt,
                 break;
 
             case OP_STORED:
+            case OP_COUNTTABLE:
             case OP_RNGEXT2:
             case OP_RNGEXTP2:
             case OP_RNGEXTTAG:


### PR DESCRIPTION
OP_COUNDTABLE isn't accounted for. This patch adds it.