### PR TITLE
physrep: abandon metadb connect retries on exit

### DIFF
--- a/db/phys_rep.c
+++ b/db/phys_rep.c
@@ -457,6 +457,8 @@ static int get_metadb_handle_int(cdb2_hndl_tp **hndl, char *dbname, char *host, 
 
         int max_connect_attempts = 10 * (*host_count);
         for (int i = 0; i < max_connect_attempts; ++i) {
+            if (db_is_exiting())
+                break;
             char *direct_host = (*hosts)[*host_index];
 
             // Move to the next host for the next attempt


### PR DESCRIPTION
`get_metadb_handle_int()` retries `10 * host_count` times against a down metadb, a second apart plus connect timeouts each. If shutdown starts mid-retry, the reverse-connection manager is stuck in there, `stop_reverse_connections_manager()` blocks joining it, and the exit alarm cores us instead. Break out of the retry loop when `db_is_exiting()`.