### PR TITLE
enable_snapshot => enable_serial in serialstep test

### DIFF
--- a/tests/serialstep.test/lrl.options
+++ b/tests/serialstep.test/lrl.options
@@ -8,7 +8,7 @@ table receipt receipt.csc2
 table rollover rollover.csc2
 table t1 t1.csc2
 table intv intv.csc2
-enable_snapshot_isolation
+enable_serial_isolation
 setattr WAIT_FOR_SEQNUM_TRACE 1
 logmsg level info
 set_coherent_state_trace on

--- a/tests/serialstep.test/s16_01.req.exp
+++ b/tests/serialstep.test/s16_01.req.exp
@@ -10,6 +10,7 @@ done
 done
 (rows updated=1)
 done
+[commit] failed with rc -103 selectv constraints
 done
 done
 (id=1, b1=x'11')
@@ -25,5 +26,5 @@ done
 done
 (rows updated=1)
 done
-[commit] failed with rc -103 constraints error, no genid
+[commit] failed with rc -103 selectv constraints
 done

--- a/tests/serialstep.test/s2_01.req.exp
+++ b/tests/serialstep.test/s2_01.req.exp
@@ -37,5 +37,6 @@ done
 done
 [commit] failed with rc 230 transaction is not serializable
 done
+[commit] failed with rc 230 transaction is not serializable
 done
 done


### PR DESCRIPTION
/adhoc-test serialstep

This PR updates a test case to comply with the new requirement that all clients running serializable transactions must set `enable_serial_isolation`. As a result, a few outputs changed because `selectv`’s range-checking implementation kicks in when `enable_serial_isolation` is used. These differences are noted in the PR comments.