### PR TITLE
HASql should replay on retry 0

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -1115,7 +1115,7 @@ public class Comdb2Handle extends AbstractConnection {
                 }
                 tdlog(Level.TRACE, "Connected to %s", dbHostConnected);
 
-                if (retry > 0 && !is_begin) {
+                if (!is_begin) {
                     retryAll = true;
                     int retryrc = retryQueries(retry, runLast);
 


### PR DESCRIPTION
The Jepson "atomic-writes" test was failing periodically.  Root cause is that HASql wasn't being replayed if a reconnect occurred when the retry variable was set to 0.