### PR TITLE
newsql: don't send a postponed row that was never saved: cldeadlock fix

### DIFF
--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -4081,8 +4081,8 @@ static int run_stmt(struct sqlthdstate *thd, struct sqlclntstate *clnt,
             if (rc)
                 return rc;
         } else {
-            postponed_write = 1;
-            send_row(clnt, stmt, row_id, 1, NULL);
+            /* only claim a postponed row if the save succeeded */
+            postponed_write = (send_row(clnt, stmt, row_id, 1, NULL) == 0);
         }
 
         rowcount++;

--- a/plugins/newsql/newsql.c
+++ b/plugins/newsql/newsql.c
@@ -616,6 +616,8 @@ static int newsql_save_postponed_row(struct sqlclntstate *clnt,
 static int newsql_send_postponed_row(struct sqlclntstate *clnt)
 {
     struct newsql_appdata *appdata = clnt->appdata;
+    if (appdata->postponed == NULL)
+        return -1;
     return appdata->write_postponed(clnt);
 }
 


### PR DESCRIPTION
`run_stmt()` set `postponed_write` even when the postponing `send_row()` failed, so `post_sqlite_processing()` went on to send a row that was never saved and `newsql_write_postponed_evbuffer()` dereferenced a NULL `appdata->postponed`.

Only set `postponed_write` when the save succeeded, and NULL-check in `newsql_send_postponed_row()` as a backstop.

Surfaced under cldeadlock. Rows are only postponed for a select replayed inside a transaction; which encode failure left `appdata->postponed` NULL there is not confirmed. The fix holds regardless of which one fired.

Issue discovered by the 'cldeadlock' test.