### PR TITLE
Fix rese_commit & readonly logic

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -1878,7 +1878,8 @@ clipper_usage:
             extern int gbl_starttime;
             logmsg(LOGMSG_USER, "uptime                  %ds\n",
                    gbl_epoch_time - gbl_starttime);
-            logmsg(LOGMSG_USER, "readonly                %c\n", gbl_readonly ? 'Y' : 'N');
+            logmsg(LOGMSG_USER, "readonly                %c\n",
+                   (gbl_readonly || gbl_is_physical_replicant) ? 'Y' : 'N');
             logmsg(LOGMSG_USER, "num sql queries         %"PRId64"\n", gbl_nsql);
             logmsg(LOGMSG_USER, "num new sql queries     %"PRId64"\n", gbl_nnewsql);
             logmsg(LOGMSG_USER, "num ssl sql queries     %"PRId64"\n", gbl_nnewsql_ssl);
@@ -2680,7 +2681,11 @@ clipper_usage:
     else if (tokcmp(tok, ltok, "readonly") == 0) {
         gbl_readonly = 1;
     } else if (tokcmp(tok, ltok, "readwrite") == 0) {
-        gbl_readonly = 0;
+        if (gbl_is_physical_replicant) {
+            logmsg(LOGMSG_ERROR, "Physical-replicants are read-only\n");
+        } else {
+            gbl_readonly = 0;
+        }
     } else if (tokcmp(tok, ltok, "machine_cache") == 0) {
 
         /* machine_cache find <dbname> <class>

--- a/db/sqloffload.c
+++ b/db/sqloffload.c
@@ -349,11 +349,11 @@ static int rese_commit(struct sqlclntstate *clnt, struct sql_thread *thd,
         /* close the block processor session and retrieve the result */
         sql_debug_logf(clnt, __func__, __LINE__, "committing\n");
         rc = osql_sock_commit(clnt, osqlreq_type, TRANS_CLNTCOMM_NORMAL);
-        if (rc && rc != SQLITE_ABORT && rc != SQLITE_DEADLOCK &&
-            rc != SQLITE_BUSY && rc != SQLITE_CLIENT_CHANGENODE) {
+        if (rc && rc != SQLITE_ABORT && rc != SQLITE_DEADLOCK && rc != SQLITE_BUSY && rc != SQLITE_READONLY &&
+            rc != SQLITE_CLIENT_CHANGENODE) {
             // XXX HERE IS THE BUG .. SQLITE_ERROR IS 1 - THE SAME AS DUP
-            logmsg(LOGMSG_ERROR, "%s line %d: rc is set to %d, changing rc to CLIENT_CHANGENODE\n", 
-                    __func__, __LINE__, rc);
+            logmsg(LOGMSG_DEBUG, "%s line %d: rc is set to %d, changing rc to CLIENT_CHANGENODE\n", __func__, __LINE__,
+                   rc);
             rc = SQLITE_CLIENT_CHANGENODE;
             //rc = SQLITE_ERROR;
         }

--- a/tests/phys_rep_tiered.test/lrl.options
+++ b/tests/phys_rep_tiered.test/lrl.options
@@ -11,6 +11,7 @@ ctrace_dbdir 1
 allow_lua_print 1
 reverse_hosts_v2 1
 physrep_keepalive_v2 1
+enable_snapshot_isolation
 
 # Reproduced 'incoherent-physrep' bug with this removed.
 # Actually could not start physrep-cluster at all.

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -2261,6 +2261,25 @@ function physrep_allowed_source
     done
 }
 
+function physrep_block_writes_correct_rcode
+{
+    # Make sure that physreps block writes & return the correct rcode when they do
+    out=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $REPL_CLUS_HOST "create table should_fail(a int)" 2>&1)
+    if [[ "$out" != *"failed with rc -21 attempt to write a readonly database"* ]]; then
+        cleanFailExit "Expected error code -21 when creating table on physrep, got: $out"
+    fi
+    # Make sure that 'readwrite' message trap returns appropriate rcode for physreps
+    out=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $REPL_CLUS_HOST "exec procedure sys.cmd.send('readwrite')" 2>&1)
+    if [[ "$out" != *"Physical-replicants are read-only"* ]]; then
+        cleanFailExit "Expected error message 'Physical-replicants are read-only' when sending 'readwrite' trap to physrep, got: $out"
+    fi
+    # Make sure that 'stat' message shows the physrep is readonly
+    out=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $REPL_CLUS_HOST "exec procedure sys.cmd.send('stat')" 2>&1 | egrep readonly)
+    if [[ "$out" != *"readonly                Y"* ]]; then
+        cleanFailExit "Expected 'readonly Y' in 'stat' output from physrep, got: $out"
+    fi
+}
+
 function verify_alt_metadb_system_table 
 {
     out=$($CDB2SQL_EXE $CDB2_OPTIONS $REPL_CLUS_DBNAME --host $REPL_CLUS_HOST "exec procedure sys.cmd.send('physrep_alt_metadb_print')" | grep "$REPL_ALTMETA_DBNAME" | wc -l)
@@ -2536,6 +2555,11 @@ function run_tests
     incoherent_master
     testcase_finish $testcase
 
+    testcase="physrep_block_writes_correct_rcode"
+    testcase_preamble $testcase
+    physrep_block_writes_correct_rcode
+    testcase_finish $testcase
+
     testcase="physrep_allowed_source"
     testcase_preamble $testcase
     physrep_allowed_source
@@ -2544,10 +2568,11 @@ function run_tests
 
 function run_one_test
 {
-    tranlog_timeout
+    physrep_block_writes_correct_rcode
 }
 
 run_tests
+#run_one_test
 cleanup
 
 exit 0


### PR DESCRIPTION
Fixes a bug where physical replicants incorrectly report 'not-durable' when writes are attempted.  Additionally fixes readwrite message trap to print a warning message when issued to a physrep.
