### PR TITLE
Enable vtab_externalauth by default

### DIFF
--- a/db/comdb2.c
+++ b/db/comdb2.c
@@ -240,7 +240,7 @@ int64_t gbl_num_auth_allowed = 0;
 int64_t gbl_num_auth_denied = 0;
 int gbl_allow_old_authn = 1;
 int gbl_uses_externalauth = 0;
-int gbl_vtab_externalauth = 0;
+int gbl_vtab_externalauth = 1;
 int gbl_vtab_externalauth_strict = 0;
 int gbl_vtab_externalauth_warn = 1;
 #ifdef COMDB2_TEST

--- a/db/db_tunables.h
+++ b/db/db_tunables.h
@@ -2508,7 +2508,7 @@ REGISTER_TUNABLE("externalauth", NULL, TUNABLE_BOOLEAN, &gbl_uses_externalauth, 
 REGISTER_TUNABLE("externalauth_connect", "Check for externalauth only once on connect", TUNABLE_BOOLEAN,
                  &gbl_uses_externalauth_connect, NOARG | READEARLY, NULL, NULL, NULL, NULL);
 
-REGISTER_TUNABLE("vtab_externalauth", "Use IAM for vtab access control (Default: off)", TUNABLE_BOOLEAN,
+REGISTER_TUNABLE("vtab_externalauth", "Use IAM for vtab access control (Default: on)", TUNABLE_BOOLEAN,
                  &gbl_vtab_externalauth, 0, NULL, NULL, NULL, NULL);
 
 REGISTER_TUNABLE("vtab_externalauth_strict", "Enforce access control on all CDB2_ALLOW_USER vtabs (Default: off)",

--- a/tests/tunables.test/t00_all_tunables.expected
+++ b/tests/tunables.test/t00_all_tunables.expected
@@ -1171,7 +1171,7 @@
 (name='view_feature', description='Enables support for VIEWs (Default: ON)', type='BOOLEAN', value='ON', read_only='N')
 (name='views_dft_preempt_roll_secs', description='Amount of seconds to run phase 1 of time partition rollout before phase 2', type='INTEGER', value='1800', read_only='N')
 (name='views_dft_roll_delete_lag_secs', description='Amount of seconds to run phase 3 of time partition rollout after phase 2', type='INTEGER', value='5', read_only='N')
-(name='vtab_externalauth', description='Use IAM for vtab access control (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
+(name='vtab_externalauth', description='Use IAM for vtab access control (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='vtab_externalauth_strict', description='Enforce access control on all CDB2_ALLOW_USER vtabs (Default: off)', type='BOOLEAN', value='OFF', read_only='N')
 (name='vtab_externalauth_warn', description='Log vtab access denials without enforcing (Default: on)', type='BOOLEAN', value='ON', read_only='N')
 (name='wait_for_prepare_seqnum', description='Wait-for-seqnum for prepare records. (Default: on)', type='BOOLEAN', value='ON', read_only='N')


### PR DESCRIPTION
Phase 1: This will deny access only to STRICT virtual tables. Enabling vtab_externalauth_strict will extend enforcement to all virtual tables.