### PR TITLE
Remove unused buf and bufsz fields from stored_proc

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -3251,10 +3251,6 @@ static void reset_sp(SP sp)
         sp->clnttype = NULL;
     }
     free_tmptbls(sp);
-    if (sp->buf) {
-        free(sp->buf);
-        sp->buf = NULL;
-    }
     if (sp->error) {
         free(sp->error);
         sp->error = NULL;
@@ -3262,7 +3258,6 @@ static void reset_sp(SP sp)
     sp->consumer = NULL;
     sp->pingpong = 0;
     sp->ntypes = 0;
-    sp->bufsz = 0;
     sp->rc = 0;
     sp->num_instructions = 0;
     sp->max_num_instructions = gbl_max_lua_instructions;

--- a/lua/sp_int.h
+++ b/lua/sp_int.h
@@ -48,10 +48,8 @@ struct stored_proc {
     struct sqlclntstate *clnt;
     struct sqlclntstate *debug_clnt;
     struct sqlthdstate *thd;
-    int bufsz;
     int num_instructions;
     int max_num_instructions;
-    uint8_t *buf;
     char *error;
     int  rc;
     SP parent;


### PR DESCRIPTION
## Summary
- Remove vestigial `buf` and `bufsz` fields from `struct stored_proc` in `lua/sp_int.h`
- Remove the corresponding free/reset code in `reset_sp()` in `lua/sp.c`
- These fields have been unused since 74a313df97 (2018), which refactored row handling to use `response_data` instead of serializing into `sp->buf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)