### PR TITLE
Exclude fingerprints from longreqs

### DIFF
--- a/bbinc/tohex.h
+++ b/bbinc/tohex.h
@@ -19,6 +19,7 @@
 #include <logmsg.h>
 #include <build/db_dbt.h>
 char *util_tohex(char *out, const char *in, size_t len);
+int util_tobytes(char *out, const char *hex, size_t len);
 void hexdumpbuf(const char *key, int keylen, char **buf);
 void hexdump(loglvl lvl, const char *key, int keylen);
 void hexdumpdbt(DBT *dbt);

--- a/db/fingerprint.h
+++ b/db/fingerprint.h
@@ -1,0 +1,20 @@
+/*
+   Copyright 2025 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#ifndef _FINGERPRINT_H_
+#define _FINGERPRINT_H_
+#define FINGERPRINTSZ 16
+#endif

--- a/db/reqlog.h
+++ b/db/reqlog.h
@@ -19,6 +19,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdint.h>
+#include <fingerprint.h>
 
 /* reqlog.c - new logging stuff */
 struct reqlogger;
@@ -45,6 +46,9 @@ void reqlog_process_message(char *line, int st, int lline);
 void reqlog_stat(void);
 void reqlog_help(void);
 void reqlog_free(struct reqlogger *reqlogger);
+void reqlog_exclude_fingerprint(const char fp[FINGERPRINTSZ]);
+void reqlog_unexclude_fingerprint(const char fp[FINGERPRINTSZ]);
+int reqlog_fingerprint_is_excluded(const char fp[FINGERPRINTSZ]);
 void reqlog_reset_logger(struct reqlogger *logger);
 int reqlog_pushprefixv(struct reqlogger *logger, const char *format,
                        va_list args);

--- a/db/sql.h
+++ b/db/sql.h
@@ -38,6 +38,7 @@
 #include "db_access.h"
 #include "sqliteInt.h"
 #include "ast.h"
+#include "fingerprint.h"
 
 /* I'm now splitting handle_fastsql_requests into two functions.  The
  * outer function will maintain state (such as temporary buffers etc) while
@@ -46,8 +47,6 @@
  * query part) and the running of the query into different threads.  This way
  * we can have a small pool of sql threads with big stacks, and a large pool
  * of appsock threads with small stacks. */
-
-#define FINGERPRINTSZ 16
 
 #define CHECK_NEXT_QUERIES 20
 

--- a/tests/excludefp.test/Makefile
+++ b/tests/excludefp.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/excludefp.test/README
+++ b/tests/excludefp.test/README
@@ -1,0 +1,1 @@
+Verify that reql excludefp works correctly

--- a/tests/excludefp.test/lrl.options
+++ b/tests/excludefp.test/lrl.options
@@ -1,0 +1,1 @@
+verbose_normalized_queries

--- a/tests/excludefp.test/runit
+++ b/tests/excludefp.test/runit
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+debug=1
+[[ $debug == "1" ]] && set -x
+
+function exclude_test
+{
+    local n=""
+    local fp=""
+    local excluded=""
+    local count=0
+    local aftercnt=0
+
+    # Grab the first cluster node
+    if [[ -n "$CLUSTER" ]]; then
+        n=$(echo "$CLUSTER" | cut -d' ' -f1)
+    else
+        n=$(hostname)
+    fi
+
+    # Create a long request
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "select sleep(15)"
+
+    # Make sure that this appeared in the longreqs log
+    log=$TESTDIR/logs/excludefp${TESTID}.${n}.db
+
+    count=$(egrep -i -c "LONG REQUEST" $log)
+    [[ "$count" == "0" ]] && failexit "long request not found in longreqs log"
+
+    # Grab fingerprint for the sleep
+    fp=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $n "select fingerprint from comdb2_fingerprints where normalized_sql like 'SELECT sleep%'")
+
+    # Make sure we got something
+    [[ -z "$fp" ]] && failexit "could not get fingerprint for sleep request"
+
+    # Verify that this is not excluded from longreqs
+    excluded=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $n "select excluded_from_longreqs from comdb2_fingerprints where fingerprint='$fp'")
+
+    [[ "$excluded" == "N" ]] || failexit "fingerprint for sleep request is already marked as excluded_from_longreqs"
+
+    # Exclude this fp from longreqs
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('reql excludefp $fp')"
+
+    # Verify that it is now excluded
+    excluded=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $n "select excluded_from_longreqs from comdb2_fingerprints where fingerprint='$fp'")
+
+    [[ "$excluded" == "Y" ]] || failexit "fingerprint for sleep request is not marked as excluded_from_longreqs"
+
+    # Run the same long request again
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "select sleep(15)"
+
+    # Verify that the new request didn't occur as a LONGREQ
+    aftercnt=$(egrep -i -c "LONG REQUEST" $log)
+
+    [[ "$aftercnt" != "$count" ]] && failexit "long request found in longreqs log after excluding fingerprint"
+
+    # Now remove the exclusion
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('reql unexcludefp $fp')"
+
+    # Run the same long request again
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "select sleep(15)"
+
+    # Verify that the request once again appears as a LONG REQUEST
+    aftercnt=$(egrep -i -c "LONG REQUEST" $log)
+
+    [[ "$aftercnt" == "$count" ]] && failexit "unexcluded long-request did not appear in longreqs log"
+}
+
+function run_tests
+{
+    exclude_test
+}
+
+run_tests
+echo "Success!"


### PR DESCRIPTION
This PR adds the ability to exclude certain fingerprints from being reported in the longreqs log.