### PR TITLE
Fix 'first-record' miss for physreps

### DIFF
--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1887,7 +1887,7 @@ REGISTER_TUNABLE("physrep_filter_by_class", "Filter physrep replication by class
                  &gbl_physrep_filter_by_class, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_max_rollback", "Maximum logs physrep can rollback. (Default: 0)", TUNABLE_INTEGER,
                  &gbl_physrep_max_rollback, 0, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("physrep_pollms", "Physical replicant poll interval in milliseconds. (Default: 0)", TUNABLE_INTEGER,
+REGISTER_TUNABLE("physrep_pollms", "Physical replicant poll interval in milliseconds. (Default: 50)", TUNABLE_INTEGER,
                  &gbl_physrep_pollms, 0, NULL, NULL, NULL, NULL);
 
 /* reversql-sql */

--- a/tests/phys_rep.test/lrl.options
+++ b/tests/phys_rep.test/lrl.options
@@ -1,0 +1,2 @@
+logmsg level debug
+physrep_debug 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -742,7 +742,7 @@
 (name='physrep_max_rollback', description='Maximum logs physrep can rollback. (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='physrep_metadb_host', description='List of physical replication metadb cluster hosts.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_metadb_name', description='Physical replication metadb cluster name.', type='STRING', value=NULL, read_only='Y')
-(name='physrep_pollms', description='Physical replicant poll interval in milliseconds. (Default: 0)', type='INTEGER', value='0', read_only='N')
+(name='physrep_pollms', description='Physical replicant poll interval in milliseconds. (Default: 50)', type='INTEGER', value='50', read_only='N')
 (name='physrep_reconnect_interval', description='Reconnect interval for physical replicants (Default: 600)', type='INTEGER', value='3600', read_only='N')
 (name='physrep_reconnect_penalty', description='Physrep wait seconds before retry to the same node. (Default: 5)', type='INTEGER', value='0', read_only='N')
 (name='physrep_repl_host', description='Current physrep host.', type='STRING', value=NULL, read_only='Y')


### PR DESCRIPTION
Physical replicants should drop their connection and re-register if the first record is invalid.
