### PR TITLE
Don't use snapshot lsn prior to recoverable lsn

### DIFF
--- a/bdb/bdb_osqltrn.c
+++ b/bdb/bdb_osqltrn.c
@@ -219,6 +219,13 @@ uint32_t bdb_latest_commit_gen = 0;
 pthread_mutex_t bdb_asof_current_lsn_mutex;
 pthread_cond_t bdb_asof_current_lsn_cond;
 
+void bdb_get_gbl_recoverable_lsn(void *lsn)
+{
+    Pthread_mutex_lock(&bdb_gbl_recoverable_lsn_mutex);
+    *(DB_LSN *)lsn = bdb_gbl_recoverable_lsn;
+    Pthread_mutex_unlock(&bdb_gbl_recoverable_lsn_mutex);
+}
+
 void bdb_set_gbl_recoverable_lsn(void *lsn, int32_t timestamp)
 {
     if (!gbl_new_snapisol_asof && !gbl_modsnap_asof)

--- a/bdb/bdb_osqltrn.h
+++ b/bdb/bdb_osqltrn.h
@@ -83,7 +83,12 @@ struct page_logical_lsn_key;
 int bdb_osql_trn_asof_ok_to_delete_log(int filenum);
 
 /**
- * set global recoverabel lsn
+ * Get global recoverable lsn
+ */
+void bdb_get_gbl_recoverable_lsn(void *lsn);
+
+/**
+ * set global recoverable lsn
  */
 void bdb_set_gbl_recoverable_lsn(void *lsn, int32_t timestamp);
 

--- a/bdb/tran.c
+++ b/bdb/tran.c
@@ -2832,7 +2832,23 @@ static int get_modsnap_start_lsn(bdb_state_type *bdb_state, bdb_attr_type *bdb_a
             return rc;
         }
     } else {
-        (void)bdb_get_current_lsn(bdb_state, p_modsnap_start_lsn_file, p_modsnap_start_lsn_offset);
+        // The 'current' LSN is the last one that updated genids.
+        // This can be lower than the recoverable LSN. If it is, then
+        // use the recoverable LSN. Othwerwise, use the current LSN.
+
+        DB_LSN current_lsn;
+        (void)bdb_get_current_lsn(bdb_state, &(current_lsn.file), &(current_lsn.offset));
+
+        DB_LSN recoverable_lsn;
+        bdb_get_gbl_recoverable_lsn(&recoverable_lsn);
+
+        if (log_compare(&current_lsn, &recoverable_lsn) < 0) {
+            *p_modsnap_start_lsn_file = recoverable_lsn.file;
+            *p_modsnap_start_lsn_offset = recoverable_lsn.offset;
+        } else {
+            *p_modsnap_start_lsn_file = current_lsn.file;
+            *p_modsnap_start_lsn_offset = current_lsn.offset;
+        }
     }
 
     return 0;

--- a/tests/logdelete.test/snapshot.testopts
+++ b/tests/logdelete.test/snapshot.testopts
@@ -1,1 +1,2 @@
 enable_snapshot_isolation
+sql_tranlevel_default snapshot


### PR DESCRIPTION
The logdelete test was failing when the default transaction mode was set to snapshot.

It failed because the test ran pushlogs, which triggered log deletion, and then ran a select. The issue was that the select started with an LSN lower than the recoverable LSN.

This happened because snapshot transactions use the LSN of the latest genid modification as their starting point. That LSN isn’t always guaranteed to be higher than the recoverable LSN. Since the snapshot start LSN was lower than the recoverable LSN, the system couldn’t find a checkpoint LSN before that point and aborted [here](https://github.com/bloomberg/comdb2/blob/c1bf885e59dc3cee638db04a813fe86bfa31b127/bdb/file.c#L335).

The fix is to use the recoverable LSN as the snapshot start LSN if the LSN of the latest genid modification is lower than the recoverable LSN.