### PR TITLE
Make tranlog exit aware

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -105,6 +105,7 @@ extern int gbl_debug_disttxn_trace;
 extern int gbl_sparse_lockerid_map;
 extern int gbl_early;
 extern int gbl_exit_alarm_sec;
+extern int gbl_exit_flush_timeout_sec;
 extern int gbl_fdb_default_ver;
 extern int gbl_fdb_track;
 extern int gbl_fdb_track_hints;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -548,6 +548,10 @@ REGISTER_TUNABLE("erron", NULL, TUNABLE_BOOLEAN, &db->errstaton, READONLY | NOAR
 REGISTER_TUNABLE("exclusive_blockop_qconsume", "Enables serialization of blockops and queue consumes. (Default: off)",
                  TUNABLE_BOOLEAN, &gbl_exclusive_blockop_qconsume, READONLY | NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("exitalarmsec", NULL, TUNABLE_INTEGER, &gbl_exit_alarm_sec, READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("exit_flush_timeout_sec",
+                 "While exiting, give up on a client write that has made no progress for this long.  0 disables.  "
+                 "(Default: 10)",
+                 TUNABLE_INTEGER, &gbl_exit_flush_timeout_sec, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("exit_on_internal_failure", NULL, TUNABLE_BOOLEAN, &gbl_exit_on_internal_error, READONLY | NOARG, NULL,
                  NULL, NULL, NULL);
 REGISTER_TUNABLE("fdb_version_emulate_precdbapi",

--- a/net/sqlwriter.c
+++ b/net/sqlwriter.c
@@ -33,6 +33,11 @@
 //send heartbeat if no data every (seconds)
 #define min_hb_time 1
 
+/* Give up on a write that has made no progress for this long while exiting */
+int gbl_exit_flush_timeout_sec = 10;
+
+extern int db_is_exiting(void);
+
 struct sqlwriter {
     sql_dispatch_timeout_fn *dispatch_timeout;
     struct sqlclntstate *clnt;
@@ -225,6 +230,28 @@ static void sql_flush_cb(int fd, short what, void *arg)
     UNLOCK_WR_LOCK_ONLY_IF_NOT_PACKING(writer);
 }
 
+/* A peer that has stopped reading never drains wr_buf, so sql_flush_cb never
+ * disables the poll and we stay here forever.  That is how an exiting node
+ * hangs: clean_exit waits for this thread in thrman_wait_for_all() under a
+ * 300s alarm.  blocked_at is reset by every successful write, so this only
+ * fires when the peer has made no progress at all. */
+static int give_up_on_exit(struct sqlwriter *writer)
+{
+    if (!writer->pollms || !db_is_exiting() || gbl_exit_flush_timeout_sec <= 0)
+        return 0;
+    if (writer->blocked_at == 0 ||
+        (comdb2_time_epochus() - writer->blocked_at) < (gbl_exit_flush_timeout_sec * 1000000LL))
+        return 0;
+
+    logmsg(LOGMSG_WARN, "%s: abandoning stalled write, exiting\n", __func__);
+    LOCK_WR_LOCK_ONLY_IF_NOT_PACKING(writer);
+    writer->bad = 1;
+    sql_disable_flush(writer);
+    update_writer_state(writer, WRITE_FAILED);
+    UNLOCK_WR_LOCK_ONLY_IF_NOT_PACKING(writer);
+    return 1;
+}
+
 static int sql_flush_int(struct sqlwriter *writer)
 {
     sql_enable_flush(writer);
@@ -234,6 +261,7 @@ static int sql_flush_int(struct sqlwriter *writer)
         int rc = poll(&writer->poll_fd, 1, writer->pollms);
         short event = rc == 0 ? EV_TIMEOUT : EV_WRITE;
         sql_flush_cb(writer->poll_fd.fd, event, writer);
+        give_up_on_exit(writer);
     } while (writer->pollms);
     return (writer->wr_continue && !writer->bad) ? 0 : -1;
 }

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -147,6 +147,19 @@ int gbl_tranlog_maxpoll = 60;
 extern int comdb2_sql_tick();
 extern int bdb_am_i_coherent(bdb_state_type *bdb_state);
 
+/* A tranlog request runs on an appsock-sql thread, and clean_exit waits for
+ * those threads to *exit* in thrman_wait_for_all(), under a 300s alarm.
+ * Replicants (sqllogfill, physrep) re-issue immediately on a successful empty
+ * result, so ending the scan quietly just hands the thread another request and
+ * the exiting node never drains.  Fail instead: the client disconnects, the
+ * appsock thread exits, and no_more_sql_connections keeps it from coming back. */
+static int tranlog_exit_error(sqlite3_vtab_cursor *cur)
+{
+    sqlite3_free(cur->pVtab->zErrMsg);
+    cur->pVtab->zErrMsg = sqlite3_mprintf("database is exiting");
+    return SQLITE_ABORT;
+}
+
 /*
 ** Advance a tranlog cursor to the next log entry
 */
@@ -165,6 +178,10 @@ static int tranlogNext(sqlite3_vtab_cursor *cur)
 
   if (pCur->notDurable || pCur->hitLast)
       return SQLITE_OK;
+
+  /* Don't start (or continue) a scan while we are shutting down */
+  if (db_is_exiting())
+      return tranlog_exit_error(cur);
 
   if (pCur->timeout > 0 && (comdb2_time_epoch() - pCur->starttime) > pCur->timeout) {
       pCur->hitLast = 1;
@@ -225,6 +242,9 @@ static int tranlogNext(sqlite3_vtab_cursor *cur)
               pCur->notDurable = 1;
               break;
           }
+
+          if (db_is_exiting())
+              return tranlog_exit_error(cur);
 
           /* We want to downgrade */
           if (bdb_the_lock_desired()) {
@@ -323,7 +343,10 @@ static int tranlogNext(sqlite3_vtab_cursor *cur)
                   }
               }
 
-              if (db_is_exiting() || pCur->startAppRecGen != gbl_apprec_gen) {
+              if (db_is_exiting())
+                    return tranlog_exit_error(cur);
+
+              if (pCur->startAppRecGen != gbl_apprec_gen) {
                     pCur->hitLast = 1;
                     return SQLITE_OK;
               }
@@ -341,12 +364,15 @@ static int tranlogNext(sqlite3_vtab_cursor *cur)
               --gbl_num_logput_listeners;
               Pthread_mutex_unlock(&gbl_logput_lk);
 
-              while (bdb_the_lock_desired()) {
+              while (bdb_the_lock_desired() && !db_is_exiting()) {
                   if (thd == NULL) {
                       thd = pthread_getspecific(query_info_key);
                   }
                   recover_deadlock_simple(thedb->bdb_env);
               }
+
+              if (db_is_exiting())
+                  return tranlog_exit_error(cur);
           } while ((rc = pCur->logc->get(pCur->logc, &pCur->curLsn, &pCur->data, DB_NEXT)));
       } else {
           pCur->hitLast = 1;
@@ -612,6 +638,13 @@ static int tranlogFilter(
 ){
   tranlog_cursor *pCur = (tranlog_cursor *)pVtabCursor;
   int i = 0;
+
+  /* This is the reliable place to refuse a request: sqlite treats the xEof
+   * return as a boolean, so an error raised from tranlogNext() by way of
+   * tranlogEof() is read as a plain end-of-scan and the client sees an empty
+   * result it will just ask for again.  xFilter errors propagate. */
+  if (db_is_exiting())
+      return tranlog_exit_error(pVtabCursor);
 
   bzero(&pCur->minLsn, sizeof(pCur->minLsn));
   if( idxNum & 1 ){

--- a/tests/phys_rep_exit.test/Makefile
+++ b/tests/phys_rep_exit.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/phys_rep_exit.test/lrl.options
+++ b/tests/phys_rep_exit.test/lrl.options
@@ -1,0 +1,2 @@
+logmsg level debug
+physrep_debug 1

--- a/tests/phys_rep_exit.test/register_replicant.lua
+++ b/tests/phys_rep_exit.test/register_replicant.lua
@@ -1,0 +1,5 @@
+local function main(dbname, node, lsn)
+    local mydbname = db:getdbname()
+    local resultset, rc = db:exec("select 0 as tier, '" .. mydbname .. "' as dbname, host from comdb2_cluster")
+    resultset:emit()
+end

--- a/tests/phys_rep_exit.test/runit
+++ b/tests/phys_rep_exit.test/runit
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+# Physreps use the same blocking comdb2_transaction_logs() path as sql-logfill,
+# so a source node that isn't exit-aware hangs in clean_exit while a physrep is
+# parked in a blocking tranlog request against it.
+#
+# Attach a physrep, keep it streaming, then exit the source node it is attached
+# to and require that node to reach 'goodbye' promptly.
+
+bash -n "$0" || exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+set -x
+
+export COPYCOMDB2_EXE=${BUILDDIR}/db/copycomdb2
+
+dbname=$1
+destdb=${TESTCASE}dest${TESTID}
+
+COPY_DBDIR=${DBDIR}/$destdb
+DEST_DBDIR=${COPY_DBDIR}/$dbname
+
+# A healthy clean exit takes a couple of seconds.  The unfixed failure mode is
+# an indefinite hang, so anything in this range separates the two cleanly.
+EXIT_DEADLINE=60
+
+writer_pid=0
+
+if [[ -z "$TEST_TIMEOUT" ]] ; then
+    export TEST_TIMEOUT=5m
+fi
+
+function cleanup
+{
+    [[ $writer_pid != 0 ]] && kill -9 $writer_pid 2>/dev/null
+    [[ -f $DEST_DBDIR/${destdb}.pid ]] && kill -9 $(cat $DEST_DBDIR/${destdb}.pid) 2>/dev/null
+    return 0
+}
+
+function override_physrep_sp()
+{
+    local mnode=`getmaster`
+    ${CDB2SQL_EXE} $CDB2_OPTIONS $dbname --host $mnode "create procedure 'sys.physrep.register_replicant' version '1' { `cat ./register_replicant.lua` }"
+}
+
+function setup_replicant()
+{
+    mkdir -p $DEST_DBDIR
+
+    if [[ -z "$CLUSTER" ]]; then
+        cl="-y @localhost"
+    else
+        cl="-y @$(echo $CLUSTER | tr ' ' ',')"
+        if [[ ! "$CLUSTER" =~ .*$myhost.* ]]; then
+            clarray=($CLUSTER)
+            rmt="${clarray[0]}:"
+        fi
+    fi
+
+    ${COPYCOMDB2_EXE} -x ${COMDB2_EXE} -H $destdb $cl $rmt${DBDIR}/${DBNAME}.lrl $DEST_DBDIR $DEST_DBDIR \
+        || failexit "copycomdb2 failed"
+
+    df $DBDIR | awk '{print $1 }' | grep "tmpfs\|nfs" && echo "setattr directio 0" >> $DEST_DBDIR/${destdb}.lrl
+
+    if [ -n "$PMUXPORT" ] ; then
+        echo "portmux_port $PMUXPORT" >> $DEST_DBDIR/${destdb}.lrl
+        echo "portmux_bind_path $pmux_socket" >> $DEST_DBDIR/${destdb}.lrl
+    fi
+
+    replog=$TESTDIR/logs/$destdb.db
+
+    (cd $DBDIR; timeout --kill-after=5s $TEST_TIMEOUT $COMDB2_EXE $destdb --lrl $DEST_DBDIR/${destdb}.lrl --pidfile $DEST_DBDIR/${destdb}.pid >$replog 2>&1) &
+
+    local retries=0
+    while [[ "$(${CDB2SQL_EXE} --tabs $destdb --host localhost 'select 1' 2>/dev/null)" != "1" ]]; do
+        sleep 1
+        let retries=retries+1
+        [[ $retries -eq 30 ]] && failexit "Timeout waiting for physrep to come up"
+    done
+}
+
+# Returns the source host the physrep attached to, per its own log.
+function physrep_source_host()
+{
+    local elapsed=0
+    while [[ $elapsed -lt 60 ]]; do
+        local host=$(grep "Physical replicant is now replicating from" $replog 2>/dev/null \
+                        | tail -1 | sed 's/.*@//' | tr -d '[:space:]')
+        if [[ -n "$host" ]]; then
+            echo "$host"
+            return 0
+        fi
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    return 1
+}
+
+# Keep the log moving so the physrep stays engaged with the source.
+function start_writer
+{
+    (
+        while :; do
+            ${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default \
+                "insert into t1 select * from generate_series(1, 200)" &>/dev/null
+        done
+    ) &
+    writer_pid=$!
+}
+
+function wait_goodbye
+{
+    local node=$1
+    local logfile
+
+    if [[ -z "$CLUSTER" ]]; then
+        logfile="${TESTDIR}/logs/${dbname}.db"
+    else
+        logfile="${TESTDIR}/logs/${dbname}.${node}.db"
+    fi
+
+    local elapsed=0
+    while [[ $elapsed -lt $EXIT_DEADLINE ]]; do
+        if grep -q "goodbye" "$logfile" 2>/dev/null; then
+            echo "$node exited cleanly after ${elapsed}s"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+trap cleanup EXIT
+
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname default "create table t1 (id int)" \
+    || failexit "Failed to create t1"
+
+override_physrep_sp
+setup_replicant
+start_writer
+
+source_host=$(physrep_source_host) \
+    || failexit "physrep never attached to a source -- test is vacuous"
+echo "physrep is attached to $source_host"
+
+# Give the in-flight tranlog request a moment to settle into its blocking wait.
+sleep 5
+
+${CDB2SQL_EXE} ${CDB2_OPTIONS} $dbname --host $source_host \
+    "exec procedure sys.cmd.send('exit')" &>/dev/null
+
+wait_goodbye "$source_host" \
+    || failexit "source $source_host did not exit within ${EXIT_DEADLINE}s"
+
+cleanup
+echo "Success"
+exit 0

--- a/tests/sql_logfill_exit.test/Makefile
+++ b/tests/sql_logfill_exit.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/sql_logfill_exit.test/lrl.options
+++ b/tests/sql_logfill_exit.test/lrl.options
@@ -1,0 +1,4 @@
+sql_logfill 1
+sql_logfill_debug 1
+
+logmsg level debug

--- a/tests/sql_logfill_exit.test/runit
+++ b/tests/sql_logfill_exit.test/runit
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# A blocking comdb2_transaction_logs() request runs on an appsock-sql thread,
+# and clean_exit waits for those threads.  Replicants running sql-logfill
+# re-issue these against the master in a loop, so if tranlog isn't exit-aware
+# the exiting master never drains and dies on the exit alarm.
+#
+# Exit the master while replicants are actively logfilling, and require that it
+# reaches 'goodbye' promptly.
+
+bash -n "$0" || exit 1
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export debug=1
+[[ "$debug" == "1" ]] && set -x
+
+db=$1
+
+# A healthy clean exit takes a couple of seconds.  The unfixed failure mode is
+# an indefinite hang, so anything in this range separates the two cleanly.
+EXIT_DEADLINE=60
+
+writer_pid=0
+
+function cleanup
+{
+    [[ $writer_pid != 0 ]] && kill -9 $writer_pid 2>/dev/null
+}
+
+# Keep the log moving so the replicants' logfill threads stay engaged with the
+# master rather than idling on an empty gap.
+function start_writer
+{
+    (
+        while :; do
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db default \
+                "insert into t1 select * from generate_series(1, 200)" &>/dev/null
+        done
+    ) &
+    writer_pid=$!
+}
+
+# Verify replicants are actually issuing logfill requests -- otherwise the test
+# would pass vacuously.
+function wait_logfill_active
+{
+    local master=$1
+    local elapsed=0
+
+    while [[ $elapsed -lt 60 ]]; do
+        for node in $CLUSTER; do
+            [[ "$node" == "$master" ]] && continue
+            if grep -q "requesting logs from master" \
+                    "${TESTDIR}/logs/${db}.${node}.db" 2>/dev/null; then
+                echo "logfill is active on $node"
+                return 0
+            fi
+        done
+        sleep 2
+        elapsed=$((elapsed + 2))
+    done
+    return 1
+}
+
+function wait_goodbye
+{
+    local node=$1
+    local logfile="${TESTDIR}/logs/${db}.${node}.db"
+    local elapsed=0
+
+    while [[ $elapsed -lt $EXIT_DEADLINE ]]; do
+        if grep -q "^.*goodbye" "$logfile" 2>/dev/null; then
+            echo "$node exited cleanly after ${elapsed}s"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    return 1
+}
+
+function run_test
+{
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $db default "create table t1 (id int)" \
+        || failexit "Failed to create t1"
+
+    start_writer
+
+    local master=$(get_master)
+    [[ -z "$master" ]] && failexit "No master"
+    echo "master is $master"
+
+    wait_logfill_active "$master" \
+        || failexit "No replicant issued a logfill request -- test is vacuous"
+
+    # Give the in-flight requests a moment to settle into their blocking wait.
+    sleep 5
+
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $db --host $master \
+        "exec procedure sys.cmd.send('exit')" &>/dev/null
+
+    wait_goodbye "$master" \
+        || failexit "master $master did not exit within ${EXIT_DEADLINE}s"
+}
+
+cnt=$(echo $CLUSTER | wc -w)
+if [[ -z "$CLUSTER" || $cnt -lt 3 ]]; then
+    failexit "This test requires a clustered installation of at least 3 nodes"
+fi
+
+trap cleanup EXIT
+
+run_test
+
+cleanup
+echo "Success"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -362,6 +362,7 @@
 (name='eventlog_fullhintsql', description='Log full sql statement in the event log for hint abbreviated sql. (Default : on)', type='BOOLEAN', value='ON', read_only='N')
 (name='eventlog_nkeep', description='Keep this many eventlog files (Default: 2)', type='INTEGER', value='0', read_only='N')
 (name='exclusive_blockop_qconsume', description='Enables serialization of blockops and queue consumes. (Default: off)', type='BOOLEAN', value='OFF', read_only='Y')
+(name='exit_flush_timeout_sec', description='While exiting, give up on a client write that has made no progress for this long.  0 disables.  (Default: 10)', type='INTEGER', value='10', read_only='N')
 (name='exit_on_internal_failure', description='', type='BOOLEAN', value='ON', read_only='Y')
 (name='exitalarmsec', description='', type='INTEGER', value='10', read_only='Y')
 (name='extended_sql_debug_trace', description='Print extended trace for durable sql debugging', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
An exiting node can hang until the exit alarm fires while serving transaction-log requests from its replicants.

A tranlog request runs on an appsock-sql thread, and `clean_exit()` waits for those threads to exit in `thrman_wait_for_all()` under a 300s alarm. `sql_flush_int()` polls until `wr_buf` drains, and `pollms` is only cleared when the buffer empties or the write hard-errors. A replicant that breaks out of its fetch loop — sqllogfill and physrep both do, on gap-filled, generation change, or lock-desired — leaves the node mid-stream with nobody reading. The buffer never drains, `poll()` returns 0 every second forever, and `thrman_stop_sql_connections()` doesn't help because it shuts down the read side only.

Give up on a write that has made no progress for `exit_flush_timeout_sec` (default 10, 0 disables) while exiting. `blocked_at` is reset by every successful write, so a slow-but-still-draining client is unaffected and the clean-exit grace period for in-flight queries is preserved.

Also stop tranlog from handing the thread more work on the way out. The poll loop already checked `db_is_exiting()` but ended the scan quietly, which the client reads as an empty result and immediately re-issues. Raise an error from `tranlogFilter()` instead — sqlite treats the `xEof` return as a boolean, so an error raised from `tranlogNext()` by way of `tranlogEof()` is swallowed as an end-of-scan — and check for exit in the `xNext` paths, where errors do propagate.

Tests: `sql_logfill_exit` exits the master while replicants are actively logfilling; `phys_rep_exit` exits the source node a physrep is streaming from. Both require the node to reach `goodbye` rather than hang.