### PR TITLE
Fix sbuf2 leak in revconn

### DIFF
--- a/bbinc/sbuf2.h
+++ b/bbinc/sbuf2.h
@@ -59,6 +59,8 @@ enum SBUF2_FLAGS {
     SBUF2_NO_BLOCK = 16,
     /* the underlying connection has been marked 'READONLY' */
     SBUF2_IS_READONLY = 32,
+    /* do not close ssl */
+    SBUF2_NO_SSL_CLOSE = 64,
 };
 
 typedef int (*sbuf2readfn)(SBUF2 *sb, char *buf, int nbytes);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3510,6 +3510,9 @@ extern int gbl_max_sql_hint_cache;
 
 /* Remote cursor support */
 /* use portmux to open an SBUF2 to local db or proxied db */
+SBUF2 *connect_remote_db_flags(const char *protocol, const char *dbname, const char *service, char *host, int use_cache,
+                         int force_rte, int sbflags);
+
 SBUF2 *connect_remote_db(const char *protocol, const char *dbname, const char *service, char *host, int use_cache,
                          int force_rte);
 int get_rootpage_numbers(int nums);

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -11496,8 +11496,8 @@ int gbl_connect_remote_rte = 0;
  */
 int gbl_fdb_socket_timeout_ms;
 
-SBUF2 *connect_remote_db(const char *protocol, const char *dbname, const char *service, char *host, int use_cache,
-                         int force_rte)
+SBUF2 *connect_remote_db_flags(const char *protocol, const char *dbname, const char *service, char *host, int use_cache,
+                         int force_rte, int sbflags)
 {
     SBUF2 *sb;
     int port;
@@ -11553,7 +11553,7 @@ retry:
     (void)setsockopt(sockfd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
 
 sbuf:
-    sb = sbuf2open(sockfd, 0);
+    sb = sbuf2open(sockfd, sbflags);
     if (!sb) {
         logmsg(LOGMSG_ERROR, "%s: failed to open sbuf\n", __func__);
         Close(sockfd);
@@ -11579,6 +11579,13 @@ sbuf:
 
     return sb;
 }
+
+SBUF2 *connect_remote_db(const char *protocol, const char *dbname, const char *service, char *host, int use_cache,
+                         int force_rte)
+{
+    return connect_remote_db_flags(protocol, dbname, service, host, use_cache, force_rte, 0);
+}
+
 
 int sqlite3PagerLockingMode(Pager *p, int mode) { return 0; }
 


### PR DESCRIPTION
This fixes a leak in send_reversesql_request.  The sbuf allocated from connect_remote_db was orphaned prior to the call to do_revconn_evbuffer.  Fix is to call sbuf2open with SBUF_NO_CLOSE_FD|SBUF2_NO_SSL_CLOSE, and free before do_revconn_evbuffer.