### PR TITLE
Testcase for long blocking fdb locks during table discovery.

### DIFF
--- a/tests/quarantine.csv
+++ b/tests/quarantine.csv
@@ -37,3 +37,4 @@ sc_resume_logicalsc_generated,UNKNOWN,181484807
 consumer_non_atomic_default_consumer_generated,DB_BUG,181573461
 unifiedcancel,UNKNOWN,181657289
 autoanalyze,UNKNOWN,181657299
+remsql_locks,DB_BUG,182504318

--- a/tests/remsql_locks.test/Makefile
+++ b/tests/remsql_locks.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=srcdb
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/remsql_locks.test/README
+++ b/tests/remsql_locks.test/README
@@ -1,0 +1,1 @@
+This test checks for long term locks on fdb table list.

--- a/tests/remsql_locks.test/lrl.options
+++ b/tests/remsql_locks.test/lrl.options
@@ -1,0 +1,5 @@
+table t t.csc2
+table t2 t.csc2
+ssl_allow_remsql 1
+foreign_db_push_remote 0
+foreign_db_push_redirect 0

--- a/tests/remsql_locks.test/rte_connect.testopts
+++ b/tests/remsql_locks.test/rte_connect.testopts
@@ -1,0 +1,1 @@
+connect_remote_rte 1

--- a/tests/remsql_locks.test/runit
+++ b/tests/remsql_locks.test/runit
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+c1="cdb2sql --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default"
+ct1="cdb2sql --tabs --cdb2cfg ${CDB2_CONFIG} ${DBNAME} default"
+c2="cdb2sql --cdb2cfg ${SECONDARY_CDB2_CONFIG} ${SECONDARY_DBNAME} default"
+
+echo "Inserting rows into t"
+$c2 "insert into t select * from generate_series(1, 60)"
+echo "Inserting rows into t2"
+$c2 "insert into t2 select * from generate_series(1, 60)"
+
+echo "Running async 60 second remote query on table t"
+$c1 "select *, sleep(1) from LOCAL_${SECONDARY_DBNAME}.t order by 1" &
+
+echo "Sleeping 5 to let query actually run"
+sleep 5
+
+
+failed=0
+echo "Try to access a secondary db on same db with a 10 seconds timeout; it will timeout on old locking"
+found_cnt=`timeout -k 1 10 $ct1 "select * from LOCAL_${SECONDARY_DBNAME}.t2 order by 1"`
+if [[ ! "$?" -eq "0" ]] ; then
+    echo "Failed to run the query on t2"
+    failed=1
+fi
+if [[ ! "$found_cnt" -eq "60" ]] ; then
+    echo "Failed to return all rows"
+    failed=1
+fi
+
+wait
+
+if [[ "$failed" = "1" ]] ; then
+   echo "FAILURE"
+   exit 1
+fi
+
+echo "SUCCESS"

--- a/tests/remsql_locks.test/t.csc2
+++ b/tests/remsql_locks.test/t.csc2
@@ -1,0 +1,4 @@
+schema
+{
+   int a
+}


### PR DESCRIPTION
/skipbuild 

It is added to quarantine since it is current code fails this test.  
https://github.com/bloomberg/comdb2/pull/5726 will fix and remove from quarantine.