### PR TITLE
{178575361} Fill autoinc value for expression fields in keys

### DIFF
--- a/db/indices.c
+++ b/db/indices.c
@@ -326,6 +326,56 @@ static inline void append_genid_to_key(dtikey_t *ditk, int ixkeylen)
     memcpy(&ditk->ixkey[ixkeylen], &ditk->genid, sizeof(ditk->genid));
 }
 
+int indexes_expressions_data(const struct dbtable *tbl, struct schema *sc, const char *inbuf, char *outbuf,
+                             blob_buffer_t *blobs, size_t maxblobs, const struct field *f,
+                             struct convert_failure *fail_reason, const char *tzname);
+
+/* The value of an autoincrement column is only assigned here on the master (see
+ * set_master_columns()).  The replicant that formed the index keys for this
+ * record therefore evaluated every index expression against a NULL placeholder
+ * instead of the real sequence value, so any expression referencing such a
+ * column produced the wrong key.
+ *
+ * Now that "od_dta" holds the completed record, re-evaluate the expression
+ * fields of the keys the replicant sent us.  Doing it here, before the keys are
+ * consumed (and before they are stashed away for delayed key adds), means every
+ * later create_key_from_ireq() caller sees a correct key without needing the
+ * blobs, which are not available in all of those places. */
+int fixup_ireq_index_expressions(struct ireq *iq, void *od_dta, blob_buffer_t *blobs, size_t maxblobs,
+                                 unsigned long long ins_keys)
+{
+    struct dbtable *db = iq->usedb;
+    struct schema *schema = get_schema(db, -1);
+
+    if (!iq->idxInsert || !db->ix_expr || !schema || !schema->has_nextseq)
+        return 0;
+
+    if (blobs == NULL)
+        maxblobs = 0;
+
+    for (int ixnum = 0; ixnum < db->nix; ixnum++) {
+        if (iq->idxInsert[ixnum] == NULL)
+            continue;
+        if (gbl_partial_indexes && db->ix_partial && !(ins_keys & (1ULL << ixnum)))
+            continue;
+
+        struct schema *idx_schema = get_schema(db, ixnum);
+        for (int nfield = 0; nfield < idx_schema->nmembers; nfield++) {
+            const struct field *idx_field = &idx_schema->member[nfield];
+            if (!idx_field->isExpr)
+                continue;
+            if (indexes_expressions_data(db, schema, od_dta, (char *)iq->idxInsert[ixnum], blobs, maxblobs, idx_field,
+                                         NULL, iq->tzname)) {
+                logmsg(LOGMSG_ERROR,
+                       "%s: table %s ix %d failed to evaluate expression "
+                       "\"%s\"\n",
+                       __func__, db->tablename, ixnum, idx_field->name);
+                return -1;
+            }
+        }
+    }
+    return 0;
+}
 
 #define REC_ERROR_LOG(fmt, ...) do {            \
     EVENTLOG_DEBUG (            \

--- a/db/indices.h
+++ b/db/indices.h
@@ -26,6 +26,9 @@ int check_for_upsert(struct ireq *iq, void *trans, blob_buffer_t *blobs, size_t 
 int check_index(struct ireq *iq, void *trans, int ixnum, blob_buffer_t *blobs, size_t maxblobs, int *opfailcode,
                        int *ixfailnum, int *retrc, void *od_dta, size_t od_len, unsigned long long ins_keys);
 
+int fixup_ireq_index_expressions(struct ireq *iq, void *od_dta, blob_buffer_t *blobs, size_t maxblobs,
+                                 unsigned long long ins_keys);
+
 int add_record_indices(struct ireq *iq, void *trans, blob_buffer_t *blobs,
                        size_t maxblobs, int *opfailcode, int *ixfailnum,
                        int *rrn, unsigned long long *genid,

--- a/db/macc_glue.c
+++ b/db/macc_glue.c
@@ -1078,6 +1078,8 @@ static int add_cmacc_stmt(dbtable *tbl, int alt, int allow_ull,
                 rc = -1;
                 goto err;
             }
+            if (fld->in_default_type == SERVER_SEQUENCE)
+                sch->has_nextseq = 1;
 
             if (_check_column_ull(fld, tbl->tablename, allow_ull)) {
                 errstat_set_rcstrf(err, rc = -1, "u_longlong is not supported");

--- a/db/record.c
+++ b/db/record.c
@@ -444,6 +444,17 @@ int add_record(struct ireq *iq, void *trans, const uint8_t *p_buf_tag_name,
         ERR("set master columns error %d", rc);
     }
 
+    /* The sequence value for an autoinc column was only just assigned by
+     * set_master_columns(), so any index expression the replicant evaluated
+     * over that column produced a key with a NULL in it. Redo those now that
+     * the record - and the blobs it may reference - are complete. */
+    rc = fixup_ireq_index_expressions(iq, od_dta, blobs, maxblobs, ins_keys);
+    if (rc) {
+        *opfailcode = OP_FAILED_INTERNAL + ERR_FORM_KEY;
+        retrc = ERR_INTERNAL;
+        ERR("failed to reform index expressions rc %d", rc);
+    }
+
     rc = verify_check_constraints(iq->usedb, od_dta, blobs, maxblobs, 1);
     if (rc < 0) {
         reqerrstr(iq, ERR_INTERNAL, "Internal error during CHECK constraint");

--- a/db/sqlglue.c
+++ b/db/sqlglue.c
@@ -1122,8 +1122,7 @@ int convert_sql_failure_reason_str(const struct convert_failure *reason,
     return 0;
 }
 
-int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info,
-                  bias_info *bias_info)
+int mem_to_ondisk(void *outbuf, const struct field *f, struct mem_info *info, bias_info *bias_info)
 {
     Mem *m = info->m;
     struct schema *s = info->s;
@@ -12978,9 +12977,8 @@ done:
     return dirty_keys;
 }
 
-static inline void build_indexes_expressions_query(strbuf *sql,
-                                                   struct schema *sc,
-                                                   char *tblname, char *expr)
+static inline void build_indexes_expressions_query(strbuf *sql, const struct schema *sc, const char *tblname,
+                                                   const char *expr)
 {
     int i;
     strbuf_clear(sql);
@@ -13022,11 +13020,9 @@ char *indexes_expressions_unescape(char *expr)
     return new_expr;
 }
 
-int indexes_expressions_data(const struct dbtable *tbl, struct schema *sc,
-                             const char *inbuf, char *outbuf, blob_buffer_t *blobs,
-                             size_t maxblobs, struct field *f,
-                             struct convert_failure *fail_reason,
-                             const char *tzname)
+int indexes_expressions_data(const struct dbtable *tbl, struct schema *sc, const char *inbuf, char *outbuf,
+                             blob_buffer_t *blobs, size_t maxblobs, const struct field *f,
+                             struct convert_failure *fail_reason, const char *tzname)
 {
     Mem *m = NULL;
     Mem mout = {{0}};

--- a/db/sqlglue.h
+++ b/db/sqlglue.h
@@ -65,6 +65,6 @@ int resolve_sfuncs_for_db(struct dbenv* thedb);
 
 void start_stat4dump_thread(void);
 
-int mem_to_ondisk(void *outbuf, struct field *f, struct mem_info *info, struct bias_info *bias_info);
+int mem_to_ondisk(void *outbuf, const struct field *f, struct mem_info *info, struct bias_info *bias_info);
 
 #endif

--- a/db/tag.c
+++ b/db/tag.c
@@ -3318,12 +3318,9 @@ int describe_update_columns(const struct ireq *iq, const struct schema *chk, int
     return 0;
 }
 
-int indexes_expressions_data(const struct dbtable *tbl, struct schema *sc,
-                             const char *inbuf, char *outbuf,
-                             blob_buffer_t *blobs, size_t maxblobs,
-                             struct field *f,
-                             struct convert_failure *fail_reason,
-                             const char *tzname);
+int indexes_expressions_data(const struct dbtable *tbl, struct schema *sc, const char *inbuf, char *outbuf,
+                             blob_buffer_t *blobs, size_t maxblobs, const struct field *f,
+                             struct convert_failure *fail_reason, const char *tzname);
 static int stag_to_stag_field(const struct dbtable *tbl, const char *inbuf,
                               char *outbuf, int flags,
                               struct convert_failure *fail_reason,
@@ -5303,6 +5300,7 @@ struct schema *clone_schema_index(struct schema *from, const char *tag,
             goto err;
         memcpy(sc->datacopy, from->datacopy, datacopy_nmembers * sizeof(int));
     }
+    sc->has_nextseq = from->has_nextseq;
     return sc;
 
 err:
@@ -6713,9 +6711,12 @@ int create_key_from_ireq(struct ireq *iq, int ixnum, int isDelete, char **tail,
     char *check_for_resolve_master;
     for (int nfield = 0; nfield < idx_schema->nmembers; nfield++) {
         const struct field *idx_field = &idx_schema->member[nfield];
-        // TODO: expression idx
+        /* Expression fields that reference an autoinc column have already been
+         * re-evaluated against the completed record by
+         * fixup_ireq_index_expressions(), so the key we were handed is good. */
         if (idx_field->isExpr)
             continue;
+
         if (idx_field->in_default_type != SERVER_SEQUENCE)
             continue;
 

--- a/db/tag.h
+++ b/db/tag.h
@@ -74,6 +74,7 @@ struct schema {
     char *sqlitetag;
     int *datacopy;
     char *where;
+    int has_nextseq; /* if the schema contains autoinc columns. Only valid for table schema */
 #if defined STACK_TAG_SCHEMA
     int frames;
     void *buf[MAX_TAG_STACK_FRAMES];

--- a/tests/nextsequence.test/runit
+++ b/tests/nextsequence.test/runit
@@ -906,6 +906,69 @@ EOF
     [[ $? != 0 ]] && failexit "$1 should have passed verify"
 }
 
+# The sequence value is only assigned on the master, so an index expression
+# that references the autoinc column is evaluated against a NULL on the
+# replicant that forms the keys.  The master has to redo those expressions or
+# the index ends up holding NULL instead of the sequence value.
+function insert_with_expr_idx_on_seq
+{
+    disable_strict_mode
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table $1 {$(cat $1.csc2)}\$\$
+EOF
+
+    for x in 1 2 3 ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into $1(a) values($x)"
+        [[ $? != 0 ]] && failexit "$1 table should have been allowed to insert"
+    done
+
+    # project the expression itself so the value is served out of the index key
+    # instead of being re-read from the data btree
+    out=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select b + 100 as e from $1 where b + 100 > 0 order by b + 100")
+    [[ $? != 0 ]] && failexit "$1 table should have been allowed to select"
+    exp=$'(e=101)\n(e=102)\n(e=103)'
+    [[ $out != $exp ]] && failexit "Got $out, Expected $exp"
+
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('$1')"
+    [[ $? != 0 ]] && failexit "$1 should have passed verify"
+}
+
+# Same, but the table has a foreign key so the keys are added by
+# delayed_key_adds(), and the expressions read a blob column.
+function insert_with_blob_expr_idx_on_seq
+{
+    disable_strict_mode
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table seqexprparent {$(cat seqexprparent.csc2)}\$\$
+EOF
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "insert into seqexprparent select * from generate_series(1,3)"
+    [[ $? != 0 ]] && failexit "seqexprparent table should have been allowed to insert"
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default - <<EOF
+create table $1 {$(cat $1.csc2)}\$\$
+EOF
+
+    # a payload that is too big to be held inline, so the expression can only
+    # be evaluated if the blob is available
+    pad=$(printf 'y%.0s' {1..5000})
+    for x in 1 2 3 ; do
+        $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default \
+            "insert into $1(a, data) values($x, '{\"n\": \"name$x\", \"k\": ${x}0, \"pad\": \"$pad\"}')" > /dev/null
+        [[ $? != 0 ]] && failexit "$1 table should have been allowed to insert"
+    done
+
+    # expression over both the sequence and the blob, read out of the index key
+    out=$($CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "select b * 1000 + json_extract(data, '\$.k') as e from $1 where b * 1000 + json_extract(data, '\$.k') > 0 order by b * 1000 + json_extract(data, '\$.k')")
+    exp=$'(e=1010)\n(e=2020)\n(e=3030)'
+    [[ $out != $exp ]] && failexit "Got $out, Expected $exp"
+
+    $CDB2SQL_EXE -tabs $CDB2_OPTIONS $DBNAME default "exec procedure sys.cmd.verify('$1')"
+    [[ $? != 0 ]] && failexit "$1 should have passed verify"
+
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table $1"
+    $CDB2SQL_EXE $CDB2_OPTIONS $DBNAME default "drop table seqexprparent"
+}
+
 function run_test
 {
     if [[ "$DBNAME" == *"nextsequencenullsorthighgenerated"* ]]; then
@@ -1018,6 +1081,10 @@ function run_test
 
     insert_with_idx_and_dummy_expr seqwithidxanddummyexpr
     insert_with_idx_and_dummy_expr seqwithdescidxanddummyexpr
+
+    insert_with_expr_idx_on_seq seqwithexpridx
+    insert_with_expr_idx_on_seq seqwithdescexpridx
+    insert_with_blob_expr_idx_on_seq seqwithblobexpridx
 }
 
 run_test

--- a/tests/nextsequence.test/seqexprparent.csc2
+++ b/tests/nextsequence.test/seqexprparent.csc2
@@ -1,0 +1,8 @@
+schema
+{
+   int id
+}
+keys
+{
+   "ID" = id
+}

--- a/tests/nextsequence.test/seqwithblobexpridx.csc2
+++ b/tests/nextsequence.test/seqwithblobexpridx.csc2
@@ -1,0 +1,17 @@
+schema
+{
+   int a
+   longlong b dbstore=nextsequence null=yes
+   vutf8 data null=yes
+}
+keys
+{
+   "b" = b
+   dup "fk" = a
+   dup "expr" = (cstring[64])"json_extract(data, '$.n')"
+   dup "exprseq" = (longlong)"b * 1000 + json_extract(data, '$.k')"
+}
+constraints
+{
+   "fk" -> <"seqexprparent":"ID">
+}

--- a/tests/nextsequence.test/seqwithdescexpridx.csc2
+++ b/tests/nextsequence.test/seqwithdescexpridx.csc2
@@ -1,0 +1,10 @@
+schema
+{
+   int a null=yes
+   longlong b dbstore=nextsequence null=yes
+}
+keys
+{
+   "b" = <DESCEND>b
+   dup "expr" = <DESCEND>(longlong)"b + 100"
+}

--- a/tests/nextsequence.test/seqwithexpridx.csc2
+++ b/tests/nextsequence.test/seqwithexpridx.csc2
@@ -1,0 +1,10 @@
+schema
+{
+   int a null=yes
+   longlong b dbstore=nextsequence null=yes
+}
+keys
+{
+   "b" = b
+   dup "expr" = (longlong)"b + 100"
+}


### PR DESCRIPTION
The sequence value for an autoinc column is only assigned on the master, by set_master_columns().  A replicant forming index keys therefore evaluates every index expression against a NULL placeholder, so any expression referencing such a column ships a key holding NULL.

Re-evaluate those expression fields in add_record(), right after the sequence is assigned, rewriting iq->idxInsert[] in place.  Every later create_key_from_ireq() caller - including delayed_key_adds(), which re-reads the record by genid and has no blobs in scope - then sees a correct key without needing the blobs the expression may reference.
