### PR TITLE
Clone SP temp tables inside the thread's implicit transaction

### DIFF
--- a/lua/sp.c
+++ b/lua/sp.c
@@ -7004,11 +7004,15 @@ static int exec_thread_int(struct sqlthdstate *thd, struct sqlclntstate *clnt)
     SP sp = clnt->sp;
     sp->thd = thd;
     Lua L = sp->lua;
-    clone_temp_tables(sp);
-    int args = lua_gettop(L) - 1;
     int rc;
     char *err = NULL;
     if ((rc = begin_sp(clnt, &err)) != 0) return rc;
+    /* Clone inside the implicit transaction: begin_sp populates the modsnap
+       state for a snapshot client, which these prepares need in order to
+       open cursors (e.g. sqlite schema init reading sqlite_stat1). */
+    clone_temp_tables(sp);
+    /* Count args after the clone: it can leave values on the lua stack. */
+    int args = lua_gettop(L) - 1;
     if ((rc = run_sp(clnt, args, &err)) != 0) return rc;
     return commit_sp(L, &err);
 }

--- a/tests/sp_thread_tmptbl.test/Makefile
+++ b/tests/sp_thread_tmptbl.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/sp_thread_tmptbl.test/lrl.options
+++ b/tests/sp_thread_tmptbl.test/lrl.options
@@ -1,0 +1,1 @@
+sql_tranlevel_default snapshot

--- a/tests/sp_thread_tmptbl.test/runit
+++ b/tests/sp_thread_tmptbl.test/runit
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# An sp thread (db:create_thread) clones the parent's temp tables.  If the
+# thread lands on a sql engine thread that has not opened its sqlite handle
+# yet, the clone's CREATE TEMP TABLE prepare runs sqlite schema init, which
+# opens a cursor on sqlite_stat1.  Before the fix the clone ran ahead of
+# begin_sp, so a snapshot client had no modsnap state at that point and the
+# cursor tripped the assert in sqlite3BtreeCursor_cursor.
+#
+# This test runs at snapshot isolation (see lrl.options) and spawns enough
+# threads to force the sql thread pool to grow, so at least some threads get
+# a fresh sqlite handle.
+
+set -x
+
+dbname=$1
+if [[ -z "$dbname" ]] ; then
+    echo "dbname missing"
+    exit 1
+fi
+
+# sqlite_stat1 is what schema init reads - give it something to read.
+cdb2sql ${CDB2_OPTIONS} $dbname default "create table t(i int)" || exit 1
+cdb2sql ${CDB2_OPTIONS} $dbname default \
+    "insert into t select * from generate_series(1, 1000)" || exit 1
+cdb2sql ${CDB2_OPTIONS} $dbname default "analyze t" || exit 1
+
+cdb2sql ${CDB2_OPTIONS} $dbname default - <<'EOF' || exit 1
+create procedure tmptbl_thd version 'test' {
+local function worker(tbl)
+    tbl:insert({i = 1})
+end
+local function main(nthd)
+    local tbl = db:table("tbl", {{"i", "int"}})
+    local thds = {}
+    for i = 1, nthd do
+        table.insert(thds, db:create_thread(worker, tbl))
+    end
+    for _, thd in ipairs(thds) do
+        thd:join()
+    end
+    db:emit("ok")
+end
+}$$
+put default procedure tmptbl_thd 'test'
+EOF
+
+for i in $(seq 1 5); do
+    out=$(cdb2sql -tabs ${CDB2_OPTIONS} $dbname default \
+        "exec procedure tmptbl_thd(20)")
+    if [[ "$out" != "ok" ]]; then
+        echo "iteration $i: expected 'ok', got '$out'"
+        exit 1
+    fi
+done
+
+# The assert would have taken the node down - make sure it is still serving.
+cdb2sql ${CDB2_OPTIONS} $dbname default "select 1" >/dev/null || exit 1
+
+echo "SUCCESS"


### PR DESCRIPTION
## Problem

`sp_snapshot_generated` (`tests/sp.test` + `snapshot.testopts`, i.e. `sql_tranlevel_default snapshot`) periodically aborts on the snapshot-cursor assert in `sqlite3BtreeCursor_cursor` (`db/sqlglue.c:8380`):

```
Assertion `clnt->dbtran.mode != TRANLEVEL_SNAPISOL || clnt->modsnap_in_progress' failed
```

## Root cause

`exec_thread_int` cloned the parent's temp tables *before* `begin_sp`. For a snapshot client, `begin_sp` → `begin_parent` → `db_begin_int` → `handle_sql_begin` is what populates the modsnap state. Neither prepare path used by lua populates it — `get_prepared_stmt_try_lock` and `get_prepared_stmt_no_lock` both skip it, only `get_prepared_stmt` does — so every lua prepare depends on `begin_sp` having established the snapshot first. When the clone's `CREATE TEMP TABLE` prepare triggers sqlite schema init, the cursor opened on `sqlite_stat1` trips the assert. It is intermittent because schema init only sometimes needs to run.

## Fix

Move `clone_temp_tables` after `begin_sp`, so the prepares run with the snapshot established. This matches the parent SP path (`push_args_and_run_sp`) and every other temp table a stored procedure creates.

Move the arg count below the clone as well. `clone_temp_tables` can leave values on the lua stack — `luabb_error` pushes `nil` and an rc when a prepare fails — and `run_sp`'s `lua_pcall` needs the function to sit at `top - argcnt`. Counting before the clone would let that residue shift the function out from under the call; counting after it preserves the behavior from when the clone ran first, where the residue is harmlessly passed along as extra arguments.

## Testing

Server builds and links clean. Not yet confirmed against a debug-build run of `sp_snapshot_generated` — the failure is intermittent, so it needs repeated runs to call it verified.

## Noticed but not addressed here

- `clone_temp_tables` ignores the prepare rc. `lua_prepare_sql_int` only assigns `*pstmt` on success, so a failed prepare hands an uninitialized pointer to `clone_temp_table` and `sqlite3_finalize`, and the SP body then runs against a temp table that was never created.
- `drop_temp_tables` has the same modsnap exposure and cannot be fixed by ordering: `run_func` drops mid-statement, but `exec_thread` and `reset_sp` drop after the implicit transaction has committed, so there is no transaction left to inherit a snapshot from.
- `populate_modsnap_state` returns 0 on every failure path (`db/sqlinterfaces.c:1767-1770`), so the rc checks at `handle_sql_begin:1812` and `get_prepared_stmt:3415` can never fire.
- `clnt->in_sqlite_init` is set exactly where the assert fires (`db/sqlinterfaces.c:3307-3360`), and `sqlglue.c` exempts that phase everywhere else (`:4944`, `:5057`, `:5061`, `:5335`) but not at `:8380`. Worth deciding whether that assert should tolerate schema init — if it should, this whole class of failure collapses to a one-line change.
