### PR TITLE
Don't wait-for-seqnum while holding schema-lk

### DIFF
--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1446,8 +1446,9 @@ int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *prefix, int r
         }
 
         if (tmp_tran != tran) {
-            rc = trans_commit(iq, tmp_tran, gbl_myhostname);
-            if (rc && !replication_only_error_code(rc)) return -1;
+            rc = trans_commit_nowait(iq, tmp_tran, gbl_myhostname);
+            if (rc)
+                return -1;
         }
     }
 

--- a/tests/largetxn.test/Makefile
+++ b/tests/largetxn.test/Makefile
@@ -1,0 +1,8 @@
+t ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=30m
+endif

--- a/tests/largetxn.test/README
+++ b/tests/largetxn.test/README
@@ -1,0 +1,2 @@
+Make sure 'select 1' returns quickly on all nodes 
+Master should not hold schema-lk while in distributed commit

--- a/tests/largetxn.test/runit
+++ b/tests/largetxn.test/runit
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stopfile.txt
+export kb=1024
+export mb=$(( kb * 1024 ))
+export gb=$(( mb * 1024 ))
+export blobsz=$(( 128 * mb ))
+
+function select_timed
+{
+    local node=$1
+    local fl=select1.out.$$.${node}
+    while [[ ! -f $stopfile ]]; do
+        $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $DBNAME --host $node "select comdb2_host()" > $fl 2>&1 &
+        cpid=$!
+        cnt=0
+        while [[ $cnt -lt 5 ]]; do
+            sleep 1
+            if ! kill -0 $cpid >/dev/null 2>&1; then
+                break
+            fi
+            cnt=$((cnt + 1))
+        done
+        if [[ $cnt -ge 5 ]]; then
+            echo "ERROR: select 1 against $node took more than 5 seconds"
+            rm $fl
+            touch $stopfile
+            kill -9 $cpid >/dev/null 2>&1
+            wait
+            failexit "Test failed"
+        fi
+        #echo "$(cat $fl) selected quickly"
+
+    done
+}
+
+function large_transaction
+{
+    local szgb=$1
+    local sz=$(( szgb * gb ))
+    local txnfile=./txnfl.$$.$RANDOM.sql
+    local elapsed=0
+
+    echo "Truncating t1"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "truncate t1"
+
+    echo "Writing $szgb Gb transaction"
+    echo "BEGIN" > $txnfile
+    while [[ $sz -gt $blobsz ]]; do
+        echo "INSERT INTO t1(a, b) values (1, randomblob($blobsz))" >> $txnfile
+        sz=$(( sz - blobsz ))
+    done
+    if [[ $sz -gt 0 ]]; then
+        echo "INSERT INTO t1(a, b) values (1, randomblob($sz))" >> $txnfile
+    fi
+    echo "COMMIT" >> $txnfile
+
+    TIMEFORMAT='%R'
+    elapsed=$( { time $CDB2SQL_EXE -s -f $txnfile $CDB2_OPTIONS $DBNAME default - ; } 2>&1 )
+
+    echo $(echo $szgb Gb transaction took $elapsed seconds)
+    rm -f $txnfile >/dev/null 2>&1
+}
+
+# Basic idea of this test: run a "select 1" loop against 
+# all nodes in the cluster.  If any select 1 takes more than
+# 5 seconds, fail the test
+function run_test
+{
+    local j=0
+    local failed=0
+    rm -Rf $stopfile >/dev/null 2>&1
+    for node in $CLUSTER; do
+        select_timed $node &
+    done
+
+    # writing large transactions from a single thread takes time
+    # limit iterations to 5
+    while [[ $j -lt 3 ]]; do
+        large_transaction 2
+        if [[ -f $stopfile ]]; then
+            failed=1
+            break
+        fi
+        j=$((j + 1))
+    done
+    
+    touch $stopfile
+    wait
+
+    if [[ "$failed" -ne 0 ]]; then
+        echo "Test failed"
+        failexit "Testcase failed"
+    else
+        echo "Success"
+    fi
+}
+
+function setup
+{
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table t1" >/dev/null 2>&1
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1 (a int, b blob)" >/dev/null 2>&1
+}
+
+[[ -z $CLUSTER ]] && failexit "This test requires a cluster"
+
+setup
+run_test


### PR DESCRIPTION
This bug caused 'select 1' hangs on the master while I was testing large transactions.  Schema-change code performs distributed commit later, after finalize.