### PR TITLE
Fix identity in comdb2 connections

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -6554,7 +6554,7 @@ static void gather_connection_int(struct connection_info *c, struct sqlclntstate
     c->is_admin = clnt->admin;
     c->is_ssl = clnt->plugin.has_ssl(clnt);
     c->has_cert = clnt->plugin.has_x509(clnt);
-    c->identity = clnt->externalAuthUser;
+    c->identity = clnt->externalAuthUser ? strdup(clnt->externalAuthUser) : NULL;
     if (!c->has_cert) {
         c->common_name = NULL;
     } else {
@@ -6613,6 +6613,7 @@ void free_connection_info(struct connection_info *info, int num_connections)
         free(info[i].sql);
         free(info[i].fingerprint);
         free(info[i].uuid);
+        free(info[i].identity);
         /* state is static, don't free */
     }
     free(info);

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -133,6 +133,7 @@ static void free_newsql_appdata_evbuffer(struct newsql_appdata_evbuffer *appdata
     if (appdata->query) {
         cdb2__query__free_unpacked(appdata->query, &pb_alloc);
         appdata->query = NULL;
+        clnt->externalAuthUser = NULL;
     }
     sqlwriter_free(appdata->writer);
     shutdown(fd, SHUT_RDWR);
@@ -170,6 +171,7 @@ static int newsql_done_cb(struct sqlclntstate *clnt)
             cdb2__query__free_unpacked(appdata->query, &pb_alloc);
         }
         appdata->query = NULL;
+        clnt->externalAuthUser = NULL;
         evtimer_once(appdata->base, rd_hdr, appdata);
     } else {
         appdata->cleanup_ev = event_new(appdata->base, -1, 0, newsql_cleanup, appdata);


### PR DESCRIPTION
stop printing random strings