### PR TITLE
enable_snapshot -> enable_serial in blkseq test

### DIFF
--- a/tests/blkseq.test/runit
+++ b/tests/blkseq.test/runit
@@ -42,7 +42,7 @@ function replay_count
 cdb2sql -tabs ${CDB2_OPTIONS} $dbname default 'create table t1 { schema { int a } }'
 cdb2sql -tabs ${CDB2_OPTIONS} $dbname default 'create table t2 { schema { int a } keys { "a" = a } }'
 
-if [[ $TESTCASE == "blkseq_snapiso_generated" ]] ; then
+if [[ $TESTCASE == "blkseq_serial_generated" ]] ; then
     echo "
 set hasql on
 set transaction serializable" > insert.t1

--- a/tests/blkseq.test/serial.testopts
+++ b/tests/blkseq.test/serial.testopts
@@ -1,0 +1,1 @@
+enable_serial_isolation

--- a/tests/blkseq.test/snapiso.testopts
+++ b/tests/blkseq.test/snapiso.testopts
@@ -1,1 +1,0 @@
-enable_snapshot_isolation


### PR DESCRIPTION
The `blkseq_snapiso_generated` test uses serializable txns, not snapshot txns. The changes in this PR change the tunable that this test uses from `enable_snapshot_isolation` to `enable_serial_isolation` and also changes its name to `blkseq_serial_generated`.