### PR TITLE
Race between sc_set_running(0) and ddl replication

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -175,6 +175,7 @@ extern int gbl_test_trigger_deadlock;
 extern int gbl_llmeta_deadlock_poll;
 extern int gbl_test_scindex_deadlock;
 extern int gbl_test_sc_resume_race;
+extern int gbl_test_sc_delay_after_unset_running;
 extern int gbl_track_weighted_queue_metrics_separately;
 extern int gbl_typessql;
 extern int gbl_typessql_records_max;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1221,6 +1221,10 @@ REGISTER_TUNABLE("test_sc_resume_race",
                  "Test race between schemachange resume and blockprocessor",
                  TUNABLE_BOOLEAN, &gbl_test_sc_resume_race, READONLY, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("test_sc_delay_after_unset_running",
+                 "Delay in seconds after sc_set_running(0) before commit, to "
+                 "reproduce sc_set_running/trans_commit race",
+                 TUNABLE_INTEGER, &gbl_test_sc_delay_after_unset_running, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("throttlesqloverlog",
                  "On a full queue of SQL requests, dump the current thread "
                  "pool this often (in secs). (Default: 5sec)",

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1584,6 +1584,10 @@ void *resume_sc_multiddl_txn_finalize(void *p)
     }
     iq->sc_logical_tran = NULL;
 
+    /* Clear sc_running after trans_commit_logical so that replicants have
+     * the new schema visible before stat shows SC as done */
+    osql_clear_sc_running(iq);
+
     osql_postcommit_handle(iq);
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE);
 

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6919,6 +6919,15 @@ int osql_set_usedb(struct ireq *iq, const char *tablename, int tableversion, int
  * Handle the finalize part of a chain of schema changes
  *
  */
+void osql_clear_sc_running(struct ireq *iq)
+{
+    struct schema_change_type *sc = iq->sc_pending;
+    while (sc != NULL) {
+        sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__, __LINE__);
+        sc = sc->sc_next;
+    }
+}
+
 int osql_finalize_scs(struct ireq *iq, tran_type *trans)
 {
     int rc;
@@ -6982,14 +6991,6 @@ int osql_finalize_scs(struct ireq *iq, tran_type *trans)
             }
             sc = sc->sc_next;
         }
-    }
-
-    /* Success: reset the table counters */
-    iq->sc = iq->sc_pending;
-    while (iq->sc != NULL) {
-        sc_set_running(iq, iq->sc, iq->sc->tablename, 0, NULL, 0,
-                       __func__, __LINE__);
-        iq->sc = iq->sc->sc_next;
     }
 
     if (iq->sc_pending) {

--- a/db/osqlcomm.h
+++ b/db/osqlcomm.h
@@ -450,6 +450,7 @@ uint8_t *osqlcomm_scl_put(struct sc_list *scl,
  *
  */
 int osql_finalize_scs(struct ireq *iq, tran_type *trans);
+void osql_clear_sc_running(struct ireq *iq);
 
 /**
  * Return non-zero if host is known to osqlnet, 0 if not

--- a/db/toblock.c
+++ b/db/toblock.c
@@ -5780,6 +5780,10 @@ add_blkseq:
                                                    gbl_myhostname, 0, 1, NULL,
                                                    0, NULL, 0);
                     }
+                    /* Clear sc_running after trans_commit_logical so that
+                     * replicants have the new tableversion visible before
+                     * stat shows SC as done */
+                    osql_clear_sc_running(iq);
                     assert(outrc || iq->sc_running == 0);
                     iq->sc_logical_tran = NULL;
                 } else {
@@ -6117,6 +6121,12 @@ add_blkseq:
                     Pthread_rwlock_unlock(&commit_lock);
                     hascommitlock = 0;
                 }
+
+                /* In rowlocks mode, trans IS the sc_logical_tran (see
+                 * start_new_transaction). Clear sc_running after commit,
+                 * mirroring the non-rowlocks tranddl path at ~line 5786. */
+                if (iq->tranddl)
+                    osql_clear_sc_running(iq);
 
                 if (rc == BDBERR_NOT_DURABLE)
                     rc = ERR_NOT_DURABLE;

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -320,6 +320,7 @@ static inline int wait_to_resume(struct schema_change_type *s)
 
 int gbl_test_scindex_deadlock = 0;
 int gbl_test_sc_resume_race = 0;
+int gbl_test_sc_delay_after_unset_running = 0;
 int gbl_readonly_sc = 0;
 
 /*********** Outer Business logic for schemachanges ************************/

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -360,6 +360,13 @@ done:
            __func__, table, running, func, line, rc);
 
     Pthread_mutex_unlock(&schema_change_in_progress_mutex);
+
+    if (!running && rc == 0 && gbl_test_sc_delay_after_unset_running) {
+        logmsg(LOGMSG_INFO, "%s: sleeping %ds after clearing sc_running for %s\n", __func__,
+               gbl_test_sc_delay_after_unset_running, table);
+        sleep(gbl_test_sc_delay_after_unset_running);
+    }
+
     return rc;
 }
 

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -523,6 +523,7 @@ void sc_errf(struct schema_change_type *s, const char *fmt, ...);
 int do_dryrun(struct schema_change_type *);
 
 extern int gbl_test_scindex_deadlock;
+extern int gbl_test_sc_delay_after_unset_running;
 extern int gbl_altersc_latency;
 extern int gbl_altersc_delay_usec;
 

--- a/tests/sc_setrunning_race.test/Makefile
+++ b/tests/sc_setrunning_race.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/sc_setrunning_race.test/lrl.options
+++ b/tests/sc_setrunning_race.test/lrl.options
@@ -1,0 +1,2 @@
+setattr DURABLE_LSNS 1
+test_sc_delay_after_unset_running 5

--- a/tests/sc_setrunning_race.test/runit
+++ b/tests/sc_setrunning_race.test/runit
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Reproduce the race between sc_set_running(0) and trans_commit:
+#
+# sc_set_running(0) is called inside osql_finalize_scs(), before the schema
+# change transaction is committed.  This means the master's 'stat' output
+# stops showing "Schema change in progress" while the new tableversion is not
+# yet durable or visible on replicants.
+#
+# The test_sc_delay_after_unset_running tunable (set in lrl.options) inserts a
+# sleep between sc_set_running(0) and trans_commit inside osql_finalize_scs(),
+# widening the race window to make the bug reliably reproducible.
+#
+# This is a CLUSTER-ONLY test: we need replicants to demonstrate the race.
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+set -x
+
+dbname=$1
+
+echo "CLUSTER='$CLUSTER' dbname=$dbname"
+
+if [ -z "$CLUSTER" ]; then
+    echo "This test requires a cluster; skipping on single node"
+    exit 0
+fi
+
+getmaster() {
+    master=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbname default \
+        "exec procedure sys.cmd.send('bdb cluster')" \
+        | grep MASTER | cut -f1 -d: | tr -d '[:space:]')
+    ok=0
+    while [[ "$ok" != "1" ]]; do
+        ok=1
+        for node in $CLUSTER; do
+            m2=$(cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbname \
+                "exec procedure sys.cmd.send('bdb cluster')" \
+                | grep MASTER | cut -f1 -d: | tr -d '[:space:]')
+            if [[ "$master" == "" || "$master" != "$m2" ]]; then
+                master="$m2"
+                ok=0
+                break
+            fi
+        done
+    done
+    echo $master
+}
+
+get_replicant() {
+    for node in $CLUSTER; do
+        if [[ "$node" != "$master" ]]; then
+            echo $node
+            return
+        fi
+    done
+}
+
+get_table_version() {
+    local node=$1
+    cdb2sql --tabs ${CDB2_OPTIONS} --host $node $dbname \
+        "select table_version('t')" 2>/dev/null
+}
+
+# Setup
+cdb2sql ${CDB2_OPTIONS} $dbname default "create table t {`cat t.csc2`}"
+cdb2sql ${CDB2_OPTIONS} $dbname default \
+    "insert into t select value, 'row'||value from generate_series(1, 200)"
+assertcnt t 200
+
+master=$(getmaster)
+replicant=$(get_replicant)
+echo "master=$master replicant=$replicant"
+
+# Record the version before the ALTER so we know what the new version should be
+ver_before=$(get_table_version $master)
+ver_expected=$((ver_before + 1))
+echo "version before alter=$ver_before expected after=$ver_expected"
+
+# The lrl.options sets test_sc_delay_after_unset_running 5, which inserts a
+# 5-second sleep between sc_set_running(0) and trans_commit inside
+# osql_finalize_scs().  During that window, 'stat' shows no SC running but the
+# schema change transaction is not yet committed.
+(cdb2sql ${CDB2_OPTIONS} $dbname default \
+    "alter table t {`cat t2.csc2`}" &> alter.out || touch alter.failed) &
+
+# Wait for SC to start
+sleep 2
+
+echo "Polling master stat tightly for SC completion..."
+while true; do
+    cdb2sql ${CDB2_OPTIONS} --host $master $dbname \
+        "exec procedure sys.cmd.send('stat')" \
+        | grep "Schema change in progress" > /dev/null 2>&1
+    if [ $? -ne 0 ]; then
+        echo "SC stopped showing as running on master (sc_set_running(0) fired)"
+        break
+    fi
+    # tight poll — no sleep, to hit the window as soon as sc_set_running(0) fires
+done
+
+# At this point sc_set_running(0) has fired but trans_commit has NOT yet run
+# (because of the 5s delay in test_sc_delay_after_unset_running).
+# The replicant does not yet have the new schema; its tableversion is still old.
+master_ver=$(get_table_version $master)
+replicant_ver=$(get_table_version $replicant)
+
+echo "Immediately after sc_set_running(0), before trans_commit:"
+echo "  master    table_version='$master_ver' (expected $ver_expected)"
+echo "  replicant table_version='$replicant_ver' (expected $ver_expected)"
+
+wait  # let the alter finish
+
+if [[ "$replicant_ver" != "$ver_expected" ]]; then
+    failexit "RACE REPRODUCED: replicant has table_version='$replicant_ver' but stat showed SC done (expected $ver_expected); sc_set_running(0) fires before trans_commit"
+fi
+
+if [[ "$master_ver" != "$ver_expected" ]]; then
+    failexit "master has table_version='$master_ver' but stat showed SC done (expected $ver_expected)"
+fi
+
+echo "SUCCESS"

--- a/tests/sc_setrunning_race.test/t.csc2
+++ b/tests/sc_setrunning_race.test/t.csc2
@@ -1,0 +1,9 @@
+schema
+{
+    int a
+    cstring b[32]
+}
+keys
+{
+    "A" = a
+}

--- a/tests/sc_setrunning_race.test/t2.csc2
+++ b/tests/sc_setrunning_race.test/t2.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    int a
+    cstring b[32]
+    int c dbstore=0
+}
+keys
+{
+    "A" = a
+}

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1059,6 +1059,7 @@
 (name='test_ddl_backout_nomaster', description='Force a NOMASTER error in toblock.', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_delay_analyze_commit', description='Delay analyze commit', type='BOOLEAN', value='OFF', read_only='N')
 (name='test_io_time', description='Check I/O in watchdog this often', type='INTEGER', value='10', read_only='N')
+(name='test_sc_delay_after_unset_running', description='Delay in seconds after sc_set_running(0) before commit, to reproduce sc_set_running/trans_commit race', type='INTEGER', value='0', read_only='Y')
 (name='test_sc_resume_race', description='Test race between schemachange resume and blockprocessor', type='BOOLEAN', value='OFF', read_only='Y')
 (name='test_scindex_deadlock', description='Test index on expressions schema change deadlock', type='BOOLEAN', value='OFF', read_only='Y')
 (name='test_sql_time', description='Check SQL in watchdog this often', type='INTEGER', value='0', read_only='N')


### PR DESCRIPTION
This adds a test to show the issue.
Adds gbl_test_sc_delay_after_unset_running tunable that inserts a configurable sleep between sc_set_running(0) and the return from osql_finalize_scs(), widening the window between the running flag clearing and trans_commit to reliably reproduce the race where stat shows no schema change running but tableversion is not yet committed.

