### PR TITLE
Physrep poll-time set by physrep_pollms tunable

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -510,6 +510,7 @@ extern int gbl_physrep_reconnect_interval;
 extern int gbl_physrep_shuffle_host_list;
 extern int gbl_physrep_ignore_queues;
 extern int gbl_physrep_max_rollback;
+extern int gbl_physrep_pollms;
 
 /* source-name / host is from lrl */
 extern char *gbl_physrep_source_dbname;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1907,6 +1907,8 @@ REGISTER_TUNABLE("physrep_ignore_queues", "Don't replicate queues.", TUNABLE_BOO
                  READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_max_rollback", "Maximum logs physrep can rollback. (Default: 0)", TUNABLE_INTEGER,
                  &gbl_physrep_max_rollback, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("physrep_pollms", "Physical replicant poll interval in milliseconds. (Default: 200)", TUNABLE_INTEGER,
+                 &gbl_physrep_pollms, 0, NULL, NULL, NULL, NULL);
 
 /* reversql-sql */
 REGISTER_TUNABLE("revsql_allow_command_execution",

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -23,7 +23,7 @@
 #include <pthread.h>
 #include <stdint.h>
 #include <unistd.h>
-#include <time.h>
+#include <poll.h>
 
 #include <bdb_int.h>
 #include <bdbglue.h>
@@ -1277,6 +1277,7 @@ static int do_wait_for_reverse_conn(cdb2_hndl_tp *repl_metadb) {
        This is the database/node that to replicant connects to retrieve and
        apply physical logs.
 */
+int gbl_physrep_pollms = 200;
 extern __thread int physrep_out_of_order;
 static void *physrep_worker(void *args)
 {
@@ -1562,7 +1563,7 @@ repl_loop:
             do_truncate = 1;
         }
 sleep_and_retry:
-        sleep(1);
+        poll(0, 0, gbl_physrep_pollms);
     }
 
     if (repl_db_connected == 1) {

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -736,6 +736,7 @@
 (name='physrep_max_rollback', description='Maximum logs physrep can rollback. (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='physrep_metadb_host', description='List of physical replication metadb cluster hosts.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_metadb_name', description='Physical replication metadb cluster name.', type='STRING', value=NULL, read_only='Y')
+(name='physrep_pollms', description='Physical replicant poll interval in milliseconds. (Default: 200)', type='INTEGER', value='200', read_only='N')
 (name='physrep_reconnect_interval', description='Reconnect interval for physical replicants (Default: 600)', type='INTEGER', value='600', read_only='N')
 (name='physrep_reconnect_penalty', description='Physrep wait seconds before retry to the same node. (Default: 5)', type='INTEGER', value='0', read_only='N')
 (name='physrep_repl_host', description='Current physrep host.', type='STRING', value=NULL, read_only='Y')


### PR DESCRIPTION
Lower poll-time will provide lower replication latency.