### PR TITLE
clean-exit: keep the transaction grace period inside the exit alarm

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -1704,6 +1704,10 @@ static void begin_clean_exit(void)
 
     wait_for_transactions();
 
+    /* The transaction grace period above is an intended wait; restart the
+     * stall watchdog so it times only the exit work that follows. */
+    alarm(alarmtime);
+
     print_all_time_accounting();
     wait_for_sc_to_stop("exit", __func__, __LINE__);
 
@@ -1765,6 +1769,10 @@ void clean_exit(void)
     block_new_requests(thedb);
 
     wait_for_transactions();
+
+    /* The transaction grace period above is an intended wait; restart the
+     * stall watchdog so it times only the exit work that follows. */
+    alarm(alarmtime);
 
     print_all_time_accounting();
     wait_for_sc_to_stop("exit", __func__, __LINE__);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -7225,9 +7225,16 @@ int gbl_transaction_grace_period = 60;
 void wait_for_transactions(void) {
     int ntrans;
     int nwaits = 0;
+    int maxwaits = gbl_transaction_grace_period;
+    extern int gbl_abort_on_stalled_exit;
+    extern int gbl_exit_alarm_sec;
 
+    /* This is an intended wait, not a stall: never let it outlive the
+     * exit alarm, which aborts under gbl_abort_on_stalled_exit. */
+    if (gbl_abort_on_stalled_exit && gbl_exit_alarm_sec > 2 && gbl_exit_alarm_sec - 2 < maxwaits)
+        maxwaits = gbl_exit_alarm_sec - 2;
 
-    for (nwaits = 0; nwaits < gbl_transaction_grace_period; nwaits++) {
+    for (nwaits = 0; nwaits < maxwaits; nwaits++) {
         ntrans = 0;
         struct connection_info *connections;
         int nconnections;


### PR DESCRIPTION
clean-exit: keep the transaction grace period inside the exit alarm

`wait_for_transactions()` is an intended wait, not a stall.  Clamp it to finish
inside the exit alarm, and re-arm the alarm afterwards so the watchdog times
only the exit work that follows.

`gbl_abort_on_stalled_exit` defaults on and the test framework writes
`exitalarmsec 10` into every generated lrl (`tests/setup`), against a
`gbl_transaction_grace_period` of 60.  So a client parked in an open
transaction at shutdown turns a clean exit into an abort-with-core: the alarm
fires while we are still deliberately waiting out the grace period.  This cored
`cdb2api_rollback_rc` on every run.

`wait_for_transactions()` now caps its wait at `gbl_exit_alarm_sec - 2` when
`gbl_abort_on_stalled_exit` is set, and `begin_clean_exit()`/`clean_exit()`
re-arm `alarm(alarmtime)` once it returns.

`trangrace.test` sets `exitalarmsec 60` with the comment "set shutdown no
matter what higher than the grace period", but sets it equal to the 60s grace
period.  The cap makes the grace period 58s, which is what that comment meant.

Independent of the physrep/log-checksum work, and merges first to unblock CI
for the rest: clean-exit-alarm, physrep-skip-truncation, log-cksum-prev,
physrep-verify-chain.  All four merge clean in that order and the combined tree
builds.
