### PR TITLE
{184231472}: Fixing time_t arithmetic overflow for cnonce

### DIFF
--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -5288,26 +5288,26 @@ static int next_cnonce(cdb2_hndl_tp *hndl)
        4. Otherwise, return an error. */
 
     int rc;
-    struct timeval tv;
+    struct timespec ts;
     uint64_t cnt, seq, tm, now;
     cnonce_t *c;
 
     static char hex[] = "0123456789abcdef";
     char *in, *out, *end;
 
-    rc = gettimeofday(&tv, NULL);
+    rc = clock_gettime(CLOCK_MONOTONIC, &ts);
     if (rc != 0)
         return rc;
     c = &hndl->cnonce;
     seq = c->seq;
     tm = (seq & TIME_MASK) >> CNT_BITS;
-    now = tv.tv_sec * 1000000 + tv.tv_usec;
+    now = (uint64_t)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
     if (now == tm) {
         cnt = ((seq & CNT_MASK) + 1) & CNT_MASK;
         if (cnt == 0) {
             snprintf(hndl->errstr, sizeof(hndl->errstr),
                      "Transaction rate too high.");
-            rc = E2BIG;
+            rc = -1;
         } else {
             c->seq = (seq & TIME_MASK) | cnt;
         }
@@ -5316,12 +5316,9 @@ static int next_cnonce(cdb2_hndl_tp *hndl)
             c->hostid = _MACHINE_ID;
             c->pid = _PID;
             c->hndl = hndl;
-            c->ofs = sprintf(c->str, CNONCE_STR_FMT, c->hostid, c->pid,
-                             (unsigned long long)c->hndl);
+            c->ofs = sprintf(c->str, CNONCE_STR_FMT, c->hostid, c->pid, (intptr_t)c->hndl);
         }
         c->seq = (now << CNT_BITS);
-    } else {
-        rc = EINVAL;
     }
 
     if (rc == 0) {

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -5288,30 +5288,22 @@ static int next_cnonce(cdb2_hndl_tp *hndl)
        4. Otherwise, return an error. */
 
     int rc;
-    struct timespec ts;
+    struct timeval tv;
     uint64_t cnt, seq, tm, now;
     cnonce_t *c;
 
     static char hex[] = "0123456789abcdef";
     char *in, *out, *end;
 
-    rc = clock_gettime(CLOCK_MONOTONIC, &ts);
+retry:
+    rc = gettimeofday(&tv, NULL);
     if (rc != 0)
         return rc;
     c = &hndl->cnonce;
     seq = c->seq;
     tm = (seq & TIME_MASK) >> CNT_BITS;
-    now = (uint64_t)ts.tv_sec * 1000000 + ts.tv_nsec / 1000;
-    if (now == tm) {
-        cnt = ((seq & CNT_MASK) + 1) & CNT_MASK;
-        if (cnt == 0) {
-            snprintf(hndl->errstr, sizeof(hndl->errstr),
-                     "Transaction rate too high.");
-            rc = -1;
-        } else {
-            c->seq = (seq & TIME_MASK) | cnt;
-        }
-    } else if (now > tm) {
+    now = (uint64_t)tv.tv_sec * 1000000 + tv.tv_usec;
+    if (now > tm) {
         if (tm == 0) {
             c->hostid = _MACHINE_ID;
             c->pid = _PID;
@@ -5319,6 +5311,15 @@ static int next_cnonce(cdb2_hndl_tp *hndl)
             c->ofs = sprintf(c->str, CNONCE_STR_FMT, c->hostid, c->pid, (intptr_t)c->hndl);
         }
         c->seq = (now << CNT_BITS);
+    } else {
+        cnt = ((seq & CNT_MASK) + 1) & CNT_MASK;
+        if (cnt == 0) {
+            /* Transaction rate too high */
+            poll(NULL, 0, 100);
+            goto retry;
+        } else {
+            c->seq = (seq & TIME_MASK) | cnt;
+        }
     }
 
     if (rc == 0) {

--- a/cdb2api/cdb2api_hndl.h
+++ b/cdb2api/cdb2api_hndl.h
@@ -23,6 +23,7 @@
 #define INCLUDED_CDB2API_HNDL_H
 #include <comdb2buf.h>
 
+#include <inttypes.h>
 #include <sys/types.h>
 #include <sys/queue.h>
 
@@ -60,8 +61,8 @@ struct cdb2_event {
    4096 txn/us (~4 billion transactions per second) till September 17, 2112.
 
    See next_cnonce() for details. */
-#define CNONCE_STR_FMT "%lx-%x-%llx-"
-#define CNONCE_STR_SZ 60 /* 16 + 1 + 8 + 1 + 16 + 1 + 16 + 1 (NUL) */
+#define CNONCE_STR_FMT "%lx-%x-%" PRIxPTR "-"
+#define CNONCE_STR_SZ ((sizeof(long) + sizeof(int) + sizeof(intptr_t)) * 2 + 3 + 16 + 1)
 
 #define CNT_BITS 12
 #define TIME_MASK (-1ULL << CNT_BITS)


### PR DESCRIPTION
This patch also adds protection for clock going backwards, which I think is not that uncommon.