### PR TITLE
Add physrep_ignore_legacy_queues tunable

### DIFF
--- a/bdb/file.c
+++ b/bdb/file.c
@@ -4518,7 +4518,9 @@ deadlock_again:
         else
             pagesize = bdb_state->attr->pagesizedta;
 
-        if (gbl_is_physical_replicant && physrep_ignore_table(bdb_state->name)) {
+        extern int gbl_physrep_ignore_legacy_queues;
+        if (gbl_is_physical_replicant &&
+            (physrep_ignore_table(bdb_state->name) || (bdbtype == BDBTYPE_QUEUE && gbl_physrep_ignore_legacy_queues))) {
             char new[PATH_MAX];
             print(bdb_state, "truncating ignored queue %s\n", bdb_trans(tmpname, new));
             rc = truncate(bdb_trans(tmpname, new), pagesize * 2);

--- a/bdb/phys_rep_lsn.c
+++ b/bdb/phys_rep_lsn.c
@@ -21,14 +21,13 @@
 
 int matchable_log_type(DB_ENV *dbenv, int rectype);
 
-extern int should_ignore_btree(const char *filename,
-                               int (*should_ignore_table)(const char *),
-                               int should_ignore_queues,
-                               int name_boundary_exists);
+extern int should_ignore_btree(const char *filename, int (*should_ignore_table)(const char *), int should_ignore_queues,
+                               int should_ignore_legacy_queues, int name_boundary_exists);
 extern int gbl_import_mode;
 extern int gbl_physrep_debug;
 int gbl_physrep_exit_on_invalid_logstream = 0;
 int gbl_physrep_ignore_queues = 1;
+int gbl_physrep_ignore_legacy_queues = 1;
 
 int compare_log(DBT *logrec, void *blob, unsigned int blob_len)
 {
@@ -647,5 +646,6 @@ int physrep_ignore_table_count()
 
 int physrep_ignore_btree(const char *filename)
 {
-    return should_ignore_btree(filename, physrep_ignore_table, gbl_physrep_ignore_queues, 1);
+    return should_ignore_btree(filename, physrep_ignore_table, gbl_physrep_ignore_queues,
+                               gbl_physrep_ignore_legacy_queues, 1);
 }

--- a/berkdb/dbreg/dbreg_util.c
+++ b/berkdb/dbreg/dbreg_util.c
@@ -51,7 +51,8 @@ static inline int nameboundary(char c)
 	}
 }
 
-int should_ignore_btree(const char *filename, int (*should_ignore_table)(const char *), int should_ignore_queues, int name_boundary_exists)
+int should_ignore_btree(const char *filename, int (*should_ignore_table)(const char *), int should_ignore_queues,
+    int should_ignore_legacy_queues, int name_boundary_exists)
 {
 	char *start = (char *)&filename[0];
 	char *end = (char *)&filename[strlen(filename) - 1];
@@ -60,6 +61,9 @@ int should_ignore_btree(const char *filename, int (*should_ignore_table)(const c
 		end--;
 	}
 	if (should_ignore_queues && !strcmp(end, ".queuedb")) {
+		return 1;
+	}
+	if (should_ignore_legacy_queues && !strcmp(end, ".queue")) {
 		return 1;
 	}
 	end -= 17;

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -550,6 +550,7 @@ extern int gbl_physrep_reconnect_interval;
 extern int gbl_physrep_find_new_repl_db_timeout;
 extern int gbl_physrep_shuffle_host_list;
 extern int gbl_physrep_ignore_queues;
+extern int gbl_physrep_ignore_legacy_queues;
 extern int gbl_physrep_max_rollback;
 extern int gbl_physrep_filter_by_class;
 extern int gbl_physrep_pollms;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1967,6 +1967,8 @@ REGISTER_TUNABLE("query_comdb2db_for_absent_physrep_source_dbnum",
                  &gbl_query_comdb2db_for_absent_physrep_source_dbnum, INTERNAL, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_ignore_queues", "Don't replicate queues.", TUNABLE_BOOLEAN, &gbl_physrep_ignore_queues,
                  READONLY, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("physrep_ignore_legacy_queues", "Don't replicate legacy queues.", TUNABLE_BOOLEAN,
+                 &gbl_physrep_ignore_legacy_queues, READONLY, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_filter_by_class", "Filter physrep replication by class. (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_physrep_filter_by_class, 0, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("physrep_max_rollback", "Maximum logs physrep can rollback. (Default: 0)", TUNABLE_INTEGER,

--- a/schemachange/sc_import.c
+++ b/schemachange/sc_import.c
@@ -92,10 +92,8 @@ extern char *gbl_file_copier;
 extern char gbl_dbname[MAX_DBNAME_LENGTH];
 extern char *gbl_dbdir;
 
-extern int should_ignore_btree(const char *filename,
-                               int (*should_ignore_table)(const char *),
-                               int should_ignore_queues,
-                               int name_boundary_exists);
+extern int should_ignore_btree(const char *filename, int (*should_ignore_table)(const char *), int should_ignore_queues,
+                               int should_ignore_legacy_queues, int name_boundary_exists);
 
 static uint64_t gbl_import_id = 0;
 pthread_mutex_t import_id_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -145,7 +143,7 @@ int bulk_import_tmpdb_should_ignore_table(const char *table) {
 
 int bulk_import_tmpdb_should_ignore_btree(const char *filename)
 {
-    return should_ignore_btree(filename, bulk_import_tmpdb_should_ignore_table, 0, 1);
+    return should_ignore_btree(filename, bulk_import_tmpdb_should_ignore_table, 0, 0, 1);
 }
 
 static void get_import_dbdir(char *import_dbdir, size_t sz_import_dbdir, const uint64_t import_id) {
@@ -1382,7 +1380,7 @@ static enum comdb2_import_tmpdb_op comdb2_files_tmpdb_process_filenames(cdb2_hnd
             goto err;
         }
 
-        if (!should_ignore_btree(fname, bulk_import_tmpdb_should_ignore_table, 0, 0)) {
+        if (!should_ignore_btree(fname, bulk_import_tmpdb_should_ignore_table, 0, 0, 0)) {
             str_list_elt * const elt = calloc(1, sizeof(str_list_elt));
             if (!elt) {
                 __import_logmsg(LOGMSG_ERROR, "Could not allocate memory\n");

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -759,6 +759,7 @@
 (name='physrep_hung_replicant_check_freq_sec', description='Check for hung physical replicant this often. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_hung_replicant_threshold', description='Report if the physical replicant has been inactive for this duration. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_i_am_metadb', description='I am physical replication metadb (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
+(name='physrep_ignore_legacy_queues', description='Don't replicate legacy queues.', type='BOOLEAN', value='ON', read_only='Y')
 (name='physrep_ignore_queues', description='Don't replicate queues.', type='BOOLEAN', value='ON', read_only='Y')
 (name='physrep_keepalive_freq_sec', description='Periodically send lsn to source node after this interval. (Default: 60)', type='INTEGER', value='60', read_only='N')
 (name='physrep_keepalive_v2', description='Use version 2 of keepalive which also reports the oldest (first) lsn. Enable only after the metadb comdb2_physreps table has a firstfile column and the fleet is upgraded. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')


### PR DESCRIPTION
Physreps already skip queuedbs via physrep_ignore_queues.  Do the same for legacy .queue files under a separate tunable, on by default: ignore their log records during apply, and truncate the queue file at open.