### PR TITLE
{184332933}: Fix strcasecmp check in ssl_whitelisted for localhost

### DIFF
--- a/util/ssl_glue.c
+++ b/util/ssl_glue.c
@@ -312,7 +312,7 @@ int ssl_whitelisted(const char *host)
 {
     if (gbl_ssl_allow_localhost) {
         if (host != NULL) {
-            if (strcasecmp(host, "localhost") || strcasecmp(host, "localhost.localdomain")) {
+            if (strcasecmp(host, "localhost") == 0 || strcasecmp(host, "localhost.localdomain") == 0) {
                 return 1;
             }
         }


### PR DESCRIPTION
## Summary
`strcasecmp` returns 0 on match, but `ssl_whitelisted` was treating any non-zero (i.e. non-match) as truthy, so the localhost whitelist check was inverted — it whitelisted any host other than `localhost`/`localhost.localdomain` instead.

## Fix
Compare `strcasecmp(...) == 0` for both `localhost` and `localhost.localdomain` so only those hosts are whitelisted when `gbl_ssl_allow_localhost` is set.