### PR TITLE
Use only one node so that tunable works and avoid random analyze failures

### DIFF
--- a/tests/analyze.test/t16.req.out
+++ b/tests/analyze.test/t16.req.out
@@ -1,5 +1,7 @@
 (rows inserted=50000)
 (rows inserted=50000)
+[exec procedure sys.cmd.send('setsqlattr analyze_empty_tables off')] rc 0
+[ANALYZE t15] rc 0
 (count(*)=2)
 (count(*)=48)
 (count(*)=1)

--- a/tests/analyze.test/t16.sh
+++ b/tests/analyze.test/t16.sh
@@ -22,20 +22,27 @@ ${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default "INSERT INTO t15 SELECT * FROM 
 ${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default "PUT COUNTER t15 SET 1"
 #insert more records -> after this both partitions should have records
 ${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default "INSERT INTO t15 SELECT * FROM generate_series(50000, 99999)"
-#disable analyze for empty tables, it has a bug
-${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default " exec procedure sys.cmd.send('setsqlattr analyze_empty_tables off')"
 }
 
 
 #test analyzing partitioned table
+if [ -z "${CLUSTER}" ] ; then
+    host=`${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} ${DBNAME} default "select host from comdb2_cluster"`
+else
+    host=`${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} ${DBNAME} default "select host from comdb2_cluster where is_master='N' limit 1"`
+fi
 setup_table
 purge_stats
-${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default "ANALYZE t15"
+${CDB2SQL_EXE} ${CDB2_OPTIONS} --host ${host} ${DBNAME} <<EOF
+exec procedure sys.cmd.send('setsqlattr analyze_empty_tables off')
+ANALYZE t15
+EOF
+
 count_stats
 
 
 #test analyzeing individual shard
 SHARDNAME=$(${CDB2SQL_EXE} -tabs ${CDB2_OPTIONS} ${DBNAME} default "select shardname from comdb2_timepartshards where name='t15' limit 1")
 purge_stats
-${CDB2SQL_EXE} ${CDB2_OPTIONS} ${DBNAME} default "ANALYZE \"$SHARDNAME\""
+${CDB2SQL_EXE} ${CDB2_OPTIONS} --host ${host} ${DBNAME} "ANALYZE \"$SHARDNAME\""
 count_stats


### PR DESCRIPTION
Fixes random failures for tpt analyze in test analyze.