### PR TITLE
Don't send heartbeats for discarded transactions

### DIFF
--- a/db/disttxn.c
+++ b/db/disttxn.c
@@ -2205,6 +2205,11 @@ int osql_sanction_disttxn(const char *dist_txnid, unsigned long long *rqid, uuid
     Pthread_mutex_lock(&sanc_lk);
     sanc = hash_find(sanctioned_hash, &dist_txnid);
     if (sanc != NULL) {
+        if (sanc->sanctioned == -1) {
+            logmsg(LOGMSG_ERROR, "%s: dist_txnid %s has been discarded, ignoring prepare\n", __func__, dist_txnid);
+            Pthread_mutex_unlock(&sanc_lk);
+            return -1;
+        }
         (*rqid) = sanc->rqid;
         comdb2uuidcpy((*uuid), sanc->uuid);
         sanc->sanctioned = 1;

--- a/db/osqlsession.c
+++ b/db/osqlsession.c
@@ -317,6 +317,9 @@ int osql_prepare(const char *dist_txnid, const char *coordinator_dbname, const c
         logmsg(LOGMSG_INFO, "%s: coordinator beat participant prepare dist-txn %s\n", __func__, dist_txnid);
         return 0;
     }
+    if (rc < 0) {
+        return -1;
+    }
 
     osql_sess_t *sess = osql_repository_get(uuid);
     if (!sess) {


### PR DESCRIPTION
Discarded transactions never set hbeats.sanc, and should never send heartbeats.