### PR TITLE
Emit regop-gen commits unless recovering

### DIFF
--- a/berkdb/txn/txn.c
+++ b/berkdb/txn/txn.c
@@ -1131,7 +1131,7 @@ __txn_commit_int(txnp, flags, ltranid, llid, last_commit_lsn, rlocks, inlks,
 	}
 
     /* don't let full recovery write a (higher) generation: it will force this newly-recovered node to be master on the next election */
-	elect_highest_committed_gen = (dbenv->attr.elect_highest_committed_gen && !gbl_fullrecovery);
+	elect_highest_committed_gen = !gbl_fullrecovery;
 	db_rep = dbenv->rep_handle;
 	rep = db_rep->region;
 


### PR DESCRIPTION
First part of a strategy to enable elect_highest_committed_gen is to enable regop-gen commits everywhere.