### PR TITLE
Failed recently because 'get_master' failed

### DIFF
--- a/tests/longreq_stats.test/runit
+++ b/tests/longreq_stats.test/runit
@@ -4,7 +4,7 @@ bash -n "$0" | exit 1
 . ${TESTSROOTDIR}/tools/cluster_utils.sh
 . ${TESTSROOTDIR}/tools/runit_common.sh
 
-#export debug=1
+export debug=1
 [[ $debug == "1" ]] && set -x
 
 function setup_longreq


### PR DESCRIPTION
The longreqs_stats test failed recently because its call to 'get_master' returned an empty string.  This PR enables debug-trace for that test.