### PR TITLE
Faster scl abort on resume.

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1628,6 +1628,8 @@ int bdb_llmeta_set_schema_change_list(tran_type *input_trans, char *key,
 int bdb_llmeta_get_all_sc_lists(tran_type *t, void ***dtas, int **dtalens,
                                 void ***keys, int *keylen, int *num, int *bdberr);
 
+int bdb_llmeta_rem_all_sc_lists(tran_type *input_trans);
+
 int bdb_set_in_schema_change(tran_type *input_trans, const char *db_name,
                              void *schema_change_data,
                              size_t schema_change_data_len, int *bdberr);

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -4154,7 +4154,7 @@ int bdb_llmeta_get_all_sc_redo_genids(tran_type *t, const char *tablename, llmet
     return 0;
 }
 
-/* return all schema change pending transactons */
+/* return all schema change pending lists */
 int bdb_llmeta_get_all_sc_lists(tran_type *t, void ***dtas, int **dtalens, void ***keys,
                                 int *keylen, int *num, int *bdberr)
 {
@@ -4175,6 +4175,80 @@ int bdb_llmeta_get_all_sc_lists(tran_type *t, void ***dtas, int **dtalens, void 
     }
 
     return 0;
+}
+
+static int _rem_all_schema_change_lists(tran_type *trans)
+{
+    uint8_t key[LLMETA_IXLEN] = {0};
+    int key_type = htonl(LLMETA_SCHEMACHANGE_LIST);
+    int keylen = sizeof(key_type);
+    uint8_t out[LLMETA_IXLEN];
+    int fnd;
+    int rc = 0;
+    int bdberr = 0;
+    int cnt = 0;
+
+    memcpy(key, &key_type, keylen);
+
+    do {
+        /* find the first key */
+        rc = bdb_lite_fetch_partial_tran(llmeta_bdb_state, trans, key, keylen, out, &fnd, &bdberr);
+        if (rc == 0 && fnd == 1) {
+            if (memcmp(key, out, keylen) != 0)
+                break;
+
+            /* delete first entry, if any */
+            rc = bdb_lite_exact_del(llmeta_bdb_state, trans, out, &bdberr);
+            if (rc)
+                break;
+            cnt++;
+        } else
+            break;
+    } while (1);
+
+    if (cnt > 0) {
+        logmsg(LOGMSG_USER, "Deleted %d scl llmeta objects\n", cnt);
+    }
+
+    if (rc && bdberr == BDBERR_DEL_DTA) /* deleted all keys, if any */
+        return 0;
+    return rc;
+}
+
+/* remove all schema change pending lists */
+int bdb_llmeta_rem_all_sc_lists(tran_type *input_trans)
+{
+    tran_type *trans = input_trans;
+    int rc = 0;
+    int bdberr = 0;
+
+    if (!input_trans) {
+        trans = bdb_tran_begin(llmeta_bdb_state, NULL, &bdberr);
+        if (!trans) /* TODO: consider adding a retry */
+            return -1;
+    }
+
+    rc = _rem_all_schema_change_lists(trans);
+    if (rc)
+        goto err;
+
+    if (!input_trans) {
+        rc = bdb_tran_commit(llmeta_bdb_state, trans, &bdberr);
+        if (rc)
+            return -1;
+    }
+
+    return 0;
+
+err:
+    if (!input_trans) {
+        rc = bdb_tran_abort(llmeta_bdb_state, trans, &bdberr);
+        if (rc) {
+            logmsg(LOGMSG_ERROR, "%s failed to abort txn rc %d bdberr %d\n", __func__, rc, bdberr);
+        }
+    }
+
+    return -1;
 }
 
 int bdb_newsc_del_redo_genid(tran_type *t, const char *tablename, uint64_t genid, int *bdberr)

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1052,42 +1052,6 @@ extern const uint8_t *osqlcomm_scl_get_key(struct sc_list *scl,
         const uint8_t *p_buf, const uint8_t *p_buf_end);
 extern const uint8_t *osqlcomm_scl_get(struct sc_list *scl,
         const uint8_t *p_buf, const uint8_t *p_buf_end);
-extern int osql_delete_sc_list_int(uuid_t uuid, tran_type *trans, const char *c, int l);
-
-/**
- * Receive an array of serialized sclists and removes them
- *
- */
-int resume_sc_multiddl_scabort(void **keys, int keylen, int num)
-{
-    sc_list_t scl = {0};
-    uint8_t *p_buf_key, *p_buf_key_end;
-    int i;
-
-    for (i = 0; i < num; i++) {
-        p_buf_key = keys[i];
-        p_buf_key_end = p_buf_key + keylen;
-        if (!osqlcomm_scl_get_key(&scl, p_buf_key, p_buf_key_end)) {
-            logmsg(LOGMSG_ERROR, "%s: failed to read key\n", __func__);
-            continue;
-        }
-
-        if (scl.version != SESS_SC_LIST_VER) {
-            logmsg(LOGMSG_ERROR,
-                   "%s found incompatible sc list version %d expected %d\n",
-                   __func__, scl.version, SESS_SC_LIST_VER);
-        }
-        uuidstr_t us;
-        comdb2uuidstr(scl.uuid, us);
-        int rc = osql_delete_sc_list_int(scl.uuid, NULL, __func__, __LINE__);
-        if (rc) {
-            logmsg(LOGMSG_ERROR, "Failed to delete sc list uuid %s\n", us);
-        } else {
-            logmsg(LOGMSG_ERROR, "Aborted sc list uuid %s\n", us);
-        }
-    }
-    return 0;
-}
 
 extern int resume_sc_multiddl_txn(sc_list_t *scl);
 
@@ -1108,6 +1072,10 @@ int resume_sc_multiddl(int scabort)
     int bdberr = 0;
     uint8_t *p_buf, *p_buf_end, *p_buf_key, *p_buf_key_end;
 
+    if (scabort) {
+        return bdb_llmeta_rem_all_sc_lists(NULL);
+    }
+
     rc = bdb_llmeta_get_all_sc_lists(NULL, &dtas, &dtalens, &keys, &keylen,
                                      &num, &bdberr);
     if (rc) {
@@ -1115,11 +1083,6 @@ int resume_sc_multiddl(int scabort)
                "Failed to retrieve pending schema changes rc %d bdberr %d\n",
                rc, bdberr);
         return -1;
-    }
-
-    if (scabort) {
-        rc = resume_sc_multiddl_scabort(keys, keylen, num);
-        goto freetime;
     }
 
     for (i = 0; i < num; i++) {


### PR DESCRIPTION
When we abort schema change on a resume, do not reconstruct the whole scl set.
Instead delete them one at the time.
