### PR TITLE
contrib/docker: publish the Docker image to ghcr.io

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,199 @@
+name: Publish Docker image
+
+# This repo does not cut releases, so pushes to main are what keep the published
+# image fresh; the tag trigger is here in case tagging resumes.
+on:
+  push:
+    branches: [main]
+    tags: ["[0-9]+.[0-9]+.[0-9]+"]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+# Cancelling between the per-arch pushes and the merge would leave untagged digests.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Native runners rather than QEMU, which would take hours to compile Comdb2.
+  build:
+    name: Build [${{ matrix.platform }}]
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
+
+    permissions:
+      contents: read
+      packages: write
+
+    defaults:
+      run:
+        shell: bash -o errexit -o nounset -o pipefail {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # ghcr.io rejects uppercase names and nothing downstream normalizes case.
+      - name: Compute image name
+        run: echo "IMAGE=${REGISTRY}/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      # For its labels; org.opencontainers.image.source links the package to the repo.
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: contrib/docker/Dockerfile.dev
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.platform }}
+
+      # upload-artifact rejects colons in paths; merge puts the prefix back.
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ strategy.job-index }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifest
+    needs: build
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+
+    defaults:
+      run:
+        shell: bash -o errexit -o nounset -o pipefail {0}
+
+    steps:
+      - name: Compute image name
+        run: echo "IMAGE=${REGISTRY}/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Compute tags
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE }}
+          # Without the branch tag, a manual run off a non-default branch produces
+          # no tags at all. The priority keeps latest canonical on main.
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}},priority=1000
+            type=ref,event=branch
+            type=sha,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect image
+        run: docker buildx imagetools inspect "${IMAGE}:${{ steps.meta.outputs.version }}"
+
+  verify:
+    name: Verify [${{ matrix.platform }}]
+    needs: merge
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.runner }}
+
+    permissions:
+      contents: read
+      packages: read
+
+    defaults:
+      run:
+        shell: bash -o errexit -o nounset -o pipefail {0}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Compute image name
+        run: echo "IMAGE=${REGISTRY}/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      # Needed while the package is private; harmless once it is public.
+      - name: Log in to ${{ env.REGISTRY }}
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run the standalone smoke test against the published image
+        env:
+          COMDB2_DOCKER_IMAGE: ${{ env.IMAGE }}:${{ needs.merge.outputs.version }}
+        run: ./tests/contrib_docker/runit standalone

--- a/contrib/docker/Dockerfile.dev
+++ b/contrib/docker/Dockerfile.dev
@@ -78,3 +78,5 @@ EXPOSE 5105
 COPY contrib/docker/standalone-entrypoint.sh /standalone-entrypoint.sh
 RUN chmod +x /standalone-entrypoint.sh
 ENTRYPOINT ["/standalone-entrypoint.sh"]
+
+# No CMD: it would leak into the compose services, which override entrypoint only.

--- a/contrib/docker/README.md
+++ b/contrib/docker/README.md
@@ -9,6 +9,19 @@ plus a client container, with a single command and no manual steps.
 - [Docker Engine](https://docs.docker.com/engine/install/) with the
   [Compose](https://docs.docker.com/compose/install/) plugin (`docker compose`).
 
+## Using the published image
+
+To skip compiling, pull the prebuilt image (`linux/amd64` and `linux/arm64`, tagged
+`latest` and `sha-<short>`):
+
+```sh
+docker run -d --name comdb2 ghcr.io/bloomberg/comdb2:latest mydb
+docker exec comdb2 cdb2sql mydb local "select 1"
+```
+
+See [Running a standalone database](#running-a-standalone-database) below. Build from
+source instead to run a cluster or to test changes in your working tree.
+
 ## Quick start
 
 From this directory (`contrib/docker/`):
@@ -109,7 +122,8 @@ docker compose ps
 The same image can also run one or more **standalone** (non-clustered)
 databases in a single container.
 
-First make sure the image is built (Compose builds it, or build it directly):
+First make sure the image is built (Compose builds it, or build it directly), or
+substitute the published image for `comdb2-dev:latest` below:
 
 ```sh
 docker compose build

--- a/contrib/docker/standalone-entrypoint.sh
+++ b/contrib/docker/standalone-entrypoint.sh
@@ -6,6 +6,11 @@ while [[ $1 = -* ]]; do
     shift
 done
 
+if [[ $# -eq 0 ]]; then
+    echo "usage: docker run <image> DBNAME [DBNAME...]" >&2
+    exit 1
+fi
+
 pmux -l
 
 host=$(hostname -i)

--- a/tests/contrib_docker/runit
+++ b/tests/contrib_docker/runit
@@ -80,6 +80,17 @@ if [ -n "$run_standalone" ]; then
         docker compose build
     fi
 
+    # Match the message, not just a non-zero exit: a failed pull is also non-zero.
+    if usage="$(docker run --rm "$IMAGE" 2>&1)"; then
+        echo "expected a usage error when no database is named" >&2
+        exit 1
+    fi
+    if ! grep -q '^usage: ' <<<"$usage"; then
+        echo "expected a usage message when no database is named; got:" >&2
+        echo "$usage" >&2
+        exit 1
+    fi
+
     container="$(docker run -d "$IMAGE" db1 db2)"
     trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
 

--- a/tests/contrib_docker/runit
+++ b/tests/contrib_docker/runit
@@ -7,77 +7,117 @@
 # would run. It checks two things: that a fresh `docker compose up` stands up a
 # cluster you can query, and that the image's standalone (non-clustered) mode
 # runs and serves databases. It is not an exhaustive functional test.
+#
+# usage: runit [all|cluster|standalone]. COMDB2_DOCKER_IMAGE overrides the image
+# for the standalone section; the cluster section always builds from source.
 
 set -euo pipefail
+
+DEFAULT_IMAGE=comdb2-dev:latest
+IMAGE="${COMDB2_DOCKER_IMAGE:-$DEFAULT_IMAGE}"
+
+run_cluster=
+run_standalone=
+case "${1:-all}" in
+    all)        run_cluster=1; run_standalone=1 ;;
+    cluster)    run_cluster=1 ;;
+    standalone) run_standalone=1 ;;
+    *)
+        echo "usage: ${0##*/} [all|cluster|standalone]" >&2
+        exit 1
+        ;;
+esac
+
+if [ -n "$run_cluster" ] && [ "$IMAGE" != "$DEFAULT_IMAGE" ]; then
+    echo "COMDB2_DOCKER_IMAGE only applies to the standalone section;" >&2
+    echo "the cluster section builds from the source tree. Run 'standalone'." >&2
+    exit 1
+fi
 
 # Run from contrib/docker so the commands match the README verbatim.
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$script_dir/../../contrib/docker"
 
-# Not really necessary in ephemeral CI environments but nice for local dev.
-trap 'docker compose down -v' EXIT
-
 # ----------------------------------------------------------------------------
 # Clustered setup: 3-node cluster + client container.
 # ----------------------------------------------------------------------------
 
-# Start the cluster + client. Nodes declare a healthcheck, so by the time this
-# returns the cluster can serve queries.
-docker compose up -d
+if [ -n "$run_cluster" ]; then
+    # Not really necessary in ephemeral CI environments but nice for local dev.
+    trap 'docker compose down -v' EXIT
 
-# `-T` disables pseudo-TTY allocation, which is required when there's no
-# terminal (e.g. CI).
-docker compose exec -T dev cdb2sql testdb default "select 1"
-docker compose exec -T dev cdb2sql testdb default "create table t(i int)"
-docker compose exec -T dev cdb2sql testdb default "insert into t values(42)"
+    # Start the cluster + client. Nodes declare a healthcheck, so by the time this
+    # returns the cluster can serve queries.
+    docker compose up -d
 
-out="$(docker compose exec -T dev cdb2sql testdb default "select * from t")"
-echo "$out"
-echo "$out" | grep -q 'i=42'
+    # `-T` disables pseudo-TTY allocation, which is required when there's no
+    # terminal (e.g. CI).
+    docker compose exec -T dev cdb2sql testdb default "select 1"
+    docker compose exec -T dev cdb2sql testdb default "create table t(i int)"
+    docker compose exec -T dev cdb2sql testdb default "insert into t values(42)"
 
-# Test that the `docker compose run` variant works as well.
-out="$(docker compose run --rm dev cdb2sql testdb default "select * from t")"
-echo "$out"
-echo "$out" | grep -q 'i=42'
+    out="$(docker compose exec -T dev cdb2sql testdb default "select * from t")"
+    echo "$out"
+    echo "$out" | grep -q 'i=42'
 
-# Disarm the cleanup trap to prevent double-`down`.
-trap - EXIT
-docker compose down -v
+    # Test that the `docker compose run` variant works as well.
+    out="$(docker compose run --rm dev cdb2sql testdb default "select * from t")"
+    echo "$out"
+    echo "$out" | grep -q 'i=42'
+
+    # Disarm the cleanup trap to prevent double-`down`.
+    trap - EXIT
+    docker compose down -v
+fi
 
 # ----------------------------------------------------------------------------
 # Standalone setup: one or more non-clustered databases in a single container.
 # ----------------------------------------------------------------------------
 
-# Ordering: the comdb2-dev:latest image is built and tagged by the earlier
-# `docker compose up -d` step.
-container="$(docker run -d comdb2-dev:latest db1 db2)"
-trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+if [ -n "$run_standalone" ]; then
+    # The cluster section would have built this as a side effect.
+    if [ "$IMAGE" = "$DEFAULT_IMAGE" ] && ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+        docker compose build
+    fi
 
-# No compose healthcheck here, so wait until each db answers before querying it.
-for db in db1 db2; do
-    for _ in $(seq 1 60); do
-        docker exec "$container" cdb2sql "$db" local "select 1" >/dev/null 2>&1 && break
-        sleep 1
+    container="$(docker run -d "$IMAGE" db1 db2)"
+    trap 'docker rm -f "$container" >/dev/null 2>&1 || true' EXIT
+
+    # No compose healthcheck here, so wait until each db answers before querying it.
+    for db in db1 db2; do
+        ready=
+        for _ in $(seq 1 120); do
+            if docker exec "$container" cdb2sql "$db" local "select 1" >/dev/null 2>&1; then
+                ready=1
+                break
+            fi
+            sleep 1
+        done
+        if [ -z "$ready" ]; then
+            echo "$db did not come up; container logs follow:" >&2
+            docker logs "$container" >&2 || true
+            exit 1
+        fi
     done
-done
 
-# db1
-docker exec "$container" cdb2sql db1 local "create table t(i int)"
-docker exec "$container" cdb2sql db1 local "insert into t values(1)"
-out="$(docker exec "$container" cdb2sql db1 local "select * from t")"
-echo "$out"
-echo "$out" | grep -q 'i=1'
+    # db1
+    docker exec "$container" cdb2sql db1 local "create table t(i int)"
+    docker exec "$container" cdb2sql db1 local "insert into t values(1)"
+    out="$(docker exec "$container" cdb2sql db1 local "select * from t")"
+    echo "$out"
+    echo "$out" | grep -q 'i=1'
 
-# db2 (a separate database running in the same container)
-docker exec "$container" cdb2sql db2 local "create table t(i int)"
-docker exec "$container" cdb2sql db2 local "insert into t values(2)"
-out="$(docker exec "$container" cdb2sql db2 local "select * from t")"
-echo "$out"
-echo "$out" | grep -q 'i=2'
+    # db2 (a separate database running in the same container)
+    docker exec "$container" cdb2sql db2 local "create table t(i int)"
+    docker exec "$container" cdb2sql db2 local "insert into t values(2)"
+    out="$(docker exec "$container" cdb2sql db2 local "select * from t")"
+    echo "$out"
+    echo "$out" | grep -q 'i=2'
 
-# Disarm the cleanup trap to prevent double-`rm`.
-docker stop "$container" >/dev/null
-trap - EXIT
-docker rm -f "$container" >/dev/null
+    # Disarm the cleanup trap to prevent double-`rm`.
+    docker stop "$container" >/dev/null
+    trap - EXIT
+    docker rm -f "$container" >/dev/null
+fi
 
 echo "PASSED"


### PR DESCRIPTION
Three changes:

1. f0df082dceb00b20f4990b7328cc02d3ada1a82c: make it so that the tests that exercise standalone dbs can run with a pre-built image (making the clustered tests work with a pre-built image will require more thought).
2. 63060899471a9fe8afc265ade7f149d49b370569: add a sanity check to the image's entrypoint - user must specify a dbname for the database to start.
3. c54421b691916ab045483836ecf8f477ca9a872f: add a GitHub Actions workflow for publishing the image to the GitHub container registry (`ghcr`). This does the following:
  a. Build the image for both `amd64` and `arm64`.
  b. "Merge" the manifests so that a `docker pull` can choose the best image for the native architecture, and publish to ghcr.
  c. Verify that the published images pass `tests/contrib_docker`.


Tested the publish workflow from my fork:

```
schakravorti@G0071XFCV7 comdb2 % docker run -d --name comdb2 ghcr.io/schakravorti21/comdb2:latest mydb
84585048748d722437d938a59a090a5af4659a91a6d8197885dc5b5aba839e30
schakravorti@G0071XFCV7 comdb2 % docker exec comdb2 cdb2sql mydb local "create table t(i int)"
schakravorti@G0071XFCV7 comdb2 % docker exec comdb2 cdb2sql mydb local "insert into t values(42)"
(rows inserted=1)
schakravorti@G0071XFCV7 comdb2 % docker exec comdb2 cdb2sql mydb local "select * from t"
(i=42)
```