### PR TITLE
NEWMASTER: broadcast the committed gen via __rep_send_message

### DIFF
--- a/berkdb/rep/rep_method.c
+++ b/berkdb/rep/rep_method.c
@@ -411,8 +411,10 @@ __rep_start(dbenv, dbt, gen, flags)
 		 */
 		logmsg(LOGMSG_DEBUG, "%s line %d sending REP_NEWMASTER\n", 
 				__func__, __LINE__);
-		(void)__rep_send_message_gen(dbenv,
-			db_eid_broadcast, REP_NEWMASTER, &lsn, NULL, 0, gen, NULL);
+		/* NEWMASTER must carry our committed gen; the wrapper reads rep->gen.
+		 * The old gen arg was stale/0 on the start-as-master path. */
+		(void)__rep_send_message(dbenv,
+			db_eid_broadcast, REP_NEWMASTER, &lsn, NULL, 0, NULL);
 		ret = 0;
 		if (role_chg) {
 			ret = __txn_reset(dbenv);


### PR DESCRIPTION
## Why
`__rep_start` broadcast its REP_NEWMASTER with the incoming `gen` **argument** (`berkdb/rep/rep_method.c:415`). But `gen` is a by-value copy and `__rep_set_gen` only ever writes `rep->gen`, so the broadcast can't reflect the generation the function derived.

On the start-as-master path (`rep_start(gen=0)`, `dbenv_open`) the real generation is derived into `rep->gen` (`recover_gen+1` / `egen`) while the broadcast still sent `0`. A gen-0 NEWMASTER is **inert**: if the receiver's `mygen > 0` it's dropped as `badgen` (`rep_record.c:1298`), and `0` can never be `> mygen` (`:1320`) so it never triggers adopt/downgrade. It conveyed no generation — the cluster converged only via the forced checkpoint + replicated log.

## What
Use the existing `__rep_send_message` wrapper, which locks the region mutex, reads `rep->gen`, and forwards it (`rep_util.c:302-308`). NEWMASTER now advertises the generation we actually upgraded to — consistent with every other emitter. When a non-zero `gen` was passed it already equalled `rep->gen` (set at `:362`), so only the derived-gen paths change. Net diff is 2 lines.
