### PR TITLE
start needs to be at least a configurable number of hours in the future (default 24)

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -595,6 +595,7 @@ extern int gbl_transaction_grace_period;
 extern int gbl_partition_sc_reorder;
 extern int gbl_retro_tpt;
 extern int gbl_retro_tpt_verbose;
+extern int gbl_retro_tpt_start;
 extern int gbl_dohsql_joins;
 extern int gbl_altersc_latency;
 extern int gbl_altersc_delay_usec;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2534,6 +2534,10 @@ REGISTER_TUNABLE("partition_retroactively",
 REGISTER_TUNABLE("partition_retroactively_verbose",
                  "Disable/enable data routing debugging for retroactively time partitioning (Default: OFF)",
                  TUNABLE_BOOLEAN, &gbl_retro_tpt_verbose, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE(
+    "partition_retroactively_start",
+    "Block any retroactively time partitioning if start is earlier that that many hours in the future (Default: 24)",
+    TUNABLE_INTEGER, &gbl_retro_tpt_start, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("dohsql_joins", "Enable to support joins in parallel sql execution (default: on)", TUNABLE_BOOLEAN,
                  &gbl_dohsql_joins, 0, NULL, NULL, NULL, NULL);

--- a/db/views.c
+++ b/db/views.c
@@ -44,6 +44,7 @@ int gbl_partitioned_table_enabled = 1;
 int gbl_merge_table_enabled = 1;
 int gbl_retro_tpt = 1;
 int gbl_retro_tpt_verbose = 0;
+int gbl_retro_tpt_start = 24; /* default 24 hours in the future */
 
 struct timepart_shard {
     char *tblname; /* name of the table covering the shard, can be an alias */

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -45,6 +45,7 @@ extern int gbl_lightweight_rename;
 extern int gbl_transactional_drop_plus_rename;
 extern int gbl_gen_shard_verbose;
 extern int gbl_sc_protobuf;
+extern int gbl_retro_tpt_start;
 int gbl_view_feature = 1;
 int gbl_disable_sql_table_replacement = 0;
 
@@ -7891,6 +7892,18 @@ void comdb2CreateTimePartition(Parse* pParse, Token* period, Token* retention,
                                      (int32_t*)&partition->u.tpt.retention,
                                      (int64_t*)&partition->u.tpt.start)) {
         free_ddl_context(pParse);
+    }
+
+    /* if retroactively partitioning, make sure the start is one day in the future */
+    if (retro) {
+        time_t crtTime = time(NULL);
+        int startTime = partition->u.tpt.start;
+        if (gbl_retro_tpt_start > 0) {
+            if (crtTime >= (startTime - 3600 * gbl_retro_tpt_start)) {
+                setError(pParse, SQLITE_ABORT, "Bad start argument, please check partition_retroactively_start tunable");
+                return;
+            }
+        }
     }
 }
 

--- a/tests/timepart_retro.test/lrl.options
+++ b/tests/timepart_retro.test/lrl.options
@@ -1,3 +1,4 @@
 table t t.csc2
 init_with_genid48 0
 partition_retroactively_verbose 1
+partition_retroactively_start 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -704,6 +704,7 @@
 (name='parallel_sync', description='Run checkpoint/memptrickle code with parallel writes', type='BOOLEAN', value='ON', read_only='N')
 (name='participantid_bits', description='Number of bits allocated for the participant stripe ID (remaining bits are used for the update ID).', type='INTEGER', value='0', read_only='N')
 (name='partition_retroactively', description='Disable/enable time partition syntax to retroactively partition an existing table (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
+(name='partition_retroactively_start', description='Block any retroactively time partitioning if start is earlier that that many hours in the future (Default: 24)', type='INTEGER', value='24', read_only='N')
 (name='partition_retroactively_verbose', description='Disable/enable data routing debugging for retroactively time partitioning (Default: OFF)', type='BOOLEAN', value='OFF', read_only='N')
 (name='partition_sc_reorder', description='If the schema change is serialized for a partition, run current shard last', type='BOOLEAN', value='ON', read_only='N')
 (name='partitioned_table_enabled', description='Allow syntax create/alter table ... partitioned by ...', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
This is simply to prevent the case when clients choose a start time for retroactive time partition in the past.  Start is the next rollout, not the first rollout. 


