### PR TITLE
Disable verify_no_distcommit test

### DIFF
--- a/tests/disttxn.test/runit
+++ b/tests/disttxn.test/runit
@@ -3609,10 +3609,14 @@ function run_test
     no_coordinator_writes
     testcase_finish $testcase
 
-    testcase="verify_no_distcommit"
-    testcase_preamble $testcase
-    verify_no_distcommit
-    testcase_finish $testcase
+    # This test is flakey- peridically returns 'unknown error'..
+    # also fixed by fdb push-mode.  Disable until push-mode verify-retry
+    # is implemented- will re-test thoroughly then
+
+    #testcase="verify_no_distcommit"
+    #testcase_preamble $testcase
+    #verify_no_distcommit
+    #testcase_finish $testcase
 
     # Writes to comdb2_distributed_transactions
     testcase="allow_write_to_disttxn_table"


### PR DESCRIPTION
The verify-no-distcommit test is flaky- disable it for now.  We will re-test this thoroughly when feb-push mode handles verify-retries correctly.
