### PR TITLE
Fix max key size using client sizes instead of server sizes

### DIFF
--- a/csc2/dynschemaload.h
+++ b/csc2/dynschemaload.h
@@ -83,6 +83,11 @@ int dyns_get_table_count(void);
 int dyns_get_table_tag_size(char *tabletag);
 int dyns_get_table_field_count(char *tabletag);
 
+/* Convert a server-type length to on-disk length; client_type is used for
+ * SERVER_BCSTR to distinguish pstr from cstr.
+ */
+int dyns_adjust_ondisk_field_length(int server_type, int len, int client_type);
+
 /* constraint accessors */
 int dyns_get_constraint_count(void);
 int dyns_get_constraint_at(int idx, char **consname, char **keyname,

--- a/csc2/macc_so.c
+++ b/csc2/macc_so.c
@@ -59,6 +59,7 @@ int dimidx = 0, dims[7], rngidx = 0, ranges[2], range_or_array = 0, range = 0,
 char *dims_cnst[7];
 
 int lastidx = 0;
+int gbl_max_key_size_new = 1;
 #define MAX_NESTED_RECTYPE 16
 static int ncases = -1;
 static int nested_rectype[MAX_NESTED_RECTYPE];
@@ -404,9 +405,9 @@ char * sqltypetxt(int t, int size)
         case T_DECIMAL64: return "decimal64";
         case T_DECIMAL128: return "decimal128";
 
-        case T_PSTR:  
+        case T_PSTR:
         case T_CSTR:
-        case T_FCHAR: 
+        case T_FCHAR:
         case T_VUTF8:
                            {
                                return "char";
@@ -723,6 +724,49 @@ int keysize(struct key *ck) /* CALCULATES SIZE OF A STRUCT KEY */
     }
 }
 
+static int keysize2(struct key *ck) /* CALCULATES ONDISK SIZE OF A KEY PIECE */
+{
+    int arr, chr, rng;
+    int ondtidx = ck->stbl;
+
+    if (ck->expr) {
+        /* TODO: calculate correct on-disk size for expression index pieces. The current code does this (incorrectly) as
+         * well. */
+        return 1;
+    }
+    if (ondtidx < 0) {
+        csc2_error("ERROR: INVALID KEY TABLE INDEX %d.\n", ck->stbl);
+        any_errors++;
+        return 0;
+    }
+
+    struct table *tables = macc_globals->tables;
+    struct symbol *sym = &tables[ondtidx].sym[ck->sym];
+    int sz = sym->szof; /* start with client fullsize like _create_schema_column */
+    int server_type;
+    int client_type;
+
+    arr = (sym->dim[0] != -1);              /* is this an array? */
+    rng = (ck->rg[0] > 0 && ck->rg[1] > 0); /* is a character range specified? */
+    chr = ((sym->type == T_PSTR) || (sym->type == T_UCHAR) || (sym->type == T_CSTR));
+
+    if (chr && rng)
+        sz = ck->rg[1] - ck->rg[0] + 1;
+    else if (arr && (ck->el[0] != -1))
+        sz = sym->size;
+
+    /* For cstrings, artificially add 1 to the size. Since we strip the '\0' at the end when storing on disk, we could
+     * technically store a cstring of size 513 in a key. But that would be confusing to the client. */
+    if (sym->type == T_CSTR) {
+        ++sz;
+    }
+
+    /* Then adjust to the on-disk representation like _set_column_ondisk_length. */
+    server_type = field_type(sym->type, 1);
+    client_type = field_type(sym->type, 0);
+    return dyns_adjust_ondisk_field_length(server_type, sz, client_type);
+}
+
 static int
 keyondisksize(struct key *wk) /* CALCULATE THE SIZE IN BYTES OF A WHOLE KEY */
 {
@@ -737,6 +781,19 @@ keyondisksize(struct key *wk) /* CALCULATE THE SIZE IN BYTES OF A WHOLE KEY */
             /* one byte extra header will be needed for every column in key. */
             sz++;
         }
+    }
+    return sz;
+}
+
+static int keyondisksize2(struct key *wk) /* CALCULATE ONDISK SIZE IN BYTES OF A WHOLE KEY */
+{
+    struct key *ck;
+    int sz;
+    sz = 0;
+    ck = wk;
+    while (ck) {
+        sz += keysize2(ck);
+        ck = ck->cmp;
     }
     return sz;
 }
@@ -1056,8 +1113,13 @@ static void key_add_comn(int ix, char *tag, char *exprname,
             return;
         }
     }
-    int sz = keyondisksize(macc_globals->workkey);
-    if (sz > MAXKEYLEN) { /* COMDB2 CURRENTLY SUPPORTS 512 byte KEYS*/
+    int sz;
+    if (gbl_max_key_size_new)
+        sz = keyondisksize2(macc_globals->workkey) -
+             1; /* COMDB2 CURRENTLY SUPPORTS 512 byte KEYS (not including null byte) */
+    else
+        sz = keyondisksize(macc_globals->workkey);
+    if (sz > MAXKEYLEN) {
         csc2_error(
             "Error at line %3d: KEY %s TOO BIG(%d)! VALID SIZE=1-%d BYTES\n",
             current_line, tag, sz, MAXKEYLEN);
@@ -3278,7 +3340,7 @@ int dyns_get_table_field_option(char *tag, int fidx, int option,
             *value_type = CLIENT_FUNCTION;
             *value_sz = len;
             return 0;
-        } 
+        }
         default:
             return -1;
         }

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -127,6 +127,7 @@ extern int gbl_debug_blkseq_race;
 extern int gbl_debug_stat4dump_loop;
 extern int gbl_master_swing_osql_verbose;
 extern int gbl_master_swing_sock_restart_sleep;
+extern int gbl_max_key_size_new;
 extern int gbl_max_lua_instructions;
 extern int gbl_max_sqlcache;
 extern int __gbl_max_mpalloc_sleeptime;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -789,6 +789,8 @@ REGISTER_TUNABLE("max_lua_instructions",
                  "procedure is looping and kill it. (Default: 10000)",
                  TUNABLE_INTEGER, &gbl_max_lua_instructions, 0, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("max_key_size_new", "Use new logic for checking max key size (Default: on)", TUNABLE_INTEGER,
+                 &gbl_max_key_size_new, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_num_compact_pages_per_txn", NULL, TUNABLE_INTEGER,
                  &gbl_max_num_compact_pages_per_txn, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("maxq",

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -24,6 +24,8 @@ static int init_check_constraints(dbtable *tbl);
 static int add_cmacc_stmt(dbtable *db, int alt, int allow_ull,
                           int no_side_effects, struct errstat *err);
 
+extern int gbl_max_key_size_new;
+
 char gbl_ver_temp_table[] = ".COMDB2.TEMP.VER.";
 
 struct dbtable *create_new_dbtable(struct dbenv *dbenv, char *tablename,
@@ -184,7 +186,7 @@ static dbtable *newdb_from_schema(struct dbenv *env, char *tblname, int dbnum)
     }
     for (ii = 0; ii < tbl->nix; ii++) {
         tmpidxsz = dyns_get_idx_size(ii);
-        if (tmpidxsz < 1 || tmpidxsz > MAXKEYLEN) {
+        if (tmpidxsz < 1 || (!gbl_max_key_size_new && tmpidxsz > MAXKEYLEN)) {
             logmsg(LOGMSG_ERROR, "index %d bad keylen %d in csc schema %s\n",
                    ii, tmpidxsz, tblname);
             cleanup_newdb(tbl);
@@ -333,7 +335,7 @@ static struct schema * _create_index_datacopy_schema(struct schema *sch, int ix,
         m = &p->member[piece];
         m->idx = find_field_idx_in_tag(sch, temp->field);
         if (m->idx == -1) {
-            /* DEFAULT tag can fail here, but error is ignored, 
+            /* DEFAULT tag can fail here, but error is ignored,
              * no datacopy idx for comdbgi
              */
             rc = -ix - 1;
@@ -796,7 +798,7 @@ static struct schema * _create_table_schema(char *tag, int alt)
         return NULL;
 
     /* ondisk format has an extra byte per field, and some other types have other
-     * way to store (strings, blobs); this is why ondisk is wrong here, since 
+     * way to store (strings, blobs); this is why ondisk is wrong here, since
      * parser just returns the length of the values!
      */
     sch->recsize = dyns_get_table_tag_size(tag); /* wrong for .ONDISK */
@@ -850,87 +852,73 @@ static int _set_column_blobs(struct field *fld, int nblobs)
     return nblobs;
 }
 
+int dyns_adjust_ondisk_field_length(int server_type, int len, int client_type)
+{
+    switch (server_type) {
+    case SERVER_BLOB:
+        /* TODO use the enums that are used in types.c */
+        /* blobs are stored as flag byte + 32 bit length */
+        return 5;
+    case SERVER_VUTF8:
+    case SERVER_BLOB2:
+        /* TODO use the enums that are used in types.c */
+        /* vutf8s are stored as flag byte + 32 bit length, plus
+         * optionally strings up to a certain length can be stored
+         * in the record itself */
+        return (len == -1) ? 5 : (len + 5);
+    case SERVER_BCSTR:
+        if (client_type == CLIENT_PSTR || client_type == CLIENT_PSTR2)
+            return len + 1;
+        /* no change needed from client length */
+        return len;
+    case SERVER_DATETIME:
+        /* server CLIENT_DATETIME is a server_datetime_t */
+        return sizeof(server_datetime_t);
+    case SERVER_DATETIMEUS:
+        /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
+        return sizeof(server_datetimeus_t);
+    case SERVER_INTVYM:
+        /* server CLIENT_INTVYM is a server_intv_ym_t */
+        return sizeof(server_intv_ym_t);
+    case SERVER_INTVDS:
+        /* server CLIENT_INTVDS is a server_intv_ds_t */
+        return sizeof(server_intv_ds_t);
+    case SERVER_INTVDSUS:
+        /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
+        return sizeof(server_intv_dsus_t);
+    case SERVER_DECIMAL:
+        switch (len) {
+        case 14:
+            return sizeof(server_decimal32_t);
+        case 24:
+            return sizeof(server_decimal64_t);
+        case 43:
+            return sizeof(server_decimal128_t);
+        default:
+            abort();
+        }
+    default:
+        return len + 1; /* most server types have a leading null/not-null byte */
+    }
+}
+
 /* for ondisk, we need to set the field length to server type proper
  * return current offset
  */
 static int _set_column_ondisk_length(struct field *fld, int idx, char *tag,
                                     int offset)
 {
-    char buf[MAXCOLNAME + 1] = {0}; /* scratch space buffer */
+    int clnt_type = -1;
 
-    /* cheat: change type to be ondisk type */
-    switch (fld->type) {
-        case SERVER_BLOB:
-            /* TODO use the enums that are used in types.c */
-            /* blobs are stored as flag byte + 32 bit length */
-            fld->len = 5;
-            break;
-        case SERVER_VUTF8:
-        case SERVER_BLOB2:
-            /* TODO use the enums that are used in types.c */
-            /* vutf8s are stored as flag byte + 32 bit length, plus
-             * optionally strings up to a certain length can be stored
-             * in the record itself */
-            if (fld->len == -1)
-                fld->len = 5;
-            else
-                fld->len += 5;
-            break;
-        case SERVER_BCSTR: {
-            int clnt_type = 0;
-            int clnt_offset = 0;
-            int clnt_len = 0;
+    if (fld->type == SERVER_BCSTR) {
+        char buf[MAXCOLNAME + 1] = {0}; /* scratch space buffer */
+        int clnt_offset = 0;
+        int clnt_len = 0;
 
-            dyns_get_table_field_info(tag, idx, buf, sizeof(buf),
-                                      &clnt_type, &clnt_offset, NULL,
-                                      &clnt_len, NULL, 0);
-
-            if (clnt_type == CLIENT_PSTR || clnt_type == CLIENT_PSTR2) {
-                fld->len++;
-            } else {
-                /* no change needed from client length */
-            }
-            } break;
-        case SERVER_DATETIME:
-            /* server CLIENT_DATETIME is a server_datetime_t */
-            fld->len = sizeof(server_datetime_t);
-            break;
-        case SERVER_DATETIMEUS:
-            /* server CLIENT_DATETIMEUS is a server_datetimeus_t */
-            fld->len = sizeof(server_datetimeus_t);
-            break;
-        case SERVER_INTVYM:
-            /* server CLIENT_INTVYM is a server_intv_ym_t */
-            fld->len = sizeof(server_intv_ym_t);
-            break;
-        case SERVER_INTVDS:
-            /* server CLIENT_INTVDS is a server_intv_ds_t */
-            fld->len = sizeof(server_intv_ds_t);
-            break;
-        case SERVER_INTVDSUS:
-            /* server CLIENT_INTVDSUS is a server_intv_dsus_t */
-            fld->len = sizeof(server_intv_dsus_t);
-            break;
-        case SERVER_DECIMAL:
-            switch (fld->len) {
-            case 14:
-                fld->len = sizeof(server_decimal32_t);
-                break;
-            case 24:
-                fld->len = sizeof(server_decimal64_t);
-                break;
-            case 43:
-                fld->len = sizeof(server_decimal128_t);
-                break;
-            default:
-                abort();
-            }
-            break;
-        default:
-            /* other types just add one for the flag byte */
-            fld->len++;
-            break;
+        dyns_get_table_field_info(tag, idx, buf, sizeof(buf), &clnt_type, &clnt_offset, NULL, &clnt_len, NULL, 0);
     }
+
+    fld->len = dyns_adjust_ondisk_field_length(fld->type, fld->len, clnt_type);
     fld->offset = offset;
     offset += fld->len;
     return offset;
@@ -1039,7 +1027,7 @@ static int add_cmacc_stmt(dbtable *tbl, int alt, int allow_ull,
 
     ntags = dyns_get_table_count();
 
-    /*  we will store the schemas here and add them at the end, so we 
+    /*  we will store the schemas here and add them at the end, so we
      *  do not polute tag hash in case of error
      */
     /* a server schema per tag + one client schema for ondisk */

--- a/tests/insert_maxindex.test/lrl.options
+++ b/tests/insert_maxindex.test/lrl.options
@@ -1,1 +1,1 @@
-#
+max_key_size_new 1

--- a/tests/insert_maxindex.test/old_logic.testopts
+++ b/tests/insert_maxindex.test/old_logic.testopts
@@ -1,0 +1,1 @@
+max_key_size_new 0

--- a/tests/insert_maxindex.test/runit
+++ b/tests/insert_maxindex.test/runit
@@ -83,7 +83,12 @@ runsql 'create table t3 {schema {cstring a[512]}}'
 runsql 'create index t3_a on t3(a)'
 
 runsql 'create table t4 {schema {cstring a[513]}}'
-runsqlfail 'create index t4_a on t4(a)' # Index exceeds max length
+runsqlfail 'create index t4_a on t4(a)' # Index exceeds max length. Ths really only takes 512 bytes + 1 NULL byte since we chop off the '\0' at the end. But would be confusing to allow 513, so disallow this.
+
+if [[ "$DBNAME" != *"insertmaxindexoldlogicgenerated"* ]]; then
+    runsql 'create table t5 {schema { byte b[501] datetime d } keys { "b" = b + d } }' # datetime used to be interpreted as 76 bytes! Should be 11
+    runsqlfail 'create table t6 {schema { byte b[502] datetime d } keys { "b" = b + d } }'
+fi
 
 # Verify this comes up after bounce
 bounce_cluster

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -550,6 +550,7 @@
 (name='max_identity_cache', description='Max cache size of externalauth identities (Default: 500)', type='INTEGER', value='500', read_only='Y')
 (name='max_incoherent_nodes', description='', type='INTEGER', value='1', read_only='Y')
 (name='max_incoherent_slow', description='Sets maximum number of incoherent-slow nodes.  (Default: 3)', type='INTEGER', value='3', read_only='N')
+(name='max_key_size_new', description='Use new logic for checking max key size (Default: on)', type='INTEGER', value='1', read_only='N')
 (name='max_latch', description='Size of latch array', type='INTEGER', value='200000', read_only='N')
 (name='max_latch_lockerid', description='Size of latch lockerid array', type='INTEGER', value='10000', read_only='N')
 (name='max_lua_instructions', description='Maximum lua opcodes to execute before we assume the stored procedure is looping and kill it. (Default: 10000)', type='INTEGER', value='10000', read_only='N')


### PR DESCRIPTION
Max key size was based on client sizes for some types, not server.

Max key size is defined as 512, but internally really 513 so we can have a key on byte(512) (+1 for null byte).

Don't allow cstring 513 though, even though this takes up 513 - 1 + 1 = 513 bytes. Subtract one because we don't store '\0' on disk.