### PR TITLE
Fix retry queries bug? Don't retry if non hasql

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -5262,7 +5262,7 @@ static int retry_queries(cdb2_hndl_tp *hndl, int num_retry, int run_last)
         return 0;
 
     int rc = 0;
-    if (!(hndl->snapshot_file || hndl->query_no <= 1)) {
+    if (!hndl->snapshot_file) {
         debugprint("in_trans=%d snapshot_file=%d query_no=%d\n", hndl->in_trans,
                    hndl->snapshot_file, hndl->query_no);
         sprintf(hndl->errstr, "Database disconnected while in transaction.");


### PR DESCRIPTION
Different solution for https://github.com/bloomberg/comdb2/pull/5720

Fixes memtest test 9