### PR TITLE
{182689785} fix: normalized sql for sp

### DIFF
--- a/tests/fingerprints.test/README
+++ b/tests/fingerprints.test/README
@@ -9,7 +9,7 @@ result set (i.e. via the WHERE clause):
 
     4f16a8ec9db90f803e406659938b2602: "SELECT 1" ==> "SELECT?;"
     69d1558c950bbb908f4b8df0d63e2cf4: "SELECT comdb2_host();"
-    812bdde365a22a61bcd52bf005990c37: "EXEC PROCEDURE sys.cmd.send(?);"
+    ba65a98635122c91120d37676cbfc1ef: "EXEC PROCEDURE sys.cmd.send();"
 
 The corresponding SQL statements are excluded because these are (sometimes?)
 used by the test suite itself at various stages.  Since the exact quantity

--- a/tests/fingerprints.test/t03.req
+++ b/tests/fingerprints.test/t03.req
@@ -1,1 +1,1 @@
-SELECT fingerprint, count, total_cost, total_rows, normalized_sql FROM comdb2_fingerprints WHERE fingerprint NOT IN ('4f16a8ec9db90f803e406659938b2602', '69d1558c950bbb908f4b8df0d63e2cf4', '812bdde365a22a61bcd52bf005990c37') ORDER BY fingerprint;
+SELECT fingerprint, count, total_cost, total_rows, normalized_sql FROM comdb2_fingerprints WHERE fingerprint NOT IN ('4f16a8ec9db90f803e406659938b2602', '69d1558c950bbb908f4b8df0d63e2cf4', 'ba65a98635122c91120d37676cbfc1ef') ORDER BY fingerprint;

--- a/tests/fingerprints.test/t09.req
+++ b/tests/fingerprints.test/t09.req
@@ -1,0 +1,33 @@
+-- Create a dummy procedure
+CREATE PROCEDURE fp_proc VERSION 'test' {local function main() end}$$
+
+-- Call it with different argument counts
+EXEC PROCEDURE fp_proc()
+EXEC PROCEDURE fp_proc(1)
+EXEC PROCEDURE fp_proc(1,2,3)
+EXEC PROCEDURE fp_proc(1, 'hello', x'DEADBEEF', 3.14, NULL)
+EXECUTE PROCEDURE fp_proc('a','b','c',4,5,6)
+EXECUTE PROCEDURE fp_proc('()','fun()')
+EXECUTE PROCEDURE fp_proc('-47', '1', x'DEADBEEF')
+
+-- Call with bound parameters
+@bind CDB2_INTEGER myint 42
+EXEC PROCEDURE fp_proc(@myint)
+@bind CDB2_CSTRING mystr hello
+@bind CDB2_INTEGER myint 99
+EXEC PROCEDURE fp_proc(@myint, @mystr)
+@bind CDB2_REAL myreal 2.718
+@bind CDB2_INTEGER myint 1
+@bind CDB2_CSTRING mystr world
+EXEC PROCEDURE fp_proc(@myint, @mystr, @myreal)
+
+-- Mix bound parameters with literals
+@bind CDB2_INTEGER myint 7
+EXEC PROCEDURE fp_proc(@myint, 'literal', 3.14, NULL)
+
+-- Syntax error but still has the same fingerprint
+EXEC PROCEDURE fp_proc(fun())
+
+-- All should produce the same fingerprint
+SELECT COUNT(DISTINCT fingerprint) as 'unique_fps' FROM comdb2_fingerprints WHERE normalized_sql LIKE 'EXEC PROCEDURE fp_proc%'
+SELECT normalized_sql FROM comdb2_fingerprints WHERE normalized_sql LIKE 'EXEC PROCEDURE fp_proc%'

--- a/tests/fingerprints.test/t09.req.out
+++ b/tests/fingerprints.test/t09.req.out
@@ -1,0 +1,4 @@
+(version='test')
+[EXEC PROCEDURE fp_proc(fun())] failed with rc -3 bad argument -> fun())
+(unique_fps=1)
+(normalized_sql='EXEC PROCEDURE fp_proc();')


### PR DESCRIPTION
Change SQL normalization to always produce the same `normalized_sql` and fingerprint regardless of argument values, types, or count. All argument tokens are stripped so that e.g. both `EXEC PROCEDURE foo(1)` and `EXEC PROCEDURE foo(1, 'hello', x'DEADBEEF')` normalize to `EXEC PROCEDURE foo();`.