### PR TITLE
Fixing build for ubuntu 26 and glibc 2.43

### DIFF
--- a/archive/ar_wrap.c
+++ b/archive/ar_wrap.c
@@ -267,12 +267,12 @@ int recognize_data_file(const char *filename, uint8_t *is_data_file,
                         uint8_t *is_queue_file, uint8_t *is_queuedb_file,
                         char **out_table_name)
 {
-    char *dot_pos = strchr(filename, '.');
+    const char *dot_pos = strchr(filename, '.');
     if (dot_pos == NULL) {
         return 0;
     }
 
-    char *ext = dot_pos + 1;
+    const char *ext = dot_pos + 1;
     size_t len = dot_pos - filename;
 
     // queues are the same whether we are llmeta or not

--- a/cdb2api/cdb2api.c
+++ b/cdb2api/cdb2api.c
@@ -1217,8 +1217,8 @@ static int cdb2_tcpresolve(const char *host, struct in_addr *in, int *port)
     /*RESOLVE AN ADDRESS*/
     in_addr_t inaddr;
     int len;
-    char tok[128], *cc;
-    cc = strchr(host, (int)':');
+    char tok[128];
+    const char *cc = strchr(host, (int)':');
     if (cc == 0) {
         len = strlen(host);
         if (len >= sizeof(tok))
@@ -9439,7 +9439,7 @@ char *cdb2_string_escape(cdb2_hndl_tp *hndl, const char *src)
     const char *escapestr = "'";
     size_t count = 2; // set initial value for wrapping characters
 
-    char *curr = strchr(src, *escapestr);
+    const char *curr = strchr(src, *escapestr);
     while (curr != NULL) {
         ++count;
         curr = strchr(curr + 1, *escapestr);

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -3623,8 +3623,8 @@ static int archive_file(const char *fname, const char *savdir) {
  */
 static int does_file_have_db_extension(const char *fname) {
     const char * extension;
-    char * pos;
-    char * ext;
+    const char *pos;
+    const char *ext;
     int cmp;
 
     ext = strrchr(fname, '.');

--- a/db/resource.c
+++ b/db/resource.c
@@ -92,7 +92,8 @@ void initresourceman(const char *newlrlname)
  */
 char *getdbrelpath(const char *relpath)
 {
-    char *index, *newpath;
+    const char *index;
+    char *newpath;
     size_t reltolen, relpathlen;
     const char *relto = lrlname;
 

--- a/db/sql_stmt_cache.c
+++ b/db/sql_stmt_cache.c
@@ -340,7 +340,7 @@ static int has_sql_hint_table(char *sql_hint)
 
 int has_sqlcache_hint(const char *sql, const char **pstart, const char **pend)
 {
-    char *start, *end;
+    const char *start, *end;
     start = strstr(sql, SQLCACHEHINT);
     if (pstart)
         *pstart = start;

--- a/db/views.c
+++ b/db/views.c
@@ -780,7 +780,7 @@ static int _extract_shardname_index(const char *tblName,
         nextNum = atoi(tblName + 1); /* skip $ */
 
         if (span) {
-            char *_ = strchr(tblName, '_');
+            const char *_ = strchr(tblName, '_');
             if (_) {
                 *span = _ - tblName - 1;
             }

--- a/lua/sp.c
+++ b/lua/sp.c
@@ -212,7 +212,7 @@ static void remove_thd_funcs(Lua);
 */
 static int two_part_tbl_name(const char *name, char *n1, char *n2)
 {
-    char *dot;
+    const char *dot;
     if ((dot = strstr(name, ".")) != NULL) {
         if (dot - name >= MAXTABLELEN) {
             return -1;

--- a/sqlite/ext/expert/sqlite3expert.c
+++ b/sqlite/ext/expert/sqlite3expert.c
@@ -1848,15 +1848,15 @@ sqlite3expert *sqlite3_expert_new(sqlite3 *db, char **pzErrmsg){
         " AND sql NOT LIKE 'CREATE VIRTUAL %%'"
     );
     while( rc==SQLITE_OK && SQLITE_ROW==sqlite3_step(pSql) ){
-      const char *zSql = (const char*)sqlite3_column_text(pSql, 0);
 #if defined(SQLITE_BUILDING_FOR_COMDB2)
+      const char *zSql = (const char*)sqlite3_column_text(pSql, 0);
       char *coll = NULL;
       // transform all the "collate DATACOPY" instances from:
       // create index "$I1_792AC8AF" on "t1" ("i", "b" collate DATACOPY, "c");
       // to 
       // create index "$I1_792AC8AF" on "t1" ("i", "b" , "c") INCLUDE ALL;
       // note that there is enough space because 'INCLUDE ALL' is less characters than 'collate DATACOPY'
-      if ((coll = strstr(zSql, " collate DATACOPY"))) {
+      if ((coll = strstr((char *)zSql, " collate DATACOPY"))) {
         char *end = coll + sizeof(" collate DATACOPY") - 1;
         while(*end != ';') {
             *coll = *end;
@@ -1871,6 +1871,7 @@ sqlite3expert *sqlite3_expert_new(sqlite3 *db, char **pzErrmsg){
       rc = sqlite3_exec(pNew->dbm, newSql, 0, 0, pzErrmsg);
       sqlite3_free(newSql);
 #else /* defined(SQLITE_BUILDING_FOR_COMDB2) */
+      const char *zSql = (const char*)sqlite3_column_text(pSql, 0);
       rc = sqlite3_exec(pNew->dbm, zSql, 0, 0, pzErrmsg);
 #endif /* defined(SQLITE_BUILDING_FOR_COMDB2) */
     }

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -782,7 +782,7 @@ static void comdb2Rebuild(Parse *p, Token* nm, Token* lnm, int opt, int oplog_cn
 
 static int authenticateSC(const char * table,  Parse *pParse)
 {
-    char *username = strstr(table, "@");
+    const char *username = strstr(table, "@");
     struct sqlclntstate *clnt = get_sql_clnt();
     if (username && strcmp(username+1, clnt->current_user.name) == 0) {
         return 0;

--- a/tests/docker/Dockerfile.db
+++ b/tests/docker/Dockerfile.db
@@ -1,7 +1,7 @@
 ARG REVISION=HEAD
 FROM comdb2test:${REVISION}
 
-RUN mkdir /var/run/sshd && \
+RUN mkdir -p /var/run/sshd && \
     echo 'root:bigsecret' | chpasswd && \
     sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/sshd_config && \
     echo "StrictHostKeyChecking no" > /etc/ssh/ssh_config && \

--- a/tests/docker/Dockerfile.install
+++ b/tests/docker/Dockerfile.install
@@ -17,7 +17,6 @@ RUN apt-get update && \
     lcov \
     libevent-dev \
     liblz4-dev \
-    liblz4-tool \
     libprotobuf-c1 \
     libprotobuf-c-dev \
     libreadline-dev \
@@ -37,7 +36,6 @@ RUN apt-get update && \
     openssh-server \
     protobuf-c-compiler \
     psmisc \
-    pstack \
     rsync \
     socat \
     strace \
@@ -48,6 +46,7 @@ RUN apt-get update && \
     valgrind \
     vim \
     uuid-dev && \
+  (apt-get install -y lz4 liblz4-tool pstack || true ) && \
   ln -fs /usr/share/zoneinfo/America/New_York /etc/localtime && \
   dpkg-reconfigure --frontend noninteractive tzdata
 

--- a/util/bb_getopt_long.c
+++ b/util/bb_getopt_long.c
@@ -167,7 +167,7 @@ static void replace_args(int argc, char *argv[], char *options,
 static int getopt_internal(int nargc, char *const *nargv, const char *ostr)
 {
     static char *place = EMSG; /* option letter processing */
-    char *oli;                 /* option letter list index */
+    const char *oli;           /* option letter list index */
 
     _DIAGASSERT(nargv != NULL);
     _DIAGASSERT(ostr != NULL);

--- a/util/portmuxusr.c
+++ b/util/portmuxusr.c
@@ -910,8 +910,8 @@ static bool portmux_client_side_validation(int fd, const char *app,
                     memcpy(&features, buf, sizeof(features));
                     features = ntohl(features);
 
-                    const char *app_s = buf + sizeof(uint32_t);
-                    const char *service_s = NULL;
+                    char *app_s = buf + sizeof(uint32_t);
+                    char *service_s = NULL;
                     const char *instance_s = NULL;
 
                     char *pos = strchr(app_s, '/');

--- a/util/tcputil.c
+++ b/util/tcputil.c
@@ -181,8 +181,8 @@ int tcpresolve(const char *host, struct in_addr *in, int *port)
     in_addr_t inaddr;
 
     int len;
-    char tok[128], *cc;
-    cc = strchr(host, (int)':');
+    char tok[128];
+    const char *cc = strchr(host, (int)':');
     if (cc == 0) {
         len = strlen(host);
         if (len >= sizeof(tok))


### PR DESCRIPTION
ubuntux-26: The lz4tool package is relocated into lz4.

glibc-2.43: glibc now uses type-safe macros for quite a few libc functions:

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

```
For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr,
strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return
pointers into their input arrays now have definitions as macros that
return a pointer to a const-qualified type when the input argument is
a pointer to a const-qualified type.
```
