### PR TITLE
Remove release-locks-on-slow-reader tunable

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -733,8 +733,6 @@ int gbl_sql_release_locks_on_si_lockwait = 1;
 /* If this is set, recom_replay will see the same row multiple times in a scan &
  * fail */
 int gbl_sql_release_locks_on_emit_row = 0;
-int gbl_sql_release_locks_on_slow_reader = 1;
-int gbl_sql_no_timeouts_on_release_locks = 1;
 int gbl_sql_release_locks_in_update_shadows = 1;
 int gbl_sql_random_release_interval = 0;
 int gbl_sql_release_locks_trace = 0;
@@ -5444,12 +5442,6 @@ static void register_all_int_switches()
     register_int_switch("sql_release_locks_on_emit_row_lockwait",
                         "Release sql locks when we are about to emit a row",
                         &gbl_sql_release_locks_on_emit_row);
-    register_int_switch("sql_release_locks_on_slow_reader",
-                        "Release sql locks if a tcp write to the client blocks",
-                        &gbl_sql_release_locks_on_slow_reader);
-    register_int_switch("no_timeouts_on_release_locks",
-                        "Disable client-timeouts if we're releasing locks",
-                        &gbl_sql_no_timeouts_on_release_locks);
     register_int_switch("sql_release_locks_in_update_shadows",
                         "Release sql locks in update_shadows on lockwait",
                         &gbl_sql_release_locks_in_update_shadows);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3742,7 +3742,6 @@ void destroy_password_cache();
 
 extern int gbl_rcache;
 extern int gbl_throttle_txn_chunks_msec;
-extern int gbl_sql_release_locks_on_slow_reader;
 extern int gbl_fail_client_write_lock;
 extern int gbl_server_admin_mode;
 

--- a/db/sql.h
+++ b/db/sql.h
@@ -1701,7 +1701,6 @@ void curtran_assert_nolocks(void);
 void curtran_puttran(tran_type *tran);
 int sbuf_is_local(COMDB2BUF *);
 int fdb_access_control_create(struct sqlclntstate *, char *str);
-int disable_server_sql_timeouts(void);
 int osql_clean_sqlclntstate(struct sqlclntstate *);
 void handle_failed_dispatch(struct sqlclntstate *, char *err);
 int start_new_transaction(struct sqlclntstate *);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -168,8 +168,6 @@ extern int gbl_print_syntax_err;
 extern int gbl_max_sqlcache;
 extern int gbl_track_sqlengine_states;
 extern struct ruleset *gbl_ruleset;
-extern int gbl_sql_release_locks_on_slow_reader;
-extern int gbl_sql_no_timeouts_on_release_locks;
 extern int get_snapshot(struct sqlclntstate *clnt, int *f, int *o);
 
 extern void clnt_try_enable_logdel(struct sqlclntstate *clnt);
@@ -283,11 +281,6 @@ static inline void comdb2_set_sqlite_vdbe_dtprec_int(Vdbe *p,
                                                      struct sqlclntstate *clnt)
 {
     p->dtprec = clnt->dtprec;
-}
-
-int disable_server_sql_timeouts(void)
-{
-    return gbl_sql_release_locks_on_slow_reader && gbl_sql_no_timeouts_on_release_locks;
 }
 
 #define XRESPONSE(x) #x,
@@ -5629,9 +5622,6 @@ int sbuf_is_local(COMDB2BUF *sb)
 
 int recover_deadlock_evbuffer(struct sqlclntstate *clnt)
 {
-    if (!gbl_sql_release_locks_on_slow_reader) {
-        return 0;
-    }
     int waiters = -1, lock_desired = -1;
     if ((waiters = bdb_curtran_has_waiters(thedb->bdb_env, clnt->dbtran.cursor_tran)) == 0
         && (lock_desired = bdb_lock_desired(thedb->bdb_env)) == 0

--- a/docs/pages/config/config_files.md
+++ b/docs/pages/config/config_files.md
@@ -276,7 +276,6 @@ shalloc_timing|  on |Berkeley DB will keep stats on time
 sql_release_locks_in_update_shadows|  on |Release sql locks in update_shadows on lockwait
 sql_release_locks_on_emit_row_lockwait|  off |Release sql locks when we are about to emit a row
 sql_release_locks_on_si_lockwait|  on |Release sql locks from si if the rep thread is waiting
-sql_release_locks_on_slow_reader|  on |Release sql locks if a tcp write to the client blocks
 sqlclient_use_random_readnode|  off |Sql client will use random sql allocation by default 
 sqlite3openserial|  on |Serialize calls to sqlite3_open to prevent excess CPU
 superset_foreign_keys|  on |Allow foreign key to be a superset of your key

--- a/tests/parenttran_fail.test/lrl.options
+++ b/tests/parenttran_fail.test/lrl.options
@@ -2,7 +2,6 @@ table t1 t1.csc2
 
 off sql_release_locks_on_si_lockwait
 off sql_release_locks_on_emit_row_lockwait
-off sql_release_locks_on_slow_reader
 off sql_release_locks_in_update_shadows
 off release_locks_trace
 enable_snapshot_isolation

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -985,7 +985,6 @@
 (name='sql_release_locks_in_update_shadows', description='Release sql locks in update_shadows on lockwait', type='BOOLEAN', value='ON', read_only='N')
 (name='sql_release_locks_on_emit_row_lockwait', description='Release sql locks when we are about to emit a row', type='BOOLEAN', value='OFF', read_only='N')
 (name='sql_release_locks_on_si_lockwait', description='Release sql locks from si if the rep thread is waiting', type='BOOLEAN', value='ON', read_only='N')
-(name='sql_release_locks_on_slow_reader', description='Release sql locks if a tcp write to the client blocks', type='BOOLEAN', value='ON', read_only='N')
 (name='sql_row_delay_msecs', description='Add this delay before sending back a row, for every row (default: 0)', type='INTEGER', value='0', read_only='N')
 (name='sql_time_threshold', description='Sets the threshold time in ms after which queries are reported as running a long time. (Default: 5000 ms)', type='INTEGER', value='5000', read_only='N')
 (name='sql_tranlevel_default', description='Sets the default SQL transaction level for the database.', type='ENUM', value='BLOCKSQL', read_only='Y')


### PR DESCRIPTION
release-locks-on-slow-reader is required: we cannot allow a stalled reader to deadlock the cluster.