### PR TITLE
Reject malformed SET PARTITION commands

### DIFF
--- a/db/fdb_fend.c
+++ b/db/fdb_fend.c
@@ -6057,6 +6057,8 @@ int process_fdb_set_cdb2api(sqlclntstate *clnt, char *sqlstr, char *err,
             return -1;
         }
 
+        free(clnt->remsql_set.srcdbname); /* re-issued set */
+        clnt->remsql_set.srcdbname = NULL;
         GET_PCSTR(sqlstr, "srcdbname", clnt->remsql_set.srcdbname);
 
         if (!fdb_is_dbname_in_whitelist(clnt->remsql_set.srcdbname)) {

--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -1955,7 +1955,20 @@ int osql_schemachange_logic(struct schema_change_type *sc, int usedb)
         /* this is a distributed create for a partition, creating individual shard here, info passed from
          * SET OPTIONS through clnt struct
          */
-        if (sc->kind == SC_ADDTABLE) { 
+        /* the SET PARTITION commands are independent of each other, so a client
+         * can announce a count without ever sending the matching names; refuse
+         * rather than walk an array that was never built. A DROP legitimately
+         * has no partitioning columns. */
+        if (clnt->remsql_set.numdbs == 0 || !clnt->remsql_set.dbnames || !clnt->remsql_set.shardnames ||
+            (clnt->remsql_set.numcols > 0 && !clnt->remsql_set.columns)) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: incomplete SET PARTITION state (numdbs=%u dbnames=%p shardnames=%p numcols=%d columns=%p)\n",
+                   __func__, clnt->remsql_set.numdbs, clnt->remsql_set.dbnames, clnt->remsql_set.shardnames,
+                   clnt->remsql_set.numcols, clnt->remsql_set.columns);
+            return SQLITE_ERROR;
+        }
+
+        if (sc->kind == SC_ADDTABLE) {
             sc->partition.type = PARTITION_ADD_GENSHARD;
         } else {
             sc->partition.type = PARTITION_REM_GENSHARD;
@@ -1963,18 +1976,24 @@ int osql_schemachange_logic(struct schema_change_type *sc, int usedb)
         snprintf(sc->partition.u.genshard.tablename, sizeof(sc->partition.u.genshard.tablename),
                  "%s", clnt->remsql_set.tablename);
         sc->partition.u.genshard.numdbs = clnt->remsql_set.numdbs;
-        sc->partition.u.genshard.dbnames = malloc(sizeof(char*) * clnt->remsql_set.numdbs);
-        for (int i = 0; i < clnt->remsql_set.numdbs; i++) {
+        sc->partition.u.genshard.dbnames = calloc(clnt->remsql_set.numdbs, sizeof(char *));
+        /* +1: a DROP has numcols=0 and calloc(0) may return NULL */
+        sc->partition.u.genshard.columns = calloc(clnt->remsql_set.numcols + 1, sizeof(char *));
+        sc->partition.u.genshard.shardnames = calloc(clnt->remsql_set.numdbs, sizeof(char *));
+        if (!sc->partition.u.genshard.dbnames || !sc->partition.u.genshard.columns ||
+            !sc->partition.u.genshard.shardnames) {
+            logmsg(LOGMSG_ERROR, "%s: out of memory for genshard partition\n", __func__);
+            return SQLITE_NOMEM;
+        }
+        for (uint32_t i = 0; i < clnt->remsql_set.numdbs; i++) {
             sc->partition.u.genshard.dbnames[i] = strdup(clnt->remsql_set.dbnames[i]);
         }
 
         sc->partition.u.genshard.numcols = clnt->remsql_set.numcols;
-        sc->partition.u.genshard.columns = malloc(sizeof(char*) * clnt->remsql_set.numcols);
-        for(int i=0;i<clnt->remsql_set.numcols;i++) {
+        for (int i = 0; i < clnt->remsql_set.numcols; i++) {
             sc->partition.u.genshard.columns[i] = strdup(clnt->remsql_set.columns[i]);
         }
-        sc->partition.u.genshard.shardnames = malloc(sizeof(char*) * clnt->remsql_set.numdbs);
-        for (int i = 0; i < clnt->remsql_set.numdbs; i++) {
+        for (uint32_t i = 0; i < clnt->remsql_set.numdbs; i++) {
             sc->partition.u.genshard.shardnames[i] = strdup(clnt->remsql_set.shardnames[i]);
         }
     }

--- a/db/sql.h
+++ b/db/sql.h
@@ -1437,6 +1437,7 @@ void reset_clnt(struct sqlclntstate *, int initial);
 void cleanup_clnt(struct sqlclntstate *);
 void free_client_info(struct sqlclntstate *);
 void free_client_adj_col_names(struct sqlclntstate *);
+void free_partition_string_array(char ***arr, uint32_t nelems);
 void reset_query_effects(struct sqlclntstate *, int, int);
 
 int sqlite_to_ondisk(struct schema *s, const void *inp, int len, void *outp,

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -5456,6 +5456,29 @@ int cdb2_in_client_trans() {
     return clnt->in_client_trans;
 }
 
+/* Release one of the genshard partition arrays built by the SET PARTITION
+ * DBS/COLS/SHARDS commands. nelems must be the count the array was allocated
+ * with; the SET handlers keep remsql_set.numdbs/numcols in sync with the
+ * allocation by freeing an array whenever its count changes. */
+void free_partition_string_array(char ***arr, uint32_t nelems)
+{
+    if (!*arr)
+        return;
+    for (uint32_t i = 0; i < nelems; i++)
+        free((*arr)[i]);
+    free(*arr);
+    *arr = NULL;
+}
+
+static void free_remsql_set(struct sqlclntstate *clnt)
+{
+    free_partition_string_array(&clnt->remsql_set.dbnames, clnt->remsql_set.numdbs);
+    free_partition_string_array(&clnt->remsql_set.shardnames, clnt->remsql_set.numdbs);
+    free_partition_string_array(&clnt->remsql_set.columns, clnt->remsql_set.numcols);
+    free(clnt->remsql_set.srcdbname);
+    clnt->remsql_set.srcdbname = NULL;
+}
+
 void reset_clnt(struct sqlclntstate *clnt, int initial)
 {
     if (initial) {
@@ -5646,6 +5669,7 @@ void reset_clnt(struct sqlclntstate *clnt, int initial)
         clear_modsnap_state(clnt);
     }
 
+    free_remsql_set(clnt);
     bzero(&clnt->remsql_set, sizeof(clnt->remsql_set));
     _free_set_commands(clnt);
 }

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -1687,12 +1687,20 @@ int handle_set_querylimits(char *sqlstr, struct sqlclntstate *clnt)
         return 1;
 }
 
+/* Extract exactly nparams space separated names out of sql into dbnames, which
+ * the caller has allocated with room for nparams entries and zeroed. Returns 0
+ * on success; on failure the caller releases whatever was extracted so far. */
 int partition_extract_string_params(char *sql, char **dbnames, uint32_t nparams, const char *fc)
 {
     char *strt= skipws(sql);
     char *crt = strt;
-    int i = 0;
-    do {
+
+    for (uint32_t i = 0; i < nparams; i++) {
+        if (strt[0] == '\0') {
+            logmsg(LOGMSG_ERROR, "%s: expected %u params, got %u\n", fc, nparams, i);
+            return -1;
+        }
+
         while (crt[0] != ' ' && crt[0] != '\0') crt++;
 
         int len = crt - strt + 1;
@@ -1707,7 +1715,7 @@ int partition_extract_string_params(char *sql, char **dbnames, uint32_t nparams,
         }
         strt = skipws(crt);
         crt = strt;
-    } while (++i < nparams);
+    }
 
     return 0;
 }
@@ -2136,9 +2144,14 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
             } else if (strncasecmp(sqlstr, "PARTITION NUMDBS ", 17) == 0) {
                 sqlstr += 17;
                 int numdbs = strtol(sqlstr, &endp, 10);
-                if (endp != sqlstr && numdbs > 0 && numdbs <= 4096)
+                if (endp != sqlstr && numdbs > 0 && numdbs <= 4096) {
+                    /* dbnames and shardnames are both sized by numdbs; drop any
+                     * array built under the previous count so that the count
+                     * and the allocations can never disagree. */
+                    free_partition_string_array(&clnt->remsql_set.dbnames, clnt->remsql_set.numdbs);
+                    free_partition_string_array(&clnt->remsql_set.shardnames, clnt->remsql_set.numdbs);
                     clnt->remsql_set.numdbs = numdbs;
-                else {
+                } else {
                     logmsg(LOGMSG_ERROR,
                            "Error: bad value for remsql_set.numdbs %s\n", sqlstr);
                     snprintf(err, sizeof(err), "bad value for PARTITION NUMDBS");
@@ -2149,14 +2162,19 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
                        clnt->remsql_set.numdbs);
                 }
             } else if (strncasecmp(sqlstr, "PARTITION DBS ", 14) == 0) {
-                clnt->remsql_set.dbnames = (char**)malloc(sizeof(char*) * clnt->remsql_set.numdbs);
-                if (!clnt->remsql_set.dbnames) {
+                /* the count has to come first: it sizes the array below */
+                free_partition_string_array(&clnt->remsql_set.dbnames, clnt->remsql_set.numdbs);
+                if (clnt->remsql_set.numdbs == 0) {
+                    snprintf(err, sizeof(err), "PARTITION NUMDBS must be set before PARTITION DBS");
+                    rc = ii + 1;
+                } else if (!(clnt->remsql_set.dbnames = (char **)calloc(clnt->remsql_set.numdbs, sizeof(char *)))) {
                     snprintf(err, sizeof(err), "out of memory for dbnames");
                     rc = ii + 1;
                 } else {
                     rc = partition_extract_string_params(&sqlstr[14], clnt->remsql_set.dbnames, clnt->remsql_set.numdbs,
                                                          __func__);
                     if (rc) {
+                        free_partition_string_array(&clnt->remsql_set.dbnames, clnt->remsql_set.numdbs);
                         snprintf(err, sizeof(err), "failed to extract dbnames");
                         rc = ii + 1;
                     }
@@ -2164,9 +2182,11 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
             } else if (strncasecmp(sqlstr, "PARTITION NUMCOLS ", 18) == 0) {
                 sqlstr += 18;
                 int numcols = strtol(sqlstr, &endp, 10);
-                if (endp != sqlstr && numcols >= 0 && numcols <= 4096)
+                if (endp != sqlstr && numcols >= 0 && numcols <= 4096) {
+                    /* columns is sized by numcols; see PARTITION NUMDBS */
+                    free_partition_string_array(&clnt->remsql_set.columns, clnt->remsql_set.numcols);
                     clnt->remsql_set.numcols = numcols;
-                else {
+                } else {
                     logmsg(LOGMSG_ERROR,
                            "Error: bad value for remsql_set.numcols %s\n", sqlstr);
                     snprintf(err, sizeof(err), "bad value for PARTITION NUMCOLS");
@@ -2177,28 +2197,35 @@ int process_set_commands(struct sqlclntstate *clnt, CDB2SQLQUERY *sql_query)
                        clnt->remsql_set.numcols);
                 }
             } else if (strncasecmp(sqlstr, "PARTITION COLS ", 15) == 0) {
+                free_partition_string_array(&clnt->remsql_set.columns, clnt->remsql_set.numcols);
                 if (clnt->remsql_set.numcols == 0) {
                     /* DROP sends numcols=0; no columns to extract */
-                } else if (!(clnt->remsql_set.columns = (char **)malloc(sizeof(char *) * clnt->remsql_set.numcols))) {
+                } else if (!(clnt->remsql_set.columns = (char **)calloc(clnt->remsql_set.numcols, sizeof(char *)))) {
                     snprintf(err, sizeof(err), "out of memory for columns");
                     rc = ii + 1;
                 } else {
                     rc = partition_extract_string_params(&sqlstr[15], clnt->remsql_set.columns,
                                                          clnt->remsql_set.numcols, __func__);
                     if (rc) {
+                        free_partition_string_array(&clnt->remsql_set.columns, clnt->remsql_set.numcols);
                         snprintf(err, sizeof(err), "failed to extract columns");
                         rc = ii + 1;
                     }
                 }
             } else if (strncasecmp(sqlstr, "PARTITION SHARDS ", 17) == 0) {
-                clnt->remsql_set.shardnames = (char**)malloc(sizeof(char*) * clnt->remsql_set.numdbs);
-                if (!clnt->remsql_set.shardnames) {
+                /* the count has to come first: it sizes the array below */
+                free_partition_string_array(&clnt->remsql_set.shardnames, clnt->remsql_set.numdbs);
+                if (clnt->remsql_set.numdbs == 0) {
+                    snprintf(err, sizeof(err), "PARTITION NUMDBS must be set before PARTITION SHARDS");
+                    rc = ii + 1;
+                } else if (!(clnt->remsql_set.shardnames = (char **)calloc(clnt->remsql_set.numdbs, sizeof(char *)))) {
                     snprintf(err, sizeof(err), "out of memory for shardnames");
                     rc = ii + 1;
                 } else {
                     rc = partition_extract_string_params(&sqlstr[17], clnt->remsql_set.shardnames,
                                                          clnt->remsql_set.numdbs, __func__);
                     if (rc) {
+                        free_partition_string_array(&clnt->remsql_set.shardnames, clnt->remsql_set.numdbs);
                         snprintf(err, sizeof(err), "failed to extract shardnames");
                         rc = ii + 1;
                     }

--- a/tests/partition_set_malformed.test/Makefile
+++ b/tests/partition_set_malformed.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/partition_set_malformed.test/runit
+++ b/tests/partition_set_malformed.test/runit
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+set -x
+
+# The SET PARTITION ... commands feed the generic-shard DDL that a coordinator
+# sends to its participants. They are processed at query intake, before the SQL
+# engine authenticates, and each one is independent of the others -- so a client
+# can send them out of order, with a count that does not match the names, or
+# with no count at all. None of that may corrupt the heap or take the db down.
+
+SQL="cdb2sql ${CDB2_OPTIONS} $DBNAME default"
+
+nfail=0
+
+# $1 description, $2 statement that makes the buffered SET commands take effect,
+# rest: the SET commands. The statement must fail and the db must stay up. Cases
+# all run even after one fails, so a single run reports the whole matrix.
+function expect_failure
+{
+    local desc=$1
+    local trigger=$2
+    shift 2
+    local out
+
+    out=$(printf '%s\n' "$@" "$trigger" | $SQL - 2>&1)
+    if [[ $? -eq 0 ]]; then
+        echo "FAIL: '$desc' was accepted, expected an error; got: $out"
+        nfail=$((nfail+1))
+    else
+        echo "ok: '$desc' rejected with: $out"
+    fi
+
+    if ! $SQL "select 1" >/dev/null 2>&1; then
+        echo "FAIL: db is not serving after '$desc'"
+        nfail=$((nfail+1))
+    fi
+}
+
+# No PARTITION NUMDBS at all: numdbs defaults to 0, so the names array is
+# zero-length and must not be written to.
+expect_failure "dbs without numdbs" "select 1;" "set partition dbs adb bdb"
+expect_failure "shards without numdbs" "select 1;" "set partition shards ashard bshard"
+
+# Count set back to zero is refused outright, so the names still have no array.
+expect_failure "numdbs 0 then dbs" "select 1;" "set partition numdbs 0" "set partition dbs adb bdb"
+
+# Fewer names than the announced count: the tail of the array would otherwise be
+# left uninitialized and strdup'd later.
+expect_failure "numdbs 3 with one dbname" "select 1;" "set partition numdbs 3" "set partition dbs onlydb"
+expect_failure "numdbs 3 with one shardname" "select 1;" "set partition numdbs 3" "set partition shards onlyshard"
+expect_failure "numcols 2 with one column" "select 1;" "set partition numcols 2" "set partition cols onlycol"
+
+# Count raised after the names were extracted: the array is sized by the old
+# count, the loop that consumes it uses the new one.
+expect_failure "numdbs raised after dbs" "select 1;" \
+    "set partition numdbs 1" "set partition dbs adb" "set partition numdbs 4096" \
+    "set partition shards ashard"
+
+# A create that claims to be a distributed shard create but never sends the
+# dbnames/shardnames: the DDL path used to walk NULL arrays here.
+expect_failure "remcreate with counts but no names" "create table t1(a int);" \
+    "set partition name p1" "set partition numdbs 2" "set partition numcols 1"
+
+# Same, but with dbnames present and shardnames missing.
+expect_failure "remcreate missing shardnames" "create table t1(a int);" \
+    "set partition name p1" "set partition numdbs 2" "set partition dbs adb bdb" \
+    "set partition numcols 1" "set partition cols acol"
+
+# Re-issuing the names is legal -- the second set replaces the first -- but it
+# must release the previous array rather than leak or reuse it.
+for i in $(seq 1 50); do
+    out=$(printf '%s\n' "set partition numdbs 2" "set partition dbs adb bdb" \
+        "set partition dbs cdb ddb" "set partition shards ashard bshard" "select 1;" | $SQL - 2>&1)
+    if [[ $? -ne 0 ]]; then
+        echo "FAIL: re-issued dbs/shards #$i was rejected: $out"
+        nfail=$((nfail+1))
+        break
+    fi
+done
+
+# The db has to be healthy and usable at the end of all of that.
+$SQL "create table t2(a int)" || nfail=$((nfail+1))
+$SQL "insert into t2 values(1)" || nfail=$((nfail+1))
+count=$($SQL --tabs "select count(*) from t2")
+if [[ $count != "1" ]]; then
+    echo "FAIL: expected 1 row in t2, got '$count'"
+    nfail=$((nfail+1))
+fi
+
+if [[ $nfail -ne 0 ]]; then
+    echo "$nfail check(s) failed"
+    exit 1
+fi
+
+echo "Success"


### PR DESCRIPTION
PARTITION DBS and PARTITION SHARDS now require a prior PARTITION NUMDBS and exactly the announced number of names; anything else is refused instead of writing past the end of the name array. A shard create that never sends the db or shard names no longer takes the database down. The name arrays are released on replacement and connection reset.
