### PR TITLE
Make sure txns are recom in selectv_recom suite

### DIFF
--- a/tests/selectv_recom.test/lrl.options
+++ b/tests/selectv_recom.test/lrl.options
@@ -1,3 +1,4 @@
 table t1 t1.csc2
 table t2 t2.csc2
 round_robin_stripes
+sql_tranlevel_default recom

--- a/tests/selectv_recom.test/t2_01.req.exp
+++ b/tests/selectv_recom.test/t2_01.req.exp
@@ -5,7 +5,6 @@ done
 done
 (rows deleted=1)
 done
-[commit] failed with rc -103 constraints error, no genid
 done
 (rows inserted=1)
 done

--- a/tests/selectv_recom.test/t6_01.req.exp
+++ b/tests/selectv_recom.test/t6_01.req.exp
@@ -9,19 +9,16 @@ done
 done
 (rows updated=1)
 done
-[commit] failed with rc -103 constraints error, no genid
 done
 done
 (count(*)=1)
 done
 (rows updated=1)
 done
-[commit] failed with rc -103 constraints error, no genid
 done
 done
 (id=2, b1=x'22')
 done
 (rows updated=1)
 done
-[commit] failed with rc -103 constraints error, no genid
 done

--- a/tests/selectv_recom.test/t7_01.req
+++ b/tests/selectv_recom.test/t7_01.req
@@ -4,8 +4,6 @@
 1 insert into t7 values (3, 30)
 1 insert into t7 values (4, 40)
 1 insert into t7 values (5, 50)
-1 set transaction read committed
-2 set transaction read committed
 1 begin
 1 selectv * from t7 where a = 2
 1 insert into t7 values (10, 100)

--- a/tests/selectv_recom.test/t7_01.req.exp
+++ b/tests/selectv_recom.test/t7_01.req.exp
@@ -10,8 +10,6 @@ done
 (rows inserted=1)
 done
 done
-done
-done
 (a=2, b=20)
 done
 done


### PR DESCRIPTION
This suite is supposed to test selectv under read committed isolation, but only actually sets the transaction level to read committed for one test in the suite. The changes in this PR make read committed the default txn level in this suite's lrl so that the it actually tests selectv under read committed.