### PR TITLE
{181677165}: Fixing memory leak in dohast order-by processing

### DIFF
--- a/db/dohast.c
+++ b/db/dohast.c
@@ -88,11 +88,13 @@ static char *describeExprList(Vdbe *v, const ExprList *lst, int *order_size,
         return NULL;
 
     /* handle descending keys */
-    *order_size = lst->nExpr;
-    *order_dir = (int *)malloc((*order_size) * sizeof(int));
-    if (!*order_dir) {
-        sqlite3_free(ret);
-        return NULL;
+    if (*order_size == 0) {
+        *order_size = lst->nExpr;
+        *order_dir = (int *)malloc((*order_size) * sizeof(int));
+        if (!*order_dir) {
+            sqlite3_free(ret);
+            return NULL;
+        }
     }
 
     if (((*order_dir)[0] = lst->a[0].sortOrder) != 0) {


### PR DESCRIPTION
This patch frees the `order_dir` variable on the parent dohsql struct before overwriting it.