### PR TITLE
Switch to central-publishing-maven-plugin plugin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,8 @@ jobs:
           java-version: 8
           java-package: jdk
           check-latest: true
-          server-id: ossrh
+          # Must match <publishingServerId> in cdb2jdbc/pom.xml's ossrh profile.
+          server-id: central
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
           gpg-private-key: ${{ secrets.GPG_KEY }}
@@ -31,6 +32,9 @@ jobs:
         working-directory: cdb2jdbc
         run: mvn --batch-mode -Possrh -Dmaven.test.skip=true -Dgpg.keyname=${{ secrets.GPG_KEY_ID }} -Dgpg.passphrase=${{ secrets.GPG_KEY_PASSPHRASE }} clean deploy
         env:
+          # NOTE: these secrets must now hold a Central Portal user token
+          # (name + password from https://central.sonatype.com/account), NOT the
+          # legacy OSSRH credentials. An old OSSRH token returns 401.
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           GPG_KEY_PASSPHRASE: ${{ secrets.GPG_KEY_PASSPHRASE }}

--- a/cdb2jdbc/pom.xml
+++ b/cdb2jdbc/pom.xml
@@ -51,13 +51,12 @@ limitations under the License. -->
     <url>https://github.com/bloomberg/comdb2/tree/main/cdb2jdbc</url>
   </scm>
 
+  <!-- Releases are published to Maven Central by the central-publishing-maven-plugin
+       (see the ossrh profile), so no release <repository> is needed here. Only the
+       snapshot repository is declared, for SNAPSHOT deployments. -->
   <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <url>https://ossrh-staging-api.central.sonatype.com/service/local/</url>
-    </repository>
     <snapshotRepository>
-      <id>ossrh</id>
+      <id>central</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
@@ -297,15 +296,18 @@ limitations under the License. -->
               </execution>
             </executions>
           </plugin>
+          <!-- Publish to Maven Central via the Central Portal. With extensions=true
+               this handles `deploy`, uploads a signed bundle to the `central` server
+               (see settings.xml), and auto-releases once validation passes. -->
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>1.7.0</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.11.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Switch to Sonatype's plugin, as recommended on https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#plugins-tested-for-compatibility 