### PR TITLE
Fix fdb race: double-linking remote table on concurrent discovery

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -982,6 +982,7 @@ static int _add_table_and_stats_fdb(sqlclntstate *clnt, sqlite3InitInfo *init, f
         /* table was already added with the right version */
         _free_fdb_tbl(fdb, tbl);
         tbl = remtbl;
+        link_table = 0; /* already linked by the winning thread */
         goto done;
     }
 


### PR DESCRIPTION
When two threads discover the same remote table simultaneously, both fetch from remote and allocate different rootpages. The losing thread correctly reuses the winner's table but failed to reset link_table, causing _link_fdb_table on an already-linked table. This double-added entries to fdb hashes, leaving dangling pointers after stale table cleanup.

