### PR TITLE
Update cdb2hibernatedialect for Spring Boot 3.5.16 (Hibernate 6.6.53, Java 17)

### DIFF
--- a/contrib/cdb2hibernatedialect/build.gradle
+++ b/contrib/cdb2hibernatedialect/build.gradle
@@ -21,11 +21,11 @@ plugins {
 }
 
 group = "com.bloomberg.comdb2"
-version = "0.2.0-M2"
+version = "0.3.0-M1"
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("org.hibernate.orm:hibernate-platform:6.4.4.Final"))
+    implementation(platform("org.hibernate.orm:hibernate-platform:6.6.53.Final"))
     implementation("org.hibernate.orm:hibernate-core")
 }
 


### PR DESCRIPTION
## Summary

Updates `contrib/cdb2hibernatedialect` to align with **Spring Boot 3.5.16**, which manages **Hibernate ORM 6.6.53.Final** and requires **Java 17+**.

## Changes (`build.gradle` only)

- Java toolchain: **11 → 17**
- `hibernate-platform`: **6.4.4.Final → 6.6.53.Final** (the Hibernate version managed by the Spring Boot 3.5.16 BOM)
- version: **0.2.0-M2 → 0.3.0-M1** (minor bump signalling the raised platform floor, matching the convention used for the previous Hibernate baseline bump)

## No source changes needed

All Hibernate APIs used by the dialect have identical signatures in 6.6.53. Verified by compiling all sources against the 6.6.53 jars with `javac --release 17` — builds cleanly, all classes produced.

The only compiler output is a deprecation warning on the no-arg `Dialect()` constructor (still functional in 6.6.53; a heads-up for a future Hibernate 7 major). Left as-is since it is non-breaking.
