### PR TITLE
Address physrep replication bugs

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -68,6 +68,7 @@ int gbl_prefault_latency = 0;
 int gbl_long_log_truncation_warn_thresh_sec = INT_MAX;
 int gbl_long_log_truncation_abort_thresh_sec = INT_MAX;
 int gbl_debug_drop_nth_rep_message = 0;
+int gbl_broadcast_newmaster = 1;
 extern int gbl_debug_stat4dump_loop;
 
 extern struct thdpool *gbl_udppfault_thdpool;
@@ -4837,6 +4838,10 @@ void berkdb_receive_msg(void *ack_handle, void *usr_ptr, char *from_host,
         }
 
         bdb_state->dbenv->rep_flush(bdb_state->dbenv);
+
+        if (gbl_broadcast_newmaster) {
+            bdb_state->dbenv->rep_newmaster(bdb_state->dbenv);
+        }
 
         logmsg(LOGMSG_INFO, "USER_TYPE_LSNCMP %d %d    %d %d host:%s\n", lsn_cmp.lsn.file,
                 cur_lsn.file, lsn_cmp.lsn.offset, cur_lsn.offset, from_host);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2592,6 +2592,7 @@ struct __db_env {
 	void *rep_handle;		/* Replication handle and methods. */
 	int  (*rep_elect) __P((DB_ENV *, int, int, u_int32_t, u_int32_t *, int *, char **));
 	int  (*rep_flush) __P((DB_ENV *));
+	int  (*rep_newmaster) __P((DB_ENV *));
 	int  (*rep_process_message) __P((DB_ENV *, DBT *, DBT *,
 		char **, DB_LSN *, uint32_t *, uint32_t *, char **, int));
 	int  (*rep_verify_will_recover) __P((DB_ENV *, DBT *, DBT *));

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -345,6 +345,7 @@ extern int gbl_ufid_dbreg_test;
 extern int gbl_debug_add_replication_latency;
 extern int gbl_javasp_early_release;
 extern int gbl_debug_drop_nth_rep_message;
+extern int gbl_broadcast_newmaster;
 extern int gbl_fdb_emulate_old;
 
 extern long long sampling_threshold;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1498,6 +1498,10 @@ REGISTER_TUNABLE("debug_drop_nth_rep_message", "Drop the Nth replication message
                  "for testing purposes (Default: 0)", TUNABLE_INTEGER,
                  &gbl_debug_drop_nth_rep_message, EXPERIMENTAL | INTERNAL, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("broadcast_newmaster",
+                 "Broadcast new-master periodically.  "
+                 "(Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_broadcast_newmaster, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE(
     "max_clientstats",
     "Max number of client stats stored in comdb2_clientstats. (Default: 10000)",

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1883,6 +1883,91 @@ function check_metadb_memstat
     fi
 }
 
+# Halt a clustered physical replicant .. swing the master on that cluster
+# a number of times, then restart the physical replicant .. looking at the 
+# trace, verify that nothing ignores rectype 2, 11, or 10 ..
+function verify_non_ignored_reptype
+{
+    # Find the physrep-cluster master
+    local exit_node=""
+    local j=0
+    local cnt=0
+    local available=0
+    local clus_master=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_CLUS_DBNAME --host $firstNode "select host from comdb2_cluster where is_master='Y'")
+    local found_incoherent=1
+
+    for node in $CLUSTER ; do
+        if [[ "$node" != "$clus_master" ]]; then
+            exit_node=$node
+            break
+        fi
+    done
+
+    echo "Exiting $exit_node"
+    $CDB2SQL_EXE $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $exit_node "exec procedure sys.cmd.send('exit')"
+
+    sleep 5
+
+    echo "Create a table against source"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table ignored_reptype(a int)"
+
+    echo "Insert into source"
+    j=0
+    while [[ "$j" -lt 10 ]]; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into ignored_reptype select * from generate_series(1, 1000)"
+        let j=j+1
+    done
+
+    echo "Block until cluster has these records"
+    while [[ "$cnt" -ne "10000" ]]; do
+        sleep 1
+        cnt=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_CLUS_DBNAME --host $clus_master "select count(*) from ignored_reptype")
+    done
+
+    echo "Force 5 elections"
+
+    j=0
+    while [[ "$j" -lt 5 ]]; do
+        for node in $CLUSTER ; do
+            if [[ "$node" == "$clus_master" ]]; then
+                continue
+            fi
+            $CDB2SQL_EXE $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $node "exec procedure sys.cmd.send('downgrade')"
+        done
+        sleep 5
+        let j=j+1
+    done
+
+    echo "Restart $exit_node"
+    logFile=$TESTDIR/logs/${REPL_CLUS_DBNAME}.${exit_node}.log
+    ssh ${exit_node} "$COMDB2_EXE ${REPL_CLUS_DBNAME} --lrl ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.lrl --pidfile ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.pid" >> ${logFile} 2>&1 < /dev/null &
+    PIDs="${PIDx} $!"
+
+    echo "Block until $exit_node is available"
+    while [[ "$available" -eq 0 ]]; do
+        sleep 1
+        $CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_CLUS_DBNAME --host $exit_node "select 1" >/dev/null 2>&1
+        if [[ $? -eq 0 ]]; then
+            available=1
+        fi
+    done
+
+    echo "Find master again"
+    clus_master=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_CLUS_DBNAME --host $firstNode "select host from comdb2_cluster where is_master='Y'")
+
+    while [[ "$found_incoherent" -ne 0 ]]; do
+        sleep 1
+        found_incoherent=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_CLUS_DBNAME --host $clus_master "select count(*) from comdb2_cluster where coherent_state != 'coherent'")
+    done
+
+    echo "We are coherent- verify that rep-messages were not ignored"
+    ignored=$(egrep "Ignoring rp->gen" ${TESTDIR}/logs/${REPL_CLUS_DBNAME}.*.log | egrep "rectype=2\>|rectype=11\>|rectype=10\>")
+
+    [[ -n "$ignored" ]] && cleanFailExit "Found ignored rep-messages after incoherent recovery: $ignored"
+}
+
+# egrep "Ignoring rp->gen" * | egrep "rectype=2\>|rectype=11\>|rectype=10\>"
+
 function announce
 {
     typeset text=$1
@@ -2015,6 +2100,11 @@ function run_tests
     testcase="check_metadb_memstat"
     testcase_preamble $testcase
     check_metadb_memstat
+    testcase_finish $testcase
+
+    testcase="verify_non_ignored_reptype"
+    testcase_preamble $testcase
+    verify_non_ignored_reptype
     testcase_finish $testcase
 }
 


### PR DESCRIPTION
Fixes two bugs for clustered physrep installations.  

First is that physical replicants would incorrectly ignore ALIVE_REQ, NEWCLIENT, and MASTER_REQ requests from lower generation clients.  This fixes the issue where a newly started physical replicant would be unable to join a physrep cluster.

Second is that skip-recovery code failed to update the last-locked-lsn with the truncated-lsn.  Leaving this as 0 prevented physreps from broadcasting the correct seqnum to the cluster.  Non-physrep clusters paper over this issue when the master issues a write when it sees an incoherent replicant.

Additionally, adopts new convention of master periodically broadcasting 'NEWMASTER' from the watcher thread.