### PR TITLE
selectv corner case when table becomes empty

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -281,8 +281,7 @@ static int pselectv_callback(void *arg, const char *tablename, int tableversion,
     if ((rc = ix_check_genid_wl(iq, trans, genid, &bdberr)) != 0) {
         if (rc != 1) {
             unsigned long long lclgenid = bdb_genid_to_host_order(genid);
-            if ((bdberr == 0 && rc == 0) ||
-                (bdberr == IX_PASTEOF && rc == -1)) {
+            if ((bdberr == 0 && rc == 0) || (bdberr == IX_PASTEOF && rc == -1) || (bdberr == IX_EMPTY && rc == -1)) {
                 err->ixnum = -1;
                 err->errcode = ERR_CONSTR;
                 ctrace("constraints error, no genid %llx (%llu)\n", lclgenid,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7810,8 +7810,7 @@ done_delete:
 
         /* was error? verify error ? */
         if (rc != 1) {
-            if ((bdberr == 0 && rc == 0) ||
-                (bdberr == IX_PASTEOF && rc == -1)) {
+            if ((bdberr == 0 && rc == 0) || (bdberr == IX_PASTEOF && rc == -1) || (bdberr == IX_EMPTY && rc == -1)) {
                 /* verify error */
                 err->ixnum = -1; /* data */
                 err->errcode = ERR_CONSTR;

--- a/tests/selectv.test/t5_10.req
+++ b/tests/selectv.test/t5_10.req
@@ -1,0 +1,5 @@
+1 begin
+1 selectv id from t2
+1 update t2 set id = id + 1
+2 delete from t2
+1 commit

--- a/tests/selectv.test/t5_10.req.exp
+++ b/tests/selectv.test/t5_10.req.exp
@@ -1,0 +1,14 @@
+done
+(id=5)
+(id=2)
+(id=6)
+(id=3)
+(id=7)
+(id=4)
+(id=8)
+done
+done
+(rows deleted=7)
+done
+[commit] failed with rc -103 constraints error, no genid
+done


### PR DESCRIPTION
Without this fix, we send the wrong error code to the client (203 == CDB2ERR_DEADLOCK), error message looks like:
"unable to find genid =69fc6d5c00010000 rc=99"
This fixes the return code (-103 == CDB2ERR_CONSTRAINTS), message: "constraints error, no genid".

