### PR TITLE
Reorder log-cursor thread in test

### DIFF
--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1474,10 +1474,6 @@ function physrep_truncate
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table cktruncate(a int, b cstring(32))"
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into cktruncate select *, 'good' from generate_series(1, 1000)"
 
-    rm -Rf $logcursor_output >/dev/null 2>&1
-    blocking_logcursor $logcursor_output $startlsn &
-    logcursorpid=$!
-
     # Block until all standalones have these records
     for node in $CLUSTER ; do
         name="${REPL_DBNAME_PREFIX}_${node}"
@@ -1528,6 +1524,12 @@ function physrep_truncate
         done
         echo "Db $name on node $node has caught up"
     done
+
+    rm -Rf $logcursor_output >/dev/null 2>&1
+    blocking_logcursor $logcursor_output $startlsn &
+    logcursorpid=$!
+
+    sleep 5
 
     echo "Truncate to good LSN $goodlsn"
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $mnode "exec procedure sys.cmd.truncate_log(\"$goodlsn\")"

--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -33,5 +33,4 @@ sc_timepart,UNKNOWN,181186021
 snapshot_during_truncate,UNKNOWN,181344241
 reqlog_update_during_sc,UNKNOWN,181484732
 scupdates_logicalsc_generated,UNKNOWN,181484749
-phys_rep_tiered_firstfile_generated,UNKNOWN,181484776
 sc_resume_logicalsc_generated,UNKNOWN,181484807


### PR DESCRIPTION
Addresses "blocked-logcursor" test failures in phys_rep_tiered tests.