### PR TITLE
Disable cache for physrep metadb

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -2715,6 +2715,25 @@ static void sockpool_close_all(void)
     for ((v) = TAILQ_FIRST(head); (v) && ((tmp) = TAILQ_NEXT((v), field), 1); (v) = (tmp))
 #endif
 
+/* Available in server builds (for diagnostics) and test builds (for unit tests) */
+#if defined(CDB2API_SERVER) || defined(CDB2API_TEST)
+int get_num_cached_connections_for(const char *dbname)
+{
+    char *typestr = alloca(strlen(dbname) + 3);
+    snprintf(typestr, strlen(dbname) + 3, "/%s/", dbname);
+    struct local_cached_connection *cc;
+    int nconn = 0;
+    pthread_mutex_lock(&local_connection_cache_lock);
+    TAILQ_FOREACH(cc, &local_connection_cache, local_cache_lnk)
+    {
+        if (strstr(cc->typestr, typestr))
+            nconn++;
+    }
+    pthread_mutex_unlock(&local_connection_cache_lock);
+    return nconn;
+}
+#endif
+
 #ifdef CDB2API_TEST
 
 void dump_cached_connections(void)
@@ -2739,24 +2758,10 @@ void dump_cached_connections(void)
     printf("hits %d missed %d evicts %d\n", num_cache_hits, num_cache_misses, num_cache_lru_evicts);
 }
 
-int get_num_cached_connections_for(const char *dbname)
-{
-    char typestr[20];
-    sprintf(typestr, "/%s/", dbname);
-    struct local_cached_connection *cc;
-    int nconn = 0;
-    TAILQ_FOREACH(cc, &local_connection_cache, local_cache_lnk)
-    {
-        if (strstr(cc->typestr, typestr))
-            nconn++;
-    }
-    return nconn;
-}
-
 int get_cached_connection_index(const char *dbname)
 {
-    char typestr[20];
-    sprintf(typestr, "/%s/", dbname);
+    char *typestr = alloca(strlen(dbname) + 3);
+    snprintf(typestr, strlen(dbname) + 3, "/%s/", dbname);
     struct local_cached_connection *cc;
     int nconn = 0;
     TAILQ_FOREACH(cc, &local_connection_cache, local_cache_lnk)
@@ -3043,6 +3048,10 @@ static int local_connection_cache_put_sbuf(const cdb2_hndl_tp *hndl, const char 
 
 static int local_connection_cache_put(const cdb2_hndl_tp *hndl, const char *typestr, COMDB2BUF *sb)
 {
+#ifdef CDB2API_SERVER
+    if (hndl->flags & CDB2_DISABLE_LOCAL_CACHE)
+        return 0;
+#endif
     if (local_connection_cache_use_sbuf)
         return local_connection_cache_put_sbuf(hndl, typestr, sb);
     return local_connection_cache_put_fd(hndl, typestr, sb);

--- a/cdb2api/cdb2api.h
+++ b/cdb2api/cdb2api.h
@@ -43,7 +43,10 @@ enum cdb2_hndl_alloc_flags {
     CDB2_REQUIRE_FASTSQL = 512,
     CDB2_MASTER = 1024,
     CDB2_ALLOW_INCOHERENT = 2048,
-    CDB2_SET_TAGGED = 4096
+    CDB2_SET_TAGGED = 4096,
+#ifdef CDB2API_SERVER
+    CDB2_DISABLE_LOCAL_CACHE = 8192,
+#endif
 };
 
 enum cdb2_request_type {

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -195,6 +195,32 @@ void physrep_alt_metadb_print(void)
     }
 }
 
+extern int get_num_cached_connections_for(const char *dbname);
+
+void physrep_metadb_cached_connections(void)
+{
+    int total = 0;
+    int count = 0;
+
+    /* Check main metadb */
+    if (gbl_physrep_metadb_name) {
+        count = get_num_cached_connections_for(gbl_physrep_metadb_name);
+        physrep_logmsg(LOGMSG_USER, "Cached connections to %s: %d\n", gbl_physrep_metadb_name, count);
+        total += count;
+    }
+
+    /* Check alternate metadbs */
+    for (int i = 0; i < gbl_altmetadb_count; i++) {
+        if (gbl_altmetadb[i].dbname) {
+            count = get_num_cached_connections_for(gbl_altmetadb[i].dbname);
+            physrep_logmsg(LOGMSG_USER, "Cached connections to %s: %d\n", gbl_altmetadb[i].dbname, count);
+            total += count;
+        }
+    }
+
+    physrep_logmsg(LOGMSG_USER, "Total cached metadb connections: %d\n", total);
+}
+
 void cleanup_hosts()
 {
     DB_Connection *cnct;
@@ -314,7 +340,7 @@ static int append_quoted_source_hosts(char *buf, int buf_len, int *rc) {
         cdb2_get_comdb2db(&comdb2dbname, &comdb2dbclass);
     }
 
-    *rc = cdb2_open(&comdb2db, comdb2dbname, comdb2dbclass, 0);
+    *rc = cdb2_open(&comdb2db, comdb2dbname, comdb2dbclass, CDB2_DISABLE_LOCAL_CACHE);
     if (*rc) {
         physrep_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (err: %s rc: %d)\n", __func__, __LINE__,
                        comdb2dbname, comdb2dbclass, cdb2_errstr(comdb2db), *rc);
@@ -360,7 +386,7 @@ err:
 }
 
 static int get_local_hndl(cdb2_hndl_tp **hndl) {
-    int rc = cdb2_open(hndl, gbl_dbname, "local", 0);
+    int rc = cdb2_open(hndl, gbl_dbname, "local", CDB2_DISABLE_LOCAL_CACHE);
     if (rc != 0) {
         physrep_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (rc: %d)\n",
                        __func__, __LINE__, gbl_dbname, "local", rc);
@@ -421,7 +447,7 @@ static int get_metadb_handle_int(cdb2_hndl_tp **hndl, char *dbname, char *host, 
             // Move to the next host for the next attempt
             *host_index = (*host_index + 1) % *host_count;
 
-            int rc = cdb2_open(hndl, dbname, direct_host, CDB2_DIRECT_CPU);
+            int rc = cdb2_open(hndl, dbname, direct_host, CDB2_DIRECT_CPU | CDB2_DISABLE_LOCAL_CACHE);
             if (rc != 0) {
                 physrep_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (rc: %d, attempt: %d)\n",
                                __func__, __LINE__, dbname, direct_host, rc, i+1);
@@ -456,7 +482,7 @@ static int get_metadb_handle_int(cdb2_hndl_tp **hndl, char *dbname, char *host, 
         return 1;
     }
 
-    int rc = cdb2_open(hndl, dbname, host, 0);
+    int rc = cdb2_open(hndl, dbname, host, CDB2_DISABLE_LOCAL_CACHE);
     if (rc != 0) {
         physrep_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (rc: %d)\n",
                        __func__, __LINE__, dbname, host, rc);
@@ -1000,7 +1026,7 @@ static DB_Connection *find_new_repl_db(cdb2_hndl_tp *repl_metadb, cdb2_hndl_tp *
                                __func__, __LINE__, cnct->hostname, cnct->dbname);
             }
 
-            rc = cdb2_open(repl_db, cnct->dbname, cnct->hostname, CDB2_DIRECT_CPU);
+            rc = cdb2_open(repl_db, cnct->dbname, cnct->hostname, CDB2_DIRECT_CPU | CDB2_DISABLE_LOCAL_CACHE);
             if (rc != 0) {
                 physrep_logmsg(LOGMSG_ERROR, "%s:%d: Couldn't connect to %s@%s (rc: %d error: %s)\n",
                                __func__, __LINE__, cnct->dbname,

--- a/db/phys_rep.h
+++ b/db/phys_rep.h
@@ -55,6 +55,7 @@ int physrep_fanout_get(const char *dbname);
 void physrep_fanout_dump(void);
 int physrep_add_alternate_metadb(char *dbname, char *host);
 void physrep_alt_metadb_print(void);
+void physrep_metadb_cached_connections(void);
 int physrep_allowed_source(const char *dbname, const char *hostname);
 
 #endif /* PHYS_REP_H */

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2286,6 +2286,8 @@ clipper_usage:
         have_overlap_check(plow, phigh, mylow, myhigh);
     } else if (tokcmp(tok, ltok, "physrep_alt_metadb_print") == 0) {
         physrep_alt_metadb_print();
+    } else if (tokcmp(tok, ltok, "physrep_cached_metadb_connections") == 0) {
+        physrep_metadb_cached_connections();
     } else if (tokcmp(tok, ltok, "refreshrevconn") == 0) {
         refresh_reverse_conn_hosts();
     } else if (tokcmp(tok, ltok, "leaktxn") == 0) {

--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -151,7 +151,7 @@ int replace_tier_by_hostname(reverse_conn_host_list_tp *new_reverse_conn_hosts) 
             cdb2_hndl_tp *hndl;
             int rc;
 
-            if ((rc = cdb2_open(&hndl, new_host->dbname, new_host->host, 0)) != 0) {
+            if ((rc = cdb2_open(&hndl, new_host->dbname, new_host->host, CDB2_DISABLE_LOCAL_CACHE)) != 0) {
                 revconn_logmsg(LOGMSG_ERROR, "%s:%d Failed to connect to %s@%s (rc: %d)\n", __func__, __LINE__, new_host->dbname, new_host->host, rc);
                 free_rev_conn_host(listc_rfl(&new_reverse_conn_hosts, new_host));
                 continue;

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -11,6 +11,9 @@ export comdb2ar=${COMDB2AR_EXE}
 
 export FIGLET=$(which figlet)
 
+# Enable local connection cache to test that physrep doesn't cache metadb connections
+export COMDB2_CONFIG_MAX_LOCAL_CONNECTION_CACHE_ENTRIES=10
+
 dbname=$1
 dgpid=0
 first=""
@@ -732,7 +735,7 @@ END
         # 2. Start instances
         for node in ${CLUSTER}; do
             logFile=$TESTDIR/logs/${_dbname}.${node}.log
-            ssh ${node} "$COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+            ssh ${node} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
             PIDs="${PIDs} $!"
         done
 
@@ -919,7 +922,7 @@ function setup_physrep_cluster()
         # 2. Start instances
         for node in ${CLUSTER}; do
             logFile=$TESTDIR/logs/${_dbname}.${node}.log
-            ssh ${node} "$COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+            ssh ${node} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${_dbname} --lrl ${_dbdir}/${_dbname}.lrl --pidfile ${_dbdir}/${_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
             PIDs="${PIDs} $!"
         done
 
@@ -977,7 +980,7 @@ function setup_alt_replicant()
     add_to_physrep_sources ${_altmeta_dbname2} ${_altmeta_host2} ${_cluster_dbname} ${_cluster_host} ${_alt_dbname} ${_alt_host}
 
     # Start the alt-replicant
-    ssh ${_alt_host} "$COMDB2_EXE ${_alt_dbname} --lrl ${_repl_dbdir}/${_alt_dbname}.lrl --pidfile ${_repl_dbdir}/${_alt_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+    ssh ${_alt_host} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${_alt_dbname} --lrl ${_repl_dbdir}/${_alt_dbname}.lrl --pidfile ${_repl_dbdir}/${_alt_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
     PIDs="${PIDs} $!"
 
     out=0
@@ -1077,7 +1080,7 @@ function setup_physrep_replicants()
                 ssh $node "echo \"machine_class mips\" >> ${_repl_dbdir}/${_repl_dbname}.lrl" 2>&1 < /dev/null
             fi
 
-            ssh ${node} "$COMDB2_EXE ${_repl_dbname} --lrl ${_repl_dbdir}/${_repl_dbname}.lrl --pidfile ${_repl_dbdir}/${_repl_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
+            ssh ${node} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${_repl_dbname} --lrl ${_repl_dbdir}/${_repl_dbname}.lrl --pidfile ${_repl_dbdir}/${_repl_dbname}.pid" >> ${logFile} 2>&1 < /dev/null &
             PIDs="${PIDs} $!"
 
             # Wait for the node to start
@@ -2141,6 +2144,22 @@ else                         # Cluster
     done
 fi
 
+# Create replicant_env_vars file for remote nodes
+# This file will be sourced when starting databases on remote machines via SSH
+cat > ${TESTDIR}/phys_rep_tiered_replicant_vars <<EOF
+export COMDB2_CONFIG_MAX_LOCAL_CONNECTION_CACHE_ENTRIES=10
+EOF
+
+# Copy to remote nodes if running in cluster mode
+if [[ -n "$CLUSTER" ]]; then
+    for node in $CLUSTER; do
+        scp ${TESTDIR}/phys_rep_tiered_replicant_vars ${node}:${TESTDIR}/ < /dev/null
+    done
+fi
+
+# Also set REP_ENV_VARS for the test
+export REP_ENV_VARS="${TESTDIR}/phys_rep_tiered_replicant_vars"
+
 # Setup both metadb and altmeta
 setup_physrep_metadb ${REPL_META_DBNAME} ${REPL_META_DBDIR}
 setup_physrep_metadb ${REPL_ALTMETA_DBNAME} ${REPL_ALTMETA_DBDIR}
@@ -2426,7 +2445,7 @@ function verify_non_ignored_reptype
 
     echo "Restart $exit_node"
     logFile=$TESTDIR/logs/${REPL_CLUS_DBNAME}.${exit_node}.log
-    ssh ${exit_node} "$COMDB2_EXE ${REPL_CLUS_DBNAME} --lrl ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.lrl --pidfile ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.pid" >> ${logFile} 2>&1 < /dev/null &
+    ssh ${exit_node} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${REPL_CLUS_DBNAME} --lrl ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.lrl --pidfile ${REPL_CLUS_DBDIR}/${REPL_CLUS_DBNAME}.pid" >> ${logFile} 2>&1 < /dev/null &
     PIDs="${PIDx} $!"
 
     echo "Block until $exit_node is available"
@@ -2721,6 +2740,107 @@ function physrep_metadb_sql_count_test
     echo "SUCCESS: Total metadb SQL count ($total_count) is within acceptable range (<= 2500)"
 }
 
+# Test that physrep is not holding cached connections to the metadb
+function physrep_no_cached_metadb_connections_test
+{
+    echo "== Checking for cached metadb connections =="
+    local found_cached=0
+    local node=""
+    local dbname=""
+    local output=""
+    local cached_count=0
+
+    # Check source database
+    echo "Checking source database: $DBNAME"
+    if [[ -z "$CLUSTER" ]]; then
+        node=$(hostname)
+    else
+        node="$firstNode"
+    fi
+
+    output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${DBNAME} --host ${node} "exec procedure sys.cmd.send('physrep_cached_metadb_connections')" 2>&1)
+    echo "$output"
+
+    # Parse total from output
+    if echo "$output" | grep -q "Total cached metadb connections:"; then
+        cached_count=$(echo "$output" | grep "Total cached metadb connections:" | awk '{print $NF}')
+        if [[ $cached_count -gt 0 ]]; then
+            echo "ERROR: Source database has $cached_count cached metadb connections"
+            found_cached=1
+        fi
+    fi
+
+    # Check replication cluster nodes
+    echo "Checking replication cluster: $REPL_CLUS_DBNAME"
+    if [[ -z "$CLUSTER" ]]; then
+        node=$(hostname)
+        output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${REPL_CLUS_DBNAME} --host ${node} "exec procedure sys.cmd.send('physrep_cached_metadb_connections')" 2>&1)
+        echo "$output"
+
+        if echo "$output" | grep -q "Total cached metadb connections:"; then
+            cached_count=$(echo "$output" | grep "Total cached metadb connections:" | awk '{print $NF}')
+            if [[ $cached_count -gt 0 ]]; then
+                echo "ERROR: Replication cluster node $node has $cached_count cached metadb connections"
+                found_cached=1
+            fi
+        fi
+    else
+        for node in $CLUSTER; do
+            output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${REPL_CLUS_DBNAME} --host ${node} "exec procedure sys.cmd.send('physrep_cached_metadb_connections')" 2>&1)
+            echo "$output"
+
+            if echo "$output" | grep -q "Total cached metadb connections:"; then
+                cached_count=$(echo "$output" | grep "Total cached metadb connections:" | awk '{print $NF}')
+                if [[ $cached_count -gt 0 ]]; then
+                    echo "ERROR: Replication cluster node $node has $cached_count cached metadb connections"
+                    found_cached=1
+                fi
+            fi
+        done
+    fi
+
+    # Check standalone physreps
+    echo "Checking standalone physreps"
+    if [[ -z "$CLUSTER" ]]; then
+        node=$(hostname)
+        dbname="${REPL_DBNAME_PREFIX}_${node}"
+        output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${dbname} --host ${node} "exec procedure sys.cmd.send('physrep_cached_metadb_connections')" 2>&1)
+        echo "$output"
+
+        if echo "$output" | grep -q "Total cached metadb connections:"; then
+            cached_count=$(echo "$output" | grep "Total cached metadb connections:" | awk '{print $NF}')
+            if [[ $cached_count -gt 0 ]]; then
+                echo "ERROR: Standalone physrep $dbname has $cached_count cached metadb connections"
+                found_cached=1
+            fi
+        fi
+    else
+        for node in $CLUSTER; do
+            dbname="${REPL_DBNAME_PREFIX}_${node}"
+            output=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} ${dbname} --host ${node} "exec procedure sys.cmd.send('physrep_cached_metadb_connections')" 2>&1)
+            echo "$output"
+
+            if echo "$output" | grep -q "Total cached metadb connections:"; then
+                cached_count=$(echo "$output" | grep "Total cached metadb connections:" | awk '{print $NF}')
+                if [[ $cached_count -gt 0 ]]; then
+                    echo "ERROR: Standalone physrep $dbname has $cached_count cached metadb connections"
+                    found_cached=1
+                fi
+            fi
+        done
+    fi
+
+    echo ""
+    echo "========================================="
+    if [[ $found_cached -eq 0 ]]; then
+        echo "SUCCESS: No cached metadb connections found"
+    else
+        cleanFailExit "FAILED: Found cached metadb connections (see errors above)"
+    fi
+    echo "========================================="
+    echo ""
+}
+
 function announce
 {
     typeset text=$1
@@ -2919,11 +3039,16 @@ function run_tests
     testcase_preamble $testcase
     physrep_metadb_sql_count_test
     testcase_finish $testcase
+
+    testcase="physrep_no_cached_metadb_connections"
+    testcase_preamble $testcase
+    physrep_no_cached_metadb_connections_test
+    testcase_finish $testcase
 }
 
 function run_one_test
 {
-    physrep_metadb_sql_count_test
+    physrep_no_cached_metadb_connections_test
 }
 
 run_tests


### PR DESCRIPTION
We saw an increased number of connections against the physrep metadb with the new software.  This PR disables handle/connection caching for the physrep metadb.
