### PR TITLE
Fix test typo

### DIFF
--- a/tests/tools/compare_results.sh
+++ b/tests/tools/compare_results.sh
@@ -84,7 +84,7 @@ for sqlfile in $sqlfiles; do
         echo "see diffs here: $HOSTNAME"
         echo "> diff -u ${PWD}/{$testname.$exp_extn,$testname.output}"
         echo "first 10 lines of the diff:"
-        $cmd | head -10
+        diff $testname.$exp_extn $testname.output | head -10
         echo
         exit 1
     fi


### PR DESCRIPTION
/skipbuild

Right now, when the actual and expected outputs don’t match, `compare_results.sh` reruns the failed test and shows the first 10 lines of that output. It’s supposed to show the first 10 lines of the diff instead.

This PR fixes that behavior — the script now correctly displays the diff between the actual and expected results, instead of rerunning the test.