### PR TITLE
fix luatests, rm

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3564,7 +3564,7 @@ carray_err:     *err = sqlite3_mprintf("carray_bind: invalid param:%s count:%d t
         }
     }
 out:if (rc) {
-        *err = sqlite3_mprintf("bad parameter name:%s pos:%d type:%d\n", p.name, p.pos, p.type);
+        *err = sqlite3_mprintf("bad parameter name:%s type:%d\n", p.name, p.type);
     }
     return rc;
 }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -6498,7 +6498,7 @@ static int push_args(const char **argstr, struct sqlclntstate *clnt, char **err,
     if (rc != arg_end) {
         *err = malloc(64);
         if (arg.type == arg_param) {
-            snprintf0(*err, 60, "Bad parameter:%s type:%d", arg.buf + 1, rc);
+            snprintf0(*err, 60, "bad parameter name:%s pos:%d type:%d", arg.buf + 1, argcnt, rc);
         } else {
             if (snprintf0(*err, 60, "bad argument -> %s", msg) >= 60) {
                 strcat(*err, "...");


### PR DESCRIPTION
had to get pos again, as sqlinterfaces.c:3459 doesn't set it, also newsql_param_value, (param_value func) that set p.pos, returns err, before it's set .. so refetched 

+ one thing to note is that sqlite3_bind_parameter_index is 1 based index, so changed rm expected output too .. 
