### PR TITLE
Fixing reqlog queuetime for verify-retry

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4566,7 +4566,6 @@ static void sqlengine_work_lua_thread(void *thddata, void *work)
     thr_set_user("appsock", (intptr_t)clnt->appsock_id);
 
     clnt->osql.timings.query_dispatched = osql_log_time();
-    clnt->deque_timeus = comdb2_time_epochus();
     clnt->thd = thd;
     /* Reset the cancel-statement flag */
     if (clnt->discard_this) {
@@ -4845,7 +4844,6 @@ void sqlengine_work_appsock(struct sqlthdstate *thd, struct sqlclntstate *clnt)
     clnt->was_consumer = 0;
     clnt_change_state(clnt, CONNECTION_RUNNING);
     clnt->osql.timings.query_dispatched = osql_log_time();
-    clnt->deque_timeus = comdb2_time_epochus();
 
     reqlog_set_origin(thd->logger, "%s", clnt->origin);
 
@@ -4927,6 +4925,7 @@ static void sqlengine_work_appsock_pp(struct thdpool *pool, void *work,
 
     switch (op) {
     case THD_RUN:
+        clnt->deque_timeus = comdb2_time_epochus();
         if (clnt->exec_lua_thread)
             sqlengine_work_lua_thread(thddata, work);
         else


### PR DESCRIPTION
`clnt->enque_timeus` is calculated exactly once per `thdpool_enqueue`, whereas `clnt->deque_timeus` is re-calculated on each `sqlengine_work_appsock` call. This causes inline retries from a verify error to inflate reqlog's queuetime (`queuetime = deque_timeus - enque_timeus`).

This patch moves the `deque_timeus` stamping to `sqlengine_work_appsock_pp`, so that it's truly the time when dequeue from the thread pool happens.