### PR TITLE
{182781126} fix api_history_hung

### DIFF
--- a/db/api_history.c
+++ b/db/api_history.c
@@ -21,14 +21,11 @@
 #include <pthread.h>
 #include <string.h>
 
+#include "comdb2.h"
 #include "logmsg.h"
+#include "sql.h"
 
 #include "api_history.h"
-
-struct api_history {
-    hash_t *entries;
-    pthread_rwlock_t lock;
-};
 
 static int hash_entry(api_driver_t *entry, int len)
 {
@@ -73,101 +70,55 @@ static int free_entry(api_driver_t *entry, void *arg)
     return 0;
 }
 
-void acquire_api_history_lock(api_history_t *api_history, int write) 
-{
-    if (write) {
-        Pthread_rwlock_wrlock(&api_history->lock);
-    } else {
-        Pthread_rwlock_rdlock(&api_history->lock);
-    }
-}
-
-void release_api_history_lock(api_history_t *api_history) 
-{
-    Pthread_rwlock_unlock(&api_history->lock);
-}
-
 api_history_t *init_api_history()
 {
-    api_history_t *api_history = malloc(sizeof(api_history_t));
-    assert(api_history);
-    Pthread_rwlock_init(&api_history->lock, NULL);
-    
-    api_history->entries = hash_init_user((hashfunc_t *)hash_entry, (cmpfunc_t *)compare_entries, 0, 0);
-    if (!api_history->entries) {
+    api_history_t *api_history = hash_init_user((hashfunc_t *)hash_entry, (cmpfunc_t *)compare_entries, 0, 0);
+    if (!api_history) {
         logmsg(LOGMSG_FATAL, "Unable to initialize api history.\n");
         abort();
     }
-    
+
     return api_history;
 }
 
-int free_api_history(api_history_t *api_history)
+void free_api_history(api_history_t *api_history)
 {
     assert(api_history);
-    acquire_api_history_lock(api_history, 1);
-    
-    int rc = hash_for(api_history->entries, (hashforfunc_t *)free_entry, NULL);
-    if (rc) {
-        logmsg(LOGMSG_FATAL, "Unable to free api history entries.\n");
-        release_api_history_lock(api_history);
-        return rc;
-    }
-
-    hash_free(api_history->entries);
-    release_api_history_lock(api_history);
-    Pthread_rwlock_destroy(&api_history->lock);
-    free(api_history);
-    return 0;
+    hash_for(api_history, (hashforfunc_t *)free_entry, NULL);
+    hash_free(api_history);
 }
 
-api_driver_t *get_next_api_history_entry(api_history_t *api_history, void **curr, unsigned int *iter)
+int get_num_api_history_entries(struct rawnodestats *stats)
 {
-    assert(api_history);
-    acquire_api_history_lock(api_history, 0);
-    api_driver_t *entry;
-    
-    if (!*curr && !*iter) {
-        entry = (api_driver_t *)hash_first(api_history->entries, curr, iter);
-    } else {
-        entry = (api_driver_t *)hash_next(api_history->entries, curr, iter);
-    }
-    
-    release_api_history_lock(api_history);
-    return entry;
-}
-
-int get_num_api_history_entries(api_history_t *api_history) {
-    assert(api_history);
-    acquire_api_history_lock(api_history, 0);
-    
-    int num = hash_get_num_entries(api_history->entries);
-    
-    release_api_history_lock(api_history);
+    assert(stats);
+    Pthread_mutex_lock(&stats->lk);
+    int num = stats->api_history ? hash_get_num_entries(stats->api_history) : 0;
+    Pthread_mutex_unlock(&stats->lk);
     return num;
 }
 
-int update_api_history(api_history_t *api_history, char *api_driver_name, char *api_driver_version)
+int update_api_history(struct sqlclntstate *clnt)
 {
-    assert(api_history);
-    acquire_api_history_lock(api_history, 1);
-    
-    api_driver_t *search_entry = create_entry(api_driver_name, api_driver_version);
-    api_driver_t *found_entry = hash_find(api_history->entries, search_entry);
-    
+    assert(clnt && clnt->rawnodestats);
+    struct rawnodestats *stats = clnt->rawnodestats;
+
+    Pthread_mutex_lock(&stats->lk);
+    api_driver_t *search_entry = create_entry(clnt->api_driver_name, clnt->api_driver_version);
+    api_driver_t *found_entry = hash_find(stats->api_history, search_entry);
+
     if (found_entry) {
         time(&found_entry->last_seen);
         free_entry(search_entry, NULL);
     } else {
         time(&search_entry->last_seen);
-        int rc = hash_add(api_history->entries, search_entry);
+        int rc = hash_add(stats->api_history, search_entry);
         if (rc) {
+            Pthread_mutex_unlock(&stats->lk);
             logmsg(LOGMSG_FATAL, "Unable to add api history entry.\n");
-            release_api_history_lock(api_history);
             return rc;
         }
     }
 
-    release_api_history_lock(api_history);
+    Pthread_mutex_unlock(&stats->lk);
     return 0;
 }

--- a/db/api_history.h
+++ b/db/api_history.h
@@ -18,6 +18,7 @@
 #define _API_HISTORY_H_
 
 #include <sys/time.h>
+#include <plhash_glue.h>
 
 typedef struct api_driver {
     char *name;
@@ -25,14 +26,14 @@ typedef struct api_driver {
     time_t last_seen;
 } api_driver_t;
 
-typedef struct api_history api_history_t;
+typedef hash_t api_history_t; // holds api_driver_t entries, keyed by name+version
 
-void acquire_api_history_lock(api_history_t*, int);
-void release_api_history_lock(api_history_t*);
+struct sqlclntstate;
+struct rawnodestats;
+
 api_history_t *init_api_history();
-int free_api_history(api_history_t*);
-api_driver_t *get_next_api_history_entry(api_history_t*, void**, unsigned int*);
-int get_num_api_history_entries(api_history_t*);
-int update_api_history(api_history_t*, char*, char*);
+void free_api_history(api_history_t *);
+int get_num_api_history_entries(struct rawnodestats *);
+int update_api_history(struct sqlclntstate *);
 
 #endif

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -80,6 +80,7 @@ void berk_memp_sync_alarm_ms(int);
 #include "sql.h"
 #include "logmsg.h"
 #include "reqlog.h"
+#include "reqlog_int.h"
 
 #include "comdb2_trn_intrl.h"
 #include "history.h"
@@ -1800,6 +1801,7 @@ void clean_exit(void)
 
     backend_cleanup(thedb);
     net_cleanup();
+    cleanup_clientstats();
 
     if (gbl_ssl_ctx != NULL) {
         SSL_CTX_free(gbl_ssl_ctx);

--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2550,6 +2550,7 @@ static void update_clientstats_cache(nodestats_t *entry) {
     Pthread_mutex_unlock(&clientstats_cache_mtx);
 }
 
+static int free_nodestats_entry(void *elem, void *unused);
 static nodestats_t *add_clientstats(unsigned checksum, const char *whoami, int task_len, int stack_len, int id_len,
                                     char *host, int node, int fd)
 {
@@ -2582,15 +2583,7 @@ static nodestats_t *add_clientstats(unsigned checksum, const char *whoami, int t
         nodestats_t *old_entry = listc_rtl(&clientstats_cache);
         if (old_entry) {
             hash_del(clientstats, old_entry);
-            if (old_entry->rawtotals.fingerprints) {
-                hash_for(old_entry->rawtotals.fingerprints, hash_free_element, NULL);
-                hash_free(old_entry->rawtotals.fingerprints);
-            }
-            free_api_history(old_entry->rawtotals.api_history);
-            time_metric_free(old_entry->rawtotals.svc_time);
-            Pthread_mutex_destroy(&old_entry->mtx);
-            Pthread_mutex_destroy(&old_entry->rawtotals.lk);
-            free(old_entry);
+            free_nodestats_entry(old_entry, NULL);
         } else {
             break;
         }
@@ -2664,7 +2657,6 @@ static int release_clientstats(unsigned checksum, int node)
         rc = -1;
         goto done;
     }
-
     Pthread_mutex_lock(&entry->mtx);
     entry->ref--;
     update_clientstats_cache(entry);
@@ -2676,20 +2668,34 @@ done:
     return rc;
 }
 
-nodestats_t *get_next_clientstats_entry(void **curr, unsigned int *iter)
+static int free_nodestats_entry(void *elem, void *unused)
+{
+    nodestats_t *entry = (nodestats_t *)elem;
+    if (entry->rawtotals.fingerprints) {
+        hash_for(entry->rawtotals.fingerprints, hash_free_element, NULL);
+        hash_free(entry->rawtotals.fingerprints);
+    }
+    free_api_history(entry->rawtotals.api_history);
+    time_metric_free(entry->rawtotals.svc_time);
+    Pthread_mutex_destroy(&entry->mtx);
+    Pthread_mutex_destroy(&entry->rawtotals.lk);
+    free(entry);
+    return 0;
+}
+
+void cleanup_clientstats(void)
+{
+    acquire_clientstats_lock(1);
+    hash_for(clientstats, free_nodestats_entry, NULL);
+    hash_free(clientstats);
+    clientstats = NULL;
+    release_clientstats_lock();
+}
+
+int hash_for_clientstats(hashforfunc_t *func, void *arg)
 {
     assert(clientstats);
-    acquire_clientstats_lock(0);
-    nodestats_t *entry;
-    
-    if (!*curr && !*iter) {
-        entry = (nodestats_t *)hash_first(clientstats, curr, iter);
-    } else {
-        entry = (nodestats_t *)hash_next(clientstats, curr, iter);
-    }
-    
-    release_clientstats_lock();
-    return entry;
+    return hash_for(clientstats, func, arg);
 }
 
 struct rawnodestats *get_raw_node_stats(const char *task, const char *stack, const char *id, char *host, int fd,

--- a/db/reqlog_int.h
+++ b/db/reqlog_int.h
@@ -6,6 +6,7 @@
 #include "cson.h"
 #include "sql.h"
 #include "reqlog.h"
+#include <plhash_glue.h>
 
 /* This used to be private to reqlog.  Moving to a shared header since
    eventlog also needs access to reqlog internals.  I am not sure
@@ -242,7 +243,8 @@ typedef struct nodestats {
 
 void acquire_clientstats_lock(int);
 void release_clientstats_lock();
-nodestats_t *get_next_clientstats_entry(void**, unsigned int*);
+void cleanup_clientstats(void);
+int hash_for_clientstats(hashforfunc_t *func, void *arg);
 
 extern int gbl_time_fdb;
 

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -1354,7 +1354,7 @@ static void sql_statement_done(struct sql_thread *thd, struct reqlogger *logger,
         if (have_fingerprint)
             add_fingerprint_to_rawstats(clnt->rawnodestats, fingerprint, cost,
                                         rows, time);
-        update_api_history(clnt->rawnodestats->api_history, clnt->api_driver_name, clnt->api_driver_version);
+        update_api_history(clnt);
     }
 
     reset_sql_steps(thd);

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -2371,7 +2371,7 @@ static void lua_end_step(struct sqlclntstate *clnt, SP sp,
             put_ref(&sql_ref);
             if (clnt->rawnodestats) {
                 add_fingerprint_to_rawstats(clnt->rawnodestats, fingerprint, cost, pVdbe->luaRows, timeMs);
-                update_api_history(clnt->rawnodestats->api_history, clnt->api_driver_name, clnt->api_driver_version);
+                update_api_history(clnt);
             }
 
             clnt->spcost.cost += cost;

--- a/sqlite/ext/comdb2/api_history.c
+++ b/sqlite/ext/comdb2/api_history.c
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <unistd.h>
 
 #include "comdb2.h"
 #include "reqlog_int.h"
@@ -37,58 +38,99 @@ typedef struct systable_api_history {
     cdb2_client_datetime_t last_seen;
 } systable_api_history_t;
 
-static void append_entries(systable_api_history_t **data, int *nrecords, api_history_t *api_history, const char *host, const char *task)
+typedef struct api_history_collect_ctx {
+    systable_api_history_t *base;
+    const char *host;
+    const char *task;
+    int nrecords;
+    int nalloc;
+} api_history_collect_ctx_t;
+
+void free_api_history_data(void *data, int nrecords);
+
+static int collect_api_history_rows(void *obj, void *arg)
 {
-    acquire_api_history_lock(api_history, 0);
-    int num_entries = get_num_api_history_entries(api_history);
-    assert(num_entries > -1);
-    if (!num_entries) {
-        release_api_history_lock(api_history);
-        return;
+    api_driver_t *entry = (api_driver_t *)obj;
+    api_history_collect_ctx_t *ctx = (api_history_collect_ctx_t *)arg;
+    if (ctx->nrecords >= ctx->nalloc) {
+        
+        size_t new_size = ctx->nalloc * 2 * sizeof(systable_api_history_t);
+        systable_api_history_t *new_block = realloc(ctx->base, new_size);
+        if (!new_block) {
+            free_api_history_data(ctx->base, ctx->nrecords);
+            ctx->base = NULL;
+            ctx->nrecords = 0;
+            return SQLITE_NOMEM;
+        }
+        ctx->base = new_block;
+        ctx->nalloc = ctx->nalloc * 2;
     }
+    systable_api_history_t *row = &ctx->base[ctx->nrecords];
+    row->host = strdup(ctx->host ? ctx->host : "unknown");
+    row->task = strdup(ctx->task ? ctx->task : "unknown");
+    row->api_driver_name = strdup(entry->name ? entry->name : "unknown");
+    row->api_driver_version = strdup(entry->version ? entry->version : "unknown");
+    dttz_t dt = (dttz_t){.dttz_sec = entry->last_seen ? entry->last_seen : time(NULL)};
+    dttz_to_client_datetime(&dt, "UTC", &row->last_seen);
+    ctx->nrecords++;
+    return 0;
+}
 
-    int prev = *nrecords;
-    *nrecords += num_entries;
-    systable_api_history_t *buffer = realloc(*data, *nrecords * sizeof(systable_api_history_t));
-    
-    void *curr = NULL;
-    unsigned int iter = 0;
-    for (unsigned int i = prev; i < *nrecords; i++) {
-        api_driver_t *entry = get_next_api_history_entry(api_history, &curr, &iter);
-        assert(entry);
+static int count_api_entries(void *obj, void *arg)
+{
+    nodestats_t *entry = (nodestats_t *)obj;
+    int *total = (int *)arg;
+    *total += get_num_api_history_entries(&entry->rawtotals);
+    return 0;
+}
 
-        buffer[i].host = strdup(host);
-        buffer[i].task = strdup(task);
-        buffer[i].api_driver_name = strdup(entry->name);
-        buffer[i].api_driver_version = strdup(entry->version);
-
-        dttz_t dt = (dttz_t){.dttz_sec = entry->last_seen};
-        dttz_to_client_datetime(&dt, "UTC", &buffer[i].last_seen); 
+static int collect_node_api_history(void *obj, void *arg)
+{
+    nodestats_t *entry = (nodestats_t *)obj;
+    api_history_collect_ctx_t *ctx = (api_history_collect_ctx_t *)arg;
+    ctx->host = entry->host;
+    ctx->task = entry->task;
+    if (entry->rawtotals.api_history) {
+        Pthread_mutex_lock(&entry->rawtotals.lk);
+        int rc = hash_for(entry->rawtotals.api_history, collect_api_history_rows, ctx);
+        Pthread_mutex_unlock(&entry->rawtotals.lk);
+        if (rc) return rc;
     }
-
-    *data = buffer;
-    release_api_history_lock(api_history); 
+    return 0;
 }
 
 int init_api_history_data(void **data, int *nrecords)
 {
     *nrecords = 0;
-    systable_api_history_t *systable = calloc(*nrecords, sizeof(systable_api_history_t));
+    *data = NULL;
+
     acquire_clientstats_lock(0);
-   
-    void *curr = NULL;
-    unsigned int iter = 0;
-    nodestats_t *entry = get_next_clientstats_entry(&curr, &iter);
-    
-    while (entry) {
-        assert(entry->rawtotals.api_history);
-        Pthread_mutex_lock(&entry->rawtotals.lk);
-        append_entries(&systable, nrecords, entry->rawtotals.api_history, entry->host, entry->task);
-        Pthread_mutex_unlock(&entry->rawtotals.lk);
-        entry = get_next_clientstats_entry(&curr, &iter);
+
+    int total_entries = 0;
+    hash_for_clientstats(count_api_entries, &total_entries);
+
+    if (total_entries == 0) { //no clientstats so no api history entries
+        release_clientstats_lock();
+        return 0;
     }
 
-    *data = systable;
+    systable_api_history_t *systable = calloc(total_entries, sizeof(systable_api_history_t));
+    if (!systable) {
+        logmsg(LOGMSG_ERROR, "%s: out of memory for %d entries\n", __func__, total_entries);
+        release_clientstats_lock();
+        return SQLITE_NOMEM;
+    }
+
+    api_history_collect_ctx_t ctx = { .base = systable, .host = NULL, .task = NULL, .nrecords = 0, .nalloc = total_entries };
+    int rc = hash_for_clientstats(collect_node_api_history, &ctx);
+    if (rc) {
+        if (ctx.base) free_api_history_data(ctx.base, ctx.nrecords);
+        release_clientstats_lock();
+        return rc;
+    }
+
+    *nrecords = ctx.nrecords;
+    *data = ctx.base;
     release_clientstats_lock();
     return 0;
 }

--- a/tests/comdb2sys.test/Makefile
+++ b/tests/comdb2sys.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=6m
+	export TEST_TIMEOUT=10m
 endif

--- a/tests/comdb2sys.test/lrl.options
+++ b/tests/comdb2sys.test/lrl.options
@@ -5,3 +5,5 @@ table t2 t2.csc2
 table t3 t3.csc2
 table t4 t4.csc2
 enable_partial_indexes
+logmsg level debug
+do reql events on

--- a/tests/comdb2sys.test/testapihistory
+++ b/tests/comdb2sys.test/testapihistory
@@ -1,18 +1,112 @@
 #!/bin/bash
 
+bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
 a_dbn=$1
 
-replicant=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_cluster where is_master="N" limit 1')
+if [[ "x${DEBUGGER}" != "x" ]] ; then
+    cdb2sql="$DEBUG_PREFIX ${CDB2SQL_EXE}" 
+else 
+    cdb2sql="${CDB2SQL_EXE}"
+fi
+
+TMPDIR=${TMPDIR:-${TESTDIR}/tmp}
+
+export DUMPLOCK_ON_TIMEOUT=1
+export CORE_ON_TIMEOUT=1
+
+master=$($cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_cluster where is_master="Y" limit 1')
+master=$(echo $master | grep -oP \'\(.*?\)\')
+master=${master:1:-1}
+
+replicant=$($cdb2sql ${CDB2_OPTIONS} $a_dbn default "select host from comdb2_cluster where is_master='N' limit 1")
 replicant=$(echo $replicant | grep -oP \'\(.*?\)\')
 replicant=${replicant:1:-1}
 
-cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT 1"
-cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT CASE WHEN length(host) > 0 THEN 'hostname' ELSE '' END AS host, task, api_driver_name, api_driver_version FROM comdb2_api_history WHERE task='cdb2sql'" > testapihistory.out
+if [[ -z "$replicant" ]]; then
+    echo "Failed to find replicant host for test, requires cluster!"
+    exit 1
+fi
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT 1"
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT CASE WHEN length(host) > 0 THEN 'hostname' ELSE '' END AS host, task, api_driver_name, api_driver_version FROM comdb2_api_history WHERE task='cdb2sql'" > testapihistory.out
 diff testapihistory.out testapihistory.expected >/dev/null
 rc=$?
 if [[ $rc -ne 0 ]]; then
     echo "Failed systable comdb2_api_history test"
-    echo diff $(pwd)/testapihistory.out $(pwd)/testapihistory.expected
+    echo $(diff $(pwd)/testapihistory.out $(pwd)/testapihistory.expected)
 fi
 
-exit $rc
+echo "Running concurrent api_history access regression test..."
+
+
+end=$(( $(date +%s) + 5 )) 
+
+(   
+    $cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "drop table if exists t" >/dev/null 2>&1
+    $cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "create table t (i int)" >/dev/null 2>&1
+    i=1
+    while [[ $(date +%s) -lt $end ]]; do
+        $cdb2sql ${CDB2_OPTIONS} $a_dbn default "insert into t select * from generate_series( $(( $i+1 )) , $(( $i+1000 )) );" >/dev/null 2>&1
+        [[ $? -ne 0 ]] && echo "Error inserting into t1" && exit 1
+        i=$((i+1000))
+    done
+    echo "rows inserted into t: $i"
+
+) 
+
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "EXEC PROCEDURE sys.cmd.send('memstat util')" >> testapihistory.out 2>&1
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT SUM(used) FROM comdb2_memstats WHERE name='util'" >> testapihistory.out 2>&1
+
+select_1_in_loop() {
+
+    for i in $(seq 1 5000); do
+        ln -sf "$cdb2sql" /tmp/client_$i
+        /tmp/client_$i ${CDB2_OPTIONS} $a_dbn default "SELECT 1" > /dev/null 2>&1
+    done
+    rm -f /tmp/client_{1..5000}
+
+}
+
+echo "Checking clientstats count..."
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT count(*) FROM comdb2_clientstats"
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "EXEC PROCEDURE sys.cmd.send('memstat util')" >> testapihistory.out 2>&1
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $replicant "SELECT SUM(used) FROM comdb2_memstats WHERE name='util'" >> testapihistory.out 2>&1
+
+echo "selecting from comdb2_api_history"
+
+select_1_in_loop
+wait $!
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "select count(*) from comdb2_api_history" &
+$cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "select count(*) from comdb2_api_history" &
+
+wait 
+
+select_1_in_loop &
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "select distinct api_driver_name from comdb2_api_history" &
+$cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "select count(*) from comdb2_api_history" &
+
+wait
+if [[ $? -ne 0 ]]; then
+    echo "couldn't select from comdb2_api_history"
+    exit 1
+fi
+
+wait
+
+$cdb2sql ${CDB2_OPTIONS} $a_dbn --host $replicant default "select * from comdb2_locks where object=''" >> testapihistory.out 2>&1
+$cdb2sql ${CDB2_OPTIONS} $a_dbn default "select 1" >> testapihistory.out 2>&1
+for node in $CLUSTER; do
+    $cdb2sql ${CDB2_OPTIONS} $a_dbn default "select 1" >> testapihistory.out 2>&1
+    if [[ $? -ne 0 ]]; then
+        echo "couldn't select 1"
+        exit 1
+    fi
+done
+
+echo "PASSED: Concurrent api_history test"
+exit 0

--- a/tests/comdb2sys.test/testindexusage
+++ b/tests/comdb2sys.test/testindexusage
@@ -5,6 +5,11 @@ replicant=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_clus
 replicant=$(echo $replicant | grep -oP \'\(.*?\)\')
 replicant=${replicant:1:-1}
 
+if [[ -z "$replicant" ]]; then
+    echo "Failed to find replicant host for test, requires cluster!"
+    exit 1
+fi
+
 cdb2sql ${CDB2_OPTIONS} $a_dbn default - <<EOF
 create table ixtest(a int, b int); \$\$
 create index ixtest_a on ixtest(a);

--- a/tests/comdb2sys.test/testtablemetrics
+++ b/tests/comdb2sys.test/testtablemetrics
@@ -6,9 +6,21 @@ master=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_cluster
 master=$(echo $master | grep -oP \'\(.*?\)\')
 master=${master:1:-1}
 
+echo "master: $master"
+if [[ -z "$master" ]]; then
+    echo "Failed to find master host for test, requires cluster!"
+    exit 1
+fi
+
 replicant=$(cdb2sql ${CDB2_OPTIONS} $a_dbn default 'select host from comdb2_cluster where is_master="N" limit 1')
 replicant=$(echo $replicant | grep -oP \'\(.*?\)\')
 replicant=${replicant:1:-1}
+
+echo "replicant: $replicant"
+if [[ -z "$replicant" ]]; then
+    echo "Failed to find replicant host for test, requires cluster!"
+    exit 1
+fi
 
 cdb2sql ${CDB2_OPTIONS} $a_dbn default --host $master - <<EOF
 create table metricstest (a int unique, b int); \$\$


### PR DESCRIPTION
fixes dangling state of curr/iter when get_next_entry is called on a hash, uses hash_for instead. 
uses ctx for collecting api_history entries of node/task of clientstats.
