### PR TITLE
Update nobbenv path if comdb2 root is /bb

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2126,6 +2126,8 @@ static int get_config_file(const char *dbname, char *f, size_t s, int use_pkg_pa
 
     if (root == NULL)
         root = QUOTE(COMDB2_ROOT);
+    if (strcmp(root, "/bb") == 0) // TODO: Do this a better way
+        root = "/opt/bb";
     n = snprintf(f, s, "%s%s%s.cfg", root, CDB2DBCONFIG_NOBBENV_PATH, dbname);
     if (n >= s)
         return -1;


### PR DESCRIPTION
Can't always set to /opt/bb/ since roborivers uses comdb2_root as the testdir to use this file

Open to suggestions for better way to do this

In bbcdb2api, CDB2DBCONFIG_NOBBENV_PATH starts with /opt/bb, which is not the same as the comdb2_root (/bb)