### PR TITLE
start_modsnap_transaction -> populate_modsnap_state

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -4997,7 +4997,7 @@ int sqlite3BtreeBeginTrans(Vdbe *vdbe, Btree *pBt, int wrflag, int *pSchemaVersi
         &thedb->static_table; 
     /* Latch last commit LSN */
     if (clnt->dbtran.mode == TRANLEVEL_MODSNAP && !clnt->modsnap_in_progress && (db->handle != NULL) &&
-        (start_modsnap_transaction(clnt) != 0)) {
+        (populate_modsnap_state(clnt) != 0)) {
         rc = SQLITE_INTERNAL;
         goto done;
     }

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1730,7 +1730,7 @@ int cache_table_versions(struct sqlclntstate *clnt)
     return 0;
 }
 
-int start_modsnap_transaction(struct sqlclntstate *clnt)
+int populate_modsnap_state(struct sqlclntstate *clnt)
 {
     struct dbtable *db = &thedb->static_table;
     assert(db->handle);
@@ -1795,7 +1795,7 @@ int handle_sql_begin(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                 (clnt->sql) ? clnt->sql : "(???.)");
 
     /* Latch the last commit LSN */
-    if (clnt->dbtran.mode == TRANLEVEL_MODSNAP && (start_modsnap_transaction(clnt) != 0)) {
+    if (clnt->dbtran.mode == TRANLEVEL_MODSNAP && (populate_modsnap_state(clnt) != 0)) {
         rc = SQLITE_INTERNAL;
         goto done;
     }

--- a/db/sqlinterfaces.h
+++ b/db/sqlinterfaces.h
@@ -87,7 +87,7 @@ struct param_data *clnt_find_param(struct sqlclntstate *clnt, const char *name,
                                    int index);
 int bind_parameters(struct reqlogger *logger, sqlite3_stmt *stmt, struct sqlclntstate *clnt, char **err,
                     int sample_queries);
-int start_modsnap_transaction(struct sqlclntstate *clnt);
+int populate_modsnap_state(struct sqlclntstate *clnt);
 int cache_table_versions(struct sqlclntstate *clnt);
 
 #endif


### PR DESCRIPTION
/skipbuild

`start_modsnap_transaction` was a confusing name since there’s also a `trans_start_modsnap` function. From the names alone, it wasn’t obvious how they were different.

This PR renames `start_modsnap_transaction` to `populate_modsnap_state` to better reflect what it actually does — it just sets up modsnap-specific state and doesn’t start a database transaction.