### PR TITLE
Only build string refs table for tests

### DIFF
--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -858,15 +858,3 @@ Generic stack collection
 * `id` - index of this stack.
 * `hits` - number of times this stack has been collected.
 * `stack` - flattened stack.
-
-## comdb2_stringrefs
-
-Active string references
-
-   comdb2_stringrefs(string, func, line, refcnt, stack)
-
-* `string` - stringref string value.
-* `func` - function which allocated the string.
-* `line` - line number which allocates the string.
-* `refcnt` - number of active references.
-* `stack` - stack which allocated string.

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -232,9 +232,9 @@ int comdb2SystblInit(
     rc = systblTriggersInit(db);
   if (rc == SQLITE_OK)  
     rc = systblStacks(db);
+#ifdef COMDB2_TEST
   if (rc == SQLITE_OK)
     rc = systblStringRefsInit(db);
-#ifdef COMDB2_TEST
   if (rc == SQLITE_OK)
     rc = systblTranCommitInit(db);
 #endif


### PR DESCRIPTION
Any reason we need otherwise?