### PR TITLE
physrep: skip rtcpu'd / decommissioned hosts when establishing reverse connections

### DIFF
--- a/db/process_message.c
+++ b/db/process_message.c
@@ -2214,6 +2214,17 @@ clipper_usage:
         tokcpy(tok, ltok, hostname);
         int rtn = physrep_allowed_source(dbname, hostname);
         logmsg(LOGMSG_USER, "physrep_allowed_source dbname=%s hostname=%s rtn=%d\n", dbname, hostname, rtn);
+    } else if (tokcmp(tok, ltok, "revconn_host_is_up") == 0) {
+        char *hostname = NULL;
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0) {
+            logmsg(LOGMSG_ERROR, "revconn_host_is_up requires hostname\n");
+            return -1;
+        }
+        hostname = alloca(ltok + 1);
+        tokcpy(tok, ltok, hostname);
+        int rtn = physrep_revconn_host_is_up(hostname);
+        logmsg(LOGMSG_USER, "revconn_host_is_up hostname=%s rtn=%d\n", hostname, rtn);
     } else if (tokcmp(tok, ltok, "physrep_force_registration") == 0) {
         extern int gbl_physrep_force_registration;
         logmsg(LOGMSG_USER, "physrep forcing registration, current-value is %d\n", gbl_physrep_force_registration);

--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -33,6 +33,7 @@
 #include "machclass.h"
 #include "net_appsock.h"
 #include "machcache.h"
+#include "intern_strings.h"
 
 #define revconn_logmsg(lvl, ...)                                               \
     do {                                                                       \
@@ -92,6 +93,16 @@ enum {
 
 int gbl_revsql_force_rte = 1;
 int gbl_revconn_rdtimeout = 100;
+
+/* Returns 1 if 'host' is up per rtcpu, 0 if it is rtcpu'd-down or
+ * unknown/decommissioned. Used to gate whether *this* node should source reverse
+ * connections (an rtcpu-down machine should not initiate them); the target's
+ * rtcpu state is intentionally not consulted. */
+int physrep_revconn_host_is_up(const char *host)
+{
+    /* is_node_up() -> machine_is_up() aborts on a non-interned host. */
+    return is_node_up(intern(host)) == 1;
+}
 
 int send_reversesql_request(const char *dbname, const char *host, const char *command)
 {
@@ -192,6 +203,20 @@ static void *reverse_connection_worker(void *args) {
         if (!bdb_am_i_coherent(thedb->bdb_env)) {
             if (gbl_revsql_debug == 1) {
                 revconn_logmsg(LOGMSG_USER, "%s:%d not starting connection, not coherent\n", __func__, __LINE__);
+            }
+            sleep(1);
+            continue;
+        }
+
+        /* Don't initiate reverse connections while this node itself is rtcpu'd
+         * down -- an rtcpu-down machine should not act as a reverse-connection
+         * source. Replicants can pick up another source. The target's rtcpu
+         * state is intentionally not consulted. */
+        if (!physrep_revconn_host_is_up(gbl_myhostname)) {
+            if (gbl_revsql_debug == 1) {
+                revconn_logmsg(LOGMSG_USER,
+                               "%s:%d Not initiating reverse connections, this host (%s) is rtcpu'd down\n", __func__,
+                               __LINE__, gbl_myhostname);
             }
             sleep(1);
             continue;

--- a/db/reverse_conn.h
+++ b/db/reverse_conn.h
@@ -24,4 +24,9 @@ int dump_reverse_connection_host_list();
 int refresh_reverse_conn_hosts();
 int send_reversesql_request(const char *dbname, const char *host, const char *command);
 
+/* Returns 1 if 'host' is up per rtcpu, 0 if it is rtcpu'd-down or
+ * unknown/decommissioned. Used to gate whether a node should source reverse
+ * connections (a rtcpu-down machine should not initiate/serve them). */
+int physrep_revconn_host_is_up(const char *host);
+
 #endif /* INCLUDED_REVERSE_CONN_H */

--- a/plugins/reversesql/reversesql.c
+++ b/plugins/reversesql/reversesql.c
@@ -41,6 +41,7 @@
 
 #include "phys_rep.h"
 #include "reversesql.h"
+#include "reverse_conn.h"
 
 #include "cdb2api.h"
 #include "cdb2api_int.h"
@@ -200,6 +201,17 @@ static int handle_reversesql_request(comdb2_appsock_arg_t *arg) {
         goto done;
     }
     remote_host[read_bytes-1] = 0; // discard trailing '\n'
+
+    // Reject reverse connections originating from a source that rtcpu reports as
+    // down/decommissioned -- a rtcpu-down machine should not act as a reverse-
+    // connection source. This is the receiver-side mirror of the sender's own
+    // self-gate in reverse_conn.c.
+    if (!physrep_revconn_host_is_up(remote_host)) {
+        logmsg(LOGMSG_WARN, "%s:%d Rejecting 'reversesql' request from down/rtcpu'd source %s@%s\n", __func__, __LINE__,
+               remote_dbname, remote_host);
+        rc = -1;
+        goto done;
+    }
 
     read_bytes = cdb2buf_gets(command, sizeof(command), sb);
     if (read_bytes >= 1)           // Safety

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -2649,6 +2649,73 @@ function physrep_rtcpu_source
     done
 }
 
+function physrep_revconn_rtcpu
+{
+    local out
+    local cmd
+    local sql
+    local rc
+
+    echo "== physrep_revconn_rtcpu =="
+
+    # Verify the reverse-connection rtcpu predicate (physrep_revconn_host_is_up):
+    # a rtcpu'd-down node should not source reverse connections. The predicate
+    # gates the sender's own self-gate (reverse_conn.c, on gbl_myhostname) and the
+    # receiver's acceptance of an inbound source (reversesql.c). The *target's*
+    # rtcpu state is intentionally NOT consulted (DRQS 185361198). Exercised via
+    # the 'revconn_host_is_up' message command on the intermediary source db, which
+    # is the side that runs the revconn workers.
+    #
+    # Connections use --admin: $firstNode is itself one of $CLUSTER, so on the
+    # iteration where it is marked rtcpu'd (drtest) it would otherwise refuse
+    # normal client traffic.
+    for tgt in $CLUSTER ; do
+        cmd="revconn_host_is_up $tgt"
+        sql="exec procedure sys.cmd.send(\"$cmd\")"
+
+        # Host is up before it is marked rtcpu'd -> connection allowed
+        out=$($CDB2SQL_EXE --tabs --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode "$sql")
+        rc=${out##*=}
+        [[ "$rc" == "1" ]] || cleanFailExit "revconn_host_is_up should allow $tgt before rtcpu, got rc=$rc"
+
+        # Mark the host rtcpu'd -> connection must be skipped
+        echo "Marking $tgt as RTCPU'd"
+        $CDB2SQL_EXE --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode \
+            "exec procedure sys.cmd.send(\"fakedr add $tgt\")"
+        out=$($CDB2SQL_EXE --tabs --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode "$sql")
+        rc=${out##*=}
+        [[ "$rc" == "0" ]] || cleanFailExit "revconn_host_is_up should skip rtcpu'd $tgt, got rc=$rc"
+
+        # Clear the rtcpu mark -> connection allowed again
+        echo "Removing RTCPU mark for $tgt"
+        $CDB2SQL_EXE --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode \
+            "exec procedure sys.cmd.send(\"fakedr del $tgt\")"
+        out=$($CDB2SQL_EXE --tabs --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode "$sql")
+        rc=${out##*=}
+        [[ "$rc" == "1" ]] || cleanFailExit "revconn_host_is_up should allow $tgt after removing rtcpu, got rc=$rc"
+    done
+
+    # Source self-gate: a node evaluates its OWN eligibility (gbl_myhostname)
+    # before initiating reverse connections. Mark $firstNode itself rtcpu'd and
+    # confirm it reports itself ineligible (so reverse_connection_worker would
+    # skip initiating), then clear it and confirm it is eligible again.
+    echo "Verify reverse-conn source self-gate on $firstNode"
+    cmd="revconn_host_is_up $firstNode"
+    sql="exec procedure sys.cmd.send(\"$cmd\")"
+
+    $CDB2SQL_EXE --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode \
+        "exec procedure sys.cmd.send(\"fakedr add $firstNode\")"
+    out=$($CDB2SQL_EXE --tabs --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode "$sql")
+    rc=${out##*=}
+    [[ "$rc" == "0" ]] || cleanFailExit "self-gate: $firstNode should report itself ineligible when rtcpu'd, got rc=$rc"
+
+    $CDB2SQL_EXE --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode \
+        "exec procedure sys.cmd.send(\"fakedr del $firstNode\")"
+    out=$($CDB2SQL_EXE --tabs --admin $CDB2_OPTIONS ${REPL_CLUS_DBNAME} --host $firstNode "$sql")
+    rc=${out##*=}
+    [[ "$rc" == "1" ]] || cleanFailExit "self-gate: $firstNode should report itself eligible after clearing rtcpu, got rc=$rc"
+}
+
 function physrep_block_writes_correct_rcode
 {
     # Make sure that physreps block writes & return the correct rcode when they do
@@ -3359,6 +3426,11 @@ function run_tests
     testcase="physrep_rtcpu_source"
     testcase_preamble $testcase
     physrep_rtcpu_source
+    testcase_finish $testcase
+
+    testcase="physrep_revconn_rtcpu"
+    testcase_preamble $testcase
+    physrep_revconn_rtcpu
     testcase_finish $testcase
 
     testcase="test_intermediate_physrep_active_status"


### PR DESCRIPTION
## Summary

The physrep reverse-connection path did not consult rtcpu at all. This change makes a node decline to *source* reverse connections while it is itself rtcpu'd down, enforced on both the sending and receiving sides. A machine that rtcpu reports as down is being routed out of service and should not be handing replication sockets to replicants; replicants can pick up another source. The target replicant's rtcpu state is deliberately left alone.

## Background

For cross-cloud physrep (PPCLD -> PDCLD), the replicant often cannot dial out to its source, so the source dials in to the replicant and hands it a socket (a "reverse connection"), which the replicant then uses to pull logs. There are two sides: the sender of reverse connections is the source/intermediary (`db/reverse_conn.c`), which runs one worker thread per target host and periodically calls `send_reversesql_request()`; the receiver is the replicant accepting the inbound `reversesql` appsock (`plugins/reversesql/reversesql.c`). Neither side consulted rtcpu before this change.

## Changes

Sender (`db/reverse_conn.c`): before initiating a connection, the reverse-connection worker now checks *this node's own* rtcpu state (`gbl_myhostname`) and skips initiating while the node is rtcpu'd down, resuming automatically once it is back up. This sits alongside the existing `bdb_am_i_coherent()` self-gate.

Receiver (`plugins/reversesql/reversesql.c`): an inbound `reversesql` request from a source that rtcpu reports as down is rejected — the receiver-side mirror of the sender's self-gate.

The **target** host's rtcpu state is intentionally **not** consulted. A replicant that is merely rtcpu'd out of client service but still alive should keep replicating, exactly as it does on the normal (pull) path where the replicant dials out itself. The shared predicate `physrep_revconn_host_is_up()` is a simple `is_node_up(host) == 1` and is now only applied to the sourcing node (self-gate) and the inbound source (receiver).

The predicate is exposed via a new `revconn_host_is_up <host>` message command for testing.

## Testing

Adds `physrep_revconn_rtcpu` to `tests/phys_rep_tiered.test`, modeled on the existing `physrep_rtcpu_source` case. Using the `fakedr` trap to force rtcpu to report a host as down, it asserts that `revconn_host_is_up` returns "up" for a healthy host, "down" once the host is marked rtcpu'd, and "up" again after the mark is cleared, and that a node reports itself ineligible to source reverse connections while it is rtcpu'd down (the sender self-gate). Connections use `--admin`, since the node under test can itself be the one marked rtcpu'd (drtest) and would otherwise refuse normal client traffic.

## Notes

This is hardening rather than the root-cause fix. The reverse-connect storm that prompted this was traced to an increase in `physrep-fanout` on the physrep metadb: each source then services a larger set of reverse-hosts and fans out many more simultaneous outbound connect attempts. That has been addressed separately. This change is defense-in-depth so that a node which has been rtcpu'd down no longer sources reverse connections, regardless of fanout.
