### PR TITLE
Bump unionpar_maxqueue test timeout

### DIFF
--- a/tests/unionpar_maxqueue.test/Makefile
+++ b/tests/unionpar_maxqueue.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=15m
 endif


### PR DESCRIPTION
This test has been failing due to timeouts. It was making progress before timing out. Successful runs also cut close to the timeout limit. This PR increases the timeout to give it a bit more breathing room.