### PR TITLE
Fix retry queries bug? starts at 0

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -5262,7 +5262,7 @@ static int retry_queries(cdb2_hndl_tp *hndl, int num_retry, int run_last)
         return 0;
 
     int rc = 0;
-    if (!(hndl->snapshot_file || hndl->query_no <= 1)) {
+    if (!(hndl->snapshot_file || hndl->query_no <= 0)) {
         debugprint("in_trans=%d snapshot_file=%d query_no=%d\n", hndl->in_trans,
                    hndl->snapshot_file, hndl->query_no);
         sprintf(hndl->errstr, "Database disconnected while in transaction.");


### PR DESCRIPTION
This fixes memtest test 9

query_no starts at 0. Guessing this is supposed to be logic for begin stmt?

This query no logic isn't in retry_queries for bbcdb2api. Maybe we shouldn't have it here at all.
Imagining sending begin (query no 0), db disconnect, send insert stmt (query no increments to 1, then back to 0 since failure), then will call retry queries with query no = 0. Should we even be retrying in this case? See https://github.com/bloomberg/comdb2/pull/5721