### PR TITLE
Abort earlier on transaction error

### DIFF
--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4914,6 +4914,7 @@ static int retrieve_locks_from_prepare(DB_ENV *dbenv, DB_LSN *lsn, DBT *locks, u
 }
 
 int gbl_debug_lock_get_list_copy_compare = 0;
+int gbl_panic_on_transaction_apply_error = 1;
 
 /*
  * __rep_process_txn --
@@ -5453,11 +5454,14 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, rep_gen, loc
 					needed_to_get_record_from_log ? &data_dbt :
 					&lcin_dbt, lsnp, DB_TXN_APPLY,
 					txninfo)) != 0) {
-				if (ret != DB_LOCK_DEADLOCK)
+				if (ret != DB_LOCK_DEADLOCK) {
 					__db_err(dbenv,
 						"transaction failed at [%lu][%lu]",
 						(u_long)lsnp->file,
 						(u_long)lsnp->offset);
+					if (gbl_panic_on_transaction_apply_error)
+						__db_panic(dbenv, ret);
+				}
 				if (ret == DB_LOCK_DEADLOCK && rectype >= 10000)
 					ret = DB_LOCK_DEADLOCK_CUSTOM;
 				line = __LINE__;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -648,6 +648,8 @@ extern int gbl_db_track_open;
 extern int gbl_clear_ufid_on_db_close;
 extern int gbl_get_peer_fqdn;
 
+extern int gbl_panic_on_transaction_apply_error;
+
 int parse_int64(const char *value, int64_t *num);
 
 /*

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2688,4 +2688,7 @@ REGISTER_TUNABLE("clear_ufid_on_db_close", "Clear ufid hash on db->close", TUNAB
                  INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("get_peer_fqdn", "When set, use peer's FQDN", TUNABLE_BOOLEAN, &gbl_get_peer_fqdn, INTERNAL, NULL,
                  NULL, NULL, NULL);
+REGISTER_TUNABLE("panic_on_transaction_apply_error", "When set, panic if any LSN can't be applied (Default: ON)",
+                 TUNABLE_BOOLEAN, &gbl_panic_on_transaction_apply_error, 0, NULL, NULL, NULL, NULL);
+
 #endif /* _DB_TUNABLES_H */

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -712,6 +712,7 @@
 (name='pagesizeix', description='', type='INTEGER', value='4096', read_only='N')
 (name='panicfulldiag', description='Enables full diagnostic on a panic.', type='BOOLEAN', value='OFF', read_only='N')
 (name='paniclogsnap', description='', type='BOOLEAN', value='ON', read_only='N')
+(name='panic_on_transaction_apply_error', description='When set, panic if any LSN can''t be applied (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='parallel_count', description='When 'direct_count' is on, enable thread-per-stripe', type='BOOLEAN', value='OFF', read_only='N')
 (name='parallel_recovery', description='', type='INTEGER', value='0', read_only='Y')
 (name='parallel_sync', description='Run checkpoint/memptrickle code with parallel writes', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
We call panic() when the entire transaction fails at which point it's too late to get value out of the core.