### PR TITLE
All commits contain generation

### DIFF
--- a/tests/nogensc.test/runit
+++ b/tests/nogensc.test/runit
@@ -7,16 +7,10 @@ $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table t1(a int)"
 
 g=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "select generation from comdb2_transaction_logs where rectype=2015 or rectype=2150")
 
-if [[ "$DBNAME" == *"usegen"* ]]; then
-    if [[ "$g" == "NULL" ]]; then
-        echo "Committed-gen database should have non-NULL for generation"
-        exit 1
-    fi
-else
-    if [[ "$g" != "NULL" ]]; then
-        echo "No-gen database should have NULL for generation in regop_rowlocks record"
-        exit 1
-    fi
+# We will always emit commit-gen records
+if [[ "$g" == "NULL" ]]; then
+    echo "Committed-gen database should have non-NULL for generation"
+    exit 1
 fi
 
 echo "Success"

--- a/tests/nogensc.test/usegen.testopts
+++ b/tests/nogensc.test/usegen.testopts
@@ -1,1 +1,0 @@
-berkattr elect_highest_committed_gen 1


### PR DESCRIPTION
Changes the nogensc test to always expect a generation number.
