### PR TITLE
Add test quarantine

### DIFF
--- a/tests/TODO
+++ b/tests/TODO
@@ -47,6 +47,8 @@ serialstep.test           -- rewrite test to get counts of relevant updated rows
 snap_ha_retry.test        -- hatest task core dumps (disconnect_cdb2h hatest.c:451)
                              set transaction snapshot isolation   returns effects (garbage)
 
+# TODO: Move these to quarantine where appropriate
+
 flaky:
 sc_tableversion
 sc_swapfields

--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -1,0 +1,7 @@
+# rows are of the form: test,type,ticket
+# do not use spaces
+# type must be one of [FLAKEY/DB_BUG/UNKNOWN]
+sc_inserts,FLAKEY,180387017
+sc_downgrade,DB_BUG,180377358
+sc_transactional_rowlocks_generated,UNKNOWN,180364183
+sc_truncate_lockorder_generated,UNKNOWN,180390150

--- a/tests/quarantine.sh
+++ b/tests/quarantine.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+declare -A quarantined_test_names_to_types
+declare -A quarantine_types_to_descriptions
+
+quarantine_types_to_descriptions["FLAKEY"]="it is flakey"
+quarantine_types_to_descriptions["DB_BUG"]="it exposes a database bug"
+quarantine_types_to_descriptions["UNKNOWN"]="it has failures we don't understand"
+
+test_is_quarantined() {
+    local -r test_name="$1"
+    if [[ -n "${quarantined_test_names_to_types[$test_name]}" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+is_valid_quarantine_type() {
+    local -r type="$1"
+    if [[ -n "${quarantine_types_to_descriptions[$type]}" ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+get_quarantined_test_description() {
+    local -r test_name="$1"
+    local -r type="${quarantined_test_names_to_types[$test_name]}"
+    if [[ -n "$type" ]]; then
+        echo "Test is quarantined because ${quarantine_types_to_descriptions[$type]}"
+    else
+        echo "No description available for $test_name"
+        return 1
+    fi
+}
+
+read_quarantine_csv() {
+    local -r csv_file="${TESTSROOTDIR}/quarantine.csv"
+
+    if [ ! -f "$csv_file" ]; then
+        echo "File $csv_file not found."
+        exit 1
+    fi
+
+    while IFS=, read -r name type ticket; do
+        # Skip comment lines (starting with #)
+        if [[ "$name" == \#* ]]; then
+            continue
+        fi
+        if ! is_valid_quarantine_type $type; then
+            echo "Invalid quarantine type '$type' for test '$name'."
+            exit 1
+        fi
+        quarantined_test_names_to_types["$name"]="$type" 
+    done < "$csv_file"
+}
+
+read_quarantine_csv
+

--- a/tests/runtestcase
+++ b/tests/runtestcase
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 . ${TESTSROOTDIR}/testutils
+. ${TESTSROOTDIR}/quarantine.sh
 
 testdb_start_testcase
 
@@ -524,6 +525,12 @@ if [ -t 1 ] ; then
 fi
 
 teststatus=0
+
+if test_is_quarantined $TESTCASE ; then
+    msg="!$TESTCASE: ${YELLOW}WARNING: $(get_quarantined_test_description $TESTCASE)${NEUTRAL}"
+    echo -e "$msg"
+    echo "$msg" >> ${TEST_LOG}
+fi
 
 if [[ -n "$dbdown" ]] ; then
     # if this is intentional, please run test with 'CHECK_DB_AT_FINISH=0' (ex. put in test Makefile:export CHECK_DB_AT_FINISH=0)


### PR DESCRIPTION
The test quarantine keeps track of what tests are failing, why they are failing, and what tickets are tracking them.

The updates in this PR add a warning when running a quarantined test.
```
!example_test: WARNING: Test is quarantined because it is flakey
!example_test: success (logs in logs/exampletest48907.testcase)
```

After this PR is merged, we can update our CI pipeline to report failures of quarantined tests separately from other tests.

