### PR TITLE
osql: don't send startgen with a zeroed rqid: fix for 'cldeadlock' test

### DIFF
--- a/db/osqlsqlthr.c
+++ b/db/osqlsqlthr.c
@@ -246,9 +246,12 @@ retry:
     rc = clnt_check_bdb_lock_desired(clnt);
     if (rc) {
         logmsg(LOGMSG_ERROR, "recover_deadlock returned %d\n", rc);
-        rc = osql_end(clnt);
-        if (rc) {
-            logmsg(LOGMSG_ERROR, "%s failed to end osql %d\n", __func__, rc);
+        /* keep_rqid: session is being restarted, don't zero rqid */
+        if (!keep_rqid) {
+            rc = osql_end(clnt);
+            if (rc) {
+                logmsg(LOGMSG_ERROR, "%s failed to end osql %d\n", __func__, rc);
+            }
         }
         return SQLITE_BUSY;
     }
@@ -1211,7 +1214,8 @@ retry:
                         int keep_session = !is_final || (get_cnonce(clnt, &snap) == 0);
 
                         rc = osql_sock_restart(clnt, 1, keep_session, is_final);
-                        if (sock_restart_retryable_rcode(rc) && !clnt->is_coordinator) {
+                        /* don't resend on an ended session (rqid 0) */
+                        if (sock_restart_retryable_rcode(rc) && osql->rqid && !clnt->is_coordinator) {
                             if (gbl_master_swing_sock_restart_sleep) {
                                 sleep(gbl_master_swing_sock_restart_sleep);
                             }


### PR DESCRIPTION
Two paths reach the master with `rqid` 0 after the session was unregistered:

- `osql_sock_start_int()` called `osql_end()` on the bdb-lock-desired restart path even when `keep_rqid` was set. `osql_end()` unregisters from the checkboard, which zeroes `clnt->osql.rqid` — but `keep_rqid` means the caller is restarting this session and still needs it.
- the master-swing retry resent the commit after `osql_sock_restart()` even when the restart had ended the session.

cldeadlock produces both conditions: truncate-under-cursor takes `BDB_WRITELOCK` so `bdb_lock_desired` is true, and the downgrade loop swings the master every 20s.

Keep the rqid when `keep_rqid` is set, and gate the resend on a live rqid.

Issue discovered by`cldeadlock` test.