### PR TITLE
Increase cldeadlock timeout

### DIFF
--- a/tests/cldeadlock.test/Makefile
+++ b/tests/cldeadlock.test/Makefile
@@ -5,5 +5,5 @@ else
 endif
 
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=15m
 endif


### PR DESCRIPTION
This test slowed down when coverage was enabled.  Increase the timeout to 15 minutes.
