### PR TITLE
Disable physrep filter-by-class

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -518,7 +518,6 @@ extern int gbl_physrep_i_am_metadb;
 extern int gbl_physrep_keepalive_v2;
 extern int gbl_physrep_keepalive_freq_sec;
 extern int gbl_physrep_max_candidates;
-extern int gbl_physrep_max_pending_replicants;
 extern int gbl_physrep_reconnect_penalty;
 extern int gbl_physrep_reconnect_interval;
 extern int gbl_physrep_shuffle_host_list;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1856,10 +1856,6 @@ REGISTER_TUNABLE("physrep_max_candidates",
                  "new physical replicant during registration. (Default: 6)",
                  TUNABLE_INTEGER, &gbl_physrep_max_candidates, 0, NULL,
                  NULL, NULL, NULL);
-REGISTER_TUNABLE("physrep_max_pending_replicants",
-                 "There can be no more than this many physical replicants in "
-                 "pending state. (Default: 10)",
-                 TUNABLE_INTEGER, &gbl_physrep_max_pending_replicants, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_metadb_host", "List of physical replication metadb cluster hosts.", TUNABLE_STRING,
                  &gbl_physrep_metadb_host, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_metadb_name", "Physical replication metadb cluster name.",

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -62,7 +62,6 @@ int gbl_physrep_reconnect_penalty = 0;
 int gbl_blocking_physrep = 1;
 int gbl_physrep_fanout = 8;
 int gbl_physrep_max_candidates = 6;
-int gbl_physrep_max_pending_replicants = 10;
 int gbl_deferred_phys_flag = 0;
 int gbl_physrep_source_nodes_refresh_freq_sec = 10;
 int gbl_physrep_slow_replicant_check_freq_sec = 10;

--- a/lua/syssp.c.in
+++ b/lua/syssp.c.in
@@ -571,7 +571,6 @@ static int db_comdb_delete_sc_history(Lua L)
 }
 
 extern int gbl_physrep_fanout;
-extern int gbl_physrep_max_pending_replicants;
 extern int gbl_physrep_max_candidates;
 
 static int db_comdb_physrep_tunables(Lua L)
@@ -596,10 +595,6 @@ static int db_comdb_physrep_tunables(Lua L)
 
     lua_pushstring(L, "physrep_max_candidates");
     lua_pushinteger(L, gbl_physrep_max_candidates);
-    lua_settable(L, -3);
-
-    lua_pushstring(L, "physrep_max_pending_replicants");
-    lua_pushinteger(L, gbl_physrep_max_pending_replicants);
     lua_settable(L, -3);
 
     int firstfile = 0;

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -744,7 +744,6 @@
 (name='physrep_keepalive_freq_sec', description='Periodically send lsn to source node after this interval. (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='physrep_keepalive_v2', description='Use version 2 of keepalive which includes first lsn. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='physrep_max_candidates', description='Maximum number of candidates that should be returned to a new physical replicant during registration. (Default: 6)', type='INTEGER', value='6', read_only='N')
-(name='physrep_max_pending_replicants', description='There can be no more than this many physical replicants in pending state. (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='physrep_max_rollback', description='Maximum logs physrep can rollback. (Default: 0)', type='INTEGER', value='0', read_only='N')
 (name='physrep_metadb_host', description='List of physical replication metadb cluster hosts.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_metadb_name', description='Physical replication metadb cluster name.', type='STRING', value=NULL, read_only='Y')


### PR DESCRIPTION
We believe this causes too many physical replicants to replicate directly from the source.
