### PR TITLE
Enable CDB2API_TEST flag when COMDB2_TEST is enabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           cd build
 
           echo "Running CMake"
-          cmake ..
+          cmake -DCOMDB2_TEST=1 ..
 
       - name: Build [all]
         working-directory: build

--- a/cdb2api/CMakeLists.txt
+++ b/cdb2api/CMakeLists.txt
@@ -28,6 +28,10 @@ include_directories(
 add_definitions(-DDISABLE_HOSTADDR_CACHE)
 add_definitions(-DSBUF2_SERVER=0)
 
+if (COMDB2_TEST)
+  add_definitions(-DCDB2API_TEST)
+endif()
+
 if (COMDB2_BBCMAKE)
   include(${EXTRA_PLUGINS}/cdb2api/cdb2api.cmake)
   add_library(opencdb2api STATIC ${src})

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -360,7 +360,7 @@ MAKE_CDB2API_TEST_COUNTER(num_sockpool_send_timeouts)
 // managed by the caller - I could strdup locally, but don't want to be
 // flagged by valgrind.
 #define MAKE_CDB2API_TEST_TUNABLE(name)                                                                                \
-    static char *cdb2api_test_##name;                                                                                  \
+    static const char *cdb2api_test_##name;                                                                            \
     void set_cdb2api_test_##name(const char *value)                                                                    \
     {                                                                                                                  \
         cdb2api_test_##name = value;                                                                                   \
@@ -7962,10 +7962,11 @@ retry:
         /* Try dbinfo on same room first */
         for (i = 0; i < hndl->num_hosts_sameroom; i++) {
             int try_node = (node_seq + i) % hndl->num_hosts_sameroom;
-#ifdef CDB2API_TEST
-            if (cdb2_use_bmsd)
-                printf("Try node %d name %s master %d\n", try_node, hndl->hosts[try_node], hndl->master);
-#endif
+            // comment out for now. Extra output fails ssl_dbname and ssl_set_cmd test.
+            // #ifdef CDB2API_TEST
+            //             if (cdb2_use_bmsd)
+            //                 printf("Try node %d name %s master %d\n", try_node, hndl->hosts[try_node], hndl->master);
+            // #endif
             rc = cdb2_dbinfo_query(hndl, hndl->type, hndl->dbname, hndl->dbnum,
                                    hndl->hosts[try_node], hndl->hosts,
                                    hndl->ports, &hndl->master, &hndl->num_hosts,

--- a/cdb2api/cdb2api_test.h
+++ b/cdb2api/cdb2api_test.h
@@ -1,0 +1,89 @@
+#ifndef INCLUDED_CDB2API_TEST_H
+#define INCLUDED_CDB2API_TEST_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+int get_dbinfo_state(void);
+void set_dbinfo_state(int);
+
+int get_num_get_dbhosts(void);
+int get_num_skip_dbinfo(void);
+int get_num_sockpool_fd(void);
+int get_num_sql_connects(void);
+int get_num_tcp_connects(void);
+int get_num_sockpool_recv(void);
+int get_num_sockpool_send(void);
+int get_num_sockpool_send_timeouts(void);
+int get_num_sockpool_recv_timeouts(void);
+
+void set_fail_dbhosts_invalid_response(int);
+void set_fail_dbhosts_bad_response(int);
+void set_fail_dbhosts_cant_read_response(int);
+void set_fail_dbinfo_invalid_header(int);
+void set_fail_dbinfo_invalid_response(int);
+void set_fail_dbinfo_no_response(int);
+
+int get_num_cache_lru_evicts(void);
+int get_num_cache_hits(void);
+int get_num_cache_misses(void);
+
+void set_fail_next(int);
+void set_fail_read(int);
+void set_fail_reject(int);
+void set_fail_sb(int);
+void set_fail_send(int);
+void set_fail_sockpool(int);
+void set_fail_tcp(int);
+void set_fail_timeout_sockpool_recv(int);
+void set_fail_timeout_sockpool_send(int);
+
+void set_allow_pmux_route(int allow);
+void set_atexit_delay(int on);
+
+void set_local_connections_limit(int lim);
+int get_num_cached_connections_for(const char *dbname);
+void dump_cached_connections(void);
+int get_cached_connection_index(const char *dbname);
+void test_process_env_vars(void);
+int get_max_local_connection_cache_entries(void);
+void reset_once(void);
+void local_connection_cache_clear(int);
+
+void set_fail_mutex_lock_in_add_ssl_session(int);
+void set_ignore_san(int);
+void set_fail_ssl_ctx_new(int);
+void set_fail_sslio_connect(int);
+void set_fail_sslio_read(int);
+void set_fail_sslio_write(int);
+void set_fail_sslio_zero_return(int);
+void set_fail_sslio_syscall(int);
+void set_fail_sslio_others(int);
+void set_fail_key_ownership(int);
+void set_fake_root_key(int);
+void set_override_dbname_in_cert(int);
+// void set_override_hostname_in_cert(int);
+void set_fail_reverse_dns(int);
+void set_fail_forward_dns(int);
+void set_fail_null_server_cert(int);
+void set_fail_null_ssl_ctx(int);
+void set_fail_ssl_accept_twice(int);
+void set_fail_ssl_new(int);
+void set_fail_ssl_negotiation_once(int);
+void set_fail_ssl_poll(int);
+void set_fail_sslio_close_in_local_cache(int);
+
+void set_cdb2api_test_comdb2db_cfg(const char *);
+void set_cdb2api_test_single_cfg(const char *);
+void set_cdb2api_test_dbname_cfg(const char *);
+
+struct cdb2_hndl;
+const char *get_default_cluster(void);
+const char *get_default_cluster_hndl(struct cdb2_hndl *);
+
+#if defined __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* INCLUDED_CDB2API_TEST_H */

--- a/tests/cdb2api_tests.test/Makefile
+++ b/tests/cdb2api_tests.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/cdb2api_tests.test/runit
+++ b/tests/cdb2api_tests.test/runit
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+exit 0


### PR DESCRIPTION
Subset of https://github.com/bloomberg/comdb2/pull/5574 which passed robots.

Add infrastructure in this pr so can add tests separately later and adhoc test if needed

This will enable cdb2api_test for roborivers