### PR TITLE
Validate offload block request lengths

### DIFF
--- a/db/handle_buf.c
+++ b/db/handle_buf.c
@@ -879,9 +879,24 @@ int handle_buf_block_offload(struct dbenv *dbenv, uint8_t *p_buf,
                              const uint8_t *p_buf_end, int debug,
                              char *frommach, unsigned long long rqid)
 {
-    int length = p_buf_end - p_buf;
+    if (p_buf == NULL || p_buf_end == NULL || p_buf_end < p_buf) {
+        logmsg(LOGMSG_ERROR, "%s: invalid block request buffer\n", __func__);
+        return ERR_INTERNAL;
+    }
+
+    ptrdiff_t length = p_buf_end - p_buf;
+    if (length > MAX_BUFFER_SIZE) {
+        logmsg(LOGMSG_ERROR, "%s: invalid block request length %td\n", __func__, length);
+        return ERR_INTERNAL;
+    }
+
     uint8_t *p_bigbuf = get_bigbuf();
-    memcpy(p_bigbuf, p_buf, length);
+    if (p_bigbuf == NULL) {
+        logmsg(LOGMSG_ERROR, "%s: unable to acquire block request buffer\n", __func__);
+        return ERR_INTERNAL;
+    }
+
+    memcpy(p_bigbuf, p_buf, (size_t)length);
     if (length < EXTRA_RESPONSE_ROOM)
         length = EXTRA_RESPONSE_ROOM;
     int rc = handle_buf_main(dbenv, NULL, p_bigbuf, p_bigbuf + length, debug,

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3642,11 +3642,28 @@ static void net_block_req(void *hndl, void *uptr, char *fromhost,
                           struct interned_string *frominterned, int usertype,
                           void *dtap, int dtalen, uint8_t is_tcp)
 {
+    /* The payload starts at 'data'; sizeof() may include trailing padding. */
+    const size_t header_len = offsetof(net_block_msg_t, data);
+
+    /* Validate the received message before reading any of its fields. */
+    if (dtap == NULL || dtalen < 0 || (size_t)dtalen < header_len) {
+        logmsg(LOGMSG_ERROR, "%s: invalid block request message length %d\n", __func__, dtalen);
+        return;
+    }
 
     net_block_msg_t *net_msg = dtap;
-    handle_buf_block_offload(thedb, (uint8_t *)net_msg->data,
-                             (uint8_t *)net_msg->data + net_msg->datalen, 0,
-                             fromhost, net_msg->rqid);
+    int datalen = net_msg->datalen;
+    size_t available = (size_t)dtalen - header_len;
+
+    /* The declared payload length has to fit in what was actually received
+     * and in the buffer it will be copied into. */
+    if (datalen < 0 || (size_t)datalen > available || (size_t)datalen > MAX_BUFFER_SIZE) {
+        logmsg(LOGMSG_ERROR, "%s: invalid block request payload length %d\n", __func__, datalen);
+        return;
+    }
+
+    handle_buf_block_offload(thedb, (uint8_t *)net_msg->data, (uint8_t *)net_msg->data + datalen, 0, fromhost,
+                             net_msg->rqid);
 }
 
 int offload_comm_send_blockreply(char *host, unsigned long long rqid, void *buf,


### PR DESCRIPTION
{185614748}
Check the received and declared payload sizes before processing block requests and add defensive bounds checks to block request handling.
