### PR TITLE
{180846526} fix(reqlog): initialize last LSN before diffing

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4723,6 +4723,8 @@ void *statthd(void *p)
     const struct berkdb_thread_stats *pstats;
     char lastlsn[63] = "", curlsn[64];
     uint64_t lastlsnbytes = 0, curlsnbytes;
+    bdb_get_cur_lsn_str(thedb->bdb_env, &lastlsnbytes, lastlsn, sizeof(lastlsn));
+
     int ii;
     int jj;
     int thresh;

--- a/tests/reqlog_init_last_lsn.test/Makefile
+++ b/tests/reqlog_init_last_lsn.test/Makefile
@@ -1,0 +1,12 @@
+# Skip auto-starting a database, we will handle it in the test case.
+COMDB2_UNITTEST=1
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif

--- a/tests/reqlog_init_last_lsn.test/runit
+++ b/tests/reqlog_init_last_lsn.test/runit
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+bash -n "${0}" || exit 1
+
+source "${TESTSROOTDIR}/tools/cluster_utils.sh"
+source "${TESTSROOTDIR}/tools/runit_common.sh"
+
+DBNAME="${1}"
+PIDFILE="${TMPDIR}/${DBNAME}.pid"
+LOGDIR="${TESTDIR}/var/log/cdb2"
+STATREQS_FILE="${LOGDIR}/${DBNAME}.statreqs"
+
+function create_database()
+{
+    mkdir -p "${DBDIR}"
+    mkdir -p "${TMPDIR}"
+    mkdir -p "${LOGDIR}"
+
+    # Update /bb/data/$dbname.statreq every second.
+    echo "reqldiffstat 1" >> "${DBDIR}/${DBNAME}.lrl"
+    echo "dir ${DBDIR}" >> "${DBDIR}/${DBNAME}.lrl"
+
+    "${COMDB2_EXE}" "${DBNAME}" --create --lrl "${DBDIR}/${DBNAME}.lrl" || failexit "failed to create database ${DBNAME}"
+}
+
+function wait_for_db()
+{
+    local out=""
+
+    while [[ "${out}" != "1" ]]; do
+        sleep 1
+        out="$( ${CDB2SQL_EXE} ${CDB2_OPTIONS} --tabs ${DBNAME} local 'select 1' )"
+    done
+}
+
+function start_database()
+{
+    "${COMDB2_EXE}" "${DBNAME}" --lrl "${DBDIR}/${DBNAME}.lrl" --no-global-lrl --pidfile "${PIDFILE}" >> "${TESTDIR}/logs/${DBNAME}.db" 2>&1 &
+    wait_for_db "${DBNAME}"
+}
+
+function create_table()
+{
+    "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" local "create table t (i int)" || failexit "failed to create table"
+}
+
+function populate_table()
+{
+    local -r num_iter=200
+    local -r num_rows_per_iter=1000
+
+    echo "Inserting $(( num_iter * num_rows_per_iter )) rows"
+
+    for i in `seq 1 ${num_iter}`; do
+        "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" local "insert into t select * from generate_series(1, ${num_rows_per_iter})" >/dev/null || failexit "failed to insert rows into table"
+    done
+}
+
+function stop_database()
+{
+    local -r pid=$(cat "${PIDFILE}")
+    kill -9 "${pid}" >/dev/null || failexit "failed to kill database. pid=${pid}"
+
+    # Wait for database to exit. Keep trying to query until we get the "cannot
+    # connect to db" error.
+    local out="1"
+
+    while [[ "${out}" != "1" ]]; do
+        sleep 1
+        out="$( ${CDB2SQL_EXE} ${CDB2_OPTIONS} --tabs ${DBNAME} local 'select 1' )"
+    done
+
+    rm -f "${PIDFILE}"
+
+    # Need to also deregister the database from pmux. Otherwise, the database
+    # will fail to allocate a port on the next startup since a reservation with
+    # the same name will already exist.
+    "${TESTSROOTDIR}/tools/send_msg_port.sh" "del comdb2/replication/${DBNAME}" "${pmux_port}" >/dev/null || failexit "failed to unregister database from pmux"
+}
+
+function validate_first_lsn_diff()
+{
+    local -r logfile="${1}"
+
+    # Wait for a line that looks like this: "10/21 23:17:11:   LSN 3:28254432 diff 154083552"
+    local -r line=$(grep --max-count=1 'LSN .*:.* diff .*' <(tail -f -n +1 "${logfile}"))
+    echo "Found first LSN diff in statreqs: '${line}'"
+
+    # Without fix: "10/21 23:17:11:   LSN 3:28254432 diff 154083552"
+    # With fix:    "10/21 23:25:54:   LSN 3:26238981 diff 4015"
+    #
+    # For deleting a single row, we expect the LSN diff to be very small.
+    # 50KB seems like a generous upper bound and is much lower than 150MB.
+    local -r diff=$( awk '{ print $NF }' <<< "${line}" )
+
+    if (( diff > ( 50 * 1024 ) )); then
+        failexit "LSN diff reported in statreqs is unexpectedly large. diff=${diff}"
+    else
+        echo "LSN diff reported in statreqs looks reasonable. diff=${diff}"
+    fi
+}
+
+function main()
+{
+    # Initialize database with some dummy data.
+    echo "Creating database"
+    create_database
+    echo "Starting database"
+    start_database
+    echo "Creating table"
+    create_table
+    echo "Populating table"
+    populate_table
+
+    # Stop the database and clear existing statreqs.
+    echo "Stopping database"
+    stop_database
+    echo "Clearing statreqs"
+    rm "${STATREQS_FILE}" || failexit "couldn't clear statreqs file. filepath=${STATREQS_FILE}"
+
+    # Restart the database and run a DML query so we write some log records.
+    echo "Restarting database"
+    start_database
+
+    echo "Running a DML query to generate statreqs"
+    "${CDB2SQL_EXE}" ${CDB2_OPTIONS} "${DBNAME}" local "delete from t limit 1" > /dev/null || failexit "failed to run DML query"
+
+    # Check that the first LSN diff reported in statreqs looks sane.
+    echo "Waiting for first LSN diff in statreqs"
+    validate_first_lsn_diff "${STATREQS_FILE}"
+
+    # Stop the database.
+    echo "Stopping database"
+    stop_database
+}
+
+main
+echo "Success"


### PR DESCRIPTION
We get unexpectedly large values in statreqs on database startup because `lastlsn` is not initialized and the "diff" ends up being the total number of log bytes ever written to the database. Initialize `lastlsn` so that LSN diffs are calculated correctly.