### PR TITLE
Remove misspelled tunable from legacy_defaults

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -458,8 +458,7 @@ static char *legacy_options[] = {
     "sc_protobuf 0",
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
-    "endianize_locklist 0",
-    "create_default_consumers_atomically 0"
+    "endianize_locklist 0"
 };
 // clang-format on
 


### PR DESCRIPTION
/skipbuild

We don't need this tunable in legacy defaults anymore