### PR TITLE
Blkseq commitlsn

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2204,15 +2204,19 @@ int bdb_create_private_blkseq(bdb_state_type *bdb_state);
 int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe);
 int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data, int datalen,
                       void **dtaout, int *lenout, int overwrite);
+int bdb_blkseq_commitlsn_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data,
+                                int datalen, void **dtaout, int *lenout, int overwrite);
+int bdb_blkseq_update_commitlsn(bdb_state_type *bdb_state, void *key, int klen, int file, int offset);
 int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key,
                     int klen, void **dtaout, int *lenout);
+int bdb_blkseq_commitlsn_find(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void **dtaout,
+                              int *lenout);
 void bdb_blkseq_dumpall(bdb_state_type *bdb_state);
 int bdb_recover_blkseq(bdb_state_type *bdb_state);
 int bdb_blkseq_dumplogs(bdb_state_type *bdb_state);
 int bdb_blkseq_can_delete_log(bdb_state_type *bdb_state, int lognum);
 void bdb_blkseq_for_each(bdb_state_type *bdb_state, void *arg,
-                         void (*func)(int, int, void *, void *, void *,
-                                      void *));
+                         void (*func)(int, int, void *, void *, void *, void *, void *));
 
 /* low level calls to add things to a single btree for debugging and emergency
  * repair */
@@ -2362,6 +2366,7 @@ int bdb_first_user_get(bdb_state_type *bdb_state, tran_type *tran,
 int bdb_next_user_get(bdb_state_type *bdb_state, tran_type *tran, char *key,
                       char *user_out, int *isop, int *bdberr);
 int bdb_latest_commit_is_durable(void *bdb_state);
+int bdb_blkseq_is_durable(void *in_bdb_state, void *blkseq, int seqlen);
 int bdb_is_standalone(void *dbenv, void *in_bdb_state);
 int bdb_valid_lease(void *bdb_state);
 

--- a/bdb/bdb_blkseq.c
+++ b/bdb/bdb_blkseq.c
@@ -41,13 +41,13 @@
 #include "locks.h"
 
 extern int blkseq_get_rcode(void *data, int datalen);
-extern int dist_txn_abort_write_blkseq(void *bdb_state, void *bskey, int bskeylen);
+extern int dist_txn_abort_write_blkseq(void *bdb_state, void *bskey, int bskeylen, void *commitlsn, int commitlsn_sz);
 static int bdb_blkseq_update_lsn_locked(bdb_state_type *bdb_state,
                                         int timestamp, DB_LSN lsn, int stripe);
 
 extern int gbl_is_physical_replicant;
 
-static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
+static DB *create_blkseq_int(bdb_state_type *bdb_state, int stripe, int num, const char *inname)
 {
     char fname[1024];
     DB *db;
@@ -62,8 +62,7 @@ static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
         logmsg(LOGMSG_ERROR, "blkseq create rc %d\n", rc);
         return NULL;
     }
-    snprintf(fname, sizeof(fname), "%s/_blkseq.%d.%d.XXXXXX", bdb_state->tmpdir,
-             stripe, num);
+    snprintf(fname, sizeof(fname), "%s/%s.%d.%d.XXXXXX", bdb_state->tmpdir, inname, stripe, num);
     fd = mkstemp(fname);
     if (fd == -1) {
         logmsg(LOGMSG_ERROR, "mkstemp rc %d %s\n", errno, strerror(errno));
@@ -87,6 +86,16 @@ static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
     return db;
 }
 
+static DB *create_blkseq(bdb_state_type *bdb_state, int stripe, int num)
+{
+    return create_blkseq_int(bdb_state, stripe, num, "_blkseq");
+}
+
+static DB *create_blkseq_commitlsns(bdb_state_type *bdb_state, int stripe, int num)
+{
+    return create_blkseq_int(bdb_state, stripe, num, "_blkseq_commitlsns");
+}
+
 void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
 {
     if (!bdb_state) 
@@ -97,6 +106,8 @@ void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
             Pthread_mutex_destroy(&bdb_state->blkseq_lk[stripe]);
             for (int i = 0; i < 2; i++) {
                 DB *to_be_deleted = bdb_state->blkseq[i][stripe];
+                to_be_deleted->close(to_be_deleted, DB_NOSYNC);
+                to_be_deleted = bdb_state->blkseq_commitlsns[i][stripe];
                 to_be_deleted->close(to_be_deleted, DB_NOSYNC);
             }
 
@@ -118,9 +129,17 @@ void bdb_cleanup_private_blkseq(bdb_state_type *bdb_state)
         free(bdb_state->blkseq[0]);
         bdb_state->blkseq[0] = NULL;
     }
+    if (bdb_state->blkseq_commitlsns[0]) {
+        free(bdb_state->blkseq_commitlsns[0]);
+        bdb_state->blkseq_commitlsns[0] = NULL;
+    }
     if (bdb_state->blkseq[1]) {
         free(bdb_state->blkseq[1]);
         bdb_state->blkseq[1] = NULL;
+    }
+    if (bdb_state->blkseq_commitlsns[1]) {
+        free(bdb_state->blkseq_commitlsns[1]);
+        bdb_state->blkseq_commitlsns[1] = NULL;
     }
     if (bdb_state->blkseq_last_lsn[0]) {
         free(bdb_state->blkseq_last_lsn[0]);
@@ -149,6 +168,8 @@ int bdb_create_private_blkseq(bdb_state_type *bdb_state)
     bdb_state->blkseq_lk = malloc(nstripes * sizeof(pthread_mutex_t));
     bdb_state->blkseq[0] = malloc(nstripes * sizeof(DB *));
     bdb_state->blkseq[1] = malloc(nstripes * sizeof(DB *));
+    bdb_state->blkseq_commitlsns[0] = malloc(nstripes * sizeof(DB *));
+    bdb_state->blkseq_commitlsns[1] = malloc(nstripes * sizeof(DB *));
     bdb_state->blkseq_last_lsn[0] = malloc(nstripes * sizeof(DB_LSN));
     bdb_state->blkseq_last_lsn[1] = malloc(nstripes * sizeof(DB_LSN));
     bdb_state->blkseq_last_roll_time = malloc(nstripes * sizeof(time_t));
@@ -184,6 +205,9 @@ int bdb_create_private_blkseq(bdb_state_type *bdb_state)
             bdb_state->blkseq[i][stripe] = create_blkseq(bdb_state, stripe, i);
             if (bdb_state->blkseq[i][stripe] == NULL)
                 return -1;
+            bdb_state->blkseq_commitlsns[i][stripe] = create_blkseq_commitlsns(bdb_state, stripe, i);
+            if (bdb_state->blkseq_commitlsns[i][stripe] == NULL)
+                return -1;
             bzero(&bdb_state->blkseq_last_lsn[i][stripe], sizeof(DB_LSN));
         }
         listc_init(&bdb_state->blkseq_log_list[stripe],
@@ -206,6 +230,8 @@ static uint8_t get_stripe(bdb_state_type *bdb_state, uint8_t *bytes, int len)
     return stripe % bdb_state->pvt_blkseq_stripes;
 }
 
+extern __thread DB_LSN commit_lsn;
+
 /* recovery callback from berkeley (through bdb_apprec) */
 int bdb_blkseq_recover(DB_ENV *dbenv, u_int32_t rectype, llog_blkseq_args *args,
                        DB_LSN *lsn, db_recops op)
@@ -213,6 +239,7 @@ int bdb_blkseq_recover(DB_ENV *dbenv, u_int32_t rectype, llog_blkseq_args *args,
     int rc = 0;
     bdb_state_type *bdb_state;
     uint8_t stripe;
+    DBT commitlsn = {0};
 
     bdb_state = dbenv->app_private;
 
@@ -238,6 +265,9 @@ int bdb_blkseq_recover(DB_ENV *dbenv, u_int32_t rectype, llog_blkseq_args *args,
         return (0);
     }
 
+    commitlsn.data = &commit_lsn;
+    commitlsn.size = sizeof(commit_lsn);
+
     if (op == DB_TXN_APPLY || op == DB_TXN_FORWARD_ROLL) {
         stripe =
             get_stripe(bdb_state, (uint8_t *)args->key.data, args->key.size);
@@ -250,6 +280,9 @@ int bdb_blkseq_recover(DB_ENV *dbenv, u_int32_t rectype, llog_blkseq_args *args,
         rc = bdb_state->blkseq[0][stripe]->put(bdb_state->blkseq[0][stripe],
                 NULL, &args->key,
                 &args->data, DB_NOOVERWRITE);
+
+        bdb_state->blkseq_commitlsns[0][stripe]->put(bdb_state->blkseq_commitlsns[0][stripe], NULL, &args->key,
+                                                     &commitlsn, DB_NOOVERWRITE);
         if (rc == 0) {
             bdb_state->blkseq_last_lsn[0][stripe] = *lsn;
             rc = bdb_blkseq_update_lsn_locked(bdb_state, args->time, *lsn,
@@ -270,9 +303,11 @@ int bdb_blkseq_recover(DB_ENV *dbenv, u_int32_t rectype, llog_blkseq_args *args,
         Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
         rc = bdb_state->blkseq[0][stripe]->del(bdb_state->blkseq[0][stripe],
                                                NULL, &args->key, 0);
+        bdb_state->blkseq_commitlsns[0][stripe]->del(bdb_state->blkseq_commitlsns[0][stripe], NULL, &args->key, 0);
         if (rc == 0 || rc == DB_NOTFOUND) {
             rc = bdb_state->blkseq[1][stripe]->del(bdb_state->blkseq[1][stripe],
                                                    NULL, &args->key, 0);
+            bdb_state->blkseq_commitlsns[1][stripe]->del(bdb_state->blkseq_commitlsns[1][stripe], NULL, &args->key, 0);
             if (rc == DB_NOTFOUND)
                 rc = 0;
         }
@@ -320,8 +355,8 @@ static int bdb_blkseq_update_lsn_locked(bdb_state_type *bdb_state,
     return 0;
 }
 
-int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key,
-                    int klen, void **dtaout, int *lenout)
+static int bdb_blkseq_find_int(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void **dtaout,
+                               int *lenout, int iscommitlsn)
 {
     DBT dkey = {0}, ddata = {0};
     int rc;
@@ -334,8 +369,13 @@ int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key,
     dkey.data = key;
     dkey.size = klen;
     for (int i = 0; i < 2; i++) {
-        rc = bdb_state->blkseq[i][stripe]->get(bdb_state->blkseq[i][stripe],
-                                               NULL, &dkey, &ddata, 0);
+        if (!iscommitlsn) {
+            rc = bdb_state->blkseq[i][stripe]->get(bdb_state->blkseq[i][stripe], NULL, &dkey, &ddata, 0);
+        } else {
+            rc = bdb_state->blkseq_commitlsns[i][stripe]->get(bdb_state->blkseq_commitlsns[i][stripe], NULL, &dkey,
+                                                              &ddata, 0);
+        }
+
         if (rc == 0) {
             if (dtaout)
                 *dtaout = ddata.data;
@@ -352,12 +392,23 @@ int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key,
     return IX_NOTFND;
 }
 
+int bdb_blkseq_find(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void **dtaout, int *lenout)
+{
+    return bdb_blkseq_find_int(bdb_state, tran, key, klen, dtaout, lenout, 0);
+}
+
+int bdb_blkseq_commitlsn_find(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void **dtaout,
+                              int *lenout)
+{
+    return bdb_blkseq_find_int(bdb_state, tran, key, klen, dtaout, lenout, 1);
+}
+
 /*
  * TODO: create 'distributed-abort' blkseq response & update blkseq when
  * we see a dist_abort log-record.
  */
-int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data, int datalen,
-                      void **dtaout, int *lenout, int overwrite)
+static int bdb_blkseq_insert_int(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data,
+                                 int datalen, void **dtaout, int *lenout, int overwrite, int is_commitlsn)
 {
     DBT dkey = {0}, ddata = {0};
     DB_LSN lsn;
@@ -383,8 +434,12 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int
     now = comdb2_time_epoch();
 
     for (int i = 0; i < 2; i++) {
-        rc = bdb_state->blkseq[i][stripe]->get(bdb_state->blkseq[i][stripe],
-                                               NULL, &dkey, &ddata, 0);
+        if (is_commitlsn) {
+            rc = bdb_state->blkseq_commitlsns[i][stripe]->get(bdb_state->blkseq_commitlsns[i][stripe], NULL, &dkey,
+                                                              &ddata, 0);
+        } else {
+            rc = bdb_state->blkseq[i][stripe]->get(bdb_state->blkseq[i][stripe], NULL, &dkey, &ddata, 0);
+        }
         if (rc == 0) {
             if (overwrite) {
                 write_ix = i;
@@ -412,7 +467,12 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int
     /* not found in either tree - put it in the first */
     int flags = overwrite ? 0 : DB_NOOVERWRITE;
 
-    rc = bdb_state->blkseq[write_ix][stripe]->put(bdb_state->blkseq[write_ix][stripe], NULL, &dkey, &ddata, flags);
+    if (is_commitlsn) {
+        rc = bdb_state->blkseq_commitlsns[write_ix][stripe]->put(bdb_state->blkseq_commitlsns[write_ix][stripe], NULL,
+                                                                 &dkey, &ddata, flags);
+    } else {
+        rc = bdb_state->blkseq[write_ix][stripe]->put(bdb_state->blkseq[write_ix][stripe], NULL, &dkey, &ddata, flags);
+    }
     if (rc) {
         logmsg(LOGMSG_ERROR, "blkseq put stripe %d error %d\n", stripe, rc);
         Pthread_mutex_unlock(&bdb_state->blkseq_lk[stripe]);
@@ -421,7 +481,7 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int
 
     /* succeded in updating local table, log the update if transactional
      * (recovery isn't) */
-    if (tran) {
+    if (tran && !is_commitlsn) {
         if (!gbl_is_physical_replicant)
             rc = llog_blkseq_log(bdb_state->dbenv, tran->tid, &lsn, 0, now,
                                  &dkey, &ddata);
@@ -439,13 +499,32 @@ int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int
     return rc;
 }
 
+int bdb_blkseq_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data, int datalen,
+                      void **dtaout, int *lenout, int overwrite)
+{
+    return bdb_blkseq_insert_int(bdb_state, tran, key, klen, data, datalen, dtaout, lenout, overwrite, 0);
+}
+
+int bdb_blkseq_commitlsn_insert(bdb_state_type *bdb_state, tran_type *tran, void *key, int klen, void *data,
+                                int datalen, void **dtaout, int *lenout, int overwrite)
+{
+    return bdb_blkseq_insert_int(bdb_state, tran, key, klen, data, datalen, dtaout, lenout, overwrite, 1);
+}
+
+int bdb_blkseq_update_commitlsn(bdb_state_type *bdb_state, void *key, int klen, int file, int offset)
+{
+    DB_LSN lsn = {.file = file, .offset = offset};
+    return bdb_blkseq_commitlsn_insert(bdb_state, NULL, key, klen, &lsn, sizeof(lsn), NULL, NULL, 1);
+}
+
 /* Every N seconds, we shift all the trees down and delete the oldest */
 static int bdb_blkseq_clean_int(bdb_state_type *bdb_state, uint8_t stripe)
 {
     time_t now, last;
-    DB *to_be_deleted;
-    DB *newdb;
-    char *oldname = NULL;
+    DB *to_be_deleted, *to_be_deleted2;
+    DB *newdb, *newdb2;
+    char *oldname = NULL, *oldname2 = NULL;
+    ;
     int rc = 0;
     DB_ENV *env;
     int start, end;
@@ -504,12 +583,24 @@ static int bdb_blkseq_clean_int(bdb_state_type *bdb_state, uint8_t stripe)
         goto done;
     }
 
+    /* create commitlsns */
+    newdb2 = create_blkseq_commitlsns(bdb_state, stripe, 0);
+    if (newdb2 == NULL) {
+        rc = BDBERR_MISC;
+        goto done;
+    }
+
     /* swap pointers */
     to_be_deleted = bdb_state->blkseq[1][stripe];
+    to_be_deleted2 = bdb_state->blkseq_commitlsns[1][stripe];
+
     bdb_state->blkseq[1][stripe] = bdb_state->blkseq[0][stripe];
     bdb_state->blkseq[0][stripe] = newdb;
-    bdb_state->blkseq_last_lsn[1][stripe] = bdb_state->blkseq_last_lsn[0][stripe];
 
+    bdb_state->blkseq_commitlsns[1][stripe] = bdb_state->blkseq_commitlsns[0][stripe];
+    bdb_state->blkseq_commitlsns[0][stripe] = newdb2;
+
+    bdb_state->blkseq_last_lsn[1][stripe] = bdb_state->blkseq_last_lsn[0][stripe];
     bdb_state->blkseq_last_roll_time[stripe] = now;
 
     /* Clean up the old blkseq file. Get its name, close it, delete it. */
@@ -523,6 +614,15 @@ static int bdb_blkseq_clean_int(bdb_state_type *bdb_state, uint8_t stripe)
         oldname = strdup(oldname);
 
     to_be_deleted->close(to_be_deleted, DB_NOSYNC);
+
+    rc = to_be_deleted2->get_dbname(to_be_deleted2, (const char **)&oldname2, NULL);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "can't find filename of blkseq-commitlsns table\n");
+    } else {
+        oldname2 = strdup(oldname2);
+    }
+
+    to_be_deleted2->close(to_be_deleted2, DB_NOSYNC);
 
     if (oldname) {
         DB *db;
@@ -542,6 +642,26 @@ static int bdb_blkseq_clean_int(bdb_state_type *bdb_state, uint8_t stripe)
             goto done;
         }
     }
+
+    if (oldname2) {
+        DB *db;
+        env = bdb_state->blkseq_env[stripe];
+
+        rc = db_create(&db, env, 0);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "blkseq create rc %d\n", rc);
+            rc = BDBERR_MISC;
+            goto done;
+        }
+
+        rc = db->remove(db, oldname2, NULL, 0);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "db->remove %s rc %d\n", oldname2, rc);
+            rc = BDBERR_MISC;
+            goto done;
+        }
+    }
+
     if (bdb_state->attr->private_blkseq_close_warn_time) {
         end = comdb2_time_epochms();
         if ((end - start) > bdb_state->attr->private_blkseq_close_warn_time) {
@@ -553,6 +673,8 @@ done:
     Pthread_mutex_unlock(&bdb_state->blkseq_lk[stripe]);
     if (oldname)
         free(oldname);
+    if (oldname2)
+        free(oldname2);
 
     return rc;
 }
@@ -566,16 +688,14 @@ int bdb_blkseq_clean(bdb_state_type *bdb_state, uint8_t stripe)
     return rc;
 }
 
-static int bdb_blkseq_stripe_for_each(bdb_state_type *bdb_state, uint8_t stripe,
-                                      void *arg,
-                                      void (*func)(int, int, void *, void *,
-                                                   void *, void *))
+static int bdb_blkseq_stripe_for_each(bdb_state_type *bdb_state, uint8_t stripe, void *arg,
+                                      void (*func)(int, int, void *, void *, void *, void *, void *))
 {
-    DBC *dbc = NULL;
-    DBT dkey = {0}, ddata = {0};
-    int rc;
+    DBC *dbc = NULL, *dbc2 = NULL;
+    DBT dkey = {0}, ddata = {0}, ddata2 = {0};
+    int rc, rc2;
 
-    dkey.flags = ddata.flags = DB_DBT_REALLOC;
+    dkey.flags = ddata.flags = ddata2.flags = DB_DBT_REALLOC;
     Pthread_mutex_lock(&bdb_state->blkseq_lk[stripe]);
 
     for (int i = 0; i < 2; i++) {
@@ -583,10 +703,15 @@ static int bdb_blkseq_stripe_for_each(bdb_state_type *bdb_state, uint8_t stripe,
                                                   NULL, &dbc, 0);
         if (rc)
             goto done;
+        rc2 = bdb_state->blkseq_commitlsns[i][stripe]->cursor(bdb_state->blkseq_commitlsns[i][stripe], NULL, &dbc2, 0);
+        if (rc2)
+            goto done;
         rc = dbc->c_get(dbc, &dkey, &ddata, DB_FIRST);
         while (rc == 0) {
-            func(stripe, i, &(bdb_state->blkseq_last_lsn[i][stripe]), &dkey,
-                 &ddata, arg);
+            void *commitlsn;
+            rc2 = dbc2->c_get(dbc2, &dkey, &ddata2, DB_SET);
+            commitlsn = (rc2 == 0) ? ddata2.data : NULL;
+            func(stripe, i, &(bdb_state->blkseq_last_lsn[i][stripe]), &dkey, &ddata, commitlsn, arg);
             rc = dbc->c_get(dbc, &dkey, &ddata, DB_NEXT);
         }
         if (rc) {
@@ -597,6 +722,8 @@ static int bdb_blkseq_stripe_for_each(bdb_state_type *bdb_state, uint8_t stripe,
         }
         dbc->c_close(dbc);
         dbc = NULL;
+        dbc2->c_close(dbc2);
+        dbc2 = NULL;
     }
 
 done:
@@ -607,12 +734,16 @@ done:
         free(ddata.data);
     if (dbc)
         dbc->c_close(dbc);
+    if (ddata2.data)
+        free(ddata2.data);
+    if (dbc2)
+        dbc2->c_close(dbc2);
 
     return rc;
 }
 
 void bdb_blkseq_for_each(bdb_state_type *bdb_state, void *arg,
-                         void (*func)(int, int, void *, void *, void *, void *))
+                         void (*func)(int, int, void *, void *, void *, void *, void *))
 {
     int rc = 0;
     int nstripes =
@@ -626,12 +757,14 @@ void bdb_blkseq_for_each(bdb_state_type *bdb_state, void *arg,
     }
 }
 
-static void dump_blkseq(int stripe, int ix, void *plsn, void *pkey, void *pdata,
-                        void *arg)
+static void dump_blkseq(int stripe, int ix, void *plsn, void *pkey, void *pdata, void *incommitlsn, void *arg)
 {
     DB_LSN *lsn = plsn;
     DBT *key = pkey;
     DBT *data = pdata;
+    DB_LSN *commitlsn = incommitlsn ? (DB_LSN *)incommitlsn : NULL;
+    int commitlsn_file = commitlsn ? commitlsn->file : -1;
+    int commitlsn_offset = commitlsn ? commitlsn->offset : -1;
     int now;
     now = comdb2_time_epoch();
 
@@ -652,16 +785,15 @@ static void dump_blkseq(int stripe, int ix, void *plsn, void *pkey, void *pdata,
             memcpy(p, key->data, key->size);
             p[key->size] = '\0';
             logmsg(LOGMSG_USER,
-                   "stripe %d idx %d last_lsn=[%d][%d]: %s sz %d age %d rcode "
+                   "stripe %d idx %d last_lsn=[%d][%d] commit_lsn=[%d][%d]: %s sz %d age %d rcode "
                    "%d\n",
-                   stripe, ix, lsn->file, lsn->offset, p, data->size, age,
-                   rcode);
+                   stripe, ix, lsn->file, lsn->offset, commitlsn_file, commitlsn_offset, p, data->size, age, rcode);
         } else {
             logmsg(LOGMSG_USER,
-                   "stripe %d idx %d last_lsn=[%d][%d]: %x %x %x sz %d age %d "
+                   "stripe %d idx %d last_lsn=[%d][%d] commit_lsn=[%d][%d]: %x %x %x sz %d age %d "
                    "rcode %d\n",
-                   stripe, ix, lsn->file, lsn->offset, k[0], k[1], k[2],
-                   data->size, age, rcode);
+                   stripe, ix, lsn->file, lsn->offset, commitlsn_file, commitlsn_offset, k[0], k[1], k[2], data->size,
+                   age, rcode);
         }
     }
 }
@@ -692,6 +824,7 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
     int last_log_filenum;
     int oldest_blkseq;
     struct seen_blkseq *logseq;
+    DB_LSN commitlsn = {0};
 
     /* Walk the log file list backwards, stop when we get to blkseqs older than
      * we care about. */
@@ -715,6 +848,7 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
             normalize_rectype(&rectype);
 
             if (rectype == DB___txn_dist_abort) {
+                commitlsn = lsn;
                 bp = (((char*)logdta.data) + sizeof(u_int32_t) + sizeof(u_int32_t));
                 LOGCOPY_TOLSN(&bslsn, bp);
                 rc = logc->get(logc, &bslsn, &logdta, DB_SET);
@@ -727,13 +861,15 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
                             logmsg(LOGMSG_ERROR, "at " PR_LSN " __txn_dist_prepare_read rc %d\n", PARM_LSN(bslsn), rc);
                             goto err;
                         }
-                        dist_txn_abort_write_blkseq(bdb_state, prepare->blkseq_key.data, prepare->blkseq_key.size);
+                        dist_txn_abort_write_blkseq(bdb_state, prepare->blkseq_key.data, prepare->blkseq_key.size,
+                                                    &commitlsn, sizeof(commitlsn));
                     }
                 }
             } else if (rectype == DB___txn_regop || rectype == DB___txn_regop_gen ||
                        rectype == DB___txn_regop_rowlocks || rectype == DB___txn_dist_commit ||
                        rectype == DB___txn_regop_rowlocks_endianize || rectype == DB___txn_regop_gen_endianize) {
                 /* Skip past rectype & txnid */
+                commitlsn = lsn;
                 bp = (((char*)logdta.data) + sizeof(u_int32_t) + sizeof(u_int32_t));
                 LOGCOPY_TOLSN(&bslsn, bp);
                 rc = logc->get(logc, &bslsn, &logdta, DB_SET);
@@ -811,14 +947,18 @@ int bdb_recover_blkseq(bdb_state_type *bdb_state)
 
                         rc = bdb_blkseq_insert(bdb_state, NULL, blkseq->key.data, blkseq->key.size, blkseq->data.data,
                                                blkseq->data.size, NULL, NULL, 0);
-                        if (rc == IX_DUP)
+                        bdb_blkseq_commitlsn_insert(bdb_state, NULL, blkseq->key.data, blkseq->key.size, &commitlsn,
+                                                    sizeof(commitlsn), NULL, NULL, 1);
+
+                        if (rc == IX_DUP) {
                             ndupes++;
-                        else if (rc) {
+                        } else if (rc) {
                             logmsg(LOGMSG_ERROR, "at " PR_LSN " bdb_blkseq_insert %x %x %x rc %d\n", PARM_LSN(bslsn),
                                    k[0], k[1], k[2], rc);
                             goto err;
-                        } else
+                        } else {
                             nblkseq++;
+                        }
                         free(blkseq);
                         blkseq = NULL;
                     }

--- a/bdb/bdb_int.h
+++ b/bdb/bdb_int.h
@@ -1052,6 +1052,7 @@ struct bdb_state_tag {
     pthread_mutex_t *blkseq_lk;
     DB_ENV **blkseq_env;
     DB **blkseq[2];
+    DB **blkseq_commitlsns[2];
     time_t *blkseq_last_roll_time;
     DB_LSN *blkseq_last_lsn[2];
     listc_t *blkseq_log_list;

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -91,6 +91,7 @@ as long as there was a successful move in the past
 #include "thrman.h"
 
 #include "genid.h"
+#include "comdb2_atomic.h"
 
 //#define MERGE_DEBUG 1
 
@@ -2697,44 +2698,38 @@ done:
     bdb_state->dbenv->set_durable_lsn(bdb_state->dbenv, &found_lsn, generation);
 }
 
-int bdb_latest_commit_is_durable(void *in_bdb_state)
+static int bdb_commit_is_durable(bdb_state_type *bdb_state, DB_LSN commit_lsn, uint32_t commit_gen)
 {
     extern int gbl_durable_replay_test;
     char *master;
-    bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
     seqnum_type ss = {{0}};
     int timeoutms;
     int needwait = 0;
     int rc = 0;
     uint32_t durable_gen;
-    uint32_t latest_gen;
     DB_LSN durable_lsn;
-    DB_LSN latest_lsn;
 
     bdb_get_rep_master(bdb_state, &master, NULL, NULL);
-    bdb_latest_commit(bdb_state, &latest_lsn, &latest_gen);
     bdb_state->dbenv->get_durable_lsn(bdb_state->dbenv, &durable_lsn,
                                       &durable_gen);
 
-    logmsg(LOGMSG_INFO, "%s line %d master=%s latest-commit=[%d][%d] gen %d, "
-                        "latest-durable=[%d][%d] gen %d\n",
-           __func__, __LINE__, master, latest_lsn.file, latest_lsn.offset,
-           latest_gen, durable_lsn.file, durable_lsn.offset, durable_gen);
+    logmsg(LOGMSG_INFO,
+           "%s line %d master=%s check-commit=[%d][%d] gen %d, "
+           "latest-durable=[%d][%d] gen %d\n",
+           __func__, __LINE__, master, commit_lsn.file, commit_lsn.offset, commit_gen, durable_lsn.file,
+           durable_lsn.offset, durable_gen);
 
-    if (durable_gen < latest_gen) {
-        logmsg(LOGMSG_INFO,
-               "%s line %d waiting because durable_gen %d < latest_gen %d\n",
-               __func__, __LINE__, durable_gen, latest_gen);
+    if (durable_gen != commit_gen) {
+        logmsg(LOGMSG_INFO, "%s line %d waiting because durable_gen %d != commit_gen %d\n", __func__, __LINE__,
+               durable_gen, commit_gen);
         needwait = 1;
     }
 
-    if ((latest_gen == durable_gen) &&
-        log_compare(&durable_lsn, &latest_lsn) < 0) {
+    if ((commit_gen == durable_gen) && log_compare(&durable_lsn, &commit_lsn) < 0) {
         logmsg(LOGMSG_INFO,
-               "%s line %d waiting because durable_lsn [%d][%d] < latest_lsn "
+               "%s line %d waiting because durable_lsn [%d][%d] < commit_lsn "
                "[%d][%d]\n",
-               __func__, __LINE__, durable_lsn.file, durable_lsn.offset,
-               latest_lsn.file, latest_lsn.offset);
+               __func__, __LINE__, durable_lsn.file, durable_lsn.offset, commit_lsn.file, commit_lsn.offset);
         needwait = 1;
     }
 
@@ -2745,8 +2740,8 @@ int bdb_latest_commit_is_durable(void *in_bdb_state)
     }
 
     if (needwait) {
-        ss.lsn = latest_lsn;
-        ss.generation = latest_gen;
+        ss.lsn = commit_lsn;
+        ss.generation = commit_gen;
         rc = (bdb_wait_for_seqnum_from_all_adaptive_newcoh(bdb_state, &ss, 0,
                                                            &timeoutms) == 0)
                  ? 1
@@ -2759,6 +2754,38 @@ int bdb_latest_commit_is_durable(void *in_bdb_state)
     logmsg(LOGMSG_INFO, "%s line %d returning 1\n", __func__, __LINE__);
 
     return 1;
+}
+
+int bdb_latest_commit_is_durable(void *in_bdb_state)
+{
+    bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
+    uint32_t latest_gen;
+    DB_LSN latest_lsn;
+    bdb_latest_commit(bdb_state, &latest_lsn, &latest_gen);
+    return bdb_commit_is_durable(bdb_state, latest_lsn, latest_gen);
+}
+
+int64_t gbl_durable_blkseq_cnt = 0;
+int64_t gbl_durable_latest_cnt = 0;
+
+int bdb_blkseq_is_durable(void *in_bdb_state, void *blkseq, int seqlen)
+{
+    bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
+    DB_LSN lsn;
+    void *replay_data = NULL;
+    int replay_len, rc, ret;
+
+    rc = bdb_blkseq_commitlsn_find(bdb_state, NULL, blkseq, seqlen, &replay_data, &replay_len);
+    if (rc != IX_FND || replay_len != sizeof(DB_LSN)) {
+        if (replay_data)
+            free(replay_data);
+        ATOMIC_ADD64(gbl_durable_latest_cnt, 1);
+        return bdb_latest_commit_is_durable(in_bdb_state);
+    }
+    lsn = *(DB_LSN *)replay_data;
+    free(replay_data);
+    ATOMIC_ADD64(gbl_durable_blkseq_cnt, 1);
+    return bdb_commit_is_durable(bdb_state, lsn, 0);
 }
 
 int bdb_get_lsn_context_from_timestamp(bdb_state_type *bdb_state,

--- a/bdb/cursor.c
+++ b/bdb/cursor.c
@@ -2773,7 +2773,7 @@ int bdb_blkseq_is_durable(void *in_bdb_state, void *blkseq, int seqlen)
     bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
     DB_LSN lsn;
     void *replay_data = NULL;
-    int replay_len, rc, ret;
+    int replay_len, rc;
 
     rc = bdb_blkseq_commitlsn_find(bdb_state, NULL, blkseq, seqlen, &replay_data, &replay_len);
     if (rc != IX_FND || replay_len != sizeof(DB_LSN)) {

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3161,6 +3161,7 @@ int gbl_ignore_final_non_durable_retry = 1;
 
 int gbl_replicant_retry_on_not_durable = 0;
 int gbl_debug_force_non_durable = 0;
+int gbl_debug_random_non_durable_pct = 0;
 int gbl_assert_no_schemalk_in_distributed_commit = 0;
 
 int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state, seqnum_type *seqnum, int *timeoutms, int is_final)

--- a/berkdb/dbinc_auto/txn_ext.h
+++ b/berkdb/dbinc_auto/txn_ext.h
@@ -145,7 +145,7 @@ int __txn_rep_discard_recovered __P((DB_ENV *, const char *dist_txnid));
 int __txn_discard_recovered __P((DB_ENV *, const char *dist_txnid));
 int __txn_discard_all_recovered __P((DB_ENV *));
 int __rep_commit_dist_prepared __P((DB_ENV *, const char *dist_txnid));
-int __rep_abort_dist_prepared __P((DB_ENV *, const char *dist_txnid));
+int __rep_abort_dist_prepared __P((DB_ENV *, const char *dist_txnid, DB_LSN commitlsn));
 int __txn_prepared_collect_pp __P((DB_ENV *, collect_prepared_f, void *));
 int __txn_lowest_prepared_lsn __P((DB_ENV *, DB_LSN *lsn));
 

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -3865,7 +3865,7 @@ gap_check:		use_range = 0;
 		dist_txnid = alloca(dist_abort_args->dist_txnid.size + 1);
 		memcpy(dist_txnid, dist_abort_args->dist_txnid.data, dist_abort_args->dist_txnid.size);
 		dist_txnid[dist_abort_args->dist_txnid.size] = '\0';
-		if ((ret = __rep_abort_dist_prepared(dbenv, dist_txnid)) != 0) {
+		if ((ret = __rep_abort_dist_prepared(dbenv, dist_txnid, rp->lsn)) != 0) {
 			goto err;
 		}
 		__os_free(dbenv, dist_abort_args);

--- a/berkdb/txn/txn_util.c
+++ b/berkdb/txn/txn_util.c
@@ -35,7 +35,7 @@ void comdb2_cheapstack_sym(FILE *f, char *fmt, ...);
 /* TODO: callback funcs rather than layer-violation */
 int osql_blkseq_register_cnonce(void *cnonce, int len);
 int osql_blkseq_unregister_cnonce(void *cnonce, int len);
-int dist_txn_abort_write_blkseq(void *bdb_state, void *bskey, int bskeylen);
+int dist_txn_abort_write_blkseq(void *bdb_state, void *bskey, int bskeylen, void *commitlsn, int commitlsnlen);
 
 extern int set_commit_context_prepared(unsigned long long context);
 
@@ -1601,15 +1601,17 @@ int __txn_abort_recovered(dbenv, dist_txnid)
 	MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);
 
 	u_int64_t timestamp = comdb2_time_epoch();
+    DB_LSN commitlsn;
 
 	if ((ret = __txn_dist_abort_log(dbenv, p->txnp, &p->txnp->last_lsn, 0, gen, timestamp, &dtxnid)) != 0) {
 		logmsg(LOGMSG_FATAL, "Error writing dist-abort for txn %s, LSN %d:%d\n", p->dist_txnid,
 			p->prev_lsn.file, p->prev_lsn.offset);
 		abort();
 	}
+    commitlsn = p->txnp->last_lsn;
 
 	/* Write blkseq record for aborted prepare */
-	dist_txn_abort_write_blkseq(dbenv->app_private, p->blkseq_key.data, p->blkseq_key.size);
+	dist_txn_abort_write_blkseq(dbenv->app_private, p->blkseq_key.data, p->blkseq_key.size, &commitlsn, sizeof(DB_LSN));
 
 	/* Unregister cnonce */
 	osql_blkseq_unregister_cnonce(p->blkseq_key.data, p->blkseq_key.size);
@@ -1886,11 +1888,12 @@ int __rep_commit_dist_prepared(dbenv, dist_txnid)
  * Replication saw a dist-abort for this prepared txn.	Write the blkseq
  * and remove it from the prepared-txn list.
  *
- * PUBLIC: int __rep_abort_dist_prepared __P((DB_ENV *, const char *, ));
+ * PUBLIC: int __rep_abort_dist_prepared __P((DB_ENV *, const char *, DB_LSN commitlsn));
  */
-int __rep_abort_dist_prepared(dbenv, dist_txnid)
+int __rep_abort_dist_prepared(dbenv, dist_txnid, commitlsn)
 	DB_ENV *dbenv;
 	const char *dist_txnid;
+    DB_LSN commitlsn;
 {
 #if defined (DEBUG_PREPARE)
 	comdb2_cheapstack_sym(stderr, "%s", __func__);
@@ -1912,7 +1915,7 @@ int __rep_abort_dist_prepared(dbenv, dist_txnid)
 #endif
 	}
 
-	dist_txn_abort_write_blkseq(dbenv->app_private, p->blkseq_key.data, p->blkseq_key.size);
+	dist_txn_abort_write_blkseq(dbenv->app_private, p->blkseq_key.data, p->blkseq_key.size, &commitlsn, sizeof(DB_LSN));
 	assert(!F_ISSET(p, DB_DIST_HAVELOCKS));
 	__free_prepared_txn(dbenv, p);
 	return 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2188,6 +2188,7 @@ int trans_commit_adaptive(struct ireq *iq, void *trans, char *source_host);
 int trans_commit_logical(struct ireq *iq, void *trans, char *source_host,
                          int timeoutms, int adaptive, void *blkseq, int blklen,
                          void *blkkey, int blkkeylen);
+int blkseq_update_commitlsn(struct ireq *iq);
 int trans_abort(struct ireq *iq, void *trans);
 int trans_abort_priority(struct ireq *iq, void *trans, int *priority);
 int trans_abort_logical(struct ireq *iq, void *trans, void *blkseq, int blklen,

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -112,6 +112,8 @@ struct comdb2_metrics_store {
     double watchdog_time;
     int64_t distributed_commits;
     int64_t not_durable_commits;
+    int64_t durable_blkseq_cnt;
+    int64_t durable_latest_cnt;
     int64_t incoherent_slow_skips;
     int64_t inmem_repdb_memory;
     int64_t physrep_metadb_sql_count;
@@ -318,6 +320,10 @@ comdb2_metric gbl_metrics[] = {
      &stats.distributed_commits, NULL},
     {"not_durable_commits", "Number of not durable commits", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE,
      &stats.not_durable_commits, NULL},
+    {"durable_blkseq_cnt", "Replay-durability count filled by private blkseq", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.durable_blkseq_cnt, NULL},
+    {"durable_latest_cnt", "Replay-durability count filled by private latest", STATISTIC_INTEGER,
+     STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.durable_latest_cnt, NULL},
     {"disabled_incoherent_slows", "Disabled incoherent-slow count", STATISTIC_INTEGER,
      STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.incoherent_slow_skips, NULL},
     {"inmem_repdb_memory", "Memory utilized by in-memory repdb", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_LATEST,
@@ -447,6 +453,8 @@ int64_t gbl_fastsql_execute_stop;
 
 extern int64_t gbl_distributed_commit_count;
 extern int64_t gbl_not_durable_commit_count;
+extern int64_t gbl_durable_blkseq_cnt;
+extern int64_t gbl_durable_latest_cnt;
 extern int64_t gbl_incoherent_slow_skips;
 extern int64_t gbl_inmem_repdb_memory;
 extern int64_t gbl_physrep_metadb_sql_count;
@@ -661,6 +669,8 @@ int refresh_metrics(void)
     stats.watchdog_time = time_metric_average(thedb->watchdog_time);
     stats.distributed_commits = gbl_distributed_commit_count;
     stats.not_durable_commits = gbl_not_durable_commit_count;
+    stats.durable_blkseq_cnt = gbl_durable_blkseq_cnt;
+    stats.durable_latest_cnt = gbl_durable_latest_cnt;
     stats.incoherent_slow_skips = gbl_incoherent_slow_skips;
     stats.inmem_repdb_memory = gbl_inmem_repdb_memory;
     stats.physrep_metadb_sql_count = gbl_physrep_metadb_sql_count;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -483,6 +483,7 @@ extern int gbl_debug_sleep_in_summarize;
 extern int gbl_debug_sleep_in_trigger_info;
 extern int gbl_replicant_retry_on_not_durable;
 extern int gbl_debug_force_non_durable;
+extern int gbl_debug_random_non_durable_pct;
 extern int gbl_ignore_final_non_durable_retry;
 extern int gbl_enable_internal_sql_stmt_caching;
 extern int gbl_longreq_log_freq_sec;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2356,6 +2356,11 @@ REGISTER_TUNABLE("replicant_retry_on_not_durable", "Replicant retries non-durabl
 REGISTER_TUNABLE("debug_force_non_durable", "Debug tunable which makes all commits not durable.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_debug_force_non_durable, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("debug_random_non_durable_pct",
+                 "Debug: Percentage chance (0-100) to randomly return non-durable from blkseq durability check. "
+                 "Used for testing retry mechanism.  (Default: 0)",
+                 TUNABLE_INTEGER, &gbl_debug_random_non_durable_pct, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("hide_non_durable_rcode", "Hide non-durable rcode from clients.  (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_ignore_final_non_durable_retry, 0, NULL, NULL, NULL, NULL);
 

--- a/db/glue.c
+++ b/db/glue.c
@@ -811,6 +811,21 @@ static void make_tag(struct ireq *iq, char *tag, int taglen)
     tag[taglen - 1] = '\0';
 }
 
+int blkseq_update_commitlsn(struct ireq *iq)
+{
+    void *bskey;
+    int bskeylen;
+
+    if (IQ_HAS_SNAPINFO_KEY(iq)) {
+        bskey = IQ_SNAPINFO(iq)->key;
+        bskeylen = IQ_SNAPINFO(iq)->keylen;
+    } else {
+        bskey = iq->seq;
+        bskeylen = iq->seqlen;
+    }
+    return bdb_blkseq_update_commitlsn(thedb->bdb_env, bskey, bskeylen, iq->commit_file, iq->commit_offset);
+}
+
 static int trans_commit_int(struct ireq *iq, void *trans, char *source_host, int timeoutms, int adaptive, int logical,
                             void *blkseq, int blklen, void *blkkey, int blkkeylen, int release_schema_lk, int nowait)
 {

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -901,6 +901,7 @@ int dist_txn_abort_write_blkseq(void *in_bdb_state, void *bskey, int bskeylen, v
 }
 
 extern int gbl_debug_force_non_durable;
+extern int gbl_debug_random_non_durable_pct;
 
 static inline int durable_change_rcode(struct ireq *iq)
 {
@@ -916,6 +917,14 @@ static inline int durable_change_rcode(struct ireq *iq)
     /* Return normal rcode if retry-on-not-durable disabled */
     if (!gbl_replicant_retry_on_not_durable) {
         return 0;
+    }
+
+    /* Debug: randomly return NOT_DURABLE to trigger retries and test blkseq_commitlsn */
+    if (gbl_debug_random_non_durable_pct > 0) {
+        int r = rand() % 100;
+        if (r < gbl_debug_random_non_durable_pct) {
+            return 1; /* Force NOT_DURABLE return code */
+        }
     }
 
     /* Return NOT_DURABLE if ignore-final-retry disabled */

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -881,7 +881,7 @@ int prepare_dist_abort_blkseq(uint8_t *buf_fstblk, int *outlen)
     return 0;
 }
 
-int dist_txn_abort_write_blkseq(void *in_bdb_state, void *bskey, int bskeylen)
+int dist_txn_abort_write_blkseq(void *in_bdb_state, void *bskey, int bskeylen, void *commitlsn, int commitlsn_sz)
 {
     bdb_state_type *bdb_state = (in_bdb_state ? in_bdb_state : thedb->bdb_env);
     uint8_t buf_fstblk[FSTBLK_MAX_BUF_LEN];
@@ -891,7 +891,13 @@ int dist_txn_abort_write_blkseq(void *in_bdb_state, void *bskey, int bskeylen)
         return rc;
     }
     assert(outlen <= FSTBLK_MAX_BUF_LEN);
-    return bdb_blkseq_insert(bdb_state, NULL, bskey, bskeylen, buf_fstblk, outlen, NULL, NULL, 1);
+    if ((rc = bdb_blkseq_insert(bdb_state, NULL, bskey, bskeylen, buf_fstblk, outlen, NULL, NULL, 1)) != 0) {
+        logmsg(LOGMSG_ERROR, "%s: error %d inserting blkseq\n", __func__, rc);
+    }
+    if (commitlsn_sz > 0) {
+        rc = bdb_blkseq_commitlsn_insert(bdb_state, NULL, bskey, bskeylen, commitlsn, commitlsn_sz, NULL, NULL, 1);
+    }
+    return rc;
 }
 
 extern int gbl_debug_force_non_durable;
@@ -943,12 +949,12 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
 
     int blkseq_line = 0;
     int datalen = replay_data_len - 4;
+    int need_free = 0;
 
     if (!replay_data) {
 
         if (!IQ_HAS_SNAPINFO(iq)) {
-            assert( (seqlen == (sizeof(fstblkseq_t))) || 
-                    (seqlen == (sizeof(uuid_t))));
+            assert((seqlen == (sizeof(fstblkseq_t))) || (seqlen == (sizeof(uuid_t))));
         }
 
         rc = bdb_blkseq_find(thedb->bdb_env, NULL, fstseqnum, seqlen,
@@ -956,6 +962,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
         if (rc == IX_FND) {
             memcpy(buf_fstblk, replay_data, replay_data_len - 4);
             datalen = replay_data_len - 4;
+            need_free = 1;
         }
     }
 
@@ -1248,7 +1255,7 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
     int force_non_durable = non_durable_retry && gbl_debug_force_non_durable;
 
     if ((bdb_attr_get(thedb->bdb_attr, BDB_ATTR_DURABLE_LSNS) || non_durable_retry) &&
-        (!bdb_latest_commit_is_durable(thedb->bdb_env) || force_non_durable)) {
+        (!bdb_blkseq_is_durable(thedb->bdb_env, fstseqnum, seqlen) || force_non_durable)) {
         if (IQ_HAS_SNAPINFO_KEY(iq)) {
             logmsg(LOGMSG_ERROR,
                    "%u replay rc changed from %d to NOT_DURABLE for blkseq '%s'\n",
@@ -1264,12 +1271,16 @@ static int do_replay_case(struct ireq *iq, void *fstseqnum, int seqlen,
                iq->sorese ? iq->sorese->rcout : 0);
     }
     blkseq_replay_count++;
+    if (need_free)
+        free(replay_data);
     return outrc;
 
 replay_error:
     logmsg(LOGMSG_ERROR, "%s:%d in REPLAY ERROR\n", __func__, blkseq_line);
     if (check_long_trn) {
         outrc = RC_TRAN_CLIENT_RETRY;
+        if (need_free)
+            free(replay_data);
         return outrc;
     }
     struct block_rsp errrsp;
@@ -1278,6 +1289,8 @@ replay_error:
 
     outrc = ERR_BLOCK_FAILED;
     blkseq_replay_error_count++;
+    if (need_free)
+        free(replay_data);
     return outrc;
 }
 
@@ -2844,7 +2857,7 @@ static inline void debug_prepare_tests(struct ireq *iq, tran_type *parent_trans,
     if (!prepared || debug_prepared_should_commit()) {
         trans_commit_adaptive(iq, parent_trans, source_host);
     } else if (prepared && debug_prepared_should_abort()) {
-        dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen);
+        dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen, NULL, 0);
         trans_abort(iq, parent_trans);
     } else {
         assert(gbl_all_prepare_leak);
@@ -3141,6 +3154,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
                 outrc = do_replay_case(iq, IQ_SNAPINFO(iq)->key,
                                        IQ_SNAPINFO(iq)->keylen, num_reqs, 0,
                                        replay_data, replay_len, __LINE__);
+                if (replay_data)
+                    free(replay_data);
                 bdb_rellock(thedb->bdb_env, __func__, __LINE__);
 #if DEBUG_DID_REPLAY
                 did_replay = 1;
@@ -3148,6 +3163,8 @@ static int toblock_main_int(struct javasp_trans_state *javasp_trans_handle, stru
                 fromline = __LINE__;
                 goto cleanup;
             }
+            if (replay_data)
+                free(replay_data);
             bdb_rellock(thedb->bdb_env, __func__, __LINE__);
         }
 
@@ -5835,7 +5852,7 @@ add_blkseq:
                                 }
 
                                 /* Prepare failed to reach a majority of the cluster: fail the txn */
-                                dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen);
+                                dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen, NULL, 0);
                                 trans_abort(iq, parent_trans);
 
                                 /* Wrote & replicated prepare record */
@@ -5863,6 +5880,7 @@ add_blkseq:
                                     prepared_count--;
                                     Pthread_mutex_unlock(&blklk);
                                     irc = trans_commit_adaptive(iq, parent_trans, source_host);
+                                    blkseq_update_commitlsn(iq);
                                     if (iq->sorese->is_coordinator) {
                                         if (gbl_coordinator_wait_propagate) {
                                             coordinator_wait_propagate(iq->sorese->dist_txnid);
@@ -5897,13 +5915,15 @@ add_blkseq:
                                                __func__, __LINE__, iq->sorese->dist_txnid, iq->sorese->is_coordinator,
                                                iq->sorese->is_participant, err.errcode, outrc, iq->errstat.errstr);
                                     }
+                                    trans_abort(iq, parent_trans);
                                     if ((outrc == ERR_NOTSERIAL ||
                                          (outrc == ERR_BLOCK_FAILED && err.errcode == ERR_VERIFY)) &&
                                         can_retry) {
+                                        /*
+                                         */
                                     } else {
-                                        dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen);
+                                        dist_txn_abort_write_blkseq(thedb->bdb_env, bskey, bskeylen, NULL, 0);
                                     }
-                                    trans_abort(iq, parent_trans);
 
                                     /* Downgrade, but disttxn commit record hasn't replicated */
                                 } else {
@@ -5981,9 +6001,11 @@ add_blkseq:
                                                        iq->errstat.errstr);
                             }
                             irc = trans_commit_adaptive(iq, parent_trans, source_host);
+                            blkseq_update_commitlsn(iq);
                         }
                     } else if (!debug_prepare_testcase()) {
                         irc = trans_commit_adaptive(iq, parent_trans, source_host);
+                        blkseq_update_commitlsn(iq);
                         /* 2pc testcases */
                     } else {
                         debug_prepare_tests(iq, parent_trans, source_host, bskey, bskeylen);
@@ -6238,6 +6260,7 @@ add_blkseq:
                 irc = trans_commit_adaptive(iq, trans, source_host);
                 if (irc == BDBERR_NOT_DURABLE)
                     irc = rc = ERR_NOT_DURABLE;
+                blkseq_update_commitlsn(iq);
             }
             if (hascommitlock) {
                 Pthread_rwlock_unlock(&commit_lock);

--- a/sqlite/ext/comdb2/blkseq.c
+++ b/sqlite/ext/comdb2/blkseq.c
@@ -39,6 +39,7 @@ typedef struct systable_blkseq {
     int64_t rcode;
     int64_t time;
     int64_t age;
+    char *commitlsn;
 } systable_blkseq_t;
 
 typedef struct getblkseq {
@@ -48,8 +49,9 @@ typedef struct getblkseq {
 } getblkseq_t;
 
 static void collect_blkseq(int stripe, int ix, void *plsn, void *pkey,
-                           void *pdata, void *arg)
+                           void *pdata, void *incommitlsn, void *arg)
 {
+    DB_LSN *commitlsn = incommitlsn;
     DBT *key = pkey;
     DBT *data = pdata;
     int now = comdb2_time_epoch();
@@ -70,6 +72,10 @@ static void collect_blkseq(int stripe, int ix, void *plsn, void *pkey,
 
     b->stripe = stripe;
     b->ix = ix;
+
+    char lsnstr[64];
+    snprintf(lsnstr, sizeof(lsnstr), "%d:%d", commitlsn ? commitlsn->file : -1, commitlsn ? commitlsn->offset : -1);
+    b->commitlsn = strdup(lsnstr);
 
     int *k;
     k = (int *)key->data;
@@ -116,6 +122,8 @@ static void free_blkseq(void *p, int n)
     for (int i = 0; i < n; i++) {
         if (t[i].id)
             free(t[i].id);
+        if (t[i].commitlsn)
+            free(t[i].commitlsn);
     }
     free(p);
 }
@@ -136,5 +144,6 @@ int systblBlkseqInit(sqlite3 *db)
         CDB2_INTEGER, "rcode", -1, offsetof(systable_blkseq_t, rcode),
         CDB2_INTEGER, "time", -1, offsetof(systable_blkseq_t, time),
         CDB2_INTEGER, "age", -1, offsetof(systable_blkseq_t, age),
+        CDB2_CSTRING, "commitlsn", -1, offsetof(systable_blkseq_t, commitlsn),
         SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/final_non_durable_retry.test/blkseq_commitlsn.testopts
+++ b/tests/final_non_durable_retry.test/blkseq_commitlsn.testopts
@@ -1,0 +1,1 @@
+enable_private_blkseq

--- a/tests/final_non_durable_retry.test/runit
+++ b/tests/final_non_durable_retry.test/runit
@@ -205,13 +205,165 @@ EOF
     $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "delete from t1 where 1" >/dev/null 2>&1
 }
 
+function test_blkseq_commitlsn
+{
+    echo "Testing blkseq_commitlsn durability"
+
+    # This test requires a cluster for bounce verification
+    [[ -z "$CLUSTER" ]] && failexit "test_blkseq_commitlsn requires a cluster setup"
+
+    typeset -l master=$(get_master)
+
+    # Get baseline counts before test
+    echo "Getting baseline counts..."
+    nodes="$CLUSTER"
+
+    # Track initial blkseq count on master
+    initial_blkseq_count=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select count(*) from comdb2_blkseq")
+    echo "Initial blkseq entries on master: $initial_blkseq_count"
+
+    # Track initial invalid commitlsn count per node (e.g., schema changes produce -1:-1)
+    declare -A initial_invalid_counts
+    for n in $nodes ; do
+        initial_invalid_counts[$n]=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $n \
+            "select count(*) from comdb2_blkseq where commitlsn = '-1:-1'")
+        echo "Node $n: Initial invalid commitlsn count = ${initial_invalid_counts[$n]}"
+    done
+
+    # Track initial metrics
+    initial_durable_latest=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select value from comdb2_metrics where name = 'durable_latest_cnt'")
+    echo "Initial durable_latest_cnt: $initial_durable_latest"
+
+    # Set random non-durable percentage to 50%
+    # This will randomly return NOT_DURABLE to trigger retries
+    echo "Enabling random non-durable (50%)..."
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "put tunable 'debug_random_non_durable_pct' = 50"
+
+    # Run 100 inserts
+    echo "Running 100 inserts..."
+    for i in {1..100}; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into t1 values($i)" >/dev/null 2>&1
+        rc=$?
+        [[ $rc -ne 0 ]] && failexit "Insert $i failed with rc $rc"
+    done
+
+    # Disable random non-durable
+    echo "Disabling random non-durable..."
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $master "put tunable 'debug_random_non_durable_pct' = 0"
+
+    # Get final blkseq count on master
+    final_blkseq_count=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select count(*) from comdb2_blkseq")
+    new_blkseq_count=$((final_blkseq_count - initial_blkseq_count))
+    echo "Final blkseq entries on master: $final_blkseq_count"
+    echo "New blkseq entries: $new_blkseq_count"
+
+    # Verify we have at least 100 new entries
+    [[ "$new_blkseq_count" -ne 100 ]] && failexit "Expected 100 new blkseq entries"
+
+    echo "Verifying commitlsn entries for new inserts..."
+    # Query comdb2_blkseq on each node to verify new inserts have valid commitlsn
+    for n in $nodes ; do
+        # Count entries with NULL or invalid commitlsn (format should be "file:offset" not "-1:-1")
+        final_invalid_count=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $n \
+            "select count(*) from comdb2_blkseq where commitlsn = '-1:-1'")
+
+        invalid_delta=$((final_invalid_count - initial_invalid_counts[$n]))
+        echo "Node $n: Final invalid commitlsn count = $final_invalid_count (delta = $invalid_delta)"
+
+        # Delta should be 0 - no NEW invalid entries (our 100 inserts should all have valid commitlsn)
+        [[ "$invalid_delta" -ne 0 ]] && failexit "Node $n has $invalid_delta new entries with invalid commitlsn (expected 0)"
+    done
+
+    echo "Checking metrics on master..."
+    # Check final metrics on master
+    final_durable_latest=$($CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select value from comdb2_metrics where name = 'durable_latest_cnt'")
+    durable_latest_delta=$((final_durable_latest - initial_durable_latest))
+
+    echo "Final durable_latest_cnt: $final_durable_latest"
+    echo "durable_latest_cnt delta: $durable_latest_delta"
+
+    # Success criteria:
+    # - We added at least 100 new blkseq entries
+    # - All entries have valid commitlsn (not "-1:-1")
+    # - durable_latest_cnt did not increase (delta = 0, meaning no fallback to latest commit method)
+    [[ "$durable_latest_delta" -ne 0 ]] && failexit "Expected durable_latest_cnt delta=0, got $durable_latest_delta (no fallback should occur)"
+
+    echo "blkseq_commitlsn initial test passed!"
+    echo "  - Added $new_blkseq_count new blkseq entries (expected >=100)"
+    echo "  - All new entries have valid commitlsn (invalid delta=0 on all nodes)"
+    echo "  - No fallback to durable_latest (delta=$durable_latest_delta)"
+
+    # Bounce cluster to verify commitlsns survive recovery
+    echo ""
+    echo "Bouncing cluster to verify commitlsn recovery..."
+
+    # Capture commitlsn data before bounce for verification
+    pre_bounce_blkseq_file=./pre_bounce_blkseq.$$.$RANDOM
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select id, commitlsn from comdb2_blkseq where commitlsn != '-1:-1'" >  $pre_bounce_blkseq_file
+
+    # Bounce all nodes
+    for n in $nodes ; do
+        echo "Bouncing node $n..."
+        kill_restart_node $n 1
+    done
+
+    # Wait for cluster to stabilize
+    sleep 5
+    master=$(get_master)
+    echo "New master after bounce: $master"
+
+    # Gather blkseq, commitlsn data again
+    echo "Verifying commitlsns after bounce..."
+    post_bounce_blkseq_file=./post_bounce_blkseq.$$.$RANDOM
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME --host $master \
+        "select id, commitlsn from comdb2_blkseq where commitlsn != '-1:-1'" > $post_bounce_blkseq_file
+
+    echo "Assert all of the blkseqs are retained after the bounce"
+    echo "Before-file: $(pwd)/$pre_bounce_blkseq_file"
+    echo "After-file: $(pwd)/$post_bounce_blkseq_file"
+
+    # Recovery will add a commit-lsn to the schema-change which wasn't previously there
+    while read ln ; do 
+        egrep "$ln" $post_bounce_blkseq_file >/dev/null 2>&1 || failexit "Missing blkseq entry after bounce: $ln"
+    done < $pre_bounce_blkseq_file
+
+    echo "Cluster bounce verification passed!"
+    echo "  - All nodes recovered successfully"
+    echo "  - commitlsn entries retained after recovery"
+
+    # Shutdown cluster cleanly after bounce test
+    echo ""
+    echo "Shutting down cluster..."
+    for n in $nodes ; do
+        echo "Stopping node $n..."
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $n "exec procedure sys.cmd.send('exit')" >/dev/null 2>&1 &
+    done
+
+    # Wait for all nodes to exit
+    sleep 5
+    echo "Cluster shutdown complete"
+
+    # Note: Data cleanup not needed since we're exiting the database
+}
+
 function run_test
 {
     echo "Running tests"
-    hide_non_durable_good_insert
-    show_non_durable_good_insert
-    hide_non_durable_constraint_violation
-    show_non_durable_constraint_violation
+
+    # Run blkseq_commitlsn test if this is the blkseq_commitlsn variant
+    if [[ "$DBNAME" == *"blkseqcommitlsn"* ]]; then
+        test_blkseq_commitlsn
+    else
+        hide_non_durable_good_insert
+        show_non_durable_good_insert
+        hide_non_durable_constraint_violation
+        show_non_durable_constraint_violation
+    fi
 }
 
 create_table


### PR DESCRIPTION
This PR changes the durability algorithm used for blkseq replays.  If we detected a replay previously, the master would return 'this is durable' only if the most recent commit was durable.  This instead records a transactions's  blkseq->commitlsn mapping in the blkseq_commitlsns table.  This allows us to determine durability using the transaction's actual commit-lsn, falling through to the previous logic if we cannot find it.