### PR TITLE
{183287032}: Fix REPLACE INTO to mark AUXDELETE for partial index deletes

### DIFF
--- a/sqlite/src/delete.c
+++ b/sqlite/src/delete.c
@@ -821,7 +821,11 @@ void sqlite3GenerateRowDelete(
     if( pParse->nested==0 || 0==sqlite3_stricmp(pTab->zName, "sqlite_stat1") ){
       sqlite3VdbeAppendP4(v, (char*)pTab, P4_TABLE);
     }
-    if( eMode!=ONEPASS_OFF ){
+#if defined(SQLITE_BUILDING_FOR_COMDB2)
+  if( eMode!=ONEPASS_OFF || (iIdxNoSeek>=0 && iIdxNoSeek!=iDataCur)){
+#else
+  if( eMode!=ONEPASS_OFF ){
+#endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
       sqlite3VdbeChangeP5(v, OPFLAG_AUXDELETE);
     }
     if( iIdxNoSeek>=0 && iIdxNoSeek!=iDataCur ){

--- a/tests/partial_index.test/Makefile
+++ b/tests/partial_index.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/partial_index.test/runit
+++ b/tests/partial_index.test/runit
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+dbnm=$1
+
+r="cdb2sql ${CDB2_OPTIONS} $dbnm default"
+
+assert_eq() {
+    local actual="$1" expected="$2" msg="$3"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "FAIL: $msg"
+        echo "  expected: $expected"
+        echo "  actual:   $actual"
+        exit 1
+    fi
+}
+
+# =====================================================
+# Case 1: One primary key, one partial key, both unique      
+# =====================================================
+
+$r 'create table t1 {
+schema
+{
+	int         id
+	int         id2            null=yes
+	int         is_active      dbstore=0
+    int         day
+}
+keys
+{
+	"PRIMARY_KEY"                       = id
+	uniqnulls "COLLECTION_IS_ACTIVE"    = id2 + is_active {where is_active = 1}
+}
+}
+'
+
+# --------- Test 1.1: Primary key conflict ---------
+
+$r "INSERT OR REPLACE INTO t1(id, day) VALUES(7, 1)"
+out=$($r "SELECT * FROM t1" 2>&1)
+assert_eq "$out" "(id=7, id2=NULL, is_active=0, day=1)" "Test 1.1: initial insert"
+
+$r "INSERT OR REPLACE INTO t1(id, day) VALUES(7, 2)"
+out=$($r "SELECT * FROM t1" 2>&1)
+assert_eq "$out" "(id=7, id2=NULL, is_active=0, day=2)" "Test 1.1: replace on primary key"
+
+# Verify with explicit commit
+$r - <<'EOF'
+BEGIN
+INSERT OR REPLACE INTO t1(id, day) VALUES(7, 3)
+COMMIT
+EOF
+out=$($r "SELECT * FROM t1" 2>&1)
+assert_eq "$out" "(id=7, id2=NULL, is_active=0, day=3)" "Test 1.1: replace on primary key with explicit commit"
+
+# --------- Test 1.2: Partial key conflict ---------
+
+$r "INSERT OR REPLACE INTO t1(id, id2, is_active, day) VALUES(8, 15, 1, 1)"
+out=$($r "SELECT * FROM t1 WHERE is_active = 1" 2>&1)
+assert_eq "$out" "(id=8, id2=15, is_active=1, day=1)" "Test 1.2: insert with partial key"
+
+$r "INSERT OR REPLACE INTO t1(id, id2, is_active, day) VALUES(9, 15, 1, 2)"
+out=$($r "SELECT * FROM t1 WHERE is_active = 1" 2>&1)
+assert_eq "$out" "(id=9, id2=15, is_active=1, day=2)" "Test 1.2: replace on partial key"
+
+# --------- Test 1.3: Both primary and partial key conflict ---------
+
+# Conflict with one record on primary key and one on partial key
+$r "INSERT OR REPLACE INTO t1(id, id2, is_active, day) VALUES(7, 15, 1, 3)"
+out=$($r "SELECT * FROM t1" 2>&1)
+assert_eq "$out" "(id=7, id2=15, is_active=1, day=3)" "Test 1.3: replace on both primary and partial key"
+
+# =====================================
+# Case 2: Two partial keys, both unique
+# =====================================
+
+$r 'create table t2 {
+schema
+{
+	int         id1            null=yes
+	int         id2            null=yes
+	int         is_active1     dbstore=0
+	int         is_active2     dbstore=0
+    int         day
+}
+keys {
+	uniqnulls "COLLECTION_IS_ACTIVE1"    = id1 + is_active1 {where is_active1 = 1}
+	uniqnulls "COLLECTION_IS_ACTIVE2"    = id2 + is_active2 {where is_active2 = 1}
+}
+}
+'
+
+# --------- Test 2.1: One partial key conflict ---------
+
+$r "INSERT OR REPLACE INTO t2(id1, is_active1, day) VALUES(13, 1, 1)"
+out=$($r "SELECT * FROM t2" 2>&1)
+assert_eq "$out" "(id1=13, id2=NULL, is_active1=1, is_active2=0, day=1)" "Test 2.1: insert with one partial key"
+
+$r "INSERT OR REPLACE INTO t2(id1, is_active1, day) VALUES(13, 1, 2)"
+out=$($r "SELECT * FROM t2" 2>&1)
+assert_eq "$out" "(id1=13, id2=NULL, is_active1=1, is_active2=0, day=2)" "Test 2.1: replace on one partial key"
+
+# --------- Test 2.2: Both partial keys conflict ---------
+
+$r "INSERT OR REPLACE INTO t2(id2, is_active2, day) VALUES(15, 1, 3)"
+out=$($r "SELECT * FROM t2 WHERE is_active2 = 1" 2>&1)
+assert_eq "$out" "(id1=NULL, id2=15, is_active1=0, is_active2=1, day=3)" "Test 2.2: insert with second partial key"
+
+$r "INSERT OR REPLACE INTO t2(id1, id2, is_active1, is_active2, day) VALUES(13, 15, 1, 1, 4)"
+out=$($r "SELECT * FROM t2" 2>&1)
+assert_eq "$out" "(id1=13, id2=15, is_active1=1, is_active2=1, day=4)" "Test 2.2: replace on both partial keys"
+
+# =============================================
+# Case 3: Two partial keys, one unique, one not
+# =============================================
+
+$r 'create table t3 {
+schema
+{
+	int         id1            null=yes
+	int         id2            null=yes
+	int         is_active1     dbstore=0
+	int         is_active2     dbstore=0
+    int         day
+}
+keys {
+	uniqnulls "COLLECTION_IS_ACTIVE1" = id1 + is_active1 {where is_active1 = 1}
+	dup "COLLECTION_IS_ACTIVE2"       = id2 + is_active2 {where is_active2 = 1}
+}
+}
+'
+
+# --------- Test 3.1: Unique partial key conflict ---------
+
+$r "INSERT OR REPLACE INTO t3(id1, is_active1, day) VALUES(21, 1, 1)"
+out=$($r "SELECT * FROM t3" 2>&1)
+assert_eq "$out" "(id1=21, id2=NULL, is_active1=1, is_active2=0, day=1)" "Test 3.1: insert with unique partial key"
+
+$r "INSERT OR REPLACE INTO t3(id1, is_active1, day) VALUES(21, 1, 2)"
+out=$($r "SELECT * FROM t3" 2>&1)
+assert_eq "$out" "(id1=21, id2=NULL, is_active1=1, is_active2=0, day=2)" "Test 3.1: replace on unique partial key"
+
+# --------- Test 3.2: Non-unique partial key, no conflict ---------
+
+$r "INSERT OR REPLACE INTO t3(id2, is_active2, day) VALUES(23, 1, 3)"
+out=$($r "SELECT * FROM t3 WHERE is_active2 = 1" 2>&1)
+assert_eq "$out" "(id1=NULL, id2=23, is_active1=0, is_active2=1, day=3)" "Test 3.2: insert with non-unique partial key"
+
+$r "INSERT OR REPLACE INTO t3(id2, is_active2, day) VALUES(23, 1, 4)"
+out=$($r "SELECT * FROM t3 WHERE is_active2 = 1 ORDER BY day" 2>&1)
+expected=$'(id1=NULL, id2=23, is_active1=0, is_active2=1, day=3)\n(id1=NULL, id2=23, is_active1=0, is_active2=1, day=4)'
+assert_eq "$out" "$expected" "Test 3.2: non-unique partial key allows duplicate"
+
+# =====================================================================
+# Case 4: One primary key, two partial keys, one unique, one not unique
+# =====================================================================
+
+$r 'create table t4 {
+schema
+{
+	int         id
+	int         id1            null=yes
+	int         id2            null=yes
+	int         is_active1     dbstore=0
+	int         is_active2     dbstore=0
+    int         day
+}
+keys {
+	"PRIMARY_KEY"                     = id
+	uniqnulls "COLLECTION_IS_ACTIVE1" = id1 + is_active1 {where is_active1 = 1}
+	dup "COLLECTION_IS_ACTIVE2"       = id2 + is_active2 {where is_active2 = 1}
+}
+}
+'
+
+# --------- Test 4.1: Primary key conflict ---------
+
+$r "INSERT OR REPLACE INTO t4(id, id2, is_active2, day) VALUES(31, 15, 1, 1)"
+out=$($r "SELECT * FROM t4" 2>&1)
+assert_eq "$out" "(id=31, id1=NULL, id2=15, is_active1=0, is_active2=1, day=1)" "Test 4.1: initial insert"
+
+$r "INSERT OR REPLACE INTO t4(id, id2, is_active2, day) VALUES(31, 15, 1, 2)"
+out=$($r "SELECT * FROM t4" 2>&1)
+assert_eq "$out" "(id=31, id1=NULL, id2=15, is_active1=0, is_active2=1, day=2)" "Test 4.1: replace on primary key"
+
+# Verify with explicit commit
+$r - <<'EOF'
+BEGIN
+INSERT OR REPLACE INTO t4(id, id2, is_active2, day) VALUES(31, 15, 1, 3)
+COMMIT
+EOF
+out=$($r "SELECT * FROM t4" 2>&1)
+assert_eq "$out" "(id=31, id1=NULL, id2=15, is_active1=0, is_active2=1, day=3)" "Test 4.1: replace on primary key with explicit commit"
+
+# --------- Test 4.2: Unique partial key conflict ---------
+
+$r "INSERT OR REPLACE INTO t4(id, id1, is_active1, id2, is_active2, day) VALUES(32, 75, 1, 15, 1, 4)"
+out=$($r "SELECT * FROM t4 WHERE is_active1 = 1" 2>&1)
+assert_eq "$out" "(id=32, id1=75, id2=15, is_active1=1, is_active2=1, day=4)" "Test 4.2: insert with unique partial key"
+
+$r "INSERT OR REPLACE INTO t4(id, id1, is_active1, id2, is_active2, day) VALUES(33, 75, 1, 15, 1, 5)"
+out=$($r "SELECT * FROM t4 WHERE is_active1 = 1" 2>&1)
+assert_eq "$out" "(id=33, id1=75, id2=15, is_active1=1, is_active2=1, day=5)" "Test 4.2: replace on unique partial key"
+
+# --------- Test 4.3: Both primary key and unique partial key conflict (match two different records) ---------
+
+$r "INSERT OR REPLACE INTO t4(id, id1, is_active1, id2, is_active2, day) VALUES(31, 75, 1, 15, 1, 6)"
+out=$($r "SELECT * FROM t4" 2>&1)
+assert_eq "$out" "(id=31, id1=75, id2=15, is_active1=1, is_active2=1, day=6)" "Test 4.3: replace on both primary and unique partial key"
+
+# --------- Test 4.4: Both primary key and non-unique partial key conflict (match one record) ---------
+
+$r "INSERT OR REPLACE INTO t4(id, id1, is_active1, id2, is_active2, day) VALUES(31, 75, 1, 15, 1, 7)"
+out=$($r "SELECT * FROM t4" 2>&1)
+assert_eq "$out" "(id=31, id1=75, id2=15, is_active1=1, is_active2=1, day=7)" "Test 4.4: replace on primary and non-unique partial key"


### PR DESCRIPTION
## Problem

When `INSERT OR REPLACE INTO` encounters a uniqueness conflict on an index, the VDBE generates inline conflict resolution that deletes the conflicting row. For example, when a conflict is found on `PRIMARY_KEY`:

```
 27 [     NoConflict]: If cursor [2] does not contain R11, then jump to 38
 ...
 35 [      IdxDelete]: Delete key in R18..R20 from index "COLLECTION_IS_ACTIVE" using cursor [1]
 36 [         Delete]: Delete current record from cursor [0] on table "t1"
 37 [         Delete]: Delete current record from cursor [2] on index "PRIMARY_KEY"
```

Line 35 uses `IdxDelete` because cursor [1] is not positioned on the old row's entry — it must look up the key by value. Line 37 uses `Delete` (positional) because `NoConflict` at line 27 already positioned cursor [2] on the conflicting entry.

The problem is that line 36 (the data row delete) is **not** marked with `OPFLAG_AUXDELETE`. In `delete.c:825`, `AUXDELETE` is only set when `eMode != ONEPASS_OFF` or `iIdxNoSeek >= 0 && iIdxNoSeek != iDataCur`. For REPLACE INTO conflict resolution, `eMode` is always `ONEPASS_OFF` (we cannot change it to `ONEPASS_SINGLE`/`ONEPASS_MULTI` without breaking data cursor positioning).

Without `AUXDELETE`, line 36 is treated as the primary delete and triggers `osql_delrec`, which computes `del_keys` without accounting for the fact that the VDBE is handling index deletions explicitly. Line 37 (the positional `Delete` on the index cursor) does not update `del_keys`, so the `PRIMARY_KEY` deletion is never reflected in the bitmask sent to the block processor. The block processor's `del_record` then uses the incorrect `del_keys`, fails to remove the old `PRIMARY_KEY` index entry, and the subsequent `delayed_key_adds` fails with a duplicate key constraint (RC 2).

Note: The issue also reproduces without a partial index — line 35 simply wouldn't be executed in that case, but the missing `AUXDELETE` flag on line 36 still causes line 37's index deletion to be lost.

## Fix

Mark the data delete (line 36) with `OPFLAG_AUXDELETE` when it is part of REPLACE INTO conflict resolution and the conflicting index cursor will be deleted separately (line 37). This ensures `del_keys` is updated correctly to include all indexes whose keys are being explicitly deleted by the VDBE.

## Note

During investigation, I found that autocommit REPLACE INTO upgrades from the default SOSQL level to read committed before execution. This is necessary because the VDBE processes each row independently: for every row, it emits OP_NoConflict against each unique index to detect conflicts, deletes any conflicting rows, and then inserts the new one.

In SOSQL, cursors are opened with BDB_OPEN_REAL and cannot see their own writes. Consider:

```sql
CREATE TABLE t (a INT UNIQUE, b TEXT);
REPLACE INTO t VALUES (1, 'hello'), (1, 'world');
```

After (1, 'hello') is inserted, the subsequent OP_NoConflict for (1, 'world') seeks the index for a=1. In SOSQL, `bdb_cursor_find_merge` only searches the real btree (STEP 1) and skips the shadow btree (STEP 3, because `cur->sd` is NULL). It finds no conflict, so the VDBE skips the delete and issues a second insert with `a=1`. The master then fails with a duplicate key violation.

Upgrading to read committed opens cursors with `BDB_OPEN_BOTH_CREATE`, which enables shadow merging. The insert of `(1, 'hello')` is recorded in the shadow index tables via `osql_save_insrec` → `insert_record_indexes`, and `check_shadows` is set. When the cursor seeks `a=1` for the second row, STEP 3 of `bdb_cursor_find_merge` finds the shadow entry and returns `IX_FND`. The VDBE sees the conflict, deletes `(1, 'hello')`, and inserts `(1, 'world')` — resolving the conflict correctly.