### PR TITLE
{180685083} fix(reqlog): do not block statreq updates during schema change

### DIFF
--- a/bbinc/thread_stats.h
+++ b/bbinc/thread_stats.h
@@ -36,6 +36,7 @@ struct berkdb_thread_stats {
     unsigned n_memp_fgets;
     uint64_t memp_fget_time_us;
 
+    /* number of times data had to be paged into / out of the buffer pool */
     unsigned n_memp_pgs;
     uint64_t memp_pg_time_us;
 

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4851,233 +4851,191 @@ void *statthd(void *p)
         if (count % gbl_update_metrics_interval == 0)
             update_metrics();
 
-        if (!get_schema_change_in_progress(__func__, __LINE__)) {
-            thresh = reqlog_diffstat_thresh();
-            if ((thresh > 0) && (count >= thresh)) { /* every thresh-seconds */
-                strbuf *logstr = strbuf_new();
-                diff_qtrap = nqtrap - last_report_nqtrap;
-                diff_fstrap = nfstrap - last_report_nfstrap;
-                diff_nsql = nsql - last_report_nsql;
-                diff_nsql_steps = nsql_steps - last_report_nsql_steps;
-                diff_newsql = newsql - last_report_newsql;
-                int diff_newsql_steps = newsql_steps - last_report_newsql_steps;
-                diff_nretries = nretries - last_report_nretries;
-                diff_ncommits = ncommits - last_report_ncommits;
-                diff_ncommit_time = ncommit_time - last_report_ncommit_time;
+        thresh = reqlog_diffstat_thresh();
+        if ((thresh > 0) && (count >= thresh)) { /* every thresh-seconds */
+            strbuf *logstr = strbuf_new();
+            diff_qtrap = nqtrap - last_report_nqtrap;
+            diff_fstrap = nfstrap - last_report_nfstrap;
+            diff_nsql = nsql - last_report_nsql;
+            diff_nsql_steps = nsql_steps - last_report_nsql_steps;
+            diff_newsql = newsql - last_report_newsql;
+            int diff_newsql_steps = newsql_steps - last_report_newsql_steps;
+            diff_nretries = nretries - last_report_nretries;
+            diff_ncommits = ncommits - last_report_ncommits;
+            diff_ncommit_time = ncommit_time - last_report_ncommit_time;
 
-                diff_bpool_hits = bpool_hits - last_report_bpool_hits;
-                diff_bpool_misses = bpool_misses - last_report_bpool_misses;
+            diff_bpool_hits = bpool_hits - last_report_bpool_hits;
+            diff_bpool_misses = bpool_misses - last_report_bpool_misses;
 
-                if (diff_qtrap || diff_newsql || diff_nsql || diff_nsql_steps ||
-                    diff_fstrap || diff_bpool_hits || diff_bpool_misses ||
-                    diff_ncommit_time) {
+            if (diff_qtrap || diff_newsql || diff_nsql || diff_nsql_steps || diff_fstrap || diff_bpool_hits ||
+                diff_bpool_misses || diff_ncommit_time) {
 
-                    strbuf_appendf(logstr, "diff");
-                    if (diff_qtrap || diff_nretries) {
-                        strbuf_appendf(logstr, " n_reqs %d n_retries %d",
-                                       diff_qtrap, diff_nretries);
-                    }
-                    if (diff_nsql) {
-                        strbuf_appendf(logstr, " nsql %d", diff_nsql);
-                    }
-                    if (diff_newsql) {
-                        strbuf_appendf(logstr, " newsql %d", diff_newsql);
-                    }
-                    if (diff_nsql_steps) {
-                        strbuf_appendf(logstr, " nsqlsteps %d",
-                                       diff_nsql_steps);
-                    }
-                    if (diff_newsql_steps) {
-                        strbuf_appendf(logstr, " newsqlsteps %d",
-                                       diff_newsql_steps);
-                    }
-                    if (diff_fstrap) {
-                        strbuf_appendf(logstr, " n_fsreqs %d", diff_fstrap);
-                    }
-                    if (diff_ncommit_time && diff_ncommits) {
-                        strbuf_appendf(logstr, " n_commit_time %lld ms",
-                                       diff_ncommit_time /
-                                           (1000 * diff_ncommits));
-                    }
-                    if (diff_bpool_hits) {
-                        strbuf_appendf(logstr, " n_cache_hits %llu",
-                                       (long long unsigned int)diff_bpool_hits);
-                    }
-                    if (diff_bpool_misses) {
-                        strbuf_appendf(
-                            logstr, " n_cache_misses %llu",
-                            (long long unsigned int)diff_bpool_misses);
-                    }
-                    strbuf_appendf(logstr, "\n");
-                    reqlog_logl(statlogger, REQL_INFO, strbuf_buf(logstr));
+                strbuf_appendf(logstr, "diff");
+                if (diff_qtrap || diff_nretries) {
+                    strbuf_appendf(logstr, " n_reqs %d n_retries %d", diff_qtrap, diff_nretries);
                 }
-
-                int aa_include_updates = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_AA_COUNT_UPD);
-                rdlock_schema_lk();
-                for (ii = 0; ii < dbenv->num_dbs; ++ii) {
-                    dbtable *tbl = dbenv->dbs[ii];
-                    int hdr = 0;
-
-                    for (jj = 0; jj <= MAXTYPCNT; jj++) {
-                        log_tbl_item(tbl->typcnt[jj], &tbl->prev_typcnt[jj], req2a, 
-                                     jj, NULL, &hdr, statlogger, tbl, 1);
-                    }
-
-                    for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
-                        log_tbl_item(tbl->blocktypcnt[jj], &tbl->prev_blocktypcnt[jj],
-                                     breq2a, jj, NULL, &hdr, statlogger, tbl, 0);
-                    }
-                    for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
-                        log_tbl_item(tbl->blockosqltypcnt[jj], &tbl->prev_blockosqltypcnt[jj],
-                                     osql_reqtype_str, jj, NULL, &hdr, statlogger, tbl, 0);
-                    }
-
-                    log_tbl_item(dbenv->txns_committed, &dbenv->prev_txns_committed,
-                                 NULL, 0, "txns committed", &hdr, statlogger, tbl, 0);
-
-                    log_tbl_item(dbenv->txns_aborted, &dbenv->prev_txns_aborted, NULL,
-                                 0, "txns aborted", &hdr, statlogger, tbl, 0);
-
-                    log_tbl_item(tbl->nsql, &tbl->prev_nsql, NULL, 0, "nsql",
-                                 &hdr, statlogger, tbl, 0);
-
-                    // log write_count, save in saved_write_count, compute autoanalyze delta
-                    int64_t prev = tbl->saved_write_count[RECORD_WRITE_DEL] +
-                                    tbl->saved_write_count[RECORD_WRITE_INS];
-                    int64_t curr = tbl->write_count[RECORD_WRITE_DEL] +
-                                    tbl->write_count[RECORD_WRITE_INS];
-
-                    if (aa_include_updates) {
-                        prev += tbl->saved_write_count[RECORD_WRITE_UPD];
-                        curr += tbl->write_count[RECORD_WRITE_UPD];
-                    }
-
-                    ATOMIC_ADD64(tbl->aa_saved_counter, (curr - prev));
-                    log_tbl_item(tbl->write_count[RECORD_WRITE_INS], &tbl->saved_write_count[RECORD_WRITE_INS],
-                                 NULL, 0, "inserted rows", &hdr, statlogger, tbl, 0);
-                    log_tbl_item(tbl->write_count[RECORD_WRITE_UPD], &tbl->saved_write_count[RECORD_WRITE_UPD],
-                                 NULL, 0, "updated rows", &hdr, statlogger, tbl, 0);
-                    log_tbl_item(tbl->write_count[RECORD_WRITE_DEL], &tbl->saved_write_count[RECORD_WRITE_DEL],
-                                 NULL, 0, "deleted rows", &hdr, statlogger, tbl, 0);
-                    log_tbl_item(tbl->casc_write_count, &tbl->saved_casc_write_count,
-                                 NULL, 0, "cascaded upd/del rows", &hdr, statlogger, tbl, 0);
-                    log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count,
-                                 NULL, 0, "deadlock count", &hdr, statlogger, tbl, 0);
+                if (diff_nsql) {
+                    strbuf_appendf(logstr, " nsql %d", diff_nsql);
                 }
-                unlock_schema_lk();
-
-                pstats = bdb_get_process_stats();
-                cur_bdb_stats = *pstats;
-                if (cur_bdb_stats.n_lock_waits > last_bdb_stats.n_lock_waits) {
-                    unsigned nwaits = cur_bdb_stats.n_lock_waits -
-                                      last_bdb_stats.n_lock_waits;
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "%u locks, avg time %ums, worst time %ums\n",
-                                nwaits,
-                                U2M(cur_bdb_stats.lock_wait_time_us -
-                                    last_bdb_stats.lock_wait_time_us) /
-                                    nwaits,
-                                U2M(cur_bdb_stats.worst_lock_wait_time_us));
-                    bb_berkdb_reset_worst_lock_wait_time_us();
+                if (diff_newsql) {
+                    strbuf_appendf(logstr, " newsql %d", diff_newsql);
                 }
-                if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
-                    unsigned npreads =
-                        cur_bdb_stats.n_preads - last_bdb_stats.n_preads;
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "%u preads, %u bytes, avg time %ums\n", npreads,
-                                cur_bdb_stats.pread_bytes -
-                                    last_bdb_stats.pread_bytes,
-                                U2M(cur_bdb_stats.pread_time_us -
-                                    last_bdb_stats.pread_time_us) /
-                                    npreads);
+                if (diff_nsql_steps) {
+                    strbuf_appendf(logstr, " nsqlsteps %d", diff_nsql_steps);
                 }
-                if (cur_bdb_stats.n_pwrites > last_bdb_stats.n_pwrites) {
-                    unsigned npwrites =
-                        cur_bdb_stats.n_pwrites - last_bdb_stats.n_pwrites;
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "%u pwrites, %u bytes, avg time %ums\n",
-                                npwrites, cur_bdb_stats.pwrite_bytes -
-                                              last_bdb_stats.pwrite_bytes,
-                                U2M(cur_bdb_stats.pwrite_time_us -
-                                    last_bdb_stats.pwrite_time_us) /
-                                    npwrites);
+                if (diff_newsql_steps) {
+                    strbuf_appendf(logstr, " newsqlsteps %d", diff_newsql_steps);
                 }
-                if (cur_bdb_stats.n_memp_fgets > last_bdb_stats.n_memp_fgets) {
-                    unsigned n_memp_fgets = cur_bdb_stats.n_memp_fgets -
-                                            last_bdb_stats.n_memp_fgets;
-                    unsigned us = cur_bdb_stats.memp_fget_time_us -
-                                  last_bdb_stats.memp_fget_time_us;
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "n_memp_fgets=%u, memp_fgets avg time=%ums\n",
-                                n_memp_fgets, U2M(us) / n_memp_fgets);
+                if (diff_fstrap) {
+                    strbuf_appendf(logstr, " n_fsreqs %d", diff_fstrap);
                 }
-                if (cur_bdb_stats.n_memp_pgs > last_bdb_stats.n_memp_pgs) {
-                    unsigned n_memp_pgs =
-                        cur_bdb_stats.n_memp_pgs - last_bdb_stats.n_memp_pgs;
-                    unsigned us = cur_bdb_stats.memp_pg_time_us -
-                                  last_bdb_stats.memp_pg_time_us;
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "n_memp_pgs=%u, memp_pgs avg time=%ums\n",
-                                n_memp_pgs, U2M(us) / n_memp_pgs);
+                if (diff_ncommit_time && diff_ncommits) {
+                    strbuf_appendf(logstr, " n_commit_time %lld ms", diff_ncommit_time / (1000 * diff_ncommits));
                 }
-                last_bdb_stats = cur_bdb_stats;
-
-                diff_deadlocks = ndeadlocks - last_report_deadlocks;
-                diff_lockwaits = nlockwaits - last_report_lockwaits;
-                diff_vreplays = vreplays - last_report_vreplays;
-
-                if (diff_deadlocks || diff_lockwaits || diff_vreplays)
-                    reqlog_logf(statlogger, REQL_INFO,
-                                "ndeadlocks %d, nlockwaits %d, vreplays %d, "
-                                "locks aborted %d\n",
-                                diff_deadlocks, diff_lockwaits, diff_vreplays,
-                                diff_locks_aborted);
-
-                bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes, curlsn,
-                                    sizeof(curlsn));
-                if (strcmp(curlsn, lastlsn) != 0) {
-                    reqlog_logf(statlogger, REQL_INFO, "LSN %s diff %llu\n",
-                                curlsn, curlsnbytes - lastlsnbytes);
-                    strncpy0(lastlsn, curlsn, sizeof(lastlsn));
-                    lastlsnbytes = curlsnbytes;
+                if (diff_bpool_hits) {
+                    strbuf_appendf(logstr, " n_cache_hits %llu", (long long unsigned int)diff_bpool_hits);
                 }
-
-                if (conns - last_report_conns || curr_conns) {
-                   reqlog_logf(statlogger, REQL_INFO, "connections %lld timeouts %lld current_connections %lld\n", 
-                         conns - last_report_conns,
-                         conn_timeouts - last_report_conn_timeouts,
-                         curr_conns);
+                if (diff_bpool_misses) {
+                    strbuf_appendf(logstr, " n_cache_misses %llu", (long long unsigned int)diff_bpool_misses);
                 }
-
-
-                reqlog_diffstat_dump(statlogger);
-
-                count = 0;
-                last_report_nqtrap = nqtrap;
-                last_report_nfstrap = nfstrap;
-                last_report_nsql = nsql;
-                last_report_nsql_steps = nsql_steps;
-                last_report_newsql = newsql;
-                last_report_newsql_steps = newsql_steps;
-                last_report_nretries = nretries;
-                last_report_bpool_hits = bpool_hits;
-                last_report_bpool_misses = bpool_misses;
-
-                last_report_deadlocks = ndeadlocks;
-                last_report_lockwaits = nlockwaits;
-                last_report_vreplays = vreplays;
-
-                last_report_ncommits = ncommits;
-                last_report_ncommit_time = ncommit_time;
-
-                last_report_conns = conns;
-                last_report_conn_timeouts = conn_timeouts;
-
-                osql_comm_diffstat(statlogger, NULL);
-                strbuf_free(logstr);
-
-                dump_client_sql_data(statlogger, 1);
+                strbuf_appendf(logstr, "\n");
+                reqlog_logl(statlogger, REQL_INFO, strbuf_buf(logstr));
             }
+
+            int aa_include_updates = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_AA_COUNT_UPD);
+            rdlock_schema_lk();
+            for (ii = 0; ii < dbenv->num_dbs; ++ii) {
+                dbtable *tbl = dbenv->dbs[ii];
+                int hdr = 0;
+
+                for (jj = 0; jj <= MAXTYPCNT; jj++) {
+                    log_tbl_item(tbl->typcnt[jj], &tbl->prev_typcnt[jj], req2a, jj, NULL, &hdr, statlogger, tbl, 1);
+                }
+
+                for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
+                    log_tbl_item(tbl->blocktypcnt[jj], &tbl->prev_blocktypcnt[jj], breq2a, jj, NULL, &hdr, statlogger,
+                                 tbl, 0);
+                }
+                for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
+                    log_tbl_item(tbl->blockosqltypcnt[jj], &tbl->prev_blockosqltypcnt[jj], osql_reqtype_str, jj, NULL,
+                                 &hdr, statlogger, tbl, 0);
+                }
+
+                log_tbl_item(dbenv->txns_committed, &dbenv->prev_txns_committed, NULL, 0, "txns committed", &hdr,
+                             statlogger, tbl, 0);
+
+                log_tbl_item(dbenv->txns_aborted, &dbenv->prev_txns_aborted, NULL, 0, "txns aborted", &hdr, statlogger,
+                             tbl, 0);
+
+                log_tbl_item(tbl->nsql, &tbl->prev_nsql, NULL, 0, "nsql", &hdr, statlogger, tbl, 0);
+
+                // log write_count, save in saved_write_count, compute autoanalyze delta
+                int64_t prev = tbl->saved_write_count[RECORD_WRITE_DEL] + tbl->saved_write_count[RECORD_WRITE_INS];
+                int64_t curr = tbl->write_count[RECORD_WRITE_DEL] + tbl->write_count[RECORD_WRITE_INS];
+
+                if (aa_include_updates) {
+                    prev += tbl->saved_write_count[RECORD_WRITE_UPD];
+                    curr += tbl->write_count[RECORD_WRITE_UPD];
+                }
+
+                ATOMIC_ADD64(tbl->aa_saved_counter, (curr - prev));
+                log_tbl_item(tbl->write_count[RECORD_WRITE_INS], &tbl->saved_write_count[RECORD_WRITE_INS], NULL, 0,
+                             "inserted rows", &hdr, statlogger, tbl, 0);
+                log_tbl_item(tbl->write_count[RECORD_WRITE_UPD], &tbl->saved_write_count[RECORD_WRITE_UPD], NULL, 0,
+                             "updated rows", &hdr, statlogger, tbl, 0);
+                log_tbl_item(tbl->write_count[RECORD_WRITE_DEL], &tbl->saved_write_count[RECORD_WRITE_DEL], NULL, 0,
+                             "deleted rows", &hdr, statlogger, tbl, 0);
+                log_tbl_item(tbl->casc_write_count, &tbl->saved_casc_write_count, NULL, 0, "cascaded upd/del rows",
+                             &hdr, statlogger, tbl, 0);
+                log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count, NULL, 0, "deadlock count", &hdr,
+                             statlogger, tbl, 0);
+            }
+            unlock_schema_lk();
+
+            pstats = bdb_get_process_stats();
+            cur_bdb_stats = *pstats;
+            if (cur_bdb_stats.n_lock_waits > last_bdb_stats.n_lock_waits) {
+                unsigned nwaits = cur_bdb_stats.n_lock_waits - last_bdb_stats.n_lock_waits;
+                reqlog_logf(statlogger, REQL_INFO, "%u locks, avg time %ums, worst time %ums\n", nwaits,
+                            U2M(cur_bdb_stats.lock_wait_time_us - last_bdb_stats.lock_wait_time_us) / nwaits,
+                            U2M(cur_bdb_stats.worst_lock_wait_time_us));
+                bb_berkdb_reset_worst_lock_wait_time_us();
+            }
+            if (cur_bdb_stats.n_preads > last_bdb_stats.n_preads) {
+                unsigned npreads = cur_bdb_stats.n_preads - last_bdb_stats.n_preads;
+                reqlog_logf(statlogger, REQL_INFO, "%u preads, %u bytes, avg time %ums\n", npreads,
+                            cur_bdb_stats.pread_bytes - last_bdb_stats.pread_bytes,
+                            U2M(cur_bdb_stats.pread_time_us - last_bdb_stats.pread_time_us) / npreads);
+            }
+            if (cur_bdb_stats.n_pwrites > last_bdb_stats.n_pwrites) {
+                unsigned npwrites = cur_bdb_stats.n_pwrites - last_bdb_stats.n_pwrites;
+                reqlog_logf(statlogger, REQL_INFO, "%u pwrites, %u bytes, avg time %ums\n", npwrites,
+                            cur_bdb_stats.pwrite_bytes - last_bdb_stats.pwrite_bytes,
+                            U2M(cur_bdb_stats.pwrite_time_us - last_bdb_stats.pwrite_time_us) / npwrites);
+            }
+            if (cur_bdb_stats.n_memp_fgets > last_bdb_stats.n_memp_fgets) {
+                unsigned n_memp_fgets = cur_bdb_stats.n_memp_fgets - last_bdb_stats.n_memp_fgets;
+                unsigned us = cur_bdb_stats.memp_fget_time_us - last_bdb_stats.memp_fget_time_us;
+                reqlog_logf(statlogger, REQL_INFO, "n_memp_fgets=%u, memp_fgets avg time=%ums\n", n_memp_fgets,
+                            U2M(us) / n_memp_fgets);
+            }
+            if (cur_bdb_stats.n_memp_pgs > last_bdb_stats.n_memp_pgs) {
+                unsigned n_memp_pgs = cur_bdb_stats.n_memp_pgs - last_bdb_stats.n_memp_pgs;
+                unsigned us = cur_bdb_stats.memp_pg_time_us - last_bdb_stats.memp_pg_time_us;
+                reqlog_logf(statlogger, REQL_INFO, "n_memp_pgs=%u, memp_pgs avg time=%ums\n", n_memp_pgs,
+                            U2M(us) / n_memp_pgs);
+            }
+            last_bdb_stats = cur_bdb_stats;
+
+            diff_deadlocks = ndeadlocks - last_report_deadlocks;
+            diff_lockwaits = nlockwaits - last_report_lockwaits;
+            diff_vreplays = vreplays - last_report_vreplays;
+
+            if (diff_deadlocks || diff_lockwaits || diff_vreplays)
+                reqlog_logf(statlogger, REQL_INFO,
+                            "ndeadlocks %d, nlockwaits %d, vreplays %d, "
+                            "locks aborted %d\n",
+                            diff_deadlocks, diff_lockwaits, diff_vreplays, diff_locks_aborted);
+
+            bdb_get_cur_lsn_str(thedb->bdb_env, &curlsnbytes, curlsn, sizeof(curlsn));
+            if (strcmp(curlsn, lastlsn) != 0) {
+                reqlog_logf(statlogger, REQL_INFO, "LSN %s diff %llu\n", curlsn, curlsnbytes - lastlsnbytes);
+                strncpy0(lastlsn, curlsn, sizeof(lastlsn));
+                lastlsnbytes = curlsnbytes;
+            }
+
+            if (conns - last_report_conns || curr_conns) {
+                reqlog_logf(statlogger, REQL_INFO, "connections %lld timeouts %lld current_connections %lld\n",
+                            conns - last_report_conns, conn_timeouts - last_report_conn_timeouts, curr_conns);
+            }
+
+            reqlog_diffstat_dump(statlogger);
+
+            count = 0;
+            last_report_nqtrap = nqtrap;
+            last_report_nfstrap = nfstrap;
+            last_report_nsql = nsql;
+            last_report_nsql_steps = nsql_steps;
+            last_report_newsql = newsql;
+            last_report_newsql_steps = newsql_steps;
+            last_report_nretries = nretries;
+            last_report_bpool_hits = bpool_hits;
+            last_report_bpool_misses = bpool_misses;
+
+            last_report_deadlocks = ndeadlocks;
+            last_report_lockwaits = nlockwaits;
+            last_report_vreplays = vreplays;
+
+            last_report_ncommits = ncommits;
+            last_report_ncommit_time = ncommit_time;
+
+            last_report_conns = conns;
+            last_report_conn_timeouts = conn_timeouts;
+
+            osql_comm_diffstat(statlogger, NULL);
+            strbuf_free(logstr);
+
+            dump_client_sql_data(statlogger, 1);
         }
 
         if (gbl_repscore)

--- a/tests/reqlog_update_during_sc.test/Makefile
+++ b/tests/reqlog_update_during_sc.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/reqlog_update_during_sc.test/extract_timestamps.awk
+++ b/tests/reqlog_update_during_sc.test/extract_timestamps.awk
@@ -1,0 +1,10 @@
+# If the line starts with a timestamp in the format "MM/DD HH:MM:SS",
+match($0, /^([0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/, a) {
+    # Parse it into Unix time (e.g. `date -d "YYYY/MM/DD HH:MM:SS" +%s`).
+    cmd = "date -d \"" strftime("%Y") "/" a[1] "\" +%s"
+    cmd | getline timestamp
+    close(cmd)
+
+    # Emit just the timestamp.
+    print timestamp
+}

--- a/tests/reqlog_update_during_sc.test/filter.awk
+++ b/tests/reqlog_update_during_sc.test/filter.awk
@@ -1,0 +1,13 @@
+{
+    # If the line starts with a timestamp in the format "MM/DD HH:MM:SS",
+    if (match($0, /^([0-9]{2}\/[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2})/, a)) {
+        # Parse it into Unix time (e.g. `date -d "YYYY/MM/DD HH:MM:SS" +%s`).
+        cmd = "date -d \"" strftime("%Y") "/" a[1] "\" +%s"
+        cmd | getline timestamp
+        close(cmd)
+
+        # Emit the entire line if it was logged within the specified range.
+        if (timestamp >= start && timestamp <= end)
+            print $0
+    }
+}

--- a/tests/reqlog_update_during_sc.test/lrl.options
+++ b/tests/reqlog_update_during_sc.test/lrl.options
@@ -1,0 +1,2 @@
+# Update /bb/data/$dbname.statreq every second.
+reqldiffstat 1

--- a/tests/reqlog_update_during_sc.test/runit
+++ b/tests/reqlog_update_during_sc.test/runit
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+bash -n "${0}" || exit 1
+
+source "${TESTSROOTDIR}/tools/cluster_utils.sh"
+source "${TESTSROOTDIR}/tools/runit_common.sh"
+
+set -e
+DBNAME="${1}"
+
+#declare -rx debug=1
+
+function create_table()
+{
+    "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" default "create table t (i int)"
+}
+
+function populate_table()
+{
+    # Adjust the number of rows inserted based on whether we are running against
+    # cluster vs. standalone. The latter is able to rebuild the table faster and
+    # thus may not run long enough to exercise the logic of this test.
+    local -r num_iter=$(if [[ -n "${CLUSTER}" ]]; then echo 200; else echo 500; fi)
+
+    for i in `seq 1 ${num_iter}`; do
+        "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" default "insert into t select * from generate_series(1, 1000)"
+    done
+}
+
+function spam_queries()
+{
+    # Spam queries to generate statreqs while schema change is running.
+    while true; do
+        "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" default "delete from t limit 1" > /dev/null
+    done
+}
+
+function run_schema_change()
+{
+    # Trigger a schema change that will cover multiple iterations of the statthd loop.
+    "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" default "rebuild t"
+}
+
+function filter_logs()
+{
+    local -r logfile="${1}"
+    local -r start_time="${2}"
+    local -r end_time="${3}"
+
+    awk -f "${TESTDIR}/${TESTCASE}.test/filter.awk" -v start="${start_time}" -v end="${end_time}" "${logfile}"
+}
+
+function extract_log_timestamps()
+{
+    local -r logfile="${1}"
+
+    awk -f "${TESTDIR}/${TESTCASE}.test/extract_timestamps.awk" "${logfile}" | sort -nu
+}
+
+function verify_log_continuity()
+{
+    local -r timestamps_file="${1}"
+    local -r start_time="${2}"
+    local -r end_time="${3}"
+    local -r node="${4}"  # only for logging purposes
+
+    for (( timestamp = start_time; timestamp <= end_time; timestamp++ )); do
+        if ! grep -q "^${timestamp}$" "${timestamps_file}"; then
+            failexit "Missing statreqs for timestamp on node '${node}': ${timestamp} ($( date -d @${timestamp} '+%m/%d %H:%M:%S' ))"
+        fi
+    done
+}
+
+function verify_logs_for_node()
+{
+    local -r logfile="${1}"
+    local -r start_time="${2}"
+    local -r end_time="${3}"
+    local -r node="${4}"
+
+    # Filter logs to only include entries between when schema change started and ended.
+    filter_logs "${logfile}" "${start_time}" "${end_time}" > "${logfile}.filtered"
+
+    if [[ -n "${debug}" ]]; then
+        echo
+        echo "Full log contents on node ${node}:"
+        echo
+        cat "${logfile}"
+        echo
+        echo "Filtered log contents on node ${node} (between ${start_time} and ${end_time}):"
+        echo
+        cat "${logfile}.filtered"
+        echo
+    fi
+    
+    # Get the timestamps for all the seconds during which we got statreqs.
+    extract_log_timestamps "${logfile}.filtered" > "${logfile}.filtered.timestamps"
+
+    # Check that for every second between when schema change started and ended,
+    # we got statreqs. Use `start_time + 1` and `end_time - 1` as the logs from
+    # the first and last seconds may not have overlapped with schema change.
+    verify_log_continuity "${logfile}.filtered.timestamps" $(( start_time + 1 )) $(( end_time - 1 )) "${node}"
+}
+
+function verify_logs()
+{
+    local -r start_time="${1}"
+    local -r end_time="${2}"
+
+    src="${TESTDIR}/var/log/cdb2/${DBNAME}.statreqs"
+
+    if [[ -n "${CLUSTER}" ]]; then
+        for node in ${CLUSTER}; do
+            # Grab logs from node.
+            local dest="${TESTDIR}/logs/${DBNAME}_${node}.statreqs"
+            ssh -o StrictHostKeyChecking=no "${node}" "cat ${src}" > "${dest}"
+            verify_logs_for_node "${dest}" "${start_time}" "${end_time}" "${node}"
+        done
+    else
+        # Single node case.
+        local dest="${TESTDIR}/logs/${DBNAME}_standalone.statreqs"
+        cp "${src}" "${dest}"
+        verify_logs_for_node "${dest}" "${start_time}" "${end_time}" "standalone"
+    fi
+}
+
+function main()
+{
+    # Set up dummy data.
+    create_table
+    populate_table
+
+    # Run schema change and spam queries at the same time.
+    spam_queries &
+    spam_pid=$!
+
+    echo "Master is $(get_master)"
+    local -r rebuild_start_time=$(date +%s)
+    echo "Starting schema change at $(date -d @${rebuild_start_time} '+%m/%d %H:%M:%S')"
+    run_schema_change
+    local -r rebuild_end_time=$(date +%s)
+    echo "Finished schema change at $(date -d @${rebuild_end_time} '+%m/%d %H:%M:%S')"
+
+    # Stop spamming queries.
+    kill "${spam_pid}"
+
+    # Give time for log files to flush.
+    sleep 1
+
+    # Check that we got statreqs on all nodes from the spam queries despite
+    # schema change running at the same time.
+    verify_logs "${rebuild_start_time}" "${rebuild_end_time}"
+}
+
+main
+echo "Success"


### PR DESCRIPTION
It seems this logic has existed since before schema lock was a thing. The critical section of `statthd` that inspects `dbenv` now acquires the schema lock, so this check should no longer be necessary. Remove the check in `statthd` for whether schema change is in progress so that statreqs are not missing on the master during schema change.