### PR TITLE
{185333845}: reject type-incompatible foreign-key constraints at sche…

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -642,6 +642,8 @@ int gbl_fk_allow_prefix_keys = 1;
 
 int gbl_fk_allow_superset_keys = 1;
 
+int gbl_fk_constraint_type_check = 1;
+
 int gbl_update_delete_limit = 1;
 
 int verbose_deadlocks = 0;

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -3461,6 +3461,7 @@ extern int gbl_use_block_mode_status_code;
 
 extern int gbl_fk_allow_prefix_keys;
 extern int gbl_fk_allow_superset_keys;
+extern int gbl_fk_constraint_type_check;
 extern long long gbl_converted_blocksql_requests;
 extern int gbl_sql_tranlevel_default;
 extern int gbl_sql_tranlevel_preserved;

--- a/db/constraints.c
+++ b/db/constraints.c
@@ -2166,6 +2166,71 @@ static inline int key_has_expressions_members(struct schema *key)
     return 0;
 }
 
+/* Conversion-compatible classes of ondisk (server) types.  A foreign-key
+ * column can only map onto a parent-key column when both fall in the same
+ * class; otherwise stag_to_stag_buf_ckey() fails at runtime (rc -1) and the
+ * constraint can never be satisfied. */
+enum fk_type_class {
+    FK_TYPE_CLASS_INVALID = 0,
+    FK_TYPE_CLASS_NUMERIC,
+    FK_TYPE_CLASS_STRING,
+    FK_TYPE_CLASS_DATETIME,
+    FK_TYPE_CLASS_INTERVAL_YM,
+    FK_TYPE_CLASS_INTERVAL_DS,
+};
+
+static enum fk_type_class fk_type_class_of(int server_type)
+{
+    switch (server_type) {
+    case SERVER_UINT:
+    case SERVER_BINT:
+    case SERVER_BREAL:
+    case SERVER_DECIMAL:
+        return FK_TYPE_CLASS_NUMERIC;
+    case SERVER_BCSTR:
+    case SERVER_BYTEARRAY:
+    case SERVER_VUTF8:
+        return FK_TYPE_CLASS_STRING;
+    case SERVER_DATETIME:
+    case SERVER_DATETIMEUS:
+        return FK_TYPE_CLASS_DATETIME;
+    case SERVER_INTVYM:
+        return FK_TYPE_CLASS_INTERVAL_YM;
+    case SERVER_INTVDS:
+    case SERVER_INTVDSUS:
+        return FK_TYPE_CLASS_INTERVAL_DS;
+    default:
+        return FK_TYPE_CLASS_INVALID;
+    }
+}
+
+/* Verify that each positionally-corresponding pair of key columns is
+ * type-compatible.  comdb2 maps foreign-key columns by position (not name),
+ * converting only the first min(local, parent) members, so that's the range we
+ * check.  Guarded by gbl_fk_constraint_type_check.  Returns the number of
+ * incompatible columns found (0 == ok). */
+static int constraint_key_types_check(struct schema_change_type *s, struct dbtable *from_db, constraint_t *ct, int rule,
+                                      struct schema *fky, struct schema *bky)
+{
+    int n_errors = 0;
+    if (!gbl_fk_constraint_type_check || !fky || !bky)
+        return 0;
+    int ncmp = fky->nmembers < bky->nmembers ? fky->nmembers : bky->nmembers;
+    for (int c = 0; c < ncmp; c++) {
+        enum fk_type_class fc = fk_type_class_of(fky->member[c].type);
+        if (fc == FK_TYPE_CLASS_INVALID || fc != fk_type_class_of(bky->member[c].type)) {
+            char errs[256];
+            snprintf(errs, sizeof(errs),
+                     "incompatible types for key column %d: local '%s' vs "
+                     "parent '%s'",
+                     c + 1, fky->member[c].name, bky->member[c].name);
+            constraint_err(s, from_db, ct, rule, errs);
+            n_errors++;
+        }
+    }
+    return n_errors;
+}
+
 /* Verify that the tables and keys referred to by this table's constraints all
  * exist & have the correct column count.  If they don't it's a bit of a show
  * stopper. */
@@ -2251,6 +2316,9 @@ int verify_constraints_exist(struct dbtable *from_db, struct dbtable *to_db,
                 constraint_err(s, from_db, ct, jj, "invalid number of columns");
                 n_errors++;
             }
+
+            /* Reject constraints whose key columns can never convert. */
+            n_errors += constraint_key_types_check(s, from_db, ct, jj, fky, bky);
         }
     }
 

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -432,6 +432,10 @@ REGISTER_TUNABLE("dont_superset_foreign_keys",
                  "Disables 'superset_foreign_keys'", TUNABLE_BOOLEAN,
                  &gbl_fk_allow_superset_keys, INVERSE_VALUE | READONLY | NOARG,
                  NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("fk_constraint_type_check",
+                 "Reject foreign-key constraints whose key columns are not "
+                 "type-compatible, checked at schema-change time (default ON)",
+                 TUNABLE_BOOLEAN, &gbl_fk_constraint_type_check, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("dont_sort_nulls_with_header",
                  "Disables 'sort_nulls_with_header'", TUNABLE_BOOLEAN,
                  &gbl_sort_nulls_correctly, INVERSE_VALUE | READONLY | NOARG,

--- a/tests/fk_type_check.test/Makefile
+++ b/tests/fk_type_check.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/fk_type_check.test/README
+++ b/tests/fk_type_check.test/README
@@ -1,0 +1,12 @@
+Foreign-key key-column type-compatibility check at schema-change time.
+
+comdb2 maps foreign-key columns to the referenced key positionally (not by
+name).  If the positionally-corresponding columns are not type-compatible the
+FK conversion (stag_to_stag_buf_ckey) fails at runtime and the constraint can
+never be satisfied -- leaving an un-writable table that only surfaces at insert
+or verify time.
+
+This test asserts that such a constraint is rejected at create/alter time
+(gbl_fk_constraint_type_check, default ON), that a type-compatible constraint
+is still accepted, and that turning the tunable off restores the old
+(permissive) behavior.

--- a/tests/fk_type_check.test/c_bad.csc2
+++ b/tests/fk_type_check.test/c_bad.csc2
@@ -1,0 +1,18 @@
+// FK key lists b+a, but the referenced PRIMARY lists a+b.  FK columns are
+// matched positionally, so this maps cstring<->int and int<->cstring, which
+// can never convert.
+schema
+{
+    int      a
+    cstring  b[8]
+}
+
+keys
+{
+    dup "FK" = b + a
+}
+
+constraints
+{
+    "FK" -> <"p":"PRIMARY">
+}

--- a/tests/fk_type_check.test/c_good.csc2
+++ b/tests/fk_type_check.test/c_good.csc2
@@ -1,0 +1,17 @@
+// Same columns as c_bad, but the FK key order matches the referenced PRIMARY
+// (a + b), so every positional pair is type-compatible.
+schema
+{
+    int      a
+    cstring  b[8]
+}
+
+keys
+{
+    dup "FK" = a + b
+}
+
+constraints
+{
+    "FK" -> <"p":"PRIMARY">
+}

--- a/tests/fk_type_check.test/p.csc2
+++ b/tests/fk_type_check.test/p.csc2
@@ -1,0 +1,10 @@
+schema
+{
+    int      a
+    cstring  b[8]
+}
+
+keys
+{
+    "PRIMARY" = a + b
+}

--- a/tests/fk_type_check.test/runit
+++ b/tests/fk_type_check.test/runit
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+dbname=$1
+if [[ -z $dbname ]] ; then
+    echo dbname missing
+    exit 1
+fi
+
+SQL="cdb2sql ${CDB2_OPTIONS} ${dbname} default"
+
+cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbname default \
+    'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':'`
+
+fail() { echo "FAIL: $1" ; exit 1 ; }
+
+# Toggle the type check on every node so it is in effect wherever the schema
+# change runs.
+set_type_check() {
+    val=$1
+    if [ -z "$cluster" ] ; then
+        cdb2sql ${CDB2_OPTIONS} $dbname default \
+            "put tunable 'fk_constraint_type_check' $val" || fail "put tunable"
+    else
+        for node in $cluster ; do
+            cdb2sql ${CDB2_OPTIONS} $dbname --host $node \
+                "put tunable 'fk_constraint_type_check' $val" || fail "put tunable"
+        done
+    fi
+}
+
+echo "create parent table p"
+$SQL "create table p { `cat p.csc2` }" || fail "could not create parent table"
+
+echo "=== 1. type-incompatible FK should be REJECTED (check on, the default) ==="
+out=$($SQL "create table c { `cat c_bad.csc2` }" 2>&1)
+rc=$?
+echo "$out"
+(( rc != 0 )) || fail "type-incompatible FK was accepted"
+echo "$out" | grep -qi "incompatible types" || fail "expected 'incompatible types' in error"
+echo "PASS: rejected with the expected error"
+
+echo "=== 2. type-compatible FK should be ACCEPTED ==="
+$SQL "create table c_ok { `cat c_good.csc2` }" || fail "type-compatible FK was rejected"
+echo "PASS: accepted"
+
+echo "=== 3. with fk_constraint_type_check OFF, incompatible FK is ALLOWED ==="
+set_type_check 0
+$SQL "create table c { `cat c_bad.csc2` }" || fail "with check off, incompatible FK should be allowed"
+echo "PASS: allowed when tunable is off"
+set_type_check 1
+
+echo "Testcase passed."
+exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -387,6 +387,7 @@
 (name='fingerprint_queries', description='Compute fingerprint for SQL queries', type='BOOLEAN', value='ON', read_only='N')
 (name='fix_cstr', description='Fix validation of cstrings', type='BOOLEAN', value='ON', read_only='N')
 (name='fix_pinref', description='fix_pinref', type='BOOLEAN', value='ON', read_only='N')
+(name='fk_constraint_type_check', description='Reject foreign-key constraints whose key columns are not type-compatible, checked at schema-change time (default ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_check_active_peer', description='Check if still have active connection when trying to flush', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_on_prepare', description='Flush master log on prepare. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='flush_replicant_on_prepare', description='Flush replicant log on prepare. (Default: on)', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
…ma-change time

comdb2 matches foreign-key columns to the referenced key positionally (not by name), converting only the first min(local, parent) columns via stag_to_stag_buf_ckey. If a positionally-corresponding pair is type-incompatible -- e.g. a swapped key order that lines an int up against a cstring -- the conversion returns -1 at runtime: every write to the child table is rejected and existing rows fail verify with 'error loading rc = -1'. Nothing caught this at schema-change time: verify_constraints_exist only checked column counts, and even that is short-circuited when prefix_foreign_keys and superset_foreign_keys are both on (the legacy default).

Add a per-column type-class compatibility check to verify_constraints_exist so such a constraint is rejected up front on add/alter, guarded by a new runtime tunable fk_constraint_type_check (default ON). Startup is unaffected: existing tables load via populate_reverse_constraints, which is not touched, so a db that already has such a constraint still boots.

Add tests/fk_type_check.test and update tests/tunables.test per AGENTS.md.