### PR TITLE
Fix Lua db:sp() crash on large stored procedures

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -416,6 +416,7 @@ char *gbl_spfile_name = NULL;
 char *gbl_user_vers_spfile_name = NULL;
 char *gbl_timepart_file_name = NULL;
 int gbl_max_lua_instructions = 10000;
+int gbl_max_lua_source_len = 1 * 1024 * 1024;
 int gbl_check_wrong_cmd = 1;
 int gbl_updategenids = 0;
 int gbl_chkpoint_alarm_time = 60;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -133,6 +133,7 @@ extern int gbl_master_swing_osql_verbose;
 extern int gbl_master_swing_sock_restart_sleep;
 extern int gbl_max_key_size_new;
 extern int gbl_max_lua_instructions;
+extern int gbl_max_lua_source_len;
 extern int gbl_max_sqlcache;
 extern int __gbl_max_mpalloc_sleeptime;
 extern int gbl_mem_nice;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -800,6 +800,11 @@ REGISTER_TUNABLE("max_lua_instructions",
                  "procedure is looping and kill it. (Default: 10000)",
                  TUNABLE_INTEGER, &gbl_max_lua_instructions, 0, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("max_lua_source_len",
+                 "Maximum size in bytes of stored procedure source code. "
+                 "Procedures exceeding this limit will be rejected. "
+                 "(Default: 1048576)",
+                 TUNABLE_INTEGER, &gbl_max_lua_source_len, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_key_size_new", "Use new logic for checking max key size (Default: on)", TUNABLE_INTEGER,
                  &gbl_max_key_size_new, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("max_num_compact_pages_per_txn", NULL, TUNABLE_INTEGER,

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -82,6 +82,7 @@ extern int gbl_return_long_column_names;
 extern int gbl_max_sqlcache;
 extern int gbl_lua_new_trans_model;
 extern int gbl_max_lua_instructions;
+extern int gbl_max_lua_source_len;
 extern int gbl_lua_version;
 extern int gbl_notimeouts;
 extern int gbl_allow_lua_print;
@@ -4751,13 +4752,27 @@ static int db_sp(Lua L)
         return 1;
     }
     size_t size = strlen(src);
-    char buf[size + 32];
+    if (gbl_max_lua_source_len > 0 && size > gbl_max_lua_source_len) {
+        free(src);
+        return luaL_error(L,
+                          "stored procedure '%s' source too large "
+                          "(%zu bytes, max %d)",
+                          name, size, gbl_max_lua_source_len);
+    }
+    char *buf = malloc(size + 32);
+    if (buf == NULL) {
+        free(src);
+        return luaL_error(L,
+                          "out of memory loading stored procedure '%s'",
+                          name);
+    }
     sprintf(buf, "%s\nreturn main", src);
     free(src);
     if (luaL_dostring(L, buf) != 0) {
         luabb_error(L, getsp(L), lua_tostring(L, -1));
         lua_pushnil(L);
     }
+    free(buf);
     return 1;
 }
 
@@ -6446,6 +6461,13 @@ static int setup_sp_int(char *spname, struct sqlthdstate *thd, struct sqlclntsta
         if (locked)
             unlock_schema_lk();
         if (sp->src == NULL) {
+            close_sp(clnt);
+            return -1;
+        }
+        if (gbl_max_lua_source_len > 0 &&
+            strlen(sp->src) > gbl_max_lua_source_len) {
+            *err = strdup(
+                "stored procedure source exceeds max_lua_source_len");
             close_sp(clnt);
             return -1;
         }

--- a/schemachange/sc_lua.c
+++ b/schemachange/sc_lua.c
@@ -13,6 +13,7 @@
 
 #include "logmsg.h"
 
+extern int gbl_max_lua_source_len;
 int gbl_fail_to_create_default_cons = 0;
 int gbl_create_default_consumer_atomically = 1;
 
@@ -329,6 +330,14 @@ static int add_versioned_sp(struct schema_change_type *sc, tran_type *tran)
     int rc, bdberr;
     char *spname = sc->tablename;
     char *version = sc->fname;
+    size_t srclen = strlen(sc->newcsc2);
+    if (gbl_max_lua_source_len > 0 && srclen > gbl_max_lua_source_len) {
+        logmsg(LOGMSG_ERROR,
+               "stored procedure '%s' source too large "
+               "(%zu bytes, max %d)\n",
+               spname, srclen, gbl_max_lua_source_len);
+        return -1;
+    }
     int default_ver_num = bdb_get_sp_get_default_version(spname, &bdberr);
     char *default_ver_str = NULL;
     bdb_get_default_versioned_sp(spname, &default_ver_str);
@@ -454,6 +463,15 @@ static int add_sp(struct schema_change_type *sc, int *version, tran_type *tran)
     COMDB2BUF *sb = sc->sb;
     char *schemabuf = sc->newcsc2;
     int rc, bdberr;
+    size_t srclen = strlen(schemabuf);
+    if (gbl_max_lua_source_len > 0 && srclen > gbl_max_lua_source_len) {
+        cdb2buf_printf(sb,
+                       "!Stored procedure source too large "
+                       "(%zu bytes, max %d).\n",
+                       srclen, gbl_max_lua_source_len);
+        cdb2buf_printf(sb, "FAILED\n");
+        return -1;
+    }
     if ((rc = bdb_set_sp_lua_source(NULL, tran, sc->tablename, schemabuf,
                                     strlen(schemabuf) + 1, 0, &bdberr)) != 0) {
         cdb2buf_printf(sb, "!Unable to add lua source. \n");

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -560,6 +560,7 @@
 (name='max_latch', description='Size of latch array', type='INTEGER', value='200000', read_only='N')
 (name='max_latch_lockerid', description='Size of latch lockerid array', type='INTEGER', value='10000', read_only='N')
 (name='max_lua_instructions', description='Maximum lua opcodes to execute before we assume the stored procedure is looping and kill it. (Default: 10000)', type='INTEGER', value='10000', read_only='N')
+(name='max_lua_source_len', description='Maximum size in bytes of stored procedure source code. Procedures exceeding this limit will be rejected. (Default: 1048576)', type='INTEGER', value='1048576', read_only='N')
 (name='max_num_compact_pages_per_txn', description='', type='INTEGER', value='-1', read_only='N')
 (name='max_password_cache_size', description='Password cache size, set to <=0 to turn off caching (Default: 100)', type='INTEGER', value='100', read_only='N')
 (name='max_plan_query_plans', description='Maximum number of plans to be placed into the query plan hash for each fingerprint (Default: 20)', type='INTEGER', value='20', read_only='N')


### PR DESCRIPTION
Replace stack-allocated VLA with heap allocation in db_sp() to prevent stack overflow on large SP source. Add configurable max_lua_source_len tunable (default 1 MiB) to reject oversized procedures at creation time and at load time with a SQL error instead of crashing.
