### PR TITLE
remote write only transaction need to also reset clnt effects before accouting

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1037,6 +1037,14 @@ int osql_sock_commit(struct sqlclntstate *clnt, int type, enum trans_clntcomm si
     osql->timings.commit_start = osql_log_time();
 
     if (clnt->dbtran.mode == TRANLEVEL_SOSQL && !osql->sock_started) {
+        /* we only have remote writes; at this point, we have clnt->effects tracking all remote writes
+         * also clnt->remote_effects
+         * if we have local writes, the clnt->effects gets reset, so final commit results are ok (we 
+         * add whatever local master sends to the clnt->remote_effects);
+         * HERE howewer, there is no local write, so clnt->effects does not get reset; we need to reset
+         * it so we do not overcount
+         */
+        bzero(&clnt->effects, sizeof(clnt->effects));
         goto done;
     }
 

--- a/tests/fdb_push.test/output.log
+++ b/tests/fdb_push.test/output.log
@@ -546,3 +546,25 @@ Number of rows selected 4
 Number of rows deleted 0
 Number of rows updated 0
 Number of rows inserted 0
+only remote writes, no verifyretry
+Effects not sent by comdb2 server. 
+Number of rows affected 0
+Number of rows selected 0
+Number of rows deleted 0
+Number of rows updated 0
+Number of rows inserted 0
+Number of rows affected 5
+Number of rows selected 0
+Number of rows deleted 0
+Number of rows updated 5
+Number of rows inserted 0
+Number of rows affected 9
+Number of rows selected 0
+Number of rows deleted 4
+Number of rows updated 5
+Number of rows inserted 0
+Number of rows affected 9
+Number of rows selected 0
+Number of rows deleted 4
+Number of rows updated 5
+Number of rows inserted 0

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -226,6 +226,16 @@ select * from LOCAL_${a_remdbname}.t order by 1
 select * from LOCAL_${a_remdbname2}.t order by 1
 EOF
 
+echo "only remote writes, no verifyretry" >> $output
+#echo cdb2sql -f q.txt -s -showeffects$a_dbname localhost - 
+cdb2sql -s -showeffects ${SRC_CDB2_OPTIONS} $a_dbname default -  >> $output 2>&1 << EOF
+set verifyretry off
+begin
+update LOCAL_${a_remdbname}.t set id = id + 100
+delete from LOCAL_${a_remdbname2}.t
+commit
+EOF
+
 #convert the table to actual dbname
 sed "s/dorintdb/${a_remdbname}/g" output.log > output.log.actual
 


### PR DESCRIPTION
If the local master resets a replicant clnt effects structure, and that makes the final accounting for effects work.  If a transaction has only remote writes, there is no local master so the accounting double counts remote writes if verifyretry is off.  Fix is to reset effects in this case too.