### PR TITLE
Fix memory leak of fake BtCursor in _retrieve_fdb_tbl

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -1427,6 +1427,7 @@ close:
     }
 
 done:
+    free(cur);
     sqlite3_free(sql);
     return rc;
 }


### PR DESCRIPTION
### What                                                                                           
`_retrieve_fdb_tbl()` calloc's a fake `BtCursor`+`Btree` (`cur`) to drive the remote `sqlite_master` fetch but never freed it. Neither `fdb_cursor_close()` nor `fdb_cursor_close_on_open()` free the cursor object itself — they only free `cur->fdbc` — and the `close:`/`done:` cleanup only freed `sql`. So `cur` (~1–2 KB) leaked on every call.                                                       
                                                                                                   
### Impact                                                                                         
The path normally runs once per remote table, then the schema is cached, so the leak was latent. When a foreign db is unreachable or a remote table name is misspelled, `fdb_connect` → `fdb_cursor_open` fails on every query, the table is never cached, and each retry re-enters `_retrieve_fdb_tbl` and leaks another cursor — steady growth under the repeating `failed to connect remote sqlite_master` / `no such table` retry storm.                                                                   
                                                                                                   
### Fix                                                                                            
Free `cur` in the shared `done:` label. `close:` falls through to `done:`, so it covers both the normal path and the early `fdb_cursor_open`-failure path; `free(NULL)` makes the malloc-failure path safe. `cur` and `cur->fdbc` are disjoint allocations, so no double-free.                           
                                                                                                   
### Follow-up (separate commit)                                                                    
This allocation is raw libc `calloc` (`fdb_fend.c` doesn't include `mem_override.h`), so it's invisible to `comdb2_memstats`. A worthwhile future change is to route it through the tracked allocator so leaks on this path show up on the memstat radar (and become testable via the existing memstat-diff pattern).