### PR TITLE
{179579733}: fix sql query plan worse for parameter binding

### DIFF
--- a/sqlite/src/where.c
+++ b/sqlite/src/where.c
@@ -2311,7 +2311,7 @@ static void whereLoopOutputAdjust(
 ){
   WhereTerm *pTerm, *pX;
   Bitmask notAllowed = ~(pLoop->prereq|pLoop->maskSelf);
-  int i, j, k;
+  int i, j;
   LogEst iReduce = 0;    /* pLoop->nOut should not exceed nRow-iReduce */
 
   assert( (pLoop->wsFlags & WHERE_AUTO_INDEX)==0 );
@@ -2336,8 +2336,10 @@ static void whereLoopOutputAdjust(
         pLoop->nOut--;
         if( pTerm->eOperator&(WO_EQ|WO_IS) ){
           Expr *pRight = pTerm->pExpr->pRight;
+          Parse *pParse = pWC->pWInfo->pParse;
+          int k = 0;
           testcase( pTerm->pExpr->op==TK_IS );
-          if( sqlite3ExprIsInteger(pRight, &k, 0) && k>=(-1) && k<=1 ){
+          if( sqlite3ExprIsInteger(pRight, &k, pParse) && k>=(-1) && k<=1 ){
             k = 10;
           }else{
             k = 20;

--- a/tests/bind_query_plan.test/Makefile
+++ b/tests/bind_query_plan.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/bind_query_plan.test/runit
+++ b/tests/bind_query_plan.test/runit
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+bash -n "$0" || exit 1
+
+set -e
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+
+if [ "x$dbnm" == "x" ] ; then
+    failexit "need a DB name"
+fi
+
+# Setup tables
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t1(a INT, b INT)"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE TABLE t2(x INT, y INT)"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE INDEX t1_a ON t1(a)"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE INDEX t1_b ON t1(b)"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "CREATE INDEX t2_x ON t2(x)"
+
+# Populate t1: 1000 rows, a = i%33, b = i
+cdb2sql ${CDB2_OPTIONS} $dbnm default "WITH s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i<999) INSERT INTO t1 SELECT i%33, i FROM s"
+
+# Populate t2: 60 rows, x = i, y = i%3
+cdb2sql ${CDB2_OPTIONS} $dbnm default "WITH s(i) AS (SELECT 0 UNION ALL SELECT i+1 FROM s WHERE i<59) INSERT INTO t2 SELECT i, i%3 FROM s"
+
+# Gather statistics
+cdb2sql ${CDB2_OPTIONS} $dbnm default "ANALYZE t1"
+cdb2sql ${CDB2_OPTIONS} $dbnm default "ANALYZE t2"
+
+# Test: query plan with bound parameter ?=0
+echo "@bind CDB2_INTEGER zero 0
+explain query plan SELECT * FROM t1 JOIN t2 ON t1.b = t2.x WHERE t1.a = 5 AND t2.y = @zero" | cdb2sql ${CDB2_OPTIONS} $dbnm default - | grep "detail=" | sed "s/id=[0-9]*/id=N/" > plan_bound.txt
+
+# Test: query plan with literal 0
+cdb2sql ${CDB2_OPTIONS} $dbnm default "explain query plan SELECT * FROM t1 JOIN t2 ON t1.b = t2.x WHERE t1.a = 5 AND t2.y = 0" | grep "detail=" | sed "s/id=[0-9]*/id=N/" > plan_literal.txt
+
+echo "Bound parameter plan:"
+cat plan_bound.txt
+echo ""
+echo "Literal plan:"
+cat plan_literal.txt
+
+# A bound value of 0 should be handled the same way as a literal 0
+# when estimating the probability of (x=<some-integer>).
+if ! diff plan_bound.txt plan_literal.txt > /dev/null; then
+    echo "FAIL: bound parameter produces different query plan than literal"
+    diff plan_bound.txt plan_literal.txt
+    exit 1
+fi
+
+echo "Success!"


### PR DESCRIPTION
In `whereLoopOutputAdjust`, we call `sqlite3ExprIsInteger` to adjust output number estimation for small numbers like -1, 0, 1. We always pass in 0 as the third parameter. The function would estimate based on the real value for literal values but skipped `sqlite3VdbeGetBoundValue` since `pParse==0`. This could cause the query planner to choose a significantly worse plan when using bound parameters vs literals.

Fix has been made on upstream sqlite [branch-3.28](https://github.com/sqlite/sqlite/commit/c3687b5c5c984c1df35d731c108aa324dca7b740).