### PR TITLE
Logfill bounded tranlog stream

### DIFF
--- a/db/sqllogfill.c
+++ b/db/sqllogfill.c
@@ -555,13 +555,23 @@ static int request_logs_from_master(bdb_state_type *bdb_state)
         /* Release bdb-lock before querying */
         BDB_RELLOCK();
 
+        /* Already at the gap: the bound would be at or below the start, and the
+         * empty result set that comes back reads as a stream failure below. */
+        DB_LSN start_lsn = {last_lsn.file, last_lsn.offset};
+        if (log_compare(&start_lsn, &gap_lsn) >= 0) {
+            return 1;
+        }
+
         int timeout = gbl_sql_logfill_next_timeout;
         timeout = timeout > 0 ? timeout : 10;
 
-        /* Query transaction log with BLOCK and SENTINEL flags */
+        /* Stop the stream at the gap.  An unbounded stream never ends, so we
+         * abandon it mid-result-set and cdb2api has to drop the socket rather
+         * than donate it back to sockpool. */
         rc = snprintf(sql_cmd, SQL_CMD_LEN,
-                      "select lsn, generation, payload from comdb2_transaction_logs('{%u:%u}', NULL, %d, %d)",
-                      last_lsn.file, last_lsn.offset, TRANLOG_FLAGS_BLOCK | TRANLOG_FLAGS_SENTINEL, timeout);
+                      "select lsn, generation, payload from comdb2_transaction_logs('{%u:%u}', '{%u:%u}', %d, %d)",
+                      last_lsn.file, last_lsn.offset, gap_lsn.file, gap_lsn.offset,
+                      TRANLOG_FLAGS_BLOCK | TRANLOG_FLAGS_SENTINEL, timeout);
 
         if (rc < 0 || rc >= SQL_CMD_LEN) {
             logmsg(LOGMSG_ERROR, "%s: snprintf failed, rc=%d\n", __func__, rc);

--- a/sqlite/ext/comdb2/tranlog.c
+++ b/sqlite/ext/comdb2/tranlog.c
@@ -166,6 +166,14 @@ static int tranlogNext(sqlite3_vtab_cursor *cur)
   if (pCur->notDurable || pCur->hitLast)
       return SQLITE_OK;
 
+  /* We've already returned maxLsn: don't block for a successor that Eof would
+   * discard anyway. */
+  if (pCur->openCursor && pCur->maxLsn.file > 0 &&
+          log_compare(&pCur->curLsn, &pCur->maxLsn) >= 0) {
+      pCur->hitLast = 1;
+      return SQLITE_OK;
+  }
+
   if (pCur->timeout > 0 && (comdb2_time_epoch() - pCur->starttime) > pCur->timeout) {
       pCur->hitLast = 1;
       return SQLITE_OK;

--- a/tests/sql_logfill_socket_reuse.test/Makefile
+++ b/tests/sql_logfill_socket_reuse.test/Makefile
@@ -1,0 +1,9 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+export CHECK_DB_AT_FINISH=0
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/sql_logfill_socket_reuse.test/lrl.options
+++ b/tests/sql_logfill_socket_reuse.test/lrl.options
@@ -1,0 +1,6 @@
+# sql_logfill is READONLY - must be set at startup.  The debug trace is what
+# the test counts: it logs every log-request and every master disconnect.
+sql_logfill 1
+sql_logfill_debug 1
+
+logmsg level debug

--- a/tests/sql_logfill_socket_reuse.test/runit
+++ b/tests/sql_logfill_socket_reuse.test/runit
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# An unbounded comdb2_transaction_logs() stream never ends, so sql-logfill
+# walks away from it as soon as the gap is filled.  cdb2api cannot donate a
+# half-read result set back to sockpool, so every gap-fill burns a connection
+# and lands as a sockpool miss.
+#
+# Drop rep messages on one replicant to force gaps, then require that its
+# gap-fills issue far more log-requests than master disconnects.
+
+bash -n "$0" || exit 1
+
+. ${TESTSROOTDIR}/tools/runit_common.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export debug=1
+[[ "$debug" == "1" ]] && set -x
+
+db=$1
+
+# Bounded, disconnects come only from rare events (gap closing early,
+# generation change).  Unbounded, they track requests one-for-one, so a tenth
+# separates the two cleanly.
+MAX_DISCONNECT_PCT=10
+# Floor the budget so a low-throughput run isn't judged on a handful of
+# disconnects.  Unbounded gives ~1:1, so this still separates cleanly.
+MIN_DISCONNECTS_ALLOWED=10
+MIN_REQUESTS=50
+MEASURE_SECONDS=60
+DROP_NTH=20
+WRITERS=2
+
+victim=""
+declare -a clnt_pids
+
+function cleanup
+{
+    [[ -n "$victim" ]] && set_drops $victim 0 &>/dev/null
+    for pid in ${clnt_pids[@]}; do
+        kill -9 $pid 2>/dev/null
+    done
+}
+
+# A gap is an out-of-order arrival, not just being behind: gap_lsn is repdb's
+# waiting_lsn.  Dropping a rep message leaves its successor waiting, which is
+# exactly what logfill exists to fill.
+function set_drops
+{
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $db --host $1 "put tunable debug_drop_nth_rep_message $2"
+}
+
+# Sustained load: one cdb2sql per writer fed from 'yes', rather than a process
+# per insert.
+function start_writers
+{
+    local target=$1
+    local sql="insert into t1 select 1, 1 from generate_series(1, 1000)"
+    local i
+
+    for ((i = 0; i < $WRITERS; ++i)); do
+        timeout --kill-after=5s ${TEST_TIMEOUT:-5m} yes "$sql" | \
+            $CDB2SQL_EXE ${CDB2_OPTIONS} $db --host $target - &>/dev/null &
+        clnt_pids+=( $! )
+    done
+}
+
+function logfile_for
+{
+    echo "${TESTDIR}/logs/${db}.${1}.db"
+}
+
+function count_in_log
+{
+    local f=$(logfile_for $1)
+    [[ -f "$f" ]] || { echo 0; return; }
+    # grep -c prints 0 and exits 1 when nothing matches.
+    grep -c "$2" "$f" 2>/dev/null || true
+}
+
+function run_test
+{
+    local master=$(get_master)
+    [[ -z "$master" ]] && failexit "No master"
+
+    local node
+    for node in $CLUSTER; do
+        [[ "$node" == "$master" ]] && continue
+        victim=$node
+        break
+    done
+    [[ -z "$victim" ]] && failexit "No replicant to drop messages on"
+    echo "master=$master victim=$victim"
+
+    $CDB2SQL_EXE ${CDB2_OPTIONS} $db --host $master \
+        "create table t1 (id int index, val int)" || failexit "Failed to create t1"
+
+    start_writers $master
+    sleep 5
+
+    local base_req=$(count_in_log $victim "requesting logs from master")
+    local base_dis=$(count_in_log $victim "disconnecting from")
+    local base_drop=$(count_in_log $victim "dropping message!")
+
+    set_drops $victim $DROP_NTH || failexit "Failed to enable drops on $victim"
+    sleep $MEASURE_SECONDS
+    set_drops $victim 0
+
+    local drops=$(( $(count_in_log $victim "dropping message!") - base_drop ))
+    local requests=$(( $(count_in_log $victim "requesting logs from master") - base_req ))
+    local disconnects=$(( $(count_in_log $victim "disconnecting from") - base_dis ))
+    echo "$victim: $drops drops, $requests log-requests, $disconnects disconnects"
+
+    # Separates "the tunable never took" from "logfill never fired".
+    [[ $drops -eq 0 ]] && failexit "$victim dropped no rep messages -- drop tunable had no effect"
+
+    [[ $requests -lt $MIN_REQUESTS ]] && \
+        failexit "$victim issued only $requests requests over $drops drops -- test is vacuous"
+
+    local allowed=$((requests * MAX_DISCONNECT_PCT / 100))
+    [[ $allowed -lt $MIN_DISCONNECTS_ALLOWED ]] && allowed=$MIN_DISCONNECTS_ALLOWED
+    [[ $disconnects -gt $allowed ]] && \
+        failexit "$victim: $disconnects disconnects over $requests requests exceeds $allowed - logfill is not reusing its connection"
+
+    echo "$victim: within budget ($disconnects <= $allowed)"
+
+    # A mid-run election would invalidate the counts above.
+    [[ "$(get_master)" == "$master" ]] || failexit "Master moved during the run"
+}
+
+cnt=$(echo $CLUSTER | wc -w)
+if [[ -z "$CLUSTER" || $cnt -lt 3 ]]; then
+    failexit "This test requires a clustered installation of at least 3 nodes"
+fi
+
+trap cleanup EXIT
+
+run_test
+
+cleanup
+echo "Success"


### PR DESCRIPTION
## Problem

A replicant running `sql_logfill` destroys one connection to the master per gap-fill, and each of those is a sockpool miss. Observed in production at roughly 890 log-requests/sec across seven replicants, sustained for hours.

## Cause

`request_logs_from_master()` asks for an unbounded stream (`NULL` stop LSN, `TRANLOG_FLAGS_BLOCK`), so it never ends on its own. logfill consumes only as far as the gap and abandons the rest — in production the master averaged 636 rows per query against a gap of a couple of records. `newsql_disconnect()` will not donate a handle whose last response was not `LAST_ROW`, and `cdb2_discard_unread_socket_data` defaults to off, so the socket is closed rather than pooled and the next request misses.

This happens on both sides of `0ed0d3f3b`: with it, logfill hangs up and reconnects explicitly; without it, `consume_previous_query()` drains at most 10 rows and then disconnects from inside `cdb2_run_statement`.

## Fix

Pass `gap_lsn` as the stop LSN. `tranlogEof()` already terminates on it, so the result set ends with `LAST_ROW`, the existing `consumed` path skips the disconnect, and the connection persists across gap-fills.

A second hunk stops `tranlogNext()` from entering the blocking poll once it has returned `maxLsn` — that loop checks only `blockLsn` and `timeout`, so otherwise the bound would trade connection churn for a stall.

## Test

`tests/sql_logfill_socket_reuse.test` drops every Nth rep message on one replicant to force out-of-order arrivals, then counts log-requests against master disconnects. A gap is an out-of-order arrival rather than simply being behind — `gap_lsn` is repdb's `waiting_lsn` — so dropping messages is what reproduces the production condition. Unbounded, disconnects track requests one-for-one; the test allows a tenth. Verified 8 consecutive passes with the fix, and confirmed failing without it.
