### PR TITLE
reqlog: don't divide by zero when longreq_log_freq_sec is 0

### DIFF
--- a/db/reqlog.c
+++ b/db/reqlog.c
@@ -2090,8 +2090,8 @@ void reqlog_long_running_clnt(struct sqlclntstate *clnt)
 
 void reqlog_log_all_longreqs(void)
 {
-    /* Periodic long request logging disabled */
-    if (gbl_longreq_log_freq_sec < 0)
+    /* Periodic long request logging disabled; 0 too, it is used as a modulus */
+    if (gbl_longreq_log_freq_sec <= 0)
         return;
 
     /*

--- a/tests/longreq_freq_divzero.test/Makefile
+++ b/tests/longreq_freq_divzero.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=5m
+endif

--- a/tests/longreq_freq_divzero.test/lrl.options
+++ b/tests/longreq_freq_divzero.test/lrl.options
@@ -1,0 +1,1 @@
+nowatch

--- a/tests/longreq_freq_divzero.test/runit
+++ b/tests/longreq_freq_divzero.test/runit
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+bash -n "$0" || exit 1
+
+# longreq_log_freq_sec is runtime-settable and not READONLY, but
+# reqlog_long_running_clnt() uses it as a modulus:
+#
+#     duration_beyond_thresh_sec % gbl_longreq_log_freq_sec
+#
+# and reqlog_log_all_longreqs() only rejected negative values. Setting it to 0
+# was therefore an integer divide-by-zero in the watchdog thread -- any client
+# could take the server down with a tunable and one slow query.
+#
+# Reproduce it exactly: drop the long-request threshold so an ordinary
+# statement qualifies, set the frequency to 0, and run something slow enough
+# for the watchdog's once-a-second scan to notice it.
+#
+#   unfixed server - watchdog thread takes SIGFPE, node dies
+#   fixed server   - 0 disables the scan, query completes, node survives
+
+set -x
+source ${TESTSROOTDIR}/tools/runit_common.sh
+
+dbnm=$1
+
+if [ -z "$dbnm" ] ; then
+    echo "need a DB name"
+    exit 1
+fi
+
+if [ -n "$CLUSTER" ] ; then
+    nodes="$CLUSTER"
+else
+    nodes=`hostname`
+fi
+
+function set_tunable_all_nodes() {
+    local tunable=$1
+    local value=$2
+    local node
+    for node in $nodes ; do
+        cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node \
+            "PUT TUNABLE '$tunable' $value" || \
+            failexit "could not set $tunable on $node"
+    done
+}
+
+# Every statement counts as long-running, so the watchdog will look at ours.
+set_tunable_all_nodes 'sql_time_threshold' 1
+
+# The divisor. On an unfixed build this is what kills the watchdog thread.
+set_tunable_all_nodes 'longreq_log_freq_sec' 0
+
+# Slow enough that the once-a-second watchdog scan sees it in flight. Run it on
+# each node in turn: the watchdog is per-node and only faults on the node
+# actually holding a long-running statement.
+for node in $nodes ; do
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "SELECT SLEEP(5)" \
+        > sleep.$node.out 2>&1
+    echo "sleep on $node: rc=$?"
+done
+
+# Best-effort restore; these fail if a node already died, which is fine because
+# the liveness check below is the real arbiter.
+for node in $nodes ; do
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node \
+        "PUT TUNABLE 'longreq_log_freq_sec' 60" || true
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node \
+        "PUT TUNABLE 'sql_time_threshold' 5000" || true
+done
+
+# Fresh connection per node -- do not reuse a handle that may have been dropped
+# when its server died.
+for node in $nodes ; do
+    cdb2sql --tabs ${CDB2_OPTIONS} $dbnm --host $node "SELECT 1" > alive.$node.out 2>&1 || \
+        failexit "node $node is not answering: watchdog likely took SIGFPE on longreq_log_freq_sec 0"
+    if ! grep -q "^1$" alive.$node.out ; then
+        failexit "unexpected response from node $node"
+    fi
+done
+
+echo "Success"
+exit 0


### PR DESCRIPTION
`reqlog_long_running_clnt()` uses `gbl_longreq_log_freq_sec` as a modulus, but `reqlog_log_all_longreqs()` only rejected negatives. The tunable is runtime-settable and not READONLY, so setting it to 0 is an integer divide-by-zero in the watchdog thread: one slow query takes the node down.

Treat `<= 0` as disabled, matching the `gbl_sql_time_threshold` check beside it.

Test: `longreq_freq_divzero`.