### PR TITLE
ci: do not run workflow on pushes to `main`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,12 @@
 name: Build
 
 on:
-  # Run anytime a new commit is pushed to main.
-  push:
-    branches: [main]
-
   # Run on every PR that is opened against main.
   pull_request:
     branches: [main]
 
   # Run on a schedule (daily @ 6am Eastern time).
+  # These run against the default branch (main).
   schedule:
     - cron: "0 11 * * *"
 


### PR DESCRIPTION
/skipbuild

In the event that a developer is using a personal access token that does not have `workflow` permissions, pushing to `main` on the developer's fork will fail. Since we run the workflow on PRs, additionally checking commits to `main` seems redundant anyway. Do not run checks on pushes to main to avoid disrupting developers.