### PR TITLE
{181750589} bdb: Fix error code from odh unpack

### DIFF
--- a/bdb/odh.c
+++ b/bdb/odh.c
@@ -1008,7 +1008,7 @@ static int bdb_cget_unpack_int(bdb_state_type *bdb_state, DBC *dbcp, DBT *key, D
         if (rc == ENOMEM) {
             /* Secondly, allocate the needed size and get from the current cursor position. */
             if ((data->data = fn_malloc((int)data->size)) == NULL)
-                rc = BDBERR_MALLOC;
+                rc = ENOMEM;
             else {
                 data->ulen = data->size;
                 rc = dbcp->c_get(dbcp, key, data, DB_CURRENT);


### PR DESCRIPTION
`bdb_cget_unpack_int` returned `BDBERR_MALLOC`, but this was interpreted as `errno` by the caller. This matches `EMFILE` and incorrectly logs 'Too many open files.'