### PR TITLE
180565576: Fix cdb2sql test failure

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5473,6 +5473,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
     clnt->netwaitus = 0;
     clnt->set_continue_on_chunk_verify_error = 0;
     clnt->continued_on_chunk_verify_error = 0;
+    clnt->multiline = 0;
 
     if (gbl_sockbplog) {
         init_bplog_socket(clnt);

--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -10,7 +10,6 @@ analyze,UNKNOWN,180528295
 analyze_partial_index_off_generated,UNKNOWN,180528295
 analyze_fastinit_race,DB_BUG,180915422
 incoherent_slow,UNKNOWN,180565323
-cdb2sql,UNKNOWN,180565576
 logfill_logput_window_generated,UNKNOWN,180717427
 logfill,UNKNOWN,180717427
 comdb2sys,FLAKEY,180779255


### PR DESCRIPTION
Resetting clnt doesn't set `clnt->multiline` to 0, so if a previous client ran in multiline mode, then a future client could also run in multiline mode even if they don't request it. Addressing this appears to fix the cdb2sql test failure.