### PR TITLE
cleanup sending dummy byte, and use isnull instead

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -7083,13 +7083,7 @@ static void cdb2_bind_param_helper(cdb2_hndl_tp *hndl, int type, const void *var
         bindval->value.len = 0;
         bindval->has_isnull = 1;
         bindval->isnull = 1;
-    } else if (type == CDB2_CSTRING && length == 0) {
-        /* R6 and old R7 ignore isnull for cstring and treat a 0-length string
-           as NULL. So we send 1 dummy byte here to be backward compatible with
-           an old backend. */
-        bindval->value.data = (unsigned char *)"";
-        bindval->value.len = 1;
-    } else if (type == CDB2_BLOB && length == 0) {
+    } else if ((type == CDB2_BLOB || type == CDB2_CSTRING) && length == 0) {
         bindval->value.data = (unsigned char *)"";
         bindval->value.len = 0;
         bindval->has_isnull = 1;

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2PreparedStatement.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2PreparedStatement.java
@@ -142,11 +142,6 @@ public class Comdb2PreparedStatement extends Comdb2Statement implements Prepared
         byte[] data;
         if (x == null)
             data = null;
-        else if (x.length() == 0)
-            /* R6 and old R7 ignore the isnull flag for cstring and hence always
-               treat a 0-length string as NULL. We have to send a zero byte here
-               to be backward compatible. */
-            data = new byte[1];
         else
             data = x.getBytes();
         bindParameter(parameterIndex, Constants.Types.CDB2_CSTRING, data);

--- a/tests/sp_perf.test/t1.expected
+++ b/tests/sp_perf.test/t1.expected
@@ -2,12 +2,14 @@
 [create table t (b blob)] rc 0
 (version='t')
 [create procedure p version 't' {
-    local function main()
+    local function main(str)
         local t = db:table("t")
-        local b = db:cast("text", 'blob')
+        local b = db:cast(str, 'blob')
         return t:insert({b=b})
     end
 }] rc 0
-[exec procedure p()] rc 0
+[exec procedure p("text")] rc 0
+[exec procedure p("")] rc 0
 (b=x'74657874')
+(b=x'')
 [select * from t] rc 0

--- a/tests/sp_perf.test/t1.sql
+++ b/tests/sp_perf.test/t1.sql
@@ -2,11 +2,12 @@
 drop table if exists t
 create table t (b blob)$$
 create procedure p version 't' {
-    local function main()
+    local function main(str)
         local t = db:table("t")
-        local b = db:cast("text", 'blob')
+        local b = db:cast(str, 'blob')
         return t:insert({b=b})
     end
 }$$
-exec procedure p()
+exec procedure p("text")
+exec procedure p("")
 select * from t


### PR DESCRIPTION
(backend new supports isnull flag, can remove sending 1 byte dummy data)
