### PR TITLE
proto: Add SKIP_ROWS alias to support legacy API

### DIFF
--- a/protobuf/sqlquery.proto
+++ b/protobuf/sqlquery.proto
@@ -15,6 +15,8 @@ enum CDB2RequestType {
 }
 
 enum CDB2ClientFeatures {
+    option allow_alias = true;
+    SKIP_ROWS              = 1;
     SKIP_INTRANS_RESULTS   = 1;
     ALLOW_MASTER_EXEC      = 2;
     ALLOW_MASTER_DBINFO    = 3;

--- a/protobuf/sqlresponse.proto
+++ b/protobuf/sqlresponse.proto
@@ -116,6 +116,8 @@ enum CDB2SyncMode {
 }
 
 enum CDB2ServerFeatures {
+    option allow_alias = true;
+    SKIP_ROWS            = 1;
     SKIP_INTRANS_RESULTS = 1;
 }
 


### PR DESCRIPTION
Add legacy alias for SKIP_INTRANS_RESULTS. There is nothing in current code that uses this.

This will be used in forthcoming amalgamation build by having a common protobuf definition.