### PR TITLE
Single write corner case fix

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -5096,6 +5096,11 @@ int sqlite3BtreeCommit(Btree *pBt)
         goto done;
     }
 
+    /* have we set an error because client d/c ? */
+    if (clnt->query_rc == CDB2ERR_IO_ERROR) {
+        return sqlite3BtreeRollback(pBt, 0, 0);
+    }
+
     clnt->recno = 0;
 
     /* reset the state of the sqlengine */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4013,7 +4013,14 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
     }
 
     if ((rc = send_columns(clnt, stmt)) != 0) {
-        return rc;
+        /* read only requests */
+        if (clnt->isselect || v->explain)
+            return rc;
+        /* if we are in a single write transaction and client disconnected, set error here
+         * to let sqlite know we want a rollback
+         * NOTE: explicit transactions do not send columns here so they will not get an error
+         */
+        clnt->query_rc = CDB2ERR_IO_ERROR;
     }
 
     if (clnt->intrans == 0) {


### PR DESCRIPTION
when a client disconnects before the server manages to send back the columns format message, the server will fail to send back the columns and fail early, skipping the rest of processing code; the cleanup code detects a pending transaction and commits it. 
The committing/aborting of a comdb2 transaction should not happen at that point in time (i.e. when sqlite3_finalize() is called).
This change allows the server follow the rest of the processing code, and aborts the transaction. 
The change in behavior better matches the explicit transaction case, in which any client disconnect aborts the whole transaction.

re: 183647682