### PR TITLE
Trigger master upgrade from the election vote-tally, not bdb_open_int

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -6042,22 +6042,6 @@ static bdb_state_type *bdb_open_int(int envonly, const char name[], const char d
         } else
             iammaster = 0;
 
-        if (is_real_netinfo(bdb_state->repinfo->netinfo) && iammaster) {
-
-            logmsg(LOGMSG_USER,
-                   "%s line %d calling rep_start as master with egen %d\n",
-                   __func__, __LINE__, gen);
-            rc = bdb_state->dbenv->rep_start(bdb_state->dbenv, NULL, gen,
-                                             DB_REP_MASTER);
-            if (rc != 0) {
-                logmsg(LOGMSG_ERROR, "rep_start as master failed %d %s\n", rc,
-                        db_strerror(rc));
-            } else {
-                print(bdb_state, "bdb_open_int: started rep as MASTER\n");
-            }
-            defer_commits_for_upgrade(bdb_state, 0, __func__);
-        }
-
         /* we used to blindly set read_write to 1 on startup.  this caused
          * mayhem when we tried stopping unnecessary upgrades -- SJ */
         bdb_state->read_write = iammaster ? 1 : 0;

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -2506,6 +2506,8 @@ rep_verify_err:if (logc != NULL && (t_ret = __log_c_close(logc)) != 0 &&
 			F_SET(rep, REP_F_EPHASE2);
 			F_CLR(rep, REP_F_EPHASE1);
 			if (master == rep->eid) {
+				/* Tally our own vote; don't emit NEWMASTER here (no vote2
+				 * lock in the VOTE1 path -> would abort). The VOTE2 path does. */
 				(void)__rep_tally(dbenv, rep, rep->eid,
 					&rep->votes, egen, rep->v2tally_off, __func__, __LINE__);
 				goto errunlock;
@@ -2624,13 +2626,18 @@ rep_verify_err:if (logc != NULL && (t_ret = __log_c_close(logc)) != 0 &&
 			__db_err(dbenv, "Counted vote %d", rep->votes);
 #endif
 		if (done) {
+			/* First majority-crossing vote2 of the term emits NEWMASTER (drives
+			 * bdb_upgrade); use REP_F_MASTERELECT, not the vote count, since the
+			 * self-vote can push the count past the bare-majority slot. */
+			int already_elected = F_ISSET(rep, REP_F_MASTERELECT);
 			logmsg(LOGMSG_USER,
-					"%s line %d elected master %s for egen %d\n",
-					__func__, __LINE__, rep->eid, vi_egen);
+					"%s line %d elected master %s for egen %d (votes %d, %s)\n",
+					__func__, __LINE__, rep->eid, vi_egen, rep->votes,
+					already_elected ? "already-elected" : "NEWMASTER");
 			__rep_elect_master(dbenv, rep, eidp);
 			if (newgen) *newgen = vi_egen;
 			if (newmaster) *newmaster = *eidp;
-			ret = (rep->votes > rep->nsites / 2 + 1) ? DB_HAS_MAJORITY : DB_REP_NEWMASTER;
+			ret = already_elected ? DB_HAS_MAJORITY : DB_REP_NEWMASTER;
 			goto errunlock;
 		} else {
 			MUTEX_UNLOCK(dbenv, db_rep->rep_mutexp);


### PR DESCRIPTION
## Why
On a contested cold-restart election the election could complete (a node wins) without ever triggering `bdb_upgrade`. `bdb_open_int` then force-upgraded the winner via its fallback `rep_start`, using the stale *recovered* generation instead of the won one, so the committed generation regressed (`noresetgen`: `prev == new`).

## What
The root cause is in the berkdb vote tally. The winner's self-vote is tallied into `rep->votes` from the `(GEN_)VOTE1` path but never emits `DB_REP_NEWMASTER`. The `(GEN_)VOTE2` path decided whether to emit `NEWMASTER` from the vote *count* (`votes > nsites/2 + 1`), so once the self-vote had pushed the count past the bare-majority slot, the peer vote2 that completed the majority returned `DB_HAS_MAJORITY` instead and `bdb_upgrade` never fired.

- Emit `DB_REP_NEWMASTER` on the **first majority-crossing vote2 of the term**, discriminated by `REP_F_MASTERELECT` (set at elect, cleared at upgrade) instead of the fragile count.
- Keep the self-vote path a pure tally: it runs without the vote2 lock, so returning `NEWMASTER` there would `abort()` in the dispatch.
- Remove the `bdb_open_int` master-start `rep_start` fallback entirely; the election path is now the single upgrade source.

## Risk
berkdb election/upgrade path. Validated on a 3-node cluster: `noresetgen` gen strictly increasing across 10 restarts (7→33, master rotating across all nodes); `sqllogfill_reset_gen` still resets; server logs show one `NEWMASTER` per election, no `abort()` / `DUPMASTER` / gen regression.
