### PR TITLE
Do not overwrite test certificates

### DIFF
--- a/tests/cdb2jdbc.test/Makefile
+++ b/tests/cdb2jdbc.test/Makefile
@@ -1,7 +1,8 @@
 export SECONDARY_DB_PREFIX=nossl
+export SSL_CERT_PATH=${TESTDIR}/certs
 # The test uses a server certificate with wrong CN
-$(shell rm -f ${TESTDIR}/*.key)
-$(shell TESTDIR="${TESTDIR}" CLUSTER="${CLUSTER}" SKIPSSL="${SKIPSSL}" SCN="example.com" $(TESTSROOTDIR)/tools/keygen.sh)
+$(shell mkdir -p ${TESTDIR}/certs)
+$(shell TESTDIR="${TESTDIR}/certs" CLUSTER="${CLUSTER}" SKIPSSL="${SKIPSSL}" SCN="example.com" $(TESTSROOTDIR)/tools/keygen.sh)
 
 ifeq ($(TESTSROOTDIR),)
   include ../testcase.mk

--- a/tests/cdb2jdbc.test/lrl.options
+++ b/tests/cdb2jdbc.test/lrl.options
@@ -1,2 +1,3 @@
 ssl_client_mode VERIFY_CA
 ssl_dbname_field street
+ssl_cert_path ${TESTDIR}/certs

--- a/tests/cdb2jdbc.test/runit
+++ b/tests/cdb2jdbc.test/runit
@@ -1,34 +1,36 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 
+CERTDIR=${TESTDIR}/certs
+
 # Generate Java key store and trust store
-rm -f ${TESTDIR}/client-keystore.pkcs12 ${TESTDIR}/keystore ${TESTDIR}/truststore
+rm -f ${CERTDIR}/client-keystore.pkcs12 ${CERTDIR}/keystore ${CERTDIR}/truststore
 
 openssl pkcs12 -export \
-        -in ${TESTDIR}/client.crt \
-        -inkey ${TESTDIR}/client.key \
+        -in ${CERTDIR}/client.crt \
+        -inkey ${CERTDIR}/client.key \
         -name cdb2clikey \
         -passout pass:cdb2jdbctest \
-        -out ${TESTDIR}/client-keystore.pkcs12
+        -out ${CERTDIR}/client-keystore.pkcs12
 keytool -noprompt -importkeystore \
-        -srckeystore ${TESTDIR}/client-keystore.pkcs12 \
+        -srckeystore ${CERTDIR}/client-keystore.pkcs12 \
         -srcstoretype pkcs12 \
         -srcstorepass cdb2jdbctest \
-        -destkeystore ${TESTDIR}/keystore \
+        -destkeystore ${CERTDIR}/keystore \
         -deststoretype JKS \
         -deststorepass cdb2jdbctest
 keytool -noprompt -importcert \
         -alias cdb2ca \
-        -file ${TESTDIR}/root.crt \
-        -keystore ${TESTDIR}/truststore \
+        -file ${CERTDIR}/root.crt \
+        -keystore ${CERTDIR}/truststore \
         -storepass cdb2jdbctest
 
-chmod 644 ${TESTDIR}/keystore ${TESTDIR}/truststore
+chmod 644 ${CERTDIR}/keystore ${CERTDIR}/truststore
 
 export envSkipTests='false'
 export envSSLTestDatabase=${DBNAME}
 export envTestDatabase=${SECONDARY_DBNAME}
-export envSSLCertPath=${TESTDIR}
+export envSSLCertPath=${CERTDIR}
 export envSSLCertPass='cdb2jdbctest'
 
 if [ -n "${CLUSTER}" ]; then

--- a/tests/ssl_comdb2ar.test/runit
+++ b/tests/ssl_comdb2ar.test/runit
@@ -23,4 +23,4 @@ find . -name 'root.crt' | grep 'root.crt'
 find . -name 'server.crt' | grep 'server.crt'
 find . -name 'server.key' | grep 'server.key'
 
-ls -al server.key | grep 'r--------'
+ls -al server.key | grep 'rw-------'

--- a/tests/ssl_san.test/lrl.options
+++ b/tests/ssl_san.test/lrl.options
@@ -1,2 +1,2 @@
-ssl_cert /tmp/san.crt
-ssl_key /tmp/san.key
+ssl_cert ${TESTDIR}/san.crt
+ssl_key ${TESTDIR}/san.key

--- a/tests/ssl_san.test/runit
+++ b/tests/ssl_san.test/runit
@@ -10,10 +10,10 @@ dbnm=$1
 set -e
 
 # Firstly verify that the certificate has SAN records.
-openssl x509 -in /tmp/san.crt -text -noout | grep -A1 'Subject Alternative Name'
+openssl x509 -in ${TESTDIR}/san.crt -text -noout | grep -A1 'Subject Alternative Name'
 
 # Secondly verify the CN isn't a real domain.
-openssl x509 -in /tmp/san.crt -text -noout | grep 'www.example.com'
+openssl x509 -in ${TESTDIR}/san.crt -text -noout | grep 'www.example.com'
 
 # Lastly verify that we validate the SAN records correctly.
 cat << EOF | cdb2sql ${CDB2_OPTIONS} -s --tabs $dbnm default - >output.actual 2>&1

--- a/tests/tools/keygen.sh
+++ b/tests/tools/keygen.sh
@@ -25,7 +25,7 @@ fi
 # Setup ssl certificate
 # Create root key
 openssl genrsa -out $CADIR/root.key 4096
-chmod 700 $CADIR/root.key
+chmod 600 $CADIR/root.key
 # Create and self sign the root certificate
 openssl req -x509 -new -nodes -key $CADIR/root.key -days 30 -out $CADIR/root.crt \
             -subj "/C=US/ST=New York/L=New York/O=Bloomberg/OU=Comdb2/CN=$CN"
@@ -85,7 +85,7 @@ openssl req -new -key $CADIR/server.key -out $CADIR/server.key.csr \
 openssl x509 -req -in $CADIR/server.key.csr -CA $CADIR/root.crt -CAkey $CADIR/root.key \
              -CAcreateserial -out $CADIR/server.crt -days 10
 # Change key permissions
-chmod 700 $CADIR/server.key
+chmod 600 $CADIR/server.key
 
 # Create client key
 openssl genrsa -out $CADIR/client.key 4096
@@ -96,7 +96,7 @@ openssl req -new -key $CADIR/client.key -out $CADIR/client.key.csr \
 openssl x509 -req -in $CADIR/client.key.csr -CA $CADIR/root.crt -CAkey $CADIR/root.key \
              -CAserial $CADIR/root.srl -out $CADIR/client.crt -days 10
 # Change key permissions
-chmod 700 $CADIR/client.key
+chmod 600 $CADIR/client.key
 
 # Create revoked key
 openssl genrsa -out $CADIR/revoked.key 4096
@@ -107,7 +107,7 @@ openssl req -new -key $CADIR/revoked.key -out $CADIR/revoked.key.csr \
 openssl x509 -req -in $CADIR/revoked.key.csr -CA $CADIR/root.crt -CAkey $CADIR/root.key \
              -CAserial $CADIR/root.srl -out $CADIR/revoked.crt -days 10
 # Change key permissions
-chmod 700 $CADIR/revoked.key
+chmod 600 $CADIR/revoked.key
 ## Revoke
 openssl ca -config $CADIR/ca.cnf -revoke $CADIR/revoked.crt \
            -keyfile $CADIR/root.key -cert $CADIR/root.crt
@@ -157,9 +157,7 @@ openssl req -new -key $CADIR/san.key -out $CADIR/san.key.csr \
 openssl x509 -req -in $CADIR/san.key.csr -CA $CADIR/root.crt -CAkey $CADIR/root.key \
              -CAcreateserial -out $CADIR/san.crt -days 10 -extensions v3_req -extfile $CADIR/san.cnf
 # Change key permissions
-chmod 700 $CADIR/san.key
-cp $CADIR/san.crt /tmp/san.crt
-cp $CADIR/san.key /tmp/san.key
+chmod 600 $CADIR/san.key
 
 myhostname=`hostname`
 # copy over SSL certificate and change permission on private key
@@ -188,12 +186,12 @@ for node in $CLUSTER; do
   openssl x509 -req -in $CADIR/server_$fqdn.key.csr -CA $CADIR/root.crt -CAkey $CADIR/root.key \
                -CAcreateserial -out $CADIR/server_$fqdn.crt -days 10 ${extensions}
   # Change key permissions
-  chmod 700 $CADIR/server_$fqdn.key
+  chmod 600 $CADIR/server_$fqdn.key
 
   scp -o StrictHostKeyChecking=no $CADIR/server_$fqdn.crt $node:$CADIR/server.crt
   scp -o StrictHostKeyChecking=no $CADIR/server_$fqdn.key $node:$CADIR/server.key
-  scp -o StrictHostKeyChecking=no $CADIR/san.crt $node:/tmp/san.crt
-  scp -o StrictHostKeyChecking=no $CADIR/san.key $node:/tmp/san.key
+  scp -o StrictHostKeyChecking=no $CADIR/san.crt $node:$CADIR/san.crt
+  scp -o StrictHostKeyChecking=no $CADIR/san.key $node:$CADIR/san.key
   scp -o StrictHostKeyChecking=no $CADIR/root.crt $CADIR/root.crl $node:$CADIR
 done
 


### PR DESCRIPTION
The cdb2jdbc testcase regenerates and overwrites certificates in the same test directory, interfering with other tests on the fly. This patch changes the cdb2jdbc testcase to generate certificates in its own directory.