### PR TITLE
Remove unused `<error.h>` include to fix macOS build

### DIFF
--- a/tests/tools/partialwrite.c
+++ b/tests/tools/partialwrite.c
@@ -1,5 +1,4 @@
 #include <dlfcn.h>
-#include <error.h>
 #include <unistd.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
`tests/tools/partialwrite.c` includes `<error.h>`, which is a glibc-only header not available on macOS. The include is unused — the file only uses `fprintf`, `perror`, and abort for error handling. Removing it fixes the test-tools build on macOS.