### PR TITLE
{183434696}: Use non-blocking for SSL client socket

### DIFF
--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -82,8 +82,10 @@ int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
 int debug_switch_ignore_null_auth_func(void);      /* 0 */
 int debug_switch_load_cache_delay(void);           /* 0 */
+#ifdef COMDB2_TEST
 int debug_switch_stall_ssl_write(void);            /* 0 */
 int debug_switch_newsql_response_is_row(void);     /* 0 */
+#endif /* COMDB2_TEST */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */
@@ -93,6 +95,9 @@ void debug_switch_set_rep_verify_req_delay(int);
 void debug_switch_set_dbq_get_delayed(int);
 void debug_switch_set_rep_rec_delayed(int);
 int debug_switch_set_tmp_dir_sleep(int);
+#ifdef COMDB2_TEST
 int debug_switch_set_newsql_response_is_row(int);
 void debug_switch_set_stall_ssl_write(int);
+#endif /* COMDB2_TEST */
+
 #endif

--- a/bbinc/debug_switches.h
+++ b/bbinc/debug_switches.h
@@ -82,6 +82,8 @@ int debug_switch_is_rep_rec_delayed(void);         /* 0 */
 int debug_switch_get_tmp_dir_sleep(void);          /* 0 */
 int debug_switch_ignore_null_auth_func(void);      /* 0 */
 int debug_switch_load_cache_delay(void);           /* 0 */
+int debug_switch_stall_ssl_write(void);            /* 0 */
+int debug_switch_newsql_response_is_row(void);     /* 0 */
 
 /* value switches */
 int debug_switch_net_delay(void); /* 0 */
@@ -91,4 +93,6 @@ void debug_switch_set_rep_verify_req_delay(int);
 void debug_switch_set_dbq_get_delayed(int);
 void debug_switch_set_rep_rec_delayed(int);
 int debug_switch_set_tmp_dir_sleep(int);
+int debug_switch_set_newsql_response_is_row(int);
+void debug_switch_set_stall_ssl_write(int);
 #endif

--- a/net/ssl_evbuffer.c
+++ b/net/ssl_evbuffer.c
@@ -29,6 +29,11 @@
 #include <ssl_glue.h>
 #include <ssl_support.h>
 
+#ifdef COMDB2_TEST
+#include <dlfcn.h>
+#include <debug_switches.h>
+#endif
+
 extern char gbl_dbname[];
 extern int gbl_nid_dbname;
 extern SSL_CTX *gbl_ssl_ctx;
@@ -198,6 +203,15 @@ int wr_ssl_evbuffer(struct ssl_data *ssl_data, struct evbuffer *wr_buf)
     if (len > KB(16)) len = KB(16);
     const void *buf = evbuffer_pullup(wr_buf, len);
     ERR_clear_error();
+#ifdef COMDB2_TEST
+    if (debug_switch_stall_ssl_write() && debug_switch_newsql_response_is_row()) {
+        logmsg(LOGMSG_WARN, "Stalling SSL_write...\n");
+        int *pstall = dlsym(RTLD_NEXT, "__partial_write_stall");
+        if (pstall != NULL)
+            *pstall = 60;
+        debug_switch_set_stall_ssl_write(0);
+    }
+#endif
     int rc = SSL_write(ssl, buf, len);
     if (rc > 0) {
         evbuffer_drain(wr_buf, rc);

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -31,6 +31,10 @@
 #include "newsql.h"
 #include "cheapstack.h"
 
+#ifdef COMDB2_TEST
+#include "debug_switches.h"
+#endif
+
 void free_original_normalized_sql(struct sqlclntstate *);
 
 extern int gbl_allow_incoherent_sql;
@@ -834,7 +838,22 @@ static int newsql_row(struct sqlclntstate *clnt, struct response_data *arg,
     } else if (arg->pingpong) {
         return newsql_response_int(clnt, &r, RESPONSE_HEADER__SQL_RESPONSE_PING, 1);
     }
-    return newsql_response(clnt, &r, !clnt->rowbuffer);
+
+#ifdef COMDB2_TEST
+    if (debug_switch_stall_ssl_write()) {
+        debug_switch_set_newsql_response_is_row(1);
+    }
+#endif
+
+    int rc = newsql_response(clnt, &r, !clnt->rowbuffer);
+
+#ifdef COMDB2_TEST
+    if (debug_switch_stall_ssl_write()) {
+        debug_switch_set_newsql_response_is_row(0);
+    }
+#endif
+
+    return rc;
 }
 
 static int newsql_row_remtran(struct sqlclntstate *clnt, const char *name,
@@ -888,7 +907,21 @@ static int newsql_row_last(struct sqlclntstate *clnt)
     _has_effects(clnt, resp);
     _has_snapshot(clnt, resp);
     _has_features(clnt, resp);
-    return newsql_response(clnt, &resp, 1);
+
+#ifdef COMDB2_TEST
+    if (debug_switch_stall_ssl_write()) {
+        debug_switch_set_newsql_response_is_row(1);
+    }
+#endif
+
+    int rc = newsql_response(clnt, &resp, 1);
+
+#ifdef COMDB2_TEST
+    if (debug_switch_stall_ssl_write()) {
+        debug_switch_set_newsql_response_is_row(0);
+    }
+#endif
+    return rc;
 }
 
 static int newsql_row_last_dummy(struct sqlclntstate *clnt)

--- a/tests/ssl_partial_write_hang.test/Makefile
+++ b/tests/ssl_partial_write_hang.test/Makefile
@@ -1,0 +1,10 @@
+export LD_PRELOAD=${TESTSBUILDDIR}/libpartialwrite.so
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=1m
+endif
+$(shell mkdir -p ${DBDIR}/; echo "export LD_PRELOAD=${TESTSBUILDDIR}/libpartialwrite.so" >> ${DBDIR}/replicant_env_vars )

--- a/tests/ssl_partial_write_hang.test/expected
+++ b/tests/ssl_partial_write_hang.test/expected
@@ -1,0 +1,1 @@
+[SELECT SLEEP(1) FROM GENERATE_SERIES(1, 10)] failed with rc -1 cdb2_next_record_int: Timeout while reading response from server

--- a/tests/ssl_partial_write_hang.test/lrl.options
+++ b/tests/ssl_partial_write_hang.test/lrl.options
@@ -1,0 +1,1 @@
+ssl_client_mode ALLOW

--- a/tests/ssl_partial_write_hang.test/output.expected
+++ b/tests/ssl_partial_write_hang.test/output.expected
@@ -1,0 +1,3 @@
+[SELECT 1] failed with rc -1 SSL Error: Could not read cacert NONEXISTENCE/root.crt: No such file or directory.
+1
+[SELECT 1] failed with rc -1 SSL Error: Certificate does not match database name.

--- a/tests/ssl_partial_write_hang.test/runit
+++ b/tests/ssl_partial_write_hang.test/runit
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbnm=$1
+
+host=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()'`
+
+SSL_MODE=REQUIRE cdb2sql ${CDB2_OPTIONS} $dbnm --host $host - >/dev/null 2>actual <<EOF &
+SET ROWBUFFER OFF
+SELECT SLEEP(1) FROM GENERATE_SERIES(1, 10)
+EOF
+
+sleep 5
+
+# Turn on partial SSL write mid-query to simulate network failure:
+# blocking IO would hang;
+# non-blocking IO will fail.
+SSL_MODE=ALLOW cdb2sql ${CDB2_OPTIONS} $dbnm --host $host "EXEC PROCEDURE sys.cmd.send('stall_ssl_write 1')"
+
+wait
+
+diff expected actual

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -148,6 +148,9 @@ foreach(executable ${test-tools})
   endif()
 endforeach()
 
+add_library(partialwrite SHARED partialwrite.c)
+list(APPEND test-tools partialwrite)
+
 add_subdirectory(tcl)
 list(APPEND test-tools tclcdb2)
 

--- a/tests/tools/copy_files_to_cluster.sh
+++ b/tests/tools/copy_files_to_cluster.sh
@@ -63,6 +63,18 @@ copy_files_to_node() {
         scp $SSH_OPT $SSH_MSTR $COMDB2_EXE $node:$COMDB2_EXE
         scp $SSH_OPT $SSH_MSTR $CDB2SQL_EXE $node:$CDB2SQL_EXE
     fi
+
+    if [[ -n "$LD_PRELOAD" ]] ; then
+        SAVIFS=$IFS
+        IFS=' :'
+        for so in $LD_PRELOAD; do
+            echo "Copying $so to $node"
+            ssh $SSH_OPT $SSH_MSTR $node "mkdir -p $(dirname $so)"
+            scp $SSH_OPT $SSH_MSTR $so $node:$so
+        done
+        IFS=$SAVIFS
+    fi
+
     if [ -n "$RESTARTPMUX" ] ; then
         echo stop pmux on $node first before copying and starting it
         ssh $SSH_OPT $SSH_MSTR $node "$stop_pmux" < /dev/null

--- a/tests/tools/partialwrite.c
+++ b/tests/tools/partialwrite.c
@@ -1,0 +1,44 @@
+#include <dlfcn.h>
+#include <error.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <time.h>
+
+int __partial_write_stall = 0;
+ssize_t (*libcwrite)(int fd, const void *buf, size_t count) = NULL;
+ssize_t write(int fd, const void *buf, size_t count)
+{
+    ssize_t nw;
+    struct stat s;
+    int nsleep;
+    if (libcwrite == NULL) {
+        libcwrite = dlsym(RTLD_NEXT, "write");
+        if (libcwrite == NULL) {
+            fprintf(stderr, "error finding system write\n");
+            abort();
+        }
+    }
+    if (fd == -1)
+        return -1;
+
+    if (fstat(fd, &s) != 0) {
+        perror("fstat");
+        return -1;
+    }
+
+    if (!S_ISSOCK(s.st_mode) || __partial_write_stall == 0)
+        return libcwrite(fd, buf, count);
+
+    srand(time(NULL));
+    int nn = (rand() % count) + 1;
+    fprintf(stderr, "Performing a partial write of %d out %zu bytes and then stalling\n", nn, count);
+    nw = libcwrite(fd, buf, nn);
+    nsleep = __partial_write_stall;
+    __partial_write_stall = 0;
+    sleep(nsleep);
+    return nw;
+}

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -89,8 +89,10 @@ static struct debug_switches {
     int get_tmp_dir_sleep;
     int ignore_null_auth_func;
     int load_cache_delay;
+#   ifdef COMDB2_TEST
     int stall_ssl_write;
     int newsql_response_is_row;
+#   endif /* COMDB2_TEST */
 } debug_switches;
 
 int init_debug_switches(void)
@@ -274,7 +276,9 @@ int init_debug_switches(void)
     register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
     register_debug_switch("ignore_null_auth_func", &debug_switches.ignore_null_auth_func);
     register_debug_switch("load_cache_delay", &debug_switches.load_cache_delay);
+#   ifdef COMDB2_TEST
     register_debug_switch("stall_ssl_write", &debug_switches.stall_ssl_write);
+#   endif /* COMDB2_TEST */
     return 0;
 }
 
@@ -553,6 +557,7 @@ int debug_switch_load_cache_delay(void)
 {
     return debug_switches.load_cache_delay;
 }
+#ifdef COMDB2_TEST
 int debug_switch_stall_ssl_write(void)
 {
     return debug_switches.stall_ssl_write;
@@ -569,3 +574,4 @@ void debug_switch_set_newsql_response_is_row(int val)
 {
     debug_switches.newsql_response_is_row = !!val;
 }
+#endif /* COMDB2_TEST */

--- a/util/debug_switches.c
+++ b/util/debug_switches.c
@@ -89,6 +89,8 @@ static struct debug_switches {
     int get_tmp_dir_sleep;
     int ignore_null_auth_func;
     int load_cache_delay;
+    int stall_ssl_write;
+    int newsql_response_is_row;
 } debug_switches;
 
 int init_debug_switches(void)
@@ -272,6 +274,7 @@ int init_debug_switches(void)
     register_debug_switch("get_tmp_dir_sleep", &debug_switches.get_tmp_dir_sleep);
     register_debug_switch("ignore_null_auth_func", &debug_switches.ignore_null_auth_func);
     register_debug_switch("load_cache_delay", &debug_switches.load_cache_delay);
+    register_debug_switch("stall_ssl_write", &debug_switches.stall_ssl_write);
     return 0;
 }
 
@@ -549,4 +552,20 @@ int debug_switch_ignore_null_auth_func(void)
 int debug_switch_load_cache_delay(void)
 {
     return debug_switches.load_cache_delay;
+}
+int debug_switch_stall_ssl_write(void)
+{
+    return debug_switches.stall_ssl_write;
+}
+void debug_switch_set_stall_ssl_write(int val)
+{
+    debug_switches.stall_ssl_write = !!val;
+}
+int debug_switch_newsql_response_is_row(void)
+{
+    return debug_switches.newsql_response_is_row;
+}
+void debug_switch_set_newsql_response_is_row(int val)
+{
+    debug_switches.newsql_response_is_row = !!val;
 }

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -383,12 +383,6 @@ re_accept_or_connect:
     } else {
         sb->protocolerr = 0;
     }
-    /* Put blocking back. */
-    if (fcntl(fd, F_SETFL, flags) < 0) {
-        ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr), my_ssl_eprintln,
-                     "fcntl: (%d) %s", errno, strerror(errno));
-        return -1;
-    }
     if (rc != 1 && close_on_verify_error) {
     error:
         if (sb->ssl != NULL) {
@@ -498,7 +492,7 @@ int CDB2BUF_FUNC(sslio_close)(COMDB2BUF *sb, int wait_for_peer)
 {
     /* Upon success, the 1st call to SSL_shutdown
        returns 0, and the 2nd returns 1. */
-    int rc = 0;
+    int rc = 0, flags = 0;
     if (sb->ssl == NULL)
         return 0;
 
@@ -511,6 +505,10 @@ int CDB2BUF_FUNC(sslio_close)(COMDB2BUF *sb, int wait_for_peer)
         if (rc == 1)
             rc = 0;
     }
+
+    /* Puts blocking back. The fd may be returned to sockpool */
+    if (rc == 0 && ((flags = fcntl(sb->fd, F_GETFL, NULL)) < 0 || fcntl(sb->fd, F_SETFL, flags & ~O_NONBLOCK) < 0))
+        rc = -1;
 
     sslio_free(sb);
     return rc;


### PR DESCRIPTION
A partial write of an SSL encrypted block may cause the client to hang in SSL_read. Hence this patch uses non-blocking IO for SSL client sockets.
