### PR TITLE
Don't double close a dbp

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -6967,6 +6967,7 @@ int get_dbnum_by_name(bdb_state_type *bdb_state, const char *name)
     return found;
 }
 
+int gbl_clear_ufid_on_db_close = 1;
 static int bdb_close_only_flags(bdb_state_type *bdb_state, DB_TXN *tid, int *bdberr, int flags)
 {
     int i;
@@ -6985,8 +6986,8 @@ static int bdb_close_only_flags(bdb_state_type *bdb_state, DB_TXN *tid, int *bdb
     /* close doesn't fail */
     if (flags & BDB_CLOSE_FLAGS_FLUSH) {
        close_dbs_flush(bdb_state);
-    } else if (flags & BDB_CLOSE_FLAGS_CLR_UFID) {
-        close_dbs_int(bdb_state, NULL, DB_NOSYNC, BDB_CLOSE_FLAGS_CLR_UFID);
+    } else if ((flags & BDB_CLOSE_FLAGS_CLR_UFID) && gbl_clear_ufid_on_db_close) {
+        close_dbs_int(bdb_state, NULL, DB_NOSYNC, flags);
     } else {
         close_dbs(bdb_state);
     }

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -964,7 +964,7 @@ __db_dbenv_mpool(dbp, fname, flags)
  *
  * PUBLIC: int __db_clear_ufid_hash __P((DB *, DB_TXN *, u_int32_t));
  */
-	int
+int
 __db_clear_ufid_hash(dbp, txn, flags)
 	DB *dbp;
 	DB_TXN *txn;
@@ -980,7 +980,12 @@ __db_clear_ufid_hash(dbp, txn, flags)
 	ZERO_LSN(dummy_lsn);
 	ufid_dbp = NULL;
 
-	ret = __ufid_find_db_noabort(dbenv, txn, &ufid_dbp, dbp->fileid, &dummy_lsn);
+	ret = __ufid_find_db_for_removal(dbenv, txn, &ufid_dbp, dbp->fileid, &dummy_lsn);
+	if (ufid_dbp == dbp) {
+		/* prevent double-close */
+		return 0;
+	}
+
 	if (ret != 0 || ufid_dbp == NULL || !F_ISSET(ufid_dbp, DB_AM_RECOVER)) {
 		/* Ignore this file if its fileid is deleted, missing, or not opened by recovery */
 		return 0;

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -545,7 +545,7 @@ __ufid_open(dbenv, txn, dbpp, inufid, name, lsnp)
 int gbl_abort_on_missing_ufid = 0;
 
 static int
-__ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, create, abort_on_not_found)
+__ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, create, abort_on_not_found, remove_on_found)
 	DB_ENV *dbenv;
 	DB_TXN *txn;
 	DB **dbpp;
@@ -554,6 +554,7 @@ __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, create, abort_on_no
 	void **is_trigger;
 	int create;
 	int abort_on_not_found;
+	int remove_on_found;
 {
 	struct __ufid_to_db_t *ufid;
 	int ret = 0;
@@ -583,6 +584,10 @@ __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, create, abort_on_no
 		}
 		ret = ret ? ret : (ufid->ignore ? DB_IGNORED : 0);
 		(*dbpp) = ufid->dbp;
+		if (remove_on_found) {
+			/* caller is going to close the dbp */
+			ufid->dbp = NULL;
+		}
 	} else {
 		if (abort_on_not_found && gbl_abort_on_missing_ufid) {
 			abort();
@@ -612,7 +617,7 @@ __ufid_to_db(dbenv, txn, dbpp, inufid, is_trigger, lsnp)
 	void **is_trigger;
 	DB_LSN *lsnp;
 {
-	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, 1, 1);
+	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, is_trigger, 1, 1, 0);
 }
 
 // PUBLIC: int __ufid_find_db __P(( DB_ENV *, DB_TXN *, DB **, u_int8_t *, DB_LSN *));
@@ -624,19 +629,19 @@ __ufid_find_db(dbenv, txn, dbpp, inufid, lsnp)
 	u_int8_t *inufid;
 	DB_LSN *lsnp;
 {
-	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, NULL, 0, 1);
+	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, NULL, 0, 1, 0);
 }
 
-// PUBLIC: int __ufid_find_db_noabort __P(( DB_ENV *, DB_TXN *, DB **, u_int8_t *, DB_LSN *));
+// PUBLIC: int __ufid_find_db_for_removal __P(( DB_ENV *, DB_TXN *, DB **, u_int8_t *, DB_LSN *));
 int
-__ufid_find_db_noabort(dbenv, txn, dbpp, inufid, lsnp)
+__ufid_find_db_for_removal(dbenv, txn, dbpp, inufid, lsnp)
 	DB_ENV *dbenv;
 	DB_TXN *txn;
 	DB **dbpp;
 	u_int8_t *inufid;
 	DB_LSN *lsnp;
 {
-	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, NULL, 0, 0);
+	return __ufid_to_db_int(dbenv, txn, dbpp, inufid, lsnp, NULL, 0, 0, 1);
 }
 
 // PUBLIC: int __ufid_to_fname __P(( DB_ENV *, char **, u_int8_t *));

--- a/db/config.c
+++ b/db/config.c
@@ -458,7 +458,9 @@ static char *legacy_options[] = {
     "recovery_ckp 0",
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
-    "endianize_locklist 0"
+    "endianize_locklist 0",
+    "track_db_open 0",
+    "clear_ufid_on_db_close 0"
 };
 // clang-format on
 

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -625,6 +625,7 @@ int gbl_nudge_replication_when_idle = 100;
 extern int gbl_new_connection_grace_ms;
 extern int gbl_accept_headroom;
 extern int gbl_db_track_open;
+extern int gbl_clear_ufid_on_db_close;
 
 int parse_int64(const char *value, int64_t *num);
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2609,4 +2609,6 @@ REGISTER_TUNABLE("accept_headroom", "", TUNABLE_INTEGER, &gbl_accept_headroom, I
 REGISTER_TUNABLE("simpleauth", NULL, TUNABLE_BOOLEAN, &gbl_uses_simpleauth, NOARG | READEARLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("track_db_open", "Track berkdb open DB handles", TUNABLE_INTEGER, &gbl_db_track_open, INTERNAL, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("clear_ufid_on_db_close", "Clear ufid hash on db->close", TUNABLE_INTEGER, &gbl_clear_ufid_on_db_close,
+                 INTERNAL, NULL, NULL, NULL, NULL);
 #endif /* _DB_TUNABLES_H */


### PR DESCRIPTION
This patch also places the clear-ufid-on-close logic under a tunable.