### PR TITLE
{183405691}: Get identity only once per client

### DIFF
--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -2536,6 +2536,15 @@ void free_newsql_appdata(struct sqlclntstate *clnt)
 void *(*externalMakeNewsqlAuthData)(void *, CDB2SQLQUERY__IdentityBlob *id) = NULL;
 void (*externalFreeNewsqlAuthData)(void *) = NULL;
 
+static int newsql_free_authdata(struct sqlclntstate *clnt)
+{
+    if (clnt->authdata) {
+        externalFreeNewsqlAuthData(clnt->authdata);
+        clnt->authdata = NULL;
+    }
+    return 0;
+}
+
 static void *newsql_get_authdata(struct sqlclntstate *clnt)
 {
     struct newsql_appdata *appdata = clnt->appdata;
@@ -2551,27 +2560,25 @@ static void *newsql_get_authdata(struct sqlclntstate *clnt)
         }
 
     }
-    if (clnt->authdata) {
-        externalFreeNewsqlAuthData(clnt->authdata);
-        clnt->authdata = NULL;
-    }
+    newsql_free_authdata(clnt);
     return NULL;
 }
 
-static int newsql_free_authdata(struct sqlclntstate *clnt)
-{
-    if (clnt->authdata) {
-        externalFreeNewsqlAuthData(clnt->authdata);
-        clnt->authdata = NULL;
-    }
-    return 0;
-}
-
+/* Returns the identity in the current protocol buffer.
+   The identity is invalid after the request is processed
+   and the protobuf buffer is freed. */
 void *newsql_get_identity(struct sqlclntstate *clnt)
 {
-    // latch the identity in clnt, if not there already
-    newsql_get_authdata(clnt);
-    return clnt->externalAuthUser;
+    void *id = NULL;
+    struct newsql_appdata *appdata = clnt->appdata;
+
+    if (appdata) {
+        CDB2SQLQUERY *sql_query = appdata->sqlquery;
+        if (sql_query && sql_query->identity)
+            id = sql_query->identity->principal;
+    }
+
+    return id;
 }
 
 void newsql_setup_clnt(struct sqlclntstate *clnt)

--- a/plugins/newsql/newsql_evbuffer.c
+++ b/plugins/newsql/newsql_evbuffer.c
@@ -101,6 +101,22 @@ static int rd_evbuffer_ciphertext(struct newsql_appdata_evbuffer *);
 static void disable_ssl_evbuffer(struct newsql_appdata_evbuffer *);
 static int newsql_write_hdr_evbuffer(struct sqlclntstate *, int, int);
 
+static void inline free_pb_cdb2query(struct sqlclntstate *clnt, CDB2QUERY *query)
+{
+    struct newsql_appdata_evbuffer *appdata;
+
+    if (clnt == NULL || query == NULL)
+        return;
+
+    appdata = clnt->appdata;
+
+    /* clnt->externalAuthUser and appdata->sqlquery point into the protobuf memory.
+       ensure that they are cleared before freeing the memory */
+    appdata->sqlquery = NULL;
+    clnt->externalAuthUser = NULL;
+    cdb2__query__free_unpacked(query, &pb_alloc);
+}
+
 static void free_newsql_appdata_evbuffer(struct newsql_appdata_evbuffer *appdata)
 {
     check_thd(appdata->thd);
@@ -130,11 +146,7 @@ static void free_newsql_appdata_evbuffer(struct newsql_appdata_evbuffer *appdata
         disable_ssl_evbuffer(appdata);
         free(appdata->ssl_data);
     }
-    if (appdata->query) {
-        cdb2__query__free_unpacked(appdata->query, &pb_alloc);
-        appdata->query = NULL;
-        clnt->externalAuthUser = NULL;
-    }
+    free_pb_cdb2query(clnt, appdata->query);
     sqlwriter_free(appdata->writer);
     shutdown(fd, SHUT_RDWR);
     Close(fd);
@@ -167,11 +179,10 @@ static int newsql_done_cb(struct sqlclntstate *clnt)
     if (sql_done(appdata->writer) == 0) {
         if (clnt->added_to_hist) {
             clnt->added_to_hist = 0;
-        } else if (appdata->query) {
-            cdb2__query__free_unpacked(appdata->query, &pb_alloc);
+        } else {
+            free_pb_cdb2query(clnt, appdata->query);
         }
         appdata->query = NULL;
-        clnt->externalAuthUser = NULL;
         evtimer_once(appdata->base, rd_hdr, appdata);
     } else {
         appdata->cleanup_ev = event_new(appdata->base, -1, 0, newsql_cleanup, appdata);
@@ -730,8 +741,7 @@ static void process_query(struct newsql_appdata_evbuffer *appdata)
     int commit_rollback;
     if (newsql_should_dispatch(clnt, &commit_rollback) != 0) {
     read:
-        if (appdata->query)
-            cdb2__query__free_unpacked(appdata->query, &pb_alloc);
+        free_pb_cdb2query(clnt, appdata->query);
         appdata->query = NULL;
         evtimer_once(appdata->base, rd_hdr, appdata);
         return;
@@ -891,8 +901,7 @@ static void process_cdb2query(struct newsql_appdata_evbuffer *appdata, CDB2QUERY
     if (disttxn) {
         process_disttxn(appdata, disttxn);
     }
-    if (query)
-        cdb2__query__free_unpacked(query, &pb_alloc);
+    free_pb_cdb2query(&appdata->clnt, query);
 }
 
 static void add_rd_event_ssl(struct newsql_appdata_evbuffer *appdata, struct event *ev, struct timeval *t)
@@ -1105,6 +1114,10 @@ static void rd_hdr(int fd, short what, void *arg)
 {
     struct newsqlheader hdr;
     struct newsql_appdata_evbuffer *appdata = arg;
+
+    /* Free the protocol buffer from last query, if any */
+    free_pb_cdb2query(&appdata->clnt, appdata->query);
+
     if (evbuffer_get_length(appdata->rd_buf) >= sizeof(struct newsqlheader)) {
         goto hdr;
     }


### PR DESCRIPTION
Calling newsql_get_authdata() repeatedly leaks memory. Since newsql_get_identity() only cares about the cleartext principal, we don't need to allocate any authdata there at all.