### PR TITLE
{184332905} fix sockbplog crash via negative-length bplog packet

### DIFF
--- a/db/osqlsqlsocket.c
+++ b/db/osqlsqlsocket.c
@@ -301,6 +301,12 @@ int osqlcomm_req_socket(COMDB2BUF *sb, char **sql, char tzname[DB_MAX_TZNAMEDB],
     GDATA(sqlqlen);
     sqlqlen = htonl(sqlqlen);
 
+    if (sqlqlen < 0) {
+        logmsg(LOGMSG_ERROR, "%s: invalid sql query length %d\n", __func__, sqlqlen);
+        rc = -1;
+        goto done;
+    }
+
     *sql = malloc(sqlqlen + 1);
     if (!*sql) {
         rc = ENOMEM;
@@ -334,6 +340,12 @@ int osqlcomm_bplog_socket(COMDB2BUF *sb, osql_sess_t *sess)
     while (!is_msg_done) {
         GDATA(buflen);
         buflen = htonl(buflen);
+
+        if (buflen <= 0) {
+            logmsg(LOGMSG_ERROR, "%s: invalid bplog packet length %d\n", __func__, buflen);
+            rc = -1;
+            goto done;
+        }
 
         if (gbl_sockbplog_debug)
             logmsg(LOGMSG_ERROR, "%p Received a packet of length %d\n",


### PR DESCRIPTION
Validate that buffer length fields are non-negative before using them in memory operations in the sockbplog handler. A crafted packet with length -1 (0xFFFFFFFF) could skip allocation and pass a negative size to cdb2buf_fread, causing a segfault.
