### PR TITLE
fix new regression as seen in timepart_retro test

### DIFF
--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6116,8 +6116,14 @@ static int start_schema_change_tran_wrapper(const char *tblname,
             iq->sc_pending = sc;
         }
         /* mark scdone so that cleanup removes llmeta */
-        if (rc != SC_OK && rc != SC_MASTER_DOWNGRADE)
-            iq->osql_flags |= OSQL_FLAGS_SCDONE;
+        if (rc != SC_OK) {
+            if (rc != SC_MASTER_DOWNGRADE)
+                iq->osql_flags |= OSQL_FLAGS_SCDONE;
+            else {
+                /* potential downgrade during the last shard processing */
+                iq->osql_flags ^= OSQL_FLAGS_SCDONE;
+            }
+        }
     } else {
         iq->sc->sc_next = iq->sc_pending;
         iq->sc_pending = iq->sc;
@@ -6244,8 +6250,14 @@ static int start_schema_change_tran_wrapper_merge(const char *tblname,
     }
 
     /* mark scdone so that cleanup removes llmeta */
-    if (rc != SC_OK && rc != SC_MASTER_DOWNGRADE)
-        iq->osql_flags |= OSQL_FLAGS_SCDONE;
+    if (rc != SC_OK) {
+        if (rc != SC_MASTER_DOWNGRADE)
+            iq->osql_flags |= OSQL_FLAGS_SCDONE;
+        else {
+            /* potential downgrade during the last shard processing */
+            iq->osql_flags ^= OSQL_FLAGS_SCDONE;
+        }
+    }
     return rc;
 }
 
@@ -6277,6 +6289,10 @@ static int _process_single_table_sc_merge(struct ireq *iq)
     if (rc != SC_OK) {
         if (rc != SC_MASTER_DOWNGRADE)
             iq->osql_flags |= OSQL_FLAGS_SCDONE;
+        else {
+            /* potential downgrade during the last shard processing */
+            iq->osql_flags ^= OSQL_FLAGS_SCDONE;
+        }
         return ERR_SC;
     }
 
@@ -6342,6 +6358,8 @@ static int _process_partitioned_table_merge(struct ireq *iq)
         if (rc != SC_OK) {
             if (rc != SC_MASTER_DOWNGRADE)
                 iq->osql_flags |= OSQL_FLAGS_SCDONE;
+            else
+                iq->osql_flags ^= OSQL_FLAGS_SCDONE;
             return ERR_SC;
         }
 
@@ -6361,6 +6379,8 @@ static int _process_partitioned_table_merge(struct ireq *iq)
         if (rc != SC_OK) {
             if (rc != SC_MASTER_DOWNGRADE)
                 iq->osql_flags |= OSQL_FLAGS_SCDONE;
+            else
+                iq->osql_flags ^= OSQL_FLAGS_SCDONE;
             return ERR_SC;
         }
 
@@ -6625,8 +6645,12 @@ static int _process_single_table_sc_partitioning(struct ireq *iq)
             iq->sc_pending = iq->sc;
 
             /* mark scdone so that cleanup removes llmeta */
-            if (rc != SC_OK && rc != SC_MASTER_DOWNGRADE)
-                iq->osql_flags |= OSQL_FLAGS_SCDONE;
+            if (rc != SC_OK) {
+                if (rc != SC_MASTER_DOWNGRADE)
+                    iq->osql_flags |= OSQL_FLAGS_SCDONE;
+                else
+                    iq->osql_flags ^= OSQL_FLAGS_SCDONE;
+            }
         }
     }
     free(arg.part_name);


### PR DESCRIPTION
OSQL_FLAGS_SCDONE flag is set when we start schema change for the last shard.

If we downgrade during this time, a new bug introduced triggers and deletes sc list, making the schema change non-resummable. Clear that flag when we detect downgrade in such a scenario.
