### PR TITLE
Remove blocking tranlog from longreqs

### DIFF
--- a/db/sql.h
+++ b/db/sql.h
@@ -1075,6 +1075,8 @@ struct sqlclntstate {
 
     // this is not an SQL request, distpatch it elsewhere
     int is_tagged;
+
+    unsigned blocking_tranlog : 1;
 };
 typedef struct sqlclntstate sqlclntstate;
 

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <string.h>
 #include "comdb2.h"
+#include "sql.h"
 #include "build/db.h"
 #include "dbinc/db_swap.h"
 #include "dbinc_auto/txn_auto.h"
@@ -825,6 +826,10 @@ static int tranlogFilter(
   if( idxNum & 4 ){
     int64_t flags = sqlite3_value_int64(argv[i++]);
     pCur->flags = flags;
+    if (flags & TRANLOG_FLAGS_BLOCK) {
+      struct sql_thread *thd = pthread_getspecific(query_info_key);
+      thd->clnt->blocking_tranlog = 1;
+    }
   }
   pCur->timeout = gbl_tranlog_default_timeout;
   if( idxNum & 8 ){

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1215,6 +1215,15 @@ function tranlog_timeout()
     if [[ $total -lt 29 || $total -gt 35 ]]; then
         cleanFailExit "tranlog timeout test failed, total time $total wanted 30"
     fi
+
+    echo "Make sure there is no LONG REQUEST trace database output"
+    for node in $CLUSTER ; do 
+        logfile=$TESTDIR/logs/${DBNAME}.${node}.db
+        egrep "LONG REQUEST" $logfile
+        if [[ $? -eq 0 ]]; then
+            cleanFailExit "Found LONG REQUEST trace output in $logfile"
+        fi
+    done
 }
 
 function get_log_cursor_gen()
@@ -2535,7 +2544,7 @@ function run_tests
 
 function run_one_test
 {
-    incoherent_master
+    tranlog_timeout
 }
 
 run_tests


### PR DESCRIPTION
The testcase verifies that there is no "LONG REQUEST" trace emitted during the tranlog_timeout test.
