### PR TITLE
Keep a list of nodes allowed to cluster with us.

### DIFF
--- a/bdb/info.c
+++ b/bdb/info.c
@@ -23,6 +23,7 @@
 
 #include <segstr.h>
 
+#include "cluster_allow_list.h"
 #include "net.h"
 #include "bdb_int.h"
 #include "locks.h"
@@ -972,6 +973,10 @@ static void process_add(bdb_state_type *bdb_state, char *host)
 {
     const char *hostlist[REPMAX];
     netinfo_type *netinfo = bdb_state->repinfo->netinfo;
+    /* Adding a node to the sanctioned list means we want to cluster with it.
+     * Do this before net_add_to_sanctioned(), which asks the cluster policy
+     * whether the host is allowed. */
+    cluster_allow_list_add_host(host);
     net_add_to_sanctioned(netinfo, host, 0);
     int count = net_get_all_nodes_connected(netinfo, hostlist);
     for (int i = 0; i < count; i++) {

--- a/bdb/rep.c
+++ b/bdb/rep.c
@@ -25,6 +25,7 @@
 #include <unistd.h>
 #include <poll.h>
 
+#include "cluster_allow_list.h"
 #include "debug_switches.h"
 
 #include "bdb_int.h"
@@ -4771,6 +4772,7 @@ void berkdb_receive_msg(void *ack_handle, void *usr_ptr, char *from_host,
             buf_get(&node, sizeof(int), p_buf, p_buf_end);
 
             print(bdb_state, "adding node %d to sanctioned list\n", node);
+            cluster_allow_list_add_host(hostname(node));
             net_add_to_sanctioned(bdb_state->repinfo->netinfo, hostname(node),
                                   0);
         }
@@ -4784,6 +4786,7 @@ void berkdb_receive_msg(void *ack_handle, void *usr_ptr, char *from_host,
         } else {
             print(bdb_state, "adding host %s to sanctioned list\n",
                   (char *)dta);
+            cluster_allow_list_add_host((char *)dta);
             net_add_to_sanctioned(bdb_state->repinfo->netinfo,
                                   intern((char *)dta), 0);
         }

--- a/db/CMakeLists.txt
+++ b/db/CMakeLists.txt
@@ -6,6 +6,7 @@ set(src
   block_internal.c
   bpfunc.c
   clienthost.c
+  cluster_allow_list.c
   comdb2.c
   comdb2uuid.c
   comdb2_ruleset.c

--- a/db/clienthost.h
+++ b/db/clienthost.h
@@ -30,6 +30,18 @@ struct clienthost {
     int mach_class;
     struct interned_string *s;
     int machine_dc;
+    /* Interned resolved name of this host, as the cluster allow list keys on
+     * it.  Resolved once by comdb2_gethostbyname(). */
+    const char *resolved_host;
+    /* Cached group-membership verdict for the cluster allow list.  The
+     * generation goes stale when the allowed group set changes. */
+    int cluster_group_gen;
+    int cluster_group_time;
+    int cluster_group_ok;
+    /* Epoch of the last "the cluster allow list would reject this host"
+     * warning.  Rate limits the warning while we still enforce the old
+     * policy. */
+    int cluster_warn_time;
     LINKC_T (struct clienthost) lnk;
 };
 

--- a/db/cluster_allow_list.c
+++ b/db/cluster_allow_list.c
@@ -1,0 +1,307 @@
+/*
+   Copyright 2026 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <stdlib.h>
+#include <string.h>
+#include <pthread.h>
+
+#include <plhash_glue.h>
+
+#include "bb_oscompat.h"
+#include "comdb2.h"
+#include "cluster_allow_list.h"
+#include "clienthost.h"
+#include "epochlib.h"
+#include "intern_strings.h"
+#include "logmsg.h"
+#include "rtcpu.h"
+#include "sys_wrap.h"
+
+/* How long we trust a cached group-membership verdict.  A membership change
+ * outside of us takes at most this long to take effect. */
+#define GROUP_CACHE_TTL 60
+
+static pthread_mutex_t lk = PTHREAD_MUTEX_INITIALIZER;
+static hash_t *allowed_hosts = NULL;  /* objects are strdup'd host names */
+static hash_t *allowed_groups = NULL; /* objects are strdup'd group names */
+
+/* Bumped whenever the group set changes.  A cached verdict from an older
+ * generation is stale.  Starts at 1 so that a freshly calloc'd clienthost
+ * never matches. */
+static int group_generation = 1;
+
+static void init_hashes_lk(void)
+{
+    if (!allowed_hosts)
+        allowed_hosts = hash_init_str(0);
+    if (!allowed_groups)
+        allowed_groups = hash_init_str(0);
+}
+
+static int add_lk(hash_t *h, const char *name)
+{
+    if (hash_find(h, name))
+        return 0;
+    hash_add(h, strdup(name));
+    return 1;
+}
+
+static int del_lk(hash_t *h, const char *name)
+{
+    char *found = hash_find(h, name);
+    if (!found)
+        return 0;
+    hash_del(h, found);
+    free(found);
+    return 1;
+}
+
+/* We key on the resolved name, so that an operator can name a host any way the
+ * machine-name plugin understands.  Small integer machine identifiers are the
+ * reason this matters: "allow cluster with 12345" must land on the same entry
+ * as the name the net layer reports.
+ *
+ * comdb2_gethostbyname() turns the number into the bare machine name.  Do not
+ * use comdb2_getcanonicalname() here; that appends the domain, which is not
+ * the name the rest of the database uses.
+ *
+ * Resolving asks the operating system or the plugin, so cache the answer on
+ * the clienthost.  The answer does not change while we run.  Interned strings
+ * live forever, which keeps the cached pointer valid. */
+static const char *resolved_name(const char *host)
+{
+    struct clienthost *c = retrieve_clienthost(intern_ptr(host));
+
+    if (!c->resolved_host) {
+        char *name = (char *)host;
+        /* This leaves the name alone when it cannot resolve it. */
+        (void)comdb2_gethostbyname(&name, NULL);
+        c->resolved_host = intern(name ? name : host);
+    }
+    return c->resolved_host;
+}
+
+void cluster_allow_list_init(void)
+{
+    if (gbl_myhostname)
+        cluster_allow_list_add_host(gbl_myhostname);
+    for (int ii = 0; thedb && ii < thedb->nsiblings; ii++)
+        cluster_allow_list_add_host(thedb->sibling_hostname[ii]);
+}
+
+int cluster_allow_list_add_host(const char *host)
+{
+    if (!host)
+        return 0;
+    const char *name = resolved_name(host);
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int added = add_lk(allowed_hosts, name);
+    Pthread_mutex_unlock(&lk);
+    return added;
+}
+
+int cluster_allow_list_del_host(const char *host)
+{
+    if (!host)
+        return 0;
+    const char *name = resolved_name(host);
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int removed = del_lk(allowed_hosts, name);
+    Pthread_mutex_unlock(&lk);
+    return removed;
+}
+
+int cluster_allow_list_add_group(const char *group)
+{
+    if (!group)
+        return 0;
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int added = add_lk(allowed_groups, group);
+    if (added)
+        group_generation++;
+    Pthread_mutex_unlock(&lk);
+    return added;
+}
+
+int cluster_allow_list_del_group(const char *group)
+{
+    if (!group)
+        return 0;
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int removed = del_lk(allowed_groups, group);
+    if (removed)
+        group_generation++;
+    Pthread_mutex_unlock(&lk);
+    return removed;
+}
+
+struct name_collector {
+    char **names;
+    int count;
+    int max;
+};
+
+static int collect_name(void *obj, void *arg)
+{
+    struct name_collector *c = arg;
+    if (c->count < c->max)
+        c->names[c->count++] = (char *)obj;
+    return 0;
+}
+
+/* Copy the group names out from under the lock.  Resolving a group asks the
+ * machine registry, which may be slow, so we do not want to do it while we
+ * hold the lock. */
+static int copy_groups(char ***names_out)
+{
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int count = hash_get_num_entries(allowed_groups);
+    if (count == 0) {
+        Pthread_mutex_unlock(&lk);
+        *names_out = NULL;
+        return 0;
+    }
+    struct name_collector c = {.names = malloc(sizeof(char *) * count), .count = 0, .max = count};
+    hash_for(allowed_groups, collect_name, &c);
+    for (int ii = 0; ii < c.count; ii++)
+        c.names[ii] = strdup(c.names[ii]);
+    Pthread_mutex_unlock(&lk);
+
+    *names_out = c.names;
+    return c.count;
+}
+
+static void free_names(char **names, int count)
+{
+    for (int ii = 0; ii < count; ii++)
+        free(names[ii]);
+    free(names);
+}
+
+/* A group is a machine cluster.  machine_cluster_machs() lists the hosts in
+ * one: machinfo.c answers from the machine registry, and without that plugin
+ * the built-in registry that the lrl "machine_cluster" directive feeds answers
+ * instead.  An unknown group has no members.
+ *
+ * host is already resolved.  Compare the plain member name first, then put
+ * the member through the same resolution, so that the two sides agree however
+ * the group named its machines. */
+static int host_in_group(const char *host, const char *group)
+{
+    const char **machs = NULL;
+    int count = 0;
+
+    if (machine_cluster_machs(group, &count, &machs) != 0)
+        return 0;
+
+    for (int ii = 0; ii < count; ii++) {
+        if (!machs[ii])
+            continue;
+        if (strcmp(machs[ii], host) == 0)
+            return 1;
+        if (strcmp(resolved_name(machs[ii]), host) == 0)
+            return 1;
+    }
+    return 0;
+}
+
+static int in_any_allowed_group(const char *host)
+{
+    char **groups;
+    int count = copy_groups(&groups);
+    int member = 0;
+
+    for (int ii = 0; ii < count && !member; ii++)
+        member = host_in_group(host, groups[ii]);
+
+    free_names(groups, count);
+    return member;
+}
+
+int cluster_allow_list_permits(const char *host)
+{
+    if (!host)
+        return 0;
+
+    /* We always cluster with ourselves. */
+    if (gbl_myhostname && strcmp(host, gbl_myhostname) == 0)
+        return 1;
+
+    /* Look up by the same name we store under. */
+    const char *name = resolved_name(host);
+
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    int found = (hash_find(allowed_hosts, name) != NULL);
+    int ngroups = hash_get_num_entries(allowed_groups);
+    int generation = group_generation;
+    Pthread_mutex_unlock(&lk);
+
+    if (found)
+        return 1;
+    if (ngroups == 0)
+        return 0;
+
+    /* Fall back to the groups.  This asks a plugin, so cache the answer. */
+    struct clienthost *c = retrieve_clienthost(intern_ptr(name));
+    int now = comdb2_time_epoch();
+    if (c->cluster_group_gen == generation && c->cluster_group_time != 0 &&
+        (now - c->cluster_group_time) < GROUP_CACHE_TTL) {
+        return c->cluster_group_ok;
+    }
+
+    int member = in_any_allowed_group(name);
+    c->cluster_group_ok = member;
+    c->cluster_group_gen = generation;
+    c->cluster_group_time = now;
+    return member;
+}
+
+static int cmp_names(const void *a, const void *b)
+{
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+static void dump_hash(hash_t *h, const char *what)
+{
+    int count = hash_get_num_entries(h);
+    if (count == 0) {
+        logmsg(LOGMSG_USER, "  no %ss\n", what);
+        return;
+    }
+    struct name_collector c = {.names = malloc(sizeof(char *) * count), .count = 0, .max = count};
+    hash_for(h, collect_name, &c);
+    qsort(c.names, c.count, sizeof(char *), cmp_names);
+    for (int ii = 0; ii < c.count; ii++)
+        logmsg(LOGMSG_USER, "  %s %s\n", what, c.names[ii]);
+    free(c.names);
+}
+
+void cluster_allow_list_dump(void)
+{
+    Pthread_mutex_lock(&lk);
+    init_hashes_lk();
+    logmsg(LOGMSG_USER, "Cluster allow list (%s)\n",
+           gbl_enforce_cluster_allow_list ? "enforced" : "not enforced, warn only");
+    dump_hash(allowed_hosts, "host");
+    dump_hash(allowed_groups, "group");
+    Pthread_mutex_unlock(&lk);
+}

--- a/db/cluster_allow_list.h
+++ b/db/cluster_allow_list.h
@@ -1,0 +1,63 @@
+/*
+   Copyright 2026 Bloomberg Finance L.P.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* The cluster allow list names the hosts that may cluster with us.
+ *
+ * It holds hosts and machine groups only.  It holds no machine classes, which
+ * is what makes it narrower than the "cluster with" remote policy in
+ * rmtpolicy.c.
+ *
+ * A group is a machine cluster.  machine_cluster_machs() lists its hosts:
+ * machinfo.c answers from the machine registry, and without that plugin the
+ * built-in registry that the lrl "machine_cluster" directive and the
+ * "machine_cluster add" message trap feed answers instead.
+ *
+ * The list lives in memory only.  At startup it holds this host plus the hosts
+ * from the "cluster nodes" lrl directive.  "allow cluster with" adds to it,
+ * "disallow cluster with" removes from it.
+ *
+ * Every host name that goes in or out of the list first goes through
+ * comdb2_gethostbyname(), so that an operator can name a host by a small
+ * integer machine identifier.  The "cluster with" remote policy in rmtpolicy.c
+ * does not do this; it still keys on the name as typed.
+ *
+ * gbl_enforce_cluster_allow_list selects who enforces the list.  When it is
+ * off we enforce the old remote policy and only warn about the hosts this list
+ * would reject.  When it is on this list decides.
+ */
+
+#ifndef INCLUDED_CLUSTER_ALLOW_LIST_H
+#define INCLUDED_CLUSTER_ALLOW_LIST_H
+
+/* Seed the list with this host and the "cluster nodes" hosts.  Call this after
+ * the lrl file is read and before the saved "allow" lines are replayed. */
+void cluster_allow_list_init(void);
+
+/* Return 1 if the entry was added, 0 if it was already there. */
+int cluster_allow_list_add_host(const char *host);
+int cluster_allow_list_add_group(const char *group);
+
+/* Return 1 if the entry was removed, 0 if it was not there. */
+int cluster_allow_list_del_host(const char *host);
+int cluster_allow_list_del_group(const char *group);
+
+/* Return 1 if host may cluster with us, 0 if it may not. */
+int cluster_allow_list_permits(const char *host);
+
+/* Print the list and the enforcement state. */
+void cluster_allow_list_dump(void);
+
+#endif /* !INCLUDED_CLUSTER_ALLOW_LIST_H */

--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -117,6 +117,7 @@ void berk_memp_sync_alarm_ms(int);
 
 #include "intern_strings.h"
 #include "bb_oscompat.h"
+#include "cluster_allow_list.h"
 #include "comdb2uuid.h"
 #include "debug_switches.h"
 #include "eventlog.h"
@@ -4171,6 +4172,10 @@ static int init(int argc, char **argv)
         }
         csc2_disallow_bools();
     }
+
+    /* Seed the cluster allow list with the "cluster nodes" hosts.  The saved
+     * "allow cluster with" directives below then extend it. */
+    cluster_allow_list_init();
 
     /* Now process all the directives we saved up from the lrl file. */
     for (ii = 0; ii < thedb->num_allow_lines; ii++) {

--- a/db/comdb2.h
+++ b/db/comdb2.h
@@ -1728,6 +1728,9 @@ extern int gbl_thd_linger;   /* number of seconds for threads to linger */
 extern char *gbl_myhostname; /* my hostname */
 extern struct interned_string *gbl_myhostname_interned;
 extern char *gbl_machine_class; /* my machine class */
+/* 0: enforce the "cluster with" remote policy, warn about the hosts the
+ * cluster allow list would reject.  1: enforce the cluster allow list. */
+extern int gbl_enforce_cluster_allow_list;
 extern struct in_addr gbl_myaddr;   /* my IPV4 address */
 extern int gbl_mynodeid;     /* node number, for backwards compatibility */
 extern pid_t gbl_mypid;      /* my pid */

--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -351,6 +351,7 @@ extern int gbl_sc_close_txn;
 extern int gbl_sc_protobuf;
 extern int gbl_sc_current_version;
 extern int gbl_create_dba_user;
+extern int gbl_enforce_cluster_allow_list;
 extern int gbl_lock_dba_user;
 extern int gbl_dump_sql_on_repwait_sec;
 extern int gbl_client_queued_slow_seconds;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -443,6 +443,12 @@ REGISTER_TUNABLE("early",
                  "point, and reads on that node will either see the records or "
                  "block. (Default: on)",
                  TUNABLE_BOOLEAN, &gbl_early, READONLY | NOARG, NULL, NULL, NULL, NULL);
+REGISTER_TUNABLE("enforce_cluster_allow_list",
+                 "Enforce the cluster allow list, which names the hosts and "
+                 "machine groups that may cluster with us. When off, enforce "
+                 "the older cluster remote policy instead and only warn about "
+                 "the hosts the allow list would reject. (Default: off)",
+                 TUNABLE_BOOLEAN, &gbl_enforce_cluster_allow_list, NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("enable_berkdb_retry_deadlock_bias", NULL, TUNABLE_BOOLEAN,
                  &gbl_enable_berkdb_retry_deadlock_bias, READONLY | NOARG, NULL,
                  NULL, NULL, NULL);

--- a/db/process_message.c
+++ b/db/process_message.c
@@ -33,6 +33,7 @@ extern int __berkdb_read_alarm_ms;
 #include <ctrace.h>
 
 #include "comdb2.h"
+#include "cluster_allow_list.h"
 #include "timer.h"
 #include "sigutil.h"
 #include "memdebug.h"
@@ -1821,9 +1822,12 @@ clipper_usage:
                        allow_cluster_from_remote(host) ? "YES" : "NO");
                 logmsg(LOGMSG_USER, "Allow queue broadcast to %s ? %s\n", host,
                        allow_broadcast_to_remote(host) ? "YES" : "NO");
-            }
-            else
+                logmsg(LOGMSG_USER, "Cluster allow list permits %s ? %s\n", host,
+                       cluster_allow_list_permits(host) ? "YES" : "NO");
+            } else {
                 dump_remote_policy();
+                cluster_allow_list_dump();
+            }
         } else if (tokcmp(tok, ltok, "size") == 0) {
             dump_table_sizes(thedb);
         } else if (tokcmp(tok, ltok, "reql") == 0) {

--- a/db/rmtpolicy.c
+++ b/db/rmtpolicy.c
@@ -30,11 +30,20 @@
 #include <segstr.h>
 
 #include "comdb2.h"
+#include "cluster_allow_list.h"
 #include "intern_strings.h"
 #include <clienthost.h>
+#include "epochlib.h"
 #include "util.h"
 #include "rtcpu.h"
 #include "logmsg.h"
+
+/* How often we repeat the "the cluster allow list would reject this host"
+ * warning for one host.  A host that cannot connect retries about once a
+ * second, so a warning with no rate limit would flood the log. */
+#define WOULD_REJECT_WARN_INTERVAL 60
+
+int gbl_enforce_cluster_allow_list = 0;
 
 struct rmtpol {
     const char *descr;
@@ -146,6 +155,23 @@ int allow_cluster_from_remote(const char *host)
         else
             rc = 0;
     }
+
+    if (gbl_enforce_cluster_allow_list)
+        return cluster_allow_list_permits(host);
+
+    /* The cluster allow list is not enforced yet.  Tell the operator which
+     * hosts it would turn away, so that they can fix the list first. */
+    if (rc && !cluster_allow_list_permits(host)) {
+        int now = comdb2_time_epoch();
+        if (now - c->cluster_warn_time >= WOULD_REJECT_WARN_INTERVAL) {
+            c->cluster_warn_time = now;
+            logmsg(LOGMSG_WARN,
+                   "host %s clusters with us now, but the cluster allow list "
+                   "would reject it.  Run \"allow cluster with %s\" to keep it "
+                   "once the list is enforced.\n",
+                   host, host);
+        }
+    }
     return rc;
 }
 
@@ -214,6 +240,7 @@ int process_allow_command(char *line, int lline)
     struct clienthost *r = NULL;
     int ii, mark;
     char *new_mach = NULL;
+    char *new_group = NULL;
 
     /* scan for end of line */
     for (mark = 0, ii = 0; ii < lline; ii++)
@@ -277,8 +304,17 @@ int process_allow_command(char *line, int lline)
     tok = segtok(line, lline, &st, &ltok);
     if (ltok == 0)
         goto bad;
-    if (parse_mach_or_group(tok, ltok, &new_mach, &cls) != 0)
+    /* "allow cluster with group <name>" names a machine group.  A plugin
+     * decides who belongs to a group.  Only the cluster allow list understands
+     * groups, so leave the write and broadcast policies alone. */
+    if (pol == &cluster_pol && tokcmp(tok, ltok, "group") == 0) {
+        tok = segtok(line, lline, &st, &ltok);
+        if (ltok == 0)
+            goto bad;
+        new_group = tokdup(tok, ltok);
+    } else if (parse_mach_or_group(tok, ltok, &new_mach, &cls) != 0) {
         goto bad;
+    }
     if (new_mach) {
         struct interned_string *new_mach_interned = intern_ptr(new_mach);
         r = retrieve_clienthost(new_mach_interned);
@@ -302,7 +338,17 @@ int process_allow_command(char *line, int lline)
             goto ignore;
     }
 
-    if (r != NULL) {
+    if (new_group != NULL) {
+        /* Only the cluster allow list knows about groups.  There is no old
+         * list to update here. */
+        if (allow == 1) {
+            cluster_allow_list_add_group(new_group);
+            logmsg(LOGMSG_USER, "allowing %s group %s\n", pol->descr, new_group);
+        } else {
+            cluster_allow_list_del_group(new_group);
+            logmsg(LOGMSG_USER, "no longer allowing %s group %s\n", pol->descr, new_group);
+        }
+    } else if (r != NULL) {
         if (allow == 1) {
             hostpol->explicit_allow = 1;
             hostpol->explicit_disallow = 0;
@@ -315,6 +361,14 @@ int process_allow_command(char *line, int lline)
             hostpol->explicit_disallow = 0;
             hostpol->explicit_allow = 0;
             logmsg(LOGMSG_USER, "resetting policy for %s machine %s\n", pol->descr, new_mach);
+        }
+        /* The cluster allow list is a pure allow list.  Both "disallow" and
+         * "clrpol" drop the entry. */
+        if (pol == &cluster_pol) {
+            if (allow == 1)
+                cluster_allow_list_add_host(new_mach);
+            else
+                cluster_allow_list_del_host(new_mach);
         }
     } else if (cls != CLASS_UNKNOWN) {
         if (allow == 1) {
@@ -333,18 +387,27 @@ int process_allow_command(char *line, int lline)
             logmsg(LOGMSG_USER, "resetting policy for %s %s machines\n",
                    pol->descr, mach_class_class2name(cls));
         }
+        if (pol == &cluster_pol) {
+            logmsg(LOGMSG_WARN,
+                   "the cluster allow list ignores machine class %s.  Name a "
+                   "host or a group instead.\n",
+                   mach_class_class2name(cls));
+        }
     } else {
         goto bad;
     }
 
     logmsg(LOGMSG_DEBUG, "processed <%*.*s>\n", lline, lline, line);
+    free(new_group);
     return 0;
 
 ignore:
     logmsg(LOGMSG_WARN, "ignoring command <%*.*s>\n", lline, lline, line);
+    free(new_group);
     return 0;
 bad:
     logmsg(LOGMSG_ERROR, "bad command <%*.*s>\n", lline, lline, line);
+    free(new_group);
     return -1;
 }
 

--- a/net/net_evbuffer.c
+++ b/net/net_evbuffer.c
@@ -44,6 +44,7 @@
 
 #include <bb_oscompat.h>
 #include <berkdb/dbinc/rep_types.h>
+#include <cluster_allow_list.h>
 #include <comdb2_atomic.h>
 #include <comdb2buf.h>
 #include <compat.h>
@@ -1464,13 +1465,26 @@ static int hello_msg_common(struct event_info *e)
             if (need_free) free(host);
             continue;
         }
-        struct host_info *hi = host_info_find(host);
+        char *ihost = intern(host);
+        if (need_free)
+            free(host);
+        /* We already cluster with the peer that sent this hello, and it says
+         * that ihost is in the cluster with it.  Take its word and add ihost,
+         * the same as "bdb add" does.
+         *
+         * Do this before both skips below.  We must learn a host even when we
+         * already have an event for it, which is the case for the peer that
+         * sent the hello and for any host we tried to connect to.  We must
+         * also learn it before the allow check, so that the cluster allow list
+         * does not turn away a node that the rest of the cluster knows. */
+        if (cluster_allow_list_add_host(ihost)) {
+            logmsg(LOGMSG_WARN, "host %s joins the cluster allow list, named by %s\n", ihost,
+                   e->host_node_ptr ? e->host_node_ptr->host : "a peer");
+        }
+        struct host_info *hi = host_info_find(ihost);
         if (hi && event_info_find(e->net_info, hi)) {
-            if (need_free) free(host);
             continue;
         }
-        char *ihost = intern(host);
-        if (need_free) free(host);
         netinfo_type *netinfo_ptr = e->net_info->netinfo_ptr;
         if (netinfo_ptr->allow_rtn && !netinfo_ptr->allow_rtn(netinfo_ptr, ihost)) { /* net_allow_node */
             logmsg(LOGMSG_ERROR, "connection to host:%s not allowed\n", ihost);

--- a/tests/cluster_allow_list.test/Makefile
+++ b/tests/cluster_allow_list.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=2m
+endif

--- a/tests/cluster_allow_list.test/runit
+++ b/tests/cluster_allow_list.test/runit
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+# Exercise the cluster allow list: the narrow list of hosts and machine groups
+# that are permitted to cluster with us.  See db/cluster_allow_list.c.
+
+set -e
+
+# The list is per node, so every command must reach the same node.  ${target}
+# holds how we get there.
+send() {
+    cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} ${target} \
+        "exec procedure sys.cmd.send('$1')"
+}
+
+sql() {
+    cdb2sql ${CDB2_OPTIONS} ${DBNAME} ${target} "$1"
+}
+
+# Fail with a message unless the text is in the output.
+expect() {
+    local text=$1
+    shift
+    if ! grep -qF -- "$text" "$OUT"; then
+        echo "expected to find '$text' in:" >&2
+        cat "$OUT" >&2
+        exit 1
+    fi
+}
+
+reject() {
+    local text=$1
+    shift
+    if grep -qF -- "$text" "$OUT"; then
+        echo "did not expect to find '$text' in:" >&2
+        cat "$OUT" >&2
+        exit 1
+    fi
+}
+
+OUT=$(mktemp)
+trap 'rm -f "$OUT"' EXIT
+
+myhost=$(cdb2sql --tabs ${CDB2_OPTIONS} ${DBNAME} default 'select comdb2_host()')
+
+# On a cluster we must name the node, because "default" would spread the
+# commands over the whole cluster.  On a single node "default" is the only
+# thing that works, because the host name may not resolve.
+target="default"
+[[ -n "${CLUSTER}" ]] && target="--host ${myhost}"
+
+echo "driving ${myhost}, peers: ${CLUSTER:-none, single node}"
+
+# 1. We start out allowing ourselves and our cluster, and no group.
+send "stat rmtpol" > "$OUT"
+expect "Cluster allow list (not enforced, warn only)"
+expect "host ${myhost}"
+expect "no groups"
+
+# The "cluster nodes" lrl directive seeds the list, so every peer is in it.
+for node in ${CLUSTER}; do
+    expect "host ${node}"
+done
+
+# 2. "allow cluster with <host>" adds a host.
+send "allow cluster with mach1" > "$OUT"
+expect "allowing cluster with machine mach1"
+send "stat rmtpol" > "$OUT"
+expect "host mach1"
+send "stat rmtpol mach1" > "$OUT"
+expect "Cluster allow list permits mach1 ? YES"
+
+# 3. A machine class is not a host.  The old policy still takes it, the allow
+#    list warns and ignores it.
+send "allow cluster with prod" > "$OUT"
+expect "allowing cluster with prod machines"
+expect "the cluster allow list ignores machine class prod"
+send "stat rmtpol" > "$OUT"
+reject "host prod"
+
+# 4. A host that nobody allowed is not permitted.  The old policy still lets
+#    mach2 in, so we warn that the allow list would turn it away.
+send "stat rmtpol mach2" > "$OUT"
+expect "Cluster allow list permits mach2 ? NO"
+expect "Allow cluster with mach2       ? YES"
+expect "but the cluster allow list would reject it"
+
+# 5. "allow cluster with group <name>" registers a machine group.  A group is a
+#    machine cluster, so machine_cluster_machs() lists its members.
+send "machine_cluster add mach9 grp1" > "$OUT"
+send "machine_cluster dump grp1" > "$OUT"
+expect "mach9"
+
+send "allow cluster with group grp1" > "$OUT"
+expect "allowing cluster with group grp1"
+send "stat rmtpol" > "$OUT"
+expect "group grp1"
+
+# mach9 belongs to the group, so the list permits it although no one named it.
+send "stat rmtpol mach9" > "$OUT"
+expect "Cluster allow list permits mach9 ? YES"
+# mach2 belongs to no group.
+send "stat rmtpol mach2" > "$OUT"
+expect "Cluster allow list permits mach2 ? NO"
+
+# An unknown group has no members.
+send "allow cluster with group nosuchgroup" > "$OUT"
+send "stat rmtpol mach2" > "$OUT"
+expect "Cluster allow list permits mach2 ? NO"
+send "disallow cluster with group nosuchgroup" > "$OUT"
+
+# 6. "disallow" removes the entry.  The list is a pure allow list, so there is
+#    no deny state to leave behind.
+send "disallow cluster with mach1" > "$OUT"
+send "stat rmtpol" > "$OUT"
+reject "host mach1"
+send "stat rmtpol mach1" > "$OUT"
+expect "Cluster allow list permits mach1 ? NO"
+
+send "disallow cluster with group grp1" > "$OUT"
+expect "no longer allowing cluster with group grp1"
+send "stat rmtpol" > "$OUT"
+expect "no groups"
+# Dropping the group drops the membership it granted.
+send "stat rmtpol mach9" > "$OUT"
+expect "Cluster allow list permits mach9 ? NO"
+
+# 7. "clrpol" also drops the host.
+send "allow cluster with mach3" > "$OUT"
+send "stat rmtpol" > "$OUT"
+expect "host mach3"
+send "clrpol cluster with mach3" > "$OUT"
+send "stat rmtpol" > "$OUT"
+reject "host mach3"
+
+# 8. Turning enforcement on switches which list decides.  We always permit
+#    ourselves; a host that no one allowed is refused.
+sql "PUT TUNABLE enforce_cluster_allow_list 1"
+send "stat rmtpol" > "$OUT"
+expect "Cluster allow list (enforced)"
+send "stat rmtpol ${myhost}" > "$OUT"
+expect "Allow cluster with ${myhost}       ? YES"
+send "stat rmtpol mach2" > "$OUT"
+expect "Allow cluster with mach2       ? NO"
+
+# Enforcement must not turn away a node we already cluster with.  This is the
+# risk of the phase 2 switch, so check every peer.
+for node in ${CLUSTER}; do
+    send "stat rmtpol ${node}" > "$OUT"
+    expect "Allow cluster with ${node}       ? YES"
+done
+
+# A host we allow is accepted again, even though it is not a like-class
+# machine.
+send "allow cluster with mach2" > "$OUT"
+send "stat rmtpol mach2" > "$OUT"
+expect "Allow cluster with mach2       ? YES"
+
+sql "PUT TUNABLE enforce_cluster_allow_list 0"
+
+# 9. The list keys on the resolved name, so every entry goes through
+#    comdb2_gethostbyname().  A numeric address must survive that.
+send "allow cluster with 127.0.0.1" > "$OUT"
+expect "allowing cluster with machine 127.0.0.1"
+send "stat rmtpol" > "$OUT"
+expect "host 127.0.0.1"
+
+echo "Success"
+exit 0

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -359,6 +359,7 @@
 (name='enable_upgrade_ahead', description='Occasionally update read records to the newest schema version (saves some processing when reading them later). (Default: off)', type='INTEGER', value='0', read_only='Y')
 (name='enablecursorser', description='', type='BOOLEAN', value='OFF', read_only='N')
 (name='endianize_locklist', description='Endianize locklist before writing to txnlog.  (Default: on)', type='BOOLEAN', value='ON', read_only='N')
+(name='enforce_cluster_allow_list', description='Enforce the cluster allow list, which names the hosts and machine groups that may cluster with us. When off, enforce the older cluster remote policy instead and only warn about the hosts the allow list would reject. (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='epochms_repts', description='', type='BOOLEAN', value='OFF', read_only='Y')
 (name='erroff', description='Disables 'erron'', type='BOOLEAN', value='OFF', read_only='Y')
 (name='erron', description='', type='BOOLEAN', value='ON', read_only='Y')

--- a/util/bb_oscompat.c
+++ b/util/bb_oscompat.c
@@ -49,8 +49,10 @@ static int os_get_host_and_cname_by_name(char **name_ptr, struct in_addr *addr,
         *addr = ((struct sockaddr_in*)res->ai_addr)->sin_addr;
     }
 
+    /* getaddrinfo leaves ai_canonname NULL for some inputs, a numeric address
+     * among them. */
     if (cname != NULL)
-        *cname = strdup(res->ai_canonname);
+        *cname = res->ai_canonname ? strdup(res->ai_canonname) : NULL;
 
     freeaddrinfo(res);
     return 0;


### PR DESCRIPTION
Two phases:
In first, just warn if a node is able to join today but won't be once `enforce_cluster_allow_list` is enabled, eg:

```
host cdb2machine2 clusters with us now, but the cluster allow list would reject it.  Run "allow cluster with cdb2machine2" to keep it once the list is enforced.
```

Hosts can be added via, eg `allow cluster with cdb2machine` or `allow cluster with group c2machinegroup`

`bdb add`'ed nodes are allowed.  Nodes that are allowed to join bring their `lrl`-configured list with them, and nodes on that list are also allowed to join.