### PR TITLE
Handle ix_addk rcode correctly during master swing

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -369,6 +369,8 @@ static int gbl_db_is_exiting = 0; /* Indicates this process is exiting */
 
 int gbl_debug_omit_dta_write;
 int gbl_debug_omit_idx_write;
+int gbl_debug_ix_addk_nomaster;
+int gbl_debug_ix_addk_nomaster_skip;
 int gbl_debug_omit_blob_write;
 int gbl_debug_omit_zap_on_rebuild = 0;
 int gbl_debug_txn_sleep = 0;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -477,6 +477,8 @@ extern int gbl_abort_on_dangling_stringrefs;
 extern int gbl_debug_alter_sequences_sleep;
 extern int gbl_debug_omit_dta_write;
 extern int gbl_debug_omit_idx_write;
+extern int gbl_debug_ix_addk_nomaster;
+extern int gbl_debug_ix_addk_nomaster_skip;
 extern int gbl_debug_omit_blob_write;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_debug_pb_connectmsg_dbname_check;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1360,6 +1360,11 @@ REGISTER_TUNABLE("debug.omit_dta_write", "Deliberately corrupt insertion randoml
                  &gbl_debug_omit_dta_write, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.omit_idx_write", "Deliberately corrupt insertion randomly to debug db_verify", TUNABLE_BOOLEAN,
                  &gbl_debug_omit_idx_write, INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("debug.ix_addk_nomaster",
+                 "Fail this many subsequent key adds with ERR_NOMASTER, as if downgraded mid-transaction",
+                 TUNABLE_INTEGER, &gbl_debug_ix_addk_nomaster, INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("debug.ix_addk_nomaster_skip", "Let this many key adds through before debug.ix_addk_nomaster kicks in",
+                 TUNABLE_INTEGER, &gbl_debug_ix_addk_nomaster_skip, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.omit_blob_write", "Deliberately corrupt insertion randomly to debug db_verify", TUNABLE_BOOLEAN,
                  &gbl_debug_omit_blob_write, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.skip_constraintscheck_on_insert",

--- a/db/glue.c
+++ b/db/glue.c
@@ -154,6 +154,8 @@ extern int gbl_lost_master_time;
 extern int gbl_use_fastseed_for_comdb2_seqno;
 extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
+extern int gbl_debug_ix_addk_nomaster;
+extern int gbl_debug_ix_addk_nomaster_skip;
 
 extern int gbl_import_mode;
 extern int bulk_import_tmpdb_should_ignore_table(const char *table);
@@ -1075,6 +1077,18 @@ int ix_addk(struct ireq *iq, void *trans, void *key, int ixnum,
 {
     if (gbl_debug_omit_idx_write) {
         return 0;
+    }
+    /* Simulate a master swing: after letting gbl_debug_ix_addk_nomaster_skip
+     * key adds through, the next gbl_debug_ix_addk_nomaster key adds fail as
+     * if we had been downgraded mid-transaction. */
+    if (gbl_debug_ix_addk_nomaster > 0) {
+        if (gbl_debug_ix_addk_nomaster_skip > 0 && ATOMIC_ADD32(gbl_debug_ix_addk_nomaster_skip, -1) >= 0) {
+            /* not yet */
+        } else if (ATOMIC_ADD32(gbl_debug_ix_addk_nomaster, -1) >= 0) {
+            logmsg(LOGMSG_USER, "%s: returning ERR_NOMASTER for table '%s' ix %d\n", __func__, iq->usedb->tablename,
+                   ixnum);
+            return ERR_NOMASTER;
+        }
     }
     int rc;
     ACCUMULATE_TIMING(CHR_IXADDK,

--- a/db/indices.c
+++ b/db/indices.c
@@ -514,13 +514,15 @@ int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
                 goto done;
             } else if (rc != 0) {
                 *ixfailnum = ixnum;
-                /* If following changes, update OSQL_INSREC in osqlcomm.c */
-                *opfailcode = OP_FAILED_UNIQ; /* really? */
-
-                // If this transaction has already added this key and adding this key again
-                // violates a duplicate key constraint, then this txn is uncommittable. 
-                if (dup_txn_insert == 1) {
-                    iq->dup_key_insert = 1;
+                if (rc == IX_DUP) {
+                    *opfailcode = OP_FAILED_UNIQ;
+                    // If this transaction has already added this key and adding this key again
+                    // violates a duplicate key constraint, then this txn is uncommittable.
+                    if (dup_txn_insert) {
+                        iq->dup_key_insert = 1;
+                    }
+                } else {
+                    *opfailcode = OP_FAILED_INTERNAL;
                 }
 
                 ERR(rc, "add error", 0);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1181,6 +1181,7 @@ static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
 
     if (iq->vfy_idx_track) {
         hash_clear(iq->vfy_idx_hash);
+        iq->dup_key_insert = 0;
     }
 
     /* create a cursor */

--- a/tests/upsert_nomaster.test/Makefile
+++ b/tests/upsert_nomaster.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/upsert_nomaster.test/README
+++ b/tests/upsert_nomaster.test/README
@@ -1,0 +1,19 @@
+Regression test for "Handle ix_addk rcode correctly during master swing".
+
+ix_addk() returns ERR_NOMASTER when the node is downgraded in the middle of a
+transaction. add_record_indices() used to report every ix_addk() failure as
+OP_FAILED_UNIQ (duplicate key), which upsert (insert ... on conflict do
+nothing) is entitled to ignore. Two things went wrong:
+
+  1) the upsert was told it succeeded, but the data record was left without its
+     index entry, and
+  2) the transaction was marked as having inserted a duplicate key, i.e.
+     uncommittable, which is a permanent failure instead of a retry.
+
+The test drives ERR_NOMASTER out of ix_addk() directly through the
+debug.ix_addk_nomaster[_skip] tunables instead of racing a real master swing.
+
+Not covered: apply_changes() also resets iq->dup_key_insert when it clears the
+per-attempt index hash. That only matters when an attempt that saw a genuine
+duplicate is retried (e.g. a deadlock later in the same block), which this test
+does not force.

--- a/tests/upsert_nomaster.test/lrl.options
+++ b/tests/upsert_nomaster.test/lrl.options
@@ -1,0 +1,4 @@
+# Index tracking (and therefore the "uncommittable txn" check) is only armed
+# after this many verify-retries. Arm it from the very first attempt so that
+# the second part of this test is deterministic.
+osql_verify_ext_chk 0

--- a/tests/upsert_nomaster.test/runit
+++ b/tests/upsert_nomaster.test/runit
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+if [[ -z $dbnm ]] ; then
+    failexit "need a DB name"
+fi
+
+master=$(getmaster)
+[[ -z $master ]] && failexit "could not find master"
+
+# ix_addk returns ERR_NOMASTER when we get downgraded in the middle of a
+# transaction. Simulate that: let $1 key adds through on the master, then fail
+# the next $2 of them with ERR_NOMASTER.
+function arm_nomaster
+{
+    typeset skip=$1
+    typeset nfail=$2
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master \
+        "put tunable 'debug.ix_addk_nomaster_skip' $skip" >/dev/null || failexit "could not arm skip"
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $master \
+        "put tunable 'debug.ix_addk_nomaster' $nfail" >/dev/null || failexit "could not arm nomaster"
+}
+
+function disarm_nomaster
+{
+    arm_nomaster 0 0
+}
+
+# Report every symptom in one run rather than stopping at the first one.
+failures=0
+function fail
+{
+    echo "FAILED: $1"
+    failures=$((failures+1))
+}
+
+# 1) An upsert must not silently lose its index entry.
+#
+# ERR_NOMASTER used to be reported as a duplicate key error, which
+# 'insert ... on conflict do nothing' happily ignores. The data record was
+# added, its key was not, and the client was told the insert succeeded.
+echo "part 1: upsert must not lose its index entry"
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table if exists t1" >/dev/null
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t1 (i int primary key)" >/dev/null || failexit "create t1"
+
+arm_nomaster 0 1
+out=$(cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1 values(3) on conflict do nothing" 2>&1)
+disarm_nomaster
+echo "insert returned: $out"
+
+# The insert is allowed to fail (ERR_NOMASTER is retryable), but it is not
+# allowed to report success and leave the row unindexed.
+scan=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select count(*) from t1 where i+0 = 3")
+idx=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select count(*) from t1 where i = 3")
+echo "rows found by scan: $scan, rows found through the index: $idx"
+if [[ "$scan" != "$idx" ]] ; then
+    fail "row 3 is in the data file ($scan) but not in the index ($idx)"
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t1')" &> verify_t1.out
+if ! grep -q succeeded verify_t1.out ; then
+    cat verify_t1.out
+    fail "verify of t1 failed"
+fi
+
+# 2) An upsert must not turn the transaction uncommittable.
+#
+# The same mismapping marked the transaction as one that inserted a duplicate
+# key, which is a permanent (non-retryable) failure.
+echo "part 2: upsert must not make the transaction uncommittable"
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "drop table if exists t2" >/dev/null
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t2 (i int primary key)" >/dev/null || failexit "create t2"
+
+# Both key adds of key 6 fail: the first one because of the injected
+# ERR_NOMASTER, and the second one because the first one never made it into the
+# btree and so gets re-added within the same transaction.
+arm_nomaster 0 2
+cat > uncommittable.sql <<'EOF'
+begin
+insert into t2 values(6) on conflict do nothing
+insert into t2 values(6) on conflict do nothing
+commit
+EOF
+out=$(cdb2sql ${CDB2_OPTIONS} $dbnm default -f uncommittable.sql 2>&1)
+disarm_nomaster
+echo "$out"
+
+if echo "$out" | grep -qi uncommittable ; then
+    fail "transaction was incorrectly marked uncommittable"
+fi
+
+cnt=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select count(*) from t2 where i = 6")
+if [[ "$cnt" != "1" ]] ; then
+    fail "expected exactly one row with i=6, found $cnt"
+fi
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t2')" &> verify_t2.out
+if ! grep -q succeeded verify_t2.out ; then
+    cat verify_t2.out
+    fail "verify of t2 failed"
+fi
+
+if [[ $failures != 0 ]] ; then
+    failexit "$failures check(s) failed"
+fi
+
+echo "Testcase passed."
+exit 0


### PR DESCRIPTION
ERR_NOMASTER is treated as a duplicate key error, which causes upsert to misbehave during master swing: an upsert may miss its index entry, or may fail incorrectly during verify-retry.

Case 1) upsert misses its index entry

```
mydb4> create table t2 (i int primary key)$$
[create table t2 (i int primary key)] rc 0
```

Upsert receives a good rcode, but misses its index entry:
```
mydb4> insert into t2 values(3) on conflict do nothing
(rows inserted=1)
[insert into t2 values(3) on conflict do nothing] rc 0
mydb4> select * from t2
(i=3)

mydb4> select count(*) from t2 where i = 3
(count(*)=0)
```

Case 2) upsert fails incorrectly during verify-retry

Insert-on-conflict-do-nothing, still receives a dupkey error:

```
mydb4> begin
[begin] rc 0
mydb4> insert into t2 values(6) on conflict do nothing
[insert into t2 values(6) on conflict do nothing] rc 0
mydb4> insert into t2 values(6) on conflict do nothing
[insert into t2 values(6) on conflict do nothing] rc 0
mydb4> update t2 set i = sleep(1) where i = 1
[update t2 set i = sleep(1) where i = 1] rc 0
mydb4> commit
[commit] failed with rc 2 Transaction is uncommittable: Duplicate insert on key 'COMDB2_PK' in table 't2' index 0
```

Database logs the following:

```
[ERROR] Forced VERIFY-FAIL for uncommittable blocksql transaction
```