### PR TITLE
Fix null-deref in os_get_host_and_cname_by_name when ai_canonname is NULL

### DIFF
--- a/util/bb_oscompat.c
+++ b/util/bb_oscompat.c
@@ -50,7 +50,7 @@ static int os_get_host_and_cname_by_name(char **name_ptr, struct in_addr *addr,
     }
 
     if (cname != NULL)
-        *cname = strdup(res->ai_canonname);
+        *cname = res->ai_canonname ? strdup(res->ai_canonname) : NULL;
 
     freeaddrinfo(res);
     return 0;


### PR DESCRIPTION
## Type of change
Bug fix.

## Current behavior
`os_get_host_and_cname_by_name()` in `util/bb_oscompat.c` does `*cname = strdup(res->ai_canonname)` unconditionally. Per POSIX, `getaddrinfo` with `AI_CANONNAME` may leave `ai_canonname == NULL`; macOS does this for bare IPv4 hostnames. Result: `strdup(NULL)` → SIGSEGV in `getmyid()` before the server logs anything. Linux is unaffected because glibc populates `ai_canonname` with the  input literal.

## Expected behavior                                                                                   
Tolerate `ai_canonname == NULL`. The only real caller (`getmyid` at `db/comdb2.c`) already handles `cname == NULL` by falling back to `gbl_myhostname`, so NULL is a legal return per the caller contract. 

## Steps to reproduce                                                                                  
On macOS with the system hostname set to a bare IP:
`comdb2 --create --dir ~/db testdb` → SIGSEGV.
After the patch it creates the DB and `comdb2 --lrl ...` reaches `I AM READY.`