### PR TITLE
Include identity attributes when cloning Comdb2

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -200,6 +200,10 @@ public class Comdb2Handle extends AbstractConnection {
         ret.hasSendStack = hasSendStack;
         ret.sendStack = sendStack;
 
+        ret.hasUseIdentity = hasUseIdentity;
+        ret.useIdentity = useIdentity;
+        ret.ic = ic;
+
         return ret;
     }
 


### PR DESCRIPTION
To help us review your pull request, please consider providing an overview of the following:
* What is the type of the change (bug fix, feature, documentation and etc.) ?
Bug fix

* What are the current behavior and expected behavior, if this is a bugfix ?
The connection is not using the provided identity when retrieving the connection metadata (via `connection.getMetaData()`)

* What are the steps required to reproduce the bug, if this is a bugfix ?
1. Open a connection using an identity,
2. Attempt to retrieve database metadata (e.g. by doing `connection.getMetaData().getPrimaryKeys(
        catalogPattern, schemaPattern, tablePattern)`)
