### PR TITLE
Hide things from cdb2api if not server build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ if(COMDB2_TEST)
   add_definitions(-DCOMDB2_TEST)
   add_definitions(-DCDB2API_TEST)
 endif()
+add_definitions(-DCDB2API_SERVER)
 
 option(WITH_TINFO "Turn ON on platforms where tinfo library is required for cdb2sql" OFF)
 if(WITH_TINFO)

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -36,8 +36,10 @@ enum cdb2_hndl_alloc_flags {
     CDB2_RANDOMROOM = 16,
     CDB2_ROOM = 32,
     CDB2_ADMIN = 64,
+#ifdef CDB2API_SERVER
     CDB2_SQL_ROWS = 128,
     CDB2_TYPE_IS_FD = 256,
+#endif
     CDB2_REQUIRE_FASTSQL = 512,
     CDB2_MASTER = 1024,
     CDB2_ALLOW_INCOHERENT = 2048

--- a/cdb2api/cdb2api_int.h
+++ b/cdb2api/cdb2api_int.h
@@ -34,8 +34,10 @@ COMDB2BUF *cdb2_socket_pool_get(cdb2_hndl_tp *hndl, const char *typestr, int dbn
 int cdb2_socket_pool_get_fd(cdb2_hndl_tp *hndl, const char *typestr, int dbnum, int *port);
 void cdb2_socket_pool_donate_ext(const cdb2_hndl_tp *hndl, const char *typestr, int fd, int ttl, int dbnum);
 
+#ifdef CDB2API_SERVER
 int cdb2_send_2pc(cdb2_hndl_tp *hndl, char *dbname, char *pname, char *ptier, char *source, unsigned int op,
                   char *dist_txnid, int rcode, int outrc, char *errmsg, int async);
+#endif
 
 COMDB2BUF *cdb2_cdb2buf_openread(const char *filename);
 int cdb2_read_line(char *line, int maxlen, COMDB2BUF *s, const char *buf, int *chrno);


### PR DESCRIPTION
Create new flag cdb2api_server for server builds (I guess currently open cdb2api would contain this, but we can at least hide from bb to start)

Can't use sbuf2server since that's defined as 0 in cdb2api

Open to suggestions if there is a better method