### PR TITLE
Fixing use-after-free from reqlog + stmt-caching

### DIFF
--- a/db/sql_stmt_cache.c
+++ b/db/sql_stmt_cache.c
@@ -624,6 +624,6 @@ int stmt_cache_put(struct sqlthdstate *thd, struct sqlclntstate *clnt,
 void stmt_cache_free_vdbe(sqlite3_stmt *stmt, struct sqlclntstate *clnt)
 {
     sqlite3_finalize(stmt); /* no-op on NULL */
-    if (clnt != NULL) /* zNormSql is owned by the VDBE */
+    if (clnt != NULL)       /* zNormSql is owned by the VDBE */
         clnt->work.zNormSql = NULL;
 }

--- a/db/sql_stmt_cache.c
+++ b/db/sql_stmt_cache.c
@@ -24,7 +24,7 @@ int gbl_max_sqlcache = 10;
 int gbl_enable_sql_stmt_caching = STMT_CACHE_ALL;
 
 extern int gbl_debug_temptables;
-static int stmt_cache_finalize_entry(stmt_cache_entry_t *entry);
+static int stmt_cache_finalize_entry(stmt_cache_entry_t *entry, struct sqlclntstate *clnt);
 
 static int query_data_func(struct sqlclntstate *clnt, void **data, int *sz,
                            int type, int op)
@@ -38,7 +38,7 @@ static int query_data_func(struct sqlclntstate *clnt, void **data, int *sz,
 static int stmt_cache_finalize_entry_cb(void *stmt_entry, void *args)
 {
     (void)args;
-    return stmt_cache_finalize_entry(stmt_entry);
+    return stmt_cache_finalize_entry(stmt_entry, NULL);
 }
 
 /* Teardown statement cache */
@@ -140,9 +140,9 @@ static void stmt_cache_free_entry(stmt_cache_entry_t *entry)
     sqlite3_free(entry);
 }
 
-static int stmt_cache_finalize_entry(stmt_cache_entry_t *entry)
+static int stmt_cache_finalize_entry(stmt_cache_entry_t *entry, struct sqlclntstate *clnt)
 {
-    sqlite3_finalize(entry->stmt);
+    stmt_cache_free_vdbe(entry->stmt, clnt);
     if (entry->qd_func && entry->stmt_data) {
         entry->qd_func(NULL, &entry->stmt_data, NULL, QUERY_STMT_DATA,
                        QUERY_DATA_DELETE);
@@ -160,7 +160,7 @@ static int stmt_cache_delete_last_entry(stmt_cache_t *stmt_cache, void *list)
         logmsg(LOGMSG_ERROR, "%s:%d failed to delete entry (rc: %d)\n",
                __func__, __LINE__, rc);
     }
-    stmt_cache_finalize_entry(entry);
+    stmt_cache_finalize_entry(entry, NULL);
     return rc;
 }
 
@@ -556,7 +556,7 @@ int stmt_cache_put_int(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                 query_data_func(clnt, NULL, NULL, QUERY_STMT_DATA, QUERY_DATA_SET);
             }
             if (stmt_cache_requeue_old_entry(thd->stmt_cache, rec->stmt_entry)) { /* put back in queue... */
-                stmt_cache_finalize_entry(rec->stmt_entry);                   /* ...and on error, cleanup */
+                stmt_cache_finalize_entry(rec->stmt_entry, clnt);                 /* ...and on error, cleanup */
             }
             return 0;
         }
@@ -598,9 +598,8 @@ int stmt_cache_put_distributed(struct sqlthdstate *thd,
     dohsql_wait_for_master((rec) ? rec->stmt : NULL, clnt);
 
     rc = stmt_cache_put_int(thd, clnt, rec, 0, outrc, distributed);
-    if (rc != 0 && rec->stmt) {
-        sqlite3_finalize(rec->stmt);
-        rec->stmt = NULL;
+    if (rc != 0) {
+        stmt_cache_free_vdbe(rec->stmt, clnt);
     }
     if ((rec->status & CACHE_HAS_HINT) && (rec->status & CACHE_FOUND_STR)) {
         char *k = rec->cache_hint;
@@ -620,4 +619,11 @@ int stmt_cache_put(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                    struct sql_state *rec, int outrc)
 {
     return stmt_cache_put_distributed(thd, clnt, rec, outrc, 0);
+}
+
+void stmt_cache_free_vdbe(sqlite3_stmt *stmt, struct sqlclntstate *clnt)
+{
+    sqlite3_finalize(stmt); /* no-op on NULL */
+    if (clnt != NULL) /* zNormSql is owned by the VDBE */
+        clnt->work.zNormSql = NULL;
 }

--- a/db/sql_stmt_cache.h
+++ b/db/sql_stmt_cache.h
@@ -98,4 +98,5 @@ int stmt_cache_find_and_remove_entry(stmt_cache_t *stmt_cache, const char *sql, 
 int stmt_cache_add_new_entry(stmt_cache_t *stmt_cache, const char *sql, const char *actual_sql, sqlite3_stmt *stmt,
                              struct sqlclntstate *clnt);
 int stmt_cache_requeue_old_entry(stmt_cache_t *, stmt_cache_entry_t *);
+void stmt_cache_free_vdbe(sqlite3_stmt *, struct sqlclntstate *);
 #endif /* !__INCLUDED_SQL_STMT_CACHE_H */

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -2999,7 +2999,7 @@ static void update_schema_remotes(struct sqlclntstate *clnt,
     }
 
     /* terminate the current statement; we are gonna reprepare */
-    sqlite3_finalize(rec->stmt);
+    stmt_cache_free_vdbe(rec->stmt, clnt);
     rec->stmt = NULL;
     clnt->dbtran.pStmt = NULL;
 }
@@ -4652,7 +4652,7 @@ static int execute_verify_indexes(struct sqlthdstate *thd, struct sqlclntstate *
             else
                 stmt_cache_add_new_entry(thd->stmt_cache, clnt->sql, 0, stmt, clnt);
         } else {
-            sqlite3_finalize(stmt);
+            stmt_cache_free_vdbe(stmt, clnt);
         }
         return rc;
     }
@@ -4663,7 +4663,7 @@ static int execute_verify_indexes(struct sqlthdstate *thd, struct sqlclntstate *
         else
             stmt_cache_add_new_entry(thd->stmt_cache, clnt->sql, 0, stmt, clnt);
     } else {
-        sqlite3_finalize(stmt);
+        stmt_cache_free_vdbe(stmt, clnt);
     }
 
     clnt->has_sqliterow = 0;


### PR DESCRIPTION
When statement-caching is enabled, `clnt.work.zNormSql` points to memory owned by the VDBE. The long-running-sql-logging code from the watchdog thread may then read its value after the VDBE is finalized (ineligible for caching, cache full, etc.), as shown by valgrind.

```
==50609== Thread watchdog_thread:
==50609== Invalid read of size 1
==50609==    at 0x484F226: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==50609==    by 0x15A92E: calc_fingerprint (db_fingerprint.c:91)
==50609==    by 0x15A92E: calc_fingerprint (db_fingerprint.c:81)
==50609==    by 0x206F41: reqlog_long_running_clnt (reqlog.c:2057)
==50609==    by 0x25F3B5: reqlog_long_running_sql_statements (sqlinterfaces.c:6703)
==50609==    by 0x203E5C: reqlog_log_all_longreqs (reqlog.c:2115)
==50609==    by 0x2A12AC: watchdog_thread (watchdog.c:390)
==50609==    by 0x5063AA3: start_thread (pthread_create.c:447)
==50609==    by 0x50F0A63: clone (clone.S:100)
==50609==  Address 0x39008e60 is 0 bytes inside a block of size 32 free'd
==50609==    at 0x484988F: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==50609==    by 0x526D46: sqlite3VdbeClearObject (vdbeaux.c:3499)
==50609==    by 0x526EA8: sqlite3VdbeDelete (vdbeaux.c:3546)
==50609==    by 0x5292B7: sqlite3VdbeFinalize (vdbeaux.c:3433)
==50609==    by 0x591EBA: sqlite3_finalize (vdbeapi.c:280)
==50609==    by 0x26901A: stmt_cache_put_distributed (sql_stmt_cache.c:603)
==50609==    by 0x2545A1: sqlite_done (sqlinterfaces.c:4149)
==50609==    by 0x25D3F8: handle_sqlite_requests (sqlinterfaces.c:4307)
==50609==    by 0x25E690: execute_sql_query (sqlinterfaces.c:4358)
==50609==    by 0x25E690: sqlengine_work_appsock (sqlinterfaces.c:4903)
==50609==    by 0x25EF67: sqlengine_work_appsock_pp (sqlinterfaces.c:4940)
==50609==    by 0x5F3177: thdpool_thd (thdpool.c:804)
==50609==    by 0x5063AA3: start_thread (pthread_create.c:447)
```

This patch ensures `clnt.work.zNormSql` is cleared after the VDBE is finalized.