### PR TITLE
Fixing ufid-hash stale DB pointer

### DIFF
--- a/berkdb/btree/bt_open.c
+++ b/berkdb/btree/bt_open.c
@@ -299,6 +299,8 @@ __bam_metachk(dbp, name, btm)
 
 	/* Copy the file's ID. */
 	memcpy(dbp->fileid, btm->dbmeta.uid, DB_FILE_ID_LEN);
+    dbp->use_close_fileid = 0;
+	memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 
 	return (0);
 

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -1602,6 +1602,8 @@ struct __db {
 	u_int32_t open_flags;		/* Flags passed to DB->open. */
 
 	u_int8_t fileid[DB_FILE_ID_LEN];/* File's unique ID for locking. */
+	u_int8_t close_fileid[DB_FILE_ID_LEN]; /* File's unique ID for closing, if db_refresh is called. */
+	int use_close_fileid; /* 1 if db_close should use close_fileid */
 
 	u_int32_t adj_fileid;		/* File's unique ID for curs. adj. */
 

--- a/berkdb/db/db.c
+++ b/berkdb/db/db.c
@@ -1410,6 +1410,12 @@ never_opened:
 
 	MUTEX_THREAD_UNLOCK(dbenv, dbenv->dblist_mutexp);
 
+	/* Save the fileid for close, if not done already */
+	if (!dbp->use_close_fileid) {
+		memcpy(dbp->close_fileid, dbp->fileid, sizeof(dbp->fileid));
+		dbp->use_close_fileid = 1;
+	}
+
 	/* Clear out fields that normally get set during open. */
 	memset(dbp->fileid, 0, sizeof(dbp->fileid));
 	dbp->adj_fileid = 0;

--- a/berkdb/db/db_open.c
+++ b/berkdb/db/db_open.c
@@ -626,6 +626,8 @@ swap_retry:
 
 		/* Copy the file's ID. */
 		memcpy(dbp->fileid, ((DBMETA *)meta)->uid, DB_FILE_ID_LEN);
+		dbp->use_close_fileid = 0;
+		memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 
 		break;
 	default:

--- a/berkdb/db/db_rename.c
+++ b/berkdb/db/db_rename.c
@@ -324,6 +324,8 @@ __db_subdb_rename(dbp, txn, name, subdb, newname)
 	if ((ret = __memp_fget(mdbp->mpf, &dbp->meta_pgno, 0, &meta)) != 0)
 		goto err;
 	memcpy(dbp->fileid, ((DBMETA *)meta)->uid, DB_FILE_ID_LEN);
+	dbp->use_close_fileid = 0;
+	memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 	if ((ret = __fop_lock_handle(dbenv,
 	    dbp, mdbp->lid, DB_LOCK_WRITE, NULL, 0)) != 0)
 		goto err;

--- a/berkdb/dbreg/dbreg_rec.c
+++ b/berkdb/dbreg/dbreg_rec.c
@@ -344,18 +344,10 @@ __dbreg_register_recover(dbenv, dbtp, lsnp, op, info)
 					F_SET(dbp, DB_AM_DISCARD);
 
 				if (op == DB_TXN_ABORT &&
-				    !F_ISSET(dbp, DB_AM_RECOVER)) {
-					/*
-					 * The __db_refresh() call below will zap dbp->fileid.
-					 * __db_close() won't be able to find itself in ufid-hash,
-					 * leaving a stale DB pointer in ufid-hash.
-					 * So we must clear it here.
-					 */
-					if (dbp->added_to_ufid)
-						__ufid_clear_dbp(dbenv,  dbp);
+				    !F_ISSET(dbp, DB_AM_RECOVER))
 					t_ret = __db_refresh(dbp,
 					    NULL, DB_NOSYNC, NULL);
-				} else {
+				else {
 					if (op == DB_TXN_APPLY)
 						__db_sync(dbp);
 					t_ret =

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -398,10 +398,12 @@ __ufid_clear_dbp(dbenv, dbp)
 	DB_ENV *dbenv;
 	DB *dbp;
 {
+	u_int8_t *fileid;
 	struct __ufid_to_db_t *ufid;
 	dbp->added_to_ufid = 0;
 	Pthread_mutex_lock(&dbenv->ufid_to_db_lk);
-	if ((ufid = hash_find(dbenv->ufid_to_db_hash, dbp->fileid))) {
+	fileid = dbp->use_close_fileid ? dbp->close_fileid : dbp->fileid;
+	if ((ufid = hash_find(dbenv->ufid_to_db_hash, fileid)) != NULL) {
 		if (ufid->dbp) {
 			ufid->dbp->added_to_ufid = 0;
 		}
@@ -1158,6 +1160,8 @@ __dbreg_do_open(dbenv,
 	F_SET(dbp, DB_AM_RECOVER);
 	if (meta_pgno != PGNO_BASE_MD) {
 		memcpy(dbp->fileid, uid, DB_FILE_ID_LEN);
+		dbp->use_close_fileid = 0;
+		memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 		dbp->meta_pgno = meta_pgno;
 	}
 

--- a/berkdb/fileops/fop_util.c
+++ b/berkdb/fileops/fop_util.c
@@ -538,6 +538,8 @@ creat2:	if ((ret = __db_appname(dbenv,
 	/* Construct a file_id. */
 	if ((ret = __os_fileid(dbenv, real_tmpname, 1, dbp->fileid)) != 0)
 		goto errmsg;
+	dbp->use_close_fileid = 0;
+	memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 
 	if ((ret = __db_new_file(dbp, stxn, fhp, tmpname)) != 0)
 		goto err;
@@ -759,6 +761,8 @@ __fop_subdb_setup(dbp, txn, mname, name, mode, flags)
 	 */
 
 	memcpy(dbp->fileid, mdbp->fileid, DB_FILE_ID_LEN);
+	dbp->use_close_fileid = 0;
+	memset(dbp->close_fileid, 0, DB_FILE_ID_LEN);
 	if ((ret = __fop_lock_handle(dbenv, dbp,
 	    txn == NULL ? dbp->lid : txn->txnid,
 	    F_ISSET(dbp, DB_AM_CREATED) || LF_ISSET(DB_WRITEOPEN) ?
@@ -1126,6 +1130,8 @@ __fop_dummy(dbp, txn, old, new, flags)
 	if ((ret = db_create(&tmpdbp, dbenv, 0)) != 0)
 		goto err;
 	memcpy(&tmpdbp->fileid, ((DBMETA *)mbuf)->uid, DB_FILE_ID_LEN);
+	tmpdbp->use_close_fileid = 0;
+	memset(tmpdbp->close_fileid, 0, DB_FILE_ID_LEN);
 
 	/* Now, lock the name space while we initialize this file. */
 	if ((ret = __db_appname(dbenv,

--- a/db/config.c
+++ b/db/config.c
@@ -458,7 +458,7 @@ static char *legacy_options[] = {
     "sc_current_version 3",
     "disable_sql_table_replacement 1",
     "track_db_open 0",
-    "clear_ufid_on_db_close 0",
+    "clear_ufid_on_db_close 1",
     "get_peer_fqdn 0"
 };
 // clang-format on


### PR DESCRIPTION
We may leave a stale DB pointer in ufid-hash, after backing out from a schema change. This patch ensures that a DB pointer is removed from ufid-hash before its fileid is zapped.
