### PR TITLE
logicalops: normalize rectype before compare

### DIFF
--- a/sqlite/ext/comdb2/logicalops.c
+++ b/sqlite/ext/comdb2/logicalops.c
@@ -910,6 +910,7 @@ static int unpack_logical_record(logicalops_cursor *pCur)
             return SQLITE_INTERNAL;
         }
         LOGCOPY_32(&rectype, logdta.data);
+        normalize_rectype(&rectype);
         assert(rectype == rec->type);
 
         switch(rec->type) {


### PR DESCRIPTION
`unpack_logical_record` asserts the rectype read from the raw log record matches `rec->type`, but raw llog records carry the utxnid `+2000` bias while `rec->type` is a plain `DB_llog_*` constant, so the assert trips on every record on a utxnid-enabled debug build. Normalize before comparing, matching the `LOGCOPY_32` + `normalize_rectype` pairing every other raw-log consumer uses; unbiased records are left untouched.