### PR TITLE
Fix cache hits

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -240,34 +240,19 @@ void bdb_get_txn_stats(bdb_state_type *bdb_state, int64_t *active,
     free(txn_stats);
 }
 
-void bdb_get_cache_stats(bdb_state_type *bdb_state, uint64_t *hits,
-                         uint64_t *misses, uint64_t *reads, uint64_t *writes,
-                         uint64_t *thits, uint64_t *tmisses)
+/* Buffer-pool hit/miss statistics for the temp-table environment (a separate
+   mpool from the main database).  Main buffer-pool counters come from
+   bdb_get_bpool_counters(). */
+void bdb_get_temp_cache_stats(bdb_state_type *bdb_state, uint64_t *thits, uint64_t *tmisses)
 {
     DB_MPOOL_STAT *mpool_stats;
 
-    BDB_READLOCK("bdb_get_cache_stats");
-    bdb_state->dbenv->memp_stat(bdb_state->dbenv, &mpool_stats, NULL,
-                                DB_STAT_MINIMAL);
-
-    /* We find leaf pages only a more useful metric. */
-    if (hits)
-        *hits = mpool_stats->st_cache_lhit;
-    if (misses)
-        *misses = mpool_stats->st_cache_lmiss;
-    if (reads)
-        *reads = mpool_stats->st_page_in;
-    if (writes)
-        *writes = mpool_stats->st_page_out;
-
-    free(mpool_stats);
-
+    BDB_READLOCK("bdb_get_temp_cache_stats");
     bdb_temp_table_stat(bdb_state, &mpool_stats);
     if (thits)
         *thits = mpool_stats->st_cache_hit;
     if (tmisses)
         *tmisses = mpool_stats->st_cache_miss;
-
     BDB_RELLOCK();
 
     free(mpool_stats);

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1264,9 +1264,7 @@ void bdb_temp_table_reset_datapointers(struct temp_cursor *cur);
 
 void *bdb_temp_table_get_cur(struct temp_cursor *skippy);
 
-void bdb_get_cache_stats(bdb_state_type *bdb_state, uint64_t *hits,
-                         uint64_t *misses, uint64_t *reads, uint64_t *writes,
-                         uint64_t *thits, uint64_t *tmisses);
+void bdb_get_temp_cache_stats(bdb_state_type *bdb_state, uint64_t *thits, uint64_t *tmisses);
 
 void bdb_stripe_get(bdb_state_type *bdb_state);
 void bdb_stripe_done(bdb_state_type *bdb_state);
@@ -2083,8 +2081,8 @@ int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
                           int64_t *deadlock_locks, int64_t *waits,
                           int64_t *requests);
 
-int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits,
-                           int64_t *bpool_misses, int64_t *rw_evicts);
+int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits, int64_t *bpool_misses, int64_t *bpool_lhits,
+                           int64_t *bpool_lmisses, int64_t *page_reads, int64_t *page_writes, int64_t *rw_evicts);
 
 int bdb_master_should_reject(bdb_state_type *bdb_state);
 

--- a/bdb/info.c
+++ b/bdb/info.c
@@ -218,20 +218,34 @@ int bdb_get_lock_counters(bdb_state_type *bdb_state, int64_t *deadlocks,
     return 0;
 }
 
-int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits,
-                           int64_t *bpool_misses, int64_t *rw_evicts)
+int bdb_get_bpool_counters(bdb_state_type *bdb_state, int64_t *bpool_hits, int64_t *bpool_misses, int64_t *bpool_lhits,
+                           int64_t *bpool_lmisses, int64_t *page_reads, int64_t *page_writes, int64_t *rw_evicts)
 {
     int rc;
     DB_MPOOL_STAT *mpool_stats;
 
-    rc = bdb_state->dbenv->memp_stat(bdb_state->dbenv, &mpool_stats, NULL,
-                                     0);
+    /* The eviction counters are only aggregated on a full stat; the
+       hit/miss and page-io counters are available under the cheaper
+       DB_STAT_MINIMAL, so avoid the full buffer-cache walk unless a
+       caller actually asks for evictions. */
+    rc = bdb_state->dbenv->memp_stat(bdb_state->dbenv, &mpool_stats, NULL, rw_evicts ? 0 : DB_STAT_MINIMAL);
     if (rc)
         return rc;
 
-    *bpool_hits = mpool_stats->st_cache_hit;
-    *bpool_misses = mpool_stats->st_cache_miss;
-    *rw_evicts = mpool_stats->st_rw_evict;
+    if (bpool_hits)
+        *bpool_hits = mpool_stats->st_cache_hit;
+    if (bpool_misses)
+        *bpool_misses = mpool_stats->st_cache_miss;
+    if (bpool_lhits)
+        *bpool_lhits = mpool_stats->st_cache_lhit;
+    if (bpool_lmisses)
+        *bpool_lmisses = mpool_stats->st_cache_lmiss;
+    if (page_reads)
+        *page_reads = mpool_stats->st_page_in;
+    if (page_writes)
+        *page_writes = mpool_stats->st_page_out;
+    if (rw_evicts)
+        *rw_evicts = mpool_stats->st_rw_evict;
 
     free(mpool_stats);
     return 0;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4777,8 +4777,8 @@ void *statthd(void *p)
         curr_conns = net_get_num_current_non_appsock_accepts(thedb->handle_sibling)+ active_appsock_conns;
         conn_timeouts = net_get_num_accept_timeouts(thedb->handle_sibling);
 
-        bdb_get_bpool_counters(thedb->bdb_env, (int64_t *)&bpool_hits,
-                               (int64_t *)&bpool_misses, &rw_evicts);
+        bdb_get_bpool_counters(thedb->bdb_env, (int64_t *)&bpool_hits, (int64_t *)&bpool_misses, NULL, NULL, NULL, NULL,
+                               &rw_evicts);
 
         bdb_get_lock_counters(thedb->bdb_env, &ndeadlocks, &nlocks_aborted,
                               &nlockwaits, NULL);

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -2136,8 +2136,6 @@ int open_bdb_env(struct dbenv *dbenv);
 int backend_close(struct dbenv *dbenv);
 void backend_cleanup(struct dbenv *dbenv);
 void backend_stat(struct dbenv *dbenv);
-void backend_get_cachestats(struct dbenv *dbenv, int *cachekb, int *hits,
-                            int *misses);
 
 void backend_get_iostats(int *n_reads, int *l_reads, int *n_writes,
                          int *l_writes);

--- a/db/db_metrics.c
+++ b/db/db_metrics.c
@@ -38,6 +38,9 @@ struct comdb2_metrics_store {
     int64_t cache_hits;
     int64_t cache_misses;
     double  cache_hit_rate;
+    int64_t leaf_cache_hits;
+    int64_t leaf_cache_misses;
+    double leaf_cache_hit_rate;
     int64_t commits;
     int64_t connections;
     int64_t connection_timeouts;
@@ -169,10 +172,16 @@ static struct comdb2_metrics_store stats;
 comdb2_metric gbl_metrics[] = {
     {"cache_hits", "Buffer pool hits", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.cache_hits,
      NULL},
-    {"cache_misses", "Buffer pool misses", (int64_t)STATISTIC_COLLECTION_TYPE_CUMULATIVE, (int64_t)STATISTIC_INTEGER,
-     &stats.cache_misses, NULL},
+    {"cache_misses", "Buffer pool misses", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.cache_misses,
+     NULL},
     {"cache_hit_rate", "Buffer pool request hit rate", STATISTIC_DOUBLE, STATISTIC_COLLECTION_TYPE_LATEST,
      &stats.cache_hit_rate, NULL},
+    {"leaf_cache_hits", "Buffer pool leaf-page hits", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE,
+     &stats.leaf_cache_hits, NULL},
+    {"leaf_cache_misses", "Buffer pool leaf-page misses", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE,
+     &stats.leaf_cache_misses, NULL},
+    {"leaf_cache_hit_rate", "Buffer pool leaf-page request hit rate", STATISTIC_DOUBLE,
+     STATISTIC_COLLECTION_TYPE_LATEST, &stats.leaf_cache_hit_rate, NULL},
     {"commits", "Number of commits", STATISTIC_INTEGER, STATISTIC_COLLECTION_TYPE_CUMULATIVE, &stats.commits, NULL},
     {"concurrent_sql", "Concurrent SQL queries", STATISTIC_DOUBLE, STATISTIC_COLLECTION_TYPE_LATEST,
      &stats.concurrent_sql, NULL},
@@ -584,8 +593,8 @@ int refresh_metrics(void)
         return 1;
     }
 
-    rc = bdb_get_bpool_counters(thedb->bdb_env, &stats.cache_hits,
-                                &stats.cache_misses, &stats.rw_evicts);
+    rc = bdb_get_bpool_counters(thedb->bdb_env, &stats.cache_hits, &stats.cache_misses, &stats.leaf_cache_hits,
+                                &stats.leaf_cache_misses, NULL, NULL, &stats.rw_evicts);
     if (rc) {
         logmsg(LOGMSG_ERROR, "failed to refresh statistics (%s:%d)\n", __FILE__,
                __LINE__);
@@ -604,10 +613,11 @@ int refresh_metrics(void)
     int64_t total_reqs = stats.sql_count + stats.nonsql;
     stats.connection_to_sql_ratio = (total_reqs > 0) ? (stats.connections/(double)total_reqs) : 0;
 
-    /* cache hit rate */
-    uint64_t hits, misses;
-    bdb_get_cache_stats(thedb->bdb_env, &hits, &misses, NULL, NULL, NULL, NULL);
-    stats.cache_hit_rate = 100 * ((double) hits / ((double) hits + (double) misses));
+    /* cache hit rate (total) and leaf-page hit rate */
+    int64_t th = stats.cache_hits, tm = stats.cache_misses;
+    stats.cache_hit_rate = (th + tm) ? 100 * ((double)th / ((double)th + (double)tm)) : 100.0;
+    int64_t lh = stats.leaf_cache_hits, lm = stats.leaf_cache_misses;
+    stats.leaf_cache_hit_rate = (lh + lm) ? 100 * ((double)lh / ((double)lh + (double)lm)) : 100.0;
 
     stats.memory_ulimit = 0;
     stats.memory_usage = 0;

--- a/db/glue.c
+++ b/db/glue.c
@@ -4366,22 +4366,6 @@ void backend_cleanup(struct dbenv *dbenv)
     }
 }
 
-void backend_get_cachestats(struct dbenv *dbenv, int *cachekb, int *hits,
-                            int *misses)
-{
-    if (dbenv->bdb_env == NULL)
-        return;
-
-    uint64_t h, m;
-
-    bdb_get_cache_stats(dbenv->bdb_env, &h, &m, NULL, NULL, NULL, NULL);
-
-    *cachekb = dbenv->cacheszkb;
-    /* lossy */
-    *hits = (int)h;
-    *misses = (int)m;
-}
-
 void backend_get_iostats(int *n_reads, int *l_reads, int *n_writes,
                          int *l_writes)
 {
@@ -4391,7 +4375,8 @@ void backend_get_iostats(int *n_reads, int *l_reads, int *n_writes,
 void backend_stat(struct dbenv *dbenv)
 {
     double f;
-    uint64_t hits, misses, reads, writes, thits, tmisses;
+    uint64_t thits = 0, tmisses = 0;
+    int64_t hits = 0, misses = 0, reads = 0, writes = 0;
     char *who = dbenv->master;
     int delay, delaymax;
     if (dbenv->bdb_env == NULL)
@@ -4406,16 +4391,16 @@ void backend_stat(struct dbenv *dbenv)
     else
         logmsg(LOGMSG_USER, "I AM NOT MASTER.  MASTER IS %s\n", who);
     backend_sync_stat(dbenv);
-    bdb_get_cache_stats(dbenv->bdb_env, &hits, &misses, &reads, &writes, &thits,
-                        &tmisses);
+    bdb_get_bpool_counters(dbenv->bdb_env, &hits, &misses, NULL, NULL, &reads, &writes, NULL);
+    bdb_get_temp_cache_stats(dbenv->bdb_env, &thits, &tmisses);
     if (!bdb_am_i_coherent(dbenv->bdb_env))
         logmsg(LOGMSG_USER, "!!! I AM NOT COHERENT !!!\n");
     f = dbenv->cacheszkb / 1024.0;
     logmsg(LOGMSG_USER, "cachesize %.3f mb\n", f);
-    logmsg(LOGMSG_USER, "hits        %" PRIu64 "\n", hits);
-    logmsg(LOGMSG_USER, "misses      %" PRIu64 "\n", misses);
-    logmsg(LOGMSG_USER, "page reads  %" PRIu64 "\n", reads);
-    logmsg(LOGMSG_USER, "page writes %" PRIu64 "\n", writes);
+    logmsg(LOGMSG_USER, "hits        %" PRId64 "\n", hits);
+    logmsg(LOGMSG_USER, "misses      %" PRId64 "\n", misses);
+    logmsg(LOGMSG_USER, "page reads  %" PRId64 "\n", reads);
+    logmsg(LOGMSG_USER, "page writes %" PRId64 "\n", writes);
     if ((hits + misses) == 0)
         f = 100.0;
     else

--- a/docs/pages/operating/op.md
+++ b/docs/pages/operating/op.md
@@ -788,7 +788,7 @@ LOG DELETE ENABLED
 LOG DELETE POLICY: delete all eligible log files
 # Database buffer pool size
 cachesize 64.000 mb
-# Cache hits and misses, page read/write information
+# Cache hits and misses, page read/write information (total buffer pool)
 hits        457
 misses      50
 page reads  102

--- a/tests/cachehits.test/Makefile
+++ b/tests/cachehits.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=3m
+endif

--- a/tests/cachehits.test/runit
+++ b/tests/cachehits.test/runit
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+bash -n "$0" | exit 1
+
+# Regression test for DRQS 185346999.
+#
+# The 'stat' message-trap used to report leaf-page-only buffer-pool counters
+# (st_cache_lhit/st_cache_lmiss) as its "hits"/"misses", while comdb2_metrics
+# reported the total counters (st_cache_hit/st_cache_miss).  The fix makes the
+# trap report totals and exposes the leaf-page counters as their own metrics
+# (leaf_cache_hits / leaf_cache_misses / leaf_cache_hit_rate).
+#
+# This test asserts:
+#   1. the three new leaf_cache_* metrics exist,
+#   2. total counters are a superset of the leaf counters (single snapshot),
+#   3. the 'stat' trap now reports the total counters (not leaf), and
+#   4. both hit-rate metrics are in [0,100].
+
+dbnm=$1
+FAIL=0
+
+# Buffer-pool counters and the 'stat' trap are per-node, so pin every query to a
+# single host; otherwise, under CLUSTER, separate 'default' connections could hit
+# different nodes and make the cross-query comparisons below meaningless.
+host=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select comdb2_host()')
+
+runtabs() { cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host "$host" "$1"; }
+run() { cdb2sql ${CDB2_OPTIONS} $dbnm --host "$host" "$1"; }
+
+# 1) the new leaf_cache_* metrics are registered
+cnt=$(runtabs "select count(*) from comdb2_metrics where name in ('leaf_cache_hits','leaf_cache_misses','leaf_cache_hit_rate')")
+if [ "$cnt" != "3" ]; then
+    echo "FAIL: expected 3 leaf_cache_* metrics, got '$cnt'" >&2
+    FAIL=1
+fi
+
+# 2) drive buffer-pool activity so the counters are non-trivial
+run "create table t(a int, b blob)"
+for i in $(seq 1 20); do
+    run "insert into t select value, randomblob(64) from generate_series(1, 2500)" >/dev/null
+done
+for i in $(seq 1 10); do
+    runtabs "select count(*) from t" >/dev/null
+    runtabs "select count(*) from t where b is not null" >/dev/null
+    runtabs "select count(*) from t where a > 1000" >/dev/null
+done
+
+# 3) total counters are a superset of the leaf counters.  Reading all four in a
+#    single SELECT means they come from one refresh_metrics()/mpool snapshot, so
+#    the >= comparisons are race-free.  Rows come back ordered by name:
+#    cache_hits, cache_misses, leaf_cache_hits, leaf_cache_misses.
+vals=$(runtabs "select cast(value as integer) from comdb2_metrics where name in ('cache_hits','cache_misses','leaf_cache_hits','leaf_cache_misses') order by name")
+ch=$(echo "$vals" | sed -n 1p)
+cm=$(echo "$vals" | sed -n 2p)
+lh=$(echo "$vals" | sed -n 3p)
+lm=$(echo "$vals" | sed -n 4p)
+echo "cache_hits=$ch cache_misses=$cm leaf_cache_hits=$lh leaf_cache_misses=$lm"
+
+if [ -z "$ch" ] || [ -z "$cm" ] || [ -z "$lh" ] || [ -z "$lm" ]; then
+    echo "FAIL: could not read cache metrics from comdb2_metrics" >&2
+    FAIL=1
+else
+    if [ "$ch" -lt "$lh" ]; then
+        echo "FAIL: cache_hits($ch) < leaf_cache_hits($lh)" >&2
+        FAIL=1
+    fi
+    if [ "$cm" -lt "$lm" ]; then
+        echo "FAIL: cache_misses($cm) < leaf_cache_misses($lm)" >&2
+        FAIL=1
+    fi
+    if [ "$ch" -le 0 ]; then
+        echo "FAIL: cache_hits not positive ($ch)" >&2
+        FAIL=1
+    fi
+    if [ "$lh" -le 0 ]; then
+        echo "FAIL: leaf_cache_hits not positive ($lh)" >&2
+        FAIL=1
+    fi
+fi
+
+# 4) the 'stat' trap must report TOTAL hits/misses.  cache_hits is monotonic, so
+#    reading it just before firing the trap gives a lower bound the trap must
+#    meet or exceed.  The old (buggy) trap reported leaf hits, which are far
+#    below the total, so this comparison catches a regression.
+ch_before=$(runtabs "select cast(value as integer) from comdb2_metrics where name='cache_hits'")
+stat_out=$(runtabs 'exec procedure sys.cmd.send("stat")')
+trap_hits=$(echo "$stat_out" | awk '$1=="hits"{print $2; exit}')
+trap_misses=$(echo "$stat_out" | awk '$1=="misses"{print $2; exit}')
+echo "stat trap: hits=$trap_hits misses=$trap_misses (cache_hits before trap=$ch_before)"
+
+if ! [[ "$trap_hits" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: could not parse a numeric 'hits' from stat trap output (got '$trap_hits')" >&2
+    FAIL=1
+elif ! [[ "$ch_before" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: could not read cache_hits before trap (got '$ch_before')" >&2
+    FAIL=1
+elif [ "$trap_hits" -lt "$ch_before" ]; then
+    echo "FAIL: stat trap hits($trap_hits) < cache_hits($ch_before): trap is not reporting total counters" >&2
+    FAIL=1
+fi
+
+# 5) both hit-rate metrics are sane percentages
+inrange() { awk -v v="$1" 'BEGIN{ if (v == "") exit 1; exit !(v >= 0 && v <= 100) }'; }
+chr=$(runtabs "select value from comdb2_metrics where name='cache_hit_rate'")
+lhr=$(runtabs "select value from comdb2_metrics where name='leaf_cache_hit_rate'")
+echo "cache_hit_rate=$chr leaf_cache_hit_rate=$lhr"
+if ! inrange "$chr"; then
+    echo "FAIL: cache_hit_rate out of range: '$chr'" >&2
+    FAIL=1
+fi
+if ! inrange "$lhr"; then
+    echo "FAIL: leaf_cache_hit_rate out of range: '$lhr'" >&2
+    FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+    echo "TESTCASE FAILED" >&2
+    exit 1
+fi
+
+echo "TESTCASE PASSED"
+exit 0


### PR DESCRIPTION
## Summary
The `stat` message-trap reported **leaf-page-only** buffer-pool counters (`st_cache_lhit`/`st_cache_lmiss`) as its `hits`/`misses`, while the `comdb2_metrics` table reported the **total** counters (`st_cache_hit`/`st_cache_miss`). The two disagreed, and the trap's numbers were feeding Foundational Databases reporting. This makes the trap report totals and exposes the leaf-page counters as their own metrics.

Example of the discrepancy on a live db:
```
stat trap:      hits 5994838   misses 1776848
comdb2_metrics: cache_hits 10741512   cache_misses 1924544
```

## Changes
- `backend_stat` (the `stat` trap) now reports total `hits`/`misses`/`hit rate` instead of leaf-only.
- `comdb2_metrics`: `cache_hit_rate` now uses total counters (it was leaf-only, inconsistent with `cache_hits`/`cache_misses`); adds `leaf_cache_hits`, `leaf_cache_misses`, and `leaf_cache_hit_rate` so the leaf-page view is still available.
- `DBINFO2_STATS`/`DBINFO2_IOSTATS` responses now report total counters (were leaf).
- Consolidated the mpool accessors: `bdb_get_bpool_counters` is now the single main-buffer-pool accessor (total + leaf + page-io + evictions), using `DB_STAT_MINIMAL` unless evictions are requested to preserve the previous cost. Added `bdb_get_temp_cache_stats` for the temp-table environment (the trap's `tmp hit rate`). Removed `bdb_get_cache_stats` and the unused `backend_get_cachestats`.

## Testing
New test `cachehits` (`tests/cachehits.test`) that drives buffer-pool activity and asserts: the new `leaf_cache_*` metrics exist; the total counters are a superset of the leaf counters (checked from a single metrics snapshot, so it is race-free); the `stat` trap reports the total counters; and both hit-rate metrics are valid percentages.