### PR TITLE
Half is sufficient to ensure durability

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3479,7 +3479,7 @@ done_wait:
 
     uint32_t cluster_size = total_commissioned + 1;
     uint32_t number_with_this_update = num_successfully_acked + 1;
-    uint32_t durable_target = (cluster_size / 2) + 1;
+    uint32_t durable_target = (cluster_size % 2) ? (cluster_size / 2) + 1 : (cluster_size / 2);
 
     ATOMIC_ADD64(gbl_distributed_commit_count, 1);
 


### PR DESCRIPTION
Any commit which has replicated to half of the cluster must be part of a quorum.  Requiring it to replicate to a quorum to be called 'durable' was too conservative.
