### PR TITLE
Default to emitting 'recovery-ckp' on a copy

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -455,7 +455,6 @@ static char *legacy_options[] = {
     "usenames",
     "setattr max_sql_idle_time 864000",
     "retrieve_gen_from_ckp 0",
-    "recovery_ckp 0",
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
     "endianize_locklist 0",


### PR DESCRIPTION
Recovery checkpoints are never used to cast a vote.