### PR TITLE
tests: Fix rollover race in manual_partition

### DIFF
--- a/tests/manual_partition.test/run.log.exp
+++ b/tests/manual_partition.test/run.log.exp
@@ -59,7 +59,7 @@ XXXXX we should see to empty partitions with no counters
 (name='Truncate', type='testpart2', epoch=10, arg1='testpart2', arg2=NULL, arg3=NULL)
 (rows inserted=1)
 (rows inserted=1)
-XXXXX we should see the data in part1, and the counter, no rollout yet
+XXXXX we should see the data in part1, the counter, and the rollout
 (a=1, alltypes_vutf8='hi')
 (a=2, alltypes_vutf8='ho')
 [
@@ -79,8 +79,8 @@ XXXXX we should see the data in part1, and the counter, no rollout yet
   },
   {
    "TABLENAME"    : "$1_7DA96DB",
-   "LOW"          : 2147483647,
-   "HIGH"         : 2147483647
+   "LOW"          : 1,
+   "HIGH"         : 2
   }
   ]
  }

--- a/tests/manual_partition.test/runit
+++ b/tests/manual_partition.test/runit
@@ -33,15 +33,17 @@ function gorun_filter
 
 function timepart_stats
 {
-    # check the current partitions 
+    #a rollout or drop triggered by the caller runs on a cron thread and lands
+    #whenever it lands; sleep first so every read below sees the same side of it
+    sleep 6
+
+    # check the current partitions
     gorun_filter "exec procedure sys.cmd.send('partitions')" "SOURCE_ID"
 
     gorun "select name, period, retention, nshards, version,shard0name from comdb2_timepartitions "
 
     gorun "select name, shardname from comdb2_timepartshards"
 
-    #randomly we catch a drop event here; sleep to skip the deterministically
-    sleep 6
     gorun_master "select name, arg1, arg2, arg3 from comdb2_timepartevents"
 
     gorun_master "select * from comdb2_cron_schedulers where name not like 'QueueDB %'"
@@ -85,7 +87,7 @@ gorun "put counter testpart1 increment"
 gorun "insert into testpart1 values (1, 'hi')"
 gorun "insert into testpart1 values (2, 'ho')"
 
-echo "XXXXX we should see the data in part1, and the counter, no rollout yet" >> $output
+echo "XXXXX we should see the data in part1, the counter, and the rollout" >> $output
 gorun "select * from testpart1 order by a"
 timepart_stats
 


### PR DESCRIPTION
### Why

`manual_partition` fails intermittently with a two-line diff — shard `$1_7DA96DB` reports `LOW/HIGH = 1/2` where `run.log.exp` wants `2147483647/2147483647`. Seen on two separate roborivers runs at different commits.

`timepart_stats()` read the partition layout before its `sleep 6` and the cron tables after it, so the expected output encoded a single snapshot straddling the epoch-1 rollover: not-yet-rolled in the layout, already-rolled in the cron tables. Only two inserts separate the counter increment from that first read, so when the cron thread wins the race the layout shows the rolled-over ranges and the test fails.

### What

Sleep once on entry to `timepart_stats()` instead of mid-function, so every read in a snapshot sees the same side of the rollover, and update the two `run.log.exp` lines accordingly. The pre-rollover state is still asserted by the earlier `timepart_stats` call, which runs before the counter is advanced.