### PR TITLE
Reconnect-interval -> 1 week

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1903,7 +1903,7 @@ REGISTER_TUNABLE("physrep_metadb_name", "Physical replication metadb cluster nam
                  NULL);
 REGISTER_TUNABLE("physrep_reconnect_penalty", "Physrep wait seconds before retry to the same node. (Default: 5)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_penalty, 0, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("physrep_reconnect_interval", "Reconnect interval for physical replicants (Default: 600)",
+REGISTER_TUNABLE("physrep_reconnect_interval", "Reconnect interval for physical replicants (Default: 604800)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_interval, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_shuffle_host_list",
                  "Shuffle the host list returned by register_replicant() "

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -59,7 +59,7 @@ typedef struct DB_Connection {
     } while (0)
 
 int gbl_physrep_debug = 0;
-int gbl_physrep_reconnect_interval = 3600; // force re-registration every hour
+int gbl_physrep_reconnect_interval = 604800; // force re-registration every week
 int gbl_physrep_reconnect_penalty = 0;
 int gbl_blocking_physrep = 1;
 int64_t gbl_physrep_metadb_sql_count = 0;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -758,7 +758,7 @@
 (name='physrep_metadb_host', description='List of physical replication metadb cluster hosts.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_metadb_name', description='Physical replication metadb cluster name.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_pollms', description='Physical replicant poll interval in milliseconds. (Default: 50)', type='INTEGER', value='50', read_only='N')
-(name='physrep_reconnect_interval', description='Reconnect interval for physical replicants (Default: 600)', type='INTEGER', value='3600', read_only='N')
+(name='physrep_reconnect_interval', description='Reconnect interval for physical replicants (Default: 604800)', type='INTEGER', value='604800', read_only='N')
 (name='physrep_reconnect_penalty', description='Physrep wait seconds before retry to the same node. (Default: 5)', type='INTEGER', value='0', read_only='N')
 (name='physrep_repl_host', description='Current physrep host.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_repl_name', description='Current physrep parent.', type='STRING', value=NULL, read_only='Y')


### PR DESCRIPTION
Our current default still forces physical replicants to reconnect to a source machine, and run recovery once every hour.  This PR changes the reconnect interval to once every week.
