### PR TITLE
Always enable check hb on blocked write for chunk transactions. Indic…

### DIFF
--- a/bbinc/comdb2buf.h
+++ b/bbinc/comdb2buf.h
@@ -64,7 +64,7 @@ enum CDB2BUF_FLAGS {
 };
 
 typedef int (*cdb2buf_readfn)(COMDB2BUF *sb, char *buf, int nbytes);
-typedef int (*cdb2buf_writefn)(COMDB2BUF *sb, const char *buf, int nbytes);
+typedef int (*cdb2buf_writefn)(COMDB2BUF *sb, const char *buf, int nbytes, int *timeout_error);
 
 /* retrieve underlying fd */
 int CDB2BUF_FUNC(cdb2buf_fileno)(COMDB2BUF *sb);
@@ -91,6 +91,11 @@ int CDB2BUF_FUNC(cdb2buf_close)(COMDB2BUF *sb);
 /* flush output, close fd, and free COMDB2BUF.*/
 int CDB2BUF_FUNC(cdb2buf_free)(COMDB2BUF *sb);
 #define cdb2buf_free CDB2BUF_FUNC(cdb2buf_free)
+
+/* flush output.  returns # of bytes written or <0 for error. If timeout_error is not NULL, it will be set to 1 if a
+ * timeout occurred */
+int CDB2BUF_FUNC(cdb2buf_flush_chk_timeout)(COMDB2BUF *sb, int *timeout_error);
+#define cdb2buf_flush_chk_timeout CDB2BUF_FUNC(cdb2buf_flush_chk_timeout)
 
 /* flush output.  returns # of bytes written or <0 for error */
 int CDB2BUF_FUNC(cdb2buf_flush)(COMDB2BUF *sb);

--- a/bbinc/ssl_io.h
+++ b/bbinc/ssl_io.h
@@ -32,7 +32,7 @@ void CDB2BUF_FUNC(sslio_free)(COMDB2BUF *);
 
 int CDB2BUF_FUNC(sslio_read)(COMDB2BUF *, char *cc, int len);
 #define sslio_read CDB2BUF_FUNC(sslio_read)
-int CDB2BUF_FUNC(sslio_write)(COMDB2BUF *, const char *cc, int len);
+int CDB2BUF_FUNC(sslio_write)(COMDB2BUF *, const char *cc, int len, int *timeout_error);
 #define sslio_write CDB2BUF_FUNC(sslio_write)
 
 /* Return the associated SSL object. */

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -4783,24 +4783,15 @@ static int cdb2_send_query(cdb2_hndl_tp *hndl, cdb2_hndl_tp *event_hndl, COMDB2B
     if (rc != len)
         debugprint("cdb2buf_write rc = %d (len = %d)\n", rc, len);
 
-    struct timeval start;
-    if (check_hb_on_blocked_write)
-        gettimeofday(&start, NULL);
+    // Always enable for chunk transactions
+    int check_hb_on_blocked_write_final = (check_hb_on_blocked_write || (hndl && hndl->is_chunk != CHUNK_NO));
+    int timeout_error = 0;
+    rc = cdb2buf_flush_chk_timeout(sb, &timeout_error);
 
-    rc = cdb2buf_flush(sb);
-
-    if (check_hb_on_blocked_write && rc < 0) {
-        // Failed writing to server. Don't know if cdb2buf_flush failed due to
-        // a timeout. Make a best effort guess:
-        struct timeval end;
-        gettimeofday(&end, NULL);
-        int64_t end_us = end.tv_sec * 1000000 + end.tv_usec;
-        int64_t start_us = start.tv_sec * 1000000 + start.tv_usec;
-        int64_t elapsed_us = end_us - start_us;
-        if (!is_begin && hndl && !hndl->is_read && hndl->in_trans && hndl->socket_timeout &&
-            elapsed_us >= (hndl->socket_timeout * 1000)) {
-            rc = wait_for_write(sb, hndl, event_hndl);
-        }
+    // Failed writing to server due to a timeout
+    if (check_hb_on_blocked_write_final && timeout_error && !is_begin && hndl && !hndl->is_read && hndl->in_trans &&
+        hndl->socket_timeout) {
+        rc = wait_for_write(sb, hndl, event_hndl);
     }
 
     if (rc < 0) {

--- a/net/net.c
+++ b/net/net.c
@@ -148,7 +148,7 @@ static sanc_node_type *add_to_sanctioned_nolock(netinfo_type *netinfo_ptr,
                                                 const char hostname[],
                                                 int portnum);
 
-static int net_writes(COMDB2BUF *sb, const char *buf, int nbytes);
+static int net_writes(COMDB2BUF *sb, const char *buf, int nbytes, int *timeout_error);
 static int net_reads(COMDB2BUF *sb, char *buf, int nbytes);
 
 static watchlist_node_type *get_watchlist_node(COMDB2BUF *, const char *funcname);
@@ -2695,14 +2695,14 @@ static watchlist_node_type *get_watchlist_node(COMDB2BUF *sb, const char *funcna
     }
 }
 
-static int net_writes(COMDB2BUF *sb, const char *buf, int nbytes)
+static int net_writes(COMDB2BUF *sb, const char *buf, int nbytes, int *timeout_error)
 {
     int outrc;
     watchlist_node_type *watchlist_node = get_watchlist_node(sb, __func__);
     if (!watchlist_node)
         return -1;
     watchlist_node->write_age = comdb2_time_epoch();
-    outrc = watchlist_node->writefn(sb, buf, nbytes);
+    outrc = watchlist_node->writefn(sb, buf, nbytes, timeout_error);
     watchlist_node->write_age = 0;
     return outrc;
 }

--- a/tests/cdb2api_chunk.test/Makefile
+++ b/tests/cdb2api_chunk.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=15m
+	export TEST_TIMEOUT=20m
 endif

--- a/tests/cdb2api_chunk.test/runit
+++ b/tests/cdb2api_chunk.test/runit
@@ -20,19 +20,19 @@ function check {
 }
 
 
-#####################
-## RUN WITHOUT FIX ##
-#####################
+########################################
+## RUN WITHOUT FIX EXPLICITLY ENABLED ##
+########################################
 echo 'comdb2_config:check_hb_on_blocked_write=0' >> ${cfg}
 ${chunk} ${dbname} ${tier} ${total}
-if [[ $? -eq 0 ]]; then
-    echo >&2 'Tunabled disabled - test expected to fail'
+if [[ $? -ne 0 ]]; then
+    echo >&2 'Tunabled always enabled for chunks - test expected to work'
     echo >&2 'chunk - fail'
     exit 1
 fi
 
 check
-if [[ $? -eq 0 ]]; then
+if [[ $? -ne 0 ]]; then
     cat >&2 ${cfg}
     echo >&2 "count:${count} (expected:${total})  min:${min} (expected:0)  max:${max} (expected:${expected_max})"
     echo >&2 'chunk - fail'

--- a/util/comdb2buf.c
+++ b/util/comdb2buf.c
@@ -188,10 +188,11 @@ int CDB2BUF_FUNC(cdb2buf_close)(COMDB2BUF *sb)
     return cdb2buf_free(sb);
 }
 
-/* flush output */
-int CDB2BUF_FUNC(cdb2buf_flush)(COMDB2BUF *sb)
+int CDB2BUF_FUNC(cdb2buf_flush_chk_timeout)(COMDB2BUF *sb, int *timeout_error)
 {
     int cnt = 0, rc, len;
+    if (timeout_error)
+        *timeout_error = 0;
 
     if (sb == 0)
         return -1;
@@ -206,17 +207,18 @@ int CDB2BUF_FUNC(cdb2buf_flush)(COMDB2BUF *sb)
         void *ssl;
 ssl_downgrade:
         ssl = sb->ssl;
-        rc = sb->write(sb, (char *)&sb->wbuf[sb->wtl], len);
+        rc = sb->write(sb, (char *)&sb->wbuf[sb->wtl], len, timeout_error);
         if (rc == 0 && sb->ssl != ssl) {
             /* Fall back to plaintext if client donates
                the socket to sockpool. */
             goto ssl_downgrade;
         }
 #else
-        rc = sb->write(sb, (char *)&sb->wbuf[sb->wtl], len);
+        rc = sb->write(sb, (char *)&sb->wbuf[sb->wtl], len, timeout_error);
 #endif
-        if (rc <= 0)
+        if (rc <= 0) {
             return -1 + rc;
+        }
         cnt += rc;
         sb->wtl += rc;
         if (sb->wtl >= sb->lbuf)
@@ -226,6 +228,12 @@ ssl_downgrade:
     /* this reduces fragmentation for Nagle-disabled sockets*/
     sb->whd = sb->wtl = 0;
     return cnt;
+}
+
+/* flush output */
+int CDB2BUF_FUNC(cdb2buf_flush)(COMDB2BUF *sb)
+{
+    return cdb2buf_flush_chk_timeout(sb, NULL);
 }
 
 int CDB2BUF_FUNC(cdb2buf_putc)(COMDB2BUF *sb, char c)
@@ -536,7 +544,7 @@ int CDB2BUF_FUNC(cdb2buf_printfx)(COMDB2BUF *sb, char *buf, int lbuf, char *fmt,
 
 /* default read/write functions for sbuf, which implement timeouts and
  * retry on EINTR. */
-static int swrite_unsecure(COMDB2BUF *sb, const char *cc, int len)
+static int swrite_unsecure(COMDB2BUF *sb, const char *cc, int len, int *timeout_error)
 {
     int rc;
     struct pollfd pol;
@@ -550,8 +558,11 @@ static int swrite_unsecure(COMDB2BUF *sb, const char *cc, int len)
             rc = poll(&pol, 1, sb->writetimeout);
         } while (rc == -1 && errno == EINTR);
 
-        if (rc <= 0)
+        if (rc <= 0) {
+            if (timeout_error && rc == 0)
+                *timeout_error = 1;
             return rc; /*timed out or error*/
+        }
         if ((pol.revents & POLLOUT) == 0)
             return -100000 + pol.revents;
         /*can write*/
@@ -564,13 +575,13 @@ static int swrite_unsecure(COMDB2BUF *sb, const char *cc, int len)
     return write(sb->fd, cc, len);
 }
 
-static int swrite(COMDB2BUF *sb, const char *cc, int len)
+static int swrite(COMDB2BUF *sb, const char *cc, int len, int *timeout_error)
 {
     int rc;
     if (sb->ssl == NULL)
-        rc = swrite_unsecure(sb, cc, len);
+        rc = swrite_unsecure(sb, cc, len, timeout_error);
     else
-        rc = sslio_write(sb, cc, len);
+        rc = sslio_write(sb, cc, len, timeout_error);
     return rc;
 }
 

--- a/util/ssl_io.c
+++ b/util/ssl_io.c
@@ -122,7 +122,7 @@ int CDB2BUF_FUNC(sslio_has_x509)(COMDB2BUF *sb)
     return (sb != NULL && sb->cert != NULL);
 }
 
-static int sslio_pollin(COMDB2BUF *sb)
+static int sslio_pollin(COMDB2BUF *sb, int *timeout_error)
 {
     int rc;
     struct pollfd pol;
@@ -138,6 +138,8 @@ static int sslio_pollin(COMDB2BUF *sb)
     } while (rc == -1 && errno == EINTR);
 
     if (rc <= 0) { /* timedout or error. */
+        if (timeout_error && rc == 0)
+            *timeout_error = 1;
         ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr), my_ssl_eprintln, "failed to poll rc %d errno %d", rc, errno);
         return rc;
     }
@@ -151,7 +153,7 @@ static int sslio_pollin(COMDB2BUF *sb)
     return 1;
 }
 
-static int sslio_pollout(COMDB2BUF *sb)
+static int sslio_pollout(COMDB2BUF *sb, int *timeout_error)
 {
     int rc;
     struct pollfd pol;
@@ -164,6 +166,8 @@ static int sslio_pollout(COMDB2BUF *sb)
     } while (rc == -1 && errno == EINTR);
 
     if (rc <= 0) { /* timedout or error. */
+        if (timeout_error && rc == 0)
+            *timeout_error = 1;
         ssl_sfeprint(sb->sslerr, sizeof(sb->sslerr), my_ssl_eprintln, "failed to poll rc %d errno %d", rc, errno);
         return rc;
     }
@@ -359,7 +363,7 @@ re_accept_or_connect:
             /* This forces an incomplete SSL handshake */
             if (!fail_ssl_poll) {
 #endif
-                rc = sslio_pollin(sb);
+                rc = sslio_pollin(sb, NULL);
                 if (rc > 0)
                     goto re_accept_or_connect;
 #ifdef CDB2API_TEST
@@ -368,7 +372,7 @@ re_accept_or_connect:
             sb->protocolerr = 0;
             break;
         case SSL_ERROR_WANT_WRITE: /* Renegotiate */
-            rc = sslio_pollout(sb);
+            rc = sslio_pollout(sb, NULL);
             if (rc > 0)
                 goto re_accept_or_connect;
             sb->protocolerr = 0;
@@ -432,7 +436,7 @@ int CDB2BUF_FUNC(sslio_read)(COMDB2BUF *sb, char *cc, int len)
 
 reread:
     ERR_clear_error();
-    n = wantread ? sslio_pollin(sb) : sslio_pollout(sb);
+    n = wantread ? sslio_pollin(sb, NULL) : sslio_pollout(sb, NULL);
     if (n <= 0)
         return n;
 
@@ -456,7 +460,7 @@ reread:
     return n;
 }
 
-int CDB2BUF_FUNC(sslio_write)(COMDB2BUF *sb, const char *cc, int len)
+int CDB2BUF_FUNC(sslio_write)(COMDB2BUF *sb, const char *cc, int len, int *timeout_error)
 {
     int n, ioerr, wantwrite;
 
@@ -464,7 +468,7 @@ int CDB2BUF_FUNC(sslio_write)(COMDB2BUF *sb, const char *cc, int len)
 
 rewrite:
     ERR_clear_error();
-    n = wantwrite ? sslio_pollout(sb) : sslio_pollin(sb);
+    n = wantwrite ? sslio_pollout(sb, timeout_error) : sslio_pollin(sb, timeout_error);
     if (n <= 0)
         return n;
 
@@ -506,10 +510,10 @@ int CDB2BUF_FUNC(sslio_close)(COMDB2BUF *sb, int wait_for_peer)
             ioerr = SSL_get_error(sb->ssl, rc);
             switch (ioerr) {
             case SSL_ERROR_WANT_READ:
-                rc = sslio_pollin(sb);
+                rc = sslio_pollin(sb, NULL);
                 break;
             case SSL_ERROR_WANT_WRITE:
-                rc = sslio_pollout(sb);
+                rc = sslio_pollout(sb, NULL);
                 break;
             default:
                 rc = -1;


### PR DESCRIPTION
…ate when timeout occurred

Same as https://github.com/bloomberg/comdb2/pull/5864

robor wouldn't let me resubmit 5864