### PR TITLE
Fdb stat rootpage race

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -111,6 +111,7 @@ extern int gbl_fdb_track_hints;
 extern int gbl_fdb_watchdog_secs;
 extern int gbl_fdb_watchdog_latency_secs;
 extern int gbl_fdb_watchdog_debug;
+extern int gbl_fdb_add_stat_delay_ms;
 extern int gbl_fdb_watchdog_alerts;
 extern int gbl_forbid_ulonglong;
 extern int gbl_force_highslot;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -570,6 +570,10 @@ REGISTER_TUNABLE("fdb_watchdog_latency_sec",
                  &gbl_fdb_watchdog_latency_secs, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("fdb_watchdog_debug", "Introduces a long lock wait for fdb array to test fdb watchdog",
                  TUNABLE_INTEGER, &gbl_fdb_watchdog_debug, INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("fdb_add_stat_delay_ms",
+                 "Testing only: sleep this many ms in the fdb schema/stats retrieval window to widen the "
+                 "stat-collection race. (Default: 0)",
+                 TUNABLE_INTEGER, &gbl_fdb_add_stat_delay_ms, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("fdb_watchdog_alerts", "Output only, reports how many fdb watchdog alerts were reported",
                  TUNABLE_INTEGER, &gbl_fdb_watchdog_alerts, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("forbid_ulonglong", "Disallow u_longlong. (Default: on)", TUNABLE_BOOLEAN, &gbl_forbid_ulonglong,

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -90,6 +90,8 @@ int gbl_fdb_auth_enabled = 1;
 int gbl_fdb_remsql_cdb2api = 1;
 int gbl_fdb_emulate_old = 0;
 int gbl_fdb_watchdog_debug = 0;         /* keep fdbs mutex blocked for this many seconds for watchdog testing */
+int gbl_fdb_add_stat_delay_ms = 0;      /* testing only: sleep this many ms in the schema/stats retrieval window
+                                           to widen the stat-collection race in _add_table_and_stats_fdb */
 int gbl_fdb_watchdog_alerts = 0;        /* keep count of how many alerts were generated */
 int gbl_fdb_watchdog_secs = 60;         /* run watched every this number of seconds */
 int gbl_fdb_watchdog_latency_secs = 59; /* alert if ping takes longer */
@@ -1036,6 +1038,12 @@ static int _add_table_and_stats_fdb(sqlclntstate *clnt, sqlite3InitInfo *init, f
      * this can end up with redundant retries, but it will not block the hash during this time
      */
     Pthread_mutex_unlock(&fdb->tables_mtx);
+
+    /* testing only: widen the window between reading "initial" and re-linking so a
+     * second concurrent request for a different table also observes initial==1 and
+     * double-collects the shared stats (see gbl_fdb_add_stat_delay_ms) */
+    if (gbl_fdb_add_stat_delay_ms > 0 && initial)
+        poll(NULL, 0, gbl_fdb_add_stat_delay_ms);
 
     /* this COULD be taken out of tbls_mtx, but I want to clear table
        under lock so I don't add garbage table structures when mispelling

--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -143,6 +143,8 @@ struct fdb_tbl {
      */
     struct fdb *fdb;
 
+    int linked; /* 1 while linked in fdb hashes/list; guards free from dangling */
+
     int nix;        /* number of indexes */
     int ix_partial; /* is there partial index */
     int ix_expr;    /* is there expressions index */
@@ -1132,6 +1134,24 @@ static int _add_table_and_stats_fdb(sqlclntstate *clnt, sqlite3InitInfo *init, f
                 /* artificial corner case: no stat1 but stat4 */
                 _remove_table_stat(fdb, tbl, "sqlite_stat4");
             }
+        }
+
+        /* keep-first stat dedup: a concurrent thread may have collected and
+         * linked the shared stats while we were unlocked for the remote
+         * retrieval. If so, discard our freshly-built (not-yet-linked)
+         * duplicates and let the done: block reuse the already-linked
+         * generation via hash_find. This guarantees a single stat generation
+         * so every engine bakes the same rootpage (mirrors the main-table
+         * dedup above). Freeing here is safe: these stat tbls are not linked. */
+        if (link_stat1 && stat1 && hash_find_readonly(fdb->h_tbls_name, &sqlite_stat1)) {
+            _free_fdb_tbl(fdb, stat1);
+            stat1 = NULL;
+            link_stat1 = 0;
+        }
+        if (link_stat4 && stat4 && hash_find_readonly(fdb->h_tbls_name, &sqlite_stat4)) {
+            _free_fdb_tbl(fdb, stat4);
+            stat4 = NULL;
+            link_stat4 = 0;
         }
     }
 
@@ -4566,9 +4586,11 @@ static void _xlink_fdb_table(fdb_t *fdb, fdb_tbl_t *tbl, int add)
         tbl->fdb = fdb;
         listc_abl(&fdb->tables, tbl);
         hash_add(fdb->h_tbls_name, tbl);
+        tbl->linked = 1;
     } else {
         listc_rfl(&fdb->tables, tbl);
         hash_del(fdb->h_tbls_name, tbl);
+        tbl->linked = 0;
     }
 }
 static void _link_fdb_table(fdb_t *fdb, fdb_tbl_t *tbl)
@@ -5133,6 +5155,12 @@ int fdb_unlock_table(sqlclntstate *clnt, fdb_tbl_ent_t *ent)
 
         /* shared table changed, our table is stale */
         Pthread_rwlock_unlock(&our_table->table_lock);
+
+        /* defensive: a stale table must not reach the free path still linked, or
+         * _free_fdb_tbl would leave dangling ents in h_ents_rootp/h_ents_name.
+         * Normally the superseding thread already unlinked it (linked==0). */
+        if (our_table->linked)
+            _unlink_fdb_table(fdb, our_table);
 
         /* try to free it if we are the last reader */
         _try_free_fdb_tbl(fdb, our_table);

--- a/tests/fdb_stat_rootpage_race.test/Makefile
+++ b/tests/fdb_stat_rootpage_race.test/Makefile
@@ -1,0 +1,10 @@
+export SECONDARY_DB_PREFIX=srcdb
+
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/fdb_stat_rootpage_race.test/README
+++ b/tests/fdb_stat_rootpage_race.test/README
@@ -1,0 +1,45 @@
+fdb_stat_rootpage_race
+======================
+
+Reproduces a startup race in the foreign-db (remote sql) schema attach path,
+surfacing the exact error from the field:
+
+    fdb_cursor_open: unable to find rootpage <N>
+    comdb2_dynamic_attach: failed to find table "<t>" after init
+    sqlite3FindTable_int: failed to find table <db>.<t> rc=1 unable to open database: <db>
+
+Mechanism
+---------
+When the querying node's fdb cache is empty, two concurrent first-touch queries
+for DIFFERENT tables (t1 on engine E1, t2 on engine E2) both observe
+`initial == 1` in `_add_table_and_stats_fdb` (db/fdb_fend.c). Each independently
+collects the shared `sqlite_stat1`/`sqlite_stat4` tables and allocates its own
+(monotonic, never-reused) rootpage numbers via get_rootpage_numbers()
+(db/sqlmaster.c, `| 0x40000000`). The re-check under the re-acquired lock only
+dedups the MAIN table, not the stats, so two stat generations with different
+rootpages end up in the shared fdb cache. One engine's SQLite schema now holds
+stat rootpages that differ from the generation kept in the fdb name hash.
+
+Each connection then queries a NEW remote table (t3/t4) on its SAME engine.
+That forces `comdb2_dynamic_attach` -> `sqlite3InitOne` -> `sqlite3AnalysisLoad`,
+whose internal "SELECT ... FROM sqlite_stat1" opens a cursor on the stat rootpage
+recorded in the engine's schema. That rootpage is stale relative to the client
+cache rebuilt for this prepare, so `fdb_clnt_cache_get_ent()` misses and the
+attach fails with "unable to find rootpage". The db stays up (no crash).
+
+Discriminator (why this is specifically the stat double-collection)
+-------------------------------------------------------------------
+  - concurrent queries to the SAME table  -> SUCCESS: the existing main-table
+    dedup catches it; a single sqlite_stat1 rootpage remains.
+  - concurrent queries to DIFFERENT tables -> the second engine keeps a stale
+    stat rootpage, and its follow-up new-table query fails as above.
+
+Determinism
+-----------
+The race is widened by the INTERNAL, test-only tunable `fdb_add_stat_delay_ms`
+(set in lrl.options); it is 0 (a no-op) in production. Note: querying
+comdb2_fdb_info against the corrupted cache CRASHES the db, so the test avoids
+that systable and detects the error via the client rc / db log instead.
+
+RED == reproduced. The fix (dedup the stat tables before linking, like the main
+table) keeps one shared stat rootpage and the follow-up new-table query finds it.

--- a/tests/fdb_stat_rootpage_race.test/lrl.options
+++ b/tests/fdb_stat_rootpage_race.test/lrl.options
@@ -1,0 +1,5 @@
+ssl_allow_remsql 1
+foreign_db_push_remote 0
+foreign_db_push_redirect 0
+foreign_db_resolve_local 1
+fdb_add_stat_delay_ms 300

--- a/tests/fdb_stat_rootpage_race.test/runit
+++ b/tests/fdb_stat_rootpage_race.test/runit
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Reproduce the fdb stat-rootpage double-collection race and surface the
+# "unable to find rootpage" error (instead of crashing on comdb2_fdb_info).
+#
+# MAIN ($DBNAME)              = querying node (fdb race runs here; carries the
+#                               fdb_add_stat_delay_ms debug delay via lrl.options)
+# SECONDARY (srcdb$DBNAME)    = remote data source (tables t1..t4 + ANALYZE)
+#
+# Scenario:
+#   - Two connections C1/C2 (engines E1/E2) run concurrent first-touch queries
+#     for two DIFFERENT tables (t1, t2) while the fdb cache is empty. Both
+#     observe initial==1 in _add_table_and_stats_fdb() and each collects the
+#     shared sqlite_stat1/sqlite_stat4, allocating a fresh (never-reused)
+#     rootpage per collection. One engine's schema ends up holding stat
+#     rootpages that no longer match the winning generation in the fdb cache.
+#   - Each connection then prepares a query on a NEW remote table (t3/t4) on its
+#     same engine. That forces comdb2_dynamic_attach -> sqlite3AnalysisLoad,
+#     which opens a cursor on the stat rootpage recorded in the engine's schema.
+#     That rootpage is stale relative to the rebuilt client cache, so
+#     fdb_clnt_cache_get_ent() misses -> "unable to find rootpage".
+#
+# RED == reproduced. Fixed code keeps a single shared stat rootpage, so the
+# follow-up query on a new table finds it.
+################################################################################
+
+echo "main db vars"
+vars="TESTCASE DBNAME DBDIR TESTSROOTDIR TESTDIR CDB2_OPTIONS CDB2_CONFIG SECONDARY_DBNAME SECONDARY_DBDIR SECONDARY_CDB2_CONFIG SECONDARY_CDB2_OPTIONS"
+for required in $vars; do
+    q=${!required}
+    echo "$required=$q"
+    if [[ -z "$q" ]]; then
+        echo "$required not set" >&2
+        exit 1
+    fi
+done
+
+SRC_OPTS="${SECONDARY_CDB2_OPTIONS}"   # talk to the data-source db
+QRY_OPTS="${CDB2_OPTIONS}"             # talk to the querying db
+SEC="${SECONDARY_DBNAME}"
+
+# Pin every querying-node request to one host: the fdb cache is per-node.
+mach=$(cdb2sql --tabs ${QRY_OPTS} $DBNAME default "select comdb2_host()")
+echo "querying node = $mach"
+
+query() { cdb2sql ${QRY_OPTS} --host $mach $DBNAME "$@" ; }
+
+################################################################################
+# 1) Build the remote source: t1,t2 for the double-collect, plus t3,t4 as the
+#    "new" tables the follow-up queries attach. ANALYZE creates the shared
+#    sqlite_stat1/sqlite_stat4.
+################################################################################
+echo "Populating data source $SEC"
+for t in t1 t2 t3 t4 ; do
+    cdb2sql ${SRC_OPTS} $SEC default "create table ${t}(i int)" || exit 1
+    cdb2sql ${SRC_OPTS} $SEC default "create index ${t}ix on ${t}(i)" || exit 1
+    for i in $(seq 1 200) ; do echo "insert into ${t}(i) values($((i % 37)))" ; done | \
+        cdb2sql ${SRC_OPTS} $SEC default - >/dev/null || exit 1
+done
+cdb2sql ${SRC_OPTS} $SEC default "analyze" || exit 1
+
+################################################################################
+# 2) Two persistent connections. Each fires its first-touch query concurrently
+#    (double-collect), then -- on the SAME engine -- queries a NEW table so the
+#    re-attach runs analyze-load against the engine's (now stale) stat rootpage.
+#    The `select sleep(3)` between the two statements keeps the connection (and
+#    its engine) alive and lets both first-touch queries overlap first.
+################################################################################
+echo "Firing concurrent first-touch + follow-up new-table queries"
+rm -f q.out
+
+{
+    echo "select count(*) from LOCAL_${SEC}.t1"
+    echo "select sleep(3)"
+    echo "select count(*) from LOCAL_${SEC}.t3"
+} | timeout 60 cdb2sql ${QRY_OPTS} --host $mach $DBNAME - >> q.out 2>&1 &
+
+{
+    echo "select count(*) from LOCAL_${SEC}.t2"
+    echo "select sleep(3)"
+    echo "select count(*) from LOCAL_${SEC}.t4"
+} | timeout 60 cdb2sql ${QRY_OPTS} --host $mach $DBNAME - >> q.out 2>&1 &
+
+wait
+
+# Broader net: also hit pooled engines from fresh connections with new tables.
+for t in t3 t4 ; do
+    for n in 1 2 3 4 5 ; do
+        timeout 20 cdb2sql ${QRY_OPTS} --host $mach $DBNAME \
+            "select count(*) from LOCAL_${SEC}.${t}" >> q.out 2>&1
+    done
+done
+
+echo "==== query output (q.out) ===="
+cat q.out
+
+################################################################################
+# 3) Detect the race.  Primary signal: the "unable to find rootpage" family of
+#    errors.  We deliberately do NOT query comdb2_fdb_info (iterating the
+#    corrupted cache via that systable crashes the db and masks the error).
+################################################################################
+sigs='unable to find rootpage|failed to find table.*after init|unable to open database'
+dblogs=$(ls ${TESTDIR}/logs/${DBNAME}.db ${TESTDIR}/logs/${DBNAME}.*.db 2>/dev/null)
+
+fail=0
+if grep -Eq "$sigs" q.out 2>/dev/null || { [[ -n "$dblogs" ]] && grep -Eq "$sigs" $dblogs 2>/dev/null; } ; then
+    echo "RACE REPRODUCED: stale stat rootpage / schema-attach error detected"
+    grep -EH "$sigs" q.out $dblogs 2>/dev/null | head
+    fail=1
+fi
+if ! query "select 1" >/dev/null 2>&1 ; then
+    echo "RACE REPRODUCED: querying db is unavailable (crashed under the corrupted fdb cache)"
+    fail=1
+fi
+
+if (( fail )) ; then
+    echo "FAILURE"
+    exit 1
+fi
+
+echo "SUCCESS"
+exit 0


### PR DESCRIPTION
Fix for "unable to find rootpage" while using remote sql queries.
Includes test to reproduce the race while warming up the coordinator fdb cache; the race allows two versions of remote sqlite stat to exist in fdb hashing.
Please see the test README for a detailed description of the problem and the solution.

re:  184750627