### PR TITLE
Metrics requires 'comdb2_tables' & 'comdb2_queues'

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -745,20 +745,22 @@ void sqlinit(void)
     if (sqlite3_initialize()) abort();
 }
 
-static char *vtable_lockname(sqlite3 *db, const char *vtable, int *is_system_table)
+static const char **vtable_locknames(sqlite3 *db, const char *vtable, int *is_system_table, int *lk_count)
 {
     *is_system_table = 0;
+    *lk_count = 0;
     if (vtable == NULL || db == NULL || db->aModule.count == 0)
         return NULL;
     struct Module *module;
-    char *lockname = NULL;
+    const char **locknames = NULL;
     sqlite3_mutex_enter(db->mutex);
     if ((module = sqlite3HashFind(&db->aModule, vtable)) != NULL) {
         *is_system_table = 1;
-        lockname = module->pModule->systable_lock;
+        *lk_count = module->pModule->systable_lock_count;
+        locknames = module->pModule->systable_locks;
     }
     sqlite3_mutex_leave(db->mutex);
-    return lockname;
+    return locknames;
 }
 
 static int vtable_search(char **vtables, int ntables, const char *table)
@@ -773,12 +775,14 @@ static int vtable_search(char **vtables, int ntables, const char *table)
 
 static void record_locked_vtable(struct sql_authorizer_state *pAuthState, const char *table)
 {
-    int is_system_table;
-    const char *vtable_lock = vtable_lockname(pAuthState->db, table, &is_system_table);
-    if (vtable_lock && !vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_lock)) {
-        pAuthState->vTableLocks =
-            (char **)realloc(pAuthState->vTableLocks, sizeof(char *) * (pAuthState->numVTableLocks + 1));
-        pAuthState->vTableLocks[pAuthState->numVTableLocks++] = strdup(vtable_lock);
+    int is_system_table, lk_cnt;
+    const char **vtable_locks = vtable_locknames(pAuthState->db, table, &is_system_table, &lk_cnt);
+    for (int i = 0; i < lk_cnt; i++) {
+        if (!vtable_search(pAuthState->vTableLocks, pAuthState->numVTableLocks, vtable_locks[i])) {
+            pAuthState->vTableLocks =
+                (char **)realloc(pAuthState->vTableLocks, sizeof(char *) * (pAuthState->numVTableLocks + 1));
+            pAuthState->vTableLocks[pAuthState->numVTableLocks++] = strdup(vtable_locks[i]);
+        }
     }
     if (is_system_table && !pAuthState->hasVTables)
         pAuthState->hasVTables = 1;

--- a/sqlite/ext/comdb2/api_history.c
+++ b/sqlite/ext/comdb2/api_history.c
@@ -27,7 +27,8 @@
 
 sqlite3_module systblApiHistoryModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 typedef struct systable_api_history {

--- a/sqlite/ext/comdb2/auto_analyze_tables.c
+++ b/sqlite/ext/comdb2/auto_analyze_tables.c
@@ -27,7 +27,8 @@ extern struct dbenv *thedb;
 
 sqlite3_module systblAutoAnalyzeTablesModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 typedef struct systable_auto_analyze_tables {

--- a/sqlite/ext/comdb2/columns.c
+++ b/sqlite/ext/comdb2/columns.c
@@ -159,7 +159,8 @@ static void free_columns(void *data, int n)
 
 sqlite3_module systblColumnsModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables"
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblColumnsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/constraints.c
+++ b/sqlite/ext/comdb2/constraints.c
@@ -440,7 +440,8 @@ const sqlite3_module systblConstraintsModule = {
   0,                             /* xRollbackTo */
   0,                             /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/dbinfo.c
+++ b/sqlite/ext/comdb2/dbinfo.c
@@ -30,7 +30,8 @@
 
 static sqlite3_module systblDbInfoModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblDbInfoInit(sqlite3 *db) {

--- a/sqlite/ext/comdb2/indexuse.c
+++ b/sqlite/ext/comdb2/indexuse.c
@@ -29,7 +29,8 @@
 
 static sqlite3_module systblIndexUsageModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables"
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 struct index_usage {

--- a/sqlite/ext/comdb2/keycomponents.c
+++ b/sqlite/ext/comdb2/keycomponents.c
@@ -110,7 +110,8 @@ static void free_keycomponents(void *data, int n)
 
 sqlite3_module systblKeyComponentsModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblKeyComponentsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/keys.c
+++ b/sqlite/ext/comdb2/keys.c
@@ -113,7 +113,8 @@ static void free_keys(void *data, int n)
 
 sqlite3_module systblKeysModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblKeysInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/metrics.c
+++ b/sqlite/ext/comdb2/metrics.c
@@ -197,7 +197,8 @@ const sqlite3_module systblMetricsModule = {
     0,                       /* xShadowName */
     .access_flag = CDB2_ALLOW_USER,
     /* this system table calculates table sizes. grab the 'comdb2_table' lock */
-    .systable_lock = "comdb2_tables"
+    .systable_lock_count = 2,
+    .systable_locks = (const char *[]){ "comdb2_tables", "comdb2_queues" }
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2))       \

--- a/sqlite/ext/comdb2/partial_datacopies.c
+++ b/sqlite/ext/comdb2/partial_datacopies.c
@@ -24,7 +24,8 @@ extern struct dbenv *thedb;
 
 sqlite3_module systblPartialDatacopiesModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 typedef struct systable_partial_datacopies {

--- a/sqlite/ext/comdb2/permissions.c
+++ b/sqlite/ext/comdb2/permissions.c
@@ -290,7 +290,8 @@ static int populate_timepart_permissions(void **data, int *nrows)
 
 sqlite3_module systblTablePermissionsModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblTablePermissionsInit(sqlite3 *db)
@@ -303,7 +304,8 @@ int systblTablePermissionsInit(sqlite3 *db)
 
 sqlite3_module systblSystabPermissionsModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblSystabPermissionsInit(sqlite3 *db)
@@ -316,7 +318,8 @@ int systblSystabPermissionsInit(sqlite3 *db)
 
 sqlite3_module systblTimepartPermissionsModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblTimepartPermissionsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/queues.c
+++ b/sqlite/ext/comdb2/queues.c
@@ -298,7 +298,8 @@ const sqlite3_module systblQueuesModule = {
   0,                         /* xRollbackTo */
   0,                         /* xShadowName */
   .access_flag = CDB2_ALLOW_USER,
-  .systable_lock = "comdb2_queues",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_queues" }
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/schemaversions.c
+++ b/sqlite/ext/comdb2/schemaversions.c
@@ -64,7 +64,8 @@ static void free_versions(void *p, int n)
 
 sqlite3_module systblSchemaVersionsModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblSchemaVersionsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/table_metrics.c
+++ b/sqlite/ext/comdb2/table_metrics.c
@@ -25,7 +25,8 @@
 extern struct dbenv *thedb;
 sqlite3_module systblTableMetricsModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 typedef struct systable_table_metrics {

--- a/sqlite/ext/comdb2/table_properties.c
+++ b/sqlite/ext/comdb2/table_properties.c
@@ -24,7 +24,8 @@ extern struct dbenv *thedb;
 char *bdb_get_type_str(bdb_state_type *);
 sqlite3_module systblTablePropertiesModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 typedef struct systable_table_properties {

--- a/sqlite/ext/comdb2/tables.c
+++ b/sqlite/ext/comdb2/tables.c
@@ -48,7 +48,8 @@
 
 sqlite3_module systblTablesModule = {
     .access_flag = CDB2_ALLOW_ALL,
-    .systable_lock = "comdb2_tables"
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 static int collect_tables(void **pd, int *pn)

--- a/sqlite/ext/comdb2/tablesizes.c
+++ b/sqlite/ext/comdb2/tablesizes.c
@@ -222,7 +222,8 @@ const sqlite3_module systblTblSizeModule = {
   0,                       /* xRollbackTo */
   0,                       /* xShadowName */
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 #endif /* (!defined(SQLITE_CORE) || defined(SQLITE_BUILDING_FOR_COMDB2)) \

--- a/sqlite/ext/comdb2/tag_columns.c
+++ b/sqlite/ext/comdb2/tag_columns.c
@@ -150,7 +150,8 @@ static void free_tag_cols(void *data, int n)
 
 sqlite3_module systblTagColsModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables"
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblTagColumnsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/tags.c
+++ b/sqlite/ext/comdb2/tags.c
@@ -132,7 +132,8 @@ static void free_tags(void *data, int n)
 
 sqlite3_module systblTagsModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_tables"
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 int systblTagsInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/timepartitions.c
+++ b/sqlite/ext/comdb2/timepartitions.c
@@ -31,15 +31,18 @@ static int systblTimepartitionsEventsInit(sqlite3 *db);
 
 sqlite3_module systblTimepartitionsModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 sqlite3_module systblTimepartitionShardsModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 sqlite3_module systblTimepartitionEventsModule = {
     .access_flag = CDB2_ALLOW_USER,
-    .systable_lock = "comdb2_tables",
+    .systable_lock_count = 1,
+    .systable_locks = (const char *[]){ "comdb2_tables" }
 };
 
 

--- a/sqlite/ext/comdb2/triggers.c
+++ b/sqlite/ext/comdb2/triggers.c
@@ -77,7 +77,8 @@ static int get_triggers(void **data, int *npoints)
 
 static sqlite3_module systblTriggersModule = {
   .access_flag = CDB2_ALLOW_ALL,
-  .systable_lock = "comdb2_queues",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_queues" }
 };
 
 int systblTriggersInit(sqlite3 *db)

--- a/sqlite/ext/comdb2/views.c
+++ b/sqlite/ext/comdb2/views.c
@@ -28,7 +28,8 @@
 
 sqlite3_module systblViewsModule = {
     .access_flag = CDB2_ALLOW_USER,
-  .systable_lock = "comdb2_views",
+  .systable_lock_count = 1,
+  .systable_locks = (const char *[]){ "comdb2_views" }
 };
 
 typedef struct view_entry {

--- a/sqlite/src/sqlite3.h
+++ b/sqlite/src/sqlite3.h
@@ -6530,7 +6530,8 @@ struct sqlite3_module {
   int (*xShadowName)(const char*);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   int access_flag;
-  char *systable_lock;
+  int systable_lock_count;
+  const char **systable_locks;
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
 };
 

--- a/sqlite/src/vdbe.c
+++ b/sqlite/src/vdbe.c
@@ -8060,15 +8060,18 @@ case OP_VOpen: {
   rc = pModule->xOpen(pVtab, &pVCur);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
   extern int views_needs_comdb2_tables_lock(const char *);
-  if( p->crtPartitionLocks>0 && pModule->systable_lock &&
-      !strncasecmp(pModule->systable_lock, "comdb2_tables", strlen("comdb2_tables")+1 )){
-    p->crtPartitionLocks--;
-    if( p->crtPartitionLocks==0 ){
-        /* done collecting all schema, release the views lock for the rest
-         * of execution
-         */
-        extern void views_unlock(void);
-        views_unlock();
+  if( p->crtPartitionLocks>0 && pModule->systable_locks && pModule->systable_lock_count ){
+    for (int j=0; j < pModule->systable_lock_count; j++) {
+      if(!strncasecmp(pModule->systable_locks[j], "comdb2_tables", strlen("comdb2_tables")+1 )){
+      p->crtPartitionLocks--;
+        if( p->crtPartitionLocks==0 ){
+            /* done collecting all schema, release the views lock for the rest
+             * of execution
+             */
+            extern void views_unlock(void);
+            views_unlock();
+        }
+      }
     }
   }
 #endif

--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -5244,9 +5244,11 @@ WhereInfo *sqlite3WhereBegin(
       int iCur = pTabItem->iCursor;
       sqlite3VdbeAddOp4(v, OP_VOpen, iCur, 0, 0, pVTab, P4_VTAB);
 #ifdef SQLITE_BUILDING_FOR_COMDB2
-      const char *lockname = ((VTable*)pVTab)->pVtab->pModule->systable_lock;
-      if( lockname && !strncasecmp(lockname, "comdb2_tables", sizeof("comdb2_tables")) )
-        v->numPartitionLocks++;
+      for (int j = 0; j<((VTable*)pVTab)->pVtab->pModule->systable_lock_count; j++ ) {
+          const char *lockname = ((VTable*)pVTab)->pVtab->pModule->systable_locks[j];
+          if( lockname && !strncasecmp(lockname, "comdb2_tables", sizeof("comdb2_tables")) )
+              v->numPartitionLocks++;
+      }
 #endif
     }else if( IsVirtual(pTab) ){
       /* noop */


### PR DESCRIPTION
The maxtable test periodically crashes.  The issue is that for the comdb2_metrics table, the code scans both the dbenv->dbs and dbenv->qdbs arrays, but only acquires the "comdb2_tables" lock.  The crash occurs because a concurrent schema-change is modifying the qdbs array.  This PR addresses by changing the structure to allow a systable to acquire multiple locks, and by acquiring both the 'comdb2_tables' and  'comdb2_queues' lock when accessing comdb2_metrics.