### PR TITLE
more consistent order for views_lk / schema_lk / bdb lock ordering 

### DIFF
--- a/db/toblock.c
+++ b/db/toblock.c
@@ -6376,10 +6376,37 @@ static int toblock_main(struct javasp_trans_state *javasp_trans_handle, struct i
     }
 
     if (iq->tptlock) {
+        /*
+         * Lock ordering problem: this path acquires views_lk(rd) here, then
+         * bplog_schemachange_run() acquires schema_lk(wr) deep inside
+         * toblock_main_int().  That is the reverse of the canonical order
+         * (schema_lk -> views_lk) used by the time-partition cron threads
+         * (_view_cron_phase1/2/3) and by views_cron_restart().
+         *
+         * If a transaction holds both a BPFUNC for time-partition retention
+         * (sets tptlock, acquires views_lk(rd)) and a DDL schema change (sets
+         * tranddl, acquires schema_lk(wr) via bplog_schemachange_run), the
+         * following deadlock can occur:
+         *
+         *   Thread A (this block processor):
+         *     holds views_lk(rd), waits for schema_lk(wr)
+         *
+         *   Thread B (cron phase1/2/3 or any SC path):
+         *     holds schema_lk(wr or rd), waits for views_lk(wr)
+         *
+         * Thread A cannot get schema_lk(wr) because Thread B holds it.
+         * Thread B cannot get views_lk(wr) because Thread A holds views_lk(rd)
+         * (readers block writers).
+         *
+         * The proper fix requires either narrowing the views_lk scope inside
+         * toblock_main_int() or hoisting schema_lk acquisition to before
+         * views_lock() — both require significant refactoring.
+         *
+         * Until then, we prevent the deadlock by rejecting any transaction that
+         * sets both tptlock (BPFUNC TIMEPART_RETENTION) and tranddl (DDL schema
+         * changes) in the same transaction.
+         */
         if (iq->tranddl) {
-            /* avoid a lock inversion here; simply forbit mixing bpfunc that
-             * requires tpt lock with other schema changes
-             */
             reqlog_set_error(
                 iq->reqlogger,
                 "Error cannot mix tpt retention with other schema changes",

--- a/db/views.c
+++ b/db/views.c
@@ -1111,6 +1111,7 @@ void *_view_cron_phase2(struct cron_event *event, struct errstat *err)
 
     if (run) {
         bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START);
+        BDB_READLOCK(__func__);
         rdlock_schema_lk();
         Pthread_rwlock_wrlock(&views_lk);
 
@@ -1128,7 +1129,7 @@ void *_view_cron_phase2(struct cron_event *event, struct errstat *err)
                           (arg1) ? (char *)arg1 : "NULL", arg2,
                           (arg2) ? (char *)arg2 : "NULL", arg3);
 
-        /* this is a safeguard! we take effort to schedule cleanup of 
+        /* this is a safeguard! we take effort to schedule cleanup of
         a dropped partition ahead of everything, but jic ! */
         if (unlikely(
                 _validate_view_id(view, event->source_id, "phase 2", err))) {
@@ -1147,8 +1148,6 @@ void *_view_cron_phase2(struct cron_event *event, struct errstat *err)
         /* lets save this */
         timeCrtRollout = view->roll_time;
 
-        BDB_READLOCK(__func__);
-
         rc = _views_rollout_phase2(view, pShardName, &timeNextRollout,
                                    &removeShardName, err);
 
@@ -1158,13 +1157,10 @@ void *_view_cron_phase2(struct cron_event *event, struct errstat *err)
                 thedb->bdb_env, view->name,
                 0 /*not sure it is safe here to wait, so don't*/, &bdberr);
             if (rc != 0) {
-                logmsg(LOGMSG_ERROR, 
-                        "%s -- bdb_llog_views view %s rc:%d bdberr:%d\n",
-                        __func__, view->name, rc, bdberr);
+                logmsg(LOGMSG_ERROR, "%s -- bdb_llog_views view %s rc:%d bdberr:%d\n", __func__, view->name, rc,
+                       bdberr);
             }
         }
-
-        BDB_RELLOCK();
 
         /* tell the world */
         gbl_views_gen++;
@@ -1178,6 +1174,7 @@ done:
         Pthread_rwlock_unlock(&views_lk);
         unlock_schema_lk();
         csc2_free_all();
+        BDB_RELLOCK();
         bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE);
 
         /*  schedule next */
@@ -1937,9 +1934,16 @@ int views_cron_restart(timepart_views_t *views)
        we will requeue them */
     cron_clear_queue(timepart_sched);
 
+    /* Acquire BDB replock before views_lk to match the ordering used in
+       _view_cron_phase1/3 (BDB_READLOCK -> views_lk).  Consistent ordering
+       across all callers avoids a potential deadlock if the bdb_lock is ever
+       initialized with writer preference, and makes lock auditing simpler. */
+    bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START);
+    BDB_READLOCK(__func__);
+
     /* corner case: master started and schema change for time partition
-       submitted before watchdog thread has time to restart it, will deadlock
-       if this is the case, abort the schema change */
+       submitted before watchdog thread has time to restart it; abort the
+       schema change so views_cron_restart does not wait indefinitely */
     rc = pthread_rwlock_trywrlock(&views_lk);
     if (rc == EBUSY) {
         if (get_schema_change_in_progress(__func__, __LINE__)) {
@@ -1952,9 +1956,6 @@ int views_cron_restart(timepart_views_t *views)
     } else if (rc) {
         abort();
     }
-
-    bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_START);
-    BDB_READLOCK(__func__);
 
     if (thedb->master == gbl_myhostname && !gbl_is_physical_replicant) {
         /* queue all the events required for this */
@@ -1984,9 +1985,8 @@ int views_cron_restart(timepart_views_t *views)
     rc = VIEW_NOERR;
 
 done:
-    BDB_RELLOCK();
-
     Pthread_rwlock_unlock(&views_lk);
+    BDB_RELLOCK();
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE);
     return rc;
 }


### PR DESCRIPTION
1. views_cron_restart (db/views.c): BDB_READLOCK was acquired AFTER views_lk, inverting the order of tpt rollout code.  While a deadlock is not possible, it is cleaner and more consistent.

2. _view_cron_phase2 (db/views.c): BDB_READLOCK was acquired mid-function after both schema_lk and views_lk were already held.

3. toblock.c: views_lk(rd) is acquired before schema_lk(wr) is taken deep inside bplog_schemachange_run(); we block any transaction that contains both a tpt bptran and another ddl; this prevents a deadlock from happening; fixing the order requires more complicated refactoring.

Existing tests extensively exercise the rollout and the locking (16 rr tests, 4 rm tests)