### PR TITLE
close a remote cursor that reads sqlite_master

### DIFF
--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -6627,7 +6627,7 @@ int sqlite3BtreeCloseCursor(BtCursor *pCur)
 
     cursorid = pCur->cursorid;
     if (pCur->bt && pCur->bt->is_remote &&
-        pCur->rootpage != RTPAGE_SQLITE_MASTER) /* sqlite_master is local */
+        (pCur->rootpage != RTPAGE_SQLITE_MASTER || !fdb_master_is_local(pCur))) /* is sqlite_master local ? */
     {
         /* release the fdb cursor */
         if (pCur->fdbc) {


### PR DESCRIPTION
When accessing sqlite_master through remsql, we call fdb_cursor_open() but not fdb_cursor_close() because we treat all sqlite_master cursors as locals.   Make sure we close remote cursor if we are accessing remote sqlite_master.