### PR TITLE
Fixes for cancel() interface.

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -229,20 +229,20 @@ static const char *HELP_STAT[] = {
 };
 static const char *HELP_SQL[] = {
     "sql ...",
-    "dump               - dump currently running statements and cursor info",
-    "dump repblockers   - dump info on currently running statements that are"
-    "                     blocking replication thread",
-    "keep N             - keep stats on last N statements",
-    "hist               - show recently run statements",
-    "cancel N           - cancel running statement with id N",
-    "cancelcnonce N     - cancel running statement with cnonce N",
-    "ucancel cnonce N   - cancel running statement with unified uuid N (per comdb2_connections)",
-    "ucancel fp N       - cancel running statement with fingerprint N (per comdb2_connections)",
-    "ucancel running    - cancel all running statement (leaves queued statements intact)",
-    "ucancel queued     - cancel all queued statement (leaves running statements intact)",
-    "ucancel all        - cancel all queued and running statements",
-    "wrtimeout N        - set write timeout in ms",
-    "help               - this information",
+    "dump                  - dump currently running statements and cursor info",
+    "dump repblockers      - dump info on currently running statements that are"
+    "                        blocking replication thread",
+    "keep N                - keep stats on last N statements",
+    "hist                  - show recently run statements",
+    "cancel N              - cancel running statement with id N",
+    "cancelcnonce N        - cancel running statement with cnonce N",
+    "ucancel uuid N        - cancel running statement with unified uuid N (per comdb2_connections)",
+    "ucancel fingerprint N - cancel all running statements with fingerprint N (per comdb2_connections)",
+    "ucancel running       - cancel all running statement (leaves queued statements intact)",
+    "ucancel queued        - cancel all queued statement (leaves running statements intact)",
+    "ucancel all           - cancel all queued and running statements",
+    "wrtimeout N           - set write timeout in ms",
+    "help                  - this information",
     NULL,
 };
 static const char *HELP_SCHEMA[] = {
@@ -3121,7 +3121,7 @@ clipper_usage:
                 free(cnonce);
             }
         } else if (tokcmp(tok, ltok, "ucancel") == 0) {
-            char *uuid = NULL;
+            char *str = NULL;
             enum ucancel_type t = UCANCEL_INV;
             tok = segtok(line, lline, &st, &ltok);
             if (ltok) {
@@ -3131,23 +3131,23 @@ clipper_usage:
                     t = UCANCEL_RUN;
                 else if (tokcmp(tok, ltok, "queued") == 0)
                     t = UCANCEL_QUE;
-                else if (tokcmp(tok, ltok, "cnonce") == 0)
+                else if (tokcmp(tok, ltok, "uuid") == 0)
                     t = UCANCEL_CNO;
-                else if (tokcmp(tok, ltok, "fp") == 0)
+                else if (tokcmp(tok, ltok, "fingerprint") == 0)
                     t = UCANCEL_FPT;
 
                 if (t == UCANCEL_CNO || t == UCANCEL_FPT) {
                     tok =  segtok(line, lline, &st, &ltok);
                     if (ltok)
-                        uuid = tokdup(tok, ltok);
+                        str = tokdup(tok, ltok);
                     else
                         t = UCANCEL_INV;
                 }
                 if (t != UCANCEL_INV)
-                    ucancel_sql_statements(t, uuid);
+                    ucancel_sql_statements(t, str);
             }
             if (t == UCANCEL_INV)
-                logmsg(LOGMSG_ERROR, "Usage sql ucancel [all|queued|running|fp N|cnonce N]");
+                logmsg(LOGMSG_ERROR, "Usage sql ucancel [all|queued|running|fingerprint N|uuid N]");
         } else if (tokcmp(tok, ltok, "help") == 0) {
             print_help_page(HELP_SQL);
         } else if (tokcmp(tok, ltok, "debug") == 0) {

--- a/db/sql.h
+++ b/db/sql.h
@@ -1741,7 +1741,7 @@ int osql_test_create_genshard(struct schema_change_type *sc, char **errmsg, int 
                               char **dbnames, uint32_t numcols, char **columns, char **shardnames);
 int osql_test_remove_genshard(struct schema_change_type *sc, char **errmsg);
 
-void cancel_connections(int only_queued, uuid_t filter_fp);
+void cancel_connections(int only_queued, uuid_t uuid, char *fp);
 
 struct sp_tmptbl {
     pthread_mutex_t lk;

--- a/lua/syssp.c.in
+++ b/lua/syssp.c.in
@@ -492,7 +492,7 @@ static int db_send(Lua L)
 static int db_unified_cancel(Lua L)
 {
     const char *type;
-    const char *uuid = NULL;
+    const char *str = NULL;
     char cmd[256];
 
     int nargs = lua_gettop(L);
@@ -507,18 +507,21 @@ static int db_unified_cancel(Lua L)
             strncasecmp(type, "queued", sizeof("queued")) == 0) {
             if (!lua_isnil(L, -1))
                 return luaL_error(L, "Extra argument present for type %s", type);
-    } else if (strncasecmp(type, "cnonce", sizeof("cnonce")) == 0 ||
-            strncasecmp(type, "fp", sizeof("fp")) == 0) {
+    } else if (strncasecmp(type, "uuid", sizeof("uuid")) == 0) {
         if (lua_isnil(L, -1))
             return luaL_error(L, "Missing uuid for type %s", type);
-        uuid = lua_tostring(L, -1);
+        str = lua_tostring(L, -1);
+    } else if (strncasecmp(type, "fingerprint", sizeof("fingerprint")) == 0) {
+        if (lua_isnil(L, -1))
+            return luaL_error(L, "Missing fingerprint for type %s", type);
+        str = lua_tostring(L, -1);
     } else {
         return luaL_error(L, "Unrecognized cancel type %s", type);
     }
 
     lua_settop(L, 0);
 
-    snprintf(cmd, sizeof(cmd), "sql ucancel %s%s%s\n", type, uuid ? " ": "", uuid ? uuid : "");
+    snprintf(cmd, sizeof(cmd), "sql ucancel %s%s%s\n", type, str ? " " : "", str ? str : "");
 
     return _db_process_command(L, cmd, "result");
 }

--- a/tests/remsqltimeout.test/test_remsql.sh
+++ b/tests/remsqltimeout.test/test_remsql.sh
@@ -30,10 +30,10 @@ function kill_query
         exit 1
     fi
 
-    echo "running cancel('cnonce', '${uuid}') trap"
-    ${SM} "exec procedure sys.cmd.cancel('cnonce', '${uuid}')"
+    echo "running cancel('uuid', '${uuid}') trap"
+    ${SM} "exec procedure sys.cmd.cancel('uuid', '${uuid}')"
     if [[ $? != 0 ]] ; then
-        echo "Failed to run cancel cnonce sp"
+        echo "Failed to run cancel uuid sp"
         exit 1
     fi
 }

--- a/tests/unifiedcancel.test/output.log
+++ b/tests/unifiedcancel.test/output.log
@@ -1,6 +1,6 @@
 [exec procedure sys.cmd.cancel()] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Expected string type argument: all|queued|running|cnonce|fp
 [exec procedure sys.cmd.cancel(123)] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Unrecognized cancel type 123
 [exec procedure sys.cmd.cancel('blah')] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Unrecognized cancel type blah
-[exec procedure sys.cmd.cancel('cnonce')] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Missing uuid for type cnonce
+[exec procedure sys.cmd.cancel('uuid')] failed with rc -3 [local msg = sys.cancel(cmd, uui...]:10: Missing uuid for type uuid
 [ERROR] Failed to parse uuid "123"
 [ERROR] Failed to parse uuid "1-23-456"


### PR DESCRIPTION
Fix the syntax to be more intuitive (uuid in comdb2_connections, uuid as argument in cancel, fix fingerprint - no more fp).
Do not show bogus fingerprints for connections without sql.

