### PR TITLE
{169607487} feat: enable distributed trace addon by default

### DIFF
--- a/cdb2api/cdb2api_test.h
+++ b/cdb2api/cdb2api_test.h
@@ -82,6 +82,9 @@ struct cdb2_hndl;
 const char *get_default_cluster(void);
 const char *get_default_cluster_hndl(struct cdb2_hndl *);
 
+// Defined in Bloomberg plugins, not used in OSS builds/tests.
+void list_installed_addons(const char ***installed, int *ninstalls);
+
 #if defined __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
Enable the (Bloomberg-internal) distributed trace plugin by default so that users get it out of the box. For open source builds of cdb2api, this is a no-op.

Additionally, provide a way to disable this behavior. We already have the ability to do so through an environment variable
(`COMDB2_CONFIG_UNINSTALL_STATIC_LIBS=dt`) or using the config file (`comdb2_config:uninstall_static_libs_v4=dt`), but both only accept _one_ addon name. If we want to enable more plugins by default in the future, users should be able to selectively disable them as well. Support supplying a list of plugin names for both the environment variable and the config file setting.

To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
* What are the current behavior and expected behavior, if this is a bugfix ?
* What are the steps required to reproduce the bug, if this is a bugfix ?
* What is the current behavior and new behavior, if this is a feature change or enhancement ?
* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
