### PR TITLE
{184399399}: Disable `debug.setmetatable` in Lua stored procedures

### DIFF
--- a/lua/ldblib.c
+++ b/lua/ldblib.c
@@ -383,7 +383,7 @@ static const luaL_Reg dblib[] = {
   {"setfenv", db_setfenv},
   {"sethook", db_sethook},
   {"setlocal", db_setlocal},
-  {"setmetatable", db_setmetatable},
+  // {"setmetatable", db_setmetatable},  -- security risk
   {"setupvalue", db_setupvalue},
   {"traceback", db_errorfb},
   {NULL, NULL}

--- a/tests/sp.test/t23.req
+++ b/tests/sp.test/t23.req
@@ -1,0 +1,13 @@
+CREATE PROCEDURE metacrash_gc version '1' {
+local function main()
+  local b = db:guid()
+  local s = db:prepare('select 1')
+  debug.setmetatable(b, getmetatable(s))
+  s = nil
+  b = nil
+  collectgarbage('collect')
+  collectgarbage('collect')
+  return 1
+end
+}$$
+EXEC PROCEDURE metacrash_gc()

--- a/tests/sp.test/t23.req.out
+++ b/tests/sp.test/t23.req.out
@@ -1,0 +1,2 @@
+(version='1')
+[EXEC PROCEDURE metacrash_gc()] failed with rc -3 [string "..."]:5: attempt to call field 'setmetatable' (a nil value)


### PR DESCRIPTION
`debug.setmetatable` bypasses `__metatable` protection, letting any stored procedure swap the metatable of comdb2 internal types (e.g. `db:guid()`, a prepared statement) and trigger crashes — see the `metacrash_gc` repro. Drop the `{"setmetatable", db_setmetatable}` entry from `dblib[]` in `lua/ldblib.c`. The static C function and the `lua_setmetatable` C API are untouched, so internal callers in `sp.c` etc. are unaffected; from a stored procedure, `debug.setmetatable` is now `nil`. The standard global `setmetatable(...)` (base lib) still works and continues to respect `__metatable`.

Adds `tests/sp.test/t21` as a focused regression that asserts `attempt to call field 'setmetatable' (a nil value)`.