### PR TITLE
Physrep fail copy on recovery

### DIFF
--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -2393,6 +2393,10 @@ void bdb_get_txn_stats(bdb_state_type *bdb_state, int64_t *active,
 
 uint32_t bdb_get_rep_gen(bdb_state_type *bdb_state);
 int bdb_recoverlk_blocked(bdb_state_type *bdb_state);
+/* Take/release the recovery lock in read mode (held by a copy so recovery
+ * cannot rewind pages underneath it; poll bdb_recoverlk_blocked to yield). */
+int bdb_readlock_recovery(bdb_state_type *bdb_state);
+int bdb_unlock_recovery(bdb_state_type *bdb_state);
 
 void send_newmaster(bdb_state_type *bdb_state, int online);
 

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -2062,6 +2062,20 @@ int bdb_recoverlk_blocked(bdb_state_type *bdb_state)
     return bdb_state->dbenv->wrlock_recovery_blocked(bdb_state->dbenv);
 }
 
+/* Take/release the recovery lock in read mode.  Recovery write-locks recoverlk
+ * before it rewinds any page, in both online and offline modes, so a reader
+ * blocks it.  A copy holds this for its duration and polls
+ * bdb_recoverlk_blocked() to learn when to yield. */
+int bdb_readlock_recovery(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->lock_recovery_lock(bdb_state->dbenv, __func__, __LINE__);
+}
+
+int bdb_unlock_recovery(bdb_state_type *bdb_state)
+{
+    return bdb_state->dbenv->unlock_recovery_lock(bdb_state->dbenv, __func__, __LINE__);
+}
+
 void send_newmaster(bdb_state_type *bdb_state, int online)
 {
     bdb_state->dbenv->rep_start(bdb_state->dbenv, NULL, 0, DB_REP_MASTER);

--- a/plugins/logdelete/logdelete.c
+++ b/plugins/logdelete/logdelete.c
@@ -19,12 +19,61 @@
 #include "comdb2_appsock.h"
 #include <comdb2_atomic.h>
 #include "unistd.h"
+#include <errno.h>
+#include <string.h>
+#include <poll.h>
+#include <sys/socket.h>
+
+#include <bdb_api.h>
+#include <bdbglue.h>
 
 /* For testcase demonstrating that file-delete cannot occur during a copy */
 int gbl_debug_block_comdb2ar = 0;
 
-/* Forward declaration */
+/* How often (ms) the logdelete4 copy loop wakes to check for a waiting
+ * exclusive operation and for the client disconnecting. */
+static int copy_poll_ms = 1000;
+
+/* Forward declarations */
 comdb2_appsock_t logdelete3_plugin;
+comdb2_appsock_t logdelete4_plugin;
+
+/* Return 1 if the peer has closed the connection.  comdb2buf cannot distinguish
+ * a read timeout from an EOF, so probe the socket directly. */
+static int copy_peer_closed(int fd)
+{
+    struct pollfd pfd = {.fd = fd, .events = POLLIN};
+    int rc = poll(&pfd, 1, 0);
+    if (rc <= 0)
+        return 0; /* no event pending -> it was a timeout, peer is alive */
+    if (pfd.revents & (POLLHUP | POLLERR | POLLNVAL))
+        return 1;
+    if (pfd.revents & POLLIN) {
+        char c;
+        int r = recv(fd, &c, 1, MSG_PEEK | MSG_DONTWAIT);
+        if (r == 0)
+            return 1; /* orderly shutdown */
+    }
+    return 0;
+}
+
+/* If an exclusive operation (recovery, upgrade/downgrade) is waiting on a lock
+ * the copy holds, release the locks so it can proceed and mark the copy aborted.
+ * Returns 1 if it just aborted the copy. */
+static int copy_yield_if_blocked(bdb_state_type *bdb_state, int *locks_held, int *aborted)
+{
+    if (!*locks_held || !(bdb_lock_desired(bdb_state) || bdb_recoverlk_blocked(bdb_state)))
+        return 0;
+    logmsg(LOGMSG_WARN,
+           "%s: releasing copy locks, an exclusive operation is waiting; "
+           "copy will be failed\n",
+           __func__);
+    bdb_unlock_recovery(bdb_state);
+    bdb_rellock(bdb_state, __func__, __LINE__);
+    *locks_held = 0;
+    *aborted = 1;
+    return 1;
+}
 
 static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
 {
@@ -43,6 +92,14 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
 
     thr_self = arg->thr_self;
     sb = arg->sb;
+
+    /* v3+ hands back recovery options; v4 additionally holds the copy's read
+     * locks against recovery and answers the copy_complete handshake. */
+    int is_v3 = (strncmp(logdelete3_plugin.name, arg->cmdline, strlen(logdelete3_plugin.name)) == 0);
+    int is_v4 = (strncmp(logdelete4_plugin.name, arg->cmdline, strlen(logdelete4_plugin.name)) == 0);
+    bdb_state_type *bdb_state = thedb->bdb_env;
+    int locks_held = 0;
+    int aborted = 0;
 
     /*
       There is no difference between log delete one and two, just that
@@ -64,7 +121,19 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
     before_sc = gbl_sc_commit_count;
     logmsg(LOGMSG_INFO, "Disabling log file deletion\n");
 
-    while (gbl_debug_block_comdb2ar) {
+    /* logdelete4: hold the bdb read lock and recoverlk in read mode for the
+     * copy's duration.  That excludes recovery (which write-locks recoverlk
+     * before rewinding any page) and node upgrade/downgrade (bdb write lock).
+     * Same lock order as recovery, so we cannot deadlock. */
+    if (is_v4) {
+        bdb_get_readlock(bdb_state, 0, "copy", __func__, __LINE__);
+        bdb_readlock_recovery(bdb_state);
+        locks_held = 1;
+    }
+
+    /* Gated on is_v4 so the testcase can stall the v4 handshake while a fallback
+     * logdelete3/2 connection still answers. */
+    while (gbl_debug_block_comdb2ar && is_v4) {
         logmsg(LOGMSG_USER, "%s blocking comdb2ar for testcase\n", __func__);
         sleep(1);
     }
@@ -73,58 +142,108 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
     cdb2buf_printf(sb, "log file deletion disabled\n");
     cdb2buf_flush(sb);
 
-    if (strncmp(logdelete3_plugin.name, arg->cmdline,
-                strlen(logdelete3_plugin.name)) == 0) {
-        rc = bdb_recovery_start_lsn(thedb->bdb_env, recovery_lsn,
-                                    sizeof(recovery_lsn));
+    if (is_v3 || is_v4) {
+        rc = bdb_recovery_start_lsn(thedb->bdb_env, recovery_lsn, sizeof(recovery_lsn));
         if (rc) {
             logmsg(LOGMSG_ERROR, "bdb_recovery_start_lsn rc %d\n", rc);
-            snprintf(recovery_command, sizeof(recovery_command),
-                     "-fullrecovery");
+            snprintf(recovery_command, sizeof(recovery_command), "-fullrecovery");
         } else {
-            snprintf(recovery_command, sizeof(recovery_command),
-                     "-recovery_lsn %s", recovery_lsn);
+            snprintf(recovery_command, sizeof(recovery_command), "-recovery_lsn %s", recovery_lsn);
         }
     }
 
-    /* read from socket until it closes */
-    cdb2buf_settimeout(sb, 0, 0);
-    while (cdb2buf_gets(line, sizeof(line), sb) > 0) {
-        static const char *delims = " \r\t\n";
-        char *lasts;
-        char *tok;
-        tok = strtok_r(line, delims, &lasts);
-        if (!tok) {
-            continue;
-        } else if (strcmp(tok, "report_back") == 0) {
-            report_back = 1;
-            break;
-        } else if (strcmp(tok, "filenum") == 0) {
-            int filenum;
-            tok = strtok_r(NULL, delims, &lasts);
-            errno = 0;
-            if (tok && (filenum = strtol(tok, &lasts, 0)) > 0 && errno == 0 &&
-                lasts && *lasts == '\0') {
-                log_delete_state.filenum = filenum;
-                log_delete_counter_change(thedb, LOG_DEL_REFRESH);
-                backend_update_sync(thedb);
-            } else {
-                logmsg(LOGMSG_ERROR, "logdelete2 thread got bad filenum <%s>\n",
-                       tok);
-                cdb2buf_printf(sb, "expected +ve filenum\n");
-                cdb2buf_flush(sb);
+    if (is_v4) {
+        /* Poll loop: wake every copy_poll_ms to yield the locks if an exclusive
+         * operation is waiting, and to notice a disconnect.  Read timeout only:
+         * a write timeout here could drop the copy_complete reply on a slow
+         * link and fail a copy that was actually fine. */
+        int fd = cdb2buf_fileno(sb);
+        cdb2buf_settimeout(sb, copy_poll_ms, 0);
+        while (1) {
+            static const char *delims = " \r\t\n";
+            char *lasts;
+            char *tok;
+
+            if (cdb2buf_gets(line, sizeof(line), sb) <= 0) {
+                if (copy_peer_closed(fd))
+                    break;
+                /* read timeout: has an exclusive operation started waiting? */
+                copy_yield_if_blocked(bdb_state, &locks_held, &aborted);
                 continue;
             }
-        } else if (strcmp(tok, "recovery_options") == 0) {
-            logmsg(LOGMSG_DEBUG, "sent recovery options: %s\n",
-                   recovery_command);
-            cdb2buf_printf(sb, "%s\n", recovery_command);
-            cdb2buf_flush(sb);
-        } else {
-            logmsg(LOGMSG_ERROR, "logdelete2 thread got unknown token <%s>\n",
-                   tok);
-            /* la la la la fingers in my ears */
+
+            tok = strtok_r(line, delims, &lasts);
+            if (!tok) {
+                continue;
+            } else if (strcmp(tok, "filenum") == 0) {
+                int filenum;
+                tok = strtok_r(NULL, delims, &lasts);
+                errno = 0;
+                if (tok && (filenum = strtol(tok, &lasts, 0)) > 0 && errno == 0 && lasts && *lasts == '\0') {
+                    log_delete_state.filenum = filenum;
+                    log_delete_counter_change(thedb, LOG_DEL_REFRESH);
+                    backend_update_sync(thedb);
+                } else {
+                    logmsg(LOGMSG_ERROR, "logdelete4 got bad filenum <%s>\n", tok ? tok : "");
+                    cdb2buf_printf(sb, "expected +ve filenum\n");
+                    cdb2buf_flush(sb);
+                }
+            } else if (strcmp(tok, "recovery_options") == 0) {
+                cdb2buf_printf(sb, "%s\n", recovery_command);
+                cdb2buf_flush(sb);
+            } else if (strcmp(tok, "copy_complete") == 0) {
+                /* A fast copy can get here before the poll timeout ever runs, so
+                 * check once more: a waiting exclusive op is still blocked behind
+                 * our read locks. */
+                copy_yield_if_blocked(bdb_state, &locks_held, &aborted);
+                cdb2buf_printf(sb, "%s\n", aborted ? "aborted" : "ok");
+                cdb2buf_flush(sb);
+            } else {
+                logmsg(LOGMSG_ERROR, "logdelete4 got unknown token <%s>\n", tok);
+            }
         }
+    } else {
+        /* read from socket until it closes */
+        cdb2buf_settimeout(sb, 0, 0);
+        while (cdb2buf_gets(line, sizeof(line), sb) > 0) {
+            static const char *delims = " \r\t\n";
+            char *lasts;
+            char *tok;
+            tok = strtok_r(line, delims, &lasts);
+            if (!tok) {
+                continue;
+            } else if (strcmp(tok, "report_back") == 0) {
+                report_back = 1;
+                break;
+            } else if (strcmp(tok, "filenum") == 0) {
+                int filenum;
+                tok = strtok_r(NULL, delims, &lasts);
+                errno = 0;
+                if (tok && (filenum = strtol(tok, &lasts, 0)) > 0 && errno == 0 && lasts && *lasts == '\0') {
+                    log_delete_state.filenum = filenum;
+                    log_delete_counter_change(thedb, LOG_DEL_REFRESH);
+                    backend_update_sync(thedb);
+                } else {
+                    logmsg(LOGMSG_ERROR, "logdelete2 thread got bad filenum <%s>\n", tok);
+                    cdb2buf_printf(sb, "expected +ve filenum\n");
+                    cdb2buf_flush(sb);
+                    continue;
+                }
+            } else if (strcmp(tok, "recovery_options") == 0) {
+                logmsg(LOGMSG_DEBUG, "sent recovery options: %s\n", recovery_command);
+                cdb2buf_printf(sb, "%s\n", recovery_command);
+                cdb2buf_flush(sb);
+            } else {
+                logmsg(LOGMSG_ERROR, "logdelete2 thread got unknown token <%s>\n", tok);
+                /* la la la la fingers in my ears */
+            }
+        }
+    }
+
+    if (locks_held) {
+        bdb_unlock_recovery(bdb_state);
+        bdb_rellock(bdb_state, __func__, __LINE__);
+        locks_held = 0;
     }
 
     logmsg(LOGMSG_INFO, "Reenabling log file deletion\n");
@@ -151,8 +270,7 @@ static int handle_logdelete_request(comdb2_appsock_arg_t *arg)
         /* If we committed a schema change then that's ruined it too...
          */
         if (before_sc != after_sc) {
-            cdb2buf_printf(sb,
-                        "Alert: schema changes committed during operation\n");
+            cdb2buf_printf(sb, "Alert: schema changes committed during operation\n");
         }
 
         cdb2buf_printf(sb, ".\n");
@@ -179,6 +297,14 @@ comdb2_appsock_t logdelete2_plugin = {
 
 comdb2_appsock_t logdelete3_plugin = {
     "logdelete3",            /* Name */
+    "",                      /* Usage info */
+    0,                       /* Execution count */
+    0,                       /* Flags */
+    handle_logdelete_request /* Handler function */
+};
+
+comdb2_appsock_t logdelete4_plugin = {
+    "logdelete4",            /* Name */
     "",                      /* Usage info */
     0,                       /* Execution count */
     0,                       /* Flags */

--- a/plugins/logdelete/plugin.h.in
+++ b/plugins/logdelete/plugin.h.in
@@ -32,4 +32,15 @@ struct comdb2_plugin @PLUGIN_SYM@[] = {
        NULL,                  /* Destroy function */
        &logdelete3_plugin     /* Plugin-specific data */
    },
+   {
+       "logdelete",           /* Plugin identifier */
+       "logdelete plugin",    /* Plugin description */
+       COMDB2_PLUGIN_APPSOCK, /* Plugin type */
+       4,                     /* Plugin version */
+       1,                     /* Plugin interface version */
+       0,                     /* Plugin flags */
+       NULL,                  /* Initialization function */
+       NULL,                  /* Destroy function */
+       &logdelete4_plugin     /* Plugin-specific data */
+   },
    {0, 0, 0, 0, 0, 0, 0, 0, 0}};

--- a/tests/abort_copy_on_recovery.test/Makefile
+++ b/tests/abort_copy_on_recovery.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+  export TEST_TIMEOUT=5m
+endif

--- a/tests/abort_copy_on_recovery.test/README
+++ b/tests/abort_copy_on_recovery.test/README
@@ -1,0 +1,23 @@
+This test verifies that a copy (comdb2ar) is aborted if the database runs
+recovery that rewinds the log (rep_verify_match) while the copy is in flight.
+
+Such a rewind -- which happens on a physical replicant when it truncates to
+resync, or on a normal replicant that connects to a new master -- rewrites data
+pages backwards, so the pages captured by an overlapping copy no longer
+reconcile with the forward log replay the archive relies on.  The copy would
+otherwise be silently corrupt.
+
+The copy (logdelete4) holds the recovery lock and the bdb lock in read mode for
+its duration; recovery write-locks these before it rewinds any page, in both
+online and offline recovery modes.  When recovery (or another exclusive
+operation) waits on one of those locks, the copy releases them and is marked
+aborted, and comdb2ar discards the archive.
+
+The test, for BOTH online_recovery on and off:
+  1. Connects a copy and holds it at connect (debug_block_comdb2ar) after it has
+     taken the read locks.
+  2. Forces a rewind with sys.cmd.truncate_time (blocks on the bdb write lock
+     when offline, on recoverlk when online).
+  3. Releases the copy and verifies comdb2ar aborts with a non-zero exit,
+     reporting that recovery ran during the copy.
+  4. Also verifies a copy with no concurrent recovery still succeeds.

--- a/tests/abort_copy_on_recovery.test/lrl.options
+++ b/tests/abort_copy_on_recovery.test/lrl.options
@@ -1,0 +1,5 @@
+# Hold the copy open at connect time so we can force a rewind underneath it.
+debug_block_comdb2ar 1
+# Keep checkpoints frequent so there is log history to rewind to.
+setattr CHECKPOINTTIME 5
+setattr CHECKPOINTRAND 2

--- a/tests/abort_copy_on_recovery.test/runit
+++ b/tests/abort_copy_on_recovery.test/runit
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export archivepid=0
+export truncpid=0
+export archiveout=./archive.out.$$
+
+# Pin the node we operate on up front.  The copy connects here and the rewind and
+# the unblock all target this same node.
+export MASTER=$(getmaster)
+export MASTERLOG=${TESTDIR}/logs/${DBNAME}.${MASTER}.db
+
+# Create a table with some data and force a checkpoint so there is log history to
+# rewind to.
+function setup_data
+{
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME default "create table t1 (id int)"
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME default "insert into t1 select * from generate_series(1, 1000)"
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "exec procedure sys.cmd.send('flush')"
+}
+
+function set_online_recovery
+{
+    local val=$1
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable online_recovery $val"
+}
+
+# Start a copy against the master.  The remote copy stream (stdout) is discarded;
+# its stderr is forwarded to us so we can capture the exit status and messages.
+function start_archive
+{
+    rm -f $archiveout
+    ssh $MASTER "$COMDB2AR_EXE c ${DBDIR}/${DBNAME}.lrl 2>&1 >/dev/null" > $archiveout 2>&1 </dev/null &
+    archivepid=$!
+}
+
+# Count how many times a copy has parked in the debug_block loop.  The log is
+# shared across scenarios, so we wait for a *new* occurrence rather than any.
+function hold_count
+{
+    # egrep -c exits non-zero with no matches; capture and normalize rather than
+    # `|| echo 0`, which would emit a second line.
+    local n
+    n=$(egrep -c "blocking comdb2ar for testcase" "$MASTERLOG" 2>/dev/null)
+    echo "${n:-0}"
+}
+
+# Wait until the logdelete handler for THIS copy has taken its read locks and
+# parked in the debug_block_comdb2ar loop.  $1 is the hold_count from before.
+function wait_for_hold
+{
+    local base=$1
+    local cnt=0
+    while :; do
+        if [[ "$(hold_count)" -gt "$base" ]]; then
+            return 0
+        fi
+        if ! kill -0 $archivepid 2>/dev/null; then
+            cat $archiveout
+            failexit "Archive process exited before it took the hold"
+        fi
+        let cnt=cnt+1
+        if [[ $cnt -gt 20 ]]; then
+            cat $archiveout
+            failexit "Timed out waiting for the copy to take the hold"
+        fi
+        sleep 1
+    done
+}
+
+# Scenario: a copy that overlaps a rewind must be aborted.
+function run_abort_scenario
+{
+    local online=$1
+    echo "=== abort scenario, online_recovery=$online ==="
+    set_online_recovery $online
+
+    # rewind target is now; the copy connects a moment later and the write below
+    # lands after it, so the truncate actually rolls something back.
+    local rewind_time=$(date +%s)
+
+    local base=$(hold_count)
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable debug_block_comdb2ar 1"
+    start_archive
+    wait_for_hold $base
+
+    # A write that lands after rewind_time; it proceeds under the copy's read
+    # locks (normal writes take neither the bdb write lock nor recoverlk).
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME default "insert into t1 select * from generate_series(1, 100)" >/dev/null 2>&1
+
+    # Force the rewind while the copy still holds its locks.  The truncate parks
+    # on the bdb write lock (offline) or recoverlk (online); give it a moment.
+    ( $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "exec procedure sys.cmd.truncate_time($rewind_time)" ) &
+    truncpid=$!
+    sleep 3
+
+    # Release the copy.  The truncate is still blocked behind its read locks, so
+    # it drops them, marks the copy aborted, and comdb2ar discards the archive.
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable debug_block_comdb2ar 0"
+
+    wait $archivepid
+    local rc=$?
+    wait $truncpid 2>/dev/null
+    cat $archiveout
+
+    if [[ $rc -eq 0 ]]; then
+        failexit "online_recovery=$online: archive succeeded but should have aborted"
+    fi
+    if ! egrep -q "recovery ran on the database during the copy" $archiveout; then
+        failexit "online_recovery=$online: archive aborted (rc=$rc) but not for the expected reason"
+    fi
+    echo "online_recovery=$online: archive correctly aborted (rc=$rc)"
+}
+
+# Scenario: a copy with no concurrent recovery must succeed (no false abort).
+function run_success_scenario
+{
+    local online=$1
+    echo "=== success scenario, online_recovery=$online ==="
+    set_online_recovery $online
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable debug_block_comdb2ar 0"
+    rm -f $archiveout
+
+    ssh $MASTER "$COMDB2AR_EXE c ${DBDIR}/${DBNAME}.lrl 2>/dev/null >/dev/null" > $archiveout 2>&1 </dev/null
+    local rc=$?
+    cat $archiveout
+    if [[ $rc -ne 0 ]]; then
+        failexit "online_recovery=$online: archive failed (rc=$rc) with no concurrent recovery"
+    fi
+    echo "online_recovery=$online: archive succeeded as expected"
+}
+
+# Scenario: if the v4 handshake stalls -- as it does when the database is busy
+# taking the copy locks behind an in-flight recovery -- comdb2ar must fail rather
+# than downgrade to logdelete3 and copy unprotected.  debug_block_comdb2ar parks
+# the v4 handler so the handshake times out; the block is gated to v4, so a
+# downgrade *would* have succeeded -- proving comdb2ar does not take it.
+function run_hardfail_on_stalled_v4_scenario
+{
+    local online=$1
+    echo "=== hard-fail on stalled v4 handshake, online_recovery=$online ==="
+    set_online_recovery $online
+
+    local base=$(hold_count)
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable debug_block_comdb2ar 1"
+    start_archive
+    # Wait until the v4 handler has connected, taken its locks and parked; from
+    # here comdb2ar's 10s handshake read timeout runs and, with the fix, aborts.
+    wait_for_hold $base
+
+    wait $archivepid
+    local rc=$?
+
+    # Release the parked v4 handler so it drops its read locks before we finish.
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $DBNAME --host $MASTER "put tunable debug_block_comdb2ar 0"
+    sleep 2
+    cat $archiveout
+
+    if [[ $rc -eq 0 ]]; then
+        failexit "online_recovery=$online: archive succeeded but a stalled v4 handshake should have failed it"
+    fi
+    if ! egrep -q "refusing to fall back to an unprotected copy" $archiveout; then
+        failexit "online_recovery=$online: archive failed (rc=$rc) but not with the expected hard-fail reason"
+    fi
+    # It must NOT have quietly stepped down to a lower, unprotected version.
+    if egrep -q "Doesn't support logdelete4" $archiveout; then
+        failexit "online_recovery=$online: comdb2ar downgraded from logdelete4 instead of failing hard"
+    fi
+    echo "online_recovery=$online: stalled v4 handshake correctly failed the archive (rc=$rc)"
+}
+
+function run_test
+{
+    setup_data
+    # Cover both online recovery (OSS default) and offline recovery (Bloomberg).
+    run_abort_scenario 1
+    run_abort_scenario 0
+    run_success_scenario 1
+    run_success_scenario 0
+    # A stalled v4 handshake must fail the copy, not silently downgrade.
+    run_hardfail_on_stalled_v4_scenario 0
+}
+
+run_test
+echo "success"

--- a/tools/comdb2ar/appsock.cpp
+++ b/tools/comdb2ar/appsock.cpp
@@ -329,14 +329,17 @@ bool Appsock::response(const std::string& rsp)
 {
     SigPipeBlocker block_sigpipe;
 
-    // Get the response - we expect "log file deletion disable"
+    // No line within the timeout means the database took the request but is
+    // stuck (for logdelete4: blocked on the copy locks behind a recovery) --
+    // throw, so the caller fails hard rather than downgrading.  A wrong line
+    // means it doesn't understand the request -- return false so it steps down.
     cdb2buf_settimeout(impl->m_sb, 10 * 1000, 10 * 1000);
     char line[256];
     if(cdb2buf_gets(line, sizeof(line), impl->m_sb) <= 0) {
-        std::clog << "no response from " << impl->m_dbname << " expected " 
-            << rsp << std::endl;
-        return false;
-    } else if(std::strcmp(line, rsp.c_str()) != 0) {
+        throw Error("no response from " + impl->m_dbname +
+                    " (timeout or closed connection)");
+    }
+    if(std::strcmp(line, rsp.c_str()) != 0) {
         std::clog << "bad response from " << impl->m_dbname << " expected "
             << rsp << std::endl;
         return false;

--- a/tools/comdb2ar/appsock.h
+++ b/tools/comdb2ar/appsock.h
@@ -45,8 +45,10 @@ public:
     // Send a request to the database.
 
     bool response(const std::string& rsp);
-    // Listen for a response froom the database, returns true if the expected
-    // response was received.
+    // Listen for a response from the database.  True on the expected response,
+    // false if a different line came back (an older database).  Throws on a
+    // timeout or a closed connection, so logdelete4 negotiation fails hard
+    // instead of downgrading.
 
     std::string read_response();
 };

--- a/tools/comdb2ar/logholder.cpp
+++ b/tools/comdb2ar/logholder.cpp
@@ -45,22 +45,59 @@ void LogHolder_impl::reset(const std::string& dbname, const std::string& request
     }
 }
 
-LogHolder::LogHolder(const std::string& dbname) : impl(new LogHolder_impl(dbname, "logdelete3\n"))
+// logdelete3/2 keep their original semantics: a timeout is just another bad
+// response and we step down a version.  Only the v4 handshake fails hard.
+static bool legacy_handshake_ok(Appsock *appsock)
 {
-    
-    m_version = 3;
-    if(impl->mp_appsock.get()
-            && !impl->mp_appsock->response("log file deletion disabled\n")) {
+    try {
+        return appsock->response("log file deletion disabled\n");
+    } catch(Error&) {
+        return false;
+    }
+}
+
+LogHolder::LogHolder(const std::string& dbname) : impl(new LogHolder_impl(dbname, "logdelete4\n"))
+{
+
+    m_version = 4;
+
+    // Negotiate the highest logdelete version: a database that doesn't know a
+    // version answers "-1 #unknown command" immediately and we step down.  A
+    // *timeout* on logdelete4 is different -- the handler is blocked taking the
+    // copy locks behind an in-flight recovery -- so response() throws and we fail
+    // hard rather than copy unprotected against that recovery.
+    bool v4_ok = false;
+    if(impl->mp_appsock.get()) {
+        try {
+            v4_ok = impl->mp_appsock->response("log file deletion disabled\n");
+        } catch(Error&) {
+            close();
+            throw Error("logdelete4 handshake timed out on " + dbname +
+                        " (database busy, possibly running recovery); refusing "
+                        "to fall back to an unprotected copy");
+        }
+    }
+
+    if(impl->mp_appsock.get() && !v4_ok) {
         close();
 
-        std::clog << "Doesn't support logdelete3" << std::endl;
+        std::clog << "Doesn't support logdelete4" << std::endl;
 
-        impl->reset(dbname, "logdelete2\n");
-        m_version = 2;
+        impl->reset(dbname, "logdelete3\n");
+        m_version = 3;
         if(impl->mp_appsock.get()
-                && !impl->mp_appsock->response("log file deletion disabled\n")) {
+                && !legacy_handshake_ok(impl->mp_appsock.get())) {
             close();
-            throw Error("Log holder appsock: bad response from " + dbname);
+
+            std::clog << "Doesn't support logdelete3" << std::endl;
+
+            impl->reset(dbname, "logdelete2\n");
+            m_version = 2;
+            if(impl->mp_appsock.get()
+                    && !legacy_handshake_ok(impl->mp_appsock.get())) {
+                close();
+                throw Error("Log holder appsock: bad response from " + dbname);
+            }
         }
     }
 
@@ -97,4 +134,25 @@ std::string LogHolder::recovery_options()
     }
     else
         return "";
+}
+
+bool LogHolder::copy_ok()
+{
+    // Ask a v4 database whether its lock hold stayed valid for the whole copy.
+    // It always answers, so anything but "ok" -- including a timeout or a
+    // dropped socket -- means the copy is not trustworthy.  Pre-v4 databases
+    // have no such handshake.
+    if(impl->mp_appsock.get() && m_version >= 4) {
+        std::ostringstream request ;
+        request << "copy_complete" << "\n";
+        impl->mp_appsock->request(request.str());
+        try {
+            return impl->mp_appsock->read_response() == "ok";
+        } catch(Error& e) {
+            std::clog << "copy_complete: no response from database: "
+                      << e.what() << std::endl;
+            return false;
+        }
+    }
+    return true;
 }

--- a/tools/comdb2ar/logholder.h
+++ b/tools/comdb2ar/logholder.h
@@ -33,10 +33,11 @@ public:
 
     LogHolder(const std::string& dbname);
     // Construct a log holder object, opening the socket to the database and
-    // telling it to hold off on log file deletion.  If this cannot be done
-    // for some reason then we will log this to std::clog but still construct
-    // a valid (inert) object.  This is because the database might be down,
-    // so failure here is not an error.
+    // telling it to hold off on log file deletion.  If the database cannot be
+    // reached at all (e.g. it is down) we log to std::clog and construct an
+    // inert object, which is not an error.  But if a logdelete4 connection is
+    // accepted and the handshake then times out, we throw rather than fall back
+    // to an older, unprotected version.
 
     virtual ~LogHolder();
     // Destroy the object, closing our socket interface.
@@ -51,6 +52,11 @@ public:
     // the database in the first place.
 
     std::string recovery_options();
+
+    bool copy_ok();
+    // Ask the database (logdelete4+) whether the copy stayed valid -- no recovery
+    // or other exclusive operation ran during it.  True if confirmed good or the
+    // database is pre-v4; false if it reports an abort or does not answer.
 
     int version() { return m_version; };
 };

--- a/tools/comdb2ar/serialise.cpp
+++ b/tools/comdb2ar/serialise.cpp
@@ -1485,15 +1485,28 @@ void serialise_database(
     }
 
     // Generate fingerprint SHA file
+    std::string sha;
     if(incr_create || incr_gen){
-        std::string sha = generate_fingerprint();
+        sha = generate_fingerprint();
 
         std::clog << "Calculated SHA fingerprint as: " << sha << std::endl;
 
         // Serialise the SHA file
         serialise_string("fingerprint.sha", sha);
+    }
 
-        // Write the SHA file so that the next increment can know it
+    // If recovery ran while we were copying, the pages we captured no longer
+    // reconcile with the forward log replay, so the archive would be corrupt.
+    // Fail, so it is discarded and retried instead.
+    if(log_holder.get() && !log_holder->copy_ok()) {
+        throw Error("recovery ran on the database during the copy; "
+                    "archive would be corrupt - aborting");
+    }
+
+    // Only now record the fingerprint for the next increment to diff against.
+    // Persisting it before the check above would advance the incremental chain
+    // to an archive that was then discarded.
+    if(incr_create || incr_gen){
         std::string sha_filename = incr_path + "/fingerprint.sha";
         std::ofstream sha_file(sha_filename, std::ofstream::trunc);
 


### PR DESCRIPTION
## Abort a copy when recovery runs

A copy (`copycomdb2`/`comdb2ar`, via the `logdelete` appsock) can be silently corrupted if recovery rewinds the log while the copy is in progress — routine on a physical replicant that truncates to resync, and on a normal replicant that connects to a new master.

Make the copy and recovery mutually exclusive, and fail the copy (rather than stall it) when recovery needs to run. A new `logdelete4` appsock has the copy hold `recoverlk` and the bdb lock in read mode for its duration; when recovery (or a node upgrade/downgrade) waits on either, the handler releases the locks and marks the copy aborted. A `copy_complete` handshake reports `ok`/`aborted`, and `comdb2ar` discards the archive (non-zero exit) on anything but `ok`.

### What changed
- `bdb/rep.c`, `bdb/bdb_api.h`: `bdb_readlock_recovery` / `bdb_unlock_recovery` wrappers over `recoverlk`.
- `plugins/logdelete`: new `logdelete4` appsock (read-lock hold, poll-and-yield, `copy_complete`); `logdelete`/`2`/`3` unchanged.
- `tools/comdb2ar`: negotiate `logdelete4` (fallback to `3`/`2`), add `LogHolder::copy_ok()`, fail `serialise_database` when it returns false.

### Compatibility
Safe either direction: a new `comdb2ar` falls back to `logdelete3`/`2` against an old DB, and an old `comdb2ar` uses `logdelete3` against a new DB. Full protection needs both sides new. Companion client PR: comdb2ar `logdelete4-fail-copy-on-recovery`.

### Testing
`tests/abort_copy_on_recovery.test` forces a rewind during a held copy and asserts it aborts, under both `online_recovery` on and off, plus a no-recovery run that still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
