### PR TITLE
Fix flakiness in limitsortingtbl test

### DIFF
--- a/tests/limitsortingtbl.test/err.expected
+++ b/tests/limitsortingtbl.test/err.expected
@@ -1,1 +1,1 @@
-[SELECT t1.* FROM t1,t2,t2 order by t1.k] failed with rc 202 transaction too big
+[SELECT t1.* FROM t1,t2,t2,t2 order by t1.k] failed with rc 202 transaction too big

--- a/tests/limitsortingtbl.test/runit
+++ b/tests/limitsortingtbl.test/runit
@@ -52,9 +52,9 @@ cdb2sql ${CDB2_OPTIONS} $DBNAME default "explain query plan SELECT t1.* FROM t1,
 cdb2sql ${CDB2_OPTIONS} $DBNAME default "SELECT t1.* FROM t1,t2 order by t1.k" &>> sel2.res
 
 
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "explain query plan SELECT t1.* FROM t1,t2,t2 order by t1.k" &> sel3.res
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "explain query plan SELECT t1.* FROM t1,t2,t2,t2 order by t1.k" &> sel3.res
 set +e
-cdb2sql ${CDB2_OPTIONS} $DBNAME default "SELECT t1.* FROM t1,t2,t2 order by t1.k" &> err.res
+cdb2sql ${CDB2_OPTIONS} $DBNAME default "SELECT t1.* FROM t1,t2,t2,t2 order by t1.k" &> err.res
 rc=$?
 
 if [ $rc == 0 ] || ! diff err.expected err.res ; then


### PR DESCRIPTION
This test checks that an expensive sorter query fails when a tunable is set to block sorter queries that push the DB past a disk usage limit.

The limit’s set to 1% higher than current usage, so the idea is that running an expensive query will go over the limit and get rejected.

This PR just makes the query heavier so it’s more likely to hit that limit consistently.