### PR TITLE
{180681308}: do not produce logical log for schema change

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2503,5 +2503,5 @@ void llmeta_collect_tablename_alias(void);
 typedef int (*collect_unused_files_f)(void *args, int lognum, char *filename);
 
 void oldfile_hash_collect(collect_unused_files_f func, void *arg);
-
+void bdb_tran_set_is_sc_rebuild(tran_type *tran, int is_sc_rebuild);
 #endif

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -438,6 +438,8 @@ struct tran_tag {
 
     /* Set to 1 if this is a schema change txn */
     int schema_change_txn;
+    /* 1 if this is from a schema change rebuild */
+    int is_sc_rebuild;
     struct tran_tag *sc_parent_tran;
 
     /* Set to 1 if this txn touches a logical live sc table */

--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -168,8 +168,8 @@ int add_snapisol_logging(bdb_state_type *bdb_state, tran_type *tran)
      * handle_truncation->vrfy_match->do_rcvry->reload_schemas->commit
      * reload_schemas opens btrees transactionally.  We call commit, but this
      * won't produce a log record if no other record has been written. */
-    if ((bdb_state->attr->snapisol || bdb_state->logical_live_sc) &&
-        !gbl_rowlocks && !gbl_is_physical_replicant) {
+    if ((bdb_state->attr->snapisol || bdb_state->logical_live_sc) && !gbl_rowlocks && !gbl_is_physical_replicant &&
+        !tran->is_sc_rebuild) {
         if (bdb_state->logical_live_sc) {
             if (tran->parent)
                 tran = tran->parent;

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -86,6 +86,11 @@ int bdb_tran_set_request_ack(tran_type *tran)
     return 0;
 }
 
+void bdb_tran_set_is_sc_rebuild(tran_type *tran, int is_sc_rebuild)
+{
+    tran->is_sc_rebuild = is_sc_rebuild;
+}
+
 tran_type *bdb_tran_begin_logical_norowlocks_int(bdb_state_type *bdb_state,
                                                  unsigned long long tranid,
                                                  int trak, int *bdberr)

--- a/db/glue.c
+++ b/db/glue.c
@@ -296,6 +296,7 @@ static int trans_start_int(struct ireq *iq, tran_type *parent_trans,
     }
 
     if (*out_trans != NULL) {
+        bdb_tran_set_is_sc_rebuild(*out_trans, (iq->opcode == OP_REBUILD));
         if (iq->sorese && iq->sorese->dist_txnid) {
             extern int gbl_debug_disttxn_trace;
             assert(iq->sorese->dist_timestamp > 0);

--- a/schemachange/sc_records.c
+++ b/schemachange/sc_records.c
@@ -36,6 +36,7 @@
 #include "logmsg.h"
 #include "debug_switches.h"
 #include "localrep.h"
+#include "views.h"
 
 int gbl_logical_live_sc = 0;
 

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -5122,6 +5122,8 @@ void comdb2AlterTableEnd(Parse *pParse)
                          "Cannot partition a constraint target table");
                 goto cleanup;
             }
+        } else if (sc->partition.type == PARTITION_MERGE) {
+            sc->force_rebuild = 1;
         }
     }
 

--- a/tests/logical_ops.test/runit
+++ b/tests/logical_ops.test/runit
@@ -63,6 +63,51 @@ insert 1 10
 export COMDB2TZ="America/New_York"
 $CDB2SQL_EXE -s $CDB2_OPTIONS $DBNAME default "select opnum, operation, tablename, oldrecord, record from comdb2_logical_operations" > select.txt
 
+nbefore=`$CDB2SQL_EXE --tabs -s $CDB2_OPTIONS $DBNAME default "SELECT COUNT(*) FROM comdb2_logical_operations"`
+$CDB2SQL_EXE -s $CDB2_OPTIONS $DBNAME default "REBUILD alltypes"
+nafter=`$CDB2SQL_EXE --tabs -s $CDB2_OPTIONS $DBNAME default "SELECT COUNT(*) FROM comdb2_logical_operations"`
+
+# rebuild should not write llog records
+if [[ "$nbefore" != "$nafter" ]]; then
+    failexit "Rebuild shouldn't generate logical log records!"
+fi
+
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbname default - <<"EOF"
+create table yet_another_alltypes {
+schema
+{
+    short           alltypes_short           null=yes
+    u_short         alltypes_ushort          null=yes
+    int             alltypes_int             null=yes
+    u_int           alltypes_uint            null=yes
+    longlong        alltypes_longlong        null=yes
+    float           alltypes_float           null=yes
+    double          alltypes_double          null=yes
+    byte            alltypes_byte[16]        null=yes
+    cstring         alltypes_cstring[16]     null=yes
+    datetime        alltypes_datetime        null=yes
+    datetimeus      alltypes_datetimeus      null=yes
+    intervalym      alltypes_intervalym      null=yes
+    intervalds      alltypes_intervalds      null=yes
+    intervaldsus    alltypes_intervaldsus    null=yes
+    decimal32       alltypes_decimal32       null=yes
+    decimal64       alltypes_decimal64       null=yes
+    decimal128      alltypes_decimal128      null=yes
+}
+}
+EOF
+
+# partition-table should not write llog
+nbefore=`$CDB2SQL_EXE --tabs -s $CDB2_OPTIONS $DBNAME default "SELECT COUNT(*) FROM comdb2_logical_operations"`
+$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "ALTER TABLE yet_another_alltypes PARTITIONED BY TIME PERIOD 'DAILY' RETENTION 3 START '1970-01-01'"
+$CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "ALTER TABLE yet_another_alltypes PARTITIONED BY NONE"
+nafter=`$CDB2SQL_EXE --tabs -s $CDB2_OPTIONS $DBNAME default "SELECT COUNT(*) FROM comdb2_logical_operations"`
+
+# partitioning should not write llog records
+if [[ "$nbefore" != "$nafter" ]]; then
+    failexit "Partitioning shouldn't generate logical log records!"
+fi
+
 diff ./select.txt ./expected.txt
 if [[ $? != 0 ]]; then
     failexit "Unexpected results from comdb2_logical_operations"

--- a/tests/timepart_trunc.test/run.log.alpha
+++ b/tests/timepart_trunc.test/run.log.alpha
@@ -982,6 +982,8 @@ Test ALTER table MERGE
 (a=100)
 (a=200)
 [select * from t16 order by a] failed with rc -3 no such table: t16
+(a=100, c=NULL)
+(a=200, c=NULL)
 cdb2sql -tabs ${CDB2_OPTIONS} dorintdb default exec procedure sys.cmd.send('partitions')
 [
  {

--- a/tests/timepart_trunc.test/runit
+++ b/tests/timepart_trunc.test/runit
@@ -486,6 +486,37 @@ $cmd "select * from t15 order by a" >> $OUT
 echo $cmd "select * from t16 order by a"
 $cmd "select * from t16 order by a" >> $OUT 2>&1
 
+echo $cmd "delete from t15"
+$cmd "delete from t15"
+if (( $? != 0 )) ; then
+   echo "FAILURE to alter merge"
+   exit 1
+fi
+
+echo $cmd "CREATE TABLE t16_2(a int)"
+$cmd "CREATE TABLE t16_2(a int)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to create table t16_2"
+   exit 1
+fi
+
+echo $cmd "insert into t16_2 values (100), (200)"
+$cmd "insert into t16_2 values (100), (200)"
+if (( $? != 0 )) ; then
+   echo "FAILURE to insert into t16_2"
+   exit 1
+fi
+
+echo $cmd "alter table t15 add column c int, merge t16_2"
+$cmd "alter table t15 add column c int, merge t16_2"
+if (( $? != 0 )) ; then
+   echo "FAILURE to alter merge"
+   exit 1
+fi
+
+echo $cmd "select * from t15 order by a"
+$cmd "select * from t15 order by a" >> $OUT
+
 timepart_stats 0
 
 header 16 "Test PARTITION NONE on ALIASED table"


### PR DESCRIPTION
A schema change rebuild produces logical log for its writes against the `NEW.` table, when logical logging is enabled. This is wasteful, and slows down non-modsnap and serializable transactions in flight.