### PR TITLE
Fix local replication for tables with expression indexes.

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -608,6 +608,33 @@ static int osql_send_ins_logic(struct BtCursor *pCur, struct sql_thread *thd,
     return SQLITE_OK;
 }
 
+/* When gbl_replicate_local=1, mem_to_ondisk generates a fresh seqno via
+ * get_unique_longlong() each time it encounters a NULL comdb2_seqno value.
+ * This is called once for the data record (storing seqno1 in pCur->ondisk_buf)
+ * and independently once per index key containing comdb2_seqno (storing a
+ * different seqno2 in clnt->idxInsert[i]).  The mismatch means DELETE later
+ * tries to remove a key with seqno1 (read from the data record) but finds
+ * seqno2 in the index -> DB_NOTFOUND -> rc 304.
+ *
+ * Fix: rebuild each comdb2_seqno index key from the ondisk data record so
+ * that the stored key and any future delete key use the same seqno value. */
+static void fixup_replicate_local_seqno(struct BtCursor *pCur, const char *ondisk_record, struct sqlclntstate *clnt)
+{
+    if (!gbl_replicate_local || !gbl_expressions_indexes || !pCur->db->ix_expr || !clnt->idxInsert)
+        return;
+
+    for (int i = 0; i < pCur->db->nix; i++) {
+        if (!clnt->idxInsert[i])
+            continue;
+        struct schema *ixsc = get_schema(pCur->db, i);
+        if (!ixsc || find_field_idx_in_tag(ixsc, "comdb2_seqno") < 0)
+            continue;
+        char correct_key[MAXKEYLEN];
+        if (stag_ondisk_to_ix(pCur->db, i, ondisk_record, correct_key) == 0)
+            memcpy(clnt->idxInsert[i], correct_key, pCur->db->ix_keylen[i]);
+    }
+}
+
 /**
  * Process a sqlite insert row request
  * Row is provided by (pData, nData, blobs, maxblobs)
@@ -627,6 +654,8 @@ int osql_insrec(struct BtCursor *pCur, struct sql_thread *thd, char *pData,
     /* limit transaction*/
     if ((rc = check_osql_capacity(thd)))
         return rc;
+
+    fixup_replicate_local_seqno(pCur, pData, clnt);
 
     if (clnt->dbtran.mode == TRANLEVEL_SOSQL) {
         START_SOCKSQL;

--- a/tests/seqno_ix_delete.test/Makefile
+++ b/tests/seqno_ix_delete.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=2m
+endif

--- a/tests/seqno_ix_delete.test/README
+++ b/tests/seqno_ix_delete.test/README
@@ -1,0 +1,37 @@
+Regression test for a DELETE failure on a table that has all of:
+
+  - replicate_local 1 (sets gbl_replicate_local)
+  - a user-defined comdb2_seqno column declared null=yes
+  - a plain key on that comdb2_seqno column
+  - at least one expression index (e.g. checksum_md5), which sets ix_expr=1
+    for the entire table
+
+Root cause
+----------
+When ix_expr=1, sqlite3BtreeInsert builds every index key on the replicant
+via sqlite_to_ondisk() and stores the results in clnt->idxInsert[].  For a
+NULL comdb2_seqno value, mem_to_ondisk() calls get_unique_longlong() to
+generate a seqno.  This happens independently for:
+
+  1. The data record  (OP_Insert)  -> seqno1 stored in pCur->ondisk_buf
+  2. The index key    (OP_IdxInsert for the comdb2_seqno index) -> seqno2
+     stored in clnt->idxInsert[2]
+
+Because get_unique_longlong() returns a different value on each call,
+seqno1 != seqno2.  The data record and the index key therefore contain
+different seqno values.
+
+On DELETE, the engine reads seqno1 from the data record and uses it to
+build the delete key for the comdb2_seqno index.  The stored key has seqno2,
+so the lookup fails:
+
+  [delete from t where id = 1] failed with rc 304
+  Table 't' key not found on index 2 unable to delete genid=... rc=2
+
+Fix
+---
+In osql_insrec() (db/osqlsqlthr.c), after pCur->ondisk_buf has been
+populated with the authoritative seqno1, rebuild any index key that
+contains a comdb2_seqno member using stag_ondisk_to_ix() so that it
+matches the data record before the key is sent to the master or saved
+to the shadow table.

--- a/tests/seqno_ix_delete.test/lrl.options
+++ b/tests/seqno_ix_delete.test/lrl.options
@@ -1,0 +1,1 @@
+replicate_local 1

--- a/tests/seqno_ix_delete.test/runit
+++ b/tests/seqno_ix_delete.test/runit
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -e
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+if [ "x$dbnm" == "x" ] ; then
+    failexit "need a DB name"
+fi
+
+# Create a table with:
+#   - a user-defined comdb2_seqno column (null=yes)
+#   - an expression index (checksum_md5), which sets ix_expr=1 for the table
+#   - a plain key on the comdb2_seqno column
+#
+# With replicate_local=1, mem_to_ondisk calls get_unique_longlong() independently
+# for the data record and for the comdb2_seqno index key, producing two different
+# seqno values.  DELETE then fails with rc 304 ("key not found on index 2") because
+# the delete key (built from the data record's seqno) does not match the stored
+# index key (built from a separately generated seqno).
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default 'CREATE TABLE t {
+    schema {
+        int id
+        vutf8 text[100]
+        longlong comdb2_seqno null=yes
+    }
+    keys {
+        "KEY_ID" = id
+        dup "KEY_TEXT_MD5" = (cstring[33]) "checksum_md5(text)"
+        "COMDB2_SEQNO" = comdb2_seqno
+    }
+}'
+
+# Insert without providing comdb2_seqno — the engine generates one internally.
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "INSERT INTO t (id, text) VALUES (1, 'hello world')"
+
+# Verify the row exists and the seqno was assigned.
+assertcnt t 1
+
+seqno=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $dbnm default \
+    "SELECT comdb2_seqno FROM t WHERE id = 1")
+if [ -z "$seqno" ] || [ "$seqno" = "NULL" ] ; then
+    failexit "comdb2_seqno was not assigned on insert"
+fi
+echo "Inserted row with comdb2_seqno=$seqno"
+
+# Before the fix this DELETE failed with:
+#   [delete from t where id = 1] failed with rc 304
+#   Table 't' key not found on index 2 unable to delete genid=... rc=2
+$CDB2SQL_EXE ${CDB2_OPTIONS} $dbnm default "DELETE FROM t WHERE id = 1"
+
+# Verify the row is gone.
+assertcnt t 0
+
+echo "SUCCESS"
+exit 0


### PR DESCRIPTION
Bug is comdb2_seqno is different in data and index records because we generated twice.

