### PR TITLE
statreqs: log trigger/consumer counters

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -4686,7 +4686,9 @@ static inline void log_tbl_item(int64_t curr, int64_t *prev, const char *(*type_
     int diff = curr - *prev;
     if (diff > 0) {
         if (*hdr_p == 0) {
-            const char hdr_fmt[] = "DIFF REQUEST STATS FOR TABLE '%s'\n";
+            int is_queue = (tbl->dbtype == DBTYPE_QUEUE || tbl->dbtype == DBTYPE_QUEUEDB);
+            const char *hdr_fmt =
+                is_queue ? "DIFF REQUEST STATS FOR QUEUE '%s'\n" : "DIFF REQUEST STATS FOR TABLE '%s'\n";
             reqlog_logf(statlogger, REQL_INFO, hdr_fmt, tbl->tablename);
             *hdr_p = 1;
         }
@@ -4694,6 +4696,14 @@ static inline void log_tbl_item(int64_t curr, int64_t *prev, const char *(*type_
                     (type_to_str ? type_to_str(type) : string), diff);
     }
     *prev = curr;
+}
+
+static inline void log_osql_tbl_stats(struct reqlogger *statlogger, dbtable *tbl, int *hdr_p)
+{
+    for (int jj = 0; jj < MAX_OSQL_TYPES; jj++) {
+        log_tbl_item(tbl->blockosqltypcnt[jj], &tbl->prev_blockosqltypcnt[jj], osql_reqtype_str, jj, NULL, hdr_p,
+                     statlogger, tbl, 0);
+    }
 }
 
 void *statthd(void *p)
@@ -4970,10 +4980,7 @@ void *statthd(void *p)
                     log_tbl_item(tbl->blocktypcnt[jj], &tbl->prev_blocktypcnt[jj], breq2a, jj, NULL, &hdr, statlogger,
                                  tbl, 0);
                 }
-                for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
-                    log_tbl_item(tbl->blockosqltypcnt[jj], &tbl->prev_blockosqltypcnt[jj], osql_reqtype_str, jj, NULL,
-                                 &hdr, statlogger, tbl, 0);
-                }
+                log_osql_tbl_stats(statlogger, tbl, &hdr);
 
                 log_tbl_item(dbenv->txns_committed, &dbenv->prev_txns_committed, NULL, 0, "txns committed", &hdr,
                              statlogger, tbl, 0);
@@ -5003,6 +5010,18 @@ void *statthd(void *p)
                              &hdr, statlogger, tbl, 0);
                 log_tbl_item(tbl->deadlock_count, &tbl->saved_deadlock_count, NULL, 0, "deadlock count", &hdr,
                              statlogger, tbl, 0);
+            }
+
+            for (ii = 0; ii < dbenv->num_qdbs; ++ii) {
+                dbtable *qdb = dbenv->qdbs[ii];
+                int hdr = 0;
+
+                log_osql_tbl_stats(statlogger, qdb, &hdr);
+
+                log_tbl_item(qdb->write_count[RECORD_WRITE_INS], &qdb->saved_write_count[RECORD_WRITE_INS], NULL, 0,
+                             "enqueued", &hdr, statlogger, qdb, 0);
+                log_tbl_item(qdb->write_count[RECORD_WRITE_DEL], &qdb->saved_write_count[RECORD_WRITE_DEL], NULL, 0,
+                             "dequeued", &hdr, statlogger, qdb, 0);
             }
 
             int num_sc = 0;

--- a/db/glue.c
+++ b/db/glue.c
@@ -5271,6 +5271,7 @@ int dbq_add_recno(struct ireq *iq, void *trans, uint32_t recno, const void *dta,
 
     if (bdberr == 0) {
         struct dbtable *qdb = iq->usedb;
+        ATOMIC_ADD64(qdb->write_count[RECORD_WRITE_INS], 1);
         if (qdb->dbtype == DBTYPE_QUEUEDB) {
             return 0;
         }
@@ -5317,8 +5318,10 @@ int dbq_consume(struct ireq *iq, void *trans, int consumer, const struct bdb_que
     bdb_queue_consume(bdb_handle, trans, consumer, fnd, &bdberr);
     iq->gluewhere = "bdb_queue_consume done";
 
-    if (bdberr == 0)
+    if (bdberr == 0) {
+        ATOMIC_ADD64(iq->usedb->write_count[RECORD_WRITE_DEL], 1);
         return 0;
+    }
     if (bdberr == BDBERR_DEADLOCK)
         return RC_INTERNAL_RETRY;
     if (bdberr == BDBERR_READONLY)

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -5237,6 +5237,9 @@ static void request_stats(struct dbenv *dbenv)
     for (ii = 0; ii < dbenv->num_dbs; ii++) {
         req_stats(dbenv->dbs[ii]);
     }
+    for (ii = 0; ii < dbenv->num_qdbs; ii++) {
+        req_stats(dbenv->qdbs[ii]);
+    }
 }
 
 void fastcount(char *tablename)

--- a/db/sltdbt.c
+++ b/db/sltdbt.c
@@ -74,34 +74,36 @@ const char *req2a(int opcode)
         return "????";
 }
 
+static void req_stats_hdr(struct dbtable *db, int *hdr)
+{
+    if (*hdr)
+        return;
+    if (db->dbtype == DBTYPE_QUEUE || db->dbtype == DBTYPE_QUEUEDB)
+        logmsg(LOGMSG_USER, "REQUEST STATS FOR QUEUE '%s'\n", db->tablename);
+    else
+        logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
+    *hdr = 1;
+}
+
 void req_stats(struct dbtable *db)
 {
     int ii, jj;
     int hdr = 0;
     for (ii = 0; ii <= MAXTYPCNT; ii++) {
         if (db->typcnt[ii]) {
-            if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
-                hdr = 1;
-            }
+            req_stats_hdr(db, &hdr);
             logmsg(LOGMSG_USER, "%-20s %"PRId64"\n", req2a(ii), db->typcnt[ii]);
         }
     }
     for (jj = 0; jj < BLOCK_MAXOPCODE; jj++) {
         if (db->blocktypcnt[jj]) {
-            if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
-                hdr = 1;
-            }
+            req_stats_hdr(db, &hdr);
             logmsg(LOGMSG_USER, "    %-20s %"PRId64"\n", breq2a(jj), db->blocktypcnt[jj]);
         }
     }
     for (jj = 0; jj < MAX_OSQL_TYPES; jj++) {
         if (db->blockosqltypcnt[jj]) {
-            if (hdr == 0) {
-                logmsg(LOGMSG_USER, "REQUEST STATS FOR DB %d '%s'\n", db->dbnum, db->tablename);
-                hdr = 1;
-            }
+            req_stats_hdr(db, &hdr);
             logmsg(LOGMSG_USER, "    %-20s %"PRId64"\n", osql_reqtype_str(jj), db->blockosqltypcnt[jj]);
         }
     }

--- a/tests/queuedb_statreqs.test/Makefile
+++ b/tests/queuedb_statreqs.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/queuedb_statreqs.test/runit
+++ b/tests/queuedb_statreqs.test/runit
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+bash -n "$0" || exit 1
+
+# Verify that queuedbs (lua consumers / triggers) are accounted for in the
+# statreqs diff-stat log and in the on-demand 'stat long' dump: the osql op
+# counters, plus the enqueued/dequeued row counters.
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+
+[[ $debug == "1" ]] && set -x
+
+dbnm=$1
+
+# events enqueued on each of the two queues
+NEVENTS_CONSUME=10
+NEVENTS_NEXT=5
+
+if [[ -n "$CLUSTER" ]]; then
+    master=$(${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} ${dbnm} default \
+        "select host from comdb2_cluster where is_master='Y'")
+    [[ -z "$master" ]] && failexit "could not determine master"
+    hostopt="--host $master"
+else
+    master=""
+    hostopt=""
+fi
+
+run() {
+    timeout 90 ${CDB2SQL_EXE} --tabs ${CDB2_OPTIONS} ${dbnm} default "$@"
+}
+
+# counters live on the master, so message traps have to land there
+mtrap() {
+    ${CDB2SQL_EXE} --tabs $hostopt ${CDB2_OPTIONS} ${dbnm} default \
+        "exec procedure sys.cmd.send('$1')"
+}
+
+# ... and so does the statreqs file
+statreqs() {
+    local log=${TESTDIR}/var/log/cdb2/${dbnm}.statreqs
+    if [[ -n "$CLUSTER" ]]; then
+        ssh -o StrictHostKeyChecking=no $master "cat $log" </dev/null
+    else
+        cat $log
+    fi
+}
+
+# Sum one counter across every diff bucket of one queue's block, reading the
+# log from stdin.  Blocks look like:
+#   08/22 11:32:49:   DIFF REQUEST STATS FOR QUEUE '__qsp_next'
+#   08/22 11:32:49:       OSQL_DELREC            5
+#   08/22 11:32:49:       enqueued               5
+# and end at the next header or at the first line that is not an indented
+# "<label> <count>" pair.
+sum_counter() {
+    local qname=$1 label=$2
+    awk -v q="'${qname}'" -v lbl="$label" '
+        index($0, "DIFF REQUEST STATS FOR") { inblk = (index($0, "QUEUE " q) > 0); next }
+        inblk && !match($0, "^.*:[ ]+[A-Za-z_][A-Za-z0-9_ ]*[ ]+[0-9]+$") { inblk = 0; next }
+        inblk && match($0, "[ ]" lbl "[ ]+[0-9]+$") {
+            s = substr($0, RSTART); n = split(s, a, " "); total += a[n]
+        }
+        END { print total + 0 }
+    '
+}
+
+# dump the diff stats every 5s so they land well inside the test
+mtrap "reql diffstat 5"
+
+err=$(statreqs 2>&1 >/dev/null) ||
+    failexit "cannot read the master's statreqs log: $err"
+
+run "create table ta(i int)" || failexit "create table ta failed"
+run "create table tb(i int)" || failexit "create table tb failed"
+
+# sp_consume: consumes exactly one event per invocation via consumer:consume(),
+# which reaches the master as OSQL_DBQ_CONSUME
+run "create procedure sp_consume version 'statreqs' {
+local function main()
+    local c = db:consumer()
+    if c:poll(60000) == nil then return -1, 'no event' end
+    c:consume()
+end}" || failexit "create procedure sp_consume failed"
+run "create lua consumer sp_consume on (table ta for insert)" ||
+    failexit "create lua consumer sp_consume failed"
+
+# sp_next: consumes exactly one event per invocation via consumer:next(), which
+# reaches the master as OSQL_DELREC against the queue
+run "create procedure sp_next version 'statreqs' {
+local function main()
+    local c = db:consumer()
+    if c:poll(60000) == nil then return -1, 'no event' end
+    db:begin()
+    c:next()
+    db:commit()
+end}" || failexit "create procedure sp_next failed"
+run "create lua consumer sp_next on (table tb for insert)" ||
+    failexit "create lua consumer sp_next failed"
+
+# each insert fires its trigger, which enqueues one event
+i=0
+while [[ $i -lt $NEVENTS_CONSUME ]]; do
+    run "insert into ta values($i)" >/dev/null || failexit "insert into ta failed"
+    i=$((i + 1))
+done
+
+i=0
+while [[ $i -lt $NEVENTS_NEXT ]]; do
+    run "insert into tb values($i)" >/dev/null || failexit "insert into tb failed"
+    i=$((i + 1))
+done
+
+# drain both queues, one event per invocation
+i=0
+while [[ $i -lt $NEVENTS_CONSUME ]]; do
+    run "exec procedure sp_consume()" >/dev/null || failexit "sp_consume failed"
+    i=$((i + 1))
+done
+
+i=0
+while [[ $i -lt $NEVENTS_NEXT ]]; do
+    run "exec procedure sp_next()" >/dev/null || failexit "sp_next failed"
+    i=$((i + 1))
+done
+
+depth=$(timeout 90 ${CDB2SQL_EXE} --tabs $hostopt ${CDB2_OPTIONS} ${dbnm} default \
+    "select coalesce(sum(depth), 0) from comdb2_queues")
+[[ "$depth" != "0" ]] && failexit "queues not drained, depth is '$depth'"
+
+# statthd dumps on a 5s cadence; poll until the counters catch up.  The
+# counters are bumped pre-commit, so a deadlock-retried transaction can inflate
+# them - assert a lower bound rather than exact equality.
+ok=0
+i=0
+while [[ $i -lt 90 ]]; do
+    snap=$(statreqs 2>/dev/null)
+    enq_c=$(printf '%s\n' "$snap" | sum_counter __qsp_consume enqueued)
+    deq_c=$(printf '%s\n' "$snap" | sum_counter __qsp_consume dequeued)
+    osql_c=$(printf '%s\n' "$snap" | sum_counter __qsp_consume OSQL_DBQ_CONSUME)
+    enq_n=$(printf '%s\n' "$snap" | sum_counter __qsp_next enqueued)
+    deq_n=$(printf '%s\n' "$snap" | sum_counter __qsp_next dequeued)
+    osql_n=$(printf '%s\n' "$snap" | sum_counter __qsp_next OSQL_DELREC)
+
+    if [[ $enq_c -ge $NEVENTS_CONSUME && $deq_c -ge $NEVENTS_CONSUME &&
+          $osql_c -ge $NEVENTS_CONSUME && $enq_n -ge $NEVENTS_NEXT &&
+          $deq_n -ge $NEVENTS_NEXT && $osql_n -ge $NEVENTS_NEXT ]]; then
+        ok=1
+        break
+    fi
+    sleep 1
+    i=$((i + 1))
+done
+
+if [[ $ok -ne 1 ]]; then
+    echo "statreqs queue counters wrong after $i polls:"
+    echo "  __qsp_consume enqueued=$enq_c dequeued=$deq_c" \
+         "OSQL_DBQ_CONSUME=$osql_c (want >= $NEVENTS_CONSUME each)"
+    echo "  __qsp_next    enqueued=$enq_n dequeued=$deq_n" \
+         "OSQL_DELREC=$osql_n (want >= $NEVENTS_NEXT each)"
+    statreqs 2>/dev/null | grep -A 8 "STATS FOR QUEUE"
+    failexit "queue counters missing or wrong in statreqs"
+fi
+
+# the on-demand dump should report the queues too
+statlong=$(mtrap "stat long")
+for q in __qsp_consume __qsp_next; do
+    echo "$statlong" | grep -q "REQUEST STATS FOR QUEUE '$q'" ||
+        failexit "'stat long' is missing queue $q"
+done
+echo "$statlong" | grep -q "OSQL_DBQ_CONSUME" ||
+    failexit "'stat long' is missing OSQL_DBQ_CONSUME for a queue"
+
+echo "__qsp_consume: enqueued=$enq_c dequeued=$deq_c OSQL_DBQ_CONSUME=$osql_c"
+echo "__qsp_next:    enqueued=$enq_n dequeued=$deq_n OSQL_DELREC=$osql_n"
+
+run "drop lua consumer sp_consume" >/dev/null
+run "drop lua consumer sp_next" >/dev/null
+
+echo "passed queuedb_statreqs"
+exit 0


### PR DESCRIPTION
Show queuedb counters in statreqs as well as `stat long`, e.g.,

```
DIFF REQUEST STATS FOR QUEUE '__qsp_consume'
      OSQL_DONE_SNAP         10
      OSQL_DBQ_CONSUME       10
      OSQL_STARTGEN          10
      enqueued               10
      dequeued               10
```