### PR TITLE
Fix union-all subquery with limit flattening optimization (port from newer sqlite)

### DIFF
--- a/sqlite/src/select.c
+++ b/sqlite/src/select.c
@@ -2670,7 +2670,7 @@ static int multiSelect(
         pPrior->iOffset = p->iOffset;
         pPrior->pLimit = p->pLimit;
         rc = sqlite3Select(pParse, pPrior, &dest);
-        p->pLimit = 0;
+        pPrior->pLimit = 0;
         if( rc ){
           goto multi_select_end;
         }
@@ -2691,8 +2691,8 @@ static int multiSelect(
         pDelete = p->pPrior;
         p->pPrior = pPrior;
         p->nSelectRow = sqlite3LogEstAdd(p->nSelectRow, pPrior->nSelectRow);
-        if( pPrior->pLimit
-         && sqlite3ExprIsInteger(pPrior->pLimit->pLeft, &nLimit, 0)
+        if( p->pLimit
+         && sqlite3ExprIsInteger(p->pLimit->pLeft, &nLimit, 0)
          && nLimit>0 && p->nSelectRow > sqlite3LogEst((u64)nLimit) 
         ){
           p->nSelectRow = sqlite3LogEst((u64)nLimit);


### PR DESCRIPTION
Port fix from sqlite https://sqlite.org/src/info/2025-12-09T19:15:52Z
i.e. fix limit for union-all subqueries can that flattened.

re: 181655879

