### PR TITLE
Add bound parameter support to fdb push writes

### DIFF
--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -164,9 +164,34 @@ int fdb_push_write_setup(Parse *pParse, enum ast_type type, Table *pTab)
     if (!push)
         return -1;
 
-    clnt->fdb_push = push;
+    // Copy params from clnt plugin into push connector
+    int nparams = param_count(clnt);
+    if (nparams > 0) {
+        struct param_data *params = calloc(nparams, sizeof(struct param_data));
+        if (!params)
+            goto err;
 
+        for (int i = 0; i < nparams; i++) {
+            if (param_value(clnt, &params[i], i) != 0) {
+                free(params);
+                goto err;
+            }
+        }
+
+        if (dohsql_clone_params(nparams, params, &push->nparams, &push->params)) {
+            free(params);
+            goto err;
+        }
+        free(params);
+    }
+
+    clnt->fdb_push = push;
     return 0;
+
+err:
+    free(push->remotedb);
+    free(push);
+    return -1;
 }
 
 /**
@@ -638,7 +663,7 @@ int handle_fdb_push_write(sqlclntstate *clnt, struct errstat *err,
                 }
             }
 
-            rc = cdb2_run_statement(tran->fcon.hndl, "begin");      
+            rc = cdb2_run_statement(tran->fcon.hndl, "begin");
             while (rc == CDB2_OK) {
                 rc = cdb2_next_record(tran->fcon.hndl);
             }
@@ -805,9 +830,7 @@ free_push:
         /* This will get retried as non-cdb2api, free fdb_push
          * so that the postpone message works
          */
-        clnt->fdb_push = NULL;
-        free(push->remotedb);
-        free(push);
+        fdb_push_free(&clnt->fdb_push);
         if (set_intrans) {
             /* if this tried to short call to local sqlite3BtreeBeginTrans
              * first time we try to push, and we set clnt->intrans,

--- a/tests/fdb_push.test/output.log
+++ b/tests/fdb_push.test/output.log
@@ -29,6 +29,15 @@ Test parameters
 (i=NULL, r=NULL, s=NULL, b=x'deadbeaf', d=NULL, d2=NULL)
 (i=NULL, r=NULL, s=NULL, b=NULL, d="2023-09-13T000000.000 America/New_York", d2=NULL)
 (i=NULL, r=NULL, s=NULL, b=NULL, d=NULL, d2="2023-09-13T000000.000001 America/New_York")
+Test write with bound parameters
+(rows inserted=1)
+(id=50, b1='Bound1')
+(rows updated=1)
+(id=50, b1='Updated')
+(rows deleted=1)
+(rows inserted=1)
+(i=99, r=3.140000, s='bound', b=NULL, d=NULL, d2=NULL)
+(rows deleted=1)
 Test set statement
 (i=NULL, r=NULL, s=NULL, b=NULL, d="2023-09-13T130000.000 Asia/Tokyo", d2=NULL)
 (i=NULL, r=NULL, s=NULL, b=NULL, d="2023-09-13T130000.000 Asia/Tokyo", d2=NULL)

--- a/tests/fdb_push.test/test_fdb_push.sh
+++ b/tests/fdb_push.test/test_fdb_push.sh
@@ -82,6 +82,45 @@ cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
 select * from LOCAL_${a_remdbname}.t2 where d2=@d2
 EOF
 
+echo "Test write with bound parameters" >> $output
+# INSERT with bound integer and cstring params
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+@bind CDB2_INTEGER id 50
+@bind CDB2_CSTRING b1 Bound1
+insert into LOCAL_${a_remdbname}.t values (@id, @b1)
+EOF
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t where id=50" >> $output 2>&1
+
+# UPDATE with bound params
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+@bind CDB2_CSTRING b1 Updated
+@bind CDB2_INTEGER id 50
+update LOCAL_${a_remdbname}.t set b1=@b1 where id=@id
+EOF
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t where id=50" >> $output 2>&1
+
+# DELETE with bound param
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+@bind CDB2_INTEGER id 50
+delete from LOCAL_${a_remdbname}.t where id=@id
+EOF
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t where id=50" >> $output 2>&1
+
+# INSERT into t2 with multiple typed params
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+@bind CDB2_INTEGER i 99
+@bind CDB2_REAL r 3.14
+@bind CDB2_CSTRING s bound
+insert into LOCAL_${a_remdbname}.t2(i, r, s) values (@i, @r, @s)
+EOF
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default "select * from LOCAL_${a_remdbname}.t2 where i=99" >> $output 2>&1
+
+# DELETE from t2 with bound param to clean up
+cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
+@bind CDB2_INTEGER i 99
+delete from LOCAL_${a_remdbname}.t2 where i=@i
+EOF
+
 echo "Test set statement" >> $output
 cdb2sql -s ${SRC_CDB2_OPTIONS} $a_dbname default - >> $output 2>&1 << EOF
 set timezone Asia/Tokyo


### PR DESCRIPTION
## Summary
- Remote push writes (INSERT/UPDATE/DELETE) now forward bound parameters to the remote database, matching the existing behavior for push reads
- Adds test coverage for write operations with various bound parameter types (integer, real, cstring)

## Test plan
- Added INSERT, UPDATE, DELETE test cases with `@bind` parameters to `fdb_push.test`
- Verified parameter types: `CDB2_INTEGER`, `CDB2_REAL`, `CDB2_CSTRING`