### PR TITLE
Core-dump on stalled clean exit

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -180,6 +180,7 @@ int gbl_trigger_timepart = 0;
 int gbl_extended_sql_debug_trace = 0;
 int gbl_perform_full_clean_exit = 1;
 int gbl_abort_on_dangling_stringrefs = 0;
+int gbl_abort_on_stalled_exit = 1;
 struct ruleset *gbl_ruleset = NULL;
 
 void myctrace(const char *c) { ctrace("%s", c); }
@@ -1671,8 +1672,10 @@ static void finish_clean()
         abort();
 }
 
-void call_abort(int s)
+/* exit-alarm fired: core-dump so we can see what we are stuck on */
+static void abort_stalled_exit(int signum)
 {
+    logmsg(LOGMSG_FATAL, "CLEAN EXIT: stalled, aborting\n");
     abort();
 }
 
@@ -1687,9 +1690,9 @@ static void begin_clean_exit(void)
 
     logmsg(LOGMSG_INFO, "CLEAN EXIT: alarm time %d\n", alarmtime);
 
-#ifndef NDEBUG
-    signal(SIGALRM, call_abort);
-#endif
+    if (gbl_abort_on_stalled_exit)
+        signal(SIGALRM, abort_stalled_exit);
+
     /* this defaults to 5 minutes */
     alarm(alarmtime);
 
@@ -1748,6 +1751,9 @@ void clean_exit(void)
     int alarmtime = (gbl_exit_alarm_sec > 0 ? gbl_exit_alarm_sec : 300);
 
     logmsg(LOGMSG_INFO, "CLEAN EXIT: alarm time %d\n", alarmtime);
+
+    if (gbl_abort_on_stalled_exit)
+        signal(SIGALRM, abort_stalled_exit);
 
     /* this defaults to 5 minutes */
     alarm(alarmtime);

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -474,6 +474,7 @@ extern int gbl_perform_full_clean_exit;
 extern int gbl_clean_exit_on_sigterm;
 extern int gbl_stack_string_refs;
 extern int gbl_abort_on_dangling_stringrefs;
+extern int gbl_abort_on_stalled_exit;
 extern int gbl_debug_alter_sequences_sleep;
 extern int gbl_debug_omit_dta_write;
 extern int gbl_debug_omit_idx_write;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2112,6 +2112,9 @@ REGISTER_TUNABLE("stack_string_refs", "Acquire a cheapstack for every string-ref
 REGISTER_TUNABLE("abort_on_dangling_string_refs", "Abort-on-exit on dangling stringrefs.  (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_abort_on_dangling_stringrefs, 0, NULL, NULL, NULL, NULL);
 
+REGISTER_TUNABLE("abort_on_stalled_exit", "Core-dump if the clean-exit alarm fires.  (Default: on)", TUNABLE_BOOLEAN,
+                 &gbl_abort_on_stalled_exit, NOARG, NULL, NULL, NULL, NULL);
+
 REGISTER_TUNABLE("msgwaittime", "Network timeout for pushnext & queue changes.  (Default: 10000)", TUNABLE_INTEGER,
                  &gbl_msgwaittime, 0, NULL, NULL, NULL, NULL);
 

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -9,6 +9,7 @@
 (name='abort_on_in_use_rqid', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='abort_on_invalid_context', description='abort_on_invalid_context', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_on_replicant_log_write', description='Abort if replicant is writing to logs', type='BOOLEAN', value='OFF', read_only='N')
+(name='abort_on_stalled_exit', description='Core-dump if the clean-exit alarm fires.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='abort_on_ufid_mismatch', description='Abort in dbreg-open on ufid mismatch. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='abort_on_unfound_txn', description='Abort if we cannot find a txn for a thread.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='abort_ufid_open', description='Abort ufid_open when applying a transaction', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
A stalled `clean_exit` currently just dies on the default SIGALRM disposition (or aborts only in debug builds), leaving nothing to diagnose.  This installs a SIGALRM handler in `clean_exit` that logs and aborts, so the exit alarm produces a corefile showing what we were stuck on.  Gated on new tunable `abort_on_stalled_exit` (`gbl_abort_on_stalled_exit`), default on. Only the clean-exit path is affected; the bdb watchdog path is unchanged.