### PR TITLE
{181342478} legacy_defaults: reducing sqlite sorter in-memory size

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -449,6 +449,8 @@ static char *legacy_options[] = {
     "setattr NET_SEND_GBLCONTEXT 1",
     /* Sqlite sorter uses 2 mmap'd files. This sets the total mmap size per sorter to 32MiB */
     "sqlsortermaxmmapsize 16777216",
+    /* 16MiB sorter in-memory array size before spilling to disk. */
+    "sqlsortermem 16777216",
     "unnatural_types 1",
     "wal_osync 1",
     "usenames",


### PR DESCRIPTION
The mmap size for external sorting was already lowered to 16MiB. This patch changes the in-memory array size to match the mmap size of tempfiles.
