### PR TITLE
Remove ireq from open_temp_db_resume

### DIFF
--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3648,8 +3648,8 @@ const char *sc_tag_change_subtype_text(sc_tag_change_subtype);
 int cmp_index_int(struct schema *oldix, struct schema *newix, char *descr,
                   size_t descrlen);
 int get_dbtable_idx_by_name(const char *tablename);
-int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *tablename, int resume);
-int open_temp_newdb_resume(struct ireq *iq, struct dbtable *db, int resume);
+int open_temp_db_resume(struct dbtable *db, char *tablename, int resume);
+int open_temp_newdb_resume(struct dbtable *db, int resume);
 int find_constraint(struct dbtable *db, constraint_t *ct);
 
 /* END OF SCHEMACHANGE DECLARATIONS*/

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -130,7 +130,7 @@ int add_table_to_environment(char *table, const char *csc2,
 
     if (s && s->resume && s->partition.type == PARTITION_ADD_TIMED_RETRO) {
         /* this is adding a shard, we need to try to open an existing shard, which may have data */
-        if ((rc = open_temp_db_resume(iq, newdb, newdb->tablename, s->resume))) {
+        if ((rc = open_temp_db_resume(newdb, newdb->tablename, s->resume))) {
             sc_errf(s, "Failed to open shard %s\n", newdb->tablename);
             reqerrstr(iq, ERR_SC, "Failed to open shard %s\n", newdb->tablename);
         }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -521,7 +521,7 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
     print_schemachange_info(s, db, newdb);
 
     /*************** open  tables ********************************************/
-    rc = open_temp_newdb_resume(iq, newdb, s->resume);
+    rc = open_temp_newdb_resume(newdb, s->resume);
     if (rc) {
         if (rc == BDBERR_EXCEEDED_BLOBS) {
             sc_errf(s, "Maximum number of vutf8/blob fields exceeded\n");

--- a/schemachange/sc_fastinit_table.c
+++ b/schemachange/sc_fastinit_table.c
@@ -106,7 +106,7 @@ int do_fastinit(struct ireq *iq, struct schema_change_type *s, tran_type *tran)
         local_lock = 1;
         wrlock_schema_lk();
     }
-    rc = open_temp_newdb_resume(iq, newdb, 0);
+    rc = open_temp_newdb_resume(newdb, 0);
     if (local_lock)
         unlock_schema_lk();
     if (rc) {

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1347,7 +1347,7 @@ int resume_schema_change(void)
 /****************** Table functions ***********************************/
 /****************** Functions down here will likely be moved elsewhere *****/
 
-int open_temp_newdb_resume(struct ireq *iq, struct dbtable *db, int resume)
+int open_temp_newdb_resume(struct dbtable *db, int resume)
 {
     char *tmpname;
     int bdberr;
@@ -1363,14 +1363,14 @@ int open_temp_newdb_resume(struct ireq *iq, struct dbtable *db, int resume)
     tmpname = malloc(nbytes);
     snprintf(tmpname, nbytes, "%s%s", prefix, db->tablename);
 
-    rc = open_temp_db_resume(iq, db, tmpname, resume);
+    rc = open_temp_db_resume(db, tmpname, resume);
 
     free(tmpname);
 
     return rc;
 }
 
-int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *tablename, int resume)
+int open_temp_db_resume(struct dbtable *db, char *tablename, int resume)
 {
     int bdberr;
 
@@ -1398,30 +1398,34 @@ int open_temp_db_resume(struct ireq *iq, struct dbtable *db, char *tablename, in
     if (!db->handle) /* did not/could not open existing one, creating new one */
     {
         int rc;
-        tran_type *tran = NULL;
+        tran_type *tran;
+        seqnum_type seqnum;
     retry:
-        rc = trans_start(iq, NULL, &tran);
-        if (rc)
-            return -1;
+        tran = bdb_tran_begin(thedb->bdb_env, NULL, &bdberr);
+        if (!tran)
+            return ERR_INTERNAL;
 
         db->handle = bdb_create_tran(tablename, db->dbenv->basedir, db->lrl, db->nix, (short *)db->ix_keylen,
                                      db->ix_dupes, db->ix_recnums, db->ix_datacopy, db->ix_datacopylen, db->ix_collattr,
                                      db->ix_nullsallowed, db->numblobs + 1, /* one main record + the blobs blobs */
                                      db->dbenv->bdb_env, 0, &bdberr, tran);
         if (db->handle == NULL) {
-            trans_abort(iq, tran);
+            int create_err = bdberr;
+            int abort_err;
+            bdb_tran_abort(thedb->bdb_env, tran, &abort_err);
             tran = NULL;
-            if (bdberr == BDBERR_DEADLOCK) {
+            if (create_err == BDBERR_DEADLOCK) {
                 logmsg(LOGMSG_WARN, "%s: retrying on BDBERR_DEADLOCK\n", __func__);
                 goto retry;
             }
 
-            logmsg(LOGMSG_ERROR, "%s: failed to open %s, rcode %d\n", __func__, tablename, bdberr);
+            logmsg(LOGMSG_ERROR, "%s: failed to open %s, rcode %d\n", __func__, tablename, create_err);
 
-            return bdberr;
+            return create_err;
         }
 
-        rc = trans_commit_nowait(iq, tran, gbl_myhostname);
+        bdb_trans_set_nowait(tran);
+        rc = bdb_tran_commit_with_seqnum_size(thedb->bdb_env, tran, &seqnum, NULL, &bdberr);
         if (rc)
             return -1;
     }

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -940,7 +940,7 @@ static int add_table_for_recovery(struct ireq *iq, struct schema_change_type *s)
         abort();
     }
 
-    rc = open_temp_newdb_resume(iq, newdb, 1);
+    rc = open_temp_newdb_resume(newdb, 1);
     if (rc) {
         backout_schemas(newdb->tablename);
         abort();


### PR DESCRIPTION
Schema change phase 1 (the asynchronous phase) does not need an iq objects; this is first PR to achieve that goal; removes iq from lower level function that creates a new btree-s for the table being altered.