### PR TITLE
Physrep revconn fallback and find timeout

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -539,6 +539,7 @@ extern int gbl_physrep_slow_replicant_check_freq_sec;
 extern int gbl_physrep_max_candidates;
 extern int gbl_physrep_reconnect_penalty;
 extern int gbl_physrep_reconnect_interval;
+extern int gbl_physrep_find_new_repl_db_timeout;
 extern int gbl_physrep_shuffle_host_list;
 extern int gbl_physrep_ignore_queues;
 extern int gbl_physrep_max_rollback;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1911,8 +1911,8 @@ REGISTER_TUNABLE("physrep_metadb_name", "Physical replication metadb cluster nam
 REGISTER_TUNABLE("physrep_reconnect_penalty", "Physrep wait seconds before retry to the same node. (Default: 5)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_penalty, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_find_new_repl_db_timeout",
-                 "Max seconds to spend in find_new_repl_db before giving up. (Default: 60)",
-                 TUNABLE_INTEGER, &gbl_physrep_find_new_repl_db_timeout, 0, NULL, NULL, NULL, NULL);
+                 "Max seconds to spend in find_new_repl_db before giving up. (Default: 60)", TUNABLE_INTEGER,
+                 &gbl_physrep_find_new_repl_db_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_reconnect_interval", "Reconnect interval for physical replicants (Default: 600)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_interval, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_shuffle_host_list",

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1910,6 +1910,9 @@ REGISTER_TUNABLE("physrep_metadb_name", "Physical replication metadb cluster nam
                  NULL);
 REGISTER_TUNABLE("physrep_reconnect_penalty", "Physrep wait seconds before retry to the same node. (Default: 5)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_penalty, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("physrep_find_new_repl_db_timeout",
+                 "Max seconds to spend in find_new_repl_db before giving up. (Default: 60)",
+                 TUNABLE_INTEGER, &gbl_physrep_find_new_repl_db_timeout, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_reconnect_interval", "Reconnect interval for physical replicants (Default: 600)",
                  TUNABLE_INTEGER, &gbl_physrep_reconnect_interval, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_shuffle_host_list",

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -1510,8 +1510,8 @@ repl_loop:
             int do_revconn = do_wait_for_reverse_conn(repl_metadb);
             if (do_revconn == -1) {
                 if (is_revconn == 1) {
-                    physrep_logmsg(LOGMSG_USER, "%s:%d Metadb unreachable, using cached revconn state\n",
-                                   __func__, __LINE__);
+                    physrep_logmsg(LOGMSG_USER, "%s:%d Metadb unreachable, using cached revconn state\n", __func__,
+                                   __LINE__);
                     do_revconn = 1;
                 } else {
                     do_revconn = 0;

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -72,6 +72,7 @@ int gbl_physrep_keepalive_freq_sec = 60;
 int gbl_physrep_hung_replicant_check_freq_sec = 60;
 int gbl_physrep_hung_replicant_threshold = 60;
 int gbl_physrep_revconn_check_interval = 60;
+int gbl_physrep_find_new_repl_db_timeout = 60;
 int gbl_physrep_update_registry_interval = 60;
 int gbl_physrep_shuffle_host_list = 0;
 int gbl_physrep_i_am_metadb = 0;
@@ -247,6 +248,7 @@ static void set_repl_db_disconnected()
     repl_db_connected = 0;
     gbl_physrep_repl_name = NULL;
     gbl_physrep_repl_host = NULL;
+    physrep_logmsg(LOGMSG_USER, "Physical replicant has disconnected\n");
 }
 
 static void close_repl_connection(DB_Connection *cnct, cdb2_hndl_tp *repl_db,
@@ -1015,6 +1017,7 @@ static int seedsort(const void *arg1, const void *arg2)
 static DB_Connection *find_new_repl_db(cdb2_hndl_tp *repl_metadb, cdb2_hndl_tp **repl_db) {
     int rc, count = 0;
     DB_Connection *cnct;
+    int start_time = time(NULL);
 
     assert(repl_db_connected == 0);
 
@@ -1077,6 +1080,13 @@ static DB_Connection *find_new_repl_db(cdb2_hndl_tp *repl_metadb, cdb2_hndl_tp *
         }
 
         count++;
+        int elapsed = time(NULL) - start_time;
+        if (gbl_physrep_find_new_repl_db_timeout > 0 && elapsed >= gbl_physrep_find_new_repl_db_timeout) {
+            physrep_logmsg(LOGMSG_USER,
+                           "%s:%d: Couldn't connect to source hosts within %d seconds, break to re-register\n",
+                           __func__, __LINE__, elapsed);
+            return NULL;
+        }
         if (count < 10) {
             physrep_logmsg(LOGMSG_USER,
                            "%s:%d: Couldn't connect to any of the replication source hosts, retrying in a second\n",
@@ -1497,7 +1507,15 @@ repl_loop:
             }
 
             last_revconn_check = comdb2_time_epoch();
-            if (do_wait_for_reverse_conn(repl_metadb) == 1) {
+            int do_revconn = do_wait_for_reverse_conn(repl_metadb);
+            if (do_revconn == -1) {
+                if (is_revconn == 1) {
+                    do_revconn = 1;
+                } else {
+                    do_revconn = 0;
+                }
+            }
+            if (do_revconn == 1) {
                 is_revconn = 1;
                 int wait_timeout_sec = 60;
 

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -1510,6 +1510,8 @@ repl_loop:
             int do_revconn = do_wait_for_reverse_conn(repl_metadb);
             if (do_revconn == -1) {
                 if (is_revconn == 1) {
+                    physrep_logmsg(LOGMSG_USER, "%s:%d Metadb unreachable, using cached revconn state\n",
+                                   __func__, __LINE__);
                     do_revconn = 1;
                 } else {
                     do_revconn = 0;

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1594,6 +1594,89 @@ function verify_revconn_fix
     fi
 }
 
+# Verify that a revconn replicant uses cached is_revconn state when metadb is
+# temporarily unreachable, rather than falling into find_new_repl_db.
+function revconn_metadb_failure_test
+{
+    echo "== revconn_metadb_failure_test =="
+
+    local repl_name=${REPL_DBNAME_PREFIX}_${firstNode}
+    local repl_node=${firstNode}
+    local logFile=$TESTDIR/logs/${repl_name}.log
+
+    echo "Setting low find_new_repl_db_timeout as safety net"
+    $CDB2SQL_EXE --admin ${CDB2_OPTIONS} --host ${repl_node} ${repl_name} "exec procedure sys.cmd.send('put tunable physrep_find_new_repl_db_timeout 5')"
+
+    echo "Recording log position before test"
+    local log_lines_before=$(wc -l < $logFile)
+
+    echo "Killing altmeta (the replicant's metadb)"
+    if [[ -z "$CLUSTER" ]]; then
+        kill -9 $(cat ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.pid)
+    else
+        for node in $CLUSTER ; do
+            ssh ${node} "kill -9 \$(cat ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.pid)" < /dev/null 2>/dev/null
+        done
+    fi
+
+    sleep 2
+
+    echo "Forcing replicant to re-register (triggers revconn decision point)"
+    $CDB2SQL_EXE --admin ${CDB2_OPTIONS} --host ${repl_node} ${repl_name} "exec procedure sys.cmd.send('physrep_force_registration')"
+
+    echo "Sleeping 15s to allow replicant to hit the decision point with metadb down"
+    sleep 15
+
+    echo "Restarting altmeta"
+    if [[ -z "$CLUSTER" ]]; then
+        local node=$(hostname)
+        local altLogFile=$TESTDIR/logs/${REPL_ALTMETA_DBNAME}.${node}.log
+        $COMDB2_EXE ${REPL_ALTMETA_DBNAME} --lrl ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.lrl --pidfile ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.pid >> ${altLogFile} 2>&1 &
+    else
+        for node in $CLUSTER ; do
+            local altLogFile=$TESTDIR/logs/${REPL_ALTMETA_DBNAME}.${node}.log
+            ssh ${node} "source ${REP_ENV_VARS} ; $COMDB2_EXE ${REPL_ALTMETA_DBNAME} --lrl ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.lrl --pidfile ${REPL_ALTMETA_DBDIR}/${REPL_ALTMETA_DBNAME}.pid" >> ${altLogFile} 2>&1 < /dev/null &
+        done
+    fi
+
+    echo "Waiting for altmeta to come back online"
+    local out=""
+    local wait_count=0
+    while [[ "$out" != "1" ]] && [[ $wait_count -lt 60 ]]; do
+        sleep 1
+        out=$($CDB2SQL_EXE ${CDB2_OPTIONS} --tabs --host ${REPL_ALTMETA_HOST} ${REPL_ALTMETA_DBNAME} 'select 1' 2>/dev/null)
+        let wait_count=wait_count+1
+    done
+    if [[ "$out" != "1" ]]; then
+        cleanFailExit "Altmeta failed to come back online"
+    fi
+
+    echo "Waiting for replicant to resume replication"
+    sleep 10
+
+    echo "Checking replicant log for expected behavior"
+    local new_log=$(tail -n +$((log_lines_before+1)) $logFile)
+
+    local found_cached=$(echo "$new_log" | grep "Metadb unreachable, using cached revconn state" | wc -l)
+    local found_find_timeout=$(echo "$new_log" | grep "Couldn't connect to source hosts within" | wc -l)
+
+    echo "  Cached revconn path hits: $found_cached"
+    echo "  find_new_repl_db timeout hits: $found_find_timeout"
+
+    if [[ "$found_find_timeout" -gt 0 ]]; then
+        cleanFailExit "Replicant fell into find_new_repl_db despite being a revconn replicant"
+    fi
+
+    if [[ "$found_cached" -eq 0 ]]; then
+        echo "  WARNING: did not see cached revconn message (may not have hit the code path)"
+    fi
+
+    echo "Restoring default find_new_repl_db_timeout"
+    $CDB2SQL_EXE --admin ${CDB2_OPTIONS} --host ${repl_node} ${repl_name} "exec procedure sys.cmd.send('put tunable physrep_find_new_repl_db_timeout 60')"
+
+    echo "== revconn_metadb_failure_test passed =="
+}
+
 # Count number of file-descriptors used by the revconn-source
 function revconn_leak_test
 {
@@ -3204,6 +3287,11 @@ function run_tests
     revconn_leak_test
     testcase_finish $testcase
 
+    testcase="revconn_metadb_failure_test"
+    testcase_preamble $testcase
+    revconn_metadb_failure_test
+    testcase_finish $testcase
+
     testcase="physrep_truncate"
     testcase_preamble $testcase
     physrep_truncate
@@ -3297,7 +3385,7 @@ function run_tests
 
 function run_one_test
 {
-    physrep_rtcpu_source
+    revconn_metadb_failure_test
 }
 
 run_tests

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1950,7 +1950,7 @@ function require_recent_heartbeat
     retries=0
 
     while [[ $retries -lt 10 ]]; do
-        $CDB2SQL_EXE $CDB2_OPTIONS $REPL_ALTMETA_DBNAME --host $REPL_ALTMETA_HOST "update comdb2_physreps set last_keepalive = '1981-08-30T23:59:59.987 US/Eastern' where dbname = '$name' and host = '$host'"
+        $CDB2SQL_EXE $CDB2_OPTIONS $REPL_ALTMETA_DBNAME --host $REPL_ALTMETA_HOST "update comdb2_physreps set last_keepalive = '1981-08-30T23:59:59.987' where dbname = '$name' and host = '$host'"
 
         lsn=`$CDB2SQL_EXE -admin --tabs $CDB2_OPTIONS $DBNAME default 'select lsn from comdb2_transaction_logs(NULL, NULL, 4) limit 1' | tr -d {}`
         out2=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} $REPL_ALTMETA_DBNAME --host $REPL_ALTMETA_HOST "exec procedure sys.physrep.register_replicant('testdb', 'testmach', '$lsn', '$DBNAME', \"'$firstNode'\")")

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -749,6 +749,7 @@
 (name='physrep_exit_on_invalid_logstream', description='Exit physreps on invalid logstream.  (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='physrep_fanout', description='Maximum number of physical replicants that a node can service (Default: 8)', type='INTEGER', value='8', read_only='N')
 (name='physrep_filter_by_class', description='Filter physrep replication by class. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='physrep_find_new_repl_db_timeout', description='Max seconds to spend in find_new_repl_db before giving up. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_hung_replicant_check_freq_sec', description='Check for hung physical replicant this often. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_hung_replicant_threshold', description='Report if the physical replicant has been inactive for this duration. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_i_am_metadb', description='I am physical replication metadb (Default: off)', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
The metadb overload issue caused a physrep to incorrectly attempt to establish a direct connection against a source rather than waiting for a reverse connection.  This mistake was costly: it was stuck in find_new_repl_db for 45 minutes.  This PR adds a timeout to find_new_repl_db, and tells the code to fallback to the last known good 'should_wait_for_revconn' request rather than attempting a direct connection for that case.
