### PR TITLE
Increase silogdel select timeout

### DIFF
--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -37,4 +37,3 @@ sc_resume_logicalsc_generated,UNKNOWN,181484807
 consumer_non_atomic_default_consumer_generated,DB_BUG,181573461
 unifiedcancel,UNKNOWN,181657289
 autoanalyze,UNKNOWN,181657299
-silogdel,UNKNOWN,182868793

--- a/tests/silogdel.test/Makefile
+++ b/tests/silogdel.test/Makefile
@@ -4,5 +4,5 @@ else
 	include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=10m
+	export TEST_TIMEOUT=11m
 endif

--- a/tests/silogdel.test/runit
+++ b/tests/silogdel.test/runit
@@ -123,7 +123,9 @@ function check_table
 
     echo "select count(*) from $table" >&${COPROC[1]}
 
-    read -t 15 -ru "${COPROC[0]}" out
+    # Instrumentation shows this test is cpu-starved
+    # Just increase the timeout .. 
+    read -t 100 -ru "${COPROC[0]}" out
     rc=$?
 
     if [[ $rc != 0 ]]; then


### PR DESCRIPTION
Instrumentation shows that this is suffering from cpu-pressure.  Increase the timeout for the 'SELECT' statement.  Also, change the test's timeout with the hope that it will be scheduled to run concurrent with less cpu-intensive tests.
