### PR TITLE
limit total concurrent scl objects in llmeta

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1629,6 +1629,7 @@ int bdb_llmeta_get_all_sc_lists(tran_type *t, void ***dtas, int **dtalens,
                                 void ***keys, int *keylen, int *num, int *bdberr);
 
 int bdb_llmeta_rem_all_sc_lists(tran_type *input_trans);
+int bdb_llmeta_get_num_sc_lists(tran_type *t, int *bdberr);
 
 int bdb_set_in_schema_change(tran_type *input_trans, const char *db_name,
                              void *schema_change_data,

--- a/bdb/llmeta.c
+++ b/bdb/llmeta.c
@@ -202,6 +202,7 @@ static int kv_put(tran_type *tran, void *k, void *v, size_t vlen, int *bdberr);
 static int kv_del(tran_type *tran, void *k, int *bdberr);
 static int kv_get_kv(tran_type *t, void *k, size_t klen, void ***keys,
                      void ***values, int **valuelens, int *num, int *bdberr);
+static int kv_get_num_keys(tran_type *t, void *k, size_t klen, int *num, int *bdberr);
 static int kv_del_by_value(tran_type *tran, void *k, size_t klen, void *v, size_t vlen, int *bdberr);
 static int kv_del(tran_type *tran, void *k, int *bdberr);
 typedef int kv_for_each_cb(void *k, void *v, void *data);
@@ -4175,6 +4176,25 @@ int bdb_llmeta_get_all_sc_lists(tran_type *t, void ***dtas, int **dtalens, void 
     }
 
     return 0;
+}
+
+int bdb_llmeta_get_num_sc_lists(tran_type *t, int *bdberr)
+{
+    int num = 0;
+    int rc = 0;
+    union {
+        int type;
+        uint8_t buf[LLMETA_IXLEN];
+    } key = {0};
+    key.type = htonl(LLMETA_SCHEMACHANGE_LIST);
+
+    rc = kv_get_num_keys(t, &key, sizeof(key.type), &num, bdberr);
+    if (rc) {
+        logmsg(LOGMSG_ERROR, "%s: failed to retrieve num of sc lists rc %d bdberr %d\n", __func__, rc, *bdberr);
+        return -1;
+    }
+
+    return num;
 }
 
 static int _rem_all_schema_change_lists(tran_type *trans)
@@ -9897,6 +9917,26 @@ static int kv_get_keys(tran_type *t, void *k, size_t klen, void ***ret,
     }
     *num = n;
     *ret = names;
+    return rc;
+}
+
+// get num of matching key partial keys
+static int kv_get_num_keys(tran_type *t, void *k, size_t klen, int *num, int *bdberr)
+{
+    int n = 0;
+    int fnd;
+    uint8_t out[LLMETA_IXLEN];
+    int rc = bdb_lite_fetch_partial_tran(llmeta_bdb_state, t, k, klen, out, &fnd, bdberr);
+    while (rc == 0 && fnd == 1) {
+        if (memcmp(k, out, klen) != 0) {
+            break;
+        }
+        ++n;
+        uint8_t nxt[LLMETA_IXLEN];
+        rc = bdb_lite_fetch_keys_fwd_tran(llmeta_bdb_state, t, out, nxt, 1, &fnd, bdberr);
+        memcpy(out, nxt, sizeof(out));
+    }
+    *num = n;
     return rc;
 }
 

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1622,6 +1622,7 @@ typedef struct {
 extern int gbl_sc_timeoutms;
 extern int gbl_trigger_timepart;
 extern int gbl_multitable_ddl;
+extern int gbl_max_sc_lists;
 
 extern int64_t gbl_num_auth_allowed;
 extern int64_t gbl_num_auth_denied;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2580,6 +2580,9 @@ REGISTER_TUNABLE(
 REGISTER_TUNABLE("multitable_ddl",
                  "Enables single schema change object ddl implementation (default: off)",
                  TUNABLE_BOOLEAN, &gbl_multitable_ddl, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("max_sc_lists",
+                 "Limit how many total schema change lists object can coexist in llmeta (Default :10000)",
+                 TUNABLE_INTEGER, &gbl_max_sc_lists, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("sc_history_max_rows", "Max number of rows returned in comdb2_sc_history (Default: 1000)",
                  TUNABLE_INTEGER, &gbl_sc_history_max_rows, 0, NULL, NULL, NULL, NULL);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1416,8 +1416,9 @@ int bplog_schemachange(struct ireq *iq)
     /* save the SCHEMA_CHANGES object in LLMETA to be able to resume */
     rc = osql_sess_save_sc_list(iq->sorese);
     if (rc) {
-        logmsg(LOGMSG_ERROR, "%s failed to save sc list rc %d\n", __func__, rc);
-        return -1;
+        logmsg(LOGMSG_ERROR, "%s failed to save sc list rc %d %s\n", __func__, rc, iq->sorese->xerr.errstr);
+        reqerrstr(iq, ERR_SC, "%s", iq->sorese->xerr.errstr);
+        return ERR_SC;
     }
 
     rc = bplog_schemachange_run(iq, iq->sorese->uuid, &iq->sorese->scs);

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -39,6 +39,8 @@
 
 #include <disttxn.h>
 
+int gbl_max_sc_lists = 10000;
+
 struct sess_impl {
     int clients; /* number of threads using the session */
 
@@ -817,6 +819,20 @@ int osql_sess_save_sc_list(osql_sess_t *sess)
     if (rc) {
         logmsg(LOGMSG_ERROR, "%s: failed to create sc_list\n",
                __func__);
+        goto done;
+    }
+
+    /* check if too many scl-s */
+    int bdberr = 0;
+    int num_scl = bdb_llmeta_get_num_sc_lists(NULL, &bdberr);
+    if (num_scl < 0 || bdberr) {
+        errstat_set_rcstrf(&sess->xerr, rc = ERR_SC, "failed to count scl %d", bdberr);
+        logmsg(LOGMSG_ERROR, "%s: failed to count sc_lists rc %d bdberr %d\n", __func__, rc, bdberr);
+        goto done;
+    }
+    if (num_scl >= gbl_max_sc_lists) {
+        errstat_set_rcstrf(&sess->xerr, rc = ERR_SC, "too many sc lists objects %d >= %d", num_scl, gbl_max_sc_lists);
+        logmsg(LOGMSG_ERROR, "%s: too many sc lists objects %d >= %d\n", __func__, num_scl, gbl_max_sc_lists);
         goto done;
     }
 

--- a/tests/multiddl.test/lrl.options
+++ b/tests/multiddl.test/lrl.options
@@ -1,2 +1,3 @@
 table t t.csc2
+table t2 t.csc2
 multitable_ddl 1

--- a/tests/multiddl.test/output.log
+++ b/tests/multiddl.test/output.log
@@ -8,3 +8,11 @@ checking llmeta for first rebuild
 Launch racing rebuild on same table
 checking llmeta making sure we do not leak sclist
 (out='LLMETA_SCHEMACHANGE_STATUS_V2')
+limit number of pending scl to maximum one
+launching parallel rebuild
+checking llmeta for scl for running rebuild
+(out='LLMETA_SCHEMACHANGE_STATUS_V2')
+(out='LLMETA_SCHEMACHANGE_LIST:')
+checking that any new schema change is blocked now
+[rebuild t2] failed with rc 240 too many sc lists objects 1 >= 1
+waiting for thread

--- a/tests/multiddl.test/runit
+++ b/tests/multiddl.test/runit
@@ -15,6 +15,9 @@ CM="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${master}"
 rm $OUT 2>/dev/null
 touch $OUT
 
+
+echo "TEST 1: make sure we do no leak scl"
+
 echo "Inserting the rows"
 echo "Inserting the rows" >> $OUT
 $C "insert into t(a) select * from generate_series(1, 60)" >> $OUT
@@ -68,6 +71,52 @@ if (( $? != 0 )) ; then
    echo "FAILURE to get the llmeta list second"
    exit 1
 fi
+
+echo "TEST 2: make sure we block too many scl"
+
+echo "limit number of pending scl to maximum one"
+echo "limit number of pending scl to maximum one" >> $OUT
+$CM "put tunable max_sc_lists 1"
+if (( $? != 0 )) ; then
+   echo "FAILURE to adjust max_sc_lists"
+   exit 1
+fi
+
+echo "launching parallel rebuild"
+echo "launching parallel rebuild" >> $OUT
+$CM "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')"
+if (( $? != 0 )) ; then
+   echo "FAILURE to setattr sc_force_delay"
+   exit 1
+fi
+$CM "exec procedure sys.cmd.send('scdelay 1000')"
+if (( $? != 0 )) ; then
+   echo "FAILURE to scdelay"
+   exit 1
+fi
+$C "rebuild t" &
+
+sleep 5
+
+echo "checking llmeta for scl for running rebuild"
+echo "checking llmeta for scl for running rebuild" >> $OUT
+$C "exec procedure sys.cmd.send('llmeta list')" | grep "LLMETA_SCHEMACHANGE"  | grep -v "HISTORY">> $OUT
+if (( $? != 0 )) ; then
+   echo "FAILURE to get the llmeta list first"
+   exit 1
+fi
+
+echo "checking that any new schema change is blocked now" 
+echo "checking that any new schema change is blocked now" >> $OUT
+$C "rebuild t2" >> $OUT 2>&1
+if (( $? == 0 )) ; then
+   echo "FAILURE to stop new schema change"
+   exit 1
+fi
+
+echo "waiting for thread"
+echo "waiting for thread" >> $OUT
+wait
 
 testcase_output=$(cat $OUT)
 expected_output=$(cat output.log)

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -559,6 +559,7 @@
 (name='max_query_fingerprints', description='Maximum number of queries to be placed into the fingerprint hash (Default: 1000)', type='INTEGER', value='1000', read_only='N')
 (name='max_query_sample_queries', description='Maximum number of queries to be placed into the sample queries hash (Default: 1000)', type='INTEGER', value='1000', read_only='N')
 (name='max_rowlocks_reposition', description='Release a physical cursor an re-establish.', type='INTEGER', value='10', read_only='N')
+(name='max_sc_lists', description='Limit how many total schema change lists object can coexist in llmeta (Default :10000)', type='INTEGER', value='10000', read_only='N')
 (name='max_sql_idle_time', description='Warn when an SQL connection remains idle for this long.', type='INTEGER', value='3600', read_only='N')
 (name='max_sqlcache_hints', description='Maximum number of "hinted" query plans to keep (global). (Default: 100)', type='INTEGER', value='100', read_only='Y')
 (name='max_sqlcache_per_thread', description='Maximum number of plans to cache per sql thread (statement cache is per-thread). (Default: 10)', type='INTEGER', value='10', read_only='Y')


### PR DESCRIPTION
limit the amount of concurrent schema change lists (a.k.a. scl-s) we store in llmeta.

configurable by max_sc_lists tunable.

