### PR TITLE
Fix broken analyze for aliased tables

### DIFF
--- a/db/sqlanalyze.c
+++ b/db/sqlanalyze.c
@@ -729,14 +729,8 @@ int analyze_regular_table(const char *tablename, table_descriptor_t *td,
     else
         strncpy0(sqltablename, tablename, sizeof(sqltablename));
 
-    if (table->sqlaliasname) {
-        rc = analyze_rename_table_for_backup_stats(sqltablename, clnt, err);
-        if (rc) 
-            goto err;
-    }
-    /* we need to this is either way */
-    rc = analyze_rename_table_for_backup_stats(tablename, clnt, err);
-    if (rc)
+    rc = analyze_rename_table_for_backup_stats(sqltablename, clnt, err);
+    if (rc) 
         goto err;
 
     /* grab the size of the table */

--- a/tests/analyze.test/t16.req.out
+++ b/tests/analyze.test/t16.req.out
@@ -4,5 +4,7 @@
 [ANALYZE t15] rc 0
 (count(*)=2)
 (count(*)=48)
+[exec procedure sys.cmd.send('setsqlattr analyze_empty_tables off')] rc 0
+[ANALYZE t15] rc 0
 (count(*)=1)
 (count(*)=24)

--- a/tests/analyze.test/t16.sh
+++ b/tests/analyze.test/t16.sh
@@ -40,6 +40,11 @@ EOF
 
 count_stats
 
+#test analyzing again, so that backing up stats also gets checked
+${CDB2SQL_EXE} ${CDB2_OPTIONS} --host ${host} ${DBNAME} <<EOF
+exec procedure sys.cmd.send('setsqlattr analyze_empty_tables off')
+ANALYZE t15
+EOF
 
 #test analyzeing individual shard
 SHARDNAME=$(${CDB2SQL_EXE} -tabs ${CDB2_OPTIONS} ${DBNAME} default "select shardname from comdb2_timepartshards where name='t15' limit 1")


### PR DESCRIPTION
This affects time partitions created on existing tables; the initial analyze works; the follow-up fails because code tries to delete same rows twice by calling backup for stats for both tablename and sqlaliasname.

Also, preserve aliased shard 0 analyze, i.e. if we run "analyze $0_..." do not convert that to "analyze <partition_name>"