### PR TITLE
fdb push: always resolve tier name in _hndl_open

### DIFF
--- a/db/fdb_push.c
+++ b/db/fdb_push.c
@@ -414,10 +414,10 @@ static cdb2_hndl_tp *_hndl_open(sqlclntstate *clnt, int *client_redir,
                                 int n_sets, const char **sets)
 {
     fdb_push_connector_t *push = clnt->fdb_push;
-    const char *class = "default";
+    const char *class;
     if (push->local)
         class = "local";
-    else if (push->class != get_my_mach_class()) {
+    else {
         class = mach_class_class2name(push->class);
         assert(class);
     }


### PR DESCRIPTION
## Summary

- After 8a158e03a0 replaced `class_override` with `push->class != get_my_mach_class()`, `_hndl_open` passes the unresolved literal `"default"` to `cdb2_open` when the remote DB is on the same tier as the local node. This leaks `"default"` into the sockpool typestr (e.g. `comdb2/<db>/default/newsql/<policy>`), which is invalid — the tier slot must contain a resolved name like `dev` or `prod`.
- In normal builds this silently prevents sockpool reuse for same-tier fdb push connections (no cached connection matches a `"default"` typestr). In `CDB2API_TEST` builds it aborts in `cdb2_socket_pool_get`.
- Always resolve via `mach_class_class2name(push->class)` regardless of whether the tier matches the local machine's class.

## Test plan

- [x] Verify `_hndl_open` no longer produces a typestr containing `"default"` when remote and local tiers match
- [ ] Run Lua SP with remote `db:exec` on same-tier DB under `CDB2API_TEST` build — no longer aborts
- [x] Existing `fdb_push` test suite passes (exercises the `_hndl_open` path, though it does not build with `CDB2API_TEST` so it cannot catch the typestr issue directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)