### PR TITLE
Adjust reqlog_netwait test timing

### DIFF
--- a/tests/reqlog_netwait.test/runit
+++ b/tests/reqlog_netwait.test/runit
@@ -35,7 +35,7 @@ if [ "$milliseconds" -gt 100 ]; then
 fi
 echo netwait 1: $milliseconds
 milliseconds=`grep rowcount=5 $logfile | awk '{print substr($0, index($0, "netwait=") + length("netwait=")) + 0}'`
-if [ "$milliseconds" -lt 5000 ]; then
+if [ "$milliseconds" -lt 4000 ]; then
     echo netwait latency too low $milliseconds >&2
     exit 1
 fi


### PR DESCRIPTION
This PR updates the minimum latency check to match expected behavior. The check ensures that [this big query](https://github.com/bloomberg/comdb2/blob/main/tests/tools/slowreaders.c#L17-L20) blocks the db’s network buffer for the expected duration. It used to assume 5 seconds, but in reality it seems like it should be 4 seconds: That’s because the db can already load the last record into the buffer after the client calls `cdb2_next_record` 4 times—corresponding to 4 `sleep(1)`s.  






