### PR TITLE
Emit correctly endianized locklists by default

### DIFF
--- a/db/config.c
+++ b/db/config.c
@@ -458,7 +458,6 @@ static char *legacy_options[] = {
     "recovery_ckp 0",
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
-    "endianize_locklist 0",
     "track_db_open 0",
     "clear_ufid_on_db_close 0",
     "get_peer_fqdn 0"


### PR DESCRIPTION
This has been fixed for a year- this PR enables endianized locklist by default.
