### PR TITLE
Bug Fix: Don't treat COMDB2_SCHEMACHANGE_OK as an error

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -5393,13 +5393,14 @@ int sqlite3BtreeCommit(Btree *pBt)
             }
         } else {
             rc = osql_sock_commit(clnt, OSQL_SOCK_REQ, TRANS_CLNTCOMM_NORMAL);
-            osqlstate_t *osql = &thd->clnt->osql;
-            if (osql->xerr.errval == COMDB2_SCHEMACHANGE_OK) {
-                osql->xerr.errval = 0;
-            }
         }
         break;
 
+    }
+
+    osqlstate_t *osql = &thd->clnt->osql;
+    if (osql->xerr.errval == COMDB2_SCHEMACHANGE_OK) {
+        osql->xerr.errval = 0;
     }
 
     clnt->ins_keys = 0ULL;

--- a/tests/consumer.test/lrl.options
+++ b/tests/consumer.test/lrl.options
@@ -1,0 +1,2 @@
+enable_snapshot_isolation
+enable_serial_isolation

--- a/tests/consumer.test/t09.expected
+++ b/tests/consumer.test/t09.expected
@@ -1,0 +1,3 @@
+(version='comdb2 default consumer 1.1')
+(version='comdb2 default consumer 1.1')
+(version='comdb2 default consumer 1.1')

--- a/tests/consumer.test/t09.sql
+++ b/tests/consumer.test/t09.sql
@@ -1,0 +1,14 @@
+drop table if exists t
+create table t(i int)$$
+
+set transaction read committed
+create default lua consumer recom_test with sequence on (table t for insert)
+select version from comdb2_procedures where name='recom_test'
+
+set transaction snapshot
+create default lua consumer snap_test with sequence on (table t for insert)
+select version from comdb2_procedures where name='snap_test'
+
+set transaction serializable
+create default lua consumer serial_test with sequence on (table t for insert)
+select version from comdb2_procedures where name='serial_test'

--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -35,3 +35,4 @@ reqlog_update_during_sc,UNKNOWN,181484732
 scupdates_logicalsc_generated,UNKNOWN,181484749
 phys_rep_tiered_firstfile_generated,UNKNOWN,181484776
 sc_resume_logicalsc_generated,UNKNOWN,181484807
+consumer_non_atomic_default_consumer_generated,DB_BUG,181573461


### PR DESCRIPTION
Previously, the `COMDB2_SCHEMACHANGE_OK` return code was ignored only after blocksql commits. This PR extends that behavior to recom, snapshot, and serializable commits as well.

This change fixes a bug where those transaction types would incorrectly report an error when clients added default consumers, even though the operation had actually succeeded.