### PR TITLE
Don't stall clean exit on replication acks or analyze page scans

### DIFF
--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -3012,6 +3012,17 @@ again:
         }
         return 0;
     }
+
+    /* on our way out and this node hasn't acked: nothing is going to arrive,
+     * so don't burn the full replication timeout waiting for it */
+    if (bdb_state->exiting) {
+        Pthread_mutex_unlock(&(bdb_state->seqnum_info->lock));
+        if (bdb_state->attr->wait_for_seqnum_trace) {
+            logmsg(LOGMSG_USER, PR_LSN " %s exiting, not waiting\n", PARM_LSN(seqnum->lsn), host->str);
+        }
+        return 1;
+    }
+
     /* this node may have been decommissioned, in which case we
      * get woken up.  Check that this node still exists. */
     if (!bdb_state->attr->repalwayswait) {
@@ -3328,8 +3339,7 @@ int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state, seqnum_type *seq
                 goto got_ack;
             }
         }
-    } while (comdb2_time_epochms() - begin_time <
-                 bdb_state->attr->rep_timeout_maxms &&
+    } while (comdb2_time_epochms() - begin_time < bdb_state->attr->rep_timeout_maxms && !bdb_state->exiting &&
              !(lock_desired = bdb_lock_desired(bdb_state)));
 
     /* if we get here then we timed out without finding even one good node.
@@ -3343,7 +3353,9 @@ int bdb_wait_for_seqnum_from_all_int(bdb_state_type *bdb_state, seqnum_type *seq
         bdb_state->attr->rep_timeout_minms - bdb_state->attr->rep_timeout_maxms;
     if (waitms < 0)
         waitms = 0;
-    if(!lock_desired)
+    if (bdb_state->exiting)
+        logmsg(LOGMSG_WARN, "exiting, not waiting for initial replication of <%s>\n", lsn_to_str(str, &(seqnum->lsn)));
+    else if (!lock_desired)
         logmsg(LOGMSG_WARN, "timed out waiting for initial replication of <%s>\n",
                lsn_to_str(str, &(seqnum->lsn)));
     else
@@ -3740,6 +3752,10 @@ void bdb_exiting(bdb_state_type *bdb_state)
 
     bdb_state->exiting = 1;
     MEMORY_SYNC;
+
+    /* wake seqnum waiters.  no lock: clean exit can run on the SIGTERM
+     * handler, and waiters recheck ->exiting every seqnum_wait_interval */
+    Pthread_cond_broadcast(&(bdb_state->seqnum_info->cond));
 }
 
 void bdb_set_seqnum(void *in_bdb_state)

--- a/bdb/summarize.c
+++ b/bdb/summarize.c
@@ -387,6 +387,41 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
         if (usedio && ((++nread) % FADVISE_THRESH) == 0)
             (void)posix_fadvise(fd, (nread - FADVISE_THRESH) * pgsz, FADVISE_THRESH * pgsz, POSIX_FADV_DONTNEED);
 #endif
+        /* Check disk space, schema changes, analyze abort request etc.
+           Every page: unsampled and non-leaf pages have to abort too. */
+        now = comdb2_time_epoch();
+        if (now - last >= 10) {
+            last = now;
+            rc = check_free_space(bdb_state->dir);
+            if (rc != BDBERR_NOERROR) {
+                *bdberr = rc;
+                rc = -1;
+                goto done;
+            }
+        }
+
+        int inprogress;
+        if ((inprogress = get_schema_change_in_progress(__func__, __LINE__)) || get_analyze_abort_requested() ||
+            db_is_exiting()) {
+            if (inprogress)
+                logmsg(LOGMSG_ERROR,
+                       "%s: Aborting Analyze because "
+                       "schema_change_in_progress\n",
+                       __func__);
+            if (get_analyze_abort_requested())
+                logmsg(LOGMSG_ERROR,
+                       "%s: Aborting Analyze because "
+                       "of send analyze abort\n",
+                       __func__);
+            if (db_is_exiting())
+                logmsg(LOGMSG_ERROR,
+                       "%s: Aborting Analyze because "
+                       "db is exiting\n",
+                       __func__);
+            rc = -1;
+            goto done;
+        }
+
         /* If it is not a leaf page, continue reading the file. */
         if (!ISLEAF(page))
             continue;
@@ -463,34 +498,6 @@ int bdb_summarize_table(bdb_state_type *bdb_state, int ixnum, int comp_pct,
             continue;
         NUM_ENT(page) = n;
         nrecs += (n >> 1);
-
-        /* Check disk space, schema changes, analyze abort request etc. */
-        now = comdb2_time_epoch();
-        if (now - last >= 10) {
-            last = now;
-            rc = check_free_space(bdb_state->dir);
-            if (rc != BDBERR_NOERROR) {
-                *bdberr = rc;
-                rc = -1;
-                goto done;
-            }
-        }
-
-        int inprogress;
-        if ((inprogress = get_schema_change_in_progress(__func__, __LINE__)) ||
-            get_analyze_abort_requested() || db_is_exiting()) {
-            if (inprogress)
-                logmsg(LOGMSG_ERROR, "%s: Aborting Analyze because "
-                        "schema_change_in_progress\n", __func__);
-            if (get_analyze_abort_requested())
-                logmsg(LOGMSG_ERROR, "%s: Aborting Analyze because "
-                        "of send analyze abort\n", __func__);
-            if (db_is_exiting())
-                logmsg(LOGMSG_ERROR, "%s: Aborting Analyze because "
-                        "db is exiting\n", __func__);
-            rc = -1;
-            goto done;
-        }
 
         db_indx_t *inp = P_INP(dbp, page);
         /* Remember the value before byteswap.

--- a/tests/analyze_exit_immediately.test/runit
+++ b/tests/analyze_exit_immediately.test/runit
@@ -66,6 +66,13 @@ function runtest {
     if [ $sample -eq 1 ]; then
         cdb2sql $dbnm --host $master "exec procedure sys.cmd.send('analyze sample')" >/dev/null
         cdb2sql $dbnm --host $master "exec procedure sys.cmd.send('analyze thresh 1000')" >/dev/null
+
+        # Pin coverage low so nearly every page is skipped by the sampling
+        # filter.  At the default 20% this only stalled the exit now and then.
+        for table in t v;
+        do
+            cdb2sql $dbnm --host $master "put analyze coverage $table 1" >/dev/null
+        done
     else
         cdb2sql $dbnm --host $master "exec procedure sys.cmd.send('analyze nosample')" >/dev/null
     fi


### PR DESCRIPTION
A clean exit can begin while the purge-old-files thread is inside trans_commit waiting for seqnum acks. Exit stops the net threads, so acks (and disconnect processing) never arrive, and the waiter runs out its full replication timeout while thrman waits on it. With a short exit alarm the stalled-exit watchdog fires and the node aborts:

```
#5 abort_stalled_exit
...
#5 bdb_wait_for_seqnum_from_node_int
#6 bdb_wait_for_seqnum_from_all_int
#7 trans_wait_for_seqnum_int
#10 purge_old_files_thread
```

Check `bdb_state->exiting` in the seqnum-wait paths the same way we already check lock-desired, and have `bdb_exiting` broadcast the seqnum cond so blocked waiters notice immediately. The check sits after the seqnum comparison, so a node which has already acked still returns a good rcode and still counts towards durability. The broadcast deliberately runs without `seqnum_info->lock`: clean exit can run inline on the SIGTERM handler, and taking that lock there would deadlock against an interrupted thread which holds it. Waiters re-check `exiting` every `seqnum_wait_interval`, so a missed wakeup costs one interval at worst.

The second commit fixes a related stall which was making `analyze_exit_immediately` fail periodically. `bdb_summarize_table` checked analyze-abort / db-exiting / schema-change only after the sampling filter, so at low coverage a long run of skipped pages would scan with no check at all and hold up the exit past the alarm. The check now runs at the top of the page loop, ahead of both the sampling filter and the leaf-page filter, and the test pins coverage to 1% so it reproduces this every time rather than on a coin toss.