### PR TITLE
Refresh cursor dbtable and schema after a chunk transaction relocks

### DIFF
--- a/db/db_tunables.c
+++ b/db/db_tunables.c
@@ -479,6 +479,7 @@ extern int gbl_stack_string_refs;
 extern int gbl_abort_on_dangling_stringrefs;
 extern int gbl_abort_on_stalled_exit;
 extern int gbl_debug_alter_sequences_sleep;
+extern int gbl_debug_poison_freed_schemas;
 extern int gbl_debug_omit_dta_write;
 extern int gbl_debug_omit_idx_write;
 extern int gbl_debug_ix_addk_nomaster;

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -1342,6 +1342,12 @@ REGISTER_TUNABLE("debug.alter_sequences_sleep",
                  "Sleep for 10 seconds before setting sequence to highest value found in existing column during alter "
                  "table 10 seconds prior (Default: 0)",
                  TUNABLE_BOOLEAN, &gbl_debug_alter_sequences_sleep, INTERNAL, NULL, NULL, NULL, NULL);
+#ifdef COMDB2_TEST
+REGISTER_TUNABLE("debug.poison_freed_schemas",
+                 "Poison the schemas freed by commit_schemas so that a stale reference to one (e.g. a BtCursor that "
+                 "outlived a schema change) crashes instead of reading recycled memory (Default: OFF)",
+                 TUNABLE_BOOLEAN, &gbl_debug_poison_freed_schemas, EXPERIMENTAL | INTERNAL, NULL, NULL, NULL, NULL);
+#endif
 REGISTER_TUNABLE("debug.autoanalyze", "debug autoanalyze operations",
                  TUNABLE_BOOLEAN, &gbl_debug_aa, NOARG, NULL, NULL, NULL, NULL);
 REGISTER_TUNABLE("debug.thdpool_queue_only",

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -8688,6 +8688,76 @@ int sqlite3BtreeBeginStmt(Btree *pBt, int iStatement)
     sqlite3VdbeError(vdbe, "%s", errstr);                                      \
     sqlite3_mutex_leave(sqlite3_db_mutex(vdbe->db));
 
+/* Committing a chunk drops the curtran table locks, which lets a concurrent
+ * schema change finalize and replace the dbtable behind our back.  The dbtable
+ * itself is recycled in place (see free_db_and_replace), but its schemas are
+ * not: commit_schemas frees the old ".ONDISK" and index schemas, leaving every
+ * open cursor with a dangling pCur->sc.
+ *
+ * Once the locks are back, re-derive db and sc for each local cursor.  Bail out
+ * if the table went away or its version moved: the rest of the cursor state
+ * (ondisk_buf/keybuf sizes, numblobs, ...) was sized at open time and would be
+ * stale as well.
+ */
+static int refresh_chunk_cursors(struct sql_thread *thd)
+{
+    BtCursor *cur = NULL;
+    int rc = SQLITE_OK;
+
+    if (!thd->bt)
+        return SQLITE_OK;
+
+    Pthread_mutex_lock(&thd->lk);
+
+    LISTC_FOR_EACH(&thd->bt->cursors, cur, lnk)
+    {
+        struct dbtable *db;
+        struct schema *sc;
+
+        /* temp tables, sqlite_master and remotes don't cache a dbtable schema */
+        if (!cur->db || (cur->bt && cur->bt->is_remote))
+            continue;
+
+        db = get_sqlite_db(thd, cur->rootpage, NULL);
+        if (!db) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: table for rootpage %d was dropped during chunk "
+                   "transaction\n",
+                   __func__, cur->rootpage);
+            rc = SQLITE_SCHEMA;
+            break;
+        }
+
+        if (cur->tableversion != db->tableversion || cur->ixnum >= db->nix) {
+            logmsg(LOGMSG_ERROR,
+                   "%s: table %s schema changed during chunk transaction, "
+                   "version %d -> %llu\n",
+                   __func__, db->tablename, cur->tableversion, db->tableversion);
+            rc = SQLITE_SCHEMA;
+            break;
+        }
+
+        sc = (cur->ixnum == -1) ? db->schema : db->ixschema[cur->ixnum];
+
+        /* A same-schema change (rebuild, truncate, timepart truncate rollout)
+         * keeps the table version, so the check above lets it through: say so,
+         * this is the case that used to leave cur->sc dangling.
+         */
+        if (cur->sc != sc)
+            logmsg(LOGMSG_INFO,
+                   "%s: refreshed stale schema for table %s cursor %d ixnum "
+                   "%d\n",
+                   __func__, db->tablename, cur->cursorid, cur->ixnum);
+
+        cur->db = db;
+        cur->sc = sc;
+    }
+
+    Pthread_mutex_unlock(&thd->lk);
+
+    return rc;
+}
+
 static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
                              struct sql_thread *thd)
 {
@@ -8829,6 +8899,14 @@ static int chunk_transaction(BtCursor *pCur, struct sqlclntstate *clnt,
             if (newlocks_rc == 0)
                 newlocks_rc = sqlite3LockStmtTables(clnt->dbtran.pStmt);
             unlock_schema_lk();
+
+            /* sqlite3LockStmtTables() re-checked the versions of the tables
+             * registered by the statement, but the cursors still cache the
+             * dbtable and schema pointers they latched at open time.  Now that
+             * we hold the table locks again, refresh them.
+             */
+            if (newlocks_rc == 0)
+                newlocks_rc = refresh_chunk_cursors(thd);
 
             if (newlocks_rc) {
                 comdb2_sqlite3VdbeError(

--- a/db/tag.c
+++ b/db/tag.c
@@ -69,6 +69,7 @@ const int gbl_ondisk_ver_len = sizeof ".ONDISK.VER.255xx";
 
 int _dbg_tags = 0;
 int gbl_debug_alter_sequences_sleep = 0;
+int gbl_debug_poison_freed_schemas = 0;
 
 #define TAGLOCK_RW_LOCK
 #ifdef TAGLOCK_RW_LOCK
@@ -5479,8 +5480,17 @@ void commit_schemas(const char *tblname)
         }
 
         /* free schemas themselves */
-        for (i = 0; i < count; i++)
+        for (i = 0; i < count; i++) {
+#ifdef COMDB2_TEST
+            /* Anything still pointing here is a bug (a BtCursor that cached
+             * db->schema and outlived a schema change, for example).  Poison
+             * the schema so such a reference fails loudly instead of reading
+             * plausible-looking recycled memory. */
+            if (gbl_debug_poison_freed_schemas)
+                memset(s[i], 0xff, sizeof(struct schema));
+#endif
             free(s[i]);
+        }
         free(s);
     }
 

--- a/tests/transchunk_tablelocks.test/Makefile
+++ b/tests/transchunk_tablelocks.test/Makefile
@@ -4,5 +4,5 @@ else
   include $(TESTSROOTDIR)/testcase.mk
 endif
 ifeq ($(TEST_TIMEOUT),)
-	export TEST_TIMEOUT=3m
+	export TEST_TIMEOUT=5m
 endif

--- a/tests/transchunk_tablelocks.test/README
+++ b/tests/transchunk_tablelocks.test/README
@@ -1,1 +1,10 @@
-This test checks the case of altering and dropping a table while running a chunk transaction.
+This test checks the case of altering, dropping and rebuilding a table while
+running a chunk transaction.
+
+Committing a chunk releases the curtran table locks, so a schema change can
+finalize before the next chunk reacquires them.  The alter and the drop are
+caught by the table version check in sqlite3LockStmtTables().  The rebuild is
+not: it sets same_schema, so the table version does not move even though the
+dbtable has been replaced and the old schemas freed.  The open cursors have to
+have their cached dbtable/schema pointers refreshed, otherwise pCur->sc points
+at freed memory.

--- a/tests/transchunk_tablelocks.test/runit
+++ b/tests/transchunk_tablelocks.test/runit
@@ -91,5 +91,101 @@ if [[ "$testcase_output" != "$expected_output" ]]; then
 
 fi
 
+################################################################################
+# Race a chunked delete against a table rebuild.
+#
+# The two races above (alter, drop) are both caught when the chunk transaction
+# reacquires its table locks, because they move the table version.  A rebuild
+# does not: it sets same_schema, so finalize_alter_table keeps the version.
+# The version check therefore lets it through, even though the rebuild has
+# already replaced the dbtable and commit_schemas() has freed the schemas the
+# open cursors latched at cursor-open time.  Those cursors have to be
+# refreshed, or they are left pointing at freed memory.
+#
+# The delete has to go through the index: cursor_move_index() is what reads
+# pCur->sc (via ondisk_to_sqlite_tz).  A "where 1" table scan never looks at
+# it and the stale pointer goes unnoticed.
+################################################################################
+
+echo "Deleting the rows, will rebuild the table after the first chunk"
+
+# Make a stale schema reference fail immediately instead of reading memory
+# that happens to still look valid.  COMDB2_TEST builds only, so best effort.
+for node in $(cdb2sql --tabs ${CDB2_OPTIONS} $a_dbn default "select host from comdb2_cluster"); do
+    cdb2sql -s -n ${node} ${CDB2_OPTIONS} $a_dbn default "put tunable debug.poison_freed_schemas 1"
+    # lrl throttles chunks by 20s, more than this scenario needs
+    cdb2sql -s -n ${node} ${CDB2_OPTIONS} $a_dbn default "put tunable throttle_txn_chunks_msec 3000"
+done
+
+# the drop above took the table with it
+$rt "create table t {`cat t.csc2`}"
+if (( $? != 0 )) ; then
+    echo "FAILURE: could not recreate t"
+    exit 1
+fi
+
+$r << "EOF"
+set transaction chunk 10
+begin
+insert into t select value from generate_series(1, 60)
+commit
+EOF
+if (( $? != 0 )) ; then
+    echo "FAILURE: could not populate t"
+    exit 1
+fi
+
+$r << "EOF" &
+set transaction chunk 10
+begin
+delete from t where a > 0
+commit
+EOF
+delete_pid=$!
+
+sleep 4
+
+$rt "rebuild t"
+if (( $? != 0 )) ; then
+    echo "FAILURE: rebuild failed"
+    exit 1
+fi
+
+# If the delete already finished the rebuild did not land inside a chunk
+# window and this run proved nothing.
+if ! kill -0 $delete_pid 2>/dev/null ; then
+    echo "FAILURE: chunked delete completed before the rebuild, race did not happen"
+    exit 1
+fi
+
+wait $delete_pid
+
+# The server is expected to survive this and finish the delete.  Without the
+# cursor refresh it reads a freed schema here and dies.
+cnt=$($rt --tabs "select count(*) from t")
+if (( $? != 0 )) ; then
+    echo "FAILURE: database is not reachable after racing a rebuild against a chunked delete"
+    exit 1
+fi
+if [[ "$cnt" != "0" ]] ; then
+    echo "FAILURE: expected the chunked delete to remove every row, $cnt left"
+    exit 1
+fi
+
+# Single node only: on a cluster we do not know which node ran the delete.
+if [[ -z "$CLUSTER" ]] ; then
+    dbglog="${TESTDIR}/logs/${a_dbn}.db"
+    if ! grep -q "refreshed stale schema for table t" $dbglog ; then
+        echo "FAILURE: no cursor was refreshed, the rebuild did not land in a chunk window"
+        echo "         (expected 'refreshed stale schema' in $dbglog)"
+        exit 1
+    fi
+    if ! grep -q "refreshed stale schema for table t cursor .* ixnum 0" $dbglog ; then
+        echo "FAILURE: the index cursor was not refreshed, pCur->sc would still be stale"
+        grep "refreshed stale schema" $dbglog
+        exit 1
+    fi
+fi
+
 echo "Testcase passed."
 


### PR DESCRIPTION
^title

re: 185860317