### PR TITLE
Interface to cancel running and queued sql statements

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -745,6 +745,7 @@ struct sqlclntstate {
 
     struct rawnodestats *rawnodestats;
 
+    uuid_t      unifieduuid;         /* assigned to any statement running, used for canceling live sql */
     osqlstate_t osql;                /* offload sql state is kept here */
     enum ctrl_sqleng ctrl_sqlengine; /* use to mark a begin/end out of state,
                                         see enum ctrl_sqleng

--- a/db/sql.h
+++ b/db/sql.h
@@ -322,6 +322,17 @@ typedef struct sqlclntstate_fdb {
     int failed_heartbeats; /* used to signal failed communication with remotes */
 } sqlclntstate_fdb_t;
 
+enum ucancel_type {
+    UCANCEL_INV = 0,
+    UCANCEL_ALL = 1,    /* both queued and running */
+    UCANCEL_RUN = 2,    /* running only */
+    UCANCEL_QUE = 4,    /* queued only */
+    UCANCEL_CNO = 8,    /* filter by cnonce */
+    UCANCEL_FPT = 16    /* filter by fp */
+};
+
+int ucancel_sql_statements(enum ucancel_type type, char *uuid);
+
 CurRange *currange_new();
 #define CURRANGEARR_INIT_CAP 2
 void currangearr_init(CurRangeArr *arr);

--- a/db/sql.h
+++ b/db/sql.h
@@ -1341,6 +1341,7 @@ struct connection_info {
     enum connection_state state_int;
     int64_t in_transaction;
     int64_t in_local_cache;
+    char *uuid;
 };
 
 /* makes master swing verbose */

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9742,6 +9742,12 @@ static int _ucancel_sql_statements_run(void)
     return 0;
 }
 
+static int _ucancel_sql_statements_que(void)
+{
+    return 0;
+}
+
+
 /*
  * "Unified" sql statements cancel routine
  * MODES:
@@ -9758,8 +9764,9 @@ int ucancel_sql_statements(enum ucancel_type type, char *uuid) {
         return _ucancel_sql_statements_cno(uuid);
     case UCANCEL_RUN:
         return _ucancel_sql_statements_run();
-    case UCANCEL_ALL:
     case UCANCEL_QUE:
+        return _ucancel_sql_statements_que();
+    case UCANCEL_ALL:
     case UCANCEL_FPT:
        logmsg(LOGMSG_ERROR, "%d unimplemented\n", type);
        return -1;

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -9701,6 +9701,72 @@ void cancel_sql_statement_with_cnonce(const char *cnonce)
         logmsg(LOGMSG_USER, "Query with cnonce %s not found (finished?)\n", cnonce);
 }
 
+static int _ucancel_sql_statements_cno(char *uuidstr)
+{
+    struct sql_thread *thd;
+    int rc = -1;
+
+    uuid_t uuid;
+
+    if (uuid_parse(uuidstr, uuid)) {
+        logmsg(LOGMSG_ERROR, "Failed to parse uuid \"%s\"\n", uuidstr);
+        return rc;
+    }
+
+    Pthread_mutex_lock(&gbl_sql_lock);
+    LISTC_FOR_EACH(&thedb->sql_threads, thd, lnk) {
+        if (thd->clnt && memcmp(thd->clnt->unifieduuid, uuid, sizeof(uuid_t)) == 0) {
+            logmsg(LOGMSG_ERROR, "Cancelling sql %s\n", thd->clnt->sql);
+            thd->stop_this_statement = 1;
+            rc = 0;
+            break;
+        }
+    }
+    Pthread_mutex_unlock(&gbl_sql_lock);
+    if (rc)
+        logmsg(LOGMSG_ERROR, "Sql cnonce \"%s\" not found\n", uuidstr);
+    return rc;
+}
+
+static int _ucancel_sql_statements_run(void)
+{
+    struct sql_thread *thd;
+
+    Pthread_mutex_lock(&gbl_sql_lock);
+    LISTC_FOR_EACH(&thedb->sql_threads, thd, lnk) {   
+        if (thd->clnt)
+            thd->stop_this_statement = 1;
+    }
+    Pthread_mutex_unlock(&gbl_sql_lock);
+
+    return 0;
+}
+
+/*
+ * "Unified" sql statements cancel routine
+ * MODES:
+ *  type == UCANCEL_ALL #cancel all running and queued statements
+ *  type == UCANCEL_RUN #cancel all running statements
+ *  type == UCANCEL_QUE #cancel all queued statements
+ *  type == UCANCEL_CNO #cancel one running statement with cnonce = "uuid"
+ *  type == UCANCEL_FPT #cancel all running statement with fingerprint = "uuid"
+ *
+ */
+int ucancel_sql_statements(enum ucancel_type type, char *uuid) {
+    switch(type) {
+    case UCANCEL_CNO:
+        return _ucancel_sql_statements_cno(uuid);
+    case UCANCEL_RUN:
+        return _ucancel_sql_statements_run();
+    case UCANCEL_ALL:
+    case UCANCEL_QUE:
+    case UCANCEL_FPT:
+       logmsg(LOGMSG_ERROR, "%d unimplemented\n", type);
+       return -1;
+    }
+    return 0;
+}
+
 void sql_dump_running_statements(void)
 {
     struct sql_thread *thd;

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6728,6 +6728,10 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
     c->in_transaction = clnt->in_client_trans;
     c->in_local_cache = clnt->in_local_cache;
     Pthread_mutex_unlock(&clnt->state_lk);
+    uuidstr_t us;
+    comdb2uuidstr(clnt->unifieduuid, us);
+    c->uuid = malloc(strlen(us) + 1);
+    snprintf(c->uuid, strlen(us) + 1, "%s", us);
 }
 
 static void gather_connections_evbuffer(struct connection_info **info, int *num_connections)
@@ -6757,8 +6761,9 @@ void free_connection_info(struct connection_info *info, int num_connections)
 {
     if (info == NULL) return;
     for (int i = 0; i < num_connections; i++) {
-        if (info[i].sql) free(info[i].sql);
-        if (info[i].fingerprint) free(info[i].fingerprint);
+        free(info[i].sql);
+        free(info[i].fingerprint);
+        free(info[i].uuid);
         /* state is static, don't free */
     }
     free(info);

--- a/lua/syssp.c.in
+++ b/lua/syssp.c.in
@@ -491,36 +491,32 @@ static int db_send(Lua L)
 
 static int db_unified_cancel(Lua L)
 {
-    char *type;
-    char *uuid = NULL;
+    const char *type;
+    const char *uuid = NULL;
     char cmd[256];
 
     int nargs = lua_gettop(L);
+    assert(nargs == 2);
+
     /* type */
-    if (nargs == 2) {
-        if (!lua_isstring(L, -2))
-            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
-        type = (char*) lua_tostring(L, -2);
-        if (strncasecmp(type, "cnonce", sizeof("cnonce")) != 0 &&
-                strncasecmp(type, "fp", sizeof("fp")) != 0) {
-            return luaL_error(L, "Extra argument present\n");
-        }
+    if (!lua_isstring(L, -2))
+        return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
+    type = lua_tostring(L, -2);
+    /* check argument combinations */
+    if (strncasecmp(type, "all", sizeof("all")) == 0 ||
+            strncasecmp(type, "running", sizeof("running")) == 0 ||
+            strncasecmp(type, "queued", sizeof("queued")) == 0) {
+            if (!lua_isnil(L, -1))
+                return luaL_error(L, "Extra argument present for type %s", type);
+    } else if (strncasecmp(type, "cnonce", sizeof("cnonce")) == 0 ||
+            strncasecmp(type, "fp", sizeof("fp")) == 0) {
+        if (lua_isnil(L, -1))
+            return luaL_error(L, "Missing uuid for type %s", type);
+        uuid = lua_tostring(L, -1);
     } else {
-        if (!lua_isstring(L, -1))
-            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
-        type = (char*) lua_tostring(L, -1);
-        if (strncasecmp(type, "all", sizeof("all")) != 0 &&
-                strncasecmp(type, "running", sizeof("running")) != 0 && 
-                strncasecmp(type, "queued", sizeof("queued")) != 0) {
-            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
-        }
+        return luaL_error(L, "Unrecognized cancel type %s", type);
     }
 
-    if (nargs == 2) {
-        if (!lua_isstring(L, -1))
-            return luaL_error(L, "Wrong type uuid for %s type", type);
-        uuid = (char*) lua_tostring(L, -1);
-    }
     lua_settop(L, 0);
 
     snprintf(cmd, sizeof(cmd), "sql ucancel %s%s%s\n", type, uuid ? " ": "", uuid ? uuid : "");

--- a/lua/syssp.c.in
+++ b/lua/syssp.c.in
@@ -491,15 +491,39 @@ static int db_send(Lua L)
 
 static int db_unified_cancel(Lua L)
 {
-    char *uuid;
+    char *type;
+    char *uuid = NULL;
     char cmd[256];
 
-    if (!lua_isstring(L, 1))
-        return luaL_error(L, "Expected string uuid argument");
-    uuid = (char*) lua_tostring(L, -1);
+    int nargs = lua_gettop(L);
+    /* type */
+    if (nargs == 2) {
+        if (!lua_isstring(L, -2))
+            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
+        type = (char*) lua_tostring(L, -2);
+        if (strncasecmp(type, "cnonce", sizeof("cnonce")) != 0 &&
+                strncasecmp(type, "fp", sizeof("fp")) != 0) {
+            return luaL_error(L, "Extra argument present\n");
+        }
+    } else {
+        if (!lua_isstring(L, -1))
+            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
+        type = (char*) lua_tostring(L, -1);
+        if (strncasecmp(type, "all", sizeof("all")) != 0 &&
+                strncasecmp(type, "running", sizeof("running")) != 0 && 
+                strncasecmp(type, "queued", sizeof("queued")) != 0) {
+            return luaL_error(L, "Expected string type argument: all|queued|running|cnonce|fp");
+        }
+    }
+
+    if (nargs == 2) {
+        if (!lua_isstring(L, -1))
+            return luaL_error(L, "Wrong type uuid for %s type", type);
+        uuid = (char*) lua_tostring(L, -1);
+    }
     lua_settop(L, 0);
 
-    snprintf(cmd, sizeof(cmd), "cancel %s\n", uuid);
+    snprintf(cmd, sizeof(cmd), "sql ucancel %s%s%s\n", type, uuid ? " ": "", uuid ? uuid : "");
 
     return _db_process_command(L, cmd, "result");
 }
@@ -795,7 +819,7 @@ static struct sp_source syssps[] = {
     }
     ,{
         "sys.cmd.cancel",
-        "local function main(cmd)\n"
+        "local function main(cmd, uuid)\n"
         "    local schema = {\n"
         "        { 'string', 'result' },\n"
         "    }\n"
@@ -804,7 +828,7 @@ static struct sp_source syssps[] = {
         "        db:column_name(v[2], i)\n"
         "        db:column_type(v[1], i)\n"
         "    end\n"
-        "    local msg = sys.cancel(cmd)\n"
+        "    local msg = sys.cancel(cmd, uuid)\n"
         "    for i, v in ipairs(msg) do\n"
         "        db:emit(v)\n"
         "    end\n"

--- a/lua/syssp.c.in
+++ b/lua/syssp.c.in
@@ -424,19 +424,16 @@ static int db_comdb_truncate_time(Lua L) {
     return 1;
 }
 
-static int db_send(Lua L) {
+static int _db_process_command(Lua L, char *cmd, const char *colname)
+{
     FILE *f;
     char buf[1024];
     int rownum = 1;
-    char *cmd;
     SP sp = getsp(L);
 
     if (sp) {
         sp->max_num_instructions = 1000000; //allow large number of steps
     }
-
-    if (!lua_isstring(L, 1))
-        return luaL_error(L, "Expected string argument");
 
     if (gbl_uses_password) {
       if (sp && sp->clnt) {
@@ -447,9 +444,6 @@ static int db_send(Lua L) {
           }
       }
     }
-
-    cmd = (char*) lua_tostring(L, -1);
-    lua_settop(L, 0);
 
     lua_createtable(L, 0, 0);
 
@@ -472,7 +466,7 @@ static int db_send(Lua L) {
 
         lua_createtable(L, 0, 1);
 
-        lua_pushstring(L, "out");
+        lua_pushstring(L, colname);
         lua_pushstring(L, buf);
         lua_settable(L, -3);
 
@@ -482,6 +476,34 @@ static int db_send(Lua L) {
 
     return 1;
 }
+
+static int db_send(Lua L)
+{
+    char *cmd;
+
+    if (!lua_isstring(L, 1))
+        return luaL_error(L, "Expected string argument");
+    cmd = (char*) lua_tostring(L, -1);
+    lua_settop(L, 0);
+
+    return _db_process_command(L, cmd, "out");
+}
+
+static int db_unified_cancel(Lua L)
+{
+    char *uuid;
+    char cmd[256];
+
+    if (!lua_isstring(L, 1))
+        return luaL_error(L, "Expected string uuid argument");
+    uuid = (char*) lua_tostring(L, -1);
+    lua_settop(L, 0);
+
+    snprintf(cmd, sizeof(cmd), "cancel %s\n", uuid);
+
+    return _db_process_command(L, cmd, "result");
+}
+
 static int db_comdb_start_replication(Lua L)
 {
     int rc;
@@ -591,6 +613,7 @@ static const luaL_Reg sys_funcs[] = {
     { "stop_replication", db_comdb_stop_replication },
     { "physrep_tunables", db_comdb_physrep_tunables },
     { "delete_sc_history", db_comdb_delete_sc_history },
+    { "cancel", db_unified_cancel},
     { NULL, NULL }
 }; 
 
@@ -767,6 +790,24 @@ static struct sp_source syssps[] = {
         "  else\n"
         "    db:emit('Failed to delete from sc_history for tablename '..t)\n"
         "  end \n"
+        "end\n",
+        NULL
+    }
+    ,{
+        "sys.cmd.cancel",
+        "local function main(cmd)\n"
+        "    local schema = {\n"
+        "        { 'string', 'result' },\n"
+        "    }\n"
+        "    db:num_columns(table.getn(schema))\n"
+        "    for i, v in ipairs(schema) do\n"
+        "        db:column_name(v[2], i)\n"
+        "        db:column_type(v[1], i)\n"
+        "    end\n"
+        "    local msg = sys.cancel(cmd)\n"
+        "    for i, v in ipairs(msg) do\n"
+        "        db:emit(v)\n"
+        "    end\n"
         "end\n",
         NULL
     },

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2470,6 +2470,10 @@ newsql_loop_result newsql_loop(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_quer
 
     /* coherent  _or_ in middle of transaction */
     if ((!incoh_reject(clnt->admin, thedb->bdb_env) || clnt->features.allow_incoherent) || clnt->ctrl_sqlengine != SQLENG_NORMAL_PROCESS) {
+        uuidstr_t us;
+        comdb2uuid(clnt->unifieduuid);
+        fprintf(stderr, "GENERATED %s for \"%s\"\n", comdb2uuidstr(clnt->unifieduuid, us), clnt->sql);
+
         return NEWSQL_SUCCESS;
     }
     if (gbl_incoherent_clnt_wait > 0) {

--- a/sqlite/ext/comdb2/connections.c
+++ b/sqlite/ext/comdb2/connections.c
@@ -98,5 +98,6 @@ int systblConnectionsInit(sqlite3 *db) {
             CDB2_INTEGER, "has_cert", -1, offsetof(struct connection_info, has_cert),
             CDB2_CSTRING, "common_name", -1, offsetof(struct connection_info, common_name),
             CDB2_INTEGER, "in_local_cache", -1, offsetof(struct connection_info, in_local_cache),
+            CDB2_CSTRING, "uuid", -1, offsetof(struct connection_info, uuid),
             SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -229,9 +229,6 @@ EOF
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
 
-#convert the table to actual dbname
-sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
-
 # validate results 
 testcase_output=$(cat $output)
 expected_output=$(cat output.log.actual)

--- a/tests/unifiedcancel.test/Makefile
+++ b/tests/unifiedcancel.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=s
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/unifiedcancel.test/README
+++ b/tests/unifiedcancel.test/README
@@ -1,0 +1,1 @@
+This test checks cancel and block message traps for both sql and transactions.

--- a/tests/unifiedcancel.test/lrl.options
+++ b/tests/unifiedcancel.test/lrl.options
@@ -1,0 +1,1 @@
+table t t.csc2

--- a/tests/unifiedcancel.test/output.log
+++ b/tests/unifiedcancel.test/output.log
@@ -1,0 +1,6 @@
+[exec procedure sys.cmd.cancel()] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Expected string type argument: all|queued|running|cnonce|fp
+[exec procedure sys.cmd.cancel(123)] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Unrecognized cancel type 123
+[exec procedure sys.cmd.cancel('blah')] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Unrecognized cancel type blah
+[exec procedure sys.cmd.cancel('cnonce')] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Missing uuid for type cnonce
+[ERROR] Failed to parse uuid "123"
+[ERROR] Failed to parse uuid "1-23-456"

--- a/tests/unifiedcancel.test/runit
+++ b/tests/unifiedcancel.test/runit
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Remote cursor moves testcase for comdb2
+################################################################################
+
+
+# args
+# <dbname> <dbdir> <testdir> <autodbname> <autodbnum> <cluster>
+echo "main db vars"
+vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG"
+for required in $vars; do
+    q=${!required}
+    echo "$required=$q" 
+    if [[ -z "$q" ]]; then
+        echo "$required not set" >&2
+        exit 1
+    fi
+done
+
+
+#run tests
+echo "Starting cancel tests"
+echo ./test_cancel.sh $DBNAME $CDB2_CONFIG $DBDIR $TESTDIR
+./test_cancel.sh $DBNAME $CDB2_CONFIG $DBDIR $TESTDIR
+result=$?
+
+if (( $result != 0 )) ; then
+   echo "Failure in cancel tests"
+   exit 1
+fi
+
+echo "Starting block tests"
+
+echo "Not implemented yet"
+
+echo "Success"

--- a/tests/unifiedcancel.test/t.csc2
+++ b/tests/unifiedcancel.test/t.csc2
@@ -1,0 +1,8 @@
+schema
+{
+   int  id
+}
+keys
+{
+   "ID"  = id
+}

--- a/tests/unifiedcancel.test/test_cancel.sh
+++ b/tests/unifiedcancel.test/test_cancel.sh
@@ -31,16 +31,15 @@ function header
 
 header 1 "running a long query, retrieve it and cancel it"
 echo "Running tests on node ${mach}"
-echo "inserting 3 records"
-$S_SQL "insert into t values (1), (2), (3)"
+echo "inserting 60 records"
+$S_SQL "insert into t select * from generate_series(1,60)"
 if [[ $? != 0 ]] ; then
     echo "Failed to insert"
     exit 1
 fi
 
 echo "running async select sleep"
-#$S_SQL "select *, sleep(10, 1) from t order by id"
-$S_SQL "select *, sleep(60) from t order by id" &
+$S_SQL "select *, sleep(1) from t order by 1" &
 if [[ $? != 0 ]] ; then
     echo "Failed to async run sleep"
     exit 1
@@ -60,11 +59,13 @@ if [[ -z ${uuid} ]] ; then
 fi
 
 echo "running cancel ${uuid} trap"
-$S_SQL "exec procedure sys.cmd.cancel('${uuid}')"
+$S_SQL "exec procedure sys.cmd.cancel('cnonce', '${uuid}')"
 if [[ $? != 0 ]] ; then
     echo "Failed to run cancel message"
     exit 1
 fi
+
+sleep 2
 
 echo "check if the ${uuid} is gone"
 found_uuid=`$S_TSQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`

--- a/tests/unifiedcancel.test/test_cancel.sh
+++ b/tests/unifiedcancel.test/test_cancel.sh
@@ -20,6 +20,7 @@ S_CDB2_OPTIONS="--cdb2cfg ${a_cdb2config}"
 mach=`cdb2sql ${S_CDB2_OPTIONS} --tabs $a_dbname default "SELECT comdb2_host()"`
 
 S_SQL="cdb2sql ${S_CDB2_OPTIONS} --host $mach $a_dbname"
+S_TSQL="cdb2sql --tabs ${S_CDB2_OPTIONS} --host $mach $a_dbname"
 
 function header
 {
@@ -46,7 +47,7 @@ if [[ $? != 0 ]] ; then
 fi
 
 echo "collecting the sleep uuid"
-uuid=`$S_SQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
+uuid=`$S_TSQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
 if [[ $? != 0 ]] ; then
     echo "Failed to select uuid"
     exit 1
@@ -65,14 +66,14 @@ if [[ $? != 0 ]] ; then
     exit 1
 fi
 
-echo "check the ${uuid} is gone"
-found_uuid=`$S_SQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"
+echo "check if the ${uuid} is gone"
+found_uuid=`$S_TSQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
 if [[ $? != 0 ]] ; then
     echo "Failed to run cancel message"
     exit 1
 fi
 
-if [[ ! =z ${found_uuid} ]] ; then
+if [[ ! -z ${found_uuid} ]] ; then
     echo "Failed to cancel the sleep select"
     exit 1
 fi

--- a/tests/unifiedcancel.test/test_cancel.sh
+++ b/tests/unifiedcancel.test/test_cancel.sh
@@ -7,8 +7,6 @@ set -x
 
 # args
 # <dbname> <autodbname> <dbdir> <testdir>
-a_rdbname=$4
-a_rcdb2config=$2
 a_dbname=$1
 a_cdb2config=$2
 a_dbdir=$3
@@ -29,7 +27,24 @@ function header
     echo "$2"
 }
 
-header 1 "running a long query, retrieve it and cancel it"
+function waitforsql
+{
+    local cnt=0
+    local mx=$1
+    local itr=0
+
+    while true; do 
+        cnt=`$S_TSQL "select count(*) from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
+        echo "Found $d queries iteration $itr"
+        if [[ "$cnt" -eq "$mx" ]] ; then
+            echo "Done waiting after $itr iterations"
+            break;
+        fi
+        let itr=itr+1
+        sleep 1
+    done
+}
+
 echo "Running tests on node ${mach}"
 echo "inserting 60 records"
 $S_SQL "insert into t select * from generate_series(1,60)"
@@ -38,12 +53,15 @@ if [[ $? != 0 ]] ; then
     exit 1
 fi
 
+header 1 "running a long query, retrieve it and cancel it"
 echo "running async select sleep"
 $S_SQL "select *, sleep(1) from t order by 1" &
 if [[ $? != 0 ]] ; then
     echo "Failed to async run sleep"
     exit 1
 fi
+
+waitforsql 1
 
 echo "collecting the sleep uuid"
 uuid=`$S_TSQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
@@ -58,7 +76,7 @@ if [[ -z ${uuid} ]] ; then
     exit 1
 fi
 
-echo "running cancel ${uuid} trap"
+echo "running cancel('cnonce', '${uuid}') trap"
 $S_SQL "exec procedure sys.cmd.cancel('cnonce', '${uuid}')"
 if [[ $? != 0 ]] ; then
     echo "Failed to run cancel message"
@@ -77,6 +95,98 @@ fi
 if [[ ! -z ${found_uuid} ]] ; then
     echo "Failed to cancel the sleep select"
     exit 1
+fi
+
+
+header 2 "running three long queries, and cancel all running"
+
+for cnt in {1..3} ; do
+    echo "running async select sleep $cnt"
+    $S_SQL "select *, sleep(1) from t order by 1" &
+    if [[ $? != 0 ]] ; then
+        echo "Failed to async run sleep $cnt"
+        exit 1
+    fi
+done
+
+waitforsql 3
+
+echo "running cancel('running') trap"
+$S_SQL "exec procedure sys.cmd.cancel('running')"
+if [[ $? != 0 ]] ; then
+    echo "Failed to run cancel message"
+    exit 1
+fi
+
+sleep 6
+
+echo "check if the sleepy queries are gone"
+found_uuid=`$S_TSQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
+if [[ $? != 0 ]] ; then
+    echo "Failed to run cancel message"
+    exit 1
+fi
+
+if [[ ! -z ${found_uuid} ]] ; then
+    echo "Failed to cancel the sleep select, found $found_uuid"
+    exit 1
+fi
+
+ooo=run.log
+
+header 3 "checking syntax arguments"
+
+$S_TSQL "exec procedure sys.cmd.cancel()" > $ooo 2>&1
+if [[ $? == 0 ]] ; then
+    echo "Failed no type"
+    exit 1
+fi
+$S_TSQL "exec procedure sys.cmd.cancel(123)" >> $ooo 2>&1
+if [[ $? == 0 ]] ; then
+    echo "Failed wrong non-string type"
+    exit 1
+fi
+$S_TSQL "exec procedure sys.cmd.cancel('blah')" >> $ooo 2>&1
+if [[ $? == 0 ]] ; then
+    echo "Failed bogus string type"
+    exit 1
+fi
+$S_TSQL "exec procedure sys.cmd.cancel('cnonce')" >> $ooo 2>&1
+if [[ $? == 0 ]] ; then
+    echo "Failed no uuid cnonce"
+    exit 1
+fi
+$S_TSQL "exec procedure sys.cmd.cancel('cnonce', 123)" >> $ooo 2>&1
+if [[ $? != 0 ]] ; then
+    echo "Failed wrong type uuid cnonce"
+    exit 1
+fi
+$S_TSQL "exec procedure sys.cmd.cancel('cnonce', '1-23-456')" >> $ooo 2>&1
+if [[ $? != 0 ]] ; then
+    echo "Failed invalid uuid cnonce"
+    exit 1
+fi
+
+#convert the table to actual dbname
+sed "s/dorintdb/${a_dbname}/g" output.log > output.log.actual
+
+# validate results
+testcase_output=$(cat ${ooo})
+expected_output=$(cat output.log.actual)
+if [[ "$testcase_output" != "$expected_output" ]]; then
+
+   # print message
+   echo "  ^^^^^^^^^^^^"
+   echo "The above testcase (${testcase}) has failed!!!"
+   echo " "
+   echo "Use 'diff <expected-output> <my-output>' to see why:"
+   echo "> diff ${PWD}/{${ooo}, output.log.actual}"
+   echo " "
+   diff ${ooo} output.log.actual
+   echo " "
+
+   # quit
+   exit 1
 fi
 
 echo "Testcase passed."

--- a/tests/unifiedcancel.test/test_cancel.sh
+++ b/tests/unifiedcancel.test/test_cancel.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+# Cancel sql and transactions test
+################################################################################
+
+set -x 
+
+# args
+# <dbname> <autodbname> <dbdir> <testdir>
+a_rdbname=$4
+a_rcdb2config=$2
+a_dbname=$1
+a_cdb2config=$2
+a_dbdir=$3
+a_testdir=$4
+
+S_CDB2_OPTIONS="--cdb2cfg ${a_cdb2config}"
+
+# Make sure we talk to the same host
+mach=`cdb2sql ${S_CDB2_OPTIONS} --tabs $a_dbname default "SELECT comdb2_host()"`
+
+S_SQL="cdb2sql ${S_CDB2_OPTIONS} --host $mach $a_dbname"
+
+function header
+{
+    set -x
+    echo "TEST $1"
+    echo "$2"
+}
+
+header 1 "running a long query, retrieve it and cancel it"
+echo "Running tests on node ${mach}"
+echo "inserting 3 records"
+$S_SQL "insert into t values (1), (2), (3)"
+if [[ $? != 0 ]] ; then
+    echo "Failed to insert"
+    exit 1
+fi
+
+echo "running async select sleep"
+#$S_SQL "select *, sleep(10, 1) from t order by id"
+$S_SQL "select *, sleep(60) from t order by id" &
+if [[ $? != 0 ]] ; then
+    echo "Failed to async run sleep"
+    exit 1
+fi
+
+echo "collecting the sleep uuid"
+uuid=`$S_SQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"`
+if [[ $? != 0 ]] ; then
+    echo "Failed to select uuid"
+    exit 1
+fi
+
+echo "Found uuid '${uuid}'"
+if [[ -z ${uuid} ]] ; then 
+    echo "Failed to retrieve the uuid for sleeping query"
+    exit 1
+fi
+
+echo "running cancel ${uuid} trap"
+$S_SQL "exec procedure sys.cmd.cancel('${uuid}')"
+if [[ $? != 0 ]] ; then
+    echo "Failed to run cancel message"
+    exit 1
+fi
+
+echo "check the ${uuid} is gone"
+found_uuid=`$S_SQL "select uuid from comdb2_connections where sql like '%sleep%' and sql not like '%connections%'"
+if [[ $? != 0 ]] ; then
+    echo "Failed to run cancel message"
+    exit 1
+fi
+
+if [[ ! =z ${found_uuid} ]] ; then
+    echo "Failed to cancel the sleep select"
+    exit 1
+fi
+
+echo "Testcase passed."


### PR DESCRIPTION
Syntax:
exec procedure sys.cmd.cancel('all')
exec procedure sys.cmd.cancel('running')
exec procedure sys.cmd.cancel('queued')
exec procedure sys.cmd.cancel('cnonce', 'uuid')  // from comdb2_connections
exec procedure sys.cmd.cancel('fp', 'uuid') // from comdb2_connections, client, sql dump, and so on