### PR TITLE
{184822865} Fix db:consumer() returning number on transient error

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -423,7 +423,8 @@ static int luabb_trigger_register(Lua L, trigger_reg_t *reg, int register_timeou
             --retry;
         }
         if (check_retry_conditions(L, reg, 1) != 0) {
-            rc = luabb_error(L, sp, sp->error);
+            luabb_error(L, sp, sp->error);
+            rc = -1;
             goto out;
         }
         if (rc != NET_SEND_FAIL_TIMEOUT) {


### PR DESCRIPTION
## Summary

- `luabb_trigger_register()` returns the result of `luabb_error()` (which is `1`) when `check_retry_conditions()` detects a transient error. Since `CDB2_TRIG_REQ_SUCCESS == 1`, the caller skips error handling and returns the corrupted Lua stack value (`-1` number) instead of raising an error.
- Fix: discard the `luabb_error()` return value and set `rc = -1` explicitly, so the caller's error path executes correctly.