### PR TITLE
Lock fingerprint

### DIFF
--- a/bdb/bdb.c
+++ b/bdb/bdb.c
@@ -704,6 +704,12 @@ const struct berkdb_thread_stats *bdb_get_thread_stats(void)
 BB_COMPILE_TIME_ASSERT(bdb_fingerprint_rtstats_ncounts,
                        BDB_FINGERPRINT_RTSTATS_NCOUNTS == BB_BERKDB_FP_RTSTATS_NCOUNTS);
 
+/* The bdb-level role values are passed straight through to berkdb. */
+BB_COMPILE_TIME_ASSERT(bdb_fingerprint_rtstats_roles, BDB_FP_ROLE_NONE == BB_BERKDB_FP_ROLE_NONE &&
+                                                          BDB_FP_ROLE_SQL == BB_BERKDB_FP_ROLE_SQL &&
+                                                          BDB_FP_ROLE_WRITE == BB_BERKDB_FP_ROLE_WRITE &&
+                                                          BDB_FP_ROLE_APPLY == BB_BERKDB_FP_ROLE_APPLY);
+
 void bdb_fingerprint_rtstats_set(const unsigned char *fingerprint, size_t fplen, int has_main_entry)
 {
     bb_berkdb_fingerprint_rtstats_set(fingerprint, fplen, has_main_entry);
@@ -717,6 +723,11 @@ void bdb_fingerprint_rtstats_set_write(const unsigned char *fingerprint, size_t 
 void bdb_fingerprint_rtstats_set_apply(const unsigned char *fingerprint, size_t fplen, int has_main_entry)
 {
     bb_berkdb_fingerprint_rtstats_set_apply(fingerprint, fplen, has_main_entry);
+}
+
+void bdb_fingerprint_rtstats_set_role(int role)
+{
+    bb_berkdb_fingerprint_rtstats_set_role(role);
 }
 
 void bdb_fingerprint_rtstats_clear(void)

--- a/bdb/bdb_api.h
+++ b/bdb/bdb_api.h
@@ -1379,9 +1379,19 @@ const struct berkdb_thread_stats *bdb_get_process_stats(void);
  * [0][1] SQL execution, [2][3] master write-apply, [4][5] replicant apply. */
 #define BDB_FINGERPRINT_RTSTATS_NCOUNTS 6
 
+/* Mirrors BB_BERKDB_FP_ROLE_* (berkdb/build/db.h), asserted equal in bdb.c. Picks
+ * the page-in counter pair to bill and the role comdb2_locks reports. */
+#define BDB_FP_ROLE_NONE 0
+#define BDB_FP_ROLE_SQL 1   /* 'R' -- SQL statement execution */
+#define BDB_FP_ROLE_WRITE 2 /* 'W' -- master applying a write schedule */
+#define BDB_FP_ROLE_APPLY 3 /* 'A' -- replicant applying from the log */
+
 void bdb_fingerprint_rtstats_set(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
 void bdb_fingerprint_rtstats_set_write(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
 void bdb_fingerprint_rtstats_set_apply(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
+/* Declare a role with no fingerprint, so work that has none is still
+ * attributable. Pairs with bdb_fingerprint_rtstats_clear(). */
+void bdb_fingerprint_rtstats_set_role(int role);
 void bdb_fingerprint_rtstats_clear(void);
 int bdb_fingerprint_rtstats_get(const unsigned char *fingerprint, size_t fplen,
                                 uint64_t counts[BDB_FINGERPRINT_RTSTATS_NCOUNTS]);

--- a/berkdb/build/db.h
+++ b/berkdb/build/db.h
@@ -2296,9 +2296,12 @@ struct __ufid_to_db_t {
 	DB *dbp;
 };
 
+/* fingerprint is the acquirer's 16-byte fingerprint or NULL; fingerprint_role is
+ * 'R', 'W', 'A' or 0. Independent: apply reports 'A' with a NULL fingerprint. */
 typedef int (*collect_locks_f)(void *args, int64_t threadid, int32_t lockerid,
 		const char *mode, const char *status, const char *table,
-		int64_t page, const char *rectype, int stackid);
+		int64_t page, const char *rectype, int stackid,
+		const unsigned char *fingerprint, char fingerprint_role);
 
 typedef int (*collect_prepared_f)(void *args, char *dist_txnid, uint32_t flags,
 		DB_LSN *lsn, DB_LSN *begin_lsn, uint32_t coordinator_gen, char *coordinator_name,
@@ -3132,10 +3135,19 @@ void bb_berkdb_thread_stats_reset(void);
  * [0][1] SQL execution, [2][3] master write-apply, [4][5] replicant apply. */
 #define BB_BERKDB_FP_RTSTATS_NCOUNTS 6
 
+/* Which counter pair a thread's page-ins bill to, and the role its locks report.
+ * NONE must stay 0: it is what an unarmed thread reads out of TLS. */
+#define BB_BERKDB_FP_ROLE_NONE	0
+#define BB_BERKDB_FP_ROLE_SQL	1	/* 'R' -- SQL statement execution */
+#define BB_BERKDB_FP_ROLE_WRITE	2	/* 'W' -- master applying a write schedule */
+#define BB_BERKDB_FP_ROLE_APPLY	3	/* 'A' -- replicant applying from the log */
+
 void bb_berkdb_fingerprint_rtstats_init(void);
 void bb_berkdb_fingerprint_rtstats_set(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
 void bb_berkdb_fingerprint_rtstats_set_write(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
 void bb_berkdb_fingerprint_rtstats_set_apply(const unsigned char *fingerprint, size_t fplen, int has_main_entry);
+void bb_berkdb_fingerprint_rtstats_set_role(int role);
+int bb_berkdb_fingerprint_rtstats_current(unsigned char *fingerprint, int *role);
 void bb_berkdb_fingerprint_rtstats_clear(void);
 void bb_berkdb_fingerprint_rtstats_bump_pagein(int did_io);
 int bb_berkdb_fingerprint_rtstats_get(const unsigned char *fingerprint, size_t fplen,

--- a/berkdb/dbinc/lock.h
+++ b/berkdb/dbinc/lock.h
@@ -355,6 +355,13 @@ struct __db_lock {
 	u_int32_t nlsns;
 
     int         stackid;
+
+	/*
+	 * Acquirer, stamped from TLS at allocation and reported by comdb2_locks.
+	 * All-zero fingerprint means unknown; fp_role is a BB_BERKDB_FP_ROLE_*.
+	 */
+	u_int8_t	fingerprint[16];
+	u_int8_t	fp_role;
 };
 
 /*

--- a/berkdb/lock/lock.c
+++ b/berkdb/lock/lock.c
@@ -2016,6 +2016,17 @@ stack_at_get_lock(struct __db_lock *lockp, DB_LOCK * lock, int ishandle, int isw
 					 stackutil_get_stack_id("getlock") : -1;
 }
 
+/* Stamp the acquirer for comdb2_locks: two TLS reads and a 16-byte copy. Stamped
+ * once, so re-acquire (the refcount++/UPGRADE paths below) keeps the original. */
+static inline void
+stamp_fingerprint(struct __db_lock *lockp)
+{
+	int role;
+
+	bb_berkdb_fingerprint_rtstats_current(lockp->fingerprint, &role);
+	lockp->fp_role = (u_int8_t)role;
+}
+
 /* Return 1 if this is a comdb2 rowlock, 0 otherwise. */
 static inline int
 is_comdb2_rowlock(u_int32_t sz)
@@ -2672,6 +2683,10 @@ __lock_get_internal_int(lt, locker, in_locker, flags, obj, lock_mode, timeout,
 		newl->refcount = 1;
 		newl->mode = lock_mode;
 		newl->lockobj = sh_obj;
+
+		/* Before the wait, unlike stack_at_get_lock() below: a lock
+		 * parked in DB_LSTAT_WAITING is collectable and needs a stamp. */
+		stamp_fingerprint(newl);
 
 		/*
 		 * Now, insert the lock onto its locker's list.

--- a/berkdb/lock/lock_stat.c
+++ b/berkdb/lock/lock_stat.c
@@ -635,6 +635,33 @@ static char *status_to_str(int lpstatus)
 
 #include "tohex.h"
 
+static char fp_role_to_char(u_int8_t role)
+{
+	switch (role) {
+	case BB_BERKDB_FP_ROLE_SQL:
+		return 'R';
+	case BB_BERKDB_FP_ROLE_WRITE:
+		return 'W';
+	case BB_BERKDB_FP_ROLE_APPLY:
+		return 'A';
+	default:
+		return 0;
+	}
+}
+
+/* An all-zero fingerprint is the "not known" sentinel -- see stamp_fingerprint()
+ * in lock.c -- so report it to the caller as no fingerprint at all. */
+static const unsigned char *fingerprint_or_null(const struct __db_lock *lp)
+{
+	unsigned i;
+
+	for (i = 0; i < sizeof(lp->fingerprint); i++) {
+		if (lp->fingerprint[i] != 0)
+			return lp->fingerprint;
+	}
+	return NULL;
+}
+
 static int
 __collect_lock(DB_LOCKTAB *lt, DB_LOCKER *lip, struct __db_lock *lp,
 		collect_locks_f func, void *arg)
@@ -745,7 +772,8 @@ __collect_lock(DB_LOCKTAB *lt, DB_LOCKER *lip, struct __db_lock *lp,
 	if (namep && memcmp(namep, "XXX.", 4) == 0)
 		namep += 4;
 
-	(*func)(arg, (uint64_t)lip->tid, lip->id, mode, status, namep, page, rectype, lp->stackid);
+	(*func)(arg, (uint64_t)lip->tid, lip->id, mode, status, namep, page, rectype, lp->stackid,
+		fingerprint_or_null(lp), fp_role_to_char(lp->fp_role));
 	if (hexdump)
 		free(hexdump);
 	return 0;

--- a/berkdb/mp/mp_fingerprint_rtstats.c
+++ b/berkdb/mp/mp_fingerprint_rtstats.c
@@ -69,11 +69,14 @@ int gbl_fingerprint_rtstats_max_entries = 5000;
 static struct fingerprint_rtstats gbl_fingerprint_rtstats_nofingerprint;
 
 static pthread_key_t fingerprint_rtstats_key;
-/* Which counter pair bump_pagein() increments. Per-thread, not on the entry:
- * one entry is shared by all three roles at once, even on a single node. */
-#define FP_RTSTATS_MODE_SQL	0
-#define FP_RTSTATS_MODE_WRITE	1
-#define FP_RTSTATS_MODE_APPLY	2
+/*
+ * Which counter pair bump_pagein() increments, and the role locks report.
+ * Per-thread; BB_BERKDB_FP_ROLE_* (db.h), NONE for a thread that never armed.
+ */
+#define FP_RTSTATS_MODE_NONE	BB_BERKDB_FP_ROLE_NONE
+#define FP_RTSTATS_MODE_SQL	BB_BERKDB_FP_ROLE_SQL
+#define FP_RTSTATS_MODE_WRITE	BB_BERKDB_FP_ROLE_WRITE
+#define FP_RTSTATS_MODE_APPLY	BB_BERKDB_FP_ROLE_APPLY
 static pthread_key_t fingerprint_rtstats_mode_key;
 static int fingerprint_rtstats_inited = 0;
 
@@ -168,6 +171,18 @@ bb_berkdb_fingerprint_rtstats_set_apply(const unsigned char *fingerprint, size_t
 	fingerprint_rtstats_set_internal(fingerprint, fplen, has_main_entry, FP_RTSTATS_MODE_APPLY);
 }
 
+/*
+ * Declare a role without naming a fingerprint. Deliberately leaves the
+ * fingerprint TLS alone: a _set_apply()/_set_write() may arrive later.
+ */
+void
+bb_berkdb_fingerprint_rtstats_set_role(int role)
+{
+	if (!fingerprint_rtstats_inited)
+		return;
+	Pthread_setspecific(fingerprint_rtstats_mode_key, (void *)(intptr_t)role);
+}
+
 /* Called when the statement is done (or on error paths). */
 void
 bb_berkdb_fingerprint_rtstats_clear(void)
@@ -175,7 +190,32 @@ bb_berkdb_fingerprint_rtstats_clear(void)
 	if (!fingerprint_rtstats_inited)
 		return;
 	Pthread_setspecific(fingerprint_rtstats_key, NULL);
-	Pthread_setspecific(fingerprint_rtstats_mode_key, (void *)(intptr_t)FP_RTSTATS_MODE_SQL);
+	Pthread_setspecific(fingerprint_rtstats_mode_key, (void *)(intptr_t)FP_RTSTATS_MODE_NONE);
+}
+
+/*
+ * Current attribution, for stamping onto something that outlives the call. *role
+ * is always set; returns 1 with fingerprint[] (FP_RTSTATS_KEYSZ) filled, else 0.
+ */
+int
+bb_berkdb_fingerprint_rtstats_current(unsigned char *fingerprint, int *role)
+{
+	struct fingerprint_rtstats *t = NULL;
+
+	*role = BB_BERKDB_FP_ROLE_NONE;
+
+	if (fingerprint_rtstats_inited) {
+		t = pthread_getspecific(fingerprint_rtstats_key);
+		*role = (int)(intptr_t)pthread_getspecific(fingerprint_rtstats_mode_key);
+	}
+
+	if (t == NULL) {
+		memset(fingerprint, 0, FP_RTSTATS_KEYSZ);
+		return 0;
+	}
+
+	memcpy(fingerprint, t->fingerprint, FP_RTSTATS_KEYSZ);
+	return 1;
 }
 
 /*
@@ -189,7 +229,7 @@ void
 bb_berkdb_fingerprint_rtstats_bump_pagein(int did_io)
 {
 	struct fingerprint_rtstats *t = NULL;
-	int mode = FP_RTSTATS_MODE_SQL;
+	int mode = FP_RTSTATS_MODE_NONE;
 
 	if (fingerprint_rtstats_inited) {
 		t = pthread_getspecific(fingerprint_rtstats_key);
@@ -209,7 +249,8 @@ bb_berkdb_fingerprint_rtstats_bump_pagein(int did_io)
 		if (did_io)
 			ATOMIC_ADD64(t->n_apply_pagein_read_io, 1);
 		break;
-	default:
+	default: /* SQL, and NONE -- which only reaches the no-fingerprint bucket,
+		  * where an unarmed thread landed before NONE was split out. */
 		ATOMIC_ADD64(t->n_pagein_read, 1);
 		if (did_io)
 			ATOMIC_ADD64(t->n_pagein_read_io, 1);

--- a/berkdb/rep/rep_record.c
+++ b/berkdb/rep/rep_record.c
@@ -4249,6 +4249,10 @@ worker_thd(struct thdpool *pool, void *work, void *thddata, int op)
 
 	rr = listc_rtl(&rq->records);
 
+	/* Page-in accounting only -- redo takes no locks. Bills a no-fingerprint
+	 * record's page-ins to the apply counters instead of the read ones. */
+	bb_berkdb_fingerprint_rtstats_set_role(BB_BERKDB_FP_ROLE_APPLY);
+
 	while (rr) {
 		/* Per record, not per queue: fileid fan-out splits a txn across
 		 * workers, and a txn can span statements. */
@@ -5253,6 +5257,10 @@ __rep_process_txn_int(dbenv, rctl, rec, ltrans, maxlsn, commit_gen, rep_gen, loc
 
 	gbl_rep_lockid = lockid;
 
+	/* Before __lock_get_list() below, not just before phase 2: the txn's locks
+	 * are read from the commit record and all taken there. Cleared at err:. */
+	bb_berkdb_fingerprint_rtstats_set_role(BB_BERKDB_FP_ROLE_APPLY);
+
 	if (get_locks_and_ack) {
 
 		/* XXX Used to reproduce reads-follows-writes error - 
@@ -6243,11 +6251,15 @@ bad_resize:	;
 
 	assert(gbl_rep_lock_time_ms == 0);
 	gbl_rep_lock_time_ms = comdb2_time_epochms();
+	/* The txn's locks are all taken here, off the commit record, so this is the
+	 * only arm that reaches them -- redo itself takes no locks. */
+	bb_berkdb_fingerprint_rtstats_set_role(BB_BERKDB_FP_ROLE_APPLY);
 	ret = !rp->context ?
 		__lock_get_list_context(dbenv, lockid, flags, DB_LOCK_WRITE,
 		copy_compare ? &lock_dbt_copy : lock_dbt, &rp->context, &(rctl->lsn), &pglogs, &keycnt)
 		: __lock_get_list(dbenv, lockid, flags, DB_LOCK_WRITE,
 		copy_compare ? &lock_dbt_copy : lock_dbt, &(rctl->lsn), &pglogs, &keycnt, stdout);
+	bb_berkdb_fingerprint_rtstats_clear();
 	if (copy_compare) {
 		if (memcmp(lock_dbt_copy.data, lock_dbt->data, lock_dbt->size) != 0) {
 			logmsg(LOGMSG_ERROR, "%s:%d lock_get_list modified the lock_dbt\n", __func__, __LINE__);

--- a/db/osqlblockproc.c
+++ b/db/osqlblockproc.c
@@ -1210,6 +1210,10 @@ static int apply_changes(struct ireq *iq, blocksql_tran_t *tran, void *iq_tran,
 
     listc_init(&iq->bpfunc_lst, offsetof(bpfunc_lstnode_t, linkct));
 
+    /* Unconditional: show role 'W' even when osql_send_fingerprint is off and
+     * no OSQL_FINGERPRINT arrives to name the statement. */
+    bdb_fingerprint_rtstats_set_role(BDB_FP_ROLE_WRITE);
+
     /* go through the complete list and apply all the changes */
     out_rc = process_this_session(iq, iq_tran, iq->sorese, &bdberr, nops, err,
                                   dbc, dbc_ins, func);

--- a/db/osqlcomm.c
+++ b/db/osqlcomm.c
@@ -3809,6 +3809,9 @@ int osql_comm_is_done(osql_sess_t *sess, int type, char *rpl, int rpllen,
     case OSQL_DELIDX:
     case OSQL_QBLOB:
     case OSQL_STARTGEN:
+    /* Diagnostic only: must not mark the session delayed, or every insert
+     * loses the no-constraints fast path in osql_process_packet. */
+    case OSQL_FINGERPRINT:
         break;
     case OSQL_DONE_SNAP:
         osql_extract_snap_info(sess, rpl, rpllen);

--- a/db/sqlinterfaces.c
+++ b/db/sqlinterfaces.c
@@ -3380,6 +3380,10 @@ static int get_prepared_stmt_int(struct sqlthdstate *thd,
         sqlite3_resetclock(rec->stmt);
         thr_set_current_sql(rec->sql);
 
+        /* Unconditional: show role 'R' even when fingerprinting is off and there
+         * is no fingerprint to pair with it. Cleared in sqlite_done(). */
+        bdb_fingerprint_rtstats_set_role(BDB_FP_ROLE_SQL);
+
         /* t is this fingerprint's gbl_fingerprint_hash entry (NULL until its
          * first execution completes); pass its presence as has_main_entry. */
         if (gbl_fingerprint_queries)
@@ -4131,9 +4135,9 @@ static void handle_sqlite_error(struct sqlthdstate *thd,
 static void sqlite_done(struct sqlthdstate *thd, struct sqlclntstate *clnt,
                         struct sql_state *rec, int outrc)
 {
-    /* Mirror the guard on the paired ..._set() in get_prepared_stmt_int(). */
-    if (gbl_fingerprint_queries)
-        bdb_fingerprint_rtstats_clear();
+    /* Unguarded, mirroring the unconditional ..._set_role() in
+     * get_prepared_stmt_int(): a role is armed even with fingerprinting off. */
+    bdb_fingerprint_rtstats_clear();
 
     sqlite3_stmt *stmt = rec->stmt;
     int distributed = 0;

--- a/docs/pages/programming/system_tables.md
+++ b/docs/pages/programming/system_tables.md
@@ -257,7 +257,8 @@ Describes all the hard limits in the database.
 
 Lists all active comdb2 locks.
 
-   comdb2_locks(thread, lockerid, mode, status, object, locktype, page)
+   comdb2_locks(thread, lockerid, mode, status, object, locktype, page,
+                fingerprint, fingerprint_role)
 
 * `thread` - Thread Id of the owner thread
 * `lockerid` - Locker Id
@@ -269,6 +270,12 @@ Lists all active comdb2 locks.
 * `locktype` - Lock type (`PAGE`, `HANDLE`, `KEYHASH`, `ROWLOCK`, `MINMAX`,
               `TABLELOCK`, `STRIPELOCK`, `LSN`, `ENV`)
 * `page` - Page number
+* `fingerprint` - Fingerprint of the SQL statement that took the lock, NULL if
+                  not known
+* `fingerprint_role` - What the owner was doing when it took the lock: `R`
+                       (executing a SQL statement), `W` (master applying a
+                       write), `A` (replicant applying the replication stream);
+                       NULL if not known
 
 ## comdb2_logical_operations
 

--- a/sqlite/ext/comdb2/activelocks.c
+++ b/sqlite/ext/comdb2/activelocks.c
@@ -24,6 +24,7 @@
 #include "ezsystables.h"
 #include "cdb2api.h"
 #include "str0.h"
+#include "tohex.h"
 #include <stackutil.h>
 
 typedef struct systable_activelocks {
@@ -37,6 +38,10 @@ typedef struct systable_activelocks {
     int                     page_isnull;
     int                     frames;
     char                    *stack;
+    /* Both NULL when unknown (ezsystables renders that as SQL NULL), and they
+     * move independently: apply reports 'A' with no fingerprint. */
+    char                    *fingerprint;
+    const char              *fingerprint_role;
 } systable_activelocks_t;
 
 typedef struct getactivelocks {
@@ -45,9 +50,20 @@ typedef struct getactivelocks {
     systable_activelocks_t *records;
 } getactivelocks_t;
 
+static const char *fingerprint_role_str(char role)
+{
+    switch (role) {
+    case 'R': return "R";
+    case 'W': return "W";
+    case 'A': return "A";
+    default: return NULL;
+    }
+}
+
 static int collect(void *args, int64_t threadid, int32_t lockerid,
         const char *mode, const char *status, const char *object,
-        int64_t page, const char *rectype, int stackid)
+        int64_t page, const char *rectype, int stackid,
+        const unsigned char *fingerprint, char fingerprint_role)
 {
     int64_t hits;
     int nframes;
@@ -73,6 +89,17 @@ static int collect(void *args, int64_t threadid, int32_t lockerid,
     }
     l->object = strdup(object ? object : "");
     l->type = strdup(rectype ? rectype : "");
+
+    /* strdup rather than an inline buffer: a->records is realloc'd, which would
+     * dangle a pointer into it. */
+    if (fingerprint) {
+        char hex[BDB_FINGERPRINTSZ * 2 + 1];
+        util_tohex(hex, (const char *)fingerprint, BDB_FINGERPRINTSZ);
+        l->fingerprint = strdup(hex);
+    } else {
+        l->fingerprint = NULL;
+    }
+    l->fingerprint_role = fingerprint_role_str(fingerprint_role);
 
     if ((l->stack = stackutil_get_stack_str(stackid, &type, &nframes, &hits)) == NULL) {
         l->stack = strdup("(no-stack)");
@@ -100,6 +127,7 @@ static void free_activelocks(void *p, int n)
         free(a->object);
         free(a->type);
         free(a->stack);
+        free(a->fingerprint);
     }
     free(p);
 }
@@ -119,5 +147,7 @@ int systblActivelocksInit(sqlite3 *db) {
             CDB2_CSTRING, "locktype", -1, offsetof(systable_activelocks_t, type),
             CDB2_INTEGER, "page", offsetof(systable_activelocks_t, page_isnull), offsetof(systable_activelocks_t, page),
             CDB2_CSTRING, "stack", -1, offsetof(systable_activelocks_t, stack),
+            CDB2_CSTRING, "fingerprint", -1, offsetof(systable_activelocks_t, fingerprint),
+            CDB2_CSTRING, "fingerprint_role", -1, offsetof(systable_activelocks_t, fingerprint_role),
             SYSTABLE_END_OF_FIELDS);
 }

--- a/tests/lock_fingerprint.test/Makefile
+++ b/tests/lock_fingerprint.test/Makefile
@@ -1,0 +1,8 @@
+ifeq ($(TESTSROOTDIR),)
+  include ../testcase.mk
+else
+  include $(TESTSROOTDIR)/testcase.mk
+endif
+ifeq ($(TEST_TIMEOUT),)
+	export TEST_TIMEOUT=10m
+endif

--- a/tests/lock_fingerprint.test/README
+++ b/tests/lock_fingerprint.test/README
@@ -1,0 +1,12 @@
+Verify that comdb2_locks attributes each lock to the statement that took it,
+via the 'fingerprint' and 'fingerprint_role' columns.
+
+Roles are always available: 'R' for SQL execution, 'W' for the master applying
+a write schedule, 'A' for a replicant applying from the log.  The fingerprint
+beside a role is only populated when the corresponding tunable carried one
+there -- gbl_fingerprint_queries for 'R', osql_send_fingerprint for 'W',
+log_fingerprint for 'A' -- so 'A' rows with a NULL fingerprint are expected and
+valid.  Unattributed locks (recovery, schema change, and everything else that
+is not SQL) report NULL for both columns.
+
+'A' is only exercised in a clustered run.

--- a/tests/lock_fingerprint.test/lrl.options
+++ b/tests/lock_fingerprint.test/lrl.options
@@ -1,0 +1,12 @@
+nowatch
+logmsg level info
+dtastripe   1
+osql_send_fingerprint 1
+log_fingerprint 1
+
+# Locks are held across the page fetch, so a nanosleep at the top of
+# __memp_fget widens the window in which comdb2_locks can see them.  Applies to
+# read, write-apply and replication-apply alike.  READONLY, so it has to be set
+# here rather than with 'put tunable'.  Effective sleep is timer-slack bound
+# (~50us), which is plenty; larger values just slow the whole test down.
+slowfget 1000

--- a/tests/lock_fingerprint.test/runit
+++ b/tests/lock_fingerprint.test/runit
@@ -1,0 +1,332 @@
+#!/usr/bin/env bash
+bash -n "$0" | exit 1
+
+#export debug=1
+[[ $debug == "1" ]] && set -x
+
+. ${TESTSROOTDIR}/tools/write_prompt.sh
+. ${TESTSROOTDIR}/tools/ddl.sh
+. ${TESTSROOTDIR}/tools/cluster_utils.sh
+
+export stopfile=./stop.test
+
+# Locks are short-lived, so every check here is "generate load, then poll
+# comdb2_locks until the row we want shows up or we give up".
+export poll_iters=60
+
+function failexit
+{
+    touch $stopfile
+    echo "Failed: $1: $2"
+    exit -1
+}
+
+# Every check pins its load and its poll to the SAME node.  comdb2_locks is
+# per-node, so a reader on one node and a poll on another would silently never
+# intersect.  An empty node means an unclustered run, where 'default' is the
+# only node there is.
+function query_node
+{
+    typeset node=$1
+    typeset sql=$2
+    if [[ -z "$node" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME default "$sql" 2>/dev/null
+    else
+        $CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "$sql" 2>/dev/null
+    fi
+}
+
+function sql_on
+{
+    typeset node=$1
+    typeset sql=$2
+    if [[ -z "$node" ]]; then
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "$sql" >/dev/null 2>&1
+    else
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME --host $node "$sql" >/dev/null 2>&1
+    fi
+}
+
+function background_write_thread
+{
+    typeset table=$1
+    typeset node=$2
+    typeset j=0
+    while [[ $j -lt 200 && ! -f $stopfile ]]; do
+        sql_on "$node" "insert into $table(a) select * from generate_series(1, 1000)"
+        let j=j+1
+    done
+}
+
+function background_read_thread
+{
+    typeset table=$1
+    typeset node=$2
+    typeset j=0
+    while [[ $j -lt 1000 && ! -f $stopfile ]]; do
+        sql_on "$node" "select count(*) from $table where a > 0"
+        let j=j+1
+    done
+}
+
+function background_writeload
+{
+    typeset table=$1
+    typeset node=$2
+    typeset i=0
+    while [[ $i -lt 10 ]]; do
+        background_write_thread "$table" "$node" &
+        let i=i+1
+    done
+    wait
+}
+
+function background_readload
+{
+    typeset table=$1
+    typeset node=$2
+    typeset i=0
+    while [[ $i -lt 10 ]]; do
+        background_read_thread "$table" "$node" &
+        let i=i+1
+    done
+    wait
+}
+
+# Poll $node's comdb2_locks until 'select count(*) ... where $where' is
+# non-zero.  Returns 0 on success, 1 if we ran out of iterations.
+#
+# 'select count(*)' always returns exactly one row, so empty output means the
+# query itself failed -- an unreachable node, say.  Treating that as "not yet"
+# would burn the full poll budget and then report the far more interesting-
+# sounding "never saw this lock", so call it out instead.
+function poll_for_locks
+{
+    typeset node=$1
+    typeset where=$2
+    typeset j=0
+    typeset empties=0
+    typeset x=
+
+    while [[ ! -f $stopfile && $j -lt $poll_iters ]]; do
+        x=$(query_node "$node" "select count(*) from comdb2_locks where $where")
+        if [[ -z "$x" ]]; then
+            let empties=empties+1
+            if [[ $empties -ge 3 ]]; then
+                stop_load
+                failexit "poll_for_locks" "querying comdb2_locks on ${node:-default} failed 3x -- node unreachable?"
+            fi
+        else
+            empties=0
+            [[ "$x" != "0" ]] && return 0
+        fi
+        let j=j+1
+        sleep 1
+    done
+    return 1
+}
+
+# Called before giving up, so a failure says what the node actually looked like
+# rather than only what it was missing.
+function dump_diagnostics
+{
+    typeset node=$1
+    write_prompt "diagnostics" "State of ${node:-default}:"
+    echo "  total locks: $(query_node "$node" "select count(*) from comdb2_locks")"
+    echo "  by role:"
+    query_node "$node" "select coalesce(fingerprint_role,'NULL'), count(*), count(fingerprint) from comdb2_locks group by fingerprint_role" | sed 's/^/    /'
+    echo "  t1 rows: $(query_node "$node" "select count(*) from t1")"
+    echo "  fingerprint_queries: $(query_node "$node" "select value from comdb2_tunables where name='fingerprint_queries'")"
+}
+
+# A pinned node that cannot be queried makes every later check fail in a way
+# that looks like a product bug.  Fail here instead, with the real error.
+function preflight_node
+{
+    typeset func="preflight_node"
+    typeset node=$1
+    typeset label=$2
+    typeset out=
+
+    [[ -z "$node" ]] && return 0
+
+    out=$($CDB2SQL_EXE $CDB2_OPTIONS --tabs $DBNAME --host $node "select 1" 2>&1)
+    [[ "$out" != "1" ]] && failexit $func "cannot query $label node '$node': $out"
+    write_prompt $func "$label node '$node' is reachable"
+}
+
+function stop_load
+{
+    touch $stopfile
+    wait
+    rm $stopfile >/dev/null 2>&1
+}
+
+# The two columns must never disagree with the contract: role is one of R/W/A
+# or NULL, and a fingerprint is either NULL or 32 lowercase hex characters.
+# Checked under load, so it sees the widest variety of lock holders.
+function verify_column_contract
+{
+    typeset func="verify_column_contract"
+    typeset node=$1
+    write_prompt $func "Verify fingerprint/fingerprint_role are well-formed on ${node:-default}"
+
+    x=$(query_node "$node" "select count(*) from comdb2_locks where fingerprint_role is not null and fingerprint_role not in ('R','W','A')")
+    [[ "$x" != "0" ]] && failexit $func "$x locks have an unexpected fingerprint_role"
+
+    x=$(query_node "$node" "select count(*) from comdb2_locks where fingerprint is not null and (length(fingerprint) != 32 or fingerprint != lower(fingerprint))")
+    [[ "$x" != "0" ]] && failexit $func "$x locks have a malformed fingerprint"
+
+    # A fingerprint without a role would mean we stamped one half and not the
+    # other -- the role is always set at least as early as the fingerprint.
+    x=$(query_node "$node" "select count(*) from comdb2_locks where fingerprint is not null and fingerprint_role is null")
+    [[ "$x" != "0" ]] && failexit $func "$x locks have a fingerprint but no role"
+
+    write_prompt $func "Columns are well-formed on ${node:-default}"
+}
+
+# Locks taken by SQL execution report role 'R', and (fingerprinting being on by
+# default) at least some of them name the statement that took them.  Readers
+# and poll both pinned to $node.
+function verify_read_locks
+{
+    typeset func="verify_read_locks"
+    typeset node=$1
+    write_prompt $func "Verify SQL read locks on ${node:-default} are attributed to their fingerprint"
+
+    background_readload t1 "$node" &
+
+    if ! poll_for_locks "$node" "fingerprint_role='R'"; then
+        dump_diagnostics "$node" ; stop_load
+        failexit $func "Never saw a lock with role 'R' on ${node:-default}"
+    fi
+    write_prompt $func "Found locks with role 'R'"
+
+    if ! poll_for_locks "$node" "fingerprint_role='R' and fingerprint is not null"; then
+        dump_diagnostics "$node" ; stop_load
+        failexit $func "Never saw an 'R' lock carrying a fingerprint"
+    fi
+    write_prompt $func "Found 'R' locks carrying a fingerprint"
+
+    # Every fingerprint we stamp should be one the SQL layer knows about.  Not
+    # fatal: a statement on its very first execution has no comdb2_fingerprints
+    # row yet, and both tables are sampled at different instants.
+    x=$(query_node "$node" "select count(*) from comdb2_locks l where l.fingerprint_role='R' and l.fingerprint is not null and not exists (select 1 from comdb2_fingerprints f where f.fingerprint=l.fingerprint)")
+    [[ "$x" != "0" ]] && write_prompt $func "Note: $x 'R' fingerprints not yet in comdb2_fingerprints (in-flight first execution)"
+
+    verify_column_contract "$node"
+
+    stop_load
+}
+
+# Locks the master takes applying a write schedule report role 'W'.  Writes are
+# routed to the master no matter where they are submitted, so submit them there
+# directly and poll the same node.  With osql_send_fingerprint on (lrl.options)
+# they also carry the fingerprint of the statement that produced the schedule.
+function verify_write_locks
+{
+    typeset func="verify_write_locks"
+    typeset master=$1
+    write_prompt $func "Verify master write-apply locks on ${master:-default} are attributed to their fingerprint"
+
+    background_writeload t1 "$master" &
+
+    if ! poll_for_locks "$master" "fingerprint_role='W'"; then
+        dump_diagnostics "$master" ; stop_load
+        failexit $func "Never saw a lock with role 'W' on the master"
+    fi
+    write_prompt $func "Found locks with role 'W'"
+
+    if ! poll_for_locks "$master" "fingerprint_role='W' and fingerprint is not null"; then
+        dump_diagnostics "$master" ; stop_load
+        failexit $func "Never saw a 'W' lock carrying a fingerprint"
+    fi
+    write_prompt $func "Found 'W' locks carrying a fingerprint"
+
+    verify_column_contract "$master"
+
+    stop_load
+}
+
+# Locks a replicant takes applying the stream report role 'A'.  Here the load
+# and the poll are deliberately on different nodes -- the writes have to happen
+# on the master for the replicant to have anything to apply.  Clustered runs
+# only: there is nothing applying a stream on a single node.
+function verify_apply_locks
+{
+    typeset func="verify_apply_locks"
+    typeset master=$1
+    typeset replicant=$2
+
+    if [[ -z "$replicant" ]]; then
+        write_prompt $func "Not a clustered run, skipping role 'A'"
+        return 0
+    fi
+
+    write_prompt $func "Verify replication apply locks report role 'A' on $replicant"
+
+    background_writeload t1 "$master" &
+
+    if ! poll_for_locks "$replicant" "fingerprint_role='A'"; then
+        dump_diagnostics "$replicant" ; stop_load
+        failexit $func "Never saw a lock with role 'A' on $replicant"
+    fi
+    write_prompt $func "Found locks with role 'A'"
+
+    # log_fingerprint is on, so the apply side should also see fingerprints --
+    # but a NULL fingerprint next to an 'A' is legal, so this is informational.
+    x=$(query_node "$replicant" "select count(*) from comdb2_locks where fingerprint_role='A' and fingerprint is not null")
+    write_prompt $func "$x 'A' locks carry a fingerprint"
+
+    verify_column_contract "$replicant"
+
+    stop_load
+}
+
+function run_test
+{
+    typeset func="run_test"
+    typeset master=
+    typeset replicant=
+
+    write_prompt $func "Running $func"
+
+    if [[ -n "$CLUSTER" ]]; then
+        master=$(get_master)
+        [[ -z "$master" ]] && failexit $func "Could not determine the master"
+        replicant=$(query_node "" "select host from comdb2_cluster where is_master='N' limit 1")
+        [[ -z "$replicant" ]] && failexit $func "Could not find a replicant"
+        write_prompt $func "master=$master replicant=$replicant"
+        preflight_node "$master" "master"
+        preflight_node "$replicant" "replicant"
+    fi
+
+    sql_on "" "create table t1(a int)"
+    x=$(query_node "" "select count(*) from comdb2_tables where tablename='t1'")
+    [[ "$x" != "1" ]] && failexit $func "Failed to create t1"
+
+    # Seed enough rows that a scan lasts long enough to be caught mid-flight.
+    # Chunked: one 100k-row insert is a big enough transaction to risk rc 202
+    # 'transaction too big', and a silently empty t1 makes every later check
+    # fail as "never saw a lock".
+    typeset i=0
+    while [[ $i -lt 10 ]]; do
+        sql_on "" "insert into t1(a) select * from generate_series(1, 10000)"
+        let i=i+1
+    done
+    x=$(query_node "$master" "select count(*) from t1")
+    [[ "$x" != "100000" ]] && failexit $func "t1 seed incomplete: $x rows on ${master:-default}, wanted 100000"
+    write_prompt $func "Seeded t1 with $x rows"
+
+    # Reads can run anywhere; pin them to the master so a single-node run and a
+    # clustered run exercise the same node, and so the poll cannot miss them.
+    verify_read_locks "$master"
+    verify_write_locks "$master"
+    verify_apply_locks "$master" "$replicant"
+}
+
+rm $stopfile >/dev/null 2>&1
+run_test
+wait
+
+echo "Success"


### PR DESCRIPTION
## locks: attribute each lock to the fingerprint that took it

Feature. This adds two columns to `comdb2_locks`, `fingerprint` and `fingerprint_role`, stamping each lock at allocation with the acquiring thread's fingerprint and role: `R` for SQL execution, `W` for the master applying a write schedule, `A` for a replicant applying from the log.

A role is armed unconditionally, so locks are attributable even with `fingerprint_queries`, `osql_send_fingerprint` or `log_fingerprint` off; anything that is not SQL (online-recovery, schema change) reports NULL for both. `A` rows carry no fingerprint by design — a replicant reads its locks out of the commit record and takes them all up front, before any log record is applied, so there is no per-statement fingerprint in scope at acquisition.

The stamp is two TLS reads and a 16-byte copy on the lock-allocation path, and is taken before the wait so a lock parked in `DB_LSTAT_WAITING` is attributed too. It is written once, so a lock re-acquired within a transaction keeps the statement that first took it. `struct __db_lock` grows by 16+1 bytes; all region sizing already derives from `sizeof(struct __db_lock)`.

New test `lock_fingerprint.test` polls `comdb2_locks` under read and write load for roles `R` and `W`, and for `A` on a replicant in a clustered run, pinning each check's load and poll to the same node. It also asserts the column contract: role is one of `R`/`W`/`A` or NULL, a fingerprint is 32 lowercase hex characters or NULL, and no lock carries a fingerprint without a role.