### PR TITLE
{180349757} Add support for long columns in cdb2sql

### DIFF
--- a/tests/cdb2sql.test/runit
+++ b/tests/cdb2sql.test/runit
@@ -73,6 +73,11 @@ main() {
 
     pass_sql_via_file=0
     run_tests "${file_extension_for_test}" "${extra_cdb2sql_opts_for_test}" "${pass_sql_via_file}"
+
+    file_extension_for_test=".long-columns"
+    extra_cdb2sql_opts_for_test="-long-columns"
+    pass_sql_via_file=1
+    run_tests "${file_extension_for_test}" "${extra_cdb2sql_opts_for_test}" "${pass_sql_via_file}"
 }
 
 main

--- a/tests/cdb2sql.test/t23.long-columns.expected
+++ b/tests/cdb2sql.test/t23.long-columns.expected
@@ -1,0 +1,2 @@
+(abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz=1)
+(abcdefghijklmnopqrstuvwxyzabcde=1)

--- a/tests/cdb2sql.test/t23.long-columns.sql
+++ b/tests/cdb2sql.test/t23.long-columns.sql
@@ -1,0 +1,5 @@
+ put tunable return_long_column_names 0
+ select 1 as 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
+
+ set return_long_column_names off
+ select 1 as 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'

--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -6,3 +6,4 @@ sc_downgrade,DB_BUG,180377358
 sc_transactional_rowlocks_generated,UNKNOWN,180364183
 sc_truncate_lockorder_generated,UNKNOWN,180390150
 reco-ddlk-sql,DB_BUG,180524256
+analyze,UNKNOWN,180528295


### PR DESCRIPTION
Makes gensql easier if long columns not enabled on server
Col names truncated:
```
cdb2sql -gensql t testdb local "select 1 as 'abcdefghijklmnopqrstuvwxyzabcdefghijkilmnopqrstuvwxyz'"
insert into t (abcdefghijklmnopqrstuvwxyzabcde) values (1);
```
Full col names
```
cdb2sql -long-columns -gensql t testdb local "select 1 as 'abcdefghijklmnopqrstuvwxyzabcdefghijkilmnopqrstuvwxyz'"
insert into t (abcdefghijklmnopqrstuvwxyzabcdefghijkilmnopqrstuvwxyz) values (1);
```