### PR TITLE
180877315: Print clnt info after exhausting retries

### DIFF
--- a/db/osql_srs.c
+++ b/db/osql_srs.c
@@ -355,9 +355,8 @@ static int srs_tran_replay_int(struct sqlclntstate *clnt, int(dispatch_fn)(struc
     } while (osql->replay == OSQL_RETRY_DO && clnt->verify_retries <= gbl_osql_verify_retries_max);
 
     if (clnt->verify_retries >= gbl_osql_verify_retries_max && osql->xerr.errval) {
-        uuidstr_t us;
-        logmsg(LOGMSG_ERROR, "transaction %llx %s failed %d times with verify errors\n", osql->rqid,
-               comdb2uuidstr(osql->uuid, us), clnt->verify_retries);
+        logmsg(LOGMSG_ERROR, "transaction from pid %d on origin host %s failed %d times with verify errors\n",
+               clnt->last_pid, clnt->origin, clnt->verify_retries);
         /* Set to NONE to suppress the error from srs_tran_destroy(). */
         osql_set_replay(__FILE__, __LINE__, clnt, OSQL_RETRY_NONE);
     }


### PR DESCRIPTION
The uuid that is currently printed is not useful for identifying the client. The changes in this PR print the client's pid and machine instead.

Ex:
> transaction from pid 19750 on origin host m0.comdb2 failed 2 times with verify errors