### PR TITLE
Reports JAVA_HOME (JDK/JRE path) as the task name

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
@@ -51,8 +51,15 @@ public class Comdb2ClientInfo {
         driverName = name;
         driverVersion = version;
     }
-    
+
+    public static String getJavaHome() {
+        return System.getProperty("java.home");
+    }
+
+    @Deprecated
     public static String getCallerClass() {
+        logger.warn("getCallerClass() is deprecated and will be removed in a future version");
+
         String pkg = Comdb2ClientInfo.class.getPackage().getName() + ".";
         StackTraceElement[] stes = Thread.currentThread().getStackTrace();
         for (int i = 1, len = stes.length; i < len; ++i) {

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2ClientInfo.java
@@ -56,20 +56,6 @@ public class Comdb2ClientInfo {
         return System.getProperty("java.home");
     }
 
-    @Deprecated
-    public static String getCallerClass() {
-        logger.warn("getCallerClass() is deprecated and will be removed in a future version");
-
-        String pkg = Comdb2ClientInfo.class.getPackage().getName() + ".";
-        StackTraceElement[] stes = Thread.currentThread().getStackTrace();
-        for (int i = 1, len = stes.length; i < len; ++i) {
-            StackTraceElement ste = stes[i];
-            if (!ste.getClassName().startsWith(pkg))
-                return ste.getClassName();
-        }
-        return "Unknown Java class";
-    }
-
     public static String getCallStack(int layers) {
         String pkg = Comdb2ClientInfo.class.getPackage().getName() + ".";
         StringBuilder sb = new StringBuilder("");

--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -691,7 +691,7 @@ public class Comdb2Handle extends AbstractConnection {
 
         if (!sentClientInfo) {
             sqlQuery.cinfo = new Cdb2ClientInfo();
-            sqlQuery.cinfo.argv0 = Comdb2ClientInfo.getCallerClass();
+            sqlQuery.cinfo.argv0 = Comdb2ClientInfo.getJavaHome();
             sqlQuery.cinfo.stack = Comdb2ClientInfo.getCallStack(32);
             sqlQuery.cinfo.api_driver_name = Comdb2ClientInfo.getDriverName();
             sqlQuery.cinfo.api_driver_version = Comdb2ClientInfo.getDriverVersion();

--- a/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ClientInfoIT.java
+++ b/cdb2jdbc/src/test/java/com/bloomberg/comdb2/jdbc/ClientInfoIT.java
@@ -13,6 +13,36 @@ public class ClientInfoIT {
         Assert.assertArrayEquals("driver name and version match pom.xml", expected_driver, actual_driver);
     }
 
+    @Test public void getJavaHomeTest() {
+        String expected = System.getProperty("java.home");
+        String actual = Comdb2ClientInfo.getJavaHome();
+        Assert.assertNotNull("java.home should not be null", actual);
+        Assert.assertEquals("getJavaHome should return java.home system property", expected, actual);
+    }
+
+    @Test public void verifyTaskNameIsJavaHome() throws SQLException {
+        String db = System.getProperty("cdb2jdbc.test.database");
+        String cluster = System.getProperty("cdb2jdbc.test.cluster");
+
+        Connection conn = DriverManager.getConnection(String.format("jdbc:comdb2://%s/%s", cluster, db));
+        Statement stmt = conn.createStatement();
+        /* Execute a query so that client info is sent to the server. */
+        stmt.executeQuery("SELECT 1");
+        ResultSet rs = stmt.executeQuery("SELECT task FROM comdb2_clientstats");
+        String javaHome = System.getProperty("java.home");
+        boolean found = false;
+        while (rs.next()) {
+            String task = rs.getString(1);
+            if (task != null && task.equals(javaHome))
+                found = true;
+        }
+        Assert.assertTrue("Should find java.home (" + javaHome + ") as task name in comdb2_clientstats", found);
+
+        rs.close();
+        stmt.close();
+        conn.close();
+    }
+
     @Test public void verifyDriverInfoInDatabase() throws SQLException {
         String db = System.getProperty("cdb2jdbc.test.database");
         String cluster = System.getProperty("cdb2jdbc.test.cluster");


### PR DESCRIPTION
* What is the type of the change (bug fix, feature, documentation and etc.) ?
feature

* What are the current behavior and expected behavior, if this is a bugfix ?
Other interpreted languages (like Python) report their runtimes. This PR brings JVM applications on par with applications written in other languages (both interpreted languages and compiled ones)

* What are the steps required to reproduce the bug, if this is a bugfix ?

* What is the current behavior and new behavior, if this is a feature change or enhancement ?
Currently, the `comdb2_clientstats` table reports the calling class as the task name.

```
> bash-5.2$ cdb2sql bmskconn dev "select task, stack FROM comdb2_clientstats  where task like 'org.%' LIMIT 1"
(task='org.jdbi.v3.core.statement.SqlLoggerUtil', stack='org.jdbi.v3.core.statement.SqlLoggerUtil.wrap(SqlLoggerUtil.java:32) 
org.jdbi.v3.core.statement.SqlStatement.internalExecute(SqlStatement.java:1819) 
org.jdbi.v3.core.result.ResultProducers.lambda$createResultBearing$4(ResultProducers.java:110) 
...
...
```

With this change, the task name will report the JDK/JRE used to launch the task, while the calling class will still be the first entry on the stack.

* [Optional] Why is the new behavior better than the current behavior, if this is a feature change ?
Helps determine which task/runtime is being used by the calling process.