### PR TITLE
Modify fix_commit_delay_on_copy test

### DIFF
--- a/tests/commit_delay_on_copy.test/lrl.options
+++ b/tests/commit_delay_on_copy.test/lrl.options
@@ -1,3 +1,4 @@
 setattr COMMITDELAYMAX 2000
 commit_delay_on_copy_ms 2000
 commit_delay_trace 1
+extended_sql_debug_trace 1

--- a/tests/commit_delay_on_copy.test/runit
+++ b/tests/commit_delay_on_copy.test/runit
@@ -5,7 +5,12 @@ bash -n "$0" | exit 1
 . ${TESTSROOTDIR}/tools/timers.sh
 
 #export debug=1
-export fasttime=200
+
+# We saw this take more than 500ms (??)
+# but it was not due to commit-delay
+#
+# Have enabled extended-sql debug trace
+export fasttime=500
 export slowtime=2000
 
 function failexit


### PR DESCRIPTION
An insert in this test took more than 500ms

{"time":1763411031913316,"type":"sql","cnonce":"35393061303230302d35303162302d3536336166666639313230302d30303230336635333032303233643634","id":"a139b6f6-9f0f-4506-b8b0-2e211d193e78","rows":1,"host":"c1","fingerprint":"9db011673efab19745d84d28ecb41269","startlag":81779,"connid":13,"pid":328112,"client":"/comdb2/build/tools/cdb2sql/cdb2sql","perf":{"tottime":503092,"processingtime":503067,"qtime":25},"tables":["t1"]}

The transaction log has courser grained timed-stamps, and shows the commit record being written the next second:

 This PR enables extended sql debug trace for this test and extends the threshold to 500ms. 