### PR TITLE
Physrep skip truncation

### DIFF
--- a/bdb/phys_rep_lsn.c
+++ b/bdb/phys_rep_lsn.c
@@ -561,6 +561,129 @@ LOG_INFO find_match_lsn(void *in_bdb_state, cdb2_hndl_tp *repl_db, LOG_INFO star
     return info;
 }
 
+/*
+ * physrep_logged_gen_ahead --
+ *
+ * Returns 1 when we have applied commits from a newer source generation than
+ * our own cluster is running (rep->log_gen > rep->gen).  Applying a commit
+ * from a new source generation lifts only log_gen; rep->gen moves when the
+ * rewind's recovery replays the gen record and rep_start broadcasts the new
+ * generation to our replicants.  Until that happens we ignore their messages
+ * (rep_record.c gen check), so a rewind in this state is not a no-op.
+ */
+int physrep_logged_gen_ahead(void *in_bdb_state)
+{
+    bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
+    u_int32_t gen = 0, log_gen = 0;
+
+    bdb_state->dbenv->get_rep_gen(bdb_state->dbenv, &gen);
+    bdb_state->dbenv->get_rep_log_gen(bdb_state->dbenv, &log_gen);
+    return log_gen > gen;
+}
+
+/*
+ * physrep_find_last_match --
+ *
+ * Walk forward from find_match_lsn()'s anchor comparing both logs record for
+ * record.  Returns 0 if we agree through my_end (nothing to unwind), else 1.
+ * *last_match is the newest agreed record -- the furthest we may rewind to.
+ */
+int physrep_find_last_match(void *in_bdb_state, cdb2_hndl_tp *repl_db, LOG_INFO match_info, LOG_INFO my_end,
+                            LOG_INFO *last_match)
+{
+    bdb_state_type *bdb_state = (bdb_state_type *)in_bdb_state;
+    char sql_cmd[128];
+    DB_LOGC *logc = NULL;
+    DBT logrec = {0};
+    DB_LSN lsn;
+    int rc, diverged = 1, queried = 0;
+
+    *last_match = match_info;
+
+    /* Anchor is our end-of-log: nothing past it. */
+    if (match_info.file == my_end.file && match_info.offset == my_end.offset)
+        return 0;
+
+    if ((rc = bdb_state->dbenv->log_cursor(bdb_state->dbenv, &logc, 0)) != 0) {
+        physrep_logmsg(LOGMSG_ERROR, "%s: Can't get log cursor rc %d\n", __func__, rc);
+        return 1;
+    }
+
+    logrec.flags = DB_DBT_REALLOC;
+    lsn.file = match_info.file;
+    lsn.offset = match_info.offset;
+
+    if ((rc = logc->get(logc, &lsn, &logrec, DB_SET)) != 0) {
+        physrep_logmsg(LOGMSG_ERROR, "%s: Can't position at {%u:%u} rc %d\n", __func__, match_info.file,
+                       match_info.offset, rc);
+        goto done;
+    }
+
+    snprintf(sql_cmd, sizeof(sql_cmd), "select * from comdb2_transaction_logs('{%u:%u}','{%u:%u}', 0)", match_info.file,
+             match_info.offset, my_end.file, my_end.offset);
+
+    if ((rc = cdb2_run_statement(repl_db, sql_cmd)) != 0) {
+        physrep_logmsg(LOGMSG_ERROR, "%s: %s returns %d, '%s'\n", __func__, sql_cmd, rc, cdb2_errstr(repl_db));
+        goto done;
+    }
+    queried = 1;
+
+    /* Anchor was already compared; step the source past it. */
+    if ((rc = cdb2_next_record(repl_db)) != CDB2_OK)
+        goto done;
+
+    while ((rc = logc->get(logc, &lsn, &logrec, DB_NEXT)) == 0) {
+        unsigned int src_file, src_offset;
+        char *src_lsn;
+        void *blob;
+        int blob_len;
+        int64_t *gen;
+
+        /* Source ran out: we hold records it does not. */
+        if ((rc = cdb2_next_record(repl_db)) != CDB2_OK)
+            goto done;
+
+        src_lsn = (char *)cdb2_column_value(repl_db, 0);
+        if (!src_lsn || char_to_lsn(src_lsn, &src_file, &src_offset) != 0)
+            goto done;
+
+        if (src_file != lsn.file || src_offset != lsn.offset)
+            goto done;
+
+        blob = cdb2_column_value(repl_db, 4);
+        blob_len = cdb2_column_size(repl_db, 4);
+        if (compare_log(&logrec, blob, blob_len) != 0) {
+            if (gbl_physrep_debug) {
+                physrep_logmsg(LOGMSG_USER, "%s: diverged at {%u:%u}\n", __func__, lsn.file, lsn.offset);
+            }
+            goto done;
+        }
+
+        last_match->file = lsn.file;
+        last_match->offset = lsn.offset;
+        last_match->size = blob_len;
+        /* Only commits carry a gen; keep the newest seen. */
+        if ((gen = (int64_t *)cdb2_column_value(repl_db, 2)) != NULL)
+            last_match->gen = *gen;
+
+        if (lsn.file == my_end.file && lsn.offset == my_end.offset) {
+            diverged = 0;
+            goto done;
+        }
+    }
+
+done:
+    /* Drain: cdb2api disconnects rather than auto-consume a long result set. */
+    while (queried && cdb2_next_record(repl_db) == CDB2_OK)
+        ;
+    logc->close(logc, 0);
+    if (logrec.data) {
+        free(logrec.data);
+        logrec.data = NULL;
+    }
+    return diverged;
+}
+
 int physrep_bdb_wait_for_seqnum(bdb_state_type *bdb_state, DB_LSN *lsn, void *data) {
     u_int32_t rectype;
 

--- a/bdb/phys_rep_lsn.h
+++ b/bdb/phys_rep_lsn.h
@@ -6,6 +6,7 @@
 
 struct __db_env;
 struct bdb_state_tag;
+struct cdb2_hndl;
 
 #include <log_info.h>
 
@@ -32,5 +33,14 @@ int truncate_log_lock(struct bdb_state_tag *, unsigned int file,
                       unsigned int offset, uint32_t flags);
 int find_log_timestamp(struct bdb_state_tag *, time_t time, unsigned int *file,
                        unsigned int *offset);
+
+/* Best-effort probe: does the connected source cover our current log range?
+ * Returns 1 (covers), 0 (no overlap), or -1 (unknown/transient). */
+int physrep_source_covers_me(void *bdb_state, struct cdb2_hndl *repl_db);
+
+LOG_INFO find_match_lsn(void *bdb_state, struct cdb2_hndl *repl_db, LOG_INFO start_info);
+int physrep_find_last_match(void *bdb_state, struct cdb2_hndl *repl_db, LOG_INFO match_info, LOG_INFO my_end,
+                            LOG_INFO *last_match);
+int physrep_logged_gen_ahead(void *bdb_state);
 
 #endif

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -559,6 +559,7 @@ extern int gbl_physrep_filter_by_class;
 extern int gbl_physrep_pollms;
 extern int gbl_physrep_verify_source_range;
 extern int gbl_physrep_no_source_alarm_threshold;
+extern int gbl_physrep_skip_noop_truncation;
 
 /* source-name / host is from lrl */
 extern char *gbl_physrep_source_dbname;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1942,6 +1942,10 @@ REGISTER_TUNABLE("physrep_verify_source_range",
                  "Physrep verifies a candidate source's live log range covers its LSN before connecting. Schema-"
                  "independent (queries the source directly); no compatibility concerns. (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_physrep_verify_source_range, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("physrep_skip_noop_truncation",
+                 "Skip the physrep rewind when the source already matches our end-of-log, i.e. when there is nothing "
+                 "to unwind. (Default: on)",
+                 TUNABLE_BOOLEAN, &gbl_physrep_skip_noop_truncation, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_no_source_alarm_threshold",
                  "Consecutive no-viable-source registration cycles before physrep latches the "
                  "gbl_physrep_no_viable_source flag and logs 'PHYSREP NO VIABLE SOURCE'. (Default: 10)",

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -2021,6 +2021,13 @@ static int stop_physrep_watcher_thread() {
 
     stop_physrep_watcher = 1;
 
+    /* May be blocked in a cdb2 call to a dead metadb -- don't let the
+     * join outlive the exit stall alarm. */
+    if (db_is_exiting()) {
+        physrep_logmsg(LOGMSG_USER, "Exiting: abandoning the watcher thread\n");
+        return 0;
+    }
+
     if ((rc = pthread_join(physrep_watcher_thread, NULL)) != 0) {
         logmsg(LOGMSG_ERROR, "Watcher thread failed to join (rc : %d)\n", rc);
         return 1;

--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -1502,6 +1502,7 @@ static void *physrep_worker(void *args)
     size_t sql_cmd_len = 150;
     char sql_cmd[sql_cmd_len];
     int do_truncate = 0;
+    int source_gen_changed = 0;
     int rc;
     int now;
     int is_revconn = -1;
@@ -1693,7 +1694,7 @@ repl_loop:
                 close_repl_connection(repl_db_cnct, repl_db, __func__, __LINE__);
                 goto sleep_and_retry;
             }
-            prev_info = handle_truncation(repl_db, info);
+            prev_info = handle_truncation(repl_db, info, source_gen_changed);
             if (prev_info.file == 0) {
                 close_repl_connection(repl_db_cnct, repl_db, __func__, __LINE__);
                 goto sleep_and_retry;
@@ -1703,6 +1704,7 @@ repl_loop:
             if (gbl_physrep_debug)
                 physrep_logmsg(LOGMSG_USER, "%s: gen: %" PRId64 "\n", __func__, gen);
             do_truncate = 0;
+            source_gen_changed = 0;
         }
 
         if (repl_db_connected == 0)
@@ -1779,6 +1781,7 @@ repl_loop:
                 }
                 close_repl_connection(repl_db_cnct, repl_db, __func__, __LINE__);
                 do_truncate = 1;
+                source_gen_changed = 1;
                 highest_gen = new_gen;
                 goto repl_loop;
             }

--- a/db/reverse_conn.c
+++ b/db/reverse_conn.c
@@ -581,6 +581,13 @@ int stop_reverse_connections_manager() {
 
     stop_reverse_conn_manager = 1;
 
+    /* May be blocked in a cdb2 call to a dead metadb -- don't let the
+     * join outlive the exit stall alarm. */
+    if (db_is_exiting()) {
+        revconn_logmsg(LOGMSG_USER, "Exiting: abandoning the reverse connections manager thread\n");
+        return 0;
+    }
+
     if ((rc = pthread_join(reverse_conn_manager, NULL)) != 0) {
         revconn_logmsg(LOGMSG_ERROR, "Reverse connections manager thread failed to join (rc : %d)\n", rc);
         return 1;

--- a/db/truncate_log.c
+++ b/db/truncate_log.c
@@ -9,10 +9,10 @@
 extern int gbl_physrep_debug;
 extern struct dbenv *thedb;
 
-LOG_INFO find_match_lsn(void *bdb_state, cdb2_hndl_tp *repl_db,
-                        LOG_INFO start_info);
-
 static pthread_mutex_t physrep_truncate_lock = PTHREAD_MUTEX_INITIALIZER;
+
+/* Skip the rewind when the source already agrees with our end-of-log. */
+int gbl_physrep_skip_noop_truncation = 1;
 
 int truncate_trylock(void)
 {
@@ -24,7 +24,7 @@ void truncate_unlock(void)
     Pthread_mutex_unlock(&physrep_truncate_lock);
 }
 
-LOG_INFO handle_truncation(cdb2_hndl_tp *repl_db, LOG_INFO latest_info)
+LOG_INFO handle_truncation(cdb2_hndl_tp *repl_db, LOG_INFO latest_info, int source_gen_changed)
 {
     LOG_INFO match_lsn = find_match_lsn(thedb->bdb_env, repl_db, latest_info);
 
@@ -32,6 +32,32 @@ LOG_INFO handle_truncation(cdb2_hndl_tp *repl_db, LOG_INFO latest_info)
         if (gbl_physrep_debug)
             logmsg(LOGMSG_USER, "%s: unable to find match-lsn\n", __func__);
         return match_lsn;
+    }
+
+    /* Only the rewind's recovery + rep_start lift rep->gen and broadcast a new
+     * source generation to our replicants; until then we ignore their messages
+     * and they sit at their current LSN.  A standalone physrep has none, so the
+     * skew is harmless.  The worker flags the gen change before applying the
+     * record that carries it, so logged-gen is not ahead yet -- check both. */
+    int clustered = (thedb->nsiblings > 1);
+    int rewind_for_gen = clustered && (source_gen_changed || physrep_logged_gen_ahead(thedb->bdb_env));
+
+    /* The anchor is only the last commit; the tail past it normally matches the
+     * source too.  Compare forward: a full match means nothing to unwind, and a
+     * needless rewind takes the write lock, runs recovery, and bumps
+     * log_cursor_gen -- cascading a truncation to every tier below us.  On
+     * divergence rewind to the newest agreed record, at worst the anchor. */
+    if (gbl_physrep_skip_noop_truncation && !rewind_for_gen) {
+        LOG_INFO last_match;
+        if (physrep_find_last_match(thedb->bdb_env, repl_db, match_lsn, latest_info, &last_match) == 0) {
+            logmsg(LOGMSG_USER, "%s: log matches source through my end-of-log {%u:%u}, skipping truncation\n", __func__,
+                   last_match.file, last_match.offset);
+            return last_match;
+        }
+        match_lsn = last_match;
+    } else if (gbl_physrep_skip_noop_truncation) {
+        logmsg(LOGMSG_USER, "%s: %s, rewinding to move my cluster to the new generation\n", __func__,
+               source_gen_changed ? "source generation changed" : "log_gen ahead of rep-gen");
     }
 
     if (gbl_physrep_debug) {

--- a/db/truncate_log.h
+++ b/db/truncate_log.h
@@ -9,10 +9,6 @@ int truncate_log(unsigned int file, unsigned int offset, uint32_t flags);
 int truncate_timestamp(time_t timestamp);
 int truncate_trylock(void);
 void truncate_unlock(void);
-LOG_INFO handle_truncation(cdb2_hndl_tp *repl_db, LOG_INFO prev_info);
-
-/* Best-effort probe: does the connected source cover our current log range?
- * Returns 1 (covers), 0 (no overlap), or -1 (unknown/transient). */
-int physrep_source_covers_me(void *bdb_state, cdb2_hndl_tp *repl_db);
+LOG_INFO handle_truncation(cdb2_hndl_tp *repl_db, LOG_INFO prev_info, int source_gen_changed);
 
 #endif

--- a/tests/phys_rep_tiered.test/runit
+++ b/tests/phys_rep_tiered.test/runit
@@ -1185,6 +1185,9 @@ function run_generated_tests()
         while [[ $rc != 0 && $cnt -lt 10 ]] ; do
             echo "Result not matching, retrying $cnt"
             sleep 5
+            # Refetch the source too: a replicant read mid-truncate_time
+            # serves the pre-truncate state, and never converges otherwise.
+            ${CDB2SQL_EXE} -s --tabs --maxretries=100000 -v -f $query_cmd ${CDB2_OPTIONS} $dbname default 2> src.err > src.out
             ${CDB2SQL_EXE} -s --tabs -f $query_cmd ${REPL_CLUS_DBNAME} --host ${REPL_CLUS_HOST} 2> dest.err > dest.out
             diff src.out dest.out
             rc=$?
@@ -2187,19 +2190,186 @@ function phys_rep_verify_tunable_defaults
 {
     echo "== phys_rep_verify_tunable_defaults =="
     local q="select value from comdb2_tunables where name="
-    local vsr ka2 thr
+    local vsr ka2 thr snt
     vsr=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "${q}'physrep_verify_source_range'")
     ka2=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "${q}'physrep_keepalive_v2'")
     thr=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "${q}'physrep_no_source_alarm_threshold'")
-    echo "verify_source_range=$vsr keepalive_v2=$ka2 no_source_alarm_threshold=$thr FIRSTFILE=$FIRSTFILE"
+    snt=$($CDB2SQL_EXE --tabs $CDB2_OPTIONS $DBNAME default "${q}'physrep_skip_noop_truncation'")
+    echo "verify_source_range=$vsr keepalive_v2=$ka2 no_source_alarm_threshold=$thr skip_noop_truncation=$snt FIRSTFILE=$FIRSTFILE"
     [[ "$vsr" == "ON" ]] || cleanFailExit "physrep_verify_source_range should default ON (got '$vsr')"
     [[ "$thr" == "10" ]] || cleanFailExit "physrep_no_source_alarm_threshold should default 10 (got '$thr')"
+    [[ "$snt" == "ON" ]] || cleanFailExit "physrep_skip_noop_truncation should default ON (got '$snt')"
     if [[ "$FIRSTFILE" == "1" ]]; then
         [[ "$ka2" == "ON" ]] || cleanFailExit "physrep_keepalive_v2 should be ON in firstfile variant (got '$ka2')"
     else
         [[ "$ka2" == "OFF" ]] || cleanFailExit "physrep_keepalive_v2 should default OFF (got '$ka2')"
     fi
     return 0
+}
+
+# A re-registering physrep rewinds unconditionally, but it is normally a
+# byte-exact prefix of its source and has nothing to unwind.  Re-register
+# under write load, so the end-of-log sits mid-stream past the last commit --
+# the case only the forward compare catches -- and verify we log the skip and
+# leave log_cursor_gen (which every tier below watches) alone.
+function physrep_skip_noop_truncation_test
+{
+    echo "== physrep_skip_noop_truncation_test =="
+    local skipmsg="skipping truncation"
+    local lcq="select logcgen from comdb2_transaction_logs(NULL, NULL, 0x8) limit 1"
+    local rewindmsg="Rewind to lsn"
+    local name logFile before after gen_before gen_after x cnt rw_before rw_after tries
+    local stopfile=$TESTDIR/ckskipnoop.stop.$$
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table if not exists ckskipnoop(a int)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into ckskipnoop select * from generate_series(1, 100)"
+
+    # Catch up before the writer starts -- after that the count moves.
+    for node in $CLUSTER ; do
+        name="${REPL_DBNAME_PREFIX}_${node}"
+        cnt=0
+        x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckskipnoop" 2>/dev/null)
+        while [[ "$x" != "100" ]]; do
+            sleep 1
+            let cnt=cnt+1
+            if [[ $cnt -gt 60 ]]; then
+                cleanFailExit "$name on $node never caught up (count='$x')"
+            fi
+            x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckskipnoop" 2>/dev/null)
+        done
+        echo "$name on $node has caught up"
+    done
+
+    # Keep the log advancing so each physrep re-registers with a non-commit
+    # record at its end-of-log.
+    rm -f $stopfile
+    (
+        while [[ ! -f $stopfile ]]; do
+            $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default \
+                "insert into ckskipnoop select * from generate_series(1, 50)" >/dev/null 2>&1
+            sleep 1
+        done
+    ) &
+    local writerpid=$!
+
+    for node in $CLUSTER ; do
+        name="${REPL_DBNAME_PREFIX}_${node}"
+        logFile=$TESTDIR/logs/${name}.log
+
+        # Re-registration may land on a source behind our end-of-log (tiers
+        # chase the same log at different offsets); that legitimately trims to
+        # the anchor and bumps logcgen.  Only a skip with no interleaved
+        # rewind must hold logcgen; retry until we observe one.
+        tries=0
+        while : ; do
+            before=$(egrep "$skipmsg" $logFile | wc -l)
+            rw_before=$(egrep "$rewindmsg" $logFile | wc -l)
+            gen_before=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "$lcq")
+            echo "Forcing re-registration on $name@$node (skips=$before rewinds=$rw_before logcgen=$gen_before)"
+            $CDB2SQL_EXE --admin ${CDB2_OPTIONS} --host $node $name "exec procedure sys.cmd.send('physrep_force_registration')"
+
+            # Wait for either outcome -- a pure rewind must reach the retry
+            # below, not time out here.
+            cnt=0
+            after=$before
+            rw_after=$rw_before
+            while [[ "$after" == "$before" && "$rw_after" == "$rw_before" ]]; do
+                sleep 1
+                let cnt=cnt+1
+                if [[ $cnt -gt 60 ]]; then
+                    touch $stopfile
+                    cleanFailExit "$name on $node neither skipped nor rewound after re-registration"
+                fi
+                after=$(egrep "$skipmsg" $logFile | wc -l)
+                rw_after=$(egrep "$rewindmsg" $logFile | wc -l)
+            done
+
+            # Skipped means __log_vtruncate() never ran, so logcgen must hold.
+            gen_after=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "$lcq")
+            # Re-sample rewinds after reading logcgen: a rewind landing between
+            # the loop's last sample and the query must retry, not fail below.
+            rw_after=$(egrep "$rewindmsg" $logFile | wc -l)
+            if [[ "$rw_after" != "$rw_before" ]]; then
+                let tries=tries+1
+                if [[ $tries -gt 5 ]]; then
+                    touch $stopfile
+                    cleanFailExit "$name on $node rewound across $tries re-registrations"
+                fi
+                echo "$name on $node rewound mid-check (source switch), retrying"
+                continue
+            fi
+            if [[ "$gen_after" != "$gen_before" ]]; then
+                touch $stopfile
+                cleanFailExit "$name on $node bumped logcgen ($gen_before -> $gen_after) despite skipping the rewind"
+            fi
+            echo "$name on $node skipped the no-op rewind, logcgen held at $gen_after"
+            break
+        done
+    done
+
+    touch $stopfile
+    wait $writerpid 2>/dev/null
+    rm -f $stopfile
+}
+
+# A clustered physrep must not skip while log_gen is ahead of rep->gen: only the
+# rewind lifts rep->gen and lets its own replicants move again.  Bump the source
+# generation, then check every node of the physrep cluster still advances.
+function physrep_gen_guard_test
+{
+    echo "== physrep_gen_guard_test =="
+    local name="${REPL_CLUS_DBNAME}"
+    local rw_before rw_after x cnt
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "create table if not exists ckgenguard(a int)"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into ckgenguard select * from generate_series(1, 100)"
+
+    for node in $CLUSTER ; do
+        cnt=0
+        x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckgenguard" 2>/dev/null)
+        while [[ "$x" != "100" ]]; do
+            sleep 1
+            let cnt=cnt+1
+            if [[ $cnt -gt 60 ]]; then
+                cleanFailExit "$name on $node never caught up (count='$x')"
+            fi
+            x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckgenguard" 2>/dev/null)
+        done
+    done
+
+    rw_before=0
+    for node in $CLUSTER ; do
+        let rw_before=rw_before+$(egrep "Rewind to lsn" $TESTDIR/logs/${name}.${node}.log | wc -l)
+    done
+
+    # New source generation: the physrep sees a higher rec-gen and re-truncates.
+    downgradeonce $DBNAME
+    sleep 10
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into ckgenguard select * from generate_series(1, 100)"
+
+    # The whole physrep cluster must reach 200, not just its master.
+    for node in $CLUSTER ; do
+        cnt=0
+        x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckgenguard" 2>/dev/null)
+        while [[ "$x" != "200" ]]; do
+            sleep 1
+            let cnt=cnt+1
+            if [[ $cnt -gt 120 ]]; then
+                cleanFailExit "$name on $node stalled at '$x' after the source changed generation"
+            fi
+            x=$($CDB2SQL_EXE --tabs ${CDB2_OPTIONS} --host $node $name "select count(*) from ckgenguard" 2>/dev/null)
+        done
+        echo "$name on $node advanced past the generation change"
+    done
+
+    rw_after=0
+    for node in $CLUSTER ; do
+        let rw_after=rw_after+$(egrep "Rewind to lsn" $TESTDIR/logs/${name}.${node}.log | wc -l)
+    done
+    if [[ "$rw_after" == "$rw_before" ]]; then
+        cleanFailExit "$name skipped the rewind across a generation change (rewinds=$rw_after)"
+    fi
+    echo "$name rewound across the generation change ($rw_before -> $rw_after)"
 }
 
 # DRQS 185276960: exercise the production rollout end to end, in the order it will
@@ -3380,6 +3550,18 @@ function run_tests
     testcase="phys_rep_verify_tunable_defaults"
     testcase_preamble $testcase
     phys_rep_verify_tunable_defaults
+    testcase_finish $testcase
+
+    # Run before verify_log_cursor_gen, which downgrades the source master and
+    # so provokes real (non-skippable) truncations.
+    testcase="physrep_skip_noop_truncation_test"
+    testcase_preamble $testcase
+    physrep_skip_noop_truncation_test
+    testcase_finish $testcase
+
+    testcase="physrep_gen_guard_test"
+    testcase_preamble $testcase
+    physrep_gen_guard_test
     testcase_finish $testcase
 
     testcase="tranlog_timeout"

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -775,6 +775,7 @@
 (name='physrep_repl_name', description='Current physrep parent.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_revconn_check_interval', description='Physrep recheck revconn interval.  (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_shuffle_host_list', description='Shuffle the host list returned by register_replicant() before connecting to the hosts. (Default: OFF)', type='BOOLEAN', value='OFF', read_only='N')
+(name='physrep_skip_noop_truncation', description='Skip the physrep rewind when the source already matches our end-of-log, i.e. when there is nothing to unwind. (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='physrep_slow_replicant_check_freq_sec', description='Check for slow physical replicant this often. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_source_dbname', description='Physical replication source cluster dbname.', type='STRING', value=NULL, read_only='Y')
 (name='physrep_source_dbnum', description='Physical replication source cluster db number.', type='INTEGER', value='0', read_only='Y')


### PR DESCRIPTION
Physreps truncate unconditionally on every re-registration, even when the log is already a byte-exact prefix of the source's, because find_match_lsn() anchors on the last commit and treats a trailing partial transaction as divergence. physrep_find_last_match() now walks forward from that anchor comparing records, skipping the rewind when we match through our end-of-log.

Gated on physrep_skip_noop_truncation, default on. Tested via phys_rep_tiered, which forces mid-transaction re-registration and asserts the skip is logged.
