### PR TITLE
Retry with debug trace on populate-revconn failure

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -6928,13 +6928,14 @@ void cdb2_set_debug_trace(cdb2_hndl_tp *hndl)
 {
     hndl->debug_trace = 1;
 }
-#endif
 
-#ifdef CDB2API_TEST
 void cdb2_unset_debug_trace(cdb2_hndl_tp *hndl)
 {
     hndl->debug_trace = 0;
 }
+#endif
+
+#ifdef CDB2API_TEST
 
 void cdb2_dump_ports(cdb2_hndl_tp *hndl, FILE *out)
 {

--- a/cdb2api/cdb2api_int.h
+++ b/cdb2api/cdb2api_int.h
@@ -52,6 +52,7 @@ void cdb2_hndl_set_min_retries(cdb2_hndl_tp *hndl, int min_retries);
 int cdb2_get_comdb2db(char **comdb2db_name, char **comdb2db_class);
 
 void cdb2_set_debug_trace(cdb2_hndl_tp *hndl);
+void cdb2_unset_debug_trace(cdb2_hndl_tp *hndl);
 #endif
 
 int cdb2_is_valid_int(const char *str);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -515,6 +515,7 @@ extern int gbl_physrep_hung_replicant_check_freq_sec;
 extern int gbl_physrep_hung_replicant_threshold;
 extern int gbl_physrep_revconn_check_interval;
 extern int gbl_physrep_fake_revconn_populate_error;
+extern int gbl_physrep_fake_revconn_populate_error_once;
 extern int gbl_debug_fake_rte_failure;
 extern int gbl_physrep_update_registry_interval;
 extern int gbl_physrep_i_am_metadb;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1842,6 +1842,10 @@ REGISTER_TUNABLE("physrep_revconn_check_interval", "Physrep recheck revconn inte
 REGISTER_TUNABLE("physrep_fake_revconn_populate_error",
                  "Fake physrep error when populating revcon list.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_physrep_fake_revconn_populate_error, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("physrep_fake_revconn_populate_error_once",
+                 "Fake physrep error on first attempt only, allowing retry to succeed.  (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_physrep_fake_revconn_populate_error_once, EXPERIMENTAL | INTERNAL, NULL, NULL,
+                 NULL, NULL);
 REGISTER_TUNABLE("debug_fake_rte_failure", "Fake rte failures in connect-remote-db.  (Default: off)", TUNABLE_BOOLEAN,
                  &gbl_debug_fake_rte_failure, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_i_am_metadb", "I am physical replication metadb (Default: off)",

--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -264,6 +264,49 @@ int gbl_reverse_hosts_v2 = 0;
 extern int gbl_altmetadb_count;
 int get_alt_metadb_hndl(cdb2_hndl_tp **hndl, int index);
 int gbl_physrep_fake_revconn_populate_error = 0;
+int gbl_physrep_fake_revconn_populate_error_once = 0;
+
+static int process_revconn_records(cdb2_hndl_tp *metadb, reverse_conn_host_list_tp *new_reverse_conn_hosts)
+{
+    int rc;
+    while ((rc = cdb2_next_record(metadb)) == CDB2_OK) {
+        char *dbname = (char *)cdb2_column_value(metadb, 0);
+        char *host = (char *)cdb2_column_value(metadb, 1);
+        char **class_mach_list = NULL;
+        const char **cluster_mach_list = NULL;
+        int count = 0;
+
+        if (is_valid_mach_class(host)) {
+            if (class_machs(dbname, host, &count, &class_mach_list) == 0) {
+                /* Search for hosts */
+                int add_error = 0;
+                for (int i = 0; i < count; i++) {
+                    if (!add_error) {
+                        add_error += add_reverse_host(dbname, class_mach_list[i], new_reverse_conn_hosts);
+                    }
+                    free(class_mach_list[i]);
+                }
+                free(class_mach_list);
+                if (add_error) {
+                    return 1;
+                }
+            }
+        } else if (get_cluster_machs(host, &count, &cluster_mach_list) == 0) {
+            for (int i = 0; i < count; i++) {
+                if (add_reverse_host(dbname, cluster_mach_list[i], new_reverse_conn_hosts) != 0) {
+                    return 1;
+                }
+            }
+        } else if (add_reverse_host(dbname, host, new_reverse_conn_hosts) != 0) {
+            return 1;
+        }
+
+        if (gbl_revsql_debug == 1) {
+            revconn_logmsg(LOGMSG_USER, "%s:%d Adding %s/%s to revconn list\n", __func__, __LINE__, dbname, host);
+        }
+    }
+    return 0;
+}
 
 static int populate_revconn_list(cdb2_hndl_tp *metadb, reverse_conn_host_list_tp *new_reverse_conn_hosts)
 {
@@ -298,48 +341,34 @@ static int populate_revconn_list(cdb2_hndl_tp *metadb, reverse_conn_host_list_tp
         cdb2_set_debug_trace(metadb);
     }
 
-    if ((rc = cdb2_run_statement(metadb, cmd)) == CDB2_OK) {
-        while ((rc = cdb2_next_record(metadb)) == CDB2_OK) {
-            char *dbname = (char *)cdb2_column_value(metadb, 0);
-            char *host = (char *)cdb2_column_value(metadb, 1);
-            char **class_mach_list = NULL;
-            const char **cluster_mach_list = NULL;
-            int count = 0;
-
-            if (is_valid_mach_class(host)) {
-                if (class_machs(dbname, host, &count, &class_mach_list) == 0) {
-                    /* Search for hosts */
-                    int add_error = 0;
-                    for (int i = 0; i < count; i++) {
-                        if (!add_error) {
-                            add_error += add_reverse_host(dbname, class_mach_list[i], new_reverse_conn_hosts);
-                        }
-                        free(class_mach_list[i]);
-                    }
-                    free(class_mach_list);
-                    if (add_error) {
-                        return 1;
-                    }
-                }
-            } else if (get_cluster_machs(host, &count, &cluster_mach_list) == 0) {
-                for (int i = 0; i < count; i++) {
-                    if (add_reverse_host(dbname, cluster_mach_list[i], new_reverse_conn_hosts) != 0) {
-                        return 1;
-                    }
-                }
-            } else if (add_reverse_host(dbname, host, new_reverse_conn_hosts) != 0) {
-                return 1;
-            }
-
-            if (gbl_revsql_debug == 1) {
-                revconn_logmsg(LOGMSG_USER, "%s:%d Adding %s/%s to revconn list\n", __func__, __LINE__, dbname, host);
-            }
-        }
+    // Inject fake error on first attempt if tunable is enabled
+    if (gbl_physrep_fake_revconn_populate_error_once) {
+        logmsg(LOGMSG_INFO, "%s:%d Debug: Simulating cdb2_run_statement failure (one-time)\n", __func__, __LINE__);
+        gbl_physrep_fake_revconn_populate_error_once = 0;
+        rc = -1; // Simulate failure
     } else {
-        logmsg(LOGMSG_ERROR, "%s:%d Failed to run statement '%s' (rc: %d)\n", __func__, __LINE__, cmd, rc);
-        return rc;
+        rc = cdb2_run_statement(metadb, cmd);
     }
-    return 0;
+
+    if (rc == CDB2_OK) {
+        return process_revconn_records(metadb, new_reverse_conn_hosts);
+    }
+
+    // First attempt failed - retry with debug enabled for better diagnostics
+    logmsg(LOGMSG_ERROR, "%s:%d Failed to run statement '%s' (rc: %d), retrying with debug enabled\n", __func__,
+           __LINE__, cmd, rc);
+
+    cdb2_set_debug_trace(metadb);
+    rc = cdb2_run_statement(metadb, cmd);
+    cdb2_unset_debug_trace(metadb);
+
+    if (rc == CDB2_OK) {
+        logmsg(LOGMSG_ERROR, "%s:%d Statement succeeded on retry with debug enabled\n", __func__, __LINE__);
+        return process_revconn_records(metadb, new_reverse_conn_hosts);
+    }
+
+    logmsg(LOGMSG_ERROR, "%s:%d Statement also failed on retry with debug enabled (rc: %d)\n", __func__, __LINE__, rc);
+    return rc;
 }
 
 // Refresh the 'reverse connection host' list

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -2564,6 +2564,62 @@ function physrep_revconn_populate_error
     $CDB2SQL_EXE $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "delete from comdb2_physrep_sources where dbname = '$bogusname'"
 }
 
+# Tests the debug retry logic: when populate_revconn_list fails, it should
+# automatically retry with debug enabled. This test uses a one-time failure
+# to verify that the retry succeeds and the revconn entry is added.
+function physrep_revconn_populate_retry_with_debug
+{
+    local bogusname="retrydb"
+    local count=0
+
+    # Add a database to comdb2_physrep_sources
+    add_to_physrep_sources ${REPL_META_DBNAME} ${REPL_META_HOST} ${DBNAME} ${firstNode} $bogusname ${firstNode}
+
+    # Enable the one-time failure tunable (will fail once, then succeed on retry)
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $firstNode "put tunable physrep_fake_revconn_populate_error_once 1"
+
+    # Refresh revconn host list - this should fail once, log the retry, then succeed
+    x=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $firstNode "exec procedure sys.cmd.send('refreshrevconn')")
+
+    # Wait a bit for the revconn worker to spawn and logs to be written
+    sleep 2
+
+    # Verify that the fake error was injected
+    echo "$x" | egrep  "Simulating cdb2_run_statement failure \(one-time\)" > /dev/null
+    if [[ $? -ne 0 ]]; then
+        cleanFailExit "Expected fake error injection message not found in output"
+    fi
+
+    # Verify that the "retrying with debug enabled" message appears in the log
+    echo "$x" | egrep "retrying with debug enabled" > /dev/null
+    if [[ $? -ne 0 ]]; then
+        cleanFailExit "Expected 'retrying with debug enabled' message not found in output"
+    fi
+
+    # Verify that the "Statement succeeded on retry" message appears in the log
+    echo "$x" | egrep "Statement succeeded on retry with debug enabled" > /dev/null
+    if [[ $? -ne 0 ]]; then
+        cleanFailExit "Expected 'Statement succeeded on retry with debug enabled' message not found in output"
+    fi
+
+    echo "Found expected debug retry messages in log"
+
+    # Dump revconn list and verify the entry was successfully added
+    x=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME --host $firstNode "exec procedure sys.cmd.send('stat dumprevsql')" | egrep $bogusname)
+
+    # The entry should be in "new" or "running" state (not missing, not exiting)
+    if [[ -z "$x" ]]; then
+        cleanFailExit "Revconn for $bogusname is missing - retry with debug failed"
+    fi
+
+    [[ $x == *"exiting"* ]] && cleanFailExit "Revconn for $bogusname is marked as exiting - should be running after successful retry: $x"
+
+    echo "Successfully verified debug retry logic: $bogusname is in revconn list with state: $x"
+
+    # Clean up
+    $CDB2SQL_EXE $CDB2_OPTIONS $REPL_META_DBNAME --host $REPL_META_HOST "delete from comdb2_physrep_sources where dbname = '$bogusname'"
+}
+
 function announce
 {
     typeset text=$1
@@ -2747,11 +2803,22 @@ function run_tests
     testcase_preamble $testcase
     physrep_max_pending
     testcase_finish $testcase
+
+    testcase="physrep_revconn_populate_error"
+    testcase_preamble $testcase
+    physrep_revconn_populate_error
+    testcase_finish $testcase
+
+    testcase="physrep_revconn_populate_retry_with_debug"
+    testcase_preamble $testcase
+    physrep_revconn_populate_retry_with_debug
+    testcase_finish $testcase
 }
 
 function run_one_test
 {
     physrep_revconn_populate_error
+    physrep_revconn_populate_retry_with_debug
 }
 
 run_tests


### PR DESCRIPTION
There was a 30 second period where the metadb was unavailable.  Of the four metadb nodes, one of them was getting stale leases (because of a network issue), but the other three should have been able to handle requests.  This PR will retry a failed request with cdb2api debug-trace enabled.