### PR TITLE
{185403658} bdb: Don't write the record when packing fails

### DIFF
--- a/bdb/ll.c
+++ b/bdb/ll.c
@@ -1102,6 +1102,29 @@ static int ll_dta_upd_int(bdb_state_type *bdb_state, int rrn,
             rc = bdb_prepare_put_pack_updateid(bdb_state, is_blob, dta,
                                                &packeddta, -1, &freedtaptr,
                                                formatted_record, odhready);
+            if (rc != 0) {
+                /* packeddta still aliases the caller's unpacked record.  Writing
+                 * it would store a record with no ODH, and poke_updateid() below
+                 * would stamp the updateid over the first bytes of the payload.
+                 * Fail the update instead. */
+                logmsg(LOGMSG_ERROR, "%s: bdb_prepare_put_pack_updateid rc %d for %u bytes\n", __func__, rc,
+                       (unsigned)dta->size);
+                if (malloceddta)
+                    free(malloceddta);
+                if (old_dta_out)
+                    old_dta_out->data = NULL;
+                if (freeptr)
+                    free(freeptr);
+                if (freedtaptr)
+                    free(freedtaptr);
+                if (formatted_record_needsfree)
+                    free(formatted_record);
+                crc = dbcp->c_close(dbcp);
+                dbcp = NULL;
+                if (crc == DB_LOCK_DEADLOCK)
+                    rc = DB_LOCK_DEADLOCK;
+                goto done;
+            }
             recptr = packeddta.data;
             formatted_record_len = packeddta.size;
 

--- a/bdb/odh.c
+++ b/bdb/odh.c
@@ -43,6 +43,7 @@
 
 #include "compress.h"
 #include <zlib.h>
+
 #include <comdb2rle.h>
 
 #include <lz4.h>
@@ -52,6 +53,7 @@
 #define LZ4_compress_default LZ4_compress_limitedOutput
 #endif
 
+extern int gbl_debug_pack_fail_size;
 
 static void read_odh(const void *buf, struct odh *odh);
 static void write_odh(void *buf, const struct odh *odh, uint8_t flags);
@@ -302,6 +304,11 @@ int bdb_pack(bdb_state_type *bdb_state, const struct odh *odh, void *to,
     int rc;
 
     *freeptr = NULL;
+
+    if (gbl_debug_pack_fail_size > 0 && odh->length >= gbl_debug_pack_fail_size) {
+        logmsg(LOGMSG_ERROR, "%s: failing pack of %u bytes (debug.pack_fail_size)\n", __func__, (unsigned)odh->length);
+        return ENOMEM;
+    }
 
     if (bdb_state->ondisk_header) {
         void *mallocmem = NULL;

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -371,6 +371,7 @@ static int gbl_db_is_exiting = 0; /* Indicates this process is exiting */
 int gbl_debug_omit_dta_write;
 int gbl_debug_omit_idx_write;
 int gbl_debug_omit_blob_write;
+int gbl_debug_pack_fail_size;
 int gbl_debug_omit_zap_on_rebuild = 0;
 int gbl_debug_txn_sleep = 0;
 int gbl_debug_skip_constraintscheck_on_insert;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -480,6 +480,7 @@ extern int gbl_debug_alter_sequences_sleep;
 extern int gbl_debug_omit_dta_write;
 extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_omit_blob_write;
+extern int gbl_debug_pack_fail_size;
 extern int gbl_debug_skip_constraintscheck_on_insert;
 extern int gbl_debug_pb_connectmsg_dbname_check;
 extern int gbl_debug_pb_connectmsg_physrep_check;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1372,6 +1372,10 @@ REGISTER_TUNABLE("debug.omit_idx_write", "Deliberately corrupt insertion randoml
                  &gbl_debug_omit_idx_write, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.omit_blob_write", "Deliberately corrupt insertion randomly to debug db_verify", TUNABLE_BOOLEAN,
                  &gbl_debug_omit_blob_write, INTERNAL, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("debug.pack_fail_size",
+                 "Make bdb_pack() fail for records of at least this many bytes, as if the allocation had failed. "
+                 "0 disables. (Default: 0)",
+                 TUNABLE_INTEGER, &gbl_debug_pack_fail_size, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.skip_constraintscheck_on_insert",
                  "Deliberately allow insertion without constraint check to debug db_verify", TUNABLE_BOOLEAN,
                  &gbl_debug_skip_constraintscheck_on_insert, INTERNAL, NULL, NULL, NULL, NULL);

--- a/tests/odh_pack_fail.test/Makefile
+++ b/tests/odh_pack_fail.test/Makefile
@@ -1,0 +1,5 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif

--- a/tests/odh_pack_fail.test/runit
+++ b/tests/odh_pack_fail.test/runit
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+[ "x$dbnm" == "x" ] && failexit "need a DB name"
+
+# Records at or above this size fail to pack.  The blob below is bigger; the
+# ondisk data record, the keys and everything the database writes for its own
+# bookkeeping are all smaller, so only the blob write is affected.
+threshold=8000
+blobsz=10000
+
+# The tunable has to be set everywhere, not just on the master.  The replicant
+# packs the blob first, and if that succeeds it sets OSQL_BLOB_ODH_BIT and the
+# master passes the payload through without ever calling bdb_pack().  Both packs
+# have to fail to reach the bug.
+packfail()
+{
+    if [ -n "$CLUSTER" ]; then
+        for node in $CLUSTER; do
+            cdb2sql ${CDB2_OPTIONS} $dbnm --host $node "put tunable 'debug.pack_fail_size' $1" \
+                || failexit "could not set debug.pack_fail_size on $node"
+        done
+    else
+        cdb2sql ${CDB2_OPTIONS} $dbnm default "put tunable 'debug.pack_fail_size' $1" \
+            || failexit "could not set debug.pack_fail_size"
+    fi
+}
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t(id int primary key, b blob)" \
+    || failexit "create table failed"
+
+# 0x30 has no compression bits set, so a header read out of this payload lands
+# in bdb_unpack_updateid()'s uncompressed branch -- the same one production hit.
+old=$(printf '3080%.0s' $(seq $blobsz))
+new=$(printf '4090%.0s' $(seq $blobsz))
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t values(1, x'$old')" \
+    || failexit "insert failed"
+
+# osql_odh_blob is left at its default.  The replicant tries to pack the blob
+# first (odhfy_blob_buffer -> bdb_pack_heap); that allocation fails too, so it
+# clears the ODH bit and ships the payload raw, and the master packs it itself.
+# There bdb_prepare_put_pack_updateid() leaves the DBT aliasing the unpacked
+# payload; writing it stores a blob with no ODH, and poke_updateid() then stamps
+# the updateid over the first bytes of the payload.  Nothing reads the blob back
+# before commit, so the corruption survives.  The update must fail instead.
+packfail $threshold
+cdb2sql ${CDB2_OPTIONS} $dbnm default "update t set b = x'$new' where id = 1"
+rc=$?
+packfail 0
+
+# Check the damage before checking the return code -- if the update wrongly
+# succeeded, the verify output names the corrupt genid and is far more use than
+# "update succeeded".
+cdb2sql ${CDB2_OPTIONS} $dbnm default "exec procedure sys.cmd.verify('t')" > verify.out 2>&1
+grep -q "Verify succeeded" verify.out || failexit "verify failed: $(cat verify.out)"
+
+# The blob must still be readable and still hold the original value.
+got=$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default "select quote(b) from t where id = 1")
+want="X'$(echo $old | tr '[:lower:]' '[:upper:]')'"
+[ "$got" == "$want" ] || failexit "blob was modified: ${#got} bytes"
+
+[ $rc -eq 0 ] && failexit "update succeeded while packing was failing"
+
+echo "Success"


### PR DESCRIPTION
### 🎯 The "Why" (Intent)

- There's no return code check for `bdb_prepare_put_pack_updateid`, so an update whose record fails to pack is written to disk anyway, with no ODH. `poke_updateid()` then stamps the updateid over the first bytes of the payload, so the row reads back as `Ondisk header corrupt` (-40000) and can never be read again.

### 🛠️ The "What" (Critical Changes)

- `ll_dta_upd_int()` now checks the return of `bdb_prepare_put_pack_updateid()`. On failure that DBT still aliases the caller's unpacked record, so the update aborts rather than writing it.
- New `debug.pack_fail_size` tunable forces the allocation failure; the `odh_pack_fail` test corrupts the row without the check and passes with it. It runs with `osql_odh_blob` at its default, so it follows the production path — the replicant's pack fails first and it ships the blob unpacked, then the master's pack fails too.