### PR TITLE
{181357957} fix(normalize): consolidate string literals in `IN` clauses

### DIFF
--- a/sqlite/src/vdbeaux.c
+++ b/sqlite/src/vdbeaux.c
@@ -122,8 +122,8 @@ void sqlite3VdbeAddDblquoteStr(sqlite3 *db, Vdbe *p, const char *z){
 
 #ifdef SQLITE_ENABLE_NORMALIZE
 /*
-** zId of length nId is a double-quoted identifier.  Check to see if
-** that identifier is really used as a string literal.
+** zId of length nId is a double-quoted identifier. Return non-zero
+** if that identifier is really used as a string literal.
 */
 int sqlite3VdbeUsesDoubleQuotedString(
   Vdbe *pVdbe,            /* The prepared statement */

--- a/tests/yast.test/normalize.test
+++ b/tests/yast.test/normalize.test
@@ -452,6 +452,175 @@ foreach {tnum sql flags norm} {
   {SELECT * FROM comdb2_transaction_logs('{0:1}') LIMIT 1}
   0x2
   {0 {SELECT*FROM comdb2_transaction_logs(?)LIMIT?;}}
+
+  1280
+  {
+    -- 'a' is a string literal, "a" is an identifier (column name).
+    -- 'h' and "h" are both string literals because t1 has no column
+    -- with that name.
+    SELECT 'a', "a", [b], `c`, 'h', "h" FROM t1
+  }
+  0x2
+  {0 {SELECT?,a,b,c,?,?FROM t1;}}
+
+  1290
+  {
+    -- IN clause contains identifiers.
+    SELECT a FROM t1 WHERE b IN (c, d)
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d);}}
+
+  1291
+  {SELECT a FROM t1 WHERE b IN ("c", "d")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d);}}
+
+  1292
+  {SELECT a FROM t1 WHERE b IN ([c], [d])}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d);}}
+
+  1293
+  {SELECT a FROM t1 WHERE b IN (`c`, `d`)}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d);}}
+
+  1310
+  {
+    -- IN clause contains quoted and unquoted identifiers.
+    SELECT a FROM t1 WHERE b IN (c, "d", [e], `w`)
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d,e,w);}}
+
+  1311
+  {SELECT a FROM t1 WHERE b IN ("c", [d], `e`, w)}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d,e,w);}}
+
+  1312
+  {SELECT a FROM t1 WHERE b IN ([c], `d`, e, "w")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d,e,w);}}
+
+  1313
+  {SELECT a FROM t1 WHERE b IN (`c`, d, "e", [w])}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,d,e,w);}}
+
+  1330
+  {
+    -- IN clause contains string literals and unquoted identifiers.
+    SELECT a FROM t1 WHERE b IN ('a', c)
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,c);}}
+
+  1331
+  {SELECT a FROM t1 WHERE b IN ("foo", c)}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,c);}}
+
+  1332
+  {SELECT a FROM t1 WHERE b IN (c, 'a')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,?);}}
+
+  1333
+  {SELECT a FROM t1 WHERE b IN (c, "foo")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,?);}}
+
+  1340
+  {
+    -- IN clause contains string literals and quoted identifiers.
+    SELECT a FROM t1 WHERE b IN ('a', "c")
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,c);}}
+
+  1341
+  {SELECT a FROM t1 WHERE b IN ("foo", [c])}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,c);}}
+
+  1342
+  {SELECT a FROM t1 WHERE b IN (`c`, 'a')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,?);}}
+
+  1343
+  {SELECT a FROM t1 WHERE b IN ("c", "foo")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(c,?);}}
+
+  1350
+  {
+    -- IN clause contains a string literal with the same value
+    -- as the name of an identifier.
+    SELECT a FROM t1 WHERE b IN (a, 'a')
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(a,?);}}
+
+  1351
+  {SELECT a FROM t1 WHERE b IN ('a', a)}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,a);}}
+
+  1352
+  {SELECT a FROM t1 WHERE b IN ("a", 'a')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(a,?);}}
+
+  1353
+  {SELECT a FROM t1 WHERE b IN ('a', "a")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,a);}}
+
+  1354
+  {SELECT a FROM t1 WHERE b IN ('a', [a])}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,a);}}
+
+  1355
+  {SELECT a FROM t1 WHERE b IN (`a`, 'a')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(a,?);}}
+
+  1360
+  {
+    -- String literals in IN clauses should be consolidated.
+    SELECT a FROM t1 WHERE b IN ('foo', "bar", 'baz', "qux", 'quux')
+  }
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
+
+  1361
+  {SELECT a FROM t1 WHERE b IN ('foo', "bar", 'baz', "qux")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
+
+  1362
+  {SELECT a FROM t1 WHERE b IN ('foo', "bar", 'baz')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
+
+  1363
+  {SELECT a FROM t1 WHERE b IN ('foo', "bar")}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
+
+  1364
+  {SELECT a FROM t1 WHERE b IN ('foo')}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
+
+  1365
+  {SELECT a FROM t1 WHERE b IN ()}
+  0x2
+  {0 {SELECT a FROM t1 WHERE b IN(?,?,?);}}
 } {
   do_test $tnum {
     set code [catch {


### PR DESCRIPTION
Prior to this fix, it was observed that string literals prevented `IN` clauses from being consolidated in fingerprints:

```sql
testdb> select 'a' where 'a' in ();
testdb> select 'a' where 'a' in ('b');
testdb> select 'a' where 'a' in ('b', 'c');
testdb> select 'a' where 'a' in ('b', 'c', 'd');
testdb> select 'a' where 'a' in ('b', 'c', 'd', 'e');
testdb>
testdb> select fingerprint, count, normalized_sql from comdb2_fingerprints;
(fingerprint='cf0f87fad75d1874619c28808ebabe4a', count=1, normalized_sql='SELECT?WHERE?IN(?);')
(fingerprint='0dfdc160117b48efefcbaf8ddf0ad174', count=1, normalized_sql='SELECT?WHERE?IN(?,?);')
(fingerprint='11c33d8b5523d3d12a290f12cdd7be12', count=2, normalized_sql='SELECT?WHERE?IN(?,?,?);')
(fingerprint='b8fcde675ccf4c7d1d5a834fada58ec9', count=1, normalized_sql='SELECT?WHERE?IN(?,?,?,?);')
```

All of the above queries _should_ have the same fingerprint.

This likely regressed in 0ca7333d, which attempted to fix a different problem by treating string literals similarly to identifiers. Unfortunately, when we see an identifier, we disable the consolidation of `IN` clauses so that the identifier doesn't get clobbered.  This behavior is not desirable for string literals.

Ensure that consolidation is disabled only if we see an identifier (quoted or otherwise) in an `IN` clause, not just any string. New behavior:

```sql
testdb> select 'a' where 'a' in ();
testdb> select 'a' where 'a' in ('b');
testdb> select 'a' where 'a' in ('b', 'c');
testdb> select 'a' where 'a' in ('b', 'c', 'd');
testdb> select 'a' where 'a' in ('b', 'c', 'd', 'e');
testdb>
testdb> select fingerprint, count, normalized_sql from comdb2_fingerprints;
(fingerprint='11c33d8b5523d3d12a290f12cdd7be12', count=5, normalized_sql='SELECT?WHERE?IN(?,?,?);')
```