### PR TITLE
cdb2_dump: don't skip records larger than the bulk buffer

### DIFF
--- a/tests/cdb2dump_bigblob.test/Makefile
+++ b/tests/cdb2dump_bigblob.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/cdb2dump_bigblob.test/README
+++ b/tests/cdb2dump_bigblob.test/README
@@ -1,0 +1,8 @@
+cdb2_dump reads a btree with a bulk (DB_MULTIPLE_KEY) cursor into a 1MB
+buffer.  A key/data pair larger than the buffer makes berkeley db return
+ENOMEM while leaving the cursor parked on that pair so the caller can grow
+the buffer and re-read it with DB_CURRENT.  cdb2_dump used to resume with
+DB_NEXT instead, silently stepping over the oversized record.
+
+This testcase stores a blob comfortably larger than 1MB next to a handful of
+small ones and checks that cdb2_dump emits the big one too.

--- a/tests/cdb2dump_bigblob.test/lrl.options
+++ b/tests/cdb2dump_bigblob.test/lrl.options
@@ -1,0 +1,1 @@
+dtastripe 1

--- a/tests/cdb2dump_bigblob.test/runit
+++ b/tests/cdb2dump_bigblob.test/runit
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+# Size of the oversized blob.  cdb2_dump bulk-reads into a 1MB buffer, so
+# anything comfortably over 1MB exercises the ENOMEM/realloc path.
+BIG=4194304
+SMALL=1024
+CNT=10
+
+dbnm=$1
+set -e
+set -x
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "create table t1 options rec none, blobfield none { `cat t1.csc2 ` }"
+
+i=0
+while [ $i -lt $CNT ] ; do
+ let i=i+1
+ echo "insert into t1(a, b) values ($i, zeroblob($SMALL))"
+done | cdb2sql ${CDB2_OPTIONS} $dbnm default -
+
+cdb2sql ${CDB2_OPTIONS} $dbnm default "insert into t1(a, b) values (999, zeroblob($BIG))"
+
+assertres "$(cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'select length(b) from t1 where a=999')" "$BIG"
+
+master=`getmaster`
+cluster=`cdb2sql --tabs ${CDB2_OPTIONS} $dbnm default 'exec procedure sys.cmd.send("bdb cluster")' | grep lsn | cut -f1 -d':' `
+for node in $cluster ; do
+    cdb2sql ${CDB2_OPTIONS} --host $node $dbnm "exec procedure sys.cmd.send('flush')"
+done
+
+out=$TMPDIR/t1_blob_dump.txt
+err=$TMPDIR/t1_blob_dump.err
+
+hnamelist="`hostname` `hostname -f` `hostname -s` localhost"
+if [[ " $hnamelist " =~ .*\ $master\ .* ]] ; then
+    find $DBDIR | grep '/t1_.*\.blob' | xargs ${CDB2DUMP_EXE} -f $out 2> $err
+else
+    ssh -o StrictHostKeyChecking=no $master "ln -f ${COMDB2_EXE} ${CDB2DUMP_EXE}"
+    ssh -o StrictHostKeyChecking=no $master "find $DBDIR | grep '/t1_.*\.blob' | xargs ${CDB2DUMP_EXE} " > $out 2> $err
+fi
+
+if [ -s $err ] ; then
+    cat $err
+    failexit "cdb2_dump wrote to stderr"
+fi
+
+# The blob is dumped as hex, so the record is twice its size on one line.
+nbig=`awk -v n=$((BIG * 2)) 'length($0) >= n' $out | wc -l`
+if [ $nbig -ne 1 ] ; then
+    failexit "expected 1 record of at least $BIG bytes in $out, found $nbig"
+fi
+
+echo Success

--- a/tests/cdb2dump_bigblob.test/t1.csc2
+++ b/tests/cdb2dump_bigblob.test/t1.csc2
@@ -1,0 +1,5 @@
+schema
+{
+   int      a null=yes
+   blob     b null=yes
+}

--- a/tools/cdb2_dump/cdb2_dump.c
+++ b/tools/cdb2_dump/cdb2_dump.c
@@ -516,6 +516,7 @@ dump(dbp, pflag, keyflag)
 	DBT keyret, dataret;
 	db_recno_t recno;
 	int is_recno, failed, ret;
+	u_int32_t getflags;
 	void *pointer;
 
 	/*
@@ -544,10 +545,12 @@ dump(dbp, pflag, keyflag)
 		keyret.data = &recno;
 		keyret.size = sizeof(recno);
 	}
+	getflags = DB_NEXT;
 
 retry:
-	while ((ret =
-	    dbcp->c_get(dbcp, &key, &data, DB_NEXT | DB_MULTIPLE_KEY)) == 0) {
+	while ((ret = dbcp->c_get(dbcp,
+	    &key, &data, getflags | DB_MULTIPLE_KEY)) == 0) {
+		getflags = DB_NEXT;
 		DB_MULTIPLE_INIT(pointer, &data);
 		for (;;) {
 			if (is_recno)
@@ -581,6 +584,12 @@ retry:
 			goto err;
 		}
 		data.ulen = data.size;
+		/*
+		 * The cursor is still parked on the key/data pair that did
+		 * not fit; re-read it with DB_CURRENT, otherwise DB_NEXT
+		 * steps over it and it is silently dropped from the dump.
+		 */
+		getflags = DB_CURRENT;
 		goto retry;
 	}
 


### PR DESCRIPTION
### 🎯 The "Why" (Intent)
`cdb2_dump` silently omitted any key/data pair bigger than its 1MB bulk-get buffer — no error, exit code 0 — so dumps of tables with large blobs were quietly incomplete.

### 🛠️ The "What" (Critical Changes)
- On `ENOMEM`, berkeley db deliberately leaves the cursor parked on the oversized pair so the caller can grow its buffer and re-read with `DB_CURRENT`. `dump()` instead resumed the loop with `DB_NEXT`, stepping straight over it. It now re-reads the parked pair before resuming.
- New `cdb2dump_bigblob` testcase: stores a 4MB blob alongside small ones and asserts `cdb2_dump` emits it. Fails on the old binary, passes on the new one.