### PR TITLE
{181155636}: disabling libcrypto atexit handler

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1782,6 +1782,11 @@ void clean_exit(void)
 
     backend_cleanup(thedb);
     net_cleanup();
+
+    if (gbl_ssl_ctx != NULL) {
+        SSL_CTX_free(gbl_ssl_ctx);
+        OPENSSL_cleanup();
+    }
     cleanup_sqlite_master();
 
     free_dbtables(thedb);

--- a/db/ssl_bend.c
+++ b/db/ssl_bend.c
@@ -308,7 +308,10 @@ int ssl_bend_init(const char *default_certdir)
     char errmsg[512];
     ks = (gbl_cert_dir == NULL) ? default_certdir : gbl_cert_dir;
 
-    rc = cdb2_init_ssl(1, 1);
+    rc = OPENSSL_init_crypto(OPENSSL_INIT_NO_ATEXIT, NULL);
+    if (rc != 1)
+        return -1;
+    rc = cdb2_init_ssl(1, 0);
     if (rc != 0)
         return rc;
 


### PR DESCRIPTION
By default openssl cleans up itself using an atexit handler, which may race with ongoing ssl operations. This patch disables the atexit handler, and performs cleanup in clean_exit() instead.