### PR TITLE
Enable serializable in sirandtest2

### DIFF
--- a/tests/sirandtest2.test/lrl.options
+++ b/tests/sirandtest2.test/lrl.options
@@ -4,4 +4,5 @@ dtastripe 4
 blobstripe
 round_robin_stripes
 enable_snapshot_isolation
+enable_serial_isolation
 ssl_client_mode OPTIONAL


### PR DESCRIPTION
Allows us to remove logical logging from snapshot without breaking serializable tests