### PR TITLE
Allow passing args to docker user_script

### DIFF
--- a/tests/docker/client
+++ b/tests/docker/client
@@ -42,5 +42,5 @@ fi
 echo READY
 
 if [[ -f /common/user_script ]]; then
-    /common/user_script
+    /common/user_script $(cat /common/user_script_args 2>/dev/null)
 fi

--- a/tests/docker/runit
+++ b/tests/docker/runit
@@ -3,6 +3,7 @@
 set -e
 nodeprefix="m"
 
+script_args=()
 while [[ $1 = -* ]]; do
     if [[ "$1" = "-s" ]] || [[ "$1" = "--source" ]]; then
         shift
@@ -19,6 +20,9 @@ while [[ $1 = -* ]]; do
     elif [[ "$1" = "-f" ]] || [[ "$1" = "--file" ]]; then
         shift
         script=$1
+    elif [[ "$1" = "-a" ]] || [[ "$1" = "--file-arg" ]]; then
+        shift
+        script_args+=("$1")
     fi
     shift
 done
@@ -59,6 +63,10 @@ if [[ "$script" != "" ]]; then
     cp $script common/user_script
     chmod +x common/user_script
 fi
+if ((${#script_args[@]} > 0)); then
+    printf '%s ' "${script_args[@]}" > common/user_script_args
+fi
+
 docker build -t comdb2test:$prefix -f $src/tests/docker/Dockerfile.install $src
 
 echo $cluster >common/cluster


### PR DESCRIPTION
`user_script` is the entrypoint that kicks off our testing logic inside Docker test clusters.

This change allows passing arguments to `user_script`. Existing usage remains unchanged, but optional arguments let us customize behavior when needed.

This prevents us from having to duplicate test scripts when we only need small variations in behavior.

### Testing 

Using
```
$ cat test_script.sh
#!/bin/bash

echo "Hi I was passed args '$@'"
```

1. Test with multiple arguments

```
$ comdb2/tests/docker/runit -s comdb2 -n 3 -a 0 -f test_script.sh --file-arg --my-opt --file-arg 1
...
c1        | READY
c1        | Hi I was passed args '0 --my-opt 1'
```

2. Test with no arguments

```
$ comdb2/tests/docker/runit -s comdb2 -n 3 -a 0 -f test_script.sh --file-arg --my-opt --file-arg 1
...
c1        | READY
c1        | Hi I was passed args ''
```