### PR TITLE
Require protobuf schema change serialization

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -321,7 +321,6 @@ extern int gbl_memp_dump_cache_threshold;
 extern int gbl_disable_ckp;
 extern int gbl_abort_on_illegal_log_put;
 extern int gbl_sc_close_txn;
-extern int gbl_sc_protobuf;
 extern int gbl_sc_current_version;
 extern int gbl_create_dba_user;
 extern int gbl_lock_dba_user;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2450,8 +2450,6 @@ REGISTER_TUNABLE("wal_osync", "Open WAL files using the O_SYNC flag (Default: of
                  NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sc_headroom", "Percentage threshold for low headroom calculation. (Default: 10)", TUNABLE_DOUBLE,
                  &gbl_sc_headroom, INTERNAL | SIGNED, NULL, NULL, NULL, NULL);
-REGISTER_TUNABLE("sc_protobuf", "Enable protobuf schema change object (Default: on)", TUNABLE_BOOLEAN, &gbl_sc_protobuf,
-                 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("sc_current_version", "Current schema-change version (Default: " STR(SC_VERSION) ")", TUNABLE_INTEGER,
                  &gbl_sc_current_version, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("fdb_incoherence_percentage", "Generate random incoherent errors in remsql", TUNABLE_INTEGER,

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -425,7 +425,6 @@ typedef struct sc_list sc_list_t;
  */
 int sc_list_create(sc_list_t *scl, void *vscs, uuid_t uuid);
 
-size_t schemachange_packed_size(struct schema_change_type *s);
 int start_schema_change_tran(struct ireq *, tran_type *tran);
 int start_schema_change(struct schema_change_type *);
 int create_queue(struct dbenv *, char *queuename, int avgitem, int pagesize);
@@ -465,10 +464,7 @@ void free_schema_change_type(struct schema_change_type *s);
 int pack_schema_change_protobuf(struct schema_change_type *s, void **packed_sc, size_t *packed_len);
 int unpack_schema_change_protobuf(struct schema_change_type *s, void *packed_sc, size_t *plen);
 
-void *buf_put_schemachange(struct schema_change_type *s, void *p_buf, void *p_buf_end);
 void *buf_get_schemachange(struct schema_change_type *s, void *p_buf, void *p_buf_end);
-
-void *buf_put_schemachange_protobuf(struct schema_change_type *s, void *p_buf, void *p_buf_end);
 void *buf_get_schemachange_protobuf(struct schema_change_type *s, void *p_buf, void *p_buf_end);
 void *buf_get_schemachange_v1(struct schema_change_type *s, void *p_buf, void *p_buf_end);
 void *buf_get_schemachange_v2(struct schema_change_type *s, void *p_buf,

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -44,7 +44,6 @@ extern int gbl_permit_small_sequences;
 extern int gbl_lightweight_rename;
 extern int gbl_transactional_drop_plus_rename;
 extern int gbl_gen_shard_verbose;
-extern int gbl_sc_protobuf;
 int gbl_view_feature = 1;
 int gbl_disable_sql_table_replacement = 0;
 
@@ -1754,12 +1753,6 @@ void comdb2Replace(Parse* pParse, Token *nm, Token *nm2, Token *nm3)
 {
     if (gbl_disable_sql_table_replacement) {
         setError(pParse, SQLITE_MISUSE, "sql table replacement is disabled");
-        return;
-    }
-
-    if (!gbl_sc_protobuf) {
-        setError(pParse, SQLITE_MISUSE,
-            "sc_protobuf lrl option required for sql table replacement");
         return;
     }
 

--- a/sqlite/src/comdb2lua.c
+++ b/sqlite/src/comdb2lua.c
@@ -22,7 +22,6 @@ struct dbtable;
 struct dbtable *getqueuebyname(const char *);
 int bdb_get_sp_get_default_version(const char *, int *);
 extern int gbl_create_default_consumer_atomically;
-extern int gbl_sc_protobuf;
 
 #define MAX_SPNAME_FOR_TRIGGER (MAX_SPNAME-(sizeof(Q_TAG)-1)) // includes null terminator
 #define COMDB2_DEFAULT_CONSUMER 2
@@ -137,7 +136,7 @@ Cdb2TrigTables *comdb2AddTriggerTable(Parse *parse, Cdb2TrigTables *tables, SrcL
 
 static int can_create_default_consumer_atomically()
 {
-    return gbl_create_default_consumer_atomically && gbl_sc_protobuf;
+    return gbl_create_default_consumer_atomically;
 }
 
 void comdb2CreateTrigger(Parse *parse, int consumer, int seq, Token *proc, Cdb2TrigTables *tbl)

--- a/tests/bulkimport.test/runit
+++ b/tests/bulkimport.test/runit
@@ -261,25 +261,6 @@ function test_unsupported_version() {
 	)
 }
 
-function test_protobuf_tunable() {
-	(
-		# Given
-		local src_tbl=foo dst_tbl=bar rc=0
-		fixture_src_tbl_and_dst_tbl_have_same_schema $src_tbl $dst_tbl > /dev/null
-		set_dst_tunable "sc_protobuf 0"
-
-		trap "set_dst_tunable 'sc_protobuf 1';
-			query_src_db 'drop table $src_tbl';
-			query_dst_db 'drop table $dst_tbl'" EXIT
-
-		# When
-		query_dst_db "replace table $dst_tbl with LOCAL_$SRC_DBNAME.$src_tbl"
-
-		# Then
-		(( $? != 0 ))
-	)
-}
-
 function test_feature_tunable() {
 	(
 		# Given

--- a/tests/truncoplog.test/noprotobuf.testopts
+++ b/tests/truncoplog.test/noprotobuf.testopts
@@ -1,1 +1,0 @@
-sc_protobuf 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -903,7 +903,6 @@
 (name='sc_logical_save_lsn_every_n', description='Save schema change redo lsn to llmeta every n-th transactions.', type='INTEGER', value='10', read_only='N')
 (name='sc_no_rebuild_thr_sleep', description='Sleep this many microsec when conversion threads count is at max.', type='INTEGER', value='10', read_only='N')
 (name='sc_pause_redo', description='Pauses the newsc asychronous redo-thread for testing.', type='BOOLEAN', value='OFF', read_only='N')
-(name='sc_protobuf', description='Enable protobuf schema change object (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_restart_sec', description='Delay restarting schema change for this many seconds after startup/new master election.', type='INTEGER', value='0', read_only='N')
 (name='sc_resume_autocommit', description='Always resume autocommit schemachange if possible.', type='BOOLEAN', value='ON', read_only='N')
 (name='sc_resume_watchdog_timer', description='sc_resuming_watchdog timer', type='INTEGER', value='60', read_only='N')


### PR DESCRIPTION
Deletes non-protobuf schema change serialization code.

Don't merge until we're sure we won't want to do a direct 8.0 -> 8.2 upgrade (8.0 doesn't understand the protobuf format, so we would need to have it disabled during the upgrade process so that the nodes coming up as 8.2 don't send messages that the 8.0 nodes don't understand)