### PR TITLE
Fix llmeta schema change object leaks

### DIFF
--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1445,9 +1445,16 @@ int bplog_schemachange_wait(struct ireq *iq, int rc)
             }
             sc = next;
         }
-        if (rc == ERR_NOMASTER)
+        if (rc == ERR_NOMASTER) {
             iq->sc_pending = NULL;
+            /* this is resumable: don't let the abort callback delete the
+             * sc_list, the next master needs it
+             */
+            iq->osql_flags &= ~OSQL_FLAGS_SCDONE;
+        }
     }
+    /* osql_scdone_abort_callback keys its sc_list cleanup off this */
+    assert(rc != ERR_NOMASTER || iq->sc_pending == NULL);
     logmsg(LOGMSG_INFO, ">>> DDL SCHEMA CHANGE RC %d <<<\n", rc);
 
     assert(!iq->sc_locked);
@@ -1517,10 +1524,14 @@ void *resume_sc_multiddl_txn_finalize(void *p)
     struct ireq *iq = (struct ireq*)p;
     struct schema_change_type *sc;
     tran_type *parent_trans = NULL;
-    int error = 0;
-    uuid_t uuid;
-
-    comdb2uuidcpy(uuid, iq->sc_pending->uuid);
+    /* set by the caller if some of the schema changes of this transaction
+     * failed to even start; whatever did start has to be backed out
+     */
+    int error = iq->sc_should_abort;
+    /* if we are the ones going away, the schema changes that failed to start
+     * did so because of the downgrade, not because of anything wrong with them
+     */
+    int downgrade = error && get_stopsc(__func__, __LINE__);
 
     iq->sc = sc = iq->sc_pending;
     iq->sc_pending = NULL;
@@ -1536,6 +1547,8 @@ void *resume_sc_multiddl_txn_finalize(void *p)
         } else {
             logmsg(LOGMSG_ERROR, "%s: shard '%s', rc %d\n", __func__,
                    sc->tablename, sc->sc_rc);
+            if (sc->sc_rc == SC_MASTER_DOWNGRADE)
+                downgrade = 1;
             if (sc->set_running)
                 sc_set_running(iq, sc, sc->tablename, 0, NULL, 0, __func__,
                                __LINE__);
@@ -1545,7 +1558,11 @@ void *resume_sc_multiddl_txn_finalize(void *p)
         sc = iq->sc;
     }
     iq->sc_locked = 0;
-    iq->osql_flags |= OSQL_FLAGS_SCDONE;
+    /* marking scdone makes the abort path remove the sc_list from llmeta; on a
+     * downgrade we want the opposite -- leave it for the next master to resume
+     */
+    if (!downgrade)
+        iq->osql_flags |= OSQL_FLAGS_SCDONE;
     iq->sc_tran = NULL;
     iq->sc_logical_tran = NULL;
 
@@ -1639,10 +1656,11 @@ abort_sc:
 int resume_sc_multiddl_txn(sc_list_t *scl)
 {
     LISTC_T(struct schema_change_type) scs;
-    struct schema_change_type *sc;
+    struct schema_change_type *sc, *tmp;
+    struct ireq *iq = NULL;
     int i, size;
     uuidstr_t us;
-    int rc;
+    int rc = -1;
     int resume = bdb_attr_get(thedb->bdb_attr, BDB_ATTR_SC_RESUME_AUTOCOMMIT) ?
         SC_RESUME : SC_NEW_MASTER_RESUME;
 
@@ -1658,20 +1676,25 @@ int resume_sc_multiddl_txn(sc_list_t *scl)
         sc = new_schemachange_type();
         if (!sc) {
             logmsg(LOGMSG_ERROR, "%s oom\n", __func__);
-            return -1;
+            goto done;
         }
         if (!buf_get_schemachange(sc, p_buf, p_buf_end)) {
             logmsg(LOGMSG_ERROR, "%s uuid %s failed to retrieve sc\n",
                    __func__, us);
-            return -1;
+            free_schema_change_type(sc);
+            goto done;
         }
-        sc->resume = resume;
+        /* only schema changes going through do_ddl() persist state to pick up
+         * (sc seed, in-schema-change record); the rest (sp, trigger, lua func)
+         * have nothing to resume from and must start as new
+         */
+        if (sc_kind_runs_do_ddl(sc->kind))
+            sc->resume = resume;
 
         listc_abl(&scs, sc);
     }
 
-    /* this is freed in the wait thread */
-    struct ireq *iq = calloc(1, sizeof(struct ireq));
+    iq = calloc(1, sizeof(struct ireq));
     init_fake_ireq(thedb, iq);
 
     /* this starts schema changeas;
@@ -1679,23 +1702,39 @@ int resume_sc_multiddl_txn(sc_list_t *scl)
      * but the rest of the execution is done in parallel
      * waiting is done by a separate thread that will finalize
      * the schema change
-     * NOTE: schema changes will be queued in iq->sc_pending
-     *
+     * NOTE: schema changes will be queued in iq->sc_pending; for every entry
+     * it reaches, bplog_schemachange_run() unlinks it from scs before
+     * checking rc, whether it started or not, so by the time it returns scs
+     * only holds entries it never reached (skipped after an earlier break)
      */
     rc = bplog_schemachange_run(iq, scl->uuid, &scs);
-    if (rc && !iq->sc_pending) {
-        /* nothing got started, there is nothing to unwind */
+    if (!rc || iq->sc_pending) {
+        /* either everything started (rc == 0) or at least one did
+         * (iq->sc_pending set); either way the finalize thread has to run:
+         * it checks sc_rc for each schema change, backs out whatever needs
+         * it, and owns freeing iq from here on
+         */
+        if (rc)
+            iq->sc_should_abort = 1;
+        pthread_t tid;
+        Pthread_create(&tid, &gbl_pthread_attr_detached, resume_sc_multiddl_txn_finalize, iq);
+        iq = NULL;
+    } else {
         logmsg(LOGMSG_ERROR, "%s uuid %s failed to start, rc %d\n", __func__, us, rc);
-        free(iq);
-        return -1;
     }
-    /* if some of them did start, the finalize thread has to run: it checks
-     * sc_rc for each schema change and backs the whole set out.  Return 0 so
-     * that the remaining sc lists still get resumed.
-     */
 
-    pthread_t tid;
-    Pthread_create(&tid, &gbl_pthread_attr_detached,
-                        resume_sc_multiddl_txn_finalize, iq);
-    return 0;
+done:
+    /* safe to free unconditionally, even after handing iq to the finalize
+     * thread above: scs only ever holds entries bplog_schemachange_run()
+     * never reached, which were never linked into iq->sc_pending and never
+     * had a conversion thread launched for them, so the finalize thread
+     * (which only ever walks iq->sc_pending) cannot be touching them
+     */
+    LISTC_FOR_EACH_SAFE(&scs, sc, tmp, scs_lnk)
+    {
+        listc_rfl(&scs, sc);
+        free_schema_change_type(sc);
+    }
+    free(iq);
+    return rc ? -1 : 0;
 }

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -7083,16 +7083,12 @@ void osql_clear_sc_running(struct ireq *iq)
 int osql_finalize_scs(struct ireq *iq, tran_type *trans)
 {
     int rc;
-    uuid_t uuid;
 
     // TODO (NC): Check why iq->sc_pending is not getting set for views
     iq->sc = iq->sc_pending;
 
     if (!iq->sc)
         return 0;
-
-    /* scl uuid */
-    comdb2uuidcpy(uuid, iq->sc_pending->uuid);
 
     while (iq->sc != NULL) {
         if (!iq->sc_locked) {
@@ -7150,8 +7146,10 @@ int osql_finalize_scs(struct ireq *iq, tran_type *trans)
         create_sqlite_master();
     }
 
-    /* remove scl */
-    rc = osql_delete_sc_list(uuid, iq->sc_tran);
+    /* remove scl; the object is keyed by the osql session uuid, saved in
+     * iq->scs_uuid -- sc->uuid is only set for TRANLEVEL_SOSQL
+     */
+    rc = osql_delete_sc_list(iq->scs_uuid, iq->sc_tran);
     if (rc) {
         error = ERR_SC;
     }

--- a/schemachange/sc_logic.c
+++ b/schemachange/sc_logic.c
@@ -662,6 +662,13 @@ struct {
     {0, 0, NULL, NULL, do_default_cons, finalize_default_cons},
 };
 
+int sc_kind_runs_do_ddl(int kind)
+{
+    if (kind <= SC_INVALID || kind >= SC_LAST)
+        return 0;
+    return do_schema_change_if[kind].run_do_ddl;
+}
+
 static int do_schema_change_tran_int(sc_arg_t *arg)
 {
     struct ireq *iq = arg->iq;
@@ -1086,36 +1093,48 @@ int resume_sc_multiddl(int scabort)
     }
 
     for (i = 0; i < num; i++) {
+        int irc;
+
+        bzero(&scl, sizeof(scl));
+
         p_buf_key = keys[i];
         p_buf_key_end = p_buf_key + keylen;
         if (!osqlcomm_scl_get_key(&scl, p_buf_key, p_buf_key_end)) {
+            logmsg(LOGMSG_ERROR, "%s failed to decode sc list key %d\n", __func__, i);
             rc = -1;
-            goto freetime;
+            continue;
         }
 
         p_buf = dtas[i];
         p_buf_end = p_buf + dtalens[i];
         if (!osqlcomm_scl_get(&scl, p_buf, p_buf_end)) {
+            logmsg(LOGMSG_ERROR, "%s failed to decode sc list %d\n", __func__, i);
+            free(scl.offsets);
+            free(scl.ser_scs);
             rc = -1;
-            goto freetime;
+            continue;
         }
 
-        rc = resume_sc_multiddl_txn(&scl);
-        if (rc)
-            logmsg(LOGMSG_ERROR, "%s failed to resume scl %d\n", __func__, rc);
+        irc = resume_sc_multiddl_txn(&scl);
+        if (irc) {
+            /* keep going: each sc list is an independent transaction, and
+             * skipping the rest would leave them in llmeta with nobody to
+             * ever resume or remove them
+             */
+            logmsg(LOGMSG_ERROR, "%s failed to resume scl %d\n", __func__, irc);
+            rc = irc;
+        }
 
         free(scl.offsets);
         free(scl.ser_scs);
-
-        if (rc)
-            goto freetime;
     }
 
-freetime:
     for (i = 0; i < num; i++) {
         free(dtas[i]);
         free(keys[i]);
     }
+    free(dtas);
+    free(keys);
     free(dtalens);
     return rc;
 }

--- a/schemachange/schemachange.c
+++ b/schemachange/schemachange.c
@@ -230,6 +230,7 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
         }
         if (seed == 0 && host == 0) {
             logmsg(LOGMSG_ERROR, "Failed to determine host and seed!\n");
+            free_schema_change_type(s);
             return SC_INTERNAL_ERROR; // SC_INVALID_OPTIONS?
         }
         logmsg(LOGMSG_INFO, "stored seed %016llx, stored host %u\n",
@@ -294,8 +295,11 @@ int start_schema_change_tran(struct ireq *iq, tran_type *trans)
      * transaction in replicant code; we do need here one seed per for every
      * table schema changed in this transaction, even though they share the same
      * sc_seed value
+     * NOTE: only schema changes going through do_ddl() ever call
+     * mark_schemachange_over_tran(), which is what removes this llmeta object;
+     * persisting a seed for any other kind (sp, trigger, lua func) leaks it
      */
-    if (thedb->master == gbl_myhostname && !s->resume) {
+    if (thedb->master == gbl_myhostname && !s->resume && sc_kind_runs_do_ddl(s->kind)) {
         logmsg(LOGMSG_INFO, "Calling bdb_set_disable_plan_genid 0x%llx\n", seed);
         int bdberr;
         int rc = bdb_set_sc_seed(thedb->bdb_env, NULL, s->tablename, seed,

--- a/schemachange/schemachange.h
+++ b/schemachange/schemachange.h
@@ -428,6 +428,15 @@ typedef struct sc_list sc_list_t;
 int sc_list_create(sc_list_t *scl, void *vscs, uuid_t uuid);
 
 size_t schemachange_packed_size(struct schema_change_type *s);
+
+/* Returns 1 if schema changes of this kind run through do_ddl(), which is the
+ * only path that marks the schema change in llmeta and, on completion, calls
+ * mark_schemachange_over_tran() to remove those objects.  Kinds that return 0
+ * (sp, trigger, lua func, ...) must not persist any per-table sc state: there
+ * is nothing that would ever clean it up.
+ */
+int sc_kind_runs_do_ddl(int kind);
+
 int start_schema_change_tran(struct ireq *, tran_type *tran);
 int start_schema_change(struct schema_change_type *);
 int create_queue(struct dbenv *, char *queuename, int avgitem, int pagesize);

--- a/tests/multiddl.test/Makefile
+++ b/tests/multiddl.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=5m
+	export TEST_TIMEOUT=15m
 endif

--- a/tests/multiddl.test/runit
+++ b/tests/multiddl.test/runit
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 bash -n "$0" | exit 1
 source ${TESTSROOTDIR}/tools/runit_common.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
 
 # args
 # <dbname>
@@ -122,9 +123,9 @@ testcase_output=$(cat $OUT)
 expected_output=$(cat output.log)
 if [[ "$testcase_output" != "$expected_output" ]]; then
 
-   # print message 
+   # print message
    echo "  ^^^^^^^^^^^^"
-   echo "The above testcase (${testcase}) has failed!!!" 
+   echo "The above testcase (${testcase}) has failed!!!"
    echo " "
    echo "Use 'diff <expected-output> <my-output>' to see why:"
    echo "> diff ${PWD}/{output.log,run.log}"
@@ -133,6 +134,188 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
    echo " "
 
    # quit
+   exit 1
+fi
+
+# TEST 2 dropped the limit to one, put it back so the rest can run ddl
+echo "restoring the sc list limit"
+$CM "put tunable max_sc_lists 10000"
+if (( $? != 0 )) ; then
+   echo "FAILURE to restore max_sc_lists"
+   exit 1
+fi
+
+failed=0
+scl_count=0
+seed_count=0
+
+llmeta_sc()
+{
+    $C "exec procedure sys.cmd.send('llmeta list')" 2>/dev/null
+}
+
+# both counts must match what they were after the previous check; the sc_list
+# and the sc seed are removed when a schema change finishes, so anything left
+# behind is a leaked llmeta object
+check_no_leak()
+{
+    local what=$1
+    local dump=$(llmeta_sc)
+    local n=$(echo "$dump" | grep -c "LLMETA_SCHEMACHANGE_LIST")
+    local s=$(echo "$dump" | grep -c "LLMETA_SC_SEEDS")
+
+    if (( n != scl_count )) ; then
+        echo "LEAK: ${what}: scl count ${scl_count} -> ${n}"
+        failed=1
+    else
+        echo "OK: ${what}: scl count stable at ${n}"
+    fi
+    if (( s != seed_count )) ; then
+        echo "LEAK: ${what}: seed count ${seed_count} -> ${s}"
+        failed=1
+    else
+        echo "OK: ${what}: seed count stable at ${s}"
+    fi
+    scl_count=$n
+    seed_count=$s
+}
+
+echo "TEST 3: ddl must not leak scl or sc seed at any transaction level"
+
+dump=$(llmeta_sc)
+scl_count=$(echo "$dump" | grep -c "LLMETA_SCHEMACHANGE_LIST")
+seed_count=$(echo "$dump" | grep -c "LLMETA_SC_SEEDS")
+echo "baseline scl count ${scl_count} seed count ${seed_count}"
+
+$C "create table s1(a int)" >/dev/null
+sleep 2
+check_no_leak "autocommit sosql create table"
+
+$C - <<'EOF' >/dev/null
+set transaction read committed
+create table s2(a int)
+EOF
+sleep 2
+check_no_leak "read committed create table"
+
+$C - <<'EOF' >/dev/null
+set transaction snapshot isolation
+create table s3(a int)
+EOF
+sleep 2
+check_no_leak "snapshot isolation create table"
+
+$C "alter table s1 add column c int" >/dev/null
+sleep 2
+check_no_leak "autocommit sosql alter table"
+
+$C "create procedure p1 version 'v1' {local function main() end}" >/dev/null
+sleep 2
+check_no_leak "autocommit sosql create procedure"
+
+$C - <<'EOF' >/dev/null
+set transaction read committed
+create procedure p2 version 'v1' {local function main() end}
+EOF
+sleep 2
+check_no_leak "read committed create procedure"
+
+$C - <<'EOF' >/dev/null
+set transaction read committed
+put default procedure p2 'v1'
+EOF
+sleep 2
+check_no_leak "read committed put default procedure"
+
+$C - <<'EOF' >/dev/null
+set transaction read committed
+begin
+create table s8(a int)$$
+commit
+EOF
+sleep 2
+check_no_leak "begin/commit read committed create table"
+
+$C "drop procedure p1 'v1'" >/dev/null
+sleep 2
+check_no_leak "drop procedure"
+
+echo "TEST 4: resuming a mixed table+sp transaction must not leak llmeta objects"
+
+if [[ -z "$CLUSTER" ]]; then
+    echo "skipping TEST 4, it needs a cluster to swing the master"
+else
+    echo "inserting rows so the alter takes a while"
+    $C "insert into t(a) select * from generate_series(1000, 1060)" >/dev/null
+    if (( $? != 0 )) ; then
+       echo "FAILURE inserting rows"
+       exit 1
+    fi
+
+    # create procedure runs in a transaction of its own, so it cannot be part
+    # of the one below; put default procedure can, and is equally a kind that
+    # keeps no resume state
+    $C "create procedure swingsp version 'v1' {local function main() end}" >/dev/null
+    if (( $? != 0 )) ; then
+       echo "FAILURE creating the procedure"
+       exit 1
+    fi
+
+    master=`getmaster`
+    CM="cdb2sql ${CDB2_OPTIONS} ${DBN} --host ${master}"
+    $CM "exec procedure sys.cmd.send('bdb setattr SC_FORCE_DELAY 1')" >/dev/null
+    $CM "exec procedure sys.cmd.send('scdelay 1000')" >/dev/null
+
+    # one sc_list holding an alter, which persists resume state, and a default
+    # procedure change, which does not; the new master resumes both from the
+    # saved sc_list and removes it when done.  The client is expected to get an
+    # error here, the schema changes still go through.
+    # the alter adds a key, which has to walk every record and so is still
+    # running when the master goes away -- adding a column would be an instant
+    # schema change and would be long done by then.  cdb2sql reads alter as a
+    # $$ delimited block; put default procedure is a plain single line
+    ( $C - > swing.out 2>&1 <<'EOF'
+set transaction read committed
+begin
+alter table t {schema{int a cstring b[10] null=yes} keys{"pk"=a dup "bkey"=b}}$$
+put default procedure swingsp 'v1'
+commit
+EOF
+    ) &
+
+    sleep 5
+    echo "downgrading master to force a resume"
+    downgrade_master
+
+    wait
+    echo "client returned:"
+    cat swing.out
+
+    # the new master has to finish the alter off the saved sc_list; if the list
+    # were dropped instead, the key would never show up
+    echo "waiting for the resumed schema change to finish"
+    found=0
+    i=0
+    while (( i < 180 )) ; do
+        found=$($CT "select count(*) from comdb2_keys where tablename='t' and keyname like '%BKEY%'" 2>/dev/null)
+        [[ "$found" == "1" ]] && break
+        sleep 1
+        let i=i+1
+    done
+
+    if [[ "$found" != "1" ]]; then
+        echo "FAILURE: new master did not resume the alter from the saved sc_list"
+        failed=1
+    else
+        echo "OK: new master resumed and completed the alter"
+    fi
+
+    sleep 10
+    check_no_leak "mixed table+sp ddl resumed after master swing"
+fi
+
+if (( failed != 0 )) ; then
+   echo "FAILURE"
    exit 1
 fi
 


### PR DESCRIPTION
osql_finalize_scs deleted the sc_list keyed by the schema change uuid, set only for TRANLEVEL_SOSQL; key it by the osql session uuid instead.

Only kinds running through do_ddl() reach mark_schemachange_over_tran(), so stop persisting an sc seed for the others (sp, trigger, lua func) -- nothing ever removed it.  Resumed sc lists no longer mark those kinds as resuming, as they have no persisted state to pick up.

OSQL_FLAGS_SCDONE is set when a schema change is dispatched, before a downgrade can be seen by its async conversion, and was never cleared, so the abort path deleted the sc_list the new master needed to resume from.

A failed multi-table resume dropped its ireq, orphaning the schema changes that had started and stranding the sc_list, and gave up on the remaining sc lists.

re: 185631797