### PR TITLE
Include identity attributes when cloning Comdb2

### DIFF
--- a/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
+++ b/cdb2jdbc/src/main/java/com/bloomberg/comdb2/jdbc/Comdb2Handle.java
@@ -200,6 +200,10 @@ public class Comdb2Handle extends AbstractConnection {
         ret.hasSendStack = hasSendStack;
         ret.sendStack = sendStack;
 
+        ret.hasUseIdentity = hasUseIdentity;
+        ret.useIdentity = useIdentity;
+        ret.ic = ic;
+
         return ret;
     }
 


### PR DESCRIPTION
From https://github.com/bloomberg/comdb2/pull/5840