### PR TITLE
{169607487} feat: enable distributed trace addon by default

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -248,7 +248,6 @@ int cdb2_use_ftruncate = 0;
 static int cdb2_use_ftruncate_set_from_env = 0;
 static int cdb2_use_env_vars = 1;
 static int cdb2_install_set_from_env = 0;
-static int cdb2_uninstall_set_from_env = 0;
 
 TAILQ_HEAD(local_connection_cache_list, local_cached_connection);
 
@@ -1663,15 +1662,27 @@ static void read_comdb2db_environment_cfg(cdb2_hndl_tp *hndl, const char *comdb2
                                    &check_hb_on_blocked_write_set_from_env);
 
         char *arg = getenv("COMDB2_CONFIG_INSTALL_STATIC_LIBS");
-        if ((cdb2_install != NULL) && arg != NULL) {
-            (*cdb2_install)(arg);
+        if (cdb2_install != NULL && arg != NULL) {
+            char *libs = strdup(arg), *lib = NULL, *lib_last = NULL;
+            lib = strtok_r(libs, " ", &lib_last);
+            while (lib != NULL) {
+                (*cdb2_install)(lib);
+                lib = strtok_r(NULL, " ", &lib_last);
+            }
+            free(libs);
             cdb2_install_set_from_env = 1;
         }
 
         arg = getenv("COMDB2_CONFIG_UNINSTALL_STATIC_LIBS");
-        if ((cdb2_uninstall != NULL) && arg != NULL) {
-            (*cdb2_uninstall)(arg);
-            cdb2_uninstall_set_from_env = 1;
+        if (cdb2_uninstall != NULL && arg != NULL) {
+            char *libs = strdup(arg), *lib = NULL, *lib_last = NULL;
+            lib = strtok_r(libs, " ", &lib_last);
+            while (lib != NULL) {
+                (*cdb2_uninstall)(lib);
+                lib = strtok_r(NULL, " ", &lib_last);
+            }
+            free(libs);
+            cdb2_install_set_from_env = 1;
         }
 
         have_read_env = 1;
@@ -1975,20 +1986,38 @@ static void read_comdb2db_cfg(cdb2_hndl_tp *hndl, SBUF2 *s, const char *comdb2db
                 if (tok) {
                     cdb2_allow_pmux_route = value_on_off(tok, &err);
                 }
-            } else if (!cdb2_uninstall_set_from_env && (strcasecmp("uninstall_static_libs_v4", tok) == 0 ||
-                                                        strcasecmp("disable_static_libs", tok) == 0)) {
-                /* Provide a way to disable statically installed (via
-                 * CDB2_INSTALL_LIBS) libraries. */
-                tok = strtok_r(NULL, " :,", &last);
-                if (cdb2_uninstall != NULL)
-                    (*cdb2_uninstall)(tok);
+            } else if (!cdb2_install_set_from_env && (strcasecmp("uninstall_static_libs_v4", tok) == 0 ||
+                                                      strcasecmp("disable_static_libs", tok) == 0)) {
+                /* Provide a way to disable statically linked libraries. */
+                tok = strtok_r(NULL, ":,", &last);
+                if (cdb2_uninstall != NULL && tok == NULL) {
+                    /* By convention, this should uninstall all static libs. */
+                    cdb2_uninstall(NULL);
+                } else if (cdb2_uninstall != NULL && tok != NULL) {
+                    char *libs = strdup(tok), *lib = NULL, *lib_last = NULL;
+                    lib = strtok_r(libs, " ", &lib_last);
+                    while (lib != NULL) {
+                        (*cdb2_uninstall)(lib);
+                        lib = strtok_r(NULL, " ", &lib_last);
+                    }
+                    free(libs);
+                }
             } else if (!cdb2_install_set_from_env &&
                        (strcasecmp("install_static_libs_v4", tok) == 0 || strcasecmp("enable_static_libs", tok) == 0)) {
-                /* Provide a way to enable statically installed (via
-                 * CDB2_INSTALL_LIBS) libraries. */
-                tok = strtok_r(NULL, " :,", &last);
-                if (cdb2_install != NULL)
-                    (*cdb2_install)(tok);
+                /* Provide a way to enable statically linked libraries. */
+                tok = strtok_r(NULL, ":,", &last);
+                if (cdb2_install != NULL && tok == NULL) {
+                    /* By convention, this should install all static libs. */
+                    cdb2_install(NULL);
+                } else if (cdb2_install != NULL && tok != NULL) {
+                    char *libs = strdup(tok), *lib = NULL, *lib_last = NULL;
+                    lib = strtok_r(libs, " ", &lib_last);
+                    while (lib != NULL) {
+                        (*cdb2_install)(lib);
+                        lib = strtok_r(NULL, " ", &lib_last);
+                    }
+                    free(libs);
+                }
             } else if (strcasecmp("stack_at_open", tok) == 0 && stack_at_open) {
                 tok = strtok_r(NULL, " :,", &last);
                 if (tok) {
@@ -7195,7 +7224,7 @@ static int bms_srv_lookup(char hosts[][CDB2HOSTNAME_LEN], const char *dbname, co
     }
 #ifdef CDB2API_TEST
     for (int i = 0; i < *num_hosts; i++) {
-        printf("FINAL NODE no:%d host:%s near nodes:%d\n", i, hosts[i], near_nodes);
+        fprintf(stderr, "FINAL NODE no:%d host:%s near nodes:%d\n", i, hosts[i], near_nodes);
     }
 #endif
     if (num_same_room)
@@ -7280,7 +7309,7 @@ no_roomresult:
     }
 #ifdef CDB2API_TEST
     for (int i = 0; i < *num_hosts; i++) {
-        printf("FINAL NODE no:%d host:%s near nodes:%d\n", i, hosts[i], start_count);
+        fprintf(stderr, "FINAL NODE no:%d host:%s near nodes:%d\n", i, hosts[i], start_count);
     }
 #endif
     return 0;
@@ -8009,7 +8038,8 @@ retry:
             // comment out for now. Extra output fails ssl_dbname and ssl_set_cmd test.
             // #ifdef CDB2API_TEST
             //             if (cdb2_use_bmsd)
-            //                 printf("Try node %d name %s master %d\n", try_node, hndl->hosts[try_node], hndl->master);
+            //                 fprintf(stderr, "Try node %d name %s master %d\n", try_node, hndl->hosts[try_node],
+            //                         hndl->master);
             // #endif
             rc = cdb2_dbinfo_query(hndl, hndl->type, hndl->dbname, hndl->dbnum,
                                    hndl->hosts[try_node], hndl->hosts,
@@ -8736,6 +8766,14 @@ int cdb2_open(cdb2_hndl_tp **handle, const char *dbname, const char *type,
            for it so we can fit longer hostnames in the sockpool type string which is
            merely 48 chars. */
         strcpy(hndl->policy, (hndl->flags & CDB2_DIRECT_CPU) ? "dc" : "random_room");
+    }
+
+    /* Install the distributed trace plugin by default. Configs are loaded later,
+     * so users still have a way to disable it, if so desired. */
+    if (cdb2_install != NULL) {
+        pthread_mutex_lock(&cdb2_sockpool_mutex);
+        (*cdb2_install)("dt");
+        pthread_mutex_unlock(&cdb2_sockpool_mutex);
     }
 
     int rc = 0;

--- a/cdb2api/cdb2api_test.h
+++ b/cdb2api/cdb2api_test.h
@@ -91,6 +91,9 @@ const char *cdb2_cnonce(cdb2_hndl_tp *hndl);
 int cdb2_snapshot_file(cdb2_hndl_tp *hndl, int *file, int *offset);
 void cdb2_dump_ports(cdb2_hndl_tp *hndl, FILE *out);
 
+// Defined in Bloomberg plugins, not used in OSS builds/tests.
+void list_installed_addons(const char ***installed, int *ninstalls);
+
 #if defined __cplusplus
 }
 #endif /* __cplusplus */


### PR DESCRIPTION
Enable the (Bloomberg-internal) distributed trace plugin by default so that users get it out of the box. For open source builds of cdb2api, this is a no-op.

Additionally, provide a way to disable this behavior. We already have the ability to do so through an environment variable
(`COMDB2_CONFIG_UNINSTALL_STATIC_LIBS=dt`) or using the config file (`comdb2_config:uninstall_static_libs_v4=dt`), but both only accept _one_ addon name. If we want to enable more plugins by default in the future, users should be able to selectively disable them as well. Support supplying a list of plugin names for both the environment variable and the config file setting.