### PR TITLE
`{179630312}`: Avoid blocking on bdb-lock to check coherency

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1937,6 +1937,7 @@ extern int gbl_logical_live_sc;
 extern int gbl_test_io_errors;
 extern uint64_t gbl_sc_headroom;
 extern int gbl_debug_always_reload_schemas_after_recovery;
+extern int gbl_prefer_non_blocking_coherency_check;
 
 /* init routines */
 int appsock_init(void);

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2590,5 +2590,9 @@ REGISTER_TUNABLE("debug_always_reload_schemas_after_recovery",
                  "acquire the schema lock and bdb lock in opposite orders. "
                  "(Default: off)",
                  TUNABLE_BOOLEAN, &gbl_debug_always_reload_schemas_after_recovery, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("prefer_non_blocking_coherency_check",
+                 "If set, prefer to use `bdb_try_am_i_coherent()` over `bdb_am_i_coherent()` when checking whether we "
+                 "are coherent. (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_prefer_non_blocking_coherency_check, 0, NULL, NULL, NULL, NULL);
 
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -763,6 +763,7 @@
 (name='prefaulthelper_blockops', description='', type='INTEGER', value='1', read_only='Y')
 (name='prefaulthelper_sqlreadahead', description='', type='INTEGER', value='1', read_only='Y')
 (name='prefaulthelperthreads', description='Max number of prefault helper threads. (Default: 0)', type='INTEGER', value='0', read_only='Y')
+(name='prefer_non_blocking_coherency_check', description='If set, prefer to use `bdb_try_am_i_coherent()` over `bdb_am_i_coherent()` when checking whether we are coherent. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='prefix_foreign_keys', description='Allow foreign key to be a prefix of your key', type='BOOLEAN', value='ON', read_only='N')
 (name='print_blockp_stats', description='print thread-count in block processor', type='BOOLEAN', value='OFF', read_only='N')
 (name='print_deadlock_cycles', description='Print every Nth deadlock cycle, set to 0 to turn off. (Default: 100)', type='INTEGER', value='100', read_only='N')


### PR DESCRIPTION
If the bdb-lock is desired, an election is in progress, which means we are not coherent because the master is changing. In this case, we do not need to wait on the bdb-lock to know that we are incoherent.