### PR TITLE
Make enable_selectv_range_check enable logical logging

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -1365,6 +1365,9 @@ static int read_lrl_option(struct dbenv *dbenv, char *line,
     } else if (tokcmp(tok, ltok, "use_llmeta") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_LLMETA, 1);
         logmsg(LOGMSG_INFO, "using low level meta table\n");
+    } else if (tokcmp(tok, ltok, "enable_selectv_range_check") == 0) {
+        bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
+        gbl_selectv_rangechk = 1;
     } else if (tokcmp(tok, ltok, "enable_logical_logging") == 0) {
         bdb_attr_set(dbenv->bdb_attr, BDB_ATTR_SNAPISOL, 1);
         logmsg(LOGMSG_INFO, "Enabled logical logging\n");

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -496,8 +496,7 @@ REGISTER_TUNABLE("enable_prefault_udp", "Send lossy prefault requests to replica
 REGISTER_TUNABLE("enable_selectv_range_check",
                  "If set, SELECTV will send ranges for verification, not every "
                  "touched record. (Default: off)",
-                 TUNABLE_BOOLEAN, &gbl_selectv_rangechk, NOARG, NULL, NULL,
-                 NULL, NULL);
+                 TUNABLE_BOOLEAN, &gbl_selectv_rangechk, NOARG | READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("disable_selectv_range_check",
                  "Disables 'enable_selectv_range_check'", TUNABLE_BOOLEAN,
                  &gbl_selectv_rangechk, INVERSE_VALUE | NOARG, NULL, NULL, NULL,

--- a/tests/occ_selectv.test/lrl.options
+++ b/tests/occ_selectv.test/lrl.options
@@ -1,5 +1,4 @@
 table jobs t.csc2
 table schedule t.csc2
 maxosqltransfer 200000
-enable_snapshot_isolation
 enable_selectv_range_check

--- a/tests/selectv_recom_range.test/lrl.options
+++ b/tests/selectv_recom_range.test/lrl.options
@@ -1,5 +1,4 @@
 table t1 t1.csc2
 table t2 t2.csc2
 round_robin_stripes
-enable_snapshot_isolation
 enable_selectv_range_check

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -341,7 +341,7 @@
 (name='enable_pageorder_recsz_check', description='Disables 'disable_pageorder_recsz_chk'', type='BOOLEAN', value='ON', read_only='N')
 (name='enable_partial_indexes', description='If set, allows partial index definitions in table schema. (Default: off)', type='BOOLEAN', value='ON', read_only='Y')
 (name='enable_prefault_udp', description='Send lossy prefault requests to replicants. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
-(name='enable_selectv_range_check', description='If set, SELECTV will send ranges for verification, not every touched record. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
+(name='enable_selectv_range_check', description='If set, SELECTV will send ranges for verification, not every touched record. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='enable_seqnum_generations', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='enable_serial_isolation', description='Enable to allow SERIALIZABLE level transactions to run against the database. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='enable_snapshot_isolation', description='Enable to allow SNAPSHOT level transactions to run against the database. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')


### PR DESCRIPTION
The tunable `enable_selectv_range_check` wasn’t turning on logical logging, even though the range check depends on it. Some tests worked around this by enabling snapshots just to get logical logging, even when they didn’t actually use snapshot transactions.

This PR fixes that by making `enable_selectv_range_check` automatically enable logical logging. That allows us to safely remove the logical logging dependency from snapshot.