### PR TITLE
Retro resume fix

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -622,6 +622,7 @@ extern int gbl_partition_sc_reorder;
 extern int gbl_retro_tpt;
 extern int gbl_retro_tpt_verbose;
 extern int gbl_retro_tpt_start;
+extern int gbl_debug_retro_resume_fail_shard;
 extern int gbl_legacy_tpt;
 extern int gbl_dohsql_joins;
 extern int gbl_altersc_latency;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2644,6 +2644,10 @@ REGISTER_TUNABLE(
     "partition_retroactively_start",
     "Block any retroactively time partitioning if start is earlier that that many hours in the future (Default: 24)",
     TUNABLE_INTEGER, &gbl_retro_tpt_start, 0, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("debug_retro_resume_fail_shard",
+                 "Test only: fail reopening a shard while resuming a retroactively time partitioning, to exercise the "
+                 "schema change unwind (Default: OFF)",
+                 TUNABLE_BOOLEAN, &gbl_debug_retro_resume_fail_shard, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("dohsql_joins", "Enable to support joins in parallel sql execution (default: on)", TUNABLE_BOOLEAN,
                  &gbl_dohsql_joins, 0, NULL, NULL, NULL, NULL);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1592,6 +1592,11 @@ void *resume_sc_multiddl_txn_finalize(void *p)
     osql_postcommit_handle(iq);
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE);
 
+    /* the callback above freed every schema change and cleared sc_pending,
+     * so nothing refers to this fake ireq anymore
+     */
+    free(iq);
+
     return NULL;
 
 abort_sc:
@@ -1614,6 +1619,11 @@ abort_sc:
 
     osql_postabort_handle(iq);
     bdb_thread_event(thedb->bdb_env, BDBTHR_EVENT_DONE);
+
+    /* same as the commit path: the abort callback freed the schema changes,
+     * this fake ireq is ours to release
+     */
+    free(iq);
 
     return NULL;
 }
@@ -1669,10 +1679,16 @@ int resume_sc_multiddl_txn(sc_list_t *scl)
      *
      */
     rc = bplog_schemachange_run(iq, scl->uuid, &scs);
-    if (rc) {
+    if (rc && !iq->sc_pending) {
+        /* nothing got started, there is nothing to unwind */
+        logmsg(LOGMSG_ERROR, "%s uuid %s failed to start, rc %d\n", __func__, us, rc);
         free(iq);
         return -1;
     }
+    /* if some of them did start, the finalize thread has to run: it checks
+     * sc_rc for each schema change and backs the whole set out.  Return 0 so
+     * that the remaining sc lists still get resumed.
+     */
 
     pthread_t tid;
     Pthread_create(&tid, &gbl_pthread_attr_detached,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -6041,10 +6041,14 @@ int dbtable_get_highest_genid(struct dbtable *table, unsigned long long *genids)
         if (rc == IX_FND)
             logmsg(LOGMSG_INFO, "%s: LOOKING FOR %s STRIPE %d found genid %llx (%lld)\n", __func__, table->tablename, i,
                    genids[i], genids[i]);
-        else if (rc == 1)
+        else if (rc == 1) {
+            /* nothing in this stripe: say so explicitly rather than relying on
+             * the caller having zeroed the array
+             */
+            genids[i] = 0ULL;
             logmsg(LOGMSG_INFO, "%s: LOOKING FOR %s STRIPE %d empty stripe, genid will be 0\n", __func__,
                    table->tablename, i);
-        else if (rc < 0 || bdberr != BDBERR_NOERROR) {
+        } else if (rc < 0 || bdberr != BDBERR_NOERROR) {
             return -1;
         }
     }
@@ -6418,6 +6422,7 @@ static int _process_partitioning_retro(timepart_sc_arg_t *arg)
     struct errstat err = {0};
     int rc = 0;
     int ii;
+    int attached = 0; /* set once the table owns retros */
 
     /* determine retroactive time boundaries for the shards */
     int len = sizeof(struct timepart_retro) +
@@ -6436,6 +6441,11 @@ static int _process_partitioning_retro(timepart_sc_arg_t *arg)
                                                 sc->partition.u.tpt.retention * sizeof(int));
     retros->cs = (timepart_retro_ctr_t *)((char *)retros + sizeof(struct timepart_retro) +
                                           sc->partition.u.tpt.retention * (sizeof(int) + sizeof(int *)));
+    /* set n before initializing the mutexes: timepart_retro_free() uses it to
+     * know how many to destroy, and we can fail before
+     * timepart_populate_timelimits() gets to set it to the same value
+     */
+    retros->n = sc->partition.u.tpt.retention;
     for (ii = 0; ii < sc->partition.u.tpt.retention; ii++) {
         pthread_mutex_init(&retros->cs[ii].mtx, 0);
     }
@@ -6471,19 +6481,11 @@ static int _process_partitioning_retro(timepart_sc_arg_t *arg)
     }
     retros->ss[sc->partition.u.tpt.retention - 1] = arg->s;
 
-    /* set the maximum genid for each stripe */
-    for (int stripe = 0; stripe < sc->newdb->dtastripe; stripe++) {
-        for (ii = 0; ii < sc->partition.u.tpt.retention; ii++) {
-            unsigned long long genid = retros->cs[ii].resume_genids[stripe];
-            if (genid > retros->resume_genids[stripe]) {
-                logmsg(LOGMSG_INFO,
-                       "%s: increased stripe %d resume genid from %llx (%lld) to %llx (%lld) per shard %s\n", __func__,
-                       stripe, retros->resume_genids[stripe], retros->resume_genids[stripe], genid, genid,
-                       sc->tablename);
-                retros->resume_genids[stripe] = genid;
-            }
-        }
-    }
+    /* NOTE: the per shard cs[].resume_genids collected above are consumed by
+     * do_alter_table(), which maxes them into the existing table's sc_genids
+     * so that a resume does not redo rows the previous master already
+     * distributed
+     */
 
     /* alter existing shard */
     arg->indx = 0;
@@ -6492,8 +6494,10 @@ static int _process_partitioning_retro(timepart_sc_arg_t *arg)
     sc = arg->s;
     sc->kind = SC_ALTERTABLE;
     struct dbtable *db = get_dbtable_by_name(arg->part_name);
+    /* from here on the table owns retros, live_sc_off() frees it */
     db->sharding_arg = retros;
     db->sharding_func = timepart_retro_route;
+    attached = 1;
     sc->newpartition = newpartition;
     sc->force_rebuild = 1;
     /* run this async, this can be in upgrade thread */
@@ -6517,7 +6521,15 @@ static int _process_partitioning_retro(timepart_sc_arg_t *arg)
         goto err;
     }
 err:
-    return 0;
+    if (!attached) {
+        /* the table never took ownership, nothing else is going to free it */
+        timepart_retro_free(&arg->retros);
+    }
+    /* rc is 0 when we get here from the success path; the failures above all
+     * set it, and the caller has to see them: schema changes that never got
+     * started leave nothing behind for bplog_schemachange_wait to notice
+     */
+    return rc;
 }
 
 static struct schema_change_type* _create_logical_cron_systable(const char *tblname);

--- a/db/views.c
+++ b/db/views.c
@@ -447,6 +447,27 @@ void timepart_free_view(timepart_view_t *view)
 }
 
 /**
+ * Free the retroactive partitioning routing object and clear the caller's
+ * reference; the limits, ss and cs arrays are carved out of the same
+ * allocation, only the per shard mutexes need to be destroyed first
+ *
+ */
+void timepart_retro_free(timepart_retro_t **pretros)
+{
+    timepart_retro_t *retros = *pretros;
+
+    if (!retros)
+        return;
+
+    for (int i = 0; i < retros->n; i++) {
+        Pthread_mutex_destroy(&retros->cs[i].mtx);
+    }
+
+    free(retros);
+    *pretros = NULL;
+}
+
+/**
  * Delete partime view
  *
  * NOTE: the tables are not affected, but the sqlite engines will

--- a/db/views.h
+++ b/db/views.h
@@ -85,7 +85,6 @@ typedef struct timepart_retro {
     int *limits;
     struct schema_change_type **ss;
     timepart_retro_ctr_t *cs;
-    unsigned long long resume_genids[MAXDTASTRIPE];
 } timepart_retro_t;
 
 enum shard_pos { /* keep them bits */
@@ -435,6 +434,12 @@ int timepart_populate_shards(timepart_view_t *view, int retro_partition, struct 
  *
  */
 int timepart_populate_timelimits(timepart_view_t *view, timepart_retro_t *retros, struct errstat *err);
+
+/**
+ * Free a retroactive partitioning routing object and clear the reference
+ *
+ */
+void timepart_retro_free(timepart_retro_t **pretros);
 
 /**
  * Create partition llmeta entry

--- a/schemachange/sc_add_table.c
+++ b/schemachange/sc_add_table.c
@@ -130,7 +130,14 @@ int add_table_to_environment(char *table, const char *csc2,
 
     if (s && s->resume && s->partition.type == PARTITION_ADD_TIMED_RETRO) {
         /* this is adding a shard, we need to try to open an existing shard, which may have data */
-        if ((rc = open_temp_db_resume(newdb, newdb->tablename, s->resume))) {
+        if (gbl_debug_retro_resume_fail_shard) {
+            logmsg(LOGMSG_WARN, "%s: failing shard %s, debug_retro_resume_fail_shard is set\n", __func__,
+                   newdb->tablename);
+            rc = -1;
+        } else {
+            rc = open_temp_db_resume(newdb, newdb->tablename, s->resume);
+        }
+        if (rc) {
             sc_errf(s, "Failed to open shard %s\n", newdb->tablename);
             reqerrstr(iq, ERR_SC, "Failed to open shard %s\n", newdb->tablename);
         }

--- a/schemachange/sc_alter_table.c
+++ b/schemachange/sc_alter_table.c
@@ -600,10 +600,26 @@ int do_alter_table(struct ireq *iq, struct schema_change_type *s,
 
     if (s->resume && s->partition.type == PARTITION_ADD_TIMED_RETRO) {
         /* we have more shards here where we put data,
-         * update newdb->sc_genids with the max of all shard stripes
+         * update db->sc_genids with the max of all shard stripes
          */
-        assert(db->sharding_arg);
-        assert(db->sharding_func);
+        if (!db->sharding_arg || !db->sharding_func) {
+            /* the shard routing is built by _process_partitioning_retro(),
+             * which only runs on the multiddl resume path; without it we
+             * would rebuild the table instead of partitioning it
+             */
+            sc_errf(s,
+                    "Cannot resume retroactive partitioning of %s, shard "
+                    "routing is missing (multitable_ddl not set?)\n",
+                    s->tablename);
+            logmsg(LOGMSG_ERROR,
+                   "%s: no shard routing to resume retroactive partitioning "
+                   "of %s, multitable_ddl not set?\n",
+                   __func__, s->tablename);
+            delete_temp_table(iq, newdb);
+            change_schemas_recover(s->tablename);
+            decrement_sc_yet_to_resume_counter();
+            return -1;
+        }
         for (i = 0; i < newdb->dtastripe; i++) {
             for (int shard = 0; shard < db->sharding_arg->n - 1; shard++) {
                 if (db->sc_genids[i] < db->sharding_arg->cs[shard].resume_genids[i]) {

--- a/schemachange/sc_callbacks.h
+++ b/schemachange/sc_callbacks.h
@@ -26,6 +26,8 @@ int is_genid_right_of_stripe_pointer(bdb_state_type *bdb_state,
 unsigned long long get_genid_stripe_pointer(unsigned long long genid,
                                             unsigned long long *sc_genids);
 
+struct dbtable *_distribute_rows(struct dbtable *usedb, struct dbtable *usedb_new, unsigned long long genid);
+
 int live_sc_post_del_record(struct ireq *iq, void *trans,
                             unsigned long long genid, const void *old_dta,
                             unsigned long long del_keys,

--- a/schemachange/sc_global.c
+++ b/schemachange/sc_global.c
@@ -16,6 +16,8 @@
 
 #include <unistd.h>
 #include <ctrace.h>
+#include <views.h>
+
 #include "schemachange.h"
 #include "sc_global.h"
 #include "logmsg.h"
@@ -42,6 +44,11 @@ pthread_mutex_t ongoing_alter_mtx = PTHREAD_MUTEX_INITIALIZER;
 hash_t *ongoing_alters = NULL;
 
 int gbl_abort_during_downgrade_if_scs_dont_stop = 0;
+
+/* test only: fail reopening a shard while resuming a retroactive time
+ * partition, so that the resume fails with schema changes already started
+ */
+int gbl_debug_retro_resume_fail_shard = 0;
 
 /* monitor queue latency on master during alter schema changes */
 int gbl_altersc_latency = 1; /* enable alter sc latency check and delay */
@@ -439,7 +446,10 @@ void live_sc_off(struct dbtable *db)
     db->sc_to = NULL;
     db->sc_from = NULL;
     db->sharding_func = NULL;
-    db->sharding_arg = NULL;
+    /* retroactive partitioning attached this in _process_partitioning_retro;
+     * we hold the write lock, so no router can be looking at it
+     */
+    timepart_retro_free(&db->sharding_arg);
     db->sc_abort = 0;
     db->sc_downgrading = 0;
     db->sc_adds = 0;

--- a/schemachange/sc_global.h
+++ b/schemachange/sc_global.h
@@ -27,6 +27,7 @@ extern pthread_mutex_t csc2_subsystem_mtx;
 extern struct schema_change_type *sc_resuming;
 extern volatile int gbl_lua_version;
 extern int gbl_default_livesc;
+extern int gbl_debug_retro_resume_fail_shard;
 extern int gbl_default_plannedsc;
 extern int gbl_default_sc_scanmode;
 

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -1230,6 +1230,27 @@ int resume_schema_change(void)
                 continue; /* unmark all ongoing schema changes */
             }
 
+            if (s->partition.type == PARTITION_ADD_TIMED_RETRO) {
+                /* retroactive partitioning distributes the rows of the existing
+                 * table into the past shards; the shard routing is rebuilt by
+                 * _process_partitioning_retro(), which only runs on the
+                 * multiddl resume path.  Without it there is no way to know
+                 * where the rows go, so cancel the schema change instead of
+                 * restarting an alter that would collapse the partition back
+                 * into a single table.
+                 */
+                logmsg(LOGMSG_ERROR,
+                       "%s: Cancelling resume of retroactive partitioning of "
+                       "'%s', multitable_ddl is not set\n",
+                       __func__, thedb->dbs[i]->tablename);
+                rc = bdb_set_in_schema_change(NULL, thedb->dbs[i]->tablename, NULL, 0, &bdberr);
+                if (rc)
+                    logmsg(LOGMSG_ERROR, "Failed to cancel resuming schema change %d %d\n", rc, bdberr);
+                sc_del_unused_files(thedb->dbs[i]);
+                free_schema_change_type(s);
+                continue;
+            }
+
             if (IS_UPRECS(s)) {
                 logmsg(LOGMSG_DEBUG,
                        "%s: This was a table upgrade. Skipping...\n", __func__);

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -41,6 +41,7 @@ const char *get_hostname_with_crc32(bdb_state_type *bdb_state,
                                     unsigned int hash);
 
 extern int gbl_test_sc_resume_race;
+extern int gbl_retro_tpt_verbose;
 
 /* If this is successful, it increments */
 int start_schema_change_tran(struct ireq *iq, tran_type *trans)
@@ -828,11 +829,36 @@ int live_sc_post_update_int(struct ireq *iq, void *trans,
                       oldgenid, newgenid,
                       get_genid_stripe_pointer(oldgenid, sc_genids));
         rc = unodhfy_if_necessary(iq, blobs, maxblobs);
-        if (rc == 0)
-            rc = live_sc_post_upd_record(iq, trans, oldgenid, old_dta, newgenid,
-                                         new_dta, ins_keys, del_keys, od_len,
-                                         updCols, blobs, deferredAdd, oldblobs,
-                                         newblobs);
+        if (rc == 0) {
+            /* A retro-partitioned table can route oldgenid and newgenid to
+             * different shards.  An in-place update would then leave the row
+             * in the wrong shard (or, with a deferred index add, split the
+             * row from its own keys, since the add would be routed
+             * separately by newgenid).  Do a genuine delete from the old
+             * destination plus add to the new one instead -- this is what a
+             * not-yet-converted row gets anyway once the forward scan
+             * reaches it, so placement stays consistent regardless of scan
+             * timing.
+             */
+            struct dbtable *dest_old = _distribute_rows(iq->usedb, iq->usedb->sc_to, oldgenid);
+            struct dbtable *dest_new = _distribute_rows(iq->usedb, iq->usedb->sc_to, newgenid);
+            if (dest_old && dest_new && dest_old != dest_new) {
+                if (gbl_retro_tpt_verbose)
+                    logmsg(LOGMSG_DEBUG,
+                           "%s: routing update across shard boundary, oldgenid 0x%llx dest %s, newgenid 0x%llx dest "
+                           "%s\n",
+                           __func__, oldgenid, dest_old->tablename, newgenid, dest_new->tablename);
+                rc = live_sc_post_del_record(iq, trans, oldgenid, old_dta, del_keys, oldblobs);
+                if (rc == 0) {
+                    int fabricated_rrn = 2;
+                    rc = live_sc_post_add_record(iq, trans, newgenid, new_dta, ins_keys, blobs, maxblobs, origflags,
+                                                 &fabricated_rrn);
+                }
+            } else {
+                rc = live_sc_post_upd_record(iq, trans, oldgenid, old_dta, newgenid, new_dta, ins_keys, del_keys,
+                                             od_len, updCols, blobs, deferredAdd, oldblobs, newblobs);
+            }
+        }
     }
 
     if (iq->debug) reqpopprefixes(iq, 1);

--- a/sqlite/src/comdb2build.c
+++ b/sqlite/src/comdb2build.c
@@ -5178,7 +5178,7 @@ void comdb2AlterTableEnd(Parse *pParse)
                     setError(pParse, SQLITE_MISUSE, "Retroactively partition feature disabled");
                     goto cleanup;
                 }
-                if (gbl_init_with_genid48) {
+                if (bdb_genid_format(thedb->bdb_env) == LLMETA_GENID_48BIT) {
                     setError(pParse, SQLITE_MISUSE, "Retroactively partition not working for genid48");
                     goto cleanup;
                 }
@@ -7924,7 +7924,11 @@ void comdb2CreateTimePartition(Parse* pParse, Token* period, Token* retention,
                                      (int32_t*)&partition->u.tpt.period,
                                      (int32_t*)&partition->u.tpt.retention,
                                      (int64_t*)&partition->u.tpt.start)) {
+        /* the error is already set; free_ddl_context frees partition, so
+         * there is nothing left to look at below
+         */
         free_ddl_context(pParse);
+        return;
     }
 
     /* if retroactively partitioning, make sure the start is one day in the future */

--- a/tests/timepart_retro.test/runit
+++ b/tests/timepart_retro.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 # args
 # <dbname>
@@ -36,6 +37,23 @@ delayed_writes()
         $CM "exec procedure sys.cmd.send('downgrade')"
     fi
 }
+
+# a malformed retroactive spec has to come back as an error: the parser used
+# to keep reading the partition after freeing it, see comdb2CreateTimePartition
+echo "Checking that malformed retroactive specs are rejected"
+badspecs=("PERIOD 'bogus' RETENTION 2 START '2030-01-01T000000 America/New_York'"
+          "PERIOD 'daily' RETENTION 99999 START '2030-01-01T000000 America/New_York'"
+          "PERIOD 'daily' RETENTION 2 START 'not-a-date'")
+for bad in "${badspecs[@]}" ; do
+    out=`$C "ALTER TABLE t PARTITIONED BY TIME ${bad} RETROACTIVELY" 2>&1`
+    if [[ -z "${out}" ]] ; then
+        failexit "bad retroactive spec was accepted: ${bad}"
+    fi
+    echo "rejected [${bad}] -> ${out}"
+done
+if [[ `${CT} "select 1"` != "1" ]] ; then
+    failexit "the database is gone after parsing a bad retroactive spec"
+fi
 
 echo "Inserting the first set"
 echo "Time `${CT} 'select now()'`"
@@ -143,5 +161,332 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
    # quit
    exit 1
 fi
+
+# Retroactive partitioning can only be resumed through the multiddl resume
+# path, the only one that rebuilds the shard routing.  With multitable_ddl
+# off the schema change has to be cancelled when the master goes away: it
+# must not take the resuming master down, and it must not silently rebuild
+# the table into itself.
+echo "Checking that a resume without multitable_ddl is cancelled"
+
+$C "create table t2 { `cat t.csc2` }" || failexit "failed to create t2"
+$C "insert into t2(a) select * from generate_series(1, 60)" || failexit "failed to fill t2"
+
+# turn it off before the alter is submitted, so that no sc_list is written
+# and the resume has to go through the legacy per-table path
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable multitable_ddl 0" || \
+        failexit "failed to unset multitable_ddl on $n"
+done
+
+# a restarted node reads the tunable back from its lrl, turn it off there too
+if [[ -z "${CLUSTER}" ]] ; then
+    sed -i "s/^multitable_ddl 1$/multitable_ddl 0/" ${DBDIR}/${DBNAME}.lrl || \
+        failexit "failed to rewrite ${DBDIR}/${DBNAME}.lrl"
+    if ! grep -q "^multitable_ddl 0$" ${DBDIR}/${DBNAME}.lrl ; then
+        failexit "multitable_ddl is still on in ${DBDIR}/${DBNAME}.lrl"
+    fi
+fi
+
+master=`getmaster`
+CM="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${master}"
+echo "Master is ${master}"
+
+# both are needed, and a restart resets them: scdelay alone is ignored
+$CM "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')" || failexit "failed to set sc_force_delay"
+$CM "exec procedure sys.cmd.send('scdelay 1000')" || failexit "failed to scdelay"
+
+start=`${CT} "select now() + cast(1 as days)"`
+start=`echo ${start} | sed "s/\"/'/g"`
+echo "Using ${start} as the rollout edge for t2"
+
+$C "ALTER TABLE t2 PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START ${start} RETROACTIVELY" &> alter2.out &
+alterpid=$!
+
+echo "Waiting for the conversion of t2 to start"
+converted=0
+for i in `seq 1 60` ; do
+    converted=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBN} --host ${master} \
+        "select coalesce(max(converted), 0) from comdb2_sc_status where name='t2'" 2>/dev/null`
+    [[ -z "${converted}" ]] && converted=0
+    (( converted > 0 )) && break
+    sleep 1
+done
+(( converted > 0 )) || failexit "the retroactive alter of t2 never started converting"
+echo "Converted ${converted} rows, bouncing ${master}"
+
+# stop the client first: cdb2sql reconnects transparently, and it would
+# resubmit the alter as soon as the node is back, running the partitioning
+# we are trying to see cancelled
+kill -9 ${alterpid} 2>/dev/null
+wait ${alterpid} 2>/dev/null
+echo "alter client output:"
+cat alter2.out
+
+# do not let kill_restart_node wait for us: if the resume takes the database
+# down, waitmach would spin until the testcase times out
+kill_restart_node ${master} 0 0
+
+echo "Waiting for the database to come back"
+up=""
+for i in `seq 1 120` ; do
+    up=`${CT} "select 1" 2>/dev/null`
+    [[ "${up}" == "1" ]] && break
+    sleep 1
+done
+if [[ "${up}" != "1" ]] ; then
+    failexit "the database did not come back, did resuming the partitioning crash it?"
+fi
+
+echo "Waiting for the resume to be cancelled"
+cancelled=0
+for i in `seq 1 60` ; do
+    if grep -q "Cancelling resume of retroactive partitioning" ${TESTDIR}/logs/${DBNAME}*.db* ; then
+        cancelled=1
+        break
+    fi
+    sleep 1
+done
+(( cancelled == 1 )) || failexit "the retroactive partitioning of t2 was not cancelled on resume"
+
+echo "t2 has to be left intact and unpartitioned"
+nparts=`${CT} "select count(*) from comdb2_timepartitions where name='t2'"`
+if [[ "${nparts}" != "0" ]] ; then
+    failexit "t2 should not be partitioned, found ${nparts}"
+fi
+nrows=`${CT} "select count(*) from t2"`
+if [[ "${nrows}" != "60" ]] ; then
+    failexit "expected 60 rows in t2, got ${nrows}"
+fi
+
+echo "t2 must not be left stuck in a schema change"
+$C "alter table t2 add column c int" || failexit "follow-up schema change on t2 failed"
+
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable multitable_ddl 1"
+done
+
+# A resume that fails *after* some schema changes have already started must
+# hand the unwind to the finalize thread instead of freeing the ireq and
+# walking away: that thread is what backs the set out and drops the sc_list,
+# so without it the same doomed resume is retried on every startup.
+# Force such a failure by removing a shard btree while the master is down,
+# which makes open_temp_db_resume() fail for that shard with the shard schema
+# change already registered in iq->sc_pending.
+echo "Checking that a resume failing mid-flight unwinds through the finalize thread"
+
+# this one has to go through the multiddl resume path
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable multitable_ddl 1" || \
+        failexit "failed to set multitable_ddl on $n"
+done
+if [[ -z "${CLUSTER}" ]] ; then
+    sed -i "s/^multitable_ddl 0$/multitable_ddl 1/" ${DBDIR}/${DBNAME}.lrl || \
+        failexit "failed to rewrite ${DBDIR}/${DBNAME}.lrl"
+    if ! grep -q "^multitable_ddl 1$" ${DBDIR}/${DBNAME}.lrl ; then
+        failexit "multitable_ddl is still off in ${DBDIR}/${DBNAME}.lrl"
+    fi
+fi
+
+$C "create table t3 { `cat t.csc2` }" || failexit "failed to create t3"
+$C "insert into t3(a) select * from generate_series(1, 60)" || failexit "failed to fill t3"
+
+master=`getmaster`
+CM="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${master}"
+echo "Master is ${master}"
+# phase 2 restarted the node, which reset both of these
+$CM "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')" || failexit "failed to set sc_force_delay"
+$CM "exec procedure sys.cmd.send('scdelay 1000')" || failexit "failed to scdelay"
+
+start=`${CT} "select now() + cast(1 as days)"`
+start=`echo ${start} | sed "s/\"/'/g"`
+echo "Using ${start} as the rollout edge for t3"
+
+$C "ALTER TABLE t3 PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START ${start} RETROACTIVELY" &> alter3.out &
+alterpid=$!
+
+echo "Waiting for the conversion of t3 to start"
+converted=0
+for i in `seq 1 60` ; do
+    converted=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBN} --host ${master} \
+        "select coalesce(max(converted), 0) from comdb2_sc_status where name='t3'" 2>/dev/null`
+    [[ -z "${converted}" ]] && converted=0
+    (( converted > 0 )) && break
+    sleep 1
+done
+(( converted > 0 )) || failexit "the retroactive alter of t3 never started converting"
+
+echo "Converted ${converted} rows"
+
+# do not let the client resubmit the alter once the node is back
+kill -9 ${alterpid} 2>/dev/null
+wait ${alterpid} 2>/dev/null
+
+# Make the shard fail to reopen on the way back up.  Deleting the btree does
+# not work: bdb_open_more() simply recreates it and the resume succeeds
+# against an empty shard.  Every node has to have it set, we cannot tell in
+# advance which one wins the election and resumes.
+echo "Arming debug_retro_resume_fail_shard"
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable debug_retro_resume_fail_shard 1" || \
+        failexit "failed to arm debug_retro_resume_fail_shard on $n"
+done
+# a restarted node reads its tunables back from the lrl
+if [[ -z "${CLUSTER}" ]] ; then
+    echo "debug_retro_resume_fail_shard 1" >> ${DBDIR}/${DBNAME}.lrl || \
+        failexit "failed to arm debug_retro_resume_fail_shard in the lrl"
+fi
+
+kill_restart_node ${master} 0 0
+
+echo "Waiting for the database to come back"
+up=""
+for i in `seq 1 120` ; do
+    up=`${CT} "select 1" 2>/dev/null`
+    [[ "${up}" == "1" ]] && break
+    sleep 1
+done
+if [[ "${up}" != "1" ]] ; then
+    failexit "the database did not come back after the failed resume"
+fi
+
+# only reachable if the finalize thread ran, which is what we are testing:
+# before the fix the ireq was freed and the thread was never started
+echo "The failed resume has to unwind through the finalize thread"
+unwound=0
+for i in `seq 1 60` ; do
+    if grep -q "Aborting schema change because of errors" ${TESTDIR}/logs/${DBNAME}*.db* ; then
+        unwound=1
+        break
+    fi
+    sleep 1
+done
+(( unwound == 1 )) || failexit "the failed resume of t3 did not unwind through the finalize thread"
+
+echo "t3 data has to survive the failed resume"
+nrows=`${CT} "select count(*) from t3"`
+if [[ "${nrows}" != "60" ]] ; then
+    failexit "expected 60 rows in t3, got ${nrows}"
+fi
+
+# NOTE: t3 is deliberately left with a stale in_schema_change marker.  The
+# resume dies at the shard add and never reaches t3, and nothing on that path
+# clears it.  That is a known gap in resuming retroactive partitioning, not
+# something this phase asserts.
+
+# A non-in-place update can produce a newgenid whose timestamp is far from
+# oldgenid's -- not just via 'ipu off', but on any table once a single row
+# has been updated enough times (4096) to exhaust the genid's updateid space,
+# forcing a fresh genid stamped with the current time.  If that update lands
+# after its shard's conversion has finished (so it takes the live "already
+# converted" update path) and the new timestamp now belongs to a different
+# shard than the old one, the record and its index entries used to be
+# routed independently and could end up in different shards.
+echo "Checking that an update crossing a shard boundary keeps data and index consistent"
+
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable multitable_ddl 1" || \
+        failexit "failed to set multitable_ddl on $n"
+    # use a short test-only period so a shard boundary can be crossed within
+    # this phase's own runtime, instead of needing to wait real days
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable partition_retroactively_start 0" || \
+        failexit "failed to relax partition_retroactively_start on $n"
+done
+
+$C "create table t4 { `cat t.csc2` }" || failexit "failed to create t4"
+$C "insert into t4(a, b) values (100000, 'x')" || failexit "failed to insert into t4"
+# with only our one row, the conversion (and the whole schema change) would
+# finish in under a second regardless of scdelay -- there is nothing for the
+# per-record delay below to multiply against.  Filler rows spread across all
+# 8 stripes keep the schema change genuinely live for several minutes, long
+# enough to span the sleep further down; the target row is inserted first so
+# it is early in its own stripe's queue and converts within the first few
+# seconds, same as it would with no filler at all.
+$C "insert into t4(a) select * from generate_series(1, 3000)" || failexit "failed to fill t4 with filler rows"
+
+master=`getmaster`
+CM="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${master}"
+echo "Master is ${master}"
+$CM "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')" || failexit "failed to set sc_force_delay"
+$CM "exec procedure sys.cmd.send('scdelay 1000')" || failexit "failed to scdelay"
+
+# period test2min puts a shard boundary about 2 minutes from now (retention 3
+# steps back 2 periods from START), while START itself stays a comfortable
+# 6 minutes out -- far enough that the scheduled rollout at START cannot fire
+# before this phase is done
+start=`${CT} "select now() + cast(6 as minutes)"`
+start=`echo ${start} | sed "s/\"/'/g"`
+echo "Using ${start} as the rollout edge for t4 (period test2min, retention 3)"
+
+$C "ALTER TABLE t4 PARTITIONED BY TIME PERIOD 'test2min' RETENTION 3 START ${start} RETROACTIVELY" &> alter4.out &
+alterpid=$!
+
+echo "Waiting for the conversion of t4 to start"
+converted=0
+for i in `seq 1 60` ; do
+    converted=`cdb2sql --tabs ${CDB2_OPTIONS} ${DBN} --host ${master} \
+        "select coalesce(max(converted), 0) from comdb2_sc_status where name='t4'" 2>/dev/null`
+    [[ -z "${converted}" ]] && converted=0
+    (( converted > 0 )) && break
+    sleep 1
+done
+(( converted > 0 )) || failexit "the retroactive alter of t4 never started converting"
+
+# converted>0 only proves *some* row converted; give the target row (inserted
+# first, so early in its stripe's queue) a little extra margin to be sure it
+# specifically has been converted before we start updating it
+sleep 10
+
+echo "Doing 4095 in-place updates to exhaust the row's updateid space"
+updscript="updateid_rollover.sql"
+> ${updscript}
+for i in `seq 1 4095` ; do
+    echo "update t4 set a = -a where a = 100000 or a = -100000;" >> ${updscript}
+done
+$C - < ${updscript} > update_rollover.out 2>&1
+if (( $? != 0 )) ; then
+    cat update_rollover.out
+    failexit "failed to run the 4095 in-place updates on t4"
+fi
+
+echo "Sleeping past a shard boundary so the update that forces a new genid lands in a different time bucket"
+sleep 150
+
+echo "Doing the update that forces a fresh (non-inplace) genid"
+$C "update t4 set a = -a where a = 100000 or a = -100000" || \
+    failexit "the rollover update on t4 failed"
+
+echo "Letting the schema change finish"
+$CM "exec procedure sys.cmd.send('scdelay 0')" || failexit "failed to clear scdelay"
+wait ${alterpid}
+echo "alter output:"
+cat alter4.out
+if [[ -s alter4.out ]] ; then
+    failexit "the retroactive alter of t4 reported an error"
+fi
+
+echo "Checking that the update crossing the shard boundary took the delete+add split path"
+if ! grep -q "routing update across shard boundary" ${TESTDIR}/logs/${DBNAME}*.db* ; then
+    failexit "no update on t4 was ever routed across a shard boundary -- the test did not exercise the fix"
+fi
+
+echo "t4 has to have all filler rows plus the target row intact"
+totalrows=`${CT} "select count(*) from t4"`
+if [[ "${totalrows}" != "3001" ]] ; then
+    failexit "expected 3001 total rows in t4, got ${totalrows}"
+fi
+nrows=`${CT} "select count(*) from t4 where a = 100000 or a = -100000"`
+if [[ "${nrows}" != "1" ]] ; then
+    failexit "expected 1 row for the target key in t4, got ${nrows}"
+fi
+aval=`${CT} "select a from t4 where a = 100000 or a = -100000"`
+bval=`${CT} "select b from t4 where a = 100000 or a = -100000"`
+if [[ "${aval}" != "100000" || "${bval}" != "x" ]] ; then
+    failexit "expected (100000, x) in t4, got (${aval}, ${bval})"
+fi
+
+for n in `getclusternodes` ; do
+    cdb2sql ${CDB2_OPTIONS} ${DBN} --host $n "put tunable partition_retroactively_start 1"
+done
 
 echo "SUCCESS"

--- a/tests/timepart_retro_genid48.test/Makefile
+++ b/tests/timepart_retro_genid48.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=15m
+	export TEST_TIMEOUT=5m
 endif

--- a/tests/timepart_retro_genid48.test/lrl.options
+++ b/tests/timepart_retro_genid48.test/lrl.options
@@ -1,0 +1,1 @@
+partition_retroactively_start 1

--- a/tests/timepart_retro_genid48.test/runit
+++ b/tests/timepart_retro_genid48.test/runit
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+source ${TESTSROOTDIR}/tools/runit_common.sh
+source ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+# args
+# <dbname>
+DBN=$1
+
+C="cdb2sql ${CDB2_OPTIONS} ${DBN} default"
+CT="cdb2sql --tabs ${CDB2_OPTIONS} ${DBN} default"
+
+# This db was created with the default lrl (no init_with_genid48 override),
+# so genid48 was on at creation and the format persisted to llmeta is
+# LLMETA_GENID_48BIT.  Retroactive partitioning routes rows by reading a
+# timestamp out of the top 32 bits of the genid, which only exists for the
+# original genid format -- confirm it is rejected here.
+$C "create table t { `cat t.csc2` }" || failexit "failed to create t"
+
+# force a checkpoint: the node gets kill -9'd below, and without one the table
+# just created may not have made it to disk yet
+$C "exec procedure sys.cmd.send('bdb checkpoint')" || failexit "failed to checkpoint"
+sleep 2
+
+start=`${CT} "select now() + cast(1 as days)"`
+start=`echo ${start} | sed "s/\"/'/g"`
+echo "Using ${start} as the rollout edge"
+
+out=`$C "ALTER TABLE t PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START ${start} RETROACTIVELY" 2>&1`
+echo "attempt on a genid48 table -> ${out}"
+if [[ "${out}" != *"not working for genid48"* ]] ; then
+    failexit "retroactive partition on a genid48 table should have been rejected: ${out}"
+fi
+
+# gbl_init_with_genid48 is a create-time-only knob (READONLY, consulted only
+# under gbl_create_mode); overriding it in the lrl after the table already
+# exists does not change the genid format stored in llmeta.  The parser check
+# has to consult the live per-database format (bdb_genid_format()), not this
+# tunable, or a genid48 table would be let through here.
+#
+# The tunable is per node while the genid format is per database, so from
+# here on everything has to be aimed at the one node whose lrl we rewrite:
+# the statement is parsed by the node that receives it, and that is the node
+# that has to disagree with llmeta for this to prove anything.
+node=`getmaster`
+CN="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${node}"
+CNT="cdb2sql --tabs ${CDB2_OPTIONS} ${DBN} --host ${node}"
+
+if [[ -z "${CLUSTER}" ]] ; then
+    echo "init_with_genid48 0" >> ${DBDIR}/${DBNAME}.lrl || \
+        failexit "failed to append init_with_genid48 to ${DBDIR}/${DBNAME}.lrl"
+else
+    # each node keeps its own copy of the db directory, the local one is not
+    # the one ${node} will read on the way back up
+    ssh -n -o StrictHostKeyChecking=no ${node} \
+        "echo 'init_with_genid48 0' >> ${DBDIR}/${DBNAME}.lrl" < /dev/null || \
+        failexit "failed to append init_with_genid48 to ${DBDIR}/${DBNAME}.lrl on ${node}"
+fi
+
+echo "Bouncing ${node} with init_with_genid48 now off in its lrl"
+kill_restart_node ${node} 0 0
+
+echo "Waiting for ${node} to come back"
+up=""
+for i in `seq 1 120` ; do
+    up=`${CNT} "select 1" 2>/dev/null`
+    [[ "${up}" == "1" ]] && break
+    sleep 1
+done
+if [[ "${up}" != "1" ]] ; then
+    failexit "${node} did not come back after the restart"
+fi
+
+echo "Checking that init_with_genid48 actually reads 0 on ${node} now"
+tun=`${CNT} "select value from comdb2_tunables where name='init_with_genid48'"`
+if [[ "${tun}" != "0" ]] ; then
+    failexit "expected init_with_genid48 to read 0 on ${node} after restart, got '${tun}'"
+fi
+
+start=`${CNT} "select now() + cast(1 as days)"`
+start=`echo ${start} | sed "s/\"/'/g"`
+echo "Using ${start} as the rollout edge"
+
+out=`$CN "ALTER TABLE t PARTITIONED BY TIME PERIOD 'daily' RETENTION 2 START ${start} RETROACTIVELY" 2>&1`
+echo "attempt after init_with_genid48 was turned off in the lrl -> ${out}"
+if [[ "${out}" != *"not working for genid48"* ]] ; then
+    failexit "retroactive partition on a genid48 table must still be rejected even though init_with_genid48 now reads 0: ${out}"
+fi
+
+echo "SUCCESS"

--- a/tests/timepart_retro_genid48.test/t.csc2
+++ b/tests/timepart_retro_genid48.test/t.csc2
@@ -1,0 +1,9 @@
+schema
+{
+   int      a
+   cstring  b[10] null=yes
+}
+keys
+{
+   "pk"  = a
+}


### PR DESCRIPTION
Block resuming a time partition retroactively if multitable_ddl is disabled.  Fix some older issues, including making sure that a non-ipu updated row that has different shard relocations for old vs new genids ends up in the shard based on new genid.

re: 185541819