### PR TITLE
Abort on DB_REP_STALEMASTER tunable

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -201,6 +201,7 @@ extern int gbl_abort_during_downgrade_if_scs_dont_stop;
 extern int gbl_abort_on_unset_ha_flag;
 extern int gbl_abort_on_unfound_txn;
 extern int gbl_abort_on_ufid_mismatch;
+extern int gbl_abort_on_stale_master;
 extern int gbl_write_dummy_trace;
 extern int gbl_abort_on_incorrect_upgrade;
 extern int gbl_poll_in_pg_free_recover;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1390,6 +1390,9 @@ REGISTER_TUNABLE("block_set_commit_genid_trace", "Print trace when blocking set 
 
 REGISTER_TUNABLE("abort_on_ufid_mismatch", "Abort in dbreg-open on ufid mismatch. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_abort_on_ufid_mismatch, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("abort_on_stale_master", "Abort on DB_REP_STALEMASTER if we are the master.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_abort_on_stale_master, INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("abort_on_unset_ha_flag", "Abort in snap_uid_retry if ha is unset. (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_abort_on_unset_ha_flag, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("write_dummy_trace", "Print trace when doing a dummy write. (Default: off)", TUNABLE_BOOLEAN,


### PR DESCRIPTION
The 'abort_on_stale_master' tunable will allow us to get a core file to better understand an election issue we are seeing.