### PR TITLE
Skip repeated IAM calls for vtab access in dryrun mode

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -241,6 +241,7 @@ int gbl_allow_old_authn = 1;
 int gbl_uses_externalauth = 0;
 int gbl_vtab_externalauth = 0;
 int gbl_vtab_externalauth_strict = 0;
+int gbl_vtab_externalauth_warn = 0;
 #ifdef COMDB2_TEST
 int gbl_uses_simpleauth = 0;
 #endif

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1656,6 +1656,7 @@ extern int gbl_unauth_tag_access;
 extern int gbl_uses_externalauth;
 extern int gbl_vtab_externalauth;
 extern int gbl_vtab_externalauth_strict;
+extern int gbl_vtab_externalauth_warn;
 #ifdef COMDB2_TEST
 extern int gbl_uses_simpleauth;
 #endif

--- a/db/db_access.c
+++ b/db/db_access.c
@@ -446,26 +446,23 @@ int access_control_check_read(struct ireq *iq, tran_type *trans, int *bdberr)
 int comdb2_check_vtab_access(sqlite3 *db, sqlite3_module *module)
 {
     HashElem *current;
-    int dryrun = 0;
 
     if (!gbl_uses_password && !(gbl_uses_externalauth && gbl_vtab_externalauth)) {
-        if (gbl_uses_externalauth && !gbl_vtab_externalauth)
-            dryrun = 1;
+        if (gbl_uses_externalauth && !gbl_vtab_externalauth && gbl_vtab_externalauth_warn)
+            ; /* fall through to warn-only check */
         else
             return 0;
     }
 
     struct sql_thread *thd = pthread_getspecific(query_info_key);
 
-    for (current = sqliteHashFirst(&db->aModule); current;
-         current = sqliteHashNext(current)) {
+    for (current = sqliteHashFirst(&db->aModule); current; current = sqliteHashNext(current)) {
         struct Module *mod = sqliteHashData(current);
         if (module != mod->pModule) {
             continue;
         }
 
-        if ((module->access_flag == 0) ||
-            (module->access_flag & CDB2_ALLOW_ALL)) {
+        if ((module->access_flag == 0) || (module->access_flag & CDB2_ALLOW_ALL)) {
             return SQLITE_OK;
         }
 
@@ -476,7 +473,7 @@ int comdb2_check_vtab_access(sqlite3 *db, sqlite3_module *module)
 
         int rc = access_control_check_sql_read(NULL, thd, (char *)mod->zName);
         if (rc != SQLITE_OK) {
-            if (dryrun) {
+            if (!gbl_vtab_externalauth && gbl_vtab_externalauth_warn) {
                 struct sqlclntstate *clnt = thd->clnt;
                 if (errstat_get_rc(&clnt->osql.xerr) == SQLITE_ACCESS)
                     bzero(&clnt->osql.xerr, sizeof(clnt->osql.xerr));

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2437,6 +2437,9 @@ REGISTER_TUNABLE("vtab_externalauth", "Use IAM for vtab access control (Default:
 REGISTER_TUNABLE("vtab_externalauth_strict", "Enforce access control on all CDB2_ALLOW_USER vtabs (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_vtab_externalauth_strict, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("vtab_externalauth_warn", "Log vtab access denials without enforcing (Default: off)", TUNABLE_BOOLEAN,
+                 &gbl_vtab_externalauth_warn, 0, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("externalauth_warn", "Warn instead of returning error in case of missing authdata",
                  TUNABLE_BOOLEAN, &gbl_externalauth_warn, NOARG | READEARLY,
                  NULL, NULL, NULL, NULL);

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1153,6 +1153,7 @@
 (name='views_dft_roll_delete_lag_secs', description='Amount of seconds to run phase 3 of time partition rollout after phase 2', type='INTEGER', value='5', read_only='N')
 (name='vtab_externalauth', description='Use IAM for vtab access control (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='vtab_externalauth_strict', description='Enforce access control on all CDB2_ALLOW_USER vtabs (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
+(name='vtab_externalauth_warn', description='Log vtab access denials without enforcing (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='wait_for_prepare_seqnum', description='Wait-for-seqnum for prepare records. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='wait_for_seqnum_trace', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='wal_osync', description='Open WAL files using the O_SYNC flag (Default: off)', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
just enable it later, data in decision history and not act.log