### PR TITLE
fix false +ve compiler  warning

### DIFF
--- a/net/sqlwriter.c
+++ b/net/sqlwriter.c
@@ -204,7 +204,7 @@ static void sql_flush_cb(int fd, short what, void *arg)
     if (!(what & EV_WRITE)) {
         return;
     }
-    int n;
+    int n = 0;
     LOCK_WR_LOCK_ONLY_IF_NOT_PACKING(writer);
     while (evbuffer_get_length(writer->wr_buf)) {
         if ((n = wr_evbuffer(writer, fd)) <= 0) break;


### PR DESCRIPTION
```
net/sqlwriter.c: In function "sql_flush_cb":
/bb/bigstorn/systems/gitbuilds/comdb2/opencomdb2/R20260811.9/comdb2/net/sqlwriter.c:216:15: error: "n" may be used uninitialized [-Werror=maybe-uninitialized]
  216 |     } else if (n <= 0) {
```


The warning is a false positive the compiler can't rule out: if wr_buf is empty on entry, the while loop never runs, so n is untouched. But in that case the first branch (evbuffer_get_length(...) == 0) is taken, so the else if (n <= 0) is never actually reached with an uninitialized n. Initializing to 0 silences -Werror=maybe-uninitialized without changing behavior (an empty buffer already routes to the disable-flush branch).