### PR TITLE
Increase consumer test timeout

### DIFF
--- a/tests/consumer.test/Makefile
+++ b/tests/consumer.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=2m
+	export TEST_TIMEOUT=4m
 endif


### PR DESCRIPTION
The consumer test failed due to a timeout. It was making progress and nearly finished before timing out. Looking at previous successful runs, this test often runs close to the timeout limit. This PR increases the timeout to give it a bit more breathing room.