### PR TITLE
Block "CREATE TIME PARTITION" syntax. …

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -604,6 +604,7 @@ extern int gbl_partition_sc_reorder;
 extern int gbl_retro_tpt;
 extern int gbl_retro_tpt_verbose;
 extern int gbl_retro_tpt_start;
+extern int gbl_legacy_tpt;
 extern int gbl_dohsql_joins;
 extern int gbl_altersc_latency;
 extern int gbl_altersc_delay_usec;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2554,6 +2554,9 @@ REGISTER_TUNABLE("partition_sc_reorder", "If the schema change is serialized for
 REGISTER_TUNABLE("partition_retroactively",
                  "Disable/enable time partition syntax to retroactively partition an existing table (Default: ON)",
                  TUNABLE_BOOLEAN, &gbl_retro_tpt, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("legacy_tpt_partition",
+                 "Disable/enable time partition syntax CREATE TIME PARTITION that generates legacy tpts (Default: ON)",
+                 TUNABLE_BOOLEAN, &gbl_legacy_tpt, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("partition_retroactively_verbose",
                  "Disable/enable data routing debugging for retroactively time partitioning (Default: OFF)",
                  TUNABLE_BOOLEAN, &gbl_retro_tpt_verbose, 0, NULL, NULL, NULL, NULL);

--- a/db/views.c
+++ b/db/views.c
@@ -47,6 +47,7 @@ extern int gbl_is_physical_replicant;
 int gbl_partitioned_table_enabled = 1;
 int gbl_merge_table_enabled = 1;
 int gbl_retro_tpt = 1;
+int gbl_legacy_tpt = 1;
 int gbl_retro_tpt_verbose = 0;
 int gbl_retro_tpt_start = 24; /* default 24 hours in the future */
 

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -46,6 +46,7 @@ extern int gbl_transactional_drop_plus_rename;
 extern int gbl_gen_shard_verbose;
 extern int gbl_sc_protobuf;
 extern int gbl_retro_tpt_start;
+extern int gbl_legacy_tpt;
 int gbl_view_feature = 1;
 int gbl_disable_sql_table_replacement = 0;
 extern int gbl_enable_bulk_import;
@@ -1632,7 +1633,7 @@ void comdb2CreatePartition(Parse* pParse, Token* table,
 
     if (comdb2IsDryrun(pParse)) {
         setError(pParse, SQLITE_MISUSE, "DRYRUN not supported for this operation");
-         return;
+        return;
     }
 #ifndef SQLITE_OMIT_AUTHORIZATION
     {
@@ -1642,6 +1643,17 @@ void comdb2CreatePartition(Parse* pParse, Token* table,
         }
     }
 #endif
+
+    static int once = 0;
+    if (!once) {
+        logmsg(LOGMSG_ERROR, "Deprecated time partition %.*s syntax\n", 
+                partition_name->n, partition_name->z);
+        once++;
+    }
+    if (!gbl_legacy_tpt) {
+        setError(pParse, SQLITE_MISUSE, "Deprecated time partition syntax");
+        return;
+    }
 
     Vdbe *v  = sqlite3GetVdbe(pParse);
 

--- a/tests/analyze_timepart_inversion.test/lrl.options
+++ b/tests/analyze_timepart_inversion.test/lrl.options
@@ -1,2 +1,3 @@
 table t t.csc2
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/copyschema_timepart.test/lrl.options
+++ b/tests/copyschema_timepart.test/lrl.options
@@ -1,2 +1,3 @@
 table t1 t1.csc2
 table t2 t2.csc2
+legacy_tpt_partition 1

--- a/tests/ddl_dryrun.test/lrl.options
+++ b/tests/ddl_dryrun.test/lrl.options
@@ -2,3 +2,4 @@ forbid_ulonglong 0
 table t1 t1.csc2
 table t2 t2.csc2
 table t3 t3.csc2
+legacy_tpt_partition 1

--- a/tests/ddl_no_csc2.test/lrl.options
+++ b/tests/ddl_no_csc2.test/lrl.options
@@ -1,1 +1,2 @@
 dont_forbid_ulonglong
+legacy_tpt_partition 1

--- a/tests/manual_partition_lgcy.test/lrl.options
+++ b/tests/manual_partition_lgcy.test/lrl.options
@@ -1,2 +1,3 @@
 table t1 t1.csc2
 table t2 t2.csc2
+legacy_tpt_partition 1

--- a/tests/renametable.test/lrl.options
+++ b/tests/renametable.test/lrl.options
@@ -1,3 +1,4 @@
 table t t.csc2
 
 dtastripe 4
+legacy_tpt_partition 1

--- a/tests/sc_multitable.test/lrl.options
+++ b/tests/sc_multitable.test/lrl.options
@@ -1,3 +1,4 @@
 table t t.csc2
 table t2 t2.csc2
 logmsg level info
+legacy_tpt_partition 1

--- a/tests/sc_race_timepart.test/lrl.options
+++ b/tests/sc_race_timepart.test/lrl.options
@@ -1,1 +1,2 @@
 table t t.csc2
+legacy_tpt_partition 1

--- a/tests/sc_timepart.test/lrl.options
+++ b/tests/sc_timepart.test/lrl.options
@@ -1,2 +1,3 @@
 table t t.csc2
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/selectv_timepart.test/lrl.options
+++ b/tests/selectv_timepart.test/lrl.options
@@ -1,2 +1,3 @@
 table t1 t1.csc2
 table t2 t2.csc2
+legacy_tpt_partition 1

--- a/tests/simple_timepart.test/lrl.options
+++ b/tests/simple_timepart.test/lrl.options
@@ -1,2 +1,3 @@
 table t t.csc2
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/sp.test/lrl.options
+++ b/tests/sp.test/lrl.options
@@ -1,3 +1,4 @@
 dtastripe 1
 enable_snapshot_isolation
 max_query_fingerprints 10000
+legacy_tpt_partition 1

--- a/tests/timepart_auth.test/lrl.options
+++ b/tests/timepart_auth.test/lrl.options
@@ -1,0 +1,1 @@
+legacy_tpt_partition 1

--- a/tests/timepart_changeretention.test/lrl.options
+++ b/tests/timepart_changeretention.test/lrl.options
@@ -2,3 +2,4 @@ table t t.csc2
 logmsg level user
 setattr DEBUG_TIMEPART_CRON 1
 setattr VIEWS_DFT_PREEMPT_ROLL_SECS 30
+legacy_tpt_partition 1

--- a/tests/timepart_constraints.test/lrl.options
+++ b/tests/timepart_constraints.test/lrl.options
@@ -1,3 +1,4 @@
 table t1 t1.csc2
 table t2 t2.csc2
 table t3 t3.csc2
+legacy_tpt_partition 1

--- a/tests/timepart_events.test/lrl.options
+++ b/tests/timepart_events.test/lrl.options
@@ -1,1 +1,2 @@
 table t t.csc2
+legacy_tpt_partition 1

--- a/tests/timepart_frgncnst.test/lrl.options
+++ b/tests/timepart_frgncnst.test/lrl.options
@@ -2,3 +2,4 @@ table t t.csc2
 table t2 t2.csc2
 logmsg level user
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/timepart_readonly.test/lrl.options
+++ b/tests/timepart_readonly.test/lrl.options
@@ -1,1 +1,2 @@
 table t t.csc2
+legacy_tpt_partition 1

--- a/tests/timepart_retention1.test/lrl.options
+++ b/tests/timepart_retention1.test/lrl.options
@@ -1,3 +1,4 @@
 table t t.csc2
 logmsg level user
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/timepart_trunc.test/lrl.options
+++ b/tests/timepart_trunc.test/lrl.options
@@ -1,1 +1,2 @@
 setattr DEBUG_TIMEPART_CRON 1
+legacy_tpt_partition 1

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -476,6 +476,7 @@
 (name='lclpooledbufs', description='', type='INTEGER', value='32', read_only='Y')
 (name='lease_renew_interval', description='How often we renew leases.', type='INTEGER', value='200', read_only='N')
 (name='leasebase_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
+(name='legacy_tpt_partition', description='Disable/enable time partition syntax CREATE TIME PARTITION that generates legacy tpts (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='legacy_verbose', description='Log all legacy (opcode+old sql) requests (default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='libevent_rte_only', description='Prevent listening on TCP socket. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
 (name='lightweight_rename', description='Replaces the ondisk file rename with an aliasing at llmeta level', type='BOOLEAN', value='OFF', read_only='N')

--- a/tests/ulonglong.test/lrl.options
+++ b/tests/ulonglong.test/lrl.options
@@ -1,0 +1,1 @@
+legacy_tpt_partition 1

--- a/tests/upsert.test/lrl.options
+++ b/tests/upsert.test/lrl.options
@@ -1,1 +1,2 @@
 osql_verify_retry_max 1000
+legacy_tpt_partition 1


### PR DESCRIPTION
Set tunable "legacy_tpt_partition" to reenable it.

Once time alert each time we detect usage irrespective of the tunable.

Regression tests using the features have this tunable enabled.